### PR TITLE
Fix FeatureTestCaseTest output buffer 

### DIFF
--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -34,6 +34,11 @@ class FeatureTestCase extends CIDatabaseTestCase
 	 */
 	protected $session = [];
 
+	/**
+	 * Enabled auto clean op buffer after request call
+	 *
+	 * @var bool
+	 */
 	protected $clean = true;
 
 	/**

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -34,6 +34,8 @@ class FeatureTestCase extends CIDatabaseTestCase
 	 */
 	protected $session = [];
 
+	protected $clean = true;
+
 	/**
 	 * Sets a RouteCollection that will override
 	 * the application's route collection.
@@ -115,7 +117,7 @@ class FeatureTestCase extends CIDatabaseTestCase
 			->run($this->routes, true);
 
 		// Clean up any open output buffers
-		if (ob_get_level() > 0)
+		if (ob_get_level() > 0 && $this->clean)
 		{
 			ob_end_clean();
 		}

--- a/tests/system/Test/FeatureTestCaseTest.php
+++ b/tests/system/Test/FeatureTestCaseTest.php
@@ -14,6 +14,7 @@ class FeatureTestCaseTest extends FeatureTestCase
 		parent::setUp();
 
 		$this->skipEvents();
+		$this->clean = false;
 	}
 
 	public function testCallGet()


### PR DESCRIPTION
**Description**
fix the auto cleanup after FeatureTestCase::call -> is necessary for specific test but some require the op cache to be left open.

fix #1446

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Conforms to style guide
