### PR TITLE
Composer PSR4 namespaces are now part of the modules auto-discovery

### DIFF
--- a/app/Config/Modules.php
+++ b/app/Config/Modules.php
@@ -15,6 +15,16 @@ class Modules
 	public $enabled = true;
 
 	/*
+	 |--------------------------------------------------------------------------
+	 | Auto-Discovery Within Composer Packages Enabled?
+	 |--------------------------------------------------------------------------
+	 |
+	 | If true, then auto-discovery will happen across all namespaces loaded
+	 | by Composer, as well as the namespaces configured locally.
+	 */
+	public $discoverInComposer = true;
+
+	/*
 	|--------------------------------------------------------------------------
 	| Auto-discover Rules
 	|--------------------------------------------------------------------------

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -119,7 +119,8 @@ class FileLocator
 			{
 				continue;
 			}
-			$path     = $this->getNamespaces($prefix);
+			$path = $this->getNamespaces($prefix);
+
 			$filename = implode('/', $segments);
 			break;
 		}
@@ -268,7 +269,9 @@ class FileLocator
 		{
 			$path = $this->autoloader->getNamespace($prefix);
 
-			return isset($path[0]) ? $path[0] : '';
+			return isset($path[0])
+				? rtrim($path[0], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR
+				: '';
 		}
 
 		$namespaces = [];
@@ -279,7 +282,7 @@ class FileLocator
 			{
 				$namespaces[] = [
 					'prefix' => $prefix,
-					'path'   => $path,
+					'path'   => rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR,
 				];
 			}
 		}

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -207,7 +207,7 @@ class BaseService
 
 		if ($init_autoloader)
 		{
-			static::autoloader()->initialize(new \Config\Autoload());
+			static::autoloader()->initialize(new \Config\Autoload(), new \Config\Modules());
 		}
 	}
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -393,7 +393,6 @@ class RouteCollection implements RouteCollectionInterface
 	/**
 	 * Will attempt to discover any additional routes, either through
 	 * the local PSR4 namespaces, or through selected Composer packages.
-	 * (Composer coming soon...)
 	 */
 	protected function discoverRoutes()
 	{
@@ -406,9 +405,6 @@ class RouteCollection implements RouteCollectionInterface
 		// so route files can access it.
 		$routes = $this;
 
-		/*
-		 * Discover Local Files
-		 */
 		if ($this->moduleConfig->shouldDiscover('routes'))
 		{
 			$files = $this->fileLocator->search('Config/Routes.php');
@@ -424,10 +420,6 @@ class RouteCollection implements RouteCollectionInterface
 				include $file;
 			}
 		}
-
-		/*
-		 * Discover Composer files (coming soon)
-		 */
 
 		$this->didDiscover = true;
 	}

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -111,6 +111,7 @@ require_once SYSTEMPATH . 'Common.php';
 if (! class_exists(Config\Autoload::class, false))
 {
 	require_once APPPATH . 'Config/Autoload.php';
+	require_once APPPATH . 'Config/Modules.php';
 }
 
 require_once SYSTEMPATH . 'Autoloader/Autoloader.php';
@@ -124,7 +125,7 @@ if (! class_exists('CodeIgniter\Services', false))
 }
 
 $loader = CodeIgniter\Services::autoloader();
-$loader->initialize(new Config\Autoload());
+$loader->initialize(new Config\Autoload(), new Config\Modules());
 $loader->register();    // Register the loader with the SPL autoloader stack.
 
 // Now load Composer's if it's available

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -1,6 +1,7 @@
 <?php namespace CodeIgniter\Autoloader;
 
 use Config\Autoload;
