### PR TITLE
Fix missing InvalidArgumentException in Database\BaseBuilder

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -997,7 +997,7 @@ class BaseBuilder
 		{
 			if (CI_DEBUG)
 			{
-				throw new InvalidArgumentException(sprintf('%s() expects $key to be a non-empty string', debug_backtrace(0, 2)[1]['function']));
+				throw new \InvalidArgumentException(sprintf('%s() expects $key to be a non-empty string', debug_backtrace(0, 2)[1]['function']));
 			}
 
 			return $this;
@@ -1007,7 +1007,7 @@ class BaseBuilder
 		{
 			if (CI_DEBUG)
 			{
-				throw new InvalidArgumentException(sprintf('%s() expects $values to be of type array or closure', debug_backtrace(0, 2)[1]['function']));
+				throw new \InvalidArgumentException(sprintf('%s() expects $values to be of type array or closure', debug_backtrace(0, 2)[1]['function']));
 			}
 
 			return $this;

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -221,6 +221,49 @@ class WhereTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function provideInvalidKeys()
+	{
+		return [
+			'null'         => [null],
+			'empty string' => [''],
+		];
+	}
+
+	/**
+	 * @dataProvider provideInvalidKeys
+	 */
+	public function testWhereInvalidKeyThrowInvalidArgumentException($key)
+	{
+		$this->expectException(\InvalidArgumentException::class);
+		$builder = $this->db->table('jobs');
+
+		$builder->whereIn($key, ['Politician', 'Accountant']);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function provideInvalidValues()
+	{
+		return [
+			'null'                    => [null],
+			'not array'               => ['not array'],
+			'not instanceof \Closure' => [new \stdClass],
+		];
+	}
+
+	/**
+	 * @dataProvider provideInvalidValues
+	 */
+	public function testWhereInEmptyValuesThrowInvalidArgumentException($values)
+	{
+		$this->expectException(\InvalidArgumentException::class);
+		$builder = $this->db->table('jobs');
+
+		$builder->whereIn('name', $values);
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testWhereNotIn()
 	{
 		$builder = $this->db->table('jobs');


### PR DESCRIPTION
Fix missing "\\" prefix in throw InvalidArgumentException.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage