### PR TITLE
Foreign key columns

### DIFF
--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -537,10 +537,14 @@ class Connection extends BaseConnection implements ConnectionInterface
                     SELECT
                         tc.CONSTRAINT_NAME,
                         tc.TABLE_NAME,
-                        rc.REFERENCED_TABLE_NAME
+                        kcu.COLUMN_NAME,
+                        rc.REFERENCED_TABLE_NAME,
+                        kcu.REFERENCED_COLUMN_NAME
                     FROM information_schema.TABLE_CONSTRAINTS AS tc
                     INNER JOIN information_schema.REFERENTIAL_CONSTRAINTS AS rc
                         ON tc.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
+                    INNER JOIN information_schema.KEY_COLUMN_USAGE AS kcu
+                        ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
                     WHERE
                         tc.CONSTRAINT_TYPE = ' . $this->escape('FOREIGN KEY') . ' AND
                         tc.TABLE_SCHEMA = ' . $this->escape($this->database) . ' AND
@@ -555,10 +559,12 @@ class Connection extends BaseConnection implements ConnectionInterface
 		$retVal = [];
 		foreach ($query as $row)
 		{
-			$obj                     = new \stdClass();
-			$obj->constraint_name    = $row->CONSTRAINT_NAME;
-			$obj->table_name         = $row->TABLE_NAME;
-			$obj->foreign_table_name = $row->REFERENCED_TABLE_NAME;
+			$obj                      = new \stdClass();
+			$obj->constraint_name     = $row->CONSTRAINT_NAME;
+			$obj->table_name          = $row->TABLE_NAME;
+			$obj->column_name         = $row->COLUMN_NAME;
+			$obj->foreign_table_name  = $row->REFERENCED_TABLE_NAME;
+			$obj->foreign_column_name = $row->REFERENCED_COLUMN_NAME;
 
 			$retVal[] = $obj;
 		}

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -406,11 +406,13 @@ class Connection extends BaseConnection implements ConnectionInterface
 		$retVal = [];
 		foreach ($query as $row)
 		{
-			$obj                     = new \stdClass();
-			$obj->constraint_name    = $row->constraint_name;
-			$obj->table_name         = $row->table_name;
-			$obj->foreign_table_name = $row->foreign_table_name;
-			$retVal[]                = $obj;
+			$obj                      = new \stdClass();
+			$obj->constraint_name     = $row->constraint_name;
+			$obj->table_name          = $row->table_name;
+			$obj->column_name         = $row->column_name;
+			$obj->foreign_table_name  = $row->foreign_table_name;
+			$obj->foreign_column_name = $row->foreign_column_name;
+			$retVal[]                 = $obj;
 		}
 
 		return $retVal;

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -407,6 +407,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 				$obj->constraint_name    = $row->from . ' to ' . $row->table . '.' . $row->to;
 				$obj->table_name         = $table;
 				$obj->foreign_table_name = $row->table;
+				$obj->sequence           = $row->seq;
 
 				$retVal[] = $obj;
 			}

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -323,10 +323,13 @@ class ForgeTest extends CIDatabaseTestCase
 		if ($this->db->DBDriver === 'SQLite3')
 		{
 			$this->assertEquals($foreignKeyData[0]->constraint_name, 'users_id to db_forge_test_users.id');
+			$this->assertEquals($foreignKeyData[0]->sequence, 0);
 		}
 		else
 		{
 			$this->assertEquals($foreignKeyData[0]->constraint_name, $this->db->DBPrefix . 'forge_test_invoices_users_id_foreign');
+			$this->assertEquals($foreignKeyData[0]->column_name, 'users_id');
+			$this->assertEquals($foreignKeyData[0]->foreign_column_name, 'id');
 		}
 		$this->assertEquals($foreignKeyData[0]->table_name, $this->db->DBPrefix . 'forge_test_invoices');
 		$this->assertEquals($foreignKeyData[0]->foreign_table_name, $this->db->DBPrefix . 'forge_test_users');

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -163,6 +163,11 @@ Usage example::
 	{
 		echo $key->constraint_name;
 		echo $key->table_name;
+		echo $key->column_name;
 		echo $key->foreign_table_name;
+		echo $key->foreign_column_name;
 	}
 
+The object fields may be unique to the database you are using. For instance, SQLite3 does
+not return data on column names, but has the additional *sequence* field for compound
+foreign key definitions.


### PR DESCRIPTION
**Description**
Currently `getForeignKeys()` only returns information on the related tables. While helpful, this doesn't allow any interactions based on those keys as it lacks the column name. This PR adds the locals and foreign column names to the returned object.

Note that SQLite3 does not have this information available, but does have an additional field `sequence` (also added) which is handy for composite keys. The updated User Guide makes this clear.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
