### PR TITLE
Add CLI namespace to example

### DIFF
--- a/user_guide_src/source/cli/cli_commands.rst
+++ b/user_guide_src/source/cli/cli_commands.rst
@@ -83,6 +83,7 @@ should contain the following code::
     <?php namespace App\Commands;
 
     use CodeIgniter\CLI\BaseCommand;
+    use CodeIgniter\CLI\CLI;
 
     class AppInfo extends BaseCommand
     {


### PR DESCRIPTION
**Description**
Without CLI\CLI the demo command `run` listed below will fail with: Class 'App\Commands\CLI' not found. Adding the `use` so others don't run into this issue following the guide

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
