### PR TITLE
RedisHandler test clean up: remove unneeded 2nd parameter in __construct

### DIFF
--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -60,7 +60,7 @@ class RedisHandlerTest extends \CIUnitTestCase
 
 		$this->config = new \Config\Cache();
 
-		$this->redisHandler = new RedisHandler($this->config, '127.0.0.1');
+		$this->redisHandler = new RedisHandler($this->config);
 		if (! $this->redisHandler->isSupported())
 		{
 			$this->markTestSkipped('Not support redis');
@@ -84,7 +84,7 @@ class RedisHandlerTest extends \CIUnitTestCase
 
 	public function testDestruct()
 	{
-		$this->redisHandler = new RedisHandler($this->config, '127.0.0.1');
+		$this->redisHandler = new RedisHandler($this->config);
 		$this->redisHandler->initialize();
 
 		$this->assertInstanceOf(RedisHandler::class, $this->redisHandler);


### PR DESCRIPTION
**Checklist:**
- [x] Securely signed commits
