### PR TITLE
Implement JsonSerializable on Entity class

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -46,7 +46,7 @@ use CodeIgniter\Exceptions\CastException;
 /**
  * Entity encapsulation, for use with CodeIgniter\Model
  */
-class Entity
+class Entity implements \JsonSerializable
 {
 	/**
 	 * Maps names used in sets and gets against unique
@@ -613,5 +613,16 @@ class Entity
 			}
 		}
 		return $tmp;
+	}
+
+	/**
+	 * Support for json_encode()
+	 *
+	 * @return array|mixed
+	 * @throws \Exception
+	 */
+	public function jsonSerialize()
+	{
+		return $this->toArray();
 	}
 }

--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -685,6 +685,13 @@ class EntityTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertTrue(isset($entity->FakeBar));
 	}
 
+	public function testJsonSerializableEntity()
+	{
+		$entity = $this->getEntity();
+		$entity->setBar('foo');
+		$this->assertEquals(json_encode($entity->toArray()), json_encode($entity));
+	}
+
 	protected function getEntity()
 	{
 		return new class extends Entity


### PR DESCRIPTION
Allow json_encode() to be called on an Entity class, to have its attributes returned, json_encoded. This is not just a nice to have but also solves an issue for the ResourceController (#2617).

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated (N/A)
- [x] Conforms to style guide

PS. I created a PR for this contribution before but it was messy so I closed it and did it again. First contribution, hope it meets your standards. Congrats on version 4.0!