### PR TITLE
Toolbar fix for custom collectors

### DIFF
--- a/system/Debug/Toolbar/Collectors/BaseCollector.php
+++ b/system/Debug/Toolbar/Collectors/BaseCollector.php
@@ -232,9 +232,9 @@ class BaseCollector
 	/**
 	 * Returns the data of this collector to be formatted in the toolbar
 	 *
-	 * @return array
+	 * @return array|string
 	 */
-	public function display(): array
+	public function display()
 	{
 		return [];
 	}

--- a/system/Debug/Toolbar/Views/toolbar.tpl.php
+++ b/system/Debug/Toolbar/Views/toolbar.tpl.php
@@ -136,7 +136,7 @@
 				<div id="ci-<?= $c['titleSafe'] ?>" class="tab">
 					<h2><?= $c['title'] ?> <span><?= $c['titleDetails'] ?></span></h2>
 
-					<?= $parser->setData($c['display'])->render("_{$c['titleSafe']}.tpl") ?>
+					<?= is_string($c['display']) ? $c['display'] : $parser->setData($c['display'])->render("_{$c['titleSafe']}.tpl") ?>
 				</div>
 			<?php endif ?>
 		<?php endif ?>


### PR DESCRIPTION
**Description**
Custom collectors fail because toolbar.tpl.php tries to parse their view file from `SYSTEMPATH . 'Debug/Toolbar/Views/'`. See #1971 for complete description of the issue.
This change allows `Collector->display()` to return a string (as stated in the User Guide) and then, when detected in the view template, displays it directly instead of looking for a separate template to parse.

*There's probably a better way to handle this by checking for a namespaced view template for the collector.*

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
