### PR TITLE
Add missing test group directives

### DIFF
--- a/tests/system/Database/Live/AliasTest.php
+++ b/tests/system/Database/Live/AliasTest.php
@@ -2,6 +2,9 @@
 
 use CodeIgniter\Test\CIDatabaseTestCase;
 
+/**
+ * @group DatabaseLive
+ */
 class AliasTest extends CIDatabaseTestCase
 {
 	protected $refresh = true;

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -1,11 +1,12 @@
 <?php namespace CodeIgniter\Database\Live;
 
-;
-
 use CodeIgniter\Config\Config;
 use CodeIgniter\Test\CIDatabaseTestCase;
 use Config\Database;
 
+/**
+ * @group DatabaseLive
+ */
 class ConnectTest extends CIDatabaseTestCase
 {
 	protected $group1;

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -4,6 +4,9 @@ use Config\Migrations;
 use org\bovigo\vfs\vfsStream;
 use CodeIgniter\Test\CIDatabaseTestCase;
 
+/**
+ * @group DatabaseLive
+ */
 class MigrationRunnerTest extends CIDatabaseTestCase
 {
 	protected $root;


### PR DESCRIPTION
Three of the database tests were not flagged as being in the DatabaseLive group, causing failure of the non-DB unit tests (184 errors!). Fixed this.