### PR TITLE
Retain CLI segments

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -838,13 +838,18 @@ class CodeIgniter
 	 */
 	protected function runController($class)
 	{
+		// If this is a CLI request then use the input segments as parameters
+		$params = (is_cli() && ! (ENVIRONMENT === 'testing'))
+			? $this->request->getSegments()
+			: $this->router->params();
+
 		if (method_exists($class, '_remap'))
 		{
-			$output = $class->_remap($this->method, ...$this->router->params());
+			$output = $class->_remap($this->method, ...$params);
 		}
 		else
 		{
-			$output = $class->{$this->method}(...$this->router->params());
+			$output = $class->{$this->method}(...$params);
 		}
 
 		$this->benchmark->stop('controller');

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -838,10 +838,8 @@ class CodeIgniter
 	 */
 	protected function runController($class)
 	{
-		// If this is a CLI request then use the input segments as parameters
-		$params = (is_cli() && ! (ENVIRONMENT === 'testing'))
-			? $this->request->getSegments()
-			: $this->router->params();
+		// If this is a console request then use the input segments as parameters
+		$params = defined('SPARKED') ? $this->request->getSegments() : $this->router->params();
 
 		if (method_exists($class, '_remap'))
 		{


### PR DESCRIPTION
**Description**
Currently CLI segments are pushed together with a "/" and run through the router as though it were an actual route. This works most of the time, but fails in cases like #2148 where one of the parameters already contains a "/" (e.g. `spark import:file /tmp/files/myfile.csv`).

This PR changes the framework to use the actual segments as parameters, instead of the smushed router version. It will probably also do some general CLI cleanup.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
