### PR TITLE
fix. getYear can't week based year

### DIFF
--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -423,7 +423,7 @@ class Time extends DateTime
 	 */
 	public function getYear(): string
 	{
-		return $this->toLocalizedString('Y');
+		return $this->toLocalizedString('y');
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -240,8 +240,10 @@ class TimeTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testGetYear()
 	{
 		$time = Time::parse('January 1, 2016');
+		$time2 = Time::parse('December 31, 2019');
 
 		$this->assertEquals(2016, $time->year);
+		$this->assertEquals(2019, $time2->year);
 	}
 
 	public function testGetMonth()


### PR DESCRIPTION
Fix #2663 `CodeIgniter\I18n\Time` default format is `yyyy-MM-dd HH:mm:ss`, but `getYear` use `Y`,
the method return based week year. Last days of the some year, the method reutn current year +1.It's confusing 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
