### PR TITLE
Fix curl debug bug

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -682,7 +682,7 @@ class CURLRequest extends Request
 		if ($config['debug'])
 		{
 			$curl_options[CURLOPT_VERBOSE] = 1;
-			$curl_options[CURLOPT_STDERR]  = is_string($config['debug']) ? fopen($config['debug'], 'a+') : fopen('php://output', 'w+');
+			$curl_options[CURLOPT_STDERR]  = is_string($config['debug']) ? fopen($config['debug'], 'a+') : fopen('php://stderr', 'w');
 		}
 
 		// Decode Content

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -246,8 +246,10 @@ An example::
 debug
 =====
 
-When ``debug`` is passed and set to ``true``, this will enable additional debugging to echo to STDOUT during the
-script execution. This is done by passing CURLOPT_VERBOSE and echoing the output::
+When ``debug`` is passed and set to ``true``, this will enable additional debugging to echo to STDERR during the
+script execution. This is done by passing CURLOPT_VERBOSE and echoing the output. So, when you're running a build-in
+server via ``spark serve`` you will see the output in the console. Otherwise, the output will be written to
+the server's error log.
 
 	$response->request('GET', 'http://example.com', ['debug' => true]);
 

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -247,7 +247,7 @@ debug
 =====
 
 When ``debug`` is passed and set to ``true``, this will enable additional debugging to echo to STDERR during the
-script execution. This is done by passing CURLOPT_VERBOSE and echoing the output. So, when you're running a build-in
+script execution. This is done by passing CURLOPT_VERBOSE and echoing the output. So, when you're running a built-in
 server via ``spark serve`` you will see the output in the console. Otherwise, the output will be written to
 the server's error log.
 


### PR DESCRIPTION
**Description**
This PR replaces the use of `php://output` with `php://stderr`.
Ref: #2202

Tested on machines/environments:
* Win7  - spark with php 7.3.9 and xampp (apache 2.4.41 + php 7.3.9)
* MacOS - spark with php 7.3.9
* Ubuntu - nginx 1.13.3 + php 7.2.11

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
