### PR TITLE
Inccorectly formated JSON response , if body is string

### DIFF
--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -447,9 +447,9 @@ class Response extends Message implements ResponseInterface
 	 *
 	 * @return $this
 	 */
-	public function setJSON($body)
+	public function setJSON($body, bool $unencoded = true)
 	{
-		$this->body = $this->formatBody($body, 'json');
+		$this->body = $this->formatBody($body, 'json' . ($unencoded ? '-unencoded' : ''));
 
 		return $this;
 	}
@@ -542,7 +542,7 @@ class Response extends Message implements ResponseInterface
 		$this->bodyFormat = $format;
 
 		// Nothing much to do for a string...
-		if (! is_string($body))
+		if (! is_string($body) || $format === 'json-unencoded')
 		{
 			/**
 			 * @var Format $config

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -536,10 +536,10 @@ class Response extends Message implements ResponseInterface
 	 * @throws \InvalidArgumentException If the body property is not string or array.
 	 */
 	protected function formatBody($body, string $format)
-	{
-		$mime = "application/{$format}";
+	{    
+		$this->bodyFormat = ($format === 'json-unencoded' ? 'json' : $format);
+		$mime = "application/{$this->bodyFormat}";
 		$this->setContentType($mime);
-		$this->bodyFormat = $format;
 
 		// Nothing much to do for a string...
 		if (! is_string($body) || $format === 'json-unencoded')

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -447,7 +447,7 @@ class Response extends Message implements ResponseInterface
 	 *
 	 * @return $this
 	 */
-	public function setJSON($body, bool $unencoded = true)
+	public function setJSON($body, bool $unencoded = false)
 	{
 		$this->body = $this->formatBody($body, 'json' . ($unencoded ? '-unencoded' : ''));
 

--- a/tests/system/Test/FeatureResponseTest.php
+++ b/tests/system/Test/FeatureResponseTest.php
@@ -219,18 +219,18 @@ class FeatureResponseTest extends CIUnitTestCase
 		$formatter = $config->getFormatter('application/json');
 
 		// this should be "" - json_encode('');
-		$this->assertEquals("", $this->feature->getJSON());
+		$this->assertEquals('""', $this->feature->getJSON());
 	}
 	
 	public function testFalseJSON()
 	{
 		$this->getFeatureResponse('<h1>Hello World</h1>');
-		$this->response->setJSON('');
+		$this->response->setJSON(false);
 		$config    = new \Config\Format();
 		$formatter = $config->getFormatter('application/json');
 
 		// this should be FALSE - json_encode(false)
-		$this->assertFalse($this->feature->getJSON());
+		$this->assertEquals('false', $this->feature->getJSON());
 	}
 	
 	public function testTrueJSON()
@@ -241,7 +241,7 @@ class FeatureResponseTest extends CIUnitTestCase
 		$formatter = $config->getFormatter('application/json');
 
 		// this should be TRUE - json_encode(true)
-		$this->assertTrue($this->feature->getJSON());
+		$this->assertEquals('true', $this->feature->getJSON());
 	}
 	
 	public function testInvalidJSON()

--- a/tests/system/Test/FeatureResponseTest.php
+++ b/tests/system/Test/FeatureResponseTest.php
@@ -236,7 +236,7 @@ class FeatureResponseTest extends CIUnitTestCase
 	public function testTrueJSON()
 	{
 		$this->getFeatureResponse('<h1>Hello World</h1>');
-		$this->response->setJSON('');
+		$this->response->setJSON(true);
 		$config    = new \Config\Format();
 		$formatter = $config->getFormatter('application/json');
 
@@ -246,13 +246,12 @@ class FeatureResponseTest extends CIUnitTestCase
 	
 	public function testInvalidJSON()
 	{
+		$tmp = ' test " case ';
 		$this->getFeatureResponse('<h1>Hello World</h1>');
-		$this->response->setBody(' test " case ');
-		$config    = new \Config\Format();
-		$formatter = $config->getFormatter('application/json');
+		$this->response->setBody($tmp);
 
 		// this should be FALSE - invalid JSON - will see if this is working that way ;-)
-		$this->assertFalse($this->feature->getJSON());
+		$this->assertFalse(json_encode(' test " case ') == $this->feature->getJSON());
 	}
 
 	public function testGetXML()

--- a/tests/system/Test/FeatureResponseTest.php
+++ b/tests/system/Test/FeatureResponseTest.php
@@ -251,7 +251,7 @@ class FeatureResponseTest extends CIUnitTestCase
 		$this->response->setBody($tmp);
 
 		// this should be FALSE - invalid JSON - will see if this is working that way ;-)
-		$this->assertFalse(json_encode(' test " case ') == $this->feature->getJSON());
+		$this->assertFalse($this->response->getBody() == $this->feature->getJSON());
 	}
 
 	public function testGetXML()

--- a/tests/system/Test/FeatureResponseTest.php
+++ b/tests/system/Test/FeatureResponseTest.php
@@ -214,7 +214,7 @@ class FeatureResponseTest extends CIUnitTestCase
 	public function testEmptyJSON()
 	{
 		$this->getFeatureResponse('<h1>Hello World</h1>');
-		$this->response->setJSON('');
+		$this->response->setJSON('', true);
 		$config    = new \Config\Format();
 		$formatter = $config->getFormatter('application/json');
 
@@ -225,7 +225,7 @@ class FeatureResponseTest extends CIUnitTestCase
 	public function testFalseJSON()
 	{
 		$this->getFeatureResponse('<h1>Hello World</h1>');
-		$this->response->setJSON(false);
+		$this->response->setJSON(false, true);
 		$config    = new \Config\Format();
 		$formatter = $config->getFormatter('application/json');
 
@@ -236,7 +236,7 @@ class FeatureResponseTest extends CIUnitTestCase
 	public function testTrueJSON()
 	{
 		$this->getFeatureResponse('<h1>Hello World</h1>');
-		$this->response->setJSON(true);
+		$this->response->setJSON(true, true);
 		$config    = new \Config\Format();
 		$formatter = $config->getFormatter('application/json');
 

--- a/tests/system/Test/FeatureResponseTest.php
+++ b/tests/system/Test/FeatureResponseTest.php
@@ -211,14 +211,47 @@ class FeatureResponseTest extends CIUnitTestCase
 		$this->assertEquals($formatter->format(['foo' => 'bar']), $this->feature->getJSON());
 	}
 
-	public function testInvalidJSON()
+	public function testEmptyJSON()
 	{
 		$this->getFeatureResponse('<h1>Hello World</h1>');
 		$this->response->setJSON('');
 		$config    = new \Config\Format();
 		$formatter = $config->getFormatter('application/json');
 
-		// this should fail because of empty JSON
+		// this should be "" - json_encode('');
+		$this->assertEquals("", $this->feature->getJSON());
+	}
+	
+	public function testFalseJSON()
+	{
+		$this->getFeatureResponse('<h1>Hello World</h1>');
+		$this->response->setJSON('');
+		$config    = new \Config\Format();
+		$formatter = $config->getFormatter('application/json');
+
+		// this should be FALSE - json_encode(false)
+		$this->assertFalse($this->feature->getJSON());
+	}
+	
+	public function testTrueJSON()
+	{
+		$this->getFeatureResponse('<h1>Hello World</h1>');
+		$this->response->setJSON('');
+		$config    = new \Config\Format();
+		$formatter = $config->getFormatter('application/json');
+
+		// this should be TRUE - json_encode(true)
+		$this->assertTrue($this->feature->getJSON());
+	}
+	
+	public function testInvalidJSON()
+	{
+		$this->getFeatureResponse('<h1>Hello World</h1>');
+		$this->response->setBody(' test " case ');
+		$config    = new \Config\Format();
+		$formatter = $config->getFormatter('application/json');
+
+		// this should be FALSE - invalid JSON - will see if this is working that way ;-)
 		$this->assertFalse($this->feature->getJSON());
 	}
 


### PR DESCRIPTION
JSON was incorrectly formatted in case we providing a string (with no " "  around) to setJSON() method.
Of course, this is not the final solution but I am pointing out the place where the issue occurs. 
```
 $this->response
            ->setJSON('my test string without closing " sings around')
            ->send();
```

