### PR TITLE
quick fix postgresql insert id

### DIFF
--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -473,7 +473,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	{
 		$v = pg_version($this->connID);
 		// 'server' key is only available since PostgreSQL 7.4
-		$v = $v['server'] ?? 0;
+		$v = explode(' ', $v['server'])[0] ?? 0;
 
 		$table  = func_num_args() > 0 ? func_get_arg(0) : null;
 		$column = func_num_args() > 1 ? func_get_arg(1) : null;


### PR DESCRIPTION
`$insertId = $model->insert()`
always give
`$insertId = 0`
on my system when
`pg_version($connID)['server'] = '10.10 (Ubuntu 10.10-0ubuntu0.18.04.1)'`

to get the correct server version, I explode the $v['server'] by space then get the first index of array.