+use Config\Modules;
 
 class AutoloaderTest extends \CIUnitTestCase
 {
@@ -17,7 +18,9 @@ class AutoloaderTest extends \CIUnitTestCase
 	{
 		parent::setUp();
 
-		$config = new Autoload();
+		$config                           = new Autoload();
+		$moduleConfig                     = new Modules();
+		$moduleConfig->discoverInComposer = false;
 
 		$config->classmap = [
 			'UnnamespacedClass' => SUPPORTPATH . 'Autoloader/UnnamespacedClass.php',
@@ -30,7 +33,7 @@ class AutoloaderTest extends \CIUnitTestCase
 		];
 
 		$this->loader = new Autoloader();
-		$this->loader->initialize($config)->register();
+		$this->loader->initialize($config, $moduleConfig)->register();
 	}
 
 	public function testLoadStoredClass()
@@ -42,11 +45,13 @@ class AutoloaderTest extends \CIUnitTestCase
 	{
 		$this->expectException(\InvalidArgumentException::class);
 
-		$config           = new Autoload();
-		$config->classmap = [];
-		$config->psr4     = [];
+		$config                           = new Autoload();
+		$config->classmap                 = [];
+		$config->psr4                     = [];
+		$moduleConfig                     = new Modules();
+		$moduleConfig->discoverInComposer = false;
 
-		(new Autoloader())->initialize($config);
+		(new Autoloader())->initialize($config, $moduleConfig);
 	}
 
 	//--------------------------------------------------------------------
@@ -69,7 +74,7 @@ class AutoloaderTest extends \CIUnitTestCase
 	{
 		$getShared   = false;
 		$auto_loader = \CodeIgniter\Config\Services::autoloader($getShared);
-		$auto_loader->initialize(new Autoload());
+		$auto_loader->initialize(new Autoload(), new Modules());
 		$auto_loader->register();
 		// look for Home controller, as that should be in base repo
 		$actual   = $auto_loader->loadClass('App\Controllers\Home');
@@ -123,12 +128,14 @@ class AutoloaderTest extends \CIUnitTestCase
 	 */
 	public function testInitializeException()
 	{
-		$config           = new Autoload();
-		$config->classmap = [];
-		$config->psr4     = [];
+		$config                           = new Autoload();
+		$config->classmap                 = [];
+		$config->psr4                     = [];
+		$moduleConfig                     = new Modules();
+		$moduleConfig->discoverInComposer = false;
 
 		$this->loader = new Autoloader();
-		$this->loader->initialize($config);
+		$this->loader->initialize($config, $moduleConfig);
 	}
 
 	public function testAddNamespaceWorks()
@@ -213,4 +220,17 @@ class AutoloaderTest extends \CIUnitTestCase
 	}
 
 	//--------------------------------------------------------------------
+
+	public function testFindsComposerRoutes()
+	{
+		$config                           = new Autoload();
+		$moduleConfig                     = new Modules();
+		$moduleConfig->discoverInComposer = true;
+
+		$this->loader = new Autoloader();
+		$this->loader->initialize($config, $moduleConfig);
+
+		$namespaces = $this->loader->getNamespace();
+		$this->assertArrayHasKey('Zend\\Escaper', $namespaces);
+	}
 }

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -1,5 +1,7 @@
 <?php namespace CodeIgniter\Autoloader;
 
+use Config\Modules;
+
 class FileLocatorTest extends \CIUnitTestCase
 {
 	/**
@@ -14,7 +16,7 @@ class FileLocatorTest extends \CIUnitTestCase
 		parent::setUp();
 
 		$autoloader = new Autoloader();
-		$autoloader->initialize(new \Config\Autoload());
+		$autoloader->initialize(new \Config\Autoload(), new Modules());
 		$autoloader->addNamespace([
 			'Unknown'       => '/i/do/not/exist',
 			'Tests/Support' => TESTPATH . '_support/',

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -84,3 +84,13 @@ If neither of the above methods find the class, and the class is not namespaced,
 a measure to help ease the transition from previous versions.
 
 There are no configuration options for legacy support.
+
+Composer Support
+================
+
+Composer support is automatically initialized by default. By default it looks for Composer's autoload file at
+ROOTPATH.'vendor/autoload.php'. If you need to change the location of that file for any reason, you can modify
+the value defined in ``Config\Constants.php``.
+
+.. note:: If the same namespace is defined in both CodeIgniter and Composer, CodeIgniter's autoloader will
+    the first one to get a chance to locate the file.

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -16,7 +16,7 @@ Namespaces
 ==========
 
 The core element of the modules functionality comes from the :doc:`PSR4-compatible autoloading </concepts/autoloader>`
-that CodeIgniter uses. While any code can use the PSR4 autoloader and namespaces, the only way to take full advantage of
+that CodeIgniter uses. While any code can use the PSR4 autoloader and namespaces, the primary way to take full advantage of
 modules is to namespace your code and add it to **app/Config/Autoload.php**, in the ``psr4`` section.
 
 For example, let's say we want to keep a simple blog module that we can re-use between applications. We might create
@@ -95,6 +95,17 @@ Specify Discovery Items
 
 With the **$activeExplorers** option, you can specify which items are automatically discovered. If the item is not
 present, then no auto-discovery will happen for that item, but the others in the array will still be discovered.
+
+Discovery and Composer
+======================
+
+Packages that were installed via Composer will also be discovered by default. This only requires that the namespace
+that Composer knows about is a PSR4 namespace. PSR0 namespaces will not be detected.
+
+If you do not want all of Composer's known directories to be scanned when locating files, you can turn this off
+by editing the ``$discoverInComposer`` variable in ``Config\Modules.php``::
+
+    public $discoverInComposer = false;
 
 ==================
 Working With Files


### PR DESCRIPTION
All PSR4 namespaces are scanned when "discovering" files for our modules by default. This feature can be turned off. 

Applies to all forms of discovery: routes, config files, views, etc.

Fixes #1662 