### PR TITLE
Fixed pathinfo mode 404 error (array index of uri segments from array_filter()) 

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -564,7 +564,8 @@ class Router implements RouterInterface
 	 */
 	protected function validateRequest(array $segments): array
 	{
-		$segments = array_values(array_filter($segments));
+		$segments = array_filter($segments);
+		$segments = array_values($segments);
 
 		$c                  = count($segments);
 		$directory_override = isset($this->directory);

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -564,7 +564,7 @@ class Router implements RouterInterface
 	 */
 	protected function validateRequest(array $segments): array
 	{
-		$segments = array_filter($segments);
+		$segments = array_values(array_filter($segments));
 
 		$c                  = count($segments);
 		$directory_override = isset($this->directory);


### PR DESCRIPTION
function validateRequest in Router,  rebuild array index: array_values(array_filter($segments))

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

#1965