### PR TITLE
Replace null log file extension check

### DIFF
--- a/system/Log/Handlers/FileHandler.php
+++ b/system/Log/Handlers/FileHandler.php
@@ -79,7 +79,7 @@ class FileHandler extends BaseHandler implements HandlerInterface
 
 		$this->path = $config['path'] ?? WRITEPATH . 'logs/';
 
-		$this->fileExtension = $config['fileExtension'] ?? 'log';
+		$this->fileExtension = empty($config['fileExtension']) ? 'log' : $config['fileExtension'];
 		$this->fileExtension = ltrim($this->fileExtension, '.');
 
 		$this->filePermissions = $config['filePermissions'] ?? 0644;


### PR DESCRIPTION
**Description**
The recent Logger change to default to `.log` added a null check for `config->fileExtension`, but since this is defined in **app/Config/Logger.php** it won't normally be null, just empty.

This PR checks for an empty value (could also use `?:` but this covers cases where it isn't set at all).

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
