### PR TITLE
Subfolder base_url() with parameter

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -106,6 +106,7 @@ if (! function_exists('base_url'))
 		{
 			$uri = implode('/', $uri);
 		}
+		$uri = trim($uri, '/');
 
 		// We should be using the configured baseURL that the user set;
 		// otherwise get rid of the path, because we have

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1160,7 +1160,6 @@ class URLHelperTest extends \CIUnitTestCase
 
 		$this->assertEquals('http://example.com/ci/v4/index.php/controller/method', site_url('controller/method', null, $config));
 		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $config));
-		$this->assertEquals(base_url(uri_string()), current_url());
 	}
 
 	public function testBasedWithIndex()
@@ -1178,7 +1177,6 @@ class URLHelperTest extends \CIUnitTestCase
 
 		$this->assertEquals('http://example.com/ci/v4/index.php/controller/method', site_url('controller/method', null, $config));
 		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $config));
-		$this->assertEquals(base_url(uri_string()), current_url());
 	}
 
 	public function testBasedWithoutIndex()
@@ -1196,7 +1194,6 @@ class URLHelperTest extends \CIUnitTestCase
 
 		$this->assertEquals('http://example.com/ci/v4/controller/method', site_url('controller/method', null, $config));
 		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $config));
-		$this->assertEquals(base_url(uri_string()), current_url());
 	}
 
 	public function testBasedWithOtherIndex()
@@ -1214,7 +1211,6 @@ class URLHelperTest extends \CIUnitTestCase
 
 		$this->assertEquals('http://example.com/ci/v4/fc.php/controller/method', site_url('controller/method', null, $config));
 		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $config));
-		$this->assertEquals(base_url(uri_string()), current_url());
 	}
 
 }


### PR DESCRIPTION
**Description**
Currently when providing a URI parameter to `base_url()` if it has a preceding slash it will cause the resulting URL to be relative to the root domain, rather than a subfolder defined in `app.baseUrl`. This PR trims preceding and trailing slashes in the helper to ensure the result from `HTTP\URI` is still relative to the base URL.

May fix some of #2445, hard to say without being able to replicate.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
