### PR TITLE
Fix exceptions for OpenSSLHandler

### DIFF
--- a/system/Encryption/Handlers/OpenSSLHandler.php
+++ b/system/Encryption/Handlers/OpenSSLHandler.php
@@ -145,7 +145,7 @@ class OpenSSLHandler extends BaseHandler
 		}
 		if (empty($this->key))
 		{
-			throw EncryptionException::forStarterKeyNeeded();
+			throw EncryptionException::forNeedsStarterKey();
 		}
 
 		// derive a secret key

--- a/system/Encryption/Handlers/OpenSSLHandler.php
+++ b/system/Encryption/Handlers/OpenSSLHandler.php
@@ -64,7 +64,7 @@ class OpenSSLHandler extends BaseHandler
 	 *
 	 * @param BaseConfig $config
 	 *
-	 * @throws \CodeIgniter\Encryption\EncryptionException
+	 * @throws \CodeIgniter\Encryption\Exceptions\EncryptionException
 	 */
 	public function __construct(BaseConfig $config = null)
 	{
@@ -77,7 +77,7 @@ class OpenSSLHandler extends BaseHandler
 	 * @param  string $data   Input data
 	 * @param  array  $params Over-ridden parameters, specifically the key
 	 * @return string
-	 * @throws \CodeIgniter\Encryption\EncryptionException
+	 * @throws \CodeIgniter\Encryption\Exceptions\EncryptionException
 	 */
 	public function encrypt($data, $params = null)
 	{

--- a/system/Encryption/Handlers/OpenSSLHandler.php
+++ b/system/Encryption/Handlers/OpenSSLHandler.php
@@ -127,7 +127,7 @@ class OpenSSLHandler extends BaseHandler
 	 * @param  string $data   Encrypted data
 	 * @param  array  $params Over-ridden parameters, specifically the key
 	 * @return string
-	 * @throws \CodeIgniter\Encryption\EncryptionException
+	 * @throws \CodeIgniter\Encryption\Exceptions\EncryptionException
 	 */
 	public function decrypt($data, $params = null)
 	{

--- a/user_guide_src/source/libraries/encryption.rst
+++ b/user_guide_src/source/libraries/encryption.rst
@@ -203,7 +203,7 @@ Class Reference
 		:param	BaseConfig	$config: Configuration parameters
 		:returns:	CodeIgniter\\Encryption\\EncrypterInterface instance
 		:rtype:	CodeIgniter\\Encryption\\EncrypterInterface
-		:throws:	CodeIgniter\\Encryption\\EncryptionException
+		:throws:	CodeIgniter\\Encryption\\Exceptions\\EncryptionException
 
 		Initializes (configures) the library to use different settings.
 
@@ -241,7 +241,7 @@ Class Reference
 		:param		$params: Configuration parameters (key)
 		:returns:	Decrypted data or FALSE on failure
 		:rtype:	string
-		:throws:	CodeIgniter\\Encryption\\EncryptionException
+		:throws:	CodeIgniter\\Encryption\\Exceptions\\EncryptionException
 
 		Decrypts the input data and returns it in plain-text.
 

--- a/user_guide_src/source/libraries/encryption.rst
+++ b/user_guide_src/source/libraries/encryption.rst
@@ -221,7 +221,7 @@ Class Reference
 		:param		$params: Configuration parameters (key)
 		:returns:	Encrypted data or FALSE on failure
 		:rtype:	string
-		:throws:	CodeIgniter\\Encryption\\EncryptionException
+		:throws:	CodeIgniter\\Encryption\\Exceptions\\EncryptionException
 
 		Encrypts the input data and returns its ciphertext.
 


### PR DESCRIPTION
Fix #2680

**Description**
 - Fixed exception path
 - Called correct method when no encryption key provided

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
  
