### PR TITLE
Fix session bug when the request is ajax call

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -503,7 +503,7 @@ class Session implements SessionInterface
 		}
 		elseif (empty($_SESSION))
 		{
-			return [];
+			return $key === null ? [] : null;
 		}
 
 		if (! empty($key))

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -129,6 +129,28 @@ class SessionTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertNull($session->get('foo'));
 	}
 
+	public function testGetReturnsNullWhenNotFoundWithXmlHttpRequest()
+	{
+		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'xmlhttprequest';
+		$_SESSION                         = [];
+
+		$session = $this->getInstance();
+		$session->start();
+
+		$this->assertNull($session->get('foo'));
+	}
+
+	public function testGetReturnsEmptyArrayWhenWithXmlHttpRequest()
+	{
+		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'xmlhttprequest';
+		$_SESSION                         = [];
+
+		$session = $this->getInstance();
+		$session->start();
+
+		$this->assertEquals([], $session->get());
+	}
+
 	public function testGetReturnsItemValueisZero()
 	{
 		$_SESSION = [];


### PR DESCRIPTION
**Description**
When the session is initialized during ajax request and we use `get(null)` or `get(key)` with an empty $_SESSION variable, we always get the empty array as a result.

This pull request fixes it, so now we receive accordingly:
* empty array for `get(null)` call
* null for `get(key)` call

This is a very rare use case scenario.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide