### PR TITLE
Update current_url and previous_url in the docs for View Parser. Fixes #2460

### DIFF
--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -521,8 +521,8 @@ The following plugins are available when using the parser:
 ==================== ========================== ================================================================================== ================================================================
 Plugin               Arguments                  Description                                                           			   Example
 ==================== ========================== ================================================================================== ================================================================
-currentURL                                      Alias for the current_url helper function.                                         {+ currentURL +}
-previousURL                                     Alias for the previous_url helper function.                           		       {+ previousURL +}
+current_url                                     Alias for the current_url helper function.                                         {+ current_url +}
+previous_url                                    Alias for the previous_url helper function.                           		       {+ previous_url +}
 siteURL                                         Alias for the site_url helper function.                                            {+ siteURL "login" +}
 mailto               email, title, attributes   Alias for the mailto helper function.                                 		       {+ mailto email=foo@example.com title="Stranger Things" +}
 safe_mailto          email, title, attributes   Alias for the safe_mailto helper function.                            		       {+ safe_mailto email=foo@example.com title="Stranger Things" +}


### PR DESCRIPTION
Updated the View Parser docs to show the correct plugins for current_url and previous_url. 