### PR TITLE
[ci skip] fix warnings on compiling user guide

### DIFF
--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -487,7 +487,7 @@ at least 6 characters.”
 Translation Of Messages And Validation Labels
 =============================================
 
-To use translated strings from language files, we can simply use the dot syntax. Let's say we have a file with translations located here: ``app/Languages/en/Rules.php``. We can simply use the language lines defined in this file, like this:
+To use translated strings from language files, we can simply use the dot syntax. Let's say we have a file with translations located here: ``app/Languages/en/Rules.php``. We can simply use the language lines defined in this file, like this::
 
     $validation->setRules([
             'username' => [
@@ -716,11 +716,11 @@ alpha_space             No          Fails if field contains anything other than 
 alpha_dash              No          Fails if field contains anything other than alphanumeric characters, underscores or dashes.
 alpha_numeric           No          Fails if field contains anything other than alphanumeric characters.
 alpha_numeric_space     No          Fails if field contains anything other than alphanumeric or space characters.
-alpha_numeric_punct     No          Fails if field contains anything other than alphanumeric, space, or this limited set of 
-                                    punctuation characters: ~ (tilde), ! (exclamation), # (number), $ (dollar), % (percent), 
-                                    & (ampersand), * (asterisk), - (dash), _ (underscore), + (plus), = (equals), 
+alpha_numeric_punct     No          Fails if field contains anything other than alphanumeric, space, or this limited set of
+                                    punctuation characters: ~ (tilde), ! (exclamation), # (number), $ (dollar), % (percent),
+                                    & (ampersand), * (asterisk), - (dash), _ (underscore), + (plus), = (equals),
                                     | (vertical bar), : (colon), . (period).
-decimal                 No          Fails if field contains anything other than a decimal number. 
+decimal                 No          Fails if field contains anything other than a decimal number.
                                     Also accepts a + or  - sign for the number.
 differs                 Yes         Fails if field does not differ from the one in the parameter.                                   differs[field_name]
 exact_length            Yes         Fails if field is not exactly the parameter value. One or more comma-separated values.          exact_length[5] or exact_length[5,8,12]


### PR DESCRIPTION
Fixes 9 warnings emitted by `make html` when compiling the user guide. Error is found in the syntax of `validation.rst`

**Description**
Warnings thrown are as follows:
* user_guide_src\source\libraries\validation.rst:497: WARNING: Unexpected indentation.
* user_guide_src\source\libraries\validation.rst:498: WARNING: Block quote ends without a blank line; unexpected unindent.
* user_guide_src\source\libraries\validation.rst:499: WARNING: Definition list ends without a blank line; unexpected unindent.
* user_guide_src\source\libraries\validation.rst:501: WARNING: Unexpected indentation.       
* user_guide_src\source\libraries\validation.rst:504: WARNING: Unexpected indentation.       
* user_guide_src\source\libraries\validation.rst:505: WARNING: Block quote ends without a blank line; unexpected unindent.
* user_guide_src\source\libraries\validation.rst:506: WARNING: Block quote ends without a blank line; unexpected unindent.
* user_guide_src\source\libraries\validation.rst:507: WARNING: Block quote ends without a blank line; unexpected unindent.
* user_guide_src\source\libraries\validation.rst:508: WARNING: Definition list ends without a blank line; unexpected unindent.

These warnings are fixed by adding another colon at the end of line 490.

**Checklist:**
- [x] Securely signed commits
- [x] User guide updated