### PR TITLE
View Parser - Fix ParsePair() with filter

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -414,7 +414,10 @@ class Parser extends View
 				$str .= $out;
 			}
 
-			$replace['#' . $match[0] . '#s'] = $str;
+			//Escape | character from filters as it's handled as OR in regex
+			$escaped_match = preg_replace('/(?<!\\\\)\\|/', '\\|', $match[0]);
+
+			$replace['#' . $escaped_match . '#s'] = $str;
 		}
 
 		return $replace;
@@ -766,7 +769,7 @@ class Parser extends View
 				foreach ($matchesParams[0] as $item)
 				{
 					$keyVal = explode('=', $item);
-					if (count($keyVal) == 2)
+					if (count($keyVal) === 2)
 					{
 						$params[$keyVal[0]] = str_replace('"', '', $keyVal[1]);
 					}

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -409,4 +409,59 @@ EOF;
 		$this->assertEquals('1.234.567,89 €', $parser->renderString($template));
 	}
 
+	public function testParsePairWithAbs()
+	{
+		$parser = new Parser($this->config, $this->viewsDir, $this->loader);
+
+		$data = [
+			'value1' => -1,
+			'value2' => 1,
+			'single' => [
+				[
+					'svalue1' => -2,
+					'svalue2' => 2,
+				],
+			],
+			'loop'   => [
+				[
+					'lvalue' => -3,
+				],
+				[
+					'lvalue' => 3,
+				],
+			],
+			'nested' => [
+				[
+					'nvalue1' => -4,
+					'nvalue2' => 4,
+					'nsingle' => [
+						[
+							'nsvalue1' => -5,
+							'nsvalue2' => 5,
+						],
+					],
+					'nsloop'  => [
+						[
+							'nlvalue' => -6,
+						],
+						[
+							'nlvalue' => 6,
+						],
+					],
+				],
+			],
+		];
+
+		$template = '{ value1|abs }{ value2|abs }'
+			. '{single}{ svalue1|abs }{ svalue2|abs }{/single}'
+			. '{loop}{ lvalue|abs }{/loop}'
+			. '{nested}'
+			. '{ nvalue1|abs }{ nvalue2|abs }'
+			. '{nsingle}{ nsvalue1|abs }{ nsvalue2|abs }{/nsingle}'
+			. '{nsloop}{ nlvalue|abs }{/nsloop}'
+			. '{/nested}';
+
+		$parser->setData($data);
+		$this->assertEquals('112233445566', $parser->renderString($template));
+	}
 }


### PR DESCRIPTION
**Description**
 Fixes using filters on properties in arrays

Problem is related to the use of | character in filters as | character is handled as OR in regex. This makes replace singe get multiple matches which in the end leads to multiplied data by number of | characters.

Additionally I have added test case testParsePairWithAbs in ParserFilterTest. Initially I was thinking to modify the existing tests to check for nested array elements as well. But this will require changing almost all the test methods. So I've added the new test method based on testAbs() which checks that abs filter works in various nested array properties

I've noticed some style issue. CodeSniffer replaced
```
if (count($keyVal) == 2)
```
to
```
if (count($keyVal) === 2)
```
So I also included this change in the commit

This PR Fixes #2360 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

