### PR TITLE
MySQLi: Incorrect DBDebug flag used for connection charset

### DIFF
--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -203,7 +203,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 						"Database: Unable to set the configured connection charset ('{$this->charset}').");
 					$this->mysqli->close();
 
-					if ($this->db->debug)
+					if ($this->DBDebug)
 					{
 						throw new DatabaseException('Unable to set client connection character set: ' . $this->charset);
 					}


### PR DESCRIPTION
**Description**
I found this inconsistency in MySQLi connection class. It reference `$this->db->debug`. 

**Checklist:**
- [X] Securely signed commits