### PR TITLE
Add trace()

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -1084,3 +1084,18 @@ if (! function_exists('dd'))
 		exit;
 	}
 }
+
+
+//--------------------------------------------------------------------
+
+if (! function_exists('trace'))
+{
+	/**
+	 * Provides a backtrace to the current execution point, from Kint.
+	 */
+	function trace()
+	{
+		Kint::$aliases[] = 'trace';
+		Kint::trace();
+	}
+}

--- a/user_guide_src/source/testing/debugging.rst
+++ b/user_guide_src/source/testing/debugging.rst
@@ -42,7 +42,7 @@ This method is identical to ``d()``, except that it also ``dies()`` and no furth
 
 This provides a backtrace to the current execution point, with Kint's own unique spin::
 
-    Kint::trace();
+    trace();
 
 For more information, see `Kint's page <https://kint-php.github.io/kint//>`_.
 


### PR DESCRIPTION
**Description**
We advertise `trace()` in the User Guide as a debug tool wrapping `Kint::trace()` but it isn't actually there. This PR adds it to **Common.php**.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [X] Conforms to style guide
