### PR TITLE
explanation of reset() method in section Working With Validation fixes #2535

### DIFF
--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -383,6 +383,26 @@ This method sets a rule group from the validation configuration to the validatio
 
     $validation->setRuleGroup('signup');
 
+Running Multiple Validations
+=======================================================
+
+.. note:: ``run()`` method will not reset error state. Should a previous run fail,
+   ``run()`` will always return false and ``getErrors()`` will return
+   all previous errors until explicitly reset.
+
+If you intend to run multiple validations, for instance on different data sets or with different
+rules after one another, you might need to call ``$validation->reset()`` before each run to get rid of
+errors from previous run. Be aware that ``reset()`` will invalidate any data, rule or custom error
+you previously set, so ``setRules()``, ``setRuleGroup()`` etc. need to be repeated::
+
+    for ($userAccounts as $user) {
+        $validation->reset();
+        $validation->setRules($userAccountRules);
+        if (!$validation->run($user)) {
+            // handle validation errors
+        }
+    }
+
 Working With Errors
 ************************************************
 


### PR DESCRIPTION
**Description**
Fixes issue #2535:
Documentation / Library Reference / Validation missed the part about reset() method and running multiple validations after one another.
Added description and emphasized significance of reset() in section Working With Validation.

**Checklist:**
- [x ] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide