### PR TITLE
Pager makeLinks param fix

### DIFF
--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -154,7 +154,7 @@ class Pager implements PagerInterface
 	 * @param  string|null $group    optional group (i.e. if we'd like to define custom path)
 	 * @return string
 	 */
-	public function makeLinks(int $page, int $perPage, int $total, string $template = 'default_full', int $segment = 0, ?string $group = null): string
+	public function makeLinks(int $page, int $perPage, int $total, string $template = 'default_full', int $segment = 0, ?string $group = 'default'): string
 	{
 		$name = time();
 

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -151,16 +151,16 @@ class Pager implements PagerInterface
 	 * @param string      $template The output template alias to render.
 	 * @param integer     $segment  (if page number is provided by URI segment)
 	 *
-	 * @param  string|null $group    optional group (i.e. if we'd like to define custom path)
+	 * @param  string     $group    optional group (i.e. if we'd like to define custom path)
 	 * @return string
 	 */
 	public function makeLinks(int $page, int $perPage, int $total, string $template = 'default_full', int $segment = 0, ?string $group = 'default'): string
 	{
-		$name = time();
+		$group = $group === '' ? 'default' : $group;
 
-		$this->store($group ?? $name, $page, $perPage, $total, $segment);
+		$this->store($group, $page, $perPage, $total, $segment);
 
-		return $this->displayLinks($group ?? $name, $template);
+		return $this->displayLinks($group, $template);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -343,6 +343,18 @@ class PagerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertStringContainsString(
 			'<link rel="canonical"', $this->pager->makeLinks(4, 10, 50, 'default_head')
 		);
+		$this->assertStringContainsString(
+			'?page=1', $this->pager->makeLinks(1, 10, 1, 'default_full', 0)
+		);
+		$this->assertStringContainsString(
+			'?page=1', $this->pager->makeLinks(1, 10, 1, 'default_full', 0, '')
+		);
+		$this->assertStringContainsString(
+			'?page=1', $this->pager->makeLinks(1, 10, 1, 'default_full', 0, 'default')
+		);
+		$this->assertStringContainsString(
+			'?page_custom=1', $this->pager->makeLinks(1, 10, 1, 'default_full', 0, 'custom')
+		);
 	}
 
 	public function testHeadLinks()

--- a/user_guide_src/source/libraries/pagination.rst
+++ b/user_guide_src/source/libraries/pagination.rst
@@ -116,7 +116,9 @@ If you in need to show many pagers on one page then additional parameter which w
 
 	$pager = service('pager');
 	$pager->setPath('path/for/my-group', 'my-group'); // Additionally you could define path for every group.
-	$pager->makeLinks($page, $perPage, $total, 'template_name', $segment, 'my-group'); 
+	$pager->makeLinks($page, $perPage, $total, 'template_name', $segment, 'my-group');
+
+Pagination library uses *page* query parameter for HTTP queries by default (if no group or *default* group name given) or *page_[groupName]* for custom group names. 
 
 Paginating with Only Expected Queries
 =====================================


### PR DESCRIPTION
**Description**
If $group=null then group name and query string param name is made of timestamp (change every call) making it useless. Setting default $group to "default" string literal solves the problem and generates default "page" query param name.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
  
