### PR TITLE
Exclude `sqlite_%` from listTables()

### DIFF
--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -207,6 +207,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	protected function _listTables(bool $prefixLimit = false): string
 	{
 		return 'SELECT "NAME" FROM "SQLITE_MASTER" WHERE "TYPE" = \'table\''
+			   . ' AND "NAME" NOT LIKE \'sqlite_%\''
 			   . (($prefixLimit !== false && $this->DBPrefix !== '')
 				? ' AND "NAME" LIKE \'' . $this->escapeLikeString($this->DBPrefix) . '%\' ' . sprintf($this->likeEscapeStr,
 					$this->likeEscapeChar)

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -26,6 +26,8 @@ you are currently connected to. Example::
 	{
 		echo $table;
 	}
+	
+.. note:: Some drivers have additional system tables that are excluded from this return.
 
 Determine If a Table Exists
 ===========================


### PR DESCRIPTION
**Description**
SQLite will ad-hoc add various tables prefixed "sqlite_" that function similar to MySQL's `information_schema`. See for example these metadata test results (https://travis-ci.org/codeigniter4/CodeIgniter4/jobs/586068130):
```
1) CodeIgniter\Database\Live\MetadataTest::testListTables
585Failed asserting that two arrays are equal.
586--- Expected
587+++ Actual
588@@ @@
589 Array (
590     0 => 'db_migrations'
591-    1 => 'db_user'
592-    2 => 'db_job'
593-    3 => 'db_misc'
594-    4 => 'db_empty'
595-    5 => 'db_secondary'
596+    1 => 'sqlite_sequence'
597+    2 => 'db_user'
598+    3 => 'db_job'
599+    4 => 'db_misc'
600+    5 => 'db_empty'
601+    6 => 'db_secondary'
602 )
```
... where `sqlite_sequence` is being returned as a table. I think these tables should be excluded as system data to be consistent with the other database drivers. E.g. if I use forge to add two tables to an empty database, `listTables()` should return two tables regardless of driver.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
