### PR TITLE
docblock @return fix: Model::findAll() never returns null

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -430,7 +430,7 @@ class Model
 	 * @param integer $limit
 	 * @param integer $offset
 	 *
-	 * @return array|null
+	 * @return array
 	 */
 	public function findAll(int $limit = 0, int $offset = 0)
 	{


### PR DESCRIPTION
Model::findAll() always returns array based on `ResultInterface::getResult()`

**Checklist:**
- [x] Securely signed commits