### PR TITLE
Bugfix extra autoroute slashes

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -578,10 +578,9 @@ class Router implements RouterInterface
 
 		// Loop through our segments and return as soon as a controller
 		// is found or when such a directory doesn't exist
-		while ($c -- > 0)
+		while ($c-- > 0)
 		{
-			$test = $this->directory . ucfirst($this->translateURIDashes === true ? str_replace('-', '_', $segments[0]) : $segments[0]
-			);
+			$test = $this->directory . ucfirst($this->translateURIDashes === true ? str_replace('-', '_', $segments[0]) : $segments[0]);
 
 			if (! is_file(APPPATH . 'Controllers/' . $test . '.php') && $directory_override === false && is_dir(APPPATH . 'Controllers/' . $this->directory . ucfirst($segments[0])))
 			{
@@ -606,6 +605,11 @@ class Router implements RouterInterface
 	 */
 	protected function setDirectory(string $dir = null, bool $append = false)
 	{
+		if (empty($dir))
+		{
+			return;
+		}
+
 		$dir = ucfirst($dir);
 
 		if ($append !== true || empty($this->directory))


### PR DESCRIPTION
**Description**
When controller and method are both empty and there is no explicit default route (i.e. `$routes->get('/', ...`) then **Router** will call `validateRequest()` with two blank entries in `$segments`, which in turn calls `setDirectory('')` twice resulting in a directory of `//`. This causes `autoroute()` to fail to locate existing controllers.

This PR has `setDirectory()` ignore empty requests, since `$this->directory` of `null` is already equivalent to `/`.

Fix for https://github.com/codeigniter4/CodeIgniter4/issues/2301

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
