### PR TITLE
Fix datetime extraction from debugbar file

### DIFF
--- a/system/Debug/Toolbar/Collectors/History.php
+++ b/system/Debug/Toolbar/Collectors/History.php
@@ -111,7 +111,7 @@ class History extends BaseCollector
 			if (json_last_error() === JSON_ERROR_NONE)
 			{
 				preg_match_all('/\d+/', $filename, $time);
-				$time = (int)$time[0][0];
+				$time = (int)end($time[0]);
 
 				// Debugbar files shown in History Collector
 				$files[] = [


### PR DESCRIPTION
[https://github.com/codeigniter4/CodeIgniter4/issues/1944](url)
When the full path of debugbar file contains some digits, the first group of digits was extracted as timestamp and the datetime displayed in the Hisory toolbar was wrong.

**Description**
Changed how the time is extracted from bedugbar filename by getting the las group of digits founded by preg_match_all function.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
