### PR TITLE
Fix ini_set parameter type

### DIFF
--- a/app/Config/Boot/development.php
+++ b/app/Config/Boot/development.php
@@ -8,7 +8,7 @@
   | painful debugging.
  */
 error_reporting(-1);
-ini_set('display_errors', 1);
+ini_set('display_errors', '1');
 
 /*
   |--------------------------------------------------------------------------

--- a/app/Config/Boot/production.php
+++ b/app/Config/Boot/production.php
@@ -7,7 +7,7 @@
   | Don't show ANY in production environments. Instead, let the system catch
   | it and display a generic error message.
  */
-ini_set('display_errors', 0);
+ini_set('display_errors', '0');
 error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT & ~E_USER_NOTICE & ~E_USER_DEPRECATED);
 
 /*

--- a/app/Config/Boot/testing.php
+++ b/app/Config/Boot/testing.php
@@ -9,7 +9,7 @@
   | painful debugging.
  */
 error_reporting(-1);
-ini_set('display_errors', 1);
+ini_set('display_errors', '1');
 
 /*
   |--------------------------------------------------------------------------


### PR DESCRIPTION
init_set expects second parameter to be string.

This is a sample PR, John-Betong, addressing #2234, #2235 and #2236.
One PR, as these are related.

Note: the branch name is misleading, as I thought all your suggestions were for strict typing.