### PR TITLE
Fix Language Key-File confusion

### DIFF
--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -152,14 +152,14 @@ class Language
 		$file = substr($line, 0, strpos($line, '.'));
 		$line = substr($line, strlen($file) + 1);
 
-		if (! array_key_exists($line, $this->language))
+		if (! isset( $this->language[$this->locale][$file] ) )
 		{
 			$this->load($file, $this->locale);
 		}
 
 		return [
 			$file,
-			$this->language[$this->locale][$line] ?? $line,
+			$line,
 		];
 	}
 

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -152,7 +152,7 @@ class Language
 		$file = substr($line, 0, strpos($line, '.'));
 		$line = substr($line, strlen($file) + 1);
 
-		if (! array_key_exists( $line, $this->language[$this->locale][$file] ) )
+		if (! isset($this->language[$this->locale][$file]) || ! array_key_exists($line, $this->language[$this->locale][$file]))
 		{
 			$this->load($file, $this->locale);
 		}

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -152,7 +152,7 @@ class Language
 		$file = substr($line, 0, strpos($line, '.'));
 		$line = substr($line, strlen($file) + 1);
 
-		if (! isset( $this->language[$this->locale][$file] ) )
+		if (! array_key_exists( $line, $this->language[$this->locale][$file] ) )
 		{
 			$this->load($file, $this->locale);
 		}

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -153,4 +153,21 @@ class LanguageTest extends \CIUnitTestCase
 		$this->assertEquals(1, count($lang->loaded()));
 	}
 
+	//--------------------------------------------------------------------
+
+	public function testLanguageSameKeyAndFileName()
+	{
+		$lang = new MockLanguage('en');
+
+		// first file data | example.message
+		$lang->setData(['message' => 'This is an example message']);
+
+		// force loading data into file Example
+		$this->assertEquals('This is an example message', $lang->getLine('example.message'));
+
+		// second file data | another.example
+		$lang->setData(['example' => 'Another example']);
+
+		$this->assertEquals('Another example', $lang->getLine('another.example'));
+	}
 }


### PR DESCRIPTION
The Language class currently crash if one key name is the filename of another language file

**Description**
removed the key check on file level

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide

*Im not sure why is check was implemented*