### PR TITLE
WIP Use site_url for route-based RedirectResponse

### DIFF
--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -91,7 +91,7 @@ class RedirectResponse extends Response
 			throw HTTPException::forInvalidRedirectRoute($route);
 		}
 
-		return $this->redirect(base_url($route), $method, $code);
+		return $this->redirect(site_url($route), $method, $code);
 	}
 
 	/**

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -3,6 +3,7 @@
 namespace CodeIgniter\HTTP;
 
 use Config\App;
+use CodeIgniter\Config\Config;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Validation\Validation;
 use CodeIgniter\Router\RouteCollection;
@@ -24,8 +25,10 @@ class RedirectResponseTest extends \CIUnitTestCase
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 
-		$this->config          = new App();
-		$this->config->baseURL = 'http://example.com';
+		$this->config            = new App();
+		$this->config->baseURL   = 'http://example.com';
+		$this->config->indexPage = '';
+		Config::injectMock('App', $this->config);
 
 		$this->routes = new RouteCollection(Services::locator(), new \Config\Modules());
 		Services::injectMock('routes', $this->routes);
@@ -65,6 +68,25 @@ class RedirectResponseTest extends \CIUnitTestCase
 
 		$this->assertTrue($response->hasHeader('Location'));
 		$this->assertEquals('http://example.com/exampleRoute', $response->getHeaderLine('Location'));
+	}
+
+	public function testRedirectRouteBaseUrl()
+	{
+		$config          = new App();
+		$config->baseURL = 'http://example.com/test/';
+		Config::injectMock('App', $config);
+
+		$request = new MockIncomingRequest($config, new URI('http://example.com/test/'), null, new UserAgent());
+		Services::injectMock('request', $request);
+
+		$response = new RedirectResponse(new App());
+
+		$this->routes->add('exampleRoute', 'Home::index');
+
+		$response->route('exampleRoute');
+
+		$this->assertTrue($response->hasHeader('Location'));
+		$this->assertEquals('http://example.com/test/index.php/exampleRoute', $response->getHeaderLine('Location'));
 	}
 
 	public function testRedirectRouteBad()

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -85,6 +85,8 @@ class RedirectResponseTest extends \CIUnitTestCase
 
 		$this->assertTrue($response->hasHeader('Location'));
 		$this->assertEquals('http://example.com/test/index.php/exampleRoute', $response->getHeaderLine('Location'));
+
+		Config::reset();
 	}
 
 	public function testRedirectRouteBad()

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -25,10 +25,8 @@ class RedirectResponseTest extends \CIUnitTestCase
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 
-		$this->config            = new App();
-		$this->config->baseURL   = 'http://example.com';
-		$this->config->indexPage = '';
-		Config::injectMock('App', $this->config);
+		$this->config          = new App();
+		$this->config->baseURL = 'http://example.com';
 
 		$this->routes = new RouteCollection(Services::locator(), new \Config\Modules());
 		Services::injectMock('routes', $this->routes);


### PR DESCRIPTION

**Description**
base_url does not actually add the base path if the given URL is absolute (i.e., starts with a slash) and does not add the indexPage. Both is necessary for the redirect response to work correctly in case of routes. site_url handles this correctly.

Fixes #2119 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

