### PR TITLE
fix. toolbar file 301

### DIFF
--- a/system/Debug/Toolbar/Views/toolbarloader.js.php
+++ b/system/Debug/Toolbar/Views/toolbarloader.js.php
@@ -56,7 +56,7 @@ function loadDoc(time) {
 		}
 	};
 
-	xhttp.open("GET", url + "/?debugbar_time=" + time, true);
+	xhttp.open("GET", url + "?debugbar_time=" + time, true);
 	xhttp.send();
 }
 


### PR DESCRIPTION
The toolbar does not display properly. After testing, a file was redirected incorrectly and an attempt was made to fix the problem. (Translate from Google)

![image](https://user-images.githubusercontent.com/9927289/69040632-132eea00-0a29-11ea-8ab6-621323f95b2e.png)


