### PR TITLE
New logic for Image->fit()

### DIFF
--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -572,7 +572,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 			$height = ceil(($width / $cropWidth) * $cropHeight);
 		}
 
-		list($x, $y) = $this->calcCropCoords($width, $height, $origWidth, $origHeight, $position);
+		list($x, $y) = $this->calcCropCoords($cropWidth, $cropHeight, $origWidth, $origHeight, $position);
 
 		return $this->crop($cropWidth, $cropHeight, $x, $y)
 						->resize($width, $height);
@@ -610,14 +610,14 @@ abstract class BaseHandler implements ImageHandlerInterface
 		if ($xRatio > $yRatio)
 		{
 			return [
-				(int) ($origWidth * $yRatio),
-				(int) ($origHeight * $yRatio),
+				$origWidth,
+				(int) ($origWidth * $height / $width),
 			];
 		}
 
 		return [
-			(int) ($origWidth * $xRatio),
-			(int) ($origHeight * $xRatio),
+			(int) ($origHeight * $width / $height),
+			$origHeight,
 		];
 	}
 


### PR DESCRIPTION
**Description**
Current `fit()` isn't working as expected - it does the correct crop location and resize but it is taking a much smaller-than-necessary crop from large images. This iteration starts with the premise that the crop should be the entire width or height of the image, calculates the other axis based on the desired aspect, takes the much larger crop then resizes to the desired output.

Tests are hard for image handlers but I have run this through a handful of scenarios.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
