### PR TITLE
add property_exists check on BaseBuilder and BaseConnection for $this->$key set value

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -233,7 +233,10 @@ class BaseBuilder
 		{
 			foreach ($options as $key => $value)
 			{
-				$this->$key = $value;
+				if (property_exists($this, $key))
+				{
+					$this->$key = $value;
+				}
 			}
 		}
 	}

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -338,7 +338,10 @@ abstract class BaseConnection implements ConnectionInterface
 	{
 		foreach ($params as $key => $value)
 		{
-			$this->$key = $value;
+			if (property_exists($this, $key))
+			{
+				$this->$key = $value;
+			}
 		}
 	}
 
@@ -382,7 +385,10 @@ abstract class BaseConnection implements ConnectionInterface
 					// Replace the current settings with those of the failover
 					foreach ($failover as $key => $val)
 					{
-						$this->$key = $val;
+						if (property_exists($this, $key))
+						{
+							$this->$key = $val;
+						}
 					}
 
 					// Try to connect


### PR DESCRIPTION
To avoid create non-existente property values.

**Checklist:**
- [x] Securely signed commits
