### PR TITLE
Allow hasChanged() without parameter

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -236,13 +236,20 @@ class Entity
 
 	/**
 	 * Checks a property to see if it has changed since the entity was created.
+	 * Or, without a parameter, checks if any properties have changed.
 	 *
-	 * @param string $key
+	 * @param ?string $key
 	 *
 	 * @return boolean
 	 */
-	public function hasChanged(string $key): bool
+	public function hasChanged(string $key = null): bool
 	{
+		// If no parameter was given then check all attributes
+		if ($key === null)
+		{
+			return 	$this->original !== $this->attributes;
+		}
+		
 		// Key doesn't exist in either
 		if (! array_key_exists($key, $this->original) && ! array_key_exists($key, $this->attributes))
 		{

--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -664,6 +664,15 @@ class EntityTest extends \CIUnitTestCase
 		$this->assertFalse($entity->hasChanged('default'));
 	}
 
+	public function testHasChangedWholeEntity()
+	{
+		$entity = $this->getEntity();
+		
+		$entity->foo = 'bar';
+
+		$this->assertTrue($entity->hasChanged());
+	}
+
 	protected function getEntity()
 	{
 		return new class extends Entity

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -373,3 +373,6 @@ attribute to check::
 
     $user->name = 'Fred';
     $user->hasChanged('name');      // true
+
+Or to check the whole entity for changed values omit the parameter:
+    $user->hasChanged();            // true


### PR DESCRIPTION
**Description**
Overload Entity `hasChanged()` to support a check if any attributes have been changed.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
