### PR TITLE
Add various tests for (not) null

### DIFF
--- a/tests/system/Database/Live/WhereTest.php
+++ b/tests/system/Database/Live/WhereTest.php
@@ -159,4 +159,60 @@ class WhereTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testWhereNullParam()
+	{
+		$this->db->table('job')
+				 ->insert([
+					'name'        => 'Brewmaster',
+					'description' => null,
+				 ]);
+				 
+		$jobs = $this->db->table('job')
+						 ->where('description', null)
+						 ->get()
+						 ->getResult();
+
+		$this->assertCount(1, $jobs);
+		$this->assertEquals('Brewmaster', $jobs[0]->name);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testWhereIsNull()
+	{
+		$this->db->table('job')
+				 ->insert([
+					'name'        => 'Brewmaster',
+					'description' => null,
+				 ]);
+				 
+		$jobs = $this->db->table('job')
+						 ->where('description IS NULL')
+						 ->get()
+						 ->getResult();
+
+		$this->assertCount(1, $jobs);
+		$this->assertEquals('Brewmaster', $jobs[0]->name);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testWhereIsNotNull()
+	{
+		$this->db->table('job')
+				 ->insert([
+					'name'        => 'Brewmaster',
+					'description' => null,
+				 ]);
+				 
+		$jobs = $this->db->table('job')
+						 ->where('description IS NOT NULL')
+						 ->get()
+						 ->getResult();
+
+		$this->assertCount(4, $jobs);
+	}
+
+	//--------------------------------------------------------------------
+
 }


### PR DESCRIPTION
**Description**
While working on implementing `deleted_at` I noticed there aren't good explicit tests for `IS NULL` and `IS NOT NULL`. This change provides these tests (hopefully in the right place).

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
