### PR TITLE
Fix #2776 add ability to paginate() query with group by

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1921,7 +1921,7 @@ class BaseBuilder
 		$limit         = $this->QBLimit;
 		$this->QBLimit = false;
 
-		$sql = ($this->QBDistinct === true)
+		$sql = ($this->QBDistinct === true || ! empty($this->QBGroupBy))
 			?
 			$this->countString . $this->db->protectIdentifiers('numrows') . "\nFROM (\n" . $this->compileSelect() . "\n) CI_count_all_results"
 			:

--- a/tests/system/Database/Builder/CountTest.php
+++ b/tests/system/Database/Builder/CountTest.php
@@ -42,5 +42,18 @@ class CountTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $answer));
 	}
 
+	public function testCountAllResultsWithGroupBy()
+	{
+		$builder = new BaseBuilder('jobs', $this->db);
+		$builder->groupBy('id');
+		$builder->testMode();
+
+		$answer = $builder->where('id >', 3)->countAllResults(false);
+
+		$expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM ( SELECT * FROM "jobs" WHERE "id" > :id: GROUP BY "id" ) CI_count_all_results';
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $answer));
+	}
+
 	//--------------------------------------------------------------------
 }

--- a/tests/system/Database/Builder/CountTest.php
+++ b/tests/system/Database/Builder/CountTest.php
@@ -42,6 +42,8 @@ class CountTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $answer));
 	}
 
+	//--------------------------------------------------------------------
+
 	public function testCountAllResultsWithGroupBy()
 	{
 		$builder = new BaseBuilder('jobs', $this->db);
@@ -51,6 +53,37 @@ class CountTest extends \CodeIgniter\Test\CIUnitTestCase
 		$answer = $builder->where('id >', 3)->countAllResults(false);
 
 		$expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM ( SELECT * FROM "jobs" WHERE "id" > :id: GROUP BY "id" ) CI_count_all_results';
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $answer));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testCountAllResultsWithGroupByAndHaving()
+	{
+		$builder = new BaseBuilder('jobs', $this->db);
+		$builder->groupBy('id');
+		$builder->having('1=1');
+		$builder->testMode();
+
+		$answer = $builder->where('id >', 3)->countAllResults(false);
+
+		$expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM ( SELECT * FROM "jobs" WHERE "id" > :id: GROUP BY "id" HAVING 1 = 1 ) CI_count_all_results';
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $answer));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testCountAllResultsWithHavingOnly()
+	{
+		$builder = new BaseBuilder('jobs', $this->db);
+		$builder->having('1=1');
+		$builder->testMode();
+
+		$answer = $builder->where('id >', 3)->countAllResults(false);
+
+		$expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM "jobs" WHERE "id" > :id: HAVING 1 = 1';
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $answer));
 	}

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1367,6 +1367,17 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testPaginateForQueryWithGroupBy()
+	{
+		$model = new ValidModel($this->db);
+		$model->groupBy('id');
+
+		$model->paginate();
+		$this->assertEquals(4, $model->pager->getDetails()['total']);
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testValidationByObject()
 	{
 		$model = new ValidModel($this->db);


### PR DESCRIPTION
Fixes #2776 with add `! empty($this->QBGroupBy)` after distinct check in `Database\BaseBuilder::countAllResults()`so the result query of count is a count of the query with group by.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage