### PR TITLE
fix. first and countAllResult recover tempUseSoftDeletes

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -486,6 +486,7 @@ class Model
 		$eventData = $this->trigger('afterFind', ['data' => $row]);
 
 		$this->tempReturnType = $this->returnType;
+		$this->tempUseSoftDeletes = $this->useSoftDeletes;
 
 		return $eventData['data'];
 	}
@@ -1577,7 +1578,8 @@ class Model
 		{
 			$this->builder()->where($this->table . '.' . $this->deletedField, null);
 		}
-
+		$this->tempUseSoftDeletes = $this->useSoftDeletes;
+		
 		return $this->builder()->countAllResults($reset, $test);
 	}
 

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1823,4 +1823,24 @@ class ModelTest extends CIDatabaseTestCase
 			->getBindings();
 	}
 
+	public function testFirstRecoverTempUseSoftDeletes()
+	{
+		$model = new UserModel($this->db);
+		$model->delete(1);
+		$user = $model->withDeleted()->first();
+		$this->assertEquals(1, $user->id);
+		$user2 = $model->first();
+		$this->assertEquals(2, $user2->id);
+
+	}
+
+	public function testcountAllResultsRecoverTempUseSoftDeletes()
+	{
+		$model = new UserModel($this->db);
+		$model->delete(1);
+		$this->assertEquals(4, $model->withDeleted()->countAllResults());
+		$this->assertEquals(3, $model->countAllResults());
+
+	}
+
 }


### PR DESCRIPTION
`first` and `countAllResult` didn't recover `tempUseSoftDeletes`. 
**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
