### PR TITLE
Added No Content response to API\ResponseTrait

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -65,6 +65,7 @@ trait ResponseTrait
 	protected $codes = [
 		'created'                   => 201,
 		'deleted'                   => 200,
+		'no_content'                => 204,
 		'invalid_request'           => 400,
 		'unsupported_response_type' => 400,
 		'invalid_scope'             => 400,
@@ -186,6 +187,21 @@ trait ResponseTrait
 	public function respondDeleted($data = null, string $message = '')
 	{
 		return $this->respond($data, $this->codes['deleted'], $message);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Used after a command has been successfully executed but there is no
+	 * meaningful reply to send back to the client.
+	 *
+	 * @param string $message Message.
+	 *
+	 * @return mixed
+	 */
+	public function respondNoContent(string $message = 'No Content')
+	{
+		return $this->respond(null, $this->codes['no_content'], $message);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -278,6 +278,15 @@ EOH;
 		$this->assertEquals($this->formatter->format($expected), $this->response->getBody());
 	}
 
+	public function testNoContent()
+	{
+		$controller = $this->makeController();
+		$controller->respondNoContent('');
+
+		$this->assertEquals('No Content', $this->response->getReason());
+		$this->assertEquals(204, $this->response->getStatusCode());
+	}
+
 	public function testNotFound()
 	{
 		$controller = $this->makeController();

--- a/user_guide_src/source/outgoing/api_responses.rst
+++ b/user_guide_src/source/outgoing/api_responses.rst
@@ -48,6 +48,8 @@ exist for the most common use cases::
     respondCreated($data);
     // Item successfully deleted
     respondDeleted($data);
+    // Command executed by no response required
+    respondNoContent($message);
     // Client isn't authorized
     failUnauthorized($description);
     // Forbidden action
@@ -178,6 +180,19 @@ Class Reference
 
 	    $user = $userModel->delete($id);
 	    return $this->respondDeleted(['id' => $id]);
+
+.. php:method:: respondNoContent(string $message = 'No Content')
+
+    :param string $message: A custom "reason" message to return.
+    :returns: The value of the Response object's send() method.
+
+    Sets the appropriate status code to use when a command was successfully executed by the server but there is no 
+    meaningful reply to send back to the client, typically 204.
+
+    ::
+
+	    sleep(1);
+	    return $this->respondNoContent();        
 
 .. php:method:: failUnauthorized(string $description = 'Unauthorized'[, string $code=null[, string $message = '']])
 


### PR DESCRIPTION
**Description**
Added a method in API\ResponseTrait to generate No Content (204) response to an API request that doesn't provide any meaningful response to the client but the client still needs status 204 back.

NOTE: I hope I got the commit signed properly this time.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
