### PR TITLE
null coalescing changes

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -245,7 +245,7 @@ class CLI
 		fwrite(STDOUT, $field . $extra_output . ': ');
 
 		// Read the input from keyboard.
-		$input = trim(static::input()) ?: $default;
+		$input = trim(static::input()) ?? $default;
 
 		if (isset($validation))
 		{

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -72,7 +72,7 @@ class Console
 	 */
 	public function run(bool $useSafeOutput = false)
 	{
-		$path = CLI::getURI() ?: 'list';
+		$path = CLI::getURI() ?? 'list';
 
 		// Set the path for the application to route to.
 		$this->app->setPath("ci{$path}");

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -66,7 +66,7 @@ class FileHandler implements CacheInterface
 			throw CacheException::forUnableToWrite($path);
 		}
 
-		$this->prefix = $config->prefix ?: '';
+		$this->prefix = $config->prefix ?? '';
 		$this->path   = rtrim($path, '/') . '/';
 	}
 

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -74,7 +74,7 @@ class PredisHandler implements CacheInterface
 
 	public function __construct($config)
 	{
-		$this->prefix = $config->prefix ?: '';
+		$this->prefix = $config->prefix ?? '';
 
 		if (isset($config->redis))
 		{

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -58,7 +58,7 @@ class WincacheHandler implements CacheInterface
 
 	public function __construct($config)
 	{
-		$this->prefix = $config->prefix ?: '';
+		$this->prefix = $config->prefix ?? '';
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -112,7 +112,7 @@ class Database extends BaseCollector
 		$config = config('Toolbar');
 
 		// Provide default in case it's not set
-		$max = $config->maxQueries ?: 100;
+		$max = $config->maxQueries ?? 100;
 
 		if (count(static::$queries) < $max)
 		{

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -476,7 +476,7 @@ class Response extends Message implements ResponseInterface
 			$body = $formatter->format($body);
 		}
 
-		return $body ?: null;
+		return $body ?? null;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -1029,7 +1029,7 @@ class Time extends DateTime
 		}
 		else if (is_string($testTime))
 		{
-			$timezone = $timezone ?: $this->timezone;
+			$timezone = $timezone ?? $this->timezone;
 			$timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone);
 			$testTime = new DateTime($testTime, $timezone);
 			$testTime = $testTime->format('Y-m-d H:i:s');
@@ -1189,7 +1189,7 @@ class Time extends DateTime
 		}
 		else if (is_string($time))
 		{
-			$timezone = $timezone ?: $this->timezone;
+			$timezone = $timezone ?? $this->timezone;
 			$timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone);
 			$time     = new DateTime($time, $timezone);
 			$time     = $time->setTimezone(new DateTimeZone('UTC'));

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -131,7 +131,7 @@ class Parser extends View
 		// Was it cached?
 		if (isset($options['cache']))
 		{
-			$cacheName = $options['cache_name'] ?: $view;
+			$cacheName = $options['cache_name'] ?? $view;
 
 			if ($output = cache($cacheName))
 			{

--- a/tests/_support/Cache/Handlers/MockHandler.php
+++ b/tests/_support/Cache/Handlers/MockHandler.php
@@ -98,7 +98,7 @@ class MockHandler implements CacheInterface
 	{
 		$key = $this->prefix . $key;
 
-		$data = $this->cache[$key] ?: null;
+		$data = $this->cache[$key] ?? null;
 
 		if (empty($data))
 		{
@@ -126,7 +126,7 @@ class MockHandler implements CacheInterface
 	{
 		$key = $this->prefix . $key;
 
-		$data = $this->cache[$key] ?: null;
+		$data = $this->cache[$key] ?? null;
 
 		if (empty($data))
 		{


### PR DESCRIPTION
As we are isung php version >=7.2, to maintain the consistancy throughout the code, converted ternary to null coalescing.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide