### PR TITLE
Use DBGroup variable from migration class if defined

### DIFF
--- a/system/Database/Migration.php
+++ b/system/Database/Migration.php
@@ -74,7 +74,7 @@ abstract class Migration
 	 */
 	public function __construct(Forge $forge = null)
 	{
-		$this->forge = ! is_null($forge) ? $forge : \Config\Database::forge($this->DBGroup);
+		$this->forge = ! is_null($forge) ? $forge : \Config\Database::forge($this->DBGroup ?? config('Database')->defaultGroup);
 
 		$this->db = $this->forge->getConnection();
 	}
@@ -86,7 +86,7 @@ abstract class Migration
 	 *
 	 * @return string
 	 */
-	public function getDBGroup(): string
+	public function getDBGroup(): ?string
 	{
 		return $this->DBGroup;
 	}

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -1020,7 +1020,7 @@ class MigrationRunner
 		// Determine DBGroup to use
 		$group = $instance->getDBGroup() ?? config('Database')->defaultGroup;
 
-		// Skip if migration if group filteing was set
+		// Skip migration if group filtering was set
 		if ($direction === 'up' && ! is_null($this->groupFilter) && $this->groupFilter !== $group)
 		{
 			$this->groupSkip = true;


### PR DESCRIPTION
**Description**
This PR fixes issue #2087,  as described by @lonnieezell, how this should work:
* A migration that has a group specified will always use that group when doing it's migrations
* If no group is specified it uses the default group
* If a group is specified on the cli, then it acts like a filter and only migrations that use that db group are ran. Only applies to up since rollbacks simply rollback the last set of migrations that were ran, no matter how they were filtered.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
