### PR TITLE
Add missing closing braces of condition 'hasError()' under `Check If…

### DIFF
--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -480,7 +480,7 @@ Check If Error Exists
 
 You can check to see if an error exists with the ``hasError()`` method. The only parameter is the field name::
 
-    if ($validation->hasError('username')
+    if ($validation->hasError('username'))
     {
         echo $validation->getError('username');
     }


### PR DESCRIPTION
Fix issue #2412 

**Description**
Chnages
`if ($validation->hasError('username')`
to 
`if ($validation->hasError('username'))`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide