### PR TITLE
Handle JSON POSTs in CSRF

### DIFF
--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -207,8 +207,14 @@ class Security
 			return $this->CSRFSetCookie($request);
 		}
 
-		// Do the tokens exist in both the _POST and _COOKIE arrays?
-		if (! isset($_POST[$this->CSRFTokenName], $_COOKIE[$this->CSRFCookieName]) || $_POST[$this->CSRFTokenName] !== $_COOKIE[$this->CSRFCookieName]
+		// Do the token exist in _POST or php://input (json) data?
+		$CSRFTokenValue = $_POST[$this->CSRFTokenName] ??
+            (!empty($input = file_get_contents('php://input')) && !empty($json = json_decode($input)) && json_last_error() === JSON_ERROR_NONE ?
+                ($json->{$this->CSRFTokenName} ?? null) :
+                null);
+		
+		// Do the tokens exist in both the _POST/POSTed JSON and _COOKIE arrays?
+		if (! isset($CSRFTokenValue, $_COOKIE[$this->CSRFCookieName]) || $CSRFTokenValue !== $_COOKIE[$this->CSRFCookieName]
 		) // Do the tokens match?
 		{
 			throw SecurityException::forDisallowedAction();


### PR DESCRIPTION
Important change to handle JSON POSTS in CSRF.
I wanted to send JSONS instead on normal POST but CSRF filter did not allow me to to this even if token existed in my JSON.
```
{"usr_id":1322189,"ctn":"3a111012714a58b53260ede89380d412","token":"ctn","parent":17031,"mode":{"main":"test","additional":"exam"},"time":{"start":1568992305,"end":1568993826},"result":{"2103":["T"]}}
```
my token name is: ctn

I think this is important, without this we are limiting a lot.
