### PR TITLE
Update config() to check all namespaces

### DIFF
--- a/system/Config/Config.php
+++ b/system/Config/Config.php
@@ -122,13 +122,28 @@ class Config
 		{
 			return new $name();
 		}
-
+		
 		$locator = Services::locator();
 		$file    = $locator->locateFile($name, 'Config');
-
+		
 		if (empty($file))
 		{
-			return null;
+			// No file found - check if the class was namespaced
+			if (strpos($name, '\\') !== false)
+			{
+				// Class was namespaced and locateFile couldn't find it
+				return null;
+			}
+			
+			// Check all namespaces
+			$files = $locator->search('Config/' . $name);
+			if (empty($files))
+			{
+				return null;
+			}
+			
+			// Get the first match (prioritizes user and framework)
+			$file = reset($files);
 		}
 
 		$name = $locator->getClassname($file);


### PR DESCRIPTION
**Description**
Calling `config($classname)` with an un-namespaced class passes the string to `$locator->locateFile()` which causes it to use `legacyLocate()`, which searches App and System only. This change leaves the default behavior but falls back to `$locator->search()` instead of failing immediately, allowing calls like `config('Auth')` to check first in **App** and **System** and then in any autoloaded namespaces.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
