### PR TITLE
fix. HTMLhelper ul and ol attributes type

### DIFF
--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -52,10 +52,10 @@ if (! function_exists('ul'))
 	 * multi-dimensional array.
 	 *
 	 * @param  array  $list
-	 * @param  string $attributes HTML attributes
+	 * @param  array $attributes HTML attributes
 	 * @return string
 	 */
-	function ul(array $list, string $attributes = ''): string
+	function ul(array $list, array $attributes = []): string
 	{
 		return _list('ul', $list, $attributes);
 	}
@@ -71,10 +71,10 @@ if (! function_exists('ol'))
 	 * Generates an HTML ordered list from an single or multi-dimensional array.
 	 *
 	 * @param  array  $list
-	 * @param  string $attributes HTML attributes
+	 * @param  array $attributes HTML attributes
 	 * @return string
 	 */
-	function ol(array $list, string $attributes = ''): string
+	function ol(array $list, array $attributes = []): string
 	{
 		return _list('ol', $list, $attributes);
 	}
@@ -91,11 +91,11 @@ if (! function_exists('_list'))
 	 *
 	 * @param  string  $type
 	 * @param  mixed   $list
-	 * @param  string  $attributes
+	 * @param  array  $attributes
 	 * @param  integer $depth
 	 * @return string
 	 */
-	function _list(string $type = 'ul', $list = [], string $attributes = '', int $depth = 0): string
+	function _list(string $type = 'ul', $list = [], array $attributes = [], int $depth = 0): string
 	{
 		// Set the indentation based on the depth
 		$out = str_repeat(' ', $depth)
@@ -120,7 +120,7 @@ if (! function_exists('_list'))
 			{
 				$out .= $_last_list_item
 						. "\n"
-						. _list($type, $val, '', $depth + 4)
+						. _list($type, $val, [], $depth + 4)
 						. str_repeat(' ', $depth + 2);
 			}
 

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -44,7 +44,7 @@ EOH;
 	public function testULWithClass()
 	{
 		$expected = <<<EOH
-<ul class="test">
+<ul id="testID" class="test">
   <li>foo</li>
   <li>bar</li>
 </ul>
@@ -57,7 +57,7 @@ EOH;
 			'bar',
 		];
 
-		$this->assertEquals($expected, ul($list, 'class="test"'));
+		$this->assertEquals($expected, ul($list, ['id' => 'testID', 'class' => 'test']));
 	}
 
 	public function testMultiLevelUL()
@@ -113,7 +113,7 @@ EOH;
 	public function testOLWithClass()
 	{
 		$expected = <<<EOH
-<ol class="test">
+<ol id="testId" class="test">
   <li>foo</li>
   <li>bar</li>
 </ol>
@@ -126,7 +126,7 @@ EOH;
 			'bar',
 		];
 
-		$this->assertEquals($expected, ol($list, 'class="test"'));
+		$this->assertEquals($expected, ol($list, ['id' => 'testID', 'class' => 'test']));
 	}
 
 	public function testMultiLevelOL()

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -113,7 +113,7 @@ EOH;
 	public function testOLWithClass()
 	{
 		$expected = <<<EOH
-<ol id="testId" class="test">
+<ol id="testID" class="test">
   <li>foo</li>
   <li>bar</li>
 </ol>


### PR DESCRIPTION
fix .#2473
in userguide. attributes type is array. but in code type is string. 