### PR TITLE
Email config doesn't incorporate .env items

### DIFF
--- a/app/Config/Email.php
+++ b/app/Config/Email.php
@@ -1,7 +1,9 @@
 <?php
 namespace Config;
 
-class Email
+use CodeIgniter\Config\BaseConfig;
+
+class Email extends BaseConfig
 {
 
 	/**


### PR DESCRIPTION
A line in .env such as 

    email.SMTPPort = 587

Would not be incorporated into the Email configuration
Caused by Config\Email not extending  CodeIgniter\Config\BaseConfig
  
