### PR TITLE
Fixed links to the AJAX Requests details page

### DIFF
--- a/user_guide_src/source/concepts/http.rst
+++ b/user_guide_src/source/concepts/http.rst
@@ -95,9 +95,9 @@ is an object-oriented representation of the HTTP request. It provides everything
 	$request->getMethod();  // GET, POST, PUT, etc
 
 The request class does a lot of work in the background for you, that you never need to worry about.
-The ``isAJAX()`` and ``isSecure()`` methods check several different methods to determine the correct answer.
+The `isAJAX()` and `isSecure()` methods check several different methods to determine the correct answer.
 
-.. note:: The ``isAJAX()`` method depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e. fetch). See the AJAX Requests </general/ajax> section on how to avoid this problem.
+.. note:: The ``isAJAX()`` method depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e. fetch). See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
 
 ::
 

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -166,6 +166,10 @@ In addition to the standard HTTP methods, this also supports two special cases: 
 self-explanatory here, but 'cli' would apply to all requests that were run from the command line, while 'ajax'
 would apply to every AJAX request.
 
+.. note:: The AJAX requests depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e. fetch). See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
+
+::
+
 $filters
 ========
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -71,7 +71,7 @@ be checked with the ``isAJAX()`` and ``isCLI()`` methods::
 		. . .
 	}
 
-.. note:: The ``isAJAX()`` method depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e. fetch). See the AJAX Requests </general/ajax> section on how to avoid this problem.
+.. note:: The ``isAJAX()`` method depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e. fetch). See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
 
 ::
 


### PR DESCRIPTION
**Description**
I fixed the links that should lead to the page with more information about AJAX requests.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide