### PR TITLE
History::SetFiles check #1778

### DIFF
--- a/system/Debug/Toolbar/Collectors/History.php
+++ b/system/Debug/Toolbar/Collectors/History.php
@@ -104,22 +104,25 @@ class History extends BaseCollector
 
 			// Get the contents of this specific history request
 			$contents = file_get_contents($filename);
-			$contents = json_decode($contents);
 
-			\preg_match_all('/\d+/', $filename, $time);
-			$time = (int)$time[0][0];
+			$contents = @json_decode($contents);
+			if(json_last_error() === JSON_ERROR_NONE)
+			{
+				preg_match_all('/\d+/', $filename, $time);
+				$time = (int)$time[0][0];
 
-			// Debugbar files shown in History Collector
-			$files[] = [
-				'time'        => $time,
-				'datetime'    => date('Y-m-d H:i:s', $time),
-				'active'      => $time === $current,
-				'status'      => $contents->vars->response->statusCode,
-				'method'      => $contents->method,
-				'url'         => $contents->url,
-				'isAJAX'      => $contents->isAJAX ? 'Yes' : 'No',
-				'contentType' => $contents->vars->response->contentType,
-			];
+				// Debugbar files shown in History Collector
+				$files[] = [
+					'time'        => $time,
+					'datetime'    => date('Y-m-d H:i:s', $time),
+					'active'      => $time === $current,
+					'status'      => $contents->vars->response->statusCode,
+					'method'      => $contents->method,
+					'url'         => $contents->url,
+					'isAJAX'      => $contents->isAJAX ? 'Yes' : 'No',
+					'contentType' => $contents->vars->response->contentType,
+				];
+			}
 		}
 
 		$this->files = $files;


### PR DESCRIPTION
History::SetFiles check #1778

As per the issue raised, In case one of the files in WRITEPATH.'debugger/debugbar_*.json is empty the method setFiles will crash. The reason for the crash is that History::setFiles does not check if the local variable $contents contain an object before using it in the assignment.

I have added a check whether the JSON is valid or not. If not then it will skip the iteration else proceed with it.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
