### PR TITLE
remove duplicate strtolower() call in URI::setScheme() call

### DIFF
--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -990,7 +990,7 @@ class URI
 		// Scheme
 		if (isset($parts['scheme']))
 		{
-			$this->setScheme(rtrim(strtolower($parts['scheme']), ':/'));
+			$this->setScheme(rtrim($parts['scheme'], ':/'));
 		}
 		else
 		{


### PR DESCRIPTION
There is already `strtolower()` call inside the `setScheme()` function.

**Checklist:**
- [x] Securely signed commits
