### PR TITLE
Initialize $forge property in Seeder Class - fixes #2825

### DIFF
--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -41,6 +41,7 @@ namespace CodeIgniter\Database;
 
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Config\BaseConfig;
+use CodeIgniter\Database\Forge;
 
 /**
  * Class Seeder
@@ -122,6 +123,8 @@ class Seeder
 		}
 
 		$this->db = & $db;
+
+		$this->forge = \Config\Database::forge($this->DBGroup);
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
This PR solves the problem of loading the Forge class into the Seed class, thus allowing the use of the Forge class functionalities in a seed.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
  
