### PR TITLE
Set the raw data array without any mutations for the Entity

### DIFF
--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -163,8 +163,7 @@ class Result extends BaseResult implements ResultInterface
 	{
 		if (is_subclass_of($className, Entity::class))
 		{
-			$data = $this->fetchAssoc();
-			return empty($data) ? false : (new $className())->setRawArray($data);
+			return empty($data = $this->fetchAssoc()) ? false : (new $className())->setAttributes($data);
 		}
 		return $this->resultID->fetch_object($className);
 	}

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -40,6 +40,7 @@ namespace CodeIgniter\Database\MySQLi;
 
 use CodeIgniter\Database\BaseResult;
 use CodeIgniter\Database\ResultInterface;
+use CodeIgniter\Entity;
 
 /**
  * Result for MySQLi
@@ -156,10 +157,15 @@ class Result extends BaseResult implements ResultInterface
 	 *
 	 * @param string $className
 	 *
-	 * @return object
+	 * @return object|boolean|Entity
 	 */
 	protected function fetchObject(string $className = 'stdClass')
 	{
+		if (is_subclass_of($className, Entity::class))
+		{
+			$data = $this->fetchAssoc();
+			return empty($data) ? false : (new $className())->setRawArray($data);
+		}
 		return $this->resultID->fetch_object($className);
 	}
 

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -40,6 +40,7 @@ namespace CodeIgniter\Database\Postgre;
 
 use CodeIgniter\Database\BaseResult;
 use CodeIgniter\Database\ResultInterface;
+use CodeIgniter\Entity;
 
 /**
  * Result for Postgre
@@ -154,10 +155,15 @@ class Result extends BaseResult implements ResultInterface
 	 *
 	 * @param string $className
 	 *
-	 * @return object
+	 * @return object|boolean|Entity
 	 */
 	protected function fetchObject(string $className = 'stdClass')
 	{
+		if (is_subclass_of($className, Entity::class))
+		{
+			$data = $this->fetchAssoc();
+			return empty($data) ? false : (new $className())->setRawArray($data);
+		}
 		return pg_fetch_object($this->resultID, null, $className);
 	}
 

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -161,8 +161,7 @@ class Result extends BaseResult implements ResultInterface
 	{
 		if (is_subclass_of($className, Entity::class))
 		{
-			$data = $this->fetchAssoc();
-			return empty($data) ? false : (new $className())->setRawArray($data);
+			return empty($data = $this->fetchAssoc()) ? false : (new $className())->setAttributes($data);
 		}
 		return pg_fetch_object($this->resultID, null, $className);
 	}

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -186,7 +186,7 @@ class Result extends BaseResult implements ResultInterface
 
 		if (is_subclass_of($className, Entity::class))
 		{
-			return $classObj->setRawArray($row);
+			return $classObj->setAttributes($row);
 		}
 
 		$classSet = \Closure::bind(function ($key, $value) {

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -40,6 +40,7 @@ namespace CodeIgniter\Database\SQLite3;
 use CodeIgniter\Database\BaseResult;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\ResultInterface;
+use CodeIgniter\Entity;
 
 /**
  * Result for SQLite3
@@ -182,6 +183,12 @@ class Result extends BaseResult implements ResultInterface
 		}
 
 		$classObj = new $className();
+
+		if (is_subclass_of($className, Entity::class))
+		{
+			return $classObj->setRawArray($row);
+		}
+
 		$classSet = \Closure::bind(function ($key, $value) {
 			$this->$key = $value;
 		}, $classObj, $className

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -433,7 +433,7 @@ class Entity
 	 * @param  array $data
 	 * @return $this
 	 */
-	public function setRawArray(array $data)
+	public function setAttributes(array $data)
 	{
 		$this->attributes = $data;
 		$this->syncOriginal();

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -238,7 +238,7 @@ class Entity
 	 * Checks a property to see if it has changed since the entity was created.
 	 * Or, without a parameter, checks if any properties have changed.
 	 *
-	 * @param ?string $key
+	 * @param string $key
 	 *
 	 * @return boolean
 	 */
@@ -247,9 +247,9 @@ class Entity
 		// If no parameter was given then check all attributes
 		if ($key === null)
 		{
-			return 	$this->original !== $this->attributes;
+			return     $this->original !== $this->attributes;
 		}
-		
+
 		// Key doesn't exist in either
 		if (! array_key_exists($key, $this->original) && ! array_key_exists($key, $this->attributes))
 		{
@@ -425,6 +425,19 @@ class Entity
 	public function __isset(string $key): bool
 	{
 		return isset($this->attributes[$key]);
+	}
+
+	/**
+	 * Set raw data array without any mutations
+	 *
+	 * @param  array $data
+	 * @return $this
+	 */
+	public function setRawArray(array $data)
+	{
+		$this->attributes = $data;
+		$this->syncOriginal();
+		return $this;
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
When we create, for example, the password hashing method Entity::setPassword(), this method is also called when the value from the database is filled.
As a result, we get a hash of the hash in $entity->password

This PR sets the value of the $attribute property to the unchanged values from the database.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide