### PR TITLE
CodeIgniter\HTTP\Message - Fix appendHeader

### DIFF
--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -316,7 +316,9 @@ class Message
 	{
 		$orig_name = $this->getHeaderName($name);
 
-		$this->headers[$orig_name]->appendValue($value);
+		array_key_exists($orig_name, $this->headers)
+			? $this->headers[$orig_name]->appendValue($value)
+			: $this->setHeader($name, $value);
 
 		return $this;
 	}


### PR DESCRIPTION
**Description**
appendHeader should call setHeader for non existing header. This is especially useful for HTTP2 push when it's not possible to alway know the exact order in which assets will be set to Link header so it's not very easy to call the setHeader method first.

Fix #2730 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

  
