### PR TITLE
Remove pointless check from conditional

### DIFF
--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -310,7 +310,7 @@ class FileCollection
 	 */
 	protected function getValueDotNotationSyntax(array $index, array $value)
 	{
-		if (is_array($index) && ! empty($index))
+		if (! empty($index))
 		{
 			$current_index = array_shift($index);
 		}


### PR DESCRIPTION
Because the argument `$index` has a type declaration of 'array' there is no point in using `is_array($index)` in the conditional. If `$index` is not an array an exception will have been thrown before we get to the `if()` statement.
