### PR TITLE
Fix issue #2202 + Additional header fix

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -489,6 +489,9 @@ class CURLRequest extends Request
 	{
 		$headers = $this->getHeaders();
 
+		// Unset host header since this should be passed only in response
+		unset($headers['Host']);
+
 		if (empty($headers))
 		{
 			return $curl_options;
@@ -672,10 +675,10 @@ class CURLRequest extends Request
 		}
 
 		// Debug
-		if ($config['debug'])
+		if (is_string($config['debug']))
 		{
 			$curl_options[CURLOPT_VERBOSE] = 1;
-			$curl_options[CURLOPT_STDERR]  = is_string($config['debug']) ? fopen($config['debug'], 'a+') : fopen('php://output', 'w+');
+			$curl_options[CURLOPT_STDERR]  = fopen($config['debug'], 'a+');
 		}
 
 		// Decode Content
@@ -812,7 +815,13 @@ class CURLRequest extends Request
 
 		if ($output === false)
 		{
-			throw HTTPException::forCurlError(curl_errno($ch), curl_error($ch));
+			// Check if debug is set to true (not file handler) and print error to output
+			if ($this->config['debug'] === true)
+			{
+				echo 'CURL Error: ' .  curl_errno($ch) . ', ' . curl_error($ch);
+			} else {
+				throw HTTPException::forCurlError(curl_errno($ch), curl_error($ch));
+			}
 		}
 
 		curl_close($ch);


### PR DESCRIPTION
**Description**
Fixed issue with debug option for CURLrequest. Changed the condition to check if $config['debug'] is string (it is always set in the constructor to be false) so if is file it will be handled properly via VERBOSE and STDERR. Added check to sendRequest() function if debug is 'true', if yes it will print an error message to output if debug is false it will be handled with exception handler like it is now.

P.S. Additionally here is a fixed problem with a request header where is set everything from the current response header with "host" header that shouldn't be included. Sorry, I didn't realize it is another bug and I fixed it together.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  
