### PR TITLE
Seeder adds default namespace to seeds

### DIFF
--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -154,6 +154,9 @@ class Seeder
 				throw new \InvalidArgumentException('The specified Seeder is not a valid file: ' . $path);
 			}
 
+			// Assume the class has the correct namespace
+			$class = APP_NAMESPACE . '\Database\Seeds\\' . $class;
+
 			if (! class_exists($class, false))
 			{
 				require_once $path;


### PR DESCRIPTION
Seeder adds default namespace to seeds when no namespace has been provided. Fixes #1720

