### PR TITLE
Fix FilerHandlerTest.php wierdness

### DIFF
--- a/tests/system/Log/FileHandlerTest.php
+++ b/tests/system/Log/FileHandlerTest.php
@@ -10,6 +10,7 @@ class FileHandlerTest extends \CIUnitTestCase
 
 	protected function setUp(): void
 	{
+		parent::setUp();
 		$this->root  = vfsStream::setup('root');
 		$this->start = $this->root->url() . '/';
 	}


### PR DESCRIPTION
All test methods would fail when this class was run by itself.
setUp() method needed call the parent::setUp()


