### PR TITLE
Fix CSRF hash regeneration

### DIFF
--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -221,6 +221,7 @@ class Security
 		if ($this->CSRFRegenerate)
 		{
 			// Nothing should last forever
+			$this->CSRFHash = null;
 			unset($_COOKIE[$this->CSRFCookieName]);
 		}
 


### PR DESCRIPTION
For CSRF hash regeneration, $this->CSRFHash must be set to NULL when user set 
$this->CSRFRegenerate to TRUE, because in CSRFSetHash() you compare it with NULL, but 
$this->CSRFHash !== NULL after request. I guess you need to create new method in Security class, such as CSRFHashReset() and check my commit. 

