### PR TITLE
getExtension() should return string

### DIFF
--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -348,7 +348,7 @@ class UploadedFile extends File implements UploadedFileInterface
 	 */
 	public function getExtension(): string
 	{
-		return $this->guessExtension();
+		return $this->guessExtension() ?? '';
 	}
 
 	/**


### PR DESCRIPTION
in other case this cause i.e. exception during validation if file is not provided
```
'is_image[upload_' . $i . ']|max_size[upload_' . $i . ',6144]'
```
I thought to declare this method as `public function getExtension(): ?string` but this will be worse option.
