### PR TITLE
BaseBuilder changes w.r.t. operator

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -668,10 +668,7 @@ class BaseBuilder
 				if (! empty($op))
 				{
 					$k = trim($k);
-
-					end($op);
-
-					$op = trim(current($op));
+					$op = trim($op);
 
 					if (substr($k, -1 * strlen($op)) === $op)
 					{


### PR DESCRIPTION
As the getOperator() function returns string, we can not use methods like end() and current() as they expect array as parameter.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide