### PR TITLE
Fixes session active detection on force_https function and add more test CodeIgniter::forceSecureAccess() run force_https()

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -403,7 +403,7 @@ if (! function_exists('force_https'))
 			$response = Services::response(null, true);
 		}
 
-		if (is_cli() || $request->isSecure())
+		if (ENVIRONMENT !== 'testing' && (is_cli() || $request->isSecure()))
 		{
 			return;
 		}
@@ -433,7 +433,10 @@ if (! function_exists('force_https'))
 		$response->redirect($uri);
 		$response->sendHeaders();
 
-		exit();
+		if (ENVIRONMENT !== 'testing')
+		{
+			exit();
+		}
 		// @codeCoverageIgnoreEnd
 	}
 }

--- a/system/Common.php
+++ b/system/Common.php
@@ -402,7 +402,9 @@ if (! function_exists('force_https'))
 
 		if (ENVIRONMENT !== 'testing' && (is_cli() || $request->isSecure()))
 		{
+			// @codeCoverageIgnoreStart
 			return;
+			// @codeCoverageIgnoreEnd
 		}
 
 		// If the session status is active, we should regenerate

--- a/system/Common.php
+++ b/system/Common.php
@@ -387,10 +387,7 @@ if (! function_exists('force_https'))
 	 * @param RequestInterface  $request
 	 * @param ResponseInterface $response
 	 *
-	 * Not testable, as it will exit!
-	 *
-	 * @throws             \CodeIgniter\HTTP\Exceptions\HTTPException
-	 * @codeCoverageIgnore
+	 * @throws \CodeIgniter\HTTP\Exceptions\HTTPException
 	 */
 	function force_https(int $duration = 31536000, RequestInterface $request = null, ResponseInterface $response = null)
 	{
@@ -407,7 +404,7 @@ if (! function_exists('force_https'))
 		{
 			return;
 		}
-		// @codeCoverageIgnoreStart
+
 		// If the session library is loaded, we should regenerate
 		// the session ID for safety sake.
 		if (class_exists('Session', false))
@@ -435,9 +432,10 @@ if (! function_exists('force_https'))
 
 		if (ENVIRONMENT !== 'testing')
 		{
+			// @codeCoverageIgnoreStart
 			exit();
+			// @codeCoverageIgnoreEnd
 		}
-		// @codeCoverageIgnoreEnd
 	}
 }
 

--- a/system/Common.php
+++ b/system/Common.php
@@ -405,9 +405,9 @@ if (! function_exists('force_https'))
 			return;
 		}
 
-		// If the session library is loaded, we should regenerate
+		// If the session status is active, we should regenerate
 		// the session ID for safety sake.
-		if (class_exists('Session', false))
+		if (session_status() === PHP_SESSION_ACTIVE)
 		{
 			Services::session(null, true)
 				->regenerate();

--- a/system/Common.php
+++ b/system/Common.php
@@ -409,10 +409,12 @@ if (! function_exists('force_https'))
 
 		// If the session status is active, we should regenerate
 		// the session ID for safety sake.
-		if (session_status() === PHP_SESSION_ACTIVE)
+		if (ENVIRONMENT !== 'testing' && session_status() === PHP_SESSION_ACTIVE)
 		{
+			// @codeCoverageIgnoreStart
 			Services::session(null, true)
 				->regenerate();
+			// @codeCoverageIgnoreEnd
 		}
 
 		$baseURL = config(App::class)->baseURL;

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -298,7 +298,6 @@ class CodeIgniterTest extends \CodeIgniter\Test\CIUnitTestCase
 		$codeigniter->useSafeOutput(true)->run();
 		$output = ob_get_clean();
 
-		$response = $this->getPrivateProperty($codeigniter, 'response');
 		$this->assertEquals('https://example.com', $response->getHeader('Location')->getValue());
 	}
 }

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -273,4 +273,26 @@ class CodeIgniterTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$this->assertStringContainsString('Welcome to CodeIgniter', $output);
 	}
+
+	//--------------------------------------------------------------------
+
+	public function testRunForceSecure()
+	{
+		$_SERVER['argv'] = [
+			'index.php',
+			'/',
+		];
+		$_SERVER['argc'] = 2;
+
+		$config                            = new App();
+		$config->forceGlobalSecureRequests = true;
+		$codeigniter                       = new MockCodeIgniter($config);
+
+		ob_start();
+		$codeigniter->useSafeOutput(true)->run();
+		$output = ob_get_clean();
+
+		$response = $this->getPrivateProperty($codeigniter, 'response');
+		$this->assertEquals('https://example.com', $response->getHeader('Location')->getValue());
+	}
 }

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -288,6 +288,12 @@ class CodeIgniterTest extends \CodeIgniter\Test\CIUnitTestCase
 		$config->forceGlobalSecureRequests = true;
 		$codeigniter                       = new MockCodeIgniter($config);
 
+		$this->getPrivateMethodInvoker($codeigniter, 'getRequestObject')();
+		$this->getPrivateMethodInvoker($codeigniter, 'getResponseObject')();
+
+		$response = $this->getPrivateProperty($codeigniter, 'response');
+		$this->assertNull($response->getHeader('Location'));
+
 		ob_start();
 		$codeigniter->useSafeOutput(true)->run();
 		$output = ob_get_clean();

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -444,7 +444,8 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testForceHttpsNullRequestAndResponse()
 	{
-		$this->assertNull(force_https());
+		force_https();
+		$this->assertEquals('https://example.com', Services::response()->getHeader('Location')->getValue());
 	}
 
 }

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -444,7 +444,10 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testForceHttpsNullRequestAndResponse()
 	{
+		$this->assertNull(Services::response()->getHeader('Location'));
+
 		force_https();
+
 		$this->assertEquals('https://example.com', Services::response()->getHeader('Location')->getValue());
 	}
 

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -440,4 +440,11 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertStringContainsString('<h1>is_not</h1>', view('\Tests\Support\View\Views\simples'));
 	}
 
+	//--------------------------------------------------------------------
+
+	public function testForceHttpsNullRequestAndResponse()
+	{
+		$this->assertNull(force_https());
+	}
+
 }

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -442,6 +442,10 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState  disabled
+	 */
 	public function testForceHttpsNullRequestAndResponse()
 	{
 		$this->assertNull(Services::response()->getHeader('Location'));


### PR DESCRIPTION
- Fixes session active detection on force_https function
- Add more test CodeIgniter::forceSecureAccess() run force_https() when `$config->forceGlobalSecureRequests` is true.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage