### PR TITLE
Throttler can access bucket for bucket life time

### DIFF
--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -143,7 +143,7 @@ class Throttler implements ThrottlerInterface
 			// If it hasn't been created, then we'll set it to the maximum
 			// capacity - 1, and save it to the cache.
 			$this->cache->save($tokenName, $capacity - $cost, $seconds);
-			$this->cache->save($tokenName . 'Time', time());
+			$this->cache->save($tokenName . 'Time', time(), $seconds);
 
 			return true;
 		}
@@ -172,9 +172,9 @@ class Throttler implements ThrottlerInterface
 		if ($tokens > 0)
 		{
 			$response = true;
+			$this->cache->save($tokenName, $tokens - $cost, $seconds);
+			$this->cache->save($tokenName . 'Time', time(), $seconds);
 
-			$this->cache->save($tokenName, $tokens - $cost, $elapsed);
-			$this->cache->save($tokenName . 'Time', time());
 		}
 
 		return $response;

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -138,7 +138,7 @@ class Throttler implements ThrottlerInterface
 		$tokenName = $this->prefix . $key;
 
 		// Check to see if the bucket has even been created yet.
-		if (($tokens = $this->cache->get($tokenName)) === false)
+		if (($tokens = $this->cache->get($tokenName)) === null)
 		{
 			// If it hasn't been created, then we'll set it to the maximum
 			// capacity - 1, and save it to the cache.

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -159,8 +159,8 @@ class Throttler implements ThrottlerInterface
 		// How many seconds till a new token is available.
 		// We must have a minimum wait of 1 second for a new token.
 		// Primarily stored to allow devs to report back to users.
-		$newTokenAvailable = (1/$rate) - $elapsed;
-		$this->tokenTime = max(1, $newTokenAvailable);
+		$newTokenAvailable = (1 / $rate) - $elapsed;
+		$this->tokenTime   = max(1, $newTokenAvailable);
 
 		// Add tokens based up on number per second that
 		// should be refilled, then checked against capacity

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -155,7 +155,7 @@ class Throttler implements ThrottlerInterface
 		// Number of tokens to add back per second
 		$rate = $capacity / $seconds;
 
-		// We must have a minimum wait of 1 second for a new token
+		// We must have a minimum wait of 1 second for a new token.
 		// Primarily stored to allow devs to report back to users.
 		$this->tokenTime = max(1, $rate);
 
@@ -165,7 +165,7 @@ class Throttler implements ThrottlerInterface
 		$tokens += $rate * $elapsed;
 		$tokens  = $tokens > $capacity ? $capacity : $tokens;
 
-		// If $tokens > 0, then we are save to perform the action, but
+		// If $tokens > 0, then we are safe to perform the action, but
 		// we need to decrement the number of available tokens.
 		$response = false;
 

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -167,17 +167,15 @@ class Throttler implements ThrottlerInterface
 
 		// If $tokens > 0, then we are safe to perform the action, but
 		// we need to decrement the number of available tokens.
-		$response = false;
-
 		if ($tokens > 0)
 		{
-			$response = true;
 			$this->cache->save($tokenName, $tokens - $cost, $seconds);
 			$this->cache->save($tokenName . 'Time', time(), $seconds);
 
+			return true;
 		}
 
-		return $response;
+		return false;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -152,12 +152,15 @@ class Throttler implements ThrottlerInterface
 		// based on how long it's been since the last update.
 		$throttleTime = $this->cache->get($tokenName . 'Time');
 		$elapsed      = $this->time() - $throttleTime;
+
 		// Number of tokens to add back per second
 		$rate = $capacity / $seconds;
 
+		// How many seconds till a new token is available.
 		// We must have a minimum wait of 1 second for a new token.
 		// Primarily stored to allow devs to report back to users.
-		$this->tokenTime = max(1, $rate);
+		$newTokenAvailable = (1/$rate) - $elapsed;
+		$this->tokenTime = max(1, $newTokenAvailable);
 
 		// Add tokens based up on number per second that
 		// should be refilled, then checked against capacity

--- a/tests/_support/Cache/Handlers/MockHandler.php
+++ b/tests/_support/Cache/Handlers/MockHandler.php
@@ -43,7 +43,7 @@ class MockHandler implements CacheInterface
 
 		return array_key_exists($key, $this->cache)
 			? $this->cache[$key]
-			: false;
+			: null;
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -16,20 +16,19 @@ class ThrottleTest extends \CIUnitTestCase
 	{
 		$throttler = new Throttler($this->cache);
 
-		// token time should be zero to start
+		// tokenTime should be 0 to start
 		$this->assertEquals(0, $throttler->getTokenTime());
 
-		// as soon as we try a rate check, token time affected
-		$rate = 1; // allow 1 per minute
-		$cost = 1;
+		// set $rate
+		$rate = 1;    // allow 1 request per minute
 
-		// after using one slot, still good
-		$throttler->check('127.0.0.1', $rate, MINUTE, $cost);
+		// first check just creates a bucket, so tokenTime should be 0
+		$throttler->check('127.0.0.1', $rate, MINUTE);
 		$this->assertEquals(0, $throttler->getTokenTime());
 
-		// after consuming a second, we have to wait
-		$throttler->check('127.0.0.1', $rate, MINUTE, $cost);
-		$this->assertEquals(1, $throttler->getTokenTime());
+		// additional check affects tokenTime, so tokenTime should be 1 or greater
+		$throttler->check('127.0.0.1', $rate, MINUTE);
+		$this->assertGreaterThanOrEqual(1, $throttler->getTokenTime());
 	}
 
 	public function testIPSavesBucket()


### PR DESCRIPTION
**Description**
I was encountering an issue with the rate limiting which was causing it not to behave as expected.

If i set a rate limit of 1 request a minute, I would be able to make much more than 1 request a minute provided that the requests are a few seconds apart.

This is because the original "bucket"'s life time gets updated to the time between the 1st and 2nd request, meaning the 3rd request typically creates a new "bucket".

**Edit**
Added an additional commit to resolve an additional issue regarding calculating how many seconds must pass before a new token is available. (https://github.com/codeigniter4/CodeIgniter4/pull/2074/commits/8e0ab844be5889a8703b23fcd9dc9caea6cddb70)

Added an additional commit to update ThrottleTest to getTokenTime() to have a value greater than 1 (https://github.com/codeigniter4/CodeIgniter4/pull/2074/commits/1eac5c1ba5e6dabf95fe1eb65cc6fab8628e464f)

**Checklist:**
- [ ] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide