### PR TITLE
replace mb_strlen() to strlen() in various rules as already return early in ! is_numeric

### DIFF
--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -79,7 +79,7 @@ class Rules
 			return false;
 		}
 
-		return ((int) $val === mb_strlen($str));
+		return ((int) $val === strlen($str));
 	}
 
 	//--------------------------------------------------------------------
@@ -238,7 +238,7 @@ class Rules
 			return false;
 		}
 
-		return ($val >= mb_strlen($str));
+		return ($val >= strlen($str));
 	}
 
 	//--------------------------------------------------------------------
@@ -259,7 +259,7 @@ class Rules
 			return false;
 		}
 
-		return ($val <= mb_strlen($str));
+		return ($val <= strlen($str));
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -74,12 +74,7 @@ class Rules
 	 */
 	public function exact_length(string $str = null, string $val, array $data): bool
 	{
-		if (! is_numeric($val))
-		{
-			return false;
-		}
-
-		return ((int) $val === strlen($str));
+		return ((int) $val === mb_strlen($str));
 	}
 
 	//--------------------------------------------------------------------
@@ -233,12 +228,7 @@ class Rules
 	 */
 	public function max_length(string $str = null, string $val, array $data): bool
 	{
-		if (! is_numeric($val))
-		{
-			return false;
-		}
-
-		return ($val >= strlen($str));
+		return ($val >= mb_strlen($str));
 	}
 
 	//--------------------------------------------------------------------
@@ -254,12 +244,7 @@ class Rules
 	 */
 	public function min_length(string $str = null, string $val, array $data): bool
 	{
-		if (! is_numeric($val))
-		{
-			return false;
-		}
-
-		return ($val <= strlen($str));
+		return ($val <= mb_strlen($str));
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -471,21 +471,6 @@ class RulesTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testMinLengthReturnsFalseWithNonNumericVal()
-	{
-		$data = [
-			'foo' => 'bar',
-		];
-
-		$this->validation->setRules([
-			'foo' => 'min_length[bar]',
-		]);
-
-		$this->assertFalse($this->validation->run($data));
-	}
-
-	//--------------------------------------------------------------------
-
 	public function testMinLengthReturnsTrueWithSuccess()
 	{
 		$data = [


### PR DESCRIPTION
Previously, there is a `! is_numeric()` check with return false early, so the `numeric` check is no need mbstring check with `mb_strlen()`, the `strlen()` is enough.

**Checklist:**
- [x] Securely signed commits
