### PR TITLE
fix ResourcePresenter::setModel()

### DIFF
--- a/system/RESTful/ResourcePresenter.php
+++ b/system/RESTful/ResourcePresenter.php
@@ -178,9 +178,11 @@ class ResourcePresenter extends Controller
 			if (is_object($which))
 			{
 				$this->model = $which;
+				$this->modelName = null;
 			}
 			else
 			{
+				$this->model = null;
 				$this->modelName = $which;
 			}
 		}

--- a/tests/system/RESTful/ResourcePresenterTest.php
+++ b/tests/system/RESTful/ResourcePresenterTest.php
@@ -245,4 +245,28 @@ class ResourcePresenterTest extends \CIUnitTestCase
 		$this->assertEquals('Tests\Support\Models\UserModel', $resource->getModelName());
 	}
 
+	public function testChangeSetModelByObject()
+	{
+		$resource = new \Tests\Support\RESTful\MockResourcePresenter();
+		$resource->setModel('\Tests\Support\Models\UserModel');
+		$this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
+		$this->assertEquals('\Tests\Support\Models\UserModel', $resource->getModelName());
+
+		$model    = new \Tests\Support\Models\EntityModel();
+		$resource->setModel($model);
+		$this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
+		$this->assertEquals('Tests\Support\Models\EntityModel', $resource->getModelName());
+	}
+
+	public function testChangeSetModelByName()
+	{
+		$resource = new \Tests\Support\RESTful\MockResourcePresenter();
+		$resource->setModel('\Tests\Support\Models\UserModel');
+		$this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
+		$this->assertEquals('\Tests\Support\Models\UserModel', $resource->getModelName());
+
+		$resource->setModel('\Tests\Support\Models\EntityModel');
+		$this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
+		$this->assertEquals('\Tests\Support\Models\EntityModel', $resource->getModelName());
+	}
 }


### PR DESCRIPTION
When we use the `setModel()` function for the first time everything is fine but as we allow you to change the model you have to reset the property that is not updated otherwise you risk having a different name of the created model as we can see in the tests created.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
