### PR TITLE
Fix Class Database\CLI not found

### DIFF
--- a/system/Commands/Database/MigrateRefresh.php
+++ b/system/Commands/Database/MigrateRefresh.php
@@ -39,6 +39,7 @@
 
 namespace CodeIgniter\Commands\Database;
 
+use CodeIgniter\CLI\CLI;
 use CodeIgniter\CLI\BaseCommand;
 
 /**


### PR DESCRIPTION
This minor modification fix an issue when using `php spark migrate:refresh`:
```console
maz@Maz-Laptop:~/www/project$ php spark migrate:refresh


CodeIgniter CLI Tool - Version 4.0.2 - Server-Time: 2020-03-21 13:57:57pm

An uncaught Exception was encountered

Type:        Error
Message:     Class 'CodeIgniter\Commands\Database\CLI' not found
Filename:    /media/maz/Windows/Users/maz-/Desktop/www/project/system/Commands/Database/MigrateRefresh.php
Line Number: 113
```