### PR TITLE
only use of helper(array) on Session::get() instead of Session::__construct

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -176,8 +176,6 @@ class Session implements SessionInterface
 		$this->cookieDomain = $config->cookieDomain;
 		$this->cookiePath   = $config->cookiePath;
 		$this->cookieSecure = $config->cookieSecure;
-
-		helper('array');
 	}
 
 	//--------------------------------------------------------------------
@@ -481,6 +479,8 @@ class Session implements SessionInterface
 	 */
 	public function get(string $key = null)
 	{
+		helper('array');
+
 		if (! empty($key) && $value = dot_array_search($key, $_SESSION))
 		{
 			return $value;


### PR DESCRIPTION
`helper('array');` on `Session` class only used in `get()` method. So, moved the `helper('array')` usage to `Session::get()` method.

**Checklist:**
- [x] Securely signed commits
