### PR TITLE
Test/featuretestcase

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -619,9 +619,9 @@ class RouteCollection implements RouteCollectionInterface
 	 * Example:
 	 *      $routes->add('news', 'Posts::index');
 	 *
-	 * @param string        $from
-	 * @param array|string  $to
-	 * @param array         $options
+	 * @param string       $from
+	 * @param array|string $to
+	 * @param array        $options
 	 *
 	 * @return RouteCollectionInterface
 	 */
@@ -1432,4 +1432,18 @@ class RouteCollection implements RouteCollectionInterface
 	}
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * Reset the routes, so that a FeatureTestCase can provide the
+	 * explicit ones needed for it.
+	 */
+	public function resetRoutes()
+	{
+		$this->routes = ['*' => []];
+		foreach ($this->defaultHTTPMethods as $verb)
+		{
+			$this->routes[$verb] = [];
+		}
+	}
+
 }

--- a/system/Test/FeatureResponse.php
+++ b/system/Test/FeatureResponse.php
@@ -47,6 +47,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FeatureResponse extends TestCase
 {
+
 	/**
 	 * @var \CodeIgniter\HTTP\Response
 	 */
@@ -61,9 +62,10 @@ class FeatureResponse extends TestCase
 	{
 		$this->response = $response;
 
-		if (is_string($this->response->getBody()))
+		$body = $response->getBody();
+		if (! empty($body) && is_string($body))
 		{
-			$this->domParser = (new DOMParser())->withString($this->response->getBody());
+			$this->domParser = (new DOMParser())->withString($body);
 		}
 	}
 
@@ -124,7 +126,7 @@ class FeatureResponse extends TestCase
 	 */
 	public function assertStatus(int $code)
 	{
-		$this->assertEquals($code, (int)$this->response->getStatusCode());
+		$this->assertEquals($code, (int) $this->response->getStatusCode());
 	}
 
 	/**
@@ -397,4 +399,5 @@ class FeatureResponse extends TestCase
 	{
 		return $this->response->getXML();
 	}
+
 }

--- a/tests/_support/Controllers/Popcorn.php
+++ b/tests/_support/Controllers/Popcorn.php
@@ -55,4 +55,19 @@ class Popcorn extends Controller
 		return $response;
 	}
 
+	public function canyon()
+	{
+		echo 'Hello-o-o';
+	}
+
+	public function json()
+	{
+		$this->responsd(['answer' => 42]);
+	}
+
+	public function xml()
+	{
+		$this->respond('<my><pet>cat</pet></my>');
+	}
+
 }

--- a/tests/_support/Controllers/Popcorn.php
+++ b/tests/_support/Controllers/Popcorn.php
@@ -60,6 +60,10 @@ class Popcorn extends Controller
 		echo 'Hello-o-o';
 	}
 
+	public function cat()
+	{
+	}
+
 	public function json()
 	{
 		$this->responsd(['answer' => 42]);

--- a/tests/system/Test/FeatureTestCaseTest.php
+++ b/tests/system/Test/FeatureTestCaseTest.php
@@ -16,7 +16,6 @@ class FeatureTestCaseTest extends FeatureTestCase
 		parent::setUp();
 
 		$this->skipEvents();
-		$this->clean = false;
 	}
 
 	public function testCallGet()
@@ -43,7 +42,7 @@ class FeatureTestCaseTest extends FeatureTestCase
 				'add',
 				'home',
 				function () {
-					return 'Hello World';
+					return 'Hello Earth';
 				},
 			],
 		]);
@@ -52,7 +51,7 @@ class FeatureTestCaseTest extends FeatureTestCase
 		$this->assertInstanceOf(FeatureResponse::class, $response);
 		$this->assertInstanceOf(\CodeIgniter\HTTP\Response::class, $response->response);
 		$this->assertTrue($response->isOK());
-		$this->assertEquals('Hello World', $response->response->getBody());
+		$this->assertEquals('Hello Earth', $response->response->getBody());
 		$this->assertEquals(200, $response->response->getStatusCode());
 	}
 
@@ -63,13 +62,13 @@ class FeatureTestCaseTest extends FeatureTestCase
 				'post',
 				'home',
 				function () {
-					return 'Hello World';
+					return 'Hello Mars';
 				},
 			],
 		]);
 		$response = $this->post('home');
 
-		$response->assertSee('Hello World');
+		$response->assertSee('Hello Mars');
 	}
 
 	public function testCallPut()
@@ -79,13 +78,13 @@ class FeatureTestCaseTest extends FeatureTestCase
 				'put',
 				'home',
 				function () {
-					return 'Hello World';
+					return 'Hello Pluto';
 				},
 			],
 		]);
 		$response = $this->put('home');
 
-		$response->assertSee('Hello World');
+		$response->assertSee('Hello Pluto');
 	}
 
 	public function testCallPatch()
@@ -95,13 +94,13 @@ class FeatureTestCaseTest extends FeatureTestCase
 				'patch',
 				'home',
 				function () {
-					return 'Hello World';
+					return 'Hello Jupiter';
 				},
 			],
 		]);
 		$response = $this->patch('home');
 
-		$response->assertSee('Hello World');
+		$response->assertSee('Hello Jupiter');
 	}
 
 	public function testCallOptions()
@@ -111,13 +110,13 @@ class FeatureTestCaseTest extends FeatureTestCase
 				'options',
 				'home',
 				function () {
-					return 'Hello World';
+					return 'Hello George';
 				},
 			],
 		]);
 		$response = $this->options('home');
 
-		$response->assertSee('Hello World');
+		$response->assertSee('Hello George');
 	}
 
 	public function testCallDelete()
@@ -127,13 +126,13 @@ class FeatureTestCaseTest extends FeatureTestCase
 				'delete',
 				'home',
 				function () {
-					return 'Hello World';
+					return 'Hello Wonka';
 				},
 			],
 		]);
 		$response = $this->delete('home');
 
-		$response->assertSee('Hello World');
+		$response->assertSee('Hello Wonka');
 	}
 
 	public function testSession()
@@ -145,6 +144,45 @@ class FeatureTestCaseTest extends FeatureTestCase
 
 		$response->assertSessionHas('fruit', 'apple');
 		$response->assertSessionMissing('popcorn');
+	}
+
+	public function testReturns()
+	{
+		$this->withRoutes([
+			[
+				'get',
+				'home',
+				'Tests\Support\Controllers\Popcorn::index',
+			],
+		]);
+		$response = $this->get('home');
+		$response->assertSee('Hi');
+	}
+
+	public function testIgnores()
+	{
+		$this->withRoutes([
+			[
+				'get',
+				'home',
+				'Tests\Support\Controllers\Popcorn::cat',
+			],
+		]);
+		$response = $this->get('home');
+		$response->assertEmpty($response->response->getBody());
+	}
+
+	public function testEchoes()
+	{
+		$this->withRoutes([
+			[
+				'get',
+				'home',
+				'Tests\Support\Controllers\Popcorn::canyon',
+			],
+		]);
+		$response = $this->get('home');
+		$response->assertSee('Hello-o-o');
 	}
 
 }

--- a/tests/system/Test/FeatureTestCaseTest.php
+++ b/tests/system/Test/FeatureTestCaseTest.php
@@ -4,7 +4,9 @@ use CodeIgniter\Test\FeatureTestCase;
 use CodeIgniter\Test\FeatureResponse;
 
 /**
- * @group DatabaseLive
+ * @group                       DatabaseLive
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState         disabled
  */
 class FeatureTestCaseTest extends FeatureTestCase
 {
@@ -29,9 +31,6 @@ class FeatureTestCaseTest extends FeatureTestCase
 			],
 		]);
 		$response = $this->get('home');
-
-		// close open buffer
-		ob_end_clean();
 
 		$response->assertSee('Hello World');
 		$response->assertDontSee('Again');

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -53,7 +53,7 @@ class TestCaseTest extends \CIUnitTestCase
 		CITestStreamFilter::$buffer = '';
 		$this->stream_filter        = stream_filter_append(STDOUT, 'CITestStreamFilter');
 		\CodeIgniter\CLI\CLI::write('first.');
-		$expected = "\nfirst.\n";
+		$expected = "first.\n";
 		$this->assertEquals($expected, CITestStreamFilter::$buffer);
 		stream_filter_remove($this->stream_filter);
 	}

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -53,7 +53,7 @@ class TestCaseTest extends \CIUnitTestCase
 		CITestStreamFilter::$buffer = '';
 		$this->stream_filter        = stream_filter_append(STDOUT, 'CITestStreamFilter');
 		\CodeIgniter\CLI\CLI::write('first.');
-		$expected = "first.\n";
+		$expected = "\nfirst.\n";
 		$this->assertEquals($expected, CITestStreamFilter::$buffer);
 		stream_filter_remove($this->stream_filter);
 	}

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -69,15 +69,19 @@ Shorthand methods for each of the HTTP verbs exist to ease typing and make thing
 Setting Different Routes
 ------------------------
 
-You can use a custom collection of routes by passing an array of routes into the ``withRoutes()`` method. This will
+You can use a custom collection of routes by passing an array of "routes" into the ``withRoutes()`` method. This will
 override any existing routes in the system::
 
     $routes = [
-        'users' => 'UserController::list'
-    ];
+       [ 'get', 'users', 'UserController::list' ]
+     ];
 
     $result = $this->withRoutes($routes)
         ->get('users');
+
+Each of the "routes" is a 3 element array containing the HTTP verb (or "add" for all),
+the URI to match, and the routing destination.
+
 
 Setting Session Values
 ----------------------


### PR DESCRIPTION
- added 'patch' to allowed HTTP verbs in RouteCollection
- added resetRoutes() in RouteCollection, to support FeatureTestCase
- added output capturing to FeatureTestCase::call
- added more methods to tests/_support/Controllers/Popcorn, to generate all the different kinds of responses
- added note to testing/features in user guide

Related to #1767, #1692 & possibly #1697
Closes #1767