### PR TITLE
WIP Generic User class with service and listeners

### DIFF
--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -41,3 +41,20 @@ Events::on('pre_system', function () {
 		Services::toolbar()->respond();
 	}
 });
+
+/*
+ * --------------------------------------------------------------------
+ * User Authentication Listeners.
+ * --------------------------------------------------------------------
+ * Hooks provided for external authentication modules. These may be
+ * removed if your application does not authenticate.
+ */
+
+Events::on('login', function ($user) {
+	Services::user($user);
+});
+
+Events::on('logout', function () {
+	Services::user()->remove();
+});
+

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -814,6 +814,27 @@ class Services extends BaseService
 	//--------------------------------------------------------------------
 
 	/**
+	 * The User class provides a central location to store information on
+	 * a current user.
+	 *
+	 * @param mixed   $user
+	 * @param boolean $getShared
+	 *
+	 * @return \CodeIgniter\User
+	 */
+	public static function user($user = null, bool $getShared = true)
+	{
+		if ($getShared)
+		{
+			return static::getSharedInstance('user', $user);
+		}
+
+		return new User($user);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * The Validation class provides tools for validating input data.
 	 *
 	 * @param \Config\Validation $config

--- a/system/User/User.php
+++ b/system/User/User.php
@@ -1,0 +1,112 @@
+<?php
+
+
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2014-2019 British Columbia Institute of Technology (https://bcit.ca/)
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace CodeIgniter\User;
+
+use CodeIgniter\Config\BaseConfig;
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
+use CodeIgniter\Honeypot\Exceptions\HoneypotException;
+
+/**
+ * class User
+ */
+class User
+{
+
+	/**
+	 * The current user (if any).
+	 *
+	 * @var BaseConfig
+	 */
+	protected $user;
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Constructor.
+	 *
+	 * Set an initial user (if requested).
+	 *
+	 */
+	public function __construct($user)
+	{
+		$this->user = $user;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns the current value from $user.
+	 *
+	 * @return mixed
+	 */
+	public function get()
+	{
+		return $this->user;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Sets the current value for $user.
+	 *
+	 * @param mixed     $user
+	 *
+	 * @return $this
+	 */
+	public function set($user)
+	{
+		$this->user = $user;
+		return $this;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Removes any value from $user.
+	 *
+	 * @return $this
+	 */
+	public function remove()
+	{
+		$this->user = null;
+		return $this;
+	}
+}


### PR DESCRIPTION
**Description**
This is a continuation of the conversation around the interest for a centralized "current user" (https://github.com/codeigniter4/CodeIgniter4/issues/2055). This is a concept implementation of how the framework could function as an arbiter between auth libraries and third-party modules for setting and accessing the "current user".

I'm sure there is a lot more that could be done with this class, but in the interest of leaving CI4 are of authentication material I think keeping it simple and straightforward (including not defining `$user`'s type) leaves the most options.

*See also https://github.com/codeigniter4/CodeIgniter4/pull/2058

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
