### PR TITLE
#2318 - fix parse params of plugin

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -762,28 +762,15 @@ class Parser extends View
 			{
 				$params = [];
 
-				// Split on "words", but keep quoted groups together, accounting for escaped quotes.
-				// Note: requires double quotes, not single quotes.
-				$parts = str_getcsv($match[1], ' ');
-
-				foreach ($parts as $part)
-				{
-					if (empty($part))
-					{
-						continue;
-					}
-
-					if (strpos($part, '=') !== false)
-					{
-						list($a, $b) = explode('=', $part);
-						$params[$a]  = $b;
-					}
-					else
-					{
-						$params[] = $part;
+				preg_match_all('/([\w-]+=\"[^"]+\")|([\w-]+=[^\"\s=]+)/', trim($match[1]), $matchesParams);
+				foreach ($matchesParams[0] as $item) {
+					$keyVal = explode('=', $item);
+					if (count($keyVal) == 2) {
+						$params[$keyVal[0]] = str_replace('"', '', $keyVal[1]);
+					} else {
+						$params[] = $item;
 					}
 				}
-				unset($parts);
 
 				$template = $isPair ? str_replace($match[0], $callable($match[2], $params), $template) : str_replace($match[0], $callable($params), $template);
 			}

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -763,11 +763,15 @@ class Parser extends View
 				$params = [];
 
 				preg_match_all('/([\w-]+=\"[^"]+\")|([\w-]+=[^\"\s=]+)|(\"[^"]+\")|(\S+)/', trim($match[1]), $matchesParams);
-				foreach ($matchesParams[0] as $item) {
+				foreach ($matchesParams[0] as $item)
+				{
 					$keyVal = explode('=', $item);
-					if (count($keyVal) == 2) {
+					if (count($keyVal) == 2)
+					{
 						$params[$keyVal[0]] = str_replace('"', '', $keyVal[1]);
-					} else {
+					}
+					else
+					{
 						$params[] = str_replace('"', '', $item);
 					}
 				}

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -762,7 +762,7 @@ class Parser extends View
 			{
 				$params = [];
 
-				preg_match_all('/([\w-]+=\"[^"]+\")|([\w-]+=[^\"\s=]+)/', trim($match[1]), $matchesParams);
+				preg_match_all('/([\w-]+=\"[^"]+\")|([\w-]+=[^\"\s=]+)|(\S+)/', trim($match[1]), $matchesParams);
 				foreach ($matchesParams[0] as $item) {
 					$keyVal = explode('=', $item);
 					if (count($keyVal) == 2) {

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -768,7 +768,7 @@ class Parser extends View
 					if (count($keyVal) == 2) {
 						$params[$keyVal[0]] = str_replace('"', '', $keyVal[1]);
 					} else {
-						$params[] = $item;
+						$params[] = str_replace('"', '', $item);
 					}
 				}
 

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -762,7 +762,7 @@ class Parser extends View
 			{
 				$params = [];
 
-				preg_match_all('/([\w-]+=\"[^"]+\")|([\w-]+=[^\"\s=]+)|(\S+)/', trim($match[1]), $matchesParams);
+				preg_match_all('/([\w-]+=\"[^"]+\")|([\w-]+=[^\"\s=]+)|(\"[^"]+\")|(\S+)/', trim($match[1]), $matchesParams);
 				foreach ($matchesParams[0] as $item) {
 					$keyVal = explode('=', $item);
 					if (count($keyVal) == 2) {

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -860,6 +860,28 @@ class ParserTest extends \CIUnitTestCase
 		$this->assertEquals('0. foo bar 1. baz 2. foo bar ', $parser->renderString($template));
 	}
 
+	/**
+	 * @group parserplugins
+	 */
+	public function testParserSingleTagWithNamedParams()
+	{
+		$parser = new Parser($this->config, $this->viewsDir, $this->loader);
+		$parser->addPlugin('read_params', function (array $params = []) {
+			$out = '';
+
+			foreach ($params as $index => $param)
+			{
+				$out .= "{$index}: {$param}. ";
+			}
+
+			return $out;
+		}, false);
+
+		$template = '{+ read_params title="Hello world" page=5 email=test@test.net +}';
+
+		$this->assertEquals('title: Hello world. page: 5. email: test@test.net. ', $parser->renderString($template));
+	}
+
 	//--------------------------------------------------------------------
 
 	/**


### PR DESCRIPTION
**Description**
Fix bug #2318 
Replace **str_getcsv()** function by regexp.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide