### PR TITLE
Add `patch` method to command "routes"

### DIFF
--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -109,6 +109,7 @@ class Routes extends BaseCommand
 			'get',
 			'head',
 			'post',
+			'patch',
 			'put',
 			'delete',
 			'options',


### PR DESCRIPTION
**Description**
`$routes->resource()` includes the `patch` method as a supported route but the routes CLI command doesn't list it because it is missing from the $methods property - this includes it.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
