### PR TITLE
Fixing BuilderBase resetting when getting the SQL

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1472,7 +1472,7 @@ class BaseBuilder
 		}
 
 		$result = $returnSQL
-			? $this->getCompiledSelect()
+			? $this->getCompiledSelect($reset)
 			: $this->db->query($this->compileSelect(), $this->binds, false);
 
 		if ($reset === true)

--- a/tests/system/Database/Builder/GetTest.php
+++ b/tests/system/Database/Builder/GetTest.php
@@ -1,0 +1,47 @@
+<?php namespace Builder;
+
+use Tests\Support\Database\MockConnection;
+
+class GetTest extends \CIUnitTestCase
+{
+	protected $db;
+
+	//--------------------------------------------------------------------
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->db = new MockConnection([]);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testGet()
+	{
+		$builder = $this->db->table('users');
+
+		$expectedSQL = 'SELECT * FROM "users"';
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/2141
+	 */
+	public function testGetWithReset()
+	{
+		$builder = $this->db->table('users');
+		$builder->where('username', 'bogus');
+
+		$expectedSQL           = 'SELECT * FROM "users" WHERE "username" = \'bogus\'';
+		$expectedSQLafterreset = 'SELECT * FROM "users"';
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, true, false)));
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, true, true)));
+		$this->assertEquals($expectedSQLafterreset, str_replace("\n", ' ', $builder->get(0, 50, true, true)));
+	}
+
+}


### PR DESCRIPTION
**Description**
Fixes #2141 where the builder was reset when returning the SQL.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
