### PR TITLE
Bugfix file locator slash error

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -144,7 +144,7 @@ class FileLocator
 			// or 'libraries'.
 			if (! empty($folder) && strpos($path . $filename, '/' . $folder . '/') === false)
 			{
-				$path .= $folder;
+				$path .= trim($folder, '/') . '/';
 			}
 
 			$path .= $filename;

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -136,6 +136,9 @@ class FileLocator
 		// Check each path in the namespace
 		foreach ($paths as $path)
 		{
+			// Ensure trailing slash
+			$path = rtrim($path, '/') . '/';
+			
 			// If we have a folder name, then the calling function
 			// expects this file to be within that folder, like 'Views',
 			// or 'libraries'.
@@ -144,7 +147,7 @@ class FileLocator
 				$path .= $folder;
 			}
 
-			$path = rtrim($path, '/') . '/' . $filename;
+			$path .= $filename;
 			if (is_file($path))
 			{
 				return $path;


### PR DESCRIPTION
**Description**
https://github.com/codeigniter4/CodeIgniter4/pull/2059 introduced a scenario where the combination of `$path` and `$folder` could fail to have a separating slash. This PR moves the trailing slash safety check prior to the folder test.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
