### PR TITLE
Fix case on "Seeds/" directory

### DIFF
--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -200,7 +200,7 @@ class CIDatabaseTestCase extends CIUnitTestCase
 		{
 			if (! empty($this->basePath))
 			{
-				$this->seeder->setPath(rtrim($this->basePath, '/') . '/seeds');
+				$this->seeder->setPath(rtrim($this->basePath, '/') . '/Seeds');
 			}
 
 			$this->seed($this->seed);


### PR DESCRIPTION
**Description**
If both a test seed file and a directory are passed the Seeder will set the path right to that file, but it incorrectly uses a lower-case directory "seeds" instead of "Seeds". This PR fixes the case.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
