### PR TITLE
Prevent reverseRoute from searching closures

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1111,6 +1111,12 @@ class RouteCollection implements RouteCollectionInterface
 			{
 				$from = key($route['route']);
 				$to   = $route['route'][$from];
+				
+				// ignore closures
+				if (! is_string($to))
+				{
+					continue;
+				}
 
 				// Lose any namespace slash at beginning of strings
 				// to ensure more consistent match.

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -947,14 +947,20 @@ class RouteCollectionTest extends \CIUnitTestCase
 	{
 		$routes = $this->getCollector();
 
-		$routes->add(
-				'login', function () {
-				}
-		);
+		$routes->add('login', function() { });
 
 		$match = $routes->reverseRoute('login');
 
 		$this->assertEquals('/login', $match);
+	}
+	
+	public function testReverseRoutingWithClosureNoMatch()
+	{
+		$routes = $this->getCollector();
+
+		$routes->add('login', function() { });
+
+		$this->assertFalse($routes->reverseRoute('foobar'));
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
`reverseRoute` searches loaded routes for a string match, but will throw an exception on unmatched routes when it tries to `trim` any routes whose definitions are closures. This ignores non-string destinations in the secondary search phase.
Fix for https://github.com/codeigniter4/CodeIgniter4/issues/1953

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
