### PR TITLE
Bug in CSRF parameter cleanup

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -723,6 +723,25 @@ if (! function_exists('csrf_token'))
 
 //--------------------------------------------------------------------
 
+if (! function_exists('csrf_header'))
+{
+	/**
+	 * Returns the CSRF header name.
+	 * Can be used in Views by adding it to the meta tag
+	 * or used in javascript to define a header name when using APIs.
+	 *
+	 * @return string
+	 */
+	function csrf_header(): string
+	{
+		$config = config(App::class);
+
+		return $config->CSRFHeaderName;
+	}
+}
+
+//--------------------------------------------------------------------
+
 if (! function_exists('csrf_hash'))
 {
 	/**
@@ -754,6 +773,23 @@ if (! function_exists('csrf_field'))
 	function csrf_field(string $id = null): string
 	{
 		return '<input type="hidden"' . (! empty($id) ? ' id="' . esc($id, 'attr') . '"' : '') . ' name="' . csrf_token() . '" value="' . csrf_hash() . '" />';
+	}
+}
+
+//--------------------------------------------------------------------
+
+if (! function_exists('csrf_meta'))
+{
+	/**
+	 * Generates a meta tag for use within javascript calls.
+	 *
+	 * @param string|null $id
+	 *
+	 * @return string
+	 */
+	function csrf_meta(string $id = null): string
+	{
+		return '<meta' . (! empty($id) ? ' id="' . esc($id, 'attr') . '"' : '') . ' name="' . csrf_header() . '" content="' . csrf_hash() . '" />';
 	}
 }
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -221,7 +221,17 @@ class Security
 		}
 
 		// We kill this since we're done and we don't want to pollute the _POST array
-		unset($_POST[$this->CSRFTokenName]);
+		if (isset($_POST[$this->CSRFTokenName]))
+		{
+			unset($_POST[$this->CSRFTokenName]);
+			$request->setGlobal('post', $_POST);
+		}
+		// We kill this since we're done and we don't want to pollute the JSON data
+		elseif (isset($json->{$this->CSRFTokenName}))
+		{
+			unset($json->{$this->CSRFTokenName});
+			$request->setBody(json_encode($json));
+		}
 
 		// Regenerate on every submission?
 		if ($this->CSRFRegenerate)

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -251,6 +251,11 @@ class CommonFunctionsTest extends \CIUnitTestCase
 		$this->assertEquals('csrf_test_name', csrf_token());
 	}
 
+	public function testCSRFHeader()
+	{
+		$this->assertEquals('X-CSRF-TOKEN', csrf_header());
+	}
+
 	public function testHash()
 	{
 		$this->assertEquals(32, strlen(csrf_hash()));
@@ -259,6 +264,11 @@ class CommonFunctionsTest extends \CIUnitTestCase
 	public function testCSRFField()
 	{
 		$this->assertContains('<input type="hidden" ', csrf_field());
+	}
+
+	public function testCSRFMeta()
+	{
+		$this->assertContains('<meta name="X-CSRF-TOKEN" ', csrf_meta());
 	}
 
 	// ------------------------------------------------------------------------

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -176,6 +176,13 @@ Miscellaneous Functions
 
 	Returns the name of the current CSRF token.
 
+.. php:function:: csrf_header ()
+
+	:returns: The name of the header for current CSRF token.
+	:rtype: string
+
+	The name of the header for current CSRF token.
+
 .. php:function:: csrf_hash ()
 
 	:returns: The current value of the CSRF hash.
@@ -191,6 +198,15 @@ Miscellaneous Functions
 	Returns a hidden input with the CSRF information already inserted:
 
 		<input type="hidden" name="{csrf_token}" value="{csrf_hash}">
+
+.. php:function:: csrf_meta ()
+
+	:returns: A string with the HTML for meta tag with all required CSRF information.
+	:rtype: string
+
+	Returns a meta tag with the CSRF information already inserted:
+
+		<meta name="{csrf_header}" content="{csrf_hash}">
 
 .. php:function:: force_https ( $duration = 31536000 [, $request = null [, $response = null]] )
 

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -65,6 +65,22 @@ hidden input field for you::
 	// Generates: <input type="hidden" name="{csrf_token}" value="{csrf_hash}" />
 	<?= csrf_field() ?>
 
+When sending a JSON request the CSRF token can also be passed as one of the parameters.
+The next way to pass the CSRF token is a special Http header that's name is available by
+``csrf_header()`` function.
+
+Additionally, you can use the ``csrf_meta()`` method to generate this handy
+meta tag for you::
+
+	// Generates: <meta name="{csrf_header}" content="{csrf_hash}" />
+	<?= csrf_meta() ?>
+
+The order of checking the avability of the CSRF token is as follows:
+
+- ``$_POST`` array
+- Http header
+- ``php://input`` (JSON request) - bare in mind that this approach is the slowest one since we have to decode JSON and then encode it again
+
 Tokens may be either regenerated on every submission (default) or
 kept the same throughout the life of the CSRF cookie. The default
 regeneration of tokens provides stricter security, but may result

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -77,9 +77,9 @@ meta tag for you::
 
 The order of checking the avability of the CSRF token is as follows:
 
-- ``$_POST`` array
-- Http header
-- ``php://input`` (JSON request) - bare in mind that this approach is the slowest one since we have to decode JSON and then encode it again
+1. ``$_POST`` array
+2. Http header
+3. ``php://input`` (JSON request) - bare in mind that this approach is the slowest one since we have to decode JSON and then encode it again
 
 Tokens may be either regenerated on every submission (default) or
 kept the same throughout the life of the CSRF cookie. The default


### PR DESCRIPTION
**Description**
CSRF variable is not being removed after verification. We unset POST parameter but we should also update Request object.

The same thing with JSON data - we forgot to clean it up at all.

These tests are failing right now but they will not - after merging #2272.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
