### PR TITLE
Update Session.php

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -304,7 +304,8 @@ class Session implements SessionInterface
 				$this->sessionExpiration, $this->cookiePath, $this->cookieDomain, $this->cookieSecure, true // HTTP only; Yes, this is intentional and not configurable for security reasons.
 		);
 
-		if (empty($this->sessionExpiration))
+		//if (empty($this->sessionExpiration))
+		if (!isset($this->sessionExpiration))
 		{
 			$this->sessionExpiration = (int) ini_get('session.gc_maxlifetime');
 		}


### PR DESCRIPTION
**sessionExpiration issue**
if we set $sessionExpiration to 0 (zero=expire on browser close) in app config file, but due to this condition if (empty($this->sessionExpiration)) it results true for 0 and expiration time sets to $this->sessionExpiration = (int) ini_get('session.gc_maxlifetime');
so i suggest to change this if condition to if(! isset($this->sessionExpiration))

Each pull request should address a single issue and have a meaningful title.

**Description**
Explain what you have changed, and why.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide