### PR TITLE
Pager: add classes required for Bootstrap rendering

### DIFF
--- a/system/Pager/Views/default_full.php
+++ b/system/Pager/Views/default_full.php
@@ -9,34 +9,34 @@ $pager->setSurroundCount(2);
 <nav aria-label="<?= lang('Pager.pageNavigation') ?>">
 	<ul class="pagination">
 		<?php if ($pager->hasPrevious()) : ?>
-			<li>
-				<a href="<?= $pager->getFirst() ?>" aria-label="<?= lang('Pager.first') ?>">
+			<li class="page-item">
+				<a class="page-link" href="<?= $pager->getFirst() ?>" aria-label="<?= lang('Pager.first') ?>">
 					<span aria-hidden="true"><?= lang('Pager.first') ?></span>
 				</a>
 			</li>
-			<li>
-				<a href="<?= $pager->getPrevious() ?>" aria-label="<?= lang('Pager.previous') ?>">
+			<li class="page-item">
+				<a class="page-link" href="<?= $pager->getPrevious() ?>" aria-label="<?= lang('Pager.previous') ?>">
 					<span aria-hidden="true">&laquo;</span>
 				</a>
 			</li>
 		<?php endif ?>
 
 		<?php foreach ($pager->links() as $link) : ?>
-			<li <?= $link['active'] ? 'class="active"' : '' ?>>
-				<a href="<?= $link['uri'] ?>">
+			<li class="page-item<?= $link['active'] ? ' active' : '' ?>">
+				<a class="page-link" href="<?= $link['uri'] ?>">
 					<?= $link['title'] ?>
 				</a>
 			</li>
 		<?php endforeach ?>
 
 		<?php if ($pager->hasNext()) : ?>
-			<li>
-				<a href="<?= $pager->getNext() ?>" aria-label="<?= lang('Pager.next') ?>">
+			<li class="page-item">
+				<a class="page-link" href="<?= $pager->getNext() ?>" aria-label="<?= lang('Pager.next') ?>">
 					<span aria-hidden="true">&raquo;</span>
 				</a>
 			</li>
-			<li>
-				<a href="<?= $pager->getLast() ?>" aria-label="<?= lang('Pager.last') ?>">
+			<li class="page-item">
+				<a class="page-link" href="<?= $pager->getLast() ?>" aria-label="<?= lang('Pager.last') ?>">
 					<span aria-hidden="true"><?= lang('Pager.last') ?></span>
 				</a>
 			</li>


### PR DESCRIPTION
**Description**
The user guide claims "The Pager class will render a series of links that are compatible with the Bootstrap CSS framework by default" but by default the resulting HTML is missing the necessary classes to be rendered as a Bootstrap pagination.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
