### PR TITLE
Dont replace slashes with backslashes in the to route

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -469,11 +469,7 @@ class Router implements RouterInterface
 				{
 					$val = preg_replace('#^' . $key . '$#', $val, $uri);
 				}
-				elseif (strpos($val, '/') !== false)
-				{
-					$val = str_replace('/', '\\', $val);
-				}
-
+			
 				// Is this route supposed to redirect to another?
 				if ($this->collection->isRedirect($key))
 				{

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -469,7 +469,16 @@ class Router implements RouterInterface
 				{
 					$val = preg_replace('#^' . $key . '$#', $val, $uri);
 				}
-			
+				elseif (strpos($val, '/') !== false)
+				{
+					[ $controller, $method ] = explode( '::', $val );
+					
+					// Only replace slashes in the controller, not in the method.
+					$controller = str_replace('/', '\\', $controller);
+					
+					$val = $controller . '::' . $method;
+				}
+
 				// Is this route supposed to redirect to another?
 				if ($this->collection->isRedirect($key))
 				{


### PR DESCRIPTION
Fixes #1838 

**Description**
Remove the replacement of `/` with `\` in the `$to` part of routes. This ensures that routes like `$routes->add('blog/joe', 'Blogs::users/34');` will work.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
