### PR TITLE
BaseBuilder - syncOriginal called twice on data fetch for Entity Class

### DIFF
--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -39,6 +39,8 @@
 
 namespace CodeIgniter\Database;
 
+use CodeIgniter\Entity;
+
 /**
  * Class BaseResult
  */
@@ -192,7 +194,7 @@ abstract class BaseResult implements ResultInterface
 
 		while ($row = $this->fetchObject($className))
 		{
-			if (method_exists($row, 'syncOriginal'))
+			if (! is_subclass_of($row, Entity::class) && method_exists($row, 'syncOriginal'))
 			{
 				$row->syncOriginal();
 			}
@@ -283,7 +285,7 @@ abstract class BaseResult implements ResultInterface
 		is_null($this->rowData) || $this->dataSeek(0);
 		while ($row = $this->fetchObject())
 		{
-			if (method_exists($row, 'syncOriginal'))
+			if (! is_subclass_of($row, Entity::class) && method_exists($row, 'syncOriginal'))
 			{
 				$row->syncOriginal();
 			}


### PR DESCRIPTION
**Description**
BaseResult sets data on Entity object using setAttributes method. syncOriginal is called from setAttributes method so there is no need to call it again from the BaseResult.

I don't know if there is even a good reason to call it from BaseResult. I might be useful if there is a need for data processing after it's been loaded from DB but in such case syncOriginal might not be a good name for the method.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

