### PR TITLE
Unmatched Cache Library `get()` return null

### DIFF
--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -100,7 +100,7 @@ class FileHandler implements CacheInterface
 
 		$data = $this->getItem($key);
 
-		return is_array($data) ? $data['data'] : false;
+		return is_array($data) ? $data['data'] : null;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -158,7 +158,7 @@ class MemcachedHandler implements CacheInterface
 			$data = $this->memcached->get($key);
 
 			// check for unmatched key
-			if ($this->memcached->getResultCode()==$this->memcached->RES_NOTFOUND)
+			if ($this->memcached->getResultCode()==\Memcached::RES_NOTFOUND)
 			{
 				return null;
 			}

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -153,7 +153,27 @@ class MemcachedHandler implements CacheInterface
 	{
 		$key = $this->prefix . $key;
 
-		$data = $this->memcached->get($key);
+		if ($this->memcached instanceof \Memcached)
+		{
+			$data = $this->memcached->get($key);
+
+			// check for unmatched key
+			if ($this->memcached->getResultCode()==$this->memcached->RES_NOTFOUND)
+			{
+				return null;
+			}
+		}
+		elseif ($this->memcached instanceof \Memcache)
+		{
+			$flags = false;
+			$data = $this->memcached->get($key, $flags);
+
+			// check for unmatched key (i.e. $flags is untouched)
+			if ($data===false)
+			{
+				return null;
+			}
+		}
 
 		return is_array($data) ? $data[0] : $data;
 	}

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -169,7 +169,7 @@ class MemcachedHandler implements CacheInterface
 			$data = $this->memcached->get($key, $flags);
 
 			// check for unmatched key (i.e. $flags is untouched)
-			if ($data===false)
+			if ($flags===false)
 			{
 				return null;
 			}

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -127,7 +127,7 @@ class PredisHandler implements CacheInterface
 
 		if (! isset($data['__ci_type'], $data['__ci_value']) || $data['__ci_value'] === false)
 		{
-			return false;
+			return null;
 		}
 
 		switch ($data['__ci_type'])
@@ -140,10 +140,10 @@ class PredisHandler implements CacheInterface
 			case 'double': // Yes, 'double' is returned and NOT 'float'
 			case 'string':
 			case 'NULL':
-				return settype($data['__ci_value'], $data['__ci_type']) ? $data['__ci_value'] : false;
+				return settype($data['__ci_value'], $data['__ci_type']) ? $data['__ci_value'] : null;
 			case 'resource':
 			default:
-				return false;
+				return null;
 		}
 	}
 

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -143,7 +143,7 @@ class RedisHandler implements CacheInterface
 
 		if (! isset($data['__ci_type'], $data['__ci_value']) || $data['__ci_value'] === false)
 		{
-			return false;
+			return null;
 		}
 
 		switch ($data['__ci_type'])
@@ -156,10 +156,10 @@ class RedisHandler implements CacheInterface
 			case 'double': // Yes, 'double' is returned and NOT 'float'
 			case 'string':
 			case 'NULL':
-				return settype($data['__ci_value'], $data['__ci_type']) ? $data['__ci_value'] : false;
+				return settype($data['__ci_value'], $data['__ci_type']) ? $data['__ci_value'] : null;
 			case 'resource':
 			default:
-				return false;
+				return null;
 		}
 	}
 

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -299,7 +299,7 @@ class RedisHandler implements CacheInterface
 
 		$value = $this->get($key);
 
-		if ($value !== false)
+		if ($value !== null)
 		{
 			$time = time();
 			return [
@@ -309,7 +309,7 @@ class RedisHandler implements CacheInterface
 			];
 		}
 
-		return false;
+		return null;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -94,7 +94,7 @@ class WincacheHandler implements CacheInterface
 		$data    = wincache_ucache_get($key, $success);
 
 		// Success returned by reference from wincache_ucache_get()
