### PR TITLE
Escape php binary - fixes #2367

### DIFF
--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -97,14 +97,14 @@ class Serve extends BaseCommand
 	/**
 	 * The current port offset.
 	 *
-	 * @var int
+	 * @var integer
 	 */
 	protected $portOffset = 0;
 
 	/**
 	 * The max number of ports to attempt to serve from
 	 *
-	 * @var int
+	 * @var integer
 	 */
 	protected $tries = 10;
 
@@ -136,7 +136,7 @@ class Serve extends BaseCommand
 		}
 
 		// Collect any user-supplied options and apply them.
-		$php  = CLI::getOption('php') ?? PHP_BINARY;
+		$php  = escapeshellarg(CLI::getOption('php') ?? PHP_BINARY);
 		$host = CLI::getOption('host') ?? 'localhost';
 		$port = (int) (CLI::getOption('port') ?? '8080') + $this->portOffset;
 
@@ -155,7 +155,8 @@ class Serve extends BaseCommand
 		// to ensure our environment is set and it simulates basic mod_rewrite.
 		passthru($php . ' -S ' . $host . ':' . $port . ' -t ' . $docroot . ' ' . $rewrite, $status);
 
-		if ($status && $this->portOffset < $this->tries) {
+		if ($status && $this->portOffset < $this->tries)
+		{
 			$this->portOffset += 1;
 
 			$this->run($params);


### PR DESCRIPTION
**Description**
To avoid path problems, we should use `escapeshellarg` function for PHP_BINARY.
See: #2367

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide