### PR TITLE
Update Redis legacy function

### DIFF
--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -246,7 +246,7 @@ class RedisHandler implements CacheInterface
 	{
 		$key = $this->prefix . $key;
 
-		return ($this->redis->delete($key) === 1);
+		return ($this->redis->del($key) === 1);
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
From https://github.com/phpredis/phpredis:
"Note: delete is an alias for del and will be removed in future versions of phpredis."

This PR changes the call to `delete()` to be `del()` instead.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
