### PR TITLE
Services request add URI Core System extend support

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -604,7 +604,7 @@ class Services extends BaseService
 
 		return new IncomingRequest(
 				$config,
-				new URI(),
+				static::uri(),
 				'php://input',
 				new UserAgent()
 		);

--- a/user_guide_src/source/extending/core_classes.rst
+++ b/user_guide_src/source/extending/core_classes.rst
@@ -29,6 +29,7 @@ The following is a list of the core system files that are invoked every time Cod
 * CodeIgniter\\HTTP\\Request
 * CodeIgniter\\HTTP\\Response
 * CodeIgniter\\HTTP\\Message
+* CodeIgniter\\HTTP\\URI
 * CodeIgniter\\Log\\Logger
 * CodeIgniter\\Log\\Handlers\\BaseHandler
 * CodeIgniter\\Log\\Handlers\\FileHandler


### PR DESCRIPTION
URI Core System extending

**Description**
Services::request function changed.
static::uri() was used instead of the new URI() library.
The reason is;
If we want to extend the 'URI' library, we need to extend the 'request' service.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide