### PR TITLE
MySQLi escapeLikeStringDirect()

### DIFF
--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -128,21 +128,4 @@ class BaseConnectionTest extends \CIUnitTestCase
 		$this->assertGreaterThan($start, $db->getConnectStart());
 		$this->assertGreaterThan(0.0, $db->getConnectDuration());
 	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Ensures we don't have escaped - values...
-	 *
-	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/606
-	 */
-	public function testEscapeProtectsNegativeNumbers()
-	{
-		$db = new MockConnection($this->options);
-
-		$db->initialize();
-
-		$this->assertEquals("'-100'", $db->escape(-100));
-	}
-
 }

--- a/tests/system/Database/Live/EscapeTest.php
+++ b/tests/system/Database/Live/EscapeTest.php
@@ -15,7 +15,7 @@ class EscapeTest extends CIDatabaseTestCase
 	{
 		parent::setUp();
 
-		$this->char = $db->escapeChar;
+		$this->char = $this->db->escapeChar;
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/EscapeTest.php
+++ b/tests/system/Database/Live/EscapeTest.php
@@ -1,0 +1,70 @@
+<?php namespace CodeIgniter\Database\Live;
+
+use CodeIgniter\Test\CIDatabaseTestCase;
+
+/**
+ * @group DatabaseLive
+ */
+class EscapeTest extends CIDatabaseTestCase
+{
+	protected $refresh = false;
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Ensures we don't have escaped - values...
+	 *
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/606
+	 */
+	public function testEscapeProtectsNegativeNumbers()
+	{
+		$this->assertEquals("'-100'", $this->db->escape(-100));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testEscape()
+	{
+		$expected = "SELECT * FROM brands WHERE name = 'O\'Doules'";
+		$sql      = "SELECT * FROM brands WHERE name = " . $this->db->escape("O'Doules");
+
+		$this->assertEquals($expected, $sql);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testEscapeString()
+	{
+		$expected = "SELECT * FROM brands WHERE name = 'O\'Doules'";
+		$sql      = "SELECT * FROM brands WHERE name = '" . $this->db->escapeString("O'Doules") . "'";
+
+		$this->assertEquals($expected, $sql);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testEscapeLikeString()
+	{
+		$expected = "SELECT * FROM brands WHERE column LIKE '%10!% more%' ESCAPE '!'";
+		$sql      = "SELECT * FROM brands WHERE column LIKE '%" . $this->db->escapeLikeString("10% more") . "%' ESCAPE '!'";
+
+		$this->assertEquals($expected, $sql);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testEscapeLikeStringDirect()
+	{
+		if ($this->db->DBDriver === 'MySQLi')
+		{
+			$expected = "SHOW COLUMNS FROM brands WHERE column LIKE 'wild\_chars%'";
+			$sql      = "SHOW COLUMNS FROM brands WHERE column LIKE '". $this->db->escapeLikeStringDirect("wild_chars") . "%'";
+
+			$this->assertEquals($expected, $sql);
+		}
+		else
+		{
+			$this->expectNotToPerformAssertions();
+		}
+	}
+}

--- a/tests/system/Database/Live/EscapeTest.php
+++ b/tests/system/Database/Live/EscapeTest.php
@@ -15,7 +15,7 @@ class EscapeTest extends CIDatabaseTestCase
 	{
 		parent::setUp();
 
-		$this->char = $this->db->escapeChar;
+		$this->char = $this->db->DBDriver === 'MySQLi' ? '\\' : "'";
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/EscapeTest.php
+++ b/tests/system/Database/Live/EscapeTest.php
@@ -9,6 +9,15 @@ class EscapeTest extends CIDatabaseTestCase
 {
 	protected $refresh = false;
 
+	protected $char;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->char = $db->escapeChar;
+	}
+
 	//--------------------------------------------------------------------
 
 	/**
@@ -25,7 +34,7 @@ class EscapeTest extends CIDatabaseTestCase
 
 	public function testEscape()
 	{
-		$expected = "SELECT * FROM brands WHERE name = 'O\'Doules'";
+		$expected = "SELECT * FROM brands WHERE name = 'O" . $this->char . "'Doules'";
 		$sql      = "SELECT * FROM brands WHERE name = " . $this->db->escape("O'Doules");
 
 		$this->assertEquals($expected, $sql);
@@ -35,7 +44,7 @@ class EscapeTest extends CIDatabaseTestCase
 
 	public function testEscapeString()
 	{
-		$expected = "SELECT * FROM brands WHERE name = 'O\'Doules'";
+		$expected = "SELECT * FROM brands WHERE name = 'O" . $this->char . "'Doules'";
 		$sql      = "SELECT * FROM brands WHERE name = '" . $this->db->escapeString("O'Doules") . "'";
 
 		$this->assertEquals($expected, $sql);


### PR DESCRIPTION
**Description**
As @michalsn points out, some MySQL commands (e.g. "SHOW ____") don't support custom escape characters supplied via "ESCAPE x". Currently `listTables()` is the only framework function suffering from this limitation, but it causes `listTables()` with `$constrainPrefix` to fail to constrain correctly.

This PR defines a new platform-specific function `escapeLikeStringDirect()` that can be used for those rare instances when both "SHOW" and "LIKE" are retried in the same query. This new function applies the default escape character `\` directly the the "LIKE" string for any wildcards. This also has the MySQLi driver's `_listTables()` function use this new method instead to the generic one designed for "SELECT" statements.

Refs:
* https://github.com/codeigniter4/CodeIgniter4/issues/2210
* https://github.com/codeigniter4/CodeIgniter4/pull/2211
* https://github.com/codeigniter4/CodeIgniter4/pull/2212

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
