### PR TITLE
testMode() method for BaseBuilder

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -262,8 +262,7 @@ class BaseBuilder
 	//--------------------------------------------------------------------
 
 	/**
-	 * Returns an array of bind values and their
-	 * named parameters for binding in the Query object later.
+	 * Sets a test mode status.
 	 *
 	 * @param boolean $mode Mode to set
 	 *

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -137,14 +137,13 @@ class Builder extends BaseBuilder
 	 * we simply do a DELETE and an INSERT on the first key/value
 	 * combo, assuming that it's either the primary key or a unique key.
 	 *
-	 * @param array   $set       An associative array of insert values
-	 * @param boolean $returnSQL
+	 * @param array $set An associative array of insert values
 	 *
 	 * @return   mixed
 	 * @throws   DatabaseException
 	 * @internal param true $bool returns the generated SQL, false executes the query.
 	 */
-	public function replace(array $set = null, bool $returnSQL = false)
+	public function replace(array $set = null)
 	{
 		if ($set !== null)
 		{
@@ -202,7 +201,6 @@ class Builder extends BaseBuilder
 	 * @param mixed   $where
 	 * @param integer $limit
 	 * @param boolean $reset_data
-	 * @param boolean $returnSQL
 	 *
 	 * @return   mixed
 	 * @throws   DatabaseException
@@ -210,14 +208,14 @@ class Builder extends BaseBuilder
 	 * @internal param the $mixed limit clause
 	 * @internal param $bool
 	 */
-	public function delete($where = '', int $limit = null, bool $reset_data = true, bool $returnSQL = false)
+	public function delete($where = '', int $limit = null, bool $reset_data = true)
 	{
 		if (! empty($limit) || ! empty($this->QBLimit))
 		{
 			throw new DatabaseException('PostgreSQL does not allow LIMITs on DELETE queries.');
 		}
 
-		return parent::delete($where, $limit, $reset_data, $returnSQL);
+		return parent::delete($where, $limit, $reset_data);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Builder/CountTest.php
+++ b/tests/system/Database/Builder/CountTest.php
@@ -21,10 +21,11 @@ class CountTest extends \CIUnitTestCase
 	public function testCountAll()
 	{
 		$builder = new BaseBuilder('jobs', $this->db);
+		$builder->testMode();
 
 		$expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM "jobs"';
 
-		$this->assertEquals($expectedSQL, $builder->countAll(true, true));
+		$this->assertEquals($expectedSQL, $builder->countAll(true));
 	}
 
 	//--------------------------------------------------------------------
@@ -32,8 +33,9 @@ class CountTest extends \CIUnitTestCase
 	public function testCountAllResults()
 	{
 		$builder = new BaseBuilder('jobs', $this->db);
+		$builder->testMode();
 
-		$answer = $builder->where('id >', 3)->countAllResults(false, true);
+		$answer = $builder->where('id >', 3)->countAllResults(false);
 
 		$expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM "jobs" WHERE "id" > :id:';
 

--- a/tests/system/Database/Builder/DeleteTest.php
+++ b/tests/system/Database/Builder/DeleteTest.php
@@ -21,7 +21,7 @@ class DeleteTest extends \CIUnitTestCase
 	{
 		$builder = $this->db->table('jobs');
 
-		$answer = $builder->delete(['id' => 1], null, true, true);
+		$answer = $builder->testMode()->delete(['id' => 1], null, true);
 
 		$expectedSQL   = 'DELETE FROM "jobs" WHERE "id" = :id:';
 		$expectedBinds = [

--- a/tests/system/Database/Builder/EmptyTest.php
+++ b/tests/system/Database/Builder/EmptyTest.php
@@ -22,7 +22,7 @@ class EmptyTest extends \CIUnitTestCase
 	{
 		$builder = new BaseBuilder('jobs', $this->db);
 
-		$answer = $builder->emptyTable(true);
+		$answer = $builder->testMode()->emptyTable();
 
 		$expectedSQL = 'DELETE FROM "jobs"';
 

--- a/tests/system/Database/Builder/GetTest.php
+++ b/tests/system/Database/Builder/GetTest.php
@@ -34,14 +34,14 @@ class GetTest extends \CIUnitTestCase
 	public function testGetWithReset()
 	{
 		$builder = $this->db->table('users');
-		$builder->where('username', 'bogus');
+		$builder->testMode()->where('username', 'bogus');
 
 		$expectedSQL           = 'SELECT * FROM "users" WHERE "username" = \'bogus\'';
 		$expectedSQLafterreset = 'SELECT * FROM "users"';
 
-		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, true, false)));
-		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, true, true)));
-		$this->assertEquals($expectedSQLafterreset, str_replace("\n", ' ', $builder->get(0, 50, true, true)));
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, false)));
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, true)));
+		$this->assertEquals($expectedSQLafterreset, str_replace("\n", ' ', $builder->get(0, 50, true)));
 	}
 
 	//--------------------------------------------------------------------
