### PR TITLE
Test esc() with different encodings and ignore app-only helpers

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -581,7 +581,9 @@ if (! function_exists('helper'))
 				{
 					if (strpos($path, APPPATH) === 0)
 					{
+						// @codeCoverageIgnoreStart
 						$appHelper = $path;
+						// @codeCoverageIgnoreEnd
 					}
 					elseif (strpos($path, BASEPATH) === 0)
 					{
@@ -597,7 +599,9 @@ if (! function_exists('helper'))
 			// App-level helpers should override all others
 			if (! empty($appHelper))
 			{
+				// @codeCoverageIgnoreStart
 				$includes[] = $appHelper;
+				// @codeCoverageIgnoreEnd
 			}
 
 			// All namespaced files get added in next

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -152,6 +152,15 @@ class CommonFunctionsTest extends \CIUnitTestCase
 
 	// ------------------------------------------------------------------------
 
+	public function testEscapeWithDifferentEncodings()
+	{
+		$this->assertEquals('&lt;x', esc('<x', 'html', 'utf-8'));
+		$this->assertEquals('&lt;x', esc('<x', 'html', 'iso-8859-1'));
+		$this->assertEquals('&lt;x', esc('<x', 'html', 'windows-1251'));
+	}
+
+	// ------------------------------------------------------------------------
+
 	public function testEscapeBadContext()
 	{
 		$this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
**Description**

Increase coverage.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

