### PR TITLE
Bug fix in Throttler class check validation

### DIFF
--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -145,8 +145,6 @@ class Throttler implements ThrottlerInterface
 			// capacity - 1, and save it to the cache.
 			$this->cache->save($tokenName, $capacity - $cost, $seconds);
 			$this->cache->save($tokenName . 'Time', time(), $seconds);
-
-			return true;
 		}
 
 		// If $tokens > 0, then we need to replenish the bucket
@@ -171,7 +169,7 @@ class Throttler implements ThrottlerInterface
 
 		// If $tokens > 0, then we are safe to perform the action, but
 		// we need to decrement the number of available tokens.
-		if ($tokens > 0)
+		if ($tokens >= 0)
 		{
 			$this->cache->save($tokenName, $tokens - $cost, $seconds);
 			$this->cache->save($tokenName . 'Time', time(), $seconds);

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -167,7 +167,7 @@ class Throttler implements ThrottlerInterface
 		$tokens += $rate * $elapsed;
 		$tokens  = $tokens > $capacity ? $capacity : $tokens;
 
-		// If $tokens > 0, then we are safe to perform the action, but
+		// If $tokens >= 0, then we are safe to perform the action, but
 		// we need to decrement the number of available tokens.
 		if ($tokens >= 0)
 		{

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -139,12 +139,13 @@ class Throttler implements ThrottlerInterface
 		$tokenName = $this->prefix . $key;
 
 		// Check to see if the bucket has even been created yet.
-		if (($tokens = $this->cache->get($tokenName)) === null)
-		{
+		if (($tokens = $this->cache->get($tokenName)) === null) {
 			// If it hasn't been created, then we'll set it to the maximum
 			// capacity - 1, and save it to the cache.
 			$this->cache->save($tokenName, $capacity - $cost, $seconds);
 			$this->cache->save($tokenName . 'Time', time(), $seconds);
+
+			return true;
 		}
 
 		// If $tokens > 0, then we need to replenish the bucket
@@ -167,10 +168,9 @@ class Throttler implements ThrottlerInterface
 		$tokens += $rate * $elapsed;
 		$tokens  = $tokens > $capacity ? $capacity : $tokens;
 
-		// If $tokens >= 0, then we are safe to perform the action, but
+		// If $tokens >= 1, then we are safe to perform the action, but
 		// we need to decrement the number of available tokens.
-		if ($tokens >= 0)
-		{
+		if ($tokens >= 1) {
 			$this->cache->save($tokenName, $tokens - $cost, $seconds);
 			$this->cache->save($tokenName . 'Time', time(), $seconds);
 
@@ -207,5 +207,4 @@ class Throttler implements ThrottlerInterface
 	{
 		return $this->testTime ?? time();
 	}
-
 }


### PR DESCRIPTION
**Description**
While I was structuring an example to compose my book, I found that even if I correctly set the parameters for the `check()` method, a request was always executed more than the defined limit.

This was because when checking for the existence of the cache (`($tokens = $this->cache->get($tokenName)) === null`) if it was null, `true` was returned, and just created the cache, without start the count, which always allowed one more request, because only the next time the counter would start.

The `return true` was removed in this check and in checking the amount of tokens it was adjusted to `$tokens> = 0`.

After these changes, the limit defined in `check` started to be applied successfully.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide