### PR TITLE
Make validation placeholders always available

### DIFF
--- a/app/Config/Kint.php
+++ b/app/Config/Kint.php
@@ -1,7 +1,7 @@
 <?php namespace Config;
 
-use Kint\Renderer\Renderer;
 use CodeIgniter\Config\BaseConfig;
+use Kint\Renderer\Renderer;
 
 class Kint extends BaseConfig
 {

--- a/app/Config/Services.php
+++ b/app/Config/Services.php
@@ -1,7 +1,6 @@
 <?php namespace Config;
 
 use CodeIgniter\Config\Services as CoreServices;
-use CodeIgniter\Config\BaseConfig;
 
 require_once SYSTEMPATH . 'Config/Services.php';
 

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -39,8 +39,8 @@
 
 namespace CodeIgniter\API;
 
-use Config\Format;
 use CodeIgniter\HTTP\Response;
+use Config\Format;
 
 /**
  * Response trait.

--- a/system/CLI/CommandRunner.php
+++ b/system/CLI/CommandRunner.php
@@ -40,8 +40,8 @@
 
 namespace CodeIgniter\CLI;
 
-use Config\Services;
 use CodeIgniter\Controller;
+use Config\Services;
 
 /**
  * Command runner

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -39,20 +39,20 @@
 namespace CodeIgniter;
 
 use Closure;
+use CodeIgniter\Debug\Timer;
+use CodeIgniter\Events\Events;
+use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\DownloadResponse;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Request;
-use CodeIgniter\HTTP\ResponseInterface;
-use Config\Services;
-use Config\Cache;
-use CodeIgniter\HTTP\URI;
-use CodeIgniter\Debug\Timer;
-use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\Response;
-use CodeIgniter\HTTP\CLIRequest;
+use CodeIgniter\HTTP\ResponseInterface;
+use CodeIgniter\HTTP\URI;
 use CodeIgniter\Router\Exceptions\RedirectException;
 use CodeIgniter\Router\RouteCollectionInterface;
-use CodeIgniter\Exceptions\PageNotFoundException;
+use Config\Cache;
+use Config\Services;
 use Exception;
 
 /**

--- a/system/Commands/Database/CreateMigration.php
+++ b/system/Commands/Database/CreateMigration.php
@@ -41,7 +41,6 @@ namespace CodeIgniter\Commands\Database;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use Config\Services;
-use Config\Migrations;
 
 /**
  * Creates a new migration file.

--- a/system/Commands/Database/MigrateRefresh.php
+++ b/system/Commands/Database/MigrateRefresh.php
@@ -39,8 +39,8 @@
 
 namespace CodeIgniter\Commands\Database;
 
-use CodeIgniter\CLI\CLI;
 use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
 
 /**
  * Does a rollback followed by a latest to refresh the current state

--- a/system/Commands/Database/MigrateRollback.php
+++ b/system/Commands/Database/MigrateRollback.php
@@ -42,7 +42,6 @@ namespace CodeIgniter\Commands\Database;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use Config\Services;
-use Config\Autoload;
 
 /**
  * Runs all of the migrations in reverse order, until they have

--- a/system/Common.php
+++ b/system/Common.php
@@ -37,20 +37,20 @@
  * @filesource
  */
 
-use Config\App;
-use Config\View;
-use Config\Logger;
-use Config\Database;
-use Config\Services;
-use CodeIgniter\HTTP\URI;
-use Laminas\Escaper\Escaper;
 use CodeIgniter\Config\Config;
-use CodeIgniter\Test\TestLogger;
+use CodeIgniter\Database\ConnectionInterface;
+use CodeIgniter\Files\Exceptions\FileNotFoundException;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
-use CodeIgniter\Database\ConnectionInterface;
-use CodeIgniter\Files\Exceptions\FileNotFoundException;
+use CodeIgniter\HTTP\URI;
+use CodeIgniter\Test\TestLogger;
+use Config\App;
+use Config\Database;
+use Config\Logger;
+use Config\Services;
+use Config\View;
+use Laminas\Escaper\Escaper;
 
 /**
  * Common Functions

--- a/system/Common.php
+++ b/system/Common.php
@@ -387,10 +387,7 @@ if (! function_exists('force_https'))
 	 * @param RequestInterface  $request
 	 * @param ResponseInterface $response
 	 *
-	 * Not testable, as it will exit!
-	 *
-	 * @throws             \CodeIgniter\HTTP\Exceptions\HTTPException
-	 * @codeCoverageIgnore
+	 * @throws \CodeIgniter\HTTP\Exceptions\HTTPException
 	 */
 	function force_https(int $duration = 31536000, RequestInterface $request = null, ResponseInterface $response = null)
 	{
@@ -403,17 +400,21 @@ if (! function_exists('force_https'))
 			$response = Services::response(null, true);
 		}
 
-		if (is_cli() || $request->isSecure())
+		if (ENVIRONMENT !== 'testing' && (is_cli() || $request->isSecure()))
 		{
+			// @codeCoverageIgnoreStart
 			return;
+			// @codeCoverageIgnoreEnd
 		}
-		// @codeCoverageIgnoreStart
-		// If the session library is loaded, we should regenerate
+
+		// If the session status is active, we should regenerate
 		// the session ID for safety sake.
-		if (class_exists('Session', false))
+		if (ENVIRONMENT !== 'testing' && session_status() === PHP_SESSION_ACTIVE)
 		{
+			// @codeCoverageIgnoreStart
 			Services::session(null, true)
 				->regenerate();
+			// @codeCoverageIgnoreEnd
 		}
 
 		$baseURL = config(App::class)->baseURL;
@@ -433,8 +434,12 @@ if (! function_exists('force_https'))
 		$response->redirect($uri);
 		$response->sendHeaders();
 
-		exit();
-		// @codeCoverageIgnoreEnd
+		if (ENVIRONMENT !== 'testing')
+		{
+			// @codeCoverageIgnoreStart
+			exit();
+			// @codeCoverageIgnoreEnd
+		}
 	}
 }
 

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -39,6 +39,8 @@
 namespace CodeIgniter\Config;
 
 use CodeIgniter\Cache\CacheFactory;
+use CodeIgniter\Database\ConnectionInterface;
+use CodeIgniter\Database\MigrationRunner;
 use CodeIgniter\Debug\Exceptions;
 use CodeIgniter\Debug\Iterator;
 use CodeIgniter\Debug\Timer;
@@ -70,10 +72,8 @@ use CodeIgniter\Typography\Typography;
 use CodeIgniter\Validation\Validation;
 use CodeIgniter\View\Cell;
 use CodeIgniter\View\Parser;
-use Config\App;
-use CodeIgniter\Database\ConnectionInterface;
-use CodeIgniter\Database\MigrationRunner;
 use CodeIgniter\View\RendererInterface;
+use Config\App;
 use Config\Cache;
 use Config\Images;
 use Config\Logger;

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -39,11 +39,11 @@
 
 namespace CodeIgniter;
 
-use Config\Services;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
-use CodeIgniter\Validation\Validation;
 use CodeIgniter\Validation\Exceptions\ValidationException;
+use CodeIgniter\Validation\Validation;
+use Config\Services;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -39,9 +39,9 @@
 
 namespace CodeIgniter\Database;
 
+use Closure;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
-use Closure;
 
 /**
  * Class BaseBuilder

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -39,8 +39,8 @@
 
 namespace CodeIgniter\Database;
 
-use CodeIgniter\Events\Events;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Events\Events;
 
 /**
  * Class BaseConnection

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -38,10 +38,10 @@
 
 namespace CodeIgniter\Database;
 
-use Config\Services;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Exceptions\ConfigException;
+use Config\Services;
 
 /**
  * Class MigrationRunner

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -39,8 +39,8 @@
 
 namespace CodeIgniter\Database\MySQLi;
 
-use CodeIgniter\Database\PreparedQueryInterface;
 use CodeIgniter\Database\BasePreparedQuery;
+use CodeIgniter\Database\PreparedQueryInterface;
 
 /**
  * Prepared query for MySQLi

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -40,7 +40,6 @@ namespace CodeIgniter\Database\Postgre;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use http\Encoding\Stream\Inflate;
 
 /**
  * Builder for Postgre

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -39,8 +39,8 @@
 
 namespace CodeIgniter\Database\Postgre;
 
-use CodeIgniter\Database\PreparedQueryInterface;
 use CodeIgniter\Database\BasePreparedQuery;
+use CodeIgniter\Database\PreparedQueryInterface;
 
 /**
  * Prepared query for Postgre

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -39,8 +39,8 @@
 
 namespace CodeIgniter\Database\SQLite3;
 
-use CodeIgniter\Database\PreparedQueryInterface;
 use CodeIgniter\Database\BasePreparedQuery;
+use CodeIgniter\Database\PreparedQueryInterface;
 
 /**
  * Prepared query for SQLite3

--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -41,7 +41,6 @@ namespace CodeIgniter\Database;
 
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Config\BaseConfig;
-use CodeIgniter\Database\Forge;
 
 /**
  * Class Seeder

--- a/system/Debug/Toolbar/Collectors/Config.php
+++ b/system/Debug/Toolbar/Collectors/Config.php
@@ -39,9 +39,9 @@
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
+use CodeIgniter\CodeIgniter;
 use Config\App;
 use Config\Services;
-use CodeIgniter\CodeIgniter;
 
 /**
  * Debug toolbar configuration

--- a/system/Debug/Toolbar/Collectors/Events.php
+++ b/system/Debug/Toolbar/Collectors/Events.php
@@ -39,8 +39,8 @@
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
-use Config\Services;
 use CodeIgniter\View\RendererInterface;
+use Config\Services;
 
 /**
  * Views collector

--- a/system/Debug/Toolbar/Collectors/Views.php
+++ b/system/Debug/Toolbar/Collectors/Views.php
@@ -39,8 +39,8 @@
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
-use Config\Services;
 use CodeIgniter\View\RendererInterface;
+use Config\Services;
 
 /**
  * Views collector

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -38,10 +38,8 @@
 
 namespace CodeIgniter\Encryption;
 
-use Config\Encryption as EncryptionConfig;
-use CodeIgniter\Encryption\Exceptions\EncryptionException;
 use CodeIgniter\Config\BaseConfig;
-use Config\Services;
+use CodeIgniter\Encryption\Exceptions\EncryptionException;
 
 /**
  * CodeIgniter Encryption Manager

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -39,9 +39,8 @@
 
 namespace CodeIgniter;
 
-use CodeIgniter\Exceptions\EntityException;
-use CodeIgniter\I18n\Time;
 use CodeIgniter\Exceptions\CastException;
+use CodeIgniter\I18n\Time;
 
 /**
  * Entity encapsulation, for use with CodeIgniter\Model

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -39,9 +39,9 @@
 
 namespace CodeIgniter\Files;
 
-use SplFileInfo;
 use CodeIgniter\Files\Exceptions\FileException;
 use CodeIgniter\Files\Exceptions\FileNotFoundException;
+use SplFileInfo;
 
 /**
  * Wrapper for PHP's built-in SplFileInfo, with goodies.

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -39,9 +39,9 @@
 namespace CodeIgniter\Filters;
 
 use CodeIgniter\Config\BaseConfig;
+use CodeIgniter\Filters\Exceptions\FilterException;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
-use CodeIgniter\Filters\Exceptions\FilterException;
 
 /**
  * Filters

--- a/system/Filters/Honeypot.php
+++ b/system/Filters/Honeypot.php
@@ -38,10 +38,10 @@
 
 namespace CodeIgniter\Filters;
 
+use CodeIgniter\Honeypot\Exceptions\HoneypotException;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Services;
-use CodeIgniter\Honeypot\Exceptions\HoneypotException;
 
 /**
  * Honeypot filter

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -40,10 +40,10 @@
 
 namespace CodeIgniter\HTTP;
 
-use Config\App;
-use Config\Format;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Pager\PagerInterface;
+use Config\App;
+use Config\Format;
 
 /**
  * Representation of an outgoing, getServer-side response.

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -601,7 +601,6 @@ if (! function_exists('url_title'))
 		$str = strip_tags($str);
 		foreach ($trans as $key => $val)
 		{
-			//			$str = preg_replace('#'.$key.'#i'.( UTF8_ENABLED ? 'u' : ''), $val, $str);
 			$str = preg_replace('#' . $key . '#iu', $val, $str);
 		}
 

--- a/system/Honeypot/Honeypot.php
+++ b/system/Honeypot/Honeypot.php
@@ -39,9 +39,9 @@
 namespace CodeIgniter\Honeypot;
 
 use CodeIgniter\Config\BaseConfig;
+use CodeIgniter\Honeypot\Exceptions\HoneypotException;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
-use CodeIgniter\Honeypot\Exceptions\HoneypotException;
 
 /**
  * class Honeypot

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -40,12 +40,12 @@
 namespace CodeIgniter\I18n;
 
 use CodeIgniter\I18n\Exceptions\I18nException;
-use IntlCalendar;
-use Locale;
-use DateTime;
 use DateInterval;
+use DateTime;
 use DateTimeZone;
+use IntlCalendar;
 use IntlDateFormatter;
+use Locale;
 
 /**
  * Class Time

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -39,8 +39,8 @@
 
 namespace CodeIgniter\Log;
 
-use Psr\Log\LoggerInterface;
 use CodeIgniter\Log\Exceptions\LogException;
+use Psr\Log\LoggerInterface;
 
 /**
  * The CodeIgntier Logger
@@ -466,7 +466,6 @@ class Logger implements LoggerInterface
 		// interpolate replacement values into the message and return
 		return strtr($message, $replace);
 	}
-
 
 	/**
 	 * Determines the file and line that the logging call

--- a/system/Model.php
+++ b/system/Model.php
@@ -1432,10 +1432,6 @@ class Model
 			return true;
 		}
 
-		// Replace any placeholders (i.e. {id}) in the rules with
-		// the value found in $data, if exists.
-		$rules = $this->fillPlaceholders($rules, $data);
-
 		$this->validation->setRules($rules, $this->validationMessages);
 		$valid = $this->validation->run($data, null, $this->DBGroup);
 
@@ -1467,62 +1463,6 @@ class Model
 			if (! array_key_exists($field, $data))
 			{
 				unset($rules[$field]);
-			}
-		}
-
-		return $rules;
-	}
-
-	/**
-	 * Replace any placeholders within the rules with the values that
-	 * match the 'key' of any properties being set. For example, if
-	 * we had the following $data array:
-	 *
-	 * [ 'id' => 13 ]
-	 *
-	 * and the following rule:
-	 *
-	 *  'required|is_unique[users,email,id,{id}]'
-	 *
-	 * The value of {id} would be replaced with the actual id in the form data:
-	 *
-	 *  'required|is_unique[users,email,id,13]'
-	 *
-	 * @param array $rules
-	 * @param array $data
-	 *
-	 * @return array
-	 */
-	protected function fillPlaceholders(array $rules, array $data): array
-	{
-		$replacements = [];
-
-		foreach ($data as $key => $value)
-		{
-			$replacements["{{$key}}"] = $value;
-		}
-
-		if (! empty($replacements))
-		{
-			foreach ($rules as &$rule)
-			{
-				if (is_array($rule))
-				{
-					foreach ($rule as &$row)
-					{
-						// Should only be an `errors` array
-						// which doesn't take placeholders.
-						if (is_array($row))
-						{
-							continue;
-						}
-
-						$row = strtr($row, $replacements);
-					}
-					continue;
-				}
-
-				$rule = strtr($rule, $replacements);
 			}
 		}
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -40,16 +40,16 @@
 namespace CodeIgniter;
 
 use Closure;
-use CodeIgniter\Exceptions\ModelException;
-use Config\Database;
-use CodeIgniter\I18n\Time;
-use CodeIgniter\Pager\Pager;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\ConnectionInterface;
-use CodeIgniter\Validation\ValidationInterface;
-use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Exceptions\ModelException;
+use CodeIgniter\I18n\Time;
+use CodeIgniter\Pager\Pager;
+use CodeIgniter\Validation\ValidationInterface;
+use Config\Database;
 use ReflectionClass;
 use ReflectionProperty;
 use stdClass;

--- a/system/Model.php
+++ b/system/Model.php
@@ -1469,6 +1469,66 @@ class Model
 		return $rules;
 	}
 
+	/**
+	 * Replace any placeholders within the rules with the values that
+	 * match the 'key' of any properties being set. For example, if
+	 * we had the following $data array:
+	 *
+	 * [ 'id' => 13 ]
+	 *
+	 * and the following rule:
+	 *
+	 *  'required|is_unique[users,email,id,{id}]'
+	 *
+	 * The value of {id} would be replaced with the actual id in the form data:
+	 *
+	 *  'required|is_unique[users,email,id,13]'
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @deprecated use fillPlaceholders($rules, $data) from Validation instead
+	 *
+	 * @param array $rules
+	 * @param array $data
+	 *
+	 * @return array
+	 */
+	protected function fillPlaceholders(array $rules, array $data): array
+	{
+		$replacements = [];
+
+		foreach ($data as $key => $value)
+		{
+			$replacements["{{$key}}"] = $value;
+		}
+
+		if (! empty($replacements))
+		{
+			foreach ($rules as &$rule)
+			{
+				if (is_array($rule))
+				{
+					foreach ($rule as &$row)
+					{
+						// Should only be an `errors` array
+						// which doesn't take placeholders.
+						if (is_array($row))
+						{
+							continue;
+						}
+
+						$row = strtr($row, $replacements);
+					}
+					continue;
+				}
+
+				$rule = strtr($rule, $replacements);
+			}
+		}
+
+		return $rules;
+	}
+
 	//--------------------------------------------------------------------
 
 	/**

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -40,7 +40,6 @@
 namespace CodeIgniter\Pager;
 
 use CodeIgniter\Pager\Exceptions\PagerException;
-use Config\Services;
 use CodeIgniter\View\RendererInterface;
 
 /**

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -38,10 +38,10 @@
 
 namespace CodeIgniter\Router;
 
-use CodeIgniter\HTTP\Request;
-use Config\Services;
 use CodeIgniter\Autoloader\FileLocator;
+use CodeIgniter\HTTP\Request;
 use CodeIgniter\Router\Exceptions\RouterException;
+use Config\Services;
 
 /**
  * Class RouteCollection

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -39,8 +39,8 @@
 
 namespace CodeIgniter\Router;
 
-use CodeIgniter\HTTP\Request;
 use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\HTTP\Request;
 use CodeIgniter\Router\Exceptions\RedirectException;
 use CodeIgniter\Router\Exceptions\RouterException;
 

--- a/system/Session/Handlers/ArrayHandler.php
+++ b/system/Session/Handlers/ArrayHandler.php
@@ -39,9 +39,6 @@
 
 namespace CodeIgniter\Session\Handlers;
 
-use CodeIgniter\Session\Exceptions\SessionException;
-use CodeIgniter\Config\BaseConfig;
-use CodeIgniter\Database\BaseConnection;
 use Config\Database;
 
 /**

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -39,9 +39,9 @@
 
 namespace CodeIgniter\Session\Handlers;
 
-use CodeIgniter\Session\Exceptions\SessionException;
 use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Session\Exceptions\SessionException;
 use Config\Database;
 
 /**

--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -38,14 +38,12 @@
 
 namespace CodeIgniter\Test;
 
-use CodeIgniter\Config\Config;
-use Config\Autoload;
-use Config\Database;
-use Config\Migrations;
-use Config\Services;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\MigrationRunner;
 use CodeIgniter\Exceptions\ConfigException;
+use Config\Database;
+use Config\Migrations;
+use Config\Services;
 
 /**
  * CIDatabaseTestCase

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -39,10 +39,9 @@
 
 namespace CodeIgniter\Test;
 
-use Config\Paths;
 use CodeIgniter\Events\Events;
+use Config\Paths;
 use PHPUnit\Framework\TestCase;
-use CodeIgniter\Test\TestLogger;
 
 /**
  * PHPunit test case.

--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -41,9 +41,9 @@
 namespace CodeIgniter\Test;
 
 use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\UserAgent;
 use Config\App;
 use Config\Services;
 use InvalidArgumentException;

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -38,11 +38,11 @@
 
 namespace CodeIgniter\Test;
 
-use CodeIgniter\HTTP\URI;
-use CodeIgniter\HTTP\Request;
 use CodeIgniter\Events\Events;
-use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Request;
+use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\UserAgent;
 use Config\App;
 use Config\Services;
 

--- a/system/Test/Mock/MockSecurity.php
+++ b/system/Test/Mock/MockSecurity.php
@@ -1,7 +1,7 @@
 <?php namespace CodeIgniter\Test\Mock;
 
-use CodeIgniter\Security\Security;
 use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\Security\Security;
 
 class MockSecurity extends Security
 {

--- a/system/Test/ReflectionHelper.php
+++ b/system/Test/ReflectionHelper.php
@@ -39,9 +39,9 @@
 
 namespace CodeIgniter\Test;
 
+use ReflectionClass;
 use ReflectionMethod;
 use ReflectionObject;
-use ReflectionClass;
 
 /**
  * Testing helper.

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -155,6 +155,10 @@ class Validation implements ValidationInterface
 			return false;
 		}
 
+		// Replace any placeholders (i.e. {id}) in the rules with
+		// the value found in $data, if exists.
+		$this->fillPlaceholders($data);
+
 		// Need this for searching arrays in validation.
 		helper('array');
 
@@ -601,6 +605,59 @@ class Validation implements ValidationInterface
 		}
 
 		return $this->rules;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Replace any placeholders within the rules with the values that
+	 * match the 'key' of any properties being set. For example, if
+	 * we had the following $data array:
+	 *
+	 * [ 'id' => 13 ]
+	 *
+	 * and the following rule:
+	 *
+	 *  'required|is_unique[users,email,id,{id}]'
+	 *
+	 * The value of {id} would be replaced with the actual id in the form data:
+	 *
+	 *  'required|is_unique[users,email,id,13]'
+	 *
+	 * @param array $data
+	 */
+	protected function fillPlaceholders(array $data)
+	{
+		$replacements = [];
+
+		foreach ($data as $key => $value)
+		{
+			$replacements["{{$key}}"] = $value;
+		}
+
+		if (! empty($replacements))
+		{
+			foreach ($this->rules as &$rule)
+			{
+				if (is_array($rule))
+				{
+					foreach ($rule as &$row)
+					{
+						// Should only be an `errors` array
+						// which doesn't take placeholders.
+						if (is_array($row))
+						{
+							continue;
+						}
+
+						$row = strtr($row, $replacements);
+					}
+					continue;
+				}
+
+				$rule = strtr($rule, $replacements);
+			}
+		}
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -157,7 +157,7 @@ class Validation implements ValidationInterface
 
 		// Replace any placeholders (i.e. {id}) in the rules with
 		// the value found in $data, if exists.
-		$this->fillPlaceholders($data);
+		$this->rules = $this->fillPlaceholders($this->rules, $data);
 
 		// Need this for searching arrays in validation.
 		helper('array');
@@ -624,9 +624,12 @@ class Validation implements ValidationInterface
 	 *
 	 *  'required|is_unique[users,email,id,13]'
 	 *
+	 * @param array $rules
 	 * @param array $data
+	 *
+	 * @return array
 	 */
-	protected function fillPlaceholders(array $data)
+	protected function fillPlaceholders(array $rules, array $data): array
 	{
 		$replacements = [];
 
@@ -637,7 +640,7 @@ class Validation implements ValidationInterface
 
 		if (! empty($replacements))
 		{
-			foreach ($this->rules as &$rule)
+			foreach ($rules as &$rule)
 			{
 				if (is_array($rule))
 				{
@@ -658,6 +661,8 @@ class Validation implements ValidationInterface
 				$rule = strtr($rule, $replacements);
 			}
 		}
+
+		return $rules;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -40,8 +40,8 @@ namespace CodeIgniter\View;
 
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\View\Exceptions\ViewException;
-use ReflectionMethod;
 use Config\Services;
+use ReflectionMethod;
 
 /**
  * Class Cell

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -39,8 +39,8 @@
 
 namespace CodeIgniter\View;
 
-use Psr\Log\LoggerInterface;
 use CodeIgniter\View\Exceptions\ViewException;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class Parser

--- a/tests/_support/Controllers/Popcorn.php
+++ b/tests/_support/Controllers/Popcorn.php
@@ -3,7 +3,6 @@ namespace Tests\Support\Controllers;
 
 use CodeIgniter\API\ResponseTrait;
 use CodeIgniter\Controller;
-use CodeIgniter\HTTP\Exceptions\HTTPException;
 
 /**
  * This is a testing only controller, intended to blow up in multiple

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace CodeIgniter\API;
 
+use CodeIgniter\Format\JSONFormatter;
+use CodeIgniter\Format\XMLFormatter;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
-use CodeIgniter\Test\Mock\MockResponse;
-use CodeIgniter\Format\XMLFormatter;
-use CodeIgniter\Format\JSONFormatter;
 use CodeIgniter\Test\Mock\MockIncomingRequest;
+use CodeIgniter\Test\Mock\MockResponse;
 
 class ResponseTraitTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/CLI/CommandRunnerTest.php
+++ b/tests/system/CLI/CommandRunnerTest.php
@@ -2,9 +2,9 @@
 namespace CodeIgniter\CLI;
 
 use CodeIgniter\HTTP\UserAgent;
-use Config\Services;
-use CodeIgniter\Test\Mock\MockCLIConfig;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\Mock\MockCLIConfig;
+use Config\Services;
 
 class CommandRunnerTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -1,9 +1,9 @@
 <?php namespace CodeIgniter\CLI;
 
 use CodeIgniter\HTTP\CLIRequest;
-use CodeIgniter\Test\Mock\MockCodeIgniter;
-use CodeIgniter\Test\Mock\MockCLIConfig;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\Mock\MockCLIConfig;
+use CodeIgniter\Test\Mock\MockCodeIgniter;
 
 class ConsoleTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -1,9 +1,9 @@
 <?php namespace CodeIgniter;
 
-use Config\App;
-use CodeIgniter\Test\Mock\MockCodeIgniter;
-use CodeIgniter\Router\RouteCollection;
 use \CodeIgniter\Config\Services;
+use CodeIgniter\Router\RouteCollection;
+use CodeIgniter\Test\Mock\MockCodeIgniter;
+use Config\App;
 
 /**
  * @backupGlobals enabled

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -273,4 +273,31 @@ class CodeIgniterTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$this->assertStringContainsString('Welcome to CodeIgniter', $output);
 	}
+
+	//--------------------------------------------------------------------
+
+	public function testRunForceSecure()
+	{
+		$_SERVER['argv'] = [
+			'index.php',
+			'/',
+		];
+		$_SERVER['argc'] = 2;
+
+		$config                            = new App();
+		$config->forceGlobalSecureRequests = true;
+		$codeigniter                       = new MockCodeIgniter($config);
+
+		$this->getPrivateMethodInvoker($codeigniter, 'getRequestObject')();
+		$this->getPrivateMethodInvoker($codeigniter, 'getResponseObject')();
+
+		$response = $this->getPrivateProperty($codeigniter, 'response');
+		$this->assertNull($response->getHeader('Location'));
+
+		ob_start();
+		$codeigniter->useSafeOutput(true)->run();
+		$output = ob_get_clean();
+
+		$this->assertEquals('https://example.com', $response->getHeader('Location')->getValue());
+	}
 }

--- a/tests/system/Commands/CommandClassTest.php
+++ b/tests/system/Commands/CommandClassTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace CodeIgniter\Commands;
 
-use Config\Services;
 use CodeIgniter\CLI\CommandRunner;
+use Config\Services;
 
 class BaseCommandTest extends \CodeIgniter\Test\CIUnitTestCase
 {
@@ -12,8 +12,8 @@ class BaseCommandTest extends \CodeIgniter\Test\CIUnitTestCase
 	protected function setUp(): void
 	{
 		parent::setUp();
-		$this->logger   = Services::logger();
-		$this->runner   = new CommandRunner();
+		$this->logger = Services::logger();
+		$this->runner = new CommandRunner();
 	}
 
 	public function testMagicIssetTrue()

--- a/tests/system/Commands/CommandsTest.php
+++ b/tests/system/Commands/CommandsTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace CodeIgniter\Commands;
 
-use Config\Services;
-use CodeIgniter\Test\Mock\MockAppConfig;
-use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\CLI\CommandRunner;
+use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\Mock\MockAppConfig;
+use Config\Services;
 
 class CommandsTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/Commands/SessionsCommandsTest.php
+++ b/tests/system/Commands/SessionsCommandsTest.php
@@ -1,11 +1,11 @@
 <?php namespace CodeIgniter\Commands;
 
-use Config\Services;
-use CodeIgniter\Test\Mock\MockAppConfig;
-use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\CLI\CommandRunner;
+use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\Mock\MockAppConfig;
+use Config\Services;
 
 class SessionsCommandsTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -440,4 +440,19 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertStringContainsString('<h1>is_not</h1>', view('\Tests\Support\View\Views\simples'));
 	}
 
+	//--------------------------------------------------------------------
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState  disabled
+	 */
+	public function testForceHttpsNullRequestAndResponse()
+	{
+		$this->assertNull(Services::response()->getHeader('Location'));
+
+		force_https();
+
+		$this->assertEquals('https://example.com', Services::response()->getHeader('Location')->getValue());
+	}
+
 }

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -1,17 +1,17 @@
 <?php
 
-use CodeIgniter\Session\Handlers\FileHandler;
-use CodeIgniter\HTTP\Response;
-use Config\App;
 use CodeIgniter\Config\Services;
-use CodeIgniter\Router\RouteCollection;
 use CodeIgniter\HTTP\RedirectResponse;
+use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
-use Config\Logger;
+use CodeIgniter\Router\RouteCollection;
+use CodeIgniter\Session\Handlers\FileHandler;
 use CodeIgniter\Test\Mock\MockIncomingRequest;
-use CodeIgniter\Test\TestLogger;
 use CodeIgniter\Test\Mock\MockSession;
+use CodeIgniter\Test\TestLogger;
+use Config\App;
+use Config\Logger;
 use Tests\Support\Models\JobModel;
 
 /**

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -1,10 +1,9 @@
 <?php namespace CodeIgniter;
 
-use CodeIgniter\Log\Logger;
-use Config\App;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
 use CodeIgniter\Validation\Exceptions\ValidationException;
+use Config\App;
 
 /**
  * Exercise our core Controller class.

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -1,8 +1,8 @@
 <?php namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
-use CodeIgniter\Test\Mock\MockQuery;
 use CodeIgniter\Test\Mock\MockConnection;
+use CodeIgniter\Test\Mock\MockQuery;
 
 class UpdateTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -1,7 +1,7 @@
 <?php namespace CodeIgniter\Database;
 
-use Config\Services;
 use CodeIgniter\Test\CIDatabaseTestCase;
+use Config\Services;
 
 class DatabaseTestCaseTest extends CIDatabaseTestCase
 {
@@ -23,7 +23,7 @@ class DatabaseTestCaseTest extends CIDatabaseTestCase
 	 */
 	protected $seed = [
 		'Tests\Support\Database\Seeds\CITestSeeder',
-		'Tests\Support\Database\Seeds\AnotherSeeder'
+		'Tests\Support\Database\Seeds\AnotherSeeder',
 	];
 
 	/**

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -1,7 +1,7 @@
 <?php namespace CodeIgniter\Database\Live\SQLite;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
 use CodeIgniter\Database\SQLite3\Table;
+use CodeIgniter\Test\CIDatabaseTestCase;
 use Config\Database;
 
 /**

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -1,11 +1,10 @@
 <?php namespace CodeIgniter\Database;
 
 use CodeIgniter\Exceptions\ConfigException;
-use Config\Migrations;
-use org\bovigo\vfs\vfsStream;
 use CodeIgniter\Test\CIDatabaseTestCase;
-use org\bovigo\vfs\visitor\vfsStreamStructureVisitor;
+use Config\Migrations;
 use Config\Services;
+use org\bovigo\vfs\vfsStream;
 
 /**
  * @group DatabaseLive

--- a/tests/system/Database/ModelFactoryTest.php
+++ b/tests/system/Database/ModelFactoryTest.php
@@ -1,7 +1,7 @@
 <?php namespace CodeIgniter\Database;
 
-use Tests\Support\Models\JobModel;
 use CodeIgniter\Test\CIDatabaseTestCase;
+use Tests\Support\Models\JobModel;
 
 class ModelFactoryTest extends CIDatabaseTestCase
 {

--- a/tests/system/Encryption/EncryptionTest.php
+++ b/tests/system/Encryption/EncryptionTest.php
@@ -1,9 +1,8 @@
 <?php
 namespace CodeIgniter\Encryption;
 
-use Config\Services;
-use CodeIgniter\Config\BaseConfig;
 use Config\Encryption as EncryptionConfig;
+use Config\Services;
 
 //use CodeIgniter\Encryption\Encryption;
 

--- a/tests/system/Encryption/OpenSSLHandlerTest.php
+++ b/tests/system/Encryption/OpenSSLHandlerTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace CodeIgniter\Encrypt;
 
-use CodeIgniter\Config\Services;
-
 class OpenSSLHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 {
 

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -2,10 +2,7 @@
 namespace CodeIgniter\Events;
 
 use CodeIgniter\Config\Config;
-use Config\Logger;
-use Config\Services;
 use CodeIgniter\Test\Mock\MockEvents;
-use CodeIgniter\Test\TestLogger;
 
 class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/Filters/CSRFTest.php
+++ b/tests/system/Filters/CSRFTest.php
@@ -1,11 +1,7 @@
 <?php
 namespace CodeIgniter\Filters;
 
-use Config\Filters as FilterConfig;
 use CodeIgniter\Config\Services;
-use CodeIgniter\Filters\Exceptions\FilterException;
-use CodeIgniter\Honeypot\Exceptions\HoneypotException;
-use CodeIgniter\HTTP\ResponseInterface;
 
 /**
  * @backupGlobals enabled

--- a/tests/system/Filters/DebugToolbarTest.php
+++ b/tests/system/Filters/DebugToolbarTest.php
@@ -1,10 +1,8 @@
 <?php
 namespace CodeIgniter\Filters;
 
-use Config\Filters as FilterConfig;
 use CodeIgniter\Config\Services;
-use CodeIgniter\Filters\Exceptions\FilterException;
-use CodeIgniter\HTTP\ResponseInterface;
+use Config\Filters as FilterConfig;
 
 /**
  * @backupGlobals enabled

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace CodeIgniter\Filters;
 
-use Config\Filters as FilterConfig;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Filters\Exceptions\FilterException;
 use CodeIgniter\HTTP\ResponseInterface;

--- a/tests/system/Filters/HoneypotTest.php
+++ b/tests/system/Filters/HoneypotTest.php
@@ -1,11 +1,8 @@
 <?php
 namespace CodeIgniter\Filters;
 
-use Config\Filters as FilterConfig;
 use CodeIgniter\Config\Services;
-use CodeIgniter\Filters\Exceptions\FilterException;
 use CodeIgniter\Honeypot\Exceptions\HoneypotException;
-use CodeIgniter\HTTP\ResponseInterface;
 
 /**
  * @backupGlobals enabled

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -3,8 +3,8 @@
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Config\Services;
-use Config\App;
 use CodeIgniter\Test\Mock\MockCURLRequest;
+use Config\App;
 
 class CURLRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -1,10 +1,10 @@
 <?php
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Exceptions\DownloadException;
 use CodeIgniter\Files\Exceptions\FileNotFoundException;
 use DateTime;
 use DateTimeZone;
-use CodeIgniter\Exceptions\DownloadException;
 
 class DownloadResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace CodeIgniter\HTTP\Files;
 
-use org\bovigo\vfs\vfsStream;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
+use org\bovigo\vfs\vfsStream;
 
 class FileMovingTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace CodeIgniter\HTTP;
 
-use Config\App;
 use CodeIgniter\HTTP\Files\UploadedFile;
+use Config\App;
 
 /**
  * @backupGlobals enabled

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -2,12 +2,12 @@
 
 namespace CodeIgniter\HTTP;
 
-use Config\App;
 use CodeIgniter\Config\Config;
 use CodeIgniter\Config\Services;
-use CodeIgniter\Validation\Validation;
 use CodeIgniter\Router\RouteCollection;
 use CodeIgniter\Test\Mock\MockIncomingRequest;
+use CodeIgniter\Validation\Validation;
+use Config\App;
 
 class RedirectResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -1,13 +1,13 @@
 <?php
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Config\Config;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
+use CodeIgniter\Test\Mock\MockResponse;
 use Config\App;
 use Config\Format;
 use DateTime;
 use DateTimeZone;
-use CodeIgniter\Config\Config;
-use CodeIgniter\Test\Mock\MockResponse;
 
 class ResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -1,9 +1,9 @@
 <?php
 namespace CodeIgniter\HTTP;
 
-use Config\App;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
+use Config\App;
 
 class URITest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace CodeIgniter\Helpers;
 
-use Config\App;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\Mock\MockResponse;
+use Config\App;
 
 final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -3,8 +3,8 @@
 namespace CodeIgniter\Helpers;
 
 use CodeIgniter\HTTP\URI;
-use Config\App;
 use CodeIgniter\Services;
+use Config\App;
 use Config\Filters;
 
 class FormHelperTest extends \CodeIgniter\Test\CIUnitTestCase

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1,9 +1,9 @@
 <?php
 namespace CodeIgniter\Helpers;
 
-use Config\App;
-use CodeIgniter\HTTP\URI;
 use CodeIgniter\Config\Services;
+use CodeIgniter\HTTP\URI;
+use Config\App;
 
 /**
  * @backupGlobals enabled

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -1,7 +1,7 @@
 <?php namespace CodeIgniter\Images;
 
-use CodeIgniter\Images\Exceptions\ImageException;
 use CodeIgniter\Config\Services;
+use CodeIgniter\Images\Exceptions\ImageException;
 use org\bovigo\vfs\vfsStream;
 
 /**

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace CodeIgniter\Language;
 
-use Config\Services;
 use CodeIgniter\Test\Mock\MockLanguage;
+use Config\Services;
 use Tests\Support\Language\SecondMockLanguage;
 
 class LanguageTest extends \CodeIgniter\Test\CIUnitTestCase

--- a/tests/system/Log/ChromeLoggerHandlerTest.php
+++ b/tests/system/Log/ChromeLoggerHandlerTest.php
@@ -1,9 +1,9 @@
 <?php namespace CodeIgniter\Log\Handlers;
 
-use Config\App;
+use CodeIgniter\Services;
 use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use CodeIgniter\Test\Mock\MockResponse;
-use CodeIgniter\Services;
+use Config\App;
 
 class ChromeLoggerHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 {
@@ -54,7 +54,6 @@ class ChromeLoggerHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertObjectHasAttribute('dateFormat', $result);
 		$this->assertObjectHasAttribute('dateFormat', $logger);
 	}
-
 
 	public function testChromeLoggerHeaderSent()
 	{

--- a/tests/system/Log/FileHandlerTest.php
+++ b/tests/system/Log/FileHandlerTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace CodeIgniter\Log\Handlers;
 
-use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use CodeIgniter\Test\Mock\MockFileLogger;
+use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use org\bovigo\vfs\vfsStream;
 
 class FileHandlerTest extends \CodeIgniter\Test\CIUnitTestCase

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use CodeIgniter\Log\Logger;
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\Log\Exceptions\LogException;
+use CodeIgniter\Log\Logger;
 use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use Tests\Support\Log\Handlers\TestHandler;
 

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -2,8 +2,8 @@
 namespace CodeIgniter\RESTful;
 
 use CodeIgniter\Config\Services;
-use Config\App;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
+use Config\App;
 
 /**
  * Exercise our ResourceController class.

--- a/tests/system/RESTful/ResourcePresenterTest.php
+++ b/tests/system/RESTful/ResourcePresenterTest.php
@@ -2,8 +2,8 @@
 namespace CodeIgniter\RESTful;
 
 use CodeIgniter\Config\Services;
-use Config\App;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
+use Config\App;
 
 /**
  * Exercise our core ResourcePresenter class.
@@ -252,7 +252,7 @@ class ResourcePresenterTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
 		$this->assertEquals('\Tests\Support\Models\UserModel', $resource->getModelName());
 
-		$model    = new \Tests\Support\Models\EntityModel();
+		$model = new \Tests\Support\Models\EntityModel();
 		$resource->setModel($model);
 		$this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
 		$this->assertEquals('Tests\Support\Models\EntityModel', $resource->getModelName());

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -1,11 +1,11 @@
 <?php namespace CodeIgniter\Security;
 
-use CodeIgniter\HTTP\URI;
-use CodeIgniter\HTTP\Request;
-use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\Test\Mock\MockAppConfig;
+use CodeIgniter\HTTP\Request;
+use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Security\Exceptions\SecurityException;
+use CodeIgniter\Test\Mock\MockAppConfig;
 use CodeIgniter\Test\Mock\MockSecurity;
 
 //--------------------------------------------------------------------

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -1,9 +1,9 @@
 <?php namespace CodeIgniter\Session;
 
-use Config\Logger;
-use CodeIgniter\Test\TestLogger;
-use CodeIgniter\Test\Mock\MockSession;
 use CodeIgniter\Session\Handlers\FileHandler;
+use CodeIgniter\Test\Mock\MockSession;
+use CodeIgniter\Test\TestLogger;
+use Config\Logger;
 
 /**
  * @runTestsInSeparateProcesses

--- a/tests/system/Test/ControllerTesterTest.php
+++ b/tests/system/Test/ControllerTesterTest.php
@@ -2,9 +2,9 @@
 namespace CodeIgniter\Test;
 
 use CodeIgniter\Log\Logger;
+use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use Config\App;
 use Config\Services;
-use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 
 /**
  * Exercise our Controller class.

--- a/tests/system/Test/FeatureResponseTest.php
+++ b/tests/system/Test/FeatureResponseTest.php
@@ -1,8 +1,8 @@
 <?php
 
+use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\FeatureResponse;
-use CodeIgniter\HTTP\RedirectResponse;
 
 class FeatureResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 {
@@ -251,7 +251,7 @@ class FeatureResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->response->setBody($tmp);
 
 		// this should be FALSE - invalid JSON - will see if this is working that way ;-)
-		$this->assertFalse($this->response->getBody() == $this->feature->getJSON());
+		$this->assertFalse($this->response->getBody() === $this->feature->getJSON());
 	}
 
 	public function testGetXML()

--- a/tests/system/Test/FeatureTestCaseTest.php
+++ b/tests/system/Test/FeatureTestCaseTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use CodeIgniter\Exceptions\PageNotFoundException;
-use CodeIgniter\Test\FeatureTestCase;
 use CodeIgniter\Test\FeatureResponse;
+use CodeIgniter\Test\FeatureTestCase;
 
 /**
  * @group                       DatabaseLive

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -2,8 +2,8 @@
 namespace CodeIgniter\Test;
 
 use CodeIgniter\Events\Events;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
 use CodeIgniter\HTTP\Response;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
 use Config\App;
 
 class TestCaseTest extends \CodeIgniter\Test\CIUnitTestCase

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -2,8 +2,8 @@
 
 namespace CodeIgniter\Validation;
 
-use Config\Database;
 use CodeIgniter\Test\CIDatabaseTestCase;
+use Config\Database;
 
 class RulesTest extends CIDatabaseTestCase
 {

--- a/tests/system/Validation/UniqueRulesTest.php
+++ b/tests/system/Validation/UniqueRulesTest.php
@@ -1,7 +1,7 @@
 <?php namespace CodeIgniter\Validation;
 
-use Config\Database;
 use CodeIgniter\Test\CIDatabaseTestCase;
+use Config\Database;
 
 class UniqueRulesTest extends CIDatabaseTestCase
 {

--- a/tests/system/Validation/UniqueRulesTest.php
+++ b/tests/system/Validation/UniqueRulesTest.php
@@ -112,4 +112,35 @@ class UniqueRulesTest extends CIDatabaseTestCase
 	}
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * @group DatabaseLive
+	 */
+	public function testIsUniqueIgnoresParamsPlaceholders()
+	{
+		$this->hasInDatabase('user', [
+			'name'    => 'Derek',
+			'email'   => 'derek@world.co.uk',
+			'country' => 'GB',
+		]);
+
+		$db  = Database::connect();
+		$row = $db->table('user')
+				  ->limit(1)
+				  ->get()
+				  ->getRow();
+
+		$data = [
+			'id'    => $row->id,
+			'email' => 'derek@world.co.uk',
+		];
+
+		$this->validation->setRules([
+			'email' => "is_unique[user.email,id,{id}]",
+		]);
+
+		$this->assertTrue($this->validation->run($data));
+	}
+
+	//--------------------------------------------------------------------
 }

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1,11 +1,11 @@
 <?php namespace CodeIgniter\Validation;
 
-use CodeIgniter\Validation\Exceptions\ValidationException;
-use Config\Services;
-use Config\App;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
+use CodeIgniter\Validation\Exceptions\ValidationException;
+use Config\App;
+use Config\Services;
 
 class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/View/CellTest.php
+++ b/tests/system/View/CellTest.php
@@ -1,8 +1,8 @@
 <?php
 
+use CodeIgniter\Test\Mock\MockCache;
 use CodeIgniter\View\Cell;
 use CodeIgniter\View\Exceptions\ViewException;
-use CodeIgniter\Test\Mock\MockCache;
 
 class CellTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use CodeIgniter\View\Parser;
 use CodeIgniter\View\Exceptions\ViewException;
+use CodeIgniter\View\Parser;
 
 class ParserTest extends \CodeIgniter\Test\CIUnitTestCase
 {

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -40,10 +40,10 @@ application's files. This is most important for any business-logic related class
 etc. The ``psr4`` array in the configuration file allows you to map the namespace to the directory
 those classes can be found in::
 
-	$psr4 = [
-		'App'         => APPPATH,
-		'CodeIgniter' => SYSTEMPATH,
-	];
+    $psr4 = [
+        'App'         => APPPATH,
+        'CodeIgniter' => SYSTEMPATH,
+    ];
 
 The key of each row is the namespace itself. This does not need a trailing slash. If you use double-quotes
 to define the array, be sure to escape the backward slash. That means that it would be ``My\\App``,
@@ -55,13 +55,13 @@ libraries, or models in the application directory, if you do, they will be found
 You may change this namespace by editing the **/app/Config/Constants.php** file and setting the
 new namespace value under the ``APP_NAMESPACE`` setting::
 
-	define('APP_NAMESPACE', 'App');
+    define('APP_NAMESPACE', 'App');
 
 You will need to modify any existing files that are referencing the current namespace.
 
 .. important:: Config files are namespaced in the ``Config`` namespace, not in ``App\Config`` as you might
-	expect. This allows the core system files to always be able to locate them, even when the application
-	namespace has changed.
+    expect. This allows the core system files to always be able to locate them, even when the application
+    namespace has changed.
 
 Classmap
 ========
@@ -70,9 +70,9 @@ The classmap is used extensively by CodeIgniter to eke the last ounces of perfor
 by not hitting the file-system with extra ``is_file()`` calls. You can use the classmap to link to
 third-party libraries that are not namespaced::
 
-	$classmap = [
-		'Markdown' => APPPATH .'third_party/markdown.php'
-	];
+    $classmap = [
+        'Markdown' => APPPATH .'third_party/markdown.php'
+    ];
 
 The key of each row is the name of the class that you want to locate. The value is the path to locate it at.
 
@@ -89,7 +89,7 @@ Composer Support
 ================
 
 Composer support is automatically initialized by default. By default, it looks for Composer's autoload file at
-ROOTPATH.'vendor/autoload.php'. If you need to change the location of that file for any reason, you can modify
+``ROOTPATH.'vendor/autoload.php'``. If you need to change the location of that file for any reason, you can modify
 the value defined in ``Config\Constants.php``.
 
 .. note:: If the same namespace is defined in both CodeIgniter and Composer, CodeIgniter's autoloader will be

--- a/user_guide_src/source/general/ajax.rst
+++ b/user_guide_src/source/general/ajax.rst
@@ -16,13 +16,9 @@ Fetch API
     fetch(url, {
         method: "get",
         headers: {
-
           "Content-Type": "application/json",
-
           "X-Requested-With": "XMLHttpRequest"
-
         }
-
     });
 
 
@@ -35,9 +31,7 @@ For libraries like jQuery for example, it is not necessary to make explicit the 
 
     $.ajax({
         url: "your url",
-
         headers: {'X-Requested-With': 'XMLHttpRequest'}
-
     });
 
 

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -2,7 +2,7 @@
 Global Functions and Constants
 ##############################
 
-CodeIgniter uses provides a few functions and variables that are globally defined, and are available to you at any point.
+CodeIgniter provides a few functions and variables that are globally defined, and are available to you at any point.
 These do not require loading any additional libraries or helpers.
 
 .. contents::
@@ -80,6 +80,14 @@ Service Accessors
 	Retrieves a locale-specific file based on an alias string.
 
 	For more information, see the :doc:`Localization </outgoing/localization>` page.
+
+.. php:function:: model($name [, $getShared = true [, &$conn = null ]])
+
+    :param string                   $name:
+    :param boolean                  $getShared:
+    :param ConnectionInterface|null $conn:
+    :returns: More simple way of getting model instances
+    :rtype: mixed
 
 .. php:function:: old( $key[, $default = null, [, $escape = 'html' ]] )
 
@@ -166,8 +174,26 @@ Service Accessors
 
 	For more details, see the :doc:`Views </outgoing/views>` page.
 
+.. php:function:: view_cell ( $library [, $params = null [, $ttl = 0 [, $cacheName = null]]] )
+
+    :param string      $library:
+    :param null        $params:
+    :param integer     $ttl:
+    :param string|null $cacheName:
+    :returns: View cells are used within views to insert HTML chunks that are managed by other classes.
+    :rtype: string
+
+    For more details, see the :doc:`View Cells </outgoing/view_cells>` page.
+
 Miscellaneous Functions
 =======================
+
+.. php:function:: app_timezone ()
+
+    :returns: The timezone the application has been set to display dates in.
+    :rtype: string
+
+    Returns the timezone the application has been set to display dates in.
 
 .. php:function:: csrf_token ()
 
@@ -195,7 +221,7 @@ Miscellaneous Functions
 	:returns: A string with the HTML for hidden input with all required CSRF information.
 	:rtype: string
 
-	Returns a hidden input with the CSRF information already inserted:
+	Returns a hidden input with the CSRF information already inserted::
 
 		<input type="hidden" name="{csrf_token}" value="{csrf_hash}">
 
@@ -204,7 +230,7 @@ Miscellaneous Functions
 	:returns: A string with the HTML for meta tag with all required CSRF information.
 	:rtype: string
 
-	Returns a meta tag with the CSRF information already inserted:
+	Returns a meta tag with the CSRF information already inserted::
 
 		<meta name="{csrf_header}" content="{csrf_hash}">
 
@@ -219,10 +245,22 @@ Miscellaneous Functions
 	but through HTTPS. Will set the HTTP Strict Transport Security header, which instructs
 	modern browsers to automatically modify any HTTP requests to HTTPS requests for the $duration.
 
+.. php:function:: function_usable ( $function_name )
+
+    :param string $function_name: Function to check for
+    :returns: TRUE if the function exists and is safe to call, FALSE otherwise.
+    :rtype: bool
+
 .. php:function:: is_cli ()
 
 	:returns: TRUE if the script is being executed from the command line or FALSE otherwise.
 	:rtype: bool
+
+.. php:function:: is_really_writable ( $file )
+
+    :param string $file: The filename being checked.
+    :returns: TRUE if you can write to the file, FALSE otherwise.
+    :rtype: bool
 
 .. php:function:: log_message ($level, $message [, $context])
 
@@ -318,6 +356,14 @@ Miscellaneous Functions
 	Identical to the **service()** function described above, except that all calls to this
 	function will return a new instance of the class, where **service** returns the same
 	instance every time.
+
+.. php:function:: slash_item ( $item )
+
+    :param string $item: Config item name
+    :returns: The configuration item or NULL if the item doesn't exist
+    :rtype:  string|null
+
+    Fetch a config file item with slash appended (if not empty)
 
 .. php:function:: stringify_attributes ( $attributes [, $js] )
 

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -20,39 +20,40 @@ This section is a quick overview for newer programmers, or for developers who ar
 Exceptions are simply events that happen when the exception is "thrown". This halts the current flow of the script, and
 execution is then sent to the error handler which displays the appropriate error page::
 
-	throw new \Exception("Some message goes here");
+    throw new \Exception("Some message goes here");
 
 If you are calling a method that might throw an exception, you can catch that exception using a ``try/catch`` block::
 
-	try {
-		$user = $userModel->find($id);
-	}
-	catch (\Exception $e)
-	{
-		die($e->getMessage());
-	}
+    try
+    {
+        $user = $userModel->find($id);
+    }
+    catch (\Exception $e)
+    {
+        die($e->getMessage());
+    }
 
 If the ``$userModel`` throws an exception, it is caught and the code within the catch block is executed. In this example,
 the scripts dies, echoing the error message that the ``UserModel`` defined.
 
-In this example, we catch any type of Exception. If we only want to watch for specific types of exceptions, like
-a UnknownFileException, we can specify that in the catch parameter. Any other exceptions that are thrown and are
+In the example above, we catch any type of Exception. If we only want to watch for specific types of exceptions, like
+a ``UnknownFileException``, we can specify that in the catch parameter. Any other exceptions that are thrown and are
 not child classes of the caught exception will be passed on to the error handler::
 
-	catch (\CodeIgniter\UnknownFileException $e)
-	{
-		// do something here...
-	}
+    catch (\CodeIgniter\UnknownFileException $e)
+    {
+        // do something here...
+    }
 
 This can be handy for handling the error yourself, or for performing cleanup before the script ends. If you want
 the error handler to function as normal, you can throw a new exception within the catch block::
 
-	catch (\CodeIgniter\UnknownFileException $e)
-	{
-		// do something here...
+    catch (\CodeIgniter\UnknownFileException $e)
+    {
+        // do something here...
 
-		throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
-	}
+        throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
+    }
 
 Configuration
 =============
@@ -97,10 +98,10 @@ This is used to signal a 404, Page Not Found error. When thrown, the system will
 If, in ``Config/Routes.php``, you have specified a 404 Override, that will be called instead of the standard
 404 page::
 
-	if (! $page = $pageModel->find($id))
-	{
-		throw \CodeIgniter\Exceptions\PageNotFoundException::forPageNotFound();
-	}
+    if (! $page = $pageModel->find($id))
+    {
+        throw \CodeIgniter\Exceptions\PageNotFoundException::forPageNotFound();
+    }
 
 You can pass a message into the exception that will be displayed in place of the default message on the 404 page.
 
@@ -110,7 +111,7 @@ ConfigException
 This exception should be used when the values from the configuration class are invalid, or when the config class
 is not the right type, etc::
 
-	throw new \CodeIgniter\Exceptions\ConfigException();
+    throw new \CodeIgniter\Exceptions\ConfigException();
 
 This provides an HTTP status code of 500 and an exit code of 3.
 
@@ -120,7 +121,7 @@ DatabaseException
 This exception is thrown for database errors, such as when the database connection cannot be created,
 or when it is temporarily lost::
 
-	throw new \CodeIgniter\Database\Exceptions\DatabaseException();
+    throw new \CodeIgniter\Database\Exceptions\DatabaseException();
 
 This provides an HTTP status code of 500 and an exit code of 8.
 
@@ -130,9 +131,9 @@ RedirectException
 This exception is a special case allowing for overriding of all other response routing and
 forcing a redirect to a specific route or URL::
 
-	throw new \CodeIgniter\Router\Exceptions\RedirectException($route);
+    throw new \CodeIgniter\Router\Exceptions\RedirectException($route);
 
 ``$route`` may be a named route, relative URI, or a complete URL. You can also supply a
 redirect code to use instead of the default (``302``, "temporary redirect")::
 
-	throw new \CodeIgniter\Router\Exceptions\RedirectException($route, 301);
+    throw new \CodeIgniter\Router\Exceptions\RedirectException($route, 301);

--- a/user_guide_src/source/general/helpers.rst
+++ b/user_guide_src/source/general/helpers.rst
@@ -37,17 +37,17 @@ Loading a helper file is quite simple using the following method::
 	helper('name');
 
 Where **name** is the file name of the helper, without the .php file
-extension or the "helper" part.
+extension or the "_helper" part.
 
 For example, to load the **Cookie Helper** file, which is named
 **cookie_helper.php**, you would do this::
 
-	helper('cookie');
+    helper('cookie');
 
 If you need to load more than one helper at a time, you can pass
 an array of file names in and all of them will be loaded::
 
-	helper(['cookie', 'date']);
+    helper(['cookie', 'date']);
 
 A helper can be loaded anywhere within your controller methods (or
 even within your View files, although that's not a good practice), as
@@ -57,7 +57,7 @@ any function, or you can load a helper in a specific function that needs
 it.
 
 .. note:: The Helper loading method above does not return a value, so
-	don't try to assign it to a variable. Just use it as shown.
+    don't try to assign it to a variable. Just use it as shown.
 
 .. note:: The URL helper is always loaded so you do not need to load it yourself.
 
@@ -78,10 +78,10 @@ code into its own namespace, ``Example\Blog``. The files exist on our server at
 **/Modules/Blog/Helpers/blog_helper.php**. Within our controller we could
 use the following command to load the helper for us::
 
-	helper('Modules\Blog\blog');
+    helper('Modules\Blog\blog');
 
 .. note:: The functions within files loaded this way are not truly namespaced.
-		The namespace is simply used as a convenient way to locate the files.
+    The namespace is simply used as a convenient way to locate the files.
 
 Using a Helper
 ==============
@@ -92,7 +92,7 @@ use, you'll call it the way you would a standard PHP function.
 For example, to create a link using the ``anchor()`` function in one of
 your view files you would do this::
 
-	<?php echo anchor('blog/comments', 'Click Here');?>
+    <?php echo anchor('blog/comments', 'Click Here');?>
 
 Where "Click Here" is the name of the link, and "blog/comments" is the
 URI to the controller/method you wish to link to.
@@ -109,36 +109,36 @@ function operates - then it's overkill to replace the entire helper with
 your version. In this case, it's better to simply "extend" the Helper.
 
 .. note:: The term "extend" is used loosely since Helper functions are
-	procedural and discrete and cannot be extended in the traditional
-	programmatic sense. Under the hood, this gives you the ability to
-	add to, or to replace the functions a Helper provides.
+    procedural and discrete and cannot be extended in the traditional
+    programmatic sense. Under the hood, this gives you the ability to
+    add to, or to replace the functions a Helper provides.
 
 For example, to extend the native **Array Helper** you'll create a file
 named **app/Helpers/array_helper.php**, and add or override
 functions::
 
-	// any_in_array() is not in the Array Helper, so it defines a new function
-	function any_in_array($needle, $haystack)
-	{
-		$needle = is_array($needle) ? $needle : [$needle];
+    // any_in_array() is not in the Array Helper, so it defines a new function
+    function any_in_array($needle, $haystack)
+    {
+        $needle = is_array($needle) ? $needle : [$needle];
 
-		foreach ($needle as $item)
-		{
-			if (in_array($item, $haystack))
-			{
-				return TRUE;
-			}
-	        }
+        foreach ($needle as $item)
+        {
+            if (in_array($item, $haystack))
+            {
+                return TRUE;
+            }
+            }
 
-		return FALSE;
-	}
+        return FALSE;
+    }
 
-	// random_element() is included in Array Helper, so it overrides the native function
-	function random_element($array)
-	{
-		shuffle($array);
-		return array_pop($array);
-	}
+    // random_element() is included in Array Helper, so it overrides the native function
+    function random_element($array)
+    {
+        shuffle($array);
+        return array_pop($array);
+    }
 
 The **helper()** method will scan through all PSR-4 namespaces defined in **app/Config/Autoload.php**
 and load in ALL matching helpers of the same name. This allows any module's helpers
@@ -152,5 +152,5 @@ is as follows:
 Now What?
 =========
 
-In the Table of Contents, you'll find a list of all the available Helper
-Files. Browse each one to see what they do.
+In the Table of Contents, you'll find a list of all the available :doc:`Helpers </helpers/index>`.
+Browse each one to see what they do.

--- a/user_guide_src/source/general/logging.rst
+++ b/user_guide_src/source/general/logging.rst
@@ -10,21 +10,26 @@ You can log information to the local log files by using the ``log_message()`` me
 the "level" of the error in the first parameter, indicating what type of message it is (debug, error, etc).
 The second parameter is the message itself::
 
-	if ($some_var == '')
-	{
-		log_message('error', 'Some variable did not contain a value.');
-	}
+    if ($some_var == '')
+    {
+        log_message('error', 'Some variable did not contain a value.');
+    }
 
 There are eight different log levels, matching to the `RFC 5424 <https://tools.ietf.org/html/rfc5424>`_ levels, and they are as follows:
 
-* **debug** - Detailed debug information.
-* **info** - Interesting events in your application, like a user logging in, logging SQL queries, etc.
-* **notice** - Normal, but significant events in your application.
-* **warning** - Exceptional occurrences that are not errors, like the use of deprecated APIs, poor use of an API, or other undesirable things that are not necessarily wrong.
-* **error** - Runtime errors that do not require immediate action but should typically be logged and monitored.
-* **critical** - Critical conditions, like an application component not available, or an unexpected exception.
-* **alert** - Action must be taken immediately, like when an entire website is down, the database unavailable, etc.
-* **emergency** - The system is unusable.
+=========== ==================================================================
+Level       Description
+=========== ==================================================================
+debug       Detailed debug information.
+info        Interesting events in your application, like a user logging in, logging SQL queries, etc.
+notice      Normal, but significant events in your application.
+warning     Exceptional occurrences that are not errors, like the use of deprecated APIs,
+            poor use of an API, or other undesirable things that are not necessarily wrong.
+error       Runtime errors that do not require immediate action but should typically be logged and monitored.
+critical    Critical conditions, like an application component not available, or an unexpected exception.
+alert       Action must be taken immediately, like when an entire website is down, the database unavailable, etc.
+emergency   The system is unusable.
+=========== ==================================================================
 
 The logging system does not provide ways to alert sysadmins or webmasters about these events, they solely log
 the information. For many of the more critical event levels, the logging happens automatically by the
@@ -43,15 +48,15 @@ if you want to log warning messages, and not information messages, you would set
 a level of 5 or less (which includes runtime errors, system errors, etc) would be logged and info, notices, and debug
 would be ignored::
 
-	public $threshold = 5;
+    public $threshold = 5;
 
 A complete list of levels and their corresponding threshold value is in the configuration file for your reference.
 
 You can pick and choose the specific levels that you would like logged by assigning an array of log level numbers
 to the threshold value::
 
-	// Log only debug and info type messages
-	public $threshold = [5, 8];
+    // Log only debug and info type messages
+    public $threshold = [5, 8];
 
 Using Multiple Log Handlers
 ---------------------------
@@ -72,17 +77,17 @@ Each handler's section will have one property in common: ``handles``, which is a
 *names* that the handler will log information for.
 ::
 
-	public $handlers = [
+    public $handlers = [
 
-		//--------------------------------------------------------------------
-		// File Handler
-		//--------------------------------------------------------------------
+        //--------------------------------------------------------------------
+        // File Handler
+        //--------------------------------------------------------------------
 
-		'CodeIgniter\Log\Handlers\FileHandler' => [
+        'CodeIgniter\Log\Handlers\FileHandler' => [
 
-			'handles' => ['critical', 'alert', 'emergency', 'debug', 'error', 'info', 'notice', 'warning'],
-		]
-	];
+            'handles' => ['critical', 'alert', 'emergency', 'debug', 'error', 'info', 'notice', 'warning'],
+        ]
+    ];
 
 Modifying the Message With Context
 ==================================
@@ -93,26 +98,26 @@ placeholders in your message. Each placeholder must be wrapped in curly braces. 
 you must provide an array of placeholder names (without the braces) and their values. These will be inserted
 into the message string::
 
-	// Generates a message like: User 123 logged into the system from 127.0.0.1
-	$info = [
-		'id' => $user->id,
-		'ip_address' => $this->request->ip_address()
-	];
+    // Generates a message like: User 123 logged into the system from 127.0.0.1
+    $info = [
+        'id' => $user->id,
+        'ip_address' => $this->request->ip_address()
+    ];
 
-	log_message('info', 'User {id} logged into the system from {ip_address}', $info);
+    log_message('info', 'User {id} logged into the system from {ip_address}', $info);
 
 If you want to log an Exception or an Error, you can use the key of 'exception', and the value being the
 Exception or Error itself. A string will be generated from that object containing the error message, the
 file name and line number. You must still provide the exception placeholder in the message::
 
-	try
-	{
-		... Something throws error here
-	}
-	catch (\Exception $e)
-	{
-		log_message('error', '[ERROR] {exception}', ['exception' => $e]);
-	}
+    try
+    {
+        // Something throws error here
+    }
+    catch (\Exception $e)
+    {
+        log_message('error', '[ERROR] {exception}', ['exception' => $e]);
+    }
 
 Several core placeholders exist that will be automatically expanded for you based on the current page request:
 

--- a/user_guide_src/source/general/managing_apps.rst
+++ b/user_guide_src/source/general/managing_apps.rst
@@ -42,17 +42,29 @@ several different applications, simply put all of the directories located
 inside your application directory into their own (sub)-directory.
 
 For example, let's say you want to create two applications, named "foo"
-and "bar". You could structure your application project directories like this::
+and "bar". You could structure your application project directories like this:
 
-    foo/app, public, tests and writable
-    bar/app/, public, tests and writable
-    codeigniter/system and docs
+.. code-block:: text
+
+    /foo
+        /app
+        /public
+        /tests
+        /writable
+    /bar
+        /app
+        /public
+        /tests
+        /writable
+    /codeigniter
+        /system
+        /docs
 
 This would have two apps, "foo" and "bar", both having standard application directories
 and a ``public`` folder, and sharing a common codeigniter framework.
 
 The ``index.php`` inside each application would refer to its own configuration,
-``.../app/Config/Paths.php``, and the ``$systemDirectory`` variable inside each
+``../app/Config/Paths.php``, and the ``$systemDirectory`` variable inside each
 of those would be set to refer to the shared common "system" folder.
 
 If either of the applications had a command-line component, then you would also

--- a/user_guide_src/source/incoming/restful.rst
+++ b/user_guide_src/source/incoming/restful.rst
@@ -73,10 +73,10 @@ Change the Placeholder Used
 By default, the ``segment`` placeholder is used when a resource ID is needed. You can change this by passing
 in the ``placeholder`` option with the new string to use::
 
-	$routes->resource('photos', ['placeholder' => '(:id)']);
+	$routes->resource('photos', ['placeholder' => '(:num)']);
 
 	// Generates routes like:
-	$routes->get('photos/(:id)', 'Photos::show/$1');
+	$routes->get('photos/(:num)', 'Photos::show/$1');
 
 Limit the Routes Made
 ---------------------
@@ -177,10 +177,10 @@ Change the Placeholder Used
 By default, the ``segment`` placeholder is used when a resource ID is needed. You can change this by passing
 in the ``placeholder`` option with the new string to use::
 
-	$routes->presenter('photos', ['placeholder' => '(:id)']);
+	$routes->presenter('photos', ['placeholder' => '(:num)']);
 
 	// Generates routes like:
-	$routes->get('photos/(:id)', 'Photos::show/$1');
+	$routes->get('photos/(:num)', 'Photos::show/$1');
 
 Limit the Routes Made
 ---------------------

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -257,7 +257,7 @@ separated by a double colon (::), much like you would use when writing the initi
 should be passed to the route are passed in next::
 
 	// The route is defined as:
-	$routes->add('users/(:id)/gallery(:any)', 'App\Controllers\Galleries::showUserGallery/$1/$2');
+	$routes->add('users/(:num)/gallery(:any)', 'App\Controllers\Galleries::showUserGallery/$1/$2');
 
 	// Generate the relative URL to link to user ID 15, gallery 12
 	// Generates: /users/15/gallery/12
@@ -272,7 +272,7 @@ will still work without you having to make any changes. A route is named by pass
 with the name of the route::
 
     // The route is defined as:
-    $routes->add('users/(:id)/gallery(:any)', 'Galleries::showUserGallery/$1/$2', ['as' => 'user_gallery');
+    $routes->add('users/(:num)/gallery(:any)', 'Galleries::showUserGallery/$1/$2', ['as' => 'user_gallery']);
 
     // Generate the relative URL to link to user ID 15, gallery 12
     // Generates: /users/15/gallery/12

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -487,7 +487,7 @@ at least 6 characters.”
 Translation Of Messages And Validation Labels
 =============================================
 
-To use translated strings from language files, we can simply use the dot syntax. Let's say we have a file with translations located here: ``app/Languages/en/Rules.php``. We can simply use the language lines defined in this file, like this:
+To use translated strings from language files, we can simply use the dot syntax. Let's say we have a file with translations located here: ``app/Languages/en/Rules.php``. We can simply use the language lines defined in this file, like this::
 
     $validation->setRules([
             'username' => [
@@ -716,11 +716,11 @@ alpha_space             No          Fails if field contains anything other than 
 alpha_dash              No          Fails if field contains anything other than alphanumeric characters, underscores or dashes.
 alpha_numeric           No          Fails if field contains anything other than alphanumeric characters.
 alpha_numeric_space     No          Fails if field contains anything other than alphanumeric or space characters.
-alpha_numeric_punct     No          Fails if field contains anything other than alphanumeric, space, or this limited set of 
-                                    punctuation characters: ~ (tilde), ! (exclamation), # (number), $ (dollar), % (percent), 
-                                    & (ampersand), * (asterisk), - (dash), _ (underscore), + (plus), = (equals), 
+alpha_numeric_punct     No          Fails if field contains anything other than alphanumeric, space, or this limited set of
+                                    punctuation characters: ~ (tilde), ! (exclamation), # (number), $ (dollar), % (percent),
+                                    & (ampersand), * (asterisk), - (dash), _ (underscore), + (plus), = (equals),
                                     | (vertical bar), : (colon), . (period).
-decimal                 No          Fails if field contains anything other than a decimal number. 
+decimal                 No          Fails if field contains anything other than a decimal number.
                                     Also accepts a + or  - sign for the number.
 differs                 Yes         Fails if field does not differ from the one in the parameter.                                   differs[field_name]
 exact_length            Yes         Fails if field is not exactly the parameter value. One or more comma-separated values.          exact_length[5] or exact_length[5,8,12]

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -64,11 +64,11 @@ The Form
 Using a text editor, create a form called **Signup.php**. In it, place this
 code and save it to your **app/Views/** folder::
 
-	<html>
-	<head>
-	    <title>My Form</title>
-	</head>
-	<body>
+    <html>
+    <head>
+        <title>My Form</title>
+    </head>
+    <body>
 
         <?= $validation->listErrors() ?>
 
@@ -90,8 +90,8 @@ code and save it to your **app/Views/** folder::
 
         </form>
 
-	</body>
-	</html>
+    </body>
+    </html>
 
 The Success Page
 ================================================
@@ -99,18 +99,18 @@ The Success Page
 Using a text editor, create a form called **Success.php**. In it, place
 this code and save it to your **app/Views/** folder::
 
-	<html>
-	<head>
-	    <title>My Form</title>
-	</head>
-	<body>
+    <html>
+    <head>
+        <title>My Form</title>
+    </head>
+    <body>
 
         <h3>Your form was successfully submitted!</h3>
 
         <p><?= anchor('form', 'Try it again!') ?></p>
 
-	</body>
-	</html>
+    </body>
+    </html>
 
 The Controller
 ================================================
@@ -118,43 +118,43 @@ The Controller
 Using a text editor, create a controller called **Form.php**. In it, place
 this code and save it to your **app/Controllers/** folder::
 
-	<?php namespace App\Controllers;
+    <?php namespace App\Controllers;
 
-	use CodeIgniter\Controller;
+    use CodeIgniter\Controller;
 
-	class Form extends Controller
-	{
-		public function index()
-		{
-			helper(['form', 'url']);
+    class Form extends Controller
+    {
+        public function index()
+        {
+            helper(['form', 'url']);
 
-			if (! $this->validate([]))
-			{
-				echo view('Signup', [
-					'validation' => $this->validator
-				]);
-			}
-			else
-			{
-				echo view('Success');
-			}
-		}
-	}
+            if (! $this->validate([]))
+            {
+                echo view('Signup', [
+                    'validation' => $this->validator
+                ]);
+            }
+            else
+            {
+                echo view('Success');
+            }
+        }
+    }
 
 Try it!
 ================================================
 
 To try your form, visit your site using a URL similar to this one::
 
-	example.com/index.php/form/
+    example.com/index.php/form/
 
 If you submit the form you should simply see the form reload. That's
 because you haven't set up any validation rules yet.
 
-**Since you haven't told the Validation class to validate anything
-yet, it returns false (boolean false) by default. The** ``validate()`` **method
-only returns true if it has successfully applied your rules without any
-of them failing.**
+.. note:: Since you haven't told the **Validation class** to validate anything
+    yet, it **returns false** (boolean false) **by default**. The ``validate()``
+    method only returns true if it has successfully applied your rules without
+    any of them failing.
 
 Explanation
 ================================================
@@ -171,7 +171,7 @@ The form (Signup.php) is a standard web form with a couple of exceptions:
 #. At the top of the form you'll notice the following function call:
    ::
 
-	<?= $validation->listErrors() ?>
+    <?= $validation->listErrors() ?>
 
    This function will return any error messages sent back by the
    validator. If there are no messages it returns an empty string.
@@ -417,6 +417,37 @@ you previously set, so ``setRules()``, ``setRuleGroup()`` etc. need to be repeat
         }
     }
 
+Validation Placeholders
+=======================================================
+
+The Validation class provides a simple method to replace parts of your rules based on data that's being passed into it. This
+sounds fairly obscure but can be especially handy with the ``is_unique`` validation rule. Placeholders are simply
+the name of the field (or array key) that was passed in as $data surrounded by curly brackets. It will be
+replaced by the **value** of the matched incoming field. An example should clarify this::
+
+    $validation->setRules([
+        'email' => 'required|valid_email|is_unique[users.email,id,{id}]'
+    ];
+
+In this set of rules, it states that the email address should be unique in the database, except for the row
+that has an id matching the placeholder's value. Assuming that the form POST data had the following::
+
+    $_POST = [
+        'id' => 4,
+        'email' => 'foo@example.com'
+    ]
+
+then the ``{id}`` placeholder would be replaced with the number **4**, giving this revised rule::
+
+    $validation->setRules([
+        'email' => 'required|valid_email|is_unique[users.email,id,4]'
+    ];
+
+So it will ignore the row in the database that has ``id=4`` when it verifies the email is unique.
+
+This can also be used to create more dynamic rules at runtime, as long as you take care that any dynamic
+keys passed in don't conflict with your form data.
+
 Working With Errors
 ************************************************
 
@@ -487,7 +518,9 @@ at least 6 characters.”
 Translation Of Messages And Validation Labels
 =============================================
 
-To use translated strings from language files, we can simply use the dot syntax. Let's say we have a file with translations located here: ``app/Languages/en/Rules.php``. We can simply use the language lines defined in this file, like this::
+To use translated strings from language files, we can simply use the dot syntax.
+Let's say we have a file with translations located here: ``app/Languages/en/Rules.php``.
+We can simply use the language lines defined in this file, like this::
 
     $validation->setRules([
             'username' => [
@@ -611,10 +644,10 @@ autoloader can find it. These files are called RuleSets. To add a new RuleSet, e
 add the new file to the ``$ruleSets`` array::
 
     public $ruleSets = [
-		\CodeIgniter\Validation\Rules::class,
-		\CodeIgniter\Validation\FileRules::class,
-		\CodeIgniter\Validation\CreditCardRules::class,
-	];
+        \CodeIgniter\Validation\Rules::class,
+        \CodeIgniter\Validation\FileRules::class,
+        \CodeIgniter\Validation\CreditCardRules::class,
+    ];
 
 You can add it as either a simple string with the fully qualified class name, or using the ``::class`` suffix as
 shown above. The primary benefit here is that it provides some extra navigation capabilities in more advanced IDEs.
@@ -658,41 +691,41 @@ If your method needs to work with parameters, the function will need a minimum o
 the parameter string, and an array with all of the data that was submitted the form. The $data array is especially handy
 for rules like ``require_with`` that needs to check the value of another submitted field to base its result on::
 
-	public function required_with($str, string $fields, array $data): bool
-	{
-		$fields = explode(',', $fields);
+    public function required_with($str, string $fields, array $data): bool
+    {
+        $fields = explode(',', $fields);
 
-		// If the field is present we can safely assume that
-		// the field is here, no matter whether the corresponding
-		// search field is present or not.
-		$present = $this->required($str ?? '');
+        // If the field is present we can safely assume that
+        // the field is here, no matter whether the corresponding
+        // search field is present or not.
+        $present = $this->required($str ?? '');
 
-		if ($present)
-		{
-			return true;
-		}
+        if ($present)
+        {
+            return true;
+        }
 
         // Still here? Then we fail this test if
-		// any of the fields are present in $data
-		// as $fields is the lis
-		$requiredFields = [];
+        // any of the fields are present in $data
+        // as $fields is the lis
+        $requiredFields = [];
 
-		foreach ($fields as $field)
-		{
-			if (array_key_exists($field, $data))
-			{
-				$requiredFields[] = $field;
-			}
-		}
+        foreach ($fields as $field)
+        {
+            if (array_key_exists($field, $data))
+            {
+                $requiredFields[] = $field;
+            }
+        }
 
-		// Remove any keys with empty values since, that means they
-		// weren't truly there, as far as this is concerned.
-		$requiredFields = array_filter($requiredFields, function ($item) use ($data) {
-			return ! empty($data[$item]);
-		});
+        // Remove any keys with empty values since, that means they
+        // weren't truly there, as far as this is concerned.
+        $requiredFields = array_filter($requiredFields, function ($item) use ($data) {
+            return ! empty($data[$item]);
+        });
 
-		return empty($requiredFields);
-	}
+        return empty($requiredFields);
+    }
 
 Custom errors can be returned as the fourth parameter, just as described above.
 
@@ -701,12 +734,20 @@ Available Rules
 
 The following is a list of all the native rules that are available to use:
 
-.. note:: Rule is a string; there must be no spaces between the parameters, especially the "is_unique" rule.
-	There can be no spaces before and after "ignore_value".
+.. note:: Rule is a string; there must be **no spaces** between the parameters, especially the ``is_unique`` rule.
+    There can be no spaces before and after ``ignore_value``.
 
-- "is_unique[supplier.name,uuid, $uuid]"   is not ok
-- "is_unique[supplier.name,uuid,$uuid ]"   is not ok
-- "is_unique[supplier.name,uuid,$uuid]"    is ok
+::
+
+    // is_unique[table.field,ignore_field,ignore_value]
+
+    $validation->setRules([
+        'name' => "is_unique[supplier.name,uuid, $uuid]",  // is not ok
+        'name' => "is_unique[supplier.name,uuid,$uuid ]",  // is not ok
+        'name' => "is_unique[supplier.name,uuid,$uuid]",   // is ok
+        'name' => "is_unique[supplier.name,uuid,{uuid}]",  // is ok - see "Validation Placeholders"
+    ]);
+
 
 ======================= =========== =============================================================================================== ===================================================
 Rule                    Parameter   Description                                                                                     Example
@@ -802,5 +843,5 @@ is_image                Yes         Fails if the file cannot be determined to be
 The file validation rules apply for both single and multiple file uploads.
 
 .. note:: You can also use any native PHP functions that permit up
-	to two parameters, where at least one is required (to pass
-	the field data).
+    to two parameters, where at least one is required (to pass
+    the field data).

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -364,19 +364,17 @@ Or pass all settings in an array::
     {
         public $signup = [
             'username' => [
-                'label'  => 'Username',
                 'rules'  => 'required',
                 'errors' => [
-                    'required' => 'You must choose a {field}.'
+                    'required' => 'You must choose a Username.'
                 ]
             ],
-            'email'    => 'required|valid_email'
-        ];
-
-        public $signup_errors = [
-            'email' => [
-                'valid_email' => 'Please check the Email field. It does not appear to be valid.'
-            ]
+            'email'    => [
+                'rules'  => 'required|valid_email',
+                'errors' => [
+                    'valid_email' => 'Please check the Email field. It does not appear to be valid.'
+                ]
+            ],
         ];
     }
 

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -562,37 +562,6 @@ value an array of fieldnames of interest.::
     // get the rules for only the "city" and "state" fields
     $rules = $model->getValidationRules(['only' => ['city', 'state']]);
 
-Validation Placeholders
------------------------
-
-The model provides a simple method to replace parts of your rules based on data that's being passed into it. This
-sounds fairly obscure but can be especially handy with the ``is_unique`` validation rule. Placeholders are simply
-the name of the field (or array key) that was passed in as $data surrounded by curly brackets. It will be
-replaced by the **value** of the matched incoming field. An example should clarify this::
-
-    protected $validationRules = [
-        'email' => 'required|valid_email|is_unique[users.email,id,{id}]'
-    ];
-
-In this set of rules, it states that the email address should be unique in the database, except for the row
-that has an id matching the placeholder's value. Assuming that the form POST data had the following::
-
-    $_POST = [
-        'id' => 4,
-        'email' => 'foo@example.com'
-    ]
-
-then the ``{id}`` placeholder would be replaced with the number **4**, giving this revised rule::
-
-    protected $validationRules = [
-        'email' => 'required|valid_email|is_unique[users.email,id,4]'
-    ];
-
-So it will ignore the row in the database that has ``id=4`` when it verifies the email is unique.
-
-This can also be used to create more dynamic rules at runtime, as long as you take care that any dynamic
-keys passed in don't conflict with your form data.
-
 Protecting Fields
 -----------------
 

--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -61,7 +61,7 @@ validation <../libraries/validation>` library to do this.
         {
             $model->save([
                 'title' => $this->request->getVar('title'),
-                'slug'  => url_title($this->request->getVar('title')),
+                'slug'  => url_title($this->request->getVar('title'), '-', TRUE),
                 'body'  => $this->request->getVar('body'),
             ]);
 


### PR DESCRIPTION
This are another take on #2817 and the PR #2819 to fix it.

There have been a couple of posts in the forum wanting/trying to use placeholders, but it's limited to Models. It's such a nice feature that it should be available in any form of validation.

Now people can e.g. store a rule in their config file and pass it along from the controller.

- Moved fillPlaceholders from Model into Validation
- Added test for is_unique with placeholder. I think one are enough, it either works or it dosen't with `$this->validation->run()`, as all function depending on validation are ending up in the the run() function.
- Moved "Validation Placeholders" from the Model userguide into Validation.
- "Translation Of Messages And Validation Labels" never got rendered in Validation userguide.
- Fixed some indention in Validation userguide. "tabs" gives 8 spaces, instead of 4.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
  
