### PR TITLE
[ci skip] Routes collector for toolbar should not die when a method name is calculated through _remap

### DIFF
--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -88,7 +88,25 @@ class Routes extends BaseCollector
 		$route = $router->getMatchedRoute();
 
 		// Get our parameters
-		$method    = is_callable($router->controllerName()) ? new \ReflectionFunction($router->controllerName()) : new \ReflectionMethod($router->controllerName(), $router->methodName());
+		// Closure routes
+		if (is_callable($router->controllerName()))
+		{
+			$method = new \ReflectionFunction($router->controllerName());
+		}
+		else
+		{
+			try
+			{
+				$method = new \ReflectionMethod($router->controllerName(), $router->methodName());
+			}
+			catch (\ReflectionException $e)
+			{
+				// If we're here, the method doesn't exist
+				// and is likely calculated in _remap.
+				$method = new \ReflectionMethod($router->controllerName(), '_remap');
+			}
+		}
+
 		$rawParams = $method->getParameters();
 
 		$params = [];


### PR DESCRIPTION
Routes collector for toolbar should not die when a method name is calculated through _remap. 

I'm not in love with the way it outputs to the toolbar currently, but not sure of a better way to handle this. 

Fixes #2277 