### PR TITLE
fix. session::get just use dot_array_search handle session key

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -499,7 +499,7 @@ class Session implements SessionInterface
 	 */
 	public function get(string $key = null)
 	{
-		if (! empty($key) && ! is_null($value = dot_array_search($key, $_SESSION ?? [])))
+		if (! empty($key) && (! is_null($value = isset($_SESSION[$key]) ? $_SESSION[$key] : null) || ! is_null($value = dot_array_search($key, $_SESSION ?? []))))
 		{
 			return $value;
 		}

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -532,4 +532,14 @@ class SessionTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$this->assertEquals(['foo', 'bar'], $session->getTempKeys());
 	}
+
+	public function testGetDotKey()
+	{
+		$session = $this->getInstance();
+		$session->start();
+
+		$session->set('test.1', 'value');
+
+		$this->assertEquals('value', $session->get('test.1'));
+	}
 }


### PR DESCRIPTION
Session key is `test.1`,`Session::get` use `dot_array_search` handle, return `null`. 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

