### PR TITLE
Remove log_message from Email::__construct

### DIFF
--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -373,7 +373,6 @@ class Email
 	{
 		$this->initialize($config);
 		isset(static::$func_overload) || static::$func_overload = (extension_loaded('mbstring') && ini_get('mbstring.func_overload'));
-		log_message('info', 'Email Class Initialized');
 	}
 	//--------------------------------------------------------------------
 	/**


### PR DESCRIPTION
The practice of logging a "Some Class Initialized" message is a remnant of earlier versions of CI. 

It's not being done in V4.

