### PR TITLE
Normalize dir separator of Exceptions::cleanPath and added more paths to clean

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -372,17 +372,23 @@ class Exceptions
 	 */
 	public static function cleanPath(string $file): string
 	{
-		if (strpos($file, APPPATH) === 0)
+		switch (true)
 		{
-			$file = 'APPPATH/' . substr($file, strlen(APPPATH));
-		}
-		elseif (strpos($file, SYSTEMPATH) === 0)
-		{
-			$file = 'SYSTEMPATH/' . substr($file, strlen(SYSTEMPATH));
-		}
-		elseif (strpos($file, FCPATH) === 0)
-		{
-			$file = 'FCPATH/' . substr($file, strlen(FCPATH));
+			case strpos($file, VIEWPATH) === 0:
+				$file = 'VIEWPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(VIEWPATH));
+				break;
+			case strpos($file, APPPATH) === 0:
+				$file = 'APPPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(APPPATH));
+				break;
+			case strpos($file, SYSTEMPATH) === 0:
+				$file = 'SYSTEMPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(SYSTEMPATH));
+				break;
+			case strpos($file, FCPATH) === 0:
+				$file = 'FCPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(FCPATH));
+				break;
+			case defined('VENDORPATH') && strpos($file, VENDORPATH) === 0;
+				$file = 'VENDORPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(VENDORPATH));
+				break;
 		}
 
 		return $file;

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -374,9 +374,6 @@ class Exceptions
 	{
 		switch (true)
 		{
-			case strpos($file, VIEWPATH) === 0:
-				$file = 'VIEWPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(VIEWPATH));
-				break;
 			case strpos($file, APPPATH) === 0:
 				$file = 'APPPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(APPPATH));
 				break;

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -16,7 +16,6 @@ $paths = new Config\Paths();
 defined('APPPATH')       || define('APPPATH', realpath($paths->appDirectory) . DIRECTORY_SEPARATOR);
 defined('WRITEPATH')     || define('WRITEPATH', realpath($paths->writableDirectory) . DIRECTORY_SEPARATOR);
 defined('SYSTEMPATH')    || define('SYSTEMPATH', realpath($paths->systemDirectory) . DIRECTORY_SEPARATOR);
-defined('VIEWPATH')      || define('VIEWPATH', realpath($paths->viewDirectory) . DIRECTORY_SEPARATOR);
 defined('ROOTPATH')      || define('ROOTPATH', realpath(APPPATH . '../') . DIRECTORY_SEPARATOR);
 defined('CIPATH')        || define('CIPATH', realpath(SYSTEMPATH . '../') . DIRECTORY_SEPARATOR);
 defined('FCPATH')        || define('FCPATH', realpath(PUBLICPATH) . DIRECTORY_SEPARATOR);

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -16,12 +16,14 @@ $paths = new Config\Paths();
 defined('APPPATH')       || define('APPPATH', realpath($paths->appDirectory) . DIRECTORY_SEPARATOR);
 defined('WRITEPATH')     || define('WRITEPATH', realpath($paths->writableDirectory) . DIRECTORY_SEPARATOR);
 defined('SYSTEMPATH')    || define('SYSTEMPATH', realpath($paths->systemDirectory) . DIRECTORY_SEPARATOR);
+defined('VIEWPATH')      || define('VIEWPATH', realpath($paths->viewDirectory) . DIRECTORY_SEPARATOR);
 defined('ROOTPATH')      || define('ROOTPATH', realpath(APPPATH . '../') . DIRECTORY_SEPARATOR);
 defined('CIPATH')        || define('CIPATH', realpath(SYSTEMPATH . '../') . DIRECTORY_SEPARATOR);
 defined('FCPATH')        || define('FCPATH', realpath(PUBLICPATH) . DIRECTORY_SEPARATOR);
 defined('TESTPATH')      || define('TESTPATH', realpath(HOMEPATH . 'tests/') . DIRECTORY_SEPARATOR);
 defined('SUPPORTPATH')   || define('SUPPORTPATH', realpath(TESTPATH . '_support/') . DIRECTORY_SEPARATOR);
 defined('COMPOSER_PATH') || define('COMPOSER_PATH', realpath(HOMEPATH . 'vendor/autoload.php'));
+defined('VENDORPATH')    || define('VENDORPATH', realpath(HOMEPATH . 'vendor') . DIRECTORY_SEPARATOR);
 
 // Load Common.php from App then System
 if (file_exists(APPPATH . 'Common.php'))

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -87,14 +87,6 @@ if (! defined('TESTPATH'))
 	define('TESTPATH', realpath($paths->testsDirectory) . DIRECTORY_SEPARATOR);
 }
 
-/**
- * The path to the views directory
- */
-if (! defined('VIEWPATH'))
-{
-	define('VIEWPATH', realpath($paths->viewDirectory) . DIRECTORY_SEPARATOR);
-}
-
 /*
  * ---------------------------------------------------------------
  * GRAB OUR CONSTANTS & COMMON

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -87,6 +87,14 @@ if (! defined('TESTPATH'))
 	define('TESTPATH', realpath($paths->testsDirectory) . DIRECTORY_SEPARATOR);
 }
 
+/**
+ * The path to the views directory
+ */
+if (! defined('VIEWPATH'))
+{
+	define('VIEWPATH', realpath($paths->viewDirectory) . DIRECTORY_SEPARATOR);
+}
+
 /*
  * ---------------------------------------------------------------
  * GRAB OUR CONSTANTS & COMMON
@@ -139,6 +147,16 @@ $loader->register();    // Register the loader with the SPL autoloader stack.
 // Now load Composer's if it's available
 if (is_file(COMPOSER_PATH))
 {
+	/**
+	 * The path to the vendor directory.
+	 *
+	 * We do not want to enforce this, so set the constant if Composer was used.
+	 */
+	if (! defined('VENDORPATH'))
+	{
+		define('VENDORPATH', realpath(ROOTPATH . 'vendor') . DIRECTORY_SEPARATOR);
+	}
+
 	require_once COMPOSER_PATH;
 }
 

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -7,4 +7,44 @@ class ExceptionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$actual = new Exceptions(new \Config\Exceptions(), \Config\Services::request(), \Config\Services::response());
 		$this->assertInstanceOf(Exceptions::class, $actual);
 	}
+
+	/**
+	 * @dataProvider dirtyPathsProvider
+	 */
+	public function testCleanPaths($file, $expected)
+	{
+		$this->assertEquals($expected, Exceptions::cleanPath($file));
+	}
+
+	public function dirtyPathsProvider()
+	{
+		$ds = DIRECTORY_SEPARATOR;
+
+		return [
+			[
+				APPPATH . 'Config' . $ds . 'App.php',
+				'APPPATH' . $ds . 'Config' . $ds . 'App.php',
+			],
+			[
+				APPPATH . 'Views' . $ds . 'welcome_message.php',
+				'VIEWPATH' . $ds . 'welcome_message.php',
+			],
+			[
+				SYSTEMPATH . 'CodeIgniter.php',
+				'SYSTEMPATH' . $ds . 'CodeIgniter.php',
+			],
+			[
+				VIEWPATH . 'errors' . $ds . 'html' . $ds . 'error_exception.php',
+				'VIEWPATH' . $ds . 'errors' . $ds . 'html' . $ds . 'error_exception.php',
+			],
+			[
+				VENDORPATH . 'autoload.php',
+				'VENDORPATH' . $ds . 'autoload.php',
+			],
+			[
+				FCPATH . 'index.php',
+				'FCPATH' . $ds . 'index.php',
+			],
+		];
+	}
 }

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -26,16 +26,8 @@ class ExceptionsTest extends \CodeIgniter\Test\CIUnitTestCase
 				'APPPATH' . $ds . 'Config' . $ds . 'App.php',
 			],
 			[
-				APPPATH . 'Views' . $ds . 'welcome_message.php',
-				'VIEWPATH' . $ds . 'welcome_message.php',
-			],
-			[
 				SYSTEMPATH . 'CodeIgniter.php',
 				'SYSTEMPATH' . $ds . 'CodeIgniter.php',
-			],
-			[
-				VIEWPATH . 'errors' . $ds . 'html' . $ds . 'error_exception.php',
-				'VIEWPATH' . $ds . 'errors' . $ds . 'html' . $ds . 'error_exception.php',
 			],
 			[
 				VENDORPATH . 'autoload.php',


### PR DESCRIPTION
**Description**
Change the directory separator in cleaning paths to the platform-specific DIRECTORY_SEPARATOR for nicer look, especially for Windows. Also added new paths to clean.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide