### PR TITLE
remove unneeded ternary check at HoneyPot::hasContent()

### DIFF
--- a/system/Honeypot/Honeypot.php
+++ b/system/Honeypot/Honeypot.php
@@ -82,7 +82,7 @@ class Honeypot
 	 */
 	public function hasContent(RequestInterface $request)
 	{
-		return ( ! empty($request->getPost($this->config->name))) ? true : false;
+		return ! empty($request->getPost($this->config->name));
 	}
 
 	/**


### PR DESCRIPTION
`! empty()` already return true on not empty, false on empty.

**Checklist:**
- [x] Securely signed commits
