### PR TITLE
Deprecate Devstarter, add `builds`

### DIFF
--- a/admin/starter/builds
+++ b/admin/starter/builds
@@ -1,0 +1,162 @@
+#!/usr/bin/env php
+<?php
+
+define('LATEST_RELEASE', '^4@rc');
+define('GITHUB_URL', 'https://github.com/codeigniter4/codeigniter4');
+
+/*
+ * --------------------------------------------------------------------
+ * Stability Toggle
+ * --------------------------------------------------------------------
+ * Use this script to toggle the CodeIgniter dependency between the
+ * latest stable release and the most recent development update.
+ *
+ * Usage: php builds [release|development]
+ */
+
+// Determine the requested stability
+if (empty($argv[1]) || ! in_array($argv[1], ['release', 'development']))
+{
+	echo 'Usage: php builds [release|development]' . PHP_EOL;
+	exit;
+}
+
+$dev = $argv[1] == 'development';
+$modified = [];
+
+/* Locate each file and update it for the requested stability */
+
+// Composer.json
+$file = __DIR__ . DIRECTORY_SEPARATOR . 'composer.json';
+
+if (is_file($file))
+{
+	// Make sure we can read it
+	if ($contents = file_get_contents($file))
+	{
+		if ($array = json_decode($contents, true))
+		{
+			// Development
+			if ($dev)
+			{
+				// Set 'minimum-stability'
+				$array['minimum-stability'] = 'dev';
+
+				// Make sure the repo is configured
+				if (! isset($array['repositories']))
+				{
+					$array['repositories'] = [];
+				}
+
+				// Check for the CodeIgniter repo
+				$found = false;
+				foreach ($array['repositories'] as $repository)
+				{
+					if ($repository['url'] == GITHUB_URL)
+					{
+						$found = true;
+						break;
+					}
+				}
+
+				// Add the repo if it was not found
+				if (! $found)
+				{
+					$array['repositories'][] = [
+						'type' => 'vcs',
+						'url'  => GITHUB_URL,
+					];
+				}
+
+				// Define the "require"
+				$array['require']['codeigniter4/codeigniter4'] = 'dev-develop';
+				unset($array['require']['codeigniter4/framework']);
+			}
+			
+			// Release
+			else
+			{
+				// Clear 'minimum-stability'
+				unset($array['minimum-stability']);
+
+				// If the repo is configured then clear it
+				if (isset($array['repositories']))
+				{
+					// Check for the CodeIgniter repo
+					foreach ($array['repositories'] as $i => $repository)
+					{
+						if ($repository['url'] == GITHUB_URL)
+						{
+							unset($array['repositories'][$i]);
+							break;
+						}
+					}
+					if (empty($array['repositories']))
+					{
+						unset($array['repositories']);
+					}
+				}
+
+				// Define the "require"
+				$array['require']['codeigniter4/framework'] = LATEST_RELEASE;
+				unset($array['require']['codeigniter4/codeigniter4']);
+			}
+
+			// Write out a new composer.json
+			file_put_contents($file, json_encode($array, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES) . PHP_EOL);
+			$modified[] = $file;
+		}
+		else
+		{
+			echo 'Warning: Unable to decode composer.json! Skipping...' . PHP_EOL;
+		}
+	}
+	else
+	{
+		echo 'Warning: Unable to read composer.json! Skipping...' . PHP_EOL;
+	}
+}
+
+// Paths config and PHPUnit XMLs
+$files = [
+	__DIR__ . DIRECTORY_SEPARATOR . 'app/Config/Paths.php',
+	__DIR__ . DIRECTORY_SEPARATOR . 'phpunit.xml.dist',
+	__DIR__ . DIRECTORY_SEPARATOR . 'phpunit.xml',
+];
+
+foreach ($files as $file)
+{
+	if (is_file($file))
+	{
+		$contents = file_get_contents($file);
+
+		// Development
+		if ($dev)
+		{
+			$contents = str_replace('vendor/codeigniter4/framework', 'vendor/codeigniter4/codeigniter4', $contents);
+		}
+
+		// Release
+		else
+		{
+			$contents = str_replace('vendor/codeigniter4/codeigniter4', 'vendor/codeigniter4/framework', $contents);
+		}
+
+		file_put_contents($file, $contents);
+		$modified[] = $file;
+	}
+}
+
+if (empty($modified))
+{
+	echo 'No files modified' . PHP_EOL;
+}
+else
+{
+	echo 'The following files were modified:' . PHP_EOL;
+	foreach ($modified as $file)
+	{
+		echo " * {$file}" . PHP_EOL;
+	}
+	echo 'Run `composer update` to sync changes with your vendor folder' . PHP_EOL;
+}

--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -81,70 +81,29 @@ Folders in your project after set up:
 - vendor/codeigniter4/framework/system
 - vendor/codeigniter4/framework/app & public (compare with yours after updating)
 
-Dev Starter
-============================================================
-
-Installation & Set Up
+Latest Dev
 -------------------------------------------------------
 
