### PR TITLE
Removed pointless isset() check

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1382,7 +1382,7 @@ class RouteCollection implements RouteCollectionInterface
 		}
 
 		// Limiting to subdomains?
-		else if (isset($options['subdomain']) && ! empty($options['subdomain']))
+		else if (! empty($options['subdomain']))
 		{
 			// If we don't match the current subdomain, then
 			// we don't need to add the route.


### PR DESCRIPTION
Using `isset($someVar) && ! empty($someVar)` in a conditional is redundant.
Removed `isset()` from the `if` statement.
