### PR TITLE
remove unneeded try {} catch {} on @fopen at Cache FileHandler::writeFile()

### DIFF
--- a/system/Cache/Exceptions/CacheException.php
+++ b/system/Cache/Exceptions/CacheException.php
@@ -5,6 +5,14 @@ class CacheException extends \RuntimeException implements ExceptionInterface
 	/**
 	 * @return \CodeIgniter\Cache\Exceptions\CacheException
 	 */
+	public static function forUnableToWrite(string $path)
+	{
+		return new static(lang('Cache.unableToWrite', [$path]));
+	}
+
+	/**
+	 * @return \CodeIgniter\Cache\Exceptions\CacheException
+	 */
 	public static function forInvalidHandlers()
 	{
 		return new static(lang('Cache.invalidHandlers'));

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -334,7 +334,7 @@ class FileHandler implements CacheInterface
 	 */
 	protected function writeFile($path, $data, $mode = 'wb')
 	{
-		fopen($path, $mode);
+		$fp = fopen($path, $mode);
 		flock($fp, LOCK_EX);
 
 		for ($result = $written = 0, $length = strlen($data); $written < $length; $written += $result)

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -334,7 +334,11 @@ class FileHandler implements CacheInterface
 	 */
 	protected function writeFile($path, $data, $mode = 'wb')
 	{
-		$fp = fopen($path, $mode);
+		if (($fp = @fopen($path, $mode)) === false)
+		{
+			return false;
+		}
+
 		flock($fp, LOCK_EX);
 
 		for ($result = $written = 0, $length = strlen($data); $written < $length; $written += $result)

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -329,14 +329,7 @@ class FileHandler implements CacheInterface
 	 */
 	protected function writeFile($path, $data, $mode = 'wb')
 	{
-		try
-		{
-			if (($fp = @fopen($path, $mode)) === false)
-			{
-				return false;
-			}
-		}
-		catch (\ErrorException $e)
+		if (($fp = @fopen($path, $mode)) === false)
 		{
 			return false;
 		}

--- a/system/Language/en/Cache.php
+++ b/system/Language/en/Cache.php
@@ -15,6 +15,7 @@
  */
 
 return [
+   'unableToWrite'   => 'Cache unable to write to {0}',
    'invalidHandlers' => 'Cache config must have an array of $validHandlers.',
    'noBackup'        => 'Cache config must have a handler and backupHandler set.',
    'handlerNotFound' => 'Cache config has an invalid handler or backup handler specified.',

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -65,6 +65,15 @@ class FileHandlerTest extends \CIUnitTestCase
 		$this->assertInstanceOf(FileHandler::class, $this->fileHandler);
 	}
 
+	/**
+	 * @expectedException \CodeIgniter\Cache\Exceptions\CacheException
+	 */
+	public function testNewWithNonWritablePath()
+	{
+		chmod($this->config->storePath, 0444);
+		new FileHandler($this->config);
+	}
+
 	public function testSetDefaultPath()
 	{
 		//Initialize path

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -212,7 +212,7 @@ File-based Caching
 Unlike caching from the Output Class, the driver file-based caching
 allows for pieces of view files to be cached. Use this with care, and
 make sure to benchmark your application, as a point can come where disk
-I/O will negate positive gains by caching.
+I/O will negate positive gains by caching. This require a writable cache directory to be really writable (0777).
 
 =================
 Memcached Caching


### PR DESCRIPTION
By providing `@` in front of `fopen()` will make it always return false on failure fopen, so the catch was never reached, `try {} catch {}` is not needed.

**Checklist:**
- [x] Securely signed commits
