### PR TITLE
Fix empty `$data` check since trigger had wrap it into a non-empty array

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -668,7 +668,7 @@ class Model
 
 		$data = $this->trigger('beforeInsert', ['data' => $data]);
 
-		if (empty($data))
+		if (empty($data['data']))
 		{
 			throw DataException::forEmptyDataset('insert');
 		}
@@ -790,7 +790,7 @@ class Model
 
 		$data = $this->trigger('beforeUpdate', ['id' => $id, 'data' => $data]);
 
-		if (empty($data))
+		if (empty($data['data']))
 		{
 			throw DataException::forEmptyDataset('update');
 		}


### PR DESCRIPTION
**Description**
Fix empty `$data` check since trigger had wrap it into a non-empty array

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
