### PR TITLE
lowercase 'vfsStream' in composer files

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "codeigniter4/codeigniter4-standard": "^1.0",
-        "mikey179/vfsStream": "1.6.*",
+        "mikey179/vfsstream": "1.6.*",
         "phpunit/phpunit": "^7.0",
         "squizlabs/php_codesniffer": "^3.3"
     },

--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -9,7 +9,7 @@
         "codeigniter4/framework": "^4@alpha"
     },
     "require-dev": {
-        "mikey179/vfsStream": "1.6.*",
+        "mikey179/vfsstream": "1.6.*",
         "phpunit/phpunit": "^7.0"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "codeigniter4/codeigniter4-standard": "^1.0",
-        "mikey179/vfsStream": "1.6.*",
+        "mikey179/vfsstream": "1.6.*",
         "phpunit/phpunit": "^7.0",
         "squizlabs/php_codesniffer": "^3.3"
     },


### PR DESCRIPTION
**Description**
Composer gives warnings about uppercase letters in paths. It looks like this one was missed at some point - fixing across 3 package locations.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
