### PR TITLE
Fix Debugbar url tail slash issue

### DIFF
--- a/system/Debug/Toolbar/Views/toolbarloader.js.php
+++ b/system/Debug/Toolbar/Views/toolbarloader.js.php
@@ -56,7 +56,7 @@ function loadDoc(time) {
 		}
 	};
 
-	xhttp.open("GET", url + "?debugbar_time=" + time, true);
+	xhttp.open("GET", url + "/?debugbar_time=" + time, true);
 	xhttp.send();
 }
 

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -76,7 +76,7 @@ if (! function_exists('site_url'))
 		}
 		if (! empty($uri))
 		{
-			$fullPath .= '/' . $uri;
+			$fullPath .= $uri;
 		}
 
 		$url = new \CodeIgniter\HTTP\URI($fullPath);

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -76,7 +76,7 @@ if (! function_exists('site_url'))
 		}
 		if (! empty($uri))
 		{
-			$fullPath .= $uri;
+			$fullPath .= '/' . $uri;
 		}
 
 		$url = new \CodeIgniter\HTTP\URI($fullPath);


### PR DESCRIPTION
**Description**
In `toolbarloader.js.php`, the tail slash in `url` is trimmed, so when build a request url in xhttp.open, it should add one tail slash (Otherwise server will do a 301 redirection to the one with tail slash first)

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
