### PR TITLE
Fixed issue of  phrase custom validation error message config

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -475,7 +475,7 @@ class Validation implements ValidationInterface
 	public function setRuleGroup(string $group)
 	{
 		$rules       = $this->getRuleGroup($group);
-		$this->rules = $rules;
+		$this->setRules($rules);
 
 		$errorName = $group . '_errors';
 		if (isset($this->config->$errorName))


### PR DESCRIPTION
After getRuleGroup($group),
Instead asign to $this->rule,
We should call $this->setRules($rules) at least once.

**Description**
See: (https://github.com/codeigniter4/CodeIgniter4/issues/2678)

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

