### PR TITLE
Add BaseBuilder SelectCount

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -384,7 +384,29 @@ class BaseBuilder
 	//--------------------------------------------------------------------
 
 	/**
-	 * SELECT [MAX|MIN|AVG|SUM]()
+	 * Select Count
+	 *
+	 * Generates a SELECT COUNT(field) portion of a query
+	 *
+	 * @param string $select The field, or * for all
+	 * @param string $alias  An alias
+	 *
+	 * @return BaseBuilder
+	 */
+	public function selectCount(string $select = '*', string $alias = '')
+	{
+		// Force an alias on "all" queries
+		if ($select == '*' && $alias == '')
+		{
+			$alias = 'count';
+		}
+		return $this->maxMinAvgSum($select, $alias, 'COUNT');
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * SELECT [MAX|MIN|AVG|SUM|COUNT]()
 	 *
 	 * @used-by selectMax()
 	 * @used-by selectMin()
@@ -413,7 +435,7 @@ class BaseBuilder
 
 		$type = strtoupper($type);
 
-		if (! in_array($type, ['MAX', 'MIN', 'AVG', 'SUM']))
+		if (! in_array($type, ['MAX', 'MIN', 'AVG', 'SUM', 'COUNT']))
 		{
 			throw new DatabaseException('Invalid function type: ' . $type);
 		}

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -388,18 +388,13 @@ class BaseBuilder
 	 *
 	 * Generates a SELECT COUNT(field) portion of a query
 	 *
-	 * @param string $select The field, or * for all
+	 * @param string $select The field
 	 * @param string $alias  An alias
 	 *
 	 * @return BaseBuilder
 	 */
-	public function selectCount(string $select = '*', string $alias = '')
+	public function selectCount(string $select = '', string $alias = '')
 	{
-		// Force an alias on "all" queries
-		if ($select == '*' && $alias == '')
-		{
-			$alias = 'count';
-		}
 		return $this->maxMinAvgSum($select, $alias, 'COUNT');
 	}
 

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -199,6 +199,45 @@ class SelectTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testSelectCountWithNoParameter()
+	{
+		$builder = new BaseBuilder('invoices', $this->db);
+
+		$builder->selectCount();
+
+		$expected = 'SELECT COUNT("*") AS "count" FROM "invoices"';
+
+		$this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSelectCountWithNoAlias()
+	{
+		$builder = new BaseBuilder('invoices', $this->db);
+
+		$builder->selectCount('payments');
+
+		$expected = 'SELECT COUNT("payments") AS "payments" FROM "invoices"';
+
+		$this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSelectCountWithAlias()
+	{
+		$builder = new BaseBuilder('invoices', $this->db);
+
+		$builder->selectCount('payments', 'myAlias');
+
+		$expected = 'SELECT COUNT("payments") AS "myAlias" FROM "invoices"';
+
+		$this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testSelectMinThrowsExceptionOnEmptyValue()
 	{
 		$builder = new BaseBuilder('invoices', $this->db);

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -199,19 +199,6 @@ class SelectTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testSelectCountWithNoParameter()
-	{
-		$builder = new BaseBuilder('invoices', $this->db);
-
-		$builder->selectCount();
-
-		$expected = 'SELECT COUNT("*") AS "count" FROM "invoices"';
-
-		$this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
-	}
-
-	//--------------------------------------------------------------------
-
 	public function testSelectCountWithNoAlias()
 	{
 		$builder = new BaseBuilder('invoices', $this->db);

--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -126,7 +126,7 @@ class GroupTest extends CIDatabaseTestCase
 	public function testGroupByCount()
 	{
 		$result = $this->db->table('user')
-				->selectCount('*')
+				->selectCount('id')
 				->groupBy('country')
 				->get()
 				->getResult();

--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -131,6 +131,6 @@ class GroupTest extends CIDatabaseTestCase
 				->get()
 				->getResult();
 
-		$this->assertEquals(3, $result->count);
+		$this->assertEquals(3, $result[0]->count);
 	}
 }

--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -126,7 +126,7 @@ class GroupTest extends CIDatabaseTestCase
 	public function testGroupByCount()
 	{
 		$result = $this->db->table('user')
-				->selectCount('id')
+				->selectCount('id', 'count')
 				->groupBy('country')
 				->get()
 				->getResult();

--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -123,4 +123,14 @@ class GroupTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testGroupByCount()
+	{
+		$result = $this->db->table('user')
+				->selectCount('*')
+				->groupBy('country')
+				->get()
+				->getResult();
+
+		$this->assertEquals(3, $result->count);
+	}
 }

--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -128,9 +128,10 @@ class GroupTest extends CIDatabaseTestCase
 		$result = $this->db->table('user')
 				->selectCount('id', 'count')
 				->groupBy('country')
+				->orderBy('country', 'desc')
 				->get()
 				->getResult();
 
-		$this->assertEquals(3, $result[0]->count);
+		$this->assertEquals(2, $result[0]->count);
 	}
 }

--- a/tests/system/Database/Live/SelectTest.php
+++ b/tests/system/Database/Live/SelectTest.php
@@ -91,7 +91,7 @@ class SelectTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testSelectAvgWitAlias()
+	public function testSelectAvgWithAlias()
 	{
 		$result = $this->db->table('job')->selectAvg('id', 'xam')->get()->getRow();
 
@@ -109,11 +109,38 @@ class SelectTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testSelectSumWitAlias()
+	public function testSelectSumWithAlias()
 	{
 		$result = $this->db->table('job')->selectSum('id', 'xam')->get()->getRow();
 
 		$this->assertEquals(10, $result->xam);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSelectCountNoColumn()
+	{
+		$result = $this->db->table('job')->selectCount()->get()->getRow();
+
+		$this->assertEquals(4, $result->count);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSelectCount()
+	{
+		$result = $this->db->table('job')->selectCount('id')->get()->getRow();
+
+		$this->assertEquals(4, $result->id);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSelectCountWithAlias()
+	{
+		$result = $this->db->table('job')->selectSum('id', 'xam')->get()->getRow();
+
+		$this->assertEquals(4, $result->xam);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/SelectTest.php
+++ b/tests/system/Database/Live/SelectTest.php
@@ -118,15 +118,6 @@ class SelectTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testSelectCountNoColumn()
-	{
-		$result = $this->db->table('job')->selectCount()->get()->getRow();
-
-		$this->assertEquals(4, $result->count);
-	}
-
-	//--------------------------------------------------------------------
-
 	public function testSelectCount()
 	{
 		$result = $this->db->table('job')->selectCount('id')->get()->getRow();
@@ -138,7 +129,7 @@ class SelectTest extends CIDatabaseTestCase
 
 	public function testSelectCountWithAlias()
 	{
-		$result = $this->db->table('job')->selectSum('id', 'xam')->get()->getRow();
+		$result = $this->db->table('job')->selectCount('id', 'xam')->get()->getRow();
 
 		$this->assertEquals(4, $result->xam);
 	}

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -181,8 +181,7 @@ the resulting field.
 
 Writes a "SELECT COUNT(field)" portion for your query. As with
 selectMax(), You can optionally include a second parameter to rename
-the resulting field. If no field is provided '*' will be used and the result
-will be aliased to 'count'.
+the resulting field.
 
 .. note:: This method is particularly helpful when used with ``groupBy()``. For
 counting results generally see ``countAll()`` or ``countAllResults()``.

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -177,6 +177,21 @@ the resulting field.
 	$builder->selectSum('age');
 	$query = $builder->get(); // Produces: SELECT SUM(age) as age FROM mytable
 
+**$builder->selectCount()**
+
+Writes a "SELECT COUNT(field)" portion for your query. As with
+selectMax(), You can optionally include a second parameter to rename
+the resulting field. If no field is provided '*' will be used and the result
+will be aliased to 'count'.
+
+.. note:: This method is particularly helpful when used with ``groupBy()``. For
+counting results generally see ``countAll()`` or ``countAllResults()``.
+
+::
+
+	$builder->selectSum('age');
+	$query = $builder->get(); // Produces: SELECT SUM(age) as age FROM mytable
+
 **$builder->from()**
 
 Permits you to write the FROM portion of your query::


### PR DESCRIPTION
**Description**
Currently there are no ways to return counted group results (see https://github.com/codeigniter4/CodeIgniter4/issues/2159). This provides the first of the discussed methods, `selectCount()`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
