### PR TITLE
Models now require a primary key. This is partially to keep the code …

### DIFF
--- a/system/Exceptions/ModelException.php
+++ b/system/Exceptions/ModelException.php
@@ -1,0 +1,13 @@
+<?php namespace CodeIgniter\Exceptions;
+
+/**
+ * Model Exceptions.
+ */
+
+class ModelException extends FrameworkException
+{
+	public static function forNoPrimaryKey(string $modelName)
+	{
+		return new static(lang('Database.noPrimaryKey', [$modelName]));
+	}
+}

--- a/system/Language/en/Database.php
+++ b/system/Language/en/Database.php
@@ -25,4 +25,5 @@ return [
    'parseStringFail'       => 'Parsing key string failed.',
    'featureUnavailable'    => 'This feature is not available for the database you are using.',
    'tableNotFound'         => 'Table `{0}` was not found in the current database.',
+   'noPrimaryKey'          => '`{0}` model class does not specify a Primary Key.',
 ];

--- a/system/Model.php
+++ b/system/Model.php
@@ -36,6 +36,7 @@
  * @filesource
  */
 
+use CodeIgniter\Exceptions\ModelException;
 use Config\Database;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Pager\Pager;
@@ -1091,6 +1092,14 @@ class Model
 		if ($this->builder instanceof BaseBuilder)
 		{
 			return $this->builder;
+		}
+
+		// We're going to force a primary key to exist
+		// so we don't have overly convoluted code,
+		// and future features are likely to require them.
+		if (empty($this->primaryKey))
+		{
+			throw ModelException::forNoPrimaryKey(get_class($this));
 		}
 
 		$table = empty($table) ? $this->table : $table;

--- a/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
+++ b/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
@@ -88,6 +88,11 @@ class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
 
 		//No Primary Key
 		$this->forge->addField([
+			'id'    => [
+				'type'          => 'INTEGER',
+				'constraint'    => 3,
+				$unique_or_auto => true,
+			],
 			'key'   => [
 				'type'       => 'VARCHAR',
 				'constraint' => 40,

--- a/tests/_support/Models/SecondaryModel.php
+++ b/tests/_support/Models/SecondaryModel.php
@@ -6,7 +6,7 @@ class SecondaryModel extends Model
 {
 	protected $table = 'secondary';
 
-	protected $primaryKey = null;
+	protected $primaryKey = 'id';
 
 	protected $returnType = 'object';
 

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -247,11 +247,13 @@ class ModelTest extends CIDatabaseTestCase
 
 		$this->db->table('secondary')
 				 ->insert([
+					 'id'    => 1,
 					 'key'   => 'foo',
 					 'value' => 'bar',
 				 ]);
 		$this->db->table('secondary')
 				 ->insert([
+					 'id'    => 2,
 					 'key'   => 'bar',
 					 'value' => 'baz',
 				 ]);
@@ -519,14 +521,12 @@ class ModelTest extends CIDatabaseTestCase
 			'description' => 'some great marketing stuff',
 		];
 
-		$model->setValidationMessages(
-			[
-				'name' => [
-					'required'   => 'Your baby name is missing.',
-					'min_length' => 'Too short, man!',
-				],
-			]
-		);
+		$model->setValidationMessages([
+			'name' => [
+				'required'   => 'Your baby name is missing.',
+				'min_length' => 'Too short, man!',
+			],
+		]);
 
 		$this->assertFalse($model->insert($data));
 
@@ -979,6 +979,7 @@ class ModelTest extends CIDatabaseTestCase
 
 		$this->db->table('secondary')
 				 ->insert([
+					 'id'    => 1,
 					 'key'   => 'foo',
 					 'value' => 'bar',
 				 ]);
@@ -1102,5 +1103,17 @@ class ModelTest extends CIDatabaseTestCase
 		$errors = $model->errors();
 
 		$this->assertEquals('Minimum Length Error', $model->errors()['name']);
+	}
+
+	/**
+	 * @expectedException        CodeIgniter\Exceptions\ModelException
+	 * @expectedExceptionMessage `Tests\Support\Models\UserModel` model class does not specify a Primary Key.
+	 */
+	public function testThrowsWithNoPrimaryKey()
+	{
+		$model = new UserModel();
+		$this->setPrivateProperty($model, 'primaryKey', '');
+
+		$model->find(1);
 	}
 }

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -14,7 +14,7 @@ instance of the database connection and you're good to go.
 
 ::
 
-        <?php namespace App\Models;
+    <?php namespace App\Models;
 
 	use CodeIgniter\Database\ConnectionInterface;
 
@@ -70,9 +70,9 @@ This ensures that within the model any references to ``$this->db`` are made thro
 connection.
 ::
 
-         <?php namespace App\Models;
+    <?php namespace App\Models;
 
-       use CodeIgniter\Model;
+    use CodeIgniter\Model;
 
 	class UserModel extends Model
 	{
@@ -121,6 +121,9 @@ queries.
 This is the name of the column that uniquely identifies the records in this table. This
 does not necessarily have to match the primary key that is specified in the database, but
 is used with methods like ``find()`` to know what column to match the specified value to.
+
+.. note:: All Models must have a primaryKey specified to allow all of the features to work
+    as expected.
 
 **$returnType**
 


### PR DESCRIPTION
Models now require a primary key. This is partially to keep the code from becoming a tangled mess, and partially to ensure all Model convenience features work both now and in the future. Closes #1597