### PR TITLE
Fix Code Modules documentation for psr4 namespace configuration

### DIFF
--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -32,8 +32,11 @@ directory in the main project root::
 
 Open **app/Config/Autoload.php** and add the **Acme** namespace to the ``psr4`` array property::
 
-    public $psr4 = [
-        'Acme' => ROOTPATH.'acme'
+    $psr4 = [
+        'Config'        => APPPATH . 'Config',
+        APP_NAMESPACE   => APPPATH,                // For custom namespace
+        'App'           => APPPATH,                // To ensure filters, etc still found,
+        'Acme'          => ROOTPATH.'acme'
     ];
 
 Now that this is setup we can access any file within the **acme** folder through the ``Acme`` namespace. This alone


### PR DESCRIPTION
**Description**
We must use $psr4 variable into __construct() method because public $psr4 will be overwrite after parent::__construct() method. That's why we can't use current documentation.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
