### PR TITLE
Remove unused property

### DIFF
--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -60,13 +60,6 @@ class Logger implements LoggerInterface
 {
 
 	/**
-	 * Path to save log files to.
-	 *
-	 * @var string
-	 */
-	protected $logPath;
-
-	/**
 	 * Used by the logThreshold Config setting to define
 	 * which errors to show.
 	 *


### PR DESCRIPTION
Fixes #2738 
``CodeIgniter\Log;Logger::logPath`` property never set and is never used by the Logger or any other class.