### PR TITLE
Typo in user guide "Running via the Command Line"

### DIFF
--- a/user_guide_src/source/cli/cli.rst
+++ b/user_guide_src/source/cli/cli.rst
@@ -38,7 +38,7 @@ Let's create a simple controller so you can see it in action. Using your
 text editor, create a file called Tools.php, and put the following code
 in it::
 
-	<?php namespace App\Controller;
+	<?php namespace App\Controllers;
 
         use CodeIgniter\Controller;
 


### PR DESCRIPTION
**Description**
There are a typo in the user guide for CI4 reported by the user snjlpro.
https://forum.codeigniter.com/thread-75205.html

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
  
