### PR TITLE
getRawInput support json

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -374,8 +374,14 @@ class IncomingRequest extends Request
 	 */
 	public function getRawInput()
 	{
-		parse_str($this->body, $output);
-
+		if ((($ContentType = $this->getHeader('Content-Type')) !== null) && $ContentType->getValue() === 'application/json')
+		{
+			$output = $this->getJSON(true);
+		}
+		else
+		{
+			parse_str($this->body, $output);
+		}
 		return $output;
 	}
 

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -295,6 +295,22 @@ class IncomingRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($expected, $request->getRawInput());
 	}
 
+	public function testCanParseJsonGetRawInput()
+	{
+		$rawstring = '{"test":3}';
+
+		$expected = [
+			'test' => 3,
+		];
+
+		$config          = new App();
+		$config->baseURL = 'http://example.com';
+
+		$request = new IncomingRequest($config, new URI(), $rawstring, new UserAgent());
+		$request->setHeader('Content-Type', 'application/json');
+		$this->assertEquals($expected, $request->getRawInput());
+	}
+
 	//--------------------------------------------------------------------
 
 	public function testIsCLI()


### PR DESCRIPTION
`getRawInput` get `php://input` and convert it to an array.
the method usualy parse `PUT`,`PATCH`,`DELETE` raw data.
RESTful usualy use `application/json`,
so, i think. the method should parse json data

 ( sorry, My English is poor  )
**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
