### PR TITLE
Exception 'forPageNotFound' missing default value

### DIFF
--- a/system/Exceptions/PageNotFoundException.php
+++ b/system/Exceptions/PageNotFoundException.php
@@ -9,9 +9,9 @@ class PageNotFoundException extends \OutOfBoundsException implements ExceptionIn
 	 */
 	protected $code = 404;
 
-	public static function forPageNotFound($Message)
+	public static function forPageNotFound(string $message = null)
 	{
-		return new static($Message ?? lang('HTTP.pageNotFound'));
+		return new static($message ?? lang('HTTP.pageNotFound'));
 	}
 
 	public static function forEmptyController()


### PR DESCRIPTION
**Description**
The function is designed to check for a default message but since a parameter is required it will fail with "missing parameter" unless explicitly passed null. Add a default value of null allows it to be appropriately overloaded.
This change brings it in line with what the User Guide already expects: https://codeigniter4.github.io/CodeIgniter4/general/errors.html#pagenotfoundexception

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
