### PR TITLE
Extend Controller to BaseController by default

### DIFF
--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -1,0 +1,16 @@
+<?php namespace App\Controllers;
+
+use CodeIgniter\Controller;
+
+class BaseController extends Controller
+{
+	protected $helpers = [ ];
+
+	public function initController(\CodeIgniter\HTTP\RequestInterface $request, \CodeIgniter\HTTP\ResponseInterface $response, \Psr\Log\LoggerInterface $logger)
+	{
+		parent::initController($request, $response, $logger);
+
+		// Autoload any models, libraries, etc, here.
+
+	}
+}

--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -1,16 +1,46 @@
 <?php namespace App\Controllers;
 
+/**
+ * Class BaseController
+ *
+ * BaseController provides a convenient place for loading components
+ * and performing functions that are needed by all your controllers.
+ * Extend this class in any new controllers:
+ *     class Home extends BaseController
+ * 
+ * For security be sure to declare any new methods as protected or private.
+ * 
+ * @package CodeIgniter
+ */
+ 
 use CodeIgniter\Controller;
 
 class BaseController extends Controller
 {
+
+	/**
+	 * An array of helpers to be loaded automatically upon
+	 * class instantiation. These helpers will be available
+	 * to all other controllers that extend BaseController.
+	 *
+	 * @var array
+	 */
 	protected $helpers = [ ];
 
+	/**
+	 * Constructor.
+	 *
+	 */
 	public function initController(\CodeIgniter\HTTP\RequestInterface $request, \CodeIgniter\HTTP\ResponseInterface $response, \Psr\Log\LoggerInterface $logger)
 	{
+		// Do Not Edit This Line
 		parent::initController($request, $response, $logger);
-
-		// Autoload any models, libraries, etc, here.
+		
+		//--------------------------------------------------------------------
+		// Preload any models, libraries, etc, here.
+		//--------------------------------------------------------------------
+		// E.g.:
+		// $this->session = \Config\Services::session();
 
 	}
 }

--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -2,7 +2,7 @@
 
 use CodeIgniter\Controller;
 
-class Home extends Controller
+class Home extends BaseController
 {
 	public function index()
 	{

--- a/system/Config/Routes.php
+++ b/system/Config/Routes.php
@@ -53,7 +53,7 @@ $routes->cli('migrations', '\CodeIgniter\Commands\MigrationsCommand::index');
 $routes->cli('ci(:any)', '\CodeIgniter\CLI\CommandRunner::index/$1');
 
 // Prevent access to BaseController
-$routes->add('basecontroller/(:any)', function()
+$routes->add('basecontroller(:any)', function()
 {
     throw \CodeIgniter\Exceptions\PageNotFoundException::forPageNotFound();
 }); 

--- a/system/Config/Routes.php
+++ b/system/Config/Routes.php
@@ -49,5 +49,11 @@ $routes->cli('migrations/(:segment)/(:segment)', '\CodeIgniter\Commands\Migratio
 $routes->cli('migrations/(:segment)', '\CodeIgniter\Commands\MigrationsCommand::$1');
 $routes->cli('migrations', '\CodeIgniter\Commands\MigrationsCommand::index');
 
-// CLI Catchall - uses a _remap to
+// CLI Catchall - uses a _remap to call Commands
 $routes->cli('ci(:any)', '\CodeIgniter\CLI\CommandRunner::index/$1');
+
+// Prevent access to BaseController
+$routes->add('basecontroller/(:any)', function()
+{
+    throw \CodeIgniter\Exceptions\PageNotFoundException::forPageNotFound();
+}); 

--- a/system/Config/Routes.php
+++ b/system/Config/Routes.php
@@ -44,6 +44,12 @@
  * It is called by Config\Routes, and has the $routes RouteCollection
  * already loaded up and ready for us to use.
  */
+// Prevent access to BaseController
+$routes->add('basecontroller(:any)', function()
+{
+    throw \CodeIgniter\Exceptions\PageNotFoundException::forPageNotFound();
+}); 
+
 // Migrations
 $routes->cli('migrations/(:segment)/(:segment)', '\CodeIgniter\Commands\MigrationsCommand::$1/$2');
 $routes->cli('migrations/(:segment)', '\CodeIgniter\Commands\MigrationsCommand::$1');
@@ -51,9 +57,3 @@ $routes->cli('migrations', '\CodeIgniter\Commands\MigrationsCommand::index');
 
 // CLI Catchall - uses a _remap to call Commands
 $routes->cli('ci(:any)', '\CodeIgniter\CLI\CommandRunner::index/$1');
-
-// Prevent access to BaseController
-$routes->add('basecontroller(:any)', function()
-{
-    throw \CodeIgniter\Exceptions\PageNotFoundException::forPageNotFound();
-}); 

--- a/user_guide_src/source/extending/basecontroller.rst
+++ b/user_guide_src/source/extending/basecontroller.rst
@@ -18,7 +18,7 @@ Preloading Components
 =====================
 
 The base controller is a great place to load any helpers, models, libraries, services, etc. that you intend to
-use every time your project runs. Helpers should be added to the pre-defined $helpers array. For example, if
+use every time your project runs. Helpers should be added to the pre-defined ``$helpers`` array. For example, if
 you want the HTML and Text helpers universally available::
 
 	protected $helpers = ['html', 'text'];
@@ -26,7 +26,7 @@ you want the HTML and Text helpers universally available::
 Any other components to load or data to process should be added to the constructor ``initController()``. For
 example, if your project uses the Session Library heavily you may want to initiate it here::
 
-	public function initController(\CodeIgniter\HTTP\RequestInterface $request, \CodeIgniter\HTTP\ResponseInterface $response, \Psr\Log\LoggerInterface $logger)
+	public function initController(...)
 	{
 		// Do Not Edit This Line
 		parent::initController($request, $response, $logger);
@@ -37,17 +37,16 @@ example, if your project uses the Session Library heavily you may want to initia
 Additional Methods
 ==================
 
-The base controller is not routable (system config routes it to 404 Page Not Found), but as an added security
-measure **all** new methods should be declared as protected or private and only accessed through the
-controllers you create that extend BaseController.
+The base controller is not routable (system config routes it to 404 Page Not Found). As an added security
+measure **all** new methods you create should be declared as ``protected`` or ``private`` and only be accessed through the
+controllers you create that extend ``BaseController``.
 
 Other Options
 =============
 
-You may find that you need more than one base controller, in which case you can create new base controllers to
-be extended - just make sure any controller that you make extends the correct base. For example if your project
-has an involved public interface and a simple administrative portal, you may want to extend BaseController to
-the public controllers and AdminController to any administrative controllers.
+You may find that you need more than one base controller. You can create new base controllers as long as any other controllers that you make extend the correct base. For example, if your project
+has an involved public interface and a simple administrative portal you may want to extend ``BaseController`` to
+the public controllers and make ``AdminController`` for any administrative controllers.
 
 If you do not want to use the base controller you may bypass it by having your controllers extend the system
 Controller instead::

--- a/user_guide_src/source/extending/basecontroller.rst
+++ b/user_guide_src/source/extending/basecontroller.rst
@@ -1,0 +1,58 @@
+************************
+Extending the Controller
+************************
+
+CodeIgniter's core Controller should not be changed, but a default class extension is provided for you at
+**app/Controllers/BaseController.php**. Any new controllers you make should extend ``BaseController`` to take
+advantage of preloaded components and any additional functionality you provide::
+
+	<?php namespace App\Controllers;
+	
+	use CodeIgniter\Controller;
+	
+	class Home extends BaseController {
+	
+	}
+
+Preloading Components
+=====================
+
+The base controller is a great place to load any helpers, models, libraries, services, etc. that you intend to
+use every time your project runs. Helpers should be added to the pre-defined $helpers array. For example, if
+you want the HTML and Text helpers universally available::
+
+	protected $helpers = ['html', 'text'];
+
+Any other components to load or data to process should be added to the constructor ``initController()``. For
+example, if your project uses the Session Library heavily you may want to initiate it here::
+
+	public function initController(\CodeIgniter\HTTP\RequestInterface $request, \CodeIgniter\HTTP\ResponseInterface $response, \Psr\Log\LoggerInterface $logger)
+	{
+		// Do Not Edit This Line
+		parent::initController($request, $response, $logger);
+		
+		$this->session = \Config\Services::session();
+	}
+
+Additional Methods
+==================
+
+The base controller is not routable (system config routes it to 404 Page Not Found), but as an added security
+measure **all** new methods should be declared as protected or private and only accessed through the
+controllers you create that extend BaseController.
+
+Other Options
+=============
+
+You may find that you need more than one base controller, in which case you can create new base controllers to
+be extended - just make sure any controller that you make extends the correct base. For example if your project
+has an involved public interface and a simple administrative portal, you may want to extend BaseController to
+the public controllers and AdminController to any administrative controllers.
+
+If you do not want to use the base controller you may bypass it by having your controllers extend the system
+Controller instead::
+
+	class Home extends Controller
+	{
+	
+	}

--- a/user_guide_src/source/extending/core_classes.rst
+++ b/user_guide_src/source/extending/core_classes.rst
@@ -105,15 +105,3 @@ If you need to use a constructor in your class make sure you extend the parent c
 
 **Tip:**  Any functions in your class that are named identically to the methods in the parent class will be used
 instead of the native ones (this is known as “method overriding”). This allows you to substantially alter the CodeIgniter core.
-
-If you are extending the Controller core class, then be sure to extend your new class in your application controller’s
-constructors::
-
-    <?php namespace App\Controllers;
-
-    use App\BaseController;
-
-    class Home extends BaseController {
-
-    }
-


### PR DESCRIPTION
**Description**
Create a default extended controller at app/Controllers/BaseController.php and updates Home controller and the User Guide to recommend using this for new Controllers. From a development standpoint, it makes sense to start with this extension even if it doesn't have any modifications since making the change down the road involves going back and editing every controller.
There was a fair amount of discussion on this idea in the forums already. See: https://forum.codeigniter.com/thread-73095.html

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