@@ -52,13 +52,14 @@ class GetTest extends \CIUnitTestCase
 	public function testGetWhereWithLimit()
 	{
 		$builder = $this->db->table('users');
+		$builder->testMode();
 
 		$expectedSQL             = 'SELECT * FROM "users" WHERE "username" = \'bogus\'  LIMIT 5';
 		$expectedSQLWithoutReset = 'SELECT * FROM "users" WHERE "username" = \'bogus\' AND "username" = \'bogus\'  LIMIT 5';
 
-		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, null, true, false)));
-		$this->assertEquals($expectedSQLWithoutReset, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 0, true, true)));
-		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, null, true, true)));
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, null, false)));
+		$this->assertEquals($expectedSQLWithoutReset, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 0, true)));
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, null, true)));
 	}
 
 	//--------------------------------------------------------------------
@@ -66,13 +67,14 @@ class GetTest extends \CIUnitTestCase
 	public function testGetWhereWithLimitAndOffset()
 	{
 		$builder = $this->db->table('users');
+		$builder->testMode();
 
 		$expectedSQL             = 'SELECT * FROM "users" WHERE "username" = \'bogus\'  LIMIT 10, 5';
 		$expectedSQLWithoutReset = 'SELECT * FROM "users" WHERE "username" = \'bogus\' AND "username" = \'bogus\'  LIMIT 10, 5';
 
-		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 10, true, false)));
-		$this->assertEquals($expectedSQLWithoutReset, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 10, true, true)));
-		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 10, true, true)));
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 10, false)));
+		$this->assertEquals($expectedSQLWithoutReset, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 10, true)));
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 10, true)));
 	}
 
 	//--------------------------------------------------------------------
@@ -80,13 +82,14 @@ class GetTest extends \CIUnitTestCase
 	public function testGetWhereWithWhereConditionOnly()
 	{
 		$builder = $this->db->table('users');
+		$builder->testMode();
 
 		$expectedSQL             = 'SELECT * FROM "users" WHERE "username" = \'bogus\'';
 		$expectedSQLWithoutReset = 'SELECT * FROM "users" WHERE "username" = \'bogus\' AND "username" = \'bogus\'';
 
-		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], null, null, true, false)));
-		$this->assertEquals($expectedSQLWithoutReset, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], null, null, true, true)));
-		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], null, null, true, true)));
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], null, null, false)));
+		$this->assertEquals($expectedSQLWithoutReset, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], null, null, true)));
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], null, null, true)));
 	}
 
 	//--------------------------------------------------------------------
@@ -94,10 +97,11 @@ class GetTest extends \CIUnitTestCase
 	public function testGetWhereWithoutArgs()
 	{
 		$builder = $this->db->table('users');
+		$builder->testMode();
 
 		$expectedSQL = 'SELECT * FROM "users"';
 
-		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(null, null, null, true, true)));
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(null, null, null, true)));
 	}
 
 }

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -26,7 +26,7 @@ class InsertTest extends \CIUnitTestCase
 			'id'   => 1,
 			'name' => 'Grocery Sales',
 		];
-		$builder->insert($insertData, true, true);
+		$builder->testMode()->insert($insertData, true);
 
 		$expectedSQL   = 'INSERT INTO "jobs" ("id", "name") VALUES (1, \'Grocery Sales\')';
 		$expectedBinds = [
@@ -53,7 +53,7 @@ class InsertTest extends \CIUnitTestCase
 		$this->expectException('\CodeIgniter\Database\Exceptions\DatabaseException');
 		$this->expectExceptionMessage('You must use the "set" method to update an entry.');
 
-		$builder->insert(null, true, true);
+		$builder->testMode()->insert(null, true);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Builder/ReplaceTest.php
+++ b/tests/system/Database/Builder/ReplaceTest.php
@@ -29,7 +29,7 @@ class ReplaceTest extends \CIUnitTestCase
 			'date'  => 'My date',
 		];
 
-		$this->assertSame($expected, $builder->replace($data, true));
+		$this->assertSame($expected, $builder->testMode()->replace($data));
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Builder/TruncateTest.php
+++ b/tests/system/Database/Builder/TruncateTest.php
@@ -24,7 +24,7 @@ class TruncateTest extends \CIUnitTestCase
 
 		$expectedSQL = 'TRUNCATE "user"';
 
-		$this->assertEquals($expectedSQL, $builder->truncate(true));
+		$this->assertEquals($expectedSQL, $builder->testMode()->truncate());
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -23,7 +23,7 @@ class UpdateTest extends \CIUnitTestCase
 	{
 		$builder = new BaseBuilder('jobs', $this->db);
 
-		$builder->where('id', 1)->update(['name' => 'Programmer'], null, null, true);
+		$builder->testMode()->where('id', 1)->update(['name' => 'Programmer'], null, null);
 
 		$expectedSQL   = 'UPDATE "jobs" SET "name" = \'Programmer\' WHERE "id" = 1';
 		$expectedBinds = [
@@ -47,7 +47,7 @@ class UpdateTest extends \CIUnitTestCase
 	{
 		$builder = new BaseBuilder('jobs', $this->db);
 
-		$builder->update(['name' => 'Programmer'], ['id' => 1], 5, true);
+		$builder->testMode()->update(['name' => 'Programmer'], ['id' => 1], 5);
 
 		$expectedSQL   = 'UPDATE "jobs" SET "name" = \'Programmer\' WHERE "id" = 1  LIMIT 5';
 		$expectedBinds = [
@@ -71,7 +71,7 @@ class UpdateTest extends \CIUnitTestCase
 	{
 		$builder = new BaseBuilder('jobs', $this->db);
 
-		$builder->set('name', 'Programmer')->where('id', 1)->update(null, null, null, true);
+		$builder->testMode()->set('name', 'Programmer')->where('id', 1)->update(null, null, null);
 
 		$expectedSQL   = 'UPDATE "jobs" SET "name" = \'Programmer\' WHERE "id" = 1';
 		$expectedBinds = [
@@ -193,7 +193,7 @@ WHERE "id" IN(2,3)';
 	{
 		$builder = new BaseBuilder('jobs', $this->db);
 
-		$builder->update(['name' => 'foobar'], ['name' => 'Programmer'], null, true);
+		$builder->testMode()->update(['name' => 'foobar'], ['name' => 'Programmer'], null);
 
 		$expectedSQL   = 'UPDATE "jobs" SET "name" = \'foobar\' WHERE "name" = \'Programmer\'';
 		$expectedBinds = [
@@ -218,9 +218,10 @@ WHERE "id" IN(2,3)';
 		// calling order: set() -> where()
 		$builder = new BaseBuilder('jobs', $this->db);
 
-		$builder->set('name', 'foobar')
+		$builder->testMode()
+			->set('name', 'foobar')
 			->where('name', 'Programmer')
-			->update(null, null, null, true);
+			->update(null, null, null);
 
 		$expectedSQL   = 'UPDATE "jobs" SET "name" = \'foobar\' WHERE "name" = \'Programmer\'';
 		$expectedBinds = [
@@ -245,8 +246,9 @@ WHERE "id" IN(2,3)';
 		// calling order: where() -> set() in update()
 		$builder = new BaseBuilder('jobs', $this->db);
 
-		$builder->where('name', 'Programmer')
-			->update(['name' => 'foobar'], null, null, true);
+		$builder->testMode()
+			->where('name', 'Programmer')
+			->update(['name' => 'foobar'], null, null);
 
 		$expectedSQL   = 'UPDATE "jobs" SET "name" = \'foobar\' WHERE "name" = \'Programmer\'';
 		$expectedBinds = [
@@ -271,9 +273,10 @@ WHERE "id" IN(2,3)';
 	{
 		$builder = new BaseBuilder('mytable', $this->db);
 
-		$builder->set('field', 'field+1', false)
+		$builder->testMode()
+			->set('field', 'field+1', false)
 			->where('id', 2)
-			->update(null, null, null, true);
+			->update(null, null, null);
 
 		$expectedSQL   = 'UPDATE "mytable" SET field = field+1 WHERE "id" = 2';
 		$expectedBinds = [

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1246,22 +1246,22 @@ Class Reference
 		Generates a platform-specific query string that counts
 		all records returned by an Query Builder query.
 
-	.. php:method:: get([$limit = NULL[, $offset = NULL]])
+	.. php:method:: get([$limit = NULL[, $offset = NULL[, $reset = TRUE]]]])
 
 		:param	int	$limit: The LIMIT clause
 		:param	int	$offset: The OFFSET clause
+		:param 	bool $reset: Do we want to clear query builder values?
 		:returns:	\CodeIgniter\Database\ResultInterface instance (method chaining)
 		:rtype:	\CodeIgniter\Database\ResultInterface
 
 		Compiles and runs SELECT statement based on the already
 		called Query Builder methods.
 
-	.. php:method:: getWhere([$where = NULL[, $limit = NULL[, $offset = NULL[, $returnSQL = FALSE[, $reset = TRUE]]]]])
+	.. php:method:: getWhere([$where = NULL[, $limit = NULL[, $offset = NULL[, $reset = TRUE]]]]])
 
 		:param	string	$where: The WHERE clause
 		:param	int	$limit: The LIMIT clause
 		:param	int	$offset: The OFFSET clause
-		:param 	bool $returnSQL: If true, returns the generate SQL, otherwise executes the query.
 		:param 	bool $reset: Do we want to clear query builder values?
 		:returns:	\CodeIgniter\Database\ResultInterface instance (method chaining)
 		:rtype:	\CodeIgniter\Database\ResultInterface
@@ -1313,6 +1313,15 @@ Class Reference
 
 		Adds a SELECT SUM(field) clause to a query.
 
+	.. php:method:: selectCount([$select = ''[, $alias = '']])
+
+		:param	string	$select: Field to compute the average of
+		:param	string	$alias: Alias for the resulting value name
+		:returns:	BaseBuilder instance (method chaining)
+		:rtype:	BaseBuilder
+
+		Adds a SELECT COUNT(field) clause to a query.
+
 	.. php:method:: distinct([$val = TRUE])
 
 		:param	bool	$val: Desired value of the "distinct" flag
@@ -1322,9 +1331,10 @@ Class Reference
 		Sets a flag which tells the query builder to add
 		a DISTINCT clause to the SELECT portion of the query.
 
-	.. php:method:: from($from)
+	.. php:method:: from($from[, $overwrite = FALSE])
 
 		:param	mixed	$from: Table name(s); string or array
+		:param	bool	$overwrite Should we remove the first table existing?
 		:returns:	BaseBuilder instance (method chaining)
 		:rtype:	BaseBuilder
 
@@ -1442,45 +1452,49 @@ Class Reference
 
 		Ends a group expression.
 
-	.. php:method:: like($field[, $match = ''[, $side = 'both'[, $escape = NULL]]])
+	.. php:method:: like($field[, $match = ''[, $side = 'both'[, $escape = NULL[, $insensitiveSearch = FALSE]]]])
 
 		:param	string	$field: Field name
 		:param	string	$match: Text portion to match
 		:param	string	$side: Which side of the expression to put the '%' wildcard on
 		:param	bool	$escape: Whether to escape values and identifiers
+		:param	bool    $insensitiveSearch: Whether to force a case-insensitive search
 		:returns:	BaseBuilder instance (method chaining)
 		:rtype:	BaseBuilder
 
 		Adds a LIKE clause to a query, separating multiple calls with AND.
 
-	.. php:method:: orLike($field[, $match = ''[, $side = 'both'[, $escape = NULL]]])
+	.. php:method:: orLike($field[, $match = ''[, $side = 'both'[, $escape = NULL[, $insensitiveSearch = FALSE]]]])
 
 		:param	string	$field: Field name
 		:param	string	$match: Text portion to match
 		:param	string	$side: Which side of the expression to put the '%' wildcard on
 		:param	bool	$escape: Whether to escape values and identifiers
+		:param	bool    $insensitiveSearch: Whether to force a case-insensitive search
 		:returns:	BaseBuilder instance (method chaining)
 		:rtype:	BaseBuilder
 
 		Adds a LIKE clause to a query, separating multiple class with OR.
 
-	.. php:method:: notLike($field[, $match = ''[, $side = 'both'[, $escape = NULL]]])
+	.. php:method:: notLike($field[, $match = ''[, $side = 'both'[, $escape = NULL[, $insensitiveSearch = FALSE]]]])
 
 		:param	string	$field: Field name
 		:param	string	$match: Text portion to match
 		:param	string	$side: Which side of the expression to put the '%' wildcard on
 		:param	bool	$escape: Whether to escape values and identifiers
+		:param	bool    $insensitiveSearch: Whether to force a case-insensitive search
 		:returns:	BaseBuilder instance (method chaining)
 		:rtype:	BaseBuilder
 
 		Adds a NOT LIKE clause to a query, separating multiple calls with AND.
 
-	.. php:method:: orNotLike($field[, $match = ''[, $side = 'both'[, $escape = NULL]]])
+	.. php:method:: orNotLike($field[, $match = ''[, $side = 'both'[, $escape = NULL[, $insensitiveSearch = FALSE]]]])
 
 		:param	string	$field: Field name
 		:param	string	$match: Text portion to match
 		:param	string	$side: Which side of the expression to put the '%' wildcard on
 		:param	bool	$escape: Whether to escape values and identifiers
+		:param	bool    $insensitiveSearch: Whether to force a case-insensitive search
 		:returns:	BaseBuilder instance (method chaining)
 		:rtype:	BaseBuilder
 
@@ -1544,46 +1558,50 @@ Class Reference
 		:param	string	        $key: Name of field to examine
 		:param	array|Closure   $values: Array of target values, or anonymous function for subquery
 		:param	bool	        $escape: Whether to escape values and identifiers
+		:param	bool            $insensitiveSearch: Whether to force a case-insensitive search
 		:returns:	BaseBuilder instance
 		:rtype:	object
 
 		Generates a HAVING field NOT IN('item', 'item') SQL query,
                 joined with 'AND' if appropriate.
 
-	.. php:method:: havingLike($field[, $match = ''[, $side = 'both'[, $escape = NULL]]])
+	.. php:method:: havingLike($field[, $match = ''[, $side = 'both'[, $escape = NULL[, $insensitiveSearch = FALSE]]]])
 
 		:param	string	$field: Field name
 		:param	string	$match: Text portion to match
 		:param	string	$side: Which side of the expression to put the '%' wildcard on
 		:param	bool	$escape: Whether to escape values and identifiers
+		:param	bool    $insensitiveSearch: Whether to force a case-insensitive search
 		:returns:	BaseBuilder instance (method chaining)
 		:rtype:	BaseBuilder
 
 		Adds a LIKE clause to a HAVING part of the query, separating multiple calls with AND.
 
-	.. php:method:: orHavingLike($field[, $match = ''[, $side = 'both'[, $escape = NULL]]])
+	.. php:method:: orHavingLike($field[, $match = ''[, $side = 'both'[, $escape = NULL[, $insensitiveSearch = FALSE]]]])
 
 		:param	string	$field: Field name
 		:param	string	$match: Text portion to match
 		:param	string	$side: Which side of the expression to put the '%' wildcard on
 		:param	bool	$escape: Whether to escape values and identifiers
+		:param	bool    $insensitiveSearch: Whether to force a case-insensitive search
 		:returns:	BaseBuilder instance (method chaining)
 		:rtype:	BaseBuilder
 
 		Adds a LIKE clause to a HAVING part of the query, separating multiple class with OR.
 
-	.. php:method:: notHavingLike($field[, $match = ''[, $side = 'both'[, $escape = NULL]]])
+	.. php:method:: notHavingLike($field[, $match = ''[, $side = 'both'[, $escape = NULL[, $insensitiveSearch = FALSE]]]])
 
 		:param	string	$field: Field name
 		:param	string	$match: Text portion to match
 		:param	string	$side: Which side of the expression to put the '%' wildcard on
 		:param	bool	$escape: Whether to escape values and identifiers
+		:param	bool    $insensitiveSearch: Whether to force a case-insensitive search
 		:returns:	BaseBuilder instance (method chaining)
 		:rtype:	BaseBuilder
 
 		Adds a NOT LIKE clause to a HAVING part of the query, separating multiple calls with AND.
 
-	.. php:method:: orNotHavingLike($field[, $match = ''[, $side = 'both'[, $escape = NULL]]])
+	.. php:method:: orNotHavingLike($field[, $match = ''[, $side = 'both'[, $escape = NULL[, $insensitiveSearch = FALSE]]]])
 
 		:param	string	$field: Field name
 		:param	string	$match: Text portion to match


### PR DESCRIPTION
**Description**
This PR introduces a new `testMode` variable that is meant to be used in the testing environment. It replaces all occurrences of `$returnSQL`, `$test` and `$testing` - reducing the number of parameters in a couple of methods.

**Important**
This should be considered as a BC change since some parameters from methods are removed. Those parameters weren't well documented but there is still a chance that somebody was using them.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide