### PR TITLE
Implement JsonSerializable on Entity class

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -46,7 +46,7 @@ use CodeIgniter\Exceptions\CastException;
 /**
  * Entity encapsulation, for use with CodeIgniter\Model
  */
-class Entity
+class Entity implements \JsonSerializable
 {
 	/**
 	 * Maps names used in sets and gets against unique
@@ -613,5 +613,16 @@ class Entity
 			}
 		}
 		return $tmp;
+	}
+
+
+	/**
+	 * Support for json_encode()
+	 *
+	 * @return array|mixed
+	 */
+	public function jsonSerialize()
+	{
+		return $this->attributes;
 	}
 }


### PR DESCRIPTION
Allow json_encode() to be called on an Entity class, to have its attributes returned, json_encoded. This is not just a nice to have but also solves an issue for the ResourceController (#2617 ).
