### PR TITLE
Add CLI check to RouteCollection

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -234,8 +234,11 @@ class RouteCollection implements RouteCollectionInterface
 	 */
 	public function __construct(FileLocator $locator, $moduleConfig)
 	{
+		// Load the correct request service
+		$request = (is_cli() && ! (ENVIRONMENT === 'testing')) ? Services::clirequest() : Services::request();
+		
 		// Get HTTP verb from current request (accounts for spoofing)
-		$this->HTTPVerb = Services::request()->getMethod();
+		$this->HTTPVerb = $request->getMethod();
 
 		$this->fileLocator = $locator;
 


### PR DESCRIPTION
**Description**
CodeIgniter.php sets the request method on `request` or `clirequest` service, so RouteCollection needs to check the proper service to get the correct HTTPVerb to account for CLI, spoofing, and standard scenarios.
See https://github.com/codeigniter4/CodeIgniter4/issues/2021

FWIW I believe the reason this wasn't caught is that all the request & routing clauses in `CodeIgniter.php` have conditional `! (ENVIRONMENT === 'testing')` to be able to simulate non-CLI requests from CLI. There should probably be a test that spoofs its own environment (if possible) just to check for `spark` integrity.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
