### PR TITLE
Updateing logging level restriction for logging.rst

### DIFF
--- a/user_guide_src/source/general/logging.rst
+++ b/user_guide_src/source/general/logging.rst
@@ -39,7 +39,7 @@ the ``/app/Config/Logger.php`` configuration file.
 The ``threshold`` value of the config file determines which levels are logged across your application. If any levels
 are requested to be logged by the application, but the threshold doesn't allow them to log currently, they will be
 ignored. The simplest method to use is to set this value to the minimum level that you want to have logged. For example,
-if you want to log debug messages, and not information messages, you would set the threshold to ``5``. Any log requests with
+if you want to log warning messages, and not information messages, you would set the threshold to ``5``. Any log requests with
 a level of 5 or less (which includes runtime errors, system errors, etc) would be logged and info, notices, and warnings
 would be ignored::
 

--- a/user_guide_src/source/general/logging.rst
+++ b/user_guide_src/source/general/logging.rst
@@ -40,7 +40,7 @@ The ``threshold`` value of the config file determines which levels are logged ac
 are requested to be logged by the application, but the threshold doesn't allow them to log currently, they will be
 ignored. The simplest method to use is to set this value to the minimum level that you want to have logged. For example,
 if you want to log warning messages, and not information messages, you would set the threshold to ``5``. Any log requests with
-a level of 5 or less (which includes runtime errors, system errors, etc) would be logged and info, notices, and warnings
+a level of 5 or less (which includes runtime errors, system errors, etc) would be logged and info, notices, and debug
 would be ignored::
 
 	public $threshold = 5;


### PR DESCRIPTION
If the level is 5 or less, debug message will also be ignored, thus there should be warning(level 5)，any levels higher than 5 would be ignored.

  
