### PR TITLE
Documentation Updated

### DIFF
--- a/user_guide_src/source/concepts/structure.rst
+++ b/user_guide_src/source/concepts/structure.rst
@@ -86,4 +86,4 @@ Modifying Directory Locations
 If you've relocated any of the main directories, you can change the configuration
 settings inside ``app/Config/Paths``.
 
-Please read `Managing your Applications <../general/managing.html>`_
+Please read `Managing your Applications <../general/managing_apps.html>`_

--- a/user_guide_src/source/extending/contributing.rst
+++ b/user_guide_src/source/extending/contributing.rst
@@ -44,7 +44,7 @@ Please *don't* disclose it publicly, but e-mail us at security@codeigniter.com,
 or report it via our page on `HackerOne <https://hackerone.com/codeigniter>`_.
 
 If you've found a critical vulnerability, we'd be happy to credit you in our
-`ChangeLog <https://codeigniter4.github.io/userguide/changelog.html>`_.
+`ChangeLog <../changelogs/index.html>`_.
 
 ****************************
 Tips for a Good Issue Report

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -58,8 +58,8 @@ Configuration
 =============
 
 By default, CodeIgniter will display all errors in the ``development`` and ``testing`` environments, and will not
-display any errors in the ``production`` environment. You can change this by locating the environment configuration
-portion at the top of the main ``index.php`` file.
+display any errors in the ``production`` environment. You can change this by setting the ``CI_ENVIRONMENT`` variable
+in the ``.env`` file.
 
 .. important:: Disabling error reporting DOES NOT stop logs from being written if there are errors.
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -336,7 +336,7 @@ The value for the filter must match one of the aliases defined within ``app/Conf
 
     $routes->add('users/delete/(:segment)', 'AdminController::index', ['filter' => 'admin-auth:dual,noreturn']);
 
-See `Controller filters </incoming/filters.html>`_ for more information on setting up filters.
+See `Controller filters <filters.html>`_ for more information on setting up filters.
 
 Assigning Namespace
 -------------------

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -221,7 +221,7 @@ If you need to assign options to a group, like a `namespace <#assigning-namespac
 
 This would handle a resource route to the ``App\API\v1\Users`` controller with the ``/api/users`` URI.
 
-You can also use a specific `filter </incoming/filters.html>`_ for a group of routes. This will always
+You can also use a specific `filter <filters.html>`_ for a group of routes. This will always
 run the filter before or after the controller. This is especially handy during authentication or api logging::
 
     $routes->group('api', ['filter' => 'api-auth'], function($routes)

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -309,7 +309,7 @@ available from the command line::
 Global Options
 ==============
 
-All of the methods for creating a route (add, get, post, `resource </incoming/resources.html>`_ etc) can take an array of options that
+All of the methods for creating a route (add, get, post, `resource <restful.html>`_ etc) can take an array of options that
 can modify the generated routes, or further restrict them. The ``$options`` array is always the last parameter::
 
 	$routes->add('from', 'to', $options);

--- a/user_guide_src/source/libraries/encryption.rst
+++ b/user_guide_src/source/libraries/encryption.rst
@@ -138,19 +138,6 @@ of encryption::
 	// Encrypt some text & make the results text
 	$encoded = base64_encode($encrypter->encrypt($plaintext));
 
-Message Length
---------------
-
-An encrypted string is usually
-longer than the original plain-text string.
-
-This is influenced by the cipher algorithm itself, the initialization vector (IV) 
-prepended to the
-cipher-text and the HMAC authentication message that is also prepended.
-
-Keep this information in mind when selecting your data storage mechanism.
-Cookies, for example, can only hold 4K of information.
-
 Encryption Handler Notes
 ========================
 

--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -498,10 +498,12 @@ Much like Time's humanize() method, this returns a string that displays the diff
 human readable format that is geared towards being easily understood. It can create strings like '3 hours ago',
 'in 1 month', etc. The biggest differences are in how very recent dates are handled::
 
-    // Assume current time is: March 10, 2017 (America/Chicago)
-    $time = Time::parse('March 9, 2016 12:00:00', 'America/Chicago');
+    $current = Time::parse('March 10, 2017', 'America/Chicago')
+    $test    = Time::parse('March 9, 2016 12:00:00', 'America/Chicago');
 
-    echo $time->humanize();     // 1 year ago
+    $diff = $current->difference($test)
+
+    echo $diff->humanize();     // 1 year ago
 
 The exact time displayed is determined in the following manner:
 

--- a/user_guide_src/source/testing/controllers.rst
+++ b/user_guide_src/source/testing/controllers.rst
@@ -4,7 +4,7 @@ Testing Controllers
 
 Testing your controllers is made convenient with a couple of new helper classes and traits. When testing controllers,
 you can execute the code within a controller, without first running through the entire application bootstrap process.
-Often times, using the `Feature Testing tools </testing/feature>`_ will be simpler, but this functionality is here in
+Often times, using the `Feature Testing tools <feature.html>`_ will be simpler, but this functionality is here in
 case you need it.
 
 .. note:: Because the entire framework has not been bootstrapped, there will be times when you cannot test a controller

--- a/user_guide_src/source/testing/debugging.rst
+++ b/user_guide_src/source/testing/debugging.rst
@@ -11,7 +11,7 @@ Replace var_dump
 ================
 
 While using XDebug and a good IDE can be indispensable to debug your application, sometimes a quick ``var_dump()`` is
-all you need. CodeIgniter makes that even better by bundling in the excellent `Kint <https://raveren.github.io/kint/>`_
+all you need. CodeIgniter makes that even better by bundling in the excellent `Kint <https://kint-php.github.io/kint/>`_
 debugging tool for PHP. This goes way beyond your usual tool, providing many alternate pieces of data, like formatting
 timestamps into recognizable dates, showing you hexcodes as colors, display array data like a table for easy reading,
 and much, much more.

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -243,11 +243,11 @@ a tag, as specified by type, class, or id::
     // Check that "Hello World" is on the page
     $this->assertSee('Hello World');
     // Check that "Hello World" is within an h1 tag
-    $this->assertS('Hello World', 'h1');
+    $this->assertSee('Hello World', 'h1');
     // Check that "Hello World" is within an element with the "notice" class
-    $this->assertS('Hello World', '.notice');
+    $this->assertSee('Hello World', '.notice');
     // Check that "Hello World" is within an element with id of "title"
-    $this->assertS('Hellow World', '#title');
+    $this->assertSee('Hellow World', '#title');
 
 
 **assertDontSee(string $search = null, string $element = null)**

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -15,7 +15,7 @@ The Test Class
 ==============
 
 Feature testing requires that all of your test classes extend the ``CodeIgniter\Test\FeatureTestCase`` class. Since this
-extends `CIDatabaseTestCase </testing/database>`_ you must always ensure that ``parent::setUp()`` and ``parent::tearDown()``
+extends `CIDatabaseTestCase <database.html>`_ you must always ensure that ``parent::setUp()`` and ``parent::tearDown()``
 are called before you take your actions.
 ::
 

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -95,7 +95,7 @@ have the correct namespace relative to ``App``.
 
 .. note:: Namespaces are not strictly required for test classes, but they are helpful to ensure no class names collide.
 
-When testing database results, you must use the `CIDatabaseTestClass </testing/database>`_ class.
+When testing database results, you must use the `CIDatabaseTestClass <database.html>`_ class.
 
 Additional Assertions
 ---------------------

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -143,7 +143,7 @@ in PHPunit <https://phpunit.readthedocs.io/en/7.4/annotations.html#runinseparate
 
 **assertHeaderNotEmitted($header, $ignoreCase=false)**
 
-Ensure that a header or cookie was actually emitted::
+Ensure that a header or cookie was not emitted::
 
     $response->setCookie('foo', 'bar');
 

--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -236,7 +236,7 @@ add some code to the controller and create a new view. Go back to the
 
 		if (empty($data['news']))
 		{
-			throw new \CodeIgniter\PageNotFoundException('Cannot find the news item: '. $slug);
+			throw new \CodeIgniter\Exceptions\PageNotFoundException('Cannot find the news item: '. $slug);
 		}
 
 		$data['title'] = $data['news']['title'];

--- a/user_guide_src/source/tutorial/static_pages.rst
+++ b/user_guide_src/source/tutorial/static_pages.rst
@@ -41,9 +41,9 @@ code.
             return view('welcome_message');
         }
 
-		public function showme($page = 'home')
-		{
-		}
+        public function showme($page = 'home')
+        {
+        }
 	}
 
 You have created a class named ``Pages``, with a ``showme`` method that accepts


### PR DESCRIPTION
**Description**
Documentation Updates

- Fixed all 404 links in the documentation. 
- Fixed code  sample formatting on tutorial/static_pages
- Fixed bad Exception class in code sample on tutorial/news_section
- Removed duplicated paragraph Message Length on /libraries/sessions
- Fixed example for TimeDifference humanize() method on libraries/time
- Fixed Description of assertHeaderNotEmitted() method testing/overview
- Fixed Code sample  of assertSee() method on testing/feature
- Changed text on how to change the environment config on /general/errors
