### PR TITLE
fix. After matches is not set empty

### DIFF
--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -481,6 +481,7 @@ class Filters
 				}
 
 				$this->filters['after'] = array_merge($this->filters['after'], $matches);
+				$matches                = [];
 			}
 		}
 	}


### PR DESCRIPTION
**Description**
in next foreach 
`$this->filters['before'] = array_merge($this->filters['before'], $matches);`  
will be merge last `$matches`,
This may add the last "after" to this "before"

example:

In config:
```
	public $filters = [
		'admin' => [
			'before' => [
				'admin',
			],
			'after' =>[
				'admin',
			],
		],
		'owadmin' =>[
			'after' =>[
				'admin',
			],
		],
		'api' => [
			'before' => [
				'api/v1/*',
			]
		],
	];
```

`$this->filters` is:
```
Array
(
    [before] => Array
        (
            [0] => admin
            [1] => admin
            [2] => owadmin
        )

    [after] => Array
        (
            [0] => toolbar
            [1] => admin
            [2] => admin
            [3] => owadmin
        )

)
```

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  
