### PR TITLE
Add rename option for Response download()

### DIFF
--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -1038,10 +1038,11 @@ class Response extends Message implements ResponseInterface
 	 * @param string      $filename The path to the file to send
 	 * @param string|null $data     The data to be downloaded
 	 * @param boolean     $setMime  Whether to try and send the actual MIME type
+	 * @param string|null $rename   An optional new name for the file when using a path
 	 *
 	 * @return \CodeIgniter\HTTP\DownloadResponse|null
 	 */
-	public function download(string $filename = '', $data = '', bool $setMime = false)
+	public function download(string $filename = '', $data = '', bool $setMime = false, string $rename = null)
 	{
 		if ($filename === '' || $data === '')
 		{
@@ -1056,7 +1057,7 @@ class Response extends Message implements ResponseInterface
 			$filename = end($filename);
 		}
 
-		$response = new DownloadResponse($filename, $setMime);
+		$response = new DownloadResponse($rename ?? $filename, $setMime);
 
 		if ($filepath !== '')
 		{
@@ -1069,5 +1070,4 @@ class Response extends Message implements ResponseInterface
 
 		return $response;
 	}
-
 }

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -455,6 +455,25 @@ class ResponseTest extends \CIUnitTestCase
 		$this->assertSame(file_get_contents(__FILE__), $actual_output);
 	}
 
+	public function testGetDownloadResponseRename()
+	{
+		$response = new Response(new App());
+		$rename = 'myFile.' . pathinfo(__FILE__, PATHINFO_EXTENSION);
+
+		$actual = $response->download(__FILE__, null, false, $rename);
+
+		$this->assertInstanceOf(DownloadResponse::class, $actual);
+		$actual->buildHeaders();
+		$this->assertSame('attachment; filename="' . $rename . '"; filename*=UTF-8\'\'' . $rename, $actual->getHeaderLine('Content-Disposition'));
+
+		ob_start();
+		$actual->sendBody();
+		$actual_output = ob_get_contents();
+		ob_end_clean();
+
+		$this->assertSame(file_get_contents(__FILE__), $actual_output);
+	}
+
 	public function testVagueDownload()
 	{
 		$response = new Response(new App());

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -82,7 +82,8 @@ The first parameter is the **name you want the downloaded file to be named**, th
 file data.
 
 If you set the second parameter to NULL and ``$filename`` is an existing, readable
-file path, then its content will be read instead.
+file path, then its content will be read instead with an option to change the name
+of the downloaded file with the fourth parameter.
 
 If you set the third parameter to boolean TRUE, then the actual file MIME type
 (based on the filename extension) will be sent, so that if your browser has a


### PR DESCRIPTION
**Description**
Currently an HTTP Response created with `download()` can take either a path or data with a filename, but when the path option is used the filename is set to the actual local file. This allows an additional parameter for a developer to supply a new name for the file to be downloaded.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
