### PR TITLE
Fix - Add ajax to docs "General " page [ci skip]

### DIFF
--- a/user_guide_src/source/general/index.rst
+++ b/user_guide_src/source/general/index.rst
@@ -12,6 +12,7 @@ General Topics
     logging
     errors
     caching
+    ajax
     modules
     managing_apps
     environments


### PR DESCRIPTION
Because it wasn't on index the new "ajax" page wasn't included in the build.

