### PR TITLE
Check `defined` for constants

### DIFF
--- a/app/Config/Constants.php
+++ b/app/Config/Constants.php
@@ -11,7 +11,7 @@
 // NOTE: changing this will require manually modifying the
 // existing namespaces of App\* namespaced-classes.
 //
-define('APP_NAMESPACE', 'App');
+defined('APP_NAMESPACE') || define('APP_NAMESPACE', 'App');
 
 /*
 |--------------------------------------------------------------------------
@@ -21,7 +21,7 @@ define('APP_NAMESPACE', 'App');
 | The path that Composer's autoload file is expected to live. By default,
 | the vendor folder is in the Root directory, but you can customize that here.
 */
-define('COMPOSER_PATH', ROOTPATH . 'vendor/autoload.php');
+defined('COMPOSER_PATH') || define('COMPOSER_PATH', ROOTPATH . 'vendor/autoload.php');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
**Description**
Currently the `APP_NAMESPACE` and `COMPOSER_PATH` define right out, without checking for `defined()`. This prevents using an alternative bootstrap to load from different locations, e.g. a modular test bootstrapper.

This PR adds checks for existing constants before defining them.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
