### PR TITLE
Update CURLRequest.php

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -674,8 +674,16 @@ class CURLRequest extends Request
 		// Debug
 		if (isset($config['debug']))
 		{
-			$curl_options[CURLOPT_VERBOSE] = $config['debug'] === true ? 1 : 0;
-			$curl_options[CURLOPT_STDERR]  = $config['debug'] === true ? fopen('php://output', 'w+') : $config['debug'];
+			if(is_bool($config['debug']) && $config['debug'] === true)
+			{
+				$curl_options[CURLOPT_VERBOSE] = 1;
+				$curl_options[CURLOPT_STDERR] = fopen('php://output', 'w+');
+			}
+			else if(is_resource($config['debug']))
+			{
+				$curl_options[CURLOPT_VERBOSE] = 1;
+				$curl_options[CURLOPT_STDERR] = $config['debug'];
+			}
 		}
 
 		// Decode Content


### PR DESCRIPTION
aa362d0995eb08d2d6584f08ff7c0e892fa021b7

prvious fix caused eception if debug has not been specified
Type:        ErrorException
Message:     curl_setopt_array(): supplied argument is not a valid File-Handle resource
Filename:    /home/-exchange/site/system/HTTP/CURLRequest.php
