### PR TITLE
Update of the pagination template to make the correct use of the locale

### DIFF
--- a/system/Pager/Views/default_full.php
+++ b/system/Pager/Views/default_full.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var \CodeIgniter\Pager\PagerRenderer $pager
  */
@@ -16,7 +17,7 @@ $pager->setSurroundCount(2);
 			</li>
 			<li>
 				<a href="<?= $pager->getPrevious() ?>" aria-label="<?= lang('Pager.previous') ?>">
-					<span aria-hidden="true">&laquo;</span>
+					<span aria-hidden="true"><?= lang('Pager.previous') ?></span>
 				</a>
 			</li>
 		<?php endif ?>
@@ -32,7 +33,7 @@ $pager->setSurroundCount(2);
 		<?php if ($pager->hasNext()) : ?>
 			<li>
 				<a href="<?= $pager->getNext() ?>" aria-label="<?= lang('Pager.next') ?>">
-					<span aria-hidden="true">&raquo;</span>
+					<span aria-hidden="true"><?= lang('Pager.next') ?></span>
 				</a>
 			</li>
 			<li>


### PR DESCRIPTION
**Description**
This PR corrects the following problems:

- issue #2875, where the next and previous links did not use language information, always maintaining a standard format

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
