### PR TITLE
Remove logging of controller loaded

### DIFF
--- a/system/Controller.php
+++ b/system/Controller.php
@@ -117,7 +117,6 @@ class Controller
 		$this->request  = $request;
 		$this->response = $response;
 		$this->logger   = $logger;
-		$this->logger->info('Controller "' . get_class($this) . '" loaded.');
 
 		if ($this->forceHTTPS > 0)
 		{


### PR DESCRIPTION
Every time a controller loads it logs 

    INFO - {date time} --> Controller "App\Controllers\{class} loaded. 

Every other instance of logging a class being loaded has been removed from v4. This one should be too.

