### PR TITLE
Migration and Database correction

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -1,7 +1,5 @@
 <?php namespace CodeIgniter\Autoloader;
 
-use Composer\Autoload\ClassLoader;
-
 /**
  * CodeIgniter
  *
@@ -159,7 +157,7 @@ class Autoloader
 
 			include_once $config[$class];
 		}, true, // Throw exception
-			true // Prepend
+		   true // Prepend
 		);
 	}
 
@@ -291,7 +289,7 @@ class Autoloader
 				if (strpos($class, $namespace) === 0)
 				{
 					$filePath = $directory . str_replace('\\', '/',
-							substr($class, strlen($namespace))) . '.php';
+					                                     substr($class, strlen($namespace))) . '.php';
 					$filename = $this->requireFile($filePath);
 
 					if ($filename)
@@ -422,7 +420,7 @@ class Autoloader
 			unset($paths['CodeIgniter\\']);
 		}
 
-		// Composer stores paths with trailng slash. We don't.
+		// Composer stores paths with trailing slash. We don't.
 		$newPaths = [];
 		foreach ($paths as $key => $value)
 		{

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -68,7 +68,7 @@ class Console
 	 * @param boolean $useSafeOutput
 	 *
 	 * @return \CodeIgniter\HTTP\RequestInterface|\CodeIgniter\HTTP\Response|\CodeIgniter\HTTP\ResponseInterface|mixed
-	 * @throws \CodeIgniter\HTTP\RedirectException
+	 * @throws \CodeIgniter\Filters\Exceptions\FilterException
 	 */
 	public function run(bool $useSafeOutput = false)
 	{
@@ -90,8 +90,8 @@ class Console
 		CLI::newLine(1);
 
 		CLI::write(CLI::color('CodeIgniter CLI Tool', 'green')
-				. ' - Version ' . CodeIgniter::CI_VERSION
-				. ' - Server-Time: ' . date('Y-m-d H:i:sa'));
+		           . ' - Version ' . CodeIgniter::CI_VERSION
+		           . ' - Server-Time: ' . date('Y-m-d H:i:sa'));
 
 		CLI::newLine(1);
 	}

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -580,11 +580,11 @@ abstract class BaseConnection implements ConnectionInterface
 	/**
 	 * Executes the query against the database.
 	 *
-	 * @param $sql
+	 * @param string $sql
 	 *
 	 * @return mixed
 	 */
-	abstract protected function execute($sql);
+	abstract protected function execute(string $sql);
 
 	//--------------------------------------------------------------------
 
@@ -1262,7 +1262,7 @@ abstract class BaseConnection implements ConnectionInterface
 		}
 		// Avoid breaking functions and literal values inside queries
 		elseif (ctype_digit($item) || $item[0] === "'" || ( $this->escapeChar !== '"' && $item[0] === '"') ||
-				strpos($item, '(') !== false
+			strpos($item, '(') !== false
 		)
 		{
 			return $item;
@@ -1413,14 +1413,14 @@ abstract class BaseConnection implements ConnectionInterface
 		if ($like === true)
 		{
 			return str_replace([
-				$this->likeEscapeChar,
-				'%',
-				'_',
-			], [
-				$this->likeEscapeChar . $this->likeEscapeChar,
-				$this->likeEscapeChar . '%',
-				$this->likeEscapeChar . '_',
-			], $str
+				                   $this->likeEscapeChar,
+				                   '%',
+				                   '_',
+			                   ], [
+				                   $this->likeEscapeChar . $this->likeEscapeChar,
+				                   $this->likeEscapeChar . '%',
+				                   $this->likeEscapeChar . '_',
+			                   ], $str
 			);
 		}
 

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -223,6 +223,10 @@ class MigrationRunner
 		// Sequential versions need adjusting to 3 places so they can be found later.
 		if ($this->type === 'sequential')
 		{
+			if ($targetVersion == '0')
+			{
+				return true;
+			}
 			$targetVersion = str_pad($targetVersion, 3, '0', STR_PAD_LEFT);
 		}
 
