### PR TITLE
Retry handle fatal error via pre_system

### DIFF
--- a/application/Config/Events.php
+++ b/application/Config/Events.php
@@ -30,9 +30,12 @@ if (ENVIRONMENT !== 'production')
 	Events::on('DBQuery', 'CodeIgniter\Debug\Toolbar\Collectors\Database::collect');
 
 	Events::on('pre_system', function () {
-		\ob_start(function ($buffer) {
-			return $buffer;
-		});
+		if (ENVIRONMENT !== 'testing')
+		{
+			\ob_start(function ($buffer) {
+				return $buffer;
+			});
+		}
 		Services::toolbar()->respond();
 	});
 }

--- a/application/Config/Events.php
+++ b/application/Config/Events.php
@@ -30,6 +30,9 @@ if (ENVIRONMENT !== 'production')
 	Events::on('DBQuery', 'CodeIgniter\Debug\Toolbar\Collectors\Database::collect');
 
 	Events::on('pre_system', function () {
+		\ob_start(function ($buffer) {
+			return $buffer;
+		});
 		Services::toolbar()->respond();
 	});
 }


### PR DESCRIPTION
Previously, I created PR #1510 which made coverage dropped significantly by placing `ob_start()` in  `system/Debug/Exceptions::initialize()`. 

In this PR, I am trying again this with set in in `pre_system` event.

Before patch:

![screen shot 2018-12-08 at 3 41 24 pm](https://user-images.githubusercontent.com/459648/49684038-68b40480-fb00-11e8-816d-88816d18b910.png)

After patch: 

![screen shot 2018-12-08 at 3 41 39 pm](https://user-images.githubusercontent.com/459648/49684042-75d0f380-fb00-11e8-88db-cfd366453f74.png)



**Checklist:**
- [x] Securely signed commits
