### PR TITLE
Fix typo in checking if exists db_connect()

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -111,7 +111,7 @@ if (! function_exists('config'))
 
 //--------------------------------------------------------------------
 
-if (! function_exists('db_connnect'))
+if (! function_exists('db_connect'))
 {
 	/**
 	 * Grabs a database connection and returns it to the user.


### PR DESCRIPTION
Each pull request should address a single issue, and have a meaningful title.

**Description**
There was typo in checking procedure if exists db_connect(), typo was making fatal error when was made custom function because double declaration.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide