### PR TITLE
fix. testSoftDeleteLeavesRow can't worker

### DIFF
--- a/admin/module/tests/database/ExampleDatabaseTest.php
+++ b/admin/module/tests/database/ExampleDatabaseTest.php
@@ -26,6 +26,7 @@ class ExampleDatabaseTest extends \Tests\Support\DatabaseTestCase
 	{
 		$model = new ExampleModel();
 		$this->setPrivateProperty($model, 'useSoftDeletes', true);
+		$this->setPrivateProperty($model, 'tempUseSoftDeletes', true);
 
 		$object = $model->first();
 		$model->delete($object->id);

--- a/admin/starter/tests/database/ExampleDatabaseTest.php
+++ b/admin/starter/tests/database/ExampleDatabaseTest.php
@@ -26,6 +26,7 @@ class ExampleDatabaseTest extends \Tests\Support\DatabaseTestCase
 	{
 		$model = new ExampleModel();
 		$this->setPrivateProperty($model, 'useSoftDeletes', true);
+		$this->setPrivateProperty($model, 'tempUseSoftDeletes', true);
 
 		$object = $model->first();
 		$model->delete($object->id);


### PR DESCRIPTION
In `find` `findAll` `first` ... , use `tempUseSoftDeletes` to repalce `useSoftDeletes`.
befor `setPrivateProperty`, the model already initialization.

![image](https://user-images.githubusercontent.com/9927289/76487997-209c3400-645f-11ea-9d40-fb284c3a4fd0.png)


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
