### PR TITLE
Fix ResourceController Issue, including Test Unit

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -373,11 +373,15 @@ trait ResponseTrait
 		// Determine correct response type through content negotiation
 		$config = new Format();
 
-		if (!in_array($this->format, ['json', 'xml']))
+		if (! in_array($this->format, ['json', 'xml']))
+		{
 			$format = $this->request->negotiate('media', $config->supportedResponseFormats, false);
-		else 
+		}
+		else
+		{
 			$format = "application/$this->format";
-			
+		}
+
 		$this->response->setContentType($format);
 
 		// if we don't have a formatter, make one

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -93,6 +93,12 @@ trait ResponseTrait
 		'not_implemented'           => 501,
 	];
 
+	/**
+	 *
+	 * @var string the representation format to return resource data in (json/xml)
+	 */
+	protected $format = 'json';
+
 	//--------------------------------------------------------------------
 
 	/**
@@ -366,8 +372,12 @@ trait ResponseTrait
 
 		// Determine correct response type through content negotiation
 		$config = new Format();
-		$format = $this->request->negotiate('media', $config->supportedResponseFormats, false);
 
+		if (!in_array($this->format, ['json', 'xml']))
+			$format = $this->request->negotiate('media', $config->supportedResponseFormats, false);
+		else 
+			$format = "application/$this->format";
+			
 		$this->response->setContentType($format);
 
 		// if we don't have a formatter, make one

--- a/system/RESTful/ResourceController.php
+++ b/system/RESTful/ResourceController.php
@@ -66,12 +66,6 @@ class ResourceController extends Controller
 	 */
 	protected $model = null;
 
-	/**
-	 *
-	 * @var string the representation format to return resource data in (json/xml)
-	 */
-	protected $format = 'json';
-
 	//--------------------------------------------------------------------
 
 	public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -4,7 +4,6 @@ namespace CodeIgniter\RESTful;
 use CodeIgniter\Config\Services;
 use Config\App;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
-
 /**
  * Exercise our ResourceController class.
  * We know the resource routing works, from RouterTest,
@@ -249,6 +248,64 @@ class ResourceControllerTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$resource->setFormat('xml');
 		$this->assertEquals('xml', $resource->getFormat());
+	}
+
+	//--------------------------------------------------------------------
+	public function testJSONFormatOutput()
+	{
+		$resource = new \CodeIgniter\Test\Mock\MockResourceController();
+		
+		$config = new \Config\App;
+		$uri    = new \CodeIgniter\HTTP\URI;
+		$agent  = new \CodeIgniter\HTTP\UserAgent;
+
+		$request = new \CodeIgniter\HTTP\IncomingRequest($config, $uri, '', $agent);
+		$response = new \CodeIgniter\HTTP\Response($config);
+		$logger = new \Psr\Log\NullLogger;
+
+		$resource->initController($request, $response, $logger);
+		$resource->setFormat('json');
+
+		$data = [
+			'foo' => 'bar',
+		];
+
+		$the_response = $resource->respond($data);
+		$result = $the_response->getBody();
+
+		$JSONFormatter = new \CodeIgniter\Format\JSONFormatter;
+		$expected = $JSONFormatter->format($data);
+
+		$this->assertEquals($expected, $result);
+	}
+
+	//--------------------------------------------------------------------
+	public function testXMLFormatOutput()
+	{
+		$resource = new \CodeIgniter\Test\Mock\MockResourceController();
+		
+		$config = new \Config\App;
+		$uri    = new \CodeIgniter\HTTP\URI;
+		$agent  = new \CodeIgniter\HTTP\UserAgent;
+
+		$request = new \CodeIgniter\HTTP\IncomingRequest($config, $uri, '', $agent);
+		$response = new \CodeIgniter\HTTP\Response($config);
+		$logger = new \Psr\Log\NullLogger;
+
+		$resource->initController($request, $response, $logger);
+		$resource->setFormat('xml');
+
+		$data = [
+			'foo' => 'bar',
+		];
+
+		$the_response = $resource->respond($data);
+		$result = $the_response->getBody();
+
+		$XMLFormatter = new \CodeIgniter\Format\XMLFormatter;
+		$expected = $XMLFormatter->format($data);
+
+		$this->assertEquals($expected, $result);
 	}
 
 }

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -4,6 +4,7 @@ namespace CodeIgniter\RESTful;
 use CodeIgniter\Config\Services;
 use Config\App;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
+
 /**
  * Exercise our ResourceController class.
  * We know the resource routing works, from RouterTest,
@@ -254,14 +255,14 @@ class ResourceControllerTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testJSONFormatOutput()
 	{
 		$resource = new \CodeIgniter\Test\Mock\MockResourceController();
-		
+
 		$config = new \Config\App;
 		$uri    = new \CodeIgniter\HTTP\URI;
 		$agent  = new \CodeIgniter\HTTP\UserAgent;
 
-		$request = new \CodeIgniter\HTTP\IncomingRequest($config, $uri, '', $agent);
+		$request  = new \CodeIgniter\HTTP\IncomingRequest($config, $uri, '', $agent);
 		$response = new \CodeIgniter\HTTP\Response($config);
-		$logger = new \Psr\Log\NullLogger;
+		$logger   = new \Psr\Log\NullLogger;
 
 		$resource->initController($request, $response, $logger);
 		$resource->setFormat('json');
@@ -271,10 +272,10 @@ class ResourceControllerTest extends \CodeIgniter\Test\CIUnitTestCase
 		];
 
 		$the_response = $resource->respond($data);
-		$result = $the_response->getBody();
+		$result       = $the_response->getBody();
 
 		$JSONFormatter = new \CodeIgniter\Format\JSONFormatter;
-		$expected = $JSONFormatter->format($data);
+		$expected      = $JSONFormatter->format($data);
 
 		$this->assertEquals($expected, $result);
 	}
@@ -283,14 +284,14 @@ class ResourceControllerTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testXMLFormatOutput()
 	{
 		$resource = new \CodeIgniter\Test\Mock\MockResourceController();
-		
+
 		$config = new \Config\App;
 		$uri    = new \CodeIgniter\HTTP\URI;
 		$agent  = new \CodeIgniter\HTTP\UserAgent;
 
-		$request = new \CodeIgniter\HTTP\IncomingRequest($config, $uri, '', $agent);
+		$request  = new \CodeIgniter\HTTP\IncomingRequest($config, $uri, '', $agent);
 		$response = new \CodeIgniter\HTTP\Response($config);
-		$logger = new \Psr\Log\NullLogger;
+		$logger   = new \Psr\Log\NullLogger;
 
 		$resource->initController($request, $response, $logger);
 		$resource->setFormat('xml');
@@ -300,10 +301,10 @@ class ResourceControllerTest extends \CodeIgniter\Test\CIUnitTestCase
 		];
 
 		$the_response = $resource->respond($data);
-		$result = $the_response->getBody();
+		$result       = $the_response->getBody();
 
 		$XMLFormatter = new \CodeIgniter\Format\XMLFormatter;
-		$expected = $XMLFormatter->format($data);
+		$expected     = $XMLFormatter->format($data);
 
 		$this->assertEquals($expected, $result);
 	}


### PR DESCRIPTION
This is an alternative way to fix #2617 

I found that variable `$format` should be moved to `ResponseTrait` , so that it can be used inside `format` method.

I have add two unit testing for this change

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
  
