### PR TITLE
Change after methods to use actual data

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -687,11 +687,6 @@ class Model
 			}
 		}
 
-		// Save the original data so it can be passed to
-		// any Model Event callbacks and not stripped
-		// by doProtectFields
-		$originalData = $data;
-
 		// Must be called first so we don't
 		// strip out created_at values.
 		$data = $this->doProtectFields($data);
@@ -722,7 +717,8 @@ class Model
 			$this->insertID = $this->db->insertID();
 		}
 
-		$this->trigger('afterInsert', ['data' => $originalData, 'result' => $result]);
+		// Trigger afterInsert events with the inserted data and new ID
+		$this->trigger('afterInsert', ['id' => $this->insertID, 'data' => $data, 'result' => $result]);
 
 		// If insertion failed, get out of here
 		if (! $result)
@@ -821,11 +817,6 @@ class Model
 			}
 		}
 
-		// Save the original data so it can be passed to
-		// any Model Event callbacks and not stripped
-		// by doProtectFields
-		$originalData = $data;
-
 		// Must be called first so we don't
 		// strip out updated_at values.
 		$data = $this->doProtectFields($data);
@@ -849,7 +840,7 @@ class Model
 				->set($data['data'], '', $escape)
 				->update();
 
-		$this->trigger('afterUpdate', ['id' => $id, 'data' => $originalData, 'result' => $result]);
+		$this->trigger('afterUpdate', ['id' => $id, 'data' => $data, 'result' => $result]);
 
 		return $result;
 	}

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -715,13 +715,14 @@ Event            $data contents
 ================ =========================================================================================================
 beforeInsert      **data** = the key/value pairs that are being inserted. If an object or Entity class is passed to the
                   insert method, it is first converted to an array.
-afterInsert       **data** = the original key/value pairs being inserted.
+afterInsert       **id** = the primary key of the new row, or 0 on failure.
+                  **data** = the key/value pairs being inserted.
                   **result** = the results of the insert() method used through the Query Builder.
 beforeUpdate      **id** = the primary key of the row being updated.
                   **data** = the key/value pairs that are being inserted. If an object or Entity class is passed to the
                   insert method, it is first converted to an array.
 afterUpdate       **id** = the primary key of the row being updated.
-                  **data** = the original key/value pairs being updated.
+                  **data** = the key/value pairs being updated.
                   **result** = the results of the update() method used through the Query Builder.
 afterFind         Varies by find* method. See the following:
 - find()          **id** = the primary key of the row being searched for.


### PR DESCRIPTION
**Description**
Currently model events `afterInsert` and `afterUpdate` pass on the original data they were called with. This severely limits what event triggers can do, not knowing the data that actually reached the database. This PR triggers events with the inserted/updated data instead. Additionally, `afterInsert` now passes the ID of the newly-inserted row (similar to other events), or 0 on failure.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
