### PR TITLE
Fallback to server request for default method

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -145,7 +145,7 @@ class Router implements RouterInterface
 		$this->controller = $this->collection->getDefaultController();
 		$this->method     = $this->collection->getDefaultMethod();
 
-		$this->collection->setHTTPVerb($request->getMethod() ?? 'get');
+		$this->collection->setHTTPVerb($request->getMethod() ?? strtolower($_SERVER['REQUEST_METHOD']));
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
The updated router sets the routes `HTTPVerb` based off the request method, and currently falls back to `get`. This changes the fallback to be the default value from `$_SERVER['REQUEST_METHOD']`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
