### PR TITLE
remove manual define "system/" directory prefix at ComposerScripts

### DIFF
--- a/system/ComposerScripts.php
+++ b/system/ComposerScripts.php
@@ -49,7 +49,7 @@
  */
 class ComposerScripts
 {
-	protected static $basePath = 'system/ThirdParty/';
+	protected static $basePath = 'ThirdParty/';
 
 	/**
 	 * After composer install/update, this is called to move
@@ -144,7 +144,7 @@ class ComposerScripts
 	{
 		if (class_exists('\\Zend\\Escaper\\Escaper') && is_file(static::getClassFilePath('\\Zend\\Escaper\\Escaper')))
 		{
-			$base = static::$basePath . 'ZendEscaper';
+			$base = basename(__DIR__) . '/' . static::$basePath . 'ZendEscaper';
 
 			foreach ([$base, $base . '/Exception'] as $path)
 			{
@@ -183,7 +183,7 @@ class ComposerScripts
 
 		if (is_file($filename))
 		{
-			$base = static::$basePath . 'Kint';
+			$base = basename(__DIR__) . '/' . static::$basePath . 'Kint';
 
 			// Remove the contents of the previous Kint folder, if any.
 			if (is_dir($base))


### PR DESCRIPTION
So in case the "system" directory is renamed, the composer update will install to new renamed directory/ThirdParty directory.

**Checklist:**
- [x] Securely signed commits
