### PR TITLE
make Model::paginate() use default perPage from Config\Pager->perPage if $perPage parameter not passed

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -500,7 +500,7 @@ class Services extends BaseService
 
 		if (empty($config))
 		{
-			$config = new \Config\Pager();
+			$config = config('Pager');
 		}
 
 		if (! $view instanceof RendererInterface)

--- a/system/Model.php
+++ b/system/Model.php
@@ -1123,17 +1123,16 @@ class Model
 	 */
 	public function paginate(int $perPage = null, string $group = 'default', int $page = 0)
 	{
-		$pager = \Config\Services::pager(null, null, false);
+		$pager = \Config\Services::pager(null, null, true);
 		$page  = $page >= 1 ? $page : $pager->getCurrentPage($group);
 
-		$total   = $this->countAllResults(false);
-		$perPage = $perPage ?? config('Pager')->perPage;
+		$total = $this->countAllResults(false);
 
 		// Store it in the Pager library so it can be
 		// paginated in the views.
 		$this->pager = $pager->store($group, $page, $perPage, $total);
-
-		$offset = ($page - 1) * $perPage;
+		$perPage     = $this->pager->getPerPage($group);
+		$offset      = ($page - 1) * $perPage;
 
 		return $this->findAll($perPage, $offset);
 	}

--- a/system/Model.php
+++ b/system/Model.php
@@ -1114,10 +1114,10 @@ class Model
 	 * Expects a GET variable (?page=2) that specifies the page of results
 	 * to display.
 	 *
-	 * @param integer|null $perPage
-	 * @param string       $group   Will be used by the pagination library
-	 *                              to identify a unique pagination set.
-	 * @param integer      $page    Optional page number (useful when the page number is provided in different way)
+	 * @param integer $perPage
+	 * @param string  $group   Will be used by the pagination library
+	 *                         to identify a unique pagination set.
+	 * @param integer $page    Optional page number (useful when the page number is provided in different way)
 	 *
 	 * @return array|null
 	 */

