### PR TITLE
CURLrequest fixes debugging

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -672,10 +672,10 @@ class CURLRequest extends Request
 		}
 
 		// Debug
-		if ($config['debug'])
+		if (is_String($config['debug']))
 		{
 			$curl_options[CURLOPT_VERBOSE] = 1;
-			$curl_options[CURLOPT_STDERR]  = is_string($config['debug']) ? fopen($config['debug'], 'a+') : fopen('php://output', 'w+');
+			$curl_options[CURLOPT_STDERR]  = fopen($config['debug'], 'a+');
 		}
 
 		// Decode Content
@@ -812,7 +812,12 @@ class CURLRequest extends Request
 
 		if ($output === false)
 		{
-			throw HTTPException::forCurlError(curl_errno($ch), curl_error($ch));
+			if ($this->config['debug'] === true)
+			{
+				echo 'cURL Error (' . curl_errno($ch) . '): ' . curl_error($ch);
+			} else {
+				throw HTTPException::forCurlError(curl_errno($ch), curl_error($ch));
+			}
 		}
 
 		curl_close($ch);

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -456,11 +456,8 @@ class CURLRequestTest extends \CIUnitTestCase
 
 		$options = $this->request->curl_options;
 
-		$this->assertArrayHasKey(CURLOPT_VERBOSE, $options);
-		$this->assertEquals(1, $options[CURLOPT_VERBOSE]);
-
-		$this->assertArrayHasKey(CURLOPT_STDERR, $options);
-		$this->assertTrue(is_resource($options[CURLOPT_STDERR]));
+		$this->assertArrayNotHasKey(CURLOPT_VERBOSE, $options);
+		$this->assertArrayNotHasKey(CURLOPT_STDERR, $options);
 	}
 
 	public function testDebugOptionFalse()
@@ -478,7 +475,7 @@ class CURLRequestTest extends \CIUnitTestCase
 	public function testDebugOptionFile()
 	{
 		$file = SUPPORTPATH . 'Files/baker/banana.php';
-		
+
 		$this->request->request('get', 'http://example.com', [
 			'debug' => $file,
 		]);


### PR DESCRIPTION
**Description**
Issue fix: #2202 

- Changed condition to check if config['debug'] is a string (only in that case it should allow VERBOSE and STDERR option
- Added check to sendRequest() if debug is 'true' and in that case, it will print error message in output else it will use exception handler like normal it should.
- Edit test case for true option, now it will check if in options array is not set VERBOSE and STDERR.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide