### PR TITLE
WIP: Prevent soft deletes without where condition

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1588,6 +1588,18 @@ class BaseBuilder
 	}
 
 	//--------------------------------------------------------------------
+	/**
+	 * Get compiled 'where' condition string
+	 *
+	 * Compiles the set conditions and returns the sql statement
+	 *
+	 * @return string
+	 */
+	public function getCompiledQBWhere()
+	{
+		return $this->QBWhere;
+	}
+	//--------------------------------------------------------------------
 
 	/**
 	 * Get_Where

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -223,15 +223,14 @@ class BaseBuilder
 	/**
 	 * Constructor
 	 *
-	 * @param  string|array                              $tableName
-	 * @param  \CodeIgniter\Database\ConnectionInterface $db
-	 * @param  array                                     $options
+	 * @param string|array $tableName
+	 * @param \CodeIgniter\Database\ConnectionInterface $db
+	 * @param array $options
 	 * @throws DatabaseException
 	 */
 	public function __construct($tableName, ConnectionInterface &$db, array $options = null)
 	{
-		if (empty($tableName))
-		{
+		if (empty($tableName)) {
 			throw new DatabaseException('A table must be specified when creating a new Query Builder.');
 		}
 
@@ -239,12 +238,9 @@ class BaseBuilder
 
 		$this->from($tableName);
 
-		if (! empty($options))
-		{
-			foreach ($options as $key => $value)
-			{
-				if (property_exists($this, $key))
-				{
+		if ( ! empty($options)) {
+			foreach ($options as $key => $value) {
+				if (property_exists($this, $key)) {
 					$this->$key = $value;
 				}
 			}
@@ -272,26 +268,23 @@ class BaseBuilder
 	 * Generates the SELECT portion of the query
 	 *
 	 * @param string|array $select
-	 * @param boolean      $escape
+	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
 	 */
 	public function select($select = '*', bool $escape = null)
 	{
-		if (is_string($select))
-		{
+		if (is_string($select)) {
 			$select = explode(',', $select);
 		}
 
 		// If the escape value was not set, we will base it on the global setting
 		is_bool($escape) || $escape = $this->db->protectIdentifiers;
 
-		foreach ($select as $val)
-		{
+		foreach ($select as $val) {
 			$val = trim($val);
 
-			if ($val !== '')
-			{
+			if ($val !== '') {
 				$this->QBSelect[] = $val;
 
 				/*
@@ -301,8 +294,7 @@ class BaseBuilder
 				 * This prevents NULL being escaped
 				 * @see https://github.com/codeigniter4/CodeIgniter4/issues/1169
 				 */
-				if (strtoupper(mb_substr(trim($val), 0, 4)) === 'NULL')
-				{
+				if (strtoupper(mb_substr(trim($val), 0, 4)) === 'NULL') {
 					$escape = false;
 				}
 
@@ -321,7 +313,7 @@ class BaseBuilder
 	 * Generates a SELECT MAX(field) portion of a query
 	 *
 	 * @param string $select The field
-	 * @param string $alias  An alias
+	 * @param string $alias An alias
 	 *
 	 * @return BaseBuilder
 	 */
@@ -338,7 +330,7 @@ class BaseBuilder
 	 * Generates a SELECT MIN(field) portion of a query
 	 *
 	 * @param string $select The field
-	 * @param string $alias  An alias
+	 * @param string $alias An alias
 	 *
 	 * @return BaseBuilder
 	 */
@@ -355,7 +347,7 @@ class BaseBuilder
 	 * Generates a SELECT AVG(field) portion of a query
 	 *
 	 * @param string $select The field
-	 * @param string $alias  An alias
+	 * @param string $alias An alias
 	 *
 	 * @return BaseBuilder
 	 */
@@ -372,7 +364,7 @@ class BaseBuilder
 	 * Generates a SELECT SUM(field) portion of a query
 	 *
 	 * @param string $select The field
-	 * @param string $alias  An alias
+	 * @param string $alias An alias
 	 *
 	 * @return BaseBuilder
 	 */
@@ -401,31 +393,27 @@ class BaseBuilder
 	 */
 	protected function maxMinAvgSum(string $select = '', string $alias = '', string $type = 'MAX')
 	{
-		if ($select === '')
-		{
+		if ($select === '') {
 			throw DataException::forEmptyInputGiven('Select');
 		}
 
-		if (strpos($select, ',') !== false)
-		{
+		if (strpos($select, ',') !== false) {
 			throw DataException::forInvalidArgument('column name not separated by comma');
 		}
 
 		$type = strtoupper($type);
 
-		if (! in_array($type, ['MAX', 'MIN', 'AVG', 'SUM']))
-		{
+		if ( ! in_array($type, ['MAX', 'MIN', 'AVG', 'SUM'])) {
 			throw new DatabaseException('Invalid function type: ' . $type);
 		}
 
-		if ($alias === '')
-		{
+		if ($alias === '') {
 			$alias = $this->createAliasFromTable(trim($select));
 		}
 
 		$sql = $type . '(' . $this->db->protectIdentifiers(trim($select)) . ') AS ' . $this->db->escapeIdentifiers(trim($alias));
 
-		$this->QBSelect[]   = $sql;
+		$this->QBSelect[] = $sql;
 		$this->QBNoEscape[] = null;
 
 		return $this;
@@ -442,8 +430,7 @@ class BaseBuilder
 	 */
 	protected function createAliasFromTable(string $item): string
 	{
-		if (strpos($item, '.') !== false)
-		{
+		if (strpos($item, '.') !== false) {
 			$item = explode('.', $item);
 
 			return end($item);
@@ -477,33 +464,27 @@ class BaseBuilder
 	 *
 	 * Generates the FROM portion of the query
 	 *
-	 * @param mixed   $from      can be a string or array
+	 * @param mixed $from can be a string or array
 	 * @param boolean $overwrite Should we remove the first table existing?
 	 *
 	 * @return BaseBuilder
 	 */
 	public function from($from, bool $overwrite = false)
 	{
-		if ($overwrite === true)
-		{
+		if ($overwrite === true) {
 			$this->QBFrom = [];
 			$this->db->setAliasedTables([]);
 		}
 
-		foreach ((array) $from as $val)
-		{
-			if (strpos($val, ',') !== false)
-			{
-				foreach (explode(',', $val) as $v)
-				{
+		foreach ((array)$from as $val) {
+			if (strpos($val, ',') !== false) {
+				foreach (explode(',', $val) as $v) {
 					$v = trim($v);
 					$this->trackAliases($v);
 
 					$this->QBFrom[] = $v = $this->db->protectIdentifiers($v, true, null, false);
 				}
-			}
-			else
-			{
+			} else {
 				$val = trim($val);
 
 				// Extract any aliases that might exist. We use this information
@@ -524,25 +505,21 @@ class BaseBuilder
 	 *
 	 * Generates the JOIN portion of the query
 	 *
-	 * @param string  $table
-	 * @param string  $cond   The join condition
-	 * @param string  $type   The type of join
+	 * @param string $table
+	 * @param string $cond The join condition
+	 * @param string $type The type of join
 	 * @param boolean $escape Whether not to try to escape identifiers
 	 *
 	 * @return BaseBuilder
 	 */
 	public function join(string $table, string $cond, string $type = '', bool $escape = null)
 	{
-		if ($type !== '')
-		{
+		if ($type !== '') {
 			$type = strtoupper(trim($type));
 
-			if (! in_array($type, ['LEFT', 'RIGHT', 'OUTER', 'INNER', 'LEFT OUTER', 'RIGHT OUTER'], true))
-			{
+			if ( ! in_array($type, ['LEFT', 'RIGHT', 'OUTER', 'INNER', 'LEFT OUTER', 'RIGHT OUTER'], true)) {
 				$type = '';
-			}
-			else
-			{
+			} else {
 				$type .= ' ';
 			}
 		}
@@ -553,49 +530,39 @@ class BaseBuilder
 
 		is_bool($escape) || $escape = $this->db->protectIdentifiers;
 
-		if (! $this->hasOperator($cond))
-		{
+		if ( ! $this->hasOperator($cond)) {
 			$cond = ' USING (' . ($escape ? $this->db->escapeIdentifiers($cond) : $cond) . ')';
-		}
-		elseif ($escape === false)
-		{
+		} elseif ($escape === false) {
 			$cond = ' ON ' . $cond;
-		}
-		else
-		{
+		} else {
 			// Split multiple conditions
-			if (preg_match_all('/\sAND\s|\sOR\s/i', $cond, $joints, PREG_OFFSET_CAPTURE))
-			{
+			if (preg_match_all('/\sAND\s|\sOR\s/i', $cond, $joints, PREG_OFFSET_CAPTURE)) {
 				$conditions = [];
-				$joints     = $joints[0];
+				$joints = $joints[0];
 				array_unshift($joints, ['', 0]);
 
-				for ($i = count($joints) - 1, $pos = strlen($cond); $i >= 0; $i --)
-				{
+				for ($i = count($joints) - 1, $pos = strlen($cond); $i >= 0; $i--) {
 					$joints[$i][1] += strlen($joints[$i][0]); // offset
 					$conditions[$i] = substr($cond, $joints[$i][1], $pos - $joints[$i][1]);
-					$pos            = $joints[$i][1] - strlen($joints[$i][0]);
-					$joints[$i]     = $joints[$i][0];
+					$pos = $joints[$i][1] - strlen($joints[$i][0]);
+					$joints[$i] = $joints[$i][0];
 				}
-			}
-			else
-			{
+			} else {
 				$conditions = [$cond];
-				$joints     = [''];
+				$joints = [''];
 			}
 
 			$cond = ' ON ';
-			for ($i = 0, $c = count($conditions); $i < $c; $i ++)
-			{
+			for ($i = 0, $c = count($conditions); $i < $c; $i++) {
 				$operator = $this->getOperator($conditions[$i]);
-				$cond    .= $joints[$i];
-				$cond    .= preg_match("/(\(*)?([\[\]\w\.'-]+)" . preg_quote($operator) . '(.*)/i', $conditions[$i], $match) ? $match[1] . $this->db->protectIdentifiers($match[2]) . $operator . $this->db->protectIdentifiers($match[3]) : $conditions[$i];
+				$cond .= $joints[$i];
+				$cond .= preg_match("/(\(*)?([\[\]\w\.'-]+)" . preg_quote($operator) . '(.*)/i', $conditions[$i],
+					$match) ? $match[1] . $this->db->protectIdentifiers($match[2]) . $operator . $this->db->protectIdentifiers($match[3]) : $conditions[$i];
 			}
 		}
 
 		// Do we want to escape the table name?
-		if ($escape === true)
-		{
+		if ($escape === true) {
 			$table = $this->db->protectIdentifiers($table, true, null, false);
 		}
 
@@ -613,8 +580,8 @@ class BaseBuilder
 	 * Generates the WHERE portion of the query.
 	 * Separates multiple calls with 'AND'.
 	 *
-	 * @param mixed   $key
-	 * @param mixed   $value
+	 * @param mixed $key
+	 * @param mixed $value
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
@@ -632,8 +599,8 @@ class BaseBuilder
 	 * Generates the WHERE portion of the query.
 	 * Separates multiple calls with 'OR'.
 	 *
-	 * @param mixed   $key
-	 * @param mixed   $value
+	 * @param mixed $key
+	 * @param mixed $value
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
@@ -653,72 +620,60 @@ class BaseBuilder
 	 * @used-by having()
 	 * @used-by orHaving()
 	 *
-	 * @param string  $qb_key 'QBWhere' or 'QBHaving'
-	 * @param mixed   $key
-	 * @param mixed   $value
-	 * @param string  $type
+	 * @param string $qb_key 'QBWhere' or 'QBHaving'
+	 * @param mixed $key
+	 * @param mixed $value
+	 * @param string $type
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
 	 */
 	protected function whereHaving(string $qb_key, $key, $value = null, string $type = 'AND ', bool $escape = null)
 	{
-		if (! is_array($key))
-		{
+		if ( ! is_array($key)) {
 			$key = [$key => $value];
 		}
 
 		// If the escape value was not set will base it on the global setting
 		is_bool($escape) || $escape = $this->db->protectIdentifiers;
 
-		foreach ($key as $k => $v)
-		{
+		foreach ($key as $k => $v) {
 			$prefix = empty($this->$qb_key) ? $this->groupGetType('') : $this->groupGetType($type);
 
-			if ($v !== null)
-			{
+			if ($v !== null) {
 				$op = $this->getOperator($k, true);
 
-				if (! empty($op))
-				{
+				if ( ! empty($op)) {
 					$k = trim($k);
 
 					end($op);
 
 					$op = trim(current($op));
 
-					if (substr($k, -1 * strlen($op)) === $op)
-					{
+					if (substr($k, -1 * strlen($op)) === $op) {
 						$k = rtrim(strrev(preg_replace(strrev('/' . $op . '/'), strrev(''), strrev($k), 1)));
 					}
 				}
 
 				$bind = $this->setBind($k, $v, $escape);
 
-				if (empty($op))
-				{
+				if (empty($op)) {
 					$k .= ' =';
-				}
-				else
-				{
+				} else {
 					$k .= $op;
 				}
 
 				$v = " :$bind:";
-			}
-			elseif (! $this->hasOperator($k) && $qb_key !== 'QBHaving')
-			{
+			} elseif ( ! $this->hasOperator($k) && $qb_key !== 'QBHaving') {
 				// value appears not to have been set, assign the test to IS NULL
 				$k .= ' IS NULL';
-			}
-			elseif (preg_match('/\s*(!?=|<>|IS(?:\s+NOT)?)\s*$/i', $k, $match, PREG_OFFSET_CAPTURE))
-			{
+			} elseif (preg_match('/\s*(!?=|<>|IS(?:\s+NOT)?)\s*$/i', $k, $match, PREG_OFFSET_CAPTURE)) {
 				$k = substr($k, 0, $match[0][1]) . ($match[1][0] === '=' ? ' IS NULL' : ' IS NOT NULL');
 			}
 
 			$this->{$qb_key}[] = [
 				'condition' => $prefix . $k . $v,
-				'escape'    => $escape,
+				'escape' => $escape,
 			];
 		}
 
@@ -733,8 +688,8 @@ class BaseBuilder
 	 * Generates a WHERE field IN('item', 'item') SQL query,
 	 * joined with 'AND' if appropriate.
 	 *
-	 * @param string  $key    The field to search
-	 * @param array   $values The values searched on
+	 * @param string $key The field to search
+	 * @param array $values The values searched on
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
@@ -752,8 +707,8 @@ class BaseBuilder
 	 * Generates a WHERE field IN('item', 'item') SQL query,
 	 * joined with 'OR' if appropriate.
 	 *
-	 * @param string  $key    The field to search
-	 * @param array   $values The values searched on
+	 * @param string $key The field to search
+	 * @param array $values The values searched on
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
@@ -771,8 +726,8 @@ class BaseBuilder
 	 * Generates a WHERE field NOT IN('item', 'item') SQL query,
 	 * joined with 'AND' if appropriate.
 	 *
-	 * @param string  $key    The field to search
-	 * @param array   $values The values searched on
+	 * @param string $key The field to search
+	 * @param array $values The values searched on
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
@@ -790,8 +745,8 @@ class BaseBuilder
 	 * Generates a WHERE field NOT IN('item', 'item') SQL query,
 	 * joined with 'OR' if appropriate.
 	 *
-	 * @param string  $key    The field to search
-	 * @param array   $values The values searched on
+	 * @param string $key The field to search
+	 * @param array $values The values searched on
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
@@ -811,18 +766,22 @@ class BaseBuilder
 	 * @used-by whereNotIn()
 	 * @used-by orWhereNotIn()
 	 *
-	 * @param string  $key    The field to search
-	 * @param array   $values The values searched on
-	 * @param boolean $not    If the statement would be IN or NOT IN
-	 * @param string  $type
+	 * @param string $key The field to search
+	 * @param array $values The values searched on
+	 * @param boolean $not If the statement would be IN or NOT IN
+	 * @param string $type
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
 	 */
-	protected function _whereIn(string $key = null, array $values = null, bool $not = false, string $type = 'AND ', bool $escape = null)
-	{
-		if ($key === null || $values === null)
-		{
+	protected function _whereIn(
+		string $key = null,
+		array $values = null,
+		bool $not = false,
+		string $type = 'AND ',
+		bool $escape = null
+	) {
+		if ($key === null || $values === null) {
 			return $this;
 		}
 
@@ -830,21 +789,20 @@ class BaseBuilder
 
 		$ok = $key;
 
-		if ($escape === true)
-		{
+		if ($escape === true) {
 			$key = $this->db->protectIdentifiers($key);
 		}
 
 		$not = ($not) ? ' NOT' : '';
 
 		$where_in = array_values($values);
-		$ok       = $this->setBind($ok, $where_in, $escape);
+		$ok = $this->setBind($ok, $where_in, $escape);
 
 		$prefix = empty($this->QBWhere) ? $this->groupGetType('') : $this->groupGetType($type);
 
 		$where_in = [
 			'condition' => $prefix . $key . $not . " IN :{$ok}:",
-			'escape'    => false,
+			'escape' => false,
 		];
 
 		$this->QBWhere[] = $where_in;
@@ -860,16 +818,21 @@ class BaseBuilder
 	 * Generates a %LIKE% portion of the query.
 	 * Separates multiple calls with 'AND'.
 	 *
-	 * @param mixed   $field
-	 * @param string  $match
-	 * @param string  $side
+	 * @param mixed $field
+	 * @param string $match
+	 * @param string $side
 	 * @param boolean $escape
 	 * @param boolean $insensitiveSearch IF true, will force a case-insensitive search
 	 *
 	 * @return BaseBuilder
 	 */
-	public function like($field, string $match = '', string $side = 'both', bool $escape = null, bool $insensitiveSearch = false)
-	{
+	public function like(
+		$field,
+		string $match = '',
+		string $side = 'both',
+		bool $escape = null,
+		bool $insensitiveSearch = false
+	) {
 		return $this->_like($field, $match, 'AND ', $side, '', $escape, $insensitiveSearch);
 	}
 
@@ -881,16 +844,21 @@ class BaseBuilder
 	 * Generates a NOT LIKE portion of the query.
 	 * Separates multiple calls with 'AND'.
 	 *
-	 * @param mixed   $field
-	 * @param string  $match
-	 * @param string  $side
+	 * @param mixed $field
+	 * @param string $match
+	 * @param string $side
 	 * @param boolean $escape
 	 * @param boolean $insensitiveSearch IF true, will force a case-insensitive search
 	 *
 	 * @return BaseBuilder
 	 */
-	public function notLike($field, string $match = '', string $side = 'both', bool $escape = null, bool $insensitiveSearch = false)
-	{
+	public function notLike(
+		$field,
+		string $match = '',
+		string $side = 'both',
+		bool $escape = null,
+		bool $insensitiveSearch = false
+	) {
 		return $this->_like($field, $match, 'AND ', $side, 'NOT', $escape, $insensitiveSearch);
 	}
 
@@ -902,16 +870,21 @@ class BaseBuilder
 	 * Generates a %LIKE% portion of the query.
 	 * Separates multiple calls with 'OR'.
 	 *
-	 * @param mixed   $field
-	 * @param string  $match
-	 * @param string  $side
+	 * @param mixed $field
+	 * @param string $match
+	 * @param string $side
 	 * @param boolean $escape
 	 * @param boolean $insensitiveSearch IF true, will force a case-insensitive search
 	 *
 	 * @return BaseBuilder
 	 */
-	public function orLike($field, string $match = '', string $side = 'both', bool $escape = null, bool $insensitiveSearch = false)
-	{
+	public function orLike(
+		$field,
+		string $match = '',
+		string $side = 'both',
+		bool $escape = null,
+		bool $insensitiveSearch = false
+	) {
 		return $this->_like($field, $match, 'OR ', $side, '', $escape, $insensitiveSearch);
 	}
 
@@ -923,16 +896,21 @@ class BaseBuilder
 	 * Generates a NOT LIKE portion of the query.
 	 * Separates multiple calls with 'OR'.
 	 *
-	 * @param mixed   $field
-	 * @param string  $match
-	 * @param string  $side
+	 * @param mixed $field
+	 * @param string $match
+	 * @param string $side
 	 * @param boolean $escape
 	 * @param boolean $insensitiveSearch IF true, will force a case-insensitive search
 	 *
 	 * @return BaseBuilder
 	 */
-	public function orNotLike($field, string $match = '', string $side = 'both', bool $escape = null, bool $insensitiveSearch = false)
-	{
+	public function orNotLike(
+		$field,
+		string $match = '',
+		string $side = 'both',
+		bool $escape = null,
+		bool $insensitiveSearch = false
+	) {
 		return $this->_like($field, $match, 'OR ', $side, 'NOT', $escape, $insensitiveSearch);
 	}
 
@@ -946,20 +924,26 @@ class BaseBuilder
 	 * @used-by notLike()
 	 * @used-by orNotLike()
 	 *
-	 * @param mixed   $field
-	 * @param string  $match
-	 * @param string  $type
-	 * @param string  $side
-	 * @param string  $not
+	 * @param mixed $field
+	 * @param string $match
+	 * @param string $type
+	 * @param string $side
+	 * @param string $not
 	 * @param boolean $escape
 	 * @param boolean $insensitiveSearch IF true, will force a case-insensitive search
 	 *
 	 * @return BaseBuilder
 	 */
-	protected function _like($field, string $match = '', string $type = 'AND ', string $side = 'both', string $not = '', bool $escape = null, bool $insensitiveSearch = false)
-	{
-		if (! is_array($field))
-		{
+	protected function _like(
+		$field,
+		string $match = '',
+		string $type = 'AND ',
+		string $side = 'both',
+		string $not = '',
+		bool $escape = null,
+		bool $insensitiveSearch = false
+	) {
+		if ( ! is_array($field)) {
 			$field = [$field => $match];
 		}
 
@@ -968,43 +952,33 @@ class BaseBuilder
 		// lowercase $side in case somebody writes e.g. 'BEFORE' instead of 'before' (doh)
 		$side = strtolower($side);
 
-		foreach ($field as $k => $v)
-		{
+		foreach ($field as $k => $v) {
 			$prefix = empty($this->QBWhere) ? $this->groupGetType('') : $this->groupGetType($type);
 
-			if ($insensitiveSearch === true)
-			{
+			if ($insensitiveSearch === true) {
 				$v = strtolower($v);
 			}
 
-			if ($side === 'none')
-			{
+			if ($side === 'none') {
 				$bind = $this->setBind($k, $v, $escape);
-			}
-			elseif ($side === 'before')
-			{
+			} elseif ($side === 'before') {
 				$bind = $this->setBind($k, "%$v", $escape);
-			}
-			elseif ($side === 'after')
-			{
+			} elseif ($side === 'after') {
 				$bind = $this->setBind($k, "$v%", $escape);
-			}
-			else
-			{
+			} else {
 				$bind = $this->setBind($k, "%$v%", $escape);
 			}
 
 			$like_statement = $this->_like_statement($prefix, $k, $not, $bind, $insensitiveSearch);
 
 			// some platforms require an escape sequence definition for LIKE wildcards
-			if ($escape === true && $this->db->likeEscapeStr !== '')
-			{
+			if ($escape === true && $this->db->likeEscapeStr !== '') {
 				$like_statement .= sprintf($this->db->likeEscapeStr, $this->db->likeEscapeChar);
 			}
 
 			$this->QBWhere[] = [
 				'condition' => $like_statement,
-				'escape'    => $escape,
+				'escape' => $escape,
 			];
 		}
 
@@ -1016,20 +990,24 @@ class BaseBuilder
 	/**
 	 * Platform independent LIKE statement builder.
 	 *
-	 * @param string  $prefix
-	 * @param string  $column
-	 * @param string  $not
-	 * @param string  $bind
+	 * @param string $prefix
+	 * @param string $column
+	 * @param string $not
+	 * @param string $bind
 	 * @param boolean $insensitiveSearch
 	 *
 	 * @return string     $like_statement
 	 */
-	protected function _like_statement(string $prefix = null, string $column, string $not = null, string $bind, bool $insensitiveSearch = false): string
-	{
+	protected function _like_statement(
+		string $prefix = null,
+		string $column,
+		string $not = null,
+		string $bind,
+		bool $insensitiveSearch = false
+	): string {
 		$like_statement = "{$prefix} {$column} {$not} LIKE :{$bind}:";
 
-		if ($insensitiveSearch === true)
-		{
+		if ($insensitiveSearch === true) {
 			$like_statement = "{$prefix} LOWER({$column}) {$not} LIKE :{$bind}:";
 		}
 
@@ -1041,7 +1019,7 @@ class BaseBuilder
 	/**
 	 * Starts a query group.
 	 *
-	 * @param string $not  (Internal use only)
+	 * @param string $not (Internal use only)
 	 * @param string $type (Internal use only)
 	 *
 	 * @return BaseBuilder
@@ -1051,10 +1029,10 @@ class BaseBuilder
 		$type = $this->groupGetType($type);
 
 		$this->QBWhereGroupStarted = true;
-		$prefix                    = empty($this->QBWhere) ? '' : $type;
-		$where                     = [
-			'condition' => $prefix . $not . str_repeat(' ', ++ $this->QBWhereGroupCount) . ' (',
-			'escape'    => false,
+		$prefix = empty($this->QBWhere) ? '' : $type;
+		$where = [
+			'condition' => $prefix . $not . str_repeat(' ', ++$this->QBWhereGroupCount) . ' (',
+			'escape' => false,
 		];
 
 		$this->QBWhere[] = $where;
@@ -1108,9 +1086,9 @@ class BaseBuilder
 	public function groupEnd()
 	{
 		$this->QBWhereGroupStarted = false;
-		$where                     = [
-			'condition' => str_repeat(' ', $this->QBWhereGroupCount -- ) . ')',
-			'escape'    => false,
+		$where = [
+			'condition' => str_repeat(' ', $this->QBWhereGroupCount--) . ')',
+			'escape' => false,
 		];
 
 		$this->QBWhere[] = $where;
@@ -1134,9 +1112,8 @@ class BaseBuilder
 	 */
 	protected function groupGetType(string $type): string
 	{
-		if ($this->QBWhereGroupStarted)
-		{
-			$type                      = '';
+		if ($this->QBWhereGroupStarted) {
+			$type = '';
 			$this->QBWhereGroupStarted = false;
 		}
 
@@ -1149,7 +1126,7 @@ class BaseBuilder
 	 * GROUP BY
 	 *
 	 * @param string|array $by
-	 * @param boolean      $escape
+	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
 	 */
@@ -1157,19 +1134,16 @@ class BaseBuilder
 	{
 		is_bool($escape) || $escape = $this->db->protectIdentifiers;
 
-		if (is_string($by))
-		{
+		if (is_string($by)) {
 			$by = ($escape === true) ? explode(',', $by) : [$by];
 		}
 
-		foreach ($by as $val)
-		{
+		foreach ($by as $val) {
 			$val = trim($val);
 
-			if ($val !== '')
-			{
+			if ($val !== '') {
 				$val = [
-					'field'  => $val,
+					'field' => $val,
 					'escape' => $escape,
 				];
 
@@ -1188,8 +1162,8 @@ class BaseBuilder
 	 * Separates multiple calls with 'AND'.
 	 *
 	 * @param string|array $key
-	 * @param mixed        $value
-	 * @param boolean      $escape
+	 * @param mixed $value
+	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
 	 */
@@ -1206,8 +1180,8 @@ class BaseBuilder
 	 * Separates multiple calls with 'OR'.
 	 *
 	 * @param string|array $key
-	 * @param mixed        $value
-	 * @param boolean      $escape
+	 * @param mixed $value
+	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
 	 */
@@ -1221,8 +1195,8 @@ class BaseBuilder
 	/**
 	 * ORDER BY
 	 *
-	 * @param string  $orderBy
-	 * @param string  $direction ASC, DESC or RANDOM
+	 * @param string $orderBy
+	 * @param string $direction ASC, DESC or RANDOM
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder
@@ -1231,49 +1205,42 @@ class BaseBuilder
 	{
 		$direction = strtoupper(trim($direction));
 
-		if ($direction === 'RANDOM')
-		{
+		if ($direction === 'RANDOM') {
 			$direction = '';
 
 			// Do we have a seed value?
-			$orderBy = ctype_digit((string) $orderBy) ? sprintf($this->randomKeyword[1], $orderBy) : $this->randomKeyword[0];
-		}
-		elseif (empty($orderBy))
-		{
+			$orderBy = ctype_digit((string)$orderBy) ? sprintf($this->randomKeyword[1],
+				$orderBy) : $this->randomKeyword[0];
+		} elseif (empty($orderBy)) {
 			return $this;
-		}
-		elseif ($direction !== '')
-		{
+		} elseif ($direction !== '') {
 			$direction = in_array($direction, ['ASC', 'DESC'], true) ? ' ' . $direction : '';
 		}
 
 		is_bool($escape) || $escape = $this->db->protectIdentifiers;
 
-		if ($escape === false)
-		{
+		if ($escape === false) {
 			$qb_orderBy[] = [
-				'field'     => $orderBy,
+				'field' => $orderBy,
 				'direction' => $direction,
-				'escape'    => false,
+				'escape' => false,
 			];
-		}
-		else
-		{
+		} else {
 			$qb_orderBy = [];
-			foreach (explode(',', $orderBy) as $field)
-			{
-				$qb_orderBy[] = ($direction === '' && preg_match('/\s+(ASC|DESC)$/i', rtrim($field), $match, PREG_OFFSET_CAPTURE))
+			foreach (explode(',', $orderBy) as $field) {
+				$qb_orderBy[] = ($direction === '' && preg_match('/\s+(ASC|DESC)$/i', rtrim($field), $match,
+						PREG_OFFSET_CAPTURE))
 					?
 					[
-						'field'     => ltrim(substr($field, 0, $match[0][1])),
+						'field' => ltrim(substr($field, 0, $match[0][1])),
 						'direction' => ' ' . $match[1][0],
-						'escape'    => true,
+						'escape' => true,
 					]
 					:
 					[
-						'field'     => trim($field),
+						'field' => trim($field),
 						'direction' => $direction,
-						'escape'    => true,
+						'escape' => true,
 					];
 			}
 		}
@@ -1288,20 +1255,18 @@ class BaseBuilder
 	/**
 	 * LIMIT
 	 *
-	 * @param integer $value  LIMIT value
+	 * @param integer $value LIMIT value
 	 * @param integer $offset OFFSET value
 	 *
 	 * @return BaseBuilder
 	 */
 	public function limit(int $value = null, int $offset = 0)
 	{
-		if (! is_null($value))
-		{
+		if ( ! is_null($value)) {
 			$this->QBLimit = $value;
 		}
 
-		if (! empty($offset))
-		{
+		if ( ! empty($offset)) {
 			$this->QBOffset = $offset;
 		}
 
@@ -1319,9 +1284,8 @@ class BaseBuilder
 	 */
 	public function offset(int $offset)
 	{
-		if (! empty($offset))
-		{
-			$this->QBOffset = (int) $offset;
+		if ( ! empty($offset)) {
+			$this->QBOffset = (int)$offset;
 		}
 
 		return $this;
@@ -1350,9 +1314,9 @@ class BaseBuilder
 	 *
 	 * Allows key/value pairs to be set for insert(), update() or replace().
 	 *
-	 * @param string|array|object $key    Field name, or an array of field/value pairs
-	 * @param string              $value  Field value, if $key is a single field
-	 * @param boolean             $escape Whether to escape values and identifiers
+	 * @param string|array|object $key Field name, or an array of field/value pairs
+	 * @param string $value Field value, if $key is a single field
+	 * @param boolean $escape Whether to escape values and identifiers
 	 *
 	 * @return BaseBuilder
 	 */
@@ -1360,22 +1324,17 @@ class BaseBuilder
 	{
 		$key = $this->objectToArray($key);
 
-		if (! is_array($key))
-		{
+		if ( ! is_array($key)) {
 			$key = [$key => $value];
 		}
 
 		$escape = is_bool($escape) ? $escape : $this->db->protectIdentifiers;
 
-		foreach ($key as $k => $v)
-		{
-			if ($escape)
-			{
-				$bind                                                           = $this->setBind($k, $v, $escape);
+		foreach ($key as $k => $v) {
+			if ($escape) {
+				$bind = $this->setBind($k, $v, $escape);
 				$this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = ":$bind:";
-			}
-			else
-			{
+			} else {
 				$this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = $v;
 			}
 		}
@@ -1397,8 +1356,7 @@ class BaseBuilder
 	{
 		$data = $this->QBSet;
 
-		if ($clean)
-		{
+		if ($clean) {
 			$this->QBSet = [];
 		}
 
@@ -1420,8 +1378,7 @@ class BaseBuilder
 	{
 		$select = $this->compileSelect();
 
-		if ($reset === true)
-		{
+		if ($reset === true) {
 			$this->resetSelect();
 		}
 
@@ -1443,8 +1400,7 @@ class BaseBuilder
 		$query = new Query($this->db);
 		$query->setQuery($sql, $this->binds, false);
 
-		if (! empty($this->db->swapPre) && ! empty($this->db->DBPrefix))
-		{
+		if ( ! empty($this->db->swapPre) && ! empty($this->db->DBPrefix)) {
 			$query->swapPrefix($this->db->DBPrefix, $this->db->swapPre);
 		}
 
@@ -1457,17 +1413,16 @@ class BaseBuilder
 	 * Compiles the select statement based on the other functions called
 	 * and runs the query
 	 *
-	 * @param integer $limit     The limit clause
-	 * @param integer $offset    The offset clause
+	 * @param integer $limit The limit clause
+	 * @param integer $offset The offset clause
 	 * @param boolean $returnSQL If true, returns the generate SQL, otherwise executes the query.
-	 * @param boolean $reset     Are we want to clear query builder values?
+	 * @param boolean $reset Are we want to clear query builder values?
 	 *
 	 * @return ResultInterface
 	 */
 	public function get(int $limit = null, int $offset = 0, bool $returnSQL = false, bool $reset = true)
 	{
-		if (! is_null($limit))
-		{
+		if ( ! is_null($limit)) {
 			$this->limit($limit, $offset);
 		}
 
@@ -1475,8 +1430,7 @@ class BaseBuilder
 			? $this->getCompiledSelect()
 			: $this->db->query($this->compileSelect(), $this->binds, false);
 
-		if ($reset === true)
-		{
+		if ($reset === true) {
 			$this->resetSelect();
 
 			// Clear our binds so we don't eat up memory
@@ -1495,7 +1449,7 @@ class BaseBuilder
 	 * the specified database
 	 *
 	 * @param boolean $reset Are we want to clear query builder values?
-	 * @param boolean $test  Are we running automated tests?
+	 * @param boolean $test Are we running automated tests?
 	 *
 	 * @return integer|string when $test = true
 	 */
@@ -1504,27 +1458,24 @@ class BaseBuilder
 		$table = $this->QBFrom[0];
 
 		$sql = $this->countString . $this->db->escapeIdentifiers('numrows') . ' FROM ' .
-				$this->db->protectIdentifiers($table, true, null, false);
+			$this->db->protectIdentifiers($table, true, null, false);
 
-		if ($test)
-		{
+		if ($test) {
 			return $sql;
 		}
 
 		$query = $this->db->query($sql, null, false);
-		if (empty($query->getResult()))
-		{
+		if (empty($query->getResult())) {
 			return 0;
 		}
 
 		$query = $query->getRow();
 
-		if ($reset === true)
-		{
+		if ($reset === true) {
 			$this->resetSelect();
 		}
 
-		return (int) $query->numrows;
+		return (int)$query->numrows;
 	}
 
 	//--------------------------------------------------------------------
@@ -1536,7 +1487,7 @@ class BaseBuilder
 	 * returned by an Query Builder query.
 	 *
 	 * @param boolean $reset
-	 * @param boolean $test  The reset clause
+	 * @param boolean $test The reset clause
 	 *
 	 * @return integer|string when $test = true
 	 */
@@ -1546,9 +1497,8 @@ class BaseBuilder
 		// on Microsoft SQL Server) and ultimately unnecessary
 		// for selecting COUNT(*) ...
 		$orderBy = [];
-		if (! empty($this->QBOrderBy))
-		{
-			$orderBy         = $this->QBOrderBy;
+		if ( ! empty($this->QBOrderBy)) {
+			$orderBy = $this->QBOrderBy;
 			$this->QBOrderBy = null;
 		}
 
@@ -1558,36 +1508,32 @@ class BaseBuilder
 			:
 			$this->compileSelect($this->countString . $this->db->protectIdentifiers('numrows'));
 
-		if ($test)
-		{
+		if ($test) {
 			return $sql;
 		}
 
 		$result = $this->db->query($sql, $this->binds, false);
 
-		if ($reset === true)
-		{
+		if ($reset === true) {
 			$this->resetSelect();
-		}
-		// If we've previously reset the QBOrderBy values, get them back
-		elseif (! isset($this->QBOrderBy))
-		{
+		} // If we've previously reset the QBOrderBy values, get them back
+		elseif ( ! isset($this->QBOrderBy)) {
 			$this->QBOrderBy = $orderBy ?? [];
 		}
 
-		$row = (! $result instanceof ResultInterface)
+		$row = ( ! $result instanceof ResultInterface)
 			? null
 			: $result->getRow();
 
-		if (empty($row))
-		{
+		if (empty($row)) {
 			return 0;
 		}
 
-		return (int) $row->numrows;
+		return (int)$row->numrows;
 	}
 
 	//--------------------------------------------------------------------
+
 	/**
 	 * Get compiled 'where' condition string
 	 *
@@ -1607,20 +1553,18 @@ class BaseBuilder
 	 * Allows the where clause, limit and offset to be added directly
 	 *
 	 * @param string|array $where
-	 * @param integer      $limit
-	 * @param integer      $offset
+	 * @param integer $limit
+	 * @param integer $offset
 	 *
 	 * @return ResultInterface
 	 */
 	public function getWhere($where = null, int $limit = null, int $offset = null)
 	{
-		if ($where !== null)
-		{
+		if ($where !== null) {
 			$this->where($where);
 		}
 
-		if (! empty($limit))
-		{
+		if ( ! empty($limit)) {
 			$this->limit($limit, $offset);
 		}
 
@@ -1637,8 +1581,8 @@ class BaseBuilder
 	 *
 	 * Compiles batch insert strings and runs the queries
 	 *
-	 * @param array   $set       An associative array of insert values
-	 * @param boolean $escape    Whether to escape values and identifiers
+	 * @param array $set An associative array of insert values
+	 * @param boolean $escape Whether to escape values and identifiers
 	 *
 	 * @param integer $batchSize
 	 * @param boolean $testing
@@ -1648,24 +1592,17 @@ class BaseBuilder
 	 */
 	public function insertBatch(array $set = null, bool $escape = null, int $batchSize = 100, bool $testing = false)
 	{
-		if ($set === null)
-		{
-			if (empty($this->QBSet))
-			{
-				if (CI_DEBUG)
-				{
+		if ($set === null) {
+			if (empty($this->QBSet)) {
+				if (CI_DEBUG) {
 					throw new DatabaseException('You must use the "set" method to update an entry.');
 				}
 
 				return false;
 			}
-		}
-		else
-		{
-			if (empty($set))
-			{
-				if (CI_DEBUG)
-				{
+		} else {
+			if (empty($set)) {
+				if (CI_DEBUG) {
 					throw new DatabaseException('insertBatch() called with no data');
 				}
 
@@ -1679,23 +1616,19 @@ class BaseBuilder
 
 		// Batch this baby
 		$affected_rows = 0;
-		for ($i = 0, $total = count($this->QBSet); $i < $total; $i += $batchSize)
-		{
-			$sql = $this->_insertBatch($this->db->protectIdentifiers($table, true, $escape, false), $this->QBKeys, array_slice($this->QBSet, $i, $batchSize));
+		for ($i = 0, $total = count($this->QBSet); $i < $total; $i += $batchSize) {
+			$sql = $this->_insertBatch($this->db->protectIdentifiers($table, true, $escape, false), $this->QBKeys,
+				array_slice($this->QBSet, $i, $batchSize));
 
-			if ($testing)
-			{
-				++ $affected_rows;
-			}
-			else
-			{
+			if ($testing) {
+				++$affected_rows;
+			} else {
 				$this->db->query($sql, $this->binds, false);
 				$affected_rows += $this->db->affectedRows();
 			}
 		}
 
-		if (! $testing)
-		{
+		if ( ! $testing) {
 			$this->resetWrite();
 		}
 
@@ -1709,9 +1642,9 @@ class BaseBuilder
 	 *
 	 * Generates a platform-specific insert string from the supplied data.
 	 *
-	 * @param string $table  Table name
-	 * @param array  $keys   INSERT keys
-	 * @param array  $values INSERT values
+	 * @param string $table Table name
+	 * @param array $keys INSERT keys
+	 * @param array $values INSERT values
 	 *
 	 * @return string
 	 */
@@ -1725,8 +1658,8 @@ class BaseBuilder
 	/**
 	 * The "setInsertBatch" function.  Allows key/value pairs to be set for batch inserts
 	 *
-	 * @param mixed   $key
-	 * @param string  $value
+	 * @param mixed $key
+	 * @param string $value
 	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder|null
@@ -1735,8 +1668,7 @@ class BaseBuilder
 	{
 		$key = $this->batchObjectToArray($key);
 
-		if (! is_array($key))
-		{
+		if ( ! is_array($key)) {
 			$key = [$key => $value];
 		}
 
@@ -1745,11 +1677,9 @@ class BaseBuilder
 		$keys = array_keys($this->objectToArray(current($key)));
 		sort($keys);
 
-		foreach ($key as $row)
-		{
+		foreach ($key as $row) {
 			$row = $this->objectToArray($row);
-			if (count(array_diff($keys, array_keys($row))) > 0 || count(array_diff(array_keys($row), $keys)) > 0)
-			{
+			if (count(array_diff($keys, array_keys($row))) > 0 || count(array_diff(array_keys($row), $keys)) > 0) {
 				// batch function above returns an error on an empty array
 				$this->QBSet[] = [];
 
@@ -1759,8 +1689,7 @@ class BaseBuilder
 			ksort($row); // puts $row in the same order as our keys
 
 			$clean = [];
-			foreach ($row as $k => $value)
-			{
+			foreach ($row as $k => $value) {
 				$clean[] = ':' . $this->setBind($k, $value, $escape) . ':';
 			}
 
@@ -1769,8 +1698,7 @@ class BaseBuilder
 			$this->QBSet[] = '(' . implode(',', $row) . ')';
 		}
 
-		foreach ($keys as $k)
-		{
+		foreach ($keys as $k) {
 			$this->QBKeys[] = $this->db->protectIdentifiers($k, false, $escape);
 		}
 
@@ -1790,19 +1718,17 @@ class BaseBuilder
 	 */
 	public function getCompiledInsert(bool $reset = true): string
 	{
-		if ($this->validateInsert() === false)
-		{
+		if ($this->validateInsert() === false) {
 			return false;
 		}
 
 		$sql = $this->_insert(
-				$this->db->protectIdentifiers(
-						$this->QBFrom[0], true, null, false
-				), array_keys($this->QBSet), array_values($this->QBSet)
+			$this->db->protectIdentifiers(
+				$this->QBFrom[0], true, null, false
+			), array_keys($this->QBSet), array_values($this->QBSet)
 		);
 
-		if ($reset === true)
-		{
+		if ($reset === true) {
 			$this->resetWrite();
 		}
 
@@ -1816,32 +1742,29 @@ class BaseBuilder
 	 *
 	 * Compiles an insert string and runs the query
 	 *
-	 * @param array   $set    An associative array of insert values
+	 * @param array $set An associative array of insert values
 	 * @param boolean $escape Whether to escape values and identifiers
-	 * @param boolean $test   Used when running tests
+	 * @param boolean $test Used when running tests
 	 *
 	 * @return BaseResult|Query|false
 	 */
 	public function insert(array $set = null, bool $escape = null, bool $test = false)
 	{
-		if ($set !== null)
-		{
+		if ($set !== null) {
 			$this->set($set, '', $escape);
 		}
 
-		if ($this->validateInsert() === false)
-		{
+		if ($this->validateInsert() === false) {
 			return false;
 		}
 
 		$sql = $this->_insert(
-				$this->db->protectIdentifiers(
-						$this->QBFrom[0], true, $escape, false
-				), array_keys($this->QBSet), array_values($this->QBSet)
+			$this->db->protectIdentifiers(
+				$this->QBFrom[0], true, $escape, false
+			), array_keys($this->QBSet), array_values($this->QBSet)
 		);
 
-		if ($test === false)
-		{
+		if ($test === false) {
 			$this->resetWrite();
 
 			$result = $this->db->query($sql, $this->binds, false);
@@ -1869,10 +1792,8 @@ class BaseBuilder
 	 */
 	protected function validateInsert(): bool
 	{
-		if (empty($this->QBSet))
-		{
-			if (CI_DEBUG)
-			{
+		if (empty($this->QBSet)) {
+			if (CI_DEBUG) {
 				throw new DatabaseException('You must use the "set" method to update an entry.');
 			}
 
@@ -1889,15 +1810,16 @@ class BaseBuilder
 	 *
 	 * Generates a platform-specific insert string from the supplied data
 	 *
-	 * @param string $table         The table name
-	 * @param array  $keys          The insert keys
-	 * @param array  $unescapedKeys The insert values
+	 * @param string $table The table name
+	 * @param array $keys The insert keys
+	 * @param array $unescapedKeys The insert values
 	 *
 	 * @return string
 	 */
 	protected function _insert(string $table, array $keys, array $unescapedKeys): string
 	{
-		return 'INSERT INTO ' . $table . ' (' . implode(', ', $keys) . ') VALUES (' . implode(', ', $unescapedKeys) . ')';
+		return 'INSERT INTO ' . $table . ' (' . implode(', ', $keys) . ') VALUES (' . implode(', ',
+				$unescapedKeys) . ')';
 	}
 
 	//--------------------------------------------------------------------
@@ -1907,7 +1829,7 @@ class BaseBuilder
 	 *
 	 * Compiles an replace into string and runs the query
 	 *
-	 * @param array   $set       An associative array of insert values
+	 * @param array $set An associative array of insert values
 	 * @param boolean $returnSQL
 	 *
 	 * @return BaseResult|Query|string|false
@@ -1915,15 +1837,12 @@ class BaseBuilder
 	 */
 	public function replace(array $set = null, bool $returnSQL = false)
 	{
-		if ($set !== null)
-		{
+		if ($set !== null) {
 			$this->set($set);
 		}
 
-		if (empty($this->QBSet))
-		{
-			if (CI_DEBUG)
-			{
+		if (empty($this->QBSet)) {
+			if (CI_DEBUG) {
 				throw new DatabaseException('You must use the "set" method to update an entry.');
 			}
 			return false;
@@ -1945,9 +1864,9 @@ class BaseBuilder
 	 *
 	 * Generates a platform-specific replace string from the supplied data
 	 *
-	 * @param string $table  The table name
-	 * @param array  $keys   The insert keys
-	 * @param array  $values The insert values
+	 * @param string $table The table name
+	 * @param array $keys The insert keys
+	 * @param array $values The insert values
 	 *
 	 * @return string
 	 */
@@ -1986,15 +1905,13 @@ class BaseBuilder
 	 */
 	public function getCompiledUpdate(bool $reset = true): string
 	{
-		if ($this->validateUpdate() === false)
-		{
+		if ($this->validateUpdate() === false) {
 			return false;
 		}
 
 		$sql = $this->_update($this->QBFrom[0], $this->QBSet);
 
-		if ($reset === true)
-		{
+		if ($reset === true) {
 			$this->resetWrite();
 		}
 
@@ -2008,34 +1925,29 @@ class BaseBuilder
 	 *
 	 * Compiles an update string and runs the query.
 	 *
-	 * @param array   $set   An associative array of update values
-	 * @param mixed   $where
+	 * @param array $set An associative array of update values
+	 * @param mixed $where
 	 * @param integer $limit
-	 * @param boolean $test  Are we testing the code?
+	 * @param boolean $test Are we testing the code?
 	 *
 	 * @return boolean    TRUE on success, FALSE on failure
 	 */
 	public function update(array $set = null, $where = null, int $limit = null, bool $test = false): bool
 	{
-		if ($set !== null)
-		{
+		if ($set !== null) {
 			$this->set($set);
 		}
 
-		if ($this->validateUpdate() === false)
-		{
+		if ($this->validateUpdate() === false) {
 			return false;
 		}
 
-		if ($where !== null)
-		{
+		if ($where !== null) {
 			$this->where($where);
 		}
 
-		if (! empty($limit))
-		{
-			if (! $this->canLimitWhereUpdates)
-			{
+		if ( ! empty($limit)) {
+			if ( ! $this->canLimitWhereUpdates) {
 				throw new DatabaseException('This driver does not allow LIMITs on UPDATE queries using WHERE.');
 			}
 
@@ -2044,12 +1956,10 @@ class BaseBuilder
 
 		$sql = $this->_update($this->QBFrom[0], $this->QBSet);
 
-		if (! $test)
-		{
+		if ( ! $test) {
 			$this->resetWrite();
 
-			if ($this->db->query($sql, $this->binds, false))
-			{
+			if ($this->db->query($sql, $this->binds, false)) {
 				// Clear our binds so we don't eat up memory
 				$this->binds = [];
 
@@ -2069,8 +1979,8 @@ class BaseBuilder
 	 *
 	 * Generates a platform-specific update string from the supplied data
 	 *
-	 * @param string $table  the Table name
-	 * @param array  $values the Update data
+	 * @param string $table the Table name
+	 * @param array $values the Update data
 	 *
 	 * @return string
 	 */
@@ -2078,15 +1988,14 @@ class BaseBuilder
 	{
 		$valstr = [];
 
-		foreach ($values as $key => $val)
-		{
+		foreach ($values as $key => $val) {
 			$valstr[] = $key . ' = ' . $val;
 		}
 
 		return 'UPDATE ' . $table . ' SET ' . implode(', ', $valstr)
-				. $this->compileWhereHaving('QBWhere')
-				. $this->compileOrderBy()
-				. ($this->QBLimit ? $this->_limit(' ') : '');
+			. $this->compileWhereHaving('QBWhere')
+			. $this->compileOrderBy()
+			. ($this->QBLimit ? $this->_limit(' ') : '');
 	}
 
 	//--------------------------------------------------------------------
@@ -2103,10 +2012,8 @@ class BaseBuilder
 	 */
 	protected function validateUpdate(): bool
 	{
-		if (empty($this->QBSet))
-		{
-			if (CI_DEBUG)
-			{
+		if (empty($this->QBSet)) {
+			if (CI_DEBUG) {
 				throw new DatabaseException('You must use the "set" method to update an entry.');
 			}
 
@@ -2123,8 +2030,8 @@ class BaseBuilder
 	 *
 	 * Compiles an update string and runs the query
 	 *
-	 * @param array   $set       An associative array of update values
-	 * @param string  $index     The where key
+	 * @param array $set An associative array of update values
+	 * @param string $index The where key
 	 * @param integer $batchSize The size of the batch to run
 	 * @param boolean $returnSQL True means SQL is returned, false will execute the query
 	 *
@@ -2133,33 +2040,24 @@ class BaseBuilder
 	 */
 	public function updateBatch(array $set = null, string $index = null, int $batchSize = 100, bool $returnSQL = false)
 	{
-		if ($index === null)
-		{
-			if (CI_DEBUG)
-			{
+		if ($index === null) {
+			if (CI_DEBUG) {
 				throw new DatabaseException('You must specify an index to match on for batch updates.');
 			}
 
 			return false;
 		}
 
-		if ($set === null)
-		{
-			if (empty($this->QBSet))
-			{
-				if (CI_DEBUG)
-				{
+		if ($set === null) {
+			if (empty($this->QBSet)) {
+				if (CI_DEBUG) {
 					throw new DatabaseException('You must use the "set" method to update an entry.');
 				}
 				return false;
 			}
-		}
-		else
-		{
-			if (empty($set))
-			{
-				if (CI_DEBUG)
-				{
+		} else {
+			if (empty($set)) {
+				if (CI_DEBUG) {
 					throw new DatabaseException('updateBatch() called with no data');
 				}
 				return false;
@@ -2172,18 +2070,15 @@ class BaseBuilder
 
 		// Batch this baby
 		$affected_rows = 0;
-		$savedSQL      = [];
-		for ($i = 0, $total = count($this->QBSet); $i < $total; $i += $batchSize)
-		{
-			$sql = $this->_updateBatch($table, array_slice($this->QBSet, $i, $batchSize), $this->db->protectIdentifiers($index)
+		$savedSQL = [];
+		for ($i = 0, $total = count($this->QBSet); $i < $total; $i += $batchSize) {
+			$sql = $this->_updateBatch($table, array_slice($this->QBSet, $i, $batchSize),
+				$this->db->protectIdentifiers($index)
 			);
 
-			if ($returnSQL)
-			{
+			if ($returnSQL) {
 				$savedSQL[] = $sql;
-			}
-			else
-			{
+			} else {
 				$this->db->query($sql, $this->binds, false);
 				$affected_rows += $this->db->affectedRows();
 			}
@@ -2203,35 +2098,31 @@ class BaseBuilder
 	 *
 	 * Generates a platform-specific batch update string from the supplied data
 	 *
-	 * @param string $table  Table name
-	 * @param array  $values Update data
-	 * @param string $index  WHERE key
+	 * @param string $table Table name
+	 * @param array $values Update data
+	 * @param string $index WHERE key
 	 *
 	 * @return string
 	 */
 	protected function _updateBatch(string $table, array $values, string $index): string
 	{
-		$ids   = [];
+		$ids = [];
 		$final = [];
-		foreach ($values as $key => $val)
-		{
+		foreach ($values as $key => $val) {
 			$ids[] = $val[$index];
 
-			foreach (array_keys($val) as $field)
-			{
-				if ($field !== $index)
-				{
+			foreach (array_keys($val) as $field) {
+				if ($field !== $index) {
 					$final[$field][] = 'WHEN ' . $index . ' = ' . $val[$index] . ' THEN ' . $val[$field];
 				}
 			}
 		}
 
 		$cases = '';
-		foreach ($final as $k => $v)
-		{
+		foreach ($final as $k => $v) {
 			$cases .= $k . " = CASE \n"
-					. implode("\n", $v) . "\n"
-					. 'ELSE ' . $k . ' END, ';
+				. implode("\n", $v) . "\n"
+				. 'ELSE ' . $k . ' END, ';
 		}
 
 		$this->where($index . ' IN(' . implode(',', $ids) . ')', null, false);
@@ -2245,8 +2136,8 @@ class BaseBuilder
 	 * The "setUpdateBatch" function.  Allows key/value pairs to be set for batch updating
 	 *
 	 * @param array|object $key
-	 * @param string       $index
-	 * @param boolean      $escape
+	 * @param string $index
+	 * @param boolean $escape
 	 *
 	 * @return BaseBuilder|null
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
@@ -2255,21 +2146,17 @@ class BaseBuilder
 	{
 		$key = $this->batchObjectToArray($key);
 
-		if (! is_array($key))
-		{
+		if ( ! is_array($key)) {
 			return null;
 		}
 
 		is_bool($escape) || $escape = $this->db->protectIdentifiers;
 
-		foreach ($key as $k => $v)
-		{
+		foreach ($key as $k => $v) {
 			$index_set = false;
-			$clean     = [];
-			foreach ($v as $k2 => $v2)
-			{
-				if ($k2 === $index)
-				{
+			$clean = [];
+			foreach ($v as $k2 => $v2) {
+				if ($k2 === $index) {
 					$index_set = true;
 				}
 
@@ -2278,8 +2165,7 @@ class BaseBuilder
 				$clean[$this->db->protectIdentifiers($k2, false, $escape)] = ":$bind:";
 			}
 
-			if ($index_set === false)
-			{
+			if ($index_set === false) {
 				throw new DatabaseException('One or more rows submitted for batch updating is missing the specified index.');
 			}
 
@@ -2296,7 +2182,7 @@ class BaseBuilder
 	 *
 	 * Compiles a delete string and runs "DELETE FROM table"
 	 *
-	 * @param  boolean $test
+	 * @param boolean $test
 	 * @return boolean    TRUE on success, FALSE on failure
 	 */
 	public function emptyTable(bool $test = false)
@@ -2305,8 +2191,7 @@ class BaseBuilder
 
 		$sql = $this->_delete($table);
 
-		if ($test)
-		{
+		if ($test) {
 			return $sql;
 		}
 
@@ -2334,8 +2219,7 @@ class BaseBuilder
 
 		$sql = $this->_truncate($table);
 
-		if ($test === true)
-		{
+		if ($test === true) {
 			return $sql;
 		}
 
@@ -2390,8 +2274,8 @@ class BaseBuilder
 	 *
 	 * Compiles a delete string and runs the query
 	 *
-	 * @param mixed   $where      The where clause
-	 * @param integer $limit      The limit clause
+	 * @param mixed $where The where clause
+	 * @param integer $limit The limit clause
 	 * @param boolean $reset_data
 	 * @param boolean $returnSQL
 	 *
@@ -2402,15 +2286,12 @@ class BaseBuilder
 	{
 		$table = $this->db->protectIdentifiers($this->QBFrom[0], true, null, false);
 
-		if ($where !== '')
-		{
+		if ($where !== '') {
 			$this->where($where);
 		}
 
-		if (empty($this->QBWhere))
-		{
-			if (CI_DEBUG)
-			{
+		if (empty($this->QBWhere)) {
+			if (CI_DEBUG) {
 				throw new DatabaseException('Deletes are not allowed unless they contain a "where" or "like" clause.');
 			}
 
@@ -2419,23 +2300,19 @@ class BaseBuilder
 
 		$sql = $this->_delete($table);
 
-		if (! empty($limit))
-		{
+		if ( ! empty($limit)) {
 			$this->QBLimit = $limit;
 		}
 
-		if (! empty($this->QBLimit))
-		{
-			if (! $this->canLimitDeletes)
-			{
+		if ( ! empty($this->QBLimit)) {
+			if ( ! $this->canLimitDeletes) {
 				throw new DatabaseException('SQLite3 does not allow LIMITs on DELETE queries.');
 			}
 
 			$sql = $this->_limit($sql);
 		}
 
-		if ($reset_data)
-		{
+		if ($reset_data) {
 			$this->resetWrite();
 		}
 
@@ -2447,7 +2324,7 @@ class BaseBuilder
 	/**
 	 * Increments a numeric column by the specified value.
 	 *
-	 * @param string  $column
+	 * @param string $column
 	 * @param integer $value
 	 *
 	 * @return boolean
@@ -2466,7 +2343,7 @@ class BaseBuilder
 	/**
 	 * Decrements a numeric column by the specified value.
 	 *
-	 * @param string  $column
+	 * @param string $column
 	 * @param integer $value
 	 *
 	 * @return boolean
@@ -2494,7 +2371,7 @@ class BaseBuilder
 	protected function _delete(string $table): string
 	{
 		return 'DELETE FROM ' . $table . $this->compileWhereHaving('QBWhere')
-				. ($this->QBLimit ? ' LIMIT ' . $this->QBLimit : '');
+			. ($this->QBLimit ? ' LIMIT ' . $this->QBLimit : '');
 	}
 
 	//--------------------------------------------------------------------
@@ -2510,10 +2387,8 @@ class BaseBuilder
 	 */
 	protected function trackAliases($table)
 	{
-		if (is_array($table))
-		{
-			foreach ($table as $t)
-			{
+		if (is_array($table)) {
+			foreach ($table as $t) {
 				$this->trackAliases($t);
 			}
 			return;
@@ -2521,14 +2396,12 @@ class BaseBuilder
 
 		// Does the string contain a comma?  If so, we need to separate
 		// the string into discreet statements
-		if (strpos($table, ',') !== false)
-		{
+		if (strpos($table, ',') !== false) {
 			return $this->trackAliases(explode(',', $table));
 		}
 
 		// if a table alias is used we can recognize it by a space
-		if (strpos($table, ' ') !== false)
-		{
+		if (strpos($table, ' ') !== false) {
 			// if the alias is written with the AS keyword, remove it
 			$table = preg_replace('/\s+AS\s+/i', ' ', $table);
 
@@ -2555,26 +2428,19 @@ class BaseBuilder
 	protected function compileSelect($select_override = false): string
 	{
 		// Write the "select" portion of the query
-		if ($select_override !== false)
-		{
+		if ($select_override !== false) {
 			$sql = $select_override;
-		}
-		else
-		{
+		} else {
 			$sql = ( ! $this->QBDistinct) ? 'SELECT ' : 'SELECT DISTINCT ';
 
-			if (empty($this->QBSelect))
-			{
+			if (empty($this->QBSelect)) {
 				$sql .= '*';
-			}
-			else
-			{
+			} else {
 				// Cycle through the "select" portion of the query and prep each column name.
 				// The reason we protect identifiers here rather than in the select() function
 				// is because until the user calls the from() function we don't know if there are aliases
-				foreach ($this->QBSelect as $key => $val)
-				{
-					$no_escape            = $this->QBNoEscape[$key] ?? null;
+				foreach ($this->QBSelect as $key => $val) {
+					$no_escape = $this->QBNoEscape[$key] ?? null;
 					$this->QBSelect[$key] = $this->db->protectIdentifiers($val, false, $no_escape);
 				}
 
@@ -2583,24 +2449,21 @@ class BaseBuilder
 		}
 
 		// Write the "FROM" portion of the query
-		if (! empty($this->QBFrom))
-		{
+		if ( ! empty($this->QBFrom)) {
 			$sql .= "\nFROM " . $this->_fromTables();
 		}
 
 		// Write the "JOIN" portion of the query
-		if (! empty($this->QBJoin))
-		{
+		if ( ! empty($this->QBJoin)) {
 			$sql .= "\n" . implode("\n", $this->QBJoin);
 		}
 
 		$sql .= $this->compileWhereHaving('QBWhere')
-				. $this->compileGroupBy()
-				. $this->compileWhereHaving('QBHaving')
-				. $this->compileOrderBy(); // ORDER BY
+			. $this->compileGroupBy()
+			. $this->compileWhereHaving('QBHaving')
+			. $this->compileOrderBy(); // ORDER BY
 		// LIMIT
-		if ($this->QBLimit)
-		{
+		if ($this->QBLimit) {
 			return $this->_limit($sql . "\n");
 		}
 
@@ -2624,32 +2487,27 @@ class BaseBuilder
 	 */
 	protected function compileWhereHaving(string $qb_key): string
 	{
-		if (! empty($this->$qb_key))
-		{
-			for ($i = 0, $c = count($this->$qb_key); $i < $c; $i ++)
-			{
+		if ( ! empty($this->$qb_key)) {
+			for ($i = 0, $c = count($this->$qb_key); $i < $c; $i++) {
 				// Is this condition already compiled?
-				if (is_string($this->{$qb_key}[$i]))
-				{
+				if (is_string($this->{$qb_key}[$i])) {
 					continue;
-				}
-				elseif ($this->{$qb_key}[$i]['escape'] === false)
-				{
+				} elseif ($this->{$qb_key}[$i]['escape'] === false) {
 					$this->{$qb_key}[$i] = $this->{$qb_key}[$i]['condition'];
 					continue;
 				}
 
 				// Split multiple conditions
 				$conditions = preg_split(
-						'/((?:^|\s+)AND\s+|(?:^|\s+)OR\s+)/i', $this->{$qb_key}[$i]['condition'], -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
+					'/((?:^|\s+)AND\s+|(?:^|\s+)OR\s+)/i', $this->{$qb_key}[$i]['condition'], -1,
+					PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
 				);
 
-				for ($ci = 0, $cc = count($conditions); $ci < $cc; $ci ++)
-				{
+				for ($ci = 0, $cc = count($conditions); $ci < $cc; $ci++) {
 					if (($op = $this->getOperator($conditions[$ci])) === false
-							|| ! preg_match('/^(\(?)(.*)(' . preg_quote($op, '/') . ')\s*(.*(?<!\)))?(\)?)$/i', $conditions[$ci], $matches)
-					)
-					{
+						|| ! preg_match('/^(\(?)(.*)(' . preg_quote($op, '/') . ')\s*(.*(?<!\)))?(\)?)$/i',
+							$conditions[$ci], $matches)
+					) {
 						continue;
 					}
 
@@ -2662,20 +2520,19 @@ class BaseBuilder
 					//	5 => ')'		/* optional */
 					// );
 
-					if (! empty($matches[4]))
-					{
+					if ( ! empty($matches[4])) {
 						$matches[4] = ' ' . $matches[4];
 					}
 
 					$conditions[$ci] = $matches[1] . $this->db->protectIdentifiers(trim($matches[2]))
-							. ' ' . trim($matches[3]) . $matches[4] . $matches[5];
+						. ' ' . trim($matches[3]) . $matches[4] . $matches[5];
 				}
 
 				$this->{$qb_key}[$i] = implode('', $conditions);
 			}
 
 			return ($qb_key === 'QBHaving' ? "\nHAVING " : "\nWHERE ")
-					. implode("\n", $this->$qb_key);
+				. implode("\n", $this->$qb_key);
 		}
 
 		return '';
@@ -2696,18 +2553,15 @@ class BaseBuilder
 	 */
 	protected function compileGroupBy(): string
 	{
-		if (! empty($this->QBGroupBy))
-		{
-			for ($i = 0, $c = count($this->QBGroupBy); $i < $c; $i ++)
-			{
+		if ( ! empty($this->QBGroupBy)) {
+			for ($i = 0, $c = count($this->QBGroupBy); $i < $c; $i++) {
 				// Is it already compiled?
-				if (is_string($this->QBGroupBy[$i]))
-				{
+				if (is_string($this->QBGroupBy[$i])) {
 					continue;
 				}
 
 				$this->QBGroupBy[$i] = ($this->QBGroupBy[$i]['escape'] === false ||
-						$this->isLiteral($this->QBGroupBy[$i]['field'])) ? $this->QBGroupBy[$i]['field'] : $this->db->protectIdentifiers($this->QBGroupBy[$i]['field']);
+					$this->isLiteral($this->QBGroupBy[$i]['field'])) ? $this->QBGroupBy[$i]['field'] : $this->db->protectIdentifiers($this->QBGroupBy[$i]['field']);
 			}
 
 			return "\nGROUP BY " . implode(', ', $this->QBGroupBy);
@@ -2731,12 +2585,9 @@ class BaseBuilder
 	 */
 	protected function compileOrderBy(): string
 	{
-		if (is_array($this->QBOrderBy) && ! empty($this->QBOrderBy))
-		{
-			for ($i = 0, $c = count($this->QBOrderBy); $i < $c; $i ++)
-			{
-				if ($this->QBOrderBy[$i]['escape'] !== false && ! $this->isLiteral($this->QBOrderBy[$i]['field']))
-				{
+		if (is_array($this->QBOrderBy) && ! empty($this->QBOrderBy)) {
+			for ($i = 0, $c = count($this->QBOrderBy); $i < $c; $i++) {
+				if ($this->QBOrderBy[$i]['escape'] !== false && ! $this->isLiteral($this->QBOrderBy[$i]['field'])) {
 					$this->QBOrderBy[$i]['field'] = $this->db->protectIdentifiers($this->QBOrderBy[$i]['field']);
 				}
 
@@ -2744,9 +2595,7 @@ class BaseBuilder
 			}
 
 			return $this->QBOrderBy = "\nORDER BY " . implode(', ', $this->QBOrderBy);
-		}
-		elseif (is_string($this->QBOrderBy))
-		{
+		} elseif (is_string($this->QBOrderBy)) {
 			return $this->QBOrderBy;
 		}
 
@@ -2766,17 +2615,14 @@ class BaseBuilder
 	 */
 	protected function objectToArray($object)
 	{
-		if (! is_object($object))
-		{
+		if ( ! is_object($object)) {
 			return $object;
 		}
 
 		$array = [];
-		foreach (get_object_vars($object) as $key => $val)
-		{
+		foreach (get_object_vars($object) as $key => $val) {
 			// There are some built in keys we need to ignore for this conversion
-			if (! is_object($val) && ! is_array($val) && $key !== '_parent_name')
-			{
+			if ( ! is_object($val) && ! is_array($val) && $key !== '_parent_name') {
 				$array[$key] = $val;
 			}
 		}
@@ -2797,24 +2643,20 @@ class BaseBuilder
 	 */
 	protected function batchObjectToArray($object)
 	{
-		if (! is_object($object))
-		{
+		if ( ! is_object($object)) {
 			return $object;
 		}
 
-		$array  = [];
-		$out    = get_object_vars($object);
+		$array = [];
+		$out = get_object_vars($object);
 		$fields = array_keys($out);
 
-		foreach ($fields as $val)
-		{
+		foreach ($fields as $val) {
 			// There are some built in keys we need to ignore for this conversion
-			if ($val !== '_parent_name')
-			{
+			if ($val !== '_parent_name') {
 				$i = 0;
-				foreach ($out[$val] as $data)
-				{
-					$array[$i ++][$val] = $data;
+				foreach ($out[$val] as $data) {
+					$array[$i++][$val] = $data;
 				}
 			}
 		}
@@ -2837,17 +2679,15 @@ class BaseBuilder
 	{
 		$str = trim($str);
 
-		if (empty($str) || ctype_digit($str) || (string) (float) $str === $str ||
-				in_array(strtoupper($str), ['TRUE', 'FALSE'], true)
-		)
-		{
+		if (empty($str) || ctype_digit($str) || (string)(float)$str === $str ||
+			in_array(strtoupper($str), ['TRUE', 'FALSE'], true)
+		) {
 			return true;
 		}
 
 		static $_str;
 
-		if (empty($_str))
-		{
+		if (empty($_str)) {
 			$_str = ($this->db->escapeChar !== '"') ? ['"', "'"] : ["'"];
 		}
 
@@ -2882,8 +2722,7 @@ class BaseBuilder
 	 */
 	protected function resetRun(array $qb_reset_items)
 	{
-		foreach ($qb_reset_items as $item => $default_value)
-		{
+		foreach ($qb_reset_items as $item => $default_value) {
 			$this->$item = $default_value;
 		}
 	}
@@ -2896,20 +2735,19 @@ class BaseBuilder
 	protected function resetSelect()
 	{
 		$this->resetRun([
-			'QBSelect'   => [],
-			'QBJoin'     => [],
-			'QBWhere'    => [],
-			'QBGroupBy'  => [],
-			'QBHaving'   => [],
-			'QBOrderBy'  => [],
+			'QBSelect' => [],
+			'QBJoin' => [],
+			'QBWhere' => [],
+			'QBGroupBy' => [],
+			'QBHaving' => [],
+			'QBOrderBy' => [],
 			'QBNoEscape' => [],
 			'QBDistinct' => false,
-			'QBLimit'    => false,
-			'QBOffset'   => false,
+			'QBLimit' => false,
+			'QBOffset' => false,
 		]);
 
-		if (! empty($this->db))
-		{
+		if ( ! empty($this->db)) {
 			$this->db->setAliasedTables([]);
 		}
 	}
@@ -2924,12 +2762,12 @@ class BaseBuilder
 	protected function resetWrite()
 	{
 		$this->resetRun([
-			'QBSet'     => [],
-			'QBJoin'    => [],
-			'QBWhere'   => [],
+			'QBSet' => [],
+			'QBJoin' => [],
+			'QBWhere' => [],
 			'QBOrderBy' => [],
-			'QBKeys'    => [],
-			'QBLimit'   => false,
+			'QBKeys' => [],
+			'QBLimit' => false,
 		]);
 	}
 
@@ -2944,7 +2782,8 @@ class BaseBuilder
 	 */
 	protected function hasOperator(string $str): bool
 	{
-		return (bool) preg_match('/(<|>|!|=|\sIS NULL|\sIS NOT NULL|\sEXISTS|\sBETWEEN|\sLIKE|\sIN\s*\(|\s)/i', trim($str));
+		return (bool)preg_match('/(<|>|!|=|\sIS NULL|\sIS NOT NULL|\sEXISTS|\sBETWEEN|\sLIKE|\sIN\s*\(|\s)/i',
+			trim($str));
 	}
 
 	// --------------------------------------------------------------------
@@ -2952,7 +2791,7 @@ class BaseBuilder
 	/**
 	 * Returns the SQL string operator
 	 *
-	 * @param string  $str
+	 * @param string $str
 	 * @param boolean $list
 	 *
 	 * @return mixed
@@ -2961,9 +2800,9 @@ class BaseBuilder
 	{
 		static $_operators;
 
-		if (empty($_operators))
-		{
-			$_les       = ($this->db->likeEscapeStr !== '') ? '\s+' . preg_quote(trim(sprintf($this->db->likeEscapeStr, $this->db->likeEscapeChar)), '/') : '';
+		if (empty($_operators)) {
+			$_les = ($this->db->likeEscapeStr !== '') ? '\s+' . preg_quote(trim(sprintf($this->db->likeEscapeStr,
+					$this->db->likeEscapeChar)), '/') : '';
 			$_operators = [
 				'\s*(?:<|>|!)?=\s*', // =, <=, >=, !=
 				'\s*<>?\s*', // <, <>
@@ -2980,7 +2819,8 @@ class BaseBuilder
 			];
 		}
 
-		return preg_match_all('/' . implode('|', $_operators) . '/i', $str, $match) ? ($list ? $match[0] : $match[0][count($match[0]) - 1]) : false;
+		return preg_match_all('/' . implode('|', $_operators) . '/i', $str,
+			$match) ? ($list ? $match[0] : $match[0][count($match[0]) - 1]) : false;
 	}
 
 	// --------------------------------------------------------------------
@@ -2991,16 +2831,15 @@ class BaseBuilder
 	 * with PHP 7+ we get a huge memory/performance gain with indexed
 	 * arrays instead, so lets take advantage of that here.
 	 *
-	 * @param string  $key
-	 * @param mixed   $value
+	 * @param string $key
+	 * @param mixed $value
 	 * @param boolean $escape
 	 *
 	 * @return string
 	 */
 	protected function setBind(string $key, $value = null, bool $escape = true): string
 	{
-		if (! array_key_exists($key, $this->binds))
-		{
+		if ( ! array_key_exists($key, $this->binds)) {
 			$this->binds[$key] = [
 				$value,
 				$escape,
@@ -3011,8 +2850,7 @@ class BaseBuilder
 
 		$count = 0;
 
-		while (array_key_exists($key . $count, $this->binds))
-		{
+		while (array_key_exists($key . $count, $this->binds)) {
 			++$count;
 		}
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -71,7 +71,8 @@ use stdClass;
  * @package CodeIgniter
  * @mixin   BaseBuilder
  */
-class Model {
+class Model
+{
 
 	/**
 	 * Pager instance.
@@ -125,7 +126,7 @@ class Model {
 	 *
 	 * @var boolean
 	 */
-	protected $useSoftDeletes = FALSE;
+	protected $useSoftDeletes = false;
 
 	/**
 	 * An array of field names that are allowed
@@ -141,7 +142,7 @@ class Model {
 	 *
 	 * @var boolean
 	 */
-	protected $useTimestamps = FALSE;
+	protected $useTimestamps = false;
 
 	/**
 	 * The type of column that created_at and updated_at
@@ -198,7 +199,7 @@ class Model {
 	 *
 	 * @var boolean
 	 */
-	protected $protectFields = TRUE;
+	protected $protectFields = true;
 
 	/**
 	 * Database Connection
@@ -237,7 +238,7 @@ class Model {
 	 *
 	 * @var boolean
 	 */
-	protected $skipValidation = FALSE;
+	protected $skipValidation = false;
 
 	/**
 	 * Our validator instance.
@@ -315,22 +316,19 @@ class Model {
 	 * @param ConnectionInterface $db
 	 * @param ValidationInterface $validation
 	 */
-	public function __construct(ConnectionInterface &$db = NULL, ValidationInterface $validation = NULL)
+	public function __construct(ConnectionInterface &$db = null, ValidationInterface $validation = null)
 	{
-		if ($db instanceof ConnectionInterface)
-		{
+		if ($db instanceof ConnectionInterface) {
 			$this->db = &$db;
-		} else
-		{
+		} else {
 			$this->db = Database::connect($this->DBGroup);
 		}
 
 		$this->tempReturnType = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
 
-		if (is_null($validation))
-		{
-			$validation = \Config\Services::validation(NULL, FALSE);
+		if (is_null($validation)) {
+			$validation = \Config\Services::validation(null, false);
 		}
 
 		$this->validation = $validation;
@@ -349,28 +347,24 @@ class Model {
 	 *
 	 * @return array|object|null    The resulting row of data, or null.
 	 */
-	public function find($id = NULL)
+	public function find($id = null)
 	{
 		$builder = $this->builder();
 
-		if ($this->tempUseSoftDeletes === TRUE)
-		{
-			$builder->where($this->table . '.' . $this->deletedField, NULL);
+		if ($this->tempUseSoftDeletes === true) {
+			$builder->where($this->table . '.' . $this->deletedField, null);
 		}
 
-		if (is_array($id))
-		{
+		if (is_array($id)) {
 			$row = $builder->whereIn($this->table . '.' . $this->primaryKey, $id)
 				->get();
 			$row = $row->getResult($this->tempReturnType);
-		} elseif (is_numeric($id) || is_string($id))
-		{
+		} elseif (is_numeric($id) || is_string($id)) {
 			$row = $builder->where($this->table . '.' . $this->primaryKey, $id)
 				->get();
 
 			$row = $row->getFirstRow($this->tempReturnType);
-		} else
-		{
+		} else {
 			$row = $builder->get();
 
 			$row = $row->getResult($this->tempReturnType);
@@ -396,8 +390,7 @@ class Model {
 	 */
 	public function findColumn(string $columnName)
 	{
-		if (strpos($columnName, ',') !== FALSE)
-		{
+		if (strpos($columnName, ',') !== false) {
 			throw DataException::forFindColumnHaveMultipleColumns();
 		}
 
@@ -405,7 +398,7 @@ class Model {
 			->asArray()
 			->find();
 
-		return ( ! empty($resultSet)) ? array_column($resultSet, $columnName) : NULL;
+		return ( ! empty($resultSet)) ? array_column($resultSet, $columnName) : null;
 	}
 
 	//--------------------------------------------------------------------
@@ -423,9 +416,8 @@ class Model {
 	{
 		$builder = $this->builder();
 
-		if ($this->tempUseSoftDeletes === TRUE)
-		{
-			$builder->where($this->table . '.' . $this->deletedField, NULL);
+		if ($this->tempUseSoftDeletes === true) {
+			$builder->where($this->table . '.' . $this->deletedField, null);
 		}
 
 		$row = $builder->limit($limit, $offset)
@@ -453,15 +445,13 @@ class Model {
 	{
 		$builder = $this->builder();
 
-		if ($this->tempUseSoftDeletes === TRUE)
-		{
-			$builder->where($this->table . '.' . $this->deletedField, NULL);
+		if ($this->tempUseSoftDeletes === true) {
+			$builder->where($this->table . '.' . $this->deletedField, null);
 		}
 
 		// Some databases, like PostgreSQL, need order
 		// information to consistently return correct results.
-		if (empty($builder->QBOrderBy) && ! empty($this->primaryKey))
-		{
+		if (empty($builder->QBOrderBy) && ! empty($this->primaryKey)) {
 			$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');
 		}
 
@@ -490,7 +480,7 @@ class Model {
 	 *
 	 * @return $this
 	 */
-	public function set($key, string $value = '', bool $escape = NULL)
+	public function set($key, string $value = '', bool $escape = null)
 	{
 		$data = is_array($key)
 			? $key
@@ -518,24 +508,19 @@ class Model {
 	 */
 	public function save($data): bool
 	{
-		if (empty($data))
-		{
-			return TRUE;
+		if (empty($data)) {
+			return true;
 		}
 
-		if (is_object($data) && isset($data->{$this->primaryKey}))
-		{
+		if (is_object($data) && isset($data->{$this->primaryKey})) {
 			$response = $this->update($data->{$this->primaryKey}, $data);
-		} elseif (is_array($data) && ! empty($data[$this->primaryKey]))
-		{
+		} elseif (is_array($data) && ! empty($data[$this->primaryKey])) {
 			$response = $this->update($data[$this->primaryKey], $data);
-		} else
-		{
-			$response = $this->insert($data, FALSE);
+		} else {
+			$response = $this->insert($data, false);
 			// call insert directly if you want the ID or the record object
-			if ($response !== FALSE)
-			{
-				$response = TRUE;
+			if ($response !== false) {
+				$response = true;
 			}
 		}
 
@@ -556,21 +541,18 @@ class Model {
 	 */
 	public static function classToArray(
 		$data,
-		$primaryKey = NULL,
+		$primaryKey = null,
 		string $dateFormat = 'datetime',
-		bool $onlyChanged = TRUE
+		bool $onlyChanged = true
 	): array {
-		if (method_exists($data, 'toRawArray'))
-		{
+		if (method_exists($data, 'toRawArray')) {
 			$properties = $data->toRawArray($onlyChanged);
 
 			// Always grab the primary key otherwise updates will fail.
-			if ( ! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties))
-			{
+			if ( ! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties)) {
 				$properties[$primaryKey] = $data->{$primaryKey};
 			}
-		} else
-		{
+		} else {
 			$mirror = new ReflectionClass($data);
 			$props = $mirror->getProperties(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED);
 
@@ -578,24 +560,19 @@ class Model {
 
 			// Loop over each property,
 			// saving the name/value in a new array we can return.
-			foreach ($props as $prop)
-			{
+			foreach ($props as $prop) {
 				// Must make protected values accessible.
-				$prop->setAccessible(TRUE);
+				$prop->setAccessible(true);
 				$propName = $prop->getName();
 				$properties[$propName] = $prop->getValue($data);
 			}
 		}
 
 		// Convert any Time instances to appropriate $dateFormat
-		if ($properties)
-		{
-			foreach ($properties as $key => $value)
-			{
-				if ($value instanceof Time)
-				{
-					switch ($dateFormat)
-					{
+		if ($properties) {
+			foreach ($properties as $key => $value) {
+				if ($value instanceof Time) {
+					switch ($dateFormat) {
 						case 'datetime':
 							$converted = $value->format('Y-m-d H:i:s');
 							break;
@@ -641,46 +618,40 @@ class Model {
 	 * @return integer|string|boolean
 	 * @throws \ReflectionException
 	 */
-	public function insert($data = NULL, bool $returnID = TRUE)
+	public function insert($data = null, bool $returnID = true)
 	{
-		$escape = NULL;
+		$escape = null;
 
 		$this->insertID = 0;
 
-		if (empty($data))
-		{
-			$data = $this->tempData['data'] ?? NULL;
-			$escape = $this->tempData['escape'] ?? NULL;
+		if (empty($data)) {
+			$data = $this->tempData['data'] ?? null;
+			$escape = $this->tempData['escape'] ?? null;
 			$this->tempData = [];
 		}
 
-		if (empty($data))
-		{
+		if (empty($data)) {
 			throw DataException::forEmptyDataset('insert');
 		}
 
 		// If $data is using a custom class with public or protected
 		// properties representing the table elements, we need to grab
 		// them as an array.
-		if (is_object($data) && ! $data instanceof stdClass)
-		{
-			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat, FALSE);
+		if (is_object($data) && ! $data instanceof stdClass) {
+			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat, false);
 		}
 
 		// If it's still a stdClass, go ahead and convert to
 		// an array so doProtectFields and other model methods
 		// don't have to do special checks.
-		if (is_object($data))
-		{
+		if (is_object($data)) {
 			$data = (array)$data;
 		}
 
 		// Validate data before saving.
-		if ($this->skipValidation === FALSE)
-		{
-			if ($this->validate($data) === FALSE)
-			{
-				return FALSE;
+		if ($this->skipValidation === false) {
+			if ($this->validate($data) === false) {
+				return false;
 			}
 		}
 
@@ -696,13 +667,11 @@ class Model {
 		// Set created_at and updated_at with same time
 		$date = $this->setDate();
 
-		if ($this->useTimestamps && ! empty($this->createdField) && ! array_key_exists($this->createdField, $data))
-		{
+		if ($this->useTimestamps && ! empty($this->createdField) && ! array_key_exists($this->createdField, $data)) {
 			$data[$this->createdField] = $date;
 		}
 
-		if ($this->useTimestamps && ! empty($this->updatedField) && ! array_key_exists($this->updatedField, $data))
-		{
+		if ($this->useTimestamps && ! empty($this->updatedField) && ! array_key_exists($this->updatedField, $data)) {
 			$data[$this->updatedField] = $date;
 		}
 
@@ -714,16 +683,14 @@ class Model {
 			->insert();
 
 		// If insertion succeeded then save the insert ID
-		if ($result)
-		{
+		if ($result) {
 			$this->insertID = $this->db->insertID();
 		}
 
 		$this->trigger('afterInsert', ['data' => $originalData, 'result' => $result]);
 
 		// If insertion failed, get out of here
-		if ( ! $result)
-		{
+		if ( ! $result) {
 			return $result;
 		}
 
@@ -744,15 +711,12 @@ class Model {
 	 *
 	 * @return integer|boolean Number of rows inserted or FALSE on failure
 	 */
-	public function insertBatch(array $set = NULL, bool $escape = NULL, int $batchSize = 100, bool $testing = FALSE)
+	public function insertBatch(array $set = null, bool $escape = null, int $batchSize = 100, bool $testing = false)
 	{
-		if (is_array($set) && $this->skipValidation === FALSE)
-		{
-			foreach ($set as $row)
-			{
-				if ($this->validate($row) === FALSE)
-				{
-					return FALSE;
+		if (is_array($set) && $this->skipValidation === false) {
+			foreach ($set as $row) {
+				if ($this->validate($row) === false) {
+					return false;
 				}
 			}
 		}
@@ -772,49 +736,42 @@ class Model {
 	 * @return boolean
 	 * @throws \ReflectionException
 	 */
-	public function update($id = NULL, $data = NULL): bool
+	public function update($id = null, $data = null): bool
 	{
-		$escape = NULL;
+		$escape = null;
 
-		if (is_numeric($id) || is_string($id))
-		{
+		if (is_numeric($id) || is_string($id)) {
 			$id = [$id];
 		}
 
-		if (empty($data))
-		{
-			$data = $this->tempData['data'] ?? NULL;
-			$escape = $this->tempData['escape'] ?? NULL;
+		if (empty($data)) {
+			$data = $this->tempData['data'] ?? null;
+			$escape = $this->tempData['escape'] ?? null;
 			$this->tempData = [];
 		}
 
-		if (empty($data))
-		{
+		if (empty($data)) {
 			throw DataException::forEmptyDataset('update');
 		}
 
 		// If $data is using a custom class with public or protected
 		// properties representing the table elements, we need to grab
 		// them as an array.
-		if (is_object($data) && ! $data instanceof stdClass)
-		{
+		if (is_object($data) && ! $data instanceof stdClass) {
 			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat);
 		}
 
 		// If it's still a stdClass, go ahead and convert to
 		// an array so doProtectFields and other model methods
 		// don't have to do special checks.
-		if (is_object($data))
-		{
+		if (is_object($data)) {
 			$data = (array)$data;
 		}
 
 		// Validate data before saving.
-		if ($this->skipValidation === FALSE)
-		{
-			if ($this->validate($data) === FALSE)
-			{
-				return FALSE;
+		if ($this->skipValidation === false) {
+			if ($this->validate($data) === false) {
+				return false;
 			}
 		}
 
@@ -827,8 +784,7 @@ class Model {
 		// strip out updated_at values.
 		$data = $this->doProtectFields($data);
 
-		if ($this->useTimestamps && ! empty($this->updatedField) && ! array_key_exists($this->updatedField, $data))
-		{
+		if ($this->useTimestamps && ! empty($this->updatedField) && ! array_key_exists($this->updatedField, $data)) {
 			$data[$this->updatedField] = $this->setDate();
 		}
 
@@ -836,8 +792,7 @@ class Model {
 
 		$builder = $this->builder();
 
-		if ($id)
-		{
+		if ($id) {
 			$builder = $builder->whereIn($this->table . '.' . $this->primaryKey, $id);
 		}
 
@@ -866,15 +821,12 @@ class Model {
 	 * @return mixed    Number of rows affected or FALSE on failure
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function updateBatch(array $set = NULL, string $index = NULL, int $batchSize = 100, bool $returnSQL = FALSE)
+	public function updateBatch(array $set = null, string $index = null, int $batchSize = 100, bool $returnSQL = false)
 	{
-		if (is_array($set) && $this->skipValidation === FALSE)
-		{
-			foreach ($set as $row)
-			{
-				if ($this->validate($row) === FALSE)
-				{
-					return FALSE;
+		if (is_array($set) && $this->skipValidation === false) {
+			foreach ($set as $row) {
+				if ($this->validate($row) === false) {
+					return false;
 				}
 			}
 		}
@@ -894,45 +846,38 @@ class Model {
 	 * @return mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function delete($id = NULL, bool $purge = FALSE)
+	public function delete($id = null, bool $purge = false)
 	{
-		if ( ! empty($id) && is_numeric($id))
-		{
+		if ( ! empty($id) && is_numeric($id)) {
 			$id = [$id];
 		}
 
 		$builder = $this->builder();
-		if ( ! empty($id))
-		{
+		if ( ! empty($id)) {
 			$builder = $builder->whereIn($this->primaryKey, $id);
 		}
 
 		$this->trigger('beforeDelete', ['id' => $id, 'purge' => $purge]);
 
-		if ($this->useSoftDeletes && ! $purge)
-		{
-			if (empty($builder->getCompiledQBWhere()))
-			{
-				if (CI_DEBUG)
-				{
+		if ($this->useSoftDeletes && ! $purge) {
+			if (empty($builder->getCompiledQBWhere())) {
+				if (CI_DEBUG) {
 					throw new DatabaseException('Deletes are not allowed unless they contain a "where" or "like" clause.');
 				}
-				return FALSE;
+				return false;
 			}
 			$set[$this->deletedField] = $this->setDate();
 
-			if ($this->useTimestamps && ! empty($this->updatedField))
-			{
+			if ($this->useTimestamps && ! empty($this->updatedField)) {
 				$set[$this->updatedField] = $this->setDate();
 			}
 
 			$result = $builder->update($set);
-		} else
-		{
+		} else {
 			$result = $builder->delete();
 		}
 
-		$this->trigger('afterDelete', ['id' => $id, 'purge' => $purge, 'result' => $result, 'data' => NULL]);
+		$this->trigger('afterDelete', ['id' => $id, 'purge' => $purge, 'result' => $result, 'data' => null]);
 
 		return $result;
 	}
@@ -947,9 +892,8 @@ class Model {
 	 */
 	public function purgeDeleted()
 	{
-		if ( ! $this->useSoftDeletes)
-		{
-			return TRUE;
+		if ( ! $this->useSoftDeletes) {
+			return true;
 		}
 
 		return $this->builder()
@@ -967,7 +911,7 @@ class Model {
 	 *
 	 * @return Model
 	 */
-	public function withDeleted($val = TRUE)
+	public function withDeleted($val = true)
 	{
 		$this->tempUseSoftDeletes = ! $val;
 
@@ -984,7 +928,7 @@ class Model {
 	 */
 	public function onlyDeleted()
 	{
-		$this->tempUseSoftDeletes = FALSE;
+		$this->tempUseSoftDeletes = false;
 
 		$this->builder()
 			->where($this->table . '.' . $this->deletedField . ' IS NOT NULL');
@@ -1004,14 +948,12 @@ class Model {
 	 *
 	 * @return mixed
 	 */
-	public function replace($data = NULL, bool $returnSQL = FALSE)
+	public function replace($data = null, bool $returnSQL = false)
 	{
 		// Validate data before saving.
-		if ( ! empty($data) && $this->skipValidation === FALSE)
-		{
-			if ($this->validate($data) === FALSE)
-			{
-				return FALSE;
+		if ( ! empty($data) && $this->skipValidation === false) {
+			if ($this->validate($data) === false) {
+				return false;
 			}
 		}
 
@@ -1068,18 +1010,16 @@ class Model {
 	public function chunk(int $size, Closure $userFunc)
 	{
 		$total = $this->builder()
-			->countAllResults(FALSE);
+			->countAllResults(false);
 
 		$offset = 0;
 
-		while ($offset <= $total)
-		{
+		while ($offset <= $total) {
 			$builder = clone($this->builder());
 
 			$rows = $builder->get($size, $offset);
 
-			if ($rows === FALSE)
-			{
+			if ($rows === false) {
 				throw DataException::forEmptyDataset('chunk');
 			}
 
@@ -1087,15 +1027,12 @@ class Model {
 
 			$offset += $size;
 
-			if (empty($rows))
-			{
+			if (empty($rows)) {
 				continue;
 			}
 
-			foreach ($rows as $row)
-			{
-				if ($userFunc($row) === FALSE)
-				{
+			foreach ($rows as $row) {
+				if ($userFunc($row) === false) {
 					return;
 				}
 			}
@@ -1111,7 +1048,7 @@ class Model {
 	 *
 	 * @param integer $perPage
 	 * @param string $group Will be used by the pagination library
-	 *                            to identify a unique pagination set.
+	 *                               to identify a unique pagination set.
 	 * @param integer $page Optional page number (useful when the page number is provided in different way)
 	 *
 	 * @return array|null
@@ -1121,7 +1058,7 @@ class Model {
 		// Get the necessary parts.
 		$page = $page >= 1 ? $page : (ctype_digit($_GET['page'] ?? '') && $_GET['page'] > 1 ? $_GET['page'] : 1);
 
-		$total = $this->countAllResults(FALSE);
+		$total = $this->countAllResults(false);
 
 		// Store it in the Pager library so it can be
 		// paginated in the views.
@@ -1143,7 +1080,7 @@ class Model {
 	 *
 	 * @return Model
 	 */
-	public function protect(bool $protect = TRUE)
+	public function protect(bool $protect = true)
 	{
 		$this->protectFields = $protect;
 
@@ -1160,26 +1097,23 @@ class Model {
 	 * @return BaseBuilder
 	 * @throws \CodeIgniter\Exceptions\ModelException;
 	 */
-	protected function builder(string $table = NULL)
+	protected function builder(string $table = null)
 	{
-		if ($this->builder instanceof BaseBuilder)
-		{
+		if ($this->builder instanceof BaseBuilder) {
 			return $this->builder;
 		}
 
 		// We're going to force a primary key to exist
 		// so we don't have overly convoluted code,
 		// and future features are likely to require them.
-		if (empty($this->primaryKey))
-		{
+		if (empty($this->primaryKey)) {
 			throw ModelException::forNoPrimaryKey(get_class($this));
 		}
 
 		$table = empty($table) ? $this->table : $table;
 
 		// Ensure we have a good db connection
-		if ( ! $this->db instanceof BaseConnection)
-		{
+		if ( ! $this->db instanceof BaseConnection) {
 			$this->db = Database::connect($this->DBGroup);
 		}
 
@@ -1204,22 +1138,17 @@ class Model {
 	 */
 	protected function doProtectFields(array $data): array
 	{
-		if ($this->protectFields === FALSE)
-		{
+		if ($this->protectFields === false) {
 			return $data;
 		}
 
-		if (empty($this->allowedFields))
-		{
+		if (empty($this->allowedFields)) {
 			throw DataException::forInvalidAllowedFields(get_class($this));
 		}
 
-		if (is_array($data) && count($data))
-		{
-			foreach ($data as $key => $val)
-			{
-				if ( ! in_array($key, $this->allowedFields))
-				{
+		if (is_array($data) && count($data)) {
+			foreach ($data as $key => $val) {
+				if ( ! in_array($key, $this->allowedFields)) {
 					unset($data[$key]);
 				}
 			}
@@ -1246,12 +1175,11 @@ class Model {
 	 * @return mixed
 	 * @throws \CodeIgniter\Exceptions\ModelException;
 	 */
-	protected function setDate(int $userData = NULL)
+	protected function setDate(int $userData = null)
 	{
 		$currentDate = is_numeric($userData) ? (int)$userData : time();
 
-		switch ($this->dateFormat)
-		{
+		switch ($this->dateFormat) {
 			case 'int':
 				return $currentDate;
 				break;
@@ -1293,15 +1221,13 @@ class Model {
 	 *
 	 * @return array|null
 	 */
-	public function errors(bool $forceDB = FALSE)
+	public function errors(bool $forceDB = false)
 	{
 		// Do we have validation errors?
-		if ($forceDB === FALSE && $this->skipValidation === FALSE)
-		{
+		if ($forceDB === false && $this->skipValidation === false) {
 			$errors = $this->validation->getErrors();
 
-			if ( ! empty($errors))
-			{
+			if ( ! empty($errors)) {
 				return $errors;
 			}
 		}
@@ -1309,7 +1235,7 @@ class Model {
 		// Still here? Grab the database-specific error, if any.
 		$error = $this->db->getError();
 
-		return $error['message'] ?? NULL;
+		return $error['message'] ?? null;
 	}
 
 	//--------------------------------------------------------------------
@@ -1324,7 +1250,7 @@ class Model {
 	 *
 	 * @return Model
 	 */
-	public function skipValidation(bool $skip = TRUE)
+	public function skipValidation(bool $skip = true)
 	{
 		$this->skipValidation = $skip;
 
@@ -1373,15 +1299,13 @@ class Model {
 	 */
 	public function validate($data): bool
 	{
-		if ($this->skipValidation === TRUE || empty($this->validationRules) || empty($data))
-		{
-			return TRUE;
+		if ($this->skipValidation === true || empty($this->validationRules) || empty($data)) {
+			return true;
 		}
 
 		// Query Builder works with objects as well as arrays,
 		// but validation requires array, so cast away.
-		if (is_object($data))
-		{
+		if (is_object($data)) {
 			$data = (array)$data;
 		}
 
@@ -1389,8 +1313,7 @@ class Model {
 
 		// ValidationRules can be either a string, which is the group name,
 		// or an array of rules.
-		if (is_string($rules))
-		{
+		if (is_string($rules)) {
 			$rules = $this->validation->loadRuleGroup($rules);
 		}
 
@@ -1398,9 +1321,8 @@ class Model {
 
 		// If no data existed that needs validation
 		// our job is done here.
-		if (empty($rules))
-		{
-			return TRUE;
+		if (empty($rules)) {
+			return true;
 		}
 
 		// Replace any placeholders (i.e. {id}) in the rules with
@@ -1408,7 +1330,7 @@ class Model {
 		$rules = $this->fillPlaceholders($rules, $data);
 
 		$this->validation->setRules($rules, $this->validationMessages);
-		$valid = $this->validation->run($data, NULL, $this->DBGroup);
+		$valid = $this->validation->run($data, null, $this->DBGroup);
 
 		return (bool)$valid;
 	}
@@ -1426,17 +1348,14 @@ class Model {
 	 *
 	 * @return array
 	 */
-	protected function cleanValidationRules(array $rules, array $data = NULL): array
+	protected function cleanValidationRules(array $rules, array $data = null): array
 	{
-		if (empty($data))
-		{
+		if (empty($data)) {
 			return [];
 		}
 
-		foreach ($rules as $field => $rule)
-		{
-			if ( ! array_key_exists($field, $data))
-			{
+		foreach ($rules as $field => $rule) {
+			if ( ! array_key_exists($field, $data)) {
 				unset($rules[$field]);
 			}
 		}
@@ -1468,23 +1387,17 @@ class Model {
 	{
 		$replacements = [];
 
-		foreach ($data as $key => $value)
-		{
+		foreach ($data as $key => $value) {
 			$replacements["{{$key}}"] = $value;
 		}
 
-		if ( ! empty($replacements))
-		{
-			foreach ($rules as &$rule)
-			{
-				if (is_array($rule))
-				{
-					foreach ($rule as &$row)
-					{
+		if ( ! empty($replacements)) {
+			foreach ($rules as &$rule) {
+				if (is_array($rule)) {
+					foreach ($rule as &$row) {
 						// Should only be an `errors` array
 						// which doesn't take placeholders.
-						if (is_array($row))
-						{
+						if (is_array($row)) {
 							continue;
 						}
 
@@ -1514,11 +1427,9 @@ class Model {
 	{
 		$rules = $this->validationRules;
 
-		if (isset($options['except']))
-		{
+		if (isset($options['except'])) {
 			$rules = array_diff_key($rules, array_flip($options['except']));
-		} elseif (isset($options['only']))
-		{
+		} elseif (isset($options['only'])) {
 			$rules = array_intersect_key($rules, array_flip($options['only']));
 		}
 
@@ -1548,11 +1459,10 @@ class Model {
 	 *
 	 * @return mixed
 	 */
-	public function countAllResults(bool $reset = TRUE, bool $test = FALSE)
+	public function countAllResults(bool $reset = true, bool $test = false)
 	{
-		if ($this->tempUseSoftDeletes === TRUE)
-		{
-			$this->builder()->where($this->table . '.' . $this->deletedField, NULL);
+		if ($this->tempUseSoftDeletes === true) {
+			$this->builder()->where($this->table . '.' . $this->deletedField, null);
 		}
 
 		return $this->builder()->countAllResults($reset, $test);
@@ -1580,15 +1490,12 @@ class Model {
 	protected function trigger(string $event, array $data)
 	{
 		// Ensure it's a valid event
-		if ( ! isset($this->{$event}) || empty($this->{$event}))
-		{
+		if ( ! isset($this->{$event}) || empty($this->{$event})) {
 			return $data;
 		}
 
-		foreach ($this->{$event} as $callback)
-		{
-			if ( ! method_exists($this, $callback))
-			{
+		foreach ($this->{$event} as $callback) {
+			if ( ! method_exists($this, $callback)) {
 				throw DataException::forInvalidMethodTriggered($callback);
 			}
 
@@ -1613,18 +1520,15 @@ class Model {
 	 */
 	public function __get(string $name)
 	{
-		if (in_array($name, ['primaryKey', 'table', 'returnType', 'DBGroup']))
-		{
+		if (in_array($name, ['primaryKey', 'table', 'returnType', 'DBGroup'])) {
 			return $this->{$name};
-		} elseif (isset($this->db->$name))
-		{
+		} elseif (isset($this->db->$name)) {
 			return $this->db->$name;
-		} elseif (isset($this->builder()->$name))
-		{
+		} elseif (isset($this->builder()->$name)) {
 			return $this->builder()->$name;
 		}
 
-		return NULL;
+		return null;
 	}
 
 	//--------------------------------------------------------------------
@@ -1640,25 +1544,21 @@ class Model {
 	 */
 	public function __call(string $name, array $params)
 	{
-		$result = NULL;
+		$result = null;
 
-		if (method_exists($this->db, $name))
-		{
+		if (method_exists($this->db, $name)) {
 			$result = $this->db->$name(...$params);
-		} elseif (method_exists($builder = $this->builder(), $name))
-		{
+		} elseif (method_exists($builder = $this->builder(), $name)) {
 			$result = $builder->$name(...$params);
 		}
 
 		// Don't return the builder object unless specifically requested
 		//, since that will interrupt the usability flow
 		// and break intermingling of model and builder methods.
-		if ($name !== 'builder' && empty($result))
-		{
+		if ($name !== 'builder' && empty($result)) {
 			return $result;
 		}
-		if ($name !== 'builder' && ! $result instanceof BaseBuilder)
-		{
+		if ($name !== 'builder' && ! $result instanceof BaseBuilder) {
 			return $result;
 		}
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -71,8 +71,7 @@ use stdClass;
  * @package CodeIgniter
  * @mixin   BaseBuilder
  */
-class Model
-{
+class Model {
 
 	/**
 	 * Pager instance.
@@ -126,7 +125,7 @@ class Model
 	 *
 	 * @var boolean
 	 */
-	protected $useSoftDeletes = false;
+	protected $useSoftDeletes = FALSE;
 
 	/**
 	 * An array of field names that are allowed
@@ -142,7 +141,7 @@ class Model
 	 *
 	 * @var boolean
 	 */
-	protected $useTimestamps = false;
+	protected $useTimestamps = FALSE;
 
 	/**
 	 * The type of column that created_at and updated_at
@@ -199,7 +198,7 @@ class Model
 	 *
 	 * @var boolean
 	 */
-	protected $protectFields = true;
+	protected $protectFields = TRUE;
 
 	/**
 	 * Database Connection
@@ -238,7 +237,7 @@ class Model
 	 *
 	 * @var boolean
 	 */
-	protected $skipValidation = false;
+	protected $skipValidation = FALSE;
 
 	/**
 	 * Our validator instance.
@@ -316,19 +315,22 @@ class Model
 	 * @param ConnectionInterface $db
 	 * @param ValidationInterface $validation
 	 */
-	public function __construct(ConnectionInterface &$db = null, ValidationInterface $validation = null)
+	public function __construct(ConnectionInterface &$db = NULL, ValidationInterface $validation = NULL)
 	{
-		if ($db instanceof ConnectionInterface) {
+		if ($db instanceof ConnectionInterface)
+		{
 			$this->db = &$db;
-		} else {
+		} else
+		{
 			$this->db = Database::connect($this->DBGroup);
 		}
 
 		$this->tempReturnType = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
 
-		if (is_null($validation)) {
-			$validation = \Config\Services::validation(null, false);
+		if (is_null($validation))
+		{
+			$validation = \Config\Services::validation(NULL, FALSE);
 		}
 
 		$this->validation = $validation;
@@ -347,24 +349,28 @@ class Model
 	 *
 	 * @return array|object|null    The resulting row of data, or null.
 	 */
-	public function find($id = null)
+	public function find($id = NULL)
 	{
 		$builder = $this->builder();
 
-		if ($this->tempUseSoftDeletes === true) {
-			$builder->where($this->table . '.' . $this->deletedField, null);
+		if ($this->tempUseSoftDeletes === TRUE)
+		{
+			$builder->where($this->table . '.' . $this->deletedField, NULL);
 		}
 
-		if (is_array($id)) {
+		if (is_array($id))
+		{
 			$row = $builder->whereIn($this->table . '.' . $this->primaryKey, $id)
 				->get();
 			$row = $row->getResult($this->tempReturnType);
-		} elseif (is_numeric($id) || is_string($id)) {
+		} elseif (is_numeric($id) || is_string($id))
+		{
 			$row = $builder->where($this->table . '.' . $this->primaryKey, $id)
 				->get();
 
 			$row = $row->getFirstRow($this->tempReturnType);
-		} else {
+		} else
+		{
 			$row = $builder->get();
 
 			$row = $row->getResult($this->tempReturnType);
@@ -390,7 +396,8 @@ class Model
 	 */
 	public function findColumn(string $columnName)
 	{
-		if (strpos($columnName, ',') !== false) {
+		if (strpos($columnName, ',') !== FALSE)
+		{
 			throw DataException::forFindColumnHaveMultipleColumns();
 		}
 
@@ -398,7 +405,7 @@ class Model
 			->asArray()
 			->find();
 
-		return (!empty($resultSet)) ? array_column($resultSet, $columnName) : null;
+		return ( ! empty($resultSet)) ? array_column($resultSet, $columnName) : NULL;
 	}
 
 	//--------------------------------------------------------------------
@@ -416,8 +423,9 @@ class Model
 	{
 		$builder = $this->builder();
 
-		if ($this->tempUseSoftDeletes === true) {
-			$builder->where($this->table . '.' . $this->deletedField, null);
+		if ($this->tempUseSoftDeletes === TRUE)
+		{
+			$builder->where($this->table . '.' . $this->deletedField, NULL);
 		}
 
 		$row = $builder->limit($limit, $offset)
@@ -445,13 +453,15 @@ class Model
 	{
 		$builder = $this->builder();
 
-		if ($this->tempUseSoftDeletes === true) {
-			$builder->where($this->table . '.' . $this->deletedField, null);
+		if ($this->tempUseSoftDeletes === TRUE)
+		{
+			$builder->where($this->table . '.' . $this->deletedField, NULL);
 		}
 
 		// Some databases, like PostgreSQL, need order
 		// information to consistently return correct results.
-		if (empty($builder->QBOrderBy) && !empty($this->primaryKey)) {
+		if (empty($builder->QBOrderBy) && ! empty($this->primaryKey))
+		{
 			$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');
 		}
 
@@ -480,7 +490,7 @@ class Model
 	 *
 	 * @return $this
 	 */
-	public function set($key, string $value = '', bool $escape = null)
+	public function set($key, string $value = '', bool $escape = NULL)
 	{
 		$data = is_array($key)
 			? $key
@@ -508,19 +518,24 @@ class Model
 	 */
 	public function save($data): bool
 	{
-		if (empty($data)) {
-			return true;
+		if (empty($data))
+		{
+			return TRUE;
 		}
 
-		if (is_object($data) && isset($data->{$this->primaryKey})) {
+		if (is_object($data) && isset($data->{$this->primaryKey}))
+		{
 			$response = $this->update($data->{$this->primaryKey}, $data);
-		} elseif (is_array($data) && !empty($data[$this->primaryKey])) {
+		} elseif (is_array($data) && ! empty($data[$this->primaryKey]))
+		{
 			$response = $this->update($data[$this->primaryKey], $data);
-		} else {
-			$response = $this->insert($data, false);
+		} else
+		{
+			$response = $this->insert($data, FALSE);
 			// call insert directly if you want the ID or the record object
-			if ($response !== false) {
-				$response = true;
+			if ($response !== FALSE)
+			{
+				$response = TRUE;
 			}
 		}
 
@@ -539,16 +554,23 @@ class Model
 	 * @return array
 	 * @throws \ReflectionException
 	 */
-	public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime', bool $onlyChanged = true): array
-	{
-		if (method_exists($data, 'toRawArray')) {
+	public static function classToArray(
+		$data,
+		$primaryKey = NULL,
+		string $dateFormat = 'datetime',
+		bool $onlyChanged = TRUE
+	): array {
+		if (method_exists($data, 'toRawArray'))
+		{
 			$properties = $data->toRawArray($onlyChanged);
 
 			// Always grab the primary key otherwise updates will fail.
-			if (!empty($properties) && !empty($primaryKey) && !in_array($primaryKey, $properties)) {
+			if ( ! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties))
+			{
 				$properties[$primaryKey] = $data->{$primaryKey};
 			}
-		} else {
+		} else
+		{
 			$mirror = new ReflectionClass($data);
 			$props = $mirror->getProperties(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED);
 
@@ -556,19 +578,24 @@ class Model
 
 			// Loop over each property,
 			// saving the name/value in a new array we can return.
-			foreach ($props as $prop) {
+			foreach ($props as $prop)
+			{
 				// Must make protected values accessible.
-				$prop->setAccessible(true);
+				$prop->setAccessible(TRUE);
 				$propName = $prop->getName();
 				$properties[$propName] = $prop->getValue($data);
 			}
 		}
 
 		// Convert any Time instances to appropriate $dateFormat
-		if ($properties) {
-			foreach ($properties as $key => $value) {
-				if ($value instanceof Time) {
-					switch ($dateFormat) {
+		if ($properties)
+		{
+			foreach ($properties as $key => $value)
+			{
+				if ($value instanceof Time)
+				{
+					switch ($dateFormat)
+					{
 						case 'datetime':
 							$converted = $value->format('Y-m-d H:i:s');
 							break;
@@ -614,40 +641,46 @@ class Model
 	 * @return integer|string|boolean
 	 * @throws \ReflectionException
 	 */
-	public function insert($data = null, bool $returnID = true)
+	public function insert($data = NULL, bool $returnID = TRUE)
 	{
-		$escape = null;
+		$escape = NULL;
 
 		$this->insertID = 0;
 
-		if (empty($data)) {
-			$data = $this->tempData['data'] ?? null;
-			$escape = $this->tempData['escape'] ?? null;
+		if (empty($data))
+		{
+			$data = $this->tempData['data'] ?? NULL;
+			$escape = $this->tempData['escape'] ?? NULL;
 			$this->tempData = [];
 		}
 
-		if (empty($data)) {
+		if (empty($data))
+		{
 			throw DataException::forEmptyDataset('insert');
 		}
 
 		// If $data is using a custom class with public or protected
 		// properties representing the table elements, we need to grab
 		// them as an array.
-		if (is_object($data) && !$data instanceof stdClass) {
-			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat, false);
+		if (is_object($data) && ! $data instanceof stdClass)
+		{
+			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat, FALSE);
 		}
 
 		// If it's still a stdClass, go ahead and convert to
 		// an array so doProtectFields and other model methods
 		// don't have to do special checks.
-		if (is_object($data)) {
+		if (is_object($data))
+		{
 			$data = (array)$data;
 		}
 
 		// Validate data before saving.
-		if ($this->skipValidation === false) {
-			if ($this->validate($data) === false) {
-				return false;
+		if ($this->skipValidation === FALSE)
+		{
+			if ($this->validate($data) === FALSE)
+			{
+				return FALSE;
 			}
 		}
 
@@ -663,11 +696,13 @@ class Model
 		// Set created_at and updated_at with same time
 		$date = $this->setDate();
 
-		if ($this->useTimestamps && !empty($this->createdField) && !array_key_exists($this->createdField, $data)) {
+		if ($this->useTimestamps && ! empty($this->createdField) && ! array_key_exists($this->createdField, $data))
+		{
 			$data[$this->createdField] = $date;
 		}
 
-		if ($this->useTimestamps && !empty($this->updatedField) && !array_key_exists($this->updatedField, $data)) {
+		if ($this->useTimestamps && ! empty($this->updatedField) && ! array_key_exists($this->updatedField, $data))
+		{
 			$data[$this->updatedField] = $date;
 		}
 
@@ -679,14 +714,16 @@ class Model
 			->insert();
 
 		// If insertion succeeded then save the insert ID
-		if ($result) {
+		if ($result)
+		{
 			$this->insertID = $this->db->insertID();
 		}
 
 		$this->trigger('afterInsert', ['data' => $originalData, 'result' => $result]);
 
 		// If insertion failed, get out of here
-		if (!$result) {
+		if ( ! $result)
+		{
 			return $result;
 		}
 
@@ -707,12 +744,15 @@ class Model
 	 *
 	 * @return integer|boolean Number of rows inserted or FALSE on failure
 	 */
-	public function insertBatch(array $set = null, bool $escape = null, int $batchSize = 100, bool $testing = false)
+	public function insertBatch(array $set = NULL, bool $escape = NULL, int $batchSize = 100, bool $testing = FALSE)
 	{
-		if (is_array($set) && $this->skipValidation === false) {
-			foreach ($set as $row) {
-				if ($this->validate($row) === false) {
-					return false;
+		if (is_array($set) && $this->skipValidation === FALSE)
+		{
+			foreach ($set as $row)
+			{
+				if ($this->validate($row) === FALSE)
+				{
+					return FALSE;
 				}
 			}
 		}
@@ -732,42 +772,49 @@ class Model
 	 * @return boolean
 	 * @throws \ReflectionException
 	 */
-	public function update($id = null, $data = null): bool
+	public function update($id = NULL, $data = NULL): bool
 	{
-		$escape = null;
+		$escape = NULL;
 
-		if (is_numeric($id) || is_string($id)) {
+		if (is_numeric($id) || is_string($id))
+		{
 			$id = [$id];
 		}
 
-		if (empty($data)) {
-			$data = $this->tempData['data'] ?? null;
-			$escape = $this->tempData['escape'] ?? null;
+		if (empty($data))
+		{
+			$data = $this->tempData['data'] ?? NULL;
+			$escape = $this->tempData['escape'] ?? NULL;
 			$this->tempData = [];
 		}
 
-		if (empty($data)) {
+		if (empty($data))
+		{
 			throw DataException::forEmptyDataset('update');
 		}
 
 		// If $data is using a custom class with public or protected
 		// properties representing the table elements, we need to grab
 		// them as an array.
-		if (is_object($data) && !$data instanceof stdClass) {
+		if (is_object($data) && ! $data instanceof stdClass)
+		{
 			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat);
 		}
 
 		// If it's still a stdClass, go ahead and convert to
 		// an array so doProtectFields and other model methods
 		// don't have to do special checks.
-		if (is_object($data)) {
+		if (is_object($data))
+		{
 			$data = (array)$data;
 		}
 
 		// Validate data before saving.
-		if ($this->skipValidation === false) {
-			if ($this->validate($data) === false) {
-				return false;
+		if ($this->skipValidation === FALSE)
+		{
+			if ($this->validate($data) === FALSE)
+			{
+				return FALSE;
 			}
 		}
 
@@ -780,7 +827,8 @@ class Model
 		// strip out updated_at values.
 		$data = $this->doProtectFields($data);
 
-		if ($this->useTimestamps && !empty($this->updatedField) && !array_key_exists($this->updatedField, $data)) {
+		if ($this->useTimestamps && ! empty($this->updatedField) && ! array_key_exists($this->updatedField, $data))
+		{
 			$data[$this->updatedField] = $this->setDate();
 		}
 
@@ -788,7 +836,8 @@ class Model
 
 		$builder = $this->builder();
 
-		if ($id) {
+		if ($id)
+		{
 			$builder = $builder->whereIn($this->table . '.' . $this->primaryKey, $id);
 		}
 
@@ -817,12 +866,15 @@ class Model
 	 * @return mixed    Number of rows affected or FALSE on failure
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function updateBatch(array $set = null, string $index = null, int $batchSize = 100, bool $returnSQL = false)
+	public function updateBatch(array $set = NULL, string $index = NULL, int $batchSize = 100, bool $returnSQL = FALSE)
 	{
-		if (is_array($set) && $this->skipValidation === false) {
-			foreach ($set as $row) {
-				if ($this->validate($row) === false) {
-					return false;
+		if (is_array($set) && $this->skipValidation === FALSE)
+		{
+			foreach ($set as $row)
+			{
+				if ($this->validate($row) === FALSE)
+				{
+					return FALSE;
 				}
 			}
 		}
@@ -842,38 +894,45 @@ class Model
 	 * @return mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
-	public function delete($id = null, bool $purge = false)
+	public function delete($id = NULL, bool $purge = FALSE)
 	{
-		if (!empty($id) && is_numeric($id)) {
+		if ( ! empty($id) && is_numeric($id))
+		{
 			$id = [$id];
 		}
 
 		$builder = $this->builder();
-		if (!empty($id)) {
+		if ( ! empty($id))
+		{
 			$builder = $builder->whereIn($this->primaryKey, $id);
 		}
 
 		$this->trigger('beforeDelete', ['id' => $id, 'purge' => $purge]);
 
-		if ($this->useSoftDeletes && !$purge) {
-			if (empty($builder->getCompiledQBWhere())) {
-				if (CI_DEBUG) {
+		if ($this->useSoftDeletes && ! $purge)
+		{
+			if (empty($builder->getCompiledQBWhere()))
+			{
+				if (CI_DEBUG)
+				{
 					throw new DatabaseException('Deletes are not allowed unless they contain a "where" or "like" clause.');
 				}
-				return false;
+				return FALSE;
 			}
 			$set[$this->deletedField] = $this->setDate();
 
-			if ($this->useTimestamps && !empty($this->updatedField)) {
+			if ($this->useTimestamps && ! empty($this->updatedField))
+			{
 				$set[$this->updatedField] = $this->setDate();
 			}
 
 			$result = $builder->update($set);
-		} else {
+		} else
+		{
 			$result = $builder->delete();
 		}
 
-		$this->trigger('afterDelete', ['id' => $id, 'purge' => $purge, 'result' => $result, 'data' => null]);
+		$this->trigger('afterDelete', ['id' => $id, 'purge' => $purge, 'result' => $result, 'data' => NULL]);
 
 		return $result;
 	}
@@ -888,8 +947,9 @@ class Model
 	 */
 	public function purgeDeleted()
 	{
-		if (!$this->useSoftDeletes) {
-			return true;
+		if ( ! $this->useSoftDeletes)
+		{
+			return TRUE;
 		}
 
 		return $this->builder()
@@ -907,9 +967,9 @@ class Model
 	 *
 	 * @return Model
 	 */
-	public function withDeleted($val = true)
+	public function withDeleted($val = TRUE)
 	{
-		$this->tempUseSoftDeletes = !$val;
+		$this->tempUseSoftDeletes = ! $val;
 
 		return $this;
 	}
@@ -924,7 +984,7 @@ class Model
 	 */
 	public function onlyDeleted()
 	{
-		$this->tempUseSoftDeletes = false;
+		$this->tempUseSoftDeletes = FALSE;
 
 		$this->builder()
 			->where($this->table . '.' . $this->deletedField . ' IS NOT NULL');
@@ -944,12 +1004,14 @@ class Model
 	 *
 	 * @return mixed
 	 */
-	public function replace($data = null, bool $returnSQL = false)
+	public function replace($data = NULL, bool $returnSQL = FALSE)
 	{
 		// Validate data before saving.
-		if (!empty($data) && $this->skipValidation === false) {
-			if ($this->validate($data) === false) {
-				return false;
+		if ( ! empty($data) && $this->skipValidation === FALSE)
+		{
+			if ($this->validate($data) === FALSE)
+			{
+				return FALSE;
 			}
 		}
 
@@ -1006,16 +1068,18 @@ class Model
 	public function chunk(int $size, Closure $userFunc)
 	{
 		$total = $this->builder()
-			->countAllResults(false);
+			->countAllResults(FALSE);
 
 		$offset = 0;
 
-		while ($offset <= $total) {
+		while ($offset <= $total)
+		{
 			$builder = clone($this->builder());
 
 			$rows = $builder->get($size, $offset);
 
-			if ($rows === false) {
+			if ($rows === FALSE)
+			{
 				throw DataException::forEmptyDataset('chunk');
 			}
 
@@ -1023,12 +1087,15 @@ class Model
 
 			$offset += $size;
 
-			if (empty($rows)) {
+			if (empty($rows))
+			{
 				continue;
 			}
 
-			foreach ($rows as $row) {
-				if ($userFunc($row) === false) {
+			foreach ($rows as $row)
+			{
+				if ($userFunc($row) === FALSE)
+				{
 					return;
 				}
 			}
@@ -1044,7 +1111,7 @@ class Model
 	 *
 	 * @param integer $perPage
 	 * @param string $group Will be used by the pagination library
-	 *                         to identify a unique pagination set.
+	 *                            to identify a unique pagination set.
 	 * @param integer $page Optional page number (useful when the page number is provided in different way)
 	 *
 	 * @return array|null
@@ -1054,7 +1121,7 @@ class Model
 		// Get the necessary parts.
 		$page = $page >= 1 ? $page : (ctype_digit($_GET['page'] ?? '') && $_GET['page'] > 1 ? $_GET['page'] : 1);
 
-		$total = $this->countAllResults(false);
+		$total = $this->countAllResults(FALSE);
 
 		// Store it in the Pager library so it can be
 		// paginated in the views.
@@ -1076,7 +1143,7 @@ class Model
 	 *
 	 * @return Model
 	 */
-	public function protect(bool $protect = true)
+	public function protect(bool $protect = TRUE)
 	{
 		$this->protectFields = $protect;
 
@@ -1093,23 +1160,26 @@ class Model
 	 * @return BaseBuilder
 	 * @throws \CodeIgniter\Exceptions\ModelException;
 	 */
-	protected function builder(string $table = null)
+	protected function builder(string $table = NULL)
 	{
-		if ($this->builder instanceof BaseBuilder) {
+		if ($this->builder instanceof BaseBuilder)
+		{
 			return $this->builder;
 		}
 
 		// We're going to force a primary key to exist
 		// so we don't have overly convoluted code,
 		// and future features are likely to require them.
-		if (empty($this->primaryKey)) {
+		if (empty($this->primaryKey))
+		{
 			throw ModelException::forNoPrimaryKey(get_class($this));
 		}
 
 		$table = empty($table) ? $this->table : $table;
 
 		// Ensure we have a good db connection
-		if (!$this->db instanceof BaseConnection) {
+		if ( ! $this->db instanceof BaseConnection)
+		{
 			$this->db = Database::connect($this->DBGroup);
 		}
 
@@ -1134,17 +1204,22 @@ class Model
 	 */
 	protected function doProtectFields(array $data): array
 	{
-		if ($this->protectFields === false) {
+		if ($this->protectFields === FALSE)
+		{
 			return $data;
 		}
 
-		if (empty($this->allowedFields)) {
+		if (empty($this->allowedFields))
+		{
 			throw DataException::forInvalidAllowedFields(get_class($this));
 		}
 
-		if (is_array($data) && count($data)) {
-			foreach ($data as $key => $val) {
-				if (!in_array($key, $this->allowedFields)) {
+		if (is_array($data) && count($data))
+		{
+			foreach ($data as $key => $val)
+			{
+				if ( ! in_array($key, $this->allowedFields))
+				{
 					unset($data[$key]);
 				}
 			}
@@ -1171,11 +1246,12 @@ class Model
 	 * @return mixed
 	 * @throws \CodeIgniter\Exceptions\ModelException;
 	 */
-	protected function setDate(int $userData = null)
+	protected function setDate(int $userData = NULL)
 	{
 		$currentDate = is_numeric($userData) ? (int)$userData : time();
 
-		switch ($this->dateFormat) {
+		switch ($this->dateFormat)
+		{
 			case 'int':
 				return $currentDate;
 				break;
@@ -1217,13 +1293,15 @@ class Model
 	 *
 	 * @return array|null
 	 */
-	public function errors(bool $forceDB = false)
+	public function errors(bool $forceDB = FALSE)
 	{
 		// Do we have validation errors?
-		if ($forceDB === false && $this->skipValidation === false) {
+		if ($forceDB === FALSE && $this->skipValidation === FALSE)
+		{
 			$errors = $this->validation->getErrors();
 
-			if (!empty($errors)) {
+			if ( ! empty($errors))
+			{
 				return $errors;
 			}
 		}
@@ -1231,7 +1309,7 @@ class Model
 		// Still here? Grab the database-specific error, if any.
 		$error = $this->db->getError();
 
-		return $error['message'] ?? null;
+		return $error['message'] ?? NULL;
 	}
 
 	//--------------------------------------------------------------------
@@ -1246,7 +1324,7 @@ class Model
 	 *
 	 * @return Model
 	 */
-	public function skipValidation(bool $skip = true)
+	public function skipValidation(bool $skip = TRUE)
 	{
 		$this->skipValidation = $skip;
 
@@ -1295,13 +1373,15 @@ class Model
 	 */
 	public function validate($data): bool
 	{
-		if ($this->skipValidation === true || empty($this->validationRules) || empty($data)) {
-			return true;
+		if ($this->skipValidation === TRUE || empty($this->validationRules) || empty($data))
+		{
+			return TRUE;
 		}
 
 		// Query Builder works with objects as well as arrays,
 		// but validation requires array, so cast away.
-		if (is_object($data)) {
+		if (is_object($data))
+		{
 			$data = (array)$data;
 		}
 
@@ -1309,7 +1389,8 @@ class Model
 
 		// ValidationRules can be either a string, which is the group name,
 		// or an array of rules.
-		if (is_string($rules)) {
+		if (is_string($rules))
+		{
 			$rules = $this->validation->loadRuleGroup($rules);
 		}
 
@@ -1317,8 +1398,9 @@ class Model
 
 		// If no data existed that needs validation
 		// our job is done here.
-		if (empty($rules)) {
-			return true;
+		if (empty($rules))
+		{
+			return TRUE;
 		}
 
 		// Replace any placeholders (i.e. {id}) in the rules with
@@ -1326,7 +1408,7 @@ class Model
 		$rules = $this->fillPlaceholders($rules, $data);
 
 		$this->validation->setRules($rules, $this->validationMessages);
-		$valid = $this->validation->run($data, null, $this->DBGroup);
+		$valid = $this->validation->run($data, NULL, $this->DBGroup);
 
 		return (bool)$valid;
 	}
@@ -1344,14 +1426,17 @@ class Model
 	 *
 	 * @return array
 	 */
-	protected function cleanValidationRules(array $rules, array $data = null): array
+	protected function cleanValidationRules(array $rules, array $data = NULL): array
 	{
-		if (empty($data)) {
+		if (empty($data))
+		{
 			return [];
 		}
 
-		foreach ($rules as $field => $rule) {
-			if (!array_key_exists($field, $data)) {
+		foreach ($rules as $field => $rule)
+		{
+			if ( ! array_key_exists($field, $data))
+			{
 				unset($rules[$field]);
 			}
 		}
@@ -1383,17 +1468,23 @@ class Model
 	{
 		$replacements = [];
 
-		foreach ($data as $key => $value) {
+		foreach ($data as $key => $value)
+		{
 			$replacements["{{$key}}"] = $value;
 		}
 
-		if (!empty($replacements)) {
-			foreach ($rules as &$rule) {
-				if (is_array($rule)) {
-					foreach ($rule as &$row) {
+		if ( ! empty($replacements))
+		{
+			foreach ($rules as &$rule)
+			{
+				if (is_array($rule))
+				{
+					foreach ($rule as &$row)
+					{
 						// Should only be an `errors` array
 						// which doesn't take placeholders.
-						if (is_array($row)) {
+						if (is_array($row))
+						{
 							continue;
 						}
 
@@ -1423,9 +1514,11 @@ class Model
 	{
 		$rules = $this->validationRules;
 
-		if (isset($options['except'])) {
+		if (isset($options['except']))
+		{
 			$rules = array_diff_key($rules, array_flip($options['except']));
-		} elseif (isset($options['only'])) {
+		} elseif (isset($options['only']))
+		{
 			$rules = array_intersect_key($rules, array_flip($options['only']));
 		}
 
@@ -1455,10 +1548,11 @@ class Model
 	 *
 	 * @return mixed
 	 */
-	public function countAllResults(bool $reset = true, bool $test = false)
+	public function countAllResults(bool $reset = TRUE, bool $test = FALSE)
 	{
-		if ($this->tempUseSoftDeletes === true) {
-			$this->builder()->where($this->table . '.' . $this->deletedField, null);
+		if ($this->tempUseSoftDeletes === TRUE)
+		{
+			$this->builder()->where($this->table . '.' . $this->deletedField, NULL);
 		}
 
 		return $this->builder()->countAllResults($reset, $test);
@@ -1486,12 +1580,15 @@ class Model
 	protected function trigger(string $event, array $data)
 	{
 		// Ensure it's a valid event
-		if (!isset($this->{$event}) || empty($this->{$event})) {
+		if ( ! isset($this->{$event}) || empty($this->{$event}))
+		{
 			return $data;
 		}
 
-		foreach ($this->{$event} as $callback) {
-			if (!method_exists($this, $callback)) {
+		foreach ($this->{$event} as $callback)
+		{
+			if ( ! method_exists($this, $callback))
+			{
 				throw DataException::forInvalidMethodTriggered($callback);
 			}
 
@@ -1516,15 +1613,18 @@ class Model
 	 */
 	public function __get(string $name)
 	{
-		if (in_array($name, ['primaryKey', 'table', 'returnType', 'DBGroup'])) {
+		if (in_array($name, ['primaryKey', 'table', 'returnType', 'DBGroup']))
+		{
 			return $this->{$name};
-		} elseif (isset($this->db->$name)) {
+		} elseif (isset($this->db->$name))
+		{
 			return $this->db->$name;
-		} elseif (isset($this->builder()->$name)) {
+		} elseif (isset($this->builder()->$name))
+		{
 			return $this->builder()->$name;
 		}
 
-		return null;
+		return NULL;
 	}
 
 	//--------------------------------------------------------------------
@@ -1540,21 +1640,25 @@ class Model
 	 */
 	public function __call(string $name, array $params)
 	{
-		$result = null;
+		$result = NULL;
 
-		if (method_exists($this->db, $name)) {
+		if (method_exists($this->db, $name))
+		{
 			$result = $this->db->$name(...$params);
-		} elseif (method_exists($builder = $this->builder(), $name)) {
+		} elseif (method_exists($builder = $this->builder(), $name))
+		{
 			$result = $builder->$name(...$params);
 		}
 
 		// Don't return the builder object unless specifically requested
 		//, since that will interrupt the usability flow
 		// and break intermingling of model and builder methods.
-		if ($name !== 'builder' && empty($result)) {
+		if ($name !== 'builder' && empty($result))
+		{
 			return $result;
 		}
-		if ($name !== 'builder' && !$result instanceof BaseBuilder) {
+		if ($name !== 'builder' && ! $result instanceof BaseBuilder)
+		{
 			return $result;
 		}
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -48,6 +48,7 @@ use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\ConnectionInterface;
 use CodeIgniter\Validation\ValidationInterface;
 use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use ReflectionClass;
 use ReflectionProperty;
 use stdClass;
@@ -714,13 +715,13 @@ class Model
 		$result = $this->builder()
 				->set($data['data'], '', $escape)
 				->insert();
-		
+
 		// If insertion succeeded then save the insert ID
 		if ($result)
 		{
 			$this->insertID = $this->db->insertID();
 		}
-		
+
 		$this->trigger('afterInsert', ['data' => $originalData, 'result' => $result]);
 
 		// If insertion failed, get out of here
@@ -913,6 +914,14 @@ class Model
 
 		if ($this->useSoftDeletes && ! $purge)
 		{
+			if (empty(trim($id)))
+			{
+				if (CI_DEBUG)
+				{
+					throw new DatabaseException('Deletes are not allowed unless they contain a "where" or "like" clause.');
+				}
+				return false;
+			}
 			$set[$this->deletedField] = $this->setDate();
 
 			if ($this->useTimestamps && ! empty($this->updatedField))
@@ -948,8 +957,8 @@ class Model
 		}
 
 		return $this->builder()
-			    ->where($this->table . '.' . $this->deletedField . ' IS NOT NULL')
-			    ->delete();
+				->where($this->table . '.' . $this->deletedField . ' IS NOT NULL')
+				->delete();
 	}
 
 	//--------------------------------------------------------------------
@@ -982,7 +991,7 @@ class Model
 		$this->tempUseSoftDeletes = false;
 
 		$this->builder()
-		     ->where($this->table . '.' . $this->deletedField . ' IS NOT NULL');
+			 ->where($this->table . '.' . $this->deletedField . ' IS NOT NULL');
 
 		return $this;
 	}

--- a/system/Model.php
+++ b/system/Model.php
@@ -318,20 +318,16 @@ class Model
 	 */
 	public function __construct(ConnectionInterface &$db = null, ValidationInterface $validation = null)
 	{
-		if ($db instanceof ConnectionInterface)
-		{
-			$this->db = & $db;
-		}
-		else
-		{
+		if ($db instanceof ConnectionInterface) {
+			$this->db = &$db;
+		} else {
 			$this->db = Database::connect($this->DBGroup);
 		}
 
-		$this->tempReturnType     = $this->returnType;
+		$this->tempReturnType = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
 
-		if (is_null($validation))
-		{
+		if (is_null($validation)) {
 			$validation = \Config\Services::validation(null, false);
 		}
 
@@ -355,26 +351,20 @@ class Model
 	{
 		$builder = $this->builder();
 
-		if ($this->tempUseSoftDeletes === true)
-		{
+		if ($this->tempUseSoftDeletes === true) {
 			$builder->where($this->table . '.' . $this->deletedField, null);
 		}
 
-		if (is_array($id))
-		{
+		if (is_array($id)) {
 			$row = $builder->whereIn($this->table . '.' . $this->primaryKey, $id)
-					->get();
+				->get();
 			$row = $row->getResult($this->tempReturnType);
-		}
-		elseif (is_numeric($id) || is_string($id))
-		{
+		} elseif (is_numeric($id) || is_string($id)) {
 			$row = $builder->where($this->table . '.' . $this->primaryKey, $id)
-					->get();
+				->get();
 
 			$row = $row->getFirstRow($this->tempReturnType);
-		}
-		else
-		{
+		} else {
 			$row = $builder->get();
 
 			$row = $row->getResult($this->tempReturnType);
@@ -382,7 +372,7 @@ class Model
 
 		$row = $this->trigger('afterFind', ['id' => $id, 'data' => $row]);
 
-		$this->tempReturnType     = $this->returnType;
+		$this->tempReturnType = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
 
 		return $row['data'];
@@ -400,16 +390,15 @@ class Model
 	 */
 	public function findColumn(string $columnName)
 	{
-		if (strpos($columnName, ',') !== false)
-		{
+		if (strpos($columnName, ',') !== false) {
 			throw DataException::forFindColumnHaveMultipleColumns();
 		}
 
 		$resultSet = $this->select($columnName)
-						  ->asArray()
-						  ->find();
+			->asArray()
+			->find();
 
-		return (! empty($resultSet)) ? array_column($resultSet, $columnName) : null;
+		return (!empty($resultSet)) ? array_column($resultSet, $columnName) : null;
 	}
 
 	//--------------------------------------------------------------------
@@ -427,19 +416,18 @@ class Model
 	{
 		$builder = $this->builder();
 
-		if ($this->tempUseSoftDeletes === true)
-		{
+		if ($this->tempUseSoftDeletes === true) {
 			$builder->where($this->table . '.' . $this->deletedField, null);
 		}
 
 		$row = $builder->limit($limit, $offset)
-				->get();
+			->get();
 
 		$row = $row->getResult($this->tempReturnType);
 
 		$row = $this->trigger('afterFind', ['data' => $row, 'limit' => $limit, 'offset' => $offset]);
 
-		$this->tempReturnType     = $this->returnType;
+		$this->tempReturnType = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
 
 		return $row['data'];
@@ -457,20 +445,18 @@ class Model
 	{
 		$builder = $this->builder();
 
-		if ($this->tempUseSoftDeletes === true)
-		{
+		if ($this->tempUseSoftDeletes === true) {
 			$builder->where($this->table . '.' . $this->deletedField, null);
 		}
 
 		// Some databases, like PostgreSQL, need order
 		// information to consistently return correct results.
-		if (empty($builder->QBOrderBy) && ! empty($this->primaryKey))
-		{
+		if (empty($builder->QBOrderBy) && !empty($this->primaryKey)) {
 			$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');
 		}
 
 		$row = $builder->limit(1, 0)
-				->get();
+			->get();
 
 		$row = $row->getFirstRow($this->tempReturnType);
 
@@ -488,8 +474,8 @@ class Model
 	 * data here. This allows it to be used with any of the other
 	 * builder methods and still get validated data, like replace.
 	 *
-	 * @param mixed        $key
-	 * @param string       $value
+	 * @param mixed $key
+	 * @param string $value
 	 * @param boolean|null $escape
 	 *
 	 * @return $this
@@ -501,7 +487,7 @@ class Model
 			: [$key => $value];
 
 		$this->tempData['escape'] = $escape;
-		$this->tempData['data']   = array_merge($this->tempData['data'] ?? [], $data);
+		$this->tempData['data'] = array_merge($this->tempData['data'] ?? [], $data);
 
 		return $this;
 	}
@@ -522,25 +508,18 @@ class Model
 	 */
 	public function save($data): bool
 	{
-		if (empty($data))
-		{
+		if (empty($data)) {
 			return true;
 		}
 
-		if (is_object($data) && isset($data->{$this->primaryKey}))
-		{
+		if (is_object($data) && isset($data->{$this->primaryKey})) {
 			$response = $this->update($data->{$this->primaryKey}, $data);
-		}
-		elseif (is_array($data) && ! empty($data[$this->primaryKey]))
-		{
+		} elseif (is_array($data) && !empty($data[$this->primaryKey])) {
 			$response = $this->update($data[$this->primaryKey], $data);
-		}
-		else
-		{
+		} else {
 			$response = $this->insert($data, false);
 			// call insert directly if you want the ID or the record object
-			if ($response !== false)
-			{
+			if ($response !== false) {
 				$response = true;
 			}
 		}
@@ -553,52 +532,43 @@ class Model
 	 * properties as an array suitable for use in creates and updates.
 	 *
 	 * @param string|object $data
-	 * @param string|null   $primaryKey
-	 * @param string        $dateFormat
-	 * @param boolean       $onlyChanged
+	 * @param string|null $primaryKey
+	 * @param string $dateFormat
+	 * @param boolean $onlyChanged
 	 *
 	 * @return array
 	 * @throws \ReflectionException
 	 */
 	public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime', bool $onlyChanged = true): array
 	{
-		if (method_exists($data, 'toRawArray'))
-		{
+		if (method_exists($data, 'toRawArray')) {
 			$properties = $data->toRawArray($onlyChanged);
 
 			// Always grab the primary key otherwise updates will fail.
-			if (! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties))
-			{
+			if (!empty($properties) && !empty($primaryKey) && !in_array($primaryKey, $properties)) {
 				$properties[$primaryKey] = $data->{$primaryKey};
 			}
-		}
-		else
-		{
+		} else {
 			$mirror = new ReflectionClass($data);
-			$props  = $mirror->getProperties(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED);
+			$props = $mirror->getProperties(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED);
 
 			$properties = [];
 
 			// Loop over each property,
 			// saving the name/value in a new array we can return.
-			foreach ($props as $prop)
-			{
+			foreach ($props as $prop) {
 				// Must make protected values accessible.
 				$prop->setAccessible(true);
-				$propName              = $prop->getName();
+				$propName = $prop->getName();
 				$properties[$propName] = $prop->getValue($data);
 			}
 		}
 
 		// Convert any Time instances to appropriate $dateFormat
-		if ($properties)
-		{
-			foreach ($properties as $key => $value)
-			{
-				if ($value instanceof Time)
-				{
-					switch ($dateFormat)
-					{
+		if ($properties) {
+			foreach ($properties as $key => $value) {
+				if ($value instanceof Time) {
+					switch ($dateFormat) {
 						case 'datetime':
 							$converted = $value->format('Y-m-d H:i:s');
 							break;
@@ -639,7 +609,7 @@ class Model
 	 * it will attempt to convert it to an array.
 	 *
 	 * @param array|object $data
-	 * @param boolean      $returnID Whether insert ID should be returned or not.
+	 * @param boolean $returnID Whether insert ID should be returned or not.
 	 *
 	 * @return integer|string|boolean
 	 * @throws \ReflectionException
@@ -650,39 +620,33 @@ class Model
 
 		$this->insertID = 0;
 
-		if (empty($data))
-		{
-			$data           = $this->tempData['data'] ?? null;
-			$escape         = $this->tempData['escape'] ?? null;
+		if (empty($data)) {
+			$data = $this->tempData['data'] ?? null;
+			$escape = $this->tempData['escape'] ?? null;
 			$this->tempData = [];
 		}
 
-		if (empty($data))
-		{
+		if (empty($data)) {
 			throw DataException::forEmptyDataset('insert');
 		}
 
 		// If $data is using a custom class with public or protected
 		// properties representing the table elements, we need to grab
 		// them as an array.
-		if (is_object($data) && ! $data instanceof stdClass)
-		{
+		if (is_object($data) && !$data instanceof stdClass) {
 			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat, false);
 		}
 
 		// If it's still a stdClass, go ahead and convert to
 		// an array so doProtectFields and other model methods
 		// don't have to do special checks.
-		if (is_object($data))
-		{
-			$data = (array) $data;
+		if (is_object($data)) {
+			$data = (array)$data;
 		}
 
 		// Validate data before saving.
-		if ($this->skipValidation === false)
-		{
-			if ($this->validate($data) === false)
-			{
+		if ($this->skipValidation === false) {
+			if ($this->validate($data) === false) {
 				return false;
 			}
 		}
@@ -699,13 +663,11 @@ class Model
 		// Set created_at and updated_at with same time
 		$date = $this->setDate();
 
-		if ($this->useTimestamps && ! empty($this->createdField) && ! array_key_exists($this->createdField, $data))
-		{
+		if ($this->useTimestamps && !empty($this->createdField) && !array_key_exists($this->createdField, $data)) {
 			$data[$this->createdField] = $date;
 		}
 
-		if ($this->useTimestamps && ! empty($this->updatedField) && ! array_key_exists($this->updatedField, $data))
-		{
+		if ($this->useTimestamps && !empty($this->updatedField) && !array_key_exists($this->updatedField, $data)) {
 			$data[$this->updatedField] = $date;
 		}
 
@@ -713,20 +675,18 @@ class Model
 
 		// Must use the set() method to ensure objects get converted to arrays
 		$result = $this->builder()
-				->set($data['data'], '', $escape)
-				->insert();
+			->set($data['data'], '', $escape)
+			->insert();
 
 		// If insertion succeeded then save the insert ID
-		if ($result)
-		{
+		if ($result) {
 			$this->insertID = $this->db->insertID();
 		}
 
 		$this->trigger('afterInsert', ['data' => $originalData, 'result' => $result]);
 
 		// If insertion failed, get out of here
-		if (! $result)
-		{
+		if (!$result) {
 			return $result;
 		}
 
@@ -739,8 +699,8 @@ class Model
 	/**
 	 * Compiles batch insert strings and runs the queries, validating each row prior.
 	 *
-	 * @param array   $set       An associative array of insert values
-	 * @param boolean $escape    Whether to escape values and identifiers
+	 * @param array $set An associative array of insert values
+	 * @param boolean $escape Whether to escape values and identifiers
 	 *
 	 * @param integer $batchSize
 	 * @param boolean $testing
@@ -749,12 +709,9 @@ class Model
 	 */
 	public function insertBatch(array $set = null, bool $escape = null, int $batchSize = 100, bool $testing = false)
 	{
-		if (is_array($set) && $this->skipValidation === false)
-		{
-			foreach ($set as $row)
-			{
-				if ($this->validate($row) === false)
-				{
+		if (is_array($set) && $this->skipValidation === false) {
+			foreach ($set as $row) {
+				if ($this->validate($row) === false) {
 					return false;
 				}
 			}
@@ -770,7 +727,7 @@ class Model
 	 * it will attempt to convert it into an array.
 	 *
 	 * @param integer|array|string $id
-	 * @param array|object         $data
+	 * @param array|object $data
 	 *
 	 * @return boolean
 	 * @throws \ReflectionException
@@ -779,44 +736,37 @@ class Model
 	{
 		$escape = null;
 
-		if (is_numeric($id) || is_string($id))
-		{
+		if (is_numeric($id) || is_string($id)) {
 			$id = [$id];
 		}
 
-		if (empty($data))
-		{
-			$data           = $this->tempData['data'] ?? null;
-			$escape         = $this->tempData['escape'] ?? null;
+		if (empty($data)) {
+			$data = $this->tempData['data'] ?? null;
+			$escape = $this->tempData['escape'] ?? null;
 			$this->tempData = [];
 		}
 
-		if (empty($data))
-		{
+		if (empty($data)) {
 			throw DataException::forEmptyDataset('update');
 		}
 
 		// If $data is using a custom class with public or protected
 		// properties representing the table elements, we need to grab
 		// them as an array.
-		if (is_object($data) && ! $data instanceof stdClass)
-		{
+		if (is_object($data) && !$data instanceof stdClass) {
 			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat);
 		}
 
 		// If it's still a stdClass, go ahead and convert to
 		// an array so doProtectFields and other model methods
 		// don't have to do special checks.
-		if (is_object($data))
-		{
-			$data = (array) $data;
+		if (is_object($data)) {
+			$data = (array)$data;
 		}
 
 		// Validate data before saving.
-		if ($this->skipValidation === false)
-		{
-			if ($this->validate($data) === false)
-			{
+		if ($this->skipValidation === false) {
+			if ($this->validate($data) === false) {
 				return false;
 			}
 		}
@@ -830,8 +780,7 @@ class Model
 		// strip out updated_at values.
 		$data = $this->doProtectFields($data);
 
-		if ($this->useTimestamps && ! empty($this->updatedField) && ! array_key_exists($this->updatedField, $data))
-		{
+		if ($this->useTimestamps && !empty($this->updatedField) && !array_key_exists($this->updatedField, $data)) {
 			$data[$this->updatedField] = $this->setDate();
 		}
 
@@ -839,15 +788,14 @@ class Model
 
 		$builder = $this->builder();
 
-		if ($id)
-		{
+		if ($id) {
 			$builder = $builder->whereIn($this->table . '.' . $this->primaryKey, $id);
 		}
 
 		// Must use the set() method to ensure objects get converted to arrays
 		$result = $builder
-				->set($data['data'], '', $escape)
-				->update();
+			->set($data['data'], '', $escape)
+			->update();
 
 		$this->trigger('afterUpdate', ['id' => $id, 'data' => $originalData, 'result' => $result]);
 
@@ -861,8 +809,8 @@ class Model
 	 *
 	 * Compiles an update string and runs the query
 	 *
-	 * @param array   $set       An associative array of update values
-	 * @param string  $index     The where key
+	 * @param array $set An associative array of update values
+	 * @param string $index The where key
 	 * @param integer $batchSize The size of the batch to run
 	 * @param boolean $returnSQL True means SQL is returned, false will execute the query
 	 *
@@ -871,12 +819,9 @@ class Model
 	 */
 	public function updateBatch(array $set = null, string $index = null, int $batchSize = 100, bool $returnSQL = false)
 	{
-		if (is_array($set) && $this->skipValidation === false)
-		{
-			foreach ($set as $row)
-			{
-				if ($this->validate($row) === false)
-				{
+		if (is_array($set) && $this->skipValidation === false) {
+			foreach ($set as $row) {
+				if ($this->validate($row) === false) {
 					return false;
 				}
 			}
@@ -891,48 +836,40 @@ class Model
 	 * Deletes a single record from $this->table where $id matches
 	 * the table's primaryKey
 	 *
-	 * @param integer|array|null $id    The rows primary key(s)
-	 * @param boolean            $purge Allows overriding the soft deletes setting.
+	 * @param integer|array|null $id The rows primary key(s)
+	 * @param boolean $purge Allows overriding the soft deletes setting.
 	 *
 	 * @return mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
 	public function delete($id = null, bool $purge = false)
 	{
-		if (! empty($id) && is_numeric($id))
-		{
+		if (!empty($id) && is_numeric($id)) {
 			$id = [$id];
 		}
 
 		$builder = $this->builder();
-		if (! empty($id))
-		{
+		if (!empty($id)) {
 			$builder = $builder->whereIn($this->primaryKey, $id);
 		}
 
 		$this->trigger('beforeDelete', ['id' => $id, 'purge' => $purge]);
 
-		if ($this->useSoftDeletes && ! $purge)
-		{
-			if (empty(trim($id)))
-			{
-				if (CI_DEBUG)
-				{
+		if ($this->useSoftDeletes && !$purge) {
+			if (empty($builder->getCompiledQBWhere())) {
+				if (CI_DEBUG) {
 					throw new DatabaseException('Deletes are not allowed unless they contain a "where" or "like" clause.');
 				}
 				return false;
 			}
 			$set[$this->deletedField] = $this->setDate();
 
-			if ($this->useTimestamps && ! empty($this->updatedField))
-			{
+			if ($this->useTimestamps && !empty($this->updatedField)) {
 				$set[$this->updatedField] = $this->setDate();
 			}
 
 			$result = $builder->update($set);
-		}
-		else
-		{
+		} else {
 			$result = $builder->delete();
 		}
 
@@ -951,14 +888,13 @@ class Model
 	 */
 	public function purgeDeleted()
 	{
-		if (! $this->useSoftDeletes)
-		{
+		if (!$this->useSoftDeletes) {
 			return true;
 		}
 
 		return $this->builder()
-				->where($this->table . '.' . $this->deletedField . ' IS NOT NULL')
-				->delete();
+			->where($this->table . '.' . $this->deletedField . ' IS NOT NULL')
+			->delete();
 	}
 
 	//--------------------------------------------------------------------
@@ -973,7 +909,7 @@ class Model
 	 */
 	public function withDeleted($val = true)
 	{
-		$this->tempUseSoftDeletes = ! $val;
+		$this->tempUseSoftDeletes = !$val;
 
 		return $this;
 	}
@@ -991,7 +927,7 @@ class Model
 		$this->tempUseSoftDeletes = false;
 
 		$this->builder()
-			 ->where($this->table . '.' . $this->deletedField . ' IS NOT NULL');
+			->where($this->table . '.' . $this->deletedField . ' IS NOT NULL');
 
 		return $this;
 	}
@@ -1003,7 +939,7 @@ class Model
 	 *
 	 * Compiles an replace into string and runs the query
 	 *
-	 * @param null    $data
+	 * @param null $data
 	 * @param boolean $returnSQL
 	 *
 	 * @return mixed
@@ -1011,10 +947,8 @@ class Model
 	public function replace($data = null, bool $returnSQL = false)
 	{
 		// Validate data before saving.
-		if (! empty($data) && $this->skipValidation === false)
-		{
-			if ($this->validate($data) === false)
-			{
+		if (!empty($data) && $this->skipValidation === false) {
+			if ($this->validate($data) === false) {
 				return false;
 			}
 		}
@@ -1064,7 +998,7 @@ class Model
 	 * Works with $this->builder to get the Compiled select to
 	 * determine the rows to operate on.
 	 *
-	 * @param integer  $size
+	 * @param integer $size
 	 * @param \Closure $userFunc
 	 *
 	 * @throws \CodeIgniter\Database\Exceptions\DataException
@@ -1072,18 +1006,16 @@ class Model
 	public function chunk(int $size, Closure $userFunc)
 	{
 		$total = $this->builder()
-				->countAllResults(false);
+			->countAllResults(false);
 
 		$offset = 0;
 
-		while ($offset <= $total)
-		{
+		while ($offset <= $total) {
 			$builder = clone($this->builder());
 
 			$rows = $builder->get($size, $offset);
 
-			if ($rows === false)
-			{
+			if ($rows === false) {
 				throw DataException::forEmptyDataset('chunk');
 			}
 
@@ -1091,15 +1023,12 @@ class Model
 
 			$offset += $size;
 
-			if (empty($rows))
-			{
+			if (empty($rows)) {
 				continue;
 			}
 
-			foreach ($rows as $row)
-			{
-				if ($userFunc($row) === false)
-				{
+			foreach ($rows as $row) {
+				if ($userFunc($row) === false) {
 					return;
 				}
 			}
@@ -1114,9 +1043,9 @@ class Model
 	 * to display.
 	 *
 	 * @param integer $perPage
-	 * @param string  $group   Will be used by the pagination library
+	 * @param string $group Will be used by the pagination library
 	 *                         to identify a unique pagination set.
-	 * @param integer $page    Optional page number (useful when the page number is provided in different way)
+	 * @param integer $page Optional page number (useful when the page number is provided in different way)
 	 *
 	 * @return array|null
 	 */
@@ -1129,7 +1058,7 @@ class Model
 
 		// Store it in the Pager library so it can be
 		// paginated in the views.
-		$pager       = \Config\Services::pager();
+		$pager = \Config\Services::pager();
 		$this->pager = $pager->store($group, $page, $perPage, $total);
 
 		$offset = ($page - 1) * $perPage;
@@ -1166,24 +1095,21 @@ class Model
 	 */
 	protected function builder(string $table = null)
 	{
-		if ($this->builder instanceof BaseBuilder)
-		{
+		if ($this->builder instanceof BaseBuilder) {
 			return $this->builder;
 		}
 
 		// We're going to force a primary key to exist
 		// so we don't have overly convoluted code,
 		// and future features are likely to require them.
-		if (empty($this->primaryKey))
-		{
+		if (empty($this->primaryKey)) {
 			throw ModelException::forNoPrimaryKey(get_class($this));
 		}
 
 		$table = empty($table) ? $this->table : $table;
 
 		// Ensure we have a good db connection
-		if (! $this->db instanceof BaseConnection)
-		{
+		if (!$this->db instanceof BaseConnection) {
 			$this->db = Database::connect($this->DBGroup);
 		}
 
@@ -1208,22 +1134,17 @@ class Model
 	 */
 	protected function doProtectFields(array $data): array
 	{
-		if ($this->protectFields === false)
-		{
+		if ($this->protectFields === false) {
 			return $data;
 		}
 
-		if (empty($this->allowedFields))
-		{
+		if (empty($this->allowedFields)) {
 			throw DataException::forInvalidAllowedFields(get_class($this));
 		}
 
-		if (is_array($data) && count($data))
-		{
-			foreach ($data as $key => $val)
-			{
-				if (! in_array($key, $this->allowedFields))
-				{
+		if (is_array($data) && count($data)) {
+			foreach ($data as $key => $val) {
+				if (!in_array($key, $this->allowedFields)) {
 					unset($data[$key]);
 				}
 			}
@@ -1252,10 +1173,9 @@ class Model
 	 */
 	protected function setDate(int $userData = null)
 	{
-		$currentDate = is_numeric($userData) ? (int) $userData : time();
+		$currentDate = is_numeric($userData) ? (int)$userData : time();
 
-		switch ($this->dateFormat)
-		{
+		switch ($this->dateFormat) {
 			case 'int':
 				return $currentDate;
 				break;
@@ -1300,12 +1220,10 @@ class Model
 	public function errors(bool $forceDB = false)
 	{
 		// Do we have validation errors?
-		if ($forceDB === false && $this->skipValidation === false)
-		{
+		if ($forceDB === false && $this->skipValidation === false) {
 			$errors = $this->validation->getErrors();
 
-			if (! empty($errors))
-			{
+			if (!empty($errors)) {
 				return $errors;
 			}
 		}
@@ -1356,7 +1274,7 @@ class Model
 	 * It could be used when you have to change default or override current validate messages.
 	 *
 	 * @param string $field
-	 * @param array  $fieldMessages
+	 * @param array $fieldMessages
 	 *
 	 * @return void
 	 */
@@ -1377,24 +1295,21 @@ class Model
 	 */
 	public function validate($data): bool
 	{
-		if ($this->skipValidation === true || empty($this->validationRules) || empty($data))
-		{
+		if ($this->skipValidation === true || empty($this->validationRules) || empty($data)) {
 			return true;
 		}
 
 		// Query Builder works with objects as well as arrays,
 		// but validation requires array, so cast away.
-		if (is_object($data))
-		{
-			$data = (array) $data;
+		if (is_object($data)) {
+			$data = (array)$data;
 		}
 
 		$rules = $this->validationRules;
 
 		// ValidationRules can be either a string, which is the group name,
 		// or an array of rules.
-		if (is_string($rules))
-		{
+		if (is_string($rules)) {
 			$rules = $this->validation->loadRuleGroup($rules);
 		}
 
@@ -1402,8 +1317,7 @@ class Model
 
 		// If no data existed that needs validation
 		// our job is done here.
-		if (empty($rules))
-		{
+		if (empty($rules)) {
 			return true;
 		}
 
@@ -1414,7 +1328,7 @@ class Model
 		$this->validation->setRules($rules, $this->validationMessages);
 		$valid = $this->validation->run($data, null, $this->DBGroup);
 
-		return (bool) $valid;
+		return (bool)$valid;
 	}
 
 	//--------------------------------------------------------------------
@@ -1424,7 +1338,7 @@ class Model
 	 * currently so that rules don't block updating when only updating
 	 * a partial row.
 	 *
-	 * @param array      $rules
+	 * @param array $rules
 	 *
 	 * @param array|null $data
 	 *
@@ -1432,15 +1346,12 @@ class Model
 	 */
 	protected function cleanValidationRules(array $rules, array $data = null): array
 	{
-		if (empty($data))
-		{
+		if (empty($data)) {
 			return [];
 		}
 
-		foreach ($rules as $field => $rule)
-		{
-			if (! array_key_exists($field, $data))
-			{
+		foreach ($rules as $field => $rule) {
+			if (!array_key_exists($field, $data)) {
 				unset($rules[$field]);
 			}
 		}
@@ -1472,23 +1383,17 @@ class Model
 	{
 		$replacements = [];
 
-		foreach ($data as $key => $value)
-		{
+		foreach ($data as $key => $value) {
 			$replacements["{{$key}}"] = $value;
 		}
 
-		if (! empty($replacements))
-		{
-			foreach ($rules as &$rule)
-			{
-				if (is_array($rule))
-				{
-					foreach ($rule as &$row)
-					{
+		if (!empty($replacements)) {
+			foreach ($rules as &$rule) {
+				if (is_array($rule)) {
+					foreach ($rule as &$row) {
 						// Should only be an `errors` array
 						// which doesn't take placeholders.
-						if (is_array($row))
-						{
+						if (is_array($row)) {
 							continue;
 						}
 
@@ -1518,12 +1423,9 @@ class Model
 	{
 		$rules = $this->validationRules;
 
-		if (isset($options['except']))
-		{
+		if (isset($options['except'])) {
 			$rules = array_diff_key($rules, array_flip($options['except']));
-		}
-		elseif (isset($options['only']))
-		{
+		} elseif (isset($options['only'])) {
 			$rules = array_intersect_key($rules, array_flip($options['only']));
 		}
 
@@ -1555,8 +1457,7 @@ class Model
 	 */
 	public function countAllResults(bool $reset = true, bool $test = false)
 	{
-		if ($this->tempUseSoftDeletes === true)
-		{
+		if ($this->tempUseSoftDeletes === true) {
 			$this->builder()->where($this->table . '.' . $this->deletedField, null);
 		}
 
@@ -1577,7 +1478,7 @@ class Model
 	 * or update, an array of results, etc)
 	 *
 	 * @param string $event
-	 * @param array  $data
+	 * @param array $data
 	 *
 	 * @return mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DataException
@@ -1585,15 +1486,12 @@ class Model
 	protected function trigger(string $event, array $data)
 	{
 		// Ensure it's a valid event
-		if (! isset($this->{$event}) || empty($this->{$event}))
-		{
+		if (!isset($this->{$event}) || empty($this->{$event})) {
 			return $data;
 		}
 
-		foreach ($this->{$event} as $callback)
-		{
-			if (! method_exists($this, $callback))
-			{
+		foreach ($this->{$event} as $callback) {
+			if (!method_exists($this, $callback)) {
 				throw DataException::forInvalidMethodTriggered($callback);
 			}
 
@@ -1618,16 +1516,11 @@ class Model
 	 */
 	public function __get(string $name)
 	{
-		if (in_array($name, ['primaryKey', 'table', 'returnType', 'DBGroup']))
-		{
+		if (in_array($name, ['primaryKey', 'table', 'returnType', 'DBGroup'])) {
 			return $this->{$name};
-		}
-		elseif (isset($this->db->$name))
-		{
+		} elseif (isset($this->db->$name)) {
 			return $this->db->$name;
-		}
-		elseif (isset($this->builder()->$name))
-		{
+		} elseif (isset($this->builder()->$name)) {
 			return $this->builder()->$name;
 		}
 
@@ -1641,7 +1534,7 @@ class Model
 	 * and the database connection.
 	 *
 	 * @param string $name
-	 * @param array  $params
+	 * @param array $params
 	 *
 	 * @return Model|null
 	 */
@@ -1649,24 +1542,19 @@ class Model
 	{
 		$result = null;
 
-		if (method_exists($this->db, $name))
-		{
+		if (method_exists($this->db, $name)) {
 			$result = $this->db->$name(...$params);
-		}
-		elseif (method_exists($builder = $this->builder(), $name))
-		{
+		} elseif (method_exists($builder = $this->builder(), $name)) {
 			$result = $builder->$name(...$params);
 		}
 
 		// Don't return the builder object unless specifically requested
 		//, since that will interrupt the usability flow
 		// and break intermingling of model and builder methods.
-		if ($name !== 'builder' && empty($result))
-		{
+		if ($name !== 'builder' && empty($result)) {
 			return $result;
 		}
-		if ($name !== 'builder' && ! $result instanceof BaseBuilder)
-		{
+		if ($name !== 'builder' && !$result instanceof BaseBuilder) {
 			return $result;
 		}
 

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -441,6 +441,43 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	/**
+	 * @expectedException        \CodeIgniter\Database\Exceptions\DatabaseException
+	 * @expectedExceptionMessage Deletes are not allowed unless they contain a "where" or "like" clause.
+	 * @dataProvider             emptyPkValues
+	 * @return                   void
+	 */
+	public function testThrowExceptionWhenSoftDeletePKisEmptyValue($emptyValue)
+	{
+		$model = new UserModel();
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
+		$model->delete($emptyValue);
+	}
+	/**
+	 * @expectedException        \CodeIgniter\Database\Exceptions\DatabaseException
+	 * @expectedExceptionMessage Deletes are not allowed unless they contain a "where" or "like" clause.
+	 * @dataProvider             emptyPkValues
+	 * @return                   void
+	 */
+	public function testDontDeleteRowsWhenSoftDeletePKisEmptyValue($emptyValue)
+	{
+		$model = new UserModel();
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
+		$model->delete($emptyValue);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
+		unset($model);
+	}
+
+	public function emptyPkValues()
+	{
+		return [
+			[0],
+			[null],
+			['0'],
+			[false],
+		];
+	}
+
 	public function testDeleteNoParams()
 	{
 		$model = new JobModel();

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -21,11 +21,10 @@ use Tests\Support\Models\ValidModel;
 /**
  * @group DatabaseLive
  */
-class ModelTest extends CIDatabaseTestCase
-{
+class ModelTest extends CIDatabaseTestCase {
 	use ReflectionHelper;
 
-	protected $refresh = true;
+	protected $refresh = TRUE;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
 
@@ -102,7 +101,7 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new JobModel($this->db);
 
 		$jobs = $model->asArray()
-					  ->find();
+			->find();
 
 		$this->assertCount(4, $jobs);
 
@@ -120,7 +119,7 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new JobModel($this->db);
 
 		$job = $model->asArray()
-					 ->find(4);
+			->find(4);
 
 		$this->assertInternalType('array', $job);
 	}
@@ -132,7 +131,7 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new JobModel($this->db);
 
 		$job = $model->asObject()
-					 ->find(4);
+			->find(4);
 
 		$this->assertInternalType('object', $job);
 	}
@@ -142,18 +141,18 @@ class ModelTest extends CIDatabaseTestCase
 	public function testFindRespectsSoftDeletes()
 	{
 		$this->db->table('user')
-				 ->where('id', 4)
-				 ->update(['deleted_at' => date('Y-m-d H:i:s')]);
+			->where('id', 4)
+			->update(['deleted_at' => date('Y-m-d H:i:s')]);
 
 		$model = new UserModel($this->db);
 
 		$user = $model->asObject()
-					  ->find(4);
+			->find(4);
 
 		$this->assertEmpty($user);
 
 		$user = $model->withDeleted()
-					  ->find(4);
+			->find(4);
 
 		// fix for PHP7.2
 		$count = is_array($user) ? count($user) : 1;
@@ -171,7 +170,7 @@ class ModelTest extends CIDatabaseTestCase
 
 		// Binds should be reset to 0 after each one
 		$binds = $model->builder()
-					   ->getBinds();
+			->getBinds();
 		$this->assertCount(0, $binds);
 
 		$query = $model->getLastQuery();
@@ -218,8 +217,8 @@ class ModelTest extends CIDatabaseTestCase
 	public function testFindAllRespectsSoftDeletes()
 	{
 		$this->db->table('user')
-				 ->where('id', 4)
-				 ->update(['deleted_at' => date('Y-m-d H:i:s')]);
+			->where('id', 4)
+			->update(['deleted_at' => date('Y-m-d H:i:s')]);
 
 		$model = new UserModel($this->db);
 
@@ -228,7 +227,7 @@ class ModelTest extends CIDatabaseTestCase
 		$this->assertCount(3, $user);
 
 		$user = $model->withDeleted()
-					  ->findAll();
+			->findAll();
 
 		$this->assertCount(4, $user);
 	}
@@ -240,7 +239,7 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new UserModel();
 
 		$user = $model->where('id >', 2)
-					  ->first();
+			->first();
 
 		// fix for PHP7.2
 		$count = is_array($user) ? count($user) : 1;
@@ -253,8 +252,8 @@ class ModelTest extends CIDatabaseTestCase
 	public function testFirstRespectsSoftDeletes()
 	{
 		$this->db->table('user')
-				 ->where('id', 1)
-				 ->update(['deleted_at' => date('Y-m-d H:i:s')]);
+			->where('id', 1)
+			->update(['deleted_at' => date('Y-m-d H:i:s')]);
 
 		$model = new UserModel();
 
@@ -266,7 +265,7 @@ class ModelTest extends CIDatabaseTestCase
 		$this->assertEquals(2, $user->id);
 
 		$user = $model->withDeleted()
-					  ->first();
+			->first();
 
 		$this->assertEquals(1, $user->id);
 	}
@@ -278,17 +277,17 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new SecondaryModel();
 
 		$this->db->table('secondary')
-				 ->insert([
-					 'id'    => 1,
-					 'key'   => 'foo',
-					 'value' => 'bar',
-				 ]);
+			->insert([
+				'id' => 1,
+				'key' => 'foo',
+				'value' => 'bar',
+			]);
 		$this->db->table('secondary')
-				 ->insert([
-					 'id'    => 2,
-					 'key'   => 'bar',
-					 'value' => 'baz',
-				 ]);
+			->insert([
+				'id' => 2,
+				'key' => 'bar',
+				'value' => 'baz',
+			]);
 
 		$record = $model->first();
 
@@ -302,12 +301,12 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$model = new JobModel();
 
-		$data              = new \stdClass();
-		$data->name        = 'Magician';
+		$data = new \stdClass();
+		$data->name = 'Magician';
 		$data->description = 'Makes peoples things dissappear.';
 
-		$model->protect(false)
-			  ->save($data);
+		$model->protect(FALSE)
+			->save($data);
 
 		$this->seeInDatabase('job', ['name' => 'Magician']);
 	}
@@ -319,12 +318,12 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new JobModel();
 
 		$data = [
-			'name'        => 'Apprentice',
+			'name' => 'Apprentice',
 			'description' => 'That thing you do.',
 		];
 
-		$model->protect(false)
-			  ->save($data);
+		$model->protect(FALSE)
+			->save($data);
 
 		$this->seeInDatabase('job', ['name' => 'Apprentice']);
 	}
@@ -336,13 +335,13 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new JobModel();
 
 		$data = [
-			'id'          => 1,
-			'name'        => 'Apprentice',
+			'id' => 1,
+			'name' => 'Apprentice',
 			'description' => 'That thing you do.',
 		];
 
-		$result = $model->protect(false)
-						->save($data);
+		$result = $model->protect(FALSE)
+			->save($data);
 
 		$this->seeInDatabase('job', ['name' => 'Apprentice']);
 		$this->assertTrue($result);
@@ -354,13 +353,13 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$model = new JobModel();
 
-		$data              = new \stdClass();
-		$data->id          = 1;
-		$data->name        = 'Engineer';
+		$data = new \stdClass();
+		$data->id = 1;
+		$data->name = 'Engineer';
 		$data->description = 'A fancier term for Developer.';
 
-		$result = $model->protect(false)
-						->save($data);
+		$result = $model->protect(FALSE)
+			->save($data);
 
 		$this->seeInDatabase('job', ['name' => 'Engineer']);
 		$this->assertTrue($result);
@@ -372,14 +371,14 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$model = new JobModel();
 
-		$data               = new \stdClass();
-		$data->id           = 1;
-		$data->name         = 'Engineer';
-		$data->description  = 'A fancier term for Developer.';
+		$data = new \stdClass();
+		$data->id = 1;
+		$data->name = 'Engineer';
+		$data->description = 'A fancier term for Developer.';
 		$data->random_thing = 'Something wicked'; // If not protected, this would kill the script.
 
-		$result = $model->protect(true)
-						->save($data);
+		$result = $model->protect(TRUE)
+			->save($data);
 
 		$this->assertTrue($result);
 	}
@@ -403,11 +402,11 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$model = new UserModel();
 
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
 
 		$model->delete(1);
 
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NOT NULL' => null]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NOT NULL' => NULL]);
 	}
 
 	//--------------------------------------------------------------------
@@ -416,9 +415,9 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$model = new UserModel();
 
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
 
-		$model->delete(1, true);
+		$model->delete(1, TRUE);
 
 		$this->dontSeeInDatabase('user', ['name' => 'Derek Jones']);
 	}
@@ -442,29 +441,48 @@ class ModelTest extends CIDatabaseTestCase
 	//--------------------------------------------------------------------
 
 	/**
-	 * @expectedException        \CodeIgniter\Database\Exceptions\DatabaseException
-	 * @expectedExceptionMessage Deletes are not allowed unless they contain a "where" or "like" clause.
-	 * @dataProvider             emptyPkValues
-	 * @return                   void
+	 * If where condition is set, beyond the value was empty (0,'', NULL, etc.),
+	 * Exception should not be thrown because condition was explicity set
+	 *
+	 * @dataProvider emptyPkValues
+	 * @return       void
 	 */
-	public function testThrowExceptionWhenSoftDeletePKisEmptyValue($emptyValue)
+	public function testDontThrowExceptionWhenSoftDeleteConditionIsSetWithEmptyValue($emptyValue)
 	{
 		$model = new UserModel();
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
-		$model->delete($emptyValue);
-	}
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
+		$model->where('id', $emptyValue)->delete();
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
+		unset($model);
+	}    //--------------------------------------------------------------------
+
 	/**
 	 * @expectedException        \CodeIgniter\Database\Exceptions\DatabaseException
 	 * @expectedExceptionMessage Deletes are not allowed unless they contain a "where" or "like" clause.
 	 * @dataProvider             emptyPkValues
 	 * @return                   void
 	 */
-	public function testDontDeleteRowsWhenSoftDeletePKisEmptyValue($emptyValue)
+	public function testThrowExceptionWhenSoftDeleteParamIsEmptyValue($emptyValue)
 	{
 		$model = new UserModel();
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
 		$model->delete($emptyValue);
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * @expectedException        \CodeIgniter\Database\Exceptions\DatabaseException
+	 * @expectedExceptionMessage Deletes are not allowed unless they contain a "where" or "like" clause.
+	 * @dataProvider             emptyPkValues
+	 * @return                   void
+	 */
+	public function testDontDeleteRowsWhenSoftDeleteParamIsEmpty($emptyValue)
+	{
+		$model = new UserModel();
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
+		$model->delete($emptyValue);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
 		unset($model);
 	}
 
@@ -472,9 +490,9 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		return [
 			[0],
-			[null],
+			[NULL],
 			['0'],
-			[false],
+			[FALSE],
 		];
 	}
 
@@ -485,7 +503,7 @@ class ModelTest extends CIDatabaseTestCase
 		$this->seeInDatabase('job', ['name' => 'Developer']);
 
 		$model->where('id', 1)
-			  ->delete();
+			->delete();
 
 		$this->dontSeeInDatabase('job', ['name' => 'Developer']);
 	}
@@ -497,13 +515,13 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new UserModel();
 
 		$this->db->table('user')
-				 ->where('id', 1)
-				 ->update(['deleted_at' => date('Y-m-d H:i:s')]);
+			->where('id', 1)
+			->update(['deleted_at' => date('Y-m-d H:i:s')]);
 
 		$model->purgeDeleted();
 
 		$users = $model->withDeleted()
-					   ->findAll();
+			->findAll();
 
 		$this->assertCount(3, $users);
 	}
@@ -515,11 +533,11 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new UserModel($this->db);
 
 		$this->db->table('user')
-				 ->where('id', 1)
-				 ->update(['deleted_at' => date('Y-m-d H:i:s')]);
+			->where('id', 1)
+			->update(['deleted_at' => date('Y-m-d H:i:s')]);
 
 		$users = $model->onlyDeleted()
-					   ->findAll();
+			->findAll();
 
 		$this->assertCount(1, $users);
 	}
@@ -546,7 +564,7 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new ValidModel($this->db);
 
 		$data = [
-			'name'        => null,
+			'name' => NULL,
 			'description' => 'some great marketing stuff',
 		];
 
@@ -564,12 +582,12 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new ValidModel($this->db);
 
 		$data = [
-			'name'        => null,
+			'name' => NULL,
 			'description' => 'some great marketing stuff',
 		];
 
 		$model->setValidationMessage('name', [
-			'required'   => 'Your baby name is missing.',
+			'required' => 'Your baby name is missing.',
 			'min_length' => 'Too short, man!',
 		]);
 		$this->assertFalse($model->insert($data));
@@ -586,13 +604,13 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new ValidModel($this->db);
 
 		$data = [
-			'name'        => null,
+			'name' => NULL,
 			'description' => 'some great marketing stuff',
 		];
 
 		$model->setValidationMessages([
 			'name' => [
-				'required'   => 'Your baby name is missing.',
+				'required' => 'Your baby name is missing.',
 				'min_length' => 'Too short, man!',
 			],
 		]);
@@ -603,6 +621,7 @@ class ModelTest extends CIDatabaseTestCase
 
 		$this->assertEquals('Your baby name is missing.', $errors['name']);
 	}
+
 	//--------------------------------------------------------------------
 
 	public function testValidationPlaceholdersSuccess()
@@ -610,8 +629,8 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new ValidModel($this->db);
 
 		$data = [
-			'name'  => 'abc',
-			'id'    => 13,
+			'name' => 'abc',
+			'id' => 13,
 			'token' => 13,
 		];
 
@@ -625,8 +644,8 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new ValidModel($this->db);
 
 		$data = [
-			'name'  => 'abc',
-			'id'    => 13,
+			'name' => 'abc',
+			'id' => 13,
 			'token' => 12,
 		];
 
@@ -640,27 +659,27 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new ValidModel($this->db);
 
 		$data = [
-			'name'        => '2',
+			'name' => '2',
 			'description' => 'some great marketing stuff',
 		];
 
-		$this->assertInternalType('numeric', $model->skipValidation(true)
-												   ->insert($data));
+		$this->assertInternalType('numeric', $model->skipValidation(TRUE)
+			->insert($data));
 	}
 
 	//--------------------------------------------------------------------
 
 	public function testCleanValidationRemovesAllWhenNoDataProvided()
 	{
-		$model   = new Model($this->db);
+		$model = new Model($this->db);
 		$cleaner = $this->getPrivateMethodInvoker($model, 'cleanValidationRules');
 
 		$rules = [
 			'name' => 'required',
-			'foo'  => 'bar',
+			'foo' => 'bar',
 		];
 
-		$rules = $cleaner($rules, null);
+		$rules = $cleaner($rules, NULL);
 
 		$this->assertEmpty($rules);
 	}
@@ -669,12 +688,12 @@ class ModelTest extends CIDatabaseTestCase
 
 	public function testCleanValidationRemovesOnlyForFieldsNotProvided()
 	{
-		$model   = new Model($this->db);
+		$model = new Model($this->db);
 		$cleaner = $this->getPrivateMethodInvoker($model, 'cleanValidationRules');
 
 		$rules = [
 			'name' => 'required',
-			'foo'  => 'required',
+			'foo' => 'required',
 		];
 
 		$data = [
@@ -691,17 +710,17 @@ class ModelTest extends CIDatabaseTestCase
 
 	public function testCleanValidationReturnsAllWhenAllExist()
 	{
-		$model   = new Model($this->db);
+		$model = new Model($this->db);
 		$cleaner = $this->getPrivateMethodInvoker($model, 'cleanValidationRules');
 
 		$rules = [
 			'name' => 'required',
-			'foo'  => 'required',
+			'foo' => 'required',
 		];
 
 		$data = [
-			'foo'  => 'bar',
-			'name' => null,
+			'foo' => 'bar',
+			'name' => NULL,
 		];
 
 		$rules = $cleaner($rules, $data);
@@ -729,9 +748,9 @@ class ModelTest extends CIDatabaseTestCase
 
 	public function testValidationWithGroupName()
 	{
-		$config            = new \Config\Validation();
+		$config = new \Config\Validation();
 		$config->grouptest = [
-			'name'  => [
+			'name' => [
 				'required',
 				'min_length[3]',
 			],
@@ -739,8 +758,8 @@ class ModelTest extends CIDatabaseTestCase
 		];
 
 		$data = [
-			'name'  => 'abc',
-			'id'    => 13,
+			'name' => 'abc',
+			'id' => 13,
 			'token' => 13,
 		];
 
@@ -759,7 +778,7 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new EntityModel($this->db);
 
 		$entity = $model->where('name', 'Developer')
-						->first();
+			->first();
 
 		$this->assertInstanceOf(SimpleEntity::class, $entity);
 		$this->assertEquals('Developer', $entity->name);
@@ -767,14 +786,14 @@ class ModelTest extends CIDatabaseTestCase
 
 		$time = time();
 
-		$entity->name       = 'Senior Developer';
+		$entity->name = 'Senior Developer';
 		$entity->created_at = $time;
 
 		$this->assertTrue($model->save($entity));
 
 		$result = $model->where('name', 'Senior Developer')
-						->get()
-						->getFirstRow();
+			->get()
+			->getFirstRow();
 
 		$this->assertEquals(date('Y-m-d', $time), date('Y-m-d', $result->created_at));
 	}
@@ -791,8 +810,8 @@ class ModelTest extends CIDatabaseTestCase
 		$pass = password_hash('secret123', PASSWORD_BCRYPT);
 
 		$data = [
-			'name'    => $pass,
-			'email'   => 'foo@example.com',
+			'name' => $pass,
+			'email' => 'foo@example.com',
 			'country' => 'US',
 		];
 
@@ -808,8 +827,8 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new EventModel();
 
 		$data = [
-			'name'    => 'Foo',
-			'email'   => 'foo@example.com',
+			'name' => 'Foo',
+			'email' => 'foo@example.com',
 			'country' => 'US',
 			'deleted' => 0,
 		];
@@ -827,8 +846,8 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new EventModel();
 
 		$data = [
-			'name'    => 'Foo',
-			'email'   => 'foo@example.com',
+			'name' => 'Foo',
+			'email' => 'foo@example.com',
 			'country' => 'US',
 			'deleted' => 0,
 		];
@@ -873,11 +892,11 @@ class ModelTest extends CIDatabaseTestCase
 		]);
 
 		$model->set([
-			'email'   => 'foo@example.com',
-			'name'    => 'Foo Bar',
+			'email' => 'foo@example.com',
+			'name' => 'Foo Bar',
 			'country' => 'US',
 		])
-			  ->insert();
+			->insert();
 
 		$this->seeInDatabase('user', [
 			'email' => 'foo@example.com',
@@ -895,20 +914,20 @@ class ModelTest extends CIDatabaseTestCase
 		]);
 
 		$userId = $model->insert([
-			'email'   => 'foo@example.com',
-			'name'    => 'Foo Bar',
+			'email' => 'foo@example.com',
+			'name' => 'Foo Bar',
 			'country' => 'US',
 		]);
 
 		$model->set([
 			'name' => 'Fred Flintstone',
 		])
-			  ->update($userId);
+			->update($userId);
 
 		$this->seeInDatabase('user', [
-			'id'    => $userId,
+			'id' => $userId,
 			'email' => 'foo@example.com',
-			'name'  => 'Fred Flintstone',
+			'name' => 'Fred Flintstone',
 		]);
 	}
 
@@ -923,8 +942,8 @@ class ModelTest extends CIDatabaseTestCase
 		]);
 
 		$userId = $model->insert([
-			'email'   => 'foo@example.com',
-			'name'    => 'Foo Bar',
+			'email' => 'foo@example.com',
+			'name' => 'Foo Bar',
 			'country' => 'US',
 		]);
 
@@ -936,9 +955,9 @@ class ModelTest extends CIDatabaseTestCase
 			->update();
 
 		$this->seeInDatabase('user', [
-			'id'    => $userId,
+			'id' => $userId,
 			'email' => 'foo@example.com',
-			'name'  => 'Fred Flintstone',
+			'name' => 'Fred Flintstone',
 		]);
 	}
 
@@ -949,8 +968,8 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new EventModel();
 
 		$data = [
-			'name'    => 'Foo',
-			'email'   => 'foo@example.com',
+			'name' => 'Foo',
+			'email' => 'foo@example.com',
 			'country' => 'US',
 			'deleted' => 0,
 		];
@@ -968,11 +987,11 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$job_data = [
 			[
-				'name'        => 'Comedian',
+				'name' => 'Comedian',
 				'description' => 'Theres something in your teeth',
 			],
 			[
-				'name'        => 'Cab Driver',
+				'name' => 'Cab Driver',
 				'description' => 'Iam yellow',
 			],
 		];
@@ -990,8 +1009,8 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$job_data = [
 			[
-				'name'        => 'Comedian',
-				'description' => null,
+				'name' => 'Comedian',
+				'description' => NULL,
 			],
 		];
 
@@ -1011,11 +1030,11 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$data = [
 			[
-				'name'    => 'Derek Jones',
+				'name' => 'Derek Jones',
 				'country' => 'Greece',
 			],
 			[
-				'name'    => 'Ahmadinejad',
+				'name' => 'Ahmadinejad',
 				'country' => 'Greece',
 			],
 		];
@@ -1025,11 +1044,11 @@ class ModelTest extends CIDatabaseTestCase
 		$model->updateBatch($data, 'name');
 
 		$this->seeInDatabase('user', [
-			'name'    => 'Derek Jones',
+			'name' => 'Derek Jones',
 			'country' => 'Greece',
 		]);
 		$this->seeInDatabase('user', [
-			'name'    => 'Ahmadinejad',
+			'name' => 'Ahmadinejad',
 			'country' => 'Greece',
 		]);
 	}
@@ -1040,8 +1059,8 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$data = [
 			[
-				'name'    => 'Derek Jones',
-				'country' => null,
+				'name' => 'Derek Jones',
+				'country' => NULL,
 			],
 		];
 
@@ -1060,17 +1079,17 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		// Insert value in job table
 		$this->hasInDatabase('job', [
-			'name'        => 'Rocket Scientist',
+			'name' => 'Rocket Scientist',
 			'description' => 'Plays guitar for Queen',
-			'created_at'  => time(),
+			'created_at' => time(),
 		]);
 
 		$model = new EntityModel();
 
 		// get only id, name column
 		$job = $model->select('id, name')
-					 ->where('name', 'Rocket Scientist')
-					 ->first();
+			->where('name', 'Rocket Scientist')
+			->first();
 
 		// Hence getting Null as description column not in select clause
 		$this->assertNull($job->description);
@@ -1085,14 +1104,14 @@ class ModelTest extends CIDatabaseTestCase
 
 		// check for the record to same entry exists or not
 		$this->seeInDatabase('job', [
-			'id'   => $job->id,
+			'id' => $job->id,
 			'name' => 'Rocket Scientist',
 		]);
 
 		// select all columns from job table
 		$job = $model->select('id, name, description')
-					 ->where('name', 'Rocket Scientist')
-					 ->first();
+			->where('name', 'Rocket Scientist')
+			->first();
 
 		// check whether the Null value successfully updated or not
 		$this->assertEquals('Some guitar description', $job->description);
@@ -1105,22 +1124,22 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new SecondaryModel();
 
 		$this->db->table('secondary')
-				 ->insert([
-					 'id'    => 1,
-					 'key'   => 'foo',
-					 'value' => 'bar',
-				 ]);
+			->insert([
+				'id' => 1,
+				'key' => 'foo',
+				'value' => 'bar',
+			]);
 
 		$this->dontSeeInDatabase('secondary', [
-			'key'   => 'bar',
+			'key' => 'bar',
 			'value' => 'baz',
 		]);
 
 		$model->where('key', 'foo')
-			  ->update(null, ['key' => 'bar', 'value' => 'baz']);
+			->update(NULL, ['key' => 'bar', 'value' => 'baz']);
 
 		$this->seeInDatabase('secondary', [
-			'key'   => 'bar',
+			'key' => 'bar',
 			'value' => 'baz',
 		]);
 	}
@@ -1138,7 +1157,7 @@ class ModelTest extends CIDatabaseTestCase
 		$this->assertEquals(4, $model->countAllResults());
 
 		$model->where('name', 'Derek Jones')
-			  ->delete();
+			->delete();
 
 		$this->assertEquals(3, $model->countAllResults());
 	}
@@ -1154,9 +1173,9 @@ class ModelTest extends CIDatabaseTestCase
 
 		$data = [
 			'description' => 'This is a first test!',
-			'name'        => 'valid',
-			'id'          => 42,
-			'token'       => 42,
+			'name' => 'valid',
+			'id' => 42,
+			'token' => 42,
 		];
 
 		$id = $model->insert($data);
@@ -1196,7 +1215,7 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new ValidModel($this->db);
 
 		$data = [
-			'name' => null,
+			'name' => NULL,
 		];
 
 		$this->assertFalse($model->insert($data));
@@ -1212,11 +1231,11 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new ValidModel($this->db);
 
 		$data = [
-			'name'        => 'foobar',
+			'name' => 'foobar',
 			'description' => 'just becaues we have to',
 		];
 
-		$this->assertTrue($model->insert($data) !== false);
+		$this->assertTrue($model->insert($data) !== FALSE);
 	}
 
 	//--------------------------------------------------------------------
@@ -1230,9 +1249,9 @@ class ModelTest extends CIDatabaseTestCase
 
 		$data = [
 			'description' => 'This is a first test!',
-			'name'        => 'valid',
-			'id'          => 42,
-			'token'       => 42,
+			'name' => 'valid',
+			'id' => 42,
+			'token' => 42,
 		];
 
 		$id = $model->insert($data);
@@ -1279,12 +1298,12 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new JobModel();
 
 		$data = [
-			'name'        => 'Apprentice',
+			'name' => 'Apprentice',
 			'description' => 'That thing you do.',
 		];
 
-		$model->protect(false)
-			  ->save($data);
+		$model->protect(FALSE)
+			->save($data);
 
 		$lastInsertId = $model->getInsertID();
 
@@ -1300,12 +1319,12 @@ class ModelTest extends CIDatabaseTestCase
 		$model->setTable('db_job');
 
 		$data = [
-			'name'        => 'Apprentice',
+			'name' => 'Apprentice',
 			'description' => 'That thing you do.',
 		];
 
-		$model->protect(false)
-			  ->save($data);
+		$model->protect(FALSE)
+			->save($data);
 
 		$lastInsertId = $model->getInsertID();
 
@@ -1329,15 +1348,14 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$model = new ValidModel($this->db);
 
-		$data = new class
-		{
-			public $name  = '';
-			public $id    = '';
+		$data = new class {
+			public $name = '';
+			public $id = '';
 			public $token = '';
 		};
 
-		$data->name  = 'abc';
-		$data->id    = '13';
+		$data->name = 'abc';
+		$data->id = '13';
 		$data->token = '13';
 
 		$this->assertTrue($model->validate($data));
@@ -1362,8 +1380,8 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$job_data = [
 			[
-				'name'        => 'Comedian',
-				'description' => null,
+				'name' => 'Comedian',
+				'description' => NULL,
 			],
 		];
 
@@ -1398,10 +1416,10 @@ class ModelTest extends CIDatabaseTestCase
 
 		$testModel = new JobModel();
 
-		$testModel->name        = 'my name';
+		$testModel->name = 'my name';
 		$testModel->description = 'some description';
 
-		$this->setPrivateProperty($model, 'useTimestamps', true);
+		$this->setPrivateProperty($model, 'useTimestamps', TRUE);
 
 		$model->insert($testModel);
 
@@ -1418,8 +1436,8 @@ class ModelTest extends CIDatabaseTestCase
 
 		$data = [];
 
-		$data = $model->protect(false)
-					  ->save($data);
+		$data = $model->protect(FALSE)
+			->save($data);
 
 		$this->assertTrue($data);
 	}
@@ -1432,10 +1450,10 @@ class ModelTest extends CIDatabaseTestCase
 
 		$testModel = new JobModel();
 
-		$testModel->name        = 'my name';
+		$testModel->name = 'my name';
 		$testModel->description = 'some description';
 
-		$this->setPrivateProperty($model, 'useTimestamps', true);
+		$this->setPrivateProperty($model, 'useTimestamps', TRUE);
 
 		$model->update(1, $testModel);
 
@@ -1448,12 +1466,12 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$model = new JobModel();
 
-		$this->setPrivateProperty($model, 'useTimestamps', true);
-		$this->setPrivateProperty($model, 'useSoftDeletes', true);
+		$this->setPrivateProperty($model, 'useTimestamps', TRUE);
+		$this->setPrivateProperty($model, 'useSoftDeletes', TRUE);
 
 		$model->delete(1);
 
-		$this->seeInDatabase('job', ['id' => 1, 'deleted_at IS NOT NULL' => null]);
+		$this->seeInDatabase('job', ['id' => 1, 'deleted_at IS NOT NULL' => NULL]);
 	}
 
 	//--------------------------------------------------------------------
@@ -1463,8 +1481,8 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new JobModel();
 
 		$this->db->table('job')
-				 ->where('id', 1)
-				 ->update(['deleted_at' => time()]);
+			->where('id', 1)
+			->update(['deleted_at' => time()]);
 
 		$model->purgeDeleted();
 
@@ -1480,8 +1498,8 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new ValidModel($this->db);
 
 		$data = [
-			'id'          => 1,
-			'name'        => 'my name',
+			'id' => 1,
+			'name' => 'my name',
 			'description' => 'some description',
 		];
 
@@ -1495,8 +1513,8 @@ class ModelTest extends CIDatabaseTestCase
 	public function testGetValidationMessagesForReplace()
 	{
 		$job_data = [
-			'name'        => 'Comedian',
-			'description' => null,
+			'name' => 'Comedian',
+			'description' => NULL,
 		];
 
 		$model = new JobModel($this->db);
@@ -1513,7 +1531,7 @@ class ModelTest extends CIDatabaseTestCase
 
 	public function testSaveNewEntityWithDateTime()
 	{
-		$entity    = new class extends Entity{
+		$entity = new class extends Entity {
 			protected $id;
 			protected $name;
 			protected $email;
@@ -1524,23 +1542,23 @@ class ModelTest extends CIDatabaseTestCase
 
 			protected $_options = [
 				'datamap' => [],
-				'dates'   => [
+				'dates' => [
 					'created_at',
 					'updated_at',
 					'deleted_at',
 				],
-				'casts'   => [],
+				'casts' => [],
 			];
 		};
 		$testModel = new UserModel();
 
-		$entity->name       = 'Mark';
-		$entity->email      = 'mark@example.com';
-		$entity->country    = 'India';
-		$entity->deleted    = 0;
+		$entity->name = 'Mark';
+		$entity->email = 'mark@example.com';
+		$entity->country = 'India';
+		$entity->deleted = 0;
 		$entity->created_at = new Time('now');
 
-		$this->setPrivateProperty($testModel, 'useTimestamps', true);
+		$this->setPrivateProperty($testModel, 'useTimestamps', TRUE);
 
 		$this->assertTrue($testModel->save($entity));
 	}
@@ -1549,38 +1567,36 @@ class ModelTest extends CIDatabaseTestCase
 
 	public function testSaveNewEntityWithDate()
 	{
-		$entity    = new class extends Entity
-		{
+		$entity = new class extends Entity {
 			protected $id;
 			protected $name;
 			protected $created_at;
 			protected $updated_at;
 			protected $_options = [
 				'datamap' => [],
-				'dates'   => [
+				'dates' => [
 					'created_at',
 					'updated_at',
 					'deleted_at',
 				],
-				'casts'   => [],
+				'casts' => [],
 			];
 		};
-		$testModel = new class extends Model
-		{
-			protected $table          = 'empty';
-			protected $allowedFields  = [
+		$testModel = new class extends Model {
+			protected $table = 'empty';
+			protected $allowedFields = [
 				'name',
 			];
-			protected $returnType     = 'object';
-			protected $useSoftDeletes = true;
-			protected $dateFormat     = 'date';
-			public $name              = '';
+			protected $returnType = 'object';
+			protected $useSoftDeletes = TRUE;
+			protected $dateFormat = 'date';
+			public $name = '';
 		};
 
-		$entity->name       = 'Mark';
+		$entity->name = 'Mark';
 		$entity->created_at = new Time('now');
 
-		$this->setPrivateProperty($testModel, 'useTimestamps', true);
+		$this->setPrivateProperty($testModel, 'useTimestamps', TRUE);
 
 		$this->assertTrue($testModel->save($entity));
 
@@ -1591,7 +1607,8 @@ class ModelTest extends CIDatabaseTestCase
 
 	public function testUndefinedEntityPropertyReturnsNull()
 	{
-		$entity = new class extends Entity {};
+		$entity = new class extends Entity {
+		};
 
 		$this->assertNull($entity->undefinedProperty);
 	}
@@ -1601,7 +1618,7 @@ class ModelTest extends CIDatabaseTestCase
 	public function testInsertWithNoDataException()
 	{
 		$model = new UserModel();
-		$data  = [];
+		$data = [];
 		$this->expectException(DataException::class);
 		$this->expectExceptionMessage('There is no data to insert.');
 		$model->insert($data);
@@ -1614,8 +1631,8 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new EventModel();
 
 		$data = [
-			'name'    => 'Foo',
-			'email'   => 'foo@example.com',
+			'name' => 'Foo',
+			'email' => 'foo@example.com',
 			'country' => 'US',
 			'deleted' => 0,
 		];
@@ -1637,7 +1654,7 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new JobModel();
 
 		$data = [
-			'name'        => 'Apprentice',
+			'name' => 'Apprentice',
 			'description' => 'That thing you do.',
 		];
 
@@ -1656,8 +1673,8 @@ class ModelTest extends CIDatabaseTestCase
 		$model = new EventModel();
 
 		$data = [
-			'name'    => 'Foo',
-			'email'   => 'foo@example.com',
+			'name' => 'Foo',
+			'email' => 'foo@example.com',
 			'country' => 'US',
 			'deleted' => 0,
 		];
@@ -1679,7 +1696,7 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$model = new UserModel();
 
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at' => null]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at' => NULL]);
 
 		$results = $model->join('job', 'job.id = user.id')
 			->findAll();
@@ -1695,10 +1712,10 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$model = new UserModel();
 
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at' => null]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at' => NULL]);
 
 		$results = $model->join('job', 'job.id = user.id')
-						 ->find(1);
+			->find(1);
 
 		// Just making sure it didn't throw ambiguous deleted error
 		$this->assertEquals(1, $results->id);
@@ -1711,10 +1728,10 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$model = new UserModel();
 
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at' => null]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at' => NULL]);
 
 		$results = $model->join('job', 'job.id = user.id')
-						 ->first(1);
+			->first(1);
 
 		// Just making sure it didn't throw ambiguous deleted error
 		$this->assertEquals(1, $results->id);

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -21,10 +21,11 @@ use Tests\Support\Models\ValidModel;
 /**
  * @group DatabaseLive
  */
-class ModelTest extends CIDatabaseTestCase {
+class ModelTest extends CIDatabaseTestCase
+{
 	use ReflectionHelper;
 
-	protected $refresh = TRUE;
+	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
 
@@ -305,7 +306,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$data->name = 'Magician';
 		$data->description = 'Makes peoples things dissappear.';
 
-		$model->protect(FALSE)
+		$model->protect(false)
 			->save($data);
 
 		$this->seeInDatabase('job', ['name' => 'Magician']);
@@ -322,7 +323,7 @@ class ModelTest extends CIDatabaseTestCase {
 			'description' => 'That thing you do.',
 		];
 
-		$model->protect(FALSE)
+		$model->protect(false)
 			->save($data);
 
 		$this->seeInDatabase('job', ['name' => 'Apprentice']);
@@ -340,7 +341,7 @@ class ModelTest extends CIDatabaseTestCase {
 			'description' => 'That thing you do.',
 		];
 
-		$result = $model->protect(FALSE)
+		$result = $model->protect(false)
 			->save($data);
 
 		$this->seeInDatabase('job', ['name' => 'Apprentice']);
@@ -358,7 +359,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$data->name = 'Engineer';
 		$data->description = 'A fancier term for Developer.';
 
-		$result = $model->protect(FALSE)
+		$result = $model->protect(false)
 			->save($data);
 
 		$this->seeInDatabase('job', ['name' => 'Engineer']);
@@ -377,7 +378,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$data->description = 'A fancier term for Developer.';
 		$data->random_thing = 'Something wicked'; // If not protected, this would kill the script.
 
-		$result = $model->protect(TRUE)
+		$result = $model->protect(true)
 			->save($data);
 
 		$this->assertTrue($result);
@@ -402,11 +403,11 @@ class ModelTest extends CIDatabaseTestCase {
 	{
 		$model = new UserModel();
 
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
 
 		$model->delete(1);
 
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NOT NULL' => NULL]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NOT NULL' => null]);
 	}
 
 	//--------------------------------------------------------------------
@@ -415,9 +416,9 @@ class ModelTest extends CIDatabaseTestCase {
 	{
 		$model = new UserModel();
 
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
 
-		$model->delete(1, TRUE);
+		$model->delete(1, true);
 
 		$this->dontSeeInDatabase('user', ['name' => 'Derek Jones']);
 	}
@@ -450,9 +451,9 @@ class ModelTest extends CIDatabaseTestCase {
 	public function testDontThrowExceptionWhenSoftDeleteConditionIsSetWithEmptyValue($emptyValue)
 	{
 		$model = new UserModel();
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
 		$model->where('id', $emptyValue)->delete();
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
 		unset($model);
 	}    //--------------------------------------------------------------------
 
@@ -465,7 +466,7 @@ class ModelTest extends CIDatabaseTestCase {
 	public function testThrowExceptionWhenSoftDeleteParamIsEmptyValue($emptyValue)
 	{
 		$model = new UserModel();
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
 		$model->delete($emptyValue);
 	}
 
@@ -480,9 +481,9 @@ class ModelTest extends CIDatabaseTestCase {
 	public function testDontDeleteRowsWhenSoftDeleteParamIsEmpty($emptyValue)
 	{
 		$model = new UserModel();
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
 		$model->delete($emptyValue);
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => NULL]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
 		unset($model);
 	}
 
@@ -490,9 +491,9 @@ class ModelTest extends CIDatabaseTestCase {
 	{
 		return [
 			[0],
-			[NULL],
+			[null],
 			['0'],
-			[FALSE],
+			[false],
 		];
 	}
 
@@ -564,7 +565,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$model = new ValidModel($this->db);
 
 		$data = [
-			'name' => NULL,
+			'name' => null,
 			'description' => 'some great marketing stuff',
 		];
 
@@ -582,7 +583,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$model = new ValidModel($this->db);
 
 		$data = [
-			'name' => NULL,
+			'name' => null,
 			'description' => 'some great marketing stuff',
 		];
 
@@ -604,7 +605,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$model = new ValidModel($this->db);
 
 		$data = [
-			'name' => NULL,
+			'name' => null,
 			'description' => 'some great marketing stuff',
 		];
 
@@ -663,7 +664,7 @@ class ModelTest extends CIDatabaseTestCase {
 			'description' => 'some great marketing stuff',
 		];
 
-		$this->assertInternalType('numeric', $model->skipValidation(TRUE)
+		$this->assertInternalType('numeric', $model->skipValidation(true)
 			->insert($data));
 	}
 
@@ -679,7 +680,7 @@ class ModelTest extends CIDatabaseTestCase {
 			'foo' => 'bar',
 		];
 
-		$rules = $cleaner($rules, NULL);
+		$rules = $cleaner($rules, null);
 
 		$this->assertEmpty($rules);
 	}
@@ -720,7 +721,7 @@ class ModelTest extends CIDatabaseTestCase {
 
 		$data = [
 			'foo' => 'bar',
-			'name' => NULL,
+			'name' => null,
 		];
 
 		$rules = $cleaner($rules, $data);
@@ -1010,7 +1011,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$job_data = [
 			[
 				'name' => 'Comedian',
-				'description' => NULL,
+				'description' => null,
 			],
 		];
 
@@ -1060,7 +1061,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$data = [
 			[
 				'name' => 'Derek Jones',
-				'country' => NULL,
+				'country' => null,
 			],
 		];
 
@@ -1136,7 +1137,7 @@ class ModelTest extends CIDatabaseTestCase {
 		]);
 
 		$model->where('key', 'foo')
-			->update(NULL, ['key' => 'bar', 'value' => 'baz']);
+			->update(null, ['key' => 'bar', 'value' => 'baz']);
 
 		$this->seeInDatabase('secondary', [
 			'key' => 'bar',
@@ -1215,7 +1216,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$model = new ValidModel($this->db);
 
 		$data = [
-			'name' => NULL,
+			'name' => null,
 		];
 
 		$this->assertFalse($model->insert($data));
@@ -1235,7 +1236,7 @@ class ModelTest extends CIDatabaseTestCase {
 			'description' => 'just becaues we have to',
 		];
 
-		$this->assertTrue($model->insert($data) !== FALSE);
+		$this->assertTrue($model->insert($data) !== false);
 	}
 
 	//--------------------------------------------------------------------
@@ -1302,7 +1303,7 @@ class ModelTest extends CIDatabaseTestCase {
 			'description' => 'That thing you do.',
 		];
 
-		$model->protect(FALSE)
+		$model->protect(false)
 			->save($data);
 
 		$lastInsertId = $model->getInsertID();
@@ -1323,7 +1324,7 @@ class ModelTest extends CIDatabaseTestCase {
 			'description' => 'That thing you do.',
 		];
 
-		$model->protect(FALSE)
+		$model->protect(false)
 			->save($data);
 
 		$lastInsertId = $model->getInsertID();
@@ -1348,7 +1349,8 @@ class ModelTest extends CIDatabaseTestCase {
 	{
 		$model = new ValidModel($this->db);
 
-		$data = new class {
+		$data = new class
+		{
 			public $name = '';
 			public $id = '';
 			public $token = '';
@@ -1381,7 +1383,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$job_data = [
 			[
 				'name' => 'Comedian',
-				'description' => NULL,
+				'description' => null,
 			],
 		];
 
@@ -1419,7 +1421,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$testModel->name = 'my name';
 		$testModel->description = 'some description';
 
-		$this->setPrivateProperty($model, 'useTimestamps', TRUE);
+		$this->setPrivateProperty($model, 'useTimestamps', true);
 
 		$model->insert($testModel);
 
@@ -1436,7 +1438,7 @@ class ModelTest extends CIDatabaseTestCase {
 
 		$data = [];
 
-		$data = $model->protect(FALSE)
+		$data = $model->protect(false)
 			->save($data);
 
 		$this->assertTrue($data);
@@ -1453,7 +1455,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$testModel->name = 'my name';
 		$testModel->description = 'some description';
 
-		$this->setPrivateProperty($model, 'useTimestamps', TRUE);
+		$this->setPrivateProperty($model, 'useTimestamps', true);
 
 		$model->update(1, $testModel);
 
@@ -1466,12 +1468,12 @@ class ModelTest extends CIDatabaseTestCase {
 	{
 		$model = new JobModel();
 
-		$this->setPrivateProperty($model, 'useTimestamps', TRUE);
-		$this->setPrivateProperty($model, 'useSoftDeletes', TRUE);
+		$this->setPrivateProperty($model, 'useTimestamps', true);
+		$this->setPrivateProperty($model, 'useSoftDeletes', true);
 
 		$model->delete(1);
 
-		$this->seeInDatabase('job', ['id' => 1, 'deleted_at IS NOT NULL' => NULL]);
+		$this->seeInDatabase('job', ['id' => 1, 'deleted_at IS NOT NULL' => null]);
 	}
 
 	//--------------------------------------------------------------------
@@ -1514,7 +1516,7 @@ class ModelTest extends CIDatabaseTestCase {
 	{
 		$job_data = [
 			'name' => 'Comedian',
-			'description' => NULL,
+			'description' => null,
 		];
 
 		$model = new JobModel($this->db);
@@ -1531,7 +1533,8 @@ class ModelTest extends CIDatabaseTestCase {
 
 	public function testSaveNewEntityWithDateTime()
 	{
-		$entity = new class extends Entity {
+		$entity = new class extends Entity
+		{
 			protected $id;
 			protected $name;
 			protected $email;
@@ -1558,7 +1561,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$entity->deleted = 0;
 		$entity->created_at = new Time('now');
 
-		$this->setPrivateProperty($testModel, 'useTimestamps', TRUE);
+		$this->setPrivateProperty($testModel, 'useTimestamps', true);
 
 		$this->assertTrue($testModel->save($entity));
 	}
@@ -1567,7 +1570,8 @@ class ModelTest extends CIDatabaseTestCase {
 
 	public function testSaveNewEntityWithDate()
 	{
-		$entity = new class extends Entity {
+		$entity = new class extends Entity
+		{
 			protected $id;
 			protected $name;
 			protected $created_at;
@@ -1582,13 +1586,14 @@ class ModelTest extends CIDatabaseTestCase {
 				'casts' => [],
 			];
 		};
-		$testModel = new class extends Model {
+		$testModel = new class extends Model
+		{
 			protected $table = 'empty';
 			protected $allowedFields = [
 				'name',
 			];
 			protected $returnType = 'object';
-			protected $useSoftDeletes = TRUE;
+			protected $useSoftDeletes = true;
 			protected $dateFormat = 'date';
 			public $name = '';
 		};
@@ -1596,7 +1601,7 @@ class ModelTest extends CIDatabaseTestCase {
 		$entity->name = 'Mark';
 		$entity->created_at = new Time('now');
 
-		$this->setPrivateProperty($testModel, 'useTimestamps', TRUE);
+		$this->setPrivateProperty($testModel, 'useTimestamps', true);
 
 		$this->assertTrue($testModel->save($entity));
 
@@ -1607,7 +1612,8 @@ class ModelTest extends CIDatabaseTestCase {
 
 	public function testUndefinedEntityPropertyReturnsNull()
 	{
-		$entity = new class extends Entity {
+		$entity = new class extends Entity
+		{
 		};
 
 		$this->assertNull($entity->undefinedProperty);
@@ -1696,7 +1702,7 @@ class ModelTest extends CIDatabaseTestCase {
 	{
 		$model = new UserModel();
 
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at' => NULL]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at' => null]);
 
 		$results = $model->join('job', 'job.id = user.id')
 			->findAll();
@@ -1712,7 +1718,7 @@ class ModelTest extends CIDatabaseTestCase {
 	{
 		$model = new UserModel();
 
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at' => NULL]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at' => null]);
 
 		$results = $model->join('job', 'job.id = user.id')
 			->find(1);
@@ -1728,7 +1734,7 @@ class ModelTest extends CIDatabaseTestCase {
 	{
 		$model = new UserModel();
 
-		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at' => NULL]);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at' => null]);
 
 		$results = $model->join('job', 'job.id = user.id')
 			->first(1);


### PR DESCRIPTION
Each pull request should address a single issue, and have a meaningful title.

**Description**
There's a bug, or at least a confuse behaviour, when you use soft-delete and execute $model->delete() method with empty value as parameter (0, NULL, FALSE, or simple no parameter).
When soft-delete is false, CI throw a DatabaseException warning about delete() method cannot execute without where or like condition, but, when soft-delete is true no exception nor warning is thrown because CI internally call update() method.
I modified the code in order to throw DatabaseException when soft-delete is  true and $id parameter is empty and either a where condition was set.

In order to maintain consistance between both behaviour (hard and soft delete) I needed to add a getter to QBWhere property so that I be able to eval in Model if there's a condition set.
Additionally, I think that is usefull to be able to access to the compiled 'where' condition from any Model child class in case you want to modify it o just check

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
