### PR TITLE
Include .gitignore in starters

### DIFF
--- a/admin/release-appstarter
+++ b/admin/release-appstarter
@@ -12,7 +12,7 @@ git checkout $branch
 echo -e "${BOLD}Build the framework distributable${NORMAL}"
 
 echo -e "${BOLD}Copy the main files/folders...${NORMAL}"
-releasable='app public writable README.md contributing.md env license.txt spark tests/_support .gitignore'
+releasable='app public writable README.md contributing.md env license.txt spark .gitignore'
 for fff in $releasable ; do
     if [ -d "$fff" ] ; then
         rm -rf $fff

--- a/admin/release-appstarter
+++ b/admin/release-appstarter
@@ -12,7 +12,7 @@ git checkout $branch
 echo -e "${BOLD}Build the framework distributable${NORMAL}"
 
 echo -e "${BOLD}Copy the main files/folders...${NORMAL}"
-releasable='app public writable README.md contributing.md env license.txt spark tests/_support'
+releasable='app public writable README.md contributing.md env license.txt spark tests/_support .gitignore'
 for fff in $releasable ; do
     if [ -d "$fff" ] ; then
         rm -rf $fff

--- a/admin/release-framework
+++ b/admin/release-framework
@@ -12,7 +12,7 @@ git checkout $branch
 echo -e "${BOLD}Build the framework distributable${NORMAL}"
 
 echo -e "${BOLD}Copy the main files/folders...${NORMAL}"
-releasable='app docs public system writable contributing.md env license.txt spark'
+releasable='app docs public system writable contributing.md env license.txt spark .gitignore'
 for fff in $releasable ; do
     if [ -d "$fff" ] ; then
         rm -rf $fff


### PR DESCRIPTION
**Description**
devstarter and appstarter both have very old versions of .gitignore - it isn't getting updated when new deployments are made. This PR adds .gitignore to the list of files copied out during a release.

**Checklist:**
- [X] Securely signed commits
