### PR TITLE
Fix documentation bug. Modeling data / Using Codeigniter's model

### DIFF
--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -338,7 +338,7 @@ update command, with the added benefit of validation, events, etc::
 
     $userModel
         ->whereIn('id', [1,2,3])
-        ->set(['active' => 1]
+        ->set(['active' => 1])
         ->update();
 
 **save()**


### PR DESCRIPTION
**Description**
The third update example is missing a parentisis.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
