### PR TITLE
Add missing tick to Requirements

### DIFF
--- a/user_guide_src/source/intro/requirements.rst
+++ b/user_guide_src/source/intro/requirements.rst
@@ -7,7 +7,7 @@ Server Requirements
 installed.
 
 The following PHP extensions should be enabled on your server:
-``php-json``, ``php-mbstring``, ``php-mysqlnd``, `php-xml``
+``php-json``, ``php-mbstring``, ``php-mysqlnd``, ``php-xml``
 
 In order to use the :doc:`CURLRequest </libraries/curlrequest>`, you will need
 `libcurl <https://www.php.net/manual/en/curl.requirements.php>`_ installed.


### PR DESCRIPTION
**Description**
Installation Requirements has been missing a tick and it has been driving me crazy for a while. Finally taking the time to submit a PR for what must be the smallest possible single-character change ever...

**Checklist:**
- [X] Securely signed commits
- n/a Component(s) with PHPdocs
- n/a Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
