### PR TITLE
[UG] Fix all Sphinx warnings

### DIFF
--- a/user_guide_src/source/concepts/http.rst
+++ b/user_guide_src/source/concepts/http.rst
@@ -99,8 +99,6 @@ The `isAJAX()` and `isSecure()` methods check several different methods to deter
 
 .. note:: The ``isAJAX()`` method depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e. fetch). See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
 
-::
-
 CodeIgniter also provides a :doc:`Response class </outgoing/response>` that is an object-oriented representation
 of the HTTP response. This gives you an easy and powerful way to construct your response to the client::
 

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -168,8 +168,6 @@ would apply to every AJAX request.
 
 .. note:: The AJAX requests depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e. fetch). See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
 
-::
-
 $filters
 ========
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -38,7 +38,7 @@ get a copy of it through the :doc:`Services class </concepts/services>`::
 It's preferable, though, to pass the request in as a dependency if the class is anything other than
 the controller, where you can save it as a class property::
 
-	<?php 
+	<?php
         use CodeIgniter\HTTP\RequestInterface;
 
 	class SomeClass
@@ -72,8 +72,6 @@ be checked with the ``isAJAX()`` and ``isCLI()`` methods::
 	}
 
 .. note:: The ``isAJAX()`` method depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e. fetch). See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
-
-::
 
 You can check the HTTP method that this request represents with the ``method()`` method::
 
@@ -261,7 +259,7 @@ You can retrieve a single file uploaded on its own, based on the filename given 
 
 	$file = $request->getFile('uploadedfile');
 
-You can retrieve an array of same-named files uploaded as part of a 
+You can retrieve an array of same-named files uploaded as part of a
 multi-file upload, based on the filename given in the HTML file input::
 
 	$files = $request->getFileMultiple('uploadedfile');

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -75,12 +75,12 @@ The settings for the Redis server that you wish to use when using the ``Redis`` 
 Class Reference
 ***************
 
-.. php:method:: isSupported()
+.. php:method:: ⠀isSupported()
 
 	:returns:	TRUE if supported, FALSE if not
 	:rtype:	bool
 
-.. php:method:: get($key)
+.. php:method:: ⠀get($key)
 
 	:param	string	$key: Cache item name
 	:returns:	Item value or NULL if not found
@@ -93,7 +93,7 @@ Class Reference
 
 		$foo = $cache->get('my_cached_item');
 
-.. php:method:: save($key, $data[, $ttl = 60[, $raw = FALSE]])
+.. php:method:: ⠀save($key, $data[, $ttl = 60[, $raw = FALSE]])
 
 	:param	string	$key: Cache item name
 	:param	mixed	$data: the data to save
@@ -112,7 +112,7 @@ Class Reference
 .. note:: The ``$raw`` parameter is only utilized by Memcache,
 		  in order to allow usage of ``increment()`` and ``decrement()``.
 
-.. php:method:: delete($key)
+.. php:method:: ⠀delete($key)
 
 	:param	string	$key: name of cached item
 	:returns:	TRUE on success, FALSE on failure
@@ -125,7 +125,7 @@ Class Reference
 
 		$cache->delete('cache_item_id');
 
-.. php:method:: increment($key[, $offset = 1])
+.. php:method:: ⠀increment($key[, $offset = 1])
 
 	:param	string	$key: Cache ID
 	:param	int	$offset: Step/value to add
@@ -142,7 +142,7 @@ Class Reference
 
 		$cache->increment('iterator', 3); // 'iterator' is now 6
 
-.. php:method:: decrement($key[, $offset = 1])
+.. php:method:: ⠀decrement($key[, $offset = 1])
 
 	:param	string	$key: Cache ID
 	:param	int	$offset: Step/value to reduce by
@@ -159,7 +159,7 @@ Class Reference
 
 		$cache->decrement('iterator', 2); // 'iterator' is now 3
 
-.. php:method:: clean()
+.. php:method:: ⠀clean()
 
 	:returns:	TRUE on success, FALSE on failure
 	:rtype:	bool
@@ -171,7 +171,7 @@ Class Reference
 
 			$cache->clean();
 
-.. php:method:: cache_info()
+.. php:method:: ⠀cache_info()
 
 	:returns:	Information on the entire cache database
 	:rtype:	mixed
@@ -185,7 +185,7 @@ Class Reference
 .. note:: The information returned and the structure of the data is dependent
 		  on which adapter is being used.
 
-.. php:method:: getMetadata($key)
+.. php:method:: ⠀getMetadata($key)
 
 	:param	string	$key: Cache item name
 	:returns:	Metadata for the cached item

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -10,9 +10,9 @@ helper methods to make testing every aspect of your application as painless as p
     :local:
     :depth: 2
 
-************
+*************
 System Set Up
-************
+*************
 
 Installing phpUnit
 ==================


### PR DESCRIPTION
**Description**
Commits fixing all Sphinx warnings when generating the documentation.

_Only one left: "/CodeIgniter4/user_guide_src/source/changelogs/v4.0.0.rst: WARNING: document isn't included in any toctree". Because it is not a warning, it is a "consistency issue", and I don't know if it is on purpose._

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide