### PR TITLE
Reset dir for FeatureTestCase - fixes #2393

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -603,10 +603,11 @@ class Router implements RouterInterface
 	 * @param string|null   $dir
 	 * @param boolean|false $append
 	 */
-	protected function setDirectory(string $dir = null, bool $append = false)
+	public function setDirectory(string $dir = null, bool $append = false)
 	{
 		if (empty($dir))
 		{
+			$this->directory = null;
 			return;
 		}
 

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -188,6 +188,9 @@ class FeatureTestCase extends CIDatabaseTestCase
 		}
 		// @codeCoverageIgnoreEnd
 
+		// Reset directory if it has been set
+		Services::router()->setDirectory(null);
+
 		$featureResponse = new FeatureResponse($response);
 
 		return $featureResponse;


### PR DESCRIPTION
**Description**
This change allows you to reset `$this->directory` variable in the Router class -  to use with FeatureTestCase.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide