### PR TITLE
test Logger::determineFile() for no stack trace

### DIFF
--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -419,4 +419,18 @@ class LoggerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($expected, $logger->cleanup($ohoh));
 	}
 
+	//--------------------------------------------------------------------
+
+	public function testDetermineFileNoStackTrace()
+	{
+		$config = new LoggerConfig();
+		$logger = new Logger($config);
+
+		$expected = [
+			'unknown',
+			'unknown',
+		];
+
+		$this->assertEquals($expected, $logger->determineFile());
+	}
 }


### PR DESCRIPTION
By this, `CodeIgniter\Log\Logger` will have 100% test coverage.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage