### PR TITLE
argument set() must by type of string - cannot agree

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1356,7 +1356,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function set($key, string $value = '', bool $escape = null)
+	public function set($key, ?string $value = '', bool $escape = null)
 	{
 		$key = $this->objectToArray($key);
 


### PR DESCRIPTION
set should accept at least NULL | int | string
UPDATE x SET a = NULL ...
UPDATE x SET a = 100
UPDATE x SET a = 'aaa'
