### PR TITLE
add ext-mbstring to required and update regex that sanitize file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,20 @@
 
 ## What is CodeIgniter?
 
-CodeIgniter is a PHP full-stack web framework that is light, fast, flexible, and secure. 
+CodeIgniter is a PHP full-stack web framework that is light, fast, flexible, and secure.
 More information can be found at the [official site](http://codeigniter.com).
 
-This repository holds the source code for CodeIgniter 4 only. 
-Version 4 is a complete rewrite to bring the quality and the code into a more modern version, 
-while still keeping as many of the things intact that has made people love the framework over the years. 
+This repository holds the source code for CodeIgniter 4 only.
+Version 4 is a complete rewrite to bring the quality and the code into a more modern version,
+while still keeping as many of the things intact that has made people love the framework over the years.
 
 More information about the plans for version 4 can be found in [the announcement](http://forum.codeigniter.com/thread-62615.html) on the forums.
 
 ### Documentation
 
-The [User Guide](https://codeigniter4.github.io/userguide/) is the primary documentation for CodeIgniter 4. 
+The [User Guide](https://codeigniter4.github.io/userguide/) is the primary documentation for CodeIgniter 4.
 
-The current **in-progress** User Guide can be found [here](https://codeigniter4.github.io/CodeIgniter4/). 
+The current **in-progress** User Guide can be found [here](https://codeigniter4.github.io/CodeIgniter4/).
 As with the rest of the framework, it is a work in progress, and will see changes over time to structure, explanations, etc.
 
 You might also be interested in the [API documentation](https://codeigniter4.github.io/api/) for the framework components.
@@ -43,9 +43,9 @@ The user guide updating and deployment is a bit awkward at the moment, but we ar
 
 ## Repository Management
 
-CodeIgniter is developed completely on a volunteer basis. As such, please give up to 7 days 
-for your issues to be reviewed. If you haven't heard from one of the team in that time period, 
-feel free to leave a comment on the issue so that it gets brought back to our attention. 
+CodeIgniter is developed completely on a volunteer basis. As such, please give up to 7 days
+for your issues to be reviewed. If you haven't heard from one of the team in that time period,
+feel free to leave a comment on the issue so that it gets brought back to our attention.
 
 We use Github issues to track **BUGS** and to track approved **DEVELOPMENT** work packages.
 We use our [forum](http://forum.codeigniter.com) to provide SUPPORT and to discuss
@@ -56,7 +56,7 @@ be closed! If you are not sure if you have found a bug, raise a thread on the fo
 someone else may have encountered the same thing.
 
 Before raising a new Github issue, please check that your bug hasn't already
-been reported or fixed. 
+been reported or fixed.
 
 We use pull requests (PRs) for CONTRIBUTIONS to the repository.
 We are looking for contributions that address one of the reported bugs or
@@ -72,8 +72,8 @@ to optional packages, with their own repository.
 
 We **are** accepting contributions from the community!
 
-We will try to manage the process somewhat, by adding a ["help wanted" label](https://github.com/codeigniter4/CodeIgniter4/labels/help%20wanted) to those that we are 
-specifically interested in at any point in time. Join the discussion for those issues and let us know 
+We will try to manage the process somewhat, by adding a ["help wanted" label](https://github.com/codeigniter4/CodeIgniter4/labels/help%20wanted) to those that we are
+specifically interested in at any point in time. Join the discussion for those issues and let us know
 if you want to take the lead on one of them.
 
 At this time, we are not looking for out-of-scope contributions, only those that would be considered part of our controlled evolution!
@@ -82,17 +82,17 @@ Please read the [*Contributing to CodeIgniter*](https://github.com/codeigniter4/
 
 ## Server Requirements
 
-PHP version 7.2 or higher is required, with the following extensions installed: 
+PHP version 7.2 or higher is required, with the following extensions installed:
 
 
 - [intl](http://php.net/manual/en/intl.requirements.php)
 - [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library
+- [mbstring](http://php.net/manual/en/mbstring.installation.php)
 
 Additionally, make sure that the following extensions are enabled in your PHP:
 
 - json (enabled by default - don't turn it off)
 - xml (enabled by default - don't turn it off)
-- [mbstring](http://php.net/manual/en/mbstring.installation.php)
 - [mysqlnd](http://php.net/manual/en/mysqlnd.install.php)
 
 ## Running CodeIgniter Tests

--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -9,6 +9,7 @@
         "ext-curl": "*",
         "ext-intl": "*",
         "ext-json": "*",
+        "ext-mbstring": "*",
         "kint-php/kint": "^3.3",
         "psr/log": "^1.1",
         "laminas/laminas-escaper": "^2.6"

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "ext-curl": "*",
         "ext-intl": "*",
         "ext-json": "*",
+        "ext-mbstring": "*",
         "kint-php/kint": "^3.3",
         "psr/log": "^1.1",
         "laminas/laminas-escaper": "^2.6"

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -392,7 +392,7 @@ class Autoloader
 		// be a path.
 		// http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_278
 		// Modified to allow backslash and colons for on Windows machines.
-		$filename = mb_ereg_replace('/[^a-zA-Z0-9\s\/\-\_\.\:\\\\]/', '', $filename);
+		$filename = preg_replace('/[^a-zA-Z0-9\p{L}\s\/\-\_\.\:\\\\]/', '', $filename);
 
 		// Clean up our filename edges.
 		$filename = trim($filename, '.-_');

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -392,7 +392,7 @@ class Autoloader
 		// be a path.
 		// http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_278
 		// Modified to allow backslash and colons for on Windows machines.
-		$filename = preg_replace('/[^a-zA-Z0-9\p{L}\s\/\-\_\.\:\\\\]/', '', $filename);
+		$filename = preg_replace('/[^a-zA-Z0-9\p{L}\s\/\-\_\.\:\\\\]/u', '', $filename);
 
 		// Clean up our filename edges.
 		$filename = trim($filename, '.-_');

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -392,7 +392,7 @@ class Autoloader
 		// be a path.
 		// http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_278
 		// Modified to allow backslash and colons for on Windows machines.
-		$filename = preg_replace('/[^a-zA-Z0-9\p{L}\s\/\-\_\.\:\\\\]/u', '', $filename);
+		$filename = preg_replace('/[^0-9\p{L}\s\/\-\_\.\:\\\\]/u', '', $filename);
 
 		// Clean up our filename edges.
 		$filename = trim($filename, '.-_');

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -392,7 +392,7 @@ class Autoloader
 		// be a path.
 		// http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_278
 		// Modified to allow backslash and colons for on Windows machines.
-		$filename = preg_replace('/[^a-zA-Z0-9\s\/\-\_\.\:\\\\]/', '', $filename);
+		$filename = mb_ereg_replace('/[^a-zA-Z0-9\s\/\-\_\.\:\\\\]/', '', $filename);
 
 		// Clean up our filename edges.
 		$filename = trim($filename, '.-_');

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -211,6 +211,16 @@ class AutoloaderTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testSanitizationAllowSomeUnicodeChars()
+	{
+		$test     = 'Ä/path/to/some/file.php_';
+		$expected = 'Ä/path/to/some/file.php';
+
+		$this->assertEquals($expected, $this->loader->sanitizeFilename($test));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testSanitizationAllowsWindowsFilepaths()
 	{
 		$test = 'C:\path\to\some/file.php';

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -211,7 +211,7 @@ class AutoloaderTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testSanitizationAllowSomeUnicodeChars()
+	public function testSanitizationAllowUnicodeChars()
 	{
 		$test     = 'Ä/path/to/some/file.php_';
 		$expected = 'Ä/path/to/some/file.php';

--- a/user_guide_src/source/intro/requirements.rst
+++ b/user_guide_src/source/intro/requirements.rst
@@ -2,12 +2,12 @@
 Server Requirements
 ###################
 
-`PHP <https://www.php.net/>`_ version 7.2 or newer is required, with the 
-`*intl* extension <https://www.php.net/manual/en/intl.requirements.php>`_
+`PHP <https://www.php.net/>`_ version 7.2 or newer is required, with the
+`*intl* extension <https://www.php.net/manual/en/intl.requirements.php>`_ and `*mbstring* extension <https://www.php.net/manual/en/mbstring.requirements.php>`_
 installed.
 
 The following PHP extensions should be enabled on your server:
-``php-json``, ``php-mbstring``, ``php-mysqlnd``, ``php-xml``
+``php-json``, ``php-mysqlnd``, ``php-xml``
 
 In order to use the :doc:`CURLRequest </libraries/curlrequest>`, you will need
 `libcurl <https://www.php.net/manual/en/curl.requirements.php>`_ installed.


### PR DESCRIPTION
Like in my comment at https://github.com/codeigniter4/CodeIgniter4/issues/2784#issuecomment-609515200 , that in other forum in facebook, I got people ask about `php spark serve` error as well, and solved by install mbstring extension. I also updated regex that sanitize file name.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] User guide updated