### PR TITLE
WIP Add support for non-empty string as a primaryKey in update() 

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -660,7 +660,7 @@ class Model
 	 * Updates a single record in $this->table. If an object is provided,
 	 * it will attempt to convert it into an array.
 	 *
-	 * @param int|array|string   $id
+	 * @param int|array|string   $id  if int | string | associative array updete will use where(); if indexed array update will use whereIn()
 	 * @param array|object $data
 	 *
 	 * @return bool
@@ -668,11 +668,6 @@ class Model
 	public function update($id = null, $data = null)
 	{
 		$escape = null;
-
-		if (is_numeric($id) || (!empty($id) && is_string($id)))
-		{
-			$id = [$id];
-		}
 
 		if (empty($data))
 		{
@@ -729,10 +724,25 @@ class Model
 
 		$builder = $this->builder();
 
-		if ($id)
+		if (is_numeric($id) || (!empty($id) && is_string($id)))
 		{
-			$builder = $builder->whereIn($this->table.'.'.$this->primaryKey, $id);
+			$builder = $builder->where($this->table.'.'.$this->primaryKey, $id);
 		}
+		elseif (!empty($id) && is_array($id))
+		{
+			if(array_keys($id) === range(0, count($id) -1))
+			{
+				$builder = $builder->whereIn($this->table.'.'.$this->primaryKey, $id);
+			}
+			else
+			{
+				foreach ($id as $key => $value)
+				{
+					$builder = $builder->where($this->table.'.'.$key, $value);
+				}
+			}
+		}
+
 
 		// Must use the set() method to ensure objects get converted to arrays
 		$result = $builder

--- a/system/Model.php
+++ b/system/Model.php
@@ -669,7 +669,7 @@ class Model
 	{
 		$escape = null;
 
-		if (is_numeric($id))
+		if (is_numeric($id) || (!empty($id) && is_string($id)))
 		{
 			$id = [$id];
 		}

--- a/system/Model.php
+++ b/system/Model.php
@@ -738,7 +738,14 @@ class Model
 			{
 				foreach ($id as $key => $value)
 				{
-					$builder = $builder->where($this->table.'.'.$key, $value);
+					if(!empty($value) && is_array($value))
+					{
+						$builder = $builder->whereIn($this->table.'.'.$key, $value);
+					}
+					else
+					{
+						$builder = $builder->where($this->table.'.'.$key, $value);
+					}
 				}
 			}
 		}

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -564,7 +564,7 @@ class ModelTest extends CIDatabaseTestCase
 		]);
 	}
 
-	public function testSetWorksWithUpdate()
+	public function testSetWorksWithUpdateNumeric()
 	{
 		$model = new EventModel();
 
@@ -584,6 +584,38 @@ class ModelTest extends CIDatabaseTestCase
 
 		$this->seeInDatabase('user', [
 			'id' => $userId,
+			'email' => 'foo@example.com',
+			'name' => 'Fred Flintstone'
+		]);
+	}
+
+
+	public function testSetWorksWithUpdateString()
+	{
+		$model = new EventModel();
+
+		$this->dontSeeInDatabase('user', [
+			'email' => 'foo@example.com'
+		]);
+
+		$userId = $model->insert([
+			'email' => 'foo@example.com',
+			'name' => 'Foo Bar',
+			'country' => 'US'
+		]);
+
+		$model->set([
+			'name' => 'Fred Flintstone'
+		])->update('a');
+
+		$this->seeInDatabase('user', [
+			'id' => $userId,
+			'email' => 'foo@example.com',
+			'name' => 'Fred Flintstone'
+		]);
+		
+		$this->dontSeeInDatabase('user', [
+			'id' => 'a',
 			'email' => 'foo@example.com',
 			'name' => 'Fred Flintstone'
 		]);
@@ -616,12 +648,12 @@ class ModelTest extends CIDatabaseTestCase
 		]);
 	}
 
-	public function testUpdateArray()
+	public function testUpdateArrayIndexed()
 	{
 		$model = new EventModel();
 
 		$data = [
-			'name'  => 	'Foo',
+			'name'  => 'Foo',
 			'email' => 'foo@example.com',
 			'country' => 'US',
 			'deleted' => 0
@@ -634,6 +666,24 @@ class ModelTest extends CIDatabaseTestCase
 		$this->seeInDatabase('user', ['id' => 2, 'name' => 'Foo Bar']);
 	}
 
+	public function testUpdateArrayAssoc()
+	{
+		$model = new EventModel();
+
+		$data = [
+			'name'  => 'Foo',
+			'email' => 'foobar@example.com',
+			'country' => 'PL',
+			'deleted' => 0
+		];
+
+		$id = $model->insert($data);
+		$model->update(['name' => 'Foo', 'country' => 'PL', 'email' => 'foobar@example.com', 'id' => $id], ['name' => 'Foo-Bar', 'email' => 'foo-bar@example.com']);
+
+		$this->seeInDatabase('user', ['id' => $id, 'country' => 'PL', 'name' => 'Foo-Bar', 'email' => 'foo-bar@example.com']);
+
+	}
+	
 	public function testInsertBatchSuccess()
 	{
 		$job_data = [

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -603,12 +603,19 @@ class ModelTest extends CIDatabaseTestCase
 			'name' => 'Foo Bar',
 			'country' => 'US'
 		]);
-
+		
+		// Trying to set name = 'Fred Flinston' (where id = 'a')
 		$model->set([
 			'name' => 'Fred Flintstone'
 		])->update('a');
-
+		
 		$this->seeInDatabase('user', [
+			'id' => $userId,
+			'email' => 'foo@example.com',
+			'name' => 'Foo Bar'
+		]);
+		
+		$this->dontSeeInDatabase('user', [
 			'id' => $userId,
 			'email' => 'foo@example.com',
 			'name' => 'Fred Flintstone'

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -275,20 +275,14 @@ of the columns in $table, while the array's values are the values to save for th
 
 Multiple records may be updated with a single call by passing an array of primary keys as the first parameter::
 
-    $data = [
-		'active' => 1
-	];
-
+	$data = ['active' => 1];
 	$userModel->update([1, 2, 3], $data);
 
 When you need a more flexible solution, you have two options:
 
 - you can pass as associative array as the first parameter:
 
-    $data = [
-		'active' => 1
-	];
-	
+	$data = ['active' => 1];
 	$userModel->update(['id' => [2,3,4], 'name' => 'Foo'], $data);
 	
 	// UPDATE `table` SET `active` = 1 WHERE `table`.`id` IN(2,3,4) AND `table`.`name` = 'Foo';

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -281,12 +281,24 @@ Multiple records may be updated with a single call by passing an array of primar
 
 	$userModel->update([1, 2, 3], $data);
 
-When you need a more flexible solution, you can leaven the parameters empty and it functions like the Query Builder's
-update command, with the added benefit of validation, events, etc::
+When you need a more flexible solution, you have two options:
+
+- you can pass as associative array as the first parameter:
+
+    $data = [
+		'active' => 1
+	];
+	
+	$userModel->update(['id' => [2,3,4], 'name' => 'Foo'], $data);
+	
+	// UPDATE `table` SET `active` = 1 WHERE `table`.`id` IN(2,3,4) AND `table`.`name` = 'Foo';
+
+
+- you can leave the parameters empty and it functions like the Query Builder's update command, with the added benefit of validation, events, etc::
 
     $userModel
         ->whereIn('id', [1,2,3])
-        ->set(['active' => 1]
+        ->set(['active' => 1])
         ->update();
 
 **save()**


### PR DESCRIPTION
**Description**
In current code every update which contains ID in string format was ignored inside update() method.
Actually in docs (and comments) there is an information that $id passed to update() method can contain an array... - I think it won't work as well; I will try to write a fix in a week but I am not sure about exact date so you can merge this little fix without waiting.
