### PR TITLE
WIP Global "charset" and "collate" settings not working in MySQLi Forge

### DIFF
--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -139,12 +139,12 @@ class Forge extends \CodeIgniter\Database\Forge
 			}
 		}
 
-		if (! empty($this->db->charset) && ! strpos($sql, 'CHARACTER SET') && ! strpos($sql, 'CHARSET'))
+		if ($this->db->charset && ! strpos($sql, 'CHARACTER SET') && ! strpos($sql, 'CHARSET'))
 		{
 			$sql .= ' DEFAULT CHARACTER SET = ' . $this->db->escapeString($this->db->charset);
 		}
 
-		if (! empty($this->db->DBCollat) && ! strpos($sql, 'COLLATE'))
+		if ($this->db->DBCollat && ! strpos($sql, 'COLLATE'))
 		{
 			$sql .= ' COLLATE = ' . $this->db->escapeString($this->db->DBCollat);
 		}


### PR DESCRIPTION
empty($this->db->DBCollat) and empty($this->db->charset) always return true besause "DBCollat" and "charset" properties is protected.
  
