### PR TITLE
Update `Entity.php` `__isset` method

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -424,6 +424,15 @@ class Entity
 	 */
 	public function __isset(string $key): bool
 	{
+		$key = $this->mapProperty($key);
+
+		$method = 'get' . str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $key)));
+
+		if (method_exists($this, $method))
+		{
+			return true;
+		}
+
 		return isset($this->attributes[$key]);
 	}
 


### PR DESCRIPTION
Update `Entity` -> `__isset()` method, to check if datamap or getter method exists for given variable name.

This functionaly is already declared in method phpdoc, but not been implemenet before.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide