### PR TITLE
Add model exceptions for missing/invalid dateFormat

### DIFF
--- a/system/Exceptions/ModelException.php
+++ b/system/Exceptions/ModelException.php
@@ -10,4 +10,9 @@ class ModelException extends FrameworkException
 	{
 		return new static(lang('Database.noPrimaryKey', [$modelName]));
 	}
+	
+	public static function forNoDateFormat(string $modelName)
+	{
+		return new static(lang('Database.noDateFormat', [$modelName]));
+	}
 }

--- a/system/Language/en/Database.php
+++ b/system/Language/en/Database.php
@@ -26,6 +26,7 @@ return [
    'featureUnavailable'               => 'This feature is not available for the database you are using.',
    'tableNotFound'                    => 'Table `{0}` was not found in the current database.',
    'noPrimaryKey'                     => '`{0}` model class does not specify a Primary Key.',
+   'noDateFormat'                     => '`{0}` model class does not have a valid dateFormat.',
    'fieldNotExists'                   => 'Field `{0}` not found.',
    'forEmptyInputGiven'               => 'Empty statement is given for the field `{0}`',
    'forFindColumnHaveMultipleColumns' => 'Only single column allowed in Column name.',

--- a/system/Model.php
+++ b/system/Model.php
@@ -948,8 +948,8 @@ class Model
 		}
 
 		return $this->builder()
-						->where($this->deletedField . ' IS NOT NULL')
-						->delete();
+			    ->where($this->table . '.' . $this->deletedField . ' IS NOT NULL')
+			    ->delete();
 	}
 
 	//--------------------------------------------------------------------
@@ -982,7 +982,7 @@ class Model
 		$this->tempUseSoftDeletes = false;
 
 		$this->builder()
-				->where($this->deletedField . ' IS NOT NULL');
+		     ->where($this->table . '.' . $this->deletedField . ' IS NOT NULL');
 
 		return $this;
 	}
@@ -1548,7 +1548,7 @@ class Model
 	{
 		if ($this->tempUseSoftDeletes === true)
 		{
-			$this->builder()->where($this->deletedField, null);
+			$this->builder()->where($this->table . '.' . $this->deletedField, null);
 		}
 
 		return $this->builder()->countAllResults($reset, $test);

--- a/system/Model.php
+++ b/system/Model.php
@@ -395,6 +395,7 @@ class Model
 	 * @param string $columnName
 	 *
 	 * @return array|null   The resulting row of data, or null if no data found.
+	 * @throws \CodeIgniter\Database\Exceptions\DataException
 	 */
 	public function findColumn(string $columnName)
 	{
@@ -947,8 +948,8 @@ class Model
 		}
 
 		return $this->builder()
-			    ->where($this->table . '.' . $this->deletedField . ' IS NOT NULL')
-			    ->delete();
+						->where($this->deletedField . ' IS NOT NULL')
+						->delete();
 	}
 
 	//--------------------------------------------------------------------
@@ -981,7 +982,7 @@ class Model
 		$this->tempUseSoftDeletes = false;
 
 		$this->builder()
-		     ->where($this->table . '.' . $this->deletedField . ' IS NOT NULL');
+				->where($this->deletedField . ' IS NOT NULL');
 
 		return $this;
 	}
@@ -1152,6 +1153,7 @@ class Model
 	 * @param string $table
 	 *
 	 * @return BaseBuilder
+	 * @throws \CodeIgniter\Exceptions\ModelException;
 	 */
 	protected function builder(string $table = null)
 	{
@@ -1226,8 +1228,8 @@ class Model
 	/**
 	 * A utility function to allow child models to use the type of
 	 * date/time format that they prefer. This is primarily used for
-	 * setting created_at and updated_at values, but can be used
-	 * by inheriting classes.
+	 * setting created_at, updated_at and deleted_at values, but can be
+	 * used by inheriting classes.
 	 *
 	 * The available time formats are:
 	 *  - 'int'      - Stores the date as an integer timestamp
@@ -1237,6 +1239,7 @@ class Model
 	 * @param integer $userData An optional PHP timestamp to be converted.
 	 *
 	 * @return mixed
+	 * @throws \CodeIgniter\Exceptions\ModelException;
 	 */
 	protected function setDate(int $userData = null)
 	{
@@ -1253,6 +1256,8 @@ class Model
 			case 'date':
 				return date('Y-m-d', $currentDate);
 				break;
+			default:
+				throw ModelException::forNoDateFormat(get_class($this));
 		}
 	}
 
@@ -1543,7 +1548,7 @@ class Model
 	{
 		if ($this->tempUseSoftDeletes === true)
 		{
-			$this->builder()->where($this->table . '.' . $this->deletedField, null);
+			$this->builder()->where($this->deletedField, null);
 		}
 
 		return $this->builder()->countAllResults($reset, $test);

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1232,7 +1232,7 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new UserModel();
 		$this->setPrivateProperty($model, 'dateFormat', '');
 
-		$model->find(1);
+		$model->delete(1);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1223,6 +1223,20 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	/**
+	 * @expectedException        \CodeIgniter\Exceptions\ModelException
+	 * @expectedExceptionMessage `Tests\Support\Models\UserModel` model class does not have a valid dateFormat.
+	 */
+	public function testThrowsWithNoDateFormat()
+	{
+		$model = new UserModel();
+		$this->setPrivateProperty($model, 'dateFormat', '');
+
+		$model->find(1);
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testInsertID()
 	{
 		$model = new JobModel();

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -174,9 +174,10 @@ Leave it empty to avoid update it (even useTimestamps is enabled)
 
 **$dateFormat**
 
-This value works with $useTimestamps to ensure that the correct type of date value gets
-inserted into the database. By default, this creates DATETIME values, but valid options
-are: datetime, date, or int (a PHP timestamp).
+This value works with $useTimestamps and $useSoftDeletes to ensure that the correct type of
+date value gets inserted into the database. By default, this creates DATETIME values, but
+valid options are: datetime, date, or int (a PHP timestamp). Using 'useSoftDeletes' or
+'useTimestamps' with an invalid or missing dateFormat will cause an exception.
 
 **$validationRules**
 


### PR DESCRIPTION
**Description**
Currently if `useTimeStamps` or `useSoftDeletes` is true but `dateFormat` is empty or not one of (int, datetime, date) then database changes will continue quietly but with `NULL` date fields. This PR creates a new ModelException to be thrown whenever setDate fails to determine a valid date from (int, datetime, date).

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
