### PR TITLE
Layout Renderer Fix

### DIFF
--- a/system/View/View.php
+++ b/system/View/View.php
@@ -480,9 +480,10 @@ class View implements RendererInterface
 			return;
 		}
 
-		foreach ($this->sections[$sectionName] as $contents)
+		foreach ($this->sections[$sectionName] as $key => $contents)
 		{
 			echo $contents;
+			unset($this->sections[$sectionName][$key]);
 		}
 	}
 

--- a/tests/system/View/ViewTest.php
+++ b/tests/system/View/ViewTest.php
@@ -276,6 +276,18 @@ class ViewTest extends \CIUnitTestCase
 		$this->assertContains($expected, $view->render('extend'));
 	}
 
+	public function testRenderLayoutExtendsMultipleCalls()
+	{
+		$view = new View($this->config, $this->viewsDir, $this->loader);
+
+		$view->setVar('testString', 'Hello World');
+		$expected = "<p>Open</p>\n<h1>Hello World</h1>\n<p>Hello World</p>";
+
+		$view->render('extend');
+
+		$this->assertContains($expected, $view->render('extend'));
+	}
+
 	public function testRenderLayoutMakesDataAvailableToBoth()
 	{
 		$view = new View($this->config, $this->viewsDir, $this->loader);


### PR DESCRIPTION
**Description**

Another take on #2491. This is done in proper way with unit test added first then working on fixing the issue.

The View class does not reset this->sections after completing the rendering. If multiple views are rendered using the same section name those sections are concatenated and displayed multiple times.

The first idea was to reset section in the render method which was not appropriate as this method works if there is only one section but fails to render other section when multiple sections are used. This is because render method is recessively called to render section so rendering the first section will cause other sections not to be rendered at all. 

A different approach is used here. Instead of reseting the section array completely each section is unset separately from sections array after rendering it.

I've included unit test which covers the #2491 issue but views still lack tests for some specific cases so this should be tested.

Untested area contains of testing views with layout which renders multiple sections. Currently we have only test layout which renders a single section.

Before merging this one some additional testing should be made.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
  
