### PR TITLE
Fix error_exception: threw exception

### DIFF
--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -97,7 +97,7 @@
 										foreach ($row['args'] as $key => $value) : ?>
 											<tr>
 												<td><code><?= htmlspecialchars(isset($params[$key]) ? '$' . $params[$key]->name : "#$key", ENT_SUBSTITUTE, 'UTF-8') ?></code></td>
-												<td><pre><?= print_r($value, true) ?></pre></td>
+												<td><pre><?= print_r($params[$key], true) ?></pre></td>
 											</tr>
 										<?php endforeach ?>
 


### PR DESCRIPTION
Tiny fix. `$value` of `$row['args']` was triggering an exception:

> Uncaught ErrorException: print_r(): Property access is not allowed yet

Updated to use $params[$key].