### PR TITLE
Renderer Toolbar Debug Toggle

### DIFF
--- a/system/View/View.php
+++ b/system/View/View.php
@@ -248,7 +248,7 @@ class View implements RendererInterface
 
 		$this->logPerformance($this->renderVars['start'], microtime(true), $this->renderVars['view']);
 
-		if (CI_DEBUG && (! isset($options['debug']) || $options['debug'] === true))
+		if ($this->debug && (! isset($options['debug']) || $options['debug'] === true))
 		{
 			$toolbarCollectors = config(\Config\Toolbar::class)->collectors;
 


### PR DESCRIPTION
**Description**
**View/View** uses `CIDEBUG` directly to determine whether to inject toolbar collector data, despite already having `$this->debug` which defaults to `CIDEBUG`. Using the constant directly makes it near impossible to exclude collector injections during testing.

This PR has `render()` check `$this->debug` instead, which should have the same behavior in all current cases but will allow direct overriding of the injection for test cases.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
