### PR TITLE
Fix model namespace in tutorial

### DIFF
--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -21,6 +21,8 @@ your database properly as described :doc:`here <../database/configuration>`.
 
 ::
 
+        namespace App\Models;
+
         use CodeIgniter\Model;
 
 	class NewsModel extends Model


### PR DESCRIPTION
Reported on forum. It looks like it once was correct, but deviated.