### PR TITLE
Fix Common::old()

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -264,13 +264,13 @@ if (! function_exists('esc'))
 
 			static $escaper;
 			if (! $escaper)
-					   {
+			{
 				$escaper = new \Zend\Escaper\Escaper($encoding);
 			}
 
 			if ($encoding && $escaper->getEncoding() !== $encoding)
-					   {
-					$escaper = new \Zend\Escaper\Escaper($encoding);
+			{
+				$escaper = new \Zend\Escaper\Escaper($encoding);
 			}
 
 			$data = $escaper->$method($data);
@@ -745,7 +745,7 @@ if (! function_exists('force_https'))
 
 		$uri = \CodeIgniter\HTTP\URI::createURIString(
 						$uri->getScheme(), $uri->getAuthority(true), $uri->getPath(), // Absolute URIs should use a "/" for an empty path
-											$uri->getQuery(), $uri->getFragment()
+						$uri->getQuery(), $uri->getFragment()
 		);
 
 		// Set an HSTS header
@@ -783,9 +783,12 @@ if (! function_exists('old'))
 		}
 
 		// If the result was serialized array or string, then unserialize it for use...
-		if (strpos($value, 'a:') === 0 || strpos($value, 's:') === 0)
+		if (is_string($value))
 		{
-			$value = unserialize($value);
+			if (strpos($value, 'a:') === 0 || strpos($value, 's:') === 0)
+			{
+				$value = unserialize($value);
+			}
 		}
 
 		return $escape === false ? $value : esc($value, $escape);

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -521,6 +521,9 @@ class IncomingRequest extends Request
 				return $value;
 			}
 		}
+
+		// return null if requested session key not found
+		return null;
 	}
 
 	/**

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -289,6 +289,43 @@ class CommonFunctionsTest extends \CIUnitTestCase
 		$this->assertEquals('fritz', old('zibble')); // serialized parameter
 	}
 
+	// Reference: https://github.com/codeigniter4/CodeIgniter4/issues/1492
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState  disabled
+	 */
+	public function testOldInputArray()
+	{
+		$this->injectSessionMock();
+		// setup from RedirectResponseTest...
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		$this->config          = new App();
+		$this->config->baseURL = 'http://example.com';
+
+		$this->routes = new RouteCollection(new MockFileLocator(new Autoload()), new \Config\Modules());
+		Services::injectMock('routes', $this->routes);
+
+		$this->request = new MockIncomingRequest($this->config, new URI('http://example.com'), null, new UserAgent());
+		Services::injectMock('request', $this->request);
+
+		$locations = [
+			'AB' => 'Alberta',
+			'BC' => 'British Columbia',
+			'SK' => 'Saskatchewan',
+		];
+
+		// setup & ask for a redirect...
+		$_SESSION = [];
+		$_GET     = [];
+		$_POST    = ['location' => $locations];
+
+		$response = new RedirectResponse(new App());
+		$returned = $response->withInput();
+
+		$this->assertEquals($locations, old('location'));
+	}
+
 	// ------------------------------------------------------------------------
 
 	public function testReallyWritable()

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -96,6 +96,10 @@ class IncomingRequestTest extends \CIUnitTestCase
 	}
 
 	// Reference: https://github.com/codeigniter4/CodeIgniter4/issues/1492
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState  disabled
+	 */
 	public function testCanSerializeOldArray()
 	{
 		$locations = [

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace CodeIgniter\HTTP;
 
 use Config\App;
@@ -82,6 +81,32 @@ class IncomingRequestTest extends \CIUnitTestCase
 
 		$this->assertEquals('foo', $this->request->getOldInput('banana.name'));
 		$this->assertEquals('two', $this->request->getOldInput('apple.name'));
+	}
+
+	// Reference: https://github.com/codeigniter4/CodeIgniter4/issues/1492
+	public function testCanGetOldInputArray()
+	{
+		$_SESSION['_ci_old_input'] = [
+			'get'  => ['apple' => ['name' => 'two']],
+			'post' => ['banana' => ['name' => 'foo']],
+		];
+
+		$this->assertEquals(['name' => 'two'], $this->request->getOldInput('apple'));
+		$this->assertEquals(['name' => 'foo'], $this->request->getOldInput('banana'));
+	}
+
+	// Reference: https://github.com/codeigniter4/CodeIgniter4/issues/1492
+	public function testCanSerializeOldArray()
+	{
+		$locations = [
+			'AB' => 'Alberta',
+			'BC' => 'British Columbia',
+			'SK' => 'Saskatchewan',
+		];
+		$session   = service('session');
+		$session->set(['_ci_old_input' => ['post' => ['location' => $locations]]]);
+
+		$this->assertEquals($locations, $this->request->getOldInput('location'));
 	}
 
 	//--------------------------------------------------------------------
@@ -319,6 +344,5 @@ class IncomingRequestTest extends \CIUnitTestCase
 		$this->assertEquals(124, $file->getSize());
 	}
 
-		//--------------------------------------------------------------------
-
+	//--------------------------------------------------------------------
 }

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -40,7 +40,7 @@ class SessionTest extends \CIUnitTestCase
 		];
 
 		$config = array_merge($defaults, $options);
-		$config = (object)$config;
+		$config = (object) $config;
 
 		$session = new MockSession(new FileHandler($config, '127.0.0.1'), $config);
 		$session->setLogger(new TestLogger(new Logger()));
@@ -91,6 +91,22 @@ class SessionTest extends \CIUnitTestCase
 		$this->assertEquals('bar', $_SESSION['foo']);
 		$this->assertEquals('baz', $_SESSION['bar']);
 		$this->assertArrayNotHasKey('__ci_vars', $_SESSION);
+	}
+
+	// Reference: https://github.com/codeigniter4/CodeIgniter4/issues/1492
+	public function testCanSerializeArray()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$locations = [
+			'AB' => 'Alberta',
+			'BC' => 'British Columbia',
+			'SK' => 'Saskatchewan',
+		];
+		$session->set(['_ci_old_input' => ['location' => $locations]]);
+
+		$this->assertEquals($locations, $session->get('_ci_old_input')['location']);
 	}
 
 	public function testGetSimpleKey()


### PR DESCRIPTION
Fixes #1492 
Common::old() needs to check if serialized data before trying to unserialize it.