### PR TITLE
Add retry creation server when the port is used

### DIFF
--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -95,6 +95,20 @@ class Serve extends BaseCommand
 	protected $arguments = [];
 
 	/**
+	 * The current port offset.
+	 *
+	 * @var int
+	 */
+	protected $portOffset = 0;
+
+	/**
+	 * The max number of ports to attempt to serve from
+	 *
+	 * @var int
+	 */
+	protected $tries = 10;
+
+	/**
 	 * Options
 	 *
 	 * @var array
@@ -124,7 +138,7 @@ class Serve extends BaseCommand
 		// Collect any user-supplied options and apply them.
 		$php  = CLI::getOption('php') ?? PHP_BINARY;
 		$host = CLI::getOption('host') ?? 'localhost';
-		$port = CLI::getOption('port') ?? '8080';
+		$port = (int) (CLI::getOption('port') ?? '8080') + $this->portOffset;
 
 		// Get the party started.
 		CLI::write('CodeIgniter development server started on http://' . $host . ':' . $port, 'green');
@@ -139,7 +153,13 @@ class Serve extends BaseCommand
 		// Call PHP's built-in webserver, making sure to set our
 		// base path to the public folder, and to use the rewrite file
 		// to ensure our environment is set and it simulates basic mod_rewrite.
-		passthru($php . ' -S ' . $host . ':' . $port . ' -t ' . $docroot . ' ' . $rewrite);
+		passthru($php . ' -S ' . $host . ':' . $port . ' -t ' . $docroot . ' ' . $rewrite, $status);
+
+		if ($status && $this->portOffset < $this->tries) {
+			$this->portOffset += 1;
+
+			$this->run($params);
+		}
 	}
 
 }


### PR DESCRIPTION
**Description**
When I create the server with the command sss, if my port 8080 is already in use, it will fail.
I want to add retries to use a different port if the command fails

```
CodeIgniter development server started on http://localhost:8080
Press Control-C to stop.
[Thu Feb 13 09:27:20 2020] Failed to listen on localhost:8080 (reason: Address already in use)
CodeIgniter development server started on http://localhost:8081
Press Control-C to stop.
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
  
