### PR TITLE
allows to set empty html attr

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -2,28 +2,7 @@
 
 /**
  * CodeIgniter
- *<?= form_open(current_url()); ?>
-<?=
-form_field(
-	'email',
-	['name' => 'p[username]', 'pattern' => esc(INPUT_PATTERN_EMAIL_HTML,'html'), 'autofocus' => false],
-	['use_defaults' => true],
-	array_merge($label_col, ['text' => lang('PagesUser.logInFormEmailLabel')]),
-	$field_col
-);
-?>
-<?=
-form_field(
-	'password',
-	['name' => 'p[username]'],
-	['use_defaults' => true],
-	array_merge($label_col, ['text' => lang('PagesUser.logInFormEmailLabel')]),
-	$field_col
-);
-?>
-<?= form_close(); ?>
-
-
+ *
  * An open source application development framework for PHP
  *
  * This content is released under the MIT License (MIT)

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -927,15 +927,22 @@ if (! function_exists('parse_form_attributes'))
 
 		foreach ($default as $key => $val)
 		{
-			if ($key === 'value')
+			if($val !== false)
 			{
-				$val = esc($val, 'html');
+				if ($key === 'value')
+				{
+					$val = esc($val, 'html');
+				}
+				elseif ($key === 'name' && ! strlen($default['name']))
+				{
+					continue;
+				}
+				$att .= $key . '="' . $val . '" ';
 			}
-			elseif ($key === 'name' && ! strlen($default['name']))
+			else
 			{
-				continue;
+				$att .= $key . ' ';
 			}
-			$att .= $key . '="' . $val . '" ';
 		}
 
 		return $att;

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -2,7 +2,28 @@
 
 /**
  * CodeIgniter
- *
+ *<?= form_open(current_url()); ?>
+<?=
+form_field(
+	'email',
+	['name' => 'p[username]', 'pattern' => esc(INPUT_PATTERN_EMAIL_HTML,'html'), 'autofocus' => false],
+	['use_defaults' => true],
+	array_merge($label_col, ['text' => lang('PagesUser.logInFormEmailLabel')]),
+	$field_col
+);
+?>
+<?=
+form_field(
+	'password',
+	['name' => 'p[username]'],
+	['use_defaults' => true],
+	array_merge($label_col, ['text' => lang('PagesUser.logInFormEmailLabel')]),
+	$field_col
+);
+?>
+<?= form_close(); ?>
+
+
  * An open source application development framework for PHP
  *
  * This content is released under the MIT License (MIT)
@@ -927,7 +948,7 @@ if (! function_exists('parse_form_attributes'))
 
 		foreach ($default as $key => $val)
 		{
-			if($val !== false)
+			if(!is_bool($val))
 			{
 				if ($key === 'value')
 				{

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -816,7 +816,7 @@ EOH;
 	public function testFormParseFormAttributesTrue()
 	{
 		$expected = 'readonly ';
-		$this->assertEquals($expected, parse_form_attributes(['readonly' => true]));
+		$this->assertEquals($expected, parse_form_attributes(['readonly' => true], []));
 	}
 	
 	
@@ -824,7 +824,7 @@ EOH;
 	public function testFormParseFormAttributesFalse()
 	{
 		$expected = 'disabled ';
-		$this->assertEquals($expected, parse_form_attributes(['disabled' => false]));
+		$this->assertEquals($expected, parse_form_attributes(['disabled' => false], []));
 	}
 
 	
@@ -832,7 +832,7 @@ EOH;
 	public function testFormParseFormAttributesNull()
 	{
 		$expected = 'bar="" ';
-		$this->assertEquals($expected, parse_form_attributes(['bar' => null]));
+		$this->assertEquals($expected, parse_form_attributes(['bar' => null], []));
 	}
 	
 	
@@ -840,7 +840,7 @@ EOH;
 	public function testFormParseFormAttributesStringEmpty()
 	{
 		$expected = 'bar="" ';
-		$this->assertEquals($expected, parse_form_attributes(['bar' => '']));
+		$this->assertEquals($expected, parse_form_attributes(['bar' => ''], []));
 	}
 	
 	
@@ -848,7 +848,7 @@ EOH;
 	public function testFormParseFormAttributesStringFoo()
 	{
 		$expected = 'bar="foo" ';
-		$this->assertEquals($expected, parse_form_attributes(['bar' => 'foo']));
+		$this->assertEquals($expected, parse_form_attributes(['bar' => 'foo'], []));
 	}
 
 	
@@ -856,7 +856,7 @@ EOH;
 	public function testFormParseFormAttributesInt0()
 	{
 		$expected = 'ok="0" ';
-		$this->assertEquals($expected, parse_form_attributes(['ok' => 0]));
+		$this->assertEquals($expected, parse_form_attributes(['ok' => 0], []));
 	}
 	
 	
@@ -864,6 +864,6 @@ EOH;
 	public function testFormParseFormAttributesInt1()
 	{
 		$expected = 'ok="1" ';
-		$this->assertEquals($expected, parse_form_attributes(['ok' => 1]));
+		$this->assertEquals($expected, parse_form_attributes(['ok' => 1], []));
 	}
 }

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -810,5 +810,60 @@ EOH;
 		$this->assertEquals(' checked="checked"', set_radio('code', 'alpha', true));
 		$this->assertEquals('', set_radio('code', 'beta', false));
 	}
+	
+	
+	// ------------------------------------------------------------------------
+	public function testFormParseFormAttributesTrue()
+	{
+		$expected = 'readonly ';
+		$this->assertEquals($expected, parse_form_attributes(['readonly' => true]));
+	}
+	
+	
+	// ------------------------------------------------------------------------
+	public function testFormParseFormAttributesFalse()
+	{
+		$expected = 'disabled ';
+		$this->assertEquals($expected, parse_form_attributes(['disabled' => false]));
+	}
 
+	
+	// ------------------------------------------------------------------------
+	public function testFormParseFormAttributesNull()
+	{
+		$expected = 'bar="" ';
+		$this->assertEquals($expected, parse_form_attributes(['bar' => null]));
+	}
+	
+	
+	// ------------------------------------------------------------------------
+	public function testFormParseFormAttributesStringEmpty()
+	{
+		$expected = 'bar="" ';
+		$this->assertEquals($expected, parse_form_attributes(['bar' => '']));
+	}
+	
+	
+	// ------------------------------------------------------------------------
+	public function testFormParseFormAttributesStringFoo()
+	{
+		$expected = 'bar="foo" ';
+		$this->assertEquals($expected, parse_form_attributes(['bar' => 'foo']));
+	}
+
+	
+	// ------------------------------------------------------------------------
+	public function testFormParseFormAttributesInt0()
+	{
+		$expected = 'ok="0" ';
+		$this->assertEquals($expected, parse_form_attributes(['ok' => 0]));
+	}
+	
+	
+	// ------------------------------------------------------------------------
+	public function testFormParseFormAttributesInt1()
+	{
+		$expected = 'ok="1" ';
+		$this->assertEquals($expected, parse_form_attributes(['ok' => 1]));
+	}
 }


### PR DESCRIPTION
**Description**
as for now there was no way to set empty attribute like required or autofocus

Each pull request should address a single issue, and have a meaningful title.
