### PR TITLE
Replace nonexistent "getAffectedRows"

### DIFF
--- a/user_guide_src/source/database/examples.rst
+++ b/user_guide_src/source/database/examples.rst
@@ -87,7 +87,7 @@ Standard Insert
 
 	$sql = "INSERT INTO mytable (title, name) VALUES (".$db->escape($title).", ".$db->escape($name).")";
 	$db->query($sql);
-	echo $db->getAffectedRows();
+	echo $db->affectedRows();
 
 Query Builder Query
 ===================


### PR DESCRIPTION
**Description**
In the user guide database examples open line incorrectly references a DB function "getAffectedRows" which should be "affectedRows"

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
