### PR TITLE
Revert Renderer section reset

### DIFF
--- a/system/View/View.php
+++ b/system/View/View.php
@@ -247,9 +247,6 @@ class View implements RendererInterface
 			$output       = $this->render($layoutView, $options, $saveData);
 		}
 
-		// Reset sections
-		$this->sections = [];
-
 		$this->logPerformance($this->renderVars['start'], microtime(true), $this->renderVars['view']);
 
 		if ($this->debug && (! isset($options['debug']) || $options['debug'] === true))


### PR DESCRIPTION
This reverts commit 8c7d874136d86a9d989e8f3574fd5dd44d08666e.

**Description**
Resetting the sections is causing views nested in layout sections not to return their output. My mistake for merging this without testing, also probably shows that we need some more tests in this area. Reverting for now and I will reopen the related issue.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
