### PR TITLE
BaseConnection - Nullable return type in getConnectStart()

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1054,9 +1054,9 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * Used by the Debug Toolbar's timeline.
 	 *
-	 * @return float
+	 * @return float|null
 	 */
-	public function getConnectStart(): float
+	public function getConnectStart(): ?float
 	{
 		return $this->connectTime;
 	}


### PR DESCRIPTION
**Description**
Make the method allowed to return null value so that Debug Toolbar does not crash if there were no queries executed on connection.

Ref #2158

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide