### PR TITLE
Confer silent status to nested seeders

### DIFF
--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -168,6 +168,7 @@ class Seeder
 			$seeder = new $class($this->config);
 		}
 
+		$seeder->setSilent($this->silent);
 		$seeder->run();
 
 		unset($seeder);


### PR DESCRIPTION
**Description**
Seeds can call other seeds (https://codeigniter4.github.io/userguide/dbmgmt/seeds.html#nesting-seeders) but since seeds are extensions of the seeder themselves the new seeds will start with their own `silent` value. This means any tests using nesting seeders will start displaying seed results for every test call, very undesirable. 

This PR has the parent seeder pass its `silent` value to the child before running it.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
