### PR TITLE
Centralized user identification

### DIFF
--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -41,3 +41,19 @@ Events::on('pre_system', function () {
 		Services::toolbar()->respond();
 	}
 });
+
+/*
+ * --------------------------------------------------------------------
+ * User Authentication Listeners.
+ * --------------------------------------------------------------------
+ * Hooks provided for external authentication modules. These may be
+ * removed if your application does not authenticate.
+ */
+
+Events::on('login', function ($userId) {
+	Services::session()->user($userId);
+});
+
+Events::on('logout', function () {
+	Services::session()->user(false);
+});

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -625,6 +625,36 @@ class Session implements SessionInterface
 	}
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * Sets, clears, or returns a unique user ID to signify that a user
+	 * is logged in.
+	 * null       = return current value
+	 * false      = clear current value
+	 * string/int = set a new value
+	 *
+	 * @param mixed $userId	Unique user identifier, or false
+	 *
+	 * @return false|string
+	 */
+	public function user($userId = null)
+	{
+		if ($userId === null)
+		{
+			return $_SESSION['__ci_user'] ?? false;
+		}
+		
+		if (empty($userId))
+		{
+			unset($_SESSION['__ci_user']);
+			return;
+		}
+		
+		$_SESSION['__ci_user'] = $userId;
+		return $userId;
+	}
+
+	//--------------------------------------------------------------------
 	//--------------------------------------------------------------------
 	// Flash Data Methods
 	//--------------------------------------------------------------------

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -109,3 +109,15 @@ The following is a list of available event points within the CodeIgniter core co
 * **post_controller_constructor** Called immediately after your controller is instantiated, but prior to any method calls happening.
 * **post_system** Called after the final rendered page is sent to the browser, at the end of system execution after the finalized data is sent to the browser.
 
+Additional Listeners
+====================
+
+In addition to the points described above, by default **app/Config/Events.php** also
+defines the following listeners to allow hooks from third-party modules to interact
+with framework settings:
+
+* **login** Receives a unique user identifier from an authentication library and stores it in the current session via the Session Library's ``user()`` method
+* **logout** Destroys the current Session user following a logout request from an authentication library
+
+.. note:: These events are never triggered by the framework itself and may be removed
+	if you don't plan to use a third-party library that would need them

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -382,6 +382,26 @@ intend to reuse that same key in the same request, you'd want to use
 
 	$session->removeTempdata('item');
 
+Users
+=====
+
+While CodeIgniter does not have an official authentication library, it does
+provide a centralized location to store basic identifying information for
+a logged-in user in the session library. The library's ``user()`` method
+can set, return, or destroy a unique user identifier::
+
+	// set logged-in user
+	$session->user($userId);
+	
+	// access current logged-in user
+	$userId = $session->user();
+	
+	// clear logged-in user data
+	$session->user(false);
+
+Third-party authentication libraries can use this method or the login/logout
+Events to notify the framework of their user status.
+
 Destroying a Session
 ====================
 


### PR DESCRIPTION
**Description**
This is my example of how I would like to see CI4 have an "official" location for logged-in users so that third-party libraries can consistently and reliably set and access "current user".

*See also* conversation on the forums (https://forum.codeigniter.com/thread-73257.html) and the related issue (https://github.com/codeigniter4/CodeIgniter4/issues/2055)

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [X] Conforms to style guide
