### PR TITLE
SQLite3 now supports dropping foreign keys. Fixes #1982

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1698,6 +1698,30 @@ abstract class BaseConnection implements ConnectionInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Disables foreign key checks temporarily.
+	 */
+	public function disableForeignKeyChecks()
+	{
+		$sql = $this->_disableForeignKeyChecks();
+
+		return $this->query($sql);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Enables foreign key checks temporarily.
+	 */
+	public function enableForeignKeyChecks()
+	{
+		$sql = $this->_enableForeignKeyChecks();
+
+		return $this->query($sql);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Allows the engine to be set into a mode where queries are not
 	 * actually executed, but they are still generated, timed, etc.
 	 *

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -416,16 +416,16 @@ class Forge
 	/**
 	 * Foreign Key Drop
 	 *
-	 * @param string $table        Table name
-	 * @param string $foreign_name Foreign name
+	 * @param string $table       Table name
+	 * @param string $foreignName Foreign name
 	 *
 	 * @return boolean|\CodeIgniter\Database\BaseResult|\CodeIgniter\Database\Query|false|mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function dropForeignKey(string $table, string $foreign_name)
+	public function dropForeignKey(string $table, string $foreignName)
 	{
 		$sql = sprintf($this->dropConstraintStr, $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
-			$this->db->escapeIdentifiers($this->db->DBPrefix . $foreign_name));
+			$this->db->escapeIdentifiers($this->db->DBPrefix . $foreignName));
 
 		if ($sql === false)
 		{
@@ -484,7 +484,10 @@ class Forge
 
 		if (($result = $this->db->query($sql)) !== false)
 		{
-			empty($this->db->dataCache['table_names']) || ($this->db->dataCache['table_names'][] = $table);
+			if (! isset($this->db->dataCache['table_names'][$table]))
+			{
+				$this->db->dataCache['table_names'][] = $table;
+			}
 
 			// Most databases don't support creating indexes from within the CREATE TABLE statement
 			if (! empty($this->keys))
@@ -582,16 +585,16 @@ class Forge
 	/**
 	 * Drop Table
 	 *
-	 * @param string  $table_name Table name
-	 * @param boolean $if_exists  Whether to add an IF EXISTS condition
-	 * @param boolean $cascade    Whether to add an CASCADE condition
+	 * @param string  $tableName Table name
+	 * @param boolean $ifExists  Whether to add an IF EXISTS condition
+	 * @param boolean $cascade   Whether to add an CASCADE condition
 	 *
 	 * @return mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function dropTable(string $table_name, bool $if_exists = false, bool $cascade = false)
+	public function dropTable(string $tableName, bool $ifExists = false, bool $cascade = false)
 	{
-		if ($table_name === '')
+		if ($tableName === '')
 		{
 			if ($this->db->DBDebug)
 			{
@@ -602,22 +605,26 @@ class Forge
 		}
 
 		// If the prefix is already starting the table name, remove it...
-		if (! empty($this->db->DBPrefix) && strpos($table_name, $this->db->DBPrefix) === 0)
+		if (! empty($this->db->DBPrefix) && strpos($tableName, $this->db->DBPrefix) === 0)
 		{
-			$table_name = substr($table_name, strlen($this->db->DBPrefix));
+			$tableName = substr($tableName, strlen($this->db->DBPrefix));
 		}
 
-		if (($query = $this->_dropTable($this->db->DBPrefix . $table_name, $if_exists, $cascade)) === true)
+		if (($query = $this->_dropTable($this->db->DBPrefix . $tableName, $ifExists, $cascade)) === true)
 		{
 			return true;
 		}
 
+		$this->db->query('PRAGMA foreign_keys = OFF');
+
 		$query = $this->db->query($query);
+
+		$this->db->query('PRAGMA foreign_keys = ON');
 
 		// Update table list cache
 		if ($query && ! empty($this->db->dataCache['table_names']))
 		{
-			$key = array_search(strtolower($this->db->DBPrefix . $table_name),
+			$key = array_search(strtolower($this->db->DBPrefix . $tableName),
 				array_map('strtolower', $this->db->dataCache['table_names']), true);
 			if ($key !== false)
 			{

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -615,11 +615,11 @@ class Forge
 			return true;
 		}
 
-		$this->db->query('PRAGMA foreign_keys = OFF');
+		$this->db->disableForeignKeyChecks();
 
 		$query = $this->db->query($query);
 
-		$this->db->query('PRAGMA foreign_keys = ON');
+		$this->db->enableForeignKeyChecks();
 
 		// Update table list cache
 		if ($query && ! empty($this->db->dataCache['table_names']))

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -569,6 +569,30 @@ class Connection extends BaseConnection implements ConnectionInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Returns platform-specific SQL to disable foreign key checks.
+	 *
+	 * @return string
+	 */
+	protected function _disableForeignKeyChecks()
+	{
+		return 'SET FOREIGN_KEY_CHECKS=0';
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns platform-specific SQL to enable foreign key checks.
+	 *
+	 * @return string
+	 */
+	protected function _enableForeignKeyChecks()
+	{
+		return 'SET FOREIGN_KEY_CHECKS=1';
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Returns the last error code and message.
 	 *
 	 * Must return an array with keys 'code' and 'message':

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -419,6 +419,30 @@ class Connection extends BaseConnection implements ConnectionInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Returns platform-specific SQL to disable foreign key checks.
+	 *
+	 * @return string
+	 */
+	protected function _disableForeignKeyChecks()
+	{
+		return 'SET CONSTRAINTS ALL DEFERRED';
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns platform-specific SQL to enable foreign key checks.
+	 *
+	 * @return string
+	 */
+	protected function _enableForeignKeyChecks()
+	{
+		return 'SET CONSTRAINTS ALL IMMEDIATE;';
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Returns the last error code and message.
 	 *
 	 * Must return an array with keys 'code' and 'message':

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -504,7 +504,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return boolean
 	 */
-	protected function supportsForeignKeys(): bool
+	public function supportsForeignKeys(): bool
 	{
 		$result = $this->simpleQuery('PRAGMA foreign_keys');
 

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -418,6 +418,30 @@ class Connection extends BaseConnection implements ConnectionInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Returns platform-specific SQL to disable foreign key checks.
+	 *
+	 * @return string
+	 */
+	protected function _disableForeignKeyChecks()
+	{
+		return 'PRAGMA foreign_keys = OFF';
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns platform-specific SQL to enable foreign key checks.
+	 *
+	 * @return string
+	 */
+	protected function _enableForeignKeyChecks()
+	{
+		return 'PRAGMA foreign_keys = ON';
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Returns the last error code and message.
 	 *
 	 * Must return an array with keys 'code' and 'message':

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -303,15 +303,27 @@ class Forge extends \CodeIgniter\Database\Forge
 	/**
 	 * Foreign Key Drop
 	 *
-	 * @param string $table        Table name
-	 * @param string $foreign_name Foreign name
+	 * @param string $table       Table name
+	 * @param string $foreignName Foreign name
 	 *
 	 * @return boolean
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function dropForeignKey(string $table, string $foreign_name): bool
+	public function dropForeignKey(string $table, string $foreignName): bool
 	{
-		throw new DatabaseException(lang('Database.dropForeignKeyUnsupported'));
+		// If this version of SQLite doesn't support it, we're done here
+		if ($this->db->supportsForeignKeys() !== true)
+		{
+			return true;
+		}
+
+		// Otherwise we have to copy the table and recreate
+		// without the foreign key being involved now
+		$sqlTable = new Table($this->db, $this);
+
+		return $sqlTable->fromTable($this->db->DBPrefix . $table)
+			->dropForeignKey($foreignName)
+			->run();
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -218,6 +218,40 @@ class Table
 	}
 
 	/**
+	 * Drops a foreign key from this table so that
+	 * it won't be recreated in the future.
+	 *
+	 * @param string $column
+	 *
+	 * @return \CodeIgniter\Database\SQLite3\Table
+	 */
+	public function dropForeignKey(string $column)
+	{
+		if (empty($this->foreignKeys))
+		{
+			return $this;
+		}
+
+		for ($i = 0; $i < count($this->foreignKeys); $i++)
+		{
+			if ($this->foreignKeys[$i]->table_name !== $this->tableName)
+			{
+				continue;
+			}
+
+			// The column name should be the first thing in the constraint name
+			if (strpos($this->foreignKeys[$i]->constraint_name, $column) !== 0)
+			{
+				continue;
+			}
+
+			unset($this->foreignKeys[$i]);
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Creates the new table based on our current fields.
 	 *
 	 * @return mixed

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -388,10 +388,6 @@ class ForgeTest extends CIDatabaseTestCase
 		{
 			$attributes = ['ENGINE' => 'InnoDB'];
 		}
-		if ($this->db->DBDriver === 'SQLite3')
-		{
-			$this->expectException(DatabaseException::class);
-		}
 
 		$this->forge->addField([
 			'id'   => [

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -258,8 +258,6 @@ Execute a DROP FOREIGN KEY.
 	// Produces: ALTER TABLE 'tablename' DROP FOREIGN KEY 'users_foreign'
 	$forge->dropForeignKey('tablename','users_foreign');
 
-.. note:: SQLite database driver does not support dropping of foreign keys.
-
 Renaming a table
 ================
 

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -94,6 +94,24 @@ The database connection and the database Forge class are both available to you t
 Alternatively, you can use a command-line call to generate a skeleton migration file. See
 below for more details.
 
+Foreign Keys
+============
+
+When your tables include Foreign Keys, migrations can often cause problems as you attempt to drop tables and columns.
+To temporarily bypass the foreign key checks while running migrations, use the ``disableForeignKeyConstraints()`` and
+``enableForeignKeyConstraints()`` methods on the database connection.
+
+::
+
+    public function up()
+    {
+        $this->db->disableForeignKeyConstraints();
+
+        // Migration rules would go here...
+
+        $this->db->enableForeignKeyConstraints();
+    }
+
 Using $currentVersion
 =====================
 


### PR DESCRIPTION
SQLite3 now supports dropping foreign keys. Fixes #1982