### PR TITLE
Fix multi "empty" string separated by "," marked as valid emails

### DIFF
--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -294,7 +294,13 @@ class FormatRules
 
 		foreach (explode(',', $str) as $email)
 		{
-			if (trim($email) !== '' && $this->valid_email(trim($email)) === false)
+			$email = trim($email);
+			if ($email === '')
+			{
+				return false;
+			}
+
+			if ($this->valid_email($email) === false)
 			{
 				return false;
 			}

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -241,6 +241,10 @@ class FormatRulesTest extends \CIUnitTestCase
 				null,
 				false,
 			],
+			[
+				',',
+				false,
+			],
 		];
 	}
 


### PR DESCRIPTION
In `Validation\FormatRules::valid_emails()`, if we passed a string: 

```php
','
```

It previously checked as valid email, while empty string is not valid email. We need to check if the string separated by comma is an empty string or not. If empty, then return `false` early.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
