### PR TITLE
remove php 7.3 from "allow_failures" in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ php:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7.3
     - php: nightly
 
 global:


### PR DESCRIPTION
<strike>Let see if it will make travis build success in php 7.3 env</strike>

**Checklist:**
- [x] Securely signed commits
