### PR TITLE
Add magic __isset to classes with __get

### DIFF
--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -191,6 +191,20 @@ abstract class BaseCommand
 	//--------------------------------------------------------------------
 
 	/**
+	 * Makes it simple to check our protected properties.
+	 *
+	 * @param string $key
+	 *
+	 * @return bool
+	 */
+	public function __isset(string $key): bool
+	{
+		return isset($this->$key);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * show Help include (usage,arguments,description,options)
 	 */
 	public function showHelp()

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1864,4 +1864,18 @@ abstract class BaseConnection implements ConnectionInterface
 
 	//--------------------------------------------------------------------
 
+	/**
+	 * Checker for properties existence.
+	 *
+	 * @param string $key
+	 *
+	 * @return bool
+	 */
+	public function __isset(string $key): bool
+	{
+		return property_exists($this, $key);
+	}
+
+	//--------------------------------------------------------------------
+
 }

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -195,4 +195,15 @@ class Encryption
 		return null;
 	}
 
+	/**
+	 * __isset() magic, providing checking for some of our protected properties
+	 *
+	 * @param  string $key Property name
+	 * @return bool
+	 */
+	public function __isset($key): bool
+	{
+		return in_array($key, ['key', 'digest', 'driver', 'drivers'], true);
+	}
+
 }

--- a/system/Encryption/Handlers/BaseHandler.php
+++ b/system/Encryption/Handlers/BaseHandler.php
@@ -110,4 +110,14 @@ abstract class BaseHandler implements \CodeIgniter\Encryption\EncrypterInterface
 		return null;
 	}
 
+	/**
+	 * __isset() magic, providing checking for some of our properties
+	 *
+	 * @param  string $key Property name
+	 * @return bool
+	 */
+	public function __isset($key): bool
+	{
+		return in_array($key, ['cipher', 'key'], true);
+	}
 }

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -1342,4 +1342,20 @@ class Time extends DateTime
 		return null;
 	}
 
+	//--------------------------------------------------------------------
+
+	/**
+	 * Allow for property-type checking to any getX method...
+	 *
+	 * @param $name
+	 *
+	 * @return bool
+	 */
+	public function __isset($name): bool
+	{
+		$method = 'get' . ucfirst($name);
+
+		return method_exists($this, $method);
+	}
+
 }

--- a/system/I18n/TimeDifference.php
+++ b/system/I18n/TimeDifference.php
@@ -345,4 +345,19 @@ class TimeDifference
 
 		return null;
 	}
+
+	/**
+	 * Allow property-like checking for our calculated values.
+	 *
+	 * @param $name
+	 *
+	 * @return bool
+	 */
+	public function __isset($name)
+	{
+		$name   = ucfirst(strtolower($name));
+		$method = "get{$name}";
+
+		return method_exists($this, $method);
+	}
 }

--- a/system/Model.php
+++ b/system/Model.php
@@ -1634,6 +1634,31 @@ class Model
 		return null;
 	}
 
+	/**
+	 * Checks for the existence of properties across this model, builder, and db connection.
+	 *
+	 * @param string $name
+	 *
+	 * @return bool
+	 */
+	public function __isset(string $name): bool
+	{
+		if (in_array($name, ['primaryKey', 'table', 'returnType', 'DBGroup']))
+		{
+			return true;
+		}
+		elseif (isset($this->db->$name))
+		{
+			return true;
+		}
+		elseif (isset($this->builder()->$name))
+		{
+			return true;
+		}
+
+		return false;
+	}
+
 	//--------------------------------------------------------------------
 
 	/**

--- a/system/Model.php
+++ b/system/Model.php
@@ -1643,7 +1643,7 @@ class Model
 	 */
 	public function __isset(string $name): bool
 	{
-		if (in_array($name, ['primaryKey', 'table', 'returnType', 'DBGroup']))
+		if (property_exists($this, $name))
 		{
 			return true;
 		}

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -625,6 +625,22 @@ class Session implements SessionInterface
 	}
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * Magic method to check for session variables
+	 *
+	 * @param string $key Identifier of the session property to remove.
+	 *
+	 * @return bool
+	 */
+	public function __isset(string $key): bool
+	{
+		// Note: Keep this order the same, just in case somebody wants to
+		//       use 'session_id' as a session data key, for whatever reason
+		return isset($_SESSION[$key]) || ($key === 'session_id');
+	}
+
+	//--------------------------------------------------------------------
 	//--------------------------------------------------------------------
 	// Flash Data Methods
 	//--------------------------------------------------------------------

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -628,7 +628,9 @@ class Session implements SessionInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * Magic method to check for session variables
+	 * Magic method to check for session variables.
+	 * Different from has() in that it will validate 'session_id' as well.
+	 * Mostly used by internal PHP functions, users should stick to has()
 	 *
 	 * @param string $key Identifier of the session property to remove.
 	 *
