### PR TITLE
guessExtension fallback to clientExtension

### DIFF
--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -358,7 +358,7 @@ class UploadedFile extends File implements UploadedFileInterface
 	 */
 	public function guessExtension(): ?string
 	{
-		return Mimes::guessExtensionFromType($this->getClientMimeType(), $this->getClientExtension());
+		return Mimes::guessExtensionFromType($this->getClientMimeType(), $this->getClientExtension()) ?? $this->getClientExtension();
 	}
 
 	//--------------------------------------------------------------------

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -356,7 +356,7 @@ class UploadedFile extends File implements UploadedFileInterface
 	 *
 	 * @return string|null
 	 */
-	public function guessExtension(): ?string
+	public function guessExtension(): string
 	{
 		return Mimes::guessExtensionFromType($this->getClientMimeType(), $this->getClientExtension()) ?? $this->getClientExtension();
 	}


### PR DESCRIPTION
**Description**
Currently **UploadedFile.php** has `getExtension()` returning a string (not nullable) but `Mimes::guessExtensionFromType()` can return null, effectively causing an exception anytime a file is uploaded whose extension does not match the current Mime config list. This change causes `getExtension()` to return the client file's extension if Mime returns null.

I suspect this was the original intent for passing `$this->getClientExtension()` as the second parameter to `Mimes::guessExtensionFromType()`, but that acts as an arbitrator for duplicates rather than a fallback.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
