### PR TITLE
Move debug toolbar after head tag. Fixes #2545

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -393,7 +393,7 @@ class Toolbar
 			if (strpos($response->getBody(), '<head>') !== false)
 			{
 				$response->setBody(
-						str_replace('<head>', $script . '<head>', $response->getBody())
+						str_replace('<head>', '<head>' . $script, $response->getBody())
 				);
 
 				return;


### PR DESCRIPTION
**Description**
The JavaScript code for the toolbar is injected before the `<head>` tag. This PR moves it after, fixing #2545 

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
