### PR TITLE
Remove section that prevents hotlinking

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -60,12 +60,6 @@ AddDefaultCharset utf-8
 	RewriteCond %{REQUEST_FILENAME} !-d
 	RewriteRule ^(.*)$ index.php/$1 [L]
 
-    # Disable image hotlinkiing start
-    RewriteCond %{HTTP_REFERER} !^$
-    RewriteCond %{HTTP_REFERER} !^http(s)?://(www\.)?example.com [NC]
-    RewriteRule \.(jpg|jpeg|png|gif)$ – [NC,F,L]
-    # Disable image hotlinkiing end
-
 	# Ensure Authorization header is passed along
     RewriteCond %{HTTP:Authorization} .
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]


### PR DESCRIPTION
**Description**
The rewrite rule required a hard-coded domain which developers would need to update or their assets would give 403 errors. Better to allow developers to add this themselves than supply an .htaccess file that doesn't work out-of-the-box.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
