### PR TITLE
Create id primary keys unsigned

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -356,6 +356,7 @@ class Forge
 					'id' => [
 						'type'           => 'INT',
 						'constraint'     => 9,
+						'unsigned'       => true,
 						'auto_increment' => true,
 					],
 				]);

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -144,7 +144,7 @@ Creating an id field
 --------------------
 
 There is a special exception for creating id fields. A field with type
-id will automatically be assigned as an INT(9) auto_incrementing
+id will automatically be assigned as an unsigned INT(9) auto_incrementing
 Primary Key.
 
 ::

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -143,14 +143,14 @@ string into the field definitions with addField()
 Creating an id field
 --------------------
 
-There is a special exception for creating id fields. A field with type
-id will automatically be assigned as an unsigned INT(9) auto_incrementing
+There is a special exception for creating id fields. A field with the name
+'id' will automatically be created as an unsigned INT(9) auto_incrementing
 Primary Key.
 
 ::
 
 	$forge->addField('id');
-	// gives id INT(9) NOT NULL AUTO_INCREMENT
+	// gives id INT(9) UNSIGNED NOT NULL AUTO_INCREMENT
 
 Adding Keys
 ===========


### PR DESCRIPTION
**Description**
Changes `$forge->addField('id')` to create an `unsigned` field.

Note that any existing forge foreign key commands pointing to fields created this way will need to be updated to specify the `unsigned` as well, or the `createTable()` command will fail with the generic message "Cannot add foreign key constraint".

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [X] Conforms to style guide
