### PR TITLE
Fix transaction enabling confusing (docu)

### DIFF
--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -75,16 +75,15 @@ debugging is turned off, you can manage your own errors like this::
 		// generate an error... or use the log_message() function to log your error
 	}
 
-Enabling Transactions
+Disabling Transactions
 =====================
 
-Transactions are enabled automatically the moment you use
-$this->db->transStart(). If you would like to disable transactions you
+Transactions are enabled by default. If you would like to disable transactions you
 can do so using $this->db->transOff()::
 
 	$this->db->transOff();
 
-	$this->db->trans_Start();
+	$this->db->transStart();
 	$this->db->query('AN SQL QUERY...');
 	$this->db->transComplete();
 


### PR DESCRIPTION
**Description**
fix #1638 #1639 
fix misspelled, change description and title from "Enabling Transactions" section

**Checklist:**
- [x] Securely signed commits
- [x] User guide updated
- [x] Conforms to style guide
