### PR TITLE
"application" to "app" directory doc and comments and welcome_message clean up

### DIFF
--- a/app/Config/Autoload.php
+++ b/app/Config/Autoload.php
@@ -36,7 +36,7 @@ class Autoload extends \CodeIgniter\Config\AutoloadConfig
 		 * to their location on the file system. These are used by the
 		 * Autoloader to locate files the first time they have been instantiated.
 		 *
-		 * The '/application' and '/system' directories are already mapped for
+		 * The '/app' and '/system' directories are already mapped for
 		 * you. You may change the name of the 'App' namespace if you wish,
 		 * but this should be done prior to creating any namespaced classes,
 		 * else you will need to modify all of those classes for this to work.

--- a/app/Config/Paths.php
+++ b/app/Config/Paths.php
@@ -2,7 +2,7 @@
 
 /**
  * Holds the paths that are used by the system to
- * locate the main directories, application, system, etc.
+ * locate the main directories, app, system, etc.
  * Modifying these allows you to re-structure your application,
  * share a system folder between multiple applications, and more.
  *
@@ -45,7 +45,7 @@ class Paths
 	 * This variable must contain the name of your "writable" directory.
 	 * The writable directory allows you to group all directories that
 	 * need write permission to a single place that can be tucked away
-	 * for maximum security, keeping it out of the application and/or
+	 * for maximum security, keeping it out of the app and/or
 	 * system directories.
 	 */
 	public $writableDirectory = __DIR__ . '/../../writable';
@@ -58,7 +58,7 @@ class Paths
 	 * This variable must contain the name of your "tests" directory.
 	 * The writable directory allows you to group all directories that
 	 * need write permission to a single place that can be tucked away
-	 * for maximum security, keeping it out of the application and/or
+	 * for maximum security, keeping it out of the app and/or
 	 * system directories.
 	 */
 	public $testsDirectory = __DIR__ . '/../../tests';
@@ -70,7 +70,7 @@ class Paths
 	 *
 	 * This variable must contain the name of the directory that
 	 * contains the view files used by your application. By
-	 * default this is in `application/Views`. This value
+	 * default this is in `app/Views`. This value
 	 * is used when no value is provided to `Services::renderer()`.
 	 */
 	public $viewDirectory = __DIR__ . '/../../app/Views';

--- a/app/Views/welcome_message.php
+++ b/app/Views/welcome_message.php
@@ -111,7 +111,7 @@
 
 				<pre>
 				<code>
-					application/Views/welcome_message.php
+					app/Views/welcome_message.php
 				</code>
 				</pre>
 
@@ -119,7 +119,7 @@
 
 				<pre>
 				<code>
-					application/Controllers/Home.php
+					app/Controllers/Home.php
 				</code>
 				</pre>
 

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -29,7 +29,7 @@ beginning of the framework's execution.
 Configuration
 =============
 
-Initial configuration is done in **/application/Config/Autoload.php**. This file contains two primary
+Initial configuration is done in **/app/Config/Autoload.php**. This file contains two primary
 arrays: one for the classmap, and one for PSR4-compatible namespaces.
 
 Namespaces
@@ -52,7 +52,7 @@ have a trailing slash.
 
 By default, the application folder is namespace to the ``App`` namespace. While you are not forced to namespace the controllers,
 libraries, or models in the application directory, if you do, they will be found under the ``App`` namespace.
-You may change this namespace by editing the **/application/Config/Constants.php** file and setting the
+You may change this namespace by editing the **/app/Config/Constants.php** file and setting the
 new namespace value under the ``APP_NAMESPACE`` setting::
 
 	define('APP_NAMESPACE', 'App');
@@ -80,7 +80,7 @@ Legacy Support
 ==============
 
 If neither of the above methods find the class, and the class is not namespaced, the autoloader will look in the
-**/application/Libraries** and **/application/Models** directories to attempt to locate the files. This provides
+**/app/Libraries** and **/app/Models** directories to attempt to locate the files. This provides
 a measure to help ease the transition from previous versions.
 
 There are no configuration options for legacy support.

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -20,7 +20,7 @@ Events are always enabled, and are available globally.
 Defining an Event
 =================
 
-Most events are defined within the **application/Config/Events.php** file. You can subscribe an action to an event with
+Most events are defined within the **app/Config/Events.php** file. You can subscribe an action to an event with
 the Events class' ``on()`` method. The first parameter is the name of the event to subscribe to. The second parameter is
 a callable that will be run when that event is triggered::
 

--- a/user_guide_src/source/general/caching.rst
+++ b/user_guide_src/source/general/caching.rst
@@ -45,7 +45,7 @@ you. Once the tag is in place, your pages will begin being cached.
 	your output, you have to manually delete your cache files.
 
 .. note:: Before the cache files can be written you must set the cache
-	engine up by editing **application/Config/Cache.php**.
+	engine up by editing **app/Config/Cache.php**.
 
 Deleting Caches
 ===============

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -215,7 +215,7 @@ Miscellaneous Functions
 	:returns: TRUE if was logged succesfully or FALSE if there was a problem logging it
 	:rtype: bool
 
-	Logs a message using the Log Handlers defined in **application/Config/Logger.php**.
+	Logs a message using the Log Handlers defined in **app/Config/Logger.php**.
 
 	Level can be one of the following values: **emergency**, **alert**, **critical**, **error**, **warning**,
 	**notice**, **info**, or **debug**.

--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -35,23 +35,23 @@ are public, so you access the settings like any other property::
 	$mailpath = $config->mailpath;
 
 If no namespace is provided, it will look for the files in all available namespaces that have
-been defined, as well as **/application/Config/**. All of the configuration files
+been defined, as well as **/app/Config/**. All of the configuration files
 that ship with CodeIgniter are namespaced with ``Config``. Using this namespace in your
 application will provide the best performance since it knows exactly what directory to find the
 files in and doesn't have to scan several locations in the filesystem to get there.
 
 You can locate the configuration files any place on your server by using a different namespace.
 This allows you to pull configuration files on the production server to a folder that is not in
-the web-accessible space at all, while keeping it under **/application** for ease of access during development.
+the web-accessible space at all, while keeping it under **/app** for ease of access during development.
 
 Creating Configuration Files
 ============================
 
 If you need to create a new configuration file you would create a new file at your desired location,
-**/application/Config** by default. Then create the class and fill it with public properties that
+**/app/Config** by default. Then create the class and fill it with public properties that
 represent your settings::
 
-    namespace Config;    
+    namespace Config;
     use CodeIgniter\Config\BaseConfig;
 
     class App extends BaseConfig
@@ -96,7 +96,7 @@ the environment. This will work in any environment. These variables are then ava
 	$s3_bucket = $_ENV['S3_BUCKET'];
 	$s3_bucket = $_SERVER['S3_BUCKET'];
 
-.. note:: If you are using Apache, then the CI_ENVIRONMENT can be set at the top of 
+.. note:: If you are using Apache, then the CI_ENVIRONMENT can be set at the top of
     ``public/.htaccess``, which comes with a commented line to do that. Change the
     environment setting to the one you want to use, and uncomment that line.
 

--- a/user_guide_src/source/general/helpers.rst
+++ b/user_guide_src/source/general/helpers.rst
@@ -24,8 +24,8 @@ in your :doc:`controller </incoming/controllers>` and
 :doc:`views </outgoing/views>`.
 
 Helpers are typically stored in your **system/Helpers**, or
-**application/Helpers directory**. CodeIgniter will look first in your
-**application/Helpers directory**. If the directory does not exist or the
+**app/Helpers directory**. CodeIgniter will look first in your
+**app/Helpers directory**. If the directory does not exist or the
 specified helper is not located there CI will instead look in your
 global *system/Helpers/* directory.
 
@@ -64,7 +64,7 @@ it.
 Loading from Non-standard Locations
 -----------------------------------
 
-Helpers can be loaded from directories outside of **application/Helpers** and
+Helpers can be loaded from directories outside of **app/Helpers** and
 **system/Helpers**, as long as that path can be found through a namespace that
 has been setup within the PSR-4 section of the :doc:`Autoloader config file <../concepts/autoloader>`.
 You would prefix the name of the Helper with the namespace that it can be located
@@ -100,7 +100,7 @@ URI to the controller/method you wish to link to.
 "Extending" Helpers
 ===================
 
-To "extend" Helpers, create a file in your **application/Helpers/** folder
+To "extend" Helpers, create a file in your **app/Helpers/** folder
 with an identical name to the existing Helper.
 
 If all you need to do is add some functionality to an existing helper -
@@ -114,7 +114,7 @@ your version. In this case it's better to simply "extend" the Helper.
 	add to or or to replace the functions a Helper provides.
 
 For example, to extend the native **Array Helper** you'll create a file
-named **application/Helpers/array_helper.php**, and add or override
+named **app/Helpers/array_helper.php**, and add or override
 functions::
 
 	// any_in_array() is not in the Array Helper, so it defines a new function
@@ -140,12 +140,12 @@ functions::
 		return array_pop($array);
 	}
 
-The **helper()** method will scan through all PSR-4 namespaces defined in **application/Config/Autoload.php**
+The **helper()** method will scan through all PSR-4 namespaces defined in **app/Config/Autoload.php**
 and load in ALL matching helpers of the same name. This allows any module's helpers
 to be loaded, as well as any helpers you've created specifically for this application. The load order
 is as follows:
 
-1. application/Helpers - Files loaded here are always loaded first.
+1. app/Helpers - Files loaded here are always loaded first.
 2. {namespace}/Helpers - All namespaces are looped through in the order they are defined.
 3. system/Helpers - The base file is loaded last
 

--- a/user_guide_src/source/general/logging.rst
+++ b/user_guide_src/source/general/logging.rst
@@ -34,7 +34,7 @@ Configuration
 =============
 
 You can modify which levels are actually logged, as well as assign different Loggers to handle different levels, within
-the ``/application/Config/Logger.php`` configuration file.
+the ``/app/Config/Logger.php`` configuration file.
 
 The ``threshold`` value of the config file determines which levels are logged across your application. If any levels
 are requested to be logged by the application, but the threshold doesn't allow them to log currently, they will be
@@ -142,8 +142,8 @@ You can use any other logger that you might like as long as it extends from eith
 that you can easily drop in use for any PSR3-compatible logger, or create your own.
 
 You must ensure that the third-party logger can be found by the system, by adding it to either
-the ``/application/Config/Autoload.php`` configuration file, or through another autoloader,
-like Composer. Next, you should modify ``/application/Config/Services.php`` to point the ``logger``
+the ``/app/Config/Autoload.php`` configuration file, or through another autoloader,
+like Composer. Next, you should modify ``/app/Config/Services.php`` to point the ``logger``
 alias to your new class name.
 
 Now, any call that is done through the ``log_message()`` function will use your library instead.

--- a/user_guide_src/source/general/managing_apps.rst
+++ b/user_guide_src/source/general/managing_apps.rst
@@ -12,7 +12,7 @@ Renaming the Application Directory
 ==================================
 
 If you would like to rename your application directory you may do so
-as long as you open **application/Config/Paths.php** file and set its name using
+as long as you open **app/Config/Paths.php** file and set its name using
 the ``$applicationDirectory`` variable::
 
 	$applicationDirectory = 'application';

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -17,7 +17,7 @@ Namespaces
 
 The core element of the modules functionality comes from the :doc:`PSR4-compatible autoloading </concepts/autoloader>`
 that CodeIgniter uses. While any code can use the PSR4 autoloader and namespaces, the only way to take full advantage of
-modules is to namespace your code and add it to **application/Config/Autoload.php**, in the ``psr4`` section.
+modules is to namespace your code and add it to **app/Config/Autoload.php**, in the ``psr4`` section.
 
 For example, let's say we want to keep a simple blog module that we can re-use between applications. We might create
 folder with our company name, Acme, to store all of our modules within. We will put it right alongside our **application**
@@ -30,7 +30,7 @@ directory in the main project root::
     /tests
     /writable
 
-Open **application/Config/Autoload.php** and add the **Acme** namespace to the ``psr4`` array property::
+Open **app/Config/Autoload.php** and add the **Acme** namespace to the ``psr4`` array property::
 
     public $psr4 = [
         'Acme' => ROOTPATH.'acme'
@@ -74,7 +74,7 @@ file types, including:
 - :doc:`Route files </incoming/routing>`
 - :doc:`Services </concepts/services>`
 
-This is configured in the file **application/Config/Modules.php**.
+This is configured in the file **app/Config/Modules.php**.
 
 The auto-discovery system works by scanning any psr4 namespaces that have been defined within **Config/Autoload.php**
 for familiar directories/files.
@@ -116,7 +116,7 @@ the **Modules** config file, described above.
 Controllers
 ===========
 
-Controllers outside of the main **application/Controllers** directory cannot be automatically routed by URI detection,
+Controllers outside of the main **app/Controllers** directory cannot be automatically routed by URI detection,
 but must be specified within the Routes file itself::
 
     // Routes.php

--- a/user_guide_src/source/helpers/cookie_helper.rst
+++ b/user_guide_src/source/helpers/cookie_helper.rst
@@ -53,7 +53,7 @@ The following functions are available:
 	detailed description of its use, as this function acts very
 	similarly to ``IncomingRequest::getCookie()``, except it will also prepend
 	the ``$cookiePrefix`` that you might've set in your
-	*application/Config/App.php* file.
+	*app/Config/App.php* file.
 
 .. php:function:: delete_cookie($name[, $domain = ''[, $path = '/'[, $prefix = '']]])
 

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -31,7 +31,7 @@ and put the following code in it::
 	namespace App\Controllers;
         use CodeIgniter\Controller;
 
-	class Blog extends Controller 
+	class Blog extends Controller
         {
 		public function index()
 		{
@@ -39,7 +39,7 @@ and put the following code in it::
 		}
 	}
 
-Then save the file to your **/application/Controllers/** directory.
+Then save the file to your **/app/Controllers/** directory.
 
 .. important:: The file must be called 'Blog.php', with a capital 'B'.
 
@@ -91,7 +91,7 @@ Let's try it. Add a new method to your controller::
 	namespace App\Controllers;
         use CodeIgniter\Controller;
 
-	class Blog extends Controller 
+	class Blog extends Controller
         {
 
 		public function index()
@@ -126,7 +126,7 @@ Your method will be passed URI segments 3 and 4 ("sandals" and "123")::
 	namespace App\Controllers;
         use CodeIgniter\Controller;
 
-	class Products extends Controller 
+	class Products extends Controller
         {
 
 		public function shoes($sandals, $id)
@@ -145,7 +145,7 @@ Defining a Default Controller
 
 CodeIgniter can be told to load a default controller when a URI is not
 present, as will be the case when only your site root URL is requested.
-To specify a default controller, open your **application/Config/Routes.php**
+To specify a default controller, open your **app/Config/Routes.php**
 file and set this variable::
 
 	$routes->setDefaultController('Blog');
@@ -228,7 +228,7 @@ If you are building a large application you might want to hierarchically
 organize or structure your controllers into sub-directories. CodeIgniter
 permits you to do this.
 
-Simply create sub-directories under the main *application/Controllers/*
+Simply create sub-directories under the main *app/Controllers/*
 one and place your controller classes within them.
 
 .. note:: When using this feature the first segment of your URI must
@@ -244,7 +244,7 @@ one and place your controller classes within them.
 Each of your sub-directories may contain a default controller which will be
 called if the URL contains *only* the sub-directory. Simply put a controller
 in there that matches the name of your 'default_controller' as specified in
-your *application/Config/Routes.php* file.
+your *app/Config/Routes.php* file.
 
 CodeIgniter also permits you to remap your URIs using its :doc:`URI Routing <routing>` feature.
 
@@ -301,7 +301,7 @@ inside the controller::
 	namespace App\Controllers;
         use CodeIgniter\Controller;
 
-	class MyController extends Controller 
+	class MyController extends Controller
 	{
 		protected $helpers = ['url', 'form'];
 	}

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -22,9 +22,9 @@ and power. Some common examples of tasks that might be performed with filters ar
 Creating a Filter
 *****************
 
-Filters are simple classes that implement ``CodeIgniter\Filters\FilterInterface``. 
-They contain two methods: ``before()`` and ``after()`` which hold the code that 
-will run before and after the controller respectively. Your class must contain both methods 
+Filters are simple classes that implement ``CodeIgniter\Filters\FilterInterface``.
+They contain two methods: ``before()`` and ``after()`` which hold the code that
+will run before and after the controller respectively. Your class must contain both methods
 but may leave the methods empty if they are not needed. A skeleton filter class looks like::
 
     <?php namespace App\Filters;
@@ -69,7 +69,7 @@ This is typically used to peform redirects, like in this example::
     }
 
 If a Response instance is returned, the Response will be sent back to the client and script execution will stop.
-This can be useful for implementing rate limiting for API's. See **application/Filters/Throttle.php** for an
+This can be useful for implementing rate limiting for API's. See **app/Filters/Throttle.php** for an
 example.
 
 After Filters
@@ -84,7 +84,7 @@ the final output, or even to filter the final output with a bad words filter.
 Configuring Filters
 ===================
 
-Once you've created your filters, you need to configure when they get run. This is done in ``application/Config/Filters.php``.
+Once you've created your filters, you need to configure when they get run. This is done in ``app/Config/Filters.php``.
 This file contains four properties that allow you to configure exactly when the filters run.
 
 $aliases

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -27,7 +27,7 @@ above it instead has a product ID. To overcome this, CodeIgniter allows you to r
 Setting your own routing rules
 ==============================
 
-Routing rules are defined in the **application/config/Routes.php** file. In it you'll see that
+Routing rules are defined in the **app/config/Routes.php** file. In it you'll see that
 it creates an instance of the RouteCollection class that permits you to specify your own routing criteria.
 Routes can be specified using placeholders or Regular Expressions.
 
@@ -229,7 +229,7 @@ run the filter before or after the controller. This is especially handy during a
         $routes->resource('users');
     });
 
-The value for the filter must match one of the aliases defined within ``application/Config/Filters.php``.
+The value for the filter must match one of the aliases defined within ``app/Config/Filters.php``.
 
 Environment Restrictions
 ========================
@@ -455,7 +455,7 @@ Routes Configuration Options
 ============================
 
 The RoutesCollection class provides several options that affect all routes, and can be modified to meet your
-application's needs. These options are available at the top of `/application/Config/Routes.php`.
+application's needs. These options are available at the top of `/app/Config/Routes.php`.
 
 Default Namespace
 -----------------
@@ -488,14 +488,14 @@ Default Controller
 
 When a user visits the root of your site (i.e. example.com) the controller to use is determined by the value set by
 the ``setDefaultController()`` method, unless a route exists for it explicitly. The default value for this is ``Home``
-which matches the controller at ``/application/Controllers/Home.php``::
+which matches the controller at ``/app/Controllers/Home.php``::
 
 	// example.com routes to application/Controllers/Welcome.php
 	$routes->setDefaultController('Welcome');
 
 The default controller is also used when no matching route has been found, and the URI would point to a directory
 in the controllers directory. For example, if the user visits ``example.com/admin``, if a controller was found at
-``/application/Controllers/admin/Home.php`` it would be used.
+``/app/Controllers/admin/Home.php`` it would be used.
 
 Default Method
 --------------

--- a/user_guide_src/source/installation/installing.rst
+++ b/user_guide_src/source/installation/installing.rst
@@ -2,8 +2,8 @@
 Installation
 ############
 
-CodeIgniter4 can be installed in a number of different ways: manually, 
-using `Composer <https://getcomposer.org>`_, or even using 
+CodeIgniter4 can be installed in a number of different ways: manually,
+using `Composer <https://getcomposer.org>`_, or even using
 `Git <https://git-scm.com/>`_. This section addresses how to use
 each technique, and explains some of the pros and cons of them.
 
@@ -30,11 +30,11 @@ Cons:
   of the framework, and then following the upgrade
   directions to merge that with your project (typically
   replace the ``system`` folder and inspect designated
-  ``application/Config`` folders for affected changes).
+  ``app/Config`` folders for affected changes).
 
 Resulting folder structure:
 
-- application
+- app
 - public
 - system
 - writable
@@ -170,5 +170,5 @@ Resulting folder structure:
 Coding Standards Installation
 ============================================================
 
-This is bound and installed automatically as part of the 
+This is bound and installed automatically as part of the
 codebase installation.

--- a/user_guide_src/source/installation/running.rst
+++ b/user_guide_src/source/installation/running.rst
@@ -9,12 +9,12 @@ each technique, and explains some of the pros and cons of them.
 Initial Configuration & Setup
 =================================================
 
-#. Open the **application/Config/App.php** file with a text editor and
+#. Open the **app/Config/App.php** file with a text editor and
    set your base URL. If you intend to use encryption or sessions, set
    your encryption key. If you need more flexibility, the baseURL may
    be set within the .env file as **app.baseURL="http://example.com"**.
 #. If you intend to use a database, open the
-   **application/Config/Database.php** file with a text editor and set your
+   **app/Config/Database.php** file with a text editor and set your
    database settings.
 
 One additional measure to take in production environments is to disable
@@ -43,8 +43,8 @@ Directions coming with the next release.
 Local Development Server
 =================================================
 
-CodeIgniter 4 comes with a local development server, leveraging PHP's built-in web server 
-with CodeIgniter routing. You can use the ``serve`` script to launch it, 
+CodeIgniter 4 comes with a local development server, leveraging PHP's built-in web server
+with CodeIgniter routing. You can use the ``serve`` script to launch it,
 with the following command line in the main directory::
 
     > php spark serve

--- a/user_guide_src/source/installation/troubleshooting.rst
+++ b/user_guide_src/source/installation/troubleshooting.rst
@@ -17,11 +17,11 @@ Only the default page loads
 If you find that no matter what you put in your URL only your default
 page is loading, it might be that your server does not support the
 REQUEST_URI variable needed to serve search-engine friendly URLs. As a
-first step, open your *application/Config/App.php* file and look for
+first step, open your *app/Config/App.php* file and look for
 the URI Protocol information. It will recommend that you try a couple of
 alternate settings. If it still doesn't work after you've tried this
 you'll need to force CodeIgniter to add a question mark to your URLs. To
-do this open your *application/Config/App.php* file and change this::
+do this open your *app/Config/App.php* file and change this::
 
 	public $indexPage = 'index.php';
 

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -7,12 +7,12 @@ It is more appropriate to think of converting your app, rather than upgrading it
 Once you have done that, upgrading from one version of CodeIgniter 4 to the next
 will be straightforward.
 
-The "lean, mean and simple" philosophy has been retained, but the 
+The "lean, mean and simple" philosophy has been retained, but the
 implementation has a lot of differences, compared to CodeIgniter 3.
 
 There is no 12-step checklist for upgrading. Instead, start with a copy
-of CodeIgniter 4 in a new project folder, 
-:doc:`however you wish to install and use it </installation/index>`, 
+of CodeIgniter 4 in a new project folder,
+:doc:`however you wish to install and use it </installation/index>`,
 and then convert and integrate your app components.
 We'll try to point out the most important considerations here.
 
@@ -34,7 +34,7 @@ subforum for an uptodate list!
 
 **Application Structure**
 
-- The framework still has ``application`` and ``system`` folders, with the same 
+- The framework still has ``app`` and ``system`` folders, with the same
   interpretation as before
 - The framework now provides for a ``public`` folder, intended as the document
   root for your app
@@ -91,7 +91,7 @@ subforum for an uptodate list!
 
 **Libraries**
 
-- Your app classes can still go inside ``application/Libraries``, but they
+- Your app classes can still go inside ``app/Libraries``, but they
   don't have to
 - Instead of CI3's ``$this->load->library(x);`` you can now use
   ``$this->x = new X();``, following namespaced conventions for your
@@ -108,5 +108,5 @@ subforum for an uptodate list!
 - You don't need ``MY_x`` classes inside your libraries folder
   to extend or replace CI4 pieces
 - Make any such classes where you like, and add appropriate
-  service methods in ``application/Config/Services.php`` to load
+  service methods in ``app/Config/Services.php`` to load
   your components instead of the default ones

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -40,7 +40,7 @@ You can grab an instance of the cache engine directly through the Services class
 Configuring the Cache
 =====================
 
-All configuration for the cache engine is done in **application/Config/Cache.php**. In that file,
+All configuration for the cache engine is done in **app/Config/Cache.php**. In that file,
 the following items are available.
 
 **$handler**

--- a/user_guide_src/source/libraries/email.rst
+++ b/user_guide_src/source/libraries/email.rst
@@ -32,7 +32,7 @@ Sending Email
 =============
 
 Sending email is not only simple, but you can configure it on the fly or
-set your preferences in the **application/Config/Email.php** file.
+set your preferences in the **app/Config/Email.php** file.
 
 Here is a basic example demonstrating how you might send email::
 
@@ -75,7 +75,7 @@ Setting Email Preferences in a Config File
 
 If you prefer not to set preferences using the above method, you can
 instead put them into the config file. Simply open the
-**application/Config/Email.php** file, and set your configs in the
+**app/Config/Email.php** file, and set your configs in the
 Email properties. Then save the file and it will be used automatically.
 You will NOT need to use the ``$email->initialize()`` method if
 you set your preferences in the config file.

--- a/user_guide_src/source/libraries/files.rst
+++ b/user_guide_src/source/libraries/files.rst
@@ -13,8 +13,8 @@ and :doc:`images </libraries/images>`.
 Getting a File instance
 =======================
 
-You create a new File instance by passing in the path to the file in the constructor. 
-By default the file does not need to exist. However, you can pass an additional argument of "true" 
+You create a new File instance by passing in the path to the file in the constructor.
+By default the file does not need to exist. However, you can pass an additional argument of "true"
 to check that the file exist and throw ``FileNotFoundException()`` if it does not.
 
 ::
@@ -81,7 +81,7 @@ the type of file::
 
 Attempts to determine the file extension based on the trusted ``getMimeType()`` method. If the mime type is unknown,
 will return null. This is often a more trusted source than simply using the extension provided by the filename. Uses
-the values in **application/Config/Mimes.php** to determine extension::
+the values in **app/Config/Mimes.php** to determine extension::
 
 	// Returns 'jpg' (WITHOUT the period)
 	$ext = $file->guessExtension();

--- a/user_guide_src/source/libraries/honeypot.rst
+++ b/user_guide_src/source/libraries/honeypot.rst
@@ -4,7 +4,7 @@ Honeypot Class
 
 The Honeypot Class makes it possible to determine when a Bot makes a request to a CodeIgniter4 application,
 if it's enabled in ``Application\Config\Filters.php`` file. This is done by attaching form fields to any form,
-and this form field is hidden from a human but accessible to a Bot. When data is entered into the field ,it's 
+and this form field is hidden from a human but accessible to a Bot. When data is entered into the field ,it's
 assumed the request is coming from a Bot, and you can throw a ``HoneypotException``.
 
 .. contents::
@@ -14,7 +14,7 @@ assumed the request is coming from a Bot, and you can throw a ``HoneypotExceptio
 Enabling Honeypot
 =====================
 
-To enable a Honeypot, changes have to be made to the ``application/Config/Filters.php``. Just uncomment honeypot
+To enable a Honeypot, changes have to be made to the ``app/Config/Filters.php``. Just uncomment honeypot
 from the ``$globals`` array, like...::
 
     public $globals = [
@@ -28,13 +28,13 @@ from the ``$globals`` array, like...::
             ]
         ];
 
-A sample Honeypot filter is bundled, as ``application/Filters/Honeypot.php``.
+A sample Honeypot filter is bundled, as ``app/Filters/Honeypot.php``.
 
 Customizing Honeypot
 =====================
 
-Honeypot can be customized. The fields below can be set either in 
-``application/Config/Honeypot.php`` or in ``.env``.
+Honeypot can be customized. The fields below can be set either in
+``app/Config/Honeypot.php`` or in ``.env``.
 
 * ``hidden`` - true|false to control visibility of the honeypot field; default is ``true``
 * ``label`` - HTML label for the honeypot field, default is 'Fill This Field'

--- a/user_guide_src/source/libraries/images.rst
+++ b/user_guide_src/source/libraries/images.rst
@@ -37,7 +37,7 @@ The available Handlers are as follows:
 - imagick   The ImageMagick library.
 
 If using the ImageMagick library, you must set the path to the library on your
-server in **application/Config/Images.php**.
+server in **app/Config/Images.php**.
 
 .. note:: The ImageMagick handler does NOT require the imagick extension to be
         loaded on the server. As long as your script can access the library

--- a/user_guide_src/source/libraries/pagination.rst
+++ b/user_guide_src/source/libraries/pagination.rst
@@ -134,7 +134,7 @@ View Configuration
 ==================
 
 When the links are rendered out to the page, they use a view file to describe the HTML. You can easily change the view
-that is used by editing **application/Config/Pager.php**::
+that is used by editing **app/Config/Pager.php**::
 
     public $templates = [
         'default_full'   => 'CodeIgniter\Pager\Views\default_full',
@@ -146,13 +146,13 @@ should be used. The *default_full* and *default_simple* views are used for the `
 methods, respectively. To change the way those are displayed application-wide, you could assign a new view here.
 
 For example, say you create a new view file that works with the Foundation CSS framework, instead of Bootstrap, and
-you place that file at **application/Views/Pagers/foundation_full.php**. Since the **application** directory is
+you place that file at **app/Views/Pagers/foundation_full.php**. Since the **application** directory is
 namespaced as ``App``, and all directories underneath it map directly to segments of the namespace, you can locate
 the view file through it's namespace::
 
     'default_full'   => 'App\Views\Pagers\foundation_full',
 
-Since it is under the standard **application/Views** directory, though, you do not need to namespace it since the
+Since it is under the standard **app/Views** directory, though, you do not need to namespace it since the
 ``view()`` method can locate it by filename. In that case, you can simple give the sub-directory and file name::
 
     'default_full'   => 'Pagers/foundation_full',

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -12,7 +12,7 @@ The Security Class contains methods that help protect your site against Cross-Si
 Loading the Library
 *******************
 
-If your only interest in loading the library is to handle CSRF protection, then you will never need to load it, 
+If your only interest in loading the library is to handle CSRF protection, then you will never need to load it,
 as it runs as a filter and has no manual interaction.
 
 If you find a case where you do need direct access though, you may load it through the Services file::
@@ -23,7 +23,7 @@ If you find a case where you do need direct access though, you may load it throu
 Cross-site request forgery (CSRF)
 *********************************
 
-You can enable CSRF protection by altering your **application/Config/Filters.php**
+You can enable CSRF protection by altering your **app/Config/Filters.php**
 and enabling the `csrf` filter globally::
 
 	public $globals = [
@@ -77,7 +77,7 @@ may alter this behavior by editing the following config parameter
 When a request fails the CSRF validation check, it will redirect to the previous page by default,
 setting an ``error`` flash message that you can display to the end user. This provides a nicer experience
 than simply crashing. This can be turned off by editing the ``$CSRFRedirect`` value in
-**application/Config/App.php**::
+**app/Config/App.php**::
 
 	public $CSRFRedirect = false;
 

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -437,7 +437,7 @@ careful configuration must be done. Please take your time to consider
 all of the options and their effects.
 
 You'll find the following Session related preferences in your
-**application/Config/App.php** file:
+**app/Config/App.php** file:
 
 ============================== ========================================= ============================================== ============================================================================================
 Preference                     Default                                   Options                                        Description
@@ -499,7 +499,7 @@ because it is the most safe choice and is expected to work everywhere
 (virtually every environment has a file system).
 
 However, any other driver may be selected via the ``public $sessionDriver``
-line in your **application/Config/App.php** file, if you chose to do so.
+line in your **app/Config/App.php** file, if you chose to do so.
 Have it in mind though, every driver has different caveats, so be sure to
 get yourself familiar with them (below) before you make that choice.
 

--- a/user_guide_src/source/libraries/throttler.rst
+++ b/user_guide_src/source/libraries/throttler.rst
@@ -49,7 +49,7 @@ start using it in your application.
 The Code
 ========
 
-You can find this file at **application/Filters/Throttle.php** but the relevant method is reproduced here::
+You can find this file at **app/Filters/Throttle.php** but the relevant method is reproduced here::
 
 	public function before(RequestInterface $request)
 	{
@@ -75,7 +75,7 @@ Applying the Filter
 
 We don't necessarily need to throttle every page on the site. For many web applications this makes the most sense
 to apply only to POST requests, though API's might want to limit every request made by a user. In order to apply
-this to incoming requests, you need to edit **/application/Config/Filters.php** and first add an alias to the
+this to incoming requests, you need to edit **/app/Config/Filters.php** and first add an alias to the
 filter::
 
 	public $aliases = [

--- a/user_guide_src/source/libraries/user_agent.rst
+++ b/user_guide_src/source/libraries/user_agent.rst
@@ -26,7 +26,7 @@ User Agent Definitions
 ======================
 
 The user agent name definitions are located in a config file located at:
-**application/Config/UserAgents.php**. You may add items to the various
+**app/Config/UserAgents.php**. You may add items to the various
 user agent arrays if needed.
 
 Example
@@ -85,7 +85,7 @@ Class Reference
 			}
 
 		.. note:: The string "Safari" in this example is an array key in the list of browser definitions.
-				  You can find this list in **application/Config/UserAgents.php** if you want to add new
+				  You can find this list in **app/Config/UserAgents.php** if you want to add new
 				  browsers or change the strings.
 
 	.. php:method:: isMobile([$key = NULL])
@@ -121,7 +121,7 @@ Class Reference
     		.. note:: The user agent library only contains the most common robot definitions. It is not a complete list of bots.
     				  There are hundreds of them so searching for each one would not be very efficient. If you find that some bots
     				  that commonly visit your site are missing from the list you can add them to your
-    				  **application/Config/UserAgents.php** file.
+    				  **app/Config/UserAgents.php** file.
 
 	.. php:method:: isReferral()
 

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -65,7 +65,7 @@ The Form
 ========
 
 Using a text editor, create a form called **Signup.php**. In it, place this
-code and save it to your **application/Views/** folder::
+code and save it to your **app/Views/** folder::
 
 	<html>
 	<head>
@@ -100,7 +100,7 @@ The Success Page
 ================
 
 Using a text editor, create a form called **Success.php**. In it, place
-this code and save it to your **application/Views/** folder::
+this code and save it to your **app/Views/** folder::
 
 	<html>
 	<head>
@@ -119,7 +119,7 @@ The Controller
 ==============
 
 Using a text editor, create a controller called **Form.php**. In it, place
-this code and save it to your **application/Controllers/** folder::
+this code and save it to your **app/Controllers/** folder::
 
 	<?php namespace App\Controllers;
 
@@ -505,7 +505,7 @@ Creating the Views
 
 The first step is to create the custom views. These can be placed anywhere that the ``view()`` method can locate them,
 which means the standard View directory, or any namespaced View folder will work. For example, you could create
-a new view at **/application/Views/_errors_list.php**::
+a new view at **/app/Views/_errors_list.php**::
 
     <div class="alert alert-danger" role="alert">
         <ul>

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -35,8 +35,8 @@ Create the Entity Class
 -----------------------
 
 Now create a new Entity class. Since there's no default location to store these classes, and it doesn't fit
-in with the existing directory structure, create a new directory at **application/Entities**. Create the
-Entity itself at **application/Entities/User.php**.
+in with the existing directory structure, create a new directory at **app/Entities**. Create the
+Entity itself at **app/Entities/User.php**.
 
 ::
 
@@ -60,7 +60,7 @@ database columns are represented in the Entity. This is required for the Model t
 Create the Model
 ----------------
 
-Create the model first at **application/Models/UserModel.php** so that we can interact with it::
+Create the model first at **app/Models/UserModel.php** so that we can interact with it::
 
     <?php namespace App\Models;
 
@@ -299,7 +299,7 @@ You can define which properties are automatically converted by adding the name t
     }
 
 Now, when any of those properties are set, they will be converted to a Time instance, using the application's
-current timezone, as set in **application/Config/App.php**::
+current timezone, as set in **app/Config/App.php**::
 
     $user = new App\Entities\User();
 

--- a/user_guide_src/source/outgoing/localization.rst
+++ b/user_guide_src/source/outgoing/localization.rst
@@ -14,10 +14,10 @@ CodeIgniter provides several tools to help you localize your application for dif
 localization of an application is a complex subject, it's simple to swap out strings in your application
 with different supported languages.
 
-Language strings are stored in the **application/Language** directory, with a sub-directory for each
+Language strings are stored in the **app/Language** directory, with a sub-directory for each
 supported language::
 
-    /application
+    /app
         /Language
             /en
                 app.php
@@ -42,7 +42,7 @@ to this can be found on the `W3C's site <https://www.w3.org/International/articl
 The system is smart enough to fallback to more generic language codes if an exact match
 cannot be found. If the locale code was set to **en-US** and we only have language files setup for **en**
 then those will be used since nothing exists for the more specific **en-US**. If, however, a language
-directory existed at **application/Language/en-US** then that would be used first.
+directory existed at **app/Language/en-US** then that would be used first.
 
 Locale Detection
 ================
@@ -271,7 +271,7 @@ If you have a set of messages for a given locale, for instance
 ``Language/en/app.php``, you can add language variants for that locale,
 each in its own folder, for instance ``Language/en-US/app.php``.
 
-You only need to provide values for those messages that would be 
+You only need to provide values for those messages that would be
 localized differently for that locale variant. Any missing message
 definitions will be automatically pulled from the main locale settings.
 

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -507,7 +507,7 @@ Registering a Plugin
 --------------------
 
 At its simplest, all you need to do to register a new plugin and make it ready for use is to add it to the
-**application/Config/View.php**, under the **$plugins** array. The key is the name of the plugin that is
+**app/Config/View.php**, under the **$plugins** array. The key is the name of the plugin that is
 used within the template file. The value is any valid PHP callable, including static class methods, and closures::
 
 	public $plugins = [

--- a/user_guide_src/source/outgoing/views.rst
+++ b/user_guide_src/source/outgoing/views.rst
@@ -30,7 +30,7 @@ Using your text editor, create a file called ``BlogView.php`` and put this in it
         </body>
 	</html>
 
-Then save the file in your **application/Views** directory.
+Then save the file in your **app/Views** directory.
 
 Displaying a View
 =================
@@ -175,7 +175,7 @@ into the `$option` array in the third parameter.
 	echo view('blogview', $data, ['saveData' => true]);
 
 Additionally, if you would like the default functionality of the view method to be that it does save the data
-between calls, you can set ``$saveData`` to **true** in **application/Config/Views.php**.
+between calls, you can set ``$saveData`` to **true** in **app/Config/Views.php**.
 
 Creating Loops
 ==============

--- a/user_guide_src/source/testing/database.rst
+++ b/user_guide_src/source/testing/database.rst
@@ -43,7 +43,7 @@ Test Database Setup
 
 When running database tests, you need to provide a database that can be used during testing. Instead of
 using the PHPUnit built-in database features, the framework provides tools specific to CodeIgniter. The first
-step is to ensure that you have a ``tests`` database group setup in **application/Config/Database.php**.
+step is to ensure that you have a ``tests`` database group setup in **app/Config/Database.php**.
 This specifies a database connection that is only used while running tests, to keep your other data safe.
 
 If you have multiple developers on your team, you will likely want to keep your credentials store in

--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -14,7 +14,7 @@ To input data into the database you need to create a form where you can
 input the information to be stored. This means you'll be needing a form
 with two fields, one for the title and one for the text. You'll derive
 the slug from our title in the model. Create the new view at
-*application/Views/news/create.php*.
+*app/Views/news/create.php*.
 
 ::
 
@@ -90,7 +90,7 @@ sure everything is in lowercase characters. This leaves you with a nice
 slug, perfect for creating URIs.
 
 After this, a view is loaded to display a success message. Create a view at
-**application/Views/news/success.php** and write a success message.
+**app/Views/news/success.php** and write a success message.
 
 Model
 -----

--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -15,7 +15,7 @@ should be placed in a model, so they can easily be reused later. Models
 are the place where you retrieve, insert, and update information in your
 database or other data stores. They provide access to your data.
 
-Open up the *application/Models/* directory and create a new file called
+Open up the *app/Models/* directory and create a new file called
 *NewsModel.php* and add the following code. Make sure you've configured
 your database properly as described :doc:`here <../database/configuration>`.
 
@@ -95,7 +95,7 @@ Now that the queries are written, the model should be tied to the views
 that are going to display the news items to the user. This could be done
 in our ``Pages`` controller created earlier, but for the sake of clarity,
 a new ``News`` controller is defined. Create the new controller at
-*application/Controllers/News.php*.
+*app/Controllers/News.php*.
 
 ::
 
@@ -152,7 +152,7 @@ the views. Modify the ``index()`` method to look like this::
 The code above gets all news records from the model and assigns it to a
 variable. The value for the title is also assigned to the ``$data['title']``
 element and all data is passed to the views. You now need to create a
-view to render the news items. Create *application/Views/news/index.php*
+view to render the news items. Create *app/Views/news/index.php*
 and add the next piece of code.
 
 ::
@@ -214,7 +214,7 @@ add some code to the controller and create a new view. Go back to the
 Instead of calling the ``getNews()`` method without a parameter, the
 ``$slug`` variable is passed, so it will return the specific news item.
 The only things left to do is create the corresponding view at
-*application/Views/news/view.php*. Put the following code in this file.
+*app/Views/news/view.php*. Put the following code in this file.
 
 ::
 
@@ -227,7 +227,7 @@ Routing
 
 Because of the wildcard routing rule created earlier, you need an extra
 route to view the controller that you just made. Modify your routing file
-(*application/config/routes.php*) so it looks as follows.
+(*app/config/routes.php*) so it looks as follows.
 This makes sure the requests reach the ``News`` controller instead of
 going directly to the ``Pages`` controller. The first line routes URI's
 with a slug to the ``view()`` method in the ``News`` controller.


### PR DESCRIPTION
There is still a reference to "application" which currently already renamed to "app". I applied change  to "app" in comments, docs, and welcome_message view.

**Checklist:**
- [x] Securely signed commits
- [x] User guide updated
