### PR TITLE
Fix Toolbar file loading throw exception

### DIFF
--- a/system/Debug/Toolbar/Collectors/History.php
+++ b/system/Debug/Toolbar/Collectors/History.php
@@ -107,7 +107,7 @@ class History extends BaseCollector
 			$contents = json_decode($contents);
 
 			\preg_match_all('/\d+/', $filename, $time);
-			$time = (int)$time[0][1];
+			$time = (int)$time[0][0];
 
 			// Debugbar files shown in History Collector
 			$files[] = [


### PR DESCRIPTION
**Description**
fix the access to the filename time part

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide