### PR TITLE
use $defaultGroup as default value for database session DBGroup

### DIFF
--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -102,7 +102,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 		}
 
 		// Get DB Connection
-		$this->DBGroup = $config->sessionDBGroup ?? config( Database::class )->defaultGroup;
+		$this->DBGroup = $config->sessionDBGroup ?? config(Database::class)->defaultGroup;
 
 		$this->db = Database::connect($this->DBGroup);
 

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -102,7 +102,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 		}
 
 		// Get DB Connection
-		$this->DBGroup = ! empty($config->sessionDBGroup) ? $config->sessionDBGroup : 'default';
+		$this->DBGroup = $config->sessionDBGroup ?? config( Database::class )->defaultGroup;
 
 		$this->db = Database::connect($this->DBGroup);
 


### PR DESCRIPTION
**Description**
replace the static default 'default' group name with the $defaultGroup from Database config


**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide