### PR TITLE
Added rule "alpha_numeric_punct"

### DIFF
--- a/system/Language/en/Validation.php
+++ b/system/Language/en/Validation.php
@@ -24,9 +24,10 @@ return [
 
 	// Rule Messages
    'alpha'                 => 'The {field} field may only contain alphabetical characters.',
-   'alpha_dash'            => 'The {field} field may only contain alpha-numeric characters, underscores, and dashes.',
-   'alpha_numeric'         => 'The {field} field may only contain alpha-numeric characters.',
-   'alpha_numeric_space'   => 'The {field} field may only contain alpha-numeric characters and spaces.',
+   'alpha_dash'            => 'The {field} field may only contain alphanumeric, underscore, and dash characters.',
+   'alpha_numeric'         => 'The {field} field may only contain alphanumeric characters.',
+   'alpha_numeric_punct'   => 'The {field} field may contain only alphanumeric characters, spaces, and  ~ ! # $ % & * - _ + = | : . characters.',
+   'alpha_numeric_space'   => 'The {field} field may only contain alphanumeric and space characters.',
    'alpha_space'           => 'The {field} field may only contain alphabetical characters and spaces.',
    'decimal'               => 'The {field} field must contain a decimal number.',
    'differs'               => 'The {field} field must differ from the {param} field.',

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -59,8 +59,6 @@ class FormatRules
 		return ctype_alpha($str);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Alpha with spaces.
 	 *
@@ -78,10 +76,8 @@ class FormatRules
 		return (bool) preg_match('/^[A-Z ]+$/i', $value);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
-	 * Alpha-numeric with underscores and dashes
+	 * Alphanumeric with underscores and dashes
 	 *
 	 * @param string $str
 	 *
@@ -89,13 +85,27 @@ class FormatRules
 	 */
 	public function alpha_dash(string $str = null): bool
 	{
-		return (bool) preg_match('/^[a-z0-9_-]+$/i', $str);
+			return (bool) preg_match('/^[a-z0-9_-]+$/i', $str);
 	}
 
-	//--------------------------------------------------------------------
+		/**
+		 * Alphanumeric, spaces, and a limited set of punctuation characters.
+		 * Accepted punctuation characters are: ~ tilde, ! exclamation,
+		 * # number, $ dollar, % percent, & ampersand, * asterisk, - dash,
+		 * _ underscore, + plus, = equals, | vertical bar, : colon, . period
+		 * ~ ! # $ % & * - _ + = | : .
+		 *
+		 * @param string $str
+		 *
+		 * @return boolean
+		 */
+	public function alpha_numeric_punct($str)
+	{
+		return (bool) preg_match('/^[A-Z0-9 ~!#$%\&\*\-_+=|:.]+$/i', $str);
+	}
 
 	/**
-	 * Alpha-numeric
+	 * Alphanumeric
 	 *
 	 * @param string $str
 	 *
@@ -106,10 +116,8 @@ class FormatRules
 		return ctype_alnum($str);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
-	 * Alpha-numeric w/ spaces
+	 * Alphanumeric w/ spaces
 	 *
 	 * @param string $str
 	 *
@@ -119,8 +127,6 @@ class FormatRules
 	{
 		return (bool) preg_match('/^[A-Z0-9 ]+$/i', $str);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Any type of string
@@ -137,8 +143,6 @@ class FormatRules
 		return is_string($str);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Decimal number
 	 *
@@ -150,8 +154,6 @@ class FormatRules
 	{
 		return (bool) preg_match('/^[\-+]?[0-9]+(|\.[0-9]+)$/', $str);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * String of hexidecimal characters
@@ -165,8 +167,6 @@ class FormatRules
 		return ctype_xdigit($str);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Integer
 	 *
@@ -179,8 +179,6 @@ class FormatRules
 		return (bool) preg_match('/^[\-+]?[0-9]+$/', $str);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Is a Natural number  (0,1,2,3, etc.)
 	 *
@@ -191,8 +189,6 @@ class FormatRules
 	{
 		return ctype_digit($str);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Is a Natural number, but not a zero  (1,2,3, etc.)
@@ -205,8 +201,6 @@ class FormatRules
 		return ($str !== '0' && ctype_digit($str));
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Numeric
 	 *
@@ -218,8 +212,6 @@ class FormatRules
 	{
 		return (bool) preg_match('/^[\-+]?[0-9]*\.?[0-9]+$/', $str);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Compares value against a regular expression pattern.
@@ -240,8 +232,6 @@ class FormatRules
 		return (bool) preg_match($pattern, $str);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Validates that the string is a valid timezone as per the
 	 * timezone_identifiers_list function.
@@ -257,8 +247,6 @@ class FormatRules
 		return in_array($str, timezone_identifiers_list());
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Valid Base64
 	 *
@@ -273,8 +261,6 @@ class FormatRules
 		return (base64_encode(base64_decode($str)) === $str);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Valid JSON
 	 *
@@ -287,8 +273,6 @@ class FormatRules
 		json_decode($str);
 		return json_last_error() === JSON_ERROR_NONE;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Checks for a correctly formatted email address
@@ -306,8 +290,6 @@ class FormatRules
 
 		return (bool) filter_var($str, FILTER_VALIDATE_EMAIL);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Validate a comma-separated list of email addresses.
@@ -338,8 +320,6 @@ class FormatRules
 		return true;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Validate an IP address
 	 *
@@ -366,8 +346,6 @@ class FormatRules
 
 		return (bool) filter_var($ip, FILTER_VALIDATE_IP, $which);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Checks a URL to ensure it's formed correctly.
@@ -397,8 +375,6 @@ class FormatRules
 		return (filter_var($str, FILTER_VALIDATE_URL) !== false);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Checks for a valid date and matches a given date format
 	 *
@@ -419,5 +395,4 @@ class FormatRules
 		return (bool) $date && \DateTime::getLastErrors()['warning_count'] === 0 && \DateTime::getLastErrors()['error_count'] === 0;
 	}
 
-	//--------------------------------------------------------------------
 }

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -1,7 +1,12 @@
-<?php namespace CodeIgniter\Validation;
+<?php
+
+namespace CodeIgniter\Validation;
 
 class FormatRulesTest extends \CIUnitTestCase
 {
+
+	const ALPHABET     = 'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ';
+	const ALPHANUMERIC = 'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ0123456789';
 
 	/**
 	 * @var Validation
@@ -25,8 +30,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		],
 	];
 
-	//--------------------------------------------------------------------
-
 	protected function setUp(): void
 	{
 		parent::setUp();
@@ -35,8 +38,6 @@ class FormatRulesTest extends \CIUnitTestCase
 
 		$_FILES = [];
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testRegexMatch()
 	{
@@ -53,8 +54,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		$this->assertTrue($this->validation->run($data));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testRegexMatchFalse()
 	{
 		$data = [
@@ -69,8 +68,6 @@ class FormatRulesTest extends \CIUnitTestCase
 
 		$this->assertFalse($this->validation->run($data));
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * @dataProvider urlProvider
@@ -87,8 +84,6 @@ class FormatRulesTest extends \CIUnitTestCase
 
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
-
-	//--------------------------------------------------------------------
 
 	public function urlProvider()
 	{
@@ -154,8 +149,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		];
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * @dataProvider emailProviderSingle
 	 *
@@ -174,8 +167,6 @@ class FormatRulesTest extends \CIUnitTestCase
 
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * @dataProvider emailsProvider
@@ -196,8 +187,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function emailProviderSingle()
 	{
 		return [
@@ -215,8 +204,6 @@ class FormatRulesTest extends \CIUnitTestCase
 			],
 		];
 	}
-
-	//--------------------------------------------------------------------
 
 	public function emailsProvider()
 	{
@@ -248,8 +235,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		];
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * @dataProvider ipProvider
 	 *
@@ -269,8 +254,6 @@ class FormatRulesTest extends \CIUnitTestCase
 
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
-
-	//--------------------------------------------------------------------
 
 	public function ipProvider()
 	{
@@ -323,8 +306,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		];
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * @dataProvider stringProvider
 	 *
@@ -344,8 +325,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function stringProvider()
 	{
 		return [
@@ -363,8 +342,6 @@ class FormatRulesTest extends \CIUnitTestCase
 			],
 		];
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * @dataProvider alphaProvider
@@ -385,25 +362,23 @@ class FormatRulesTest extends \CIUnitTestCase
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function alphaProvider()
 	{
 		return [
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ',
+				FormatRulesTest::ALPHABET,
 				true,
 			],
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ ',
+				FormatRulesTest::ALPHABET . ' ',
 				false,
 			],
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ1',
+				FormatRulesTest::ALPHABET . '1',
 				false,
 			],
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ*',
+				FormatRulesTest::ALPHABET . '*',
 				false,
 			],
 			[
@@ -412,8 +387,6 @@ class FormatRulesTest extends \CIUnitTestCase
 			],
 		];
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Test alpha with spaces.
@@ -436,8 +409,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function alphaSpaceProvider()
 	{
 		return [
@@ -446,25 +417,23 @@ class FormatRulesTest extends \CIUnitTestCase
 				true,
 			],
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ',
+				FormatRulesTest::ALPHABET,
 				true,
 			],
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ ',
+				FormatRulesTest::ALPHABET . ' ',
 				true,
 			],
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ1',
+				FormatRulesTest::ALPHABET . '1',
 				false,
 			],
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ*',
+				FormatRulesTest::ALPHABET . '*',
 				false,
 			],
 		];
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * @dataProvider alphaNumericProvider
@@ -485,21 +454,19 @@ class FormatRulesTest extends \CIUnitTestCase
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function alphaNumericProvider()
 	{
 		return [
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ0123456789',
+				FormatRulesTest::ALPHANUMERIC,
 				true,
 			],
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ0123456789\ ',
+				FormatRulesTest::ALPHANUMERIC . '\ ',
 				false,
 			],
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ0123456789_',
+				FormatRulesTest::ALPHANUMERIC . '_',
 				false,
 			],
 			[
@@ -509,7 +476,98 @@ class FormatRulesTest extends \CIUnitTestCase
 		];
 	}
 
-	//--------------------------------------------------------------------
+	/**
+	 * @dataProvider alphaNumericPunctProvider
+	 *
+	 * @param $str
+	 * @param $expected
+	 */
+	public function testAlphaNumericPunct($str, $expected)
+	{
+		$data = [
+			'foo' => $str,
+		];
+
+		$this->validation->setRules([
+			'foo' => 'alpha_numeric_punct',
+		]);
+
+		$this->assertEquals($expected, $this->validation->run($data));
+	}
+
+	public function alphaNumericPunctProvider()
+	{
+		return [
+			[
+				FormatRulesTest::ALPHANUMERIC . ' ~!#$%&*-_+=|:.',
+				true,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . '`',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . '@',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . '^',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . '(',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . ')',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . '\\',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . '{',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . '}',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . '[',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . ']',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . '"',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . "'",
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . '<',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . '>',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . '/',
+				false,
+			],
+			[
+				null,
+				false,
+			],
+		];
+	}
 
 	/**
 	 * @dataProvider alphaNumericProvider
@@ -530,17 +588,15 @@ class FormatRulesTest extends \CIUnitTestCase
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function alphaNumericSpaceProvider()
 	{
 		return [
 			[
-				' abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ0123456789',
+				' ' . FormatRulesTest::ALPHANUMERIC,
 				true,
 			],
 			[
-				' abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ0123456789-',
+				' ' . FormatRulesTest::ALPHANUMERIC . '-',
 				false,
 			],
 			[
@@ -549,8 +605,6 @@ class FormatRulesTest extends \CIUnitTestCase
 			],
 		];
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * @dataProvider alphaDashProvider
@@ -571,17 +625,15 @@ class FormatRulesTest extends \CIUnitTestCase
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function alphaDashProvider()
 	{
 		return [
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ0123456789-',
+				FormatRulesTest::ALPHANUMERIC . '-',
 				true,
 			],
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ0123456789-\ ',
+				FormatRulesTest::ALPHANUMERIC . '-\ ',
 				false,
 			],
 			[
@@ -590,8 +642,6 @@ class FormatRulesTest extends \CIUnitTestCase
 			],
 		];
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * @dataProvider hexProvider
@@ -612,8 +662,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function hexProvider()
 	{
 		return [
@@ -622,7 +670,11 @@ class FormatRulesTest extends \CIUnitTestCase
 				true,
 			],
 			[
-				'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ0123456789',
+				FormatRulesTest::ALPHANUMERIC,
+				false,
+			],
+			[
+				'asdfjkl;',
 				false,
 			],
 			[
@@ -631,8 +683,6 @@ class FormatRulesTest extends \CIUnitTestCase
 			],
 		];
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * @dataProvider numericProvider
@@ -652,8 +702,6 @@ class FormatRulesTest extends \CIUnitTestCase
 
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
-
-	//--------------------------------------------------------------------
 
 	public function numericProvider()
 	{
@@ -689,8 +737,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		];
 	}
 
-	//-------------------------------------------------------------------
-
 	/**
 	 * @dataProvider integerProvider
 	 *
@@ -709,8 +755,6 @@ class FormatRulesTest extends \CIUnitTestCase
 
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
-
-	//--------------------------------------------------------------------
 
 	public function integerProvider()
 	{
@@ -746,8 +790,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		];
 	}
 
-	//-------------------------------------------------------------------
-
 	/**
 	 * @dataProvider decimalProvider
 	 *
@@ -766,8 +808,6 @@ class FormatRulesTest extends \CIUnitTestCase
 
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
-
-	//--------------------------------------------------------------------
 
 	public function decimalProvider()
 	{
@@ -803,8 +843,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		];
 	}
 
-	//-------------------------------------------------------------------
-
 	/**
 	 * @dataProvider naturalProvider
 	 *
@@ -823,8 +861,6 @@ class FormatRulesTest extends \CIUnitTestCase
 
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
-
-	//--------------------------------------------------------------------
 
 	public function naturalProvider()
 	{
@@ -852,8 +888,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		];
 	}
 
-	//-------------------------------------------------------------------
-
 	/**
 	 * @dataProvider naturalZeroProvider
 	 *
@@ -872,8 +906,6 @@ class FormatRulesTest extends \CIUnitTestCase
 
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
-
-	//--------------------------------------------------------------------
 
 	public function naturalZeroProvider()
 	{
@@ -901,8 +933,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		];
 	}
 
-	//-------------------------------------------------------------------
-
 	/**
 	 * @dataProvider base64Provider
 	 *
@@ -922,8 +952,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function base64Provider()
 	{
 		return [
@@ -941,8 +969,6 @@ class FormatRulesTest extends \CIUnitTestCase
 			],
 		];
 	}
-
-	//-------------------------------------------------------------------
 
 	/**
 	 * @dataProvider jsonProvider
@@ -962,8 +988,6 @@ class FormatRulesTest extends \CIUnitTestCase
 
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
-
-	//--------------------------------------------------------------------
 
 	public function jsonProvider()
 	{
@@ -1007,8 +1031,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		];
 	}
 
-	//-------------------------------------------------------------------
-
 	/**
 	 * @dataProvider timezoneProvider
 	 *
@@ -1027,8 +1049,6 @@ class FormatRulesTest extends \CIUnitTestCase
 
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
-
-	//--------------------------------------------------------------------
 
 	public function timezoneProvider()
 	{
@@ -1052,8 +1072,6 @@ class FormatRulesTest extends \CIUnitTestCase
 		];
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * @dataProvider validDateProvider
 	 *
@@ -1073,8 +1091,6 @@ class FormatRulesTest extends \CIUnitTestCase
 
 		$this->assertEquals($expected, $this->validation->run($data));
 	}
-
-	//--------------------------------------------------------------------
 
 	public function validDateProvider()
 	{
@@ -1242,5 +1258,4 @@ class FormatRulesTest extends \CIUnitTestCase
 		];
 	}
 
-	//--------------------------------------------------------------------
 }

--- a/user_guide_src/source/helpers/text_helper.rst
+++ b/user_guide_src/source/helpers/text_helper.rst
@@ -37,7 +37,7 @@ The following functions are available:
 	specifies the length. The following choices are available:
 
 	-  **alpha**: A string with lower and uppercase letters only.
-	-  **alnum**: Alpha-numeric string with lower and uppercase characters.
+	-  **alnum**: Alphanumeric string with lower and uppercase characters.
 	-  **basic**: A random number based on ``mt_rand()`` (length ignored).
 	-  **numeric**: Numeric string.
 	-  **nozero**: Numeric string with no zeros.

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -676,10 +676,15 @@ Rule                    Parameter   Description                                 
 ======================= =========== =============================================================================================== ===================================================
 alpha                   No          Fails if field has anything other than alphabetic characters.
 alpha_space             No          Fails if field contains anything other than alphabetic characters or spaces.
-alpha_dash              No          Fails if field contains anything other than alpha-numeric characters, underscores or dashes.
-alpha_numeric           No          Fails if field contains anything other than alpha-numeric characters or numbers.
-alpha_numeric_space     No          Fails if field contains anything other than alpha-numeric characters, numbers or space.
-decimal                 No          Fails if field contains anything other than a decimal number.
+alpha_dash              No          Fails if field contains anything other than alphanumeric characters, underscores or dashes.
+alpha_numeric           No          Fails if field contains anything other than alphanumeric characters.
+alpha_numeric_space     No          Fails if field contains anything other than alphanumeric or space characters.
+alpha_numeric_punct     No          Fails if field contains anything other than alphanumeric, space, or this limited set of 
+                                    punctuation characters: ~ (tilde), ! (exclamation), # (number), $ (dollar), % (percent), 
+                                    & (ampersand), * (asterisk), - (dash), _ (underscore), + (plus), = (equals), 
+                                    | (vertical bar), : (colon), . (period).
+decimal                 No          Fails if field contains anything other than a decimal number. 
+                                    Also accepts a + or  - sign for the number.
 differs                 Yes         Fails if field does not differ from the one in the parameter.                                   differs[field_name]
 exact_length            Yes         Fails if field is not exactly the parameter value. One or more comma-separated values.          exact_length[5] or exact_length[5,8,12]
 greater_than            Yes         Fails if field is less than or equal to the parameter value or not numeric.                     greater_than[8]


### PR DESCRIPTION
As discussed in issue #2549   

Fails if the field contains anything characters other than alphanumeric, space and this set of punctuation   ~ ! # $ % & * - _ + = | : .  (that last, the period, is in the set and not just the end of the sentence.)

Other Things:
 - Removed ``//---------------`` from between functions as the docblocks visually set them apart just fine.
 - Also fixed spelling of alphanumeric. It is not a hyphenated compound word. Affected several files.
 - Added rule description to docs.
 - Created unit tests for ``alpha_numeric_punct``rule
