### PR TITLE
Migration rollback reverse

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -298,7 +298,7 @@ class MigrationRunner
 			}
 
 			// Get the migrations from each history
-			foreach ($this->getBatchHistory($batch) as $history)
+			foreach ($this->getBatchHistory($batch, 'desc') as $history)
 			{
 				// Create a UID from the history to match its migration
 				$uid = $this->getObjectUid($history);
@@ -789,13 +789,13 @@ class MigrationRunner
 	 *
 	 * @return array
 	 */
-	public function getBatchHistory(int $batch): array
+	public function getBatchHistory(int $batch, $order = 'asc'): array
 	{
 		$this->ensureTable();
 
 		$query = $this->db->table($this->table)
 						  ->where('batch', $batch)
-						  ->orderBy('id', 'asc')
+						  ->orderBy('id', $order)
 						  ->get();
 
 		return $query ? $query->getResultObject() : [];

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -90,18 +90,18 @@ Foreign Keys
 ============
 
 When your tables include Foreign Keys, migrations can often cause problems as you attempt to drop tables and columns.
-To temporarily bypass the foreign key checks while running migrations, use the ``disableForeignKeyConstraints()`` and
-``enableForeignKeyConstraints()`` methods on the database connection.
+To temporarily bypass the foreign key checks while running migrations, use the ``disableForeignKeyChecks()`` and
+``enableForeignKeyChecks()`` methods on the database connection.
 
 ::
 
     public function up()
     {
-        $this->db->disableForeignKeyConstraints();
+        $this->db->disableForeignKeyChecks();
 
         // Migration rules would go here...
 
-        $this->db->enableForeignKeyConstraints();
+        $this->db->enableForeignKeyChecks();
     }
 
 Database Groups


### PR DESCRIPTION
**Description**
Per: https://github.com/codeigniter4/CodeIgniter4/issues/2147#issuecomment-528278342

Migration rollbacks are currently rolling back batch-by-batch in the correct order, but within the batch migrations are being downgrading in ascending order. This reverses the migrations within a batch so they are downgraded appropriately.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
