### PR TITLE
revert outdated $this->uri->resolveRelativeURI() call at IncomingRequest class

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -616,7 +616,6 @@ class IncomingRequest extends Request
 			$this->uri->setScheme(parse_url($baseURL, PHP_URL_SCHEME));
 			$this->uri->setHost(parse_url($baseURL, PHP_URL_HOST));
 			$this->uri->setPort(parse_url($baseURL, PHP_URL_PORT));
-			$this->uri->resolveRelativeURI($this->uri->getPath());
 
 			// Ensure we have any query vars
 			$this->uri->setQuery($_SERVER['QUERY_STRING'] ?? '');


### PR DESCRIPTION
@MGatner Based on your comment at https://github.com/codeigniter4/CodeIgniter4/commit/8127cb2ffe577c1382aaed77121a437b313d61ad#commitcomment-37901776

**Checklist:**
- [x] Securely signed commits
