### PR TITLE
Fix issue #2391 CodeIgniter::display404errors()

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -883,7 +883,8 @@ class CodeIgniter
 				$this->runController($controller);
 			}
 
-			$this->gatherOutput();
+			$cacheConfig = new Cache();
+			$this->gatherOutput($cacheConfig);
 			$this->sendResponse();
 
 			return;


### PR DESCRIPTION
Fixes #2391 

``CodeIgniter::display404errors`` calls ``CodeIgniter::gatherOutput()`` where a TypeError exception occurs when ``$this->cachePage($cacheConfig);`` is called and ``$cacheConfig`` === null.

Fixed by instantiating a Cache config object in ``display404errors()`` and passing it to ``gatherOutput()``