### PR TITLE
Fix Session::get('key') returns null when value is (int) 0

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -305,7 +305,7 @@ class Session implements SessionInterface
 		);
 
 		//if (empty($this->sessionExpiration))
-		if (!isset($this->sessionExpiration))
+		if (! isset($this->sessionExpiration))
 		{
 			$this->sessionExpiration = (int) ini_get('session.gc_maxlifetime');
 		}
@@ -496,7 +496,7 @@ class Session implements SessionInterface
 	 */
 	public function get(string $key = null)
 	{
-		if (! empty($key) && $value = dot_array_search($key, $_SESSION))
+		if (! empty($key) && ! is_null($value = dot_array_search($key, $_SESSION)))
 		{
 			return $value;
 		}
@@ -634,7 +634,7 @@ class Session implements SessionInterface
 	 *
 	 * @param string $key Identifier of the session property to remove.
 	 *
-	 * @return bool
+	 * @return boolean
 	 */
 	public function __isset(string $key): bool
 	{

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -129,6 +129,18 @@ class SessionTest extends \CIUnitTestCase
 		$this->assertNull($session->get('foo'));
 	}
 
+	public function testGetReturnsItemValueisZero()
+	{
+		$_SESSION = [];
+
+		$session = $this->getInstance();
+		$session->start();
+
+		$session->set('foo', (int) 0);
+
+		$this->assertSame((int) 0, $session->get('foo'));
+	}
+
 	public function testGetReturnsAllWithNoKeys()
 	{
 		$_SESSION = [


### PR DESCRIPTION
Issue #2334

**Description**
The code in question is from Session.php starting at line #499 

````
if (! empty($key) && $value = dot_array_search($key, $_SESSION))
{
    return $value;
}
````
When `dot_array_search()` returns a value of 0 (zero) then `$value` is evaluated as `false` so `$value` is not returned eventhough it should be.

Proposed fix: change the conditional to

    if (! empty($key) && ! is_null($value = dot_array_search($key, $_SESSION)))

A unit test added to confirm this works.
  
