### PR TITLE
Fix: Use of CodeIgniter\Config\Services prevents Service overriding

### DIFF
--- a/system/CLI/CommandRunner.php
+++ b/system/CLI/CommandRunner.php
@@ -40,7 +40,7 @@
 
 namespace CodeIgniter\CLI;
 
-use CodeIgniter\Config\Services;
+use Config\Services;
 use CodeIgniter\Controller;
 
 /**

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -39,7 +39,7 @@
 
 namespace CodeIgniter;
 
-use CodeIgniter\Config\Services;
+use Config\Services;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Validation\Validation;

--- a/system/Debug/Toolbar/Collectors/Events.php
+++ b/system/Debug/Toolbar/Collectors/Events.php
@@ -39,7 +39,7 @@
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
-use CodeIgniter\Config\Services;
+use Config\Services;
 use CodeIgniter\View\RendererInterface;
 
 /**

--- a/system/Debug/Toolbar/Collectors/Logs.php
+++ b/system/Debug/Toolbar/Collectors/Logs.php
@@ -39,7 +39,7 @@
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
-use CodeIgniter\Config\Services;
+use Config\Services;
 
 /**
  * Loags collector

--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -38,7 +38,7 @@
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
-use CodeIgniter\Config\Services;
+use Config\Services;
 
 /**
  * Routes collector

--- a/system/Debug/Toolbar/Collectors/Timers.php
+++ b/system/Debug/Toolbar/Collectors/Timers.php
@@ -39,7 +39,7 @@
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
-use CodeIgniter\Config\Services;
+use Config\Services;
 
 /**
  * Timers collector

--- a/system/Debug/Toolbar/Collectors/Views.php
+++ b/system/Debug/Toolbar/Collectors/Views.php
@@ -39,7 +39,7 @@
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
-use CodeIgniter\Config\Services;
+use Config\Services;
 use CodeIgniter\View\RendererInterface;
 
 /**

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -41,7 +41,7 @@ namespace CodeIgniter\Encryption;
 use Config\Encryption as EncryptionConfig;
 use CodeIgniter\Encryption\Exceptions\EncryptionException;
 use CodeIgniter\Config\BaseConfig;
-use CodeIgniter\Config\Services;
+use Config\Services;
 
 /**
  * CodeIgniter Encryption Manager

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -43,7 +43,7 @@ namespace CodeIgniter\HTTP;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\Files\FileCollection;
 use CodeIgniter\HTTP\Files\UploadedFile;
-use CodeIgniter\Config\Services;
+use Config\Services;
 
 /**
  * Class IncomingRequest

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -38,7 +38,7 @@
 
 namespace CodeIgniter\Language;
 
-use CodeIgniter\Config\Services;
+use Config\Services;
 
 /**
  * Handle system messages and localization.

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -41,7 +41,7 @@ namespace CodeIgniter\Log\Handlers;
 
 use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\ResponseInterface;
-use CodeIgniter\Config\Services;
+use Config\Services;
 
 /**
  * Class ChromeLoggerHandler


### PR DESCRIPTION
Fixes #2376

The following statement is used by multiple "core" classes

     use CodeIgniter\Config\Services;

This results in `App\Config\Services` being bypassed which prevents `Service` overrides from being recognized.

All namespace use statements for `Services` in the core classes changed to ` use Config\Services;` so the overrides can be accomplished.

Note: There are a lot of test files that explicitly use `CodeIgniter\Config\Services` that were not changed in the PR. They probably don't need to be and/or should not be changed, but I wanted to point that out.


  
