### PR TITLE
Methods for (un)setting / overriding  $validationMessages

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -1364,6 +1364,39 @@ class Model
 	//--------------------------------------------------------------------
 
 	/**
+	 * Allows to set new validation messages.
+	 * It could be used when you have to change default or override current validate messages.
+	 *
+	 * @param array $validationMessages: new set of validation messages
+	 * @return void
+	 */
+	public function setValidationMessages(array $validationMessages)
+	{
+		$this->validationMessages = $validationMessages;
+	}
+
+	//--------------------------------------------------------------------
+	
+	/**
+	 * Allows to set/unset (if 2nd argument is empty) new field's validation messages.
+	 * 
+	 * @param string $field: field name
+	 * @param array|null $fieldMessages: new field's set or null
+	 */
+	public function setValidationMessage(string $field, ?array $fieldMessages)
+	{
+		if(!empty($fieldMessages))
+		{
+			$this->validationMessages[$field] = $fieldMessages;
+		}
+		elseif(array_key_exists($field, $this->validationMessages))
+		{
+			unset($this->validationMessages[$field]);
+		}
+	}
+
+	//--------------------------------------------------------------------
+	/**
 	 * Override countAllResults to account for soft deleted accounts.
 	 *
 	 * @param boolean $reset


### PR DESCRIPTION
Instead of doing this if I need to specify custom validationMessage:

```

			$user_model = (new \UserModel());

			$validation->setRules(
				$user_model->getValidationRules(),
				[
					'usr_email' => [
						'is_unique' => 'Twój adres e-mail jest już w naszej bazie. Sprónuj zalogować tak samo jak ostatnim razem, a jeśli Ci sie nie uda skorzystaj z funkcji przypominania hasła.'
					]
				]
			)->run($data, null, $user_model->DBGroup);

			if(!empty($errors = $validation->getErrors()))
			{
				helper('messages');
				set_message(B4_ALERT_DANGER, '<ul><li>' .  implode('</li><li>', $validation->getErrors()) . '</li></ul>');
			}
			else
			{

				$user_model->insert($data);
return redirect()->to(route_to('user_profile'));
			}
```
I could do this:
```

			$user_model = (new \UserModel());
			$user_model->setValidationMessage(
				'usr_email',  
				[
					'is_unique' => 'Twój adres e-mail jest już w naszej bazie. Sprónuj zalogować tak samo jak ostatnim razem, a jeśli Ci sie nie uda skorzystaj z funkcji przypominania hasła.'
				]);
			$user_model->insert($data);
			
			if(!empty($errors = $user_model->errors()))
			{
				helper('messages');
				set_message(B4_ALERT_DANGER, '<ul><li>' .  implode('</li><li>', $errors) . '</li></ul>');
			}
			else
			{
				$user_model->insert($data);
				return redirect()->to(route_to('user_profile'));
			}

```

which looks a  nicer , and  validation is calling only once.
