### PR TITLE
Update MigrationRunner.php

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -458,6 +458,8 @@ class MigrationRunner
 				$migrations[$migration->version] = $migration;
 			}
 		}
+		
+		ksort($migrations);
 
 		return $migrations;
 	}


### PR DESCRIPTION
Without this sorting "$lastMigration = end($migrations)" code block in "latest()" and "latestAll()" functions return not last migration in some cases.