### PR TITLE
Add setFileName() to DownloadResponse

### DIFF
--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -139,6 +139,19 @@ class DownloadResponse extends Message implements ResponseInterface
 	}
 
 	/**
+	 * set name for the download.
+	 *
+	 * @param string $filename
+	 *
+	 * @return $this
+	 */
+	public function setFileName(string $filename)
+	{
+		$this->filename = $filename;
+		return $this;
+	}
+
+	/**
 	 * get content length.
 	 *
 	 * @return integer

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -95,6 +95,15 @@ class DownloadResponseTest extends \CIUnitTestCase
 
 		$this->assertEquals('application/octet-stream', $response->getHeaderLine('Content-Type'));
 	}
+	
+	public function testSetFileName()
+	{
+		$response = new DownloadResponse('unit-test.txt', true);
+		$response->setFileName('myFile.txt');
+		$response->buildHeaders();
+
+		$this->assertSame('attachment; filename="myFile.txt"; filename*=UTF-8\'\'myFile.txt', $response->getHeaderLine('Content-Disposition'));
+	}
 
 	public function testNoCache()
 	{

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -100,6 +100,10 @@ do the following::
 	// Contents of photo.jpg will be automatically read
 	return $response->download('/path/to/photo.jpg', NULL);
 
+Use the optional ``setFileName()`` method to change the filename as it is sent to the client's browser::
+	
+	return $response->download('awkwardEncryptedFileName.fakeExt')->setFileName('expenses.csv');
+
 .. note:: The response object MUST be returned for the download to be sent to the client. This allows the response
     to be passed through all **after** filters before being sent to the client.
 


### PR DESCRIPTION
**Description**
Currently an HTTP Response created with download() can take either a path or data with a filename, but when the path option is used the filename is set to the actual local file. This adds a setter to the DownloadResponse so a developer can supply a new name for the file on download.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [X] Conforms to style guide
