### PR TITLE
Filter listTables cache response on constrainPrefix

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1528,7 +1528,9 @@ abstract class BaseConnection implements ConnectionInterface
 		// Is there a cached result?
 		if (isset($this->dataCache['table_names']) && $this->dataCache['table_names'])
 		{
-			return $this->dataCache['table_names'];
+			return $constrainByPrefix ?
+				preg_grep("/^{$this->DBPrefix}/", $this->dataCache['table_names'])
+				: $this->dataCache['table_names'];
 		}
 
 		if (false === ($sql = $this->_listTables($constrainByPrefix)))


### PR DESCRIPTION
**Description**
Currently if the database `datacache` has a copy of the tables it will return the whole set regardless of `$constrainPrefix`. This change checks for `$constrainPrefix` and filters the returned array accordingly.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
