### PR TITLE
Restore namespace after regress. Fixes #2474

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -305,6 +305,9 @@ class MigrationRunner
 			throw new \RuntimeException($message);
 		}
 
+		// Save the namespace to restore it after loading migrations
+		$tmpNamespace = $this->namespace;
+
 		// Get all migrations
 		$this->namespace = null;
 		$allMigrations   = $this->findMigrations();
@@ -365,6 +368,9 @@ class MigrationRunner
 				throw new \RuntimeException($message);
 			}
 		}
+
+		// Restore the namespace
+		$this->namespace = $tmpNamespace;
 
 		return true;
 	}


### PR DESCRIPTION
**Description**
`MigrationRunner::regress()` wipes the current namespace so `findMigrations()` will load ALL migration files. This has the unintended side effect of causing subsequent runs to lack an assumed preset namespace.

This PR stashes the namespace and restores it post-regression.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
