### PR TITLE
test Controller::validate() with string rules

### DIFF
--- a/system/Controller.php
+++ b/system/Controller.php
@@ -194,7 +194,7 @@ class Controller
 		// If you replace the $rules array with the name of the group
 		if (is_string($rules))
 		{
-			$validation = new \Config\Validation();
+			$validation = config('Validation');
 
 			// If the rule wasn't found in the \Config\Validation, we
 			// should throw an exception so the developer can find it.


### PR DESCRIPTION
By this, `CodeIgniter\Controller` class will have 100% test coverage. I updated manual instantiation of `Config\Validation` with `config('Validation)` which make it testable.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage