### PR TITLE
remove commented CLI::newLine($tempFiles) at FileLocator class

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -315,7 +315,6 @@ class FileLocator
 			}
 
 			$tempFiles = get_filenames($fullPath, true);
-			//CLI::newLine($tempFiles);
 
 			if (! empty($tempFiles))
 			{


### PR DESCRIPTION
It seems it was for debugging.

**Checklist:**
- [x] Securely signed commits
