### PR TITLE
Remove call to resolveRelativeURI in detectURI method

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -616,7 +616,6 @@ class IncomingRequest extends Request
 			$this->uri->setScheme(parse_url($baseURL, PHP_URL_SCHEME));
 			$this->uri->setHost(parse_url($baseURL, PHP_URL_HOST));
 			$this->uri->setPort(parse_url($baseURL, PHP_URL_PORT));
-			$this->uri->resolveRelativeURI(parse_url($baseURL, PHP_URL_PATH));
 
 			// Ensure we have any query vars
 			$this->uri->setQuery($_SERVER['QUERY_STRING'] ?? '');


### PR DESCRIPTION
**Description**
I noticed this when looking at `IncomingRequest` class. It seems like this method call does nothing here and can be safely removed.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide