### PR TITLE
Confirmation for rollback and refresh in a production environment

### DIFF
--- a/system/Commands/Database/MigrateRefresh.php
+++ b/system/Commands/Database/MigrateRefresh.php
@@ -95,6 +95,7 @@ class MigrateRefresh extends BaseCommand
 		'-n'   => 'Set migration namespace',
 		'-g'   => 'Set database group',
 		'-all' => 'Set latest for all namespace, will ignore (-n) option',
+		'-f'   => 'Force command - this option allows you to bypass the confirmation question when running this command in a production environment',
 	];
 
 	/**
@@ -105,7 +106,20 @@ class MigrateRefresh extends BaseCommand
 	 */
 	public function run(array $params = [])
 	{
-		$this->call('migrate:rollback', ['-b' => 0]);
+		$params = ['-b' => 0];
+
+		if (ENVIRONMENT === 'production')
+		{
+			$force = $params['-f'] ?? CLI::getOption('f');
+			if (is_null($force) && CLI::prompt(lang('Migrations.refreshConfirm'), ['y', 'n']) === 'n')
+			{
+				return;
+			}
+
+			$params['-f'] = '';
+		}
+
+		$this->call('migrate:rollback', $params);
 		$this->call('migrate');
 	}
 

--- a/system/Commands/Database/MigrateRollback.php
+++ b/system/Commands/Database/MigrateRollback.php
@@ -97,6 +97,7 @@ class MigrateRollback extends BaseCommand
 	protected $options = [
 		'-b' => 'Specify a batch to roll back to; e.g. "3" to return to batch #3 or "-2" to roll back twice',
 		'-g' => 'Set database group',
+		'-f' => 'Force command - this option allows you to bypass the confirmation question when running this command in a production environment',
 	];
 
 	/**
@@ -107,6 +108,15 @@ class MigrateRollback extends BaseCommand
 	 */
 	public function run(array $params = [])
 	{
+		if (ENVIRONMENT === 'production')
+		{
+			$force = $params['-f'] ?? CLI::getOption('f');
+			if (is_null($force) && CLI::prompt(lang('Migrations.rollBackConfirm'), ['y', 'n']) === 'n')
+			{
+				return;
+			}
+		}
+
 		$runner = Services::migrations();
 
 		$group = $params['-g'] ?? CLI::getOption('g');

--- a/system/Language/en/Migrations.php
+++ b/system/Language/en/Migrations.php
@@ -37,6 +37,8 @@ return [
    'badCreateName'     => 'You must provide a migration file name.',
    'writeError'        => 'Error trying to create file.',
    'migNumberError'    => 'Migration number must be three digits, and there must not be any gaps in the sequence.',
+   'rollBackConfirm'   => 'Are you sure you want to rollback?',
+   'refreshConfirm'    => 'Are you sure you want to refresh?',
 
    'latest'            => 'Running all new migrations...',
    'generalFault'      => 'Migration failed!',

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -213,6 +213,7 @@ You can use (rollback) with the following options:
 
 - (-g) to choose database group, otherwise default database group will be used.
 - (-b) to choose a batch: natural numbers specify the batch, negatives indicate a relative batch
+- (-f) to force a bypass confirmation question, it is only asked in a production environment
 
 **refresh**
 
@@ -225,6 +226,7 @@ You can use (refresh) with the following options:
 - (-g) to choose database group, otherwise default database group will be used.
 - (-n) to choose namespace, otherwise (App) namespace will be used.
 - (-all) to refresh all namespaces
+- (-f) to force a bypass confirmation question, it is only asked in a production environment
 
 **status**
 


### PR DESCRIPTION
**Description**
This pull request adds confirmation for rollback and refresh in a production environment. Confirmation can be bypassed via `-f` (force) option.

Ref: #2385

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide 
