### PR TITLE
Add $recipients property to Config\Email

### DIFF
--- a/app/Config/Email.php
+++ b/app/Config/Email.php
@@ -17,6 +17,11 @@ class Email extends BaseConfig
 	public $fromName;
 
 	/**
+	 * @var string
+	 */
+	public $recipients;
+
+	/**
 	 * The "user agent"
 	 *
 	 * @var string


### PR DESCRIPTION
Needed so that a ``recipient`` can be defined in .env and will be picked up in BaseConfig.

Most useful for automated testing situations.