### PR TITLE
groupStart() refactorization

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1237,25 +1237,11 @@ class BaseBuilder
 	/**
 	 * Starts a query group.
 	 *
-	 * @param string $not  (Internal use only)
-	 * @param string $type (Internal use only)
-	 *
 	 * @return BaseBuilder
 	 */
-	public function groupStart(string $not = '', string $type = 'AND ')
+	public function groupStart()
 	{
-		$type = $this->groupGetType($type);
-
-		$this->QBWhereGroupStarted = true;
-		$prefix                    = empty($this->QBWhere) ? '' : $type;
-		$where                     = [
-			'condition' => $prefix . $not . str_repeat(' ', ++ $this->QBWhereGroupCount) . ' (',
-			'escape'    => false,
-		];
-
-		$this->QBWhere[] = $where;
-
-		return $this;
+		return $this->groupStartPrepare('', 'AND ', 'QBWhere');
 	}
 
 	//--------------------------------------------------------------------
@@ -1267,7 +1253,7 @@ class BaseBuilder
 	 */
 	public function orGroupStart()
 	{
-		return $this->groupStart('', 'OR ');
+		return $this->groupStartPrepare('', 'OR ', 'QBWhere');
 	}
 
 	//--------------------------------------------------------------------
@@ -1279,7 +1265,7 @@ class BaseBuilder
 	 */
 	public function notGroupStart()
 	{
-		return $this->groupStart('NOT ', 'AND ');
+		return $this->groupStartPrepare('NOT ', 'AND ', 'QBWhere');
 	}
 
 	//--------------------------------------------------------------------
@@ -1291,7 +1277,7 @@ class BaseBuilder
 	 */
 	public function orNotGroupStart()
 	{
-		return $this->groupStart('NOT ', 'OR ');
+		return $this->groupStartPrepare('NOT ', 'OR ', 'QBWhere');
 	}
 
 	//--------------------------------------------------------------------
@@ -1303,15 +1289,7 @@ class BaseBuilder
 	 */
 	public function groupEnd()
 	{
-		$this->QBWhereGroupStarted = false;
-		$where                     = [
-			'condition' => str_repeat(' ', $this->QBWhereGroupCount -- ) . ')',
-			'escape'    => false,
-		];
-
-		$this->QBWhere[] = $where;
-
-		return $this;
+		return $this->groupEndPrepare('QBWhere');
 	}
 
 	// --------------------------------------------------------------------
@@ -1319,26 +1297,11 @@ class BaseBuilder
 	/**
 	 * Starts a query group for HAVING clause.
 	 *
-	 * @param string $not  (Internal use only)
-	 * @param string $type (Internal use only)
-	 *
 	 * @return BaseBuilder
 	 */
-	public function havingGroupStart(string $not = '', string $type = 'AND ')
+	public function havingGroupStart()
 	{
-		$type = $this->groupGetType($type);
-
-		$this->QBWhereGroupStarted = true;
-		$prefix                    = empty($this->QBHaving) ? '' : $type;
-		$having                    = [
-			'condition' => $prefix . $not . str_repeat(' ', ++$this->QBWhereGroupCount) . ' (',
-			'value'     => null,
-			'escape'    => false,
-		];
-
-		$this->QBHaving[] = $having;
-
-		return $this;
+		return $this->groupStartPrepare('', 'AND ', 'QBHaving');
 	}
 
 	// --------------------------------------------------------------------
@@ -1350,7 +1313,7 @@ class BaseBuilder
 	 */
 	public function orHavingGroupStart()
 	{
-		return $this->havingGroupStart('', 'OR ');
+		return $this->groupStartPrepare('', 'OR ', 'QBHaving');
 	}
 
 	// --------------------------------------------------------------------
@@ -1362,7 +1325,7 @@ class BaseBuilder
 	 */
 	public function notHavingGroupStart()
 	{
-		return $this->havingGroupStart('NOT ', 'AND ');
+		return $this->groupStartPrepare('NOT ', 'AND ', 'QBHaving');
 	}
 
 	// --------------------------------------------------------------------
@@ -1374,7 +1337,7 @@ class BaseBuilder
 	 */
 	public function orNotHavingGroupStart()
 	{
-		return $this->havingGroupStart('NOT ', 'OR ');
+		return $this->groupStartPrepare('NOT ', 'OR ', 'QBHaving');
 	}
 
 	// --------------------------------------------------------------------
@@ -1386,14 +1349,54 @@ class BaseBuilder
 	 */
 	public function havingGroupEnd()
 	{
-		$this->QBWhereGroupStarted = false;
-		$having                    = [
-			'condition' => str_repeat(' ', $this->QBWhereGroupCount -- ) . ')',
-			'value'     => null,
+		return $this->groupEndPrepare('QBHaving');
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Prepate a query group start.
+	 *
+	 * @param string $not
+	 * @param string $type
+	 * @param string $clause
+	 *
+	 * @return BaseBuilder
+	 */
+	protected function groupStartPrepare(string $not = '', string $type = 'AND ', string $clause = 'QBWhere')
+	{
+		$type = $this->groupGetType($type);
+
+		$this->QBWhereGroupStarted = true;
+		$prefix                    = empty($this->$clause) ? '' : $type;
+		$where                     = [
+			'condition' => $prefix . $not . str_repeat(' ', ++ $this->QBWhereGroupCount) . ' (',
 			'escape'    => false,
 		];
 
-		$this->QBHaving[] = $having;
+		$this->{$clause}[] = $where;
+
+		return $this;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Prepate a query group end.
+	 *
+	 * @param string $clause
+	 *
+	 * @return BaseBuilder
+	 */
+	protected function groupEndPrepare(string $clause = 'QBWhere')
+	{
+		$this->QBWhereGroupStarted = false;
+		$where                     = [
+			'condition' => str_repeat(' ', $this->QBWhereGroupCount -- ) . ')',
+			'escape'    => false,
+		];
+
+		$this->{$clause}[] = $where;
 
 		return $this;
 	}


### PR DESCRIPTION
**Description**
Since we have now `groupStart()` and `havingGroupStart()` it's a good moment to refactor the code responsible for those methods a bit.

In this PR I want to introduce two new protected methods: `groupStartPrepare()` and `groupEndPrepare()`. These will take over the responsibility for handling all other `group*` methods.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

