### PR TITLE
Notify Kint of dd alias

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -1079,6 +1079,7 @@ if (! function_exists('dd'))
 	 */
 	function dd(...$vars)
 	{
+		Kint::$aliases[] = 'dd';
 		Kint::dump(...$vars);
 		exit;
 	}


### PR DESCRIPTION
**Description**
Because `dd()` is calling `Kint::dump` directly, Kint will always display the translated parameter `reset($vars)` as variable name and `dd()`'s source as call location:
```
Called from .../codeigniter4/codeigniter4/system/Common.php:1082 [dd()]
```

This change has `dd()` add itself to Kint's alias list prior to the call so Kint correctly looks back to the originating call. Since the script will always `exit` there's not need to check `Kint::aliases` for duplicates or anything.

**Note**: This is the Kint-approved way to wrap `d()`

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
