### PR TITLE
fix #2705 : countAllResults after find

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -356,11 +356,12 @@ class Model
 	 * Fetches the row of database from $this->table with a primary key
 	 * matching $id.
 	 *
-	 * @param mixed|array|null $id One primary key or an array of primary keys
+	 * @param mixed|array|null $id    One primary key or an array of primary keys
+	 * @param boolean          $reset Are we want to clear query builder values after find?
 	 *
 	 * @return array|object|null    The resulting row of data, or null.
 	 */
-	public function find($id = null)
+	public function find($id = null, bool $reset = true)
 	{
 		$builder = $this->builder();
 
@@ -372,19 +373,19 @@ class Model
 		if (is_array($id))
 		{
 			$row = $builder->whereIn($this->table . '.' . $this->primaryKey, $id)
-					->get();
+					->get(null, 0, $reset);
 			$row = $row->getResult($this->tempReturnType);
 		}
 		elseif (is_numeric($id) || is_string($id))
 		{
 			$row = $builder->where($this->table . '.' . $this->primaryKey, $id)
-					->get();
+					->get(null, 0, $reset);
 
 			$row = $row->getFirstRow($this->tempReturnType);
 		}
 		else
 		{
-			$row = $builder->get();
+			$row = $builder->get(null, 0, $reset);
 
 			$row = $row->getResult($this->tempReturnType);
 		}

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1823,4 +1823,31 @@ class ModelTest extends CIDatabaseTestCase
 			->getBindings();
 	}
 
+	public function testFindEmptyCountAllResults()
+	{
+		$model = new UserModel($this->db);
+
+		$model->find();
+
+		$this->assertEquals(4, $model->countAllResults());
+	}
+
+	public function testFindIdCountAllResults()
+	{
+		$model = new UserModel($this->db);
+
+		$model->find(1, false);
+
+		$this->assertEquals(1, $model->countAllResults());
+	}
+
+	public function testFindArrayCountAllResults()
+	{
+		$model = new UserModel($this->db);
+
+		$model->find([1, 2], false);
+
+		$this->assertEquals(2, $model->countAllResults());
+	}
+
 }

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -229,6 +229,10 @@ insert(), update(), delete() and more.
 
 **find()**
 
+The first parameter is key(s) value of the primary key.
+
+The second parameter let you to reset or clear query builder values or not, by default it is set to `true` mean that query builder always being cleared.
+
 Returns a single row where the primary key matches the value passed in as the first parameter::
 
 	$user = $userModel->find($user_id);
@@ -242,6 +246,18 @@ of just one::
 
 If no parameters are passed in, will return all rows in that model's table, effectively acting
 like findAll(), though less explicit.
+
+**countAllResults()**
+
+Return number of row(s) affected from find() method. In order to get proper result, you should pass second parameter as `false`.
+
+	$users = $userModel->find([1,2,3]);
+	$count = $userModel->countAllResults(); // produce all rows in UserModel
+	
+	$users = $userModel->find([1,2,3], false);
+	$count = $userModel->countAllResults(); // produce 3 rows
+
+.. note:: if you call `countAllResults` after using `find` with passing `$id`, always pass second parameter with `false` to avoid resetting query builder. See [related issue](https://github.com/codeigniter4/CodeIgniter4/issues/2705).
 
 **findColumn()**
 


### PR DESCRIPTION
**Description**
This PR fixes #2705 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide