### PR TITLE
Skip running migrations for tests group by default - fix #2627

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -1027,6 +1027,13 @@ class MigrationRunner
 		// Determine DBGroup to use
 		$group = $instance->getDBGroup() ?? config('Database')->defaultGroup;
 
+		// Skip tests db group when not running in testing environment
+		if (ENVIRONMENT !== 'testing' && $group === 'tests' && $this->groupFilter !== 'tests')
+		{
+			$this->groupSkip = true;
+			return true;
+		}
+
 		// Skip migration if group filtering was set
 		if ($direction === 'up' && ! is_null($this->groupFilter) && $this->groupFilter !== $group)
 		{


### PR DESCRIPTION
**Description**
Right now running command: `php spark migrate -all` triggers migrations for the test group too. This pull request fixes that. So now, to call migrations for tests group you have to be explicit and call `php spark migrate -g tests`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide