### PR TITLE
Apply User Guide code style to Errors

### DIFF
--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -128,11 +128,11 @@ RedirectException
 -----------------
 
 This exception is a special case allowing for overriding of all other response routing and
-forcing a redirect to a specific route or URL.
+forcing a redirect to a specific route or URL::
 
 	throw new \CodeIgniter\Router\Exceptions\RedirectException($route);
 
 ``$route`` may be a named route, relative URI, or a complete URL. You can also supply a
-redirect code to use instead of the default (``302``, "temporary redirect"):
+redirect code to use instead of the default (``302``, "temporary redirect")::
 
 	throw new \CodeIgniter\Router\Exceptions\RedirectException($route, 301);


### PR DESCRIPTION
**Description**
The last few code references in **general/errors.rst** were not formatted as code, causing them to be displayed incorrectly. This PR applies the "code" style, fixing #2530 

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
