### PR TITLE
Fixed Issue #2840 on discovery of classes by FileLocator

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -353,7 +353,11 @@ class FileLocator
 				// Remove the file extension (.php)
 				$className = mb_substr($className, 0, -4);
 
-				return $className;
+				// Check if this exists
+				if (class_exists($className))
+				{
+					return $className;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fix Issue #2840 for `FileLocator::findQualifiedNameFromPath()` method

**Description**
The method returns the $className even if the class does not exist, resulting in console commands not to be discovered.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
