### PR TITLE
Simplify Validation::getErrors()

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -646,9 +646,9 @@ class Validation implements ValidationInterface
 		// passed along from a redirect_with_input request.
 		if (empty($this->errors) && ! is_cli())
 		{
-			if (isset($_SESSION) && $errors = session('_ci_validation_errors'))
+			if (isset($_SESSION, $_SESSION['_ci_validation_errors']))
 			{
-				$this->errors = unserialize($errors);
+				$this->errors = unserialize($_SESSION['_ci_validation_errors']);
 			}
 		}
 


### PR DESCRIPTION
No need to use session helper if both `$_SESSION`  and `$_SESSION['_ci_validation_errors']` are proven set.  Using `isset($var1,  $var2) ` is easier on eyes than a compound conditional - part of which is an assignment.

Change:
````
if (isset($_SESSION) && $errors  =  session('_ci_validation_errors'))

````
To:
````
if (isset($_SESSION, $_SESSION['_ci_validation_errors']))
````
 
