### PR TITLE
ImageMagick->save() return value

### DIFF
--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -232,9 +232,10 @@ class ImageMagickHandler extends BaseHandler
 	 * @param string  $action
 	 * @param integer $quality
 	 *
-	 * @return ImageMagickHandler|boolean
+	 * @return array  Lines of output from shell command
+	 * @throws \Exception
 	 */
-	protected function process(string $action, int $quality = 100)
+	protected function process(string $action, int $quality = 100): array
 	{
 		// Do we have a vaild library path?
 		if (empty($this->config->libraryPath))
@@ -303,8 +304,8 @@ class ImageMagickHandler extends BaseHandler
 		$result = $this->process($action, $quality);
 
 		unlink($this->resource);
-
-		return $result;
+		
+		return true;
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
In the Image Magick handler class, `save()` currently returns the result of `process()`, which is an array of the lines of output from `exec()`. This can cause a type error because the return type is defined as `bool`.

This PR changes `save()` to return true after `process()` calls, as `process()` will throw an exception on failure already and `$output` is unreliable for determining success or failure.

This resolves #2029.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
