### PR TITLE
Enhance 404Override

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -845,7 +845,7 @@ class CodeIgniter
 		{
 			if ($override instanceof \Closure)
 			{
-				echo $override();
+				echo $override($e->getMessage());
 			}
 			else if (is_array($override))
 			{


### PR DESCRIPTION
This allow overriding Closures to have messages for its parameter:

`
$routes->set404Override(function($message)
{
    $data['message'] = $message;
    echo view('errors/html/error_404_cs.php',$data);
});
`
I also update the docs
