### PR TITLE
WIP un-ignore application/Database/Migrations directory from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,6 @@ writable/uploads/*
 
 writable/debugbar/*
 
-application/Database/Migrations/2*
-
 php_errors.log
 
 #-------------------------

--- a/tests/system/Commands/SessionsCommandsTest.php
+++ b/tests/system/Commands/SessionsCommandsTest.php
@@ -51,6 +51,7 @@ class SessionsCommandsTest extends \CIUnitTestCase
 	public function tearDown()
 	{
 		stream_filter_remove($this->stream_filter);
+		system('rm ' . APPPATH . '/Database/Migrations/*.php');
 	}
 
 	public function testCreateMigrationCommand()

--- a/tests/system/Commands/SessionsCommandsTest.php
+++ b/tests/system/Commands/SessionsCommandsTest.php
@@ -16,6 +16,7 @@ class SessionsCommandsTest extends \CIUnitTestCase
 	protected $response;
 	protected $logger;
 	protected $runner;
+	private $result;
 
 	public function setUp()
 	{
@@ -51,7 +52,14 @@ class SessionsCommandsTest extends \CIUnitTestCase
 	public function tearDown()
 	{
 		stream_filter_remove($this->stream_filter);
-		system('rm ' . APPPATH . '/Database/Migrations/*.php');
+
+		$result = remove_invisible_characters($this->result);
+		$result = str_replace('[0;32m', '', $result);
+		$result = str_replace('[0m', '', $result);
+		$file   = trim(substr($result, 14));
+		$file   = str_replace('APPPATH', APPPATH, $file);
+
+		unlink($file);
 	}
 
 	public function testCreateMigrationCommand()
@@ -65,6 +73,8 @@ class SessionsCommandsTest extends \CIUnitTestCase
 		$this->assertContains('Created file:', $result);
 		$this->assertContains('APPPATH/Database/Migrations/', $result);
 		$this->assertContains('_create_ci_sessions_table.php', $result);
+
+		$this->result = $result;
 	}
 
 	public function testOverriddenCreateMigrationCommand()
@@ -85,6 +95,8 @@ class SessionsCommandsTest extends \CIUnitTestCase
 		$this->assertContains('Created file:', $result);
 		$this->assertContains('APPPATH/Database/Migrations/', $result);
 		$this->assertContains('_create_mygoodies_table.php', $result);
+
+		$this->result = $result;
 	}
 
 }


### PR DESCRIPTION
When developer create a migration files, they can commit and share it with other developers. So, I think it should be removed from .gitignore.

**Checklist:**
- [x] Securely signed commits
