### PR TITLE
Fix validation for array input fields

### DIFF
--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -79,7 +79,7 @@ if (! function_exists('_array_search_dot'))
 			? array_shift($indexes)
 			: null;
 
-		if (empty($currentIndex) || (! isset($array[$currentIndex]) && $currentIndex !== '*'))
+		if ((empty($currentIndex)  && intval($currentIndex) !== 0) || (! isset($array[$currentIndex]) && $currentIndex !== '*'))
 		{
 			return null;
 		}

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -614,4 +614,81 @@ class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($expected, $errors['Username']);
 	}
 
+	//--------------------------------------------------------------------
+
+	/**
+	 * @dataProvider arrayFieldDataProvider
+	 */
+	public function testRulesForArrayField($body, $rules, $results)
+	{
+		$config          = new App();
+		$config->baseURL = 'http://example.com';
+
+		$request = new IncomingRequest($config, new URI(), http_build_query($body), new UserAgent());
+		$request->setMethod('post');
+
+		$this->validation->setRules($rules);
+		$this->validation->withRequest($request)
+			->run($body);
+		$this->assertEquals($results, $this->validation->getErrors());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function arrayFieldDataProvider() {
+		return [
+			'all_rules_should_pass' => [
+				'body' => [
+					'foo' => [
+						'a',
+						'b',
+						'c'
+					]
+				],
+				'rules' => [
+					'foo.0' => 'required|alpha|max_length[2]',
+					'foo.1' => 'required|alpha|max_length[2]',
+					'foo.2' => 'required|alpha|max_length[2]'
+				],
+				'results' => []
+			],
+			'first_field_will_return_required_error' => [
+				'body' => [
+					'foo' => [
+						'',
+						'b',
+						'c'
+					]
+				],
+				'rules' => [
+					'foo.0' => 'required|alpha|max_length[2]',
+					'foo.1' => 'required|alpha|max_length[2]',
+					'foo.2' => 'required|alpha|max_length[2]'
+				],
+				'results' => [
+					'foo.0' => 'The foo.0 field is required.'
+				]
+			],
+			'first_and second_field_will_return_required_and_min_length_error' => [
+				'body' => [
+					'foo' => [
+						'',
+						'b',
+						'c'
+					]
+				],
+				'rules' => [
+					'foo.0' => 'required|alpha|max_length[2]',
+					'foo.1' => 'required|alpha|min_length[2]|max_length[4]',
+					'foo.2' => 'required|alpha|max_length[2]'
+				],
+				'results' => [
+					'foo.0' => 'The foo.0 field is required.',
+					'foo.1' => 'The foo.1 field must be at least 2 characters in length.',
+				]
+			]
+		];
+	}
+
+	//--------------------------------------------------------------------
 }


### PR DESCRIPTION
Fix #2714 

**Description**
In function `_array_search_dot` empty check for `$currentIndex` was failing for index 0 in array.
`empty()` will return `true` for value `0`. 

 Details: https://www.php.net/manual/en/function.empty.php

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide