### PR TITLE
Typo in checking if db_connect() exists

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -111,7 +111,7 @@ if (! function_exists('config'))
 
 //--------------------------------------------------------------------
 
-if (! function_exists('db_connnect'))
+if (! function_exists('db_connect'))
 {
 	/**
 	 * Grabs a database connection and returns it to the user.
@@ -815,7 +815,7 @@ if (! function_exists('force_https'))
 		$response->setHeader('Strict-Transport-Security', 'max-age=' . $duration);
 		$response->redirect($uri);
 		$response->sendHeaders();
-		
+
 		exit();
 	}
 }


### PR DESCRIPTION
Typo in checking if db_connect() exists

**Description**
Typo in common function declaration (checking before declaring funkction) db_connect() had typo so when custom db_connection() function was made, it makes error for double declaration of the same function.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
