### PR TITLE
Fix getErrors() for validation with redirect

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -648,7 +648,7 @@ class Validation implements ValidationInterface
 		{
 			if (isset($_SESSION) && session('_ci_validation_errors'))
 			{
-				$this->errors = unserialize($errors);
+				$this->errors = unserialize(session('_ci_validation_errors'));
 			}
 		}
 

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -646,9 +646,9 @@ class Validation implements ValidationInterface
 		// passed along from a redirect_with_input request.
 		if (empty($this->errors) && ! is_cli())
 		{
-			if (isset($_SESSION) && session('_ci_validation_errors'))
+			if (isset($_SESSION) && $errors = session('_ci_validation_errors'))
 			{
-				$this->errors = unserialize(session('_ci_validation_errors'));
+				$this->errors = unserialize($errors);
 			}
 		}
 


### PR DESCRIPTION
**Description**
When performing redirect `_ci validation_errors` session variable is not passed correctly.
Sadly this one is hard to test since we check `! is_cli()` a couple of lines before.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide