### PR TITLE
Enclose file paths in double quotes to capture spaces

### DIFF
--- a/admin/pre-commit
+++ b/admin/pre-commit
@@ -17,13 +17,13 @@ SFILES=${SFILES:-$STAGED_FILES_CMD}
 echo "Checking PHP Lint..."
 for FILE in $SFILES
 do
-	php -l -d display_errors=0 $PROJECT/$FILE
+	php -l -d display_errors=0 "$PROJECT/$FILE"
 	if [ $? != 0 ]
 	then
 		echo "Fix the error before commit."
 		exit 1
 	fi
-	FILES="$FILES $PROJECT/$FILE"
+	FILES="$FILES $FILE"
 done
 
 if [ "$FILES" != "" ]


### PR DESCRIPTION
**Description**
The pre-commit hook fails parsing files when the file paths contained spaces. My solution is to enclose the file path `$PROJECT/$FILE` in double quotes. This solution works with PHP's built-in linter. For Code Sniffer, I can't make it read the enclosed file path as a single file. It still breaks them at the spaces. *Perhaps a bug in Code Sniffer? I don't know.*

As a workaround, I only passed the relative file paths of the files to `phpcbf`. Tested locally, and phpcbf can still check the files.

**Checklist:**
- [x] Securely signed commits  
