### PR TITLE
Modify database tests refresh process to use migration on rollback

### DIFF
--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -169,29 +169,14 @@ class CIDatabaseTestCase extends CIUnitTestCase
 
 		if ($this->refresh === true)
 		{
-			// Delete all of the tables to ensure we're at a clean start.
-			$tables = $this->db->listTables();
 
-			if (is_array($tables))
-			{
-				$forge = Database::forge('tests');
-
-				foreach ($tables as $table)
-				{
-					if ($table === $this->db->DBPrefix . 'migrations')
-					{
-						$this->db->table($table)->truncate();
-						continue;
-					}
-
-					$forge->dropTable($table, true);
-				}
-			}
-
-			// If no namespace was specified then migrate all
+			// If no namespace was specified then rollback/migrate all
 			if (empty($this->namespace))
 			{
 				$this->migrations->setNamespace(null);
+
+				$this->migrations->regress(0,'tests');
+
 				$this->migrations->latest('tests');
 			}
 
@@ -199,6 +184,13 @@ class CIDatabaseTestCase extends CIUnitTestCase
 			else
 			{
 				$namespaces = is_array($this->namespace) ? $this->namespace : [$this->namespace];
+
+				foreach ($namespaces as $namespace)
+				{
+					$this->migrations->setNamespace($namespace);
+					$this->migrations->regress(0,'tests');
+				}
+
 				foreach ($namespaces as $namespace)
 				{
 					$this->migrations->setNamespace($namespace);


### PR DESCRIPTION
Previously the rollback process was only "delete all tables" statement, using `$forge`.

The problem with this process is the foreign key in Postgre (and probably other SQL standards databases system): droping table without the ` CASCADE` at the end of `DROP TABLE` statement throw an error:
```console
pg_query(): Query failed: ERROR:  cannot drop table db_users because other objects depend on it
DETAIL:  constraint db_cities_user_uuid_fkey on table db_cities depends on table table db_users
HINT:  Use DROP ... CASCADE to drop the dependent objects too.
```
Without this modification, the previous error was thrown and we couldn't test the database without refreshing it.

Using the `$this->migrations` process ensure that the user's migration's `down` requests are followed, such mine in this project:
```PHP
public function down()
{
	$this->db->query("
		DROP TABLE IF EXISTS " . $this->db->prefixTable('cities') ." CASCADE"
	);
}
```

Also this process ensures that if the developper have manually created some tables for any reason, these tables are not deleted, which was the case with the previous process where all the present tables were deleted without a look in the migrations files.

Hope this helps :)