--- a/system/Model.php
+++ b/system/Model.php
@@ -1123,7 +1123,7 @@ class Model
 	 */
 	public function paginate(int $perPage = null, string $group = 'default', int $page = 0)
 	{
-		$pager = \Config\Services::pager(null, null, true);
+		$pager = \Config\Services::pager(null, null, false);
 		$page  = $page >= 1 ? $page : $pager->getCurrentPage($group);
 
 		$total = $this->countAllResults(false);

--- a/system/Model.php
+++ b/system/Model.php
@@ -1114,19 +1114,20 @@ class Model
 	 * Expects a GET variable (?page=2) that specifies the page of results
 	 * to display.
 	 *
-	 * @param integer $perPage
-	 * @param string  $group   Will be used by the pagination library
-	 *                         to identify a unique pagination set.
-	 * @param integer $page    Optional page number (useful when the page number is provided in different way)
+	 * @param integer|null $perPage
+	 * @param string       $group   Will be used by the pagination library
+	 *                              to identify a unique pagination set.
+	 * @param integer      $page    Optional page number (useful when the page number is provided in different way)
 	 *
 	 * @return array|null
 	 */
-	public function paginate(int $perPage = 20, string $group = 'default', int $page = 0)
+	public function paginate(int $perPage = null, string $group = 'default', int $page = 0)
 	{
 		$pager = \Config\Services::pager(null, null, false);
 		$page  = $page >= 1 ? $page : $pager->getCurrentPage($group);
 
-		$total = $this->countAllResults(false);
+		$total   = $this->countAllResults(false);
+		$perPage = $perPage ?? config('Pager')->perPage;
 
 		// Store it in the Pager library so it can be
 		// paginated in the views.

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -145,20 +145,20 @@ class Pager implements PagerInterface
 	 * Allows for a simple, manual, form of pagination where all of the data
 	 * is provided by the user. The URL is the current URI.
 	 *
-	 * @param integer     $page
-	 * @param integer     $perPage
-	 * @param integer     $total
-	 * @param string      $template The output template alias to render.
-	 * @param integer     $segment  (if page number is provided by URI segment)
+	 * @param integer $page
+	 * @param integer $perPage
+	 * @param integer $total
+	 * @param string  $template The output template alias to render.
+	 * @param integer $segment  (if page number is provided by URI segment)
 	 *
-	 * @param  string     $group    optional group (i.e. if we'd like to define custom path)
+	 * @param  string  $group    optional group (i.e. if we'd like to define custom path)
 	 * @return string
 	 */
-	public function makeLinks(int $page, int $perPage, int $total, string $template = 'default_full', int $segment = 0, ?string $group = 'default'): string
+	public function makeLinks(int $page, int $perPage = null, int $total, string $template = 'default_full', int $segment = 0, ?string $group = 'default'): string
 	{
 		$group = $group === '' ? 'default' : $group;
 
-		$this->store($group, $page, $perPage, $total, $segment);
+		$this->store($group, $page, $perPage ?? $this->config->perPage, $total, $segment);
 
 		return $this->displayLinks($group, $template);
 	}
@@ -201,12 +201,13 @@ class Pager implements PagerInterface
 	 *
 	 * @return $this
 	 */
-	public function store(string $group, int $page, int $perPage, int $total, int $segment = 0)
+	public function store(string $group, int $page, int $perPage = null, int $total, int $segment = 0)
 	{
 		$this->segment[$group] = $segment;
 
 		$this->ensureGroup($group);
 
+		$perPage                             = $perPage ?? $this->config->perPage;
 		$this->groups[$group]['currentPage'] = $page;
 		$this->groups[$group]['perPage']     = $perPage;
 		$this->groups[$group]['total']       = $total;

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -205,7 +205,7 @@ class Pager implements PagerInterface
 	{
 		$this->segment[$group] = $segment;
 
-		$this->ensureGroup($group);
+		$this->ensureGroup($group, $perPage);
 
 		$perPage                             = $perPage ?? $this->config->perPage;
 		$this->groups[$group]['currentPage'] = $page;
@@ -494,9 +494,10 @@ class Pager implements PagerInterface
 	/**
 	 * Ensures that an array exists for the group specified.
 	 *
-	 * @param string $group
+	 * @param string  $group
+	 * @param integer $perPage
 	 */
-	protected function ensureGroup(string $group)
+	protected function ensureGroup(string $group, int $perPage = null)
 	{
 		if (array_key_exists($group, $this->groups))
 		{
@@ -507,7 +508,7 @@ class Pager implements PagerInterface
 			'uri'          => clone current_url(true),
 			'hasMore'      => false,
 			'total'        => null,
-			'perPage'      => $this->config->perPage,
+			'perPage'      => $perPage ?? $this->config->perPage,
 			'pageCount'    => 1,
 			'pageSelector' => $group === 'default' ? 'page' : 'page_' . $group,
 		];

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1345,6 +1345,9 @@ class ModelTest extends CIDatabaseTestCase
 		$perPage                 = config('Pager')->perPage;
 		config('Pager')->perPage = 1;
 
+		// ensure new instance for new "perPage" config from config('Pager')
+		\Config\Services::pager(config('Pager'), null, true);
+
 		$model = new ValidModel($this->db);
 
 		$data = $model->paginate();
@@ -1352,6 +1355,9 @@ class ModelTest extends CIDatabaseTestCase
 		$this->assertEquals(1, count($data));
 
 		config('Pager')->perPage = $perPage;
+
+		// rollback to use same instance on call
+		\Config\Services::pager(config('Pager'), null, false);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1340,6 +1340,19 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testPaginateChangeConfigPager()
+	{
+		config('Pager')->perPage = 1;
+
+		$model = new ValidModel($this->db);
+
+		$data = $model->paginate();
+
+		$this->assertEquals(1, count($data));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testValidationByObject()
 	{
 		$model = new ValidModel($this->db);
@@ -1831,7 +1844,6 @@ class ModelTest extends CIDatabaseTestCase
 		$this->assertEquals(1, $user->id);
 		$user2 = $model->first();
 		$this->assertEquals(2, $user2->id);
-
 	}
 
 	public function testcountAllResultsRecoverTempUseSoftDeletes()
@@ -1840,7 +1852,6 @@ class ModelTest extends CIDatabaseTestCase
 		$model->delete(1);
 		$this->assertEquals(4, $model->withDeleted()->countAllResults());
 		$this->assertEquals(3, $model->countAllResults());
-
 	}
 
 }

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1342,6 +1342,7 @@ class ModelTest extends CIDatabaseTestCase
 
 	public function testPaginateChangeConfigPager()
 	{
+		$perPage                 = config('Pager')->perPage;
 		config('Pager')->perPage = 1;
 
 		$model = new ValidModel($this->db);
@@ -1349,6 +1350,8 @@ class ModelTest extends CIDatabaseTestCase
 		$data = $model->paginate();
 
 		$this->assertEquals(1, count($data));
+
+		config('Pager')->perPage = $perPage;
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1345,9 +1345,6 @@ class ModelTest extends CIDatabaseTestCase
 		$perPage                 = config('Pager')->perPage;
 		config('Pager')->perPage = 1;
 
-		// ensure new instance for new "perPage" config from config('Pager')
-		\Config\Services::pager(config('Pager'), null, true);
-
 		$model = new ValidModel($this->db);
 
 		$data = $model->paginate();
@@ -1355,9 +1352,6 @@ class ModelTest extends CIDatabaseTestCase
 		$this->assertEquals(1, count($data));
 
 		config('Pager')->perPage = $perPage;
-
-		// rollback to use same instance on call
-		\Config\Services::pager(config('Pager'), null, false);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1353,6 +1353,17 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testPaginatePassPerPageParameter()
+	{
+		$model = new ValidModel($this->db);
+
+		$data = $model->paginate(2);
+
+		$this->assertEquals(2, count($data));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testValidationByObject()
 	{
 		$model = new ValidModel($this->db);

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -100,6 +100,17 @@ class PagerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($details['currentPage'], 3);
 	}
 
+	public function testStoreDoesBasicCalcsOnPerPageReadFromPagerConfig()
+	{
+		$this->pager->store('foo', 3, null, 100);
+
+		$details = $this->pager->getDetails('foo');
+
+		$this->assertEquals($details['total'], 100);
+		$this->assertEquals($details['perPage'], 20);
+		$this->assertEquals($details['currentPage'], 3);
+	}
+
 	public function testStoreAndHasMore()
 	{
 		$this->pager->store('foo', 3, 25, 100);
@@ -354,6 +365,9 @@ class PagerTest extends \CodeIgniter\Test\CIUnitTestCase
 		);
 		$this->assertStringContainsString(
 			'?page_custom=1', $this->pager->makeLinks(1, 10, 1, 'default_full', 0, 'custom')
+		);
+		$this->assertStringContainsString(
+			'?page_custom=1', $this->pager->makeLinks(1, null, 1, 'default_full', 0, 'custom')
 		);
 	}
 


### PR DESCRIPTION
Currently, the `$perPage` is default to `20` in `Model::paginate()` function. I think it should read from `config('Pager')->perPage` instead. I apply make default to null, and check if it is not passed, it will use the default `config('Pager')->perPage`

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
