### PR TITLE
Fix prevent soft delete all without conditions set

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1588,6 +1588,18 @@ class BaseBuilder
 	}
 
 	//--------------------------------------------------------------------
+	/**
+	 * Get compiled 'where' condition string
+	 *
+	 * Compiles the set conditions and returns the sql statement
+	 *
+	 * @return string
+	 */
+	public function getCompiledQBWhere()
+	{
+		return $this->QBWhere;
+	}
+	//--------------------------------------------------------------------
 
 	/**
 	 * Get_Where

--- a/system/Model.php
+++ b/system/Model.php
@@ -715,13 +715,13 @@ class Model
 		$result = $this->builder()
 				->set($data['data'], '', $escape)
 				->insert();
-		
+
 		// If insertion succeeded then save the insert ID
 		if ($result)
 		{
 			$this->insertID = $this->db->insertID();
 		}
-		
+
 		$this->trigger('afterInsert', ['data' => $originalData, 'result' => $result]);
 
 		// If insertion failed, get out of here
@@ -957,8 +957,8 @@ class Model
 		}
 
 		return $this->builder()
-			    ->where($this->table . '.' . $this->deletedField . ' IS NOT NULL')
-			    ->delete();
+				->where($this->table . '.' . $this->deletedField . ' IS NOT NULL')
+				->delete();
 	}
 
 	//--------------------------------------------------------------------
@@ -991,7 +991,7 @@ class Model
 		$this->tempUseSoftDeletes = false;
 
 		$this->builder()
-		     ->where($this->table . '.' . $this->deletedField . ' IS NOT NULL');
+			 ->where($this->table . '.' . $this->deletedField . ' IS NOT NULL');
 
 		return $this;
 	}

--- a/system/Model.php
+++ b/system/Model.php
@@ -48,6 +48,7 @@ use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\ConnectionInterface;
 use CodeIgniter\Validation\ValidationInterface;
 use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use ReflectionClass;
 use ReflectionProperty;
 use stdClass;
@@ -913,6 +914,14 @@ class Model
 
 		if ($this->useSoftDeletes && ! $purge)
 		{
+			if (empty($builder->getCompiledQBWhere()))
+			{
+				if (CI_DEBUG)
+				{
+					throw new DatabaseException('Deletes are not allowed unless they contain a "where" or "like" clause.');
+				}
+				return false;
+			}
 			$set[$this->deletedField] = $this->setDate();
 
 			if ($this->useTimestamps && ! empty($this->updatedField))

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -538,7 +538,6 @@ class ModelTest extends CIDatabaseTestCase
 			[0],
 			[null],
 			['0'],
-			[false],
 		];
 	}
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -486,7 +486,61 @@ class ModelTest extends CIDatabaseTestCase
 
 		$this->assertCount(1, $users);
 	}
+	/**
+	 * If where condition is set, beyond the value was empty (0,'', NULL, etc.),
+	 * Exception should not be thrown because condition was explicity set
+	 *
+	 * @dataProvider emptyPkValues
+	 * @return       void
+	 */
+	public function testDontThrowExceptionWhenSoftDeleteConditionIsSetWithEmptyValue($emptyValue)
+	{
+		$model = new UserModel();
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
+		$model->where('id', $emptyValue)->delete();
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
+		unset($model);
+	}    //--------------------------------------------------------------------
 
+	/**
+	 * @expectedException        \CodeIgniter\Database\Exceptions\DatabaseException
+	 * @expectedExceptionMessage Deletes are not allowed unless they contain a "where" or "like" clause.
+	 * @dataProvider             emptyPkValues
+	 * @return                   void
+	 */
+	public function testThrowExceptionWhenSoftDeleteParamIsEmptyValue($emptyValue)
+	{
+		$model = new UserModel();
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
+		$model->delete($emptyValue);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * @expectedException        \CodeIgniter\Database\Exceptions\DatabaseException
+	 * @expectedExceptionMessage Deletes are not allowed unless they contain a "where" or "like" clause.
+	 * @dataProvider             emptyPkValues
+	 * @return                   void
+	 */
+	public function testDontDeleteRowsWhenSoftDeleteParamIsEmpty($emptyValue)
+	{
+		$model = new UserModel();
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
+		$model->delete($emptyValue);
+		$this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
+		unset($model);
+	}
+
+	public function emptyPkValues()
+	{
+		return [
+			[0],
+			[null],
+			['0'],
+			[false],
+		];
+	}
 	//--------------------------------------------------------------------
 
 	public function testChunk()


### PR DESCRIPTION
**Description**
There's a bug, or at least a confuse behaviour, when you use soft-delete and execute $model->delete() method with empty value as parameter (0, NULL, FALSE, or simple no parameter).
When soft-delete is false, CI throw a DatabaseException warning about delete() method cannot execute without where or like condition, but, when soft-delete is true no exception nor warning is thrown because CI internally call update() method.
I modified the code in order to throw DatabaseException when soft-delete is true and $id parameter is empty and either a where condition was set.

In order to maintain consistance between both behaviour (hard and soft delete) I needed to add a getter to QBWhere property so that I be able to eval in Model if there's a condition set.
Additionally, I think that is usefull to be able to access to the compiled 'where' condition from any Model child class in case you want to modify it o just check

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide