### PR TITLE
passing $primaryKey to entity toRawArray() + save() improvements

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -243,16 +243,16 @@ class Entity
 	//--------------------------------------------------------------------
 
 	/**
-	 * Gets original property value
+	 * Gets original property value or $defaultValue specified by parameter if original value is not set OR null
 	 *
 	 * @param string $key
+	 * @param null $defaultValue
 	 *
 	 * @return mixed
 	 */
-	
-	public function getOriginalValue(string $key)
+	public function getOriginalValue(string $key, $defaultValue = null)
 	{
-		return $this->_original[$key] ?? false;
+		return $this->_original[$key] ?? $defaultValue;
 	}
 	
 	//--------------------------------------------------------------------
@@ -390,6 +390,7 @@ class Entity
 	 * attribute will be reset to that default value.
 	 *
 	 * @param string $key
+	 * @throws \ReflectionException
 	 */
 	public function __unset(string $key)
 	{

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -199,9 +199,10 @@ class Entity
 	 *
 	 * @param boolean $onlyChanged
 	 *
+	 * @param null|string $primaryKey
 	 * @return array
 	 */
-	public function toRawArray(bool $onlyChanged = false): array
+	public function toRawArray(bool $onlyChanged = false, ?string $primaryKey = null): array
 	{
 		$return = [];
 
@@ -214,7 +215,7 @@ class Entity
 				continue;
 			}
 
-			if ($onlyChanged && ! $this->hasPropertyChanged($key, $value))
+			if ($onlyChanged && ! $this->hasPropertyChanged($key, $value) && $key !== $primaryKey)
 			{
 				continue;
 			}

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -240,6 +240,23 @@ class Entity
 	{
 		return ! (($this->_original[$key] === null && $value === null) || $this->_original[$key] === $value);
 	}
+	
+	//--------------------------------------------------------------------
+
+	/**
+	 * Gets original property value
+	 *
+	 * @param string $key
+	 *
+	 * @return mixed
+	 */
+	
+	public function getOriginalValue(string $key)
+	{
+		return $this->_original[$key] ?? null;
+	}
+	
+	//--------------------------------------------------------------------
 
 	/**
 	 * Magic method to allow retrieval of protected and private

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -199,10 +199,9 @@ class Entity
 	 *
 	 * @param boolean $onlyChanged
 	 *
-	 * @param null|string $primaryKey
 	 * @return array
 	 */
-	public function toRawArray(bool $onlyChanged = false, ?string $primaryKey = null): array
+	public function toRawArray(bool $onlyChanged = false): array
 	{
 		$return = [];
 
@@ -215,7 +214,7 @@ class Entity
 				continue;
 			}
 
-			if ($onlyChanged && ! $this->hasPropertyChanged($key, $value) && $key !== $primaryKey)
+			if ($onlyChanged && ! $this->hasPropertyChanged($key, $value))
 			{
 				continue;
 			}

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -252,7 +252,7 @@ class Entity
 	
 	public function getOriginalValue(string $key)
 	{
-		return $this->_original[$key] ?? null;
+		return $this->_original[$key] ?? false;
 	}
 	
 	//--------------------------------------------------------------------

--- a/system/Model.php
+++ b/system/Model.php
@@ -502,13 +502,7 @@ class Model
 	{
 		if (method_exists($data, 'toRawArray'))
 		{
-			$properties = $data->toRawArray(true);
-
-			// Always grab the primary key otherwise updates will fail.
-			if (! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties))
-			{
-				$properties[$primaryKey] = $data->{$primaryKey};
-			}
+			$properties = $data->toRawArray(true, $primaryKey);
 		}
 		else
 		{

--- a/system/Model.php
+++ b/system/Model.php
@@ -524,6 +524,12 @@ class Model
 		if (method_exists($data, 'toRawArray'))
 		{
 			$properties = $data->toRawArray(true, $primaryKey);
+			
+			// Always grab the primary key otherwise updates will fail.
+			if (! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties))
+			{
+				$properties[$primaryKey] = $data->{$primaryKey};
+			}
 		}
 		else
 		{

--- a/system/Model.php
+++ b/system/Model.php
@@ -487,7 +487,7 @@ class Model
 
 		}
 
-		if (empty($data))
+		if (empty($data) || (is_array($data) && count($data) === 1 && array_key_exists($this->primaryKey, $data)))
 		{
 			return true;
 		}
@@ -524,7 +524,7 @@ class Model
 		if (method_exists($data, 'toRawArray'))
 		{
 			$properties = $data->toRawArray(true);
-			
+
 			// Always grab the primary key otherwise updates will fail.
 			if (! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties))
 			{

--- a/system/Model.php
+++ b/system/Model.php
@@ -466,7 +466,7 @@ class Model
 
 			$originalPrimaryKey = method_exists($data, 'getOriginalValue') ?
 				$data->getOriginalValue($this->primaryKey) :
-				($data->{$this->primaryKey} ?? null);
+				($data->{$this->primaryKey} ?? false);
 
 			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat);
 
@@ -475,7 +475,7 @@ class Model
 				return true;
 			}
 
-			if($originalPrimaryKey === null)
+			if($originalPrimaryKey === false)
 			{
 				$response = $this->insert($data);
 			}

--- a/system/Model.php
+++ b/system/Model.php
@@ -523,7 +523,7 @@ class Model
 	{
 		if (method_exists($data, 'toRawArray'))
 		{
-			$properties = $data->toRawArray(true, $primaryKey);
+			$properties = $data->toRawArray(true);
 			
 			// Always grab the primary key otherwise updates will fail.
 			if (! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties))

--- a/system/Model.php
+++ b/system/Model.php
@@ -473,6 +473,11 @@ class Model
 			}
 
 			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat);
+			
+			if(! $asInsert && count($data) === 1 && isset($data[$this->primaryKey]))
+			{
+				return true;
+			}
 		}
 
 		if (empty($data))


### PR DESCRIPTION
Fixing: #1770 
save() will try to insert() instead of update() in some cases [$data is instance of Entity].
i think this is fixing another issue with inserting entities with non-autoincrement primaryKeys - then save() tried to produce update()
we will see what kind of test this will break :D
