### PR TITLE
No more shared instance for Router - fix #2393

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -773,7 +773,7 @@ class CodeIgniter
 		}
 
 		// $routes is defined in Config/Routes.php
-		$this->router = Services::router($routes, $this->request);
+		$this->router = Services::router($routes, $this->request, false);
 
 		$path = $this->determinePath();
 

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -295,7 +295,7 @@ class ServicesTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testRouter()
 	{
-		$result = Services::router();
+		$result = Services::router(Services::routes(), Services::request());
 		$this->assertInstanceOf(\CodeIgniter\Router\Router::class, $result);
 	}
 


### PR DESCRIPTION
**Description**
A shared router instance caused some issues with `directory` for controllers in subfolders.
See #2393

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide