### PR TITLE
Base FeatureTestCase on CIUnitTestCase

### DIFF
--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -53,7 +53,7 @@ use Config\Services;
  *
  * @package CodeIgniter\Test
  */
-class FeatureTestCase extends CIDatabaseTestCase
+class FeatureTestCase extends CIUnitTestCase
 {
 
 	/**


### PR DESCRIPTION
FeatureTestCase extended CIDatabaseTestCase, even though there were no data calls.
This prevented testing features if the database tests weren't also being run.