### PR TITLE
Adds ?integer, ?double, ?string, etc.  cast types :)

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -412,6 +412,7 @@ class Entity
 
 	/**
 	 * Provides the ability to cast an item as a specific data type.
+	 * Add ? at the beginning of $type  (i.e. ?string) to get NULL instead of castig $value if $value === null
 	 *
 	 * @param $value
 	 * @param string $type
@@ -426,6 +427,7 @@ class Entity
 		switch($type)
 		{
 			case 'integer':
+			case 'int': //alias for 'integer'
 				$value = (int)$value;
 				break;
 			case 'float':
@@ -438,6 +440,7 @@ class Entity
 				$value = (string)$value;
 				break;
 			case 'boolean':
+			case 'bool': //alias for 'boolean'
 				$value = (bool)$value;
 				break;
 			case 'object':

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -421,6 +421,8 @@ class Entity
 
 	protected function castAs($value, string $type)
 	{
+		if(substr($type,0,1) === '?' && $value === null) return null;
+
 		switch($type)
 		{
 			case 'integer':

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -426,8 +426,8 @@ class Entity
 
 		switch($type)
 		{
-			case 'integer':
-			case 'int': //alias for 'integer'
+			case 'int':
+			case 'integer': //alias for 'integer'
 				$value = (int)$value;
 				break;
 			case 'float':
@@ -439,8 +439,8 @@ class Entity
 			case 'string':
 				$value = (string)$value;
 				break;
-			case 'boolean':
-			case 'bool': //alias for 'boolean'
+			case 'bool':
+			case 'boolean': //alias for 'boolean'
 				$value = (bool)$value;
 				break;
 			case 'object':

--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -588,7 +588,7 @@ class EntityTest extends \CIUnitTestCase
 			protected $string_null = null;
 			protected $string_empty = null;
 			protected $integer_null = null;
-			protected $integer_0 = 0;
+			protected $integer_0 = null;
 			// 'bar' is db column, 'foo' is internal representation
 			protected $_options = [
 				'casts'   => [

--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -368,6 +368,19 @@ class EntityTest extends \CIUnitTestCase
 		$this->assertEquals(['foo' => 'bar'], $entity->seventh);
 	}
 
+	
+	//--------------------------------------------------------------------
+	
+	public function testCastNullable()
+	{
+		$entity = $this->getCastNullableEntity();
+
+		$this->assertSame(null, $entity->string_null);
+		$this->assertSame('', $entity->string_empty);
+		$this->assertSame(null, $entity->integer_null);
+		$this->assertSame(0, $entity->integer_0);
+	}
+
 	//--------------------------------------------------------------------
 
 	public function testCastAsJSON()
@@ -564,5 +577,31 @@ class EntityTest extends \CIUnitTestCase
 			}
 		};
 	}
+	
+	
+	
+	protected function getCastNullableEntity()
+	{
+		return new class extends Entity
+		{
+
+			protected $string_null = null;
+			protected $string_empty = null;
+			protected $integer_null = null;
+			protected $integer_0 = 0;
+			// 'bar' is db column, 'foo' is internal representation
+			protected $_options = [
+				'casts'   => [
+					'string_null'    => '?string',
+					'string_empty'   => 'string',
+					'integner_null'  => '?integer',
+					'integer_0'      => 'integer'
+				],
+				'dates'   => [],
+				'datamap' => [],
+			];
+		};
+	}
+
 
 }

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -315,7 +315,7 @@ the **$_options** property. The **casts** option should be an array where the ke
 and the value is the data type it should be cast to. Casting only affects when values are read. No conversions happen
 that affect the permanent value in either the entity or the database. Properties can be cast to any of the following
 data types: **integer**, **float**, **double**, **string**, **boolean**, **object**, **array**, **datetime**, and
-**timestamp**.
+**timestamp**. Add question mark at the beginning of type to mark property as nullable, i.e. **?string**, **?integer**.
 
 For example, if you had a User entity with an **is_banned** property, you can cast it as a boolean::
 
@@ -329,7 +329,8 @@ For example, if you had a User entity with an **is_banned** property, you can ca
 
         protected $_options = [
             'casts' => [
-                'is_banned' => 'boolean'
+                'is_banned' => 'boolean',
+                'is_banned_nullable' => '?boolean'
             ],
             'dates' => ['created_at', 'updated_at', 'deleted_at'],
             'datamap' => []


### PR DESCRIPTION
Adds new cast types which are casting only if value !== null

i.e. I've got an nullable col in my dbtable which stores strings (empty or not) and I'd like to have possibility to determine if string is null or '';
Now I cannot when I define casting as a string. with this PR if I define ?string in 

```

	protected $_options = [
		'casts' => [
			'usr_id' 			=> 'integer',
			'usr_usp_id' 		=> 'integer',
			'usr_provider_id' 	=> 'string',

			'usr_exc_id'		=> 'integer',
			'usr_drs_id'		=> 'integer',
			'usr_dlc_id'		=> '?string',
			'usr_tzo_id'		=> 'integer',

			'usr_email' 		=> 'string',
			'usr_password' 		=> 'string',

			'usr_first_name' 	=> 'string',
			'usr_last_name' 	=> 'string',
			'usr_nick_name'		=> 'string',

			'usr_is_active' 	=> 'boolean',
			'usr_is_blocked' 	=> 'boolean',
			'usr_is_picture' 	=> 'boolean',
		],
		'dates'=> ['usr_created_at', 'usr_updated_at'],
		'datamap' => []
	];
```
I will get NULL or '' for usr_dlc_id according to database value.

```
if(substr($type, 0, 1) === '?' && $value === null) return null;
```