### PR TITLE
Add Language fallback

### DIFF
--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -115,14 +115,32 @@ class Language
 	{
 		// Parse out the file name and the actual alias.
 		// Will load the language file and strings.
-		list($file, $parsedLine) = $this->parseLine($line);
+		[
+			$file,
+			$parsedLine,
+		] = $this->parseLine($line, $this->locale);
 
-		$output = $this->language[$this->locale][$file][$parsedLine] ?? $line;
+		$output = $this->language[$this->locale][$file][$parsedLine] ?? null;
+
+		if (empty($output) && strpos($this->locale, '-'))
+		{
+			[$locale] = explode('-', $this->locale, 2);
+
+			[
+				$file,
+				$parsedLine,
+			] = $this->parseLine($line, $locale);
+
+			$output = $this->language[$locale][$file][$parsedLine] ?? null;
+		}
+
+		$output = $output ?? $line;
 
 		if (! empty($args))
 		{
 			$output = $this->formatMessage($output, $args);
 		}
+
 		return $output;
 	}
 
@@ -133,10 +151,11 @@ class Language
 	 * filename as the first segment (separated by period).
 	 *
 	 * @param string $line
+	 * @param string $locale
 	 *
 	 * @return array
 	 */
-	protected function parseLine(string $line): array
+	protected function parseLine(string $line, string $locale): array
 	{
 		// If there's no possibility of a filename being in the string
 		// simply return the string, and they can parse the replacement
@@ -152,9 +171,9 @@ class Language
 		$file = substr($line, 0, strpos($line, '.'));
 		$line = substr($line, strlen($file) + 1);
 
-		if (! isset($this->language[$this->locale][$file]) || ! array_key_exists($line, $this->language[$this->locale][$file]))
+		if (! isset($this->language[$locale][$file]) || ! array_key_exists($line, $this->language[$locale][$file]))
 		{
-			$this->load($file, $this->locale);
+			$this->load($file, $locale);
 		}
 
 		return [

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -122,7 +122,7 @@ class Language
 
 		$output = $this->language[$this->locale][$file][$parsedLine] ?? null;
 
-		if (empty($output) && strpos($this->locale, '-'))
+		if ($output === null && strpos($this->locale, '-'))
 		{
 			[$locale] = explode('-', $this->locale, 2);
 

--- a/tests/_support/Language/MockLanguage.php
+++ b/tests/_support/Language/MockLanguage.php
@@ -20,13 +20,15 @@ class MockLanguage extends Language
 	 * 'requireFile()' method to allow easy overrides
 	 * during testing.
 	 *
-	 * @param $data
+	 * @param array       $data
+	 * @param string      $file
+	 * @param string|null $locale
 	 *
 	 * @return $this
 	 */
-	public function setData($data)
+	public function setData(string $file, array $data, string $locale = null)
 	{
-		$this->data = $data;
+		$this->language[$locale ?? $this->locale][$file] = $data;
 
 		return $this;
 	}

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -19,7 +19,7 @@ class LanguageTest extends \CIUnitTestCase
 	{
 		$lang = new MockLanguage('en');
 
-		$lang->setData([
+		$lang->setData('books', [
 			'bookSaved'  => 'We kept the book free from the boogeyman',
 			'booksSaved' => 'We saved some more',
 		]);
@@ -29,11 +29,49 @@ class LanguageTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testGetLineReturnsFallbackLine()
+	{
+		$lang = new MockLanguage('en-US');
+		$lang->setData('equivalent', [
+			'touchWood'   => 'touch wood',
+			'lieOfLand'   => 'lie of the land',
+			'leaseOfLife' => 'a new lease of life',
+			'slowcoach'   => 'slowcoach',
+		], 'en');
+		$lang->setData('equivalent', [
+			'lieOfLand' => 'lay of the land',
+			'slowcoach' => 'slowpoke',
+		], 'en-US');
+
+		$this->assertEquals(
+			'lay of the land',
+			$lang->getLine('equivalent.lieOfLand')
+		);
+		$this->assertEquals(
+			'slowpoke',
+			$lang->getLine('equivalent.slowcoach')
+		);
+		$this->assertEquals(
+			'a new lease of life',
+			$lang->getLine('equivalent.leaseOfLife')
+		);
+		$this->assertEquals(
+			'touch wood',
+			$lang->getLine('equivalent.touchWood')
+		);
+		$this->assertEquals(
+			'equivalent.unknown',
+			$lang->getLine('equivalent.unknown')
+		);
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testGetLineArrayReturnsLineArray()
 	{
 		$lang = new MockLanguage('en');
 
-		$lang->setData([
+		$lang->setData('books', [
 			'booksList' => [
 				'The Boogeyman',
 				'We Saved',
@@ -58,7 +96,7 @@ class LanguageTest extends \CIUnitTestCase
 
 		$lang = new MockLanguage('en');
 
-		$lang->setData([
+		$lang->setData('books', [
 			'bookCount' => '{0, number, integer} books have been saved.',
 		]);
 
@@ -77,7 +115,7 @@ class LanguageTest extends \CIUnitTestCase
 
 		$lang = new MockLanguage('en');
 
-		$lang->setData([
+		$lang->setData('books', [
 			'bookList' => [
 				'{0, number, integer} related books.'
 			],
@@ -107,7 +145,7 @@ class LanguageTest extends \CIUnitTestCase
 		$lang = new MockLanguage('en');
 		$lang->disableIntlSupport();
 
-		$lang->setData([
+		$lang->setData('books', [
 			'bookList' => [
 				'{0, number, integer} related books.'
 			],
@@ -160,13 +198,13 @@ class LanguageTest extends \CIUnitTestCase
 		$lang = new MockLanguage('en');
 
 		// first file data | example.message
-		$lang->setData(['message' => 'This is an example message']);
+		$lang->setData('example', ['message' => 'This is an example message']);
 
 		// force loading data into file Example
 		$this->assertEquals('This is an example message', $lang->getLine('example.message'));
 
 		// second file data | another.example
-		$lang->setData(['example' => 'Another example']);
+		$lang->setData('another', ['example' => 'Another example']);
 
 		$this->assertEquals('Another example', $lang->getLine('another.example'));
 	}


### PR DESCRIPTION
**Description**

Closes #1262 

 Fixes [issue](https://github.com/codeigniter4/CodeIgniter4/issues/1433#issuecomment-437146780) of falling back to parent language.

Currently, the fallback is automatic. Is a config property needed to enable/disable it? I think no.

Test phrases from [here](https://en.wikipedia.org/wiki/Comparison_of_American_and_British_English#Idiosyncratic_differences).

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

  
