### PR TITLE
Force migrations to take into account the namespaces defined in composer

### DIFF
--- a/system/Commands/Database/CreateMigration.php
+++ b/system/Commands/Database/CreateMigration.php
@@ -40,7 +40,7 @@ namespace CodeIgniter\Commands\Database;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
-use Config\Autoload;
+use Config\Services;
 use Config\Migrations;
 
 /**
@@ -124,15 +124,14 @@ class CreateMigration extends BaseCommand
 
 		if (! empty($ns))
 		{
-			// Get all namespaces from PSR4 paths.
-			$config     = new Autoload();
-			$namespaces = $config->psr4;
+			// Get all namespaces
+			$namespaces = Services::autoloader()->getNamespace();
 
 			foreach ($namespaces as $namespace => $path)
 			{
 				if ($namespace === $ns)
 				{
-					$homepath = realpath($path);
+					$homepath = realpath(reset($path));
 					break;
 				}
 			}

--- a/system/Commands/Database/MigrateStatus.php
+++ b/system/Commands/Database/MigrateStatus.php
@@ -42,7 +42,6 @@ namespace CodeIgniter\Commands\Database;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use Config\Services;
-use Config\Autoload;
 
 /**
  * Displays a list of all migrations and whether they've been run or not.
@@ -106,6 +105,10 @@ class MigrateStatus extends BaseCommand
 		'CodeIgniter',
 		'Config',
 		'Tests\Support',
+		'Kint',
+		'Laminas\ZendFrameworkBridge',
+		'Laminas\Escaper',
+		'Psr\Log',
 	];
 
 	/**
@@ -124,9 +127,11 @@ class MigrateStatus extends BaseCommand
 			$runner->setGroup($group);
 		}
 
-		// Get all namespaces from  PSR4 paths.
-		$config     = new Autoload();
-		$namespaces = $config->psr4;
+		// Get all namespaces
+		$namespaces = Services::autoloader()->getNamespace();
+
+		// Determines whether any migrations were found
+		$found = false;
 
 		// Loop for all $namespaces
 		foreach ($namespaces as $namespace => $path)
@@ -138,15 +143,16 @@ class MigrateStatus extends BaseCommand
 
 			$runner->setNamespace($namespace);
 			$migrations = $runner->findMigrations();
-			$history    = $runner->getHistory();
-
-			CLI::write($namespace);
 
 			if (empty($migrations))
 			{
-				CLI::error(lang('Migrations.noneFound'));
 				continue;
 			}
+
+			$found   = true;
+			$history = $runner->getHistory();
+
+			CLI::write($namespace);
 
 			ksort($migrations);
 
@@ -175,6 +181,11 @@ class MigrateStatus extends BaseCommand
 				}
 				CLI::write(str_pad('  ' . $migration->name, $max + 6) . ($date ? $date : '---'));
 			}
+		}
+
+		if (! $found)
+		{
+			CLI::error(lang('Migrations.noneFound'));
 		}
 	}
 


### PR DESCRIPTION
**Description**
This pull request fixes  #2664. 
Also, to stay consistent I had to make some changes to the `migrate:status` command as well. Otherwise, the status command would display information about each namespace.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide