### PR TITLE
Fix page structure etc

### DIFF
--- a/user_guide_src/source/_themes/sphinx_rtd_theme/static/css/citheme.css
+++ b/user_guide_src/source/_themes/sphinx_rtd_theme/static/css/citheme.css
@@ -71,3 +71,14 @@ div#pulldown-menu {
 	font-family: Lucida Grande,Verdana,Geneva,sans-serif;
 	color: #aaaaaa;
 }
+
+/* override table width restrictions */
+.wy-table-responsive table td, .wy-table-responsive table th {
+    white-space: normal;
+}
+
+.wy-table-responsive {
+    margin-bottom: 24px;
+    max-width: 100%;
+    overflow: visible;
+}

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -82,8 +82,8 @@ Release Date: September 28, 2018
 
 Non-code changes:
     - User Guide adapted or rewritten
-    - [System message translations repository](https://github.com/bcit-ci/CodeIgniter4-translations)
-    - [Roadmap subforum](https://forum.codeigniter.com/forum-33.html) for more transparent planning
+    - `System message translations repository <https://github.com/bcit-ci/CodeIgniter4-translations>`_
+    - `Roadmap subforum  <https://forum.codeigniter.com/forum-33.html>`_ for more transparent planning
 
 New core classes:
     - CodeIgniter (bootstrap)
@@ -102,6 +102,8 @@ Some new, some old & some borrowed packages, all namespaced.
     :titlesonly:
 
     next
+    v4.0.0-alpha.5
+    v4.0.0-alpha.4
     v4.0.0-alpha.3
     v4.0.0-alpha.2
     v4.0.0-alpha.1

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -134,4 +134,19 @@ List the Indexes in a Table
 
 **$db->getIndexData()**
 
-please write this, someone...
+Returns an array of objects containing index information.
+
+Usage example::
+
+	$keys = $db->getIndexData('table_name');
+
+	foreach ($keys as $key)
+	{
+		echo $key->name;
+		echo $key->type;
+		echo $key->fields;  // array of field names
+	}
+
+The key types may be unique to the database you are using.
+For instance, MySQL will return one of primary, fulltext, spatial, index or unique
+for each key associated with a table.

--- a/user_guide_src/source/dbmgmt/index.rst
+++ b/user_guide_src/source/dbmgmt/index.rst
@@ -2,7 +2,7 @@
 Managing Databases
 ##################
 
-CodeIgniter comes with tools to restructure or sees your database.
+CodeIgniter comes with tools to restructure or seed your database.
 
 .. toctree::
     :titlesonly:

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -174,7 +174,7 @@ to update the schema::
 	}
 
 *******************
-Commnand-Line Tools
+Command-Line Tools
 *******************
 CodeIgniter ships with several :doc:`commands </cli/cli_commands>` that are available from the command line to help
 you work with migrations. These tools are not required to use migrations but might make things easier for those of you

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -1,5 +1,4 @@
-#####################################
-Events - Extending the Framework Core
+Events 
 #####################################
 
 CodeIgniter's Events feature provides a means to tap into and modify the inner workings of the framework without hacking

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -10,7 +10,7 @@ classes, in addition to the methods listed below.
     :depth: 2
 
 Accessing the Request
-=====================
+----------------------------------------------------------------------------
 
 An instance of the request class already populated for you if the current class is a descendant of
 ``CodeIgniter\Controller`` and can be accessed as a class property::
@@ -52,7 +52,7 @@ the controller, where you can save it as a class property::
 	$someClass = new SomeClass(\Config\Services::request());
 
 Determining Request Type
-========================
+----------------------------------------------------------------------------
 
 A request could be of several types, including an AJAX request or a request from the command line. This can
 be checked with the ``isAJAX()`` and ``isCLI()`` methods::
@@ -88,7 +88,7 @@ You can also check if the request was made through and HTTPS connection with the
 	}
 
 Retrieving Input
-================
+----------------------------------------------------------------------------
 
 You can retrieve input from $_SERVER, $_GET, $_POST, $_ENV, and $_SESSION through the Request object.
 The data is not automatically filtered and returns the raw input data as passed in the request. The main
@@ -149,8 +149,7 @@ This will retrieve data and convert it to an array. Like this::
 		'Param2' => 'Value2'
 	]
 
-Filtering Input Data
---------------------
+**Filtering Input Data**
 
 To maintain security of your application, you will want to filter all input as you access it. You can
 pass the type of filter to use in as the last parameter of any of these methods. The native ``filter_var()``
@@ -165,7 +164,7 @@ All of the methods mentioned above support the filter type passed in as the last
 exception of ``getJSON()``.
 
 Retrieving Headers
-==================
+----------------------------------------------------------------------------
 
 You can get access to any header that was sent with the request with the ``getHeaders()`` method, which returns
 an array of all headers, with the key as the name of the header, and the value being an instance of
@@ -204,7 +203,7 @@ If you need the entire header, with the name and values in a single string, simp
 	echo (string)$header;
 
 The Request URL
-===============
+----------------------------------------------------------------------------
 
 You can retrieve a :doc:`URI </libraries/uri>` object that represents the current URI for this request through the
 ``$request->uri`` property. You can cast this object as a string to get a full URL for the current request::
@@ -227,7 +226,7 @@ The object gives you full abilities to grab any part of the request on it's own:
 	echo $uri->getTotalSegments();  // 3
 
 Uploaded Files
-==============
+----------------------------------------------------------------------------
 
 Information about all uploaded files can be retrieved through ``$request->getFiles()``, which returns a
 :doc:`FileCollection </libraries/uploaded_files>` instance. This helps to ease the pain of working with uploaded files,
@@ -257,7 +256,7 @@ You can also retrieve a single file based on the filename given in the HTML file
 	$file = $request->getFile('uploadedfile');
 
 Content Negotiation
-===================
+----------------------------------------------------------------------------
 
 You can easily negotiate content types with the request through the ``negotiate()`` method::
 
@@ -270,7 +269,7 @@ You can easily negotiate content types with the request through the ``negotiate(
 See the :doc:`Content Negotiation </incoming/content_negotiation>` page for more details.
 
 Class Reference
-***************
+===========================================================================
 
 .. note:: In addition to the methods listed here, this class inherits the methods from the
 	:doc:`Request Class </incoming/request>` and the :doc:`Message Class </incoming/message>`.
@@ -402,6 +401,7 @@ The methods provided by the parent classes that are available are:
 
 	.. php:method:: getCookie([$index = null[, $filter = null[, $flags = null]]])
 
+                :noindex:
 		:param	mixed	$index: COOKIE name
 		:param  int     $filter: The type of filter to apply. A list of filters can be found `here <http://php.net/manual/en/filter.filters.php>`__.
 		:param  int     $flags: Flags to apply. A list of flags can be found `here <http://php.net/manual/en/filter.filters.flags.php>`__.

--- a/user_guide_src/source/incoming/request.rst
+++ b/user_guide_src/source/incoming/request.rst
@@ -1,6 +1,5 @@
-*************
 Request Class
-*************
+****************************************************
 
 The request class is an object-oriented representation of an HTTP request. This is meant to
 work for both incoming, such as a request to the application from a browser, and outgoing requests,
@@ -11,9 +10,8 @@ from the Request class to add specific functionality.
 See the documentation for the :doc:`IncomingRequest Class </incoming/incomingrequest>` and
 :doc:`CURLRequest Class </libraries/curlrequest>` for more usage details.
 
-***************
 Class Reference
-***************
+============================================================
 
 .. php:class:: CodeIgniter\\HTTP\\Request
 

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -5,12 +5,8 @@ Session Library
 The Session class permits you maintain a user's "state" and track their
 activity while they browse your site.
 
-CodeIgniter comes with a few session storage drivers:
-
-  - CodeIgniter\Session\Handlers\FileHandler (default; file-system based)
-  - CodeIgniter\Session\Handlers\DatabaseHandler
-  - CodeIgniter\Session\Handlers\MemcachedHandler
-  - CodeIgniter\Session\Handlers\RedisHandler
+CodeIgniter comes with a few session storage drivers, that you can see
+in the last section of the table of contents:
 
 .. contents::
     :local:
@@ -20,12 +16,11 @@ CodeIgniter comes with a few session storage drivers:
 
   <div class="custom-index container"></div>
 
-***********************
 Using the Session Class
-***********************
+*********************************************************************
 
 Initializing a Session
-======================
+==================================================================
 
 Sessions will typically run globally with each page load, so the Session
 class should be magically initialized.
@@ -429,7 +424,7 @@ accessing them:
   - last_activity: Depends on the storage, no straightforward way. Sorry!
 
 Session Preferences
-===================
+*********************************************************************
 
 CodeIgniter will usually make everything work out of the box. However,
 Sessions are a very sensitive component of any application, so some
@@ -484,7 +479,7 @@ Preference         Default         Description
 	ignored.
 
 Session Drivers
-===============
+*********************************************************************
 
 As already mentioned, the Session library comes with 4 handlers, or storage
 engines, that you can use:
@@ -503,8 +498,8 @@ line in your **app/Config/App.php** file, if you chose to do so.
 Have it in mind though, every driver has different caveats, so be sure to
 get yourself familiar with them (below) before you make that choice.
 
-FileHandler Driver
-------------------
+FileHandler Driver (the default)
+==================================================================
 
 The 'FileHandler' driver uses your file system for storing session data.
 
@@ -541,7 +536,7 @@ Instead, you should do something like this, depending on your environment
 	chown www-data /<path to your application directory>/Writable/sessions/
 
 Bonus Tip
-^^^^^^^^^
+--------------------------------------------------------
 
 Some of you will probably opt to choose another session driver because
 file storage is usually slower. This is only half true.
@@ -557,7 +552,7 @@ into using `tmpfs <http://eddmann.com/posts/storing-php-sessions-file-caches-in-
 (warning: external resource), which can make your sessions blazing fast.
 
 DatabaseHandler Driver
-----------------------
+==================================================================
 
 The 'DatabaseHandler' driver uses a relational database such as MySQL or
 PostgreSQL to store sessions. This is a popular choice among many users,
@@ -636,7 +631,7 @@ when it generates the code.
 	issues.
 
 RedisHandler Driver
--------------------
+==================================================================
 
 .. note:: Since Redis doesn't have a locking mechanism exposed, locks for
 	this driver are emulated by a separate value that is kept for up
@@ -673,7 +668,7 @@ sufficient::
 	public $sessionSavePath = 'tcp://localhost:6379';
 
 MemcachedHandler Driver
------------------------
+==================================================================
 
 .. note:: Since Memcached doesn't have a locking mechanism exposed, locks
 	for this driver are emulated by a separate value that is kept for
@@ -701,7 +696,7 @@ being just a ``host:port`` pair::
 	public $sessionSavePath = 'localhost:11211';
 
 Bonus Tip
-^^^^^^^^^
+--------------------------------------------------------
 
 Multi-server configuration with an optional *weight* parameter as the
 third colon-separated (``:weight``) value is also supported, but we have

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -1,6 +1,5 @@
-##########
 Validation
-##########
+##################################################
 
 CodeIgniter provides a comprehensive data validation class that
 helps minimize the amount of code you'll write.
@@ -9,9 +8,8 @@ helps minimize the amount of code you'll write.
     :local:
     :depth: 2
 
-********
 Overview
-********
+************************************************
 
 Before explaining CodeIgniter's approach to data validation, let's
 describe the ideal scenario:
@@ -43,9 +41,8 @@ messages, various control structures are usually placed within the form
 HTML. Form validation, while simple to create, is generally very messy
 and tedious to implement.
 
-************************
 Form Validation Tutorial
-************************
+************************************************
 
 What follows is a "hands on" tutorial for implementing CodeIgniter's Form
 Validation.
@@ -62,7 +59,7 @@ Let's create those three things, using a member sign-up form as the
 example.
 
 The Form
-========
+================================================
 
 Using a text editor, create a form called **Signup.php**. In it, place this
 code and save it to your **app/Views/** folder::
@@ -97,7 +94,7 @@ code and save it to your **app/Views/** folder::
 	</html>
 
 The Success Page
-================
+================================================
 
 Using a text editor, create a form called **Success.php**. In it, place
 this code and save it to your **app/Views/** folder::
@@ -116,7 +113,7 @@ this code and save it to your **app/Views/** folder::
 	</html>
 
 The Controller
-==============
+================================================
 
 Using a text editor, create a controller called **Form.php**. In it, place
 this code and save it to your **app/Controllers/** folder::
@@ -145,7 +142,7 @@ this code and save it to your **app/Controllers/** folder::
 	}
 
 Try it!
-=======
+================================================
 
 To try your form, visit your site using a URL similar to this one::
 
@@ -160,7 +157,7 @@ only returns true if it has successfully applied your rules without any
 of them failing.**
 
 Explanation
-===========
+================================================
 
 You'll notice several things about the above pages:
 
@@ -186,7 +183,7 @@ Based on whether the validation was successful it either presents the
 form or the success page.
 
 Loading the Library
-===================
+================================================
 
 The library is loaded as a service named **validation**::
 
@@ -199,7 +196,7 @@ for including multiple Rule sets, and collections of rules that can be easily re
     the :doc:`Model </models/model>` provide methods to make validation even easier.
 
 Setting Validation Rules
-========================
+================================================
 
 CodeIgniter lets you set as many validation rules as you need for a
 given field, cascading them in order. To set validation rules you
@@ -247,9 +244,11 @@ data to be validated::
     $validation->withRequest($this->request)
                ->run();
 
-*******************************
+Working with Validation
+************************************************
+
 Validating Keys that are Arrays
-*******************************
+================================================
 
 If your data is in a nested associative array, you can use "dot array syntax" to
 easily validate your data::
@@ -284,17 +283,15 @@ You can use the '*' wildcard symbol to match any one level of the array::
         'contacts.*.name' => 'required'
     ]);
 
-****************
 Validate 1 Value
-****************
+================================================
 
 Validate one value against a rule::
 
     $validation->check($value, 'required');
 
-**************************************************
 Saving Sets of Validation Rules to the Config File
-**************************************************
+================================================
 
 A nice feature of the Validation class is that it permits you to store all
 your validation rules for your entire application in a config file. You organize
@@ -304,7 +301,7 @@ the validation.
 .. _validation-array:
 
 How to save your rules
-======================
+-------------------------------------------------------
 
 To store your validation rules, simply create a new public property in the ``Config\Validation``
 class with the name of your group. This element will hold an array with your validation
@@ -372,25 +369,22 @@ Or pass all settings in an array::
 See below for details on the formatting of the array.
 
 Getting & Setting Rule Groups
-=============================
+-------------------------------------------------------
 
-Get Rule Group
---------------
+**Get Rule Group**
 
 This method gets a rule group from the validation configuration::
 
     $validation->getRuleGroup('signup');
 
-Set Rule Group
---------------
+**Set Rule Group**
 
 This method sets a rule group from the validation configuration to the validation service::
 
     $validation->setRuleGroup('signup');
 
-*******************
 Working With Errors
-*******************
+************************************************
 
 The Validation library provides several methods to help you set error messages, provide
 custom error messages, and retrieve one or more errors to display.
@@ -491,9 +485,8 @@ You can check to see if an error exists with the ``hasError()`` method. The only
         echo $validation->getError('username');
     }
 
-*************************
 Customizing Error Display
-*************************
+************************************************
 
 When you call ``$validation->listErrors()`` or ``$validation->showError()``, it loads a view file in the background
 that determines how the errors are displayed. By default, they display in a manner compatible with the
@@ -554,9 +547,8 @@ right after the name of the field the error should belong to::
 
     <?= $validation->showError('username', 'my_single') ?>
 
-*********************
 Creating Custom Rules
-*********************
+************************************************
 
 Rules are stored within simple, namespaced classes. They can be stored any location you would like, as long as the
 autoloader can find it. These files are called RuleSets. To add a new RuleSet, edit **Config/Validation.php** and

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -507,6 +507,7 @@ The methods provided by the parent class that are available are:
 			if ($response->hasCookie($name)) ...
 
 	.. php:method:: getCookie($name = ''[, $prefix = ''])
+                :noindex:
 
 		:param	mixed	$name: Cookie name
 		:param	string	$prefix: Cookie name prefix

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -399,40 +399,66 @@ Provided Filters
 
 The following filters are available when using the parser:
 
-==================== ========================== ==================================================================== =================================
-Filter               Arguments                  Description                                                          Example
-==================== ========================== ==================================================================== =================================
-abs                                             Displays the absolute value of a number.                             { v|abs }
-capitalize                                      Displays the string in sentence case: all lowercase with first       { v|capitalize}
-                                                letter capitalized.
-date                 format (Y-m-d)             A PHP **date**-compatible formatting string.                         { v|date(Y-m-d) }
-date_modify          value to add/subtract      A **strtotime** compatible string to modify the date, like           { v|date_modify(+1 day) }
-                                                ``+5 day`` or ``-1 week``.
-default              default value              Displays the default value if the variable is empty or undefined.    { v|default(just in case) }
-esc                  html, attr, css, js        Specifies the context to escape the data.                            { v|esc(attr) }
-excerpt              phrase, radius             Returns the text within a radius of words from a given phrase.       { v|excerpt(green giant, 20) }
-                                                Same as **excerpt** helper function.
-highlight            phrase                     Highlights a given phrase within the text using '<mark></mark>'
-                                                tags.                                                                { v|highlight(view parser) }
-highlight_code                                  Highlights code samples with HTML/CSS.                               { v|highlight_code }
-limit_chars          limit                      Limits the number of chracters to $limit.                            { v|limit_chars(100) }
-limit_words          limit                      Limits the number of words to $limit.                                { v|limit_words(20) }
-local_currency       currency, locale           Displays a localized version of a currency. "currency" value is any  { v|local_currency(EUR,en_US) }
-                                                3-letter ISO 4217 currency code.
-local_number         type, precision, locale    Displays a localized version of a number. "type" can be one of:      { v|local_number(decimal,2,en_US) }
-                                                decimal, currency, percent, scientific, spellout, ordinal, duration.
-lower                                           Converts a string to lowercase.                                      { v|lower }
-nl2br                                           Replaces all newline characters (\n) to an HTML <br/> tag.           { v|nl2br }
-number_format        places                     Wraps PHP **number_format** function for use within the parser.      { v|number_format(3) }
-prose                                           Takes a body of text and uses the **auto_typography()** method to    { v|prose }
-                                                turn it into prettier, easier-to-read, prose.
-round                places, type               Rounds a number to the specified places. Types of **ceil** and       { v|round(3) } { v|round(ceil) }
-                                                **floor** can be passed to use those functions instead.
-strip_tags           allowed chars              Wraps PHP **strip_tags**. Can accept a string of allowed tags.       { v|strip_tags(<br>) }
-title                                           Displays a "title case" version of the string, with all lowercase,   { v|title }
-                                                and each word capitalized.
-upper                                           Displays the string in all uppercase.                                { v|upper }
-==================== ========================== ==================================================================== =================================
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ **Filter**    + **Arguments**       + **Description**                                              + **Example**                         +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ abs           +                     + Displays the absolute value of a number.                     + { v|abs }                           +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ capitalize    +                     + Displays the string in sentence case: all lowercase          + { v|capitalize}                     +
++               +                     + with firstletter capitalized.                                +                                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ date          + format (Y-m-d)      + A PHP **date**-compatible formatting string.                 + { v|date(Y-m-d) }                   +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ date_modify   + value to add        + A **strtotime** compatible string to modify the date,        + { v|date_modify(+1 day) }           +
++               + / subtract          + like ``+5 day`` or ``-1 week``.                              +                                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ default       + default value       + Displays the default value if the variable is empty or       + { v|default(just in case) }         +
++               +                     + undefined.                                                   +                                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ esc           + html, attr, css, js + Specifies the context to escape the data.                    + { v|esc(attr) }                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ excerpt       + phrase, radius      + Returns the text within a radius of words from a given       + { v|excerpt(green giant, 20) }      +
++               +                     + phrase. Same as **excerpt** helper function.                 +                                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ highlight     + phrase              + Highlights a given phrase within the text using              + { v|highlight(view parser) }        +
++               +                     + '<mark></mark>' tags.                                        +                                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ highlight_code+                     + Highlights code samples with HTML/CSS.                       + { v|highlight_code }                +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ limit_chars   + limit               + Limits the number of chracters to $limit.                    + { v|limit_chars(100) }              +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ limit_words   + limit               + Limits the number of words to $limit.                        + { v|limit_words(20) }               +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ local_currency+ currency, locale    + Displays a localized version of a currency. "currency"       + { v|local_currency(EUR,en_US) }     +
++               +                     + valueis any 3-letter ISO 4217 currency code.                 +                                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ local_number  + type, precision,    + Displays a localized version of a number. "type" can be      + { v|local_number(decimal,2,en_US) } +
++               + locale              + one of: decimal, currency, percent, scientific, spellout,    +                                     +
++               +                     + ordinal, duration.                                           +                                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ lower         +                     + Converts a string to lowercase.                              + { v|lower }                         +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ nl2br         +                     + Replaces all newline characters (\n) to an HTML <br/> tag.   + { v|nl2br }                         +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ number_format + places              + Wraps PHP **number_format** function for use within the      + { v|number_format(3) }              +
++               +                     + parser.                                                      +                                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ prose         +                     + Takes a body of text and uses the **auto_typography()**      + { v|prose }                         +
++               +                     + method to turn it into prettier, easier-to-read, prose.      +                                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ round         + places, type        + Rounds a number to the specified places. Types of **ceil**   + { v|round(3) } { v|round(ceil) }    +
++               +                     + and **floor** can be passed to use those functions instead.  +                                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ strip_tags    + allowed chars       + Wraps PHP **strip_tags**. Can accept a string of allowed     + { v|strip_tags(<br>) }              +
++               +                     + tags.                                                        +                                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ title         +                     + Displays a "title case" version of the string, with all      + { v|title }                         +
++               +                     + lowercase, and each word capitalized.                        +                                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++ upper         +                     + Displays the string in all uppercase.                        + { v|upper }                         +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
++               +                     +                                                              +                                     +
++---------------+---------------------+--------------------------------------------------------------+-------------------------------------+
 
 See `PHP's NumberFormatter <http://php.net/manual/en/numberformatter.create.php>`_ for details relevant to the
 "local_number" filter.
@@ -493,12 +519,12 @@ The following plugins are available when using the parser:
 ==================== ========================== ================================================================================== ================================================================
 Plugin               Arguments                  Description                                                           			   Example
 ==================== ========================== ================================================================================== ================================================================
-current_url                                     Alias for the current_url helper function.                            			   {+ current_url +}
-previous_url                                    Alias for the previous_url helper function.                           			   {+ previous_url +}
+current_url                                     Alias for the current_url helper function.                                         {+ current_url +}
+previous_url                                    Alias for the previous_url helper function.                           		   {+ previous_url +}
 site_url                                        Alias for the site_url helper function.                                            {+ site_url "login" +}
-mailto               email, title, attributes   Alias for the mailto helper function.                                 			   {+ mailto email=foo@example.com title="Stranger Things" +}
-safe_mailto          email, title, attributes   Alias for the safe_mailto helper function.                            			   {+ safe_mailto email=foo@example.com title="Stranger Things" +}
-lang                 language string            Alias for the lang helper function.                                    			   {+ lang number.terabyteAbbr +}
+mailto               email, title, attributes   Alias for the mailto helper function.                                 		   {+ mailto email=foo@example.com title="Stranger Things" +}
+safe_mailto          email, title, attributes   Alias for the safe_mailto helper function.                            		   {+ safe_mailto email=foo@example.com title="Stranger Things" +}
+lang                 language string            Alias for the lang helper function.                                    		   {+ lang number.terabyteAbbr +}
 validation_errors    fieldname(optional)        Returns either error string for the field (if specified) or all validation errors. {+ validation_errors +} , {+ validation_errors field="email" +}
 route                route name                 Alias for the route_to helper function.                                            {+ route "login" +}
 ==================== ========================== ================================================================================== ================================================================

--- a/user_guide_src/source/tutorial/index.rst
+++ b/user_guide_src/source/tutorial/index.rst
@@ -7,7 +7,7 @@ and the basic principles of MVC architecture. It will show you how a
 basic CodeIgniter application is constructed in step-by-step fashion.
 
 If you are not familiar with PHP, we recommend that you check out
-the ``W3Schools PHP Tutorial <https://www.w3schools.com/php/default.asp>`_ before continuing.
+the `W3Schools PHP Tutorial <https://www.w3schools.com/php/default.asp>`_ before continuing.
 
 In this tutorial, you will be creating a **basic news application**. You
 will begin by writing the code that can load static pages. Next, you


### PR DESCRIPTION
Started out fixing the messed up wide table display; also fixed a number of other niggly things encountered along the way, such as TOC structures & content heading levels.
Added missing metadata method description to database page, and slightly re-arranged the sessions page.