### PR TITLE
[ci skip] Fix download badge total shows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/codeigniter4/CodeIgniter4.svg?branch=develop)](https://travis-ci.org/codeigniter4/CodeIgniter4)
 [![Coverage Status](https://coveralls.io/repos/github/codeigniter4/CodeIgniter4/badge.svg?branch=develop)](https://coveralls.io/github/codeigniter4/CodeIgniter4?branch=develop)
-[![GitHub All Releases](https://img.shields.io/github/downloads/codeigniter4/CodeIgniter4/total)](https://packagist.org/packages/codeigniter4/framework)
+[![Downloads](https://poser.pugx.org/codeigniter4/framework/downloads)](https://packagist.org/packages/codeigniter4/framework)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/codeigniter4/CodeIgniter4)](https://packagist.org/packages/codeigniter4/framework)
 [![GitHub stars](https://img.shields.io/github/stars/codeigniter4/CodeIgniter4)](https://packagist.org/packages/codeigniter4/framework)
 [![GitHub license](https://img.shields.io/github/license/codeigniter4/CodeIgniter4)](https://github.com/codeigniter4/CodeIgniter4/blob/develop/license.txt)


### PR DESCRIPTION
Previously, it only shows "4.4k", while it already "24.73k" downloads, seems because of path url location to `codeigniter4/codeigniter4` instead of `codeigniter4/framework`. 

I updated the badge to use `poser.pugx.org` as the `img.shields.io` only shows 0 downloads.

**Checklist:**
- [x] Securely signed commits
