### PR TITLE
Number Helper - Added Fraction parameter in number_to_currency method

### DIFF
--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -179,17 +179,19 @@ if (! function_exists('number_to_amount'))
 if (! function_exists('number_to_currency'))
 {
 	/**
-	 * @param float  $num
-	 * @param string $currency
-	 * @param string $locale
+	 * @param float   $num
+	 * @param string  $currency
+	 * @param string  $locale
+	 * @param integer $fraction
 	 *
 	 * @return string
 	 */
-	function number_to_currency(float $num, string $currency, string $locale = null): string
+	function number_to_currency(float $num, string $currency, string $locale = null, int $fraction = null): string
 	{
 		return format_number($num, 1, $locale, [
 			'type'     => NumberFormatter::CURRENCY,
 			'currency' => $currency,
+			'fraction' => $fraction,
 		]);
 	}
 }
@@ -217,19 +219,20 @@ if (! function_exists('format_number'))
 		// Type can be any of the NumberFormatter options, but provide a default.
 		$type = (int) ($options['type'] ?? NumberFormatter::DECIMAL);
 
-		// In order to specify a precision, we'll have to modify
-		// the pattern used by NumberFormatter.
-		$pattern = '#,##0.' . str_repeat('#', $precision);
-
 		$formatter = new NumberFormatter($locale, $type);
 
 		// Try to format it per the locale
 		if ($type === NumberFormatter::CURRENCY)
 		{
+			$formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $options['fraction']);
 			$output = $formatter->formatCurrency($num, $options['currency']);
 		}
 		else
 		{
+			// In order to specify a precision, we'll have to modify
+			// the pattern used by NumberFormatter.
+			$pattern = '#,##0.' . str_repeat('#', $precision);
+
 			$formatter->setPattern($pattern);
 			$output = $formatter->format($num);
 		}

--- a/system/View/Filters.php
+++ b/system/View/Filters.php
@@ -256,16 +256,18 @@ class Filters
 	 * @param $value
 	 * @param string      $currency
 	 * @param string|null $locale
+	 * @param integer     $fraction
 	 *
 	 * @return string
 	 */
-	public static function local_currency($value, string $currency, string $locale = null): string
+	public static function local_currency($value, string $currency, string $locale = null, $fraction = null): string
 	{
 		helper('number');
 
 		$options = [
 			'type'     => NumberFormatter::CURRENCY,
 			'currency' => $currency,
+			'fraction' => $fraction,
 		];
 
 		return format_number($value, 2, $locale, $options);

--- a/tests/system/Helpers/NumberHelperTest.php
+++ b/tests/system/Helpers/NumberHelperTest.php
@@ -112,8 +112,9 @@ final class NumberHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	 */
 	public function testCurrencyCurrentLocale()
 	{
-		$this->assertEquals('$1,234.56', number_to_currency(1234.56, 'USD', 'en_US'));
-		$this->assertEquals('£1,234.56', number_to_currency(1234.56, 'GBP', 'en_GB'));
+		$this->assertEquals('$1,234.56', number_to_currency(1234.56, 'USD', 'en_US', 2));
+		$this->assertEquals('£1,234.56', number_to_currency(1234.56, 'GBP', 'en_GB', 2));
+		$this->assertEquals('1.234,56 RSD', number_to_currency(1234.56, 'RSD', 'sr_RS', 2));
 	}
 
 	public function testNumbersThatArent()

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -403,7 +403,7 @@ EOF;
 			'mynum' => 1234567.891234567890000,
 		];
 
-		$template = '{ mynum|local_currency(EUR,de_DE) }';
+		$template = '{ mynum|local_currency(EUR,de_DE,2) }';
 
 		$parser->setData($data);
 		$this->assertEquals('1.234.567,89 €', $parser->renderString($template));

--- a/user_guide_src/source/helpers/number_helper.rst
+++ b/user_guide_src/source/helpers/number_helper.rst
@@ -95,13 +95,14 @@ The following functions are available:
     :param mixed $num: Number to format
     :param string $currency: The currency type, i.e. USD, EUR, etc
     :param string $locale: The locale to use for formatting
+    :param integer $fraction: Number of fraction digits after decimal point
     :returns: The number as the appropriate currency for the locale
     :rtype: string
 
     Converts a number in common currency formats, like USD, EUR, GBP, etc::
 
         echo number_to_currency(1234.56, 'USD');  // Returns $1,234.56
-        echo number_to_currency(1234.56, 'EUR');  // Returns £1,234.56
+        echo number_to_currency(1234.56, 'EUR');  // Returns €1,234.56
         echo number_to_currency(1234.56, 'GBP');  // Returns £1,234.56
         echo number_to_currency(1234.56, 'YEN');  // Returns YEN1,234.56
 


### PR DESCRIPTION
**Description**
Added option to specify fraction in currency formatter.  

PHP intl currency number formatter for some reason does not handle the number decimals per locale. https://www.php.net/manual/en/numberformatter.formatcurrency.php

I've added additional parameter to the method to allow specifying fraction. 

The already existing unit test was failing in my environment for the same reason so I've updated those tests to use fraction parameter as well. Additionally, I've added test case which uses locale where currency symbol should be located after the value.

Ref #2634 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

