### PR TITLE
Giving namespaced views a way to be found behind the prefix.

### DIFF
--- a/system/View/View.php
+++ b/system/View/View.php
@@ -215,7 +215,9 @@ class View implements RendererInterface
 		if (! is_file($this->renderVars['file']))
 		{
 			$this->renderVars['file'] = $this->loader->locateFile($this->renderVars['view'], 'Views', empty($fileExt) ? 'php' : $fileExt);
-		}
+		} else {
+            $this->renderVars['file'] = $this->loader->locateFile($this->renderVars['view'], null, empty($fileExt) ? 'php' : $fileExt);
+        }
 
 		// locateFile will return an empty string if the file cannot be found.
 		if (empty($this->renderVars['file']))


### PR DESCRIPTION
I came across this minor issue where my view resides in
~~~
app/Libraries/Template/Templates/template.php
~~~
where Libraries is mapped to my Namespace.
The first attempt to locate a namespaced view leads to a path
~~~
app\Libraries/Views/Template/Templates/template.php
~~~
which doesn't work. View->render() calls locateFile with the "Views" folder given and this is attached after the prefix resolved. This second try now allows for namespaced views as
~~~
MyLib\Template\Templates\template
~~~
