### PR TITLE
Remove redundant check in conditionals

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -313,7 +313,7 @@ class Entity
 			$result = $this->mutateDate($result);
 		}
 		// Or cast it as something?
-		else if ($this->_cast && isset($this->casts[$key]) && ! empty($this->casts[$key]))
+		else if ($this->_cast && ! empty($this->casts[$key]))
 		{
 			$result = $this->castAs($result, $this->casts[$key]);
 		}
@@ -471,7 +471,7 @@ class Entity
 			return $key;
 		}
 
-		if (isset($this->datamap[$key]) && ! empty($this->datamap[$key]))
+		if (! empty($this->datamap[$key]))
 		{
 			return $this->datamap[$key];
 		}


### PR DESCRIPTION
Because `empty()` is essentially the concise equivalent to `!isset($var) || $var == false` using both `isset() && !empty()` in a conditional serves no purpose.

The `isset()` check has been removed.

(OK, I know this is trivial. It's just my OCD kicking in.)