### PR TITLE
Add ajax.rst to user guide /general/index.rst

### DIFF
--- a/user_guide_src/source/general/index.rst
+++ b/user_guide_src/source/general/index.rst
@@ -12,6 +12,7 @@ General Topics
     logging
     errors
     caching
+    ajax
     modules
     managing_apps
     environments

--- a/user_guide_src/source/general/index.rst
+++ b/user_guide_src/source/general/index.rst
@@ -12,7 +12,6 @@ General Topics
     logging
     errors
     caching
-    ajax
     modules
     managing_apps
     environments


### PR DESCRIPTION
This was missed when ajax.rst documentation was added during merge #2526
Without being added to index.rst the page won't be included in the build.

