### PR TITLE
Fix default CLI command #2645

### DIFF
--- a/system/CLI/CommandRunner.php
+++ b/system/CLI/CommandRunner.php
@@ -104,7 +104,7 @@ class CommandRunner extends Controller
 
 		if (is_null($command))
 		{
-			$command = 'help';
+			$command = 'list';
 		}
 
 		return $this->runCommand($command, $params);

--- a/tests/system/CLI/CommandRunnerTest.php
+++ b/tests/system/CLI/CommandRunnerTest.php
@@ -69,8 +69,8 @@ class CommandRunnerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$result = CITestStreamFilter::$buffer;
 
 		// make sure the result looks like basic help
+		$this->assertStringContainsString('Lists the available commands.', $result);
 		$this->assertStringContainsString('Displays basic usage information.', $result);
-		$this->assertStringContainsString('help command_name', $result);
 	}
 
 	public function testHelpCommand()


### PR DESCRIPTION
**Description**
Update default CLI command to run `list` instead of `help`.
See: #2645

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide