### PR TITLE
Swap order of operations in conditional

### DIFF
--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -811,7 +811,7 @@ class ContentSecurityPolicy
 
 		foreach ($values as $value => $reportOnly)
 		{
-			if (is_numeric($value) && is_string($reportOnly) && ! empty($reportOnly))
+			if (is_numeric($value) && ! empty($reportOnly) && is_string($reportOnly))
 			{
 				$value      = $reportOnly;
 				$reportOnly = 0;


### PR DESCRIPTION
Want to be sure `$reportOnly` is there before checking if it is a string.
