### PR TITLE
Fixed Bug: testOrHavingBy() requires a select | #2584

### DIFF
--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -41,6 +41,7 @@ class GroupTest extends CIDatabaseTestCase
 	public function testOrHavingBy()
 	{
 		$result = $this->db->table('user')
+						->select('id')
 						->groupBy('id')
 						->having('id >', 3)
 						->orHaving('SUM(id) > 2')


### PR DESCRIPTION
**Description**
Fixed bug reported in issue # 2584

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
