### PR TITLE
decimal rule. shouldn't it accept integers?

### DIFF
--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -128,7 +128,7 @@ class FormatRules
 	 */
 	public function decimal(string $str = null): bool
 	{
-		return (bool) preg_match('/^[\-+]?[0-9]+\.[0-9]+$/', $str);
+		return (bool) preg_match('/^[\-+]?[0-9]+(|\.[0-9]+)$/', $str);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -700,7 +700,7 @@ class FormatRulesTest extends \CIUnitTestCase
 			],
 			[
 				'0',
-				false,
+				true,
 			],
 			[
 				'1.0a',


### PR DESCRIPTION
decimal rule
integers are subset of decimals / floats. so i think  decimal validation rule should pass if value contains decimal OR integer.
