### PR TITLE
CURLrequest fix debug verbose

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -487,10 +487,15 @@ class CURLRequest extends Request
 	 */
 	protected function applyRequestHeaders(array $curl_options = []): array
 	{
-		$headers = $this->getHeaders();
-
-		// Unset 'Host' header, CURL will determinate it automatically from URL.
-		unset($headers['Host']);
+		if (empty($this->headers))
+		{
+			$headers = $this->getHeaders();
+			unset($headers['Host']);
+		}
+		else
+		{
+			$headers = $this->getHeaders();
+		}
 
 		if (empty($headers))
 		{

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -489,6 +489,9 @@ class CURLRequest extends Request
 	{
 		$headers = $this->getHeaders();
 
+		// Unset 'Host' header, CURL will determinate it automatically from URL.
+		unset($headers['Host']);
+
 		if (empty($headers))
 		{
 			return $curl_options;

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -450,7 +450,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 	public function testDebugOptionTrue()
 	{
-		$this->request->request('get', 'http://example.com', [
+		$this->request->request('get', 'http://google.com/CodeIgniter4', [
 			'debug' => true,
 		]);
 
@@ -465,7 +465,7 @@ class CURLRequestTest extends \CIUnitTestCase
 
 	public function testDebugOptionFalse()
 	{
-		$this->request->request('get', 'http://example.com', [
+		$this->request->request('get', 'http://google.com/CodeIgniter4', [
 			'debug' => false,
 		]);
 
@@ -478,8 +478,8 @@ class CURLRequestTest extends \CIUnitTestCase
 	public function testDebugOptionFile()
 	{
 		$file = SUPPORTPATH . 'Files/baker/banana.php';
-		
-		$this->request->request('get', 'http://example.com', [
+
+		$this->request->request('get', 'http://google.com/CodeIgniter4', [
 			'debug' => $file,
 		]);
 


### PR DESCRIPTION
**Description**
- Issue fix: #2202 #2250 
- Added additional check inside check if $config['debug'] is true to check if is set exactly to 'true'. If yes, it will assign 'php://temp' stream for CURLOPT_STDERR instead of 'php://output' that is not allowed to be used there.
- Added check inside sendRequest method to check if is $this->config['debug'] set exactly to 'true'. If yes it will know that it was used temp stream and it will rewind stream to the begging and after that, it will send a formatted text to output from temp stream. If it will not pass the check for 'true' it will throw an exception like in normal mode.
- Fixed header issue when CI automatically set the header for base_url. This shouldn' happen because it will produce 404 error when accessing URL outside of the local server. So I removed 'Host' header from headers.
- Fixed also test case since https://example.com is valid URL it will never throw error, to test debugging we need to produce error so I have chosen 'google.com/CodeIgniter4' to produce 404 error. (or we can change it to point to invalid addresses on CI installation 'localhost/curlTest'.
 
**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
  
