### PR TITLE
Refactor Files module

### DIFF
--- a/system/Files/Exceptions/FileException.php
+++ b/system/Files/Exceptions/FileException.php
@@ -10,14 +10,4 @@ class FileException extends \RuntimeException implements ExceptionInterface
 		return new static(lang('Files.cannotMove', [$from, $to, $error]));
 	}
 
-	public static function forInvalidFilename(string $to = null)
-	{
-		return new self(lang('Files.invalidFilename', [$to]));
-	}
-
-	public static function forCopyError(string $to = null)
-	{
-		return new self(lang('Files.cannotCopy', [$to]));
-	}
-
 }

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -1,4 +1,5 @@
-<?php namespace CodeIgniter\Files;
+<?php
+namespace CodeIgniter\Files;
 
 /**
  * CodeIgniter
@@ -127,17 +128,9 @@ class File extends SplFileInfo
 	 */
 	public function getMimeType(): string
 	{
-		if (function_exists('finfo_file'))
-		{
-			$finfo    = finfo_open(FILEINFO_MIME_TYPE);
-			$mimeType = finfo_file($finfo, $this->getRealPath());
-			finfo_close($finfo);
-		}
-		else
-		{
-			$mimeType = mime_content_type($this->getRealPath());
-		}
-
+		$finfo    = finfo_open(FILEINFO_MIME_TYPE);
+		$mimeType = finfo_file($finfo, $this->getRealPath());
+		finfo_close($finfo);
 		return $mimeType;
 	}
 

--- a/system/Language/en/Files.php
+++ b/system/Language/en/Files.php
@@ -14,8 +14,6 @@
  */
 
 return [
-   'fileNotFound'    => 'File not found: {0}',
-   'cannotMove'      => 'Could not move file {0} to {1} ({2})',
-   'invalidFilename' => 'Target filename missing or invalid: {0}',
-   'cannotCopy'      => 'Could not copy to {0} - make sure the folder is writeable',
+   'fileNotFound' => 'File not found: {0}',
+   'cannotMove'   => 'Could not move file {0} to {1} ({2})',
 ];


### PR DESCRIPTION
Refactor the Files module:
- simplified File::getMimeType(), as fileinfo is built-in
- removed two never used exceptions in Files\Exceptions\FileExceptions
- removed the corresponding message lines in Language/en/Files
The exceptions are not thrown by any of our code, and there are equivalent exceptions for uploaded files in the HTTP module.