### PR TITLE
Remove incorrect inline doc type

### DIFF
--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -84,7 +84,7 @@ class Message
 	/**
 	 * Message body
 	 *
-	 * @var string
+	 * @var mixed
 	 */
 	protected $body;
 
@@ -108,7 +108,7 @@ class Message
 	/**
 	 * Sets the body of the current message.
 	 *
-	 * @param $data
+	 * @param mixed $data
 	 *
 	 * @return Message|Response
 	 */


### PR DESCRIPTION
**Description**
There is a discrepancy between the inline docs and actual use, such that `Message::$body` can contain non-string values (e.g. arrays). This PR changes the comment to "mixed".

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
