### PR TITLE
disable buffer check on "testing" environment

### DIFF
--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -20,14 +20,17 @@ use CodeIgniter\Events\Events;
  */
 
 Events::on('pre_system', function () {
-	while (\ob_get_level() > 0)
+	if (ENVIRONMENT !== 'testing')
 	{
-		\ob_end_flush();
-	}
+		while (\ob_get_level() > 0)
+		{
+			\ob_end_flush();
+		}
 
-	\ob_start(function ($buffer) {
-		return $buffer;
-	});
+		\ob_start(function ($buffer) {
+			return $buffer;
+		});
+	}
 
 	/*
 	 * --------------------------------------------------------------------


### PR DESCRIPTION
**Description**
To clean up the buffer notice in "testing" environment which previously shows:

```bash
There were 3 risky tests:

1) CodeIgniter\CodeIgniterTest::testRunClosureRoute
Test code or tested code did not (only) close its own output buffers

2) CodeIgniter\CodeIgniterTest::testRun404OverrideByClosure
Test code or tested code did not (only) close its own output buffers

3) FeatureTestCaseTest::testEchoes
Test code or tested code did not (only) close its own output buffers
```

**Checklist:**
- [x] Securely signed commits