@@ -636,8 +638,6 @@ class Session implements SessionInterface
 	 */
 	public function __isset(string $key): bool
 	{
-		// Note: Keep this order the same, just in case somebody wants to
-		//       use 'session_id' as a session data key, for whatever reason
 		return isset($_SESSION[$key]) || ($key === 'session_id');
 	}
 

--- a/tests/system/Commands/CommandClassTest.php
+++ b/tests/system/Commands/CommandClassTest.php
@@ -1,0 +1,46 @@
+<?php
+namespace CodeIgniter\Commands;
+
+use Config\Services;
+use CodeIgniter\CLI\CommandRunner;
+
+class BaseCommandTest extends \CIUnitTestCase
+{
+	protected $logger;
+	protected $runner;
+
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->logger   = Services::logger();
+		$this->runner   = new CommandRunner();
+	}
+
+	public function testMagicIssetTrue()
+	{
+		$command = new \Tests\Support\Commands\AppInfo($this->logger, $this->runner);
+
+		$this->assertTrue(isset($command->group));
+	}
+
+	public function testMagicIssetFalse()
+	{
+		$command = new \Tests\Support\Commands\AppInfo($this->logger, $this->runner);
+
+		$this->assertFalse(isset($command->foobar));
+	}
+
+	public function testMagicGet()
+	{
+		$command = new \Tests\Support\Commands\AppInfo($this->logger, $this->runner);
+
+		$this->assertEquals('demo', $command->group);
+	}
+
+	public function testMagicGetMissing()
+	{
+		$command = new \Tests\Support\Commands\AppInfo($this->logger, $this->runner);
+
+		$this->assertNull($command->foobar);
+	}
+}

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -128,4 +128,40 @@ class BaseConnectionTest extends \CIUnitTestCase
 		$this->assertGreaterThan($start, $db->getConnectStart());
 		$this->assertGreaterThan(0.0, $db->getConnectDuration());
 	}
+
+	//--------------------------------------------------------------------
+
+	public function testMagicIssetTrue()
+	{
+		$db = new MockConnection($this->options);
+
+		$this->assertTrue(isset($db->charset));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testMagicIssetFalse()
+	{
+		$db = new MockConnection($this->options);
+
+		$this->assertFalse(isset($db->foobar));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testMagicGet()
+	{
+		$db = new MockConnection($this->options);
+
+		$this->assertEquals('utf8', $db->charset);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testMagicGetMissing()
+	{
+		$db = new MockConnection($this->options);
+
+		$this->assertNull($db->foobar);
+	}
 }

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1772,7 +1772,7 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$model = new UserModel();
 
-		$this->assertTrue(isset($model->canLimitDeletes));
+		$this->assertTrue(isset($model->QBNoEscape));
 	}
 
 	public function testMagicGet()
@@ -1800,6 +1800,6 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$model = new UserModel();
 
-		$this->assertIsBool($model->canLimitDeletes);
+		$this->assertIsArray($model->QBNoEscape);
 	}
 }

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1735,4 +1735,71 @@ class ModelTest extends CIDatabaseTestCase
 		// Just making sure it didn't throw ambiguous deleted error
 		$this->assertEquals(1, $results->id);
 	}
+
+	//--------------------------------------------------------------------
+
+	public function testMagicIssetTrue()
+	{
+		$model = new UserModel();
+
+		$this->assertTrue(isset($model->table));
+	}
+
+	public function testMagicIssetFalse()
+	{
+		$model = new UserModel();
+
+		$this->assertFalse(isset($model->foobar));
+	}
+
+	public function testMagicIssetWithNewProperty()
+	{
+		$model = new UserModel();
+
+		$model->flavor = 'chocolate';
+
+		$this->assertTrue(isset($model->flavor));
+	}
+
+	public function testMagicIssetFromDb()
+	{
+		$model = new UserModel();
+
+		$this->assertTrue(isset($model->DBPrefix));
+	}
+
+	public function testMagicIssetFromBuilder()
+	{
+		$model = new UserModel();
+
+		$this->assertTrue(isset($model->canLimitDeletes));
+	}
+
+	public function testMagicGet()
+	{
+		$model = new UserModel();
+
+		$this->assertEquals('user', $model->table);
+	}
+
+	public function testMagicGetMissing()
+	{
+		$model = new UserModel();
+
+		$this->assertNull($model->foobar);
+	}
+
+	public function testMagicGetFromDB()
+	{
+		$model = new UserModel();
+
+		$this->assertEquals('utf8', $model->charset);
+	}
+
+	public function testMagicGetFromBuilder()
+	{
+		$model = new UserModel();
+
+		$this->assertIsBool($model->canLimitDeletes);
+	}
 }