@@ -256,8 +260,7 @@ class MigrationRunner
 		foreach ($migrations as $version => $migration)
 		{
 			// Only include migrations within the scoop
-			if (($method === 'up' && $version > $currentVersion && $version <= $targetVersion) || ( $method === 'down' && $version <= $currentVersion && $version > $targetVersion)
-			)
+			if (($method === 'up' && $version > $currentVersion && $version <= $targetVersion) || ( $method === 'down' && $version <= $currentVersion && $version > $targetVersion))
 			{
 				include_once $migration->path;
 				// Get namespaced class name

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -196,7 +196,7 @@ class MigrationRunner
 	 * @param string|null $namespace
 	 * @param string|null $group
 	 *
-	 * @return mixed TRUE if no migrations are found, current version string on success, Exception on failure
+	 * @return mixed TRUE if no migrations are found, current version string on success, False on failure
 	 * @throws ConfigException
 	 */
 	public function version(string $targetVersion, string $namespace = null, string $group = null)
@@ -223,10 +223,6 @@ class MigrationRunner
 		// Sequential versions need adjusting to 3 places so they can be found later.
 		if ($this->type === 'sequential')
 		{
-			if ($targetVersion == '0')
-			{
-				return true;
-			}
 			$targetVersion = str_pad($targetVersion, 3, '0', STR_PAD_LEFT);
 		}
 
@@ -260,7 +256,8 @@ class MigrationRunner
 		foreach ($migrations as $version => $migration)
 		{
 			// Only include migrations within the scoop
-			if (($method === 'up' && $version > $currentVersion && $version <= $targetVersion) || ( $method === 'down' && $version <= $currentVersion && $version > $targetVersion))
+			if (($method === 'up' && $version > $currentVersion && $version <= $targetVersion) || ( $method === 'down' && $version <= $currentVersion && $version > $targetVersion)
+			)
 			{
 				include_once $migration->path;
 				// Get namespaced class name
@@ -294,7 +291,7 @@ class MigrationRunner
 			}
 		}
 
-		return $targetVersion;
+		return true;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -122,7 +122,7 @@ class MigrationRunner
 	/**
 	 * used to return messages for CLI.
 	 *
-	 * @var boolean
+	 * @var array
 	 */
 	protected $cliMessages = [];
 
@@ -196,7 +196,7 @@ class MigrationRunner
 	 * @param string|null $namespace
 	 * @param string|null $group
 	 *
-	 * @return mixed TRUE if no migrations are found, current version string on success, FALSE on failure
+	 * @return mixed TRUE if no migrations are found, current version string on success, Exception on failure
 	 * @throws ConfigException
 	 */
 	public function version(string $targetVersion, string $namespace = null, string $group = null)
@@ -291,7 +291,7 @@ class MigrationRunner
 			}
 		}
 
-		return true;
+		return $targetVersion;
 	}
 
 	//--------------------------------------------------------------------
@@ -608,10 +608,10 @@ class MigrationRunner
 		$this->ensureTable();
 
 		$query = $this->db->table($this->table)
-				->where('group', $group)
-				->where('namespace', $this->namespace)
-				->orderBy('version', 'ASC')
-				->get();
+		                  ->where('group', $group)
+		                  ->where('namespace', $this->namespace)
+		                  ->orderBy('version', 'ASC')
+		                  ->get();
 
 		if (! $query)
 		{
@@ -681,11 +681,11 @@ class MigrationRunner
 		$this->ensureTable();
 
 		$row = $this->db->table($this->table)
-				->select('version')
-				->where('group', $this->group)
-				->where('namespace', $this->namespace)
-				->orderBy('version', 'DESC')
-				->get();
+		                ->select('version')
+		                ->where('group', $this->group)
+		                ->where('namespace', $this->namespace)
+		                ->orderBy('version', 'DESC')
+		                ->get();
 
 		return $row && ! is_null($row->getRow()) ? $row->getRow()->version : '0';
 	}
@@ -695,7 +695,7 @@ class MigrationRunner
 	/**
 	 * Retrieves current schema version
 	 *
-	 * @return string    Current migration version
+	 * @return array    Return messages for CLI
 	 */
 	public function getCliMessages()
 	{
@@ -714,13 +714,13 @@ class MigrationRunner
 	protected function addHistory(string $version)
 	{
 		$this->db->table($this->table)
-				->insert([
-					'version'   => $version,
-					'name'      => $this->name,
-					'group'     => $this->group,
-					'namespace' => $this->namespace,
-					'time'      => time(),
-				]);
+		         ->insert([
+			                  'version'   => $version,
+			                  'name'      => $this->name,
+			                  'group'     => $this->group,
+			                  'namespace' => $this->namespace,
+			                  'time'      => time(),
+		                  ]);
 		if (is_cli())
 		{
 			$this->cliMessages[] = "\t" . CLI::color(lang('Migrations.added'), 'yellow') . "($this->namespace) " . $version . '_' . $this->name;
@@ -737,10 +737,10 @@ class MigrationRunner
 	protected function removeHistory(string $version)
 	{
 		$this->db->table($this->table)
-				->where('version', $version)
-				->where('group', $this->group)
-				->where('namespace', $this->namespace)
-				->delete();
+		         ->where('version', $version)
+		         ->where('group', $this->group)
+		         ->where('namespace', $this->namespace)
+		         ->delete();
 		if (is_cli())
 		{
 			$this->cliMessages[] = "\t" . CLI::color(lang('Migrations.removed'), 'yellow') . "($this->namespace) " . $version . '_' . $this->name;
@@ -763,32 +763,32 @@ class MigrationRunner
 		$forge = \Config\Database::forge($this->db);
 
 		$forge->addField([
-			'version'   => [
-				'type'       => 'VARCHAR',
-				'constraint' => 255,
-				'null'       => false,
-			],
-			'name'      => [
-				'type'       => 'VARCHAR',
-				'constraint' => 255,
-				'null'       => false,
-			],
-			'group'     => [
-				'type'       => 'VARCHAR',
-				'constraint' => 255,
-				'null'       => false,
-			],
-			'namespace' => [
-				'type'       => 'VARCHAR',
-				'constraint' => 255,
-				'null'       => false,
-			],
-			'time'      => [
-				'type'       => 'INT',
-				'constraint' => 11,
-				'null'       => false,
-			],
-		]);
+			                 'version'   => [
+				                 'type'       => 'VARCHAR',
+				                 'constraint' => 255,
+				                 'null'       => false,
+			                 ],
+			                 'name'      => [
+				                 'type'       => 'VARCHAR',
+				                 'constraint' => 255,
+				                 'null'       => false,
+			                 ],
+			                 'group'     => [
+				                 'type'       => 'VARCHAR',
+				                 'constraint' => 255,
+				                 'null'       => false,
+			                 ],
+			                 'namespace' => [
+				                 'type'       => 'VARCHAR',
+				                 'constraint' => 255,
+				                 'null'       => false,
+			                 ],
+			                 'time'      => [
+				                 'type'       => 'INT',
+				                 'constraint' => 11,
+				                 'null'       => false,
+			                 ],
+		                 ]);
 
 		$forge->createTable($this->table, true);
 

--- a/system/Database/MySQLi/Utils.php
+++ b/system/Database/MySQLi/Utils.php
@@ -1,5 +1,7 @@
 <?php namespace CodeIgniter\Database\MySQLi;
 
+use CodeIgniter\Database\Exceptions\DatabaseException;
+
 /**
  * CodeIgniter
  *

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -116,39 +116,39 @@ class Forge extends \CodeIgniter\Database\Forge
 			if (version_compare($this->db->getVersion(), '8', '>=') && isset($data['type']))
 			{
 				$sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
-						. " TYPE {$data['type']}{$data['length']}";
+					. " TYPE {$data['type']}{$data['length']}";
 			}
 
 			if (! empty($data['default']))
 			{
 				$sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
-						. " SET DEFAULT {$data['default']}";
+					. " SET DEFAULT {$data['default']}";
 			}
 
 			if (isset($data['null']))
 			{
 				$sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
-						. ($data['null'] === true ? ' DROP' : ' SET') . ' NOT NULL';
+					. ($data['null'] === true ? ' DROP' : ' SET') . ' NOT NULL';
 			}
 
 			if (! empty($data['new_name']))
 			{
 				$sqls[] = $sql . ' RENAME COLUMN ' . $this->db->escapeIdentifiers($data['name'])
-						. ' TO ' . $this->db->escapeIdentifiers($data['new_name']);
+					. ' TO ' . $this->db->escapeIdentifiers($data['new_name']);
 			}
 
 			if (! empty($data['comment']))
 			{
 				$sqls[] = 'COMMENT ON COLUMN' . $this->db->escapeIdentifiers($table)
-						. '.' . $this->db->escapeIdentifiers($data['name'])
-						. " IS {$data['comment']}";
+					. '.' . $this->db->escapeIdentifiers($data['name'])
+					. " IS {$data['comment']}";
 			}
 		}
 
 		return $sqls;
 	}
 
-		//--------------------------------------------------------------------
+	//--------------------------------------------------------------------
 
 	/**
 	 * Process column
@@ -159,11 +159,11 @@ class Forge extends \CodeIgniter\Database\Forge
 	protected function _processColumn($field)
 	{
 		return $this->db->escapeIdentifiers($field['name'])
-				. ' ' . $field['type'] . $field['length']
-				. $field['default']
-				. $field['null']
-				. $field['auto_increment']
-				. $field['unique'];
+			. ' ' . $field['type'] . $field['length']
+			. $field['default']
+			. $field['null']
+			. $field['auto_increment']
+			. $field['unique'];
 	}
 
 	//--------------------------------------------------------------------
@@ -190,15 +190,14 @@ class Forge extends \CodeIgniter\Database\Forge
 			case 'TINYINT':
 				$attributes['TYPE']     = 'SMALLINT';
 				$attributes['UNSIGNED'] = false;
-				return;
+				break;
 			case 'MEDIUMINT':
 				$attributes['TYPE']     = 'INTEGER';
 				$attributes['UNSIGNED'] = false;
-				return;
+				break;
 			case 'DATETIME':
 				$attributes['TYPE'] = 'TIMESTAMP';
-			default:
-				return;
+				break;
 		}
 	}
 

--- a/system/Database/Postgre/Utils.php
+++ b/system/Database/Postgre/Utils.php
@@ -1,5 +1,7 @@
 <?php namespace CodeIgniter\Database\Postgre;
 
+use CodeIgniter\Database\Exceptions\DatabaseException;
+
 /**
  * CodeIgniter
  *

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -161,7 +161,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return mixed    \SQLite3Result object or bool
 	 */
-	public function execute($sql)
+	public function execute(string $sql)
 	{
 		return $this->isWriteType($sql)
 			? $this->connID->exec($sql)
@@ -206,9 +206,9 @@ class Connection extends BaseConnection implements ConnectionInterface
 	protected function _listTables($prefixLimit = false): string
 	{
 		return 'SELECT "NAME" FROM "SQLITE_MASTER" WHERE "TYPE" = \'table\''
-			   . (($prefixLimit !== false && $this->DBPrefix !== '')
+			. (($prefixLimit !== false && $this->DBPrefix !== '')
 				? ' AND "NAME" LIKE \'' . $this->escapeLikeString($this->DBPrefix) . '%\' ' . sprintf($this->likeEscapeStr,
-					$this->likeEscapeChar)
+				                                                                                      $this->likeEscapeChar)
 				: '');
 	}
 
@@ -231,7 +231,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @param string $table Table name
 	 *
-	 * @return array|false
+	 * @return array|bool
 	 * @throws DatabaseException
 	 */
 	public function getFieldNames($table)
@@ -302,7 +302,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	public function _fieldData(string $table): array
 	{
 		if (($query = $this->query('PRAGMA TABLE_INFO(' . $this->protectIdentifiers($table, true, null,
-					false) . ')')) === false)
+		                                                                            false) . ')')) === false)
 		{
 			throw new DatabaseException(lang('Database.failGetFieldData'));
 		}
@@ -485,6 +485,8 @@ class Connection extends BaseConnection implements ConnectionInterface
 
 	/**
 	 * Determines if the statement is a write-type query or not.
+	 *
+	 * @param $sql
 	 *
 	 * @return boolean
 	 */

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -98,7 +98,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 * @param string $db_name
 	 *
 	 * @return boolean
-	 * @throws \CodeIgniter\DatabaseException
+	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
 	public function dropDatabase($db_name): bool
 	{
@@ -158,8 +158,8 @@ class Forge extends \CodeIgniter\Database\Forge
 				$sqlTable = new Table($this->db, $this);
 
 				$sqlTable->fromTable($table)
-					->dropColumn($field)
-					->run();
+				         ->dropColumn($field)
+				         ->run();
 
 				return '';
 				break;
@@ -167,8 +167,8 @@ class Forge extends \CodeIgniter\Database\Forge
 				$sqlTable = new Table($this->db, $this);
 
 				$sqlTable->fromTable($table)
-						 ->modifyColumn($field)
-						 ->run();
+				         ->modifyColumn($field)
+				         ->run();
 
 				return null;
 				break;
@@ -195,11 +195,11 @@ class Forge extends \CodeIgniter\Database\Forge
 		}
 
 		return $this->db->escapeIdentifiers($field['name'])
-			   . ' ' . $field['type']
-			   . $field['auto_increment']
-			   . $field['null']
-			   . $field['unique']
-			   . $field['default'];
+			. ' ' . $field['type']
+			. $field['auto_increment']
+			. $field['null']
+			. $field['unique']
+			. $field['default'];
 	}
 
 	//--------------------------------------------------------------------
@@ -234,14 +234,14 @@ class Forge extends \CodeIgniter\Database\Forge
 			if (in_array($i, $this->uniqueKeys))
 			{
 				$sqls[] = 'CREATE UNIQUE INDEX ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
-						  . ' ON ' . $this->db->escapeIdentifiers($table)
-						  . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
+					. ' ON ' . $this->db->escapeIdentifiers($table)
+					. ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
 				continue;
 			}
 
 			$sqls[] = 'CREATE INDEX ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
-					  . ' ON ' . $this->db->escapeIdentifiers($table)
-					  . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
+				. ' ON ' . $this->db->escapeIdentifiers($table)
+				. ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
 		}
 
 		return $sqls;

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -37,6 +37,7 @@
  */
 
 use CodeIgniter\Database\BaseResult;
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\ResultInterface;
 
 /**
@@ -130,7 +131,7 @@ class Result extends BaseResult implements ResultInterface
 	 * @param integer $n
 	 *
 	 * @return mixed
-	 * @throws \CodeIgniter\DatabaseException
+	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
 	public function dataSeek($n = 0)
 	{
@@ -168,7 +169,7 @@ class Result extends BaseResult implements ResultInterface
 	 *
 	 * @param string $className
 	 *
-	 * @return object
+	 * @return bool|object
 	 */
 	protected function fetchObject($className = 'stdClass')
 	{

--- a/system/Database/SQLite3/Utils.php
+++ b/system/Database/SQLite3/Utils.php
@@ -1,5 +1,7 @@
 <?php namespace CodeIgniter\Database\SQLite3;
 
+use CodeIgniter\Database\Exceptions\DatabaseException;
+
 /**
  * CodeIgniter
  *

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -343,7 +343,7 @@ Class Reference
 		:param	mixed	$namespace: application namespace, if null (App) namespace will be used.
 		:param	mixed	$group: database group name, if null default database group will be used.
 		:param	mixed	$target_version: Migration version to process
-		:returns:	TRUE if no migrations are found, current version string on success, Exception on failure
+		:returns:	TRUE if no migrations are found, current version string on success, FALSE on failure
 		:rtype:	mixed
 
 		Version can be used to roll back changes or step forwards programmatically to
@@ -362,7 +362,6 @@ Class Reference
 
 	    $migration->setNamespace($path)
 	              ->latest();
-
 	.. php:method:: setGroup($group)
 
 	  :param  string  $group: database group name.
@@ -373,4 +372,3 @@ Class Reference
 
 	    $migration->setNamespace($path)
 	              ->latest();
-

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -343,7 +343,7 @@ Class Reference
 		:param	mixed	$namespace: application namespace, if null (App) namespace will be used.
 		:param	mixed	$group: database group name, if null default database group will be used.
 		:param	mixed	$target_version: Migration version to process
-		:returns:	TRUE if no migrations are found, current version string on success, FALSE on failure
+		:returns:	TRUE if no migrations are found, current version string on success, Exception on failure
 		:rtype:	mixed
 
 		Version can be used to roll back changes or step forwards programmatically to
@@ -362,6 +362,7 @@ Class Reference
 
 	    $migration->setNamespace($path)
 	              ->latest();
+
 	.. php:method:: setGroup($group)
 
 	  :param  string  $group: database group name.
@@ -372,3 +373,4 @@ Class Reference
 
 	    $migration->setNamespace($path)
 	              ->latest();
+


### PR DESCRIPTION
Resolved - MigrationRunner::version should return "current version string on success" #1766
Importing namespaces
Correction in return types
Spell checks

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide