### PR TITLE
Pagination: open page > pageCount get last page

### DIFF
--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -208,10 +208,12 @@ class Pager implements PagerInterface
 		$this->ensureGroup($group, $perPage);
 
 		$perPage                             = $perPage ?? $this->config->perPage;
+		$pageCount                           = (int)ceil($total / $perPage);
+		$page                                = $page > $pageCount ? $pageCount : $page;
 		$this->groups[$group]['currentPage'] = $page;
 		$this->groups[$group]['perPage']     = $perPage;
 		$this->groups[$group]['total']       = $total;
-		$this->groups[$group]['pageCount']   = (int)ceil($total / $perPage);
+		$this->groups[$group]['pageCount']   = $pageCount;
 
 		return $this;
 	}

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -419,4 +419,10 @@ class PagerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals((string)$expected, $this->pager->getPreviousPageURI('foo'));
 	}
 
+	public function testAccessPageMoreThanPageCountGetLastPage()
+	{
+		$this->pager->store('default', 11, 1, 10);
+		$this->assertEquals(10, $this->pager->getCurrentPage());
+	}
+
 }


### PR DESCRIPTION
So, when we have a data, for example: 10 records, and per-page is 1. We next want to pass `?page=11`, we will get latest page displayed page 10.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
