### PR TITLE
Localized label in validation rules

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -719,8 +719,8 @@ class Validation implements ValidationInterface
 			$message = lang('Validation.' . $rule);
 		}
 
-		$message = str_replace('{field}', $label ?? $field, $message);
-		$message = str_replace('{param}', $this->rules[$param]['label'] ?? $param, $message);
+		$message = str_replace('{field}', empty($label) ? $field : lang($label), $message);
+		$message = str_replace('{param}', empty($this->rules[$param]['label']) ? $param : lang($this->rules[$param]['label']), $message);
 
 		return str_replace('{value}', $value, $message);
 	}

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -709,7 +709,7 @@ class Validation implements ValidationInterface
 		// Check if custom message has been defined by user
 		if (isset($this->customErrors[$field][$rule]))
 		{
-			$message = $this->customErrors[$field][$rule];
+			$message = lang($this->customErrors[$field][$rule]);
 		}
 		else
 		{

--- a/tests/_support/Language/en/Foo.php
+++ b/tests/_support/Language/en/Foo.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+   'bar' => 'Foo Bar Translated',
+];

--- a/tests/_support/Language/en/Foo.php
+++ b/tests/_support/Language/en/Foo.php
@@ -1,5 +1,7 @@
 <?php
 
 return [
-   'bar' => 'Foo Bar Translated',
+   'bar'             => 'Foo Bar Translated',
+   'bar.min_length1' => 'The {field} field is very short.',
+   'bar.min_length2' => 'Supplied value ({value}) for {field} must have at least {param} characters.',
 ];

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -812,4 +812,101 @@ class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 	}
 
 	//--------------------------------------------------------------------
+
+	public function testTranslatedLabel()
+	{
+		$rules = [
+			'foo' => [
+				'label' => 'Foo.bar',
+				'rules' => 'min_length[10]',
+			],
+		];
+
+		$this->validation->setRules($rules, []);
+
+		$this->validation->run(['foo' => 'abc']);
+
+		$this->assertEquals('The Foo Bar Translated field must be at least 10 characters in length.', $this->validation->getError('foo'));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testTranslatedLabelIsMissing()
+	{
+		$rules = [
+			'foo' => [
+				'label' => 'Foo.bar.is.missing',
+				'rules' => 'min_length[10]',
+			],
+		];
+
+		$this->validation->setRules($rules, []);
+
+		$this->validation->run(['foo' => 'abc']);
+
+		$this->assertEquals('The Foo.bar.is.missing field must be at least 10 characters in length.', $this->validation->getError('foo'));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testTranslatedLabelWithCustomErrorMessage()
+	{
+		$rules = [
+			'foo' => [
+				'label'  => 'Foo.bar',
+				'rules'  => 'min_length[10]',
+				'errors' => [
+					'min_length' => 'The {field} field is very short.',
+				],
+			],
+		];
+
+		$this->validation->setRules($rules, []);
+
+		$this->validation->run(['foo' => 'abc']);
+
+		$this->assertEquals('The Foo Bar Translated field is very short.', $this->validation->getError('foo'));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testTranslatedLabelTagReplacement()
+	{
+		// data
+		$data = [
+			'Username' => 'Pizza',
+		];
+
+		// rules
+		$this->validation->setRules([
+			'Username' => [
+				'label' => 'Foo.bar',
+				'rules' => 'min_length[6]',
+			],
+		], [
+			'Username' => [
+				'min_length' => 'Supplied value ({value}) for {field} must have at least {param} characters.',
+			],
+		]);
+
+		// run validation
+		$this->validation->run($data);
+
+		// $errors should contain an associative array
+		$errors = $this->validation->getErrors();
+
+		// if "Username" doesn't exist in errors
+		if (! isset($errors['Username']))
+		{
+			$this->fail('Unable to find "Username"');
+		}
+
+		// expected error message
+		$expected = 'Supplied value (Pizza) for Foo Bar Translated must have at least 6 characters.';
+
+		// check if they are the same!
+		$this->assertEquals($expected, $errors['Username']);
+	}
+
+	//--------------------------------------------------------------------
 }

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -856,7 +856,7 @@ class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 				'label'  => 'Foo.bar',
 				'rules'  => 'min_length[10]',
 				'errors' => [
-					'min_length' => 'The {field} field is very short.',
+					'min_length' => 'Foo.bar.min_length1',
 				],
 			],
 		];
@@ -885,7 +885,7 @@ class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 			],
 		], [
 			'Username' => [
-				'min_length' => 'Supplied value ({value}) for {field} must have at least {param} characters.',
+				'min_length' => 'Foo.bar.min_length2',
 			],
 		]);
 

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -487,7 +487,7 @@ at least 6 characters.”
 Translation Of Messages And Validation Labels
 =============================================
 
-To use translated strings from language files, we can simply use the dot syntax. Let's say we have a file with translations located here: `app/Languages/en/Rules.php`. We can simply use the language lines defined in this file, like this:
+To use translated strings from language files, we can simply use the dot syntax. Let's say we have a file with translations located here: ``app/Languages/en/Rules.php``. We can simply use the language lines defined in this file, like this:
 
     $validation->setRules([
             'username' => [

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -484,6 +484,29 @@ at least 6 characters.”
 
 .. note:: If you pass the last parameter the labeled style error messages will be ignored.
 
+Translation Of Messages And Validation Labels
+=============================================
+
+To use translated strings from language files, we can simply use the dot syntax. Let's say we have a file with translations located here: `app/Languages/en/Rules.php`. We can simply use the language lines defined in this file, like this:
+
+    $validation->setRules([
+            'username' => [
+                'label'  => 'Rules.username',
+                'rules'  => 'required|is_unique[users.username]',
+                'errors' => [
+                    'required' => 'Rules.username.required'
+                ]
+            ],
+            'password' => [
+                'label'  => 'Rules.password',
+                'rules'  => 'required|min_length[10]',
+                'errors' => [
+                    'min_length' => 'Rules.password.min_length'
+                ]
+            ]
+        ]
+    );
+
 Getting All Errors
 ==================
 


### PR DESCRIPTION
**Description**
This pull request allows the easy localization of labels in form validation rules.

Using a "dot notation" for a label in validation rules, like: `Foo.bar` will search for file `en/Foo.php` and line `bar`. If the file or line doesn't exist the usual text will be returned.

Ref: #2845

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
