### PR TITLE
Routes dashes in URI's to be converted. Fixes #1564

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -700,7 +700,9 @@ class CodeIgniter
 
 		ob_start();
 
-		$this->controller = $this->router->handle($path);
+		// Scans the URI and attempts to match the current URI
+		$this->router->handle($path);
+		$this->controller = $this->router->controllerName();
 		$this->method     = $this->router->methodName();
 
 		// If a {locale} segment was matched in the final route,

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -216,7 +216,7 @@ class Router implements RouterInterface
 	 */
 	public function controllerName()
 	{
-		return $this->controller;
+		return $this->translateURIDashes ? str_replace('-', '_', $this->controller) : $this->controller;
 	}
 
 	//--------------------------------------------------------------------
@@ -229,7 +229,7 @@ class Router implements RouterInterface
 	 */
 	public function methodName(): string
 	{
-		return $this->method;
+		return $this->translateURIDashes ? str_replace('-', '_', $this->method) : $this->method;
 	}
 
 	//--------------------------------------------------------------------
@@ -529,7 +529,7 @@ class Router implements RouterInterface
 		}
 
 		// Load the file so that it's available for CodeIgniter.
-		$file = APPPATH . 'Controllers/' . $this->directory . $this->controller . '.php';
+		$file = APPPATH . 'Controllers/' . $this->directory . $this->controllerName() . '.php';
 		if (is_file($file))
 		{
 			include_once $file;
@@ -618,15 +618,6 @@ class Router implements RouterInterface
 			$this->setDefaultController();
 
 			return;
-		}
-
-		if ($this->translateURIDashes === true)
-		{
-			$segments[0] = str_replace('-', '_', $segments[0]);
-			if (isset($segments[1]))
-			{
-				$segments[1] = str_replace('-', '_', $segments[1]);
-			}
 		}
 
 		list($controller, $method) = array_pad(explode('::', $segments[0]), 2, null);

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -28,6 +28,8 @@ class RouterTest extends \CIUnitTestCase
 
 		$routes = [
 			'users'                                           => 'Users::index',
+			'user-setting/show-list'                          => 'User_setting::show_list',
+			'user-setting/(:any)'                             => 'User_setting::detail/$1',
 			'posts'                                           => 'Blog::posts',
 			'pages'                                           => 'App\Pages::list_all',
 			'posts/(:num)'                                    => 'Blog::show/$1',
@@ -97,6 +99,47 @@ class RouterTest extends \CIUnitTestCase
 
 		$this->assertEquals('\App\Pages', $router->controllerName());
 		$this->assertEquals('list_all', $router->methodName());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testTranslateURIDashes()
+	{
+		$router = new Router($this->collection);
+
+		$router->handle('user-setting/show-list');
+
+		$router->setTranslateURIDashes(true);
+
+		$this->assertEquals('\User_setting', $router->controllerName());
+		$this->assertEquals('show_list', $router->methodName());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testTranslateURIDashesForParams()
+	{
+		$router = new Router($this->collection);
+		$router->setTranslateURIDashes(true);
+
+		$router->handle('user-setting/2018-12-02');
+
+		$this->assertEquals('\User_setting', $router->controllerName());
+		$this->assertEquals('detail', $router->methodName());
+		$this->assertEquals(['2018-12-02'], $router->params());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testTranslateURIDashesForAutoRoute()
+	{
+		$router = new Router($this->collection);
+		$router->setTranslateURIDashes(true);
+
+		$router->autoRoute('admin-user/show-list');
+
+		$this->assertEquals('Admin_user', $router->controllerName());
+		$this->assertEquals('show_list', $router->methodName());
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
Whether dashes in URI's should be converted to underscores when determining method names.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
