### PR TITLE
Choose better types for the ci_sessions table

### DIFF
--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * CodeIgniter
  *
@@ -61,36 +60,42 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 * @var \CodeIgniter\Images\Image
 	 */
 	protected $image = null;
+
 	/**
 	 * Image width.
 	 *
 	 * @var integer
 	 */
 	protected $width = 0;
+
 	/**
 	 * Image height.
 	 *
 	 * @var integer
 	 */
 	protected $height = 0;
+
 	/**
 	 * File permission mask.
 	 *
 	 * @var type
 	 */
 	protected $filePermissions = 0644;
+
 	/**
 	 * X-axis.
 	 *
 	 * @var integer
 	 */
 	protected $xAxis = 0;
+
 	/**
 	 * Y-axis.
 	 *
 	 * @var integer
 	 */
 	protected $yAxis = 0;
+
 	/**
 	 * Master dimensioning.
 	 *
@@ -513,6 +518,8 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 * Retrieve the EXIF information from the image, if possible. Returns
 	 * an array of the information, or null if nothing can be found.
 	 *
+	 * EXIF data is only supported fr JPEG & TIFF formats.
+	 *
 	 * @param string|null $key    If specified, will only return this piece of EXIF data.
 	 *
 	 * @param boolean     $silent If true, will not throw our own exceptions.
@@ -529,10 +536,16 @@ abstract class BaseHandler implements ImageHandlerInterface
 			}
 		}
 
-		$exif = exif_read_data($this->image->getPathname());
-		if (! is_null($key) && is_array($exif))
+		$exif = null; // default
+		switch ($this->image->imageType)
 		{
-			$exif = $exif[$key] ?? false;
+			case IMAGETYPE_JPEG:
+			case IMAGETYPE_TIFF_II:
+				$exif = exif_read_data($this->image->getPathname());
+				if (! is_null($key) && is_array($exif))
+				{
+					$exif = $exif[$key] ?? false;
+				}
 		}
 
 		return $exif;
@@ -800,6 +813,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 	}
 
 	//--------------------------------------------------------------------
+
 	/**
 	 * Return image width.
 	 *

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -239,7 +239,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 			$insertData = [
 				'id'         => $sessionID,
 				'ip_address' => $this->ipAddress,
-				'timestamp'  => time(),
+				'timestamp'  => 'now()',
 				'data'       => $this->platform === 'postgre' ? '\x' . bin2hex($sessionData) : $sessionData,
 			];
 
@@ -262,7 +262,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 		}
 
 		$updateData = [
-			'timestamp' => time(),
+			'timestamp' => 'now()',
 		];
 
 		if ($this->fingerprint !== md5($sessionData))
@@ -345,7 +345,8 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 	 */
 	public function gc($maxlifetime): bool
 	{
-		return ($this->db->table($this->table)->delete('timestamp < ' . (time() - $maxlifetime))) ? true : $this->fail();
+		$interval = implode(" '"[(int)($this->platform === 'postgre')], ['', "{$maxlifetime} second", '']);
+		return ($this->db->table($this->table)->delete("timestamp < now() - INTERVAL {$interval}")) ? true : $this->fail();
 	}
 
 	//--------------------------------------------------------------------

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -594,7 +594,7 @@ For PostgreSQL::
 
 	CREATE TABLE "ci_sessions" (
 		"id" varchar(128) NOT NULL,
-		"ip_address" varchar(45) NOT NULL,
+		"ip_address" inet NOT NULL,
 		"timestamp" timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
 		"data" bytea DEFAULT '' NOT NULL
 	);

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -596,7 +596,7 @@ For PostgreSQL::
 		"id" varchar(128) NOT NULL,
 		"ip_address" varchar(45) NOT NULL,
 		"timestamp" bigint DEFAULT 0 NOT NULL,
-		"data" text DEFAULT '' NOT NULL
+		"data" bytea DEFAULT '' NOT NULL
 	);
 
 	CREATE INDEX "ci_sessions_timestamp" ON "ci_sessions" ("timestamp");

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -585,7 +585,7 @@ For MySQL::
 	CREATE TABLE IF NOT EXISTS `ci_sessions` (
 		`id` varchar(128) NOT NULL,
 		`ip_address` varchar(45) NOT NULL,
-		`timestamp` int(10) unsigned DEFAULT 0 NOT NULL,
+		`timestamp` timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
 		`data` blob NOT NULL,
 		KEY `ci_sessions_timestamp` (`timestamp`)
 	);
@@ -595,7 +595,7 @@ For PostgreSQL::
 	CREATE TABLE "ci_sessions" (
 		"id" varchar(128) NOT NULL,
 		"ip_address" varchar(45) NOT NULL,
-		"timestamp" bigint DEFAULT 0 NOT NULL,
+		"timestamp" timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
 		"data" bytea DEFAULT '' NOT NULL
 	);
 


### PR DESCRIPTION
**Description**
Choose better types for the ci_sessions table: 
* for Postgres, use type BYTEA for binary data. Compared to storing base64-encoded text, this takes less space
* update the user guide to suggest using type INET for storing IP addresses in Postgres. This type offers input error checking and specialized operators and functions
* for both MySQL and Postgres, use type timestamp instead of integer. This type is easier to work with when analyzing session activity.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide

