### PR TITLE
[ci skip] Revise documentation "General" page to include ajax.rst

### DIFF
--- a/user_guide_src/source/general/index.rst
+++ b/user_guide_src/source/general/index.rst
@@ -12,6 +12,7 @@ General Topics
     logging
     errors
     caching
+    ajax
     modules
     managing_apps
     environments

--- a/user_guide_src/source/general/index.rst
+++ b/user_guide_src/source/general/index.rst
@@ -16,3 +16,4 @@ General Topics
     modules
     managing_apps
     environments
+

--- a/user_guide_src/source/general/index.rst
+++ b/user_guide_src/source/general/index.rst
@@ -12,7 +12,6 @@ General Topics
     logging
     errors
     caching
-    ajax
     modules
     managing_apps
     environments


### PR DESCRIPTION
'ajax' needs to be added to `user_guide_src/general/index.rst`
Otherwise, ajax.rst will not be included  in the build