-		return ($success) ? $data : false;
+		return ($success) ? $data : null;
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -93,10 +93,10 @@ class FileHandlerTest extends \CIUnitTestCase
 		$this->fileHandler->save(self::$key1, 'value', 1);
 
 		$this->assertSame('value', $this->fileHandler->get(self::$key1));
-		$this->assertFalse($this->fileHandler->get(self::$dummy));
+		$this->assertNull($this->fileHandler->get(self::$dummy));
 
 		\CodeIgniter\CLI\CLI::wait(2);
-		$this->assertFalse($this->fileHandler->get(self::$key1));
+		$this->assertNull($this->fileHandler->get(self::$key1));
 	}
 
 	public function testSave()

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -54,7 +54,7 @@ class MemcachedHandlerTest extends \CIUnitTestCase
 		$this->assertFalse($this->memcachedHandler->get(self::$dummy));
 
 		\CodeIgniter\CLI\CLI::wait(2);
-		$this->assertFalse($this->memcachedHandler->get(self::$key1));
+		$this->assertNull($this->memcachedHandler->get(self::$key1));
 	}
 
 	public function testSave()

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -51,7 +51,7 @@ class MemcachedHandlerTest extends \CIUnitTestCase
 		$this->memcachedHandler->save(self::$key1, 'value', 1);
 
 		$this->assertSame('value', $this->memcachedHandler->get(self::$key1));
-		$this->assertFalse($this->memcachedHandler->get(self::$dummy));
+		$this->assertNull($this->memcachedHandler->get(self::$dummy));
 
 		\CodeIgniter\CLI\CLI::wait(2);
 		$this->assertNull($this->memcachedHandler->get(self::$key1));

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -98,7 +98,7 @@ class RedisHandlerTest extends \CIUnitTestCase
 		$this->assertNull($this->redisHandler->get(self::$dummy));
 
 		\CodeIgniter\CLI\CLI::wait(2);
-		$this->assertFalse($this->redisHandler->get(self::$key1));
+		$this->assertNull($this->redisHandler->get(self::$key1));
 	}
 
 	public function testSave()
@@ -143,7 +143,7 @@ class RedisHandlerTest extends \CIUnitTestCase
 		$time = time();
 		$this->redisHandler->save(self::$key1, 'value');
 
-		$this->assertFalse($this->redisHandler->getMetaData(self::$dummy));
+		$this->assertNull($this->redisHandler->getMetaData(self::$dummy));
 
 		$actual = $this->redisHandler->getMetaData(self::$key1);
 		$this->assertLessThanOrEqual(60, $actual['expire'] - $time);

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -95,7 +95,7 @@ class RedisHandlerTest extends \CIUnitTestCase
 		$this->redisHandler->save(self::$key1, 'value', 1);
 
 		$this->assertSame('value', $this->redisHandler->get(self::$key1));
-		$this->assertFalse($this->redisHandler->get(self::$dummy));
+		$this->assertNull($this->redisHandler->get(self::$dummy));
 
 		\CodeIgniter\CLI\CLI::wait(2);
 		$this->assertFalse($this->redisHandler->get(self::$key1));

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -25,7 +25,7 @@ Service Accessors
 
     If no $key is provided, will return the Cache engine instance. If a $key
     is provided, will return the value of $key as stored in the cache currently,
-    or false if no value is found.
+    or null if no value is found.
 
     Examples::
 

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -83,11 +83,11 @@ Class Reference
 .. php:method:: get($key)
 
 	:param	string	$key: Cache item name
-	:returns:	Item value or FALSE if not found
+	:returns:	Item value or NULL if not found
 	:rtype:	mixed
 
 	This method will attempt to fetch an item from the cache store. If the
-	item does not exist, the method will return FALSE.
+	item does not exist, the method will return NULL.
 
 	Example::
 


### PR DESCRIPTION
**Description**
Currently there is no way to distinguish between returns of a cached value `false` and "no matching key". This changes each handler to return `null` when a key isn't found.
Fixes https://github.com/codeigniter4/CodeIgniter4/issues/1870

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
