### PR TITLE
Accommodate long travis execution times

### DIFF
--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -174,7 +174,7 @@ class EntityTest extends \CIUnitTestCase
 		$time = $entity->created_at;
 
 		$this->assertInstanceOf(Time::class, $time);
-		$this->assertEquals(date('Y-m-d H:i:s', $stamp), $time->format('Y-m-d H:i:s'));
+		$this->assertCloseEnoughString(date('Y-m-d H:i:s', $stamp), $time->format('Y-m-d H:i:s'));
 	}
 
 	public function testDateMutationFromDatetime()
@@ -186,7 +186,7 @@ class EntityTest extends \CIUnitTestCase
 		$time = $entity->created_at;
 
 		$this->assertInstanceOf(Time::class, $time);
-		$this->assertEquals($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
+		$this->assertCloseEnoughString($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
 	}
 
 	public function testDateMutationFromTime()
@@ -198,7 +198,7 @@ class EntityTest extends \CIUnitTestCase
 		$time = $entity->created_at;
 
 		$this->assertInstanceOf(Time::class, $time);
-		$this->assertEquals($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
+		$this->assertCloseEnoughString($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
 	}
 
 	public function testDateMutationStringToTime()
@@ -223,7 +223,7 @@ class EntityTest extends \CIUnitTestCase
 		$time = $this->getPrivateProperty($entity, 'created_at');
 
 		$this->assertInstanceOf(Time::class, $time);
-		$this->assertEquals(date('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
+		$this->assertCloseEnoughString(date('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
 	}
 
 	public function testDateMutationDatetimeToTime()
@@ -236,7 +236,7 @@ class EntityTest extends \CIUnitTestCase
 		$time = $this->getPrivateProperty($entity, 'created_at');
 
 		$this->assertInstanceOf(Time::class, $time);
-		$this->assertEquals($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
+		$this->assertCloseEnoughString($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
 	}
 
 	public function testDateMutationTimeToTime()
@@ -249,7 +249,7 @@ class EntityTest extends \CIUnitTestCase
 		$time = $this->getPrivateProperty($entity, 'created_at');
 
 		$this->assertInstanceOf(Time::class, $time);
-		$this->assertEquals($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
+		$this->assertCloseEnoughString($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -167,7 +167,7 @@ class TimeTest extends \CIUnitTestCase
 	{
 		$time = Time::createFromTime(10, 03, 05, 'Europe/London');
 
-		$this->assertEquals(date('Y-m-d 10:03:05'), $time->toDateTimeString());
+		$this->assertCloseEnoughString(date('Y-m-d 10:03:05'), $time->toDateTimeString());
 	}
 
 	public function testCreateFromFormat()
@@ -177,7 +177,7 @@ class TimeTest extends \CIUnitTestCase
 		Time::setTestNow($now);
 		$time = Time::createFromFormat('F j, Y', 'January 15, 2017', 'America/Chicago');
 
-		$this->assertEquals(date('2017-01-15 H:i:s', $now->getTimestamp()), $time->toDateTimeString());
+		$this->assertCloseEnoughString(date('2017-01-15 H:i:s', $now->getTimestamp()), $time->toDateTimeString());
 		Time::setTestNow();
 	}
 


### PR DESCRIPTION
Some of the travis-ci timings are a second off because of long execution times.
This addresses those by checking if two formatted time resutls are "close enough", i.e. no more than 1 second different.