### PR TITLE
Use Absolute Paths

### DIFF
--- a/application/Config/Paths.php
+++ b/application/Config/Paths.php
@@ -20,7 +20,7 @@ class Paths
 	 * Include the path if the folder is not in the same directory
 	 * as this file.
 	 */
-	public $systemDirectory = 'system';
+	public $systemDirectory = FCPATH . '../system';
 
 	/*
 	 *---------------------------------------------------------------
@@ -35,7 +35,7 @@ class Paths
 	 *
 	 * NO TRAILING SLASH!
 	 */
-	public $applicationDirectory = 'application';
+	public $applicationDirectory = FCPATH . '../application';
 
 	/*
 	 * ---------------------------------------------------------------
@@ -48,7 +48,7 @@ class Paths
 	 * for maximum security, keeping it out of the application and/or
 	 * system directories.
 	 */
-	public $writableDirectory = 'writable';
+	public $writableDirectory = FCPATH . '../writable';
 
 	/*
 	 * ---------------------------------------------------------------
@@ -61,7 +61,7 @@ class Paths
 	 * for maximum security, keeping it out of the application and/or
 	 * system directories.
 	 */
-	public $testsDirectory = 'tests';
+	public $testsDirectory = FCPATH . '../tests';
 
 	/*
 	 * ---------------------------------------------------------------
@@ -75,7 +75,7 @@ class Paths
 	 * can change this to `public_html`, for example, to comply
 	 * with your host's needs.
 	 */
-	public $publicDirectory = 'public';
+	public $publicDirectory = FCPATH;
 
 	/*
 	 * ---------------------------------------------------------------
@@ -87,5 +87,5 @@ class Paths
 	 * default this is in `application/Views`. This value
 	 * is used when no value is provided to `Services::renderer()`.
 	 */
-	public $viewDirectory = 'application/Views';
+	public $viewDirectory = FCPATH . '../application/Views';
 }

--- a/public/index.php
+++ b/public/index.php
@@ -32,7 +32,7 @@ require $pathsPath;
 $paths = new Config\Paths();
 
 // Location of the framework bootstrap file.
-$app = require FCPATH . '../' . rtrim($paths->systemDirectory, '/ ') . '/bootstrap.php';
+$app = require rtrim($paths->systemDirectory, '/ ') . '/bootstrap.php';
 
 /*
  *---------------------------------------------------------------

--- a/spark
+++ b/spark
@@ -29,20 +29,16 @@ if (substr(php_sapi_name(), 0, 3) === 'cgi')
 	die("The cli tool is not supported when running php-cgi. It needs php-cli to function!\n\n");
 }
 
-// Location to the Paths config file.
-$pathsPath = 'application/Config/Paths.php';
+// Path to the front controller
+define('FCPATH', __DIR__ . '/public' . DIRECTORY_SEPARATOR);
 
 // Load our paths config file
-require $pathsPath;
+require 'application/Config/Paths.php';
+
 $paths = new Config\Paths();
 
-$public = trim($paths->publicDirectory, '/');
-
-// Path to the front controller
-define('FCPATH', realpath($public) . DIRECTORY_SEPARATOR);
-
 // Ensure the current directory is pointing to the front controller's directory
-chdir($public);
+chdir(FCPATH);
 
 $app = require rtrim($paths->systemDirectory, '/ ') . '/bootstrap.php';
 

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -46,24 +46,20 @@
  * so they are available in the config files that are loaded.
  */
 
-$public = trim($paths->publicDirectory, '/');
-
-$pos = strrpos(FCPATH, $public . DIRECTORY_SEPARATOR);
-
-/**
- * The path to the main application directory. Just above public.
- */
-if (! defined('ROOTPATH'))
-{
-	define('ROOTPATH', substr_replace(FCPATH, '', $pos, strlen($public . DIRECTORY_SEPARATOR)));
-}
-
 /**
  * The path to the application directory.
  */
 if (! defined('APPPATH'))
 {
-	define('APPPATH', realpath(ROOTPATH . $paths->applicationDirectory) . DIRECTORY_SEPARATOR);
+	define('APPPATH', realpath($paths->applicationDirectory) . DIRECTORY_SEPARATOR);
+}
+
+/**
+ * The path to the main application directory. Just above APPPATH.
+ */
+if (! defined('ROOTPATH'))
+{
+	define('ROOTPATH', realpath(APPPATH . '../') . DIRECTORY_SEPARATOR);
 }
 
 /**
@@ -71,7 +67,7 @@ if (! defined('APPPATH'))
  */
 if (! defined('BASEPATH'))
 {
-	define('BASEPATH', realpath(ROOTPATH . $paths->systemDirectory) . DIRECTORY_SEPARATOR);
+	define('BASEPATH', realpath($paths->systemDirectory) . DIRECTORY_SEPARATOR);
 }
 
 /**
@@ -79,7 +75,7 @@ if (! defined('BASEPATH'))
  */
 if (! defined('WRITEPATH'))
 {
-	define('WRITEPATH', realpath(ROOTPATH . $paths->writableDirectory) . DIRECTORY_SEPARATOR);
+	define('WRITEPATH', realpath($paths->writableDirectory) . DIRECTORY_SEPARATOR);
 }
 
 /**
@@ -87,7 +83,7 @@ if (! defined('WRITEPATH'))
  */
 if (! defined('TESTPATH'))
 {
-	define('TESTPATH', realpath(ROOTPATH . $paths->testsDirectory) . DIRECTORY_SEPARATOR);
+	define('TESTPATH', realpath($paths->testsDirectory) . DIRECTORY_SEPARATOR);
 }
 
 /*

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -320,13 +320,13 @@ The following constants are always available anywhere within your application.
 Core Constants
 ==============
 
-.. php:const:: ROOTPATH
-
-	The path to the main application directory. Just above ``public``.
-
 .. php:const:: APPPATH
 
 	The path to the **application** directory.
+
+.. php:const:: ROOTPATH
+
+	The path to the main application directory. Just above ``APPPATH``.
 
 .. php:const:: BASEPATH
 
@@ -335,10 +335,6 @@ Core Constants
 .. php:const:: FCPATH
 
 	The path to the directory that holds the front controller.
-
-.. php:const:: SELF
-
-	The path to the front controller, **index.php**.
 
 .. php:const:: WRITEPATH
 


### PR DESCRIPTION
**Description**

Now is possible set the paths to anywhere.

For composer, normally is: 

```php
public $systemDirectory = FCPATH . '../vendor/codeigniter4/framework/system';
```

Tested moving the `system` to `/usr/share/codeigniter`:

```php
public $systemDirectory = '/usr/share/codeigniter';
```

and, wow, really works! :smiley: 




**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

