### PR TITLE
[ci skip] route placeholders 'id' to 'num'

### DIFF
--- a/user_guide_src/source/incoming/restful.rst
+++ b/user_guide_src/source/incoming/restful.rst
@@ -73,10 +73,10 @@ Change the Placeholder Used
 By default, the ``segment`` placeholder is used when a resource ID is needed. You can change this by passing
 in the ``placeholder`` option with the new string to use::
 
-	$routes->resource('photos', ['placeholder' => '(:id)']);
+	$routes->resource('photos', ['placeholder' => '(:num)']);
 
 	// Generates routes like:
-	$routes->get('photos/(:id)', 'Photos::show/$1');
+	$routes->get('photos/(:num)', 'Photos::show/$1');
 
 Limit the Routes Made
 ---------------------
@@ -177,10 +177,10 @@ Change the Placeholder Used
 By default, the ``segment`` placeholder is used when a resource ID is needed. You can change this by passing
 in the ``placeholder`` option with the new string to use::
 
-	$routes->presenter('photos', ['placeholder' => '(:id)']);
+	$routes->presenter('photos', ['placeholder' => '(:num)']);
 
 	// Generates routes like:
-	$routes->get('photos/(:id)', 'Photos::show/$1');
+	$routes->get('photos/(:num)', 'Photos::show/$1');
 
 Limit the Routes Made
 ---------------------

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -272,7 +272,7 @@ will still work without you having to make any changes. A route is named by pass
 with the name of the route::
 
     // The route is defined as:
-    $routes->add('users/(:num)/gallery(:any)', 'Galleries::showUserGallery/$1/$2', ['as' => 'user_gallery');
+    $routes->add('users/(:num)/gallery(:any)', 'Galleries::showUserGallery/$1/$2', ['as' => 'user_gallery']);
 
     // Generate the relative URL to link to user ID 15, gallery 12
     // Generates: /users/15/gallery/12

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -257,7 +257,7 @@ separated by a double colon (::), much like you would use when writing the initi
 should be passed to the route are passed in next::
 
 	// The route is defined as:
-	$routes->add('users/(:id)/gallery(:any)', 'App\Controllers\Galleries::showUserGallery/$1/$2');
+	$routes->add('users/(:num)/gallery(:any)', 'App\Controllers\Galleries::showUserGallery/$1/$2');
 
 	// Generate the relative URL to link to user ID 15, gallery 12
 	// Generates: /users/15/gallery/12
@@ -272,7 +272,7 @@ will still work without you having to make any changes. A route is named by pass
 with the name of the route::
 
     // The route is defined as:
-    $routes->add('users/(:id)/gallery(:any)', 'Galleries::showUserGallery/$1/$2', ['as' => 'user_gallery');
+    $routes->add('users/(:num)/gallery(:any)', 'Galleries::showUserGallery/$1/$2', ['as' => 'user_gallery');
 
     // Generate the relative URL to link to user ID 15, gallery 12
     // Generates: /users/15/gallery/12


### PR DESCRIPTION
fix : #2889  #2888
```
	/**
	 * Defined placeholders that can be used
	 * within the
	 *
	 * @var array
	 */
	protected $placeholders = [
		'any'      => '.*',
		'segment'  => '[^/]+',
		'alphanum' => '[a-zA-Z0-9]+',
		'num'      => '[0-9]+',
		'alpha'    => '[a-zA-Z]+',
		'hash'     => '[^/]+',
	];
```