### PR TITLE
Correct the unneeded double-quote (typo)

### DIFF
--- a/system/Language/en/View.php
+++ b/system/Language/en/View.php
@@ -14,7 +14,7 @@
  */
 
 return [
-   'invalidCellMethod'     => '{class}::{method} is not a valid method."',
+   'invalidCellMethod'     => '{class}::{method} is not a valid method.',
    'missingCellParameters' => '{class}::{method} has no params.',
    'invalidCellParameter'  => '{0} is not a valid param name.',
    'noCellClass'           => 'No view cell class provided.',


### PR DESCRIPTION
**Description**
There was an unneeded double-quote that I suggest to be removed.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide