### PR TITLE
change new \Config\Database() to config('Database')

### DIFF
--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -87,7 +87,7 @@ class Config extends BaseConfig
 			$group  = 'custom-' . md5(json_encode($config));
 		}
 
-		$config = $config ?? new \Config\Database();
+		$config = $config ?? config('Database');
 
 		if (empty($group))
 		{


### PR DESCRIPTION
**Description**
Change `new \Config\Database()` to `config('Database')` in `\CodeIgniter\Database\Config::connect()`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
