### PR TITLE
using protected intead of public modifier for setUp() function in tests

### DIFF
--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -151,7 +151,7 @@ class CIDatabaseTestCase extends CIUnitTestCase
 	 *
 	 * @throws ConfigException
 	 */
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -63,7 +63,7 @@ class CIUnitTestCase extends TestCase
 	 */
 	protected $configPath = '../application/Config';
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -17,7 +17,7 @@ class ResponseTraitTest extends \CIUnitTestCase
 	 */
 	protected $formatter;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -12,7 +12,7 @@ class AutoloaderTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -13,7 +13,7 @@ class FileLocatorTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -7,7 +7,7 @@ class CLITest extends \CIUnitTestCase
 
 	private $stream_filter;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/CLI/CommandRunnerTest.php
+++ b/tests/system/CLI/CommandRunnerTest.php
@@ -17,7 +17,7 @@ class CommandRunnerTest extends \CIUnitTestCase
 	protected $logger;
 	protected $runner;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -9,7 +9,7 @@ class ConsoleTest extends \CIUnitTestCase
 
 	private $stream_filter;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Cache/CacheFactoryTest.php
+++ b/tests/system/Cache/CacheFactoryTest.php
@@ -6,7 +6,7 @@ class CacheFactoryTest extends \CIUnitTestCase
 	private $cacheFactory;
 	private $config;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Cache/Handlers/DummyHandlerTest.php
+++ b/tests/system/Cache/Handlers/DummyHandlerTest.php
@@ -4,7 +4,7 @@ class DummyHandlerTest extends \CIUnitTestCase
 {
 	private $dummyHandler;
 
-	public function setUp()
+	protected function setUp()
 	{
 		$this->dummyHandler = new DummyHandler();
 		$this->dummyHandler->initialize();

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -24,7 +24,7 @@ class FileHandlerTest extends \CIUnitTestCase
 	private $fileHandler;
 	private $config;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -18,7 +18,7 @@ class MemcachedHandlerTest extends \CIUnitTestCase
 	private static $dummy = 'dymmy';
 	private $config;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -54,7 +54,7 @@ class RedisHandlerTest extends \CIUnitTestCase
 	private static $dummy = 'dymmy';
 	private $config;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -19,7 +19,7 @@ class CodeIgniterTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Commands/CommandsTest.php
+++ b/tests/system/Commands/CommandsTest.php
@@ -19,7 +19,7 @@ class CommandsTest extends \CIUnitTestCase
 	protected $logger;
 	protected $runner;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Commands/SessionsCommandsTest.php
+++ b/tests/system/Commands/SessionsCommandsTest.php
@@ -18,7 +18,7 @@ class SessionsCommandsTest extends \CIUnitTestCase
 	protected $runner;
 	private $result;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/CommonFunctionsSendTest.php
+++ b/tests/system/CommonFunctionsSendTest.php
@@ -4,7 +4,7 @@
 class CommonFunctionsSendTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -23,7 +23,7 @@ class CommonFunctionsTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -9,7 +9,7 @@ class BaseConfigTest extends CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setup()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -15,7 +15,7 @@ class DotEnvTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setup()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -6,7 +6,7 @@ class ServicesTest extends \CIUnitTestCase
 	protected $config;
 	protected $original;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -45,7 +45,7 @@ class ControllerTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/BaseQueryTest.php
+++ b/tests/system/Database/BaseQueryTest.php
@@ -8,7 +8,7 @@ class QueryTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/AliasTest.php
+++ b/tests/system/Database/Builder/AliasTest.php
@@ -8,7 +8,7 @@ class AliasTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/CountTest.php
+++ b/tests/system/Database/Builder/CountTest.php
@@ -9,7 +9,7 @@ class CountTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/DeleteTest.php
+++ b/tests/system/Database/Builder/DeleteTest.php
@@ -8,7 +8,7 @@ class DeleteTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/DistinctTest.php
+++ b/tests/system/Database/Builder/DistinctTest.php
@@ -9,7 +9,7 @@ class DistinctTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/EmptyTest.php
+++ b/tests/system/Database/Builder/EmptyTest.php
@@ -9,7 +9,7 @@ class EmptyTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -9,7 +9,7 @@ class FromTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/GroupTest.php
+++ b/tests/system/Database/Builder/GroupTest.php
@@ -9,7 +9,7 @@ class GroupTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -9,7 +9,7 @@ class InsertTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/JoinTest.php
+++ b/tests/system/Database/Builder/JoinTest.php
@@ -9,7 +9,7 @@ class JoinTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/LikeTest.php
+++ b/tests/system/Database/Builder/LikeTest.php
@@ -9,7 +9,7 @@ class LikeTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/LimitTest.php
+++ b/tests/system/Database/Builder/LimitTest.php
@@ -9,7 +9,7 @@ class LimitTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/OrderTest.php
+++ b/tests/system/Database/Builder/OrderTest.php
@@ -9,7 +9,7 @@ class OrderTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/PrefixTest.php
+++ b/tests/system/Database/Builder/PrefixTest.php
@@ -8,7 +8,7 @@ class PrefixTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/ReplaceTest.php
+++ b/tests/system/Database/Builder/ReplaceTest.php
@@ -8,7 +8,7 @@ class ReplaceTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -9,7 +9,7 @@ class SelectTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/TruncateTest.php
+++ b/tests/system/Database/Builder/TruncateTest.php
@@ -9,7 +9,7 @@ class TruncateTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -110,10 +110,10 @@ class UpdateTest extends \CIUnitTestCase
 
 		$this->assertInstanceOf(MockQuery::class, $query);
 
-		$expected = 'UPDATE "jobs" SET "name" = CASE
+		$expected = 'UPDATE "jobs" SET "name" = CASE 
 WHEN "id" = :id: THEN :name:
 WHEN "id" = :id0: THEN :name0:
-ELSE "name" END, "description" = CASE
+ELSE "name" END, "description" = CASE 
 WHEN "id" = :id: THEN :description:
 WHEN "id" = :id0: THEN :description0:
 ELSE "description" END
@@ -121,10 +121,10 @@ WHERE "id" IN(:id:,:id0:)';
 
 		$this->assertEquals($expected, $query->getOriginalQuery() );
 
-		$expected = 'UPDATE "jobs" SET "name" = CASE
+		$expected = 'UPDATE "jobs" SET "name" = CASE 
 WHEN "id" = 2 THEN \'Comedian\'
 WHEN "id" = 3 THEN \'Cab Driver\'
-ELSE "name" END, "description" = CASE
+ELSE "name" END, "description" = CASE 
 WHEN "id" = 2 THEN \'Theres something in your teeth\'
 WHEN "id" = 3 THEN \'Iam yellow\'
 ELSE "description" END

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -10,7 +10,7 @@ class UpdateTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 
@@ -110,10 +110,10 @@ class UpdateTest extends \CIUnitTestCase
 
 		$this->assertInstanceOf(MockQuery::class, $query);
 
-		$expected = 'UPDATE "jobs" SET "name" = CASE 
+		$expected = 'UPDATE "jobs" SET "name" = CASE
 WHEN "id" = :id: THEN :name:
 WHEN "id" = :id0: THEN :name0:
-ELSE "name" END, "description" = CASE 
+ELSE "name" END, "description" = CASE
 WHEN "id" = :id: THEN :description:
 WHEN "id" = :id0: THEN :description0:
 ELSE "description" END
@@ -121,10 +121,10 @@ WHERE "id" IN(:id:,:id0:)';
 
 		$this->assertEquals($expected, $query->getOriginalQuery() );
 
-		$expected = 'UPDATE "jobs" SET "name" = CASE 
+		$expected = 'UPDATE "jobs" SET "name" = CASE
 WHEN "id" = 2 THEN \'Comedian\'
 WHEN "id" = 3 THEN \'Cab Driver\'
-ELSE "name" END, "description" = CASE 
+ELSE "name" END, "description" = CASE
 WHEN "id" = 2 THEN \'Theres something in your teeth\'
 WHEN "id" = 3 THEN \'Iam yellow\'
 ELSE "description" END

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -8,7 +8,7 @@ class WhereTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -11,7 +11,7 @@ class ConnectTest extends CIDatabaseTestCase
 
 	protected $group2;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -16,7 +16,7 @@ class ForgeTest extends CIDatabaseTestCase
 	 */
 	protected $forge;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		$this->forge = \Config\Database::forge($this->DBGroup);

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -22,7 +22,7 @@ class ModelTest extends CIDatabaseTestCase
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Debug/TimerTest.php
+++ b/tests/system/Debug/TimerTest.php
@@ -4,7 +4,7 @@ namespace CodeIgniter\Debug;
 class TimerTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 	}
 

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -10,7 +10,7 @@ class EventsTest extends \CIUnitTestCase
 	 */
 	protected $manager;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Files/FileWithVfsTest.php
+++ b/tests/system/Files/FileWithVfsTest.php
@@ -7,7 +7,7 @@ class FileWithVfsTest extends \CIUnitTestCase
 
 	protected $root;
 
-	public function setup()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -19,7 +19,7 @@ class FiltersTest extends \CIUnitTestCase
 	protected $request;
 	protected $response;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Format/JSONFormatterTest.php
+++ b/tests/system/Format/JSONFormatterTest.php
@@ -4,7 +4,7 @@ class JSONFormatterTest extends \CIUnitTestCase
 {
 	protected $jsonFormatter;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		$this->jsonFormatter = new JSONFormatter();

--- a/tests/system/Format/XMLFormatterTest.php
+++ b/tests/system/Format/XMLFormatterTest.php
@@ -4,7 +4,7 @@ class XMLFormatterTest extends \CIUnitTestCase
 {
 	protected $xmlFormatter;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		$this->xmlFormatter = new XMLFormatter();

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -17,7 +17,7 @@ class CLIRequestTest extends \CIUnitTestCase
 	 */
 	protected $request;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -13,7 +13,7 @@ class CURLRequestTest extends \CIUnitTestCase
 	 */
 	protected $request;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/HTTP/Files/FileCollectionTest.php
+++ b/tests/system/HTTP/Files/FileCollectionTest.php
@@ -4,7 +4,7 @@ namespace CodeIgniter\HTTP\Files;
 class FileCollectionTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		$_FILES = [];

--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -7,7 +7,7 @@ use CodeIgniter\HTTP\Exceptions\HTTPException;
 class FileMovingTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/HTTP/IncomingRequestDetectingTest.php
+++ b/tests/system/HTTP/IncomingRequestDetectingTest.php
@@ -15,7 +15,7 @@ class IncomingRequestDetectingTest extends \CIUnitTestCase
 	 */
 	protected $request;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -15,7 +15,7 @@ class IncomingRequestTest extends \CIUnitTestCase
 	 */
 	protected $request;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -12,7 +12,7 @@ class MessageTest extends \CIUnitTestCase
 	 */
 	protected $message;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/HTTP/NegotiateTest.php
+++ b/tests/system/HTTP/NegotiateTest.php
@@ -17,7 +17,7 @@ class NegotiateTest extends \CIUnitTestCase
 	 */
 	protected $negotiate;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -20,7 +20,7 @@ class RedirectResponseTest extends \CIUnitTestCase
 	protected $request;
 	protected $config;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -14,7 +14,7 @@ class RequestTest extends \CIUnitTestCase
 	 */
 	protected $request;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/HTTP/ResponseCookieTest.php
+++ b/tests/system/HTTP/ResponseCookieTest.php
@@ -6,7 +6,7 @@ use Config\App;
 class ResponseCookieTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		$this->server = $_SERVER;

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -11,7 +11,7 @@ use Tests\Support\HTTP\MockResponse;
 class ResponseTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		$this->server = $_SERVER;

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -6,7 +6,7 @@ use CodeIgniter\HTTP\Exceptions\HTTPException;
 class URITest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 	}

--- a/tests/system/HTTP/UserAgentTest.php
+++ b/tests/system/HTTP/UserAgentTest.php
@@ -12,7 +12,7 @@ class UserAgent_test extends \CIUnitTestCase {
 	 */
 	protected $agent;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -2,7 +2,7 @@
 
 class ArrayHelperTest extends \CIUnitTestCase
 {
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		helper('array');

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -16,7 +16,7 @@ final class CookieHelperTest extends \CIUnitTestCase
 	private $expire;
 	private $response;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Helpers/DateHelperTest.php
+++ b/tests/system/Helpers/DateHelperTest.php
@@ -9,7 +9,7 @@ final class DateHelperTest extends \CIUnitTestCase
 	private $expire;
 	private $response;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		helper('date');

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -7,7 +7,7 @@ use org\bovigo\vfs\vfsStream;
 class FilesystemHelperTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -10,7 +10,7 @@ use Config\Filters;
 class FormHelperTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -6,7 +6,7 @@ final class HTMLHelperTest extends \CIUnitTestCase
 
 	private $tracks;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Helpers/InflectorHelperTest.php
+++ b/tests/system/Helpers/InflectorHelperTest.php
@@ -4,7 +4,7 @@ namespace CodeIgniter\Helpers;
 final class InflectorHelperTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Helpers/NumberHelperTest.php
+++ b/tests/system/Helpers/NumberHelperTest.php
@@ -4,7 +4,7 @@ namespace CodeIgniter\Helpers;
 final class NumberHelperTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Helpers/SecurityHelperTest.php
+++ b/tests/system/Helpers/SecurityHelperTest.php
@@ -2,7 +2,7 @@
 
 class SecurityHelperTest extends \CIUnitTestCase
 {
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -7,7 +7,7 @@ class TextHelperTest extends \CIUnitTestCase
 
 	private $_long_string = 'Once upon a time, a framework had no tests. It sad. So some nice people began to write tests. The more time that went on, the happier it became. Everyone was happy.';
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -12,7 +12,7 @@ use CodeIgniter\Config\Services;
 class URLHelperTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -22,7 +22,7 @@ class HoneypotTest extends CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		$this->config   = new \Config\Honeypot();

--- a/tests/system/I18n/TimeDifferenceTest.php
+++ b/tests/system/I18n/TimeDifferenceTest.php
@@ -2,7 +2,7 @@
 
 class TimeDifferenceTest extends \CIUnitTestCase
 {
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -4,7 +4,7 @@ use IntlDateFormatter;
 
 class TimeTest extends \CIUnitTestCase
 {
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Images/BaseHandlerTest.php
+++ b/tests/system/Images/BaseHandlerTest.php
@@ -14,7 +14,7 @@ use org\bovigo\vfs\vfsStream;
 class BaseHandlerTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		if (! extension_loaded('gd'))
 		{

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -16,7 +16,7 @@ use org\bovigo\vfs\vfsStream;
 class GDHandlerTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		if (! extension_loaded('gd'))
 		{

--- a/tests/system/Images/ImageTest.php
+++ b/tests/system/Images/ImageTest.php
@@ -8,7 +8,7 @@ class ImageTest extends \CIUnitTestCase
 
 	protected $path = 'tests/_support/ci-logo.png';
 
-	public function setup()
+	protected function setUp()
 	{
 		// create virtual file system
 		$this->root = vfsStream::setup();

--- a/tests/system/Log/FileHandlerTest.php
+++ b/tests/system/Log/FileHandlerTest.php
@@ -7,7 +7,7 @@ use org\bovigo\vfs\vfsStream;
 class FileHandlerTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		$this->root  = vfsStream::setup('root');
 		$this->start = $this->root->url() . '/';

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -11,7 +11,7 @@ class PagerRendererTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -16,7 +16,7 @@ class PagerTest extends \CIUnitTestCase
 	protected $pager;
 	protected $config;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -18,7 +18,7 @@ class RouterTest extends \CIUnitTestCase
 	 */
 	protected $root;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -15,7 +15,7 @@ use Tests\Support\Security\MockSecurity;
  */
 class SecurityTest extends \CIUnitTestCase {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -11,7 +11,7 @@ use CodeIgniter\Session\Handlers\FileHandler;
  */
 class SessionTest extends \CIUnitTestCase
 {
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -17,7 +17,7 @@ class BootstrapFCPATHTest extends \CIUnitTestCase
 	private $dir1       = '/tmp/dir1';
 	private $file1      = '/tmp/dir1/testFile.php';
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		$this->deleteFiles();

--- a/tests/system/Test/DOMParserTest.php
+++ b/tests/system/Test/DOMParserTest.php
@@ -4,7 +4,7 @@ use Tests\Support\DOM\DOMParser;
 
 class DOMParserTest extends CIUnitTestCase
 {
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Test/FeatureResponseTest.php
+++ b/tests/system/Test/FeatureResponseTest.php
@@ -15,7 +15,7 @@ class FeatureResponseTest extends CIUnitTestCase
 	 */
 	protected $response;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 	}

--- a/tests/system/Test/FeatureTestCaseTest.php
+++ b/tests/system/Test/FeatureTestCaseTest.php
@@ -9,7 +9,7 @@ use CodeIgniter\Test\FeatureResponse;
 class FeatureTestCaseTest extends FeatureTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -5,7 +5,7 @@ use Tests\Support\Cache\Handlers\MockHandler;
 class ThrottleTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Typography/TypographyTest.php
+++ b/tests/system/Typography/TypographyTest.php
@@ -4,7 +4,7 @@ class TypographyTest extends \CIUnitTestCase
 {
 	protected $typography;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		$this->typography = new Typography();

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -27,7 +27,7 @@ class CreditCardRulesTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		$this->validation = new Validation((object) $this->config, \Config\Services::renderer());

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -27,7 +27,7 @@ class FileRulesTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		$this->validation = new Validation((object) $this->config, \Config\Services::renderer());

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -27,7 +27,7 @@ class FormatRulesTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		$this->validation = new Validation((object) $this->config, \Config\Services::renderer());

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -30,7 +30,7 @@ class RulesTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/Validation/UniqueRulesTest.php
+++ b/tests/system/Validation/UniqueRulesTest.php
@@ -32,7 +32,7 @@ class UniqueRulesTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 		$this->validation = new Validation((object)$this->config, \Config\Services::renderer());

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -39,7 +39,7 @@ class ValidationTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/View/CellTest.php
+++ b/tests/system/View/CellTest.php
@@ -16,7 +16,7 @@ class CellTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setup()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -8,7 +8,7 @@ class ParserFilterTest extends \CIUnitTestCase
 	protected $viewsDir;
 	protected $config;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -7,7 +7,7 @@ class ParserPluginTest extends \CIUnitTestCase
 	protected $parser;
 	protected $validator;
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -6,7 +6,7 @@ use CodeIgniter\View\Exceptions\ViewException;
 class ParserTest extends \CIUnitTestCase
 {
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 

--- a/tests/system/View/ViewTest.php
+++ b/tests/system/View/ViewTest.php
@@ -11,7 +11,7 @@ class ViewTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function setUp()
+	protected function setUp()
 	{
 		parent::setUp();
 


### PR DESCRIPTION
The `PHPUnit\Framework\TestCase::setUp()` is using `protected` modifier.

**Checklist:**
- [x] Securely signed commits
