### PR TITLE
Fix url helper functions to work when site hosted in subfolders. 

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -21,7 +21,7 @@ class App extends BaseConfig
 	| environments.
 	|
 	*/
-	public $baseURL = 'http://localhost:8080';
+	public $baseURL = 'http://localhost:8080/';
 
 	/*
 	|--------------------------------------------------------------------------

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -174,6 +174,11 @@ class IncomingRequest extends Request
 
 		$this->populateHeaders();
 
+		// Get our current URI.
+		// NOTE: This WILL NOT match the actual URL in the browser since for
+		// everything this cares about (and the router, etc) is the portion
+		// AFTER the script name. So, if hosted in a sub-folder this will
+		// appear different than actual URL. If you need that, use current_url().
 		$this->uri = $uri;
 
 		$this->detectURI($config->uriProtocol, $config->baseURL);
@@ -604,14 +609,10 @@ class IncomingRequest extends Request
 		// baseURL, so let's help them out.
 		$baseURL = ! empty($baseURL) ? rtrim($baseURL, '/ ') . '/' : $baseURL;
 
-		// Based on our baseURL provided by the developer (if set)
+		// Based on our baseURL provided by the developer
 		// set our current domain name, scheme
 		if (! empty($baseURL))
 		{
-			// We cannot add the path here, otherwise it's possible
-			// that the routing will not work correctly if we are
-			// within a sub-folder scheme. So it's modified in
-			// the
 			$this->uri->setScheme(parse_url($baseURL, PHP_URL_SCHEME));
 			$this->uri->setHost(parse_url($baseURL, PHP_URL_HOST));
 			$this->uri->setPort(parse_url($baseURL, PHP_URL_PORT));
@@ -715,7 +716,8 @@ class IncomingRequest extends Request
 		}
 
 		// parse_url() returns false if no host is present, but the path or query string
-		// contains a colon followed by a number
+		// contains a colon followed by a number. So we attach a dummy host since
+		// REQUEST_URI does not include the host. This allows us to parse out the query string and path.
 		$parts = parse_url('http://dummy' . $_SERVER['REQUEST_URI']);
 		$query = $parts['query'] ?? '';
 		$uri   = $parts['path'] ?? '';

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -111,7 +111,14 @@ if (! function_exists('base_url'))
 		// otherwise get rid of the path, because we have
 		// no way of knowing the intent...
 		$config = \CodeIgniter\Config\Services::request()->config;
-		$url    = new \CodeIgniter\HTTP\URI($config->baseURL);
+
+		// If baseUrl does not have a trailing slash it won't resolve
+		// correctly for users hosting in a subfolder.
+		$baseUrl = ! empty($config->baseURL) && $config->baseURL !== '/'
+			? rtrim($config->baseURL, '/ ') . '/'
+			: $config->baseURL;
+
+		$url = new \CodeIgniter\HTTP\URI($baseUrl);
 		unset($config);
 
 		// Merge in the path set by the user, if any

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -139,7 +139,7 @@ if (! function_exists('base_url'))
 			$url->setScheme($protocol);
 		}
 
-		return (string) $url;
+		return rtrim((string) $url, '/ ');
 	}
 }
 
@@ -159,7 +159,25 @@ if (! function_exists('current_url'))
 	 */
 	function current_url(bool $returnObject = false)
 	{
-		return $returnObject ? \CodeIgniter\Config\Services::request()->uri : (string) \CodeIgniter\Config\Services::request()->uri;
+		$uri = service('request')->uri;
+
+		// If hosted in a sub-folder, we will have additional
+		// segments that show up prior to the URI path we just
+		// grabbed from the request, so add it on if necessary.
+		$baseUri = new \CodeIgniter\HTTP\URI(config('App')->baseURL);
+
+		if (! empty($baseUri->getPath()))
+		{
+			$path = rtrim($baseUri->getPath(), '/ ') . '/' . $uri->getPath();
+
+			$uri->setPath($path);
+		}
+
+		// Since we're basing off of the IncomingRequest URI,
+		// we are guaranteed to have a host based on our own configs.
+		return $returnObject
+			? $uri
+			: (string)$uri->setQuery('');
 	}
 }
 

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -316,6 +316,23 @@ class URLHelperTest extends \CIUnitTestCase
 		$this->assertEquals('http://example.com/profile', base_url('profile'));
 	}
 
+	public function testBaseURLHasSubfolder()
+	{
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/test';
+
+		// Since we're on a CLI, we must provide our own URI
+		$config          = new App();
+		$config->baseURL = 'http://example.com/subfolder';
+		$request         = Services::request($config, false);
+		$request->uri    = new URI('http://example.com/subfolder/test');
+
+		Services::injectMock('request', $request);
+
+		$this->assertEquals('http://example.com/subfolder/foo', base_url('foo'));
+		$this->assertEquals('http://example.com/subfolder/', base_url());
+	}
+
 	//--------------------------------------------------------------------
 	// Test current_url
 

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -167,6 +167,22 @@ class URLHelperTest extends \CIUnitTestCase
 		$this->assertEquals('http://example.com/index.php/news/local/123', site_url(['news', 'local', '123'], null, $config));
 	}
 
+	public function testSiteURLInSubfolder()
+	{
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/foo/public/bar?baz=quip';
+
+		// Since we're on a CLI, we must provide our own URI
+		$config          = new App();
+		$config->baseURL = 'http://example.com/foo/public';
+		$request         = Services::request($config);
+		$request->uri    = new URI('http://example.com/foo/public/bar');
+
+		Services::injectMock('request', $request);
+
+		$this->assertEquals('http://example.com/foo/public/bar', current_url());
+	}
+
 	/**
 	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/240
 	 */
@@ -281,7 +297,7 @@ class URLHelperTest extends \CIUnitTestCase
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('http://example.com/', base_url());
+		$this->assertEquals('http://example.com', base_url());
 	}
 
 	/**
@@ -330,7 +346,7 @@ class URLHelperTest extends \CIUnitTestCase
 		Services::injectMock('request', $request);
 
 		$this->assertEquals('http://example.com/subfolder/foo', base_url('foo'));
-		$this->assertEquals('http://example.com/subfolder/', base_url());
+		$this->assertEquals('http://example.com/subfolder', base_url());
 	}
 
 	//--------------------------------------------------------------------
@@ -385,6 +401,22 @@ class URLHelperTest extends \CIUnitTestCase
 		Services::injectMock('request', $request);
 
 		$this->assertEquals(base_url(uri_string()), current_url());
+	}
+
+	public function testCurrentURLInSubfolder()
+	{
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/foo/public/bar?baz=quip';
+
+		// Since we're on a CLI, we must provide our own URI
+		$config          = new App();
+		$config->baseURL = 'http://example.com/foo/public';
+		$request         = Services::request($config);
+		$request->uri    = new URI('http://example.com/foo/public/bar');
+
+		Services::injectMock('request', $request);
+
+		$this->assertEquals('http://example.com/foo/public/bar', current_url());
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
- base_url fixed to ensure a trailing slash when it needs it to property resolve relative URIs
- current_url fixed to merge any folders in the request URI's path. 

Fixes #2365 
Fixes #2347 