### PR TITLE
Fix unable to use _remap without default method

### DIFF
--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -88,7 +88,7 @@ class Routes extends BaseCollector
 		$route = $router->getMatchedRoute();
 
 		// Get our parameters
-		$method    = is_callable($router->controllerName()) ? new \ReflectionFunction($router->controllerName()) : new \ReflectionMethod($router->controllerName(), $router->methodName());
+		$method    = is_callable($router->controllerName()) ? new \ReflectionFunction($router->controllerName()) : new \ReflectionMethod($router->controllerName(), method_exists($router->controllerName(), '_remap') ? '_remap' : $router->methodName());
 		$rawParams = $method->getParameters();
 
 		$params = [];


### PR DESCRIPTION
**Description**
A controller with method other than _remap creates ReflectionException error in routes collector toolbar.
Fix for #1928

**Checklist:**

- [x]  Securely signed commits

- [x]  Component(s) with PHPdocs

- [x]  Unit testing, with >80% coverage

- [x]  User guide updated

- [x]  Conforms to style guide