### PR TITLE
Avibility to change mutateDate behaviour

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -502,7 +502,7 @@ class Entity
 				$value = Time::parse($value);
 			}
 
-			if(!is_null($timezone))
+			if(!is_null($timezone) && !is_null($value))
 			{
 				$value = $value->setTimezone($timezone);
 			}

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -1,6 +1,7 @@
 <?php namespace CodeIgniter;
 
 use CodeIgniter\I18n\Time;
+use CodeIgniter\Exceptions\CastException;
 
 /**
  * CodeIgniter

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -1,5 +1,7 @@
 <?php namespace CodeIgniter;
 
+use CodeIgniter\I18n\Time;
+
 /**
  * CodeIgniter
  *


### PR DESCRIPTION
Adds possibility to set mutateDate  to return \DateTime instead of \CodeIgniter\I18n\Time instances.
To make it work simpy use this code in your Entity child constructor:
```
	public function __construct(?array $data = null)
	{
		parent::__construct($data, ['dateMutateAs' => 'DateTime']);
	}
```
or
```
	public function __construct(?array $data = null)
	{
		parent::__construct($data);
		$this->setMutateDateAs('DateTime'); // will return boolean - value changed === true.
	}
```

I think it is required to add some code to make  timezone changes work for \CodeIgniter\I18n\Time  instance. For make this work in predictable way  I think we should make some changes in \CodeIgniter\I18n\Time (#1807)


btw/ didn't know why git makes this commit diff so ugly :/