### PR TITLE
add $segment parameter in pager call by Model.php

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -1138,7 +1138,7 @@ class Model
 
 		// Store it in the Pager library so it can be
 		// paginated in the views.
-		$this->pager = $pager->store($group, $page, $perPage, $total,$segment);
+		$this->pager = $pager->store($group, $page, $perPage, $total, $segment);
 		$perPage     = $this->pager->getPerPage($group);
 		$offset      = ($page - 1) * $perPage;
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -1126,6 +1126,7 @@ class Model
 	 * @param string  $group   Will be used by the pagination library
 	 *                         to identify a unique pagination set.
 	 * @param integer $page    Optional page number (useful when the page number is provided in different way)
+	 * @param integer $segment Optional URI segment number (if page number is provided by URI segment)
 	 *
 	 * @return array|null
 	 */

--- a/system/Model.php
+++ b/system/Model.php
@@ -1129,7 +1129,7 @@ class Model
 	 *
 	 * @return array|null
 	 */
-	public function paginate(int $perPage = null, string $group = 'default', int $page = 0)
+	public function paginate(int $perPage = null, string $group = 'default', int $page = 0, int $segment = 0)
 	{
 		$pager = \Config\Services::pager(null, null, false);
 		$page  = $page >= 1 ? $page : $pager->getCurrentPage($group);
@@ -1138,7 +1138,7 @@ class Model
 
 		// Store it in the Pager library so it can be
 		// paginated in the views.
-		$this->pager = $pager->store($group, $page, $perPage, $total);
+		$this->pager = $pager->store($group, $page, $perPage, $total,$segment);
 		$perPage     = $this->pager->getPerPage($group);
 		$offset      = ($page - 1) * $perPage;
 


### PR DESCRIPTION
i don't know why the $segment parameter is not present when the Pager library is call by the Model paginate function


add the $segment option when the Pager library is call by the Model paginate function


