### PR TITLE
Add 'nullable' to MySQL field data

### DIFF
--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -491,6 +491,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 
 			sscanf($query[$i]->Type, '%[a-z](%d)', $retVal[$i]->type, $retVal[$i]->max_length);
 
+			$retVal[$i]->nullable    = $query[$i]->Null === 'YES';
 			$retVal[$i]->default     = $query[$i]->Default;
 			$retVal[$i]->primary_key = (int)($query[$i]->Key === 'PRI');
 		}


### PR DESCRIPTION
**Description**
SQLite has a handy property on field data `nullable`. This PR adds the equivalent to MySQLi.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
