### PR TITLE
using realpath() for define $pathsPath in index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -13,7 +13,7 @@ define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);
 
 // Location of the Paths config file.
 // This is the line that might need to be changed, depending on your folder structure.
-$pathsPath = FCPATH . '../app/Config/Paths.php';
+$pathsPath = realpath(FCPATH . '../app/Config/Paths.php');
 // ^^^ Change this if you move your application folder
 
 /*


### PR DESCRIPTION
Other places that define `../` in paths, using `realpath()` to ensure location, like in `system/bootstrap.php`. 

I updated as well for `$pathsPath` in `public/index.php`.

**Checklist:**
- [x] Securely signed commits