### PR TITLE
String type primary key should also wrap into an array during db update

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -740,7 +740,7 @@ class Model
 	{
 		$escape = null;
 
-		if (is_numeric($id))
+		if (is_numeric($id) || is_string($id))
 		{
 			$id = [$id];
 		}


### PR DESCRIPTION
**Description**
String type primary key should also wrap into an array during db update
Following `$builder->whereIn()` expect it to be an array.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide