### PR TITLE
Correct cleaning of namespaces in FileLocater for better Windows compatibility. See #2203

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -292,7 +292,7 @@ class FileLocator
 			{
 				$namespaces[] = [
 					'prefix' => $prefix,
-					'path'   => rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR,
+					'path'   => rtrim($path, '\\/') . DIRECTORY_SEPARATOR,
 				];
 			}
 		}


### PR DESCRIPTION
When grabbing the list of namespaces it would remove DIRECTORY_SEPARATOR and then add it back, just to make sure the end was clean. Unfortunately, that wasn't working on Windows.

  
