### PR TITLE
Add MySQL-specific character for like escapes

### DIFF
--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -72,6 +72,13 @@ class Connection extends BaseConnection implements ConnectionInterface
 	public $escapeChar = '`';
 	// --------------------------------------------------------------------
 	/**
+	 * Like wildcard escape character
+	 *
+	 * @var string
+	 */
+	public $likeEscapeChar = '\\';
+	// --------------------------------------------------------------------
+	/**
 	 * MySQLi object
 	 *
 	 * Has to be preserved without being assigned to $conn_id.


### PR DESCRIPTION
**Description**
Adds `\` as the "like escape character" for MySQLi driver. 

This would fix https://github.com/codeigniter4/CodeIgniter4/issues/2210 but I'm curious if it would break other things.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
