### PR TITLE
Make `force_https()` send headers before exit

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -814,6 +814,8 @@ if (! function_exists('force_https'))
 		// Set an HSTS header
 		$response->setHeader('Strict-Transport-Security', 'max-age=' . $duration);
 		$response->redirect($uri);
+		$response->sendHeaders();
+		
 		exit();
 	}
 }


### PR DESCRIPTION
**Description**
`force_https()` is calling `exit()` before applying the header set by `$response->redirect()`, so the browser treats it as a clean exit, no errors (i.e. blank page). Fix for #2033 

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
