### PR TITLE
Ensure previous_url() gets accurate URI.

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -373,7 +373,7 @@ class CodeIgniter
 
 		// Save our current URI as the previous URI in the session
 		// for safer, more accurate use with `previous_url()` helper function.
-		$this->storePreviousURL($this->request->uri ?? $uri);
+		$this->storePreviousURL((string)current_url(true));
 
 		unset($uri);
 


### PR DESCRIPTION
When storing previous url we should use current_url() to ensure we ge…t baseURL paths and any query vars. 

Fixes #2378
