### PR TITLE
clean up buffer tweak in FeatureTestCaseTest 

### DIFF
--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -151,6 +151,15 @@ class FeatureTestCase extends CIDatabaseTestCase
 	 */
 	public function call(string $method, string $path, array $params = null)
 	{
+		// Clean up any open output buffers
+		// not relevant to unit testing
+		// @codeCoverageIgnoreStart
+		if (\ob_get_level() > 0 && $this->clean)
+		{
+			\ob_end_clean();
+		}
+		// @codeCoverageIgnoreEnd
+
 		// Simulate having a blank session
 		$_SESSION                  = [];
 		$_SERVER['REQUEST_METHOD'] = $method;
@@ -177,16 +186,6 @@ class FeatureTestCase extends CIDatabaseTestCase
 		{
 			$response->setBody($output);
 		}
-
-		// Clean up any open output buffers
-		// not relevant to unit testing
-		// @codeCoverageIgnoreStart
-
-		if (ob_get_level() > 0 && $this->clean)
-		{
-			ob_end_clean();
-		}
-		// @codeCoverageIgnoreEnd
 
 		// Reset directory if it has been set
 		Services::router()->setDirectory(null);

--- a/tests/system/Test/FeatureTestCaseTest.php
+++ b/tests/system/Test/FeatureTestCaseTest.php
@@ -198,10 +198,6 @@ class FeatureTestCaseTest extends FeatureTestCase
 	public function testCallZeroAsPathGot404()
 	{
 		$this->expectException(PageNotFoundException::class);
-		while (\ob_get_level() > 0)
-		{
-			\ob_end_flush();
-		}
 		$this->get('0');
 	}
 
@@ -247,11 +243,6 @@ class FeatureTestCaseTest extends FeatureTestCase
 				$to,
 			],
 		]);
-
-		while (\ob_get_level() > 0)
-		{
-			\ob_end_flush();
-		}
 		$this->get($httpGet);
 	}
 }


### PR DESCRIPTION
Mostly, for testing 404 pages. By move the `ob_get_level()` check in the beginning of method `FeatureTestCase::call()`. 

> For note: there is still `ob_start()` in the test case for `testEchoes()` which currently required as content already echoed.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
