### PR TITLE
Fixes #2520 : ensure service(router)->controllername() returns fqcn

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -579,7 +579,7 @@ class Router implements RouterInterface
 		// We have to check for a length over 1, since by default it will be '\'
 		if (strpos($this->controller, '\\') === false && strlen($this->collection->getDefaultNamespace()) > 1)
 		{
-			$this->controller = '\\' . str_replace('/', '\\', $this->collection->getDefaultNamespace() . $this->directory . $this->controllerName());
+			$this->controller = '\\' . ltrim(str_replace('/', '\\', $this->collection->getDefaultNamespace() . $this->directory . $this->controllerName()), '\\');
 		}
 	}
 

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -579,7 +579,7 @@ class Router implements RouterInterface
 		// We have to check for a length over 1, since by default it will be '\'
 		if (strpos($this->controller, '\\') === false && strlen($this->collection->getDefaultNamespace()) > 1)
 		{
-			$this->controller = str_replace('/', '\\', $this->collection->getDefaultNamespace() . $this->directory . $this->controllerName());
+			$this->controller = '\\' . str_replace('/', '\\', $this->collection->getDefaultNamespace() . $this->directory . $this->controllerName());
 		}
 	}
 

--- a/tests/_support/Controllers/Product.php
+++ b/tests/_support/Controllers/Product.php
@@ -1,7 +1,0 @@
-<?php namespace App\Controllers;
-
-use CodeIgniter\Controller;
-
-class Product extends Controller
-{
-}

--- a/tests/_support/Controllers/Product.php
+++ b/tests/_support/Controllers/Product.php
@@ -1,0 +1,7 @@
+<?php namespace App\Controllers;
+
+use CodeIgniter\Controller;
+
+class Product extends Controller
+{
+}

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -815,7 +815,6 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 		$routes->add('{locale}/contact', 'myController::goto');
 
 		$this->assertEquals('/en/contact', $routes->reverseRoute('myController::goto'));
-
 	}
 
 	//--------------------------------------------------------------------
@@ -1473,6 +1472,20 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 		$expects = '\App\Controllers\Core\Home';
 
 		$this->assertEquals($expects, $router->handle('/0'));
+	}
+
+	public function testRoutesControllerNameReturnsFQCN()
+	{
+		require_once SUPPORTPATH . 'Controllers/Product.php';
+
+		$routes = $this->getCollector();
+		$routes->setAutoRoute(true);
+		$routes->setDefaultNamespace('App\Controllers');
+
+		$router = new Router($routes, Services::request());
+		$router->handle('/product');
+
+		$this->assertEquals('\App\\Controllers\\Product', $router->controllerName());
 	}
 
 }

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1476,8 +1476,6 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testRoutesControllerNameReturnsFQCN()
 	{
-		require_once SUPPORTPATH . 'Controllers/Product.php';
-
 		$routes = $this->getCollector();
 		$routes->setAutoRoute(true);
 		$routes->setDefaultNamespace('App\Controllers');

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1474,11 +1474,22 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($expects, $router->handle('/0'));
 	}
 
-	public function testRoutesControllerNameReturnsFQCN()
+	public function provideAutoRouteDefaultNamespace()
+	{
+		return [
+			'with \\ prefix'    => ['\App\Controllers'],
+			'without \\ prefix' => ['App\Controllers'],
+		];
+	}
+
+	/**
+	 * @dataProvider provideAutoRouteDefaultNamespace
+	 */
+	public function testAutoRoutesControllerNameReturnsFQCN($namespace)
 	{
 		$routes = $this->getCollector();
 		$routes->setAutoRoute(true);
-		$routes->setDefaultNamespace('App\Controllers');
+		$routes->setDefaultNamespace($namespace);
 
 		$router = new Router($routes, Services::request());
 		$router->handle('/product');

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1474,7 +1474,7 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($expects, $router->handle('/0'));
 	}
 
-	public function provideAutoRouteDefaultNamespace()
+	public function provideRouteDefaultNamespace()
 	{
 		return [
 			'with \\ prefix'    => ['\App\Controllers'],
@@ -1483,13 +1483,29 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 	}
 
 	/**
-	 * @dataProvider provideAutoRouteDefaultNamespace
+	 * @dataProvider provideRouteDefaultNamespace
 	 */
 	public function testAutoRoutesControllerNameReturnsFQCN($namespace)
 	{
 		$routes = $this->getCollector();
 		$routes->setAutoRoute(true);
 		$routes->setDefaultNamespace($namespace);
+
+		$router = new Router($routes, Services::request());
+		$router->handle('/product');
+
+		$this->assertEquals('\App\\Controllers\\Product', $router->controllerName());
+	}
+
+	/**
+	 * @dataProvider provideRouteDefaultNamespace
+	 */
+	public function testRoutesControllerNameReturnsFQCN($namespace)
+	{
+		$routes = $this->getCollector();
+		$routes->setAutoRoute(false);
+		$routes->setDefaultNamespace($namespace);
+		$routes->get('/product', 'Product');
 
 		$router = new Router($routes, Services::request());
 		$router->handle('/product');


### PR DESCRIPTION
Fixes #2520 : ensure service(router)->controllername() returns fqcn

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage