### PR TITLE
Debug Toolbar - Fix Debugbar-Time header, Render in <head>

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -375,7 +375,7 @@ class Toolbar
 			// for this response
 			if ($request->isAJAX() || strpos($format, 'html') === false)
 			{
-				$response->setHeader('Debugbar-Time', $time)
+				$response->setHeader('Debugbar-Time', "$time")
 						->setHeader('Debugbar-Link', site_url("?debugbar_time={$time}"))
 						->getBody();
 
@@ -390,10 +390,10 @@ class Toolbar
 					. '<style type="text/css" {csp-style-nonce} id="debugbar_dynamic_style"></style>'
 					. PHP_EOL;
 
-			if (strpos($response->getBody(), '</body>') !== false)
+			if (strpos($response->getBody(), '<head>') !== false)
 			{
 				$response->setBody(
-						str_replace('</body>', $script . '</body>', $response->getBody())
+						str_replace('<head>', $script . '<head>', $response->getBody())
 				);
 
 				return;


### PR DESCRIPTION
**Description**
- There is an issue with Debugbar-Time not being set correctly XHR response when integer value is set. This fixes the toolbar to pick up changes on Ajax request

- Debug toolbar scripts should be rendered immediately the beginning of <head> in order to pick up Ajax requests which happens on document load.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
  
