### PR TITLE
Ensure $_SERVER['SCRIPT_NAME'] ends with PHP

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -721,7 +721,7 @@ class IncomingRequest extends Request
 		$query = $parts['query'] ?? '';
 		$uri   = $parts['path'] ?? '';
 
-		if (isset($_SERVER['SCRIPT_NAME'][0]) AND pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_EXTENSION) === 'php')
+		if (isset($_SERVER['SCRIPT_NAME'][0]) && pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_EXTENSION) === 'php')
 		{
 			// strip the script name from the beginning of the URI
 			if (strpos($uri, $_SERVER['SCRIPT_NAME']) === 0)

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -721,7 +721,7 @@ class IncomingRequest extends Request
 		$query = $parts['query'] ?? '';
 		$uri   = $parts['path'] ?? '';
 
-		if (isset($_SERVER['SCRIPT_NAME'][0]))
+		if (isset($_SERVER['SCRIPT_NAME'][0]) AND pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_EXTENSION) === 'php')
 		{
 			// strip the script name from the beginning of the URI
 			if (strpos($uri, $_SERVER['SCRIPT_NAME']) === 0)


### PR DESCRIPTION

**Description**
When doing spark serve, `$_SERVER['SCRIPT_NAME']` has a bug that leads to URI like `/uploads/avatar/1.jpg` being treated as `/`. This solves the problem by making sure that `$_SERVER['SCRIPT_NAME']` is indeed a PHP file, otherwise don't process it futher.
This solves issue #2194 

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
