### PR TITLE
[ci skip] Error correction in reference to Query Builder emptyTable m…

### DIFF
--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1142,7 +1142,7 @@ the data to the first parameter of the function::
 	// WHERE id = $id
 
 If you want to delete all data from a table, you can use the truncate()
-function, or empty_table().
+function, or emptyTable().
 
 **$builder->emptyTable()**
 

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -261,7 +261,6 @@ The following is a table of all the config options for migrations, available in 
 Preference                 Default                Options                    Description
 ========================== ====================== ========================== =============================================================
 **enabled**                TRUE                   TRUE / FALSE               Enable or disable migrations.
-**path**                   'Database/Migrations/' None                       The path to your migrations folder.
 **table**                  migrations             None                       The table name for storing the schema version number.
 **timestampFormat**        Y-m-d-His\_                                        The format to use for timestamps when creating a migration.
 ========================== ====================== ========================== =============================================================


### PR DESCRIPTION
**Description**
Fixed an error referencing the emptyTable method in the Query Builder documentation, where the method name was empty_table, when the correct one in the new version is emptyTable.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide