### PR TITLE
Validation placeholders in Controller not replaced

### DIFF
--- a/system/Controller.php
+++ b/system/Controller.php
@@ -212,11 +212,71 @@ class Controller
 
 			$rules = $validation->$rules;
 		}
+		
+        // Replace any placeholders (i.e. {id}) in the rules with
+        // the value found in $data, if exists.
+       	$rules = $this->fillPlaceholders($rules, $this->request->getVar());
 
 		return $this->validator
 			->withRequest($this->request)
 			->setRules($rules, $messages)
 			->run();
+	}
+	
+	/**
+	 * Replace any placeholders within the rules with the values that
+	 * match the 'key' of any properties being set. For example, if
+	 * we had the following $data array:
+	 *
+	 * [ 'id' => 13 ]
+	 *
+	 * and the following rule:
+	 *
+	 *  'required|is_unique[users,email,id,{id}]'
+	 *
+	 * The value of {id} would be replaced with the actual id in the form data:
+	 *
+	 *  'required|is_unique[users,email,id,13]'
+	 *
+	 * @param array $rules
+	 * @param array $data
+	 *
+	 * @return array
+	 */
+	protected function fillPlaceholders(array $rules, array $data): array
+	{
+	$replacements = [];
+
+	foreach ($data as $key => $value)
+	{
+		$replacements["{{$key}}"] = $value;
+	}
+
+	if (! empty($replacements))
+	{
+		foreach ($rules as &$rule)
+		{
+		if (is_array($rule))
+		{
+			foreach ($rule as &$row)
+			{
+			// Should only be an `errors` array
+			// which doesn't take placeholders.
+			if (is_array($row))
+			{
+				continue;
+			}
+
+			$row = strtr($row, $replacements);
+			}
+			continue;
+		}
+
+		$rule = strtr($rule, $replacements);
+		}
+	}
+
+	return $rules;
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
This pull request should fix issues #2812 and #2817.

**Description**
Duplicated the `fillPlaceholders()` function from Model.php to Controller.php. Called the function before the validator runs.

**Checklist:**
TODO