### PR TITLE
Allows to use subDirs for cache.

### DIFF
--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -119,7 +119,8 @@ class FileHandler implements CacheInterface
 			'data' => $value,
 		];
 		
-		if(strpos(pathinfo($this->path . $key, PATHINFO_DIRNAME), WRITEPATH . 'cache') === 0 && strpos(!is_dir(pathinfo($this->path . $key, PATHINFO_DIRNAME)) && false === mkdir(pathinfo($this->path . $key, PATHINFO_DIRNAME), 0750, true))
+		$path = pathinfo($this->path . $key, PATHINFO_DIRNAME);
+		if(strpos($path, WRITEPATH . 'cache') === 0 && !is_dir($path) && !is_file($path) && false === mkdir($path, 0750, true))
 		{
 			return false;
 		}

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -118,7 +118,12 @@ class FileHandler implements CacheInterface
 			'ttl'  => $ttl,
 			'data' => $value,
 		];
-
+		
+		if(strpos(pathinfo($this->path . $key, PATHINFO_DIRNAME), WRITEPATH . 'cache') === 0 && strpos(!is_dir(pathinfo($this->path . $key, PATHINFO_DIRNAME)) && false === mkdir(pathinfo($this->path . $key, PATHINFO_DIRNAME), 0750, true))
+		{
+			return false;
+		}
+		
 		if ($this->writeFile($this->path . $key, serialize($contents)))
 		{
 			chmod($this->path . $key, 0640);


### PR DESCRIPTION
If you put thousands of files in top of your cache directory it could have impact for performance.
For if you:
- specify cache with "/"  
- using FileHandler
- and  subdirectory in cache folder does not exist 
.... then cache is not saved.
