### PR TITLE
Proposal: HTTP Response - Fix crash on CSP methods CSP is disabled

### DIFF
--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -239,13 +239,10 @@ class Response extends Message implements ResponseInterface
 		// Also ensures that a Cache-control header exists.
 		$this->noCache();
 
-		// Are we enforcing a Content Security Policy?
-		if ($config->CSPEnabled === true)
-		{
-			$this->CSP        = new ContentSecurityPolicy(new \Config\ContentSecurityPolicy());
-			$this->CSPEnabled = true;
-		}
+		// We need CSP object even if not enabled to avoid calls to non existing methods
+		$this->CSP = new ContentSecurityPolicy(new \Config\ContentSecurityPolicy());
 
+		$this->CSPEnabled     = $config->CSPEnabled;
 		$this->cookiePrefix   = $config->cookiePrefix;
 		$this->cookieDomain   = $config->cookieDomain;
 		$this->cookiePath     = $config->cookiePath;

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -13,10 +13,10 @@ class ContentSecurityPolicyTest extends \CIUnitTestCase
 {
 
 	// Having this method as setUp() doesn't work - can't find Config\App !?
-	protected function prepare()
+	protected function prepare(bool $CSPEnabled = true)
 	{
 		$config             = new App();
-		$config->CSPEnabled = true;
+		$config->CSPEnabled = $CSPEnabled;
 		$this->response     = new Response($config);
 		$this->response->pretend(false);
 		$this->csp = $this->response->CSP;
@@ -488,6 +488,19 @@ class ContentSecurityPolicyTest extends \CIUnitTestCase
 
 		$result = $this->getHeaderEmitted('content-security-policy', true);
 		$this->assertContains("base-uri 'self';", $result);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState  disabled
+	 */
+	public function testCSPDisabled()
+	{
+		$this->prepare(false);
+		$result = $this->work();
+		$this->response->CSP->addStyleSrc('https://example.com');
+
+		$this->assertHeaderNotEmitted('content-security-policy', true);
 	}
 
 }


### PR DESCRIPTION
**Description**
If CSP is disabled property $CSP in HTTP/Response is not initialized.

If we try to access the CSP methods on the request object anywhere in code with CSP disabled it will crash the framework with "Call to a member function …. on null "

In order to avoid this CSP object can be initiated regardless of CSP config.

I’m aware that this is not the most efficient way to bypass the issue but some mechanism for disabling CSP should exist without having to do modifications everywhere in code.

Maybe better idea will be to create mock class to be loaded instead which will respond with catchall  magic methods like __call __set __get ….. But I don’t know if it is worth doing it as it will require adding additional class in framework.

Fixes #2456 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
