### PR TITLE
Add escape to SQLite _listTables()

### DIFF
--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -207,7 +207,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	protected function _listTables(bool $prefixLimit = false): string
 	{
 		return 'SELECT "NAME" FROM "SQLITE_MASTER" WHERE "TYPE" = \'table\''
-			   . ' AND "NAME" NOT LIKE \'sqlite_%\''
+			   . ' AND "NAME" NOT LIKE \'sqlite!_%\' ESCAPE \'!\''
 			   . (($prefixLimit !== false && $this->DBPrefix !== '')
 				? ' AND "NAME" LIKE \'' . $this->escapeLikeString($this->DBPrefix) . '%\' ' . sprintf($this->likeEscapeStr,
 					$this->likeEscapeChar)


### PR DESCRIPTION
**Description**
Properly escape the SQLite `_listTables()` filter, per https://github.com/codeigniter4/CodeIgniter4/pull/2228#discussion_r325263010

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
