### PR TITLE
Extending entity [bool support in __set]

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -358,7 +358,11 @@ class Entity
 		}
 
 		if (! $isNullable || ! is_null($value))
-		{
+		{	
+			if (($castTo === 'bool' || $castTo === 'boolean') && !is_int($value))
+			{
+				$value = (int)$value;
+			}
 			// Array casting requires that we serialize the value
 			// when setting it so that it can easily be stored
 			// back to the database.


### PR DESCRIPTION
we are doing with bool the same what with array and json ;-)... converting to store it in database.

This should also stop to brake validation rule required if property is bool and we are setting it using true/false instead of 0/1