### PR TITLE
test for API\ResponseTrait::format() with format is not json or xml

### DIFF
--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -452,4 +452,44 @@ EOH;
 		$this->assertEquals($expected, $this->response->getBody());
 	}
 
+	public function testFormatByRequestNegotiateIfFormatIsNotJsonOrXML()
+	{
+		$config = [
+			'baseURL'          => 'http://example.com',
+			'uriProtocol'      => 'REQUEST_URI',
+			'defaultLocale'    => 'en',
+			'negotiateLocale'  => false,
+			'supportedLocales' => ['en'],
+			'CSPEnabled'       => false,
+			'cookiePrefix'     => '',
+			'cookieDomain'     => '',
+			'cookiePath'       => '/',
+			'cookieSecure'     => false,
+			'cookieHTTPOnly'   => false,
+			'proxyIPs'         => [],
+		];
+
+		$request  = new MockIncomingRequest((object) $config, new URI($config['baseURL']), null, new UserAgent());
+		$response = new MockResponse((object) $config);
+
+		$controller = new class($request, $response)
+		{
+			use ResponseTrait;
+
+			protected $request;
+			protected $response;
+
+			public function __construct(&$request, &$response)
+			{
+				$this->request  = $request;
+				$this->response = $response;
+
+				$this->format = 'txt';
+			}
+		};
+
+		$controller->respondCreated(['id' => 3], 'A Custom Reason');
+		$this->assertStringStartsWith('application/json; charset=UTF-8', $response->getHeaderLine('Content-Type'));
+	}
+
 }

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -489,7 +489,7 @@ EOH;
 		};
 
 		$controller->respondCreated(['id' => 3], 'A Custom Reason');
-		$this->assertStringStartsWith('application/json; charset=UTF-8', $response->getHeaderLine('Content-Type'));
+		$this->assertStringStartsWith(config('Format')->supportedResponseFormats[0], $response->getHeaderLine('Content-Type'));
 	}
 
 }


### PR DESCRIPTION
By this, `CodeIgniter\API\ResponseTrait` will have 100% test coverage.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage  
