### PR TITLE
Allow CLI::strlen null parameter

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -482,12 +482,16 @@ class CLI
 	 * Get the number of characters in string having encoded characters
 	 * and ignores styles set by the color() function
 	 *
-	 * @param string $string
+	 * @param ?string $string
 	 *
 	 * @return integer
 	 */
-	public static function strlen(string $string): int
+	public static function strlen(?string $string): int
 	{
+		if (is_null($string))
+		{
+			return 0;
+		}
 		foreach (static::$foreground_colors as $color)
 		{
 			$string = strtr($string, ["\033[" . $color . 'm' => '']);


### PR DESCRIPTION
**Description**
Null column values in `table()` currently throw a type error because it uses `strlen()` to determine column spacing and `strlen()` accepts strictly strings. Allowing `strlen()` to process `null` values as length 0 lets CLI commands pass otherwise-untouched data from Builder, since other types (e.g. int) are already cast as strings.
This also mimics the behavior of PHP's `strlen()` which returns 0 for `null`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
