### PR TITLE
Support for more complex conditions for update(),delete()

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -696,7 +696,7 @@ class Model
 		// is numeric or is non empty string
 		if(!empty($id))
 		{
-			if(is_numeric($id) || !is_string($id))
+			if(is_numeric($id) || is_string($id))
 			{
 				$builder = $builder->where($this->table.'.'.$this->primaryKey, $id);
 			}

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -281,19 +281,24 @@ of the columns in $table, while the array's values are the values to save for th
 
 Multiple records may be updated with a single call by passing an array of primary keys as the first parameter::
 
-    $data = [
-		'active' => 1
-	];
+    $data = ['active' => 1];
 
 	$userModel->update([1, 2, 3], $data);
 
-When you need a more flexible solution, you can leaven the parameters empty and it functions like the Query Builder's
-update command, with the added benefit of validation, events, etc::
+When you need a more flexible solution, you can:
+- leave the parameters empty and it functions like the Query Builder's update command, with the added benefit of validation, events, etc::
 
     $userModel
         ->whereIn('id', [1,2,3])
         ->set(['active' => 1]
         ->update();
+
+- pass more details about records which should be updated in the first parameter::
+
+	// Performs an update for `table`.`type` = 1 AND `table`.`mode` IN(2,3)
+	$userModel->update(['type' => 1, 'mode' => [2, 3]], $data);
+	
+	
 
 **save()**
 
@@ -396,6 +401,11 @@ a permanent delete by setting the second parameter as true.
 An array of primary keys can be passed in as the first parameter to delete multiple records at once::
 
     $userModel->delete([1,2,3]);
+    
+When you need a more flexible solution, you can pass more details about records which should be deleted in the first parameter::
+
+	// Performs an delete for `table`.`foo` = 1 AND `table`.`active` IN(-1,2)
+	$userModel->update(['foo' => 1, 'active' => [-1, 2]], $data);
 
 If no parameters are passed in, will act like the Query Builder's delete method, requiring a where call
 previously::

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -405,7 +405,7 @@ An array of primary keys can be passed in as the first parameter to delete multi
 When you need a more flexible solution, you can pass more details about records which should be deleted in the first parameter::
 
 	// Performs an delete for `table`.`foo` = 1 AND `table`.`active` IN(-1,2)
-	$userModel->update(['foo' => 1, 'active' => [-1, 2]], $data);
+	$userModel->delete(['foo' => 1, 'active' => [-1, 2]], $data);
 
 If no parameters are passed in, will act like the Query Builder's delete method, requiring a where call
 previously::


### PR DESCRIPTION
Replacement for #1441  and #1325  + improvements (outer function for parsing id, and better condition checking).

Allows to pass more complex data for update and delete methods.
Before delete and update supports only numeric $id. and produces: WHERE primaryKey IN(1); or WHERE primaryKey IN(2,3,4) - for arrays.

I've added support for:
- non empty string -> WHERE table.primaryKey = 'value'    `$id = 'value'`  (it is wired it doesn't support it and we are thinking about production version of ci4)
- associative arrays -> WHERE table.field = 'value'  `$id =['field' => 'value']`
- more complex associative arrays -> WHERE table.field = 'value' AND table.fieldin IN(2,3,4) `$id =['field' => 'value', 'fieldin' => [2,3,4]]`
