### PR TITLE
Remove copy-paste extraneous text

### DIFF
--- a/app/Config/Paths.php
+++ b/app/Config/Paths.php
@@ -56,10 +56,6 @@ class Paths
 	 * ---------------------------------------------------------------
 	 *
 	 * This variable must contain the name of your "tests" directory.
-	 * The writable directory allows you to group all directories that
-	 * need write permission to a single place that can be tucked away
-	 * for maximum security, keeping it out of the app and/or
-	 * system directories.
 	 */
 	public $testsDirectory = __DIR__ . '/../../tests';
 


### PR DESCRIPTION
**Description**
Just a small error of text that appears to be pasted from above.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
