### PR TITLE
Implement Don't Escape feature for db engine

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -327,6 +327,16 @@ abstract class BaseConnection implements ConnectionInterface
 	 */
 	protected $aliasedTables = [];
 
+	/**
+	 * Should the bindings be collected with a default escape value?
+	 * The Builder will automatically set this to false, so that any
+	 * $db->query('...', [binds]);  Will result in bindings being
+	 * automatically escaped.
+	 *
+	 * @var boolean
+	 */
+	protected $setEscapeFlags = true;
+
 	//--------------------------------------------------------------------
 
 	/**
@@ -578,6 +588,20 @@ abstract class BaseConnection implements ConnectionInterface
 	}
 
 	/**
+	 * Should query() automatically attach escape flags to each bound var?
+	 *
+	 * @param boolean $setFlags
+	 *
+	 * @return $this
+	 */
+	public function setEscapeFlags(bool $setFlags)
+	{
+		$this->setEscapeFlags = $setFlags;
+
+		return $this;
+	}
+
+	/**
 	 * Executes the query against the database.
 	 *
 	 * @param $sql
@@ -596,9 +620,11 @@ abstract class BaseConnection implements ConnectionInterface
 	 * Should automatically handle different connections for read/write
 	 * queries if needed.
 	 *
-	 * @param  string $sql
-	 * @param  array  ...$binds
-	 * @param  string $queryClass
+	 * @param string  $sql
+	 * @param array   ...$binds
+	 * @param string  $queryClass
+	 * @param boolean $setEscape
+	 *
 	 * @return BaseResult|Query|false
 	 */
 	public function query(string $sql, $binds = null, $queryClass = 'CodeIgniter\\Database\\Query')
@@ -609,13 +635,12 @@ abstract class BaseConnection implements ConnectionInterface
 		}
 
 		$resultClass = str_replace('Connection', 'Result', get_class($this));
-
 		/**
 		 * @var Query $query
 		 */
 		$query = new $queryClass($this);
 
-		$query->setQuery($sql, $binds);
+		$query->setQuery($sql, $binds, $this->setEscapeFlags);
 
 		if (! empty($this->swapPre) && ! empty($this->DBPrefix))
 		{

--- a/tests/_support/Database/MockConnection.php
+++ b/tests/_support/Database/MockConnection.php
@@ -27,7 +27,7 @@ class MockConnection extends BaseConnection
 
 		$query = new $queryClass($this);
 
-		$query->setQuery($sql, $binds);
+		$query->setQuery($sql, $binds, $this->setEscapeFlags);
 
 		if (! empty($this->swapPre) && ! empty($this->DBPrefix))
 		{

--- a/tests/system/Database/Builder/DeleteTest.php
+++ b/tests/system/Database/Builder/DeleteTest.php
@@ -24,7 +24,12 @@ class DeleteTest extends \CIUnitTestCase
 		$answer = $builder->delete(['id' => 1], null, true, true);
 
 		$expectedSQL   = 'DELETE FROM "jobs" WHERE "id" = :id:';
-		$expectedBinds = ['id' => 1];
+		$expectedBinds = [
+			'id' => [
+				1,
+				true,
+			],
+		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $answer));
 		$this->assertEquals($expectedBinds, $builder->getBinds());

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -29,7 +29,16 @@ class InsertTest extends \CIUnitTestCase
 		$builder->insert($insertData, true, true);
 
 		$expectedSQL   = 'INSERT INTO "jobs" ("id", "name") VALUES (1, \'Grocery Sales\')';
-		$expectedBinds = $insertData;
+		$expectedBinds = [
+			'id'   => [
+				1,
+				true,
+			],
+			'name' => [
+				'Grocery Sales',
+				true,
+			],
+		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
 		$this->assertEquals($expectedBinds, $builder->getBinds());
@@ -97,7 +106,7 @@ class InsertTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testInsertBatchThrowsExceptionOnEmptData()
+	public function testInsertBatchThrowsExceptionOnEmptyData()
 	{
 		$builder = $this->db->table('jobs');
 

--- a/tests/system/Database/Builder/LikeTest.php
+++ b/tests/system/Database/Builder/LikeTest.php
@@ -25,7 +25,12 @@ class LikeTest extends \CIUnitTestCase
 		$builder->like('name', 'veloper');
 
 		$expectedSQL   = "SELECT * FROM \"job\" WHERE \"name\" LIKE '%veloper%' ESCAPE '!'";
-		$expectedBinds = ['name' => '%veloper%'];
+		$expectedBinds = [
+			'name' => [
+				'%veloper%',
+				true,
+			],
+		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 		$this->assertSame($expectedBinds, $builder->getBinds());
@@ -40,7 +45,12 @@ class LikeTest extends \CIUnitTestCase
 		$builder->like('name', 'veloper', 'none');
 
 		$expectedSQL   = "SELECT * FROM \"job\" WHERE \"name\" LIKE 'veloper' ESCAPE '!'";
-		$expectedBinds = ['name' => 'veloper'];
+		$expectedBinds = [
+			'name' => [
+				'veloper',
+				true,
+			],
+		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 		$this->assertSame($expectedBinds, $builder->getBinds());
@@ -55,7 +65,12 @@ class LikeTest extends \CIUnitTestCase
 		$builder->like('name', 'veloper', 'before');
 
 		$expectedSQL   = "SELECT * FROM \"job\" WHERE \"name\" LIKE '%veloper' ESCAPE '!'";
-		$expectedBinds = ['name' => '%veloper'];
+		$expectedBinds = [
+			'name' => [
+				'%veloper',
+				true,
+			],
+		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 		$this->assertSame($expectedBinds, $builder->getBinds());
@@ -70,7 +85,12 @@ class LikeTest extends \CIUnitTestCase
 		$builder->like('name', 'veloper', 'after');
 
 		$expectedSQL   = "SELECT * FROM \"job\" WHERE \"name\" LIKE 'veloper%' ESCAPE '!'";
-		$expectedBinds = ['name' => 'veloper%'];
+		$expectedBinds = [
+			'name' => [
+				'veloper%',
+				true,
+			],
+		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 		$this->assertSame($expectedBinds, $builder->getBinds());
@@ -86,8 +106,14 @@ class LikeTest extends \CIUnitTestCase
 
 		$expectedSQL   = "SELECT * FROM \"job\" WHERE \"name\" LIKE '%veloper%' ESCAPE '!' OR  \"name\" LIKE '%ian%' ESCAPE '!'";
 		$expectedBinds = [
-			'name'  => '%veloper%',
-			'name0' => '%ian%',
+			'name'  => [
+				'%veloper%',
+				true,
+			],
+			'name0' => [
+				'%ian%',
+				true,
+			],
 		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
@@ -103,7 +129,12 @@ class LikeTest extends \CIUnitTestCase
 		$builder->notLike('name', 'veloper');
 
 		$expectedSQL   = "SELECT * FROM \"job\" WHERE \"name\" NOT LIKE '%veloper%' ESCAPE '!'";
-		$expectedBinds = ['name' => '%veloper%'];
+		$expectedBinds = [
+			'name' => [
+				'%veloper%',
+				true,
+			],
+		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 		$this->assertSame($expectedBinds, $builder->getBinds());
@@ -119,8 +150,14 @@ class LikeTest extends \CIUnitTestCase
 
 		$expectedSQL   = "SELECT * FROM \"job\" WHERE \"name\" LIKE '%veloper%' ESCAPE '!' OR  \"name\" NOT LIKE '%ian%' ESCAPE '!'";
 		$expectedBinds = [
-			'name'  => '%veloper%',
-			'name0' => '%ian%',
+			'name'  => [
+				'%veloper%',
+				true,
+			],
+			'name0' => [
+				'%ian%',
+				true,
+			],
 		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
@@ -139,7 +176,12 @@ class LikeTest extends \CIUnitTestCase
 		$builder->like('name', 'VELOPER', 'both', null, true);
 
 		$expectedSQL   = "SELECT * FROM \"job\" WHERE LOWER(name) LIKE '%veloper%' ESCAPE '!'";
-		$expectedBinds = ['name' => '%veloper%'];
+		$expectedBinds = [
+			'name' => [
+				'%veloper%',
+				true,
+			],
+		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 		$this->assertSame($expectedBinds, $builder->getBinds());

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -27,8 +27,14 @@ class UpdateTest extends \CIUnitTestCase
 
 		$expectedSQL   = 'UPDATE "jobs" SET "name" = \'Programmer\' WHERE "id" = 1';
 		$expectedBinds = [
-			'id'   => 1,
-			'name' => 'Programmer',
+			'id'   => [
+				1,
+				true,
+			],
+			'name' => [
+				'Programmer',
+				true,
+			],
 		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
@@ -45,8 +51,14 @@ class UpdateTest extends \CIUnitTestCase
 
 		$expectedSQL   = 'UPDATE "jobs" SET "name" = \'Programmer\' WHERE "id" = 1  LIMIT 5';
 		$expectedBinds = [
-			'id'   => 1,
-			'name' => 'Programmer',
+			'id'   => [
+				1,
+				true,
+			],
+			'name' => [
+				'Programmer',
+				true,
+			],
 		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
@@ -63,8 +75,14 @@ class UpdateTest extends \CIUnitTestCase
 
 		$expectedSQL   = 'UPDATE "jobs" SET "name" = \'Programmer\' WHERE "id" = 1';
 		$expectedBinds = [
-			'id'   => 1,
-			'name' => 'Programmer',
+			'id'   => [
+				1,
+				true,
+			],
+			'name' => [
+				'Programmer',
+				true,
+			],
 		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
@@ -179,8 +197,14 @@ WHERE "id" IN(2,3)';
 
 		$expectedSQL   = 'UPDATE "jobs" SET "name" = \'foobar\' WHERE "name" = \'Programmer\'';
 		$expectedBinds = [
-			'name'  => 'foobar',
-			'name0' => 'Programmer',
+			'name'  => [
+				'foobar',
+				true,
+			],
+			'name0' => [
+				'Programmer',
+				true,
+			],
 		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
@@ -200,8 +224,14 @@ WHERE "id" IN(2,3)';
 
 		$expectedSQL   = 'UPDATE "jobs" SET "name" = \'foobar\' WHERE "name" = \'Programmer\'';
 		$expectedBinds = [
-			'name'  => 'foobar',
-			'name0' => 'Programmer',
+			'name'  => [
+				'foobar',
+				true,
+			],
+			'name0' => [
+				'Programmer',
+				true,
+			],
 		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
@@ -220,8 +250,14 @@ WHERE "id" IN(2,3)';
 
 		$expectedSQL   = 'UPDATE "jobs" SET "name" = \'foobar\' WHERE "name" = \'Programmer\'';
 		$expectedBinds = [
-			'name'  => 'Programmer',
-			'name0' => 'foobar',
+			'name'  => [
+				'Programmer',
+				true,
+			],
+			'name0' => [
+				'foobar',
+				true,
+			],
 		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
@@ -240,7 +276,12 @@ WHERE "id" IN(2,3)';
 			->update(null, null, null, true);
 
 		$expectedSQL   = 'UPDATE "mytable" SET field = field+1 WHERE "id" = 2';
-		$expectedBinds = ['id' => 2];
+		$expectedBinds = [
+			'id' => [
+				2,
+				true,
+			],
+		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
 		$this->assertEquals($expectedBinds, $builder->getBinds());

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -22,7 +22,12 @@ class WhereTest extends \CIUnitTestCase
 		$builder = $this->db->table('users');
 
 		$expectedSQL   = 'SELECT * FROM "users" WHERE "id" = 3';
-		$expectedBinds = ['id' => 3];
+		$expectedBinds = [
+			'id' => [
+				3,
+				true,
+			],
+		];
 
 		$builder->where('id', 3);
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
@@ -36,7 +41,12 @@ class WhereTest extends \CIUnitTestCase
 		$builder = $this->db->table('users');
 
 		$expectedSQL   = 'SELECT * FROM "users" WHERE id = 3';
-		$expectedBinds = ['id' => 3];
+		$expectedBinds = [
+			'id' => [
+				3,
+				false,
+			],
+		];
 
 		$builder->where('id', 3, false);
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
@@ -50,7 +60,12 @@ class WhereTest extends \CIUnitTestCase
 		$builder = $this->db->table('users');
 
 		$expectedSQL   = 'SELECT * FROM "users" WHERE "id" != 3';
-		$expectedBinds = ['id' => 3];
+		$expectedBinds = [
+			'id' => [
+				3,
+				true,
+			],
+		];
 
 		$builder->where('id !=', 3);
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
@@ -70,8 +85,14 @@ class WhereTest extends \CIUnitTestCase
 
 		$expectedSQL   = 'SELECT * FROM "jobs" WHERE "id" = 2 AND "name" != \'Accountant\'';
 		$expectedBinds = [
-			'id'   => 2,
-			'name' => 'Accountant',
+			'id'   => [
+				2,
+				true,
+			],
+			'name' => [
+				'Accountant',
+				true,
+			],
 		];
 
 		$builder->where($where);
@@ -106,8 +127,14 @@ class WhereTest extends \CIUnitTestCase
 
 		$expectedSQL   = 'SELECT * FROM "jobs" WHERE "name" != \'Accountant\' OR "id" > 3';
 		$expectedBinds = [
-			'name' => 'Accountant',
-			'id'   => 3,
+			'name' => [
+				'Accountant',
+				true,
+			],
+			'id'   => [
+				3,
+				true,
+			],
 		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
@@ -125,8 +152,14 @@ class WhereTest extends \CIUnitTestCase
 
 		$expectedSQL   = 'SELECT * FROM "jobs" WHERE "name" = \'Accountant\' OR "name" = \'foobar\'';
 		$expectedBinds = [
-			'name'  => 'Accountant',
-			'name0' => 'foobar',
+			'name'  => [
+				'Accountant',
+				true,
+			],
+			'name0' => [
+				'foobar',
+				true,
+			],
 		];
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
@@ -144,8 +177,11 @@ class WhereTest extends \CIUnitTestCase
 		$expectedSQL   = 'SELECT * FROM "jobs" WHERE "name" IN (\'Politician\',\'Accountant\')';
 		$expectedBinds = [
 			'name' => [
-				'Politician',
-				'Accountant',
+				[
+					'Politician',
+					'Accountant',
+				],
+				true,
 			],
 		];
 
@@ -164,8 +200,11 @@ class WhereTest extends \CIUnitTestCase
 		$expectedSQL   = 'SELECT * FROM "jobs" WHERE "name" NOT IN (\'Politician\',\'Accountant\')';
 		$expectedBinds = [
 			'name' => [
-				'Politician',
-				'Accountant',
+				[
+					'Politician',
+					'Accountant',
+				],
+				true,
 			],
 		];
 
@@ -183,10 +222,16 @@ class WhereTest extends \CIUnitTestCase
 
 		$expectedSQL   = 'SELECT * FROM "jobs" WHERE "id" = 2 OR "name" IN (\'Politician\',\'Accountant\')';
 		$expectedBinds = [
-			'id'   => 2,
+			'id'   => [
+				2,
+				true,
+			],
 			'name' => [
-				'Politician',
-				'Accountant',
+				[
+					'Politician',
+					'Accountant',
+				],
+				true,
 			],
 		];
 
@@ -204,10 +249,16 @@ class WhereTest extends \CIUnitTestCase
 
 		$expectedSQL   = 'SELECT * FROM "jobs" WHERE "id" = 2 OR "name" NOT IN (\'Politician\',\'Accountant\')';
 		$expectedBinds = [
-			'id'   => 2,
+			'id'   => [
+				2,
+				true,
+			],
 			'name' => [
-				'Politician',
-				'Accountant',
+				[
+					'Politician',
+					'Accountant',
+				],
+				true,
 			],
 		];
 

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -33,7 +33,7 @@ class InsertTest extends CIDatabaseTestCase
 			'name'        => '1',
 			'description' => $this->db->DBDriver === 'SQLite3'
 				? "date({$timestamp}, 'unixepoch', 'localtime')"
-				: 'DATE()',
+				: 'current_date()',
 		];
 
 		$this->db->table('job')->insert($job_data, false);
@@ -78,7 +78,7 @@ class InsertTest extends CIDatabaseTestCase
 				'name'        => '1',
 				'description' => $this->db->DBDriver === 'SQLite3'
 					? "date({$timestamp}, 'unixepoch', 'localtime')"
-					: 'DATE()',
+					: 'current_date()',
 			],
 		];
 

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -25,26 +25,6 @@ class InsertTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testInsertNoEscape()
-	{
-		$timestamp = time();
-
-		$job_data = [
-			'name'        => '1',
-			'description' => $this->db->DBDriver === 'SQLite3'
-				? "date({$timestamp}, 'unixepoch', 'localtime')"
-				: 'current_date()',
-		];
-
-		$this->db->table('job')->insert($job_data, false);
-
-		$lastRecord = $this->db->table('job')->orderBy('id', 'desc')->limit(1)->get()->getResultArray()[0];
-
-		$this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($lastRecord['description'])));
-	}
-
-	//--------------------------------------------------------------------
-
 	public function testInsertBatch()
 	{
 		$job_data = [
@@ -62,31 +42,6 @@ class InsertTest extends CIDatabaseTestCase
 
 		$this->seeInDatabase('job', ['name' => 'Comedian']);
 		$this->seeInDatabase('job', ['name' => 'Cab Driver']);
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/1667
-	 */
-	public function testInsertBatchNoEscape()
-	{
-		$timestamp = time();
-
-		$job_data = [
-			[
-				'name'        => '1',
-				'description' => $this->db->DBDriver === 'SQLite3'
-					? "date({$timestamp}, 'unixepoch', 'localtime')"
-					: 'current_date()',
-			],
-		];
-
-		$this->db->table('job')->insertBatch($job_data, false);
-
-		$lastRecord = $this->db->table('job')->orderBy('id', 'desc')->limit(1)->get()->getResultArray()[0];
-
-		$this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($lastRecord['description'])));
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -25,6 +25,26 @@ class InsertTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testInsertNoEscape()
+	{
+		$timestamp = time();
+
+		$job_data = [
+			'name'        => '1',
+			'description' => $this->db->DBDriver === 'SQLite3'
+				? "date({$timestamp}, 'unixepoch', 'localtime')"
+				: 'DATE()',
+		];
+
+		$this->db->table('job')->insert($job_data, false);
+
+		$lastRecord = $this->db->table('job')->orderBy('id', 'desc')->limit(1)->get()->getResultArray()[0];
+
+		$this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($lastRecord['description'])));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testInsertBatch()
 	{
 		$job_data = [
@@ -42,6 +62,31 @@ class InsertTest extends CIDatabaseTestCase
 
 		$this->seeInDatabase('job', ['name' => 'Comedian']);
 		$this->seeInDatabase('job', ['name' => 'Cab Driver']);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/1667
+	 */
+	public function testInsertBatchNoEscape()
+	{
+		$timestamp = time();
+
+		$job_data = [
+			[
+				'name'        => '1',
+				'description' => $this->db->DBDriver === 'SQLite3'
+					? "date({$timestamp}, 'unixepoch', 'localtime')"
+					: 'DATE()',
+			],
+		];
+
+		$this->db->table('job')->insertBatch($job_data, false);
+
+		$lastRecord = $this->db->table('job')->orderBy('id', 'desc')->limit(1)->get()->getResultArray()[0];
+
+		$this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($lastRecord['description'])));
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
Add in missing don't escape feature that seemed to be missing since the original DB refactor. 

Fixes #1667
  
