### PR TITLE
add "prefer-stable" => true to admin/starter/builds when ./builds development called

### DIFF
--- a/admin/starter/builds
+++ b/admin/starter/builds
@@ -41,6 +41,7 @@ if (is_file($file))
 			{
 				// Set 'minimum-stability'
 				$array['minimum-stability'] = 'dev';
+				$array['prefer-stable']     = true;
 
 				// Make sure the repo is configured
 				if (! isset($array['repositories']))
@@ -72,7 +73,7 @@ if (is_file($file))
 				$array['require']['codeigniter4/codeigniter4'] = 'dev-develop';
 				unset($array['require']['codeigniter4/framework']);
 			}
-			
+
 			// Release
 			else
 			{


### PR DESCRIPTION
@MGatner This is to handle composer update try to catch all "dev" version of dependencies in `vendor` directory when running composer update after : 

```bash
php builds development
composer update
```

With make `"prefer-stable" => true`, it will only get dev version when required, eg: in : 

```
"codeigniter4/codeigniter4": "dev-develop"
```

Other packages will try get stable version. The result of composer.json will have: 

```json
    "minimum-stability": "dev",
    "prefer-stable": true,
```

**Checklist:**
- [x] Securely signed commits
