### PR TITLE
Fixed pathinfo mode 404 error, rebuild array index of uri segments from array_filter()

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -565,6 +565,7 @@ class Router implements RouterInterface
 	protected function validateRequest(array $segments): array
 	{
 		$segments = array_filter($segments);
+		$segments = array_values($segments);
 
 		$c                  = count($segments);
 		$directory_override = isset($this->directory);


### PR DESCRIPTION
fixes #1965 

**Description**
Rebuild array index of uri segments from array_filter(), solve $segments[0] index undefined error

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
