### PR TITLE
Bugfix Numeric Migrations

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -285,7 +285,7 @@ class MigrationRunner
 				continue;
 			}
 
-			$migrations = array_merge($migrations, $nsMigrations);
+			$migrations = $migrations + $nsMigrations;
 		}
 
 		$migrationStatus = $this->migrate('up', $migrations, end($migrations)->version);


### PR DESCRIPTION
**Description**
With the migration refactor `findMigrations()` now returns migrations with their version as their index key. `latestAll()` currently uses `array_merge()` to create one final array from all namespace migrations, but `array_merge()` renumbers numeric (i.e. integer, even as a technical string) keys so that the target version fails to locate in `checkMigrations()`.

This change uses the array union operator instead of `array_merge()` as it does no renumbering.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
