### PR TITLE
Add back filter arguments

### DIFF
--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -147,7 +147,7 @@ class Filters
 
 			if ($position === 'before')
 			{
-				$result = $class->before($this->request);
+				$result = $class->before($this->request, $this->arguments[$alias] ?? null);
 
 				if ($result instanceof RequestInterface)
 				{


### PR DESCRIPTION
**Description**
A previous commit (https://github.com/codeigniter4/CodeIgniter4/commit/ceae97469c01bc96d58e439697ec6bd584bea728#diff-63f8289a599089d6c44102ec8149bec1) accidentally overwrote the changes to allow filters to pass arguments to their targets. This restores the functionality.

Someone should probably also look into why `testEnableFilterWithArguments()` has been passing with arguments disabled.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
