### PR TITLE
Spelling and Typos corrections

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -213,7 +213,7 @@ class Autoloader
 	 *
 	 * @return array
 	 */
-	public function getNamespace(string $prefix = null)
+	public function getNamespace(string $prefix = null): array
 	{
 		if ($prefix === null)
 		{
@@ -246,7 +246,7 @@ class Autoloader
 	 *
 	 * @param string $class The fully qualified class name.
 	 *
-	 * @return string|false The mapped file on success, or boolean false
+	 * @return string|boolean The mapped file on success, or boolean false
 	 *                          on failure.
 	 */
 	public function loadClass(string $class)
@@ -273,7 +273,7 @@ class Autoloader
 	 *
 	 * @param string $class The fully-qualified class name
 	 *
-	 * @return string|false The mapped file name on success, or boolean false on fail
+	 * @return string|boolean The mapped file name on success, or boolean false on fail
 	 */
 	protected function loadInNamespace(string $class)
 	{
@@ -353,7 +353,7 @@ class Autoloader
 	 *
 	 * @param string $file
 	 *
-	 * @return string|false The filename on success, false if the file is not loaded
+	 * @return string|boolean The filename on success, false if the file is not loaded
 	 */
 	protected function requireFile(string $file)
 	{
@@ -422,7 +422,7 @@ class Autoloader
 			unset($paths['CodeIgniter\\']);
 		}
 
-		// Composer stores paths with trailng slash. We don't.
+		// Composer stores paths with trailing slash. We don't.
 		$newPaths = [];
 		foreach ($paths as $key => $value)
 		{

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -73,7 +73,7 @@ class FileLocator
 	 * @param string $folder The folder within the namespace that we should look for the file.
 	 * @param string $ext    The file extension the file should have.
 	 *
-	 * @return string|false The path to the file, or false if not found.
+	 * @return string|boolean The path to the file, or false if not found.
 	 */
 	public function locateFile(string $file, string $folder = null, string $ext = 'php')
 	{
@@ -298,7 +298,7 @@ class FileLocator
 	 *
 	 * @param string $path
 	 *
-	 * @return string|false The qualified name or false if the path is not found
+	 * @return string|boolean The qualified name or false if the path is not found
 	 */
 	public function findQualifiedNameFromPath(string $path)
 	{
@@ -383,7 +383,7 @@ class FileLocator
 	 * @param string      $file
 	 * @param string|null $folder
 	 *
-	 * @return string|false The path to the file, or false if not found.
+	 * @return string|boolean The path to the file, or false if not found.
 	 */
 	protected function legacyLocate(string $file, string $folder = null)
 	{

--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -227,7 +227,7 @@ abstract class BaseCommand
 	 *
 	 * @return integer
 	 */
-	public function getPad($array, int $pad)
+	public function getPad($array, int $pad): int
 	{
 		$max = 0;
 		foreach ($array as $key => $value)

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -270,7 +270,7 @@ class CLI
 	 * @return             boolean
 	 * @codeCoverageIgnore
 	 */
-	protected static function validate($field, $value, $rules)
+	protected static function validate($field, $value, $rules): bool
 	{
 		$validation = \Config\Services::validation(null, false);
 		$validation->setRule($field, null, $rules);
@@ -436,7 +436,7 @@ class CLI
 	 *
 	 * @return string    The color coded string
 	 */
-	public static function color(string $text, string $foreground, string $background = null, string $format = null)
+	public static function color(string $text, string $foreground, string $background = null, string $format = null): string
 	{
 		if (static::isWindows() && ! isset($_SERVER['ANSICON']))
 		{
@@ -655,7 +655,7 @@ class CLI
 	 * Parses the command line it was called from and collects all
 	 * options and valid segments.
 	 *
-	 * I tried to use getopt but had it fail occassionally to find any
+	 * I tried to use getopt but had it fail occasionally to find any
 	 * options but argc has always had our back. We don't have all of the power
 	 * of getopt but this does us just fine.
 	 */
@@ -706,7 +706,7 @@ class CLI
 	 *
 	 * @return string
 	 */
-	public static function getURI()
+	public static function getURI(): string
 	{
 		return implode('/', static::$segments);
 	}
@@ -743,7 +743,7 @@ class CLI
 	 *
 	 * @return array
 	 */
-	public static function getSegments()
+	public static function getSegments(): array
 	{
 		return static::$segments;
 	}
@@ -779,7 +779,7 @@ class CLI
 	 *
 	 * @return array
 	 */
-	public static function getOptions()
+	public static function getOptions(): array
 	{
 		return static::$options;
 	}
@@ -819,14 +819,14 @@ class CLI
 	//--------------------------------------------------------------------
 
 	/**
-	 * Returns a well formated table
+	 * Returns a well formatted table
 	 *
 	 * @param array $tbody List of rows
 	 * @param array $thead List of columns
 	 *
 	 * @return string
 	 */
-	public static function table(array $tbody, array $thead = [])
+	public static function table(array $tbody, array $thead = []): string
 	{
 		// All the rows in the table will be here until the end
 		$table_rows = [];

--- a/system/CLI/CommandRunner.php
+++ b/system/CLI/CommandRunner.php
@@ -187,7 +187,7 @@ class CommandRunner extends Controller
 	 *
 	 * @return array
 	 */
-	public function getCommands()
+	public function getCommands(): array
 	{
 		return $this->commands;
 	}

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -68,7 +68,7 @@ class Console
 	 * @param boolean $useSafeOutput
 	 *
 	 * @return \CodeIgniter\HTTP\RequestInterface|\CodeIgniter\HTTP\Response|\CodeIgniter\HTTP\ResponseInterface|mixed
-	 * @throws \CodeIgniter\HTTP\RedirectException
+	 * @throws \CodeIgniter\Filters\Exceptions\FilterException
 	 */
 	public function run(bool $useSafeOutput = false)
 	{

--- a/system/Commands/Database/MigrateLatest.php
+++ b/system/Commands/Database/MigrateLatest.php
@@ -142,7 +142,7 @@ class MigrateLatest extends BaseCommand
 	 * @param  array $params
 	 * @return boolean
 	 */
-	private function isAllNamespace(array $params)
+	private function isAllNamespace(array $params): bool
 	{
 		if (array_search('-all', $params) !== false)
 		{

--- a/system/Commands/Database/MigrateRollback.php
+++ b/system/Commands/Database/MigrateRollback.php
@@ -162,7 +162,7 @@ class MigrateRollback extends BaseCommand
 	 * @param  array $params
 	 * @return boolean
 	 */
-	private function isAllNamespace(array $params)
+	private function isAllNamespace(array $params): bool
 	{
 		if (array_search('-all', $params) !== false)
 		{

--- a/system/Commands/Help.php
+++ b/system/Commands/Help.php
@@ -37,7 +37,6 @@
  */
 
 use CodeIgniter\CLI\BaseCommand;
-use CodeIgniter\CLI\CLI;
 
 /**
  * CI Help command for the spark script.

--- a/system/Commands/ListCommands.php
+++ b/system/Commands/ListCommands.php
@@ -174,13 +174,13 @@ class ListCommands extends BaseCommand
 	 * Pads our string out so that all titles are the same length to nicely line up descriptions.
 	 *
 	 * @param string  $item
-	 * @param $max
+	 * @param integer $max
 	 * @param integer $extra  // How many extra spaces to add at the end
 	 * @param integer $indent
 	 *
 	 * @return array
 	 */
-	protected function padTitle(string $item, $max, $extra = 2, $indent = 0)
+	protected function padTitle(string $item, int $max, int $extra = 2, int $indent = 0): array
 	{
 		$max += $extra + $indent;
 

--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -61,6 +61,11 @@ class Serve extends BaseCommand
 		'-port' => 'The HTTP Host Port [default: "8080"]',
 	];
 
+	/**
+	 * Start the CodeIgniter Development Server
+	 *
+	 * @param array $params
+	 */
 	public function run(array $params)
 	{
 		// Valid PHP Version?

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -15,7 +15,7 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *RouRouddfdf
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  *

--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -71,7 +71,7 @@ class DotEnv
 	 *
 	 * @return boolean
 	 */
-	public function load()
+	public function load(): bool
 	{
 		// We don't want to enforce the presence of a .env file,
 		// they should be optional.

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -123,7 +123,7 @@ class Services extends BaseService
 	 *
 	 * @return \CodeIgniter\HTTP\CURLRequest
 	 */
-	public static function curlrequest(array $options = [], $response = null, \Config\App $config = null, bool $getShared = true)
+	public static function curlrequest(array $options = [], \CodeIgniter\HTTP\ResponseInterface $response = null, \Config\App $config = null, bool $getShared = true)
 	{
 		if ($getShared === true)
 		{
@@ -168,7 +168,7 @@ class Services extends BaseService
 		\Config\Exceptions $config = null,
 		\CodeIgniter\HTTP\IncomingRequest $request = null,
 		\CodeIgniter\HTTP\Response $response = null,
-		$getShared = true
+		bool $getShared = true
 	)
 	{
 		if ($getShared)
@@ -233,7 +233,7 @@ class Services extends BaseService
 	 *
 	 * @return \CodeIgniter\Honeypot\Honeypot|mixed
 	 */
-	public static function honeypot(BaseConfig $config = null, $getShared = true)
+	public static function honeypot(BaseConfig $config = null, bool $getShared = true)
 	{
 		if ($getShared)
 		{
@@ -290,7 +290,7 @@ class Services extends BaseService
 	 *
 	 * @return \CodeIgniter\Debug\Iterator
 	 */
-	public static function iterator($getShared = true)
+	public static function iterator(bool $getShared = true)
 	{
 		if ($getShared)
 		{
@@ -336,7 +336,7 @@ class Services extends BaseService
 	 *
 	 * @return \CodeIgniter\Log\Logger
 	 */
-	public static function logger($getShared = true)
+	public static function logger(bool $getShared = true)
 	{
 		if ($getShared)
 		{
@@ -434,7 +434,7 @@ class Services extends BaseService
 	 *
 	 * @return \CodeIgniter\View\Parser
 	 */
-	public static function parser($viewPath = null, $config = null, bool $getShared = true)
+	public static function parser(string $viewPath = null, $config = null, bool $getShared = true)
 	{
 		if ($getShared)
 		{
@@ -468,7 +468,7 @@ class Services extends BaseService
 	 *
 	 * @return \CodeIgniter\View\View
 	 */
-	public static function renderer($viewPath = null, $config = null, bool $getShared = true)
+	public static function renderer(string $viewPath = null, $config = null, bool $getShared = true)
 	{
 		if ($getShared)
 		{
@@ -584,7 +584,7 @@ class Services extends BaseService
 	 *
 	 * @return \CodeIgniter\Router\RouteCollection
 	 */
-	public static function routes($getShared = true)
+	public static function routes(bool $getShared = true)
 	{
 		if ($getShared)
 		{
@@ -693,7 +693,7 @@ class Services extends BaseService
 	 *
 	 * @return \CodeIgniter\Throttle\Throttler
 	 */
-	public static function throttler($getShared = true)
+	public static function throttler(bool $getShared = true)
 	{
 		if ($getShared)
 		{
@@ -713,7 +713,7 @@ class Services extends BaseService
 	 *
 	 * @return \CodeIgniter\Debug\Timer
 	 */
-	public static function timer($getShared = true)
+	public static function timer(bool $getShared = true)
 	{
 		if ($getShared)
 		{
@@ -756,7 +756,7 @@ class Services extends BaseService
 	 *
 	 * @return \CodeIgniter\HTTP\URI
 	 */
-	public static function uri($uri = null, bool $getShared = true)
+	public static function uri(string $uri = null, bool $getShared = true)
 	{
 		if ($getShared)
 		{
@@ -801,7 +801,7 @@ class Services extends BaseService
 	 *
 	 * @return \CodeIgniter\View\Cell
 	 */
-	public static function viewcell($getShared = true)
+	public static function viewcell(bool $getShared = true)
 	{
 		if ($getShared)
 		{
@@ -820,7 +820,7 @@ class Services extends BaseService
 	 *
 	 * @return \CodeIgniter\Typography\Typography
 	 */
-	public static function typography($getShared = true)
+	public static function typography(bool $getShared = true)
 	{
 		if ($getShared)
 		{

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -315,7 +315,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function selectMax($select = '', $alias = '')
+	public function selectMax(string $select = '', string $alias = '')
 	{
 		return $this->maxMinAvgSum($select, $alias, 'MAX');
 	}
@@ -332,7 +332,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function selectMin($select = '', $alias = '')
+	public function selectMin(string $select = '', string $alias = '')
 	{
 		return $this->maxMinAvgSum($select, $alias, 'MIN');
 	}
@@ -349,7 +349,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function selectAvg($select = '', $alias = '')
+	public function selectAvg(string $select = '', string $alias = '')
 	{
 		return $this->maxMinAvgSum($select, $alias, 'AVG');
 	}
@@ -366,7 +366,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function selectSum($select = '', $alias = '')
+	public function selectSum(string $select = '', string $alias = '')
 	{
 		return $this->maxMinAvgSum($select, $alias, 'SUM');
 	}
@@ -388,7 +388,7 @@ class BaseBuilder
 	 * @return BaseBuilder
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	protected function maxMinAvgSum($select = '', $alias = '', $type = 'MAX')
+	protected function maxMinAvgSum(string $select = '', string $alias = '', string $type = 'MAX')
 	{
 		if (! is_string($select) || $select === '')
 		{
@@ -424,7 +424,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function createAliasFromTable($item)
+	protected function createAliasFromTable(string $item): string
 	{
 		if (strpos($item, '.') !== false)
 		{
@@ -447,7 +447,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function distinct($val = true)
+	public function distinct(bool $val = true)
 	{
 		$this->QBDistinct = is_bool($val) ? $val : true;
 
@@ -466,7 +466,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function from($from, $overwrite = false)
+	public function from($from, bool $overwrite = false)
 	{
 		if ($overwrite === true)
 		{
@@ -515,7 +515,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function join($table, $cond, $type = '', $escape = null)
+	public function join(string $table, string $cond, string $type = '', string $escape = null)
 	{
 		if ($type !== '')
 		{
@@ -603,7 +603,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function where($key, $value = null, $escape = null)
+	public function where($key, $value = null, bool $escape = null)
 	{
 		return $this->whereHaving('QBWhere', $key, $value, 'AND ', $escape);
 	}
@@ -622,7 +622,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function orWhere($key, $value = null, $escape = null)
+	public function orWhere($key, $value = null, bool $escape = null)
 	{
 		return $this->whereHaving('QBWhere', $key, $value, 'OR ', $escape);
 	}
@@ -645,7 +645,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	protected function whereHaving($qb_key, $key, $value = null, $type = 'AND ', $escape = null)
+	protected function whereHaving(string $qb_key, $key, $value = null, string $type = 'AND ', bool $escape = null)
 	{
 		if (! is_array($key))
 		{
@@ -710,7 +710,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function whereIn($key = null, $values = null, $escape = null)
+	public function whereIn(string $key = null, array $values = null, bool $escape = null)
 	{
 		return $this->_whereIn($key, $values, false, 'AND ', $escape);
 	}
@@ -729,7 +729,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function orWhereIn($key = null, $values = null, $escape = null)
+	public function orWhereIn(string $key = null, array $values = null, bool $escape = null)
 	{
 		return $this->_whereIn($key, $values, false, 'OR ', $escape);
 	}
@@ -748,7 +748,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function whereNotIn($key = null, $values = null, $escape = null)
+	public function whereNotIn(string $key = null, array $values = null, bool $escape = null)
 	{
 		return $this->_whereIn($key, $values, true, 'AND ', $escape);
 	}
@@ -767,7 +767,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function orWhereNotIn($key = null, $values = null, $escape = null)
+	public function orWhereNotIn(string $key = null, array $values = null, bool $escape = null)
 	{
 		return $this->_whereIn($key, $values, true, 'OR ', $escape);
 	}
@@ -790,7 +790,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	protected function _whereIn($key = null, $values = null, $not = false, $type = 'AND ', $escape = null)
+	protected function _whereIn(string $key = null, array $values = null, bool $not = false, string $type = 'AND ', bool $escape = null)
 	{
 		if ($key === null || $values === null)
 		{
@@ -844,7 +844,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function like($field, $match = '', $side = 'both', $escape = null, $insensitiveSearch = false)
+	public function like($field, string $match = '', string $side = 'both', bool $escape = null, bool $insensitiveSearch = false)
 	{
 		return $this->_like($field, $match, 'AND ', $side, '', $escape, $insensitiveSearch);
 	}
@@ -865,7 +865,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function notLike($field, $match = '', $side = 'both', $escape = null, $insensitiveSearch = false)
+	public function notLike($field, string $match = '', string $side = 'both', bool $escape = null, bool $insensitiveSearch = false)
 	{
 		return $this->_like($field, $match, 'AND ', $side, 'NOT', $escape, $insensitiveSearch);
 	}
@@ -886,7 +886,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function orLike($field, $match = '', $side = 'both', $escape = null, $insensitiveSearch = false)
+	public function orLike($field, string $match = '', string $side = 'both', bool $escape = null, bool $insensitiveSearch = false)
 	{
 		return $this->_like($field, $match, 'OR ', $side, '', $escape, $insensitiveSearch);
 	}
@@ -907,7 +907,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function orNotLike($field, $match = '', $side = 'both', $escape = null, $insensitiveSearch = false)
+	public function orNotLike($field, string $match = '', string $side = 'both', bool $escape = null, bool $insensitiveSearch = false)
 	{
 		return $this->_like($field, $match, 'OR ', $side, 'NOT', $escape, $insensitiveSearch);
 	}
@@ -932,7 +932,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	protected function _like($field, $match = '', $type = 'AND ', $side = 'both', $not = '', $escape = null, $insensitiveSearch = false)
+	protected function _like($field, string $match = '', string $type = 'AND ', string $side = 'both', string $not = '', bool $escape = null, bool $insensitiveSearch = false)
 	{
 		if (! is_array($field))
 		{
@@ -1023,7 +1023,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function groupStart($not = '', $type = 'AND ')
+	public function groupStart(string $not = '', string $type = 'AND ')
 	{
 		$type = $this->groupGetType($type);
 
@@ -1109,7 +1109,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function groupGetType($type)
+	protected function groupGetType(string $type): string
 	{
 		if ($this->QBWhereGroupStarted)
 		{
@@ -1130,7 +1130,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function groupBy($by, $escape = null)
+	public function groupBy(string $by, bool $escape = null)
 	{
 		is_bool($escape) || $escape = $this->db->protectIdentifiers;
 
@@ -1170,7 +1170,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function having($key, $value = null, $escape = null)
+	public function having(string $key, string $value = null, bool $escape = null)
 	{
 		return $this->whereHaving('QBHaving', $key, $value, 'AND ', $escape);
 	}
@@ -1188,7 +1188,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function orHaving($key, $value = null, $escape = null)
+	public function orHaving(string $key, string $value = null, bool $escape = null)
 	{
 		return $this->whereHaving('QBHaving', $key, $value, 'OR ', $escape);
 	}
@@ -1204,7 +1204,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function orderBy($orderby, $direction = '', $escape = null)
+	public function orderBy(string $orderby, string $direction = '', bool $escape = null)
 	{
 		$direction = strtoupper(trim($direction));
 
@@ -1291,7 +1291,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function offset($offset)
+	public function offset(int $offset)
 	{
 		if (! empty($offset))
 		{
@@ -1312,7 +1312,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _limit($sql)
+	protected function _limit(string $sql): string
 	{
 		return $sql . ' LIMIT ' . ($this->QBOffset ? $this->QBOffset . ', ' : '') . $this->QBLimit;
 	}
@@ -1330,7 +1330,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function set($key, $value = '', $escape = null)
+	public function set($key, string $value = '', bool $escape = null)
 	{
 		$key = $this->objectToArray($key);
 
@@ -1367,7 +1367,7 @@ class BaseBuilder
 	 *
 	 * @return array
 	 */
-	public function getSetData(bool $clean = false)
+	public function getSetData(bool $clean = false): array
 	{
 		$data = $this->QBSet;
 
@@ -1390,7 +1390,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	public function getCompiledSelect($reset = true)
+	public function getCompiledSelect(bool $reset = true): string
 	{
 		$select = $this->compileSelect();
 
@@ -1410,7 +1410,7 @@ class BaseBuilder
 	 *
 	 * @param string $sql
 	 *
-	 * @return mixed|string
+	 * @return string
 	 */
 	protected function compileFinalQuery(string $sql): string
 	{
@@ -1438,7 +1438,7 @@ class BaseBuilder
 	 *
 	 * @return ResultInterface
 	 */
-	public function get(int $limit = null, int $offset = 0, $returnSQL = false, $reset = true)
+	public function get(int $limit = null, int $offset = 0, bool $returnSQL = false, bool $reset = true)
 	{
 		if (! is_null($limit))
 		{
@@ -1473,7 +1473,7 @@ class BaseBuilder
 	 *
 	 * @return integer
 	 */
-	public function countAll($reset = true, $test = false)
+	public function countAll(bool $reset = true, bool $test = false): int
 	{
 		$table = $this->QBFrom[0];
 
@@ -1514,7 +1514,7 @@ class BaseBuilder
 	 *
 	 * @return integer
 	 */
-	public function countAllResults($reset = true, $test = false)
+	public function countAllResults(bool $reset = true, bool $test = false): int
 	{
 		// ORDER BY usage is often problematic here (most notably
 		// on Microsoft SQL Server) and ultimately unnecessary
@@ -1571,7 +1571,7 @@ class BaseBuilder
 	 *
 	 * @return ResultInterface
 	 */
-	public function getWhere($where = null, $limit = null, $offset = null)
+	public function getWhere(string $where = null, int $limit = null, int $offset = null)
 	{
 		if ($where !== null)
 		{
@@ -1605,7 +1605,7 @@ class BaseBuilder
 	 * @return integer Number of rows inserted or FALSE on failure
 	 * @throws DatabaseException
 	 */
-	public function insertBatch($set = null, $escape = null, $batchSize = 100, $testing = false)
+	public function insertBatch(array $set = null, bool $escape = null, int $batchSize = 100, bool $testing = false): int
 	{
 		if ($set === null)
 		{
@@ -1674,7 +1674,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _insertBatch($table, $keys, $values)
+	protected function _insertBatch(string $table, array $keys, array $values): string
 	{
 		return 'INSERT INTO ' . $table . ' (' . implode(', ', $keys) . ') VALUES ' . implode(', ', $values);
 	}
@@ -1690,7 +1690,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function setInsertBatch($key, $value = '', $escape = null)
+	public function setInsertBatch($key, string $value = '', bool $escape = null)
 	{
 		$key = $this->batchObjectToArray($key);
 
@@ -1747,7 +1747,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	public function getCompiledInsert($reset = true)
+	public function getCompiledInsert(bool $reset = true): string
 	{
 		if ($this->validateInsert() === false)
 		{
@@ -1779,9 +1779,9 @@ class BaseBuilder
 	 * @param boolean $escape Whether to escape values and identifiers
 	 * @param boolean $test   Used when running tests
 	 *
-	 * @return BaseResult|Query|false
+	 * @return BaseResult|Query|boolean
 	 */
-	public function insert($set = null, $escape = null, $test = false)
+	public function insert(array $set = null, bool $escape = null, bool $test = false)
 	{
 		if ($set !== null)
 		{
@@ -1821,10 +1821,10 @@ class BaseBuilder
 	 * validate that the there data is actually being set and that table
 	 * has been chosen to be inserted into.
 	 *
-	 * @return string
+	 * @return boolean
 	 * @throws DatabaseException
 	 */
-	protected function validateInsert()
+	protected function validateInsert(): bool
 	{
 		if (empty($this->QBSet))
 		{
@@ -1852,7 +1852,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _insert($table, array $keys, array $unescapedKeys)
+	protected function _insert(string $table, array $keys, array $unescapedKeys): string
 	{
 		return 'INSERT INTO ' . $table . ' (' . implode(', ', $keys) . ') VALUES (' . implode(', ', $unescapedKeys) . ')';
 	}
@@ -1867,10 +1867,10 @@ class BaseBuilder
 	 * @param array   $set       An associative array of insert values
 	 * @param boolean $returnSQL
 	 *
-	 * @return BaseResult|Query|string|false
+	 * @return BaseResult|Query|string|boolean
 	 * @throws DatabaseException
 	 */
-	public function replace($set = null, $returnSQL = false)
+	public function replace(array $set = null, bool $returnSQL = false)
 	{
 		if ($set !== null)
 		{
@@ -1908,7 +1908,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _replace($table, $keys, $values)
+	protected function _replace(string $table, array $keys, array $values): string
 	{
 		return 'REPLACE INTO ' . $table . ' (' . implode(', ', $keys) . ') VALUES (' . implode(', ', $values) . ')';
 	}
@@ -1925,7 +1925,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _fromTables()
+	protected function _fromTables(): string
 	{
 		return implode(', ', $this->QBFrom);
 	}
@@ -1939,9 +1939,9 @@ class BaseBuilder
 	 *
 	 * @param boolean $reset TRUE: reset QB values; FALSE: leave QB values alone
 	 *
-	 * @return string
+	 * @return string|boolean
 	 */
-	public function getCompiledUpdate($reset = true)
+	public function getCompiledUpdate(bool $reset = true)
 	{
 		if ($this->validateUpdate() === false)
 		{
@@ -1971,8 +1971,9 @@ class BaseBuilder
 	 * @param boolean $test  Are we testing the code?
 	 *
 	 * @return boolean    TRUE on success, FALSE on failure
+	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function update($set = null, $where = null, int $limit = null, $test = false)
+	public function update(array $set = null, $where = null, int $limit = null, bool $test = false): bool
 	{
 		if ($set !== null)
 		{
@@ -2031,7 +2032,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _update($table, $values)
+	protected function _update(string $table, array $values): string
 	{
 		foreach ($values as $key => $val)
 		{
@@ -2056,7 +2057,7 @@ class BaseBuilder
 	 * @return boolean
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	protected function validateUpdate()
+	protected function validateUpdate(): bool
 	{
 		if (empty($this->QBSet))
 		{
@@ -2086,7 +2087,7 @@ class BaseBuilder
 	 * @return mixed    Number of rows affected, SQL string, or FALSE on failure
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function updateBatch($set = null, $index = null, $batchSize = 100, $returnSQL = false)
+	public function updateBatch(array $set = null, string $index = null, int $batchSize = 100, bool $returnSQL = false): bool
 	{
 		if ($index === null)
 		{
@@ -2164,7 +2165,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _updateBatch($table, $values, $index)
+	protected function _updateBatch(string $table, array $values, string $index): string
 	{
 		$ids = [];
 		foreach ($values as $key => $val)
@@ -2198,14 +2199,14 @@ class BaseBuilder
 	/**
 	 * The "setUpdateBatch" function.  Allows key/value pairs to be set for batch updating
 	 *
-	 * @param array   $key
-	 * @param string  $index
-	 * @param boolean $escape
+	 * @param array|object  $key
+	 * @param string        $index
+	 * @param boolean       $escape
 	 *
-	 * @return BaseBuilder
+	 * @return BaseBuilder|null
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function setUpdateBatch($key, $index = '', $escape = null)
+	public function setUpdateBatch($key, string $index = '', bool $escape = null)
 	{
 		$key = $this->batchObjectToArray($key);
 
@@ -2253,7 +2254,7 @@ class BaseBuilder
 	 * @param  boolean $test
 	 * @return boolean    TRUE on success, FALSE on failure
 	 */
-	public function emptyTable($test = false)
+	public function emptyTable(bool $test = false): bool
 	{
 		$table = $this->QBFrom[0];
 
@@ -2282,7 +2283,7 @@ class BaseBuilder
 	 *
 	 * @return boolean    TRUE on success, FALSE on failure
 	 */
-	public function truncate($test = false)
+	public function truncate(bool $test = false): bool
 	{
 		$table = $this->QBFrom[0];
 
@@ -2312,7 +2313,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _truncate($table)
+	protected function _truncate(string $table): string
 	{
 		return 'TRUNCATE ' . $table;
 	}
@@ -2328,7 +2329,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	public function getCompiledDelete($reset = true)
+	public function getCompiledDelete(bool $reset = true): string
 	{
 		$table = $this->QBFrom[0];
 
@@ -2354,7 +2355,7 @@ class BaseBuilder
 	 * @return mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function delete($where = '', $limit = null, $reset_data = true, $returnSQL = false)
+	public function delete($where = '', $limit = null, bool $reset_data = true, bool $returnSQL = false)
 	{
 		$table = $this->db->protectIdentifiers($this->QBFrom[0], true, null, false);
 
@@ -2408,7 +2409,7 @@ class BaseBuilder
 	 *
 	 * @return boolean
 	 */
-	public function increment(string $column, int $value = 1)
+	public function increment(string $column, int $value = 1): bool
 	{
 		$column = $this->db->protectIdentifiers($column);
 
@@ -2427,7 +2428,7 @@ class BaseBuilder
 	 *
 	 * @return boolean
 	 */
-	public function decrement(string $column, int $value = 1)
+	public function decrement(string $column, int $value = 1): bool
 	{
 		$column = $this->db->protectIdentifiers($column);
 
@@ -2447,7 +2448,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _delete($table)
+	protected function _delete(string $table): string
 	{
 		return 'DELETE FROM ' . $table . $this->compileWhereHaving('QBWhere')
 				. ($this->QBLimit ? ' LIMIT ' . $this->QBLimit : '');
@@ -2460,9 +2461,9 @@ class BaseBuilder
 	 *
 	 * Used to track SQL statements written with aliased tables.
 	 *
-	 * @param string $table The table to inspect
+	 * @param string|array $table The table to inspect
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	protected function trackAliases($table)
 	{
@@ -2509,7 +2510,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function compileSelect($select_override = false)
+	protected function compileSelect(bool $select_override = false): string
 	{
 		// Write the "select" portion of the query
 		if ($select_override !== false)
@@ -2579,7 +2580,7 @@ class BaseBuilder
 	 *
 	 * @return string    SQL statement
 	 */
-	protected function compileWhereHaving($qb_key)
+	protected function compileWhereHaving(string $qb_key): string
 	{
 		if (! empty($this->$qb_key))
 		{
@@ -2652,7 +2653,7 @@ class BaseBuilder
 	 *
 	 * @return string    SQL statement
 	 */
-	protected function compileGroupBy()
+	protected function compileGroupBy(): string
 	{
 		if (! empty($this->QBGroupBy))
 		{
@@ -2687,7 +2688,7 @@ class BaseBuilder
 	 *
 	 * @return string    SQL statement
 	 */
-	protected function compileOrderBy()
+	protected function compileOrderBy(): string
 	{
 		if (is_array($this->QBOrderBy) && ! empty($this->QBOrderBy))
 		{
@@ -2718,12 +2719,13 @@ class BaseBuilder
 	 *
 	 * Takes an object as input and converts the class variables to array key/vals
 	 *
-	 * @param object $object
+	 * @param object|array $object
 	 *
 	 * @return array
 	 */
-	protected function objectToArray($object)
+	protected function objectToArray($object): array
 	{
+		// Fail-Safe mechanism, if array passed instead of object
 		if (! is_object($object))
 		{
 			return $object;
@@ -2749,12 +2751,13 @@ class BaseBuilder
 	 *
 	 * Takes an object as input and converts the class variables to array key/vals
 	 *
-	 * @param object $object
+	 * @param object|array $object
 	 *
 	 * @return array
 	 */
-	protected function batchObjectToArray($object)
+	protected function batchObjectToArray($object): array
 	{
+		// Fail-Safe mechanism, if array passed instead of object
 		if (! is_object($object))
 		{
 			return $object;
@@ -2791,7 +2794,7 @@ class BaseBuilder
 	 *
 	 * @return boolean
 	 */
-	protected function isLiteral($str)
+	protected function isLiteral(string $str): bool
 	{
 		$str = trim($str);
 
@@ -2836,7 +2839,7 @@ class BaseBuilder
 	 *
 	 * @param array $qb_reset_items An array of fields to reset
 	 */
-	protected function resetRun($qb_reset_items)
+	protected function resetRun(array $qb_reset_items)
 	{
 		foreach ($qb_reset_items as $item => $default_value)
 		{
@@ -2898,7 +2901,7 @@ class BaseBuilder
 	 *
 	 * @return boolean
 	 */
-	protected function hasOperator($str)
+	protected function hasOperator(string $str): bool
 	{
 		return (bool) preg_match('/(<|>|!|=|\sIS NULL|\sIS NOT NULL|\sEXISTS|\sBETWEEN|\sLIKE|\sIN\s*\(|\s)/i', trim($str));
 	}
@@ -2912,7 +2915,7 @@ class BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function getOperator($str)
+	protected function getOperator(string $str): string
 	{
 		static $_operators;
 
@@ -2947,12 +2950,12 @@ class BaseBuilder
 	 * arrays instead, so lets take advantage of that here.
 	 *
 	 * @param string  $key
-	 * @param null    $value
+	 * @param string  $value
 	 * @param boolean $escape
 	 *
 	 * @return string
 	 */
-	protected function setBind(string $key, $value = null, bool $escape = true)
+	protected function setBind(string $key, string $value = null, bool $escape = true): string
 	{
 		if (! array_key_exists($key, $this->binds))
 		{

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -420,7 +420,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 * @param  boolean $persistent
 	 * @return mixed
 	 */
-	abstract public function connect($persistent = false);
+	abstract public function connect(bool $persistent = false);
 
 	//--------------------------------------------------------------------
 
@@ -580,11 +580,11 @@ abstract class BaseConnection implements ConnectionInterface
 	/**
 	 * Executes the query against the database.
 	 *
-	 * @param $sql
+	 * @param string $sql
 	 *
 	 * @return mixed
 	 */
-	abstract protected function execute($sql);
+	abstract protected function execute(string $sql);
 
 	//--------------------------------------------------------------------
 
@@ -601,9 +601,9 @@ abstract class BaseConnection implements ConnectionInterface
 	 * @param boolean $setEscapeFlags
 	 * @param string  $queryClass
 	 *
-	 * @return BaseResult|Query|false
+	 * @return BaseResult|Query|boolean
 	 */
-	public function query(string $sql, $binds = null, bool $setEscapeFlags = true, $queryClass = 'CodeIgniter\\Database\\Query')
+	public function query(string $sql, array $binds = null, bool $setEscapeFlags = true, string $queryClass = 'CodeIgniter\\Database\\Query')
 	{
 		if (empty($this->connID))
 		{
@@ -748,7 +748,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 * @param  boolean $test_mode = FALSE
 	 * @return boolean
 	 */
-	public function transStart($test_mode = false)
+	public function transStart(bool $test_mode = false)
 	{
 		if (! $this->transEnabled)
 		{
@@ -765,7 +765,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * @return boolean
 	 */
-	public function transComplete()
+	public function transComplete(): bool
 	{
 		if (! $this->transEnabled)
 		{
@@ -927,7 +927,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 * @return BaseBuilder
 	 * @throws DatabaseException
 	 */
-	public function table($tableName)
+	public function table(string $tableName)
 	{
 		if (empty($tableName))
 		{
@@ -1006,7 +1006,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * @return string
 	 */
-	public function showLastQuery()
+	public function showLastQuery(): string
 	{
 		return (string) $this->lastQuery;
 	}
@@ -1021,7 +1021,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * @return float
 	 */
-	public function getConnectStart()
+	public function getConnectStart(): float
 	{
 		return $this->connectTime;
 	}
@@ -1038,7 +1038,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * @return mixed
 	 */
-	public function getConnectDuration($decimals = 6)
+	public function getConnectDuration(int $decimals = 6)
 	{
 		return number_format($this->connectDuration, $decimals);
 	}
@@ -1065,14 +1065,14 @@ abstract class BaseConnection implements ConnectionInterface
 	 * insert the table prefix (if it exists) in the proper position, and escape only
 	 * the correct identifiers.
 	 *
-	 * @param string|array
-	 * @param boolean
-	 * @param mixed
-	 * @param boolean
+	 * @param string|array  $item
+	 * @param boolean       $prefixSingle
+	 * @param mixed         $protectIdentifiers
+	 * @param boolean       $fieldExists
 	 *
 	 * @return string|array
 	 */
-	public function protectIdentifiers($item, $prefixSingle = false, $protectIdentifiers = null, $fieldExists = true)
+	public function protectIdentifiers($item, bool $prefixSingle = false, $protectIdentifiers = null, bool $fieldExists = true)
 	{
 		if (! is_bool($protectIdentifiers))
 		{
@@ -1311,7 +1311,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 * @return string
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function prefixTable($table = '')
+	public function prefixTable(string $table = ''): string
 	{
 		if ($table === '')
 		{
@@ -1332,7 +1332,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * @return string
 	 */
-	public function setPrefix($prefix = '')
+	public function setPrefix(string $prefix = ''): string
 	{
 		return $this->DBPrefix = $prefix;
 	}
@@ -1342,7 +1342,7 @@ abstract class BaseConnection implements ConnectionInterface
 	/**
 	 * Returns the total number of rows affected by this query.
 	 *
-	 * @return mixed
+	 * @return int
 	 */
 	abstract public function affectedRows(): int;
 
@@ -1354,7 +1354,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 * Escapes data based on type.
 	 * Sets boolean and null types
 	 *
-	 * @param $str
+	 * @param mixed $str
 	 *
 	 * @return mixed
 	 */
@@ -1391,11 +1391,11 @@ abstract class BaseConnection implements ConnectionInterface
 	/**
 	 * Escape String
 	 *
-	 * @param  string|string[] $str  Input string
-	 * @param  boolean         $like Whether or not the string will be used in a LIKE condition
+	 * @param  string|array $str  Input string
+	 * @param  boolean      $like Whether or not the string will be used in a LIKE condition
 	 * @return string
 	 */
-	public function escapeString($str, $like = false)
+	public function escapeString($str, bool $like = false): string
 	{
 		if (is_array($str))
 		{
@@ -1435,7 +1435,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 * Calls the individual driver for platform
 	 * specific escaping for LIKE conditions
 	 *
-	 * @param  string|string[]
+	 * @param  string|array
 	 * @return mixed
 	 */
 	public function escapeLikeString($str)
@@ -1471,7 +1471,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 * @return boolean
 	 * @throws DatabaseException
 	 */
-	public function callFunction(string $functionName, ...$params)
+	public function callFunction(string $functionName, array ...$params): bool
 	{
 		$driver = ($this->DBDriver === 'postgre' ? 'pg' : strtolower($this->DBDriver)) . '_';
 
@@ -1505,7 +1505,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 * @return boolean|array
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function listTables($constrain_by_prefix = false)
+	public function listTables(bool $constrain_by_prefix = false)
 	{
 		// Is there a cached result?
 		if (isset($this->dataCache['table_names']) && $this->dataCache['table_names'])
@@ -1564,7 +1564,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 * @param  string $table_name
 	 * @return boolean
 	 */
-	public function tableExists($table_name)
+	public function tableExists(string $table_name): bool
 	{
 		return in_array($this->protectIdentifiers($table_name, true, false, false), $this->listTables());
 	}
@@ -1576,10 +1576,10 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * @param string $table Table name
 	 *
-	 * @return array|false
+	 * @return array|boolean
 	 * @throws DatabaseException
 	 */
-	public function getFieldNames($table)
+	public function getFieldNames(string $table)
 	{
 		// Is there a cached result?
 		if (isset($this->dataCache['field_names'][$table]))
@@ -1639,7 +1639,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 * @param  string
 	 * @return boolean
 	 */
-	public function fieldExists($fieldName, $tableName)
+	public function fieldExists(string $fieldName, string $tableName): bool
 	{
 		return in_array($fieldName, $this->getFieldNames($tableName));
 	}
@@ -1650,7 +1650,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 * Returns an object with field data
 	 *
 	 * @param  string $table the table name
-	 * @return array|false
+	 * @return array|boolean
 	 */
 	public function getFieldData(string $table)
 	{
@@ -1665,7 +1665,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 * Returns an object with key data
 	 *
 	 * @param  string $table the table name
-	 * @return array|false
+	 * @return array|boolean
 	 */
 	public function getIndexData(string $table)
 	{
@@ -1680,7 +1680,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 * Returns an object with foreign key data
 	 *
 	 * @param  string $table the table name
-	 * @return array|false
+	 * @return array|boolean
 	 */
 	public function getForeignKeyData(string $table)
 	{
@@ -1733,7 +1733,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * @return array
 	 */
-	abstract public function error();
+	abstract public function error(): array;
 
 	//--------------------------------------------------------------------
 
@@ -1742,7 +1742,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * @return integer
 	 */
-	abstract public function insertID();
+	abstract public function insertID(): int;
 
 	//--------------------------------------------------------------------
 
@@ -1753,7 +1753,7 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * @return string
 	 */
-	abstract protected function _listTables($constrainByPrefix = false): string;
+	abstract protected function _listTables(bool $constrainByPrefix = false): string;
 
 	//--------------------------------------------------------------------
 
@@ -1801,7 +1801,12 @@ abstract class BaseConnection implements ConnectionInterface
 
 	//--------------------------------------------------------------------
 
-	public function __get($key)
+	/**
+	 * @param string $key
+	 *
+	 * @return mixed
+	 */
+	public function __get(string $key)
 	{
 		if (property_exists($this, $key))
 		{

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -99,7 +99,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 	 *
 	 * @return mixed
 	 */
-	public function prepare(string $sql, array $options = [], $queryClass = 'CodeIgniter\\Database\\Query')
+	public function prepare(string $sql, array $options = [], string $queryClass = 'CodeIgniter\\Database\\Query')
 	{
 		// We only supports positional placeholders (?)
 		// in order to work with the execute method below, so we
@@ -145,7 +145,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 	 *
 	 * @return ResultInterface
 	 */
-	public function execute(...$data)
+	public function execute(array ...$data)
 	{
 		// Execute the Query.
 		$startTime = microtime(true);
@@ -178,7 +178,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 	 *
 	 * @return ResultInterface
 	 */
-	abstract public function _execute($data);
+	abstract public function _execute(array $data);
 
 	//--------------------------------------------------------------------
 
@@ -192,7 +192,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * Explicity closes the statement.
+	 * Explicitly closes the statement.
 	 */
 	public function close()
 	{
@@ -228,7 +228,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 	 *
 	 * @return boolean
 	 */
-	public function hasError()
+	public function hasError(): bool
 	{
 		return ! empty($this->errorString);
 	}

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -123,7 +123,7 @@ abstract class BaseResult implements ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getResult($type = 'object'): array
+	public function getResult(string $type = 'object'): array
 	{
 		if ($type === 'array')
 		{
@@ -293,7 +293,7 @@ abstract class BaseResult implements ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getRow($n = 0, $type = 'object')
+	public function getRow(int $n = 0, string $type = 'object')
 	{
 		if (! is_numeric($n))
 		{
@@ -333,7 +333,7 @@ abstract class BaseResult implements ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getCustomRowObject($n, string $className)
+	public function getCustomRowObject(int $n, string $className)
 	{
 		isset($this->customResultObject[$className]) || $this->getCustomResultObject($className);
 
@@ -361,7 +361,7 @@ abstract class BaseResult implements ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getRowArray($n = 0)
+	public function getRowArray(int $n = 0)
 	{
 		$result = $this->getResultArray();
 		if (empty($result))
@@ -388,7 +388,7 @@ abstract class BaseResult implements ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getRowObject($n = 0)
+	public function getRowObject(int $n = 0)
 	{
 		$result = $this->getResultObject();
 		if (empty($result))
@@ -447,7 +447,7 @@ abstract class BaseResult implements ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getFirstRow($type = 'object')
+	public function getFirstRow(string $type = 'object')
 	{
 		$result = $this->getResult($type);
 
@@ -463,7 +463,7 @@ abstract class BaseResult implements ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getLastRow($type = 'object')
+	public function getLastRow(string $type = 'object')
 	{
 		$result = $this->getResult($type);
 
@@ -479,7 +479,7 @@ abstract class BaseResult implements ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getNextRow($type = 'object')
+	public function getNextRow(string $type = 'object')
 	{
 		$result = $this->getResult($type);
 		if (empty($result))
@@ -499,7 +499,7 @@ abstract class BaseResult implements ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getPreviousRow($type = 'object')
+	public function getPreviousRow(string $type = 'object')
 	{
 		$result = $this->getResult($type);
 		if (empty($result))
@@ -524,7 +524,7 @@ abstract class BaseResult implements ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getUnbufferedRow($type = 'object')
+	public function getUnbufferedRow(string $type = 'object')
 	{
 		if ($type === 'array')
 		{
@@ -585,7 +585,7 @@ abstract class BaseResult implements ResultInterface
 	 *
 	 * @return mixed
 	 */
-	abstract public function dataSeek($n = 0);
+	abstract public function dataSeek(int $n = 0);
 
 	//--------------------------------------------------------------------
 
@@ -609,7 +609,7 @@ abstract class BaseResult implements ResultInterface
 	 *
 	 * @return object
 	 */
-	abstract protected function fetchObject($className = 'stdClass');
+	abstract protected function fetchObject(string $className = 'stdClass');
 
 	//--------------------------------------------------------------------
 }

--- a/system/Database/BaseUtils.php
+++ b/system/Database/BaseUtils.php
@@ -134,7 +134,7 @@ abstract class BaseUtils
 	 * @param  string $database_name
 	 * @return boolean
 	 */
-	public function databaseExists($database_name)
+	public function databaseExists(string $database_name): bool
 	{
 		return in_array($database_name, $this->listDatabases());
 	}
@@ -148,7 +148,7 @@ abstract class BaseUtils
 	 * @return boolean|mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function optimizeTable($table_name)
+	public function optimizeTable(string $table_name)
 	{
 		if ($this->optimizeTable === false)
 		{
@@ -219,7 +219,7 @@ abstract class BaseUtils
 	 * @return mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function repairTable($table_name)
+	public function repairTable(string $table_name)
 	{
 		if ($this->repairTable === false)
 		{
@@ -252,7 +252,7 @@ abstract class BaseUtils
 	 *
 	 * @return string
 	 */
-	public function getCSVFromResult(ResultInterface $query, $delim = ',', $newline = "\n", $enclosure = '"')
+	public function getCSVFromResult(ResultInterface $query, string $delim = ',', string $newline = "\n", string $enclosure = '"'): string
 	{
 		$out = '';
 		// First generate the headings from the table column names
@@ -287,7 +287,7 @@ abstract class BaseUtils
 	 *
 	 * @return string
 	 */
-	public function getXMLFromResult(ResultInterface $query, $params = [])
+	public function getXMLFromResult(ResultInterface $query, array $params = []): string
 	{
 		// Set our default values
 		foreach (['root' => 'root', 'element' => 'element', 'newline' => "\n", 'tab' => "\t"] as $key => $val)
@@ -323,7 +323,7 @@ abstract class BaseUtils
 	/**
 	 * Database Backup
 	 *
-	 * @param  array $params
+	 * @param  array|string $params
 	 * @return mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -124,7 +124,7 @@ class Config extends BaseConfig
 	 *
 	 * @return array
 	 */
-	public static function getConnections()
+	public static function getConnections(): array
 	{
 		return static::$instances;
 	}

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -59,7 +59,7 @@ interface ConnectionInterface
 	 * @param  boolean $persistent
 	 * @return mixed
 	 */
-	public function connect($persistent = false);
+	public function connect(bool $persistent = false);
 
 	//--------------------------------------------------------------------
 
@@ -156,7 +156,7 @@ interface ConnectionInterface
 	 *
 	 * @return mixed
 	 */
-	public function query(string $sql, $binds = null);
+	public function query(string $sql, array $binds = null);
 
 	//--------------------------------------------------------------------
 
@@ -176,11 +176,11 @@ interface ConnectionInterface
 	/**
 	 * Returns an instance of the query builder for this connection.
 	 *
-	 * @param string|array $tableName Table name.
+	 * @param string $tableName Table name.
 	 *
 	 * @return BaseBuilder Builder.
 	 */
-	public function table($tableName);
+	public function table(string $tableName);
 
 	//--------------------------------------------------------------------
 
@@ -199,7 +199,7 @@ interface ConnectionInterface
 	 * Escapes data based on type.
 	 * Sets boolean and null types.
 	 *
-	 * @param string $str
+	 * @param mixed $str
 	 *
 	 * @return mixed
 	 */
@@ -216,7 +216,7 @@ interface ConnectionInterface
 	 *
 	 * @return mixed
 	 */
-	public function callFunction(string $functionName, ...$params);
+	public function callFunction(string $functionName, array ...$params);
 
 	//--------------------------------------------------------------------
 }

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -202,7 +202,7 @@ class Forge
 	 * @return boolean
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function createDatabase($db_name)
+	public function createDatabase(string $db_name): bool
 	{
 		if ($this->createDatabaseStr === false)
 		{
@@ -242,7 +242,7 @@ class Forge
 	 * @return boolean
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function dropDatabase($db_name)
+	public function dropDatabase(string $db_name): bool
 	{
 		if ($this->dropDatabaseStr === false)
 		{
@@ -392,7 +392,7 @@ class Forge
 	 * @return \CodeIgniter\Database\Forge
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function addForeignKey($fieldName = '', $tableName = '', $tableField = '', $onUpdate = false, $onDelete = false)
+	public function addForeignKey(string $fieldName = '', string $tableName = '', string $tableField = '', bool $onUpdate = false, bool $onDelete = false)
 	{
 		if (! isset($this->fields[$fieldName]))
 		{
@@ -420,7 +420,7 @@ class Forge
 	 * @return boolean|\CodeIgniter\Database\BaseResult|\CodeIgniter\Database\Query|false|mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function dropForeignKey($table, $foreign_name)
+	public function dropForeignKey(string $table, string $foreign_name)
 	{
 		$sql = sprintf($this->dropConstraintStr, $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
 			$this->db->escapeIdentifiers($this->db->DBPrefix . $foreign_name));
@@ -450,7 +450,7 @@ class Forge
 	 * @return boolean
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function createTable($table, $if_not_exists = false, array $attributes = [])
+	public function createTable(string $table, bool $if_not_exists = false, array $attributes = []): bool
 	{
 		if ($table === '')
 		{
@@ -482,7 +482,7 @@ class Forge
 
 		if (($result = $this->db->query($sql)) !== false)
 		{
-			empty($this->db->dataCache['table_names']) || $this->db->dataCache['table_names'][] = $table;
+			empty($this->db->dataCache['table_names']) OR $this->db->dataCache['table_names'][] = $table;
 
 			// Most databases don't support creating indexes from within the CREATE TABLE statement
 			if (! empty($this->keys))
@@ -510,7 +510,7 @@ class Forge
 	 *
 	 * @return mixed
 	 */
-	protected function _createTable($table, $if_not_exists, $attributes)
+	protected function _createTable(string $table, bool $if_not_exists, array $attributes)
 	{
 		// For any platforms that don't support Create If Not Exists...
 		if ($if_not_exists === true && $this->createTableIfStr === false)
@@ -560,7 +560,7 @@ class Forge
 	 *
 	 * @return string
 	 */
-	protected function _createTableAttributes($attributes)
+	protected function _createTableAttributes(array $attributes): string
 	{
 		$sql = '';
 
@@ -587,7 +587,7 @@ class Forge
 	 * @return mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function dropTable($table_name, $if_exists = false, $cascade = false)
+	public function dropTable(string $table_name, bool $if_exists = false, bool $cascade = false)
 	{
 		if ($table_name === '')
 		{
@@ -639,7 +639,7 @@ class Forge
 	 *
 	 * @return string
 	 */
-	protected function _dropTable($table, $if_exists, $cascade)
+	protected function _dropTable(string $table, bool $if_exists, bool $cascade)
 	{
 		$sql = 'DROP TABLE';
 
@@ -674,7 +674,7 @@ class Forge
 	 * @return mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function renameTable($table_name, $new_table_name)
+	public function renameTable(string $table_name, string $new_table_name)
 	{
 		if ($table_name === '' || $new_table_name === '')
 		{
@@ -719,7 +719,7 @@ class Forge
 	 * @return boolean
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function addColumn($table, $field)
+	public function addColumn(string $table, array $field): bool
 	{
 		// Work-around for literal column definitions
 		is_array($field) || $field = [$field];
@@ -763,7 +763,7 @@ class Forge
 	 * @return boolean
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function dropColumn($table, $column_name)
+	public function dropColumn(string $table, string $column_name): bool
 	{
 		$sql = $this->_alterTable('DROP', $this->db->DBPrefix . $table, $column_name);
 		if ($sql === false)
@@ -790,7 +790,7 @@ class Forge
 	 * @return boolean
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function modifyColumn($table, $field)
+	public function modifyColumn(string $table, string $field): bool
 	{
 		// Work-around for literal column definitions
 		is_array($field) || $field = [$field];
@@ -842,7 +842,7 @@ class Forge
 	 *
 	 * @return string|string[]
 	 */
-	protected function _alterTable($alter_type, $table, $field)
+	protected function _alterTable(string $alter_type, string $table, $field)
 	{
 		$sql = 'ALTER TABLE ' . $this->db->escapeIdentifiers($table) . ' ';
 
@@ -873,7 +873,7 @@ class Forge
 	 *
 	 * @return array
 	 */
-	protected function _processFields($create_table = false)
+	protected function _processFields(bool $create_table = false): array
 	{
 		$fields = [];
 
@@ -973,7 +973,7 @@ class Forge
 	 *
 	 * @return string
 	 */
-	protected function _processColumn($field)
+	protected function _processColumn(array $field): string
 	{
 		return $this->db->escapeIdentifiers($field['name'])
 			   . ' ' . $field['type'] . $field['length']
@@ -995,7 +995,7 @@ class Forge
 	 *
 	 * @return void
 	 */
-	protected function _attributeType(&$attributes)
+	protected function _attributeType(array &$attributes): void
 	{
 		// Usually overridden by drivers
 	}
@@ -1019,7 +1019,7 @@ class Forge
 	 *
 	 * @return void
 	 */
-	protected function _attributeUnsigned(&$attributes, &$field)
+	protected function _attributeUnsigned(array &$attributes, array &$field): void
 	{
 		if (empty($attributes['UNSIGNED']) || $attributes['UNSIGNED'] !== true)
 		{
@@ -1061,9 +1061,9 @@ class Forge
 	 * @param array &$attributes
 	 * @param array &$field
 	 *
-	 * @return void
+	 * @return null|void
 	 */
-	protected function _attributeDefault(&$attributes, &$field)
+	protected function _attributeDefault(array &$attributes, array &$field)
 	{
 		if ($this->default === false)
 		{
@@ -1097,7 +1097,7 @@ class Forge
 	 *
 	 * @return void
 	 */
-	protected function _attributeUnique(&$attributes, &$field)
+	protected function _attributeUnique(array &$attributes, array &$field): void
 	{
 		if (! empty($attributes['UNIQUE']) && $attributes['UNIQUE'] === true)
 		{
@@ -1115,7 +1115,7 @@ class Forge
 	 *
 	 * @return void
 	 */
-	protected function _attributeAutoIncrement(&$attributes, &$field)
+	protected function _attributeAutoIncrement(array &$attributes, array &$field): void
 	{
 		if (! empty($attributes['AUTO_INCREMENT']) && $attributes['AUTO_INCREMENT'] === true
 			&& stripos($field['type'], 'int') !== false
@@ -1134,7 +1134,7 @@ class Forge
 	 *
 	 * @return string
 	 */
-	protected function _processPrimaryKeys($table)
+	protected function _processPrimaryKeys(string $table): string
 	{
 		$sql = '';
 
@@ -1164,7 +1164,7 @@ class Forge
 	 *
 	 * @return array
 	 */
-	protected function _processIndexes($table)
+	protected function _processIndexes(string $table): array
 	{
 		$sqls = [];
 
@@ -1209,7 +1209,7 @@ class Forge
 	 *
 	 * @return string
 	 */
-	protected function _processForeignKeys($table)
+	protected function _processForeignKeys(string $table): string
 	{
 		$sql = '';
 
@@ -1254,7 +1254,7 @@ class Forge
 	 *
 	 * @return void
 	 */
-	public function reset()
+	public function reset(): void
 	{
 		$this->fields = $this->keys = $this->uniqueKeys = $this->primaryKeys = $this->foreignKeys = [];
 	}

--- a/system/Database/Migration.php
+++ b/system/Database/Migration.php
@@ -84,7 +84,7 @@ abstract class Migration
 	 *
 	 * @return string
 	 */
-	public function getDBGroup()
+	public function getDBGroup(): string
 	{
 		return $this->DBGroup;
 	}

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -36,7 +36,6 @@
  * @filesource
  */
 
-use Config\Autoload;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Exceptions\ConfigException;
@@ -122,7 +121,7 @@ class MigrationRunner
 	/**
 	 * used to return messages for CLI.
 	 *
-	 * @var boolean
+	 * @var array
 	 */
 	protected $cliMessages = [];
 
@@ -405,7 +404,7 @@ class MigrationRunner
 	 *
 	 * @return array    list of migrations as $version for one namespace
 	 */
-	public function findMigrations()
+	public function findMigrations(): array
 	{
 		$migrations = [];
 		helper('filesystem');
@@ -477,7 +476,7 @@ class MigrationRunner
 	 *
 	 * @return boolean
 	 */
-	protected function checkMigrations(array $migrations, string $method, string $targetversion)
+	protected function checkMigrations(array $migrations, string $method, string $targetversion): bool
 	{
 		// Check if no migrations found
 		if (empty($migrations))
@@ -603,7 +602,7 @@ class MigrationRunner
 	 *
 	 * @return array
 	 */
-	public function getHistory(string $group = 'default')
+	public function getHistory(string $group = 'default'): array
 	{
 		$this->ensureTable();
 
@@ -647,7 +646,7 @@ class MigrationRunner
 	 *
 	 * @return string    Numeric portion of a migration filename
 	 */
-	protected function getMigrationNumber(string $migration)
+	protected function getMigrationNumber(string $migration): string
 	{
 		return sscanf($migration, '%[0-9]+', $number) ? $number : '0';
 	}
@@ -661,7 +660,7 @@ class MigrationRunner
 	 *
 	 * @return string    text portion of a migration filename
 	 */
-	protected function getMigrationName(string $migration)
+	protected function getMigrationName(string $migration): string
 	{
 		$parts = explode('_', $migration);
 		array_shift($parts);
@@ -676,7 +675,7 @@ class MigrationRunner
 	 *
 	 * @return string    Current migration version
 	 */
-	protected function getVersion()
+	protected function getVersion(): string
 	{
 		$this->ensureTable();
 
@@ -695,9 +694,9 @@ class MigrationRunner
 	/**
 	 * Retrieves current schema version
 	 *
-	 * @return string    Current migration version
+	 * @return array    Return messages for CLI
 	 */
-	public function getCliMessages()
+	public function getCliMessages(): array
 	{
 		return $this->cliMessages;
 	}

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -87,7 +87,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * @return mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function connect($persistent = false)
+	public function connect(bool $persistent = false)
 	{
 		// Do we have a socket path?
 		if ($this->hostname[0] === '/')
@@ -233,7 +233,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return void
 	 */
-	public function reconnect()
+	public function reconnect(): void
 	{
 		$this->close();
 		$this->initialize();
@@ -311,7 +311,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return mixed
 	 */
-	public function execute($sql)
+	public function execute(string $sql)
 	{
 		while ($this->connID->more_results())
 		{
@@ -336,7 +336,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return string
 	 */
-	protected function prepQuery($sql)
+	protected function prepQuery(string $sql): string
 	{
 		// mysqli_affected_rows() returns 0 for "DELETE FROM TABLE" queries. This hack
 		// modifies the query so that it a proper number of affected rows is returned.
@@ -353,7 +353,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	/**
 	 * Returns the total number of rows affected by this query.
 	 *
-	 * @return mixed
+	 * @return integer
 	 */
 	public function affectedRows(): int
 	{
@@ -392,7 +392,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return string
 	 */
-	protected function _listTables($prefixLimit = false): string
+	protected function _listTables(bool $prefixLimit = false): string
 	{
 		$sql = 'SHOW TABLES FROM ' . $this->escapeIdentifiers($this->database);
 
@@ -424,7 +424,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * Returns an array of objects with field data
 	 *
 	 * @param  string $table
-	 * @return \stdClass[]
+	 * @return array
 	 * @throws DatabaseException
 	 */
 	public function _fieldData(string $table): array
@@ -458,7 +458,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * Returns an array of objects with index data
 	 *
 	 * @param  string $table
-	 * @return \stdClass[]
+	 * @return array
 	 * @throws DatabaseException
 	 * @throws \LogicException
 	 */
@@ -524,7 +524,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * Returns an array of objects with Foreign key data
 	 *
 	 * @param  string $table
-	 * @return \stdClass[]
+	 * @return array
 	 * @throws DatabaseException
 	 */
 	public function _foreignKeyData(string $table): array
@@ -573,7 +573,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return array
 	 */
-	public function error()
+	public function error(): array
 	{
 		if (! empty($this->mysqli->connect_errno))
 		{
@@ -596,7 +596,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return integer
 	 */
-	public function insertID()
+	public function insertID(): int
 	{
 		return $this->connID->insert_id;
 	}

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -116,7 +116,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 * @param  array $attributes Associative array of table attributes
 	 * @return string
 	 */
-	protected function _createTableAttributes($attributes)
+	protected function _createTableAttributes(array $attributes): string
 	{
 		$sql = '';
 
@@ -160,7 +160,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 * @param  mixed  $field      Column definition
 	 * @return string|string[]
 	 */
-	protected function _alterTable($alter_type, $table, $field)
+	protected function _alterTable(string $alter_type, string $table, $field)
 	{
 		if ($alter_type === 'DROP')
 		{
@@ -200,7 +200,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 * @param  array $field
 	 * @return string
 	 */
-	protected function _processColumn($field)
+	protected function _processColumn(array $field): string
 	{
 		$extra_clause = isset($field['after']) ? ' AFTER ' . $this->db->escapeIdentifiers($field['after']) : '';
 
@@ -227,42 +227,42 @@ class Forge extends \CodeIgniter\Database\Forge
 	 * Process indexes
 	 *
 	 * @param  string $table (ignored)
-	 * @return string
+	 * @return array
 	 */
-	protected function _processIndexes($table)
+	protected function _processIndexes(string $table): array
 	{
-		$sql = '';
+		$sqls = [];
 
-		for ($i = 0, $c = count($this->keys); $i < $c; $i ++)
+		for ($i = 0, $c = count($this->keys); $i < $c; $i++)
 		{
-			if (is_array($this->keys[$i]))
+			$this->keys[$i] = (array)$this->keys[$i];
+
+			for ($i2 = 0, $c2 = count($this->keys[$i]); $i2 < $c2; $i2++)
 			{
-				for ($i2 = 0, $c2 = count($this->keys[$i]); $i2 < $c2; $i2 ++)
+				if (! isset($this->fields[$this->keys[$i][$i2]]))
 				{
-					if (! isset($this->fields[$this->keys[$i][$i2]]))
-					{
-						unset($this->keys[$i][$i2]);
-						continue;
-					}
+					unset($this->keys[$i][$i2]);
 				}
 			}
-			elseif (! isset($this->fields[$this->keys[$i]]))
+			if (count($this->keys[$i]) <= 0)
 			{
-				unset($this->keys[$i]);
 				continue;
 			}
 
-			is_array($this->keys[$i]) || $this->keys[$i] = [$this->keys[$i]];
+			if (in_array($i, $this->uniqueKeys))
+			{
+				$sqls[] = 'ALTER TABLE ' . $this->db->escapeIdentifiers($table)
+					. ' ADD CONSTRAINT ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
+					. ' UNIQUE (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
+				continue;
+			}
 
-			$unique = in_array($i, $this->uniqueKeys) ? 'UNIQUE ' : '';
-
-			$sql .= ",\n\t{$unique}KEY " . $this->db->escapeIdentifiers(implode('_', $this->keys[$i]))
-					. ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ')';
+			$sqls[] = 'CREATE INDEX ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
+				. ' ON ' . $this->db->escapeIdentifiers($table)
+				. ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
 		}
 
-		$this->keys = [];
-
-		return $sql;
+		return $sqls;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -79,8 +79,9 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 	 * @param array $data
 	 *
 	 * @return \CodeIgniter\Database\ResultInterface
+	 * @throws \BadMethodCallException
 	 */
-	public function _execute($data)
+	public function _execute(array $data)
 	{
 		if (is_null($this->statement))
 		{

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -124,7 +124,7 @@ class Result extends BaseResult implements ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function dataSeek($n = 0)
+	public function dataSeek(int $n = 0)
 	{
 		return $this->resultID->data_seek($n);
 	}
@@ -138,7 +138,7 @@ class Result extends BaseResult implements ResultInterface
 	 *
 	 * @return array
 	 */
-	protected function fetchAssoc()
+	protected function fetchAssoc(): array
 	{
 		return $this->resultID->fetch_assoc();
 	}
@@ -154,7 +154,7 @@ class Result extends BaseResult implements ResultInterface
 	 *
 	 * @return object
 	 */
-	protected function fetchObject($className = 'stdClass')
+	protected function fetchObject(string $className = 'stdClass'): object
 	{
 		return $this->resultID->fetch_object($className);
 	}

--- a/system/Database/MySQLi/Utils.php
+++ b/system/Database/MySQLi/Utils.php
@@ -1,5 +1,7 @@
 <?php namespace CodeIgniter\Database\MySQLi;
 
+use CodeIgniter\Database\Exceptions\DatabaseException;
+
 /**
  * CodeIgniter
  *

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -66,7 +66,7 @@ class Builder extends BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function orderBy($orderby, $direction = '', $escape = null)
+	public function orderBy(string $orderby, string $direction = '', bool $escape = null)
 	{
 		$direction = strtoupper(trim($direction));
 		if ($direction === 'RANDOM')
@@ -99,7 +99,7 @@ class Builder extends BaseBuilder
 	 *
 	 * @return boolean
 	 */
-	public function increment(string $column, int $value = 1)
+	public function increment(string $column, int $value = 1): bool
 	{
 		$column = $this->db->protectIdentifiers($column);
 
@@ -118,7 +118,7 @@ class Builder extends BaseBuilder
 	 *
 	 * @return boolean
 	 */
-	public function decrement(string $column, int $value = 1)
+	public function decrement(string $column, int $value = 1): bool
 	{
 		$column = $this->db->protectIdentifiers($column);
 
@@ -144,7 +144,7 @@ class Builder extends BaseBuilder
 	 * @throws   DatabaseException
 	 * @internal param true $bool returns the generated SQL, false executes the query.
 	 */
-	public function replace($set = null, $returnSQL = false)
+	public function replace(array $set = null, bool $returnSQL = false): bool
 	{
 		if ($set !== null)
 		{
@@ -199,8 +199,8 @@ class Builder extends BaseBuilder
 	 *
 	 * Compiles a delete string and runs the query
 	 *
-	 * @param string  $where
-	 * @param null    $limit
+	 * @param mixed   $where
+	 * @param mixed     $limit
 	 * @param boolean $reset_data
 	 * @param boolean $returnSQL
 	 *
@@ -210,7 +210,7 @@ class Builder extends BaseBuilder
 	 * @internal param the $mixed limit clause
 	 * @internal param $bool
 	 */
-	public function delete($where = '', $limit = null, $reset_data = true, $returnSQL = false)
+	public function delete($where = '', $limit = null, bool $reset_data = true, bool $returnSQL = false)
 	{
 		if (! empty($limit) || ! empty($this->QBLimit))
 		{
@@ -231,7 +231,7 @@ class Builder extends BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _limit($sql)
+	protected function _limit(string $sql): string
 	{
 		return $sql . ' LIMIT ' . $this->QBLimit . ($this->QBOffset ? " OFFSET {$this->QBOffset}" : '');
 	}
@@ -251,7 +251,7 @@ class Builder extends BaseBuilder
 	 * @internal param the $string table name
 	 * @internal param the $array update data
 	 */
-	protected function _update($table, $values)
+	protected function _update(string $table, array $values): string
 	{
 		if (! empty($this->QBLimit))
 		{
@@ -275,7 +275,7 @@ class Builder extends BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _updateBatch($table, $values, $index)
+	protected function _updateBatch(string $table, array $values, string $index): string
 	{
 		$ids = [];
 		foreach ($values as $key => $val)
@@ -315,7 +315,7 @@ class Builder extends BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _delete($table)
+	protected function _delete(string $table): string
 	{
 		$this->QBLimit = false;
 		return parent::_delete($table);
@@ -335,7 +335,7 @@ class Builder extends BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _truncate($table)
+	protected function _truncate(string $table): string
 	{
 		return 'TRUNCATE ' . $table . ' RESTART IDENTITY';
 	}
@@ -350,11 +350,11 @@ class Builder extends BaseBuilder
 	 *
 	 * @see https://www.postgresql.org/docs/9.2/static/functions-matching.html
 	 *
-	 * @param string|null $prefix
-	 * @param string      $column
-	 * @param string|null $not
-	 * @param string      $bind
-	 * @param boolean     $insensitiveSearch
+	 * @param string    $prefix
+	 * @param string    $column
+	 * @param string    $not
+	 * @param string    $bind
+	 * @param boolean   $insensitiveSearch
 	 *
 	 * @return string     $like_statement
 	 */

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -77,7 +77,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * @param  boolean $persistent
 	 * @return mixed
 	 */
-	public function connect($persistent = false)
+	public function connect(bool $persistent = false)
 	{
 		if (empty($this->DSN))
 		{
@@ -147,9 +147,9 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @param string $databaseName
 	 *
-	 * @return mixed
+	 * @return boolean
 	 */
-	public function setDatabase(string $databaseName)
+	public function setDatabase(string $databaseName): bool
 	{
 		return false;
 	}
@@ -185,7 +185,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return resource
 	 */
-	public function execute($sql)
+	public function execute(string $sql)
 	{
 		return pg_query($this->connID, $sql);
 	}
@@ -195,7 +195,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	/**
 	 * Returns the total number of rows affected by this query.
 	 *
-	 * @return mixed
+	 * @return int
 	 */
 	public function affectedRows(): int
 	{
@@ -209,7 +209,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * Escapes data based on type
 	 *
-	 * @param  string $str
+	 * @param mixed $str
 	 * @return mixed
 	 */
 	public function escape($str)
@@ -258,7 +258,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return string
 	 */
-	protected function _listTables($prefixLimit = false): string
+	protected function _listTables(bool $prefixLimit = false): string
 	{
 		$sql = 'SELECT "table_name" FROM "information_schema"."tables" WHERE "table_schema" = \'' . $this->schema . "'";
 
@@ -295,7 +295,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * Returns an array of objects with field data
 	 *
 	 * @param  string $table
-	 * @return \stdClass[]
+	 * @return array
 	 * @throws DatabaseException
 	 */
 	public function _fieldData(string $table): array
@@ -330,7 +330,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * Returns an array of objects with index data
 	 *
 	 * @param  string $table
-	 * @return \stdClass[]
+	 * @return array
 	 * @throws DatabaseException
 	 */
 	public function _indexData(string $table): array
@@ -377,7 +377,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * Returns an array of objects with Foreign key data
 	 *
 	 * @param  string $table
-	 * @return \stdClass[]
+	 * @return array
 	 * @throws DatabaseException
 	 */
 	public function _foreignKeyData(string $table): array
@@ -424,7 +424,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return array
 	 */
-	public function error()
+	public function error(): array
 	{
 		return [
 			'code'    => '',
@@ -439,7 +439,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return integer
 	 */
-	public function insertID()
+	public function insertID(): int
 	{
 		$v = pg_version($this->connID);
 		// 'server' key is only available since PostgreSQL 7.4
@@ -486,7 +486,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return void
 	 */
-	protected function buildDSN()
+	protected function buildDSN(): void
 	{
 		$this->DSN === '' || $this->DSN = '';
 
@@ -539,7 +539,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * @param  string $charset The client encoding to which the data will be converted.
 	 * @return boolean
 	 */
-	protected function setClientEncoding($charset)
+	protected function setClientEncoding(string $charset): bool
 	{
 		return pg_set_client_encoding($this->connID, $charset) === 0;
 	}

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -81,7 +81,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 * @param  array $attributes Associative array of table attributes
 	 * @return string
 	 */
-	protected function _createTableAttributes($attributes)
+	protected function _createTableAttributes(array $attributes): string
 	{
 		return '';
 	}
@@ -97,7 +97,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 *
 	 * @return string|array
 	 */
-	protected function _alterTable($alter_type, $table, $field)
+	protected function _alterTable(string $alter_type, string $table, $field)
 	{
 		if (in_array($alter_type, ['DROP', 'ADD'], true))
 		{
@@ -156,7 +156,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 * @param  array $field
 	 * @return string
 	 */
-	protected function _processColumn($field)
+	protected function _processColumn(array $field): string
 	{
 		return $this->db->escapeIdentifiers($field['name'])
 				. ' ' . $field['type'] . $field['length']
@@ -177,7 +177,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 *
 	 * @return void
 	 */
-	protected function _attributeType(&$attributes)
+	protected function _attributeType(array &$attributes): void
 	{
 		// Reset field lengths for data types that don't support it
 		if (isset($attributes['CONSTRAINT']) && stripos($attributes['TYPE'], 'int') !== false)
@@ -190,15 +190,14 @@ class Forge extends \CodeIgniter\Database\Forge
 			case 'TINYINT':
 				$attributes['TYPE']     = 'SMALLINT';
 				$attributes['UNSIGNED'] = false;
-				return;
+				break;
 			case 'MEDIUMINT':
 				$attributes['TYPE']     = 'INTEGER';
 				$attributes['UNSIGNED'] = false;
-				return;
+				break;
 			case 'DATETIME':
 				$attributes['TYPE'] = 'TIMESTAMP';
-			default:
-				return;
+				break;
 		}
 	}
 
@@ -212,7 +211,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 *
 	 * @return void
 	 */
-	protected function _attributeAutoIncrement(&$attributes, &$field)
+	protected function _attributeAutoIncrement(array &$attributes, array &$field): void
 	{
 		if (! empty($attributes['AUTO_INCREMENT']) && $attributes['AUTO_INCREMENT'] === true)
 		{
@@ -233,7 +232,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 *
 	 * @return string
 	 */
-	protected function _dropTable($table, $if_exists, $cascade)
+	protected function _dropTable(string $table, bool $if_exists, bool $cascade): string
 	{
 		$sql = parent::_dropTable($table, $if_exists, $cascade);
 

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -102,7 +102,7 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 	 *
 	 * @return boolean
 	 */
-	public function _execute($data)
+	public function _execute(array $data): string
 	{
 		if (is_null($this->statement))
 		{

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -124,7 +124,7 @@ class Result extends BaseResult implements ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function dataSeek($n = 0)
+	public function dataSeek(int $n = 0)
 	{
 		return pg_result_seek($this->resultID, $n);
 	}
@@ -138,7 +138,7 @@ class Result extends BaseResult implements ResultInterface
 	 *
 	 * @return array
 	 */
-	protected function fetchAssoc()
+	protected function fetchAssoc(): array
 	{
 		return pg_fetch_assoc($this->resultID);
 	}
@@ -154,7 +154,7 @@ class Result extends BaseResult implements ResultInterface
 	 *
 	 * @return object
 	 */
-	protected function fetchObject($className = 'stdClass')
+	protected function fetchObject(string $className = 'stdClass'): object
 	{
 		return pg_fetch_object($this->resultID, null, $className);
 	}

--- a/system/Database/Postgre/Utils.php
+++ b/system/Database/Postgre/Utils.php
@@ -1,5 +1,7 @@
 <?php namespace CodeIgniter\Database\Postgre;
 
+use CodeIgniter\Database\Exceptions\DatabaseException;
+
 /**
  * CodeIgniter
  *

--- a/system/Database/PreparedQueryInterface.php
+++ b/system/Database/PreparedQueryInterface.php
@@ -47,7 +47,7 @@ interface PreparedQueryInterface
 	 *
 	 * @return ResultInterface
 	 */
-	public function execute(...$data);
+	public function execute(array ...$data);
 
 	//--------------------------------------------------------------------
 
@@ -65,7 +65,7 @@ interface PreparedQueryInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * Explicity closes the statement.
+	 * Explicitly closes the statement.
 	 */
 	public function close();
 

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -135,7 +135,7 @@ class Query implements QueryInterface
 	 *
 	 * @return mixed
 	 */
-	public function setQuery(string $sql, $binds = null, bool $setEscape = true)
+	public function setQuery(string $sql, array $binds = null, bool $setEscape = true)
 	{
 		$this->originalQueryString = $sql;
 
@@ -183,7 +183,7 @@ class Query implements QueryInterface
 	 * Returns the final, processed query string after binding, etal
 	 * has been performed.
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	public function getQuery(): string
 	{
@@ -233,7 +233,7 @@ class Query implements QueryInterface
 	 *
 	 * @return mixed
 	 */
-	public function getStartTime($returnRaw = false, int $decimals = 6)
+	public function getStartTime(bool $returnRaw = false, int $decimals = 6)
 	{
 		if ($returnRaw)
 		{
@@ -350,7 +350,7 @@ class Query implements QueryInterface
 	 *
 	 * @return string
 	 */
-	public function getOriginalQuery()
+	public function getOriginalQuery(): string
 	{
 		return $this->originalQueryString;
 	}
@@ -416,7 +416,7 @@ class Query implements QueryInterface
 	 * @param  array  $binds
 	 * @return string
 	 */
-	protected function matchNamedBinds(string $sql, array $binds)
+	protected function matchNamedBinds(string $sql, array $binds): string
 	{
 		$replacers = [];
 
@@ -452,7 +452,7 @@ class Query implements QueryInterface
 	 * @param  integer $ml
 	 * @return string
 	 */
-	protected function matchSimpleBinds(string $sql, array $binds, int $bindCount, int $ml)
+	protected function matchSimpleBinds(string $sql, array $binds, int $bindCount, int $ml): string
 	{
 		// Make sure not to replace a chunk inside a string that happens to match the bind marker
 		if ($c = preg_match_all("/'[^']*'/i", $sql, $matches))
@@ -491,7 +491,7 @@ class Query implements QueryInterface
 	/**
 	 * Return text representation of the query
 	 *
-	 * @return mixed|string
+	 * @return string
 	 */
 	public function __toString()
 	{

--- a/system/Database/QueryInterface.php
+++ b/system/Database/QueryInterface.php
@@ -55,7 +55,7 @@ interface QueryInterface
 	 *
 	 * @return mixed
 	 */
-	public function setQuery(string $sql, $binds = null);
+	public function setQuery(string $sql, array $binds = null);
 
 	//--------------------------------------------------------------------
 

--- a/system/Database/ResultInterface.php
+++ b/system/Database/ResultInterface.php
@@ -51,7 +51,7 @@ interface ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getResult($type = 'object'): array;
+	public function getResult(string $type = 'object');
 
 	//--------------------------------------------------------------------
 
@@ -99,7 +99,7 @@ interface ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getRow($n = 0, $type = 'object');
+	public function getRow(int $n = 0, string $type = 'object');
 
 	//--------------------------------------------------------------------
 
@@ -113,7 +113,7 @@ interface ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getCustomRowObject($n, string $className);
+	public function getCustomRowObject(int $n, string $className);
 
 	//--------------------------------------------------------------------
 
@@ -126,7 +126,7 @@ interface ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getRowArray($n = 0);
+	public function getRowArray(int $n = 0);
 
 	//--------------------------------------------------------------------
 
@@ -139,7 +139,7 @@ interface ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getRowObject($n = 0);
+	public function getRowObject(int $n = 0);
 
 	//--------------------------------------------------------------------
 
@@ -162,7 +162,7 @@ interface ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getFirstRow($type = 'object');
+	public function getFirstRow(string $type = 'object');
 
 	//--------------------------------------------------------------------
 
@@ -173,7 +173,7 @@ interface ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getLastRow($type = 'object');
+	public function getLastRow(string $type = 'object');
 
 	//--------------------------------------------------------------------
 
@@ -184,7 +184,7 @@ interface ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getNextRow($type = 'object');
+	public function getNextRow(string $type = 'object');
 
 	//--------------------------------------------------------------------
 
@@ -195,7 +195,7 @@ interface ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getPreviousRow($type = 'object');
+	public function getPreviousRow(string $type = 'object');
 
 	//--------------------------------------------------------------------
 
@@ -206,7 +206,7 @@ interface ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function getUnbufferedRow($type = 'object');
+	public function getUnbufferedRow(string $type = 'object');
 
 	//--------------------------------------------------------------------
 
@@ -255,7 +255,7 @@ interface ResultInterface
 	 *
 	 * @return mixed
 	 */
-	public function dataSeek($n = 0);
+	public function dataSeek(int $n = 0);
 
 	//--------------------------------------------------------------------
 }

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -80,7 +80,7 @@ class Builder extends BaseBuilder
 	 *
 	 * @return string
 	 */
-	protected function _replace($table, $keys, $values)
+	protected function _replace(string $table, array $keys, array $values): string
 	{
 		return 'INSERT OR ' . parent::_replace($table, $keys, $values);
 	}
@@ -98,7 +98,7 @@ class Builder extends BaseBuilder
 	 * @param  string $table
 	 * @return string
 	 */
-	protected function _truncate($table)
+	protected function _truncate(string $table): string
 	{
 		return 'DELETE FROM ' . $table;
 	}

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -75,7 +75,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * @return mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function connect($persistent = false)
+	public function connect(bool $persistent = false)
 	{
 		if ($persistent && $this->db->DBDebug)
 		{
@@ -114,7 +114,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return void
 	 */
-	protected function _close()
+	protected function _close(): void
 	{
 		$this->connID->close();
 	}
@@ -159,9 +159,9 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @param string $sql
 	 *
-	 * @return mixed    \SQLite3Result object or bool
+	 * @return mixed    \SQLite3Result object or boolean
 	 */
-	public function execute($sql)
+	public function execute(string $sql)
 	{
 		return $this->isWriteType($sql)
 			? $this->connID->exec($sql)
@@ -203,7 +203,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return string
 	 */
-	protected function _listTables($prefixLimit = false): string
+	protected function _listTables(bool $prefixLimit = false): string
 	{
 		return 'SELECT "NAME" FROM "SQLITE_MASTER" WHERE "TYPE" = \'table\''
 			   . (($prefixLimit !== false && $this->DBPrefix !== '')
@@ -231,10 +231,10 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @param string $table Table name
 	 *
-	 * @return array|false
+	 * @return array|boolean
 	 * @throws DatabaseException
 	 */
-	public function getFieldNames($table)
+	public function getFieldNames(string $table)
 	{
 		// Is there a cached result?
 		if (isset($this->dataCache['field_names'][$table]))
@@ -296,7 +296,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * Returns an array of objects with field data
 	 *
 	 * @param  string $table
-	 * @return \stdClass[]
+	 * @return array
 	 * @throws DatabaseException
 	 */
 	public function _fieldData(string $table): array
@@ -333,7 +333,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * Returns an array of objects with index data
 	 *
 	 * @param  string $table
-	 * @return \stdClass[]
+	 * @return array
 	 * @throws DatabaseException
 	 */
 	public function _indexData(string $table): array
@@ -378,7 +378,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 * Returns an array of objects with Foreign key data
 	 *
 	 * @param  string $table
-	 * @return \stdClass[]
+	 * @return array
 	 */
 	public function _foreignKeyData(string $table): array
 	{
@@ -485,6 +485,8 @@ class Connection extends BaseConnection implements ConnectionInterface
 
 	/**
 	 * Determines if the statement is a write-type query or not.
+	 *
+	 * @param $sql
 	 *
 	 * @return boolean
 	 */

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -83,7 +83,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 *
 	 * @return boolean
 	 */
-	public function createDatabase($db_name): bool
+	public function createDatabase(string $db_name): bool
 	{
 		// In SQLite, a database is created when you connect to the database.
 		// We'll return TRUE so that an error isn't generated.
@@ -98,9 +98,9 @@ class Forge extends \CodeIgniter\Database\Forge
 	 * @param string $db_name
 	 *
 	 * @return boolean
-	 * @throws \CodeIgniter\DatabaseException
+	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function dropDatabase($db_name): bool
+	public function dropDatabase(string $db_name): bool
 	{
 		// In SQLite, a database is dropped when we delete a file
 		if (! is_file($db_name))
@@ -148,9 +148,9 @@ class Forge extends \CodeIgniter\Database\Forge
 	 * @param string $table      Table name
 	 * @param mixed  $field      Column definition
 	 *
-	 * @return string|array
+	 * @return string|array|null
 	 */
-	protected function _alterTable($alter_type, $table, $field)
+	protected function _alterTable(string $alter_type, string $table, $field)
 	{
 		switch ($alter_type)
 		{
@@ -186,7 +186,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 *
 	 * @return string
 	 */
-	protected function _processColumn($field)
+	protected function _processColumn(array $field):string
 	{
 		if ($field['type'] === 'TEXT' && strpos($field['length'], "('") === 0)
 		{
@@ -211,7 +211,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 *
 	 * @return array
 	 */
-	protected function _processIndexes($table)
+	protected function _processIndexes(string $table):array
 	{
 		$sqls = [];
 
@@ -257,7 +257,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 *
 	 * @return void
 	 */
-	protected function _attributeType(&$attributes)
+	protected function _attributeType(array &$attributes): void
 	{
 		switch (strtoupper($attributes['TYPE']))
 		{
@@ -281,7 +281,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 *
 	 * @return void
 	 */
-	protected function _attributeAutoIncrement(&$attributes, &$field)
+	protected function _attributeAutoIncrement(array &$attributes, array &$field): void
 	{
 		if (! empty($attributes['AUTO_INCREMENT']) && $attributes['AUTO_INCREMENT'] === true
 			&& stripos($field['type'], 'int') !== false)
@@ -307,7 +307,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	 * @return boolean
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function dropForeignKey($table, $foreign_name)
+	public function dropForeignKey(string $table, string $foreign_name): bool
 	{
 		throw new DatabaseException(lang('Database.dropForeignKeyUnsupported'));
 	}

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -87,7 +87,7 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 	 *
 	 * @return boolean
 	 */
-	public function _execute($data)
+	public function _execute(array $data): bool
 	{
 		if (is_null($this->statement))
 		{

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -37,6 +37,7 @@
  */
 
 use CodeIgniter\Database\BaseResult;
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\ResultInterface;
 
 /**
@@ -130,9 +131,9 @@ class Result extends BaseResult implements ResultInterface
 	 * @param integer $n
 	 *
 	 * @return mixed
-	 * @throws \CodeIgniter\DatabaseException
+	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function dataSeek($n = 0)
+	public function dataSeek(int $n = 0)
 	{
 		if ($n !== 0)
 		{
@@ -154,7 +155,7 @@ class Result extends BaseResult implements ResultInterface
 	 *
 	 * @return array
 	 */
-	protected function fetchAssoc()
+	protected function fetchAssoc(): array
 	{
 		return $this->resultID->fetchArray(SQLITE3_ASSOC);
 	}
@@ -168,9 +169,9 @@ class Result extends BaseResult implements ResultInterface
 	 *
 	 * @param string $className
 	 *
-	 * @return object
+	 * @return boolean|object
 	 */
-	protected function fetchObject($className = 'stdClass')
+	protected function fetchObject(string $className = 'stdClass')
 	{
 		// No native support for fetching rows as objects
 		if (($row = $this->fetchAssoc()) === false)

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -177,8 +177,10 @@ class Table
 
 	/**
 	 * Creates the new table based on our current fields.
+	 *
+	 * @return boolean
 	 */
-	protected function createTable()
+	protected function createTable(): bool
 	{
 		$this->dropIndexes();
 		$this->db->resetDataCache();
@@ -262,7 +264,7 @@ class Table
 	 *
 	 * @return array
 	 */
-	protected function formatFields($fields)
+	protected function formatFields($fields): array
 	{
 		if (! is_array($fields))
 		{

--- a/system/Database/SQLite3/Utils.php
+++ b/system/Database/SQLite3/Utils.php
@@ -1,5 +1,7 @@
 <?php namespace CodeIgniter\Database\SQLite3;
 
+use CodeIgniter\Database\Exceptions\DatabaseException;
+
 /**
  * CodeIgniter
  *

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -298,7 +298,7 @@ class Exceptions
 	 *
 	 * @return array
 	 */
-	protected function collectVars(\Throwable $exception, int $statusCode)
+	protected function collectVars(\Throwable $exception, int $statusCode): array
 	{
 		return [
 			'title'   => get_class($exception),
@@ -356,7 +356,7 @@ class Exceptions
 	 *
 	 * @return string
 	 */
-	public static function cleanPath($file)
+	public static function cleanPath(string $file): string
 	{
 		if (strpos($file, APPPATH) === 0)
 		{
@@ -403,13 +403,13 @@ class Exceptions
 	/**
 	 * Creates a syntax-highlighted version of a PHP file.
 	 *
-	 * @param $file
-	 * @param $lineNumber
-	 * @param integer    $lines
+	 * @param string    $file
+	 * @param int       $lineNumber
+	 * @param integer   $lines
 	 *
 	 * @return boolean|string
 	 */
-	public static function highlightFile($file, $lineNumber, $lines = 15)
+	public static function highlightFile(string $file, int $lineNumber, $lines = 15)
 	{
 		if (empty($file) || ! is_readable($file))
 		{

--- a/system/Debug/Iterator.php
+++ b/system/Debug/Iterator.php
@@ -90,7 +90,7 @@ class Iterator
 	 *
 	 * @return string
 	 */
-	public function run($iterations = 1000, $output = true)
+	public function run($iterations = 1000, $output = true): string
 	{
 		foreach ($this->tests as $name => $test)
 		{
@@ -129,7 +129,7 @@ class Iterator
 	 *
 	 * @return string
 	 */
-	public function getReport()
+	public function getReport(): string
 	{
 		if (empty($this->results))
 		{

--- a/system/Debug/Timer.php
+++ b/system/Debug/Timer.php
@@ -146,7 +146,7 @@ class Timer
 	 *
 	 * @return array
 	 */
-	public function getTimers(int $decimals = 4)
+	public function getTimers(int $decimals = 4): array
 	{
 		$timers = $this->timers;
 
@@ -172,7 +172,7 @@ class Timer
 	 *
 	 * @return boolean
 	 */
-	public function has(string $name)
+	public function has(string $name): bool
 	{
 		return array_key_exists(strtolower($name), $this->timers);
 	}

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -273,7 +273,7 @@ class Toolbar
 	 *
 	 * @return array
 	 */
-	protected function collectVarData()// : array
+	protected function collectVarData(): array
 	{
 		$data = [];
 
@@ -300,7 +300,7 @@ class Toolbar
 	 *
 	 * @return float
 	 */
-	protected function roundTo($number, $increments = 5)
+	protected function roundTo(float $number, int $increments = 5): float
 	{
 		$increments = 1 / $increments;
 
@@ -440,7 +440,7 @@ class Toolbar
 	 *
 	 * @return string
 	 */
-	protected function format(string $data, string $format = 'html')
+	protected function format(string $data, string $format = 'html'): string
 	{
 		$data = json_decode($data, true);
 

--- a/system/Debug/Toolbar/Collectors/BaseCollector.php
+++ b/system/Debug/Toolbar/Collectors/BaseCollector.php
@@ -90,7 +90,7 @@ class BaseCollector
 	 * @param  boolean $safe
 	 * @return string
 	 */
-	public function getTitle($safe = false): string
+	public function getTitle(bool $safe = false): string
 	{
 		if ($safe)
 		{
@@ -249,7 +249,7 @@ class BaseCollector
 	 *
 	 * @return string
 	 */
-	public function cleanPath($file)
+	public function cleanPath(string $file): string
 	{
 		if (strpos($file, APPPATH) === 0)
 		{
@@ -284,7 +284,7 @@ class BaseCollector
 	 *
 	 * @return boolean
 	 */
-	public function isEmpty()
+	public function isEmpty(): bool
 	{
 		return false;
 	}

--- a/system/Debug/Toolbar/Collectors/Config.php
+++ b/system/Debug/Toolbar/Collectors/Config.php
@@ -6,7 +6,10 @@ use CodeIgniter\CodeIgniter;
 
 class Config
 {
-	public static function display()
+	/**
+	 * @return array
+	 */
+	public static function display(): array
 	{
 		$config = config(App::class);
 

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -226,7 +226,7 @@ class Database extends BaseCollector
 	 *
 	 * @return integer
 	 */
-	public function getBadgeValue()
+	public function getBadgeValue(): int
 	{
 		return count(static::$queries);
 	}
@@ -251,7 +251,7 @@ class Database extends BaseCollector
 	 *
 	 * @return boolean
 	 */
-	public function isEmpty()
+	public function isEmpty(): bool
 	{
 		return empty(static::$queries);
 	}

--- a/system/Debug/Toolbar/Collectors/Events.php
+++ b/system/Debug/Toolbar/Collectors/Events.php
@@ -161,7 +161,7 @@ class Events extends BaseCollector
 	/**
 	 * Gets the "badge" value for the button.
 	 */
-	public function getBadgeValue()
+	public function getBadgeValue(): int
 	{
 		return count(\CodeIgniter\Events\Events::getPerformanceLogs());
 	}

--- a/system/Debug/Toolbar/Collectors/Files.php
+++ b/system/Debug/Toolbar/Collectors/Files.php
@@ -127,7 +127,7 @@ class Files extends BaseCollector
 	 *
 	 * @return integer
 	 */
-	public function getBadgeValue()
+	public function getBadgeValue(): int
 	{
 		return count(get_included_files());
 	}

--- a/system/Debug/Toolbar/Collectors/History.php
+++ b/system/Debug/Toolbar/Collectors/History.php
@@ -144,12 +144,15 @@ class History extends BaseCollector
 	 *
 	 * @return integer
 	 */
-	public function getBadgeValue()
+	public function getBadgeValue(): int
 	{
 		return count($this->files);
 	}
 
-	public function isEmpty()
+	/**
+	 * @return boolean
+	 */
+	public function isEmpty(): bool
 	{
 		return empty($this->files);
 	}

--- a/system/Debug/Toolbar/Collectors/Logs.php
+++ b/system/Debug/Toolbar/Collectors/Logs.php
@@ -93,8 +93,10 @@ class Logs extends BaseCollector
 
 	/**
 	 * Does this collector actually have any data to display?
+	 *
+	 * @return boolean
 	 */
-	public function isEmpty()
+	public function isEmpty(): bool
 	{
 		$this->collectLogs();
 
@@ -119,6 +121,8 @@ class Logs extends BaseCollector
 
 	/**
 	 * Ensures the data has been collected.
+	 *
+	 * @return mixed
 	 */
 	protected function collectLogs()
 	{

--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -137,7 +137,7 @@ class Routes extends BaseCollector
 	 *
 	 * @return integer
 	 */
-	public function getBadgeValue()
+	public function getBadgeValue(): int
 	{
 		$rawRoutes = Services::routes(true);
 

--- a/system/Debug/Toolbar/Collectors/Timers.php
+++ b/system/Debug/Toolbar/Collectors/Timers.php
@@ -74,7 +74,7 @@ class Timers extends BaseCollector
 	 * Child classes should implement this to return the timeline data
 	 * formatted for correct usage.
 	 *
-	 * @return mixed
+	 * @return array
 	 */
 	protected function formatTimelineData(): array
 	{

--- a/system/Debug/Toolbar/Collectors/Views.php
+++ b/system/Debug/Toolbar/Collectors/Views.php
@@ -170,7 +170,7 @@ class Views extends BaseCollector
 	 *
 	 * @return integer
 	 */
-	public function getBadgeValue()
+	public function getBadgeValue(): int
 	{
 		return count($this->viewer->getPerformanceData());
 	}

--- a/tests/_support/Database/MockConnection.php
+++ b/tests/_support/Database/MockConnection.php
@@ -21,7 +21,7 @@ class MockConnection extends BaseConnection
 
 	//--------------------------------------------------------------------
 
-	public function query(string $sql, $binds = null, bool $setEscapeFlags = true, $queryClass = 'CodeIgniter\\Database\\Query')
+	public function query(string $sql, array $binds = null, bool $setEscapeFlags = true, $queryClass = 'CodeIgniter\\Database\\Query')
 	{
 		$queryClass = str_replace('Connection', 'Query', get_class($this));
 
@@ -154,7 +154,7 @@ class MockConnection extends BaseConnection
 	 *
 	 * @return array
 	 */
-	public function error()
+	public function error(): array
 	{
 		return [
 			'code'    => null,
@@ -169,7 +169,7 @@ class MockConnection extends BaseConnection
 	 *
 	 * @return integer
 	 */
-	public function insertID()
+	public function insertID(): int
 	{
 		return $this->connID->insert_id;
 	}

--- a/tests/_support/Database/MockResult.php
+++ b/tests/_support/Database/MockResult.php
@@ -57,7 +57,7 @@ class MockResult extends BaseResult
 	 *
 	 * @return mixed
 	 */
-	public function dataSeek($n = 0)
+	public function dataSeek(int $n = 0)
 	{
 	}
 
@@ -85,7 +85,7 @@ class MockResult extends BaseResult
 	 *
 	 * @return object
 	 */
-	protected function fetchObject($className = 'stdClass')
+	protected function fetchObject(string $className = 'stdClass'): object
 	{
 	}
 


### PR DESCRIPTION
To make the product code consistent, we have to follow the standard syntax and semantics across the code base.
There are many things missings like datatypes, return types, spelling corrections, and function documentation. I have tried to correct them.

As all the files contain the same type of corrections or changes, committed at once only.

List of folders covered under these changes are,

- Autoloader
- CLI
- Commands
- Config
- Database
- Debug

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide