### PR TITLE
Change current_url() to use cloned URI

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -159,7 +159,7 @@ if (! function_exists('current_url'))
 	 */
 	function current_url(bool $returnObject = false)
 	{
-		$uri = service('request')->uri;
+		$uri = clone service('request')->uri;
 
 		// If hosted in a sub-folder, we will have additional
 		// segments that show up prior to the URI path we just


### PR DESCRIPTION
**Description**
Presently `current_url()` returns a reference to the shared Request service's URI property, making it possible to use the returned object to modify the global Request object to undesirable effect.

This PR makes `current_url()` return a cloned version of the URI object so it can be manipulated freely. One word - I added one word for a bug that took over an hour to track down. ONE. WORD.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
