### PR TITLE
Toolbar IE11 fix

### DIFF
--- a/system/Debug/Toolbar/Views/toolbarloader.js.php
+++ b/system/Debug/Toolbar/Views/toolbarloader.js.php
@@ -61,7 +61,11 @@ function loadDoc(time) {
 }
 
 // Track all AJAX requests
-var oldXHR = window.XMLHttpRequest;
+if (window.ActiveXObject) {
+    var oldXHR = new ActiveXObject('Microsoft.XMLHTTP');
+} else {
+    var oldXHR = window.XMLHttpRequest;
+}
 
 function newXHR() {
 	var realXHR = new oldXHR();


### PR DESCRIPTION
**Description**
I fixed the Toolbar JS Code for IE Browsers. 
The Internet Explorer Browsers including IE11 doesn't with `window.XMLHttpRequest`, these Browsers need an ActiveXObject like this `new ActiveXObject('Microsoft.XMLHTTP')`.

Fixes #1905 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  