### PR TITLE
2373 Update kint-php version to 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-curl": "*",
         "ext-intl": "*",
         "ext-json": "*",
-        "kint-php/kint": "^2.1",
+        "kint-php/kint": "^3.3",
         "psr/log": "^1.1",
         "laminas/laminas-escaper": "^2.6"
     },

--- a/user_guide_src/source/testing/debugging.rst
+++ b/user_guide_src/source/testing/debugging.rst
@@ -19,10 +19,7 @@ and much, much more.
 Enabling Kint
 =============
 
-By default, Kint is enabled in **development** and **testing** environments only. This can be altered by modifying
-the ``$useKint`` value in the environment configuration section of the main **index.php** file::
-
-    $useKint = true;
+By default, Kint is enabled in **development** and **testing** environments only.
 
 Using Kint
 ==========


### PR DESCRIPTION
Update kint version to 3.3 #2373

**Description**
Update package dependency version for kint-php/kint from 2.1 to 3.3

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide