### PR TITLE
make named constructor in Exception classes consistent: use return instead of throw

### DIFF
--- a/system/Exceptions/CastException.php
+++ b/system/Exceptions/CastException.php
@@ -19,17 +19,17 @@ class CastException extends CriticalError
 		switch($error)
 		{
 			case JSON_ERROR_DEPTH:
-				throw new static(lang('Cast.jsonErrorDepth'));
+				return new static(lang('Cast.jsonErrorDepth'));
 			case JSON_ERROR_STATE_MISMATCH:
-				throw new static(lang('Cast.jsonErrorStateMismatch'));
+				return new static(lang('Cast.jsonErrorStateMismatch'));
 			case JSON_ERROR_CTRL_CHAR:
-				throw new static(lang('Cast.jsonErrorCtrlChar'));
+				return new static(lang('Cast.jsonErrorCtrlChar'));
 			case JSON_ERROR_SYNTAX:
-				throw new static(lang('Cast.jsonErrorSyntax'));
+				return new static(lang('Cast.jsonErrorSyntax'));
 			case JSON_ERROR_UTF8:
-				throw new static(lang('Cast.jsonErrorUtf8'));
+				return new static(lang('Cast.jsonErrorUtf8'));
 			default:
-				throw new static(lang('Cast.jsonErrorUnknown'));
+				return new static(lang('Cast.jsonErrorUnknown'));
 		}
 	}
 

--- a/system/Exceptions/ConfigException.php
+++ b/system/Exceptions/ConfigException.php
@@ -16,6 +16,6 @@ class ConfigException extends CriticalError
 
 	public static function forDisabledMigrations()
 	{
-		throw new static(lang('Migrations.disabled'));
+		return new static(lang('Migrations.disabled'));
 	}
 }


### PR DESCRIPTION
As the callers already call `throw` and most other exception classes uses `return`.

**Checklist:**
- [x] Securely signed commits