### PR TITLE
Model Changes w.r.t. #1773

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -484,14 +484,6 @@ class Model
 	 */
 	public function save($data): bool
 	{
-		// If $data is using a custom class with public or protected
-		// properties representing the table elements, we need to grab
-		// them as an array.
-		if (is_object($data) && ! $data instanceof \stdClass)
-		{
-			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat);
-		}
-
 		if (empty($data))
 		{
 			return true;
@@ -525,15 +517,16 @@ class Model
 	 * @param string|object $data
 	 * @param string|null   $primaryKey
 	 * @param string        $dateFormat
+	 * @param boolean       $onlyChanged
 	 *
 	 * @return array
 	 * @throws \ReflectionException
 	 */
-	public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime'): array
+	public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime', bool $onlyChanged = true): array
 	{
 		if (method_exists($data, 'toRawArray'))
 		{
-			$properties = $data->toRawArray(true);
+			$properties = $data->toRawArray($onlyChanged);
 
 			// Always grab the primary key otherwise updates will fail.
 			if (! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties))
@@ -631,7 +624,7 @@ class Model
 		// them as an array.
 		if (is_object($data) && ! $data instanceof \stdClass)
 		{
-			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat);
+			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat, false);
 		}
 
 		// If it's still a stdClass, go ahead and convert to

--- a/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
+++ b/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
@@ -46,7 +46,10 @@ class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
 				'type'       => 'VARCHAR',
 				'constraint' => 40,
 			],
-			'description' => ['type' => 'TEXT'],
+			'description' => [
+				'type' => 'TEXT',
+				'null' => true,
+			],
 			'created_at'  => [
 				'type' => 'DATETIME',
 				'null' => true,

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -976,6 +976,7 @@ class ModelTest extends CIDatabaseTestCase
 
 	public function testSelectAndEntitiesSaveOnlyChangedValues()
 	{
+		// Insert value in job table
 		$this->hasInDatabase('job', [
 			'name'        => 'Rocket Scientist',
 			'description' => 'Plays guitar for Queen',
@@ -984,20 +985,35 @@ class ModelTest extends CIDatabaseTestCase
 
 		$model = new EntityModel();
 
+		// get only id, name column
 		$job = $model->select('id, name')
-					 ->where('name', 'Rocket Scientist')
-					 ->first();
+		             ->where('name', 'Rocket Scientist')
+		             ->first();
 
+		// Hence getting Null as description column not in select clause
 		$this->assertNull($job->description);
+
+		// Equals with name to check, correct record fetched or not.
 		$this->assertEquals('Rocket Scientist', $job->name);
 
+		$job->description = 'Some guitar description';
+
+		// saving the result set with description as empty
 		$model->save($job);
 
+		// check for the record to same entry exists or not
 		$this->seeInDatabase('job', [
-			'id'          => $job->id,
-			'name'        => 'Rocket Scientist',
-			'description' => 'Plays guitar for Queen',
+			'id'   => $job->id,
+			'name' => 'Rocket Scientist',
 		]);
+
+		// select all columns from job table
+		$job = $model->select('id, name, description')
+		             ->where('name', 'Rocket Scientist')
+		             ->first();
+
+		// check whether the Null value successfully updated or not
+		$this->assertEquals('Some guitar description', $job->description);
 	}
 
 	public function testUpdateNoPrimaryKey()


### PR DESCRIPTION
In the stated issue #1773, he is trying to save the null value in the database which expected to throw an error of required field.
But when data is passed from the insert method to classToArray, it expects to return only changed values.
The previous and current value of the property is null, hence it is not returning the property as changed value.
Hence error is not getting triggered.

So some required changes made here like,
1. Made allowed null for description column of job table in migration
2. Removed if condition from save() method as again update() or save() method performs same operation in the classToArray() method.
3. Introduced $onlyChanged parameter to classToArray() function. So we can escape the only changed value check in case of insert the data but it will return only changed values data in case of the update as the flag value is true by default.
4. Passing false value to classToArray method for variable $onlyChanged in the insert method as we required all the params, not the changed values only.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide
