### PR TITLE
Fix method name to 'toDateString()' in Date and Times user guide

### DIFF
--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -177,7 +177,7 @@ toDateString()
 Displays just the date portion of the Time::
 
     $time = Time::parse('March 9, 2016 12:00:00', 'America/Chicago');
-    echo $time->toDateTimeString();     // 2016-03-09
+    echo $time->toDateString();     // 2016-03-09
 
 toTimeString()
 --------------


### PR DESCRIPTION
Fix issue #2351 

**Description**
Update user guide

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide