### PR TITLE
database performance improvement : use foreach() when possible

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -852,10 +852,10 @@ class Forge
 		$sql .= ($alter_type === 'ADD') ? 'ADD ' : $alter_type . ' COLUMN ';
 
 		$sqls = [];
-		for ($i = 0, $c = count($field); $i < $c; $i++)
+		foreach ($field as $data)
 		{
 			$sqls[] = $sql
-					  . ($field[$i]['_literal'] !== false ? $field[$i]['_literal'] : $this->_processColumn($field[$i]));
+					  . ($data['_literal'] !== false ? $data['_literal'] : $this->_processColumn($data));
 		}
 
 		return $sqls;

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -168,11 +168,11 @@ class Forge extends \CodeIgniter\Database\Forge
 		}
 
 		$sql = 'ALTER TABLE ' . $this->db->escapeIdentifiers($table);
-		for ($i = 0, $c = count($field); $i < $c; $i ++)
+		foreach ($field as $i => $data)
 		{
-			if ($field[$i]['_literal'] !== false)
+			if ($data['_literal'] !== false)
 			{
-				$field[$i] = ($alter_type === 'ADD') ? "\n\tADD " . $field[$i]['_literal'] : "\n\tMODIFY " . $field[$i]['_literal'];
+				$field[$i] = ($alter_type === 'ADD') ? "\n\tADD " . $data['_literal'] : "\n\tMODIFY " . $data['_literal'];
 			}
 			else
 			{
@@ -182,7 +182,7 @@ class Forge extends \CodeIgniter\Database\Forge
 				}
 				else
 				{
-					$field[$i]['_literal'] = empty($field[$i]['new_name']) ? "\n\tMODIFY " : "\n\tCHANGE ";
+					$field[$i]['_literal'] = empty($data['new_name']) ? "\n\tMODIFY " : "\n\tCHANGE ";
 				}
 
 				$field[$i] = $field[$i]['_literal'] . $this->_processColumn($field[$i]);

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -86,14 +86,14 @@ class Result extends BaseResult implements ResultInterface
 		$retval    = [];
 		$fieldData = $this->resultID->fetch_fields();
 
-		for ($i = 0, $c = count($fieldData); $i < $c; $i ++)
+		foreach ($fieldData as $i => $data)
 		{
 			$retval[$i]              = new \stdClass();
-			$retval[$i]->name        = $fieldData[$i]->name;
-			$retval[$i]->type        = $fieldData[$i]->type;
-			$retval[$i]->max_length  = $fieldData[$i]->max_length;
-			$retval[$i]->primary_key = (int) ($fieldData[$i]->flags & 2);
-			$retval[$i]->default     = $fieldData[$i]->def;
+			$retval[$i]->name        = $data->name;
+			$retval[$i]->type        = $data->type;
+			$retval[$i]->max_length  = $data->max_length;
+			$retval[$i]->primary_key = (int) ($data->flags & 2);
+			$retval[$i]->default     = $data->def;
 		}
 
 		return $retval;

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -106,42 +106,42 @@ class Forge extends \CodeIgniter\Database\Forge
 
 		$sql  = 'ALTER TABLE ' . $this->db->escapeIdentifiers($table);
 		$sqls = [];
-		for ($i = 0, $c = count($field); $i < $c; $i ++)
+		foreach ($field as $data)
 		{
-			if ($field[$i]['_literal'] !== false)
+			if ($data['_literal'] !== false)
 			{
 				return false;
 			}
 
-			if (version_compare($this->db->getVersion(), '8', '>=') && isset($field[$i]['type']))
+			if (version_compare($this->db->getVersion(), '8', '>=') && isset($data['type']))
 			{
-				$sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($field[$i]['name'])
-						. " TYPE {$field[$i]['type']}{$field[$i]['length']}";
+				$sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
+						. " TYPE {$data['type']}{$data['length']}";
 			}
 
-			if (! empty($field[$i]['default']))
+			if (! empty($data['default']))
 			{
-				$sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($field[$i]['name'])
-						. " SET DEFAULT {$field[$i]['default']}";
+				$sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
+						. " SET DEFAULT {$data['default']}";
 			}
 
-			if (isset($field[$i]['null']))
+			if (isset($data['null']))
 			{
-				$sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($field[$i]['name'])
-						. ($field[$i]['null'] === true ? ' DROP' : ' SET') . ' NOT NULL';
+				$sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
+						. ($data['null'] === true ? ' DROP' : ' SET') . ' NOT NULL';
 			}
 
-			if (! empty($field[$i]['new_name']))
+			if (! empty($data['new_name']))
 			{
-				$sqls[] = $sql . ' RENAME COLUMN ' . $this->db->escapeIdentifiers($field[$i]['name'])
-						. ' TO ' . $this->db->escapeIdentifiers($field[$i]['new_name']);
+				$sqls[] = $sql . ' RENAME COLUMN ' . $this->db->escapeIdentifiers($data['name'])
+						. ' TO ' . $this->db->escapeIdentifiers($data['new_name']);
 			}
 
-			if (! empty($field[$i]['comment']))
+			if (! empty($data['comment']))
 			{
 				$sqls[] = 'COMMENT ON COLUMN' . $this->db->escapeIdentifiers($table)
-						. '.' . $this->db->escapeIdentifiers($field[$i]['name'])
-						. " IS {$field[$i]['comment']}";
+						. '.' . $this->db->escapeIdentifiers($data['name'])
+						. " IS {$data['comment']}";
 			}
 		}
 


### PR DESCRIPTION
Previously, there are `count()` and then loop with `for()`, the foreach actually should already can handle it.

**Checklist:**
- [x] Securely signed commits
