### PR TITLE
Add listTable() tests

### DIFF
--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -163,6 +163,8 @@ class ForgeTest extends CIDatabaseTestCase
 			{
 				$this->assertEquals('enum', $fields[0]->type);
 			}
+
+			$this->forge->dropTable('forge_array_constraint', true);
 		}
 		else
 		{

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -1,0 +1,34 @@
+<?php namespace CodeIgniter\Database\Live;
+
+use CodeIgniter\Test\CIDatabaseTestCase;
+
+/**
+ * @group DatabaseLive
+ */
+class MetadataTest extends CIDatabaseTestCase
+{
+	protected $refresh = true;
+
+	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+
+	public function testCanListTables()
+	{
+		$result = $this->db->listTables();
+
+		// user, job, misc, migrations
+		$this->assertCount(4, $result);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testCanListTablesConstrainPrefix()
+	{
+		$result = $this->db->listTables(true);
+
+		// user, job, misc, migrations
+		$this->assertCount(4, $result);
+	}
+  
+	//--------------------------------------------------------------------
+
+}

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -76,7 +76,7 @@ class MetadataTest extends CIDatabaseTestCase
 
 		// Clean up temporary table
 		$this->db->setPrefix('tmp_');
-		$forge->dropTable('widgets');
+		$this->forge->dropTable('widgets');
 		$this->db->setPrefix($DBPrefix);
 	}
 

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -72,7 +72,7 @@ class MetadataTest extends CIDatabaseTestCase
 		$this->db->setPrefix($DBPrefix);
 		$result = $this->db->listTables(true);
 
-		$this->assertEquals($expected, array_values($result));
+		$this->assertEquals($this->expectedTables, array_values($result));
 
 		// Clean up temporary table
 		$this->db->setPrefix('tmp_');

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -13,20 +13,38 @@ class MetadataTest extends CIDatabaseTestCase
 
 	public function testCanListTables()
 	{
+		$prefix = $this->db->getPRefix();
+		$expected = [
+			$prefix . 'migrations',
+			$prefix . 'user',
+			$prefix . 'job',
+			$prefix . 'misc',
+			$prefix . 'empty',
+			$prefix . 'secondary'
+		];
+		
 		$result = $this->db->listTables();
-
-		// user, job, misc, migrations
-		$this->assertCount(4, $result);
+		
+		$this->assertEquals($expected, $result);
 	}
 
 	//--------------------------------------------------------------------
 
 	public function testCanListTablesConstrainPrefix()
 	{
+		$prefix = $this->db->getPRefix();
+		$expected = [
+			$prefix . 'migrations',
+			$prefix . 'user',
+			$prefix . 'job',
+			$prefix . 'misc',
+			$prefix . 'empty',
+			$prefix . 'secondary'
+		];
+		
 		$result = $this->db->listTables(true);
-
-		// user, job, misc, migrations
-		$this->assertCount(4, $result);
+		
+		$this->assertEquals($expected, $result);
 	}
   
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -11,10 +11,20 @@ class MetadataTest extends CIDatabaseTestCase
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
 
-	public function testCanListTables()
+	/**
+	 * Array of expected tables.
+	 *
+	 * @var array
+	 */
+	protected $expectedTables;
+
+	protected function setUp()
 	{
-		$prefix = $this->db->getPRefix();
-		$expected = [
+		parent::setUp();
+
+		// Prepare the array of expected tables once
+		$prefix = $this->db->getPrefix();
+		$this->expectedTables = [
 			$prefix . 'migrations',
 			$prefix . 'user',
 			$prefix . 'job',
@@ -22,31 +32,54 @@ class MetadataTest extends CIDatabaseTestCase
 			$prefix . 'empty',
 			$prefix . 'secondary'
 		];
-		
+	}
+
+	public function testListTables()
+	{
 		$result = $this->db->listTables();
-		
-		$this->assertEquals($expected, $result);
+
+		$this->assertEquals($this->expectedTables, array_values($result));
 	}
 
 	//--------------------------------------------------------------------
 
-	public function testCanListTablesConstrainPrefix()
+	public function testListTablesConstrainPrefix()
 	{
-		$prefix = $this->db->getPRefix();
-		$expected = [
-			$prefix . 'migrations',
-			$prefix . 'user',
-			$prefix . 'job',
-			$prefix . 'misc',
-			$prefix . 'empty',
-			$prefix . 'secondary'
-		];
-		
 		$result = $this->db->listTables(true);
-		
-		$this->assertEquals($expected, $result);
+
+		$this->assertEquals($this->expectedTables, array_values($result));
 	}
-  
+
+	//--------------------------------------------------------------------
+
+	public function testConstrainPrefixIgnoresOtherTables()
+	{
+		$this->forge = \Config\Database::forge($this->DBGroup);
+
+		// Stash the prefix and change it
+		$DBPrefix = $this->db->getPrefix();
+		$this->db->setPrefix('tmp_');
+
+		// Create a table with the new prefix
+		$fields = [
+			'name'       => ['type' => 'varchar', 'constraint' => 31],
+			'created_at' => ['type' => 'datetime', 'null' => true],
+		];
+		$this->forge->addField($fields);
+		$this->forge->createTable('widgets');
+
+		// Restore the prefix and get the tables with the original prefix
+		$this->db->setPrefix($DBPrefix);
+		$result = $this->db->listTables(true);
+
+		$this->assertEquals($expected, array_values($result));
+
+		// Clean up temporary table
+		$this->db->setPrefix('tmp_');
+		$forge->dropTable('widgets');
+		$this->db->setPrefix($DBPrefix);
+	}
+
 	//--------------------------------------------------------------------
 
 }


### PR DESCRIPTION
**Description**
Currently there are no tests for the database metadata methods. There are a lot more that should be added but this creates the file and adds tests for `listTables()` that exhibits the error described in https://github.com/codeigniter4/CodeIgniter4/issues/2210.

Someone who knows what's up with the weird `!` escape character business take a look?

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
