### PR TITLE
Add multi-path support to `locateFile()`

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -106,7 +106,7 @@ class FileLocator
 			unset($segments[0]);
 		}
 
-		$path     = '';
+		$paths    = [];
 		$prefix   = '';
 		$filename = '';
 
@@ -115,31 +115,43 @@ class FileLocator
 
 		while (! empty($segments))
 		{
-			$prefix .= empty($prefix)
-				? ucfirst(array_shift($segments))
-				: '\\' . ucfirst(array_shift($segments));
+			$prefix .= empty($prefix) ? array_shift($segments) : '\\' . array_shift($segments);
 
 			if (empty($namespaces[$prefix]))
 			{
 				continue;
 			}
-			$path = $this->getNamespaces($prefix);
+			$paths = $namespaces[$prefix];
 
 			$filename = implode('/', $segments);
 			break;
 		}
-
-		// IF we have a folder name, then the calling function
-		// expects this file to be within that folder, like 'Views',
-		// or 'libraries'.
-		if (! empty($folder) && strpos($path . $filename, '/' . $folder . '/') === false)
+		
+		// if no namespaces matched then quit
+		if (empty($paths))
 		{
-			$filename = $folder . '/' . $filename;
+			return false;
 		}
+		
+		// Check each path in the namespace
+		foreach ($paths as $path)
+		{
+			// If we have a folder name, then the calling function
+			// expects this file to be within that folder, like 'Views',
+			// or 'libraries'.
+			if (! empty($folder) && strpos($path . $filename, '/' . $folder . '/') === false)
+			{
+				$path .= $folder;
+			}
 
-		$path .= $filename;
-
-		return is_file($path) ? $path : false;
+			$path .= '/' . $filename;
+			if (is_file($path))
+			{
+				return $path;
+			}
+		}
+		
+		return false;
 	}
 
 	//--------------------------------------------------------------------
@@ -265,21 +277,10 @@ class FileLocator
 	/**
 	 * Return the namespace mappings we know about.
 	 *
-	 * @param string|null $prefix
-	 *
 	 * @return array|string
 	 */
-	protected function getNamespaces(string $prefix = null)
+	protected function getNamespaces()
 	{
-		if ($prefix)
-		{
-			$path = $this->autoloader->getNamespace($prefix);
-
-			return isset($path[0])
-				? rtrim($path[0], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR
-				: '';
-		}
-
 		$namespaces = [];
 
 		foreach ($this->autoloader->getNamespace() as $prefix => $paths)

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -144,7 +144,7 @@ class FileLocator
 				$path .= $folder;
 			}
 
-			$path .= '/' . $filename;
+			$path = rtrim($path, '/') . '/' . $filename;
 			if (is_file($path))
 			{
 				return $path;


### PR DESCRIPTION
**Description**
Currently `locateFile()` flattens namespace paths to a single path per namespace (see https://github.com/codeigniter4/CodeIgniter4/issues/1866). This fix searches all namespace paths for the first matching file.

This change also removes the auto-capitalize of namespaces as this is not a namespace requirement and could cause `locateFile` to fail to match valid file namespaces.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
