### PR TITLE
Fix empty() bug on DBPrefix

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -605,7 +605,7 @@ class Forge
 		}
 
 		// If the prefix is already starting the table name, remove it...
-		if (! empty($this->db->DBPrefix) && strpos($tableName, $this->db->DBPrefix) === 0)
+		if ($this->db->DBPrefix && strpos($tableName, $this->db->DBPrefix) === 0)
 		{
 			$tableName = substr($tableName, strlen($this->db->DBPrefix));
 		}

--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -173,6 +173,7 @@ class CIDatabaseTestCase extends CIUnitTestCase
 			{
 				$this->migrations->setNamespace($this->namespace);
 			}
+			$this->migrations->regress(0, 'tests');
 
 			// Delete all of the tables to ensure we're at a clean start.
 			$tables = $this->db->listTables();
@@ -192,7 +193,6 @@ class CIDatabaseTestCase extends CIUnitTestCase
 				}
 			}
 
-			$this->migrations->regress(0, 'tests');
 			$this->migrations->latest('tests');
 		}
 


### PR DESCRIPTION
**Description**
When Forge runs `dropTable()` it will check for and strip the DBPrefix from a table name if found. It does this check via `(! empty($this->db->DBPrefix) ...` but since `DBPrefix` is acquired through **BaseConnection**'s magic `__get` without a corresponding `__isset()` `empty()` returns false even when it isn't empty. Because of the magic getter and the initial property we can be sure `DBPrefix` will always be there so it is fine to test `($this->db->DBPrefix` directly. Might consider adding `__isset()` to **BaseConnection** at some point.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
