### PR TITLE
Adding Events information in the 'Upgrading from 3.x to 4.x' section

### DIFF
--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -102,6 +102,14 @@ subforum for an up-to-date list!
 
 - Helpers are pretty much the same as before, though some have been simplified
 
+**Events**
+
+- Hooks have been replaced by Events
+- Instead of CI3's ``$hook['post_controller_constructor']`` you now use
+ ``Events::on('post_controller_constructor', ['MyClass', 'MyFunction']);``,
+ with the namespace ``CodeIgniter\Events\Events;``
+- Events are always enabled, and are available globally
+
 **Extending the framework**
 
 - You don't need a ``core`` folder to hold ``MY_...`` framework


### PR DESCRIPTION
**Description**
According to issue #2521 , this commit adds information about replacing Hooks with Events in the 'Upgrading from 3.x to 4.x' section of the official documentation.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide