### PR TITLE
Add resetting QBFrom part

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1000,7 +1000,7 @@ class BaseBuilder
 				throw new InvalidArgumentException(sprintf('%s() expects $key to be a non-empty string', debug_backtrace(0, 2)[1]['function']));
 			}
 
-			return this;
+			return $this;
 		}
 
 		if ($values === null || (! is_array($values) && ! ($values instanceof Closure)))
@@ -1010,7 +1010,7 @@ class BaseBuilder
 				throw new InvalidArgumentException(sprintf('%s() expects $values to be of type array or closure', debug_backtrace(0, 2)[1]['function']));
 			}
 
-			return this;
+			return $this;
 		}
 
 		is_bool($escape) || $escape = $this->db->protectIdentifiers;

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -981,12 +981,12 @@ class BaseBuilder
 	 * @used-by whereNotIn()
 	 * @used-by orWhereNotIn()
 	 *
-	 * @param string        $key    The field to search
-	 * @param array|Closure $values The values searched on, or anonymous function with subquery
-	 * @param boolean       $not    If the statement would be IN or NOT IN
-	 * @param string        $type
-	 * @param boolean       $escape
-	 * @param string        $clause (Internal use only)
+	 * @param  string        $key    The field to search
+	 * @param  array|Closure $values The values searched on, or anonymous function with subquery
+	 * @param  boolean       $not    If the statement would be IN or NOT IN
+	 * @param  string        $type
+	 * @param  boolean       $escape
+	 * @param  string        $clause (Internal use only)
 	 * @throws InvalidArgumentException
 	 *
 	 * @return BaseBuilder
@@ -998,8 +998,8 @@ class BaseBuilder
 			if (CI_DEBUG)
 			{
 				throw new InvalidArgumentException(sprintf('%s() expects $key to be a non-empty string', debug_backtrace(0, 2)[1]['function']));
-			} 
-			
+			}
+
 			return this;
 		}
 
@@ -1009,7 +1009,7 @@ class BaseBuilder
 			{
 				throw new InvalidArgumentException(sprintf('%s() expects $values to be of type array or closure', debug_backtrace(0, 2)[1]['function']));
 			}
-			
+
 			return this;
 		}
 
@@ -3328,6 +3328,12 @@ class BaseBuilder
 		{
 			$this->db->setAliasedTables([]);
 		}
+
+		// Reset QBFrom part
+		if (! empty($this->QBFrom))
+		{
+			$this->from(array_shift($this->QBFrom), true);
+		}
 	}
 
 	//--------------------------------------------------------------------
@@ -3426,7 +3432,7 @@ class BaseBuilder
 			return $key;
 		}
 
-		if (!array_key_exists($key, $this->bindsKeyCount))
+		if (! array_key_exists($key, $this->bindsKeyCount))
 		{
 			$this->bindsKeyCount[$key] = 0;
 		}

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -69,4 +69,33 @@ class FromTest extends \CodeIgniter\Test\CIUnitTestCase
 	}
 
 	//--------------------------------------------------------------------
+
+	public function testFromReset()
+	{
+		$builder = new BaseBuilder('user', $this->db);
+
+		$builder->from(['jobs', 'roles']);
+
+		$expectedSQL = 'SELECT * FROM "user", "jobs", "roles"';
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+		$expectedSQL = 'SELECT * FROM "user"';
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+		$expectedSQL = 'SELECT *';
+
+		$builder->from(null, true);
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+		$expectedSQL = 'SELECT * FROM "jobs"';
+
+		$builder->from('jobs');
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
+
+	//--------------------------------------------------------------------
 }


### PR DESCRIPTION
**Description**
The `QBFrom` part is not resetting. That can lead to unexpected results when combined with a call to `from` method. This pull request makes sure that only first table from QBFrom array is saved after the query is executed.

Ref: #2800 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide