### PR TITLE
fix forceHTTPS bug #2633

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -413,12 +413,16 @@ if (! function_exists('force_https'))
 				->regenerate();
 		}
 
-		$uri = $request->uri;
-		$uri->setScheme('https');
+		$baseURL = config(App::class)->baseURL;
+
+		if (strpos($baseURL, 'http://') === 0)
+		{
+			$baseURL = (string) substr(rtrim($baseURL, '/'), strlen('http://'));
+		}
 
 		$uri = URI::createURIString(
-			$uri->getScheme(), $uri->getAuthority(true), $uri->getPath(), // Absolute URIs should use a "/" for an empty path
-			$uri->getQuery(), $uri->getFragment()
+			'https', $baseURL, $request->uri->getPath(), // Absolute URIs should use a "/" for an empty path
+			$request->uri->getQuery(), $request->uri->getFragment()
 		);
 
 		// Set an HSTS header

--- a/system/Common.php
+++ b/system/Common.php
@@ -417,7 +417,7 @@ if (! function_exists('force_https'))
 
 		if (strpos($baseURL, 'http://') === 0)
 		{
-			$baseURL = (string) substr(rtrim($baseURL, '/'), strlen('http://'));
+			$baseURL = (string) substr($baseURL, strlen('http://'));
 		}
 
 		$uri = URI::createURIString(


### PR DESCRIPTION
**Description**
When CI was installed in a subfolder, the redirection to https did not include this folder.
See: #2633

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide 