### PR TITLE
Migrations Tests and database tweaks

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -123,7 +123,7 @@ if (! function_exists('db_connnect'))
 	 *
 	 * @return \CodeIgniter\Database\BaseConnection
 	 */
-	function db_connect($db, bool $getShared = true)
+	function db_connect($db = null, bool $getShared = true)
 	{
 		return \Config\Database::connect($db, $getShared);
 	}

--- a/system/Common.php
+++ b/system/Common.php
@@ -102,6 +102,35 @@ if (! function_exists('config'))
 
 //--------------------------------------------------------------------
 
+if (! function_exists('db_connnect'))
+{
+	/**
+	 * Grabs a database connection and returns it to the user.
+	 *
+	 * This is a convenience wrapper for \Config\Database::connect()
+	 * and supports the same parameters. Namely:
+	 *
+	 * When passing in $db, you may pass any of the following to connect:
+	 * - group name
+	 * - existing connection instance
+	 * - array of database configuration values
+	 *
+	 * If $getShared === false then a new connection instance will be provided,
+	 * otherwise it will all calls will return the same instance.
+	 *
+	 * @param \CodeIgniter\Database\ConnectionInterface|array|string $db
+	 * @param bool                                                   $getShared
+	 *
+	 * @return \CodeIgniter\Database\BaseConnection
+	 */
+	function db_connect($db, bool $getShared = true)
+	{
+		return \Config\Database::connect($db, $getShared);
+	}
+}
+
+//--------------------------------------------------------------------
+
 if (! function_exists('view'))
 {
 	/**

--- a/system/Common.php
+++ b/system/Common.php
@@ -119,7 +119,7 @@ if (! function_exists('db_connnect'))
 	 * otherwise it will all calls will return the same instance.
 	 *
 	 * @param \CodeIgniter\Database\ConnectionInterface|array|string $db
-	 * @param bool                                                   $getShared
+	 * @param boolean                                                $getShared
 	 *
 	 * @return \CodeIgniter\Database\BaseConnection
 	 */

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -141,44 +141,7 @@ class Config extends BaseConfig
 	 */
 	public static function forge($group = null)
 	{
-		// Allow custom connections to be sent in
-		if (is_array($group))
-		{
-			$config = $group;
-			$group  = 'custom-' . md5(json_encode($config));
-		}
-		else
-		{
-			$config = config('Database');
-		}
-
-		static::ensureFactory();
-
-		if (empty($group))
-		{
-			$group = ENVIRONMENT === 'testing' ? 'tests' : $config->defaultGroup;
-		}
-
-		if (is_string($group) && ! isset($config->$group) && ! is_array($config))
-		{
-			throw new \InvalidArgumentException($group . ' is not a valid database connection group.');
-		}
-
-		if (! isset(static::$instances[$group]))
-		{
-			if (is_array($config))
-			{
-				$db = static::connect($config);
-			}
-			else
-			{
-				$db = static::connect($group);
-			}
-		}
-		else
-		{
-			$db = static::$instances[$group];
-		}
+		$db = static::connect($group);
 
 		return static::$factory->loadForge($db);
 	}

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -151,50 +151,13 @@ class Config extends BaseConfig
 	/**
 	 * Returns a new instance of the Database Utilities class.
 	 *
-	 * @param string|null $group
+	 * @param string|array|null $group
 	 *
 	 * @return BaseUtils
 	 */
-	public static function utils(string $group = null)
+	public static function utils($group = null)
 	{
-		// Allow custom connections to be sent in
-		if (is_array($group))
-		{
-			$config = $group;
-			$group  = 'custom-' . md5(json_encode($config));
-		}
-		else
-		{
-			$config = config('Database');
-		}
-
-		static::ensureFactory();
-
-		if (empty($group))
-		{
-			$group = ENVIRONMENT === 'testing' ? 'tests' : $config->defaultGroup;
-		}
-
-		if (is_string($group) && ! isset($config->$group) && ! is_array($config))
-		{
-			throw new \InvalidArgumentException($group . ' is not a valid database connection group.');
-		}
-
-		if (! isset(static::$instances[$group]))
-		{
-			if (is_array($config))
-			{
-				$db = static::connect($config);
-			}
-			else
-			{
-				$db = static::connect($group);
-			}
-		}
-		else
-		{
-			$db = static::$instances[$group];
-		}
+		$db = static::connect($group);
 
 		return static::$factory->loadUtils($db);
 	}
@@ -210,7 +173,7 @@ class Config extends BaseConfig
 	 */
 	public static function seeder(string $group = null)
 	{
-		$config = new \Config\Database();
+		$config = config('Database');
 
 		return new Seeder($config, static::connect($group));
 	}

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -74,6 +74,12 @@ class Config extends BaseConfig
 	 */
 	public static function connect($group = null, bool $getShared = true)
 	{
+		// If a DB connection is passed in, just pass it back
+		if ($group instanceof BaseConnection)
+		{
+			return $group;
+		}
+
 		if (is_array($group))
 		{
 			$config = $group;

--- a/system/Exceptions/ConfigException.php
+++ b/system/Exceptions/ConfigException.php
@@ -14,11 +14,6 @@ class ConfigException extends CriticalError
 	 */
 	protected $code = 3;
 
-	public static function forMissingMigrationsTable()
-	{
-		throw new static(lang('Migrations.missingTable'));
-	}
-
 	public static function forInvalidMigrationType(string $type = null)
 	{
 		throw new static(lang('Migrations.invalidType', [$type]));

--- a/tests/_support/Database/SupportMigrations/001_Some_migration.php
+++ b/tests/_support/Database/SupportMigrations/001_Some_migration.php
@@ -1,0 +1,24 @@
+<?php namespace App\Database\Migrations;
+
+class Migration_some_migration extends \CodeIgniter\Database\Migration
+{
+	public function up()
+	{
+		$this->forge->addField([
+			'key' => [
+				'type'       => 'VARCHAR',
+				'constraint' => 255,
+			],
+		]);
+		$this->forge->createTable('foo', true);
+
+		$this->db->table('foo')->insert([
+			'key' => 'foobar',
+		]);
+	}
+
+	public function down()
+	{
+		$this->forge->dropTable('foo');
+	}
+}

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;;
+<?php namespace CodeIgniter\Database\Live;
+
+;
 
 use CodeIgniter\Config\Config;
 use CodeIgniter\Test\CIDatabaseTestCase;
@@ -58,7 +60,7 @@ class ConnectTest extends CIDatabaseTestCase
 		$db = Database::connect('tests');
 		$this->assertInstanceOf(\CodeIgniter\Database\SQLite3\Connection::class, $db);
 
-		$config = config('Database');
+		$config                      = config('Database');
 		$config->default['DBDriver'] = 'MySQLi';
 		Config::injectMock('Database', $config);
 

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -1,7 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php namespace CodeIgniter\Database\Live;;
 
-;
-
+use CodeIgniter\Config\Config;
 use CodeIgniter\Test\CIDatabaseTestCase;
 use Config\Database;
 
@@ -20,8 +19,8 @@ class ConnectTest extends CIDatabaseTestCase
 		$this->group1 = $config->default;
 		$this->group2 = $config->default;
 
-		$this->group1['strictOn'] = false;
-		$this->group2['strictOn'] = true;
+		$this->group1['DBDriver'] = 'MySQLi';
+		$this->group2['DBDriver'] = 'Postgre';
 	}
 
 	public function testConnectWithMultipleCustomGroups()
@@ -39,6 +38,32 @@ class ConnectTest extends CIDatabaseTestCase
 		$this->assertEquals(3, count($instances));
 	}
 
-	//--------------------------------------------------------------------
+	public function testConnectReturnsProvidedConnection()
+	{
+		// This will be the tests database
+		$db = Database::connect();
+		$this->assertInstanceOf(\CodeIgniter\Database\SQLite3\Connection::class, $db);
 
+		// Get an instance of the system's default db so we have something to test with.
+		$db1 = Database::connect($this->group1);
+		$this->assertEquals('MySQLi', $this->getPrivateProperty($db1, 'DBDriver'));
+
+		// If a connection is passed into connect, it should simply be returned to us...
+		$db2 = Database::connect($db1);
+		$this->assertSame($db1, $db2);
+	}
+
+	public function testConnectWorksWithGroupName()
+	{
+		$db = Database::connect('tests');
+		$this->assertInstanceOf(\CodeIgniter\Database\SQLite3\Connection::class, $db);
+
+		$config = config('Database');
+		$config->default['DBDriver'] = 'MySQLi';
+		Config::injectMock('Database', $config);
+
+		$db1 = Database::connect('default');
+		$this->assertNotInstanceOf(\CodeIgniter\Database\SQLite3\Connection::class, $db1);
+		$this->assertEquals('MySQLi', $this->getPrivateProperty($db1, 'DBDriver'));
+	}
 }

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -42,9 +42,11 @@ class ConnectTest extends CIDatabaseTestCase
 
 	public function testConnectReturnsProvidedConnection()
 	{
+		$config = config('Database');
+
 		// This will be the tests database
 		$db = Database::connect();
-		$this->assertInstanceOf(\CodeIgniter\Database\SQLite3\Connection::class, $db);
+		$this->assertEquals($config->tests['DBDriver'], $this->getPrivateProperty($db, 'DBDriver'));
 
 		// Get an instance of the system's default db so we have something to test with.
 		$db1 = Database::connect($this->group1);
@@ -57,8 +59,10 @@ class ConnectTest extends CIDatabaseTestCase
 
 	public function testConnectWorksWithGroupName()
 	{
+		$config = config('Database');
+
 		$db = Database::connect('tests');
-		$this->assertInstanceOf(\CodeIgniter\Database\SQLite3\Connection::class, $db);
+		$this->assertEquals($config->tests['DBDriver'], $this->getPrivateProperty($db, 'DBDriver'));
 
 		$config                      = config('Database');
 		$config->default['DBDriver'] = 'MySQLi';

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -1,0 +1,341 @@
+<?php namespace CodeIgniter\Database;
+
+use Config\Migrations;
+use org\bovigo\vfs\vfsStream;
+use CodeIgniter\Test\CIDatabaseTestCase;
+
+class MigrationRunnerTest extends CIDatabaseTestCase
+{
+	protected $root;
+	protected $start;
+
+	public function setUp()
+	{
+		parent::setUp();
+
+		$this->root  = vfsStream::setup('root');
+		$this->start = $this->root->url() . '/';
+	}
+
+	/**
+	 * @expectedException \CodeIgniter\Exceptions\ConfigException
+	 */
+	public function testThrowsOnInvalidMigrationType()
+	{
+		$config       = new Migrations();
+		$config->type = 'narwhal';
+
+		$runner = new MigrationRunner($config);
+	}
+
+	public function testLoadsDefaultDatabaseWhenNoneSpecified()
+	{
+		$dbConfig = new \Config\Database();
+		$config   = new Migrations();
+		$runner   = new MigrationRunner($config);
+
+		$db = $this->getPrivateProperty($runner, 'db');
+
+		$this->assertInstanceOf(BaseConnection::class, $db);
+		$this->assertEquals($dbConfig->tests['database'], $this->getPrivateProperty($db, 'database'));
+		$this->assertEquals($dbConfig->tests['DBDriver'], $this->getPrivateProperty($db, 'DBDriver'));
+	}
+
+	public function testGetCliMessages()
+	{
+		$config = new Migrations();
+		$runner = new MigrationRunner($config);
+
+		$messages = [
+			'foo',
+			'bar',
+		];
+
+		$this->setPrivateProperty($runner, 'cliMessages', $messages);
+
+		$this->assertEquals($messages, $runner->getCliMessages());
+	}
+
+	public function testGetHistory()
+	{
+		$config = new Migrations();
+		$runner = new MigrationRunner($config);
+
+		$tableMaker = $this->getPrivateMethodInvoker($runner, 'ensureTable');
+		$tableMaker();
+
+		$history = [
+			'version'   => 'abc123',
+			'name'      => 'changesomething',
+			'group'     => 'default',
+			'namespace' => 'App',
+			'time'      => time(),
+		];
+
+		$this->hasInDatabase('migrations', $history);
+
+		$this->assertEquals($history, $runner->getHistory()[0]);
+	}
+
+	public function testGetHistoryReturnsEmptyArrayWithNoResults()
+	{
+		$config = new Migrations();
+		$runner = new MigrationRunner($config);
+
+		$tableMaker = $this->getPrivateMethodInvoker($runner, 'ensureTable');
+		$tableMaker();
+
+		$this->assertEquals([], $runner->getHistory());
+	}
+
+	public function testGetMigrationNumber()
+	{
+		$config = new Migrations();
+		$runner = new MigrationRunner($config);
+
+		$method = $this->getPrivateMethodInvoker($runner, 'getMigrationNumber');
+
+		$this->assertEquals('0123456', $method('0123456_Foo'));
+	}
+
+	public function testGetMigrationNumberReturnsZeroIfNoneFound()
+	{
+		$config = new Migrations();
+		$runner = new MigrationRunner($config);
+
+		$method = $this->getPrivateMethodInvoker($runner, 'getMigrationNumber');
+
+		$this->assertEquals('0', $method('Foo'));
+	}
+
+	public function testSetSilentStoresValue()
+	{
+		$config = new Migrations();
+		$runner = new MigrationRunner($config);
+
+		$runner->setSilent(true);
+		$this->assertTrue($this->getPrivateProperty($runner, 'silent'));
+
+		$runner->setSilent(false);
+		$this->assertFalse($this->getPrivateProperty($runner, 'silent'));
+	}
+
+	public function testSetNameStoresValue()
+	{
+		$config = new Migrations();
+		$runner = new MigrationRunner($config);
+
+		$runner->setName('foo');
+		$this->assertEquals('foo', $this->getPrivateProperty($runner, 'name'));
+	}
+
+	public function testSetGroupStoresValue()
+	{
+		$config = new Migrations();
+		$runner = new MigrationRunner($config);
+
+		$runner->setGroup('foo');
+		$this->assertEquals('foo', $this->getPrivateProperty($runner, 'group'));
+	}
+
+	public function testSetNamespaceStoresValue()
+	{
+		$config = new Migrations();
+		$runner = new MigrationRunner($config);
+
+		$runner->setNamespace('foo');
+		$this->assertEquals('foo', $this->getPrivateProperty($runner, 'namespace'));
+	}
+
+	public function testFindMigrationsReturnsEmptyArrayWithNoneFound()
+	{
+		$config       = new Migrations();
+		$config->type = 'timestamp';
+		$runner       = new MigrationRunner($config);
+
+		$runner->setPath($this->start);
+
+		$this->assertEquals([], $runner->findMigrations());
+	}
+
+	public function testFindMigrationsSuccessTimestamp()
+	{
+		$config       = new Migrations();
+		$config->type = 'timestamp';
+		$runner       = new MigrationRunner($config);
+
+		$runner = $runner->setPath($this->start);
+
+		vfsStream::newFile('20180124102301_some_migration.php')->at($this->root);
+		vfsStream::newFile('20180124082302_another_migration.php')->at($this->root); // should be first
+		vfsStream::newFile('20180124082303_another_migration.py')->at($this->root); // shouldn't be included
+		vfsStream::newFile('201801240823_another_migration.py')->at($this->root); // shouldn't be included
+
+		$mig1 = (object)[
+							'name'    => 'some_migration',
+							'path'    => 'vfs://root//20180124102301_some_migration.php',
+							'version' => '20180124102301',
+						];
+		$mig2 = (object)[
+							'name'    => 'another_migration',
+							'path'    => 'vfs://root//20180124082302_another_migration.php',
+							'version' => '20180124082302',
+						];
+
+		$migrations = $runner->findMigrations();
+
+		$this->assertCount(2, $migrations);
+		$this->assertEquals($mig1, array_shift($migrations));
+		$this->assertEquals($mig2, array_shift($migrations));
+	}
+
+	public function testFindMigrationsSuccessOrder()
+	{
+		$config       = new Migrations();
+		$config->type = 'sequential';
+		$runner       = new MigrationRunner($config);
+
+		$runner = $runner->setPath($this->start);
+
+		vfsStream::newFile('002_some_migration.php')->at($this->root);
+		vfsStream::newFile('001_another_migration.php')->at($this->root); // should be first
+		vfsStream::newFile('003_another_migration.py')->at($this->root); // shouldn't be included
+		vfsStream::newFile('004_another_migration.py')->at($this->root); // shouldn't be included
+
+		$mig1 = (object)[
+							'name'    => 'some_migration',
+							'path'    => 'vfs://root//002_some_migration.php',
+							'version' => '002',
+						];
+		$mig2 = (object)[
+							'name'    => 'another_migration',
+							'path'    => 'vfs://root//001_another_migration.php',
+							'version' => '001',
+						];
+
+		$migrations = $runner->findMigrations();
+
+		$this->assertEquals($mig1, array_shift($migrations));
+		$this->assertEquals($mig2, array_shift($migrations));
+	}
+
+	/**
+	 * @expectedException        \RuntimeException
+	 * @expectedExceptionMessage There is a gap in the migration sequence near version number:  002
+	 */
+	public function testVersionThrowsMigrationGapException()
+	{
+		$config       = new Migrations();
+		$config->type = 'sequential';
+		$runner       = new MigrationRunner($config);
+
+		$runner = $runner->setPath($this->start);
+
+		vfsStream::newFile('002_some_migration.php')->at($this->root);
+
+		$version = $runner->version(0);
+
+		$this->assertEquals($version, '002');
+	}
+
+	public function testVersionReturnsTrueWhenNothingToDo()
+	{
+		$config       = new Migrations();
+		$config->type = 'sequential';
+		$runner       = new MigrationRunner($config);
+
+		$runner = $runner->setPath($this->start);
+
+		vfsStream::newFile('001_some_migration.php')->at($this->root);
+
+		$version = $runner->version(0);
+
+		$this->assertTrue($version);
+	}
+
+	/**
+	 * @expectedException        \RuntimeException
+	 * @expectedExceptionMessage The migration class "App\Database\Migrations\Migration_some_migration" could not be found.
+	 */
+	public function testVersionWithNoClassInFile()
+	{
+		$config       = new Migrations();
+		$config->type = 'sequential';
+		$runner       = new MigrationRunner($config);
+		$runner->setSilent(false);
+
+		$runner = $runner->setPath($this->start);
+
+		vfsStream::newFile('001_some_migration.php')->at($this->root);
+
+		$version = $runner->version(1);
+
+		$this->assertEquals('001', $version);
+	}
+
+	public function testVersionReturnsUpDownSuccess()
+	{
+		$config       = new Migrations();
+		$config->type = 'sequential';
+		$runner       = new MigrationRunner($config);
+		$runner->setSilent(false);
+
+		$runner = $runner->setPath($this->start);
+
+		vfsStream::copyFromFileSystem(
+			TESTPATH . '_support/Database/SupportMigrations',
+			$this->root
+		);
+
+		$version = $runner->version(1);
+
+		$this->assertEquals('001', $version);
+		$this->seeInDatabase('foo', ['key' => 'foobar']);
+
+		$version = $runner->version(0);
+
+		$this->assertTrue($version);
+		$this->assertFalse(db_connect()->tableExists('foo'));
+	}
+
+	public function testLatestSuccess()
+	{
+		$config       = new Migrations();
+		$config->type = 'sequential';
+		$runner       = new MigrationRunner($config);
+		$runner->setSilent(false);
+
+		$runner = $runner->setPath($this->start);
+
+		vfsStream::copyFromFileSystem(
+			TESTPATH . '_support/Database/SupportMigrations',
+			$this->root
+		);
+
+		$version = $runner->latest();
+
+		$this->assertEquals('001', $version);
+		$this->assertTrue(db_connect()->tableExists('foo'));
+	}
+
+	public function testCurrentSuccess()
+	{
+		$config                 = new Migrations();
+		$config->type           = 'sequential';
+		$config->currentVersion = 1;
+		$runner                 = new MigrationRunner($config);
+		$runner->setSilent(false);
+
+		$runner = $runner->setPath($this->start);
+
+		vfsStream::copyFromFileSystem(
+			TESTPATH . '_support/Database/SupportMigrations',
+			$this->root
+		);
+
+		$version = $runner->current();
+
+		$this->assertEquals('001', $version);
+		$this->assertTrue(db_connect()->tableExists('foo'));
+	}
+}

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -8,13 +8,16 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 {
 	protected $root;
 	protected $start;
+	protected $config;
 
 	public function setUp()
 	{
 		parent::setUp();
 
-		$this->root  = vfsStream::setup('root');
-		$this->start = $this->root->url() . '/';
+		$this->root            = vfsStream::setup('root');
+		$this->start           = $this->root->url() . '/';
+		$this->config          = new Migrations();
+		$this->config->enabled = true;
 	}
 
 	/**
@@ -22,7 +25,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 	 */
 	public function testThrowsOnInvalidMigrationType()
 	{
-		$config       = new Migrations();
+		$config       = $this->config;
 		$config->type = 'narwhal';
 
 		$runner = new MigrationRunner($config);
@@ -31,8 +34,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 	public function testLoadsDefaultDatabaseWhenNoneSpecified()
 	{
 		$dbConfig = new \Config\Database();
-		$config   = new Migrations();
-		$runner   = new MigrationRunner($config);
+		$runner   = new MigrationRunner($this->config);
 
 		$db = $this->getPrivateProperty($runner, 'db');
 
@@ -43,8 +45,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testGetCliMessages()
 	{
-		$config = new Migrations();
-		$runner = new MigrationRunner($config);
+		$runner = new MigrationRunner($this->config);
 
 		$messages = [
 			'foo',
@@ -58,8 +59,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testGetHistory()
 	{
-		$config = new Migrations();
-		$runner = new MigrationRunner($config);
+		$runner = new MigrationRunner($this->config);
 
 		$tableMaker = $this->getPrivateMethodInvoker($runner, 'ensureTable');
 		$tableMaker();
@@ -79,8 +79,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testGetHistoryReturnsEmptyArrayWithNoResults()
 	{
-		$config = new Migrations();
-		$runner = new MigrationRunner($config);
+		$runner = new MigrationRunner($this->config);
 
 		$tableMaker = $this->getPrivateMethodInvoker($runner, 'ensureTable');
 		$tableMaker();
@@ -90,8 +89,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testGetMigrationNumber()
 	{
-		$config = new Migrations();
-		$runner = new MigrationRunner($config);
+		$runner = new MigrationRunner($this->config);
 
 		$method = $this->getPrivateMethodInvoker($runner, 'getMigrationNumber');
 
@@ -100,8 +98,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testGetMigrationNumberReturnsZeroIfNoneFound()
 	{
-		$config = new Migrations();
-		$runner = new MigrationRunner($config);
+		$runner = new MigrationRunner($this->config);
 
 		$method = $this->getPrivateMethodInvoker($runner, 'getMigrationNumber');
 
@@ -110,8 +107,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testSetSilentStoresValue()
 	{
-		$config = new Migrations();
-		$runner = new MigrationRunner($config);
+		$runner = new MigrationRunner($this->config);
 
 		$runner->setSilent(true);
 		$this->assertTrue($this->getPrivateProperty($runner, 'silent'));
@@ -122,8 +118,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testSetNameStoresValue()
 	{
-		$config = new Migrations();
-		$runner = new MigrationRunner($config);
+		$runner = new MigrationRunner($this->config);
 
 		$runner->setName('foo');
 		$this->assertEquals('foo', $this->getPrivateProperty($runner, 'name'));
@@ -131,8 +126,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testSetGroupStoresValue()
 	{
-		$config = new Migrations();
-		$runner = new MigrationRunner($config);
+		$runner = new MigrationRunner($this->config);
 
 		$runner->setGroup('foo');
 		$this->assertEquals('foo', $this->getPrivateProperty($runner, 'group'));
@@ -140,8 +134,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testSetNamespaceStoresValue()
 	{
-		$config = new Migrations();
-		$runner = new MigrationRunner($config);
+		$runner = new MigrationRunner($this->config);
 
 		$runner->setNamespace('foo');
 		$this->assertEquals('foo', $this->getPrivateProperty($runner, 'namespace'));
@@ -149,7 +142,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testFindMigrationsReturnsEmptyArrayWithNoneFound()
 	{
-		$config       = new Migrations();
+		$config       = $this->config;
 		$config->type = 'timestamp';
 		$runner       = new MigrationRunner($config);
 
@@ -160,7 +153,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testFindMigrationsSuccessTimestamp()
 	{
-		$config       = new Migrations();
+		$config       = $this->config;
 		$config->type = 'timestamp';
 		$runner       = new MigrationRunner($config);
 
@@ -191,7 +184,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testFindMigrationsSuccessOrder()
 	{
-		$config       = new Migrations();
+		$config       = $this->config;
 		$config->type = 'sequential';
 		$runner       = new MigrationRunner($config);
 
@@ -225,7 +218,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 	 */
 	public function testVersionThrowsMigrationGapException()
 	{
-		$config       = new Migrations();
+		$config       = $this->config;
 		$config->type = 'sequential';
 		$runner       = new MigrationRunner($config);
 
@@ -240,7 +233,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testVersionReturnsTrueWhenNothingToDo()
 	{
-		$config       = new Migrations();
+		$config       = $this->config;
 		$config->type = 'sequential';
 		$runner       = new MigrationRunner($config);
 
@@ -259,7 +252,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 	 */
 	public function testVersionWithNoClassInFile()
 	{
-		$config       = new Migrations();
+		$config       = $this->config;
 		$config->type = 'sequential';
 		$runner       = new MigrationRunner($config);
 		$runner->setSilent(false);
@@ -275,7 +268,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testVersionReturnsUpDownSuccess()
 	{
-		$config       = new Migrations();
+		$config       = $this->config;
 		$config->type = 'sequential';
 		$runner       = new MigrationRunner($config);
 		$runner->setSilent(false);
@@ -300,7 +293,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testLatestSuccess()
 	{
-		$config       = new Migrations();
+		$config       = $this->config;
 		$config->type = 'sequential';
 		$runner       = new MigrationRunner($config);
 		$runner->setSilent(false);
@@ -320,7 +313,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testCurrentSuccess()
 	{
-		$config                 = new Migrations();
+		$config                 = $this->config;
 		$config->type           = 'sequential';
 		$config->currentVersion = 1;
 		$runner                 = new MigrationRunner($config);

--- a/user_guide_src/source/database/connecting.rst
+++ b/user_guide_src/source/database/connecting.rst
@@ -14,6 +14,11 @@ If the above function does **not** contain any information in the first
 parameter it will connect to the default group specified in your database config
 file. For most people, this is the preferred method of use.
 
+A convenience method exists that is purely a wrapper around the above line
+and is provided for your convenience::
+
+    $db = db_connect();
+
 Available Parameters
 --------------------
 
@@ -89,7 +94,7 @@ the same format as the groups are defined in the configuration file::
 		'failover' => [],
 		'port'     => 3306,
 	];
-    $db = \Config\Database::connect($custom); 
+    $db = \Config\Database::connect($custom);
 
 
 Reconnecting / Keeping the Connection Alive

--- a/user_guide_src/source/database/connecting.rst
+++ b/user_guide_src/source/database/connecting.rst
@@ -61,6 +61,37 @@ group names you are connecting to.
 
 	| $db->setDatabase($database2_name);
 
+Connecting with Custom Settings
+===============================
+
+You can pass in an array of database settings instead of a group name to get
+a connection that uses your custom settings. The array passed in must be
+the same format as the groups are defined in the configuration file::
+
+    $custom = [
+		'DSN'      => '',
+		'hostname' => 'localhost',
+		'username' => '',
+		'password' => '',
+		'database' => '',
+		'DBDriver' => 'MySQLi',
+		'DBPrefix' => '',
+		'pConnect' => false,
+		'DBDebug'  => (ENVIRONMENT !== 'production'),
+		'cacheOn'  => false,
+		'cacheDir' => '',
+		'charset'  => 'utf8',
+		'DBCollat' => 'utf8_general_ci',
+		'swapPre'  => '',
+		'encrypt'  => false,
+		'compress' => false,
+		'strictOn' => false,
+		'failover' => [],
+		'port'     => 3306,
+	];
+    $db = \Config\Database::connect($custom); 
+
+
 Reconnecting / Keeping the Connection Alive
 ===========================================
 


### PR DESCRIPTION
- decent coverage for MigrationRunner tests
- new `db_connect()` helper method
- Connect can now accept an existing connection, an array of details, or a group name. 
- Forge, Utils and more updated to work with updated connect method
- Fixes bugs during sequential migration running and connection-related when using custom connections.