### PR TITLE
release framework script clean up

### DIFF
--- a/admin/release-framework
+++ b/admin/release-framework
@@ -11,12 +11,12 @@ git checkout $branch
 #---------------------------------------------------
 echo -e "${BOLD}Build the framework distributable${NORMAL}"
 
+echo -e "clean up ${TARGET}";
+rm -rf *
+
 echo -e "${BOLD}Copy the main files/folders...${NORMAL}"
-releasable='application docs public system writable README.md composer.json contributing.md env license.txt spark'
+releasable='system README.md composer.json contributing.md license.txt'
 for fff in $releasable ; do
-    if [ -d "$fff" ] ; then
-        rm -rf $fff
-    fi
     cp -rf ${CI_DIR}/$fff .
 done
 


### PR DESCRIPTION
@jim-parry I think the flow before distribute `framework` files as below:

- clean up `dist/framework/*` with `rm -rf *` to ensure no unneeded old files not removed.
- cp the main directories/files ( system README.md composer.json contributing.md license.txt )

**Checklist:**
- [x] Securely signed commits
