### PR TITLE
New features for pagination

### DIFF
--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -343,4 +343,78 @@ class PagerRenderer
 	}
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * Checks to see if there is a "previous" page before our "first" page.
+	 *
+	 * @return boolean
+	 */
+	public function hasPreviousPage(): bool
+	{
+		return $this->current > 1;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns a URL to the "previous" page.
+	 *
+	 * You MUST call hasPreviousPage() first, or this value may be invalid.
+	 *
+	 * @return string|null
+	 */
+	public function getPreviousPage()
+	{
+		if (!$this->hasPreviousPage()) {
+			return null;
+		}
+
+		$uri = clone $this->uri;
+
+		if ($this->segment === 0) {
+			$uri->addQuery($this->pageSelector, $this->current - 1);
+		} else {
+			$uri->setSegment($this->segment, $this->current - 1);
+		}
+
+		return (string) $uri;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Checks to see if there is a "next" page after our "last" page.
+	 *
+	 * @return boolean
+	 */
+	public function hasNextPage(): bool
+	{
+		return $this->current < $this->last;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns a URL to the "next" page.
+	 *
+	 * You MUST call hasNextPage() first, or this value may be invalid.
+	 *
+	 * @return string|null
+	 */
+	public function getNextPage()
+	{
+		if (!$this->hasNextPage()) {
+			return null;
+		}
+
+		$uri = clone $this->uri;
+
+		if ($this->segment === 0) {
+			$uri->addQuery($this->pageSelector, $this->current + 1);
+		} else {
+			$uri->setSegment($this->segment, $this->current + 1);
+		}
+
+		return (string) $uri;
+	}
 }

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Pager;
+<?php
+
+namespace CodeIgniter\Pager;
 
 use CodeIgniter\HTTP\URI;
 
@@ -243,7 +245,7 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 			'uri'         => $uri,
 			'pageCount'   => 10, // 10 pages
 			'currentPage' => 4,
-			'total'       => 100,// 100 records, so 10 per page
+			'total'       => 100, // 100 records, so 10 per page
 		];
 
 		$pager = new PagerRenderer($details);
@@ -451,4 +453,73 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('http://example.com/foo/50?foo=bar', $pager->getLast());
 	}
 
+	//--------------------------------------------------------------------
+
+	public function testHasPreviousPageReturnsFalseWhenCurrentPageIsFirst()
+	{
+		$details = [
+			'uri'         => $this->uri,
+			'pageCount'   => 5,
+			'currentPage' => 1,
+			'total'       => 100
+		];
+
+		$pager = new PagerRenderer($details);
+
+		$this->assertFalse($pager->hasPreviousPage());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testHasNextPageReturnsFalseWhenCurrentPageIsLast()
+	{
+		$details = [
+			'uri'         => $this->uri,
+			'pageCount'   => 5,
+			'currentPage' => 5,
+			'total'       => 100
+		];
+
+		$pager = new PagerRenderer($details);
+
+		$this->assertFalse($pager->hasNextPage());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testHasPreviousPageReturnsTrueWhenFirstIsMoreThanCurrent()
+	{
+		$uri = $this->uri;
+
+		$details = [
+			'uri'         => $uri,
+			'pageCount'   => 10,
+			'currentPage' => 3,
+			'total'       => 100
+		];
+
+		$pager = new PagerRenderer($details);
+
+		$this->assertTrue($pager->hasPreviousPage());
+		$this->assertEquals('http://example.com/foo?page=2', $pager->getPreviousPage());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testHasNextPageReturnsTrueWhenLastIsMoreThanCurrent()
+	{
+		$uri = $this->uri;
+
+		$details = [
+			'uri'         => $uri,
+			'pageCount'   => 10,
+			'currentPage' => 3,
+			'total'       => 100
+		];
+
+		$pager = new PagerRenderer($details);
+
+		$this->assertTrue($pager->hasNextPage());
+		$this->assertEquals('http://example.com/foo?page=4', $pager->getNextPage());
+	}
 }

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -466,6 +466,7 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$pager = new PagerRenderer($details);
 
+		$this->assertNull($pager->getPreviousPage());
 		$this->assertFalse($pager->hasPreviousPage());
 	}
 
@@ -482,6 +483,7 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$pager = new PagerRenderer($details);
 
+		$this->assertNull($pager->getNextPage());
 		$this->assertFalse($pager->hasNextPage());
 	}
 
@@ -500,6 +502,7 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$pager = new PagerRenderer($details);
 
+		$this->assertNotNull($pager->getPreviousPage());
 		$this->assertTrue($pager->hasPreviousPage());
 		$this->assertEquals('http://example.com/foo?page=2', $pager->getPreviousPage());
 	}
@@ -519,6 +522,7 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$pager = new PagerRenderer($details);
 
+		$this->assertNotNull($pager->getNextPage());
 		$this->assertTrue($pager->hasNextPage());
 		$this->assertEquals('http://example.com/foo?page=4', $pager->getNextPage());
 	}


### PR DESCRIPTION
**Description**
The new features comprise a set of methods that will allow the user to build a pagination structure following the traditional way, where "next" and "prev" advance or return to a page and not to a group of pagination links as is the default.

Added methods:

- `hasPreviousPage:` checks if there is a page before the current page
- `getPreviousPage:` retrieves the URI of the page prior to the current page
- `hasNextPage:` checks if there is a page after the current page
- `getNextPage:` retrieves the page's URI after the current page

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide