### PR TITLE
WIP Update Validation.php

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -208,11 +208,11 @@ class Validation implements ValidationInterface
 	 * the error to $this->errors and moves on to the next,
 	 * so that we can collect all of the first errors.
 	 *
-	 * @param string      $field
-	 * @param string|null $label
-	 * @param string      $value
-	 * @param array|null  $rules
-	 * @param array       $data  // All of the fields to check.
+	 * @param string       $field
+	 * @param string|null  $label
+	 * @param string|array $value Value to be validated, can be a string or an array
+	 * @param array|null   $rules
+	 * @param array        $data  // All of the fields to check.
 	 *
 	 * @return boolean
 	 */
@@ -291,7 +291,14 @@ class Validation implements ValidationInterface
 			// Set the error message if we didn't survive.
 			if ($passed === false)
 			{
-				$this->errors[$field] = is_null($error) ? $this->getErrorMessage($rule, $field, $label, $param) : $error;
+				// if the $value is an array, convert it to as string representation
+				if (is_array($value))
+				{
+					$value = '[' . implode(', ', $value) . ']';
+				}
+
+				$this->errors[$field] = is_null($error) ? $this->getErrorMessage($rule, $field, $label, $param, $value)
+					: $error;
 
 				return false;
 			}
@@ -682,10 +689,11 @@ class Validation implements ValidationInterface
 	 * @param string      $field
 	 * @param string|null $label
 	 * @param string      $param
+	 * @param string      $value The value that caused the validation to fail.
 	 *
 	 * @return string
 	 */
-	protected function getErrorMessage(string $rule, string $field, string $label = null, string $param = null): string
+	protected function getErrorMessage(string $rule, string $field, string $label = null, string $param = null, string $value = null): string
 	{
 		// Check if custom message has been defined by user
 		if (isset($this->customErrors[$field][$rule]))
@@ -702,6 +710,7 @@ class Validation implements ValidationInterface
 
 		$message = str_replace('{field}', $label ?? $field, $message);
 		$message = str_replace('{param}', $this->rules[$param]['label'] ?? $param, $message);
+		$message = str_replace('{value}', $value, $message);
 
 		return $message;
 	}

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -576,4 +576,42 @@ class ValidationTest extends \CIUnitTestCase
 
 		$this->assertEquals('regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]', $result[1]);
 	}
+
+	//--------------------------------------------------------------------
+
+	public function testTagReplacement()
+	{
+		// data
+		$data = [
+			'Username' => 'Pizza',
+		];
+
+		// rules
+		$this->validation->setRules([
+			'Username' => 'min_length[6]',
+		], [
+			'Username' => [
+				'min_length' => 'Supplied value ({value}) for {field} must have at least {param} characters.',
+			],
+		]);
+
+		// run validation
+		$this->validation->run($data);
+
+		// $errors should contain an associative array
+		$errors = $this->validation->getErrors();
+
+		// if "Username" doesn't exist in errors
+		if (! isset($errors['Username']))
+		{
+			$this->fail('Unable to find "Username"');
+		}
+
+		// expected error message
+		$expected = 'Supplied value (Pizza) for Username must have at least 6 characters.';
+
+		// check if they are the same!
+		$this->assertEquals($expected, $errors['Username']);
+	}
+
 }

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -441,12 +441,12 @@ Or as a labeled style::
     );
 
 If you’d like to include a field’s “human” name, or the optional parameter some rules allow for (such as max_length),
-you can add the ``{field}`` and ``{param}`` tags to your message, respectively::
+or the value that was validated you can add the ``{field}``, ``{param}`` and ``{value}`` tags to your message, respectively::
 
-    'min_length' => '{field} must have at least {param} characters.'
+    'min_length' => 'Supplied value ({value}) for {field} must have at least {param} characters.'
 
-On a field with the human name Username and a rule of min_length[5], an error would display: “Username must have
-at least 5 characters.”
+On a field with the human name Username and a rule of min_length[6] with a value of “Pizza”, an error would display: “Supplied value (Pizza) for Username must have
+at least 6 characters.”
 
 .. note:: If you pass the last parameter the labeled style error messages will be ignored.
 


### PR DESCRIPTION
**Description**
Was experiencing issue where i wanted to display the supplied value within the validation error message. So I've updated the validation class to pass the value through to the error message generation and to replace {value} with the supplied value.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
