### PR TITLE
Bug fixes - Pager

### DIFF
--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -146,7 +146,7 @@ class PagerRenderer
 	 */
 	public function hasPrevious(): bool
 	{
-		return $this->first > 1;
+		return $this->current > 1;
 	}
 
 	//--------------------------------------------------------------------
@@ -171,11 +171,11 @@ class PagerRenderer
 
 		if ($this->segment === 0)
 		{
-			$uri->addQuery($this->pageSelector, $this->first - 1);
+			$uri->addQuery($this->pageSelector, $this->current - 1);
 		}
 		else
 		{
-			$uri->setSegment($this->segment, $this->first - 1);
+			$uri->setSegment($this->segment, $this->current - 1);
 		}
 
 		return (string) $uri;
@@ -190,7 +190,7 @@ class PagerRenderer
 	 */
 	public function hasNext(): bool
 	{
-		return $this->pageCount > $this->last;
+		return $this->pageCount > $this->current;
 	}
 
 	//--------------------------------------------------------------------
@@ -215,11 +215,11 @@ class PagerRenderer
 
 		if ($this->segment === 0)
 		{
-			$uri->addQuery($this->pageSelector, $this->last + 1);
+			$uri->addQuery($this->pageSelector, $this->current + 1);
 		}
 		else
 		{
-			$uri->setSegment($this->segment, $this->last + 1);
+			$uri->setSegment($this->segment, $this->current + 1);
 		}
 
 		return (string) $uri;

--- a/system/Pager/Views/default_full.php
+++ b/system/Pager/Views/default_full.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var \CodeIgniter\Pager\PagerRenderer $pager
  */
@@ -16,7 +17,7 @@ $pager->setSurroundCount(2);
 			</li>
 			<li>
 				<a href="<?= $pager->getPrevious() ?>" aria-label="<?= lang('Pager.previous') ?>">
-					<span aria-hidden="true">&laquo;</span>
+					<span aria-hidden="true"><?= lang('Pager.previous') ?></span>
 				</a>
 			</li>
 		<?php endif ?>
@@ -32,7 +33,7 @@ $pager->setSurroundCount(2);
 		<?php if ($pager->hasNext()) : ?>
 			<li>
 				<a href="<?= $pager->getNext() ?>" aria-label="<?= lang('Pager.next') ?>">
-					<span aria-hidden="true">&raquo;</span>
+					<span aria-hidden="true"><?= lang('Pager.next') ?></span>
 				</a>
 			</li>
 			<li>


### PR DESCRIPTION
**Description**
This PR corrects the following problems:

- issue #2875, where the next and previous links did not use language information, always maintaining a standard format
- next and previous links returning the same values as first and last link

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
