### PR TITLE
 using "protected" modifier for CIUnitTestCase::tearDown() 

### DIFF
--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -169,13 +169,12 @@ class CIDatabaseTestCase extends CIUnitTestCase
 
 		if ($this->refresh === true)
 		{
-
 			// If no namespace was specified then rollback/migrate all
 			if (empty($this->namespace))
 			{
 				$this->migrations->setNamespace(null);
 
-				$this->migrations->regress(0,'tests');
+				$this->migrations->regress(0, 'tests');
 
 				$this->migrations->latest('tests');
 			}
@@ -188,7 +187,7 @@ class CIDatabaseTestCase extends CIUnitTestCase
 				foreach ($namespaces as $namespace)
 				{
 					$this->migrations->setNamespace($namespace);
-					$this->migrations->regress(0,'tests');
+					$this->migrations->regress(0, 'tests');
 				}
 
 				foreach ($namespaces as $namespace)
@@ -220,7 +219,7 @@ class CIDatabaseTestCase extends CIUnitTestCase
 	 * Takes care of any required cleanup after the test, like
 	 * removing any rows inserted via $this->hasInDatabase()
 	 */
-	public function tearDown(): void
+	protected function tearDown(): void
 	{
 		if (! empty($this->insertCache))
 		{

--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -221,6 +221,8 @@ class CIDatabaseTestCase extends CIUnitTestCase
 	 */
 	protected function tearDown(): void
 	{
+		parent::tearDown();
+
 		if (! empty($this->insertCache))
 		{
 			foreach ($this->insertCache as $row)


### PR DESCRIPTION
Because it extends `CIUnitTestCase` that extends `PHPUnit\Framework\TestCase` that uses `protected` modifier for `tearDown()` method. I applied "parent::tearDown()` call first as well.

**Checklist:**
- [x] Securely signed commits
