### PR TITLE
WIP Update Router.php

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -404,10 +404,13 @@ class Router implements RouterInterface
 		// Loop through the route array looking for wildcards
 		foreach ($routes as $key => $val)
 		{
+			$localeSegment = NULL; // remove stale value 
 			// Are we dealing with a locale?
 			if (strpos($key, '{locale}') !== false)
 			{
-				$localeSegment = array_search('{locale}', explode('/', $key));
+				$tempkey = preg_replace( '#\(([^()]*)\)#i' , 'x' , $key);
+			    	$exp = explode('/', $tempkey);
+				$localeSegment = array_search('{locale}', $exp);
 
 				// Replace it with a regex so it
 				// will actually match.


### PR DESCRIPTION
Example my routes def:
`
$routes->get('/search', 'Home::search');                                                     // def 1

$routes->get('/(:segment)/(:segment)/{locale}','Product::details/$1/$2');      // def 2

$routes->get('/(:segment)/(:segment)','Product::details/$1/$2');                  // def 3

$routes->get('/(:segment)','Product::category/$1');                                    // def 4
`

My url: 
uri 1 : http://mysite.test/clothes should go to Product::category('clothes')   
uri 2 : http://mysite.test/clothes/tshirt should go to Product::details('clothes','tshirt')  
uri 3 : http://mysite.test/clothes/tshirt/id should go to Product::details('clothes','tshirt') with indonesian locale 

Error found, it says "undefined offset"

**First bug:**
After evaluating **def 2** , `$localeSegment` has array index. Then evaluating **def 3**. That value is retained and causes out-of-range index of `$this->detectedLocale = $temp[$localeSegment];` 
So `$localeSegment` needs to be reset every iteration. I don't know if this a bug or intended.

**Second bug:**
I separate `$localeSegment = array_search('{locale}', explode('/', $key));` just for debugging purpose.
Becomes: 

`
$exp = explode('/', $key);
$localeSegment = array_search('{locale}', $exp);
`

When evaluating **def 2** which is '/(:segment)/(:segment)/{locale}'
Turns out the `$exp = [ "([^" , "]+)" , "([^" , "]+)" , "{locale}"] `  (5 elements) instead of `$exp = [ "([^/]+)" , "([^/]+)" , "{locale}"] ` (3 elements)
So it has error because '/' in regex takes into account for `explode()` function.

`
$temp = (explode('/', $uri));
$this->detectedLocale = $temp[$localeSegment];
`

On **uri 3**,
Exploding `$uri` results 3 elements, but exploding matched `$key` results 5 elements --> "undefined offset"


I see 3 possible solution for this:

**First**, my used solution, 
replacing regex temporary with 'x' just to remove '/' before exploding. I think this is not good solution because to many step ( placeholder -> regex -> dummy string -> regex again). But it works for me until now.

**Second**,
Exploding and finding {locale} _index_ is done before replacing placeholder with regex. So '/' will not mess with `explode()`. I don't know how to implement this. CI4 is a large framework.

**Third**,
using preg_split instead of explode to split keys only with '/' outside parenthesis. So key `"([^/]+)/([^/]+)/{locale}"` will results [ "([^/]+)" , "([^/]+)" , "{locale}" ]
