### PR TITLE
Fix line numbering in Debug/Exceptions class

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -461,7 +461,7 @@ class Exceptions
 		$source = array_splice($source, $start, $lines, true);
 
 		// Used to format the line number in the source
-		$format = '% ' . strlen(sprintf('%sd', $start + $lines));
+		$format = '% ' . strlen(sprintf('%s', $start + $lines)) . 'd';
 
 		$out = '';
 		// Because the highlighting may have an uneven number


### PR DESCRIPTION
**Description**
Code is not showing with a line number.
Currently produced output when an error occurs:
```
/span>  */
/span> 
/span> class FrameworkException extends \RuntimeException implements ExceptionInterface
/span> {
/span> 
/span>     public static function forInvalidFile(string $path)
/span>     {
/span>         return new static(lang('Core.invalidFile', [$path]));
/span>     }
/span> 
/span>     public static function forCopyError(string $path)
/span>     {
/span>         return new static(lang('Core.copyError', [$path]));
/span>     }
/span> 
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
