### PR TITLE
Fix View config merge order

### DIFF
--- a/system/Config/View.php
+++ b/system/Config/View.php
@@ -75,8 +75,8 @@ class View extends BaseConfig
 
 	public function __construct()
 	{
-		$this->filters = array_merge($this->filters, $this->coreFilters);
-		$this->plugins = array_merge($this->plugins, $this->corePlugins);
+		$this->filters = array_merge($this->coreFilters, $this->filters);
+		$this->plugins = array_merge($this->corePlugins, $this->plugins);
 
 		parent::__construct();
 	}


### PR DESCRIPTION
The original code order would replace app settings with core settings, defeating the purpose of having app settings :-/