### PR TITLE
Revert to buggy oldInput

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -783,13 +783,13 @@ if (! function_exists('old'))
 		}
 
 		// If the result was serialized array or string, then unserialize it for use...
-		if (is_string($value))
-		{
-			if (strpos($value, 'a:') === 0 || strpos($value, 's:') === 0)
+		//      if (is_string($value))
+		//      {
+		if (strpos($value, 'a:') === 0 || strpos($value, 's:') === 0)
 			{
-				$value = unserialize($value);
-			}
+			$value = unserialize($value);
 		}
+		//      }
 
 		return $escape === false ? $value : esc($value, $escape);
 	}

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -522,8 +522,8 @@ class IncomingRequest extends Request
 			}
 		}
 
-		// return null if requested session key not found
-		return null;
+		//      // return null if requested session key not found
+		//      return null;
 	}
 
 	/**


### PR DESCRIPTION
In response to redirect() bug reported as a result of this.
Yes, the unit tests break - evidence of the original reported bug.