### PR TITLE
Fix curly brace deprecation in php 7.4

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -602,7 +602,7 @@ class Entity
 		$tmp = ! is_null($value) ? ($asArray ? [] : new \stdClass) : null;
 		if (function_exists('json_decode'))
 		{
-			if ((is_string($value) && strlen($value) > 1 && in_array($value{0}, ['[', '{', '"'])) || is_numeric($value))
+			if ((is_string($value) && strlen($value) > 1 && in_array($value[0], ['[', '{', '"'])) || is_numeric($value))
 			{
 				$tmp = json_decode($value, $asArray);
 


### PR DESCRIPTION
Fix issue #2430

**Description**
The array and string offset access syntax using curly braces has been deprecated in PHP 7.4

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
  
