### PR TITLE
[Docs] Fix Composer Installation Page - existing Project

### DIFF
--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -131,7 +131,7 @@ to your project root
 Copy the ``env``, ``phpunit.xml.dist`` and ``spark`` files, from
 ``vendor/codeigniter4/framework`` to your project root
 
-You will have to adjust paths to refer to vendor/codeigniter/framework``, 
+You will have to adjust paths to refer to ``/vendor/codeigniter4/framework``,
 - the $systemDirectory variable in ``app/Config/Paths.php``
 
 Upgrading


### PR DESCRIPTION
**Description**
- Fix unpaired backquotes and missing '4' in vendor path
- Also, added directory separator at front of vendor path, since
CI3 needs it = \_\_DIR__ . '/../../system'
