### PR TITLE
remove mb_* (mb string usage) in CreditCardRules

### DIFF
--- a/system/Validation/CreditCardRules.php
+++ b/system/Validation/CreditCardRules.php
@@ -228,7 +228,7 @@ class CreditCardRules
 		}
 
 		// Make sure we have a valid length
-		if (mb_strlen($ccNumber) === 0)
+		if (strlen($ccNumber) === 0)
 		{
 			return false;
 		}
@@ -245,7 +245,7 @@ class CreditCardRules
 		// Make sure it's a valid length for this card
 		$lengths = explode(',', $info['length']);
 
-		if (! in_array(mb_strlen($ccNumber), $lengths))
+		if (! in_array(strlen($ccNumber), $lengths))
 		{
 			return false;
 		}
@@ -257,7 +257,7 @@ class CreditCardRules
 
 		foreach ($prefixes as $prefix)
 		{
-			if (mb_strpos($ccNumber, $prefix) === 0)
+			if (strpos($ccNumber, $prefix) === 0)
 			{
 							  $validPrefix = true;
 							  break;


### PR DESCRIPTION
For `strlen()`, it already checked with compare to 0 lenght check early, even international character will be catched on it. 

Next, the `is_numeric()` already catch if any non-numeric character.

Next,  `strlen()` and `strpos()` already checked against numeric value before as `is_numeric()` check already handle before.

**Checklist:**
- [x] Securely signed commits
