### PR TITLE
Allow create table with array field constraints

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -82,7 +82,7 @@ class Forge
 	/**
 	 * List of foreign keys.
 	 *
-	 * @var type
+	 * @var array
 	 */
 	protected $foreignKeys = [];
 
@@ -340,7 +340,7 @@ class Forge
 	/**
 	 * Add Field
 	 *
-	 * @param array $field
+	 * @param array|string $field
 	 *
 	 * @return Forge
 	 */
@@ -946,19 +946,13 @@ class Forge
 
 			if (isset($attributes['TYPE']) && ! empty($attributes['CONSTRAINT']))
 			{
-				switch (strtoupper($attributes['TYPE']))
+				if (is_array($attributes['CONSTRAINT']))
 				{
-					case 'ENUM':
-					case 'SET':
-						$attributes['CONSTRAINT'] = $this->db->escapeString($attributes['CONSTRAINT']);
-						$field['length']          = is_array($attributes['CONSTRAINT']) ? "('" . implode("','",
-								$attributes['CONSTRAINT']) . "')" : '(' . $attributes['CONSTRAINT'] . ')';
-						break;
-					default:
-						$field['length'] = is_array($attributes['CONSTRAINT']) ? '(' . implode(',',
-								$attributes['CONSTRAINT']) . ')' : '(' . $attributes['CONSTRAINT'] . ')';
-						break;
+					$attributes['CONSTRAINT'] = $this->db->escape($attributes['CONSTRAINT']);
+					$attributes['CONSTRAINT'] = implode(',', $attributes['CONSTRAINT']);
 				}
+
+				$field['length'] = '(' . $attributes['CONSTRAINT'] . ')';
 			}
 
 			$fields[] = $field;

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -171,6 +171,12 @@ class Forge extends \CodeIgniter\Database\Forge
 	 */
 	protected function _processColumn($field)
 	{
+		if ($field['type'] === 'TEXT' && strpos($field['length'], "('") === 0)
+		{
+			$field['type'] .= ' CHECK(' . $this->db->escapeIdentifiers($field['name'])
+				. ' IN ' . $field['length'] . ')';
+		}
+
 		return $this->db->escapeIdentifiers($field['name'])
 			   . ' ' . $field['type']
 			   . $field['auto_increment']

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -11,6 +11,10 @@ class ForgeTest extends CIDatabaseTestCase
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+	/**
+	 * @var \CodeIgniter\Database\Forge
+	 */
+	protected $forge;
 
 	public function setUp()
 	{
@@ -317,5 +321,38 @@ class ForgeTest extends CIDatabaseTestCase
 
 		$this->forge->dropTable('forge_test_invoices', true);
 		$this->forge->dropTable('forge_test_users', true);
+	}
+
+	public function testCreateTableWithArrayFieldConstraints()
+	{
+		if ($this->db->DBDriver === 'MySQLi')
+		{
+			$this->forge->addField([
+				'enum_string' => [
+					'type' => 'ENUM("a","b")',
+				],
+				'enum_array'  => [
+					'type'       => 'ENUM',
+					'constraint' => [
+						'a',
+						'b',
+					],
+				],
+			]);
+			$this->forge->createTable('forge_test_enum');
+
+			$fields = $this->db->getFieldData('forge_test_enum');
+
+			$this->forge->dropTable('forge_test_enum');
+
+			$this->assertEquals('enum_string', $fields[0]->name);
+			$this->assertEquals('enum', $fields[0]->type);
+			$this->assertEquals('enum_array', $fields[1]->name);
+			$this->assertEquals('enum', $fields[1]->type);
+		}
+		else
+		{
+			$this->expectNotToPerformAssertions();
+		}
 	}
 }

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -325,30 +325,34 @@ class ForgeTest extends CIDatabaseTestCase
 
 	public function testCreateTableWithArrayFieldConstraints()
 	{
-		if ($this->db->DBDriver === 'MySQLi')
+		if (in_array($this->db->DBDriver, ['MySQLi', 'SQLite3']))
 		{
+			$this->forge->dropTable('forge_array_constraint', true);
 			$this->forge->addField([
-				'enum_string' => [
-					'type' => 'ENUM("a","b")',
-				],
-				'enum_array'  => [
+				'status' => [
 					'type'       => 'ENUM',
 					'constraint' => [
-						'a',
-						'b',
+						'sad',
+						'ok',
+						'happy',
 					],
 				],
 			]);
-			$this->forge->createTable('forge_test_enum');
+			$this->forge->createTable('forge_array_constraint');
 
-			$fields = $this->db->getFieldData('forge_test_enum');
+			$fields = $this->db->getFieldData('forge_array_constraint');
 
-			$this->forge->dropTable('forge_test_enum');
+			$this->assertEquals('status', $fields[0]->name);
 
-			$this->assertEquals('enum_string', $fields[0]->name);
-			$this->assertEquals('enum', $fields[0]->type);
-			$this->assertEquals('enum_array', $fields[1]->name);
-			$this->assertEquals('enum', $fields[1]->type);
+			if ($this->db->DBDriver === 'SQLite3')
+			{
+				// SQLite3 converts array constraints to TEXT CHECK(...)
+				$this->assertEquals('TEXT', $fields[0]->type);
+			}
+			else
+			{
+				$this->assertEquals('enum', $fields[0]->type);
+			}
 		}
 		else
 		{

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -73,7 +73,7 @@ also require a 'constraint' key.
 	$fields = [
 		'users' => [
 			'type'       => 'VARCHAR',
-			'constraint' => '100',
+			'constraint' => 100,
 		],
 	];
 	// will translate to "users VARCHAR(100)" when the field is added.
@@ -92,25 +92,30 @@ Additionally, the following key/values can be used:
 ::
 
 	$fields = [
-		'blog_id'          => [
+		'id'          => [
 			'type'           => 'INT',
 			'constraint'     => 5,
-			'unsigned'       => TRUE,
-			'auto_increment' => TRUE
+			'unsigned'       => true,
+			'auto_increment' => true
 		],
-		'blog_title'       => [
+		'title'       => [
 			'type'           => 'VARCHAR',
 			'constraint'     => '100',
-			'unique'         => TRUE,
+			'unique'         => true,
 		],
-		'blog_author'      => [
+		'author'      => [
 			'type'           =>'VARCHAR',
-			'constraint'     => '100',
+			'constraint'     => 100,
 			'default'        => 'King of Town',
 		],
-		'blog_description' => [
+		'description' => [
 			'type'           => 'TEXT',
-			'null'           => TRUE,
+			'null'           => true,
+		],
+		'status'      => [
+			'type'           => 'ENUM',
+			'constraint'     => ['publish', 'pending', 'draft'],
+			'default'        => 'pending',
 		],
 	];
 
@@ -132,9 +137,9 @@ string into the field definitions with addField()
 
 	$forge->addField("label varchar(100) NOT NULL DEFAULT 'default label'");
 
-.. note:: Passing raw strings as fields cannot be followed by ``add_key()`` calls on those fields.
+.. note:: Passing raw strings as fields cannot be followed by ``addKey()`` calls on those fields.
 
-.. note:: Multiple calls to add_field() are cumulative.
+.. note:: Multiple calls to addField() are cumulative.
 
 Creating an id field
 --------------------
@@ -320,7 +325,7 @@ Modifying a Column in a Table
 
 **$forge->modifyColumn()**
 
-The usage of this method is identical to ``add_column()``, except it
+The usage of this method is identical to ``addColumn()``, except it
 alters an existing column rather than adding a new one. In order to
 change the name you can add a "name" key into the field defining array.
 


### PR DESCRIPTION
**Description**

See #976

Testing only ENUM in MySQLi - but all constraints set as array will be escaped and imploded, works with MySQL SET Data Type too.


**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
