### PR TITLE
First pagination uri item must be empty not a number

### DIFF
--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -242,7 +242,7 @@ class PagerRenderer
 		}
 		else
 		{
-			$uri->setSegment($this->segment, 1);
+			$uri->setSegment($this->segment, '');
 		}
 
 		return (string) $uri;
@@ -313,7 +313,7 @@ class PagerRenderer
 		for ($i = $this->first; $i <= $this->last; $i ++)
 		{
 			$links[] = [
-				'uri'    => (string) ($this->segment === 0 ? $uri->addQuery($this->pageSelector, $i) : $uri->setSegment($this->segment, $i)),
+				'uri'    => (string) ($this->segment === 0 ? $uri->addQuery($this->pageSelector, $i) : $uri->setSegment($this->segment,  ($i == $this->first)?'':$i)),
 				'title'  => (int) $i,
 				'active' => ($i === $this->current),
 			];


### PR DESCRIPTION
Right now, when using pagination without GET-Query the first pagination uri item must be a empty instead a number. 
for example domain.com/pages_list/1 must be domain.com/pages_list

Each pull request should address a single issue and have a meaningful title.

**Description**
Explain what you have changed, and why.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

---------Remove from here down in your description----------

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository
  
