### PR TITLE
Convert all language returns to single quote

### DIFF
--- a/system/Language/en/Encryption.php
+++ b/system/Language/en/Encryption.php
@@ -16,7 +16,7 @@
 return [
    'noDriverRequested'    => 'No driver requested; Miss Daisy will be so upset!',
    'noHandlerAvailable'   => 'Unable to find an available {0} encryption handler.',
-   'unKnownHandler'       => "'{0}' cannot be configured.",
+   'unKnownHandler'       => '"{0}" cannot be configured.',
    'starterKeyNeeded'     => 'Encrypter needs a starter key.',
    'authenticationFailed' => 'Decrypting: authentication failed.',
    'encryptionFailed'     => 'Encryption failed.',

--- a/system/Language/en/RESTful.php
+++ b/system/Language/en/RESTful.php
@@ -14,5 +14,5 @@
  */
 
 return [
-   'notImplemented' => "'{0}' action not implemented.",
+   'notImplemented' => '"{0}" action not implemented.',
 ];

--- a/system/Language/en/Session.php
+++ b/system/Language/en/Session.php
@@ -16,8 +16,8 @@
 
 return [
    'missingDatabaseTable'   => '`sessionSavePath` must have the table name for the Database Session Handler to work.',
-   'invalidSavePath'        => "Session: Configured save path '{0}' is not a directory, doesn't exist or cannot be created.",
-   'writeProtectedSavePath' => "Session: Configured save path '{0}' is not writable by the PHP process.",
+   'invalidSavePath'        => 'Session: Configured save path "{0}" is not a directory, does not exist or cannot be created.',
+   'writeProtectedSavePath' => 'Session: Configured save path "{0}" is not writable by the PHP process.',
    'emptySavePath'          => 'Session: No save path configured.',
    'invalidSavePathFormat'  => 'Session: Invalid Redis save path format: {0}',
 ];


### PR DESCRIPTION
**Description**
`lang()` requires single quotes in order to parse bracketed indexes. Mostly this is all correct but there are a few files still using double quotes. This PR converts these.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
