### PR TITLE
Extension Pager::makeLinks (optional grup name)

### DIFF
--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -147,19 +147,21 @@ class Pager implements PagerInterface
 	 * @param integer $page
 	 * @param integer $perPage
 	 * @param integer $total
-	 * @param string  $template The output template alias to render.
-	 * @param integer $segment  (if page number is provided by URI segment)
+	 * @param string $template The output template alias to render.
+	 * @param integer $segment (if page number is provided by URI segment)
 	 *
+	 * @param string|null $group optional group (i.e. if we'd like to define custom path)
 	 * @return string
 	 */
-	public function makeLinks(int $page, int $perPage, int $total, string $template = 'default_full', int $segment = 0): string
+	public function makeLinks(int $page, int $perPage, int $total, string $template = 'default_full', int $segment = 0, ?string $group = null): string
 	{
 		$name = time();
 
-		$this->store($name, $page, $perPage, $total, $segment);
+		$this->store($group ?? $name, $page, $perPage, $total, $segment);
 
-		return $this->displayLinks($name, $template);
+		return $this->displayLinks($group ?? $name, $template);
 	}
+
 
 	//--------------------------------------------------------------------
 

--- a/user_guide_src/source/libraries/pagination.rst
+++ b/user_guide_src/source/libraries/pagination.rst
@@ -112,6 +112,13 @@ It is also possible to use a URI segment for the page number, instead of the pag
 
 Please note: ``$segment`` value cannot be greater than the number of URI segments plus 1.
 
+If you in need to show many pagers on one page then additional parameter which wil define a group could be helpful::
+<?php
+	$pager = service('pager');
+	$pager->setPath('path/for/my-group', 'my-group'); // Additionaly you could define path for every group.
+	$pager->makeLinks($page, $perPage, $total, 'template_name', $segment, 'my-group'); 
+?>
+
 Paginating with Only Expected Queries
 =====================================
 


### PR DESCRIPTION
Allows to specify a group name in a makeLinks method - implicated i.e. allowance to set custom path for pagination.
