### PR TITLE
Cache Drive Backups 

### DIFF
--- a/system/Cache/CacheFactory.php
+++ b/system/Cache/CacheFactory.php
@@ -39,6 +39,7 @@
 namespace CodeIgniter\Cache;
 
 use CodeIgniter\Cache\Exceptions\CacheException;
+use CodeIgniter\Exceptions\CriticalError;
 
 /**
  * Class Cache
@@ -93,7 +94,20 @@ class CacheFactory
 			}
 		}
 
-		$adapter->initialize();
+		// If $adapter->initialization throws a CriticalError exception, we will attempt to
+		// use the $backup handler, if that also fails, we resort to the dummy handler.
+		try
+		{
+			$adapter->initialize();
+		}
+		catch (CriticalError $e)
+		{
+			// log the fact that an exception occurred as well what handler we resorting to
+			log_message('critical', $e->getMessage() . ' Resorting to using ' . $backup . ' handler.');
+
+			// get the next best cache handler (or dummy if the $backup also fails)
+			$adapter = self::getHandler($config, $backup, 'dummy');
+		}
 
 		return $adapter;
 	}

--- a/system/Cache/CacheFactory.php
+++ b/system/Cache/CacheFactory.php
@@ -102,7 +102,7 @@ class CacheFactory
 		}
 		catch (CriticalError $e)
 		{
-			// log the fact that an exception occurred as well what handler we resorting to
+			// log the fact that an exception occurred as well what handler we are resorting to
 			log_message('critical', $e->getMessage() . ' Resorting to using ' . $backup . ' handler.');
 
 			// get the next best cache handler (or dummy if the $backup also fails)

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -128,12 +128,20 @@ class MemcachedHandler implements CacheInterface
 					$this->memcached->setOption(\Memcached::OPT_BINARY_PROTOCOL, true);
 				}
 
-				// TODO: check if we can connect to the server
-
 				// Add server
 				$this->memcached->addServer(
 					$this->config['host'], $this->config['port'], $this->config['weight']
 				);
+
+				// attempt to get status of servers
+				$stats = $this->memcached->getStats();
+
+				// $stats should be an associate array with a key in the format of host:port.
+				// If it doesn't have the key, we know the server is not working as expected.
+				if( !isset($stats[$this->config['host']. ':' .$this->config['port']]) )
+				{
+					throw new CriticalError('Cache: Memcached connection failed.');
+				}
 			}
 			elseif (class_exists('\Memcache'))
 			{

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -168,7 +168,7 @@ class MemcachedHandler implements CacheInterface
 		catch (\Exception $e)
 		{
 			// If an \Exception occurs, convert it into a CriticalError exception and throw it.
-			throw new CriticalError('Cache: Memcache(d) connection refused (' . $e->getMessage() . ')');
+			throw new CriticalError('Cache: Memcache(d) connection refused (' . $e->getMessage() . ').');
 		}
 	}
 

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -112,7 +112,7 @@ class PredisHandler implements CacheInterface
 		catch (\Exception $e)
 		{
 			// thrown if can't connect to redis server.
-			throw new CriticalError('Cache: Predis connection refused (' . $e->getMessage() . ')');
+			throw new CriticalError('Cache: Predis connection refused (' . $e->getMessage() . ').');
 		}
 	}
 

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -99,6 +99,8 @@ class PredisHandler implements CacheInterface
 	 */
 	public function initialize()
 	{
+		// Try to connect to Redis, if an issue occurs throw a CriticalError exception,
+		// so that the CacheFactory can attempt to initiate the next cache handler.
 		try
 		{
 			// Create a new instance of Predis\Client

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -39,6 +39,7 @@
 namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\CacheInterface;
+use CodeIgniter\Exceptions\CriticalError;
 
 /**
  * Redis cache handler
@@ -116,19 +117,38 @@ class RedisHandler implements CacheInterface
 		$config = $this->config;
 
 		$this->redis = new \Redis();
-		if (! $this->redis->connect($config['host'], ($config['host'][0] === '/' ? 0 : $config['port']), $config['timeout']))
-		{
-			log_message('error', 'Cache: Redis connection failed. Check your configuration.');
-		}
 
-		if (isset($config['password']) && ! $this->redis->auth($config['password']))
+		// Try to connect to Redis, if an issue occurs throw a CriticalError exception,
+		// so that the CacheFactory can attempt to initiate the next cache handler.
+		try
 		{
-			log_message('error', 'Cache: Redis authentication failed.');
-		}
+			// Note:: If Redis is your primary cache choice, and it is "offline", every page load will end up been delayed by the timeout duration.
+			// I feel like some sort of temporary flag should be set, to indicate that we think Redis is "offline", allowing us to bypass the timeout for a set period of time.
 
-		if (isset($config['database']) && ! $this->redis->select($config['database']))
+			if (! $this->redis->connect($config['host'], ($config['host'][0] === '/' ? 0 : $config['port']), $config['timeout']))
+			{
+				// Note:: I'm unsure if log_message() is necessary, however I'm not 100% comfortable removing it.
+				log_message('error', 'Cache: Redis connection failed. Check your configuration.');
+				throw new CriticalError('Cache: Redis connection failed. Check your configuration.');
+			}
+
+			if (isset($config['password']) && ! $this->redis->auth($config['password']))
+			{
+				log_message('error', 'Cache: Redis authentication failed.');
+				throw new CriticalError('Cache: Redis authentication failed.');
+			}
+
+			if (isset($config['database']) && ! $this->redis->select($config['database']))
+			{
+				log_message('error', 'Cache: Redis select database failed.');
+				throw new CriticalError('Cache: Redis select database failed.');
+			}
+		}
+		catch (\RedisException $e)
 		{
-			log_message('error', 'Cache: Redis select database failed.');
+			// $this->redis->connect() can sometimes throw a RedisException.
+			// We need to these to a CriticalError exception and throw it.
+			throw new CriticalError('Cache: RedisException occurred with message (' . $e->getMessage() . ').');
 		}
 	}
 

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -147,7 +147,7 @@ class RedisHandler implements CacheInterface
 		catch (\RedisException $e)
 		{
 			// $this->redis->connect() can sometimes throw a RedisException.
-			// We need to these to a CriticalError exception and throw it.
+			// We need to convert the exception into a CriticalError exception and throw it.
 			throw new CriticalError('Cache: RedisException occurred with message (' . $e->getMessage() . ').');
 		}
 	}


### PR DESCRIPTION
**Description**
If our application is unable to connect to Redis, a CriticalError exception is now thrown.

CacheFactory catches the CriticalError exceptions that are thrown when Redis, Memcache and Predis fail to connect, it logs the exception and then attempts to initialize the backup cache driver (and if that fails it initializes dummy).

**Checklist:**
- [ ] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
