### PR TITLE
Add $db->getPrefix()

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -515,6 +515,34 @@ abstract class BaseConnection implements ConnectionInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Set DB Prefix
+	 *
+	 * Set's the DB Prefix to something new without needing to reconnect
+	 *
+	 * @param string $prefix The prefix
+	 *
+	 * @return string
+	 */
+	public function setPrefix(string $prefix = ''): string
+	{
+		return $this->DBPrefix = $prefix;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns the database prefix.
+	 *
+	 * @return string
+	 */
+	public function getPrefix(): string
+	{
+		return $this->DBPrefix;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Returns the last error encountered by this connection.
 	 *
 	 * @return mixed
@@ -1325,22 +1353,6 @@ abstract class BaseConnection implements ConnectionInterface
 		}
 
 		return $this->DBPrefix . $table;
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Set DB Prefix
-	 *
-	 * Set's the DB Prefix to something new without needing to reconnect
-	 *
-	 * @param string $prefix The prefix
-	 *
-	 * @return string
-	 */
-	public function setPrefix(string $prefix = ''): string
-	{
-		return $this->DBPrefix = $prefix;
 	}
 
 	//--------------------------------------------------------------------

--- a/user_guide_src/source/database/queries.rst
+++ b/user_guide_src/source/database/queries.rst
@@ -72,6 +72,10 @@ without needing to create a new connection you can use this method::
 	$db->setPrefix('newprefix');
 	$db->prefixTable('tablename'); // outputs newprefix_tablename
 
+You can get the current prefix any time with this method::
+	
+	$DBPrefix = $db->getPrefix();
+
 **********************
 Protecting identifiers
 **********************


### PR DESCRIPTION
**Description**
Requesting a getter method for DBPrefix so it doesn't have to be hacked out of `prefixTable()` when all you want is the prefix itself.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
