### PR TITLE
[ci skip] app\Filters\Throttle.php is not exits

### DIFF
--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -69,7 +69,7 @@ This is typically used to perform redirects, like in this example::
     }
 
 If a Response instance is returned, the Response will be sent back to the client and script execution will stop.
-This can be useful for implementing rate limiting for API's. See **app/Filters/Throttle.php** for an
+This can be useful for implementing rate limiting for API's. See :doc:`Throttler </libraries/throttler>` for an
 example.
 
 After Filters


### PR DESCRIPTION
`app\Filters\Throttle.php` is not exits,  userguide libraries/throttler have example code.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
