### PR TITLE
add respondUpdated() method into API\ResponseTrait

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -66,6 +66,7 @@ trait ResponseTrait
 	protected $codes = [
 		'created'                   => 201,
 		'deleted'                   => 200,
+		'updated'                   => 200,
 		'no_content'                => 204,
 		'invalid_request'           => 400,
 		'unsupported_response_type' => 400,
@@ -194,6 +195,19 @@ trait ResponseTrait
 	public function respondDeleted($data = null, string $message = '')
 	{
 		return $this->respond($data, $this->codes['deleted'], $message);
+	}
+
+	/**
+	 * Used after a resource has been successfully updated.
+	 *
+	 * @param mixed  $data    Data.
+	 * @param string $message Message.
+	 *
+	 * @return mixed
+	 */
+	public function respondUpdated($data = null, string $message = '')
+	{
+		return $this->respond($data, $this->codes['updated'], $message);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -242,6 +242,16 @@ EOH;
 		$this->assertEquals($this->formatter->format(['id' => 3]), $this->response->getBody());
 	}
 
+	public function testUpdated()
+	{
+		$controller = $this->makeController();
+		$controller->respondUpdated(['id' => 3], 'A Custom Reason');
+
+		$this->assertEquals('A Custom Reason', $this->response->getReason());
+		$this->assertEquals(200, $this->response->getStatusCode());
+		$this->assertEquals($this->formatter->format(['id' => 3]), $this->response->getBody());
+	}
+
 	public function testUnauthorized()
 	{
 		$controller = $this->makeController();


### PR DESCRIPTION
Added method `respondUpdated()` for `Used after a resource has been successfully updated.`. The status code is 200 based on https://restfulapi.net/http-methods/#put

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage