### PR TITLE
Update TravisCI config for PHP7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
   - nightly
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ services:
   - postgresql
   - redis-server
 
+cache:
+  directories:
+    - vendor
+
 script:
   - php vendor/bin/phpunit -v
 


### PR DESCRIPTION
- Include 7.4 in builds.
- Cache vendor directory for hopefully faster builds. 

Fixes #2293 