### PR TITLE
whereIn  $value do not have to be an array

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -734,12 +734,12 @@ class BaseBuilder
 	 * joined with 'AND' if appropriate.
 	 *
 	 * @param string  $key    The field to search
-	 * @param array   $values The values searched on
+	 * @param array|string   $values The values searched on
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
 	 */
-	public function whereIn(string $key = null, array $values = null, bool $escape = null)
+	public function whereIn(string $key = null, $values = null, bool $escape = null)
 	{
 		return $this->_whereIn($key, $values, false, 'AND ', $escape);
 	}
@@ -753,12 +753,12 @@ class BaseBuilder
 	 * joined with 'OR' if appropriate.
 	 *
 	 * @param string  $key    The field to search
-	 * @param array   $values The values searched on
+	 * @param array|string   $values The values searched on
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
 	 */
-	public function orWhereIn(string $key = null, array $values = null, bool $escape = null)
+	public function orWhereIn(string $key = null, $values = null, bool $escape = null)
 	{
 		return $this->_whereIn($key, $values, false, 'OR ', $escape);
 	}
@@ -772,12 +772,12 @@ class BaseBuilder
 	 * joined with 'AND' if appropriate.
 	 *
 	 * @param string  $key    The field to search
-	 * @param array   $values The values searched on
+	 * @param array|string   $values The values searched on
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
 	 */
-	public function whereNotIn(string $key = null, array $values = null, bool $escape = null)
+	public function whereNotIn(string $key = null, $values = null, bool $escape = null)
 	{
 		return $this->_whereIn($key, $values, true, 'AND ', $escape);
 	}
@@ -791,12 +791,12 @@ class BaseBuilder
 	 * joined with 'OR' if appropriate.
 	 *
 	 * @param string  $key    The field to search
-	 * @param array   $values The values searched on
+	 * @param array|string   $values The values searched on
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
 	 */
-	public function orWhereNotIn(string $key = null, array $values = null, bool $escape = null)
+	public function orWhereNotIn(string $key = null, $values = null, bool $escape = null)
 	{
 		return $this->_whereIn($key, $values, true, 'OR ', $escape);
 	}
@@ -819,7 +819,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	protected function _whereIn(string $key = null, array $values = null, bool $not = false, string $type = 'AND ', bool $escape = null)
+	protected function _whereIn(string $key = null, $values = null, bool $not = false, string $type = 'AND ', bool $escape = null)
 	{
 		if ($key === null || $values === null)
 		{
@@ -837,7 +837,7 @@ class BaseBuilder
 
 		$not = ($not) ? ' NOT' : '';
 
-		$where_in = array_values($values);
+		$where_in = is_array($values) ? array_values($values) : $values;
 		$ok       = $this->setBind($ok, $where_in, $escape);
 
 		$prefix = empty($this->QBWhere) ? $this->groupGetType('') : $this->groupGetType($type);


### PR DESCRIPTION
i.e.:

```
			$sub_query[] = $this->type === self::API_TRADING_TRADES ? $this->prefix . 'api_trade_id' : $this->prefix . 'api_id';

			$this->select('MAX(' . $subselect[0] . ')', false);

			if($cur_id_from === null)
			{
				$this->groupBy($this->prefix . 'cur_id_1');
			}

			if($cur_id_to === null)
			{
				$this->groupBy($this->prefix . 'cur_id_2');
			}

			if ($type !== null)
			{
				$this->where($this->prefix . 'type', $type);
			}


			$sub_query[] = $this->getCompiledSelect(true);


			$this->whereIn($sub_query[0],'(' . $sub_query[1]  . ')', false);

```
should produce sth like this:
```
SELECT *
FROM `t_api_trading_trades`
WHERE aht_api_trade_id IN (SELECT MAX(aht_api_trade_id)
FROM `t_api_trading_trades`
WHERE `aht_type` = 'B'
GROUP BY `aht_cur_id_2`)
```
(tested, working as excepted)

