### PR TITLE
[ci skip] doc typo fix in entity, using "," instead of ";" in array attributes definition

### DIFF
--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -219,12 +219,12 @@ As an example, imagine you have the simplified User Entity that is used througho
     class User extends Entity
     {
         protected $attributes = [
-            'id' => null;
-            'name' => null;        // Represents a username
-            'email' => null;
-            'password' => null;
-            'created_at' => null;
-            'updated_at' => null;
+            'id' => null,
+            'name' => null,        // Represents a username
+            'email' => null,
+            'password' => null,
+            'created_at' => null,
+            'updated_at' => null,
         ];
     }
 
@@ -244,12 +244,12 @@ simply map the ``full_name`` column in the database to the ``$name`` property, a
     class User extends Entity
     {
         protected $attributes = [
-            'id' => null;
-            'name' => null;        // Represents a username
-            'email' => null;
-            'password' => null;
-            'created_at' => null;
-            'updated_at' => null;
+            'id' => null,
+            'name' => null,        // Represents a username
+            'email' => null,
+            'password' => null,
+            'created_at' => null,
+            'updated_at' => null,
         ];
 
         protected $datamap = [


### PR DESCRIPTION
typo fix.

**Checklist:**
- [x] Securely signed commits
- [x] User guide updated