### PR TITLE
Secure routable controller methods

### DIFF
--- a/system/Config/Routes.php
+++ b/system/Config/Routes.php
@@ -51,3 +51,9 @@ $routes->cli('migrations', '\CodeIgniter\Commands\MigrationsCommand::index');
 
 // CLI Catchall - uses a _remap to
 $routes->cli('ci(:any)', '\CodeIgniter\CLI\CommandRunner::index/$1');
+
+// Prevent access to initController method
+$routes->add('(:any)/initController', function()
+{
+    throw \CodeIgniter\Exceptions\PageNotFoundException::forPageNotFound();
+}); 

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -138,7 +138,7 @@ class Controller
 	 *
 	 * @throws \CodeIgniter\HTTP\Exceptions\HTTPException
 	 */
-	public function forceHTTPS(int $duration = 31536000)
+	protected function forceHTTPS(int $duration = 31536000)
 	{
 		force_https($duration, $this->request, $this->response);
 	}
@@ -151,7 +151,7 @@ class Controller
 	 *
 	 * @param integer $time
 	 */
-	public function cachePage(int $time)
+	protected function cachePage(int $time)
 	{
 		CodeIgniter::cache($time);
 	}
@@ -185,7 +185,7 @@ class Controller
 	 *
 	 * @return boolean
 	 */
-	public function validate($rules, array $messages = []): bool
+	protected function validate($rules, array $messages = []): bool
 	{
 		$this->validator = Services::validation();
 

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -87,7 +87,8 @@ class ControllerTest extends \CIUnitTestCase
 		$this->controller = new Controller();
 		$this->controller->initController($this->request, $this->response, $this->logger);
 
-		$this->assertNull($this->controller->cachePage(10));
+		$method = $this->getPrivateMethodInvoker($this->controller, 'cachePage');
+		$this->assertNull($method(10));
 	}
 
 	public function testValidate()
@@ -97,7 +98,8 @@ class ControllerTest extends \CIUnitTestCase
 		$this->controller->initController($this->request, $this->response, $this->logger);
 
 		// and that we can attempt validation, with no rules
-		$this->assertFalse($this->controller->validate([]));
+		$method = $this->getPrivateMethodInvoker($this->controller, 'validate');
+		$this->assertFalse($method([]));
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
Fix for https://github.com/codeigniter4/CodeIgniter4/issues/1849 - changes system/Controller.php methods to `protected` and adds a 404 route for initController method

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
