### PR TITLE
Use default protocol if unspecified

### DIFF
--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -716,7 +716,7 @@ class Response extends Message implements ResponseInterface
 		}
 
 		// HTTP Status
-		header(sprintf('HTTP/%s %s %s', $this->protocolVersion, $this->statusCode, $this->reason), true, $this->statusCode);
+		header(sprintf('HTTP/%s %s %s', $this->getProtocolVersion(), $this->statusCode, $this->reason), true, $this->statusCode);
 
 		// Send all of our headers
 		foreach ($this->getHeaders() as $name => $values)


### PR DESCRIPTION
**Description**
As noted in #2383 new protocols check the class property `$protocolVersion`, which will be empty. This PR changes it to use the `getProtocolVersion()` method which specifies a fallback.

Shoutout to @hcbd for the fix!

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
