### PR TITLE
having (Is NULL deletion)

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -706,7 +706,7 @@ class BaseBuilder
 
 				$v = " :$bind:";
 			}
-			elseif (! $this->hasOperator($k))
+			elseif (! $this->hasOperator($k) && $qb_key !== 'QBHaving')
 			{
 				// value appears not to have been set, assign the test to IS NULL
 				$k .= ' IS NULL';


### PR DESCRIPTION
Is it breaks anything or will repair having('MAX(sth)', null, false)
before:
```
SELECT `aht_cur_id_2` `cur_id_2`, `aht_cur_id_1` `cur_id_1`, `aht_rate` `rate`
FROM `t_api_trading_trades`
GROUP BY `aht_cur_id_2`, `aht_cur_id_1`
HAVING MAX(aht_api_trade_id) IS NULL
```
now:
```
SELECT `aht_cur_id_2` `cur_id_2`, `aht_cur_id_1` `cur_id_1`, `aht_rate` `rate`
FROM `t_api_trading_trades`
GROUP BY `aht_cur_id_2`, `aht_cur_id_1`
HAVING MAX(aht_api_trade_id)
```
