### PR TITLE
Add hex validation rule, test, Guide

### DIFF
--- a/system/Language/en/Validation.php
+++ b/system/Language/en/Validation.php
@@ -34,6 +34,7 @@ return [
    'exact_length'          => 'The {field} field must be exactly {param} characters in length.',
    'greater_than'          => 'The {field} field must contain a number greater than {param}.',
    'greater_than_equal_to' => 'The {field} field must contain a number greater than or equal to {param}.',
+   'hex'                   => 'The {field} field may only contain hexidecimal characters.',
    'in_list'               => 'The {field} field must be one of: {param}.',
    'integer'               => 'The {field} field must contain an integer.',
    'is_natural'            => 'The {field} field must only contain digits.',

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -154,6 +154,20 @@ class FormatRules
 	//--------------------------------------------------------------------
 
 	/**
+	 * String of hexidecimal characters
+	 *
+	 * @param string $str
+	 *
+	 * @return boolean
+	 */
+	public function hex(string $str = null): bool
+	{
+		return ctype_xdigit($str);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Integer
 	 *
 	 * @param string $str

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -594,6 +594,47 @@ class FormatRulesTest extends \CIUnitTestCase
 	//--------------------------------------------------------------------
 
 	/**
+	 * @dataProvider hexProvider
+	 *
+	 * @param $str
+	 * @param $expected
+	 */
+	public function testHex($str, $expected)
+	{
+		$data = [
+			'foo' => $str,
+		];
+
+		$this->validation->setRules([
+			'foo' => 'hex',
+		]);
+
+		$this->assertEquals($expected, $this->validation->run($data));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function hexProvider()
+	{
+		return [
+			[
+				'abcdefABCDEF0123456789',
+				true,
+			],
+			[
+				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ0123456789',
+				false,
+			],
+			[
+				null,
+				false,
+			],
+		];
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * @dataProvider numericProvider
 	 *
 	 * @param $str

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -664,6 +664,7 @@ differs                 Yes         Fails if field does not differ from the one 
 exact_length            Yes         Fails if field is not exactly the parameter value. One or more comma-separated values.          exact_length[5] or exact_length[5,8,12]
 greater_than            Yes         Fails if field is less than or equal to the parameter value or not numeric.                     greater_than[8]
 greater_than_equal_to   Yes         Fails if field is less than the parameter value, or not numeric.                                greater_than_equal_to[5]
+hex                     No          Fails if field contains anything other than hexadecimal characters.
 if_exist                No          If this rule is present, validation will only return possible errors if the field key exists,
                                     regardless of its value.
 in_list                 Yes         Fails if field is not within a predetermined list.                                              in_list[red,blue,green]


### PR DESCRIPTION
**Description**
Defines a validation rule for hexadecimal digits similar to alpha_numeric, etc.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
