### PR TITLE
View Renderer - Reset sections after generating the ouput

### DIFF
--- a/system/View/View.php
+++ b/system/View/View.php
@@ -247,6 +247,9 @@ class View implements RendererInterface
 			$output       = $this->render($layoutView, $options, $saveData);
 		}
 
+		// Reset sections
+		$this->sections = [];
+
 		$this->logPerformance($this->renderVars['start'], microtime(true), $this->renderVars['view']);
 
 		if ($this->debug && (! isset($options['debug']) || $options['debug'] === true))


### PR DESCRIPTION
**Description**
Sections array is left populated after generating output. This creates issues when the same shared View rendered instance is called for the second time.

Fixes #2491

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
