### PR TITLE
Zero params should be passed through when routing. Fixes #2032

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -568,7 +568,9 @@ class Router implements RouterInterface
 	 */
 	protected function validateRequest(array $segments): array
 	{
-		$segments = array_filter($segments);
+		$segments = array_filter($segments, function ($segment) {
+			return ! empty($segment) || ($segment !== '0' || $segment !== 0);
+		});
 		$segments = array_values($segments);
 
 		$c                  = count($segments);

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -151,7 +151,8 @@ class FeatureTestCase extends CIDatabaseTestCase
 	public function call(string $method, string $path, array $params = null)
 	{
 		// Simulate having a blank session
-		$_SESSION = [];
+		$_SESSION                  = [];
+		$_SERVER['REQUEST_METHOD'] = $method;
 
 		$request = $this->setupRequest($method, $path, $params);
 		$request = $this->populateGlobals($method, $request, $params);
@@ -165,7 +166,6 @@ class FeatureTestCase extends CIDatabaseTestCase
 		// Make sure any other classes that might call the request
 		// instance get the right one.
 		Services::injectMock('request', $request);
-		$_SERVER['REQUEST_METHOD'] = $method;
 
 		$response = $this->app
 				->setRequest($request)

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -490,4 +490,23 @@ class RouterTest extends \CIUnitTestCase
 	}
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/2032
+	 */
+	public function testAutoRouteMatchesZeroParams()
+	{
+		$router = new Router($this->collection, $this->request);
+
+		$router->autoRoute('myController/someMethod/0/abc');
+
+		$this->assertEquals('MyController', $router->controllerName());
+		$this->assertEquals('someMethod', $router->methodName());
+
+		$expected = [
+			'0',
+			'abc',
+		];
+		$this->assertEquals($expected, $router->params());
+	}
 }

--- a/tests/system/Test/FeatureTestCaseTest.php
+++ b/tests/system/Test/FeatureTestCaseTest.php
@@ -137,10 +137,18 @@ class FeatureTestCaseTest extends FeatureTestCase
 
 	public function testSession()
 	{
-		$response = $this->withSession([
-			'fruit'    => 'apple',
-			'greeting' => 'hello',
-		])->get('home');
+		$response = $this->withRoutes([
+			[
+				'get',
+				'home',
+				function () {
+					return 'Home';
+				},
+			],
+		])->withSession([
+			  'fruit'    => 'apple',
+			  'greeting' => 'hello',
+		  ])->get('home');
 
 		$response->assertSessionHas('fruit', 'apple');
 		$response->assertSessionMissing('popcorn');


### PR DESCRIPTION
Zero params should be passed through when routing. Fixes #2032