### PR TITLE
Ignore callbacks in routes list

### DIFF
--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -122,11 +122,14 @@ class Routes extends BaseCommand
 
 			foreach ($routes as $from => $to)
 			{
-				$tbody[] = [
-					$from,
-					$method,
-					$to,
-				];
+				// filter for strings, as callbacks aren't displayable
+				if (is_string($to)) {
+					$tbody[] = [
+						$from,
+						$method,
+						$to,
+					];
+				}
 			}
 		}
 


### PR DESCRIPTION
**Description**
The CLI command Routes iterates routes from system & app to display them as a table, but ends up trying to display callbacks. This change ignores any `$to` destinations that aren't strings.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
