### PR TITLE
Fix MySql _fromTables()

### DIFF
--- a/system/Database/MySQLi/Builder.php
+++ b/system/Database/MySQLi/Builder.php
@@ -53,4 +53,24 @@ class Builder extends BaseBuilder
 	 */
 	protected $escapeChar = '`';
 
+	/**
+	 * FROM tables
+	 *
+	 * Groups tables in FROM clauses if needed, so there is no confusion
+	 * about operator precedence.
+	 *
+	 * Note: This is only used (and overridden) by MySQL.
+	 *
+	 * @return string
+	 */
+	protected function _fromTables(): string
+	{
+		if ( ! empty($this->QBJoin) && count($this->QBFrom) > 1)
+		{
+			return '('.implode(', ', $this->QBFrom).')';
+		}
+
+		return implode(', ', $this->QBFrom);
+	}
+
 }


### PR DESCRIPTION
When there are JOINs and more than one table exists, the FROM clause must be enclosed in parentheses, otherwise an error occurs if a JOIN does not refer to the last table.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
