### PR TITLE
BaseBuilder variable type fix

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2691,7 +2691,7 @@ class BaseBuilder
 	{
 		$table = $this->QBFrom[0];
 
-		$sql = $this->delete($table, '', $reset, true);
+		$sql = $this->delete($table, null, $reset, true);
 
 		return $this->compileFinalQuery($sql);
 	}


### PR DESCRIPTION
**Description**
Changed `$this->delete` call second parameter from empty string to `null`.
In `delete` method declaration second param is type of integer or null.
IMHO it is better not to rely on type juggling where it is not necessary.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

