### PR TITLE
Dark mode for the debug bar

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -83,6 +83,7 @@
 #debug-bar #toolbar-position > a,
 #debug-bar #toolbar-theme > a {
 	padding: 0 6px;
+	text-decoration: none;
 }
 
 #debug-icon.fixed-top,

--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -80,7 +80,8 @@
 	z-index: 10000;
 }
 
-#debug-bar #toolbar-position > a {
+#debug-bar #toolbar-position > a,
+#debug-bar #toolbar-theme > a {
 	padding: 0 6px;
 }
 
@@ -404,4 +405,23 @@ simple styles to replace inline styles
 
 .debug-bar-noverflow {
 	overflow: hidden;
+}
+
+/**
+dark theme
+ */
+.dark .tab,
+.dark .toolbar {
+	-webkit-filter: invert(88%);
+	filter: invert(88%); /* Invert colors */
+}
+
+.dark .badge,
+.dark #toolbar-position a,
+.dark #toolbar-theme a,
+.dark .toolbar h1,
+.dark .current,
+.dark tr[data-active="1"] {
+	-webkit-filter: invert(88%);
+	filter: invert(88%);	/* Cancel color inversion for some elements */
 }

--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -16,6 +16,7 @@ var ciDebugBar = {
 		ciDebugBar.createListeners();
 		ciDebugBar.setToolbarState();
 		ciDebugBar.setToolbarPosition();
+		ciDebugBar.setToolbarTheme();
 		ciDebugBar.toggleViewsHints();
 
 		document.getElementById('debug-bar-link').addEventListener('click', ciDebugBar.toggleToolbar, true);
@@ -498,6 +499,37 @@ var ciDebugBar = {
 				ciDebugBar.createCookie('debug-bar-position', 'bottom', 365);
 				ciDebugBar.removeClass(ciDebugBar.icon, 'fixed-top');
 				ciDebugBar.removeClass(ciDebugBar.toolbar, 'fixed-top');
+			}
+		}, true);
+	},
+
+	//--------------------------------------------------------------------
+
+	setToolbarTheme: function () {
+		var btnTheme = document.getElementById('toolbar-theme');
+
+		if (ciDebugBar.readCookie('debug-bar-theme') === 'dark')
+		{
+			ciDebugBar.addClass(ciDebugBar.icon, 'dark');
+			ciDebugBar.addClass(ciDebugBar.toolbar, 'dark');
+		}
+
+		btnTheme.addEventListener('click', function () {
+			var theme = ciDebugBar.readCookie('debug-bar-theme');
+
+			ciDebugBar.createCookie('debug-bar-theme', '', -1);
+
+			if (!theme || theme === 'light')
+			{
+				ciDebugBar.createCookie('debug-bar-theme', 'dark', 365);
+				ciDebugBar.addClass(ciDebugBar.icon, 'dark');
+				ciDebugBar.addClass(ciDebugBar.toolbar, 'dark');
+			}
+			else
+			{
+				ciDebugBar.createCookie('debug-bar-theme', 'light', 365);
+				ciDebugBar.removeClass(ciDebugBar.icon, 'dark');
+				ciDebugBar.removeClass(ciDebugBar.toolbar, 'dark');
 			}
 		}, true);
 	},

--- a/system/Debug/Toolbar/Views/toolbar.tpl.php
+++ b/system/Debug/Toolbar/Views/toolbar.tpl.php
@@ -49,6 +49,7 @@
 <div id="debug-bar">
 	<div class="toolbar">
 		<span id="toolbar-position"><a href="javascript: void(0)">&#8597;</a></span>
+		<span id="toolbar-theme"><a href="javascript: void(0)">&#9728;</a></span>
 		<span class="ci-label">
 			<a href="javascript: void(0)" data-tab="ci-timeline">
 				<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAD7SURBVEhLY6ArSEtLK09NTbWHcvGC9PR0BaDaQiAdUl9fzwQVxg+AFvwHamqHcnGCpKQkeaDa9yD1UD09UCn8AKaBWJySkmIApFehi0ONwwRQBceBLurAh4FqFoHUAtkrgPgREN+ByYEw1DhMANVEMIhAYQ5U1wtU/wmILwLZRlAp/IBYC8gGw88CaFj3A/FnIL4ETDXGUCnyANSC/UC6HIpnQMXAqQXIvo0khxNDjcMEQEmU9AzDuNI7Lgw1DhOAJIEuhQcRKMcC+e+QNHdDpcgD6BaAANSSQqBcENFlDi6AzQKqgkFlwWhxjVI8o2OgmkFaXI8CTMDAAAAxd1O4FzLMaAAAAABJRU5ErkJggg==">


### PR DESCRIPTION
**Description**
Many devices and applications have a "dark mode" nowadays. I, myself, develop applications with this feature. When I use the current debug bar, it sometimes gives a contrast which is tiring for the eyes. So I thought it might be interesting to offer this functionality, which ultimately requires only a few lines of code.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
