### PR TITLE
Setheader dupes

### DIFF
--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -266,23 +266,16 @@ class Message
 	 */
 	public function setHeader(string $name, $value)
 	{
-		if (! isset($this->headers[$name]))
+		$origName = $this->getHeaderName($name);
+		
+		if (isset($this->headers[$origName]) && is_array($this->headers[$origName]))
 		{
-			$this->headers[$name] = new Header($name, $value);
-
-			$this->headerMap[strtolower($name)] = $name;
-
-			return $this;
+			$this->appendHeader($origName, $value);
 		}
-
-		if (! is_array($this->headers[$name]))
+		else
 		{
-			$this->headers[$name] = [$this->headers[$name]];
-		}
-
-		if (isset($this->headers[$name]))
-		{
-			$this->headers[$name] = new Header($name, $value);
+			$this->headers[$origName] = new Header($origName, $value);
+			$this->headerMap[strtolower($origName)] = $origName;
 		}
 
 		return $this;

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -181,9 +181,9 @@ class MessageTest extends \CIUnitTestCase
 
 	public function testSetHeaderReplacingHeader()
 	{
-			$this->message->setHeader('Accept', 'json');
+		$this->message->setHeader('Accept', 'json');
 
-				$this->assertEquals('json', $this->message->getHeaderLine('Accept'));
+		$this->assertEquals('json', $this->message->getHeaderLine('Accept'));
 	}
 
 	public function testSetHeaderDuplicateSettings()
@@ -191,7 +191,15 @@ class MessageTest extends \CIUnitTestCase
 		$this->message->setHeader('Accept', 'json');
 		$this->message->setHeader('Accept', 'xml');
 
-			$this->assertEquals('xml', $this->message->getHeaderLine('Accept'));
+		$this->assertEquals('xml', $this->message->getHeaderLine('Accept'));
+	}
+
+	public function testSetHeaderDuplicateSettingsInsensitive()
+	{
+		$this->message->setHeader('Accept', 'json');
+		$this->message->setHeader('accept', 'xml');
+
+		$this->assertEquals('xml', $this->message->getHeaderLine('Accept'));
 	}
 
 	public function testSetHeaderArrayValues()


### PR DESCRIPTION
**Description**
Using `setHeader()` with duplicate values of different case currently creates duplicate headers. There's also something wrong with the current `setHeader()` logic (see https://github.com/codeigniter4/CodeIgniter4/issues/2170). This PR reworks the method to be what I think it was intending to do.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
