### PR TITLE
Update Services.php

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -500,7 +500,7 @@ class Services extends BaseService
 		{
 			$paths = config('Paths');
 
-			$viewPath = $paths->viewDirectory;
+			$viewPath = ROOTPATH.$paths->viewDirectory;
 		}
 
 		return new \CodeIgniter\View\View($config, $viewPath, static::locator(true), CI_DEBUG, static::logger(true));


### PR DESCRIPTION
This was will cause wrong file path if using views like 'template.tpl' and makes real path into 'application/Views/template.tpl.php because template.tpl' isn't found and file locator will add '.php' extention.
Giving ROOTPATH makes absolute path to 'template.tpl' and be found.
