### PR TITLE
test Autoloader::initialize() with composer path not found

### DIFF
--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -232,4 +232,22 @@ class AutoloaderTest extends \CodeIgniter\Test\CIUnitTestCase
 		$namespaces = $this->loader->getNamespace();
 		$this->assertArrayHasKey('Laminas\\Escaper', $namespaces);
 	}
+
+	public function testFindsComposerRoutesWithComposerPathNotFound()
+	{
+		$composerPath = COMPOSER_PATH;
+
+		$config                           = new Autoload();
+		$moduleConfig                     = new Modules();
+		$moduleConfig->discoverInComposer = true;
+
+		$this->loader = new Autoloader();
+
+		rename(COMPOSER_PATH, COMPOSER_PATH . '.backup');
+		$this->loader->initialize($config, $moduleConfig);
+		rename(COMPOSER_PATH . '.backup', $composerPath);
+
+		$namespaces = $this->loader->getNamespace();
+		$this->assertArrayNotHasKey('Laminas\\Escaper', $namespaces);
+	}
 }


### PR DESCRIPTION
By this, `CodeIgniter\Autoloader\Autoloader` will have 100% test coverage.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage