### PR TITLE
Fix #2676 : add ability to test redirect()->route() via ControllerTester

### DIFF
--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -12,6 +12,12 @@
 		"mikey179/vfsstream": "1.6.*",
 		"phpunit/phpunit": "8.5.*"
 	},
+	"autoload": {
+		"psr-4": {
+			"App\\": "app",
+			"Config\\": "app/Config"
+		}
+	},
 	"autoload-dev": {
 		"psr-4": {
 			"Tests\\Support\\": "tests/_support"

--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -12,12 +12,6 @@
 		"mikey179/vfsstream": "1.6.*",
 		"phpunit/phpunit": "8.5.*"
 	},
-	"autoload": {
-		"psr-4": {
-			"App\\": "app",
-			"Config\\": "app/Config"
-		}
-	},
 	"autoload-dev": {
 		"psr-4": {
 			"Tests\\Support\\": "tests/_support"

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -59,7 +59,5 @@ $loader->initialize(new Config\Autoload(), new Config\Modules());
 // Register the loader with the SPL autoloader stack.
 $loader->register();
 
-$routes = \Config\Services::routes();
-$routes->getRoutes('*');
-
 require_once APPPATH . 'Config/Routes.php';
+$routes->getRoutes('*');

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -61,3 +61,5 @@ $loader->register();
 
 $routes = \Config\Services::routes();
 $routes->getRoutes('*');
+
+require_once APPPATH . 'Config/Routes.php';

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -13,14 +13,14 @@ require CONFIGPATH . 'Paths.php';
 $paths = new Config\Paths();
 
 // Define necessary framework path constants
-defined('APPPATH')       || define('APPPATH',       realpath($paths->appDirectory) . DIRECTORY_SEPARATOR);
-defined('WRITEPATH')     || define('WRITEPATH',     realpath($paths->writableDirectory) . DIRECTORY_SEPARATOR);
-defined('SYSTEMPATH')    || define('SYSTEMPATH',    realpath($paths->systemDirectory) . DIRECTORY_SEPARATOR);
-defined('ROOTPATH')      || define('ROOTPATH',      realpath(APPPATH . '../') . DIRECTORY_SEPARATOR);
-defined('CIPATH')        || define('CIPATH',        realpath(SYSTEMPATH . '../') . DIRECTORY_SEPARATOR);
-defined('FCPATH')        || define('FCPATH',        realpath(PUBLICPATH) . DIRECTORY_SEPARATOR);
-defined('TESTPATH')      || define('TESTPATH',      realpath(HOMEPATH . 'tests/') . DIRECTORY_SEPARATOR);
-defined('SUPPORTPATH')   || define('SUPPORTPATH',   realpath(TESTPATH . '_support/') . DIRECTORY_SEPARATOR);
+defined('APPPATH')       || define('APPPATH', realpath($paths->appDirectory) . DIRECTORY_SEPARATOR);
+defined('WRITEPATH')     || define('WRITEPATH', realpath($paths->writableDirectory) . DIRECTORY_SEPARATOR);
+defined('SYSTEMPATH')    || define('SYSTEMPATH', realpath($paths->systemDirectory) . DIRECTORY_SEPARATOR);
+defined('ROOTPATH')      || define('ROOTPATH', realpath(APPPATH . '../') . DIRECTORY_SEPARATOR);
+defined('CIPATH')        || define('CIPATH', realpath(SYSTEMPATH . '../') . DIRECTORY_SEPARATOR);
+defined('FCPATH')        || define('FCPATH', realpath(PUBLICPATH) . DIRECTORY_SEPARATOR);
+defined('TESTPATH')      || define('TESTPATH', realpath(HOMEPATH . 'tests/') . DIRECTORY_SEPARATOR);
+defined('SUPPORTPATH')   || define('SUPPORTPATH', realpath(TESTPATH . '_support/') . DIRECTORY_SEPARATOR);
 defined('COMPOSER_PATH') || define('COMPOSER_PATH', realpath(HOMEPATH . 'vendor/autoload.php'));
 
 // Load Common.php from App then System
@@ -58,3 +58,11 @@ $loader->initialize(new Config\Autoload(), new Config\Modules());
 
 // Register the loader with the SPL autoloader stack.
 $loader->register();
+
+helper('url');
+
+$appConfig = config(\Config\App::class);
+$app       = new \CodeIgniter\CodeIgniter($appConfig);
+$app->initialize();
+
+$app->run();

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -59,10 +59,5 @@ $loader->initialize(new Config\Autoload(), new Config\Modules());
 // Register the loader with the SPL autoloader stack.
 $loader->register();
 
-helper('url');
-
-$appConfig = config(\Config\App::class);
-$app       = new \CodeIgniter\CodeIgniter($appConfig);
-$app->initialize();
-
-$app->run();
+$routes = \Config\Services::routes();
+$routes->getRoutes('*');

--- a/tests/_support/Config/Routes.php
+++ b/tests/_support/Config/Routes.php
@@ -4,4 +4,4 @@
  * This is a simple file to include for testing the RouteCollection class.
  */
 
-$routes->add('testing', 'TestController::index');
+$routes->add('testing', 'TestController::index', ['as' => 'testing-index']);

--- a/tests/_support/Controllers/Popcorn.php
+++ b/tests/_support/Controllers/Popcorn.php
@@ -74,4 +74,9 @@ class Popcorn extends Controller
 		$this->respond('<my><pet>cat</pet></my>');
 	}
 
+	public function toindex()
+	{
+		return redirect()->route('testing-index');
+	}
+
 }

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -907,7 +907,8 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(307, $routes->getRedirectCode('users'));
 	}
 
-	public function testAddRedirectGetMethod(){
+	public function testAddRedirectGetMethod()
+	{
 		$routes = $this->getCollector();
 
 		$routes->get('zombies', 'Zombies::index', ['as' => 'namedRoute']);
@@ -1106,7 +1107,7 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$routes = $this->getCollector($config, [], $moduleConfig);
 
-		$routes->add('testing', 'MainRoutes::index');
+		$routes->add('testing', 'MainRoutes::index', ['as' => 'testing-index']);
 
 		$match = $routes->getRoutes();
 

--- a/tests/system/Test/ControllerTesterTest.php
+++ b/tests/system/Test/ControllerTesterTest.php
@@ -228,4 +228,11 @@ class ControllerTesterTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertTrue($result->isOK());
 	}
 
+	public function testRedirectRoute()
+	{
+		$result = $this->controller(\Tests\Support\Controllers\Popcorn::class)
+						->execute('toindex');
+		$this->assertTrue($result->isRedirect());
+	}
+
 }

--- a/tests/system/Test/FeatureTestCaseTest.php
+++ b/tests/system/Test/FeatureTestCaseTest.php
@@ -160,7 +160,7 @@ class FeatureTestCaseTest extends FeatureTestCase
 			[
 				'get',
 				'home',
-				'Tests\Support\Controllers\Popcorn::index',
+				'\Tests\Support\Controllers\Popcorn::index',
 			],
 		]);
 		$response = $this->get('home');
@@ -173,7 +173,7 @@ class FeatureTestCaseTest extends FeatureTestCase
 			[
 				'get',
 				'home',
-				'Tests\Support\Controllers\Popcorn::cat',
+				'\Tests\Support\Controllers\Popcorn::cat',
 			],
 		]);
 		$response = $this->get('home');
@@ -186,7 +186,7 @@ class FeatureTestCaseTest extends FeatureTestCase
 			[
 				'get',
 				'home',
-				'Tests\Support\Controllers\Popcorn::canyon',
+				'\Tests\Support\Controllers\Popcorn::canyon',
 			],
 		]);
 		ob_start();


### PR DESCRIPTION
Fixes #2676 to add ability to test redirect()->route() in test bootstrap so the existing route both in `app` and `tests` will be discovered.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage