### PR TITLE
Added ability to delete row with string primary key via Model::delete($id)

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -898,15 +898,15 @@ class Model
 	 * Deletes a single record from $this->table where $id matches
 	 * the table's primaryKey
 	 *
-	 * @param integer|array|null $id    The rows primary key(s)
-	 * @param boolean            $purge Allows overriding the soft deletes setting.
+	 * @param integer|string|array|null $id    The rows primary key(s)
+	 * @param boolean                   $purge Allows overriding the soft deletes setting.
 	 *
 	 * @return mixed
 	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
 	 */
 	public function delete($id = null, bool $purge = false)
 	{
-		if (! empty($id) && is_numeric($id))
+		if (! empty($id) && (is_numeric($id) || is_string($id)))
 		{
 			$id = [$id];
 		}

--- a/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
+++ b/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
@@ -130,6 +130,17 @@ class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
 		]);
 		$this->forge->addKey('id', true);
 		$this->forge->createTable('secondary', true);
+
+		// Stringify Primary key Table
+		$this->forge->addField([
+			'id'    => [
+				'type'       => 'VARCHAR',
+				'constraint' => 3,
+			],
+			'value' => ['type' => 'TEXT'],
+		]);
+		$this->forge->addKey('id', true);
+		$this->forge->createTable('stringifypkey', true);
 	}
 
 	//--------------------------------------------------------------------
@@ -141,6 +152,7 @@ class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
 		$this->forge->dropTable('misc', true);
 		$this->forge->dropTable('empty', true);
 		$this->forge->dropTable('secondary', true);
+		$this->forge->dropTable('stringifypkey', true);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/_support/Database/Seeds/CITestSeeder.php
+++ b/tests/_support/Database/Seeds/CITestSeeder.php
@@ -6,7 +6,7 @@ class CITestSeeder extends \CodeIgniter\Database\Seeder
 	{
 		// Job Data
 		$data = [
-			'user' => [
+			'user'          => [
 				[
 					'name'    => 'Derek Jones',
 					'email'   => 'derek@world.com',
@@ -28,7 +28,7 @@ class CITestSeeder extends \CodeIgniter\Database\Seeder
 					'country' => 'UK',
 				],
 			],
-			'job'  => [
+			'job'           => [
 				[
 					'name'        => 'Developer',
 					'description' => 'Awesome job, but sometimes makes you bored',
@@ -46,7 +46,7 @@ class CITestSeeder extends \CodeIgniter\Database\Seeder
 					'description' => 'Only Coldplay can actually called Musician',
 				],
 			],
-			'misc' => [
+			'misc'          => [
 				[
 					'key'   => '\\xxxfoo456',
 					'value' => 'Entry with \\xxx',
@@ -58,6 +58,12 @@ class CITestSeeder extends \CodeIgniter\Database\Seeder
 				[
 					'key'   => 'spaces and tabs',
 					'value' => ' One  two   three	tab',
+				],
+			],
+			'stringifypkey' => [
+				[
+					'id'    => 'A01',
+					'value' => 'test',
 				],
 			],
 		];

--- a/tests/_support/Models/StringifyPkeyModel.php
+++ b/tests/_support/Models/StringifyPkeyModel.php
@@ -1,0 +1,9 @@
+<?php namespace Tests\Support\Models;
+
+use CodeIgniter\Model;
+
+class StringifyPkeyModel extends Model
+{
+	protected $table      = 'stringifypkey';
+	protected $returnType = 'object';
+}

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -23,14 +23,15 @@ class MetadataTest extends CIDatabaseTestCase
 		parent::setUp();
 
 		// Prepare the array of expected tables once
-		$prefix = $this->db->getPrefix();
+		$prefix               = $this->db->getPrefix();
 		$this->expectedTables = [
 			$prefix . 'migrations',
 			$prefix . 'user',
 			$prefix . 'job',
 			$prefix . 'misc',
 			$prefix . 'empty',
-			$prefix . 'secondary'
+			$prefix . 'secondary',
+			$prefix . 'stringifypkey',
 		];
 	}
 
@@ -62,8 +63,14 @@ class MetadataTest extends CIDatabaseTestCase
 
 		// Create a table with the new prefix
 		$fields = [
-			'name'       => ['type' => 'varchar', 'constraint' => 31],
-			'created_at' => ['type' => 'datetime', 'null' => true],
+			'name'       => [
+				'type'       => 'varchar',
+				'constraint' => 31,
+			],
+			'created_at' => [
+				'type' => 'datetime',
+				'null' => true,
+			],
 		];
 		$this->forge->addField($fields);
 		$this->forge->createTable('widgets');

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -14,6 +14,7 @@ use Tests\Support\Models\EventModel;
 use Tests\Support\Models\JobModel;
 use Tests\Support\Models\SecondaryModel;
 use Tests\Support\Models\SimpleEntity;
+use Tests\Support\Models\StringifyPkeyModel;
 use Tests\Support\Models\UserModel;
 use Tests\Support\Models\ValidErrorsModel;
 use Tests\Support\Models\ValidModel;
@@ -395,6 +396,19 @@ class ModelTest extends CIDatabaseTestCase
 		$model->delete(1);
 
 		$this->dontSeeInDatabase('job', ['name' => 'Developer']);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testDeleteStringPrimaryKey()
+	{
+		$model = new StringifyPkeyModel();
+
+		$this->seeInDatabase('stringifypkey', ['value' => 'test']);
+
+		$model->delete('A01');
+
+		$this->dontSeeInDatabase('stringifypkey', ['value' => 'test']);
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
To make enable  to delete row with string primary key via Model::delete($id) 

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
