### PR TITLE
Rework get_filenames

### DIFF
--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -209,12 +209,12 @@ if (! function_exists('get_filenames'))
 	 * Reads the specified directory and builds an array containing the filenames.
 	 * Any sub-folders contained within the specified path are read as well.
 	 *
-	 * @param string $source_dir   Path to source
-	 * @param mixed  $include_path Whether to include the path as part of the filename; empty for no path, 'relative' for a relative path, not empty for full path
+	 * @param string       $source_dir   Path to source
+	 * @param boolean|null $include_path Whether to include the path as part of the filename; false for no path, null for a relative path, true for full path
 	 *
 	 * @return array
 	 */
-	function get_filenames(string $source_dir, $include_path = ''): array
+	function get_filenames(string $source_dir, ?bool $include_path = false): array
 	{
 		$files = [];
 
@@ -228,11 +228,11 @@ if (! function_exists('get_filenames'))
 					RecursiveIteratorIterator::SELF_FIRST
 				) as $name => $object)
 			{
-				if (empty($include_path))
+				if ($include_path === false)
 				{
 					$files[] = pathinfo($name, PATHINFO_BASENAME);
 				}
-				elseif ($include_path === 'relative')
+				elseif (is_null($include_path))
 				{
 					$files[] = str_replace($source_dir, '', $name);
 				}

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -209,12 +209,12 @@ if (! function_exists('get_filenames'))
 	 * Reads the specified directory and builds an array containing the filenames.
 	 * Any sub-folders contained within the specified path are read as well.
 	 *
-	 * @param string  $source_dir   Path to source
-	 * @param boolean $include_path Whether to include the path as part of the filename
+	 * @param string $source_dir   Path to source
+	 * @param mixed  $include_path Whether to include the path as part of the filename; empty for no path, 'relative' for a relative path, not empty for full path
 	 *
 	 * @return array
 	 */
-	function get_filenames(string $source_dir, bool $include_path = false): array
+	function get_filenames(string $source_dir, $include_path = ''): array
 	{
 		$files = [];
 
@@ -228,7 +228,18 @@ if (! function_exists('get_filenames'))
 					RecursiveIteratorIterator::SELF_FIRST
 				) as $name => $object)
 			{
-				$files[] = $include_path ? $name : str_replace($source_dir, '', $name);
+				if (empty($include_path))
+				{
+					$files[] = pathinfo($name, PATHINFO_BASENAME);
+				}
+				elseif ($include_path === 'relative')
+				{
+					$files[] = str_replace($source_dir, '', $name);
+				}
+				else
+				{
+					$files[] = $name;
+				}
 			}
 		}
 		catch (\Throwable $e)

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -218,6 +218,7 @@ if (! function_exists('get_filenames'))
 	{
 		$files = [];
 
+		$source_dir = realpath($source_dir) ?: $source_dir;
 		$source_dir = rtrim($source_dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
 		try

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -211,10 +211,11 @@ if (! function_exists('get_filenames'))
 	 *
 	 * @param string       $source_dir   Path to source
 	 * @param boolean|null $include_path Whether to include the path as part of the filename; false for no path, null for a relative path, true for full path
+	 * @param boolean      $hidden       Whether to include hidden files (files beginning with a period)
 	 *
 	 * @return array
 	 */
-	function get_filenames(string $source_dir, ?bool $include_path = false): array
+	function get_filenames(string $source_dir, ?bool $include_path = false, bool $hidden = false): array
 	{
 		$files = [];
 
@@ -228,9 +229,15 @@ if (! function_exists('get_filenames'))
 					RecursiveIteratorIterator::SELF_FIRST
 				) as $name => $object)
 			{
-				if ($include_path === false)
+				$basename = pathinfo($name, PATHINFO_BASENAME);
+
+				if (! $hidden && $basename[0] === '.')
 				{
-					$files[] = pathinfo($name, PATHINFO_BASENAME);
+					continue;
+				}
+				elseif ($include_path === false)
+				{
+					$files[] = $basename;
 				}
 				elseif (is_null($include_path))
 				{

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -218,7 +218,7 @@ class FilesystemHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$vfs = vfsStream::setup('root', null, $this->structure);
 
-		$this->assertEquals($expected, get_filenames($vfs->url(), 'relative'));
+		$this->assertEquals($expected, get_filenames($vfs->url(), null));
 	}
 
 	public function testGetFilenamesWithFullSource()

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -179,14 +179,17 @@ class FilesystemHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testGetFilenames()
 	{
-		$this->assertTrue(function_exists('delete_files'));
+		$this->assertTrue(function_exists('get_filenames'));
 
-		// Not sure the directory names should actually show up
-		// here but this matches v3.x results.
 		$expected = [
-			'foo',
-			'boo',
+			'.hidden',
 			'AnEmptyFolder',
+			'boo',
+			'boo/far',
+			'boo/faz',
+			'foo',
+			'foo/bar',
+			'foo/baz',
 			'simpleFile',
 		];
 
@@ -197,18 +200,21 @@ class FilesystemHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testGetFilenamesWithSource()
 	{
-		$this->assertTrue(function_exists('delete_files'));
-
-		// Not sure the directory names should actually show up
-		// here but this matches v3.x results.
-		$expected = [
-			DIRECTORY_SEPARATOR . 'foo',
-			DIRECTORY_SEPARATOR . 'boo',
-			DIRECTORY_SEPARATOR . 'AnEmptyFolder',
-			DIRECTORY_SEPARATOR . 'simpleFile',
-		];
+		$this->assertTrue(function_exists('get_filenames'));
 
 		$vfs = vfsStream::setup('root', null, $this->structure);
+
+		$expected = [
+			$vfs->url() . DIRECTORY_SEPARATOR . '.hidden',
+			$vfs->url() . DIRECTORY_SEPARATOR . 'AnEmptyFolder',
+			$vfs->url() . DIRECTORY_SEPARATOR . 'boo',
+			$vfs->url() . DIRECTORY_SEPARATOR . 'boo/far',
+			$vfs->url() . DIRECTORY_SEPARATOR . 'boo/faz',
+			$vfs->url() . DIRECTORY_SEPARATOR . 'foo',
+			$vfs->url() . DIRECTORY_SEPARATOR . 'foo/bar',
+			$vfs->url() . DIRECTORY_SEPARATOR . 'foo/baz',
+			$vfs->url() . DIRECTORY_SEPARATOR . 'simpleFile',
+		];
 
 		$this->assertEquals($expected, get_filenames($vfs->url(), true));
 	}

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -179,6 +179,29 @@ class FilesystemHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testGetFilenames()
 	{
+		$this->assertTrue(function_exists('delete_files'));
+
+		// Not sure the directory names should actually show up
+		// here but this matches v3.x results.
+		$expected = [
+			'.hidden',
+			'AnEmptyFolder',
+			'bar',
+			'baz',
+			'boo',
+			'far',
+			'faz',
+			'foo',
+			'simpleFile',
+		];
+
+		$vfs = vfsStream::setup('root', null, $this->structure);
+
+		$this->assertEquals($expected, get_filenames($vfs->url(), false));
+	}
+
+	public function testGetFilenamesWithRelativeSource()
+	{
 		$this->assertTrue(function_exists('get_filenames'));
 
 		$expected = [
@@ -195,10 +218,10 @@ class FilesystemHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$vfs = vfsStream::setup('root', null, $this->structure);
 
-		$this->assertEquals($expected, get_filenames($vfs->url(), false));
+		$this->assertEquals($expected, get_filenames($vfs->url(), 'relative'));
 	}
 
-	public function testGetFilenamesWithSource()
+	public function testGetFilenamesWithFullSource()
 	{
 		$this->assertTrue(function_exists('get_filenames'));
 

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -184,7 +184,6 @@ class FilesystemHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		// Not sure the directory names should actually show up
 		// here but this matches v3.x results.
 		$expected = [
-			'.hidden',
 			'AnEmptyFolder',
 			'bar',
 			'baz',
@@ -200,12 +199,34 @@ class FilesystemHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($expected, get_filenames($vfs->url(), false));
 	}
 
+	public function testGetFilenamesWithHidden()
+	{
+		$this->assertTrue(function_exists('delete_files'));
+
+		// Not sure the directory names should actually show up
+		// here but this matches v3.x results.
+		$expected = [
+			'.hidden',
+			'AnEmptyFolder',
+			'bar',
+			'baz',
+			'boo',
+			'far',
+			'faz',
+			'foo',
+			'simpleFile',
+		];
+
+		$vfs = vfsStream::setup('root', null, $this->structure);
+
+		$this->assertEquals($expected, get_filenames($vfs->url(), false, true));
+	}
+
 	public function testGetFilenamesWithRelativeSource()
 	{
 		$this->assertTrue(function_exists('get_filenames'));
 
 		$expected = [
-			'.hidden',
 			'AnEmptyFolder',
 			'boo',
 			'boo/far',
@@ -228,7 +249,6 @@ class FilesystemHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$vfs = vfsStream::setup('root', null, $this->structure);
 
 		$expected = [
-			$vfs->url() . DIRECTORY_SEPARATOR . '.hidden',
 			$vfs->url() . DIRECTORY_SEPARATOR . 'AnEmptyFolder',
 			$vfs->url() . DIRECTORY_SEPARATOR . 'boo',
 			$vfs->url() . DIRECTORY_SEPARATOR . 'boo/far',

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -148,7 +148,8 @@ The following functions are available:
 .. php:function:: get_filenames($source_dir[, $include_path = FALSE])
 
 	:param	string	$source_dir: Directory path
-	:param	string	$include_path: Whether to include the path as part of the filename; false for no path, null for the path relative to $source_dir, true for the full path
+	:param	bool|null	$include_path: Whether to include the path as part of the filename; false for no path, null for the path relative to $source_dir, true for the full path
+	:param	bool	$hidden: Whether to include hidden files (files beginning with a period)
 	:returns:	An array of file names
 	:rtype:	array
 

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -148,13 +148,14 @@ The following functions are available:
 .. php:function:: get_filenames($source_dir[, $include_path = FALSE])
 
 	:param	string	$source_dir: Directory path
-	:param	bool	$include_path: Whether to include the path as part of the filenames
+	:param	string	$include_path: Whether to include the path as part of the filename; empty for no path, 'relative' for a relative path, not empty for full path
 	:returns:	An array of file names
 	:rtype:	array
 
 	Takes a server path as input and returns an array containing the names of all files
 	contained within it. The file path can optionally be added to the file names by setting
-	the second parameter to TRUE, otherwise file names will be relative to the source.
+	the second parameter to 'relative' for relative paths or any other non-empty value for
+	a full file path.
 
 	Example::
 

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -148,7 +148,7 @@ The following functions are available:
 .. php:function:: get_filenames($source_dir[, $include_path = FALSE])
 
 	:param	string	$source_dir: Directory path
-	:param	string	$include_path: Whether to include the path as part of the filename; empty for no path, 'relative' for a relative path, not empty for full path
+	:param	string	$include_path: Whether to include the path as part of the filename; false for no path, null for the path relative to $source_dir, true for the full path
 	:returns:	An array of file names
 	:rtype:	array
 

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -154,7 +154,7 @@ The following functions are available:
 
 	Takes a server path as input and returns an array containing the names of all files
 	contained within it. The file path can optionally be added to the file names by setting
-	the second parameter to TRUE.
+	the second parameter to TRUE, otherwise file names will be relative to the source.
 
 	Example::
 


### PR DESCRIPTION
**Description**
https://forum.codeigniter.com/thread-75898.html

`get_filenames()` current has two different return types, contingent on its second parameter. The first (default) is a flat list of all files in all subdirectories:
> document.txt
> cat.jpg
> rainbow.exe

And the second is the same files by their absolute paths:
> /var/www/html/mysite/document.txt
> /var/www/html/mysite/assets/cat.jpg
> /var/www/html/mysite/downloads/cached/rainbow.exe

I am of the opinion that the first is pretty much useless, and that a relative listing of file paths would be much more helpful. See the forum discussion for more details.

This PR changes the function significantly to allow for the new return types: relative to source, and full path. It also no longer uses `realpath()` since that makes the function incompatible with virtual paths (e.g. `vfsStream` for testing) - if this is an issue an alternative would be to apply `realpath()` to the final file name before adding it to the return array.

Tests have been updated accordingly.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
