### PR TITLE
Load debugbar script before closing body tag

### DIFF
--- a/system/Debug/Toolbar/Views/toolbarloader.js.php
+++ b/system/Debug/Toolbar/Views/toolbarloader.js.php
@@ -75,9 +75,11 @@ function newXHR() {
 			var debugbarTime = realXHR.getResponseHeader('Debugbar-Time');
 			if (debugbarTime) {
 				var h2 = document.querySelector('#ci-history > h2');
-				h2.innerHTML = 'History <small>You have new debug data.</small> <button onclick="loadDoc(' + debugbarTime + ')">Update</button>';
-				var badge = document.querySelector('a[data-tab="ci-history"] > span > .badge');
-				badge.className += ' active';
+				if(h2) {
+					h2.innerHTML = 'History <small>You have new debug data.</small> <button onclick="loadDoc(' + debugbarTime + ')">Update</button>';
+					var badge = document.querySelector('a[data-tab="ci-history"] > span > .badge');
+					badge.className += ' active';
+				}
 			}
 		}
 	}, false);


### PR DESCRIPTION
Sometimes (when using VueJS for instance) dom elements can not be found by the debugbar because the elements are not ready yet. Results in JS errors like:

```
Uncaught TypeError: Cannot set property 'innerHTML' of null
    at XMLHttpRequest.<anonymous> (index.php?debugbar:77)
```

Coming from toolbarloader.js.php:
```
var h2 = document.querySelector('#ci-history > h2');
h2.innerHTML = 'History <small>You have new debug data.</small> <button onclick="loadDoc(' + debugbarTime + ')">Update</button>';
```

`#ci-history > h2` was not ready yet. Problem can be solved by making sure the debugbar is loaded right before the closing body tag.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide