### PR TITLE
Add DotEnv::parse()

### DIFF
--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -83,9 +83,9 @@ class DotEnv
 			return false;
 		}
 
-		foreach ($vars as $key => $value)
+		foreach ($vars as $name => $value)
 		{
-			$this->setVariable($line);
+			$this->setVariable($name, $value);
 		}
 
 		return true; // for success

--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -78,7 +78,7 @@ class DotEnv
 	{
 		$vars = $this->parse();
 
-		if ($vars === false)
+		if ($vars === null)
 		{
 			return false;
 		}
@@ -96,14 +96,14 @@ class DotEnv
 	/**
 	 * Parse the .env file into an array of key => value
 	 *
-	 * @return array
+	 * @return array|null
 	 */
-	public function parse(): array
+	public function parse(): ?array
 	{
 		// We don't want to enforce the presence of a .env file, they should be optional.
 		if (! is_file($this->path))
 		{
-			return false;
+			return null;
 		}
 
 		// Ensure the file is readable

--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -76,18 +76,43 @@ class DotEnv
 	 */
 	public function load(): bool
 	{
-		// We don't want to enforce the presence of a .env file,
-		// they should be optional.
+		$vars = $this->parse();
+
+		if ($vars === false)
+		{
+			return false;
+		}
+
+		foreach ($vars as $key => $value)
+		{
+			$this->setVariable($line);
+		}
+
+		return true; // for success
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Parse the .env file into an array of key => value
+	 *
+	 * @return array
+	 */
+	public function parse(): array
+	{
+		// We don't want to enforce the presence of a .env file, they should be optional.
 		if (! is_file($this->path))
 		{
 			return false;
 		}
 
-		// Ensure file is readable
+		// Ensure the file is readable
 		if (! is_readable($this->path))
 		{
 			throw new \InvalidArgumentException("The .env file is not readable: {$this->path}");
 		}
+
+		$vars = [];
 
 		$lines = file($this->path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 
@@ -99,15 +124,15 @@ class DotEnv
 				continue;
 			}
 
-			// If there is an equal sign, then we know we
-			// are assigning a variable.
+			// If there is an equal sign, then we know we are assigning a variable.
 			if (strpos($line, '=') !== false)
 			{
-				$this->setVariable($line);
+				list($name, $value) = $this->normaliseVariable($line);
+				$vars[$name] = $value;
 			}
 		}
 
-		return true; // for success
+		return $vars;
 	}
 
 	//--------------------------------------------------------------------
@@ -122,8 +147,6 @@ class DotEnv
 	 */
 	protected function setVariable(string $name, string $value = '')
 	{
-		list($name, $value) = $this->normaliseVariable($name, $value);
-
 		if (! getenv($name, true))
 		{
 			putenv("$name=$value");


### PR DESCRIPTION
**Description**
Currently `DotEnv` handles all its functionality in one go, using `load()`. This splits out the function so `parse()` returns the `key =>value` array and then `load()` still handles setting the variables. This allows external parsing of `.env` files (particularly for testing purposes). All tests and usage should remain consistent.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
