### PR TITLE
Disabled Toolbar on downloads

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -41,6 +41,7 @@ use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Debug\Toolbar\Collectors\History;
 use CodeIgniter\Format\JSONFormatter;
 use CodeIgniter\Format\XMLFormatter;
+use CodeIgniter\HTTP\DownloadResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Services;
@@ -325,17 +326,25 @@ class Toolbar
 	/**
 	 * Prepare for debugging..
 	 *
+	 * @param  RequestInterface  $request
+	 * @param  ResponseInterface $response
 	 * @global type $app
 	 * @return type
 	 */
-	public function prepare()
+	public function prepare(RequestInterface $request = null, ResponseInterface $response = null)
 	{
 		if (CI_DEBUG && ! is_cli())
 		{
 			global $app;
 
-			$request  = Services::request();
-			$response = Services::response();
+			$request  = $request ?? Services::request();
+			$response = $response ?? Services::response();
+
+			// Disable the toolbar for downloads
+			if ($response instanceof DownloadResponse)
+			{
+				return;
+			}
 
 			$toolbar = Services::toolbar(config(Toolbar::class));
 			$stats   = $app->getPerformanceStats();

--- a/system/Filters/DebugToolbar.php
+++ b/system/Filters/DebugToolbar.php
@@ -71,7 +71,7 @@ class DebugToolbar implements FilterInterface
 	 */
 	public function after(RequestInterface $request, ResponseInterface $response)
 	{
-		Services::toolbar()->prepare();
+		Services::toolbar()->prepare($request, $response);
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
Fix for #2117. This change injects `$response` from the filter to the toolbar and checks for a DownloadResponse. If found, the toolbar quits.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
