### PR TITLE
Bug fix countAllResults with LIMIT

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1552,6 +1552,10 @@ class BaseBuilder
 			$this->QBOrderBy = null;
 		}
 
+		// We cannot use a LIMIT when getting the single row COUNT(*) result
+		$limit         = $this->QBLimit;
+		$this->QBLimit = false;
+
 		$sql = ($this->QBDistinct === true)
 			?
 			$this->countString . $this->db->protectIdentifiers('numrows') . "\nFROM (\n" . $this->compileSelect() . "\n) CI_count_all_results"
@@ -1574,6 +1578,9 @@ class BaseBuilder
 		{
 			$this->QBOrderBy = $orderBy ?? [];
 		}
+
+		// Restore the LIMIT setting
+		$this->QBLimit = $limit;
 
 		$row = (! $result instanceof ResultInterface)
 			? null


### PR DESCRIPTION
**Description**
Unsets the LIMIT clause when running countAllResults() to avoid getting zero count.
Fixes #2152 

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
