### PR TITLE
Stash insert ID before event trigger

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -713,16 +713,20 @@ class Model
 		$result = $this->builder()
 				->set($data['data'], '', $escape)
 				->insert();
-
+		
+		// If insertion succeeded then save the insert ID
+		if ($result)
+		{
+			$this->insertID = $this->db->insertID();
+		}
+		
 		$this->trigger('afterInsert', ['data' => $originalData, 'result' => $result]);
 
-		// If insertion failed, get our of here
+		// If insertion failed, get out of here
 		if (! $result)
 		{
 			return $result;
 		}
-
-		$this->insertID = $this->db->insertID();
 
 		// otherwise return the insertID, if requested.
 		return $returnID ? $this->insertID : $result;


### PR DESCRIPTION
**Description**
If any afterInsert events call their own database insert then `db->insertID()` will return that key instead of the desired version. This change grabs the insert ID before triggering the event so it can be returned (if requested) after.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
