### PR TITLE
Remove reference to Encryption Key in User Guide

### DIFF
--- a/user_guide_src/source/installation/running.rst
+++ b/user_guide_src/source/installation/running.rst
@@ -16,8 +16,7 @@ Initial Configuration & Setup
 =================================================
 
 #. Open the **app/Config/App.php** file with a text editor and
-   set your base URL. If you intend to use encryption or sessions, set
-   your encryption key. If you need more flexibility, the baseURL may
+   set your base URL. If you need more flexibility, the baseURL may
    be set within the ``.env`` file as **app.baseURL="http://example.com"**.
 #. If you intend to use a database, open the
    **app/Config/Database.php** file with a text editor and set your


### PR DESCRIPTION
**Description**
The app config file no longer has an encryption key setting, which used to be required in order to use Sessions. This has caused some confusion on the forums and should probably be removed until if changes to the Session class require it.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
