### PR TITLE
Strip directory separators from auto-generated cell cache name. Fixes…

### DIFF
--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -110,7 +110,9 @@ class Cell
 		list($class, $method) = $this->determineClass($library);
 
 		// Is it cached?
-		$cacheName = ! empty($cacheName) ? $cacheName : $class . $method . md5(serialize($params));
+		$cacheName = ! empty($cacheName)
+			? $cacheName
+			: str_replace(['\\', '/'], '', $class) . $method . md5(serialize($params));
 
 		if (! empty($this->cache) && $output = $this->cache->get($cacheName))
 		{

--- a/tests/system/View/CellTest.php
+++ b/tests/system/View/CellTest.php
@@ -232,6 +232,21 @@ class CellTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::echobox', $params, 1, 'rememberme'));
 	}
 
+	public function testRenderCachedAutoName()
+	{
+		$params   = 'one=two,three=four';
+		$expected = [
+			'one'   => 'two',
+			'three' => 'four',
+		];
+
+		$this->assertEquals(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::echobox', $params, 60));
+		$params = 'one=six,three=five';
+		// When auto-generating it takes the params as part of cachename, so it wouldn't have actually cached this, but
+		// we want to make sure it doesn't throw us a curveball here.
+		$this->assertEquals('six,five', $this->cell->render('\Tests\Support\View\SampleClass::echobox', $params, 1));
+	}
+
 	//--------------------------------------------------------------------
 
 	public function testParametersMatch()


### PR DESCRIPTION
Strip directory separators from auto-generated cell cache name. Fixes #2821