### PR TITLE
Property was not cast if was defined as nullable.

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -428,7 +428,14 @@ class Entity
 
 	protected function castAs($value, string $type)
 	{
-		if(substr($type,0,1) === '?' && $value === null) return null;
+		if(substr($type,0,1) === '?')
+		{
+			if($value === null)
+			{
+				return null;
+			}
+			$type = substr($type,1);
+		}
 
 		switch($type)
 		{


### PR DESCRIPTION
If property was defined as nullable i.e.: `?array, ?json, ?json-array` then it was not cast  .

Solution 1: add all cases with '?' at the beginning to switch.
Solution 2: change type if null was not returned at the beginning of castAs method. - i've picked this one.
