### PR TITLE
Fix BaseConfig didn't load Registrar files properly

### DIFF
--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -181,8 +181,15 @@ class BaseConfig
 
 		if (! static::$didDiscovery)
 		{
-			$locator              = \Config\Services::locator();
-			static::$registrars   = $locator->search('Config/Registrar.php');
+			$locator         = \Config\Services::locator();
+			$registrarsFiles = $locator->search('Config/Registrar.php');
+
+			foreach ($registrarsFiles as $file)
+			{
+				$className = $locator->getClassname($file);
+				static::$registrars[] = new $className();
+			}
+
 			static::$didDiscovery = true;
 		}
 

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -198,8 +198,9 @@ class BaseConfigTest extends CIUnitTestCase
 		$modulesConfig          = config('Modules');
 		$modulesConfig->enabled = false;
 
-		$config   = new \RegistrarConfig();
-		$expected = $config::$registrars;
+		$config              = new \RegistrarConfig();
+		$config::$registrars = [];
+		$expected            = $config::$registrars;
 
 		$method = $this->getPrivateMethodInvoker($config, 'registerProperties');
 		$method();
@@ -212,7 +213,8 @@ class BaseConfigTest extends CIUnitTestCase
 		$modulesConfig          = config('Modules');
 		$modulesConfig->enabled = true;
 
-		$config = new \RegistrarConfig();
+		$config              = new \RegistrarConfig();
+		$config::$registrars = [];
 		$this->setPrivateProperty($config, 'didDiscovery', false);
 
 		$method = $this->getPrivateMethodInvoker($config, 'registerProperties');


### PR DESCRIPTION
**Description**
In origional `BaseConfig.php` file, in `registrProperties` function, it use `locator` to find all `Config/Registrar.php` files in known namespace, and it returned all file path as an array.

In following code, it use the file path as a callable object, to check if registrars exists (by using method_exists) for current config file, which didn't work in my case.

I'm not sure if method_exists works with file path, but I updated this function to load all registrars files first before future usage.


**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
