### PR TITLE
User Guide Documentation Correction

### DIFF
--- a/user_guide_src/README.rst
+++ b/user_guide_src/README.rst
@@ -7,7 +7,7 @@ Setup Instructions
 ******************
 
 The CodeIgniter user guide uses Sphinx to manage the documentation and
-output it to various formats.  Pages are written in human-readable
+output it to various formats. Pages are written in human-readable
 `ReStructured Text <http://sphinx.pocoo.org/rest.html>`_ format.
 
 Prerequisites
@@ -15,8 +15,8 @@ Prerequisites
 
 Sphinx requires Python, which is already installed if you are running OS X.
 You can confirm in a Terminal window by executing the ``python`` command
-without any parameters.  It should load up and tell you which version you have
-installed.  If you're not on 2.7+, go ahead and install 2.7.2 from
+without any parameters. It should load up and tell you which version you have
+installed. If you're not on 2.7+, go ahead and install 2.7.2 from
 http://python.org/download/releases/2.7.2/
 
 Installation
@@ -33,7 +33,7 @@ Editing and Creating Documentation
 ==================================
 
 All of the source files exist under *source/* and is where you will add new
-documentation or modify existing documentation.  Just as with code changes,
+documentation or modify existing documentation. Just as with code changes,
 we recommend working from feature branches and making pull requests to
 the *develop* branch of this repo.
 
@@ -41,18 +41,18 @@ So where's the HTML?
 ====================
 
 Obviously, the HTML documentation is what we care most about, as it is the
-primary documentation that our users encounter.  Since revisions to the built
-files are not of value, they are not under source control.  This also allows
-you to regenerate as necessary if you want to "preview" your work.  Generating
-the HTML is very simple.  From the root directory of your user guide repo
+primary documentation that our users encounter. Since revisions to the built
+files are not of value, they are not under source control. This also allows
+you to regenerate as necessary if you want to "preview" your work. Generating
+the HTML is very simple. From the root directory of your user guide repo
 fork issue the command you used at the end of the installation instructions::
 
 	make html
 
 You will see it do a whiz-bang compilation, at which point the fully rendered
-user guide and images will be in *build/html/*.  After the HTML has been built,
+user guide and images will be in *build/html/*. After the HTML has been built,
 each successive build will only rebuild files that have changed, saving
-considerable time.  If for any reason you want to "reset" your build files,
+considerable time. If for any reason you want to "reset" your build files,
 simply delete the *build* folder's contents and rebuild.
 
 ***************

--- a/user_guide_src/source/cli/cli.rst
+++ b/user_guide_src/source/cli/cli.rst
@@ -2,7 +2,7 @@
 Running via the Command Line
 ############################
 
-As well as calling an applications :doc:`Controllers </incoming/controllers>`
+As well as calling an application :doc:`Controllers </incoming/controllers>`
 via the URL in a browser they can also be loaded via the command-line
 interface (CLI).
 
@@ -52,7 +52,7 @@ in it::
 
 Then save the file to your **app/Controllers/** directory.
 
-Now normally you would visit the your site using a URL similar to this::
+Now normally you would visit your site using a URL similar to this::
 
 	example.com/index.php/tools/message/to
 
@@ -70,8 +70,8 @@ If you did it right, you should see *Hello World!* printed.
 
 	$ php index.php tools message "John Smith"
 
-Here we are passing it a argument in the same way that URL parameters
-work. "John Smith" is passed as a argument and output is::
+Here we are passing it an argument in the same way that URL parameters
+work. "John Smith" is passed as an argument and output is::
 
 	Hello John Smith!
 

--- a/user_guide_src/source/cli/cli.rst
+++ b/user_guide_src/source/cli/cli.rst
@@ -2,7 +2,7 @@
 Running via the Command Line
 ############################
 
-As well as calling an application :doc:`Controllers </incoming/controllers>`
+As well as calling an application's :doc:`Controllers </incoming/controllers>`
 via the URL in a browser they can also be loaded via the command-line
 interface (CLI).
 

--- a/user_guide_src/source/cli/cli_library.rst
+++ b/user_guide_src/source/cli/cli_library.rst
@@ -118,14 +118,14 @@ exactly as you would the ``write()`` method::
 
 **wrap()**
 
-This command will take a string, start printing it on the current line, and wrap it to a set length on new lines.
+This command will take a string, start printing it on the current line and wrap it to a set length on new lines.
 This might be useful when displaying a list of options with descriptions that you want to wrap in the current
 window and not go off screen::
 
 	CLI::color("task1\t", 'yellow');
 	CLI::wrap("Some long description goes here that might be longer than the current window.");
 
-By default the string will wrap at the terminal width. Windows currently doesn't provide a way to determine
+By default, the string will wrap at the terminal width. Windows currently don't provide a way to determine
 the window size, so we default to 80 characters. If you want to restrict the width to something shorter that
 you can be pretty sure fits within the window, pass the maximum line-length as the second parameter. This
 will break the string at the nearest word barrier so that words are not broken.

--- a/user_guide_src/source/cli/cli_library.rst
+++ b/user_guide_src/source/cli/cli_library.rst
@@ -118,14 +118,14 @@ exactly as you would the ``write()`` method::
 
 **wrap()**
 
-This command will take a string, start printing it on the current line and wrap it to a set length on new lines.
+This command will take a string, start printing it on the current line, and wrap it to a set length on new lines.
 This might be useful when displaying a list of options with descriptions that you want to wrap in the current
 window and not go off screen::
 
 	CLI::color("task1\t", 'yellow');
 	CLI::wrap("Some long description goes here that might be longer than the current window.");
 
-By default, the string will wrap at the terminal width. Windows currently don't provide a way to determine
+By default, the string will wrap at the terminal width. Windows currently doesn't provide a way to determine
 the window size, so we default to 80 characters. If you want to restrict the width to something shorter that
 you can be pretty sure fits within the window, pass the maximum line-length as the second parameter. This
 will break the string at the nearest word barrier so that words are not broken.

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -46,7 +46,7 @@ those classes can be found in::
 	];
 
 The key of each row is the namespace itself. This does not need a trailing slash. If you use double-quotes
-to define the array, be sure to escape the backwards slash. That means that it would be ``My\\App``,
+to define the array, be sure to escape the backward slash. That means that it would be ``My\\App``,
 not ``My\App``. The value is the location to the directory the classes can be found in. They should
 have a trailing slash.
 
@@ -79,7 +79,7 @@ The key of each row is the name of the class that you want to locate. The value 
 Legacy Support
 ==============
 
-If neither of the above methods find the class, and the class is not namespaced, the autoloader will look in the
+If neither of the above methods finds the class, and the class is not namespaced, the autoloader will look in the
 **/app/Libraries** and **/app/Models** directories to attempt to locate the files. This provides
 a measure to help ease the transition from previous versions.
 
@@ -88,7 +88,7 @@ There are no configuration options for legacy support.
 Composer Support
 ================
 
-Composer support is automatically initialized by default. By default it looks for Composer's autoload file at
+Composer support is automatically initialized by default. By default, it looks for Composer's autoload file at
 ROOTPATH.'vendor/autoload.php'. If you need to change the location of that file for any reason, you can modify
 the value defined in ``Config\Constants.php``.
 

--- a/user_guide_src/source/concepts/mvc.rst
+++ b/user_guide_src/source/concepts/mvc.rst
@@ -11,7 +11,7 @@ each piece as you need.
 
 **Models** manage the data of the application and help to enforce any special business rules the application might need.
 
-**Views** are simple files, with little to no logic, that displays the information to the user.
+**Views** are simple files, with little to no logic, that display the information to the user.
 
 **Controllers** act as glue code, marshaling data back and forth between the view (or the user that's seeing it) and
 the data storage.
@@ -69,7 +69,7 @@ Controllers
 ===========
 
 Controllers have a couple of different roles to play. The most obvious one is that they receive input from the user and
-then determine what to do with it. This often involves passing the data to a model to save it or requesting data from
+then determine what to do with it. This often involves passing the data to a model to save it, or requesting data from
 the model that is then passed on to the view to be displayed. This also includes loading up other utility classes,
 if needed, to handle specialized tasks that is outside of the purview of the model.
 

--- a/user_guide_src/source/concepts/mvc.rst
+++ b/user_guide_src/source/concepts/mvc.rst
@@ -9,15 +9,15 @@ application as separate parts. It should be noted that there are many views on t
 but this document describes our take on it. If you think of it differently, you're free to modify how you use
 each piece as you need.
 
-**Models** manage the data of the application, and help to enforce any special business rules the application might need.
+**Models** manage the data of the application and help to enforce any special business rules the application might need.
 
-**Views** are simple files, with little to no logic, that display the information to the user.
+**Views** are simple files, with little to no logic, that displays the information to the user.
 
 **Controllers** act as glue code, marshaling data back and forth between the view (or the user that's seeing it) and
 the data storage.
 
 At their most basic, controllers and models are simply classes that have a specific job. They are not the only class
-types that you can use, obviously, but the make up the core of how this framework is designed to be used. They even
+types that you can use, obviously, but they make up the core of how this framework is designed to be used. They even
 have designated directories in the **/app** directory for their storage, though you're free to store them
 wherever you desire, as long as they are properly namespaced. We will discuss that in more detail below.
 
@@ -39,7 +39,7 @@ common header or footer on every page.
 
 Views are generally stored in **/app/Views**, but can quickly become unwieldy if not organized in some fashion.
 CodeIgniter does not enforce any type of organization, but a good rule of thumb would be to create a new directory in
-the **Views** directory for each controller. Then, name views by the method name. This makes them very easy find later
+the **Views** directory for each controller. Then, name views by the method name. This makes them very easy to find later
 on. For example, a user's profile might be displayed in a controller named ``User``, and a method named ``profile``.
 You might store the view file for this method in **/app/Views/User/Profile.php**.
 
@@ -69,7 +69,7 @@ Controllers
 ===========
 
 Controllers have a couple of different roles to play. The most obvious one is that they receive input from the user and
-then determine what to do with it. This often involves passing the data to a model to save it, or requesting data from
+then determine what to do with it. This often involves passing the data to a model to save it or requesting data from
 the model that is then passed on to the view to be displayed. This also includes loading up other utility classes,
 if needed, to handle specialized tasks that is outside of the purview of the model.
 

--- a/user_guide_src/source/database/call_function.rst
+++ b/user_guide_src/source/database/call_function.rst
@@ -6,7 +6,7 @@ $db->callFunction();
 ============================
 
 This function enables you to call PHP database functions that are not
-natively included in CodeIgniter, in a platform independent manner. For
+natively included in CodeIgniter, in a platform-independent manner. For
 example, let's say you want to call the mysql_get_client_info()
 function, which is **not** natively supported by CodeIgniter. You could
 do so like this::
@@ -16,7 +16,7 @@ do so like this::
 You must supply the name of the function, **without** the mysql\_
 prefix, in the first parameter. The prefix is added automatically based
 on which database driver is currently being used. This permits you to
-run the same function on different database platforms. Obviously not all
+run the same function on different database platforms. Obviously, not all
 function calls are identical between platforms, so there are limits to
 how useful this function can be in terms of portability.
 

--- a/user_guide_src/source/database/connecting.rst
+++ b/user_guide_src/source/database/connecting.rst
@@ -23,7 +23,7 @@ Available Parameters
 --------------------
 
 #. The database group name, a string that must match the config class' property name. Default value is $config->defaultGroup.
-#. TRUE/FALSE (boolean). Whether to return the a shared connection (see
+#. TRUE/FALSE (boolean). Whether to return the shared connection (see
    Connecting to Multiple Databases below).
 
 Manually Connecting to a Database

--- a/user_guide_src/source/database/examples.rst
+++ b/user_guide_src/source/database/examples.rst
@@ -104,7 +104,7 @@ means of retrieving data::
 
 The above get() function retrieves all the results from the supplied
 table. The :doc:`Query Builder <query_builder>` class contains a full
-compliment of functions for working with data.
+complement of functions for working with data.
 
 Query Builder Insert
 ====================

--- a/user_guide_src/source/database/queries.rst
+++ b/user_guide_src/source/database/queries.rst
@@ -76,7 +76,7 @@ without needing to create a new connection you can use this method::
 Protecting identifiers
 **********************
 
-In many databases it is advisable to protect table and field names - for
+In many databases, it is advisable to protect table and field names - for
 example with backticks in MySQL. **Query Builder queries are
 automatically protected**, but if you need to manually protect an
 identifier you can use::

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -4,7 +4,7 @@ Query Builder Class
 
 CodeIgniter gives you access to a Query Builder class. This pattern
 allows information to be retrieved, inserted, and updated in your
-database with minimal scripting. In some cases only one or two lines
+database with minimal scripting. In some cases, only one or two lines
 of code are necessary to perform a database action.
 CodeIgniter does not require that each database table be its own class
 file. It instead provides a more simplified interface.
@@ -106,7 +106,7 @@ function::
 
 	$query = $builder->getWhere(['id' => $id], $limit, $offset);
 
-Please read the about the where function below for more information.
+Please read about the where function below for more information.
 
 **$builder->select()**
 
@@ -344,7 +344,7 @@ searches.
 
 .. note:: All values passed to this method are escaped automatically.
 
-.. note:: All ``like*`` method variations can be forced to be perform case-insensitive searches by passing
+.. note:: All ``like*`` method variations can be forced to perform case-insensitive searches by passing
         a fifth parameter of ``true`` to the method. This will use platform-specific features where available
         otherwise, will force the values to be lowercase, i.e. ``WHERE LOWER(column) LIKE '%search%'``. This
         may require indexes to be made for ``LOWER(column)`` instead of ``column`` to be effective.
@@ -509,7 +509,7 @@ The second parameter lets you set a result offset.
 
 ::
 
-	$builder->limit(10, 20);  // Produces: LIMIT 20, 10 (in MySQL.  Other databases have slightly different syntax)
+	$builder->limit(10, 20);  // Produces: LIMIT 20, 10 (in MySQL. Other databases have slightly different syntax)
 
 
 **$builder->countAllResults()**
@@ -581,7 +581,7 @@ Starts a new group by adding an opening parenthesis to the WHERE clause of the q
 
 **$builder->groupEnd()**
 
-Ends the current group by adding an closing parenthesis to the WHERE clause of the query.
+Ends the current group by adding a closing parenthesis to the WHERE clause of the query.
 
 **************
 Inserting Data
@@ -589,7 +589,7 @@ Inserting Data
 
 **$builder->insert()**
 
-Generates an insert string based on the data you supply, and runs the
+Generates an insert string based on the data you supply and runs the
 query. You can either pass an **array** or an **object** to the
 function. Here is an example using an array::
 
@@ -653,7 +653,7 @@ will be reset (by default it will be--just like $builder->insert())::
 
 The key thing to notice in the above example is that the second query did not
 utilize `$builder->from()` nor did it pass a table name into the first
-parameter. The reason this worked is because the query has not been executed
+parameter. The reason this worked is that the query has not been executed
 using `$builder->insert()` which resets values or reset directly using
 `$builder->resetQuery()`.
 
@@ -661,7 +661,7 @@ using `$builder->insert()` which resets values or reset directly using
 
 **$builder->insertBatch()**
 
-Generates an insert string based on the data you supply, and runs the
+Generates an insert string based on the data you supply and runs the
 query. You can either pass an **array** or an **object** to the
 function. Here is an example using an array::
 
@@ -833,7 +833,7 @@ performing updates.
 
 **$builder->updateBatch()**
 
-Generates an update string based on the data you supply, and runs the query.
+Generates an update string based on the data you supply and runs the query.
 You can either pass an **array** or an **object** to the function.
 Here is an example using an array::
 
@@ -987,7 +987,7 @@ Class Reference
 		:returns:	BaseBuilder instance (method chaining)
 		:rtype:	BaseBuilder
 
-		Resets the current Query Builder state.  Useful when you want
+		Resets the current Query Builder state. Useful when you want
 		to build a query that can be canceled under certain conditions.
 
 	.. php:method:: countAllResults([$reset = TRUE])

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -589,7 +589,7 @@ Inserting Data
 
 **$builder->insert()**
 
-Generates an insert string based on the data you supply and runs the
+Generates an insert string based on the data you supply, and runs the
 query. You can either pass an **array** or an **object** to the
 function. Here is an example using an array::
 
@@ -661,7 +661,7 @@ using `$builder->insert()` which resets values or reset directly using
 
 **$builder->insertBatch()**
 
-Generates an insert string based on the data you supply and runs the
+Generates an insert string based on the data you supply, and runs the
 query. You can either pass an **array** or an **object** to the
 function. Here is an example using an array::
 
@@ -833,7 +833,7 @@ performing updates.
 
 **$builder->updateBatch()**
 
-Generates an update string based on the data you supply and runs the query.
+Generates an update string based on the data you supply, and runs the query.
 You can either pass an **array** or an **object** to the function.
 Here is an example using an array::
 

--- a/user_guide_src/source/database/results.rst
+++ b/user_guide_src/source/database/results.rst
@@ -146,7 +146,7 @@ parameter:
 	| **$row = $query->getPreviousRow('array')**
 
 .. note:: All the methods above will load the whole result into memory
-	(prefetching). Use ``getUnbufferredRow()`` for processing large
+	(prefetching). Use ``getUnbufferedRow()`` for processing large
 	result sets.
 
 **getUnbufferedRow()**

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -15,10 +15,10 @@ transactions.
 CodeIgniter's Approach to Transactions
 ======================================
 
-CodeIgniter utilizes an approach to transactions that is very similar to
+CodeIgniter utilizes an approach to transactions that are very similar to
 the process used by the popular database class ADODB. We've chosen that
 approach because it greatly simplifies the process of running
-transactions. In most cases all that is required are two lines of code.
+transactions. In most cases, all that is required are two lines of code.
 
 Traditionally, transactions have required a fair amount of work to
 implement since they demand that you keep track of your queries and
@@ -42,13 +42,13 @@ follows::
 	$this->db->transComplete();
 
 You can run as many queries as you want between the start/complete
-functions and they will all be committed or rolled back based on success
+functions and they will all be committed or rolled back based on the success
 or failure of any given query.
 
 Strict Mode
 ===========
 
-By default CodeIgniter runs all transactions in Strict Mode. When strict
+By default, CodeIgniter runs all transactions in Strict Mode. When strict
 mode is enabled, if you are running multiple groups of transactions, if
 one group fails all groups will be rolled back. If strict mode is
 disabled, each group is treated independently, meaning a failure of one
@@ -87,7 +87,7 @@ can do so using $this->db->transOff()::
 	$this->db->query('AN SQL QUERY...');
 	$this->db->transComplete();
 
-When transactions are disabled, your queries will be auto-commited, just
+When transactions are disabled, your queries will be auto-committed, just
 as they are when running queries without transactions.
 
 Test Mode

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -15,10 +15,10 @@ transactions.
 CodeIgniter's Approach to Transactions
 ======================================
 
-CodeIgniter utilizes an approach to transactions that are very similar to
+CodeIgniter utilizes an approach to transactions that is very similar to
 the process used by the popular database class ADODB. We've chosen that
 approach because it greatly simplifies the process of running
-transactions. In most cases, all that is required are two lines of code.
+transactions. In most cases, all that is required is two lines of code.
 
 Traditionally, transactions have required a fair amount of work to
 implement since they demand that you keep track of your queries and

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -24,7 +24,7 @@ the database you want to manage isn't the default one::
 
 	$this->myforge = $this->load->dbforge('other_db');
 
-In the above example, we're passing a the name of a different database group
+In the above example, we're passing the name of a different database group
 to connect to as the first parameter.
 
 *******************************
@@ -62,7 +62,7 @@ mechanism for this.
 Adding fields
 =============
 
-Fields are normally created via an associative array. Within the array you must
+Fields are normally created via an associative array. Within the array, you must
 include a 'type' key that relates to the datatype of the field. For
 example, INT, VARCHAR, TEXT, etc. Many datatypes (for example VARCHAR)
 also require a 'constraint' key.
@@ -258,7 +258,7 @@ Execute a DROP FOREIGN KEY.
 	// Produces: ALTER TABLE 'tablename' DROP FOREIGN KEY 'users_foreign'
 	$forge->dropForeignKey('tablename','users_foreign');
 
-.. note:: SQlite database driver does not support dropping of foreign keys.
+.. note:: SQLite database driver does not support dropping of foreign keys.
 
 Renaming a table
 ================
@@ -324,7 +324,7 @@ Modifying a Column in a Table
 
 The usage of this method is identical to ``addColumn()``, except it
 alters an existing column rather than adding a new one. In order to
-change the name you can add a "name" key into the field defining array.
+change the name, you can add a "name" key into the field defining array.
 
 ::
 
@@ -384,7 +384,7 @@ Class Reference
 		:returns:	\CodeIgniter\Database\Forge instance (method chaining)
 		:rtype:	\CodeIgniter\Database\Forge
 
-		Adds an unique key to the set that will be used to create a table. Usage:  See `Adding Keys`_.
+		Adds a unique key to the set that will be used to create a table. Usage:  See `Adding Keys`_.
 
 	.. php:method:: createDatabase($db_name)
 

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -135,7 +135,7 @@ names. It will include all migrations it finds in Database/Migrations.
 
 Each namespace has it's own version sequence, this will help you upgrade and downgrade each module (namespace) without affecting other namespaces.
 
-For example, assume that we have the the following namespaces defined in our Autoload
+For example, assume that we have the following namespaces defined in our Autoload
 configuration file::
 
 	$psr4 = [
@@ -227,7 +227,7 @@ for the version. ::
 You can use (version) with the following options:
 
 - (-g) to chose database group, otherwise default database group will be used.
-- (-n) to choose namespace, , otherwise (App) namespace will be used.
+- (-n) to choose namespace, otherwise (App) namespace will be used.
 
 **rollback**
 

--- a/user_guide_src/source/extending/contributing.rst
+++ b/user_guide_src/source/extending/contributing.rst
@@ -57,11 +57,11 @@ Address a single issue in a report.
 Identify the CodeIgniter version (eg 4.0.1) and the component if you know it (eg. parser library)
 
 Explain what you expected to happen, and what did happen.
-Include error messages and stacktrace, if any.
+Include error messages and stack trace, if any.
 
 Include short code segments if they help to explain.
 Use a pastebin or dropbox facility to include longer segments of code or screenshots - do not include them in the issue report itself.
-This means setting a reasonable expiry for those, until the issue is resolved or closed.
+This means setting a reasonable expiry for those until the issue is resolved or closed.
 
 If you know how to fix the issue, you can do so in your own fork & branch, and submit a pull request.
 The issue report information above should be part of that.

--- a/user_guide_src/source/extending/core_classes.rst
+++ b/user_guide_src/source/extending/core_classes.rst
@@ -42,7 +42,7 @@ Replacing Core Classes
 ======================
 
 To use one of your own system classes instead of a default one, ensure that the :doc:`Autoloader <../concepts/autoloader>`
-can find your class, that  your new class extends the appropriate interface, and modify the appropriate
+can find your class, that your new class extends the appropriate interface, and modify the appropriate
 :doc:`Service <../concepts/services>` to load your class in place of the core class.
 
 For example, if you have a new ``App\Libraries\RouteCollection`` class that you would like to use in place of
@@ -73,8 +73,8 @@ Extending Core Classes
 ======================
 
 If all you need to is add some functionality to an existing library - perhaps add a method or two - then it's overkill
-to recreate the entire library. In this case it's better to simply extend the class. Extending the class is nearly
-identical to replacing a class with a one exception:
+to recreate the entire library. In this case, it's better to simply extend the class. Extending the class is nearly
+identical to replacing a class with one exception:
 
 * The class declaration must extend the parent class.
 

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -14,7 +14,7 @@ action when that event is triggered.
 Enabling Events
 ===============
 
-Events are always enabled and are available globally.
+Events are always enabled, and are available globally.
 
 Defining an Event
 =================

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -14,7 +14,7 @@ action when that event is triggered.
 Enabling Events
 ===============
 
-Events are always enabled, and are available globally.
+Events are always enabled and are available globally.
 
 Defining an Event
 =================

--- a/user_guide_src/source/general/caching.rst
+++ b/user_guide_src/source/general/caching.rst
@@ -18,7 +18,7 @@ How Does Caching Work?
 Caching can be enabled on a per-page basis, and you can set the length
 of time that a page should remain cached before being refreshed. When a
 page is loaded for the first time, the file will be cached using the
-currently configured cache engine. On subsequent page loads the cache file
+currently configured cache engine. On subsequent page loads, the cache file
 will be retrieved and sent to the requesting user's browser. If it has
 expired, it will be deleted and refreshed before being sent to the
 browser.

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -20,7 +20,7 @@ Service Accessors
 .. php:function:: cache ( [$key] )
 
     :param  string $key: The cache name of the item to retrieve from cache (Optional)
-    :returns: Either the cache object or the item retrieved from the cache
+    :returns: Either the cache object, or the item retrieved from the cache
     :rtype: mixed
 
     If no $key is provided, will return the Cache engine instance. If a $key
@@ -267,10 +267,10 @@ Miscellaneous Functions
 
 .. php:function:: route_to ( $method [, ...$params] )
 
-	:param   string   $method: The named route alias or name of the controller/method to match.
+	:param   string   $method: The named route alias, or name of the controller/method to match.
 	:param   mixed   $params: One or more parameters to be passed to be matched in the route.
 
-	Generates a relative URI for you based on either a named route alias or a controller::method
+	Generates a relative URI for you based on either a named route alias, or a controller::method
 	combination. Will take parameters into effect, if provided.
 
 	For full details, see the :doc:`/incoming/routing` page.

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -20,7 +20,7 @@ Service Accessors
 .. php:function:: cache ( [$key] )
 
     :param  string $key: The cache name of the item to retrieve from cache (Optional)
-    :returns: Either the cache object, or the item retrieved from the cache
+    :returns: Either the cache object or the item retrieved from the cache
     :rtype: mixed
 
     If no $key is provided, will return the Cache engine instance. If a $key
@@ -212,7 +212,7 @@ Miscellaneous Functions
 	:param   string   $level: The level of severity
 	:param   string   $message: The message that is to be logged.
 	:param   array    $context: An associative array of tags and their values that should be replaced in $message
-	:returns: TRUE if was logged succesfully or FALSE if there was a problem logging it
+	:returns: TRUE if was logged successfully or FALSE if there was a problem logging it
 	:rtype: bool
 
 	Logs a message using the Log Handlers defined in **app/Config/Logger.php**.
@@ -267,10 +267,10 @@ Miscellaneous Functions
 
 .. php:function:: route_to ( $method [, ...$params] )
 
-	:param   string   $method: The named route alias, or name of the controller/method to match.
+	:param   string   $method: The named route alias or name of the controller/method to match.
 	:param   mixed   $params: One or more parameters to be passed to be matched in the route.
 
-	Generates a relative URI for you based on either a named route alias, or a controller::method
+	Generates a relative URI for you based on either a named route alias or a controller::method
 	combination. Will take parameters into effect, if provided.
 
 	For full details, see the :doc:`/incoming/routing` page.

--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -68,8 +68,8 @@ Handling Different Environments
 ===============================
 
 Because your site can operate within multiple environments, such as the developer's local machine or
-the server used for the production site, you can modify your values based on the environment.  Within these
-you will have settings that might change depending on the server it's running on.This can include
+the server used for the production site, you can modify your values based on the environment. Within these
+you will have settings that might change depending on the server it's running on. This can include
 database settings, API credentials, and other settings that will vary between deploys.
 
 You can store values in a **.env** file in the root directory, alongside the system and application directories.
@@ -136,7 +136,7 @@ Incorporating Environment Variables Into a Configuration
 ========================================================
 
 When you instantiate a configuration file, any namespaced environment variables
-are considered for merging into the a configuration objects' properties.
+are considered for merging into the configuration objects' properties.
 
 If the prefix of a namespaced variable matches the configuration class name exactly,
 case-sensitive, then the trailing part of the variable name (after the dot) is

--- a/user_guide_src/source/general/environments.rst
+++ b/user_guide_src/source/general/environments.rst
@@ -28,7 +28,7 @@ The simplest method to set the variable is in your :doc:`.env file </general/con
 Apache
 ------
 
-This server variable can be set in your ``.htaccess`` file, or Apache
+This server variable can be set in your ``.htaccess`` file or Apache
 config using `SetEnv <https://httpd.apache.org/docs/2.2/mod/mod_env.html#setenv>`_.
 
 .. code-block:: apache

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -15,7 +15,7 @@ keep the best user experience for your users.
 Using Exceptions
 ================
 
-This section is a quick overview for newer programmers or developers who are not experienced with using exceptions.
+This section is a quick overview for newer programmers, or for developers who are not experienced with using exceptions.
 
 Exceptions are simply events that happen when the exception is "thrown". This halts the current flow of the script, and
 execution is then sent to the error handler which displays the appropriate error page::

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -5,7 +5,7 @@ Error Handling
 CodeIgniter builds error reporting into your system through Exceptions, both the `SPL collection <http://php.net/manual/en/spl.exceptions.php>`_, as
 well as a few custom exceptions that are provided by the framework. Depending on your environment's setup, the
 default action when an error or exception is thrown is to display a detailed error report, unless the application
-is running under the ``production`` environment. In this case, a more generic  message is displayed to
+is running under the ``production`` environment. In this case, a more generic message is displayed to
 keep the best user experience for your users.
 
 .. contents::
@@ -15,7 +15,7 @@ keep the best user experience for your users.
 Using Exceptions
 ================
 
-This section is a quick overview for newer programmers, or developers who are not experienced with using exceptions.
+This section is a quick overview for newer programmers or developers who are not experienced with using exceptions.
 
 Exceptions are simply events that happen when the exception is "thrown". This halts the current flow of the script, and
 execution is then sent to the error handler which displays the appropriate error page::
@@ -112,7 +112,7 @@ is not the right type, etc::
 
 	throw new \CodeIgniter\Exceptions\ConfigException();
 
-This provides an HTTP status code of 500, and an exit code of 3.
+This provides an HTTP status code of 500 and an exit code of 3.
 
 DatabaseException
 -----------------
@@ -122,4 +122,4 @@ or when it is temporarily lost::
 
 	throw new \CodeIgniter\Database\Exceptions\DatabaseException();
 
-This provides an HTTP status code of 500, and an exit code of 8.
+This provides an HTTP status code of 500 and an exit code of 8.

--- a/user_guide_src/source/general/helpers.rst
+++ b/user_guide_src/source/general/helpers.rst
@@ -53,7 +53,7 @@ A helper can be loaded anywhere within your controller methods (or
 even within your View files, although that's not a good practice), as
 long as you load it before you use it. You can load your helpers in your
 controller constructor so that they become available automatically in
-any function, or you can load a helper in a specific function that needs
+any function or you can load a helper in a specific function that needs
 it.
 
 .. note:: The Helper loading method above does not return a value, so
@@ -106,12 +106,12 @@ with an identical name to the existing Helper.
 If all you need to do is add some functionality to an existing helper -
 perhaps add a function or two, or change how a particular helper
 function operates - then it's overkill to replace the entire helper with
-your version. In this case it's better to simply "extend" the Helper.
+your version. In this case, it's better to simply "extend" the Helper.
 
 .. note:: The term "extend" is used loosely since Helper functions are
 	procedural and discrete and cannot be extended in the traditional
 	programmatic sense. Under the hood, this gives you the ability to
-	add to or or to replace the functions a Helper provides.
+	add or replace the functions a Helper provides.
 
 For example, to extend the native **Array Helper** you'll create a file
 named **app/Helpers/array_helper.php**, and add or override
@@ -152,5 +152,5 @@ is as follows:
 Now What?
 =========
 
-In the Table of Contents you'll find a list of all the available Helper
+In the Table of Contents, you'll find a list of all the available Helper
 Files. Browse each one to see what they do.

--- a/user_guide_src/source/general/helpers.rst
+++ b/user_guide_src/source/general/helpers.rst
@@ -53,7 +53,7 @@ A helper can be loaded anywhere within your controller methods (or
 even within your View files, although that's not a good practice), as
 long as you load it before you use it. You can load your helpers in your
 controller constructor so that they become available automatically in
-any function or you can load a helper in a specific function that needs
+any function, or you can load a helper in a specific function that needs
 it.
 
 .. note:: The Helper loading method above does not return a value, so
@@ -111,7 +111,7 @@ your version. In this case, it's better to simply "extend" the Helper.
 .. note:: The term "extend" is used loosely since Helper functions are
 	procedural and discrete and cannot be extended in the traditional
 	programmatic sense. Under the hood, this gives you the ability to
-	add or replace the functions a Helper provides.
+	add to, or to replace the functions a Helper provides.
 
 For example, to extend the native **Array Helper** you'll create a file
 named **app/Helpers/array_helper.php**, and add or override

--- a/user_guide_src/source/general/logging.rst
+++ b/user_guide_src/source/general/logging.rst
@@ -20,7 +20,7 @@ There are eight different log levels, matching to the `RFC 5424 <http://tools.ie
 * **debug** - Detailed debug information.
 * **info** - Interesting events in your application, like a user logging in, logging SQL queries, etc.
 * **notice** - Normal, but significant events in your application.
-* **warning** - Exceptional occurrences that are not errors, like the user of deprecated APIs, poor use of an API, or other undesirable things that are not necessarily wrong.
+* **warning** - Exceptional occurrences that are not errors, like the use of deprecated APIs, poor use of an API, or other undesirable things that are not necessarily wrong.
 * **error** - Runtime errors that do not require immediate action but should typically be logged and monitored.
 * **critical** - Critical conditions, like an application component not available, or an unexpected exception.
 * **alert** - Action must be taken immediately, like when an entire website is down, the database unavailable, etc.
@@ -39,7 +39,7 @@ the ``/app/Config/Logger.php`` configuration file.
 The ``threshold`` value of the config file determines which levels are logged across your application. If any levels
 are requested to be logged by the application, but the threshold doesn't allow them to log currently, they will be
 ignored. The simplest method to use is to set this value to the minimum level that you want to have logged. For example,
-if you want to log debug messages, and not information messages, you would set the threshold to ``5``. Any log requests with
+if you want to log debug messages and not information messages, you would set the threshold to ``5``. Any log requests with
 a level of 5 or less (which includes runtime errors, system errors, etc) would be logged and info, notices, and warnings
 would be ignored::
 
@@ -103,7 +103,7 @@ into the message string::
 
 If you want to log an Exception or an Error, you can use the key of 'exception', and the value being the
 Exception or Error itself. A string will be generated from that object containing the error message, the
-file name and line number.  You must still provide the exception placeholder in the message::
+file name and line number. You must still provide the exception placeholder in the message::
 
 	try
 	{

--- a/user_guide_src/source/general/logging.rst
+++ b/user_guide_src/source/general/logging.rst
@@ -39,7 +39,7 @@ the ``/app/Config/Logger.php`` configuration file.
 The ``threshold`` value of the config file determines which levels are logged across your application. If any levels
 are requested to be logged by the application, but the threshold doesn't allow them to log currently, they will be
 ignored. The simplest method to use is to set this value to the minimum level that you want to have logged. For example,
-if you want to log debug messages and not information messages, you would set the threshold to ``5``. Any log requests with
+if you want to log debug messages, and not information messages, you would set the threshold to ``5``. Any log requests with
 a level of 5 or less (which includes runtime errors, system errors, etc) would be logged and info, notices, and warnings
 would be ignored::
 

--- a/user_guide_src/source/general/managing_apps.rst
+++ b/user_guide_src/source/general/managing_apps.rst
@@ -2,7 +2,7 @@
 Managing your Applications
 ##########################
 
-By default it is assumed that you only intend to use CodeIgniter to
+By default, it is assumed that you only intend to use CodeIgniter to
 manage one application, which you will build in your **application**
 directory. It is possible, however, to have multiple sets of
 applications that share a single CodeIgniter installation, or even to

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -81,7 +81,7 @@ for familiar directories/files.
 
 When at the **acme** namespace above, we would need to make one small adjustment to make it so the files could be found:
 each "module" within the namespace would have to have it's own namespace defined there. **Acme** would be changed
-to **Acme\Blog**. Once  your module folder has been defined, the discover process would look for a Routes file, for example,
+to **Acme\Blog**. Once your module folder has been defined, the discover process would look for a Routes file, for example,
 at **/acme/Blog/Config/Routes.php**, just as if it was another application.
 
 Enable/Disable Discover

--- a/user_guide_src/source/general/urls.rst
+++ b/user_guide_src/source/general/urls.rst
@@ -16,7 +16,7 @@ The segments in the URL, in following with the Model-View-Controller approach, u
 
 1. The first segment represents the controller **class** that should be invoked.
 2. The second segment represents the class **method** that should be called.
-3. The third and any additional segments represent the ID and any variables that will be passed to the controller.
+3. The third, and any additional segments, represent the ID and any variables that will be passed to the controller.
 
 The :doc:`URI Library <../libraries/uri>` and the :doc:`URL Helper <../helpers/url_helper>` contain functions that make it easy
 to work with your URI data. In addition, your URLs can be remapped using the :doc:`URI Routing </incoming/routing>`

--- a/user_guide_src/source/general/urls.rst
+++ b/user_guide_src/source/general/urls.rst
@@ -16,7 +16,7 @@ The segments in the URL, in following with the Model-View-Controller approach, u
 
 1. The first segment represents the controller **class** that should be invoked.
 2. The second segment represents the class **method** that should be called.
-3. The third, and any additional segments, represent the ID and any variables that will be passed to the controller.
+3. The third and any additional segments represent the ID and any variables that will be passed to the controller.
 
 The :doc:`URI Library <../libraries/uri>` and the :doc:`URL Helper <../helpers/url_helper>` contain functions that make it easy
 to work with your URI data. In addition, your URLs can be remapped using the :doc:`URI Routing </incoming/routing>`
@@ -46,7 +46,7 @@ items:
 	RewriteCond %{REQUEST_FILENAME} !-d
 	RewriteRule ^(.*)$ index.php/$1 [L]
 
-In this example, any HTTP request other than those for existsing directories and existing files is treated as a
+In this example, any HTTP request other than those for existing directories and existing files are treated as a
 request for your index.php file.
 
 .. note:: These specific rules might not work for all server configurations.

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -110,7 +110,7 @@ The following functions are available:
 		write_file('./path/to/file.php', $data, 'r+');
 
 	The default mode is 'wb'. Please see the `PHP user guide <http://php.net/manual/en/function.fopen.php>`_
-	for mode options.
+	for more options.
 
 	.. note:: In order for this function to write data to a file, its permissions must
 		be set such that it is writable. If the file does not already exist,

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -110,7 +110,7 @@ The following functions are available:
 		write_file('./path/to/file.php', $data, 'r+');
 
 	The default mode is 'wb'. Please see the `PHP user guide <http://php.net/manual/en/function.fopen.php>`_
-	for more options.
+	for mode options.
 
 	.. note:: In order for this function to write data to a file, its permissions must
 		be set such that it is writable. If the file does not already exist,

--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -297,9 +297,9 @@ The following functions are available:
 
     	Lets you create a standard drop-down field. The first parameter will
     	contain the name of the field, the second parameter will contain an
-    	associative array of options, and the third parameter will contain the
+    	associative array of options and the third parameter will contain the
     	value you wish to be selected. You can also pass an array of multiple
-    	items through the third parameter, and the helper will create a
+    	items through the third parameter and the helper will create a
     	multiple select for you.
 
     	Example::
@@ -319,7 +319,7 @@ The following functions are available:
 
 			<select name="shirts">
 				<option value="small">Small Shirt</option>
-				<option value="med">Medium  Shirt</option>
+				<option value="med">Medium Shirt</option>
 				<option value="large" selected="selected">Large Shirt</option>
 				<option value="xlarge">Extra Large Shirt</option>
 			</select>
@@ -332,7 +332,7 @@ The following functions are available:
 
 			<select name="shirts" multiple="multiple">
 				<option value="small" selected="selected">Small Shirt</option>
-				<option value="med">Medium  Shirt</option>
+				<option value="med">Medium Shirt</option>
 				<option value="large" selected="selected">Large Shirt</option>
 				<option value="xlarge">Extra Large Shirt</option>
 			</select>
@@ -368,7 +368,7 @@ The following functions are available:
 
     	Lets you create a standard multiselect field. The first parameter will
     	contain the name of the field, the second parameter will contain an
-    	associative array of options, and the third parameter will contain the
+    	associative array of options and the third parameter will contain the
     	value or values you wish to be selected.
 
     	The parameter usage is identical to using :php:func:`form_dropdown()` above,

--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -297,9 +297,9 @@ The following functions are available:
 
     	Lets you create a standard drop-down field. The first parameter will
     	contain the name of the field, the second parameter will contain an
-    	associative array of options and the third parameter will contain the
+    	associative array of options, and the third parameter will contain the
     	value you wish to be selected. You can also pass an array of multiple
-    	items through the third parameter and the helper will create a
+    	items through the third parameter, and the helper will create a
     	multiple select for you.
 
     	Example::
@@ -368,7 +368,7 @@ The following functions are available:
 
     	Lets you create a standard multiselect field. The first parameter will
     	contain the name of the field, the second parameter will contain an
-    	associative array of options and the third parameter will contain the
+    	associative array of options, and the third parameter will contain the
     	value or values you wish to be selected.
 
     	The parameter usage is identical to using :php:func:`form_dropdown()` above,

--- a/user_guide_src/source/helpers/inflector_helper.rst
+++ b/user_guide_src/source/helpers/inflector_helper.rst
@@ -2,7 +2,7 @@
 Inflector Helper
 ################
 
-The Inflector Helper file contains functions that permits you to change
+The Inflector Helper file contains functions that permit you to change
 **English** words to plural, singular, camel case, etc.
 
 .. contents::

--- a/user_guide_src/source/helpers/text_helper.rst
+++ b/user_guide_src/source/helpers/text_helper.rst
@@ -217,7 +217,7 @@ The following functions are available:
 	The third parameter is an optional suffix added to the string, if
 	undeclared this helper uses an ellipsis.
 
-	.. note:: If you need to truncate to an exact number of characters please
+	.. note:: If you need to truncate to an exact number of characters, please
 		see the :php:func:`ellipsize()` function below.
 
 .. php:function:: ascii_to_entities($str)
@@ -231,7 +231,7 @@ The following functions are available:
 	they can be shown consistently regardless of browser settings or stored
 	reliably in a database. There is some dependence on your server's
 	supported character sets, so it may not be 100% reliable in all cases,
-	but for the most part it should correctly identify characters outside
+	but for the most part, it should correctly identify characters outside
 	the normal range (like accented characters).
 
 	Example::
@@ -372,7 +372,7 @@ The following functions are available:
 	example. a value of 1 will place the ellipsis at the right of the
 	string, .5 in the middle, and 0 at the left.
 
-	An optional forth parameter is the kind of ellipsis. By default,
+	An optional fourth parameter is the kind of ellipsis. By default,
 	&hellip; will be inserted.
 
 	Example::

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -183,7 +183,7 @@ The following functions are available:
 	different site than yours, which contains different configuration preferences.
 	We use this for unit testing the framework itself.
 
-	.. note:: Attributes passed into the anchor function are automatically escaped to protected against XSS attacks.
+	.. note:: Attributes passed into the anchor function are automatically escaped to protect against XSS attacks.
 
 .. php:function:: anchor_popup([$uri = ''[, $title = ''[, $attributes = FALSE[, $altConfig = NULL]]]])
 
@@ -234,7 +234,7 @@ The following functions are available:
         different site than yours, which contains different configuration preferences.
         We use this for unit testing the framework itself.
 
-	.. note:: Attributes passed into the anchor_popup function are automatically escaped to protected against XSS attacks.
+	.. note:: Attributes passed into the anchor_popup function are automatically escaped to protect against XSS attacks.
 
 .. php:function:: mailto($email[, $title = ''[, $attributes = '']])
 
@@ -254,7 +254,7 @@ The following functions are available:
 		$attributes = ['title' => 'Mail me'];
 		echo mailto('me@my-site.com', 'Contact Me', $attributes);
 
-	.. note:: Attributes passed into the mailto function are automatically escaped to protected against XSS attacks.
+	.. note:: Attributes passed into the mailto function are automatically escaped to protect against XSS attacks.
 
 .. php:function:: safe_mailto($email[, $title = ''[, $attributes = '']])
 
@@ -282,7 +282,7 @@ The following functions are available:
 		$string = auto_link($string);
 
 	The second parameter determines whether URLs and e-mails are converted or
-	just one or the other. Default behavior is both if the parameter is not
+	just one or the other. The default behavior is both if the parameter is not
 	specified. E-mail links are encoded as :php:func:`safe_mailto()` as shown
 	above.
 

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -183,7 +183,7 @@ The following functions are available:
 	different site than yours, which contains different configuration preferences.
 	We use this for unit testing the framework itself.
 
-	.. note:: Attributes passed into the anchor function are automatically escaped to protect against XSS attacks.
+	.. note:: Attributes passed into the anchor function are automatically escaped to protected against XSS attacks.
 
 .. php:function:: anchor_popup([$uri = ''[, $title = ''[, $attributes = FALSE[, $altConfig = NULL]]]])
 
@@ -234,7 +234,7 @@ The following functions are available:
         different site than yours, which contains different configuration preferences.
         We use this for unit testing the framework itself.
 
-	.. note:: Attributes passed into the anchor_popup function are automatically escaped to protect against XSS attacks.
+	.. note:: Attributes passed into the anchor_popup function are automatically escaped to protected against XSS attacks.
 
 .. php:function:: mailto($email[, $title = ''[, $attributes = '']])
 
@@ -254,7 +254,7 @@ The following functions are available:
 		$attributes = ['title' => 'Mail me'];
 		echo mailto('me@my-site.com', 'Contact Me', $attributes);
 
-	.. note:: Attributes passed into the mailto function are automatically escaped to protect against XSS attacks.
+	.. note:: Attributes passed into the mailto function are automatically escaped to protected against XSS attacks.
 
 .. php:function:: safe_mailto($email[, $title = ''[, $attributes = '']])
 

--- a/user_guide_src/source/incoming/content_negotiation.rst
+++ b/user_guide_src/source/incoming/content_negotiation.rst
@@ -32,7 +32,7 @@ second is an array of supported values.
 Negotiating
 ===========
 
-In this section we will discuss the 4 types of content that can be negotiated and show how that would look using
+In this section, we will discuss the 4 types of content that can be negotiated and show how that would look using
 both of the methods described above to access the negotiator.
 
 Media

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -80,7 +80,7 @@ class so that it can inherit all its methods.
 Methods
 =======
 
-In the above example the method name is ``index()``. The "index" method
+In the above example, the method name is ``index()``. The "index" method
 is always loaded by default if the **second segment** of the URI is
 empty. Another way to show your "Hello World" message would be this::
 
@@ -155,7 +155,7 @@ file and set this variable::
 
 	$routes->setDefaultController('Blog');
 
-Where 'Blog' is the name of the controller class you want used. If you now
+Where 'Blog' is the name of the controller class you want to be used. If you now
 load your main index.php file without specifying any URI segments you'll
 see your "Hello World" message by default.
 
@@ -212,7 +212,7 @@ Example::
 Private methods
 ===============
 
-In some cases you may want certain methods hidden from public access.
+In some cases, you may want certain methods hidden from public access.
 In order to achieve this, simply declare the method as being private
 or protected and it will not be served via a URL request. For example,
 if you were to have a method like this::

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -56,7 +56,7 @@ to make changes that will still be present when the controller executes.
 
 Since before filters are executed prior to your controller being executed, you may at times want to stop the
 actions in the controller from happening. You can do this by passing back anything that is not the request object.
-This is typically used to peform redirects, like in this example::
+This is typically used to perform redirects, like in this example::
 
     public function before(RequestInterface $request)
     {
@@ -169,7 +169,7 @@ would apply to every AJAX request.
 $filters
 ========
 
-This property is an array of filter aliases. For each alias you can specify before and after arrays that contain
+This property is an array of filter aliases. For each alias, you can specify before and after arrays that contain
 a list of URI patterns that filter should apply to::
 
     public filters = [

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -154,7 +154,7 @@ This will retrieve data and convert it to an array. Like this::
 **Filtering Input Data**
 
 To maintain security of your application, you will want to filter all input as you access it. You can
-pass the type of filter to use it as the last parameter of any of these methods. The native ``filter_var()``
+pass the type of filter to use as the last parameter of any of these methods. The native ``filter_var()``
 function is used for the filtering. Head over to the PHP manual for a list of `valid
 filter types <http://php.net/manual/en/filter.filters.php>`_.
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -154,7 +154,7 @@ This will retrieve data and convert it to an array. Like this::
 **Filtering Input Data**
 
 To maintain security of your application, you will want to filter all input as you access it. You can
-pass the type of filter to use in as the last parameter of any of these methods. The native ``filter_var()``
+pass the type of filter to use it as the last parameter of any of these methods. The native ``filter_var()``
 function is used for the filtering. Head over to the PHP manual for a list of `valid
 filter types <http://php.net/manual/en/filter.filters.php>`_.
 
@@ -169,7 +169,7 @@ Retrieving Headers
 ----------------------------------------------------------------------------
 
 You can get access to any header that was sent with the request with the ``getHeaders()`` method, which returns
-an array of all headers, with the key as the name of the header, and the value being an instance of
+an array of all headers, with the key as the name of the header, and the value is an instance of
 ``CodeIgniter\HTTP\Header``::
 
 	var_dump($request->getHeaders());
@@ -344,7 +344,7 @@ The methods provided by the parent classes that are available are:
 
 			$request->getVar(null, FILTER_SANITIZE_STRING); // returns all POST items with string sanitation
 
-		To return an array of multiple  POST parameters, pass all the required keys as an array::
+		To return an array of multiple POST parameters, pass all the required keys as an array::
 
 			$request->getVar(['field1', 'field2']);
 

--- a/user_guide_src/source/incoming/message.rst
+++ b/user_guide_src/source/incoming/message.rst
@@ -2,7 +2,7 @@
 HTTP Messages
 =============
 
-The Message class provides an interface to the portions of an HTTP message that is common to both
+The Message class provides an interface to the portions of an HTTP message that are common to both
 requests and responses, including the message body, protocol version, utilities for working with
 the headers, and methods for handling content negotiation.
 

--- a/user_guide_src/source/incoming/message.rst
+++ b/user_guide_src/source/incoming/message.rst
@@ -2,7 +2,7 @@
 HTTP Messages
 =============
 
-The Message class provides an interface to the portions of an HTTP message that are common to both
+The Message class provides an interface to the portions of an HTTP message that is common to both
 requests and responses, including the message body, protocol version, utilities for working with
 the headers, and methods for handling content negotiation.
 
@@ -18,7 +18,7 @@ At it's heart Content Negotiation is simply a part of the HTTP specification tha
 resource to serve more than one type of content, allowing the clients to request the type of
 data that works best for them.
 
-A classic example of this is a browser than cannot display PNG files can request only GIF or
+A classic example of this is a browser that cannot display PNG files can request only GIF or
 JPEG images. When the getServer receives the request, it looks at the available file types the client
 is requesting and selects the best match from the image formats that it supports, in this case
 likely choosing a JPEG image to return.
@@ -208,7 +208,7 @@ Class Reference
 	.. php:method:: negotiateCharset($supported)
 
 		:param array $supported: An array of character sets the application supports.
-		:returns: The supported character set that best matches what is required..
+		:returns: The supported character set that best matches what is required.
 		:rtype: string
 
 		This is used identically to the ``negotiateMedia()`` method, except that it matches against the ``Accept-Charset``
@@ -225,7 +225,7 @@ Class Reference
 	.. php:method:: negotiateEncoding($supported)
 
 		:param array $supported: An array of character encodings the application supports.
-		:returns: The supported character set that best matches what is required..
+		:returns: The supported character set that best matches what is required.
 		:rtype: string
 
 		Determines the best match between the application-supported values and the ``Accept-Encoding`` header value.
@@ -240,7 +240,7 @@ Class Reference
 	.. php:method:: negotiateLanguage($supported)
 
 		:param array $supported: An array of languages the application supports.
-		:returns: The supported language that best matches what is required..
+		:returns: The supported language that best matches what is required.
 		:rtype: string
 
 		Determines the best match between the application-supported languages and the ``Accept-Language`` header value.
@@ -253,5 +253,5 @@ Class Reference
 			];
 			$language = $message->negotiateLanguage($supported);
 
-		More information about the language tags are available in `RFC 1766 <https://www.ietf.org/rfc/rfc1766.txt>`_.
+		More information about the language tags is available in `RFC 1766 <https://www.ietf.org/rfc/rfc1766.txt>`_.
 

--- a/user_guide_src/source/incoming/methodspoofing.rst
+++ b/user_guide_src/source/incoming/methodspoofing.rst
@@ -2,7 +2,7 @@
 HTTP Method Spoofing
 ====================
 
-When working with HTML forms you can only use GET or POST HTTP verbs. In most cases this is just fine. However, to
+When working with HTML forms you can only use GET or POST HTTP verbs. In most cases, this is just fine. However, to
 support REST-ful routing you need to support other, more correct, verbs, like DELETE or PUT. Since the browsers
 don't support this, CodeIgniter provides you with a way to spoof the method that is being used. This allows you to
 make a POST request, but tell the application that it should be treated as a different request type.
@@ -16,7 +16,7 @@ that you want the request to be::
     </form>
 
 This form is converted into a PUT request and is a true PUT request as far as the routing and the IncomingRequest
-class are concerned.
+class is concerned.
 
 The form that you are using must be a POST request. GET requests cannot be spoofed.
 

--- a/user_guide_src/source/incoming/methodspoofing.rst
+++ b/user_guide_src/source/incoming/methodspoofing.rst
@@ -16,7 +16,7 @@ that you want the request to be::
     </form>
 
 This form is converted into a PUT request and is a true PUT request as far as the routing and the IncomingRequest
-class is concerned.
+class are concerned.
 
 The form that you are using must be a POST request. GET requests cannot be spoofed.
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -64,7 +64,7 @@ The following placeholders are available for you to use in your routes:
 * **(:segment)** will match any character except for a forward slash (/) restricting the result to a single segment.
 * **(:num)** will match any integer.
 * **(:alpha)** will match any string of alphabetic characters
-* **(:alphanum)** will match any string of alphabetic characters or integers or any combination of the two.
+* **(:alphanum)** will match any string of alphabetic characters or integers, or any combination of the two.
 * **(:hash)** is the same as **:segment**, but can be used to easily see which routes use hashed ids (see the :doc:`Model </models/model>` docs).
 
 .. note:: **{locale}** cannot be used as a placeholder or other part of the route, as it is reserved for use
@@ -87,12 +87,12 @@ The ID will be set to “34”::
 
 	$routes->add('product/(:any)', 'Catalog::productLookup');
 
-A URL with “product” as the first segment and anything in the second will be remapped to the “\Catalog” class
+A URL with “product” as the first segment, and anything in the second will be remapped to the “\Catalog” class
 and the “productLookup” method::
 
 	$routes->add('product/(:num)', 'Catalog::productLookupByID/$1';
 
-A URL with “product” as the first segment and a number in the second will be remapped to the “\Catalog” class
+A URL with “product” as the first segment, and a number in the second will be remapped to the “\Catalog” class
 and the “productLookupByID” method passing in the match as a variable to the method.
 
 .. important:: While the ``add()`` method is convenient, it is recommended to always use the HTTP-verb-based

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -34,7 +34,7 @@ Routes can be specified using placeholders or Regular Expressions.
 A route simply takes the URI on the left, and maps it to the controller and method on the right,
 along with any parameters that should be passed to the controller. The controller and method should
 be listed in the same way that you would use a static method, by separating the fully-namespaced class
-and its method with a double-colon, like ``Users::list``.  If that method requires parameters to be
+and its method with a double-colon, like ``Users::list``. If that method requires parameters to be
 passed to it, then they would be listed after the method name, separated by forward-slashes::
 
 	// Calls the $Users->list()
@@ -64,7 +64,7 @@ The following placeholders are available for you to use in your routes:
 * **(:segment)** will match any character except for a forward slash (/) restricting the result to a single segment.
 * **(:num)** will match any integer.
 * **(:alpha)** will match any string of alphabetic characters
-* **(:alphanum)** will match any string of alphabetic characters or integers, or any combination of the two.
+* **(:alphanum)** will match any string of alphabetic characters or integers or any combination of the two.
 * **(:hash)** is the same as **:segment**, but can be used to easily see which routes use hashed ids (see the :doc:`Model </models/model>` docs).
 
 .. note:: **{locale}** cannot be used as a placeholder or other part of the route, as it is reserved for use
@@ -87,17 +87,17 @@ The ID will be set to “34”::
 
 	$routes->add('product/(:any)', 'Catalog::productLookup');
 
-A URL with “product” as the first segment, and anything in the second will be remapped to the “\Catalog” class
+A URL with “product” as the first segment and anything in the second will be remapped to the “\Catalog” class
 and the “productLookup” method::
 
 	$routes->add('product/(:num)', 'Catalog::productLookupByID/$1';
 
-A URL with “product” as the first segment, and a number in the second will be remapped to the “\Catalog” class
+A URL with “product” as the first segment and a number in the second will be remapped to the “\Catalog” class
 and the “productLookupByID” method passing in the match as a variable to the method.
 
 .. important:: While the ``add()`` method is convenient, it is recommended to always use the HTTP-verb-based
     routes, described below, as it is more secure. It will also provide a slight performance increase, since
-    only routes that match the current request method are stored, resulting in less routes to scan through
+    only routes that match the current request method are stored, resulting in fewer routes to scan through
     when trying to find a match.
 
 Custom Placeholders
@@ -234,7 +234,7 @@ The value for the filter must match one of the aliases defined within ``app/Conf
 Environment Restrictions
 ========================
 
-You can create a set of routes that will only be viewable under a certain environment. This allows you to create
+You can create a set of routes that will only be viewable in a certain environment. This allows you to create
 tools that only the developer can use on their local machines that are not reachable on testing or production servers.
 This can be done with the ``environment()`` method. The first parameter is the name of the environment. Any
 routes defined within this closure are only accessible from the given environment::
@@ -326,7 +326,7 @@ name::
     $routes->put('photos/(:segment)',      'Photos::update/$1');
     $routes->delete('photos/(:segment)',   'Photos::delete/$1');
 
-.. important:: The routes are matched in the order they are specified, so if you have a resource photos above a get 'photos/poll' the show action's route for the resource line will be matched before the get line. To fix this, move the get line above the resource line so that it is matched first.
+.. important:: The routes are matched in the order they are specified, so if you have resource photos above a get 'photos/poll' the show action's route for the resource line will be matched before the get line. To fix this, move the get line above the resource line so that it is matched first.
 
 The second parameter accepts an array of options that can be used to modify the routes that are generated. While these
 routes are geared toward API-usage, where more methods are allowed, you can pass in the 'websafe' option to have it
@@ -441,7 +441,7 @@ Offsetting the Matched Parameters
 ---------------------------------
 
 You can offset the matched parameters in your route by any numeric value with the ``offset`` option, with the
-value being the number of segments to offset.
+value is the number of segments to offset.
 
 This can be beneficial when developing API's with the first URI segment being the version number. It can also
 be used when the first parameter is a language string::
@@ -513,7 +513,7 @@ Translate URI Dashes
 --------------------
 
 This option enables you to automatically replace dashes (‘-‘) with underscores in the controller and method
-URI segments, thus saving you additional route entries if you need to do that. This is required, because the
+URI segments, thus saving you additional route entries if you need to do that. This is required because the
 dash isn’t a valid class or method name character and would cause a fatal error if you try to use it::
 
 	$routes->setTranslateURIDashes(true);

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -441,7 +441,7 @@ Offsetting the Matched Parameters
 ---------------------------------
 
 You can offset the matched parameters in your route by any numeric value with the ``offset`` option, with the
-value is the number of segments to offset.
+value being the number of segments to offset.
 
 This can be beneficial when developing API's with the first URI segment being the version number. It can also
 be used when the first parameter is a language string::

--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -95,7 +95,7 @@ In the folder above your project root::
 Setup
 -------------------------------------------------------
 
-The command above will create an "devstarter" folder.
+The command above will create a "devstarter" folder.
 Feel free to rename that for your project.
 
 Upgrading

--- a/user_guide_src/source/installation/installing_manual.rst
+++ b/user_guide_src/source/installation/installing_manual.rst
@@ -6,7 +6,7 @@ repository holds the released versions of the framework.
 It is intended for developers who do not wish to use Composer.
 
 Develop your app inside the ``app`` folder, and the ``public`` folder 
-will be your public-facing document root.  Do not change anything inside the ``system``
+will be your public-facing document root. Do not change anything inside the ``system``
 folder!
 
 **Note**: This is the installation technique closest to that described 

--- a/user_guide_src/source/installation/troubleshooting.rst
+++ b/user_guide_src/source/installation/troubleshooting.rst
@@ -49,7 +49,7 @@ You can't follow the tutorial using PHP's built-in web server.
 It doesn't process the `.htaccess` file needed to route
 requests properly.
 
-The solution: use Apache to server your site, or else the built-in
+The solution: use Apache to serve your site, or else the built-in
 CodeIgniter equivalent, ``php spark serve`` from your project root.
 
 .. |CodeIgniter4 Welcome| image:: ../images/welcome.png

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -2,7 +2,7 @@
 Upgrading from 3.x to 4.x
 #############################
 
-CodeIgniter 4 is a rewrite of the framework, and is not backwards compatible.
+CodeIgniter 4 is a rewrite of the framework and is not backwards compatible.
 It is more appropriate to think of converting your app, rather than upgrading it.
 Once you have done that, upgrading from one version of CodeIgniter 4 to the next
 will be straightforward.
@@ -18,7 +18,7 @@ We'll try to point out the most important considerations here.
 
 Not all of the CI3 libraries have been ported or rewritten for CI4!
 See the threads in the `CodeIgniter 4 Roadmap <https://forum.codeigniter.com/forum-33.html>`_
-subforum for an uptodate list!
+subforum for an up-to-date list!
 
 **Do read the user guide** before embarking on a project conversion!
 

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -212,7 +212,7 @@ File-based Caching
 Unlike caching from the Output Class, the driver file-based caching
 allows for pieces of view files to be cached. Use this with care, and
 make sure to benchmark your application, as a point can come where disk
-I/O will negate positive gains by caching. This require a writable cache directory to be really writable (0777).
+I/O will negate positive gains by caching. This requires a writable cache directory to be really writable (0777).
 
 =================
 Memcached Caching

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -10,7 +10,7 @@ or communicate with an API, among many other things.
     :local:
     :depth: 2
 
-This class is modelled after the `Guzzle HTTP Client <http://docs.guzzlephp.org/en/latest/>`_ library since
+This class is modeled after the `Guzzle HTTP Client <http://docs.guzzlephp.org/en/latest/>`_ library since
 it is one of the more widely used libraries. Where possible, the syntax has been kept the same so that if
 your application needs something a little more powerful than what this library provides, you will have
 to change very little to move over to use Guzzle.

--- a/user_guide_src/source/libraries/files.rst
+++ b/user_guide_src/source/libraries/files.rst
@@ -14,8 +14,8 @@ Getting a File instance
 =======================
 
 You create a new File instance by passing in the path to the file in the constructor.
-By default the file does not need to exist. However, you can pass an additional argument of "true"
-to check that the file exist and throw ``FileNotFoundException()`` if it does not.
+By default, the file does not need to exist. However, you can pass an additional argument of "true"
+to check that the file exists and throw ``FileNotFoundException()`` if it does not.
 
 ::
 

--- a/user_guide_src/source/libraries/honeypot.rst
+++ b/user_guide_src/source/libraries/honeypot.rst
@@ -4,7 +4,7 @@ Honeypot Class
 
 The Honeypot Class makes it possible to determine when a Bot makes a request to a CodeIgniter4 application,
 if it's enabled in ``Application\Config\Filters.php`` file. This is done by attaching form fields to any form,
-and this form field is hidden from a human but accessible to a Bot. When data is entered into the field ,it's
+and this form field is hidden from a human but accessible to a Bot. When data is entered into the field, it's
 assumed the request is coming from a Bot, and you can throw a ``HoneypotException``.
 
 .. contents::

--- a/user_guide_src/source/libraries/images.rst
+++ b/user_guide_src/source/libraries/images.rst
@@ -57,7 +57,7 @@ For example, to create an image thumbnail you'll do this::
 		->fit(100, 100, 'center')
 		->save('/path/to/image/mypic_thumb.jpg');
 
-The above code tells the library  to look for an image
+The above code tells the library to look for an image
 called *mypic.jpg* located in the source_image folder, then create a
 new image from it that is 100 x 100pixels using the GD2 image_library,
 and save it to a new file (the thumb). Since it is using the fit() method,
@@ -261,7 +261,7 @@ Adding a Text Watermark
 -----------------------
 
 You can overlay a text watermark onto the image very simply with the text() method. This is useful for placing copyright
-notices, photogropher names, or simply marking the images as a preview so they won't be used in other people's final
+notices, photographer names, or simply marking the images as a preview so they won't be used in other people's final
 products.
 
 ::
@@ -269,7 +269,7 @@ products.
 	text(string $text, array $options = [])
 
 The first parameter is the string of text that you wish to display. The second parameter is an array of options
-that allow you to specify how the text should be displayed::
+that allows you to specify how the text should be displayed::
 
 	Services::image('imagick')
 		->withFile('/path/to/image/mypic.jpg')

--- a/user_guide_src/source/libraries/images.rst
+++ b/user_guide_src/source/libraries/images.rst
@@ -269,7 +269,7 @@ products.
 	text(string $text, array $options = [])
 
 The first parameter is the string of text that you wish to display. The second parameter is an array of options
-that allows you to specify how the text should be displayed::
+that allow you to specify how the text should be displayed::
 
 	Services::image('imagick')
 		->withFile('/path/to/image/mypic.jpg')

--- a/user_guide_src/source/libraries/pagination.rst
+++ b/user_guide_src/source/libraries/pagination.rst
@@ -228,7 +228,7 @@ usefulness. It is easiest to demonstrate creating a new view by showing you the 
 
 **setSurroundCount()**
 
-In the first line, the ``setSurroundCount()`` method specifies that we want to show two links to either side of
+In the first line, the ``setSurroundCount()`` method specifies than we want to show two links to either side of
 the current page link. The only parameter that it accepts is the number of links to show.
 
 **hasPrevious()** & **hasNext()**

--- a/user_guide_src/source/libraries/pagination.rst
+++ b/user_guide_src/source/libraries/pagination.rst
@@ -44,7 +44,7 @@ To provide a paginated list of users in your application, your controller's meth
         }
     }
 
-In this example, we first create a new instance of our UserModel. Then we populate the data to sent to the view.
+In this example, we first create a new instance of our UserModel. Then we populate the data to send to the view.
 The first element is the results from the database, **users**, which is retrieved for the correct page, returning
 10 users per page. The second item that must be sent to the view is the Pager instance itself. As a convenience,
 the Model will hold on to the instance it used and store it in the public class variable, **$pager**. So, we grab
@@ -95,7 +95,7 @@ Manual Pagination
 =================
 
 You may find times where you just need to create pagination based on known data. You can create links manually
-with the ``makeLinks()`` method, which takes the current page, the amount of results per page, and
+with the ``makeLinks()`` method, which takes the current page, the number of results per page, and
 the total number of items as the first, second, and third parameters, respectively::
 
     <?= $pager->makeLinks($page, $perPage, $total) ?>
@@ -111,12 +111,12 @@ It is also possible to use a URI segment for the page number, instead of the pag
 
 <?= $pager->makeLinks($page, $perPage, $total, 'template_name', $segment) ?>
 
-Please note: ``$segment`` value can not be greater than the number of URI segments plus 1.
+Please note: ``$segment`` value cannot be greater than the number of URI segments plus 1.
 
 Paginating with Only Expected Queries
 =====================================
 
-By default all GET queries are shown in the pagination links.
+By default, all GET queries are shown in the pagination links.
 
 For example, when accessing the URL *http://domain.tld?search=foo&order=asc&hello=i+am+here&page=2*, the page 3 link can be generated, along with the other links, as follows::
 
@@ -157,7 +157,7 @@ the view file through it's namespace::
     'default_full'   => 'App\Views\Pagers\foundation_full',
 
 Since it is under the standard **app/Views** directory, though, you do not need to namespace it since the
-``view()`` method can locate it by filename. In that case, you can simple give the sub-directory and file name::
+``view()`` method can locate it by filename. In that case, you can simply give the sub-directory and file name::
 
     'default_full'   => 'Pagers/foundation_full',
 
@@ -233,9 +233,9 @@ the current page link. The only parameter that it accepts is the number of links
 
 **hasPrevious()** & **hasNext()**
 
-These methods return a boolean true if there are more links than can be displayed on either side of the current page,
+These methods return a boolean true if there are more links that can be displayed on either side of the current page,
 based on the value passed to ``setSurroundCount``. For example, let's say we have 20 pages of data. The current
-page is page 3. If the surround count is 2, then the following links would show up in the list: 1, 2, 3, 4, and 5.
+page is page 3. If the surrounding count is 2, then the following links would show up in the list: 1, 2, 3, 4, and 5.
 Since the first link displayed is page one, ``hasPrevious()`` would return **false** since there is no page zero. However,
 ``hasNext()`` would return **true** since there are 15 additional pages of results after page five.
 

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -77,7 +77,7 @@ at the same time. To use a more appropriate technical term - requests were
 non-blocking.
 
 However, non-blocking requests in the context of sessions also means
-unsafe, because of modifications to session data (or session ID regeneration)
+unsafe, because, modifications to session data (or session ID regeneration)
 in one request can interfere with the execution of a second, concurrent
 request. This detail was at the root of many issues and the main reason why
 CodeIgniter 3.0 has a completely re-written Session library.

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -2,7 +2,7 @@
 Session Library
 ###############
 
-The Session class permits you maintain a user's "state" and track their
+The Session class permits you to maintain a user's "state" and track their
 activity while they browse your site.
 
 CodeIgniter comes with a few session storage drivers, that you can see
@@ -77,7 +77,7 @@ at the same time. To use a more appropriate technical term - requests were
 non-blocking.
 
 However, non-blocking requests in the context of sessions also means
-unsafe, because modifications to session data (or session ID regeneration)
+unsafe, because of modifications to session data (or session ID regeneration)
 in one request can interfere with the execution of a second, concurrent
 request. This detail was at the root of many issues and the main reason why
 CodeIgniter 3.0 has a completely re-written Session library.
@@ -490,7 +490,7 @@ engines, that you can use:
   - CodeIgniter\Session\Handlers\RedisHandler
 
 By default, the ``FileHandler`` Driver will be used when a session is initialized,
-because it is the most safe choice and is expected to work everywhere
+because it is the safest choice and is expected to work everywhere
 (virtually every environment has a file system).
 
 However, any other driver may be selected via the ``public $sessionDriver``
@@ -526,7 +526,7 @@ On UNIX-like operating systems, this is usually achieved by setting the
 allows only the directory's owner to perform read and write operations on
 it. But be careful because the system user *running* the script is usually
 not your own, but something like 'www-data' instead, so only setting those
-permissions will probable break your application.
+permissions will probably break your application.
 
 Instead, you should do something like this, depending on your environment
 ::

--- a/user_guide_src/source/libraries/throttler.rst
+++ b/user_guide_src/source/libraries/throttler.rst
@@ -41,8 +41,8 @@ potentially slowing down the requests enough that they attack is no longer worth
 Rate Limiting
 *************
 
-The Throttler class does not do any rate limiting or request throttling on its own, but is the key to making
-one work. An example :doc:`Filter </incoming/filters>` is provided that implements very simple rate limiting at
+The Throttler class does not do any rate limiting or request throttling on its own but is the key to making
+one work. An example :doc:`Filter </incoming/filters>` is provided that implements a very simple rate limiting at
 one request per second per IP address. Here we will run through how it works, and how you could set it up and
 start using it in your application.
 
@@ -97,7 +97,7 @@ along the lines of::
             }
     }
 
-When run, this method first grabs an instance of the throttler. Next it uses the IP address as the bucket name,
+When run, this method first grabs an instance of the throttler. Next, it uses the IP address as the bucket name,
 and sets things to limit them to one request per second. If the throttler rejects the check, returning false,
 then we return a Response with the status code set to 429 - Too Many Attempts, and the script execution ends
 before it ever hits the controller. This example will throttle based on a single IP address across all requests
@@ -106,7 +106,7 @@ made to the site, not per page.
 Applying the Filter
 ===================
 
-We don't necessarily need to throttle every page on the site. For many web applications this makes the most sense
+We don't necessarily need to throttle every page on the site. For many web applications, this makes the most sense
 to apply only to POST requests, though API's might want to limit every request made by a user. In order to apply
 this to incoming requests, you need to edit **/app/Config/Filters.php** and first add an alias to the
 filter::
@@ -122,7 +122,7 @@ Next, we assign it to all POST requests made on the site::
         'post' => ['throttle', 'CSRF']
     ];
 
-And that's all there is to it. Now all POST requests made on the site will have be rate limited.
+And that's all there is to it. Now all POST requests made on the site will have to be rate limited.
 
 ***************
 Class Reference
@@ -133,7 +133,7 @@ Class Reference
     :param string $key: The name of the bucket
     :param int $capacity: The number of tokens the bucket holds
     :param int $seconds: The number of seconds it takes for a bucket to completely fill
-    :param int $cost: The number of tokens that are spent for this action
+    :param int $cost: The number of tokens that are spent on this action
     :returns: TRUE if action can be performed, FALSE if not
     :rtype: bool
 
@@ -148,4 +148,4 @@ Class Reference
 
     After ``check()`` has been run and returned FALSE, this method can be used
     to determine the time until a new token should be available and the action can be
-    tried again. In this case the minimum enforced wait time is one second.
+    tried again. In this case, the minimum enforced wait time is one second.

--- a/user_guide_src/source/libraries/throttler.rst
+++ b/user_guide_src/source/libraries/throttler.rst
@@ -41,7 +41,7 @@ potentially slowing down the requests enough that they attack is no longer worth
 Rate Limiting
 *************
 
-The Throttler class does not do any rate limiting or request throttling on its own but is the key to making
+The Throttler class does not do any rate limiting or request throttling on its own,  but is the key to making
 one work. An example :doc:`Filter </incoming/filters>` is provided that implements a very simple rate limiting at
 one request per second per IP address. Here we will run through how it works, and how you could set it up and
 start using it in your application.

--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -73,7 +73,7 @@ for the timezone and locale in the second and third parameters::
 tomorrow()
 -----------
 
-Returns a new instance with the date set to the tomorrow's date and the time set to midnight. It accepts strings
+Returns a new instance with the date set to tomorrow's date and the time set to midnight. It accepts strings
 for the timezone and locale in the second and third parameters::
 
     $myTime = Time::tomorrow('America/Chicago', 'en_US');
@@ -148,7 +148,7 @@ Displaying the Value
 ====================
 
 Since the Time class extends DateTime, you get all of the output methods that provides, including the format() method.
-However, the DateTime methods do not provide a localize result. The Time class does provide a number of helper methods
+However, the DateTime methods do not provide a localized result. The Time class does provide a number of helper methods
 to display localized versions of the value, though.
 
 toLocalizedString()

--- a/user_guide_src/source/libraries/typography.rst
+++ b/user_guide_src/source/libraries/typography.rst
@@ -2,7 +2,7 @@
 Typography
 ##########
 
-The Typography libary contains methods that help you format text
+The Typography library contains methods that help you format text
 in semantically relevant ways.
 
 *******************

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -32,7 +32,7 @@ The Current URI
 ---------------
 
 Many times, all you really want is an object representing the current URL of this request. This can be accessed
-in two different ways. The first, is to grab it directly from the current request object. Assuming that you're in
+in two different ways. The first is to grab it directly from the current request object. Assuming that you're in
 a controller that extends ``CodeIgniter\Controller`` you can get it like::
 
 	$uri = $this->request->uri;
@@ -41,7 +41,7 @@ Second, you can use one of the functions available in the **url_helper**::
 
 	$uri = current_url(true);
 
-You must pass ``true`` as the first parameter, otherwise it will return the string representation of the current URL.
+You must pass ``true`` as the first parameter, otherwise, it will return the string representation of the current URL.
 
 ===========
 URI Strings
@@ -195,7 +195,7 @@ You can filter the query values returned by passing an options array to the ``ge
     // Returns 'foo=bar&baz=foz'
     echo $uri->getQuery(['except' => ['bar']]);
 
-This only changes the values returned during this one call. If you need to modify the URI's query values more permenantly,
+This only changes the values returned during this one call. If you need to modify the URI's query values more permanently,
 you can use the ``stripQuery()`` and ``keepQuery()`` methods to change the actual object's query variable collection::
 
     $uri = new \CodeIgniter\HTTP\URI('http://www.example.com?foo=bar&bar=baz&baz=foz');
@@ -222,7 +222,7 @@ to an on-page anchor. Media URI's can make use of them in various other ways.
 URI Segments
 ============
 
-Each section of the path between the slashes are a single segment. The URI class provides a simple way to determine
+Each section of the path between the slashes is a single segment. The URI class provides a simple way to determine
 what the values of the segments are. The segments start at 1 being the furthest left of the path.
 ::
 

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -161,7 +161,7 @@ Explanation
 
 You'll notice several things about the above pages:
 
-The form (Signup.php) is a standard web form with a couple exceptions:
+The form (Signup.php) is a standard web form with a couple of exceptions:
 
 #. It uses a form helper to create the form opening. Technically, this
    isn't necessary. You could create the form using standard HTML.
@@ -190,7 +190,7 @@ The library is loaded as a service named **validation**::
     $validation =  \Config\Services::validation();
 
 This automatically loads the ``Config\Validation`` file which contains settings
-for including multiple Rule sets, and collections of rules that can be easily reused.
+for including multiple Rulesets, and collections of rules that can be easily reused.
 
 .. note:: You may never need to use this method, as both the :doc:`Controller </incoming/controllers>` and
     the :doc:`Model </models/model>` provide methods to make validation even easier.
@@ -206,7 +206,7 @@ methods.
 setRule()
 ---------
 
-This method sets a single rule. It takes the name of field as
+This method sets a single rule. It takes the name of the field as
 the first parameter, an optional label and a string with a pipe-delimited list of rules
 that should be applied::
 
@@ -496,8 +496,8 @@ application.
 Creating the Views
 ==================
 
-The first step is to create the custom views. These can be placed anywhere that the ``view()`` method can locate them,
-which means the standard View directory, or any namespaced View folder will work. For example, you could create
+The first step is to create custom views. These can be placed anywhere that the ``view()`` method can locate them,
+which means the standard View directory or any namespaced View folder will work. For example, you could create
 a new view at **/app/Views/_errors_list.php**::
 
     <div class="alert alert-danger" role="alert">
@@ -508,7 +508,7 @@ a new view at **/app/Views/_errors_list.php**::
         </ul>
     </div>
 
-An array named ``$errors`` is available within the view that contains a list of the errors, where the key is
+An array named ``$errors`` is available within the view that contains a list of the errors where the key is
 the name of the field that had the error, and the value is the error message, like this::
 
     $errors = [
@@ -560,7 +560,7 @@ add the new file to the ``$ruleSets`` array::
 		\CodeIgniter\Validation\CreditCardRules::class,
 	];
 
-You can add it as either a simple string with the fully qualified class name, or using the ``::class`` suffix as
+You can add it as either a simple string with the fully qualified class name or using the ``::class`` suffix as
 shown above. The primary benefit here is that it provides some extra navigation capabilities in more advanced IDEs.
 
 Within the file itself, each method is a rule and must accept a string as the first parameter, and must return
@@ -575,7 +575,7 @@ a boolean true or false value signifying true if it passed the test or false if 
     }
 
 By default, the system will look within ``CodeIgniter\Language\en\Validation.php`` for the language strings used
-within errors. In custom rules you may provide error messages by accepting an $error variable by reference in the
+within errors. In custom rules, you may provide error messages by accepting a $error variable by reference in the
 second parameter::
 
     public function even(string $str, string &$error = null): bool
@@ -645,7 +645,7 @@ Available Rules
 
 The following is a list of all the native rules that are available to use:
 
-.. note:: Rule is string; there must be no spaces between the parameters, especially the "is_unique" rule.
+.. note:: Rule is a string; there must be no spaces between the parameters, especially the "is_unique" rule.
 	There can be no spaces before and after "ignore_value".
 
 - "is_unique[supplier.name,uuid, $uuid]"   is not ok

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -497,7 +497,7 @@ Creating the Views
 ==================
 
 The first step is to create custom views. These can be placed anywhere that the ``view()`` method can locate them,
-which means the standard View directory or any namespaced View folder will work. For example, you could create
+which means the standard View directory, or any namespaced View folder will work. For example, you could create
 a new view at **/app/Views/_errors_list.php**::
 
     <div class="alert alert-danger" role="alert">
@@ -508,7 +508,7 @@ a new view at **/app/Views/_errors_list.php**::
         </ul>
     </div>
 
-An array named ``$errors`` is available within the view that contains a list of the errors where the key is
+An array named ``$errors`` is available within the view that contains a list of the errors, where the key is
 the name of the field that had the error, and the value is the error message, like this::
 
     $errors = [
@@ -560,7 +560,7 @@ add the new file to the ``$ruleSets`` array::
 		\CodeIgniter\Validation\CreditCardRules::class,
 	];
 
-You can add it as either a simple string with the fully qualified class name or using the ``::class`` suffix as
+You can add it as either a simple string with the fully qualified class name, or using the ``::class`` suffix as
 shown above. The primary benefit here is that it provides some extra navigation capabilities in more advanced IDEs.
 
 Within the file itself, each method is a rule and must accept a string as the first parameter, and must return

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -14,7 +14,7 @@ Entity Usage
 ============
 
 At its core, an Entity class is simply a class that represents a single database row. It has class properties
-to represent the database columns and provides any additional methods to implement the business logic for
+to represent the database columns, and provides any additional methods to implement the business logic for
 that row. The core feature, though, is that it doesn't know anything about how to persist itself. That's the
 responsibility of the model or the repository class. That way, if anything changes on how you need to save the
 object, you don't have to change how that object is used throughout the application. This makes it possible to

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -14,14 +14,14 @@ Entity Usage
 ============
 
 At its core, an Entity class is simply a class that represents a single database row. It has class properties
-to represent the database columns, and provides any additional methods to implement the business logic for
-that row.  The core feature, though, is that it doesn't know anything about how to persist itself. That's the
+to represent the database columns and provides any additional methods to implement the business logic for
+that row. The core feature, though, is that it doesn't know anything about how to persist itself. That's the
 responsibility of the model or the repository class. That way, if anything changes on how you need to save the
 object, you don't have to change how that object is used throughout the application. This makes it possible to
 use JSON or XML files to store the objects during a rapid prototyping stage, and then easily switch to a
 database when you've proven the concept works.
 
-Lets walk through a very simple User Entity and how we'd work with it to help make things clear.
+Let's walk through a very simple User Entity and how we'd work with it to help make things clear.
 
 Assume you have a database table named ``users`` that has the following schema::
 
@@ -119,7 +119,7 @@ Filling Properties Quickly
 --------------------------
 
 The Entity class also provides a method, ``fill()`` that allows you to shove an array of key/value pairs into the class
-and populate the class properties. Only properties that already exist on the class can be populated in this way.
+and populate the class properties. Only properties that already exist in the class can be populated in this way.
 
 ::
 
@@ -191,7 +191,7 @@ class property will be accessed through the ``setCreatedAt()`` and ``getCreatedA
 In the ``setPassword()`` method we ensure that the password is always hashed.
 
 In ``setCreatedAt()`` we convert the string we receive from the model into a DateTime object, ensuring that our timezone
-is UTC so we can easily convert the the viewer's current timezone. In ``getCreatedAt()``, it converts the time to
+is UTC so we can easily convert the viewer's current timezone. In ``getCreatedAt()``, it converts the time to
 a formatted string in the application's current timezone.
 
 While fairly simple, these examples show that using Entity classes can provide a very flexible way to enforce
@@ -211,7 +211,7 @@ original column names in the database no longer make sense. Or you find that you
 class properties, but your database schema required snake_case names. These situations can be easily handled
 with the Entity class' data mapping features.
 
-As an example, imagine your have the simplified User Entity that is used throughout your application::
+As an example, imagine you have the simplified User Entity that is used throughout your application::
 
     <?php namespace App\Entities;
 
@@ -233,7 +233,7 @@ full name now, not their username like it does currently. To keep things tidy an
 in the database you whip up a migration to rename the `name` field to `full_name` for clarity.
 
 Ignoring how contrived this example is, we now have two choices on how to fix the User class. We could modify the class
-property from ``$name`` to ``$full_name``, but that would require  changes throughout the application. Instead, we can
+property from ``$name`` to ``$full_name``, but that would require changes throughout the application. Instead, we can
 simply map the ``full_name`` column in the database to the ``$name`` property, and be done with the Entity changes::
 
     <?php namespace App\Entities;
@@ -276,7 +276,7 @@ Date Mutators
 
 By default, the Entity class will convert fields named `created_at`, `updated_at`, or `deleted_at` into
 :doc:`Time </libraries/time>` instances whenever they are set or retrieved. The Time class provides a large number
-of helpful methods in a immutable, localized way.
+of helpful methods in an immutable, localized way.
 
 You can define which properties are automatically converted by adding the name to the **options['dates']** array::
 
@@ -349,7 +349,7 @@ Array/Json casting is especially useful with fields that store serialized arrays
 
 * an **array**, they will automatically be unserialized,
 * a **json**, they will automatically be set as an value of json_decode($value, false),
-* a **json-array**, they will automatically be set as an value of  json_decode($value, true),
+* a **json-array**, they will automatically be set as an value of json_decode($value, true),
 
 when you read the property's value.
 Unlike the rest of the data types that you can cast properties into, the:

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -374,7 +374,7 @@ A very simple model to work with this might look like::
 	}
 
 This model works with data from the ``jobs`` table, and returns all results as an instance of ``App\Entities\Job``.
-When you need to persist that record to the database, you will need to either write custom methods or use the
+When you need to persist that record to the database, you will need to either write custom methods, or use the
 model's ``save()`` method to inspect the class, grab any public and private properties, and save them to the database::
 
 	// Retrieve a Job instance

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -63,7 +63,7 @@ and a number of additional convenience methods.
 Connecting to the Database
 --------------------------
 
-When the class is first instantiated, if no database connection instance is passed to constructor,
+When the class is first instantiated, if no database connection instance is passed to the constructor,
 it will automatically connect to the default database group, as set in the configuration. You can
 modify which group is used on a per-model basis by adding the DBGroup property to your class.
 This ensures that within the model any references to ``$this->db`` are made through the appropriate
@@ -119,7 +119,7 @@ queries.
 **$primaryKey**
 
 This is the name of the column that uniquely identifies the records in this table. This
-does not necessarilly have to match the primary key that is specified in the database, but
+does not necessarily have to match the primary key that is specified in the database, but
 is used with methods like ``find()`` to know what column to match the specified value to.
 
 **$returnType**
@@ -138,7 +138,7 @@ can maintain a "recycle bin" of objects that can be restored, or even simply pre
 part of a security trail. If true, the find* methods will only return non-deleted rows, unless
 the withDeleted() method is called prior to calling the find* method.
 
-This requires an INT or TINYINT field to be present in the table for storing state.The default field name is  ``deleted`` however this name can be configured to any name of your choice by using $deletedField property.
+This requires an INT or TINYINT field to be present in the table for storing state. The default field name is  ``deleted`` however this name can be configured to any name of your choice by using $deletedField property.
 
 **$allowedFields**
 
@@ -264,7 +264,7 @@ Saving Data
 **insert()**
 
 An associative array of data is passed into this method as the only parameter to create a new
-row of data in the database. The array's keys must match the name of the columns in $table, while
+row of data in the database. The array's keys must match the name of the columns in a $table, while
 the array's values are the values to save for that key::
 
 	$data = [
@@ -278,7 +278,7 @@ the array's values are the values to save for that key::
 
 Updates an existing record in the database. The first parameter is the $primaryKey of the record to update.
 An associative array of data is passed into this method as the second parameter. The array's keys must match the name
-of the columns in $table, while the array's values are the values to save for that key::
+of the columns in a $table, while the array's values are the values to save for that key::
 
 	$data = [
 		'username' => 'darth',
@@ -295,7 +295,7 @@ Multiple records may be updated with a single call by passing an array of primar
 
 	$userModel->update([1, 2, 3], $data);
 
-When you need a more flexible solution, you can leaven the parameters empty and it functions like the Query Builder's
+When you need a more flexible solution, you can leave the parameters empty and it functions like the Query Builder's
 update command, with the added benefit of validation, events, etc::
 
     $userModel
@@ -305,7 +305,7 @@ update command, with the added benefit of validation, events, etc::
 
 **save()**
 
-This is a wrapper around the insert() and update() methods that handles inserting or updating the record
+This is a wrapper around the insert() and update() methods that handle inserting or updating the record
 automatically, based on whether it finds an array key matching the $primaryKey value::
 
 	// Defined as a model property
@@ -374,7 +374,7 @@ A very simple model to work with this might look like::
 	}
 
 This model works with data from the ``jobs`` table, and returns all results as an instance of ``App\Entities\Job``.
-When you need to persist that record to the database, you will need to either write custom methods, or use the
+When you need to persist that record to the database, you will need to either write custom methods or use the
 model's ``save()`` method to inspect the class, grab any public and private properties, and save them to the database::
 
 	// Retrieve a Job instance
@@ -595,7 +595,7 @@ Defining Callbacks
 
 You specify the callbacks by first creating a new class method in your model to use. This class will always
 receive a $data array as its only parameter. The exact contents of the $data array will vary between events, but
-will always contain a key named **data** that contains the primary data passed to original method. In the case
+will always contain a key named **data** that contains the primary data passed to the original method. In the case
 of the insert* or update* methods, that will be the key/value pairs that are being inserted into the database. The
 main array will also contain the other values passed to the method, and be detailed later. The callback method
 must return the original $data array so other callbacks have the full information.

--- a/user_guide_src/source/outgoing/localization.rst
+++ b/user_guide_src/source/outgoing/localization.rst
@@ -39,7 +39,7 @@ recommended that a `BCP 47 <http://www.rfc-editor.org/rfc/bcp/bcp47.txt>`_ langu
 language codes like en-US for American English, or fr-FR, for French/France. A more readable introduction
 to this can be found on the `W3C's site <https://www.w3.org/International/articles/language-tags/>`_.
 
-The system is smart enough to fallback to more generic language codes if an exact match
+The system is smart enough to fall back to more generic language codes if an exact match
 cannot be found. If the locale code was set to **en-US** and we only have language files setup for **en**
 then those will be used since nothing exists for the more specific **en-US**. If, however, a language
 directory existed at **app/Language/en-US** then that would be used first.
@@ -113,7 +113,7 @@ Languages do not have any specific naming convention that are required. The file
 describe the type of content it holds. For example, let's say you want to create a file containing error messages.
 You might name it simply: **Errors.php**.
 
-Within the file you would return an array, where each element in the array has a language key and the string to return::
+Within the file, you would return an array, where each element in the array has a language key and the string to return::
 
         'language_key' => 'The actual message to be shown.'
 
@@ -133,7 +133,7 @@ Basic Usage
 ===========
 
 You can use the ``lang()`` helper function to retrieve text from any of the language files, by passing the
-filename and the language key as the first paremeter, separated by a period (.). For example, to load the
+filename and the language key as the first parameter, separated by a period (.). For example, to load the
 ``errorEmailMissing`` string from the ``Errors`` language file, you would do the following::
 
     echo lang('Errors.errorEmailMissing');
@@ -224,7 +224,7 @@ Here are a few examples::
     echo lang('Tests.ordinal', [time()]);
 
 You should be sure to read up on the MessageFormatter class and the underlying ICU formatting to get a better
-idea on what capabilities it has, like permorming conditional replacement, pluralization, and more. Both of the links provided
+idea on what capabilities it has, like performing the conditional replacement, pluralization, and more. Both of the links provided
 earlier will give you an excellent idea as to the options available.
 
 Specifying Locale

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -127,7 +127,7 @@ to set the Cache values to what you need, though, through the ``setCache()`` met
 	$this->response->setCache($options);
 
 The ``$options`` array simply takes an array of key/value pairs that are, with a couple of exceptions, assigned
-to the ``Cache-Control`` header. You are free to set all of the options exactly as you need for you specific
+to the ``Cache-Control`` header. You are free to set all of the options exactly as you need for your specific
 situation. While most of the options are applied to the ``Cache-Control`` header, it intelligently handles
 the ``etag`` and ``last-modified`` options to their appropriate header.
 
@@ -160,7 +160,7 @@ By default, support for this is off. To enable support in your application, edit
 	public $CSPEnabled = true;
 
 When enabled, the response object will contain an instance of ``CodeIgniter\HTTP\ContentSecurityPolicy``. The
-values set in **app/Config/ContentSecurityPolicy.php** are applied to that instance and, if no changes are
+values set in **app/Config/ContentSecurityPolicy.php** are applied to that instance and if no changes are
 needed during runtime, then the correctly formatted header is sent and you're all done.
 
 With CSP enabled, two header lines are added to the HTTP response: a Content-Security-Policy header, with
@@ -171,7 +171,7 @@ of your choice.
 
 Our implementation provides for a default treatment, changeable through the ``reportOnly()`` method.
 When an additional entry is added to a CSP directive, as shown below, it will be added
-to the CSP header appropriate for blocking or preventing. That can be over-ridden on a per
+to the CSP header appropriate for blocking or preventing. That can be overridden on a per
 call basis, by providing an optional second parameter to the adding method call.
 
 Runtime Configuration
@@ -225,7 +225,7 @@ that youtube.com was allowed, and then provide several allowed but reported sour
 Inline Content
 --------------
 
-It is possible to set a website to not protect even inline scripts and styles on its own pages, since this might have
+It is possible to set a website to not protect even inline scripts and styles on its own pages since this might have
 been the result of user-generated content. To protect against this, CSP allows you to specify a nonce within the
 ``<style>`` and ``<script>`` tags, and to add those values to the response's header. This is a pain to handle in real
 life, and is most secure when generated on the fly. To make this simple, you can include a ``{csp-style-nonce}`` or
@@ -369,7 +369,7 @@ The methods provided by the parent class that are available are:
 		* proxy-revalidate
 		* no-transform
 
-		When passing the last-modified option, it can be either a date string, or a DateTime object.
+		When passing the last-modified option, it can be either a date string or a DateTime object.
 
 	.. php:method:: setLastModified($date)
 

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -160,7 +160,7 @@ By default, support for this is off. To enable support in your application, edit
 	public $CSPEnabled = true;
 
 When enabled, the response object will contain an instance of ``CodeIgniter\HTTP\ContentSecurityPolicy``. The
-values set in **app/Config/ContentSecurityPolicy.php** are applied to that instance and if no changes are
+values set in **app/Config/ContentSecurityPolicy.php** are applied to that instance, and if no changes are
 needed during runtime, then the correctly formatted header is sent and you're all done.
 
 With CSP enabled, two header lines are added to the HTTP response: a Content-Security-Policy header, with
@@ -225,7 +225,7 @@ that youtube.com was allowed, and then provide several allowed but reported sour
 Inline Content
 --------------
 
-It is possible to set a website to not protect even inline scripts and styles on its own pages since this might have
+It is possible to set a website to not protect even inline scripts and styles on its own pages, since this might have
 been the result of user-generated content. To protect against this, CSP allows you to specify a nonce within the
 ``<style>`` and ``<script>`` tags, and to add those values to the response's header. This is a pain to handle in real
 life, and is most secure when generated on the fly. To make this simple, you can include a ``{csp-style-nonce}`` or
@@ -369,7 +369,7 @@ The methods provided by the parent class that are available are:
 		* proxy-revalidate
 		* no-transform
 
-		When passing the last-modified option, it can be either a date string or a DateTime object.
+		When passing the last-modified option, it can be either a date string, or a DateTime object.
 
 	.. php:method:: setLastModified($date)
 

--- a/user_guide_src/source/outgoing/views.rst
+++ b/user_guide_src/source/outgoing/views.rst
@@ -92,7 +92,7 @@ Storing Views within Sub-directories
 ====================================
 
 Your view files can also be stored within sub-directories if you prefer that type of organization.
-When doing so you will need to include the directory name loading the view.  Example::
+When doing so you will need to include the directory name loading the view. Example::
 
 	echo view('directory_name/file_name');
 

--- a/user_guide_src/source/testing/benchmark.rst
+++ b/user_guide_src/source/testing/benchmark.rst
@@ -85,7 +85,7 @@ Using the Iterator
 The Iterator is a simple tool that is designed to allow you to try out multiple variations on a solution to
 see the speed differences and different memory usage patterns. You can add any number of "tasks" for it to
 run and the class will run the task hundreds or thousands of times to get a clearer picture of performance.
-The results can then be retrieved and used by your script or displayed as an HTML table.
+The results can then be retrieved and used by your script, or displayed as an HTML table.
 
 Creating Tasks To Run
 =====================

--- a/user_guide_src/source/testing/benchmark.rst
+++ b/user_guide_src/source/testing/benchmark.rst
@@ -22,7 +22,7 @@ With the Timer, you can measure the time between two moments in the execution of
 it simple to measure the performance of different aspects of your application. All measurement is done using
 the ``start()`` and ``stop()`` methods.
 
-The ``start()`` methods take a single parameter: the name of this timer. You can use any string as the name
+The ``start()`` methods takes a single parameter: the name of this timer. You can use any string as the name
 of the timer. It is only used for you to reference later to know which measurement is which::
 
 	$benchmark = \Config\Services::timer();

--- a/user_guide_src/source/testing/benchmark.rst
+++ b/user_guide_src/source/testing/benchmark.rst
@@ -4,7 +4,7 @@ Benchmarking
 
 CodeIgniter provides two separate tools to help you benchmark your code and test different options:
 the Timer and the Iterator. The Timer allows you to easily calculate the time between two points in the
-execution of your script. The Iterator allows you to setup several variations and run those tests, recording
+execution of your script. The Iterator allows you to setup several variations and runs those tests, recording
 performance and memory statistics to help you decide which version is the best.
 
 The Timer class is always active, being started from the moment the framework is invoked until right before
@@ -22,7 +22,7 @@ With the Timer, you can measure the time between two moments in the execution of
 it simple to measure the performance of different aspects of your application. All measurement is done using
 the ``start()`` and ``stop()`` methods.
 
-The ``start()`` methods takes a single parameter: the name of this timer. You can use any string as the name
+The ``start()`` methods take a single parameter: the name of this timer. You can use any string as the name
 of the timer. It is only used for you to reference later to know which measurement is which::
 
 	$benchmark = \Config\Services::timer();
@@ -61,7 +61,7 @@ This returns an array of benchmark information, including start, end, and durati
 		]
 	]
 
-You can change the precision of the calculated duration by passing in the number of decimal places you want shown as
+You can change the precision of the calculated duration by passing in the number of decimal places you want to be shown as
 the only parameter. The default value is 4 numbers behind the decimal point::
 
 	$timers = $benchmark->getTimers(6);
@@ -85,7 +85,7 @@ Using the Iterator
 The Iterator is a simple tool that is designed to allow you to try out multiple variations on a solution to
 see the speed differences and different memory usage patterns. You can add any number of "tasks" for it to
 run and the class will run the task hundreds or thousands of times to get a clearer picture of performance.
-The results can then be retrieved and used by your script, or displayed as an HTML table.
+The results can then be retrieved and used by your script or displayed as an HTML table.
 
 Creating Tasks To Run
 =====================

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -42,7 +42,7 @@ Requesting A Page
 Essentially, the FeatureTestCase simply allows you to call an endpoint on your application and get the results back.
 to do this, you use the ``call()`` method. The first parameter is the HTTP method to use (most frequently either GET or POST).
 The second parameter is the path on your site to test. The third parameter accepts an array that is used to populate the
-the superglobal variables for the HTTP verb you are using. So, a method of **GET** would have the **$_GET** variable
+superglobal variables for the HTTP verb you are using. So, a method of **GET** would have the **$_GET** variable
 populated, while a **post** request would have the **$_POST** array populated.
 ::
 
@@ -118,7 +118,7 @@ Checking Response Status
 
 **isOK()**
 
-Returns a boolean true/false based on whether the response is percieved to be "ok". This is primarily determined by
+Returns a boolean true/false based on whether the response is perceived to be "ok". This is primarily determined by
 a response status code in the 200 or 300's.
 ::
 

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -41,7 +41,7 @@ Phar
 ----
 
 The other option is to download the .phar file from the `phpUnit <https://phpunit.de/getting-started/phpunit-7.html>`__ site.
-This is standalone file that should be placed within your project root.
+This is a standalone file that should be placed within your project root.
 
 
 ************************

--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -2,17 +2,17 @@ Create news items
 ###############################################################################
 
 You now know how you can read data from a database using CodeIgniter, but
-you haven't written any information to the database yet. In this section
+you haven't written any information to the database yet. In this section,
 you'll expand your news controller and model created earlier to include
 this functionality.
 
 Create a form
 -------------------------------------------------------
 
-To input data into the database you need to create a form where you can
+To input data into the database, you need to create a form where you can
 input the information to be stored. This means you'll be needing a form
 with two fields, one for the title and one for the text. You'll derive
-the slug from our title in the model. Create the new view at
+the slug from our title in the model. Create a new view at
 **app/Views/news/create.php**.
 
 ::
@@ -72,7 +72,7 @@ validation <../libraries/validation>` library to do this.
 
 The code above adds a lot of functionality. The first few lines load the
 form helper and the NewsModel. After that, the Controller-provided helper
-function is used to validate the $_POST fields. In this case the title and
+function is used to validate the $_POST fields. In this case, the title and
 text fields are required.
 
 CodeIgniter has a powerful validation library as demonstrated

--- a/user_guide_src/source/tutorial/index.rst
+++ b/user_guide_src/source/tutorial/index.rst
@@ -4,7 +4,7 @@ Tutorial
 
 This tutorial is intended to introduce you to the CodeIgniter4 framework
 and the basic principles of MVC architecture. It will show you how a
-basic CodeIgniter application is constructed in step-by-step fashion.
+basic CodeIgniter application is constructed in a step-by-step fashion.
 
 If you are not familiar with PHP, we recommend that you check out
 the `W3Schools PHP Tutorial <https://www.w3schools.com/php/default.asp>`_ before continuing.

--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -19,7 +19,7 @@ You need to create a database that can be used for this tutorial,
 and then configure CodeIgniter to use it.
 
 Using your database client, connect to your database and run the SQL command below (MySQL).
-Also add some seed records. For now, we'll just show you the SQL statements needed
+Also, add some seed records. For now, we'll just show you the SQL statements needed
 to create the table, but you should be aware that this can be done programmatically
 once you are more familiar with CodeIgniter; you can read about :doc:`Migrations <../dbmgmt/migration>`
 and :doc:`Seeds <../dbmgmt/seeds>` to create more useful database setups later.
@@ -111,7 +111,7 @@ following code to your model.
 		             ->first();
 	}
 
-With this code you can perform two different queries. You can get all
+With this code, you can perform two different queries. You can get all
 news records, or get a news item by its `slug <#>`_. You might have
 noticed that the ``$slug`` variable wasn't sanitized before running the
 query; :doc:`Query Builder <../database/query_builder>` does this for you.
@@ -119,7 +119,7 @@ query; :doc:`Query Builder <../database/query_builder>` does this for you.
 The two methods used here, ``findAll()`` and ``first()``, are provided
 by the Model class. They already know the table to use based on the ``$table``
 property we set in **NewsModel** class, earlier. They are helper methods
-that use the Query Builder to run their commands on the current table, and
+that use the Query Builder to run their commands on the current table and
 returning an array of results in the format of your choice. In this example,
 ``findAll()`` returns an array of objects.
 
@@ -167,7 +167,7 @@ method in the second method. The model is using this slug to identify the
 news item to be returned.
 
 Now the data is retrieved by the controller through our model, but
-nothing is displayed yet. The next thing to do is passing this data to
+nothing is displayed yet. The next thing to do is pass this data to
 the views. Modify the ``index()`` method to look like this::
 
 	public function index()
@@ -222,7 +222,7 @@ Parser </outgoing/view_parser>` or a third party parser.
 
 The news overview page is now done, but a page to display individual
 news items is still absent. The model created earlier is made in such
-way that it can easily be used for this functionality. You only need to
+a way that it can easily be used for this functionality. You only need to
 add some code to the controller and create a new view. Go back to the
 ``News`` controller and update the ``view()`` method with the following:
 

--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -119,7 +119,7 @@ query; :doc:`Query Builder <../database/query_builder>` does this for you.
 The two methods used here, ``findAll()`` and ``first()``, are provided
 by the Model class. They already know the table to use based on the ``$table``
 property we set in **NewsModel** class, earlier. They are helper methods
-that use the Query Builder to run their commands on the current table and
+that use the Query Builder to run their commands on the current table, and
 returning an array of results in the format of your choice. In this example,
 ``findAll()`` returns an array of objects.
 
@@ -167,7 +167,7 @@ method in the second method. The model is using this slug to identify the
 news item to be returned.
 
 Now the data is retrieved by the controller through our model, but
-nothing is displayed yet. The next thing to do is pass this data to
+nothing is displayed yet. The next thing to do is, passing this data to
 the views. Modify the ``index()`` method to look like this::
 
 	public function index()

--- a/user_guide_src/source/tutorial/static_pages.rst
+++ b/user_guide_src/source/tutorial/static_pages.rst
@@ -48,7 +48,7 @@ code.
 
 You have created a class named ``Pages``, with a ``showme`` method that accepts
 one argument named ``$page``. It also has an ``index()`` method, the same
-as the defaut controller found in **app/Controllers/Home.php**; that method
+as the default controller found in **app/Controllers/Home.php**; that method
 displays the CodeIgniter welcome page.
 
 The ``Pages`` class is extending the
@@ -173,7 +173,7 @@ controller you made above produces...
   inside our `Pages` controller, which is to display the CodeIgniter "welcome" page,
   because "index" is the default controller method
 - ``localhost:8080/pages/index`` will also show the CodeIgniter "welcome" page,
-  because we explicitly asked for the "index" methid
+  because we explicitly asked for the "index" method
 - ``localhost:8080/pages/showme`` will show the "home" page that you made above,
   because it is the default "page" parameter to the `showme()` method.
 - ``localhost:8080/pages/showme/home`` will also show the "home" page that you made above,


### PR DESCRIPTION
The corrections are made in the form of,
- Spelling correction
- Multiple spaces between words
- Corrected function name
- Use of proper grammar to understand the concept

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide