### PR TITLE
listNamespaceFiles: Ensure trailing slash 

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -422,7 +422,7 @@ class Autoloader
 			unset($paths['CodeIgniter\\']);
 		}
 
-		// Composer stores paths with trailng slash. We don't.
+		// Composer stores namespaces with trailing slash. We don't.
 		$newPaths = [];
 		foreach ($paths as $key => $value)
 		{

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -408,7 +408,7 @@ class FileLocator
 		// autoloader->getNamespace($prefix) returns an array of paths for that namespace
 		foreach ($this->autoloader->getNamespace($prefix) as $namespacePath)
 		{
-			$fullPath = realpath($namespacePath . $path);
+			$fullPath = realpath(rtrim($namespacePath, '/') . '/' . $path);
 
 			if (! is_dir($fullPath))
 			{


### PR DESCRIPTION
**Description**
The Autoloader merges Composer namespace paths directly from Composer's autoloader, which doesn't include a trailing slash. This means files coming from `autoloader->getNamespace()` may or may not have a trailing slash, which sometimes causes `FileLocator->listNamespaceFiles()` to miss files it should otherwise find.
This change ensures that the namespace path coming from autoloader will always have the trailing slash.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
