### PR TITLE
Fix #2740 regex decimal format rules

### DIFF
--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -152,7 +152,7 @@ class FormatRules
 	 */
 	public function decimal(string $str = null): bool
 	{
-		return (bool) preg_match('/^[\-+]?[0-9]+(|\.[0-9]+)$/', $str);
+		return (bool) preg_match('/^[-+]?[0-9]{0,}\.?[0-9]+$/', $str);
 	}
 
 	/**
@@ -329,8 +329,8 @@ class FormatRules
 	 * @return boolean
 	 */
 	public function valid_ip(string $ip = null, string $which = null): bool
-	{	
-		if(empty($ip))
+	{
+		if (empty($ip))
 		{
 			return false;
 		}
@@ -347,7 +347,7 @@ class FormatRules
 				break;
 		}
 
-		return (bool) filter_var($ip, FILTER_VALIDATE_IP, $which) || (!ctype_print($ip) && (bool) filter_var(inet_ntop($ip), FILTER_VALIDATE_IP, $which));
+		return (bool) filter_var($ip, FILTER_VALIDATE_IP, $which) || (! ctype_print($ip) && (bool) filter_var(inet_ntop($ip), FILTER_VALIDATE_IP, $which));
 	}
 
 	/**

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -840,6 +840,10 @@ class FormatRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 				null,
 				false,
 			],
+			[
+				'.25',
+				true,
+			],
 		];
 	}
 


### PR DESCRIPTION
Fix #2740 to allow  number `.25` as a valid number.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage

