### PR TITLE
Improve readability in the userguide with a fixed size

### DIFF
--- a/user_guide_src/source/_static/css/citheme.css
+++ b/user_guide_src/source/_static/css/citheme.css
@@ -256,6 +256,11 @@ div#pulldown-menu {
 	background-color: #f1d40f !important;
 }
 
+/* override table width restrictions */
+.wy-table-responsive table td, .wy-table-responsive table th {
+	white-space: pre;
+}
+
 .rst-content dl:not(.docutils) dt {
 	background: #fdc894;
 	color: #434343;

--- a/user_guide_src/source/_static/css/citheme.css
+++ b/user_guide_src/source/_static/css/citheme.css
@@ -89,11 +89,10 @@ body, p, legend {
 }
 
 .wy-nav-content {
-	background-attachment: fixed;
 	background-image: url('../img/ci-background.png');
 	background-position: bottom right;
 	background-repeat: no-repeat;
-	background-size: contain;
+	background-size: 200px;
 }
 
 /* Titles ------------------------------------------------------------------- */
@@ -211,7 +210,6 @@ div#pulldown-menu {
 
 .wy-side-nav-search a {
 	color: #ffffff;
-	font-family: "Railway", "Helvetica", "Arial", sans-serif;
 }
 
 .wy-side-nav-search input[type=text] {
@@ -231,7 +229,7 @@ div#pulldown-menu {
 }
 
 .wy-nav-content {
-	max-width: none;
+	max-width: 900px;
 }
 
 .wy-nav-content-wrap a, .wy-nav-content-wrap a:visited {
@@ -256,17 +254,6 @@ div#pulldown-menu {
 	padding: 0px !important;
 	font-weight: inherit !important;
 	background-color: #f1d40f !important;
-}
-
-/* override table width restrictions */
-.wy-table-responsive table td, .wy-table-responsive table th {
-	white-space: normal;
-}
-
-.wy-table-responsive {
-	margin-bottom: 24px;
-	max-width: 100%;
-	overflow: visible;
 }
 
 .rst-content dl:not(.docutils) dt {

--- a/user_guide_src/source/outgoing/localization.rst
+++ b/user_guide_src/source/outgoing/localization.rst
@@ -115,15 +115,15 @@ You might name it simply: **Errors.php**.
 
 Within the file, you would return an array, where each element in the array has a language key and can have string to return::
 
-        'language_key' => 'The actual message to be shown.'
+    'language_key' => 'The actual message to be shown.'
 
-It also support nested definition:
+It also support nested definition::
 
-        'language_key' => [
-            'nested' => [
-                'key' => 'The actual message to be shown.'
-            ],
+    'language_key' => [
+        'nested' => [
+            'key' => 'The actual message to be shown.'
         ],
+    ],
 
 .. note:: It's good practice to use a common prefix for all messages in a given file to avoid collisions with
     similarly named items in other files. For example, if you are creating error messages you might prefix them


### PR DESCRIPTION
- I have now made the userguide fixed to 900px, as we previously had it extended all the way, making it harder for people to read.
- The CI flame are now positioned to the bottom right corner in the "content" box. It made it harder to read, specifically on mobile devices.
- Making tables responsive again, but with "pre" rendering instead of the default nowrap. Rendering as we see it in .rst, real "enter" in templates results in enter in the userguide itself. Or we will end up with "endless" scrolling in [Validation - Available Rules](https://codeigniter.johaneklund.com/userguide/master/libraries/validation.html#available-rules).
- Fixed incorrect rendering in "Localization". 

**Checklist:**
- [X] Securely signed commits
- [X] User guide updated
- [X] Conforms to style guide