### PR TITLE
Do not exit until all Response is completed

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -326,17 +326,6 @@ class CodeIgniter
 			$this->benchmark->stop('controller');
 		}
 
-		// Handle any redirects
-		if ($returned instanceof RedirectResponse)
-		{
-			if ($returnResponse)
-			{
-				return $returned;
-			}
-
-			$this->callExit(EXIT_SUCCESS);
-		}
-
 		// If $returned is a string, then the controller output something,
 		// probably a view, instead of echoing it directly. Send it along
 		// so it can be used with the output.

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -755,7 +755,7 @@ class Response extends Message implements ResponseInterface
 		}
 
 		$this->setStatusCode($code);
-		$this->sendHeaders();
+
 		return $this;
 	}
 


### PR DESCRIPTION
**Description**

Fixes #1393

CodeIgniter was exiting before send all headers when returning a RedirectResponse.

Now, it acts the same way as when returning a Response redirect.


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

  
