### PR TITLE
required_with and required_without definition changes

### DIFF
--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -279,7 +279,7 @@ class Rules
 	//--------------------------------------------------------------------
 
 	/**
-	 * The field is required when any of the other fields are present
+	 * The field is required when any of the other required fields are present
 	 * in the data.
 	 *
 	 * Example (field is required when the password field is present):
@@ -331,8 +331,8 @@ class Rules
 	//--------------------------------------------------------------------
 
 	/**
-	 * The field is required when all of the other fields are not present
-	 * in the data.
+	 * The field is required when all of the other fields are present
+	 * in the data but not required.
 	 *
 	 * Example (field is required when the id or email field is missing):
 	 *

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -679,8 +679,8 @@ if_exist                No          If this rule is present, validation will onl
                                     regardless of its value.
 permit_empty            No          Allows the field to receive an empty array, empty string, null or false.
 required                No          Fails if the field is an empty array, empty string, null or false.
-required_with           Yes         The field is required if any of the fields in the parameter are set.                            required_with[field1,field2]
-required_without        Yes         The field is required when any of the fields in the parameter are not set.                      required_without[field1,field2]
+required_with           Yes         The field is required when any of the other required fields are present in the data.            required_with[field1,field2]
+required_without        Yes         The field is required when all of the other fields are present in the data but not required.    required_without[field1,field2]
 is_unique               Yes         Checks if this field value exists in the database. Optionally set a                             is_unique[table.field,ignore_field,ignore_value]
                                     column and value to ignore, useful when updating records to ignore itself.
 timezone                No          Fails if field does match a timezone per ``timezone_identifiers_list``


### PR DESCRIPTION
w.r.t #1747, the functionality of required_with and required_without works as expected.
But the method definition is quite confusing. So according to functional implementation, I have changed the same.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide