### PR TITLE
Entity exception for non existed props.

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -295,12 +295,12 @@ class Entity
 			$result = $this->castAs($result, $this->_options['casts'][$key]);
 		}
 		
-		if(isset($result) && $result !== null)
+		if(! isset($result) && ! property_exists($this, $key))
 		{
-			return $result;
+			throw EntityException::forTryingToAccessNonExistentProperty($key, __CLASS__);
 		}
 
-		throw EntityException::forTryingToAccessNonExistentProperty($key, __CLASS__);
+		return $result;
 
 	}
 

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -294,8 +294,14 @@ class Entity
 		{
 			$result = $this->castAs($result, $this->_options['casts'][$key]);
 		}
+		
+		if(isset($result) && $result !== null)
+		{
+			return $result;
+		}
 
-		return $result;
+		throw EntityException::forTryingToAccessNonExistentProperty($key, __CLASS__);
+
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -297,7 +297,7 @@ class Entity
 		
 		if(! isset($result) && ! property_exists($this, $key))
 		{
-			throw EntityException::forTryingToAccessNonExistentProperty($key, __CLASS__);
+			throw EntityException::forTryingToAccessNonExistentProperty($key, get_called_class());
 		}
 
 		return $result;

--- a/system/Exceptions/EntityException.php
+++ b/system/Exceptions/EntityException.php
@@ -1,0 +1,22 @@
+<?php namespace CodeIgniter\Exceptions;
+
+/**
+ * Entity Exceptions.
+ */
+
+class EntityException extends AlertError
+{
+
+	/**
+	 * Error code
+	 *
+	 * @var integer
+	 */
+	protected $code = 3;
+
+	public static function forTryingToAccessNonExistentProperty(string $property, string $on)
+	{
+		throw new static(lang('Entity.tryingToAccessNonExistentProperty', [$property, $on]));
+	}
+
+}

--- a/system/Language/en/Entity.php
+++ b/system/Language/en/Entity.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * CLI language strings.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2014-2019 British Columbia Institute of Technology (https://bcit.ca/)
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @filesource
+ *
+ * @codeCoverageIgnore
+ */
+
+return
+[
+	'tryingToAccessNonExistentProperty' => 'Trying to access non existent property {0} of {1}'
+];


### PR DESCRIPTION
As for now if code calls non existed property of entity causing ErrorException with no info at all.
This PR is changing ErrorException to EntityException with translated information like this:
"Trying to access non existent property fle_amount_fromss of App\Entities\Fee\FeeLevel"