### PR TITLE
Add Image->convert()

### DIFF
--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -287,6 +287,22 @@ abstract class BaseHandler implements ImageHandlerInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Changes the stored image type to indicate the new file format to use when saving.
+	 * Does not touch the actual resource.
+	 *
+	 * @param integer|null $imageType A PHP imageType constant, e.g. https://www.php.net/manual/en/function.image-type-to-mime-type.php
+	 *
+	 * @return $this
+	 */
+	public function convert(int $imageType)
+	{
+		$this->image->imageType = $imageType;
+		return $this;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Rotates the image on the current canvas.
 	 *
 	 * @param float $angle

--- a/system/Images/ImageHandlerInterface.php
+++ b/system/Images/ImageHandlerInterface.php
@@ -75,6 +75,18 @@ interface ImageHandlerInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Changes the stored image type to indicate the new file format to use when saving.
+	 * Does not touch the actual resource.
+	 *
+	 * @param integer|null $imageType A PHP imagetype constant, e.g. https://www.php.net/manual/en/function.image-type-to-mime-type.php
+	 *
+	 * @return $this
+	 */
+	public function convert(int $imageType);
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Rotates the image on the current canvas.
 	 *
 	 * @param float $angle

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -334,7 +334,7 @@ class GDHandlerTest extends \CIUnitTestCase
 
 	public function testImageConvert()
 	{
-		$this->handler->withFile($this->origin . 'ci-logo.jpg');
+		$this->handler->withFile($this->origin . 'ci-logo.jpeg');
 		$this->handler->getResource(); // make sure resource is loaded
 		$this->handler->convert(IMAGETYPE_PNG);
 		$this->handler->save($this->start . 'work/ci-logo.png');

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -332,4 +332,13 @@ class GDHandlerTest extends \CIUnitTestCase
 		}
 	}
 
+	public function testImageConvert()
+	{
+		$this->handler->withFile($this->origin . 'ci-logo.jpg');
+		$this->handler->getResource(); // make sure resource is loaded
+		$this->handler->convert(IMAGETYPE_PNG);
+		$this->handler->save($this->start . 'work/ci-logo.png');
+		$$this->assertEquals(exif_imagetype($this->start . 'work/ci-logo.png'), IMAGETYPE_PNG);
+	}
+
 }

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -338,7 +338,7 @@ class GDHandlerTest extends \CIUnitTestCase
 		$this->handler->getResource(); // make sure resource is loaded
 		$this->handler->convert(IMAGETYPE_PNG);
 		$this->handler->save($this->start . 'work/ci-logo.png');
-		$$this->assertEquals(exif_imagetype($this->start . 'work/ci-logo.png'), IMAGETYPE_PNG);
+		$this->assertEquals(exif_imagetype($this->start . 'work/ci-logo.png'), IMAGETYPE_PNG);
 	}
 
 }

--- a/user_guide_src/source/libraries/images.rst
+++ b/user_guide_src/source/libraries/images.rst
@@ -159,18 +159,19 @@ offset values::
 Converting Images
 -----------------
 
-The ``convert()`` method changes the library's internal indicator for the desired file format. This doesn't touch the actual image resource, but indicates to ``save()`` what format to use.
+The ``convert()`` method changes the library's internal indicator for the desired file format. This doesn't touch the actual image resource, but indicates to ``save()`` what format to use::
 
 	convert(int $imageType)
 
-- **$imageType** is one of PHP's image type constants (see for example https://www.php.net/manual/en/function.image-type-to-mime-type.php)
+- **$imageType** is one of PHP's image type constants (see for example https://www.php.net/manual/en/function.image-type-to-mime-type.php)::
 
 	Services::image()
 		->withFile('/path/to/image/mypic.jpg')
 		->convert(IMAGETYPE_PNG)
 		->save('path/to/new/image.png');
 
-.. note:: ImageMagick already saves files in the type indicated by their extension, ignoring **$imageType**
+.. note:: ImageMagick already saves files in the type
+	indicated by their extension, ignoring **$imageType**
 
 Fitting Images
 --------------

--- a/user_guide_src/source/libraries/images.rst
+++ b/user_guide_src/source/libraries/images.rst
@@ -161,11 +161,11 @@ Converting Images
 
 The ``convert()`` method changes the library's internal indicator for the desired file format. This doesn't touch the actual image resource, but indicates to ``save()`` what format to use.
 
-    convert(int $imageType)
+	convert(int $imageType)
 
 - **$imageType** is one of PHP's image type constants (see for example https://www.php.net/manual/en/function.image-type-to-mime-type.php)
 
-    Services::image()
+	Services::image()
 		->withFile('/path/to/image/mypic.jpg')
 		->convert(IMAGETYPE_PNG)
 		->save('path/to/new/image.png');

--- a/user_guide_src/source/libraries/images.rst
+++ b/user_guide_src/source/libraries/images.rst
@@ -92,9 +92,10 @@ starting at the top left corner. The result would be saved as the thumbnail.
 Processing Methods
 ==================
 
-There are six available processing methods:
+There are seven available processing methods:
 
 -  $image->crop()
+-  $image->convert()
 -  $image->fit()
 -  $image->flatten()
 -  $image->flip()
@@ -154,6 +155,22 @@ offset values::
 		->withFile('/path/to/image/mypic.jpg')
 		->crop(50, 50, $xOffset, $yOffset)
 		->save('path/to/new/image.jpg');
+
+Converting Images
+-----------------
+
+The ``convert()`` method changes the library's internal indicator for the desired file format. This doesn't touch the actual image resource, but indicates to ``save()`` what format to use.
+
+    convert(int $imageType)
+
+- **$imageType** is one of PHP's image type constants (see for example https://www.php.net/manual/en/function.image-type-to-mime-type.php)
+
+    Services::image()
+		->withFile('/path/to/image/mypic.jpg')
+		->convert(IMAGETYPE_PNG)
+		->save('path/to/new/image.png');
+
+.. note:: ImageMagick already saves files in the type indicated by their extension, ignoring **$imageType**
 
 Fitting Images
 --------------


### PR DESCRIPTION
**Description**
Currently there is no way to indicate to GD the image file type to create. `GD->save()` uses `image->imageType` to determine the method, regardless of extension.
`convert()` acts as a setter for `image->imageType` which will later be read by `save()` to modify the file output type.

**Note** ImageMagick already saves the format based on the indicated extension, and will not be affected by this addition.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
