### PR TITLE
WhereIn() not supporting non array variables 🐛

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -987,12 +987,22 @@ class BaseBuilder
 	{
 		if (empty($key) || ! is_string($key))
 		{
-			throw new InvalidArgumentException(sprintf('%s() expects $key to be a non-empty string', debug_backtrace(0, 2)[1]['function']));
+			if (CI_DEBUG)
+			{
+				throw new InvalidArgumentException(sprintf('%s() expects $key to be a non-empty string', debug_backtrace(0, 2)[1]['function']));
+			} 
+			
+			return this;
 		}
 
 		if ($values === null || (! is_array($values) && ! ($values instanceof Closure)))
 		{
-			throw new InvalidArgumentException(sprintf('%s() expects $values to be of type array or closure', debug_backtrace(0, 2)[1]['function']));
+			if (CI_DEBUG)
+			{
+				throw new InvalidArgumentException(sprintf('%s() expects $values to be of type array or closure', debug_backtrace(0, 2)[1]['function']));
+			}
+			
+			return this;
 		}
 
 		is_bool($escape) || $escape = $this->db->protectIdentifiers;

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -984,7 +984,7 @@ class BaseBuilder
 	 */
 	protected function _whereIn(string $key = null, $values = null, bool $not = false, string $type = 'AND ', bool $escape = null, string $clause = 'QBWhere')
 	{
-		if ($key === null || $values === null || (! is_array($values) && ! ($values instanceof Closure)))
+		if ($key === null || $values === null)
 		{
 			return $this;
 		}

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -979,14 +979,20 @@ class BaseBuilder
 	 * @param string        $type
 	 * @param boolean       $escape
 	 * @param string        $clause (Internal use only)
+	 * @throws InvalidArgumentException
 	 *
 	 * @return BaseBuilder
 	 */
 	protected function _whereIn(string $key = null, $values = null, bool $not = false, string $type = 'AND ', bool $escape = null, string $clause = 'QBWhere')
 	{
-		if ($key === null || $values === null)
+		if (empty($key) || ! is_string($key))
 		{
-			return $this;
+			throw new InvalidArgumentException(sprintf('%s() expects $key to be a non-empty string', debug_backtrace(0, 2)[1]['function']));
+		}
+
+		if ($values === null || (! is_array($values) && ! ($values instanceof Closure)))
+		{
+			throw new InvalidArgumentException(sprintf('%s() expects $values to be of type array or closure', debug_backtrace(0, 2)[1]['function']));
 		}
 
 		is_bool($escape) || $escape = $this->db->protectIdentifiers;


### PR DESCRIPTION
Each pull request should address a single issue and have a meaningful title.

**Description**
- When using WhereIn if the variable being passed in is not an array or closure it is simply returned with no user feedback. 
    - However we have logic in place which allows regular values.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
  
