### PR TITLE
Fixed typo preventing link format

### DIFF
--- a/user_guide_src/source/intro/psr.rst
+++ b/user_guide_src/source/intro/psr.rst
@@ -10,7 +10,7 @@ status of our compliance with the various accepted, and some draft, proposals.
 **PSR-1: Basic Coding Standard**
 
 This recommendation covers basic class, method, and file-naming standards. Our 
-`style guide <https://github.com/codeigniter4/CodeIgniter4/blob/develop/contributing/styleguide.rst>_`
+`style guide <https://github.com/codeigniter4/CodeIgniter4/blob/develop/contributing/styleguide.rst>`_
 meets PSR-1 and adds its own requirements on top of it.
 
 **PSR-2: Coding Style Guide**


### PR DESCRIPTION
**Description**
The external link to the style guide under "PSR Compliance" had the underscore in the wrong place.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide

---------Remove from here down in your description----------

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345
- Unsolicited PRs will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository
  
