### PR TITLE
fix. delete_cookite can't delete alreday set Cookie

### DIFF
--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -986,6 +986,7 @@ class Response extends Message implements ResponseInterface
 
 		$name = $prefix . $name;
 
+		$cookieHasFlag = false;
 		foreach ($this->cookies as &$cookie)
 		{
 			if ($cookie['name'] === $name)
@@ -1000,9 +1001,14 @@ class Response extends Message implements ResponseInterface
 				}
 				$cookie['value']   = '';
 				$cookie['expires'] = '';
-
+				$cookieHasFlag     = true;
 				break;
 			}
+		}
+
+		if (! $cookieHasFlag)
+		{
+			$this->setCookie($name, '', '', $domain, $path, $prefix);
 		}
 
 		return $this;

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -104,4 +104,13 @@ final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(5, get_cookie('TEST'));
 	}
 
+	public function testDeleteCookieAfterLastSet()
+	{
+		delete_cookie($this->name);
+
+		$cookie = $this->response->getCookie($this->name);
+		// The cookie is set to be cleared when the request is sent....
+		$this->assertEquals('', $cookie['value']);
+	}
+
 }


### PR DESCRIPTION
Fix #2700.
`Response::deleteCookie` can't delete already set Cookie.
**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide