### PR TITLE
Remove LoggerAwareTrait from Email class

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -208,7 +208,6 @@ class Services extends BaseService
 			$config = new \Config\Email();
 		}
 		$email = new \CodeIgniter\Email\Email($config);
-		$email->setLogger(static::logger(true));
 		return $email;
 	}
 

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -40,7 +40,6 @@
 namespace CodeIgniter\Email;
 
 use Config\Mimes;
-use Psr\Log\LoggerAwareTrait;
 
 /**
  * CodeIgniter Email Class
@@ -55,7 +54,6 @@ use Psr\Log\LoggerAwareTrait;
  */
 class Email
 {
-	use LoggerAwareTrait;
 	/**
 	 * @var string
 	 */
@@ -355,12 +353,6 @@ class Email
 	 * @var boolean
 	 */
 	protected static $func_overload;
-	/**
-	 * Logger instance to record error messages and awarnings.
-	 *
-	 * @var \PSR\Log\LoggerInterface
-	 */
-	protected $logger;
 	//--------------------------------------------------------------------
 	/**
 	 * Constructor - Sets Email Preferences
@@ -1651,7 +1643,7 @@ class Email
 		catch (\ErrorException $e)
 		{
 			$success = false;
-			$this->logger->error('Email: ' . $method . ' throwed ' . $e->getMessage());
+			log_message('error', 'Email: ' . $method . ' throwed ' . $e->getMessage());
 		}
 		if (! $success)
 		{


### PR DESCRIPTION
I would like this considered because the `Email` class creates a `Logger` instance when it's instantiated. I'm trying to devise an `EmailHandler` for the `Logger` class which would require an instance of the `Email` class. I sure you can see the endless loop that is formed.

It doesn't seem like removing the `LoggerAwareTrait` would affect `Email` much. It only makes one call to the resulting `logger` object.  Switching that call to using the common function `log_message` seems a good substitute for `$this->logger->log...`

If this PR is merged I've got a working `EmailHandler` ready to go.