--- a/tests/system/Encryption/EncryptionTest.php
+++ b/tests/system/Encryption/EncryptionTest.php
@@ -78,11 +78,6 @@ class EncryptionTest extends \CIUnitTestCase
 		$this->assertEquals(16, strlen($this->encryption->createKey(16)));
 	}
 
-	public function testBogusProperty()
-	{
-		$this->assertNull($this->encryption->bogus);
-	}
-
 	// --------------------------------------------------------------------
 
 	public function testServiceSuccess()
@@ -127,6 +122,28 @@ class EncryptionTest extends \CIUnitTestCase
 		$config->key = 'Abracadabra';
 		$encrypter   = Services::encrypter($config, true);
 		$this->assertEquals('anything', $encrypter->key);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testMagicIssetTrue()
+	{
+		$this->assertTrue(isset($this->encryption->digest));
+	}
+
+	public function testMagicIssetFalse()
+	{
+		$this->assertFalse(isset($this->encryption->bogus));
+	}
+
+	public function testMagicGet()
+	{
+		$this->assertEquals('SHA512', $this->encryption->digest);
+	}
+
+	public function testMagicGetMissing()
+	{
+		$this->assertNull($this->encryption->bogus);
 	}
 
 }

--- a/tests/system/I18n/TimeDifferenceTest.php
+++ b/tests/system/I18n/TimeDifferenceTest.php
@@ -200,4 +200,21 @@ class TimeDifferenceTest extends \CIUnitTestCase
 		$this->assertNull($diff->nonsense);
 	}
 
+	public function testMagicIssetTrue()
+	{
+		$current = Time::parse('March 10, 2017', 'America/Chicago');
+		$diff    = $current->difference('March 18, 2017', 'America/Chicago');
+
+		$this->assertTrue(isset($diff->days));
+		$this->assertFalse(isset($diff->nonsense));
+	}
+
+	public function testMagicIssetFalse()
+	{
+		$current = Time::parse('March 10, 2017', 'America/Chicago');
+		$diff    = $current->difference('March 18, 2017', 'America/Chicago');
+
+		$this->assertFalse(isset($diff->nonsense));
+	}
+
 }

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -221,6 +221,22 @@ class TimeTest extends \CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testMagicIssetTrue()
+	{
+		$time = Time::parse('January 1, 2016');
+
+		$this->assertTrue(isset($time->year));
+	}
+
+	public function testMagicIssetFalse()
+	{
+		$time = Time::parse('January 1, 2016');
+
+		$this->assertFalse(isset($time->foobar));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testGetYear()
 	{
 		$time = Time::parse('January 1, 2016');

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -185,6 +185,26 @@ class SessionTest extends \CIUnitTestCase
 		$this->assertFalse($session->has('bar'));
 	}
 
+	public function testIssetReturnsTrueOnSuccess()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$_SESSION['foo'] = 'bar';
+
+		$this->assertTrue(isset($session->foo));
+	}
+
+	public function testIssetReturnsFalseOnNotFound()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$_SESSION['foo'] = 'bar';
+
+		$this->assertFalse(isset($session->bar));
+	}
+
 	public function testPushNewValueIntoArraySessionValue()
 	{
 		$session = $this->getInstance();


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/issues/2219

This PR adds `isset()` methods to the following classes, modeled after each class's `__get()` method:
* CodeIgniter4/system/Database/BaseConnection.php
* CodeIgniter4/system/Model.php
* CodeIgniter4/system/Session/Session.php
* CodeIgniter4/system/I18n/Time.php
* CodeIgniter4/system/CLI/BaseCommand.php
* CodeIgniter4/system/I18n/TimeDifference.php
* CodeIgniter4/system/Encryption/Encryption.php
* CodeIgniter4/system/Encryption/Handlers/BaseHandler.php

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
