### PR TITLE
doc fix: query binding fix in Seeds documentation

### DIFF
--- a/user_guide_src/source/dbmgmt/seeds.rst
+++ b/user_guide_src/source/dbmgmt/seeds.rst
@@ -24,7 +24,7 @@ stored within the **application/Database/Seeds** directory. The name of the file
 			];
 
 			// Simple Queries
-			$this->db->query("INSERT INTO users (username, email) VALUES(:username, :email)",
+			$this->db->query("INSERT INTO users (username, email) VALUES(:username:, :email:)",
 				$data
 			);
 


### PR DESCRIPTION
It was missing `:` after each named parameter.

**Checklist:**
- [x] Securely signed commits
- [x] User guide updated
