### PR TITLE
Fix batch insert performance issue found in BaseBuilder::setBinding()

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -214,6 +214,14 @@ class BaseBuilder
 	protected $binds = [];
 
 	/**
+	 * Collects the key count for named parameters
+	 * in the Query object.
+	 *
+	 * @var array
+	 */
+	protected $bindsKeyCount = [];
+
+	/**
 	 * Some databases, like SQLite, do not by default
 	 * allow limiting of delete clauses.
 	 *
@@ -3402,12 +3410,11 @@ class BaseBuilder
 			return $key;
 		}
 
-		$count = 0;
-
-		while (array_key_exists($key . $count, $this->binds))
+		if (!array_key_exists($key, $this->bindsKeyCount))
 		{
-			++$count;
+			$this->bindsKeyCount[$key] = 0;
 		}
+		$count = $this->bindsKeyCount[$key]++;
 
 		$this->binds[$key . $count] = [
 			$value,


### PR DESCRIPTION
**Description**
We found some performance regressions while doing a large `insertBatch()` function call in an app ported over from CI2. On closer inspection using xdebug profiles, the performance bottleneck was found to be in the `BaseBuilder::setBind()` function. Specifically the while loop within the function used to identify the next key counter for the binding array. This causes the function to run in O(n^2) time.

Instead I've added a simple array lookup that keeps the function in O(n) time while marginally increasing the memory footprint.

**Checklist:**
- [x] Securely signed commits
- [ ] ~~Component(s) with PHPdocs~~
- [ ] ~~Unit testing, with >80% coverage~~
- [ ] ~~User guide updated~~
- [x] Conforms to style guide
  
