### PR TITLE
Cache FileHandler unlink exception

### DIFF
--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -322,7 +322,11 @@ class FileHandler implements CacheInterface
 
 		if ($data['ttl'] > 0 && time() > $data['time'] + $data['ttl'])
 		{
-			unlink($this->path . $key);
+			// If the file is still there then remove it
+			if (is_file($this->path . $key))
+			{
+				unlink($this->path . $key);
+			}
 
 			return false;
 		}


### PR DESCRIPTION
**Description**
Currently the cache `FileHandler` checks for the existence of the file, reads its contents, then if the TTL has expired it removes the file. Because of the disk operation to read the file and unserialize its contents it is conceivable (and has happened to me a few times) that concurrent calls actually interlace the removal of the file between its check and the second removal attempt, leading to an exception when it tries to `unlink` the non-existent file. This PR adds a second check to confirm the file still exists, which should ensure no two calls attempt to remove the same file.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
