### PR TITLE
 Fix impossible length for migration table id.

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -945,8 +945,8 @@ class MigrationRunner
 
 		$forge->addField([
 			'id'        => [
-				'type'           => 'INTEGER',
-				'constraint'     => 255,
+				'type'           => 'BIGINT',
+				'constraint'     => 20,
 				'unsigned'       => true,
 				'auto_increment' => true,
 			],


### PR DESCRIPTION
Each pull request should address a single issue and have a meaningful title.

**Description**

id column is too long.

https://dev.mysql.com/doc/refman/5.6/en/integer-types.html

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

---------Remove from here down in your description----------

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository
  
