### PR TITLE
Update limit function since $offset is nullable

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1293,7 +1293,7 @@ class BaseBuilder
 	 *
 	 * @return BaseBuilder
 	 */
-	public function limit(int $value = null, int $offset = 0)
+	public function limit(int $value = null, ?int $offset = 0)
 	{
 		if (! is_null($value))
 		{


### PR DESCRIPTION
**Description**
Update BaseBuilder `limit` function, since `$offset` is nullable.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide