### PR TITLE
Direct user to follow the upgrade steps after installation

### DIFF
--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -48,6 +48,8 @@ A sample such installation command, using the default project-root "appstarter":
 
     composer create-project codeigniter4/appstarter -s beta --no-dev
 
+After installation you should follow the steps in the "Upgrading" section.
+
 Upgrading
 -------------------------------------------------------
 


### PR DESCRIPTION
As discussed on the community forums, the appstarter doesn't work out of the box after a fresh installation. This was determined to be due to the composer.lock file being out of date, running composer update installs the up to date version of the framework.

**Description**
Updated the installation via Composer documentation to direct users to follow the steps in the "Upgrading" section even after a fresh installation. This ensures the framework is up to date.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs: N/A
- [ ] Unit testing, with >80% coverage: N/A
- [x] User guide updated
- [ ] Conforms to style guide: N/A
  
