### PR TITLE
User guide minor fixes. Fix class names and code area.

### DIFF
--- a/user_guide_src/source/cli/cli_commands.rst
+++ b/user_guide_src/source/cli/cli_commands.rst
@@ -144,7 +144,7 @@ The ``BaseCommand`` class that all commands must extend have a couple of helpful
 be familiar with when creating your own commands. It also has a :doc:`Logger </general/logging>` available at
 **$this->logger**.
 
-.. php:class:: CodeIgniter\CLI\BaseCommand
+.. php:class:: CodeIgniter\\CLI\\BaseCommand
 
     .. php:method:: call(string $command[, array $params=[] ])
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1218,7 +1218,7 @@ run the query::
 Class Reference
 ***************
 
-.. php:class:: \CodeIgniter\Database\BaseBuilder
+.. php:class:: CodeIgniter\\Database\\BaseBuilder
 
 	.. php:method:: resetQuery()
 

--- a/user_guide_src/source/database/results.rst
+++ b/user_guide_src/source/database/results.rst
@@ -329,7 +329,7 @@ TRUE on success or FALSE on failure.
 Class Reference
 ***************
 
-.. php:class:: \CodeIgniter\Database\BaseResult
+.. php:class:: CodeIgniter\\Database\\BaseResult
 
 	.. php:method:: getResult([$type = 'object'])
 

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -348,7 +348,7 @@ change the name, you can add a "name" key into the field defining array.
 Class Reference
 ***************
 
-.. php:class:: \CodeIgniter\Database\Forge
+.. php:class:: CodeIgniter\\Database\\Forge
 
 	.. php:method:: addColumn($table[, $field = []])
 

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -270,7 +270,7 @@ Preference                 Default                Options                    Des
 Class Reference
 ***************
 
-.. php:class:: CodeIgniter\Database\MigrationRunner
+.. php:class:: CodeIgniter\\Database\\MigrationRunner
 
 	.. php:method:: findMigrations()
 

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -374,5 +374,6 @@ attribute to check::
     $user->name = 'Fred';
     $user->hasChanged('name');      // true
 
-Or to check the whole entity for changed values omit the parameter:
+Or to check the whole entity for changed values omit the parameter::
+
     $user->hasChanged();            // true


### PR DESCRIPTION
**Description**

Updated class names like [this](https://codeigniter4.github.io/userguide/cli/cli_commands.html#basecommand) (missing the backslashes).

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

  
