### PR TITLE
add ability to replace {locale} to request->getLocale() in form_open('action')

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -69,6 +69,12 @@ if (! function_exists('form_open'))
 		} // If an action is not a full URL then turn it into one
 		elseif (strpos($action, '://') === false)
 		{
+			// If an action has {locale}
+			if (strpos($action, '{locale}') !== false)
+			{
+				$action = str_replace('{locale}', Services::request()->getLocale(), $action);
+			}
+
 			$action = site_url($action);
 		}
 

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -56,6 +56,29 @@ EOH;
 	}
 
 	// ------------------------------------------------------------------------
+	public function testFormOpenHasLocale()
+	{
+		$config            = new App();
+		$config->baseURL   = '';
+		$config->indexPage = 'index.php';
+		$request           = Services::request($config);
+		$request->uri      = new URI('http://example.com/');
+
+		Services::injectMock('request', $request);
+		$expected = <<<EOH
+<form action="http://example.com/index.php/en/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
+
+EOH;
+
+		$attributes = [
+			'name'   => 'form',
+			'id'     => 'form',
+			'method' => 'POST',
+		];
+		$this->assertEquals($expected, form_open('{locale}/foo/bar', $attributes));
+	}
+
+	// ------------------------------------------------------------------------
 	public function testFormOpenWithoutAction()
 	{
 		$config            = new App();

--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -75,6 +75,15 @@ The following functions are available:
 
 		<form method="post" accept-charset="utf-8" action="http://example.com/index.php/email/send">
 
+	You can also add {locale} like the following::
+
+		echo form_open('{locale}/email/send');
+
+	The above example would create a form that points to your base URL plus the current request locale with
+	"email/send" URI segments, like this::
+
+		<form method="post" accept-charset="utf-8" action="http://example.com/index.php/en/email/send">
+
 	**Adding Attributes**
 
 		Attributes can be added by passing an associative array to the second
@@ -90,13 +99,13 @@ The following functions are available:
 		The above examples would create a form similar to this::
 
 			<form method="post" accept-charset="utf-8" action="http://example.com/index.php/email/send" class="email" id="myform">
-			
+
 		If CSRF filter is turned on `form_open()` will generate CSRF field at the beginning of the form. You can specify ID of this field by passing csrf_id as one of the $attribute array:
-		
+
 			form_open('/u/sign-up', ['csrf_id' => 'my-id']);
-			
+
 		will return:
-		
+
 			<form action="/u/sign-up" method="post" accept-charset="utf-8">
 			<input type="hidden" id="my-id" name="csrf_field" value="964ede6e0ae8a680f7b8eab69136717d" />
 


### PR DESCRIPTION
So no need to manually add locale from variable when call `form_open()` in view.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] User guide updated
