### PR TITLE
Updates To Kint Loading

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -266,4 +266,15 @@ class App extends BaseConfig
 	*/
 	public $CSPEnabled = false;
 
+	/*
+	|--------------------------------------------------------------------------
+	| Kint
+	|--------------------------------------------------------------------------
+	|
+	| Kint Related configuration
+	|
+	*/
+	public $kintRendererTheme  = 'aante-light.css';
+	public $kintRendererFolder = false;
+
 }

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -423,12 +423,6 @@ class Autoloader
 			unset($paths['CodeIgniter\\']);
 		}
 
-		// Also get rid of Kint to ensure we use our own copy
-		if (isset($paths['Kint\\']))
-		{
-			unset($paths['Kint\\']);
-		}
-
 		// Composer stores namespaces with trailing slash. We don't.
 		$newPaths = [];
 		foreach ($paths as $key => $value)

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -190,11 +190,45 @@ class CodeIgniter
 		$this->detectEnvironment();
 		$this->bootstrapEnvironment();
 
-		if (CI_DEBUG)
+		$this->initializeKint();
+
+		if (! CI_DEBUG)
 		{
-			require_once SYSTEMPATH . 'ThirdParty/Kint/init.php';
-			\Kint\Renderer\RichRenderer::$theme = 'aante-light.css';
+			\Kint::$enabled_mode = false;
 		}
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Initializes Kint
+	 */
+	protected function initializeKint()
+	{
+		// If we have KINT_DIR it means it's already loaded via composer
+		if (! defined('KINT_DIR'))
+		{
+			spl_autoload_register(function ($class) {
+				$class = explode('\\', $class);
+
+				if ('Kint' !== array_shift($class))
+				{
+					return;
+				}
+
+				$file = SYSTEMPATH . 'ThirdParty/Kint/' . implode('/', $class) . '.php';
+
+				file_exists($file) && require_once $file;
+			});
+
+			require_once SYSTEMPATH . 'ThirdParty/Kint/init.php';
+		}
+
+		//Set the kint theme
+		\Kint\Renderer\RichRenderer::$theme = $this->config->kintRendererTheme;
+
+		//Render kint in place instead of toolbar
+		\Kint\Renderer\RichRenderer::$folder = $this->config->kintRendererFolder;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -92,7 +92,6 @@ class AutoloadConfig
 		 */
 		$this->psr4 = [
 			'CodeIgniter' => realpath(SYSTEMPATH),
-			'Kint'        => SYSTEMPATH . 'ThirdParty/Kint',
 		];
 
 		if (isset($_SERVER['CI_ENVIRONMENT']) && $_SERVER['CI_ENVIRONMENT'] === 'testing')


### PR DESCRIPTION
**Description**
Here's another way of loading Kint. This makes it use composer version if it's available and only loads Kint from ThirdParty folder if there is no composer version already loaded. This makes it possible to properly update Kint to latest version from composer when when ComposerScripts.php is not being executed fo example when composer's been added after getting zipped framework files and script is left out.

Additionally I've added some configurations for Kint to be obtained from Config\App. We might  add additional Kint configurations there as well.

One important config to be set is 
```
\Kint\Renderer\RichRenderer::$folder = false;
```

This make Kint to be displayed in place where it's called. Otherwise it goes to bottom as toolbar which creates conflicts with debug toolbar.

This also handles the situation where there are Kint calls left out in production environment and Kint is not loaded via composer by always loading Kint classes and setting Kint as disabled. Otherwise the scripts will crash if there are Kint calls and environment is set to anything but production. With this it only skips Kint calls and the app does not crash anymore.

Ref #2373 and #2564 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
