### PR TITLE
replaced language setting in APPPATH."Language"

### DIFF
--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -323,6 +323,12 @@ class Language
 			$strings = $strings[0];
 		}
 
+		# Replace with files in  APPPATH.'Language' directory
+		if( $file = Services::locator()->locateFile($path) )
+		{
+			$strings = array_replace($strings, require $file);
+		}
+
 		return $strings;
 	}
 


### PR DESCRIPTION
Fix issue #2354 

**Description**
Updated `CodeIgniter\Language\Language::requireFile()` to prefer APPPATH."Language" Directory


**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
