### PR TITLE
Log an error if redis authentication is failed.

### DIFF
--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -117,7 +117,7 @@ class RedisHandler implements CacheInterface
 
 			if (isset($config['password']) && ! $this->redis->auth($config['password']))
 			{
-				//              log_message('error', 'Cache: Redis authentication failed.');
+				log_message('error', 'Cache: Redis authentication failed.');
 			}
 
 			if (isset($config['database']) && ! $this->redis->select($config['database']))


### PR DESCRIPTION
**Description**
Log an error if redis authentication is failed in Cache RedisHandler

**Checklist:**
- [ Y ] Securely signed commits
- [ N/A ] Component(s) with PHPdocs
- [ N/A ] Unit testing, with >80% coverage
- [ N/A ] User guide updated
- [ Y ] Conforms to style guide
