### PR TITLE
WIP Issue with casting afer fill.

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -113,9 +113,11 @@ class Entity
 	 *
 	 * @param array $data
 	 *
+	 * @param bool $casted
 	 * @return \CodeIgniter\Entity
+	 * @throws \Exception
 	 */
-	public function fill(array $data = null)
+	public function fill(array $data = null, bool $casted = false)
 	{
 		if (! is_array($data))
 		{
@@ -134,7 +136,7 @@ class Entity
 			}
 			else
 			{
-				$this->attributes[$key] = $value;
+				$casted ? $this->__set($key, $value) : $this->attributes[$key] = $value;
 			}
 		}
 


### PR DESCRIPTION
In code like this:
```

					$tmp = (new $this->returnType());
					$tmp->fill($data);

					$this->insert($tmp);
```
i've got an issue related to valid_json cuz array has not been casted to json string.
my change allows to force fill method to cast properties according to declaration from $cast property.
