### PR TITLE
Extending Route config / more flexibility for route_to and other functions / routung to different domains/proto/ports

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1251,7 +1251,7 @@ class RouteCollection implements RouteCollectionInterface
 				    $prefix = $this->getProto($collection[$search]['options']) .
 					$collection[$search]['options']['subdomain'] .
 					str_replace($old, '', $_SERVER['HTTP_HOST']) .
-					$this->getPort($collection[$search]['options']) . '/';
+					$this->getPort($collection[$search]['options']);
 				}
 				else if(!empty($collection[$search]['options']['hostname']))
 				{

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1246,13 +1246,12 @@ class RouteCollection implements RouteCollectionInterface
 			if (array_key_exists($search, $collection))
 			{
 				$prefix = '';
-				if(!empty($collection[$search]['options']['subdomain']))
+				if(!empty($collection[$search]['options']['subdomain']) && $collection[$search]['options']['subdomain'] !== ($old = $this->determineCurrentSubdomain()))
 				{
-				    $old = $this->determineCurrentSubdomain();
 				    $prefix = $this->getProto($collection[$search]['options']) .
 					$collection[$search]['options']['subdomain'] .
 					str_replace($old, '', $_SERVER['HTTP_HOST']) .
-					$this->getPort($collection[$search]['options']);
+					$this->getPort($collection[$search]['options']) . '/';
 				}
 				else if(!empty($collection[$search]['options']['hostname']))
 				{
@@ -1260,7 +1259,7 @@ class RouteCollection implements RouteCollectionInterface
 					$collection[$search]['options']['hostname'] .
 					$this->getPort($collection[$search]['options']);
 				}
-
+				
 				return
 					$prefix .
 					$this->fillRouteParams(key($collection[$search]['route']), $params);

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -541,8 +541,15 @@ class RouteCollection implements RouteCollectionInterface
 			}
 			foreach ($collection as $r)
 			{
-				$key          = key($r['route']);
-				$routes[$key] = $r['route'][$key];
+				if(
+					(empty($r['options']['subdomain']) && empty($r['options']['hostname'])) ||
+					(!empty($r['options']['subdomain']) && $r['options']['subdomain'] === $this->determineCurrentSubdomain()) ||
+					(!empty($r['options']['hostname']) && !empty($_SERVER['HTTP_HOST']) && $r['options']['hostname'] === $_SERVER['HTTP_HOST'])
+				)
+				{
+					$key          = key($r['route']);
+					$routes[$key] = $r['route'][$key];
+				}
 			}
 		}
 


### PR DESCRIPTION
Allows to add route which is not in the same domain/subdomain.
Allows to generate correct domain with route_to('doc_item','tx') -> ie. https://doc.domain.tld/i/tx 
which is defined like i.e.:


		$routes->get('', '\App\Controllers\Site\CDoc::index', ['subdomain' => 'doc', 'as' => 'doc_index']);
		$routes->get('c/(:any)', '\App\Controllers\Site\CDoc::index/$1', ['subdomain' => 'doc', 'as' => 'doc_category']);
		$routes->get('i/(:any)', '\App\Controllers\Site\CDoc::item/$1', ['subdomain' => 'doc', 'as' => 'doc_item']);



 or

	$routes->group(
	'/',
	['hostname' => 'doc.domain.tld', 'enabled' => true],
	function ($routes) {
		$routes->get('', '\App\Controllers\Site\CDoc::index', ['as' => 'doc_index']);
		$routes->get('c/(:any)', '\App\Controllers\Site\CDoc::index/$1', ['as' => 'doc_category']);
		$routes->get('i/(:any)', '\App\Controllers\Site\CDoc::item/$1', ['as' => 'doc_item']);
	}
	);


Adding support for 
$options['proto' => 'protocol for route' , 'port' => 'custom port', 'enabled' => 'enabling route even if it is in different domain/subdomain than requested page']

I will not be able to write the tests :/

Each pull request should address a single issue and have a meaningful title.

**Description**
Explain what you have changed, and why.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

---------Remove from here down in your description----------

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository
  
