### PR TITLE
Parser regexp extended with dot and slash. Tests added to date filter.

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -320,7 +320,7 @@ class Parser extends View
 	 */
 	protected function parseSingle(string $key, string $val): array
 	{
-		$pattern = '#' . $this->leftDelimiter . '!?\s*' . preg_quote($key) . '\s*\|*\s*([|a-zA-Z0-9<>=\(\),:_\-\s\+]+)*\s*!?' . $this->rightDelimiter . '#ms';
+		$pattern = '#' . $this->leftDelimiter . '!?\s*' . preg_quote($key) . '\s*\|*\s*([|\w<>=\(\),:.\-\s\+\\\\/]+)*\s*!?' . $this->rightDelimiter . '#ms';
 
 		return [$pattern => $val];
 	}
@@ -402,7 +402,7 @@ class Parser extends View
 						$val = 'Resource';
 					}
 
-					$temp['#' . $this->leftDelimiter . '!?\s*' . preg_quote($key) . '\s*\|*\s*([|\w<>=\(\),:_\-\s\+]+)*\s*!?' . $this->rightDelimiter . '#s'] = $val;
+					$temp['#' . $this->leftDelimiter . '!?\s*' . preg_quote($key) . '\s*\|*\s*([|\w<>=\(\),:.\-\s\+\\\\/]+)*\s*!?' . $this->rightDelimiter . '#s'] = $val;
 				}
 
 				// Now replace our placeholders with the new content.
@@ -686,7 +686,7 @@ class Parser extends View
 		foreach ($filters as $filter)
 		{
 			// Grab any parameter we might need to send
-			preg_match('/\([a-zA-Z0-9\-:_ +,<>=]+\)/', $filter, $param);
+			preg_match('/\([\w<>=\/\\\,:.\-\s\+]+\)/', $filter, $param);
 
 			// Remove the () and spaces to we have just the parameter left
 			$param = ! empty($param) ? trim($param[0], '() ') : null;

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -58,17 +58,22 @@ class ParserFilterTest extends \CodeIgniter\Test\CIUnitTestCase
 	{
 		$parser = new Parser($this->config, $this->viewsDir, $this->loader);
 
-		$today = date('Y-m-d');
+		$today_dash = date('Y-m-d');
+		$today_dot = date('Y.m.d');
+		$today_space = date('Y m d');
+		$today_colon = date('Y:m:d');
+		$today_slash = date('Y/m/d');
+		$today_backslash = date('Y\\\m\\\d');
 
 		$data = [
 			'value1' => time(),
 			'value2' => date('Y-m-d H:i:s'),
-		];
+		]; 
 
-		$template = '{ value1|date(Y-m-d) } { value2|date(Y-m-d) }';
+		$template = '{ value1|date(Y-m-d) } { value2|date(Y-m-d) } { value1|date(Y.m.d) } { value1|date(Y m d) } { value1|date(Y:m:d) } { value1|date(Y/m/d) } { value1|date(Y\\\m\\\d) }';
 
 		$parser->setData($data);
-		$this->assertEquals("{$today} {$today}", $parser->renderString($template));
+		$this->assertEquals("{$today_dash} {$today_dash} {$today_dot} {$today_space} {$today_colon} {$today_slash} {$today_backslash}", $parser->renderString($template));
 	}
 
 	//--------------------------------------------------------------------
@@ -403,7 +408,7 @@ EOF;
 			'mynum' => 1234567.891234567890000,
 		];
 
-		$template = '{ mynum|local_currency(EUR,de_DE,2) }';
+		$template = '{ mynum|local_currency(EUR,de_DE) }';
 
 		$parser->setData($data);
 		$this->assertEquals('1.234.567,89 €', $parser->renderString($template));

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -68,7 +68,7 @@ class ParserFilterTest extends \CodeIgniter\Test\CIUnitTestCase
 		$data = [
 			'value1' => time(),
 			'value2' => date('Y-m-d H:i:s'),
-		]; 
+		];
 
 		$template = '{ value1|date(Y-m-d) } { value2|date(Y-m-d) } { value1|date(Y.m.d) } { value1|date(Y m d) } { value1|date(Y:m:d) } { value1|date(Y/m/d) } { value1|date(Y\\\m\\\d) }';
 
@@ -408,7 +408,7 @@ EOF;
 			'mynum' => 1234567.891234567890000,
 		];
 
-		$template = '{ mynum|local_currency(EUR,de_DE) }';
+		$template = '{ mynum|local_currency(EUR,de_DE,2) }';
 
 		$parser->setData($data);
 		$this->assertEquals('1.234.567,89 €', $parser->renderString($template));


### PR DESCRIPTION
**Description**
Extended regexp patterns in parseSingle and parsePair function with dot character and slashes. This solves the issue when expression like {timestamp|date(d.m.Y)} was not working correctly (issue raised here: https://forum.codeigniter.com/thread-75571.html). Also unified regexp patterns in Parser: now they both rely on \w macro that covers [A-Za-z0-9_] range.

This is a new PR, now with signature.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage