### PR TITLE
Use lowercase service names

### DIFF
--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -66,6 +66,7 @@ class BaseService
 	/**
 	 * Cache for instance of any services that
 	 * have been requested as a "shared" instance.
+	 * Keys should be lowercase service names.
 	 *
 	 * @var array
 	 */
@@ -106,6 +107,8 @@ class BaseService
 	 */
 	protected static function getSharedInstance(string $key, ...$params)
 	{
+		$key = strtolower($key);
+
 		// Returns mock if exists
 		if (isset(static::$mocks[$key]))
 		{


### PR DESCRIPTION
**Description**
Shared and mocked instance names are all stored in lowercase, but not necessarily looked up by the same. This PR forces the lowercase version to be used during `getSharedInstance()` as well.

Fixes #2534 

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
