### PR TITLE
Add fallback for missing finfo_open

### DIFF
--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -134,6 +134,11 @@ class File extends SplFileInfo
 	 */
 	public function getMimeType(): string
 	{
+		if (! function_exists('finfo_open'))
+		{
+			return $this->originalMimeType ?? 'application/octet-stream';
+		}
+
 		$finfo    = finfo_open(FILEINFO_MIME_TYPE);
 		$mimeType = finfo_file($finfo, $this->getRealPath());
 		finfo_close($finfo);


### PR DESCRIPTION
**Description**
I've just encountered my second sizable hosting company that doesn't have the fileinfo extension available. This causes `File->getMimeType()` to fail:
```
CRITICAL - 2019-09-01 21:32:28 --> Call to undefined function CodeIgniter\Files\finfo_open()
```
Given that this is a "standard" setup it probably isn't safe to rely on this function. This PR checks for the function, and failing to find it reverts to the client's reported MIME type.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
