### PR TITLE
Ignoring errors suppressed by @

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -174,6 +174,10 @@ class Exceptions
 	 */
 	public function errorHandler(int $severity, string $message, string $file = null, int $line = null, $context = null)
 	{
+		if (! (\error_reporting() & $severity)) {
+			return;
+		}
+
 		// Convert it to an exception and pass it along.
 		throw new \ErrorException($message, 0, $severity, $file, $line);
 	}


### PR DESCRIPTION
For example, in application, we have the follwoing code: 

```php
@unlink('file');
```

The error should be ignored if the file not exists as the `unlink()` suppressed with `@`

**Checklist:**
- [x] Securely signed commits  
