### PR TITLE
Add partial Entity save() testing

### DIFF
--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1477,8 +1477,6 @@ class ModelTest extends CIDatabaseTestCase
 		$entity->deleted    = 0;
 		$entity->created_at = new Time('now');
 		
-		$this->expectException('\CodeIgniter\Database\Exceptions\DatabaseException');
-
 		$this->assertTrue($testModel->save($entity));
 	}
 

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1461,6 +1461,29 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testSaveNewEntityWithPartialData()
+	{
+		$entity = new class extends Entity
+		{
+			protected $id;
+			protected $name;
+			protected $email;
+			protected $country;
+			protected $deleted;
+		};
+		$testModel = new UserModel();
+
+		$entity->email      = 'jerome@example.com';
+		$entity->deleted    = 0;
+		$entity->created_at = new Time('now');
+		
+		$this->expectException('\CodeIgniter\Database\Exceptions\DatabaseException');
+
+		$this->assertTrue($testModel->save($entity));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testSaveNewEntityWithDateTime()
 	{
 		$entity    = new class extends Entity{


### PR DESCRIPTION
**Description**
Issue #1992 describes the scenario where an entity without every field set will cause non-null database column to error `{column_name} cannot be null`. This PR will create the necessary tests to catch this scenario prior to providing a fix.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
