### PR TITLE
fixes #2049 - debug option 

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -672,10 +672,10 @@ class CURLRequest extends Request
 		}
 
 		// Debug
-		if (isset($config['debug']))
+		if ($config['debug'])
 		{
-			$curl_options[CURLOPT_VERBOSE] = $config['debug'] === false ? 0 : 1;
-			$curl_options[CURLOPT_STDERR]  = is_string($config['debug']) ? fopen($config['debug'], 'w') : fopen('php://output', 'w+');
+			$curl_options[CURLOPT_VERBOSE] = 1;
+			$curl_options[CURLOPT_STDERR]  = is_string($config['debug']) ? fopen($config['debug'], 'a+') : fopen('php://output', 'w+');
 		}
 
 		// Decode Content

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -674,8 +674,8 @@ class CURLRequest extends Request
 		// Debug
 		if (isset($config['debug']))
 		{
-			$curl_options[CURLOPT_VERBOSE] = $config['debug'] === true ? 1 : 0;
-			$curl_options[CURLOPT_STDERR]  = $config['debug'] === true ? fopen('php://output', 'w+') : $config['debug'];
+			$curl_options[CURLOPT_VERBOSE] = $config['debug'] === false ? 0 : 1;
+			$curl_options[CURLOPT_STDERR]  = is_string($config['debug']) ? fopen($config['debug'], 'w') : fopen('php://output', 'w+');
 		}
 
 		// Decode Content

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -471,6 +471,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
+		$this->assertArrayNotHasKey(CURLOPT_VERBOSE, $options);
 		$this->assertArrayNotHasKey(CURLOPT_STDERR, $options);
 	}
 

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -468,7 +468,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertEquals(0, $options[CURLOPT_VERBOSE]);
+		$this->assertFalse($options[CURLOPT_STDERR]);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -468,7 +468,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertFalse($options[CURLOPT_STDERR]);
+		$this->assertEquals(0, $options[CURLOPT_VERBOSE]);
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
CURLRequest class with the default `debug` value reports an error:
```
curl_setopt_array(): supplied argument is not a valid File-Handle resource
```
This pull request fixes this issue and ensures to create resource if we specify a path to the log file. I believe that tests for this are already started in #2168.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
