### PR TITLE
use app_timezone() in Response and DownloadResponse when app timezone defined

### DIFF
--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -269,7 +269,7 @@ class DownloadResponse extends Message implements ResponseInterface
 	 */
 	public function setDate(\DateTime $date)
 	{
-		$date->setTimezone(new \DateTimeZone('UTC'));
+		$date->setTimezone(new \DateTimeZone(app_timezone() ?? 'UTC'));
 
 		$this->setHeader('Date', $date->format('D, d M Y H:i:s') . ' GMT');
 
@@ -332,7 +332,7 @@ class DownloadResponse extends Message implements ResponseInterface
 	{
 		if ($date instanceof \DateTime)
 		{
-			$date->setTimezone(new \DateTimeZone('UTC'));
+			$date->setTimezone(new \DateTimeZone(app_timezone() ?? 'UTC'));
 			$this->setHeader('Last-Modified', $date->format('D, d M Y H:i:s') . ' GMT');
 		}
 		elseif (is_string($date))

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -374,7 +374,7 @@ class Response extends Message implements ResponseInterface
 	 */
 	public function setDate(\DateTime $date)
 	{
-		$date->setTimezone(new \DateTimeZone('UTC'));
+		$date->setTimezone(new \DateTimeZone(app_timezone() ?? 'UTC'));
 
 		$this->setHeader('Date', $date->format('D, d M Y H:i:s') . ' GMT');
 
@@ -609,7 +609,7 @@ class Response extends Message implements ResponseInterface
 	{
 		if ($date instanceof \DateTime)
 		{
-			$date->setTimezone(new \DateTimeZone('UTC'));
+			$date->setTimezone(new \DateTimeZone(app_timezone() ?? 'UTC'));
 			$this->setHeader('Last-Modified', $date->format('D, d M Y H:i:s') . ' GMT');
 		}
 		elseif (is_string($date))

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -37,7 +37,7 @@ class DownloadResponseTest extends \CIUnitTestCase
 		$response->setDate(DateTime::createFromFormat('Y-m-d', '2000-03-10'));
 
 		$date = DateTime::createFromFormat('Y-m-d', '2000-03-10');
-		$date->setTimezone(new DateTimeZone('UTC'));
+		$date->setTimezone(new DateTimeZone(app_timezone() ?? 'UTC'));
 
 		$header = $response->getHeaderLine('Date');
 
@@ -51,7 +51,7 @@ class DownloadResponseTest extends \CIUnitTestCase
 		$response->setLastModified(DateTime::createFromFormat('Y-m-d', '2000-03-10'));
 
 		$date = DateTime::createFromFormat('Y-m-d', '2000-03-10');
-		$date->setTimezone(new DateTimeZone('UTC'));
+		$date->setTimezone(new DateTimeZone(app_timezone() ?? 'UTC'));
 
 		$header = $response->getHeaderLine('Last-Modified');
 

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -147,7 +147,7 @@ class ResponseTest extends \CIUnitTestCase
 		$response->setDate(DateTime::createFromFormat('Y-m-d', '2000-03-10'));
 
 		$date = DateTime::createFromFormat('Y-m-d', '2000-03-10');
-		$date->setTimezone(new DateTimeZone('UTC'));
+		$date->setTimezone(new DateTimeZone(app_timezone() ?? 'UTC'));
 
 		$header = $response->getHeaderLine('Date');
 
@@ -220,7 +220,7 @@ class ResponseTest extends \CIUnitTestCase
 		$response->setLastModified(DateTime::createFromFormat('Y-m-d', '2000-03-10'));
 
 		$date = DateTime::createFromFormat('Y-m-d', '2000-03-10');
-		$date->setTimezone(new DateTimeZone('UTC'));
+		$date->setTimezone(new DateTimeZone(app_timezone() ?? 'UTC'));
 
 		$header = $response->getHeaderLine('Last-Modified');
 


### PR DESCRIPTION
If Application timezone defined in configuration, it will read the timezone defined instead of 'UTC'.

**Checklist:**
- [x] Securely signed commits
