### PR TITLE
DBGroup  in __get(), allows to validate "database" data outside the model.

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -1436,7 +1436,7 @@ class Model
 	 */
 	public function __get(string $name)
 	{
-		if (in_array($name, ['primaryKey', 'table', 'returnType']))
+		if (in_array($name, ['primaryKey', 'table', 'returnType', 'DBGroup']))
 		{
 			return $this->{$name};
 		}


### PR DESCRIPTION
We need it outside model if we'd like to run validation rules which are connecting to database OUTSIDE our model.
```
		if($this->request->getPost('p'))
		{
			$post = $this->request->getPost('p');

			$user_model = (new \UserModel());

			$validation = \Config\Services::validation();
			$validation->setRules($user_model->getValidationRules())->run($data, null, $user_model->DBGroup);


			d($validation->getErrors(),$this->request->getPost());die();
		}
```
