### PR TITLE
[FIX] Issue #2202

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -672,10 +672,9 @@ class CURLRequest extends Request
 		}
 
 		// Debug
-		if (isset($config['debug']))
+		if ($config['debug'])
 		{
-			$curl_options[CURLOPT_VERBOSE] = $config['debug'] === true ? 1 : 0;
-			$curl_options[CURLOPT_STDERR]  = $config['debug'] === true ? fopen('php://output', 'w+') : $config['debug'];
+			$curl_options[CURLOPT_VERBOSE] = true;
 		}
 
 		// Decode Content


### PR DESCRIPTION
**Description**
- Changed condition on 'debug' option from isset() to testing $config['debug'] itself since it is always set at definition of class.
- Removed CURLOPT_STDERR since it is an alternative handler and default handler will handle it well and provided handler produced an error:  cannot represent a stream of type Output as a STDIO FILE* This options should be valid alternative handler or not set. False will produce an error.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  
