### PR TITLE
[ci skip] Fix name of ForeignKeyChecks

### DIFF
--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -90,18 +90,18 @@ Foreign Keys
 ============
 
 When your tables include Foreign Keys, migrations can often cause problems as you attempt to drop tables and columns.
-To temporarily bypass the foreign key checks while running migrations, use the ``disableForeignKeyConstraints()`` and
-``enableForeignKeyConstraints()`` methods on the database connection.
+To temporarily bypass the foreign key checks while running migrations, use the ``disableForeignKeyChecks()`` and
+``enableForeignKeyChecks()`` methods on the database connection.
 
 ::
 
     public function up()
     {
-        $this->db->disableForeignKeyConstraints();
+        $this->db->disableForeignKeyChecks();
 
         // Migration rules would go here...
 
-        $this->db->enableForeignKeyConstraints();
+        $this->db->enableForeignKeyChecks();
     }
 
 Database Groups


### PR DESCRIPTION
**Description**
Docs have the wrong names for foreign key methods.
I think I was supposed to use [ci skip] on the commit but trying it here anyways...

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [ ] Conforms to style guide
