### PR TITLE
Fix a user guide style issue

### DIFF
--- a/user_guide_src/source/_themes/sphinx_rtd_theme/static/css/citheme.css
+++ b/user_guide_src/source/_themes/sphinx_rtd_theme/static/css/citheme.css
@@ -171,7 +171,6 @@ div#pulldown-menu {
 
 .wy-plain-list-disc li ul, .rst-content .section ul li ul, .rst-content .toctree-wrapper ul li ul, article ul li ul {
 		margin-bottom: 0.5rem;
-		margin-top: -0.5rem;
 }
 
 .rst-content dl:not(.docutils) dt:first-child {


### PR DESCRIPTION
**Description**
In the table of contents of the user guide, there is an incorrect space between the primary and secondary titles.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide