### PR TITLE
removed $_SERVER['CI_ENVIRONMENT']

### DIFF
--- a/system/Commands/Server/rewrite.php
+++ b/system/Commands/Server/rewrite.php
@@ -14,11 +14,6 @@ if (php_sapi_name() === 'cli')
 {
 	return;
 }
-
-// If we're serving the site locally, then we need
-// to let the application know that we're in development mode
-$_SERVER['CI_ENVIRONMENT'] = 'development';
-
 $uri = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
 
 // Front Controller path - expected to be in the default folder


### PR DESCRIPTION
no need to set $_SERVER['CI_ENVIRONMENT'] variable in rewrite.php.


**Description**
removed $_SERVER['CI_ENVIRONMENT'] in rewrite.php
file path : appstarter\vendor\codeigniter4\framework\system\Commands\Server\rewrite.php
Line : 20
**Reason :**
$_SERVER['CI_ENVIRONMENT'] = 'development'; defined in rewrite. php
it is replacing CI_ENVIRONMENT variable value.
#1268

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

