### PR TITLE
User Guide: Query Builder selectCount - error correction in example

### DIFF
--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -188,8 +188,8 @@ the resulting field.
 
 ::
 
-	$builder->selectSum('age');
-	$query = $builder->get(); // Produces: SELECT SUM(age) as age FROM mytable
+	$builder->selectCount('age');
+	$query = $builder->get(); // Produces: SELECT COUNT(age) as age FROM mytable
 
 **$builder->from()**
 


### PR DESCRIPTION
**Description**
In the User Guide there was an error in the code example related to the selectCount() method, where the method called was selectSum().

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide


  