-The `CodeIgniter 4 dev starter <https://github.com/codeigniter4/devstarter>`_ 
-repository holds a skeleton application, just like the appstarter above,
-but with a composer dependency on
-the develop branch (unreleased) of the framework.
-It can be composer-installed as described here.
-
-This installation technique would suit a developer who wishes to start
-a new CodeIgniter4 based project, and who is willing to live with the
-latest unreleased changes, which may be unstable.
+The App Starter repo comes with a ``builds`` scripts to switch Composer sources between the
+current stable release and the latest development branch of the framework. Use this script
+for a developer who is willing to live with the latest unreleased changes, which may be unstable.
 
 The `development user guide <https://codeigniter4.github.io/CodeIgniter4/>`_ is accessible online.
 Note that this differs from the released user guide, and will pertain to the
 develop branch explicitly.
 
-In the folder above your project root::
+In your project root::
 
-    composer create-project codeigniter4/devstarter -s dev
+    php builds development
 
-The command above will create a "devstarter" folder.
-Feel free to rename that for your project.
+The command above will update **composer.json** to point to the ``develop`` branch of the
+working repository, and update the corresponding paths in config and XML files. To revert
+these changes run::
 
-Just like the appstarter, you can provide your own project
-name as the third composer argument, and you can add
-the "--no-dev" argument if your don't want phpunit and its dependencies included.
-An example::
+    php builds release
 
-    composer create-project codeigniter4/devstarter my-awesome-project -s dev --no-dev
-
-
-Upgrading
--------------------------------------------------------
-
-``composer update`` whenever you are ready for the latest changes,
-or ``composer update --no-dev`` if you used that argument when creating your project.
-
-Check the changelog to see if any recent changes affect your app,
-bearing in mind that the most recent changes may not have made it
-into the changelog!
-
-Pros
--------------------------------------------------------
-
-Simple installation; easy to update; bleeding edge version
-
-Cons
--------------------------------------------------------
-
-This is not guaranteed to be stable; the onus is on you to upgrade.
-You still need to check for ``app/Config`` changes after updating.
-
-Structure
--------------------------------------------------------
-
-Folders in your project after set up:
-
-- app, public, tests, writable 
-- vendor/codeigniter4/codeigniter4/system
-- vendor/codeigniter4/codeigniter4/app & public (compare with yours after updating)
+After using the ``builds`` command be sure to run ``composer update`` to sync your vendor
+folder with the latest target build.
 
 Adding CodeIgniter4 to an Existing Project
 ============================================================

--- a/user_guide_src/source/installation/repositories.rst
+++ b/user_guide_src/source/installation/repositories.rst
@@ -11,9 +11,6 @@ There are several development repositories, of interest to potential contributor
 +==================+==============+=================================================================+
 + CodeIgniter4     + contributors + Project codebase, including tests & user guide sources          +
 +------------------+--------------+-----------------------------------------------------------------+
-+ devstarter       + developers   + Starter project (app/public/writable).                          +
-+                  +              + Dependent on develop branch of codebase repository              +
-+------------------+--------------+-----------------------------------------------------------------+
 + translations     + developers   + System message translations                                     +
 +------------------+--------------+-----------------------------------------------------------------+
 + coding-standard  + contributors + Coding style conventions & rules                                +
@@ -52,7 +49,6 @@ These correspond to the repositories mentioned above:
 
 - `codeigniter4/framework <https://packagist.org/packages/codeigniter4/framework>`_
 - `codeigniter4/appstarter <https://packagist.org/packages/codeigniter4/appstarter>`_
-- `codeigniter4/devstarter <https://packagist.org/packages/codeigniter4/devstarter>`_
 - `codeigniter4/userguide <https://packagist.org/packages/codeigniter4/userguide>`_
 - `codeigniter4/translations <https://packagist.org/packages/codeigniter4/translations>`_
 - `codeigniter4/CodeIgniter4 <https://packagist.org/packages/codeigniter4/CodeIgniter4>`_
@@ -71,12 +67,6 @@ but which showcase it or make it easier to work with!
 + Repository       + Audience     + Description                                                     +
 +==================+==============+=================================================================+
 + website2         + developers   + The codeigniter.com website, written in CodeIgniter 4           +
-+------------------+--------------+-----------------------------------------------------------------+
-+ module-tests     + plugin       + PHPunit testing scaffold for CI4 module / plugin developers     +
-+                  + developers   +                                                                 +
-+------------------+--------------+-----------------------------------------------------------------+
-+ project-tests    + app          + PHPunit testugn scaffold for CI4 projects                       +
-+                  + developers   +                                                                 +
 +------------------+--------------+-----------------------------------------------------------------+
 +                  +              +                                                                 +
 +------------------+--------------+-----------------------------------------------------------------+


### PR DESCRIPTION
**Description**
With the official release around the corner the **devstarter** repo and installation method are now deprecated. This PR updates the docs to reflect that, including instead instructions on how to modify an AppStarter installation to similar effect. To assist with the toggle between release & development I've included a new `builds` script in the starter repo as well, which will update paths as needed in the following: composer.json, phpunit.xml.dist, phpunit.xml, Paths.php. At some point it would be good to figure out how to add tests for `builds` but at the moment I don't have any ideas.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
