### PR TITLE
Set Model->chunk return type

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -1005,7 +1005,7 @@ class Model
 				throw DataException::forEmptyDataset('chunk');
 			}
 
-			$rows = $rows->getResult();
+			$rows = $rows->getResult($this->tempReturnType);
 
 			$offset += $size;
 


### PR DESCRIPTION
**Description**
Model chunk is currently returning default return type, instead of the model-specific type. This change makes chunk() consistent with findAll() by changing getResult() to use tempReturnType.
Original discussion: https://forum.codeigniter.com/thread-72953.html

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide