### PR TITLE
Fix viewsDirectory bug Fixes #1701

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -434,7 +434,7 @@ class Services extends BaseService
 	 *
 	 * @return \CodeIgniter\View\Parser
 	 */
-	public static function parser($viewPath = APPPATH . 'Views/', $config = null, bool $getShared = true)
+	public static function parser($viewPath = null, $config = null, bool $getShared = true)
 	{
 		if ($getShared)
 		{
@@ -444,6 +444,12 @@ class Services extends BaseService
 		if (is_null($config))
 		{
 			$config = new \Config\View();
+		}
+
+		if (is_null($viewPath))
+		{
+			$paths = config('Paths');
+			$viewPath = $paths->viewDirectory;
 		}
 
 		return new \CodeIgniter\View\Parser($config, $viewPath, static::locator(true), CI_DEBUG, static::logger(true));

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -37,6 +37,7 @@
  */
 
 use CodeIgniter\API\ResponseTrait;
+use Config\Paths;
 
 /**
  * Exceptions manager
@@ -259,7 +260,8 @@ class Exceptions
 		$path = $this->viewPath;
 		if (empty($path))
 		{
-			$path = APPPATH . 'Views/errors/';
+			$paths = new Paths();
+			$path = $paths->viewDirectory . '/errors/';
 		}
 
 		$path = is_cli()


### PR DESCRIPTION

**Description**
Default view directory name is not work in  CodeIgniter\Config\Services\parser.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
