### PR TITLE
Fix spark serve with remove escapeshellarg() on php,host, and port

### DIFF
--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -121,9 +121,9 @@ class Serve extends BaseCommand
 		}
 
 		// Collect any user-supplied options and apply them.
-		$php  = escapeshellarg(CLI::getOption('php')) ?? PHP_BINARY;
-		$host = escapeshellarg(CLI::getOption('host')) ?? 'localhost';
-		$port = escapeshellarg(CLI::getOption('port')) ?? '8080';
+		$php  = CLI::getOption('php') ?? PHP_BINARY;
+		$host = CLI::getOption('host') ?? 'localhost';
+		$port = CLI::getOption('port') ?? '8080';
 
 		// Get the party started.
 		CLI::write('CodeIgniter development server started on http://' . $host . ':' . $port, 'green');


### PR DESCRIPTION
When php, host, and port variable has `escapeshellarg()` check, the `??` will use the value result of `escapeshellarg()` that can has result empty single quote string : "''"

**Before**
![Screen Shot 2019-03-28 at 11 04 48 PM](https://user-images.githubusercontent.com/459648/55173409-3d881a80-51ae-11e9-815f-84df92ce335e.png)

**After**
![Screen Shot 2019-03-28 at 11 05 03 PM](https://user-images.githubusercontent.com/459648/55173395-395bfd00-51ae-11e9-9a72-e5a93540d2eb.png)


**Checklist:**
- [x] Securely signed commits
