### PR TITLE
Update CLI and added new class `CLIOutput`

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -39,8 +39,6 @@
 
 namespace CodeIgniter\CLI;
 
-use CodeIgniter\CLI\Exceptions\CLIException;
-
 /**
  * Set of static methods useful for CLI request handling.
  *
@@ -86,47 +84,6 @@ class CLI
 	protected static $initialized = false;
 
 	/**
-	 * Foreground color list
-	 *
-	 * @var array
-	 */
-	protected static $foreground_colors = [
-		'black'        => '0;30',
-		'dark_gray'    => '1;30',
-		'blue'         => '0;34',
-		'dark_blue'    => '1;34',
-		'light_blue'   => '1;34',
-		'green'        => '0;32',
-		'light_green'  => '1;32',
-		'cyan'         => '0;36',
-		'light_cyan'   => '1;36',
-		'red'          => '0;31',
-		'light_red'    => '1;31',
-		'purple'       => '0;35',
-		'light_purple' => '1;35',
-		'light_yellow' => '0;33',
-		'yellow'       => '1;33',
-		'light_gray'   => '0;37',
-		'white'        => '1;37',
-	];
-
-	/**
-	 * Background color list
-	 *
-	 * @var array
-	 */
-	protected static $background_colors = [
-		'black'      => '40',
-		'red'        => '41',
-		'green'      => '42',
-		'yellow'     => '43',
-		'blue'       => '44',
-		'magenta'    => '45',
-		'cyan'       => '46',
-		'light_gray' => '47',
-	];
-
-	/**
 	 * List of array segments.
 	 *
 	 * @var array
@@ -137,15 +94,6 @@ class CLI
 	 * @var array
 	 */
 	protected static $options = [];
-
-	/**
-	 * Helps track internally whether the last
-	 * output was a "write" or a "print" to
-	 * keep the output clean and as expected.
-	 *
-	 * @var string
-	 */
-	protected static $lastWrite;
 
 	//--------------------------------------------------------------------
 
@@ -304,17 +252,13 @@ class CLI
 	 * @param string      $text
 	 * @param string|null $foreground
 	 * @param string|null $background
+	 *
+	 * @deprecated         Use `CLIOutput::print()` instead
+	 * @codeCoverageIgnore
 	 */
 	public static function print(string $text = '', string $foreground = null, string $background = null)
 	{
-		if ($foreground || $background)
-		{
-			$text = static::color($text, $foreground, $background);
-		}
-
-		static::$lastWrite = null;
-
-		fwrite(STDOUT, $text);
+		(new CLIOutput())->print($text, $foreground, $background);
 	}
 
 	/**
@@ -323,21 +267,13 @@ class CLI
 	 * @param string $text       The text to output
 	 * @param string $foreground
 	 * @param string $background
+	 *
+	 * @deprecated         Use `CLIOutput::write()` instead
+	 * @codeCoverageIgnore
 	 */
 	public static function write(string $text = '', string $foreground = null, string $background = null)
 	{
-		if ($foreground || $background)
-		{
-			$text = static::color($text, $foreground, $background);
-		}
-
-		if (static::$lastWrite !== 'write')
-		{
-			$text              = PHP_EOL . $text;
-			static::$lastWrite = 'write';
-		}
-
-		fwrite(STDOUT, $text . PHP_EOL);
+		(new CLIOutput())->write($text, $foreground, $background);
 	}
 
 	//--------------------------------------------------------------------
@@ -348,15 +284,13 @@ class CLI
 	 * @param string|array $text       The text to output, or array of errors
 	 * @param string       $foreground
 	 * @param string       $background
+	 *
+	 * @deprecated         Use `CLIOutput::error()` instead
+	 * @codeCoverageIgnore
 	 */
 	public static function error(string $text, string $foreground = 'light_red', string $background = null)
 	{
-		if ($foreground || $background)
-		{
-			$text = static::color($text, $foreground, $background);
-		}
-
-		fwrite(STDERR, $text . PHP_EOL);
+		(new CLIOutput())->error($text, $foreground, $background);
 	}
 
 	//--------------------------------------------------------------------
@@ -379,36 +313,13 @@ class CLI
 	 *
 	 * @param integer $seconds   Number of seconds
 	 * @param boolean $countdown Show a countdown or not
+	 *
+	 * @deprecated         Use `CLIOutput::wait()` instead
+	 * @codeCoverageIgnore
 	 */
 	public static function wait(int $seconds, bool $countdown = false)
 	{
-		if ($countdown === true)
-		{
-			$time = $seconds;
-
-			while ($time > 0)
-			{
-				fwrite(STDOUT, $time . '... ');
-				sleep(1);
-				$time --;
-			}
-			static::write();
-		}
-		else
-		{
-			if ($seconds > 0)
-			{
-				sleep($seconds);
-			}
-			else
-			{
-				// this chunk cannot be tested because of keyboard input
-				// @codeCoverageIgnoreStart
-				static::write(static::$wait_msg);
-				static::input();
-				// @codeCoverageIgnoreEnd
-			}
-		}
+		(new CLIOutput())->wait($seconds, $countdown);
 	}
 
 	//--------------------------------------------------------------------
@@ -430,15 +341,13 @@ class CLI
 	 *
 	 * @param integer $num Number of lines to output
 	 *
-	 * @return void
+	 * @return             void
+	 * @deprecated         Use `CLIOutput::newLine()` instead
+	 * @codeCoverageIgnore
 	 */
 	public static function newLine(int $num = 1)
 	{
-		// Do it once or more, write with empty string gives us a new line
-		for ($i = 0; $i < $num; $i ++)
-		{
-			static::write();
-		}
+		(new CLIOutput())->newLine($num);
 	}
 
 	//--------------------------------------------------------------------
@@ -447,17 +356,12 @@ class CLI
 	 * Clears the screen of output
 	 *
 	 * @return             void
+	 * @deprecated         Use `CLIOutput::clearScreen()` instead
 	 * @codeCoverageIgnore
 	 */
 	public static function clearScreen()
 	{
-		static::isWindows()
-
-				// Windows is a bit crap at this, but their terminal is tiny so shove this in
-						? static::newLine(40)
-
-				// Anything with a flair of Unix will handle these magic characters
-						: fwrite(STDOUT, chr(27) . '[H' . chr(27) . '[2J');
+		(new CLIOutput())->clearScreen();
 	}
 
 	//--------------------------------------------------------------------
@@ -469,42 +373,89 @@ class CLI
 	 * @param string $text       The text to color
 	 * @param string $foreground The foreground color
 	 * @param string $background The background color
-	 * @param string $format     Other formatting to apply. Currently only 'underline' is understood
+	 * @param string $format     Other formatting to apply.
 	 *
-	 * @return string    The color coded string
+	 * @return             string    The color coded string
+	 * @deprecated         Use `CLIOutput::color()` instead
+	 * @codeCoverageIgnore
 	 */
-	public static function color(string $text, string $foreground, string $background = null, string $format = null): string
+	public static function color(string $text, string $foreground = null, string $background = null, string $format = null): string
 	{
-		if (static::isWindows() && ! isset($_SERVER['ANSICON']))
+		$foreground = self::translateForegroundColors($foreground);
+		$background = self::translateBackgroundColors($background);
+		$format     = self::translateOption($format);
+
+		return (new CLIOutput())->color($text, $foreground, $background, $format);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Translate the foreground colors from the old list to
+	 * the new list of colors by CLIOutput.
+	 *
+	 * @param string|null $color
+	 *
+	 * @return   string|null
+	 * @internal Used only to prevent BC break
+	 */
+	private static function translateForegroundColors(?string $color): ?string
+	{
+		if ($color === null)
 		{
-			// @codeCoverageIgnoreStart
-			return $text;
-			// @codeCoverageIgnoreEnd
+			return null;
 		}
 
-		if (! array_key_exists($foreground, static::$foreground_colors))
+		$fgTrans = [
+			'dark_gray'    => 'bright_black',
+			'light_red'    => 'bright_red',
+			'light_green'  => 'bright_green',
+			'light_yellow' => 'bright_yellow',
+			'light_blue'   => 'bright_blue',
+			'light_purple' => 'bright_magenta',
+			'light_cyan'   => 'bright_cyan',
+			'white'        => 'bright_white',
+			'light_gray'   => 'white',
+		];
+
+		return strtr($color, $fgTrans);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Translate the background colors from the old list
+	 * to the new list by CLIOutput.
+	 *
+	 * @param string|null $color
+	 *
+	 * @return   string|null
+	 * @internal Used only to prevent BC break
+	 */
+	private static function translateBackgroundColors(?string $color): ?string
+	{
+		if ($color === null)
 		{
-			throw CLIException::forInvalidColor('foreground', $foreground);
+			return null;
 		}
 
-		if ($background !== null && ! array_key_exists($background, static::$background_colors))
-		{
-			throw CLIException::forInvalidColor('background', $background);
-		}
+		return strtr($color, ['light_gray' => 'white']);
+	}
 
-		$string = "\033[" . static::$foreground_colors[$foreground] . 'm';
+	//--------------------------------------------------------------------
 
-		if ($background !== null)
-		{
-			$string .= "\033[" . static::$background_colors[$background] . 'm';
-		}
-
-		if ($format === 'underline')
-		{
-			$string .= "\033[4m";
-		}
-
-		return $string . ($text . "\033[0m");
+	/**
+	 * Used to translate options written as string
+	 * to the required array format.
+	 *
+	 * @param string|null $option
+	 *
+	 * @return   array
+	 * @internal Used to prevent BC break
+	 */
+	private static function translateOption(?string $option): array
+	{
+		return $option !== null ? [$option] : [];
 	}
 
 	//--------------------------------------------------------------------
@@ -515,27 +466,13 @@ class CLI
 	 *
 	 * @param string $string
 	 *
-	 * @return integer
+	 * @return             integer
+	 * @deprecated         Use `CLIOutput::strlen()` instead
+	 * @codeCoverageIgnore
 	 */
 	public static function strlen(?string $string): int
 	{
-		if (is_null($string))
-		{
-			return 0;
-		}
-		foreach (static::$foreground_colors as $color)
-		{
-			$string = strtr($string, ["\033[" . $color . 'm' => '']);
-		}
-
-		foreach (static::$background_colors as $color)
-		{
-			$string = strtr($string, ["\033[" . $color . 'm' => '']);
-		}
-
-		$string = strtr($string, ["\033[4m" => '', "\033[0m" => '']);
-
-		return mb_strlen($string);
+		return CLIOutput::strlen($string);
 	}
 
 	//--------------------------------------------------------------------
@@ -592,36 +529,13 @@ class CLI
 	 *
 	 * @param integer|boolean $thisStep
 	 * @param integer         $totalSteps
+	 *
+	 * @deprecated         Use `CLIOutput::showProgress()` instead
+	 * @codeCoverageIgnore
 	 */
 	public static function showProgress($thisStep = 1, int $totalSteps = 10)
 	{
-		static $inProgress = false;
-
-		// restore cursor position when progress is continuing.
-		if ($inProgress !== false && $inProgress <= $thisStep)
-		{
-			fwrite(STDOUT, "\033[1A");
-		}
-		$inProgress = $thisStep;
-
-		if ($thisStep !== false)
-		{
-			// Don't allow div by zero or negative numbers....
-			$thisStep   = abs($thisStep);
-			$totalSteps = $totalSteps < 1 ? 1 : $totalSteps;
-
-			$percent = intval(($thisStep / $totalSteps) * 100);
-			$step    = (int) round($percent / 10);
-
-			// Write the progress bar
-			fwrite(STDOUT, "[\033[32m" . str_repeat('#', $step) . str_repeat('.', 10 - $step) . "\033[0m]");
-			// Textual representation...
-			fwrite(STDOUT, sprintf(' %3d%% Complete', $percent) . PHP_EOL);
-		}
-		else
-		{
-			fwrite(STDOUT, "\007");
-		}
+		(new CLIOutput())->showProgress($thisStep, $totalSteps);
 	}
 
 	//--------------------------------------------------------------------
@@ -650,12 +564,12 @@ class CLI
 
 		if ($max === 0)
 		{
-			$max = CLI::getWidth();
+			$max = static::getWidth();
 		}
 
-		if (CLI::getWidth() < $max)
+		if (static::getWidth() < $max)
 		{
-			$max = CLI::getWidth();
+			$max = static::getWidth();
 		}
 
 		$max = $max - $pad_left;
@@ -664,7 +578,7 @@ class CLI
 
 		if ($pad_left > 0)
 		{
-			$lines = explode(PHP_EOL, $lines);
+			$lines = explode("\n", $lines);
 
 			$first = true;
 
@@ -679,10 +593,27 @@ class CLI
 				}
 			});
 
-			$lines = implode(PHP_EOL, $lines);
+			$lines = implode("\n", $lines);
 		}
 
 		return $lines;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns a well formatted table
+	 *
+	 * @param array $tbody List of rows
+	 * @param array $thead List of columns
+	 *
+	 * @return             void
+	 * @deprecated         Use `CLIOutput::table()` instead
+	 * @codeCoverageIgnore
+	 */
+	public static function table(array $tbody, array $thead = [])
+	{
+		(new CLIOutput())->table($tbody, $thead);
 	}
 
 	//--------------------------------------------------------------------
@@ -842,110 +773,6 @@ class CLI
 		}
 
 		return $out;
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Returns a well formatted table
-	 *
-	 * @param array $tbody List of rows
-	 * @param array $thead List of columns
-	 *
-	 * @return void
-	 */
-	public static function table(array $tbody, array $thead = [])
-	{
-		// All the rows in the table will be here until the end
-		$table_rows = [];
-
-		// We need only indexes and not keys
-		if (! empty($thead))
-		{
-			$table_rows[] = array_values($thead);
-		}
-
-		foreach ($tbody as $tr)
-		{
-			$table_rows[] = array_values($tr);
-		}
-
-		// Yes, it really is necessary to know this count
-		$total_rows = count($table_rows);
-
-		// Store all columns lengths
-		// $all_cols_lengths[row][column] = length
-		$all_cols_lengths = [];
-
-		// Store maximum lengths by column
-		// $max_cols_lengths[column] = length
-		$max_cols_lengths = [];
-
-		// Read row by row and define the longest columns
-		for ($row = 0; $row < $total_rows; $row ++)
-		{
-			$column = 0; // Current column index
-			foreach ($table_rows[$row] as $col)
-			{
-				// Sets the size of this column in the current row
-				$all_cols_lengths[$row][$column] = static::strlen($col);
-
-				// If the current column does not have a value among the larger ones
-				// or the value of this is greater than the existing one
-				// then, now, this assumes the maximum length
-				if (! isset($max_cols_lengths[$column]) || $all_cols_lengths[$row][$column] > $max_cols_lengths[$column])
-				{
-					$max_cols_lengths[$column] = $all_cols_lengths[$row][$column];
-				}
-
-				// We can go check the size of the next column...
-				$column ++;
-			}
-		}
-
-		// Read row by row and add spaces at the end of the columns
-		// to match the exact column length
-		for ($row = 0; $row < $total_rows; $row ++)
-		{
-			$column = 0;
-			foreach ($table_rows[$row] as $col)
-			{
-				$diff = $max_cols_lengths[$column] - static::strlen($col);
-				if ($diff)
-				{
-					$table_rows[$row][$column] = $table_rows[$row][$column] . str_repeat(' ', $diff);
-				}
-				$column ++;
-			}
-		}
-
-		$table = '';
-
-		// Joins columns and append the well formatted rows to the table
-		for ($row = 0; $row < $total_rows; $row ++)
-		{
-			// Set the table border-top
-			if ($row === 0)
-			{
-				$cols = '+';
-				foreach ($table_rows[$row] as $col)
-				{
-					$cols .= str_repeat('-', static::strlen($col) + 2) . '+';
-				}
-				$table .= $cols . PHP_EOL;
-			}
-
-			// Set the columns borders
-			$table .= '| ' . implode(' | ', $table_rows[$row]) . ' |' . PHP_EOL;
-
-			// Set the thead and table borders-bottom
-			if ($row === 0 && ! empty($thead) || $row + 1 === $total_rows)
-			{
-				$table .= $cols . PHP_EOL;
-			}
-		}
-
-		static::write($table);
 	}
 
 	//--------------------------------------------------------------------

--- a/system/CLI/CLIOutput.php
+++ b/system/CLI/CLIOutput.php
@@ -1,0 +1,803 @@
+<?php
+
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace CodeIgniter\CLI;
+
+use CodeIgniter\CLI\Exceptions\CLIException;
+
+/**
+ * Dedicated output class for the CLI.
+ *
+ * This class was originally from the CLI class but was separated
+ * to support new features. For BC, the original static methods
+ * in \CodeIgniter\CLI\CLI have been retained with a link to this
+ * class' methods.
+ *
+ * @package CodeIgniter
+ */
+class CLIOutput
+{
+	/**
+	 * Available ANSI foreground colors
+	 *
+	 * @var array
+	 * @see https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-048.pdf
+	 */
+	protected static $availableForegroundColors = [
+		'black'          => [
+			'open'  => 30,
+			'close' => 39,
+		],
+		'red'            => [
+			'open'  => 31,
+			'close' => 39,
+		],
+		'green'          => [
+			'open'  => 32,
+			'close' => 39,
+		],
+		'yellow'         => [
+			'open'  => 33,
+			'close' => 39,
+		],
+		'blue'           => [
+			'open'  => 34,
+			'close' => 39,
+		],
+		'magenta'        => [
+			'open'  => 35,
+			'close' => 39,
+		],
+		'cyan'           => [
+			'open'  => 36,
+			'close' => 39,
+		],
+		'white'          => [
+			'open'  => 37,
+			'close' => 39,
+		],
+		// aixterm (not in standard)
+		'bright_black'   => [
+			'open'  => 90,
+			'close' => 39,
+		],
+		'bright_red'     => [
+			'open'  => 91,
+			'close' => 39,
+		],
+		'bright_green'   => [
+			'open'  => 92,
+			'close' => 39,
+		],
+		'bright_yellow'  => [
+			'open'  => 93,
+			'close' => 39,
+		],
+		'bright_blue'    => [
+			'open'  => 94,
+			'close' => 39,
+		],
+		'bright_magenta' => [
+			'open'  => 95,
+			'close' => 39,
+		],
+		'bright_cyan'    => [
+			'open'  => 96,
+			'close' => 39,
+		],
+		'bright_white'   => [
+			'open'  => 97,
+			'close' => 39,
+		],
+	];
+
+	/**
+	 * Available ANSI background colors
+	 *
+	 * @var array
+	 * @see https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-048.pdf
+	 */
+	protected static $availableBackgroundColors = [
+		'black'          => [
+			'open'  => 40,
+			'close' => 49,
+		],
+		'red'            => [
+			'open'  => 41,
+			'close' => 49,
+		],
+		'green'          => [
+			'open'  => 42,
+			'close' => 49,
+		],
+		'yellow'         => [
+			'open'  => 43,
+			'close' => 49,
+		],
+		'blue'           => [
+			'open'  => 44,
+			'close' => 49,
+		],
+		'magenta'        => [
+			'open'  => 45,
+			'close' => 49,
+		],
+		'cyan'           => [
+			'open'  => 46,
+			'close' => 49,
+		],
+		'white'          => [
+			'open'  => 47,
+			'close' => 49,
+		],
+		// aixterm (not in standard)
+		'bright_black'   => [
+			'open'  => 100,
+			'close' => 49,
+		],
+		'bright_red'     => [
+			'open'  => 101,
+			'close' => 49,
+		],
+		'bright_green'   => [
+			'open'  => 102,
+			'close' => 49,
+		],
+		'bright_yellow'  => [
+			'open'  => 103,
+			'close' => 49,
+		],
+		'bright_blue'    => [
+			'open'  => 104,
+			'close' => 49,
+		],
+		'bright_magenta' => [
+			'open'  => 105,
+			'close' => 49,
+		],
+		'bright_cyan'    => [
+			'open'  => 106,
+			'close' => 49,
+		],
+		'bright_white'   => [
+			'open'  => 107,
+			'close' => 49,
+		],
+	];
+
+	/**
+	 * Available ANSI options
+	 *
+	 * @var array
+	 * @see https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-048.pdf
+	 */
+	protected static $availableOptions = [
+		'reset'     => [
+			'open'  => '',
+			'close' => 0,
+		], // using this will reset all color codes after
+		'bold'      => [
+			'open'  => 1,
+			'close' => 22,
+		],
+		'italic'    => [
+			'open'  => 3,
+			'close' => 23,
+		], // not widely supported
+		'underline' => [
+			'open'  => 4,
+			'close' => 24,
+		],
+		'blink'     => [
+			'open'  => 5,
+			'close' => 25,
+		],
+		'inverse'   => [
+			'open'  => 7,
+			'close' => 27,
+		],
+		'conceal'   => [
+			'open'  => 8,
+			'close' => 28,
+		], // not widely supported
+		'strike'    => [
+			'open'  => 9,
+			'close' => 29,
+		],
+	];
+
+	/**
+	 * Helps track internally whether the last
+	 * output was a "write" or a "print" to
+	 * keep the output clean and as expected.
+	 *
+	 * @var string
+	 */
+	protected static $lastWrite;
+
+	/**
+	 * Valid CLI output stream
+	 *
+	 * @var resource
+	 */
+	private $stream;
+
+	/**
+	 * Whether the stream resource supports ANSI colors
+	 *
+	 * @var boolean
+	 */
+	private $useColors;
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * @param resource     $stream        A valid CLI output stream. Defaults to use STDOUT.
+	 * @param boolean|null $enforceColors Whether to enforce color output. Use null for auto-detection.
+	 */
+	public function __construct($stream = STDOUT, ?bool $enforceColors = null)
+	{
+		$this->setStream($stream);
+		$this->setEnforceColors($enforceColors ?? $this->hasColorSupport());
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Sets the stream resource
+	 *
+	 * @param resource $stream
+	 *
+	 * @return void
+	 * @throws \InvalidArgumentException When the stream is not a resource.
+	 */
+	public function setStream($stream): void
+	{
+		if (! is_resource($stream) || get_resource_type($stream) !== 'stream')
+		{
+			throw new \InvalidArgumentException('The CLIOutput class needs a stream as its first argument.');
+		}
+
+		$this->stream = $stream;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns the current output stream
+	 *
+	 * @return resource
+	 */
+	public function getStream()
+	{
+		return $this->stream;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Sets the useColors flag
+	 *
+	 * @param boolean $enforceColors
+	 *
+	 * @return void
+	 */
+	public function setEnforceColors(bool $enforceColors)
+	{
+		$this->useColors = $enforceColors;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns true if output is to be colored
+	 *
+	 * @return boolean
+	 */
+	public function isColored(): bool
+	{
+		return $this->useColors;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns true if output stream supports colors.
+	 *
+	 * This is tricky on Windows, because Cygwin, Msys2 etc. emulate
+	 * pseudo-terminals via named pipes, so we can only check
+	 * the environment.
+	 *
+	 * Reference: Composer\XdebugHandler\Process::supportsColor
+	 * https://github.com/composer/xdebug-handler
+	 *
+	 * @return boolean
+	 */
+	public function hasColorSupport(): bool
+	{
+		// Adhere to https://no-color.org
+		if (isset($_SERVER['NO_COLOR']) || getenv('NO_COLOR') !== false)
+		{
+			return false;
+		}
+
+		if (getenv('TERM_PROGRAM') === 'Hyper')
+		{
+			return true;
+		}
+
+		if (static::isWindows())
+		{
+			// @codeCoverageIgnoreStart
+			return (function_exists('sapi_windows_vt100_support()')
+				&& sapi_windows_vt100_support($this->stream))
+				|| isset($_SERVER['ANSICON'])
+				|| getenv('ANSICON') !== false
+				|| getenv('ConEmuANSI') === 'ON'
+				|| getenv('TERM') === 'xterm';
+			// @codeCoverageIgnoreEnd
+		}
+
+		return stream_isatty($this->stream);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * if operating system === windows
+	 *
+	 * @return boolean
+	 */
+	public static function isWindows(): bool
+	{
+		return stripos(PHP_OS, 'WIN') === 0;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Waits a certain number of seconds, optionally showing a wait message and
+	 * waiting for a key press.
+	 *
+	 * @param integer $seconds   Number of seconds
+	 * @param boolean $countdown Show a countdown or not
+	 */
+	public function wait(int $seconds, bool $countdown = false)
+	{
+		if ($countdown === true)
+		{
+			$time = $seconds;
+
+			while ($time > 0)
+			{
+				$this->print($time . '... ');
+				sleep(1);
+				$time --;
+			}
+			$this->write();
+		}
+		else
+		{
+			if ($seconds > 0)
+			{
+				sleep($seconds);
+			}
+			else
+			{
+				// this chunk cannot be tested because of keyboard input
+				// @codeCoverageIgnoreStart
+				$this->write(CLI::$wait_msg);
+				CLI::input();
+				// @codeCoverageIgnoreEnd
+			}
+		}
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Outputs a string (or series of strings) to the CLI without any surrounding newlines.
+	 * Useful for showing repeating elements on a single line.
+	 *
+	 * @param string|array|\Traversable $texts      The text to output
+	 * @param string|null               $foreground The foreground color
+	 * @param string|null               $background The background color
+	 * @param array                     $options    Other formatting options
+	 */
+	public function print($texts = '', ?string $foreground = null, ?string $background = null, array $options = [])
+	{
+		if (! is_iterable($texts))
+		{
+			$texts = [$texts];
+		}
+
+		foreach ($texts as $text)
+		{
+			if ($foreground || $background || $options)
+			{
+				$text = $this->color($text, $foreground, $background, $options);
+			}
+
+			static::$lastWrite = null;
+
+			fwrite($this->stream, $text);
+			fflush($this->stream);
+		}
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Outputs a string to the CLI on its own line.
+	 *
+	 * @param string|array|\Traversable $texts      The text to output
+	 * @param string|null               $foreground The foreground color
+	 * @param string|null               $background The background color
+	 * @param array                     $options    Other formatting options
+	 */
+	public function write($texts = '', ?string $foreground = null, ?string $background = null, array $options = [])
+	{
+		if (! is_iterable($texts))
+		{
+			$texts = [$texts];
+		}
+
+		foreach ($texts as $text)
+		{
+			if ($foreground || $background || $options)
+			{
+				$text = $this->color($text, $foreground, $background, $options);
+			}
+
+			if (static::$lastWrite !== 'write')
+			{
+				$text              = "\n" . $text;
+				static::$lastWrite = 'write';
+			}
+
+			fwrite($this->stream, $text . "\n");
+			fflush($this->stream);
+		}
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Outputs an error to the CLI using STDERR instead of STDOUT
+	 *
+	 * @param string|array|\Traversable $texts      The error text to output, or array of errors
+	 * @param string                    $foreground The foreground color
+	 * @param string|null               $background The background color
+	 * @param array                     $options    Other formatting options
+	 * @param resource                  $stream     Set stream to STDERR. Made a parameter for testability
+	 */
+	public function error($texts, string $foreground = 'bright_red', ?string $background = null, array $options = [], $stream = STDERR)
+	{
+		if (! is_iterable($texts))
+		{
+			$texts = [$texts];
+		}
+
+		foreach ($texts as $text)
+		{
+			if ($foreground || $background || $options)
+			{
+				$text = $this->color($text, $foreground, $background, $options);
+			}
+
+			fwrite($stream, $text . "\n");
+			fflush($stream);
+		}
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Enter a number of empty lines
+	 *
+	 * @param integer $num Number of lines to output
+	 *
+	 * @return void
+	 */
+	public function newLine(int $num = 1)
+	{
+		// Do it once or more, write with empty string gives us a new line
+		for ($i = 0; $i < $num; $i ++)
+		{
+			$this->write();
+		}
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Clears the screen of output
+	 *
+	 * @return             void
+	 * @codeCoverageIgnore
+	 */
+	public function clearScreen()
+	{
+		static::isWindows() && version_compare(PHP_WINDOWS_VERSION_MAJOR, '10', '<')
+			// Windows before Win10 are a bit crap at this, but their terminal is tiny so shove this in
+			? $this->newLine(40)
+			// Win10 and anything with a flair of Unix will handle this
+			: fwrite($this->stream, "\033[H\033[2J");
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns the given text with the correct color codes for a foreground and
+	 * optionally a background color and other options
+	 *
+	 * @param string      $text       The text to color
+	 * @param string|null $foreground The foreground color
+	 * @param string|null $background The background color
+	 * @param array       $options    Other formatting options to apply
+	 *
+	 * @return string     The color coded text
+	 */
+	public function color(string $text, ?string $foreground = null, ?string $background = null, array $options = [])
+	{
+		if (! $this->isColored())
+		{
+			return $text;
+		}
+
+		$open  = [];
+		$close = [];
+
+		if ($foreground !== null)
+		{
+			if (! isset(static::$availableForegroundColors[$foreground]))
+			{
+				throw CLIException::forInvalidColor('foreground', $foreground);
+			}
+
+			$open[]  = static::$availableForegroundColors[$foreground]['open'];
+			$close[] = static::$availableForegroundColors[$foreground]['close'];
+		}
+
+		if ($background !== null)
+		{
+			if (! isset(static::$availableBackgroundColors[$background]))
+			{
+				throw CLIException::forInvalidColor('background', $background);
+			}
+
+			$open[]  = static::$availableBackgroundColors[$background]['open'];
+			$close[] = static::$availableBackgroundColors[$background]['close'];
+		}
+
+		if (count($options))
+		{
+			foreach ($options as $option)
+			{
+				if (! isset(static::$availableOptions[$option]))
+				{
+					throw CLIException::forInvalidOption($option);
+				}
+
+				$open[]  = static::$availableOptions[$option]['open'];
+				$close[] = static::$availableOptions[$option]['close'];
+			}
+		}
+
+		if (empty($open))
+		{
+			return $text;
+		}
+
+		return sprintf(
+			"\033[%sm%s\033[%sm",
+			trim(implode(';', $open), ';'),
+			$text,
+			trim(implode(';', $close), ';')
+		);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Get the number of characters in string having encoded characters
+	 * and ignores styles set by the color() function
+	 *
+	 * @param string|null $string
+	 *
+	 * @return integer
+	 */
+	public static function strlen(?string $string): int
+	{
+		if ($string === null)
+		{
+			return 0;
+		}
+
+		$string = preg_replace("/(\033\[[\d;]+[m])/i", '', $string);
+
+		return mb_strlen($string);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Displays a progress bar on the CLI. You must call it repeatedly
+	 * to update it. Set $thisStep = false to erase the progress bar.
+	 *
+	 * @param integer|boolean $thisStep
+	 * @param integer         $totalSteps
+	 */
+	public function showProgress($thisStep = 1, int $totalSteps = 10)
+	{
+		static $inProgress = false;
+
+		// restore cursor position when progress is continuing.
+		if ($inProgress !== false && $inProgress <= $thisStep)
+		{
+			fwrite($this->stream, "\033[1A");
+		}
+		$inProgress = $thisStep;
+
+		if ($thisStep !== false)
+		{
+			// Don't allow div by zero or negative numbers....
+			$thisStep   = abs($thisStep);
+			$totalSteps = $totalSteps < 1 ? 1 : $totalSteps;
+
+			$percent = intval(($thisStep / $totalSteps) * 100);
+			$step    = (int) round($percent / 10);
+
+			// Write the progress bar
+			fwrite($this->stream, "[\033[32m" . str_repeat('#', $step) . str_repeat('.', 10 - $step) . "\033[39m]");
+			// Textual representation...
+			fwrite($this->stream, sprintf(' %3d%% Complete', $percent) . "\n");
+		}
+		else
+		{
+			fwrite($this->stream, "\007");
+		}
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns a well formatted table
+	 *
+	 * @param array $tbody List of rows
+	 * @param array $thead List of columns
+	 *
+	 * @return void
+	 */
+	public function table(array $tbody, array $thead = [])
+	{
+		// All the rows in the table will be here until the end
+		$table_rows = [];
+
+		// We need only indexes and not keys
+		if (! empty($thead))
+		{
+			$table_rows[] = array_values($thead);
+		}
+
+		foreach ($tbody as $tr)
+		{
+			$table_rows[] = array_values($tr);
+		}
+
+		// Yes, it really is necessary to know this count
+		$total_rows = count($table_rows);
+
+		// Store all columns lengths
+		// $all_cols_lengths[row][column] = length
+		$all_cols_lengths = [];
+
+		// Store maximum lengths by column
+		// $max_cols_lengths[column] = length
+		$max_cols_lengths = [];
+
+		// Read row by row and define the longest columns
+		for ($row = 0; $row < $total_rows; $row ++)
+		{
+			$column = 0; // Current column index
+			foreach ($table_rows[$row] as $col)
+			{
+				// Sets the size of this column in the current row
+				$all_cols_lengths[$row][$column] = static::strlen($col);
+
+				// If the current column does not have a value among the larger ones
+				// or the value of this is greater than the existing one
+				// then, now, this assumes the maximum length
+				if (! isset($max_cols_lengths[$column]) || $all_cols_lengths[$row][$column] > $max_cols_lengths[$column])
+				{
+					$max_cols_lengths[$column] = $all_cols_lengths[$row][$column];
+				}
+
+				// We can go check the size of the next column...
+				$column ++;
+			}
+		}
+
+		// Read row by row and add spaces at the end of the columns
+		// to match the exact column length
+		for ($row = 0; $row < $total_rows; $row ++)
+		{
+			$column = 0;
+			foreach ($table_rows[$row] as $col)
+			{
+				$diff = $max_cols_lengths[$column] - static::strlen($col);
+				if ($diff)
+				{
+					$table_rows[$row][$column] = $table_rows[$row][$column] . str_repeat(' ', $diff);
+				}
+				$column ++;
+			}
+		}
+
+		$table = '';
+
+		// Joins columns and append the well formatted rows to the table
+		for ($row = 0; $row < $total_rows; $row ++)
+		{
+			// Set the table border-top
+			if ($row === 0)
+			{
+				$cols = '+';
+				foreach ($table_rows[$row] as $col)
+				{
+					$cols .= str_repeat('-', static::strlen($col) + 2) . '+';
+				}
+				$table .= $cols . "\n";
+			}
+
+			// Set the column borders
+			$table .= '| ' . implode(' | ', $table_rows[$row]) . ' |' . "\n";
+
+			// Set the thead and table borders-bottom
+			if ($row === 0 && ! empty($thead) || $row + 1 === $total_rows)
+			{
+				$table .= $cols . "\n";
+			}
+		}
+
+		$this->write($table);
+	}
+
+	//--------------------------------------------------------------------
+}

--- a/system/CLI/Exceptions/CLIException.php
+++ b/system/CLI/Exceptions/CLIException.php
@@ -12,4 +12,14 @@ class CLIException extends \RuntimeException
 	{
 		return new static(lang('CLI.invalidColor', [$type, $color]));
 	}
+
+	/**
+	 * @param string $option
+	 *
+	 * @return \CodeIgniter\CLI\Exceptions\CLIException
+	 */
+	public static function forInvalidOption(string $option)
+	{
+		return new static(lang('CLI.invalidOption', [$option]));
+	}
 }

--- a/system/Language/en/CLI.php
+++ b/system/Language/en/CLI.php
@@ -21,4 +21,5 @@ return [
    'helpOptions'     => 'Options:',
    'helpArguments'   => 'Arguments:',
    'invalidColor'    => 'Invalid {0} color: {1}.',
+   'invalidOption'   => 'Invalid option: {0}.',
 ];

--- a/tests/system/CLI/CLIOutputTest.php
+++ b/tests/system/CLI/CLIOutputTest.php
@@ -1,0 +1,413 @@
+<?php namespace CodeIgniter\CLI;
+
+use CodeIgniter\CLI\Exceptions\CLIException;
+use CodeIgniter\Test\CIUnitTestCase;
+
+class CLIOutputTest extends CIUnitTestCase
+{
+	private $stream;
+
+	public function setUp(): void
+	{
+		$this->stream = @fopen('php://memory', 'a', false);
+	}
+
+	public function tearDown(): void
+	{
+		$this->stream = null;
+	}
+
+	/**
+	 * Convenience method to get the stream contents
+	 *
+	 * @return string|false
+	 */
+	private function getStreamContents()
+	{
+		rewind($this->stream);
+		return stream_get_contents($this->stream);
+	}
+
+	private function yieldIterables(): iterable
+	{
+		yield 'foo';
+		yield 'bar';
+		yield 'baz';
+	}
+
+	public function testConstructorInit()
+	{
+		$output = new CLIOutput($this->stream);
+		$this->assertEquals($this->stream, $output->getStream());
+		$this->assertIsBool($output->isColored());
+
+		$output = new CLIOutput($this->stream, true);
+		$this->assertEquals($this->stream, $output->getStream());
+		$this->assertTrue($output->isColored());
+
+		$output = new CLIOutput($this->stream, false);
+		$this->assertEquals($this->stream, $output->getStream());
+		$this->assertFalse($output->isColored());
+	}
+
+	public function testSetStreamThrowsError()
+	{
+		try
+		{
+			new CLIOutput('not_stream');
+		}
+		catch (\Throwable $th)
+		{
+			$this->assertInstanceOf('InvalidArgumentException', $th);
+			$this->assertEquals('The CLIOutput class needs a stream as its first argument.', $th->getMessage());
+		}
+	}
+
+	public function testColorSupportNoColor()
+	{
+		$_SERVER['NO_COLOR'] = true;
+		$output              = new CLIOutput($this->stream);
+		$this->assertFalse($output->isColored());
+		unset($_SERVER['NO_COLOR']);
+	}
+
+	public function testColorSupportHyper()
+	{
+		$currentTermProgram = getenv('TERM_PROGRAM');
+		putenv('TERM_PROGRAM=Hyper');
+		$output = new CLIOutput($this->stream);
+		$this->assertTrue($output->isColored());
+
+		$currentTermProgram ? putenv("TERM_PROGRAM={$currentTermProgram}") : putenv('TERM_PROGRAM');
+	}
+
+	public function testGenericColorDetection()
+	{
+		$output = new CLIOutput($this->stream);
+		$this->assertIsBool($output->isColored());
+	}
+
+	public function testIsWindows()
+	{
+		$this->assertEquals(('\\' === DIRECTORY_SEPARATOR), CLIOutput::isWindows());
+		$this->assertEquals(defined('PHP_WINDOWS_VERSION_MAJOR'), CLIOutput::isWindows());
+	}
+
+	public function testNewLine()
+	{
+		$output = new CLIOutput($this->stream);
+
+		$output->newLine();
+		$this->assertEquals("\n\n", $this->getStreamContents());
+	}
+
+	public function testWait()
+	{
+		$output = new CLIOutput($this->stream);
+
+		$time = time();
+		$output->wait(1, true);
+		$this->assertCloseEnough(1, time() - $time);
+
+		$time = time();
+		$output->wait(1);
+		$this->assertCloseEnough(1, time() - $time);
+
+		// Leaving the code fragment below in, to remind myself (or others)
+		// of what appears to be the most likely path to test this last
+		// bit of wait() functionality.
+		// The problem: if the block below is enabled, the phpunit tests
+		// go catatonic when it is executed, presumably because of
+		// the CLI::input() waiting for a key press
+		//      // test the press any key to continue...
+		//      stream_filter_register('CLITestKeyboardFilter', 'CodeIgniter\CLI\CLITestKeyboardFilter');
+		//      $spoofer = stream_filter_append(STDIN, 'CLITestKeyboardFilter');
+		//      $time = time();
+		//      CLITestKeyboardFilter::$spoofed = ' ';
+		//      CLI::wait(0);
+		//      stream_filter_remove($spoofer);
+		//      $this->assertEquals(0, time() - $time);
+	}
+
+	public function testForegroundColorException()
+	{
+		$this->expectException(CLIException::class);
+		$this->expectExceptionMessage('Invalid foreground color: rainbow');
+		(new CLIOutput($this->stream, true))->color('test', 'rainbow');
+	}
+
+	public function testBackgroundColorException()
+	{
+		$this->expectException(CLIException::class);
+		$this->expectExceptionMessage('Invalid background color: rainbow');
+		(new CLIOutput($this->stream, true))->color('test', 'white', 'rainbow');
+	}
+
+	public function testOptionsException()
+	{
+		$this->expectException(CLIException::class);
+		$this->expectExceptionMessage('Invalid option: strikethrough');
+		(new CLIOutput($this->stream, true))->color('test', null, null, ['strikethrough']);
+	}
+
+	public function testColorOutput()
+	{
+		$output = new CLIOutput($this->stream, false);
+		$this->assertEquals('test', $output->color('test', 'white', 'red'));
+
+		$output = new CLIOutput($this->stream, true);
+		$this->assertEquals('test', $output->color('test'));
+
+		$output = new CLIOutput($this->stream, true);
+		$this->assertEquals("\033[37;41mtest\033[39;49m", $output->color('test', 'white', 'red'));
+
+		$output = new CLIOutput($this->stream, true);
+		$this->assertEquals("\033[37;41;1mtest\033[39;49;22m", $output->color('test', 'white', 'red', ['bold']));
+	}
+
+	public function testPrint()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->print('test');
+		$this->assertEquals('test', $this->getStreamContents());
+	}
+
+	public function testPrintForeground()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->print('test', 'red');
+		$this->assertEquals("\033[31mtest\033[39m", $this->getStreamContents());
+	}
+
+	public function testPrintBackground()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->print('test', 'white', 'red');
+		$this->assertEquals("\033[37;41mtest\033[39;49m", $this->getStreamContents());
+	}
+
+	public function testPrintOptions()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->print('test', null, null, ['bold']);
+		$this->assertEquals("\033[1mtest\033[22m", $this->getStreamContents());
+	}
+
+	public function testPrintIterables()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->print($this->yieldIterables(), 'red');
+		$this->assertEquals(
+			"\033[31mfoo\033[39m\033[31mbar\033[39m\033[31mbaz\033[39m",
+			$this->getStreamContents()
+		);
+	}
+
+	public function testWrite()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->write('test');
+		$this->assertEquals("\ntest\n", $this->getStreamContents());
+	}
+
+	public function testWriteForeground()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->write('test', 'red');
+		$this->assertEquals("\033[31mtest\033[39m\n", $this->getStreamContents());
+	}
+
+	public function testWriteBackground()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->write('test', 'white', 'red');
+		$this->assertEquals("\033[37;41mtest\033[39;49m\n", $this->getStreamContents());
+	}
+
+	public function testWriteOptions()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->write('test', null, null, ['bold']);
+		$this->assertEquals("\033[1mtest\033[22m\n", $this->getStreamContents());
+	}
+
+	public function testWriteIterables()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->write($this->yieldIterables(), 'red');
+		$this->assertEquals(
+			"\033[31mfoo\033[39m\n\033[31mbar\033[39m\n\033[31mbaz\033[39m\n",
+			$this->getStreamContents()
+		);
+	}
+
+	public function testError()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->error('test', 'red', null, [], $this->stream);
+		$this->assertEquals("\033[31mtest\033[39m\n", $this->getStreamContents());
+	}
+
+	public function testErrorForeground()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->error('test', 'magenta', null, [], $this->stream);
+		$this->assertEquals("\033[35mtest\033[39m\n", $this->getStreamContents());
+	}
+
+	public function testErrorBackground()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->error('test', 'magenta', 'yellow', [], $this->stream);
+		$this->assertEquals("\033[35;43mtest\033[39;49m\n", $this->getStreamContents());
+	}
+
+	public function testErrorOptions()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->error('test', 'red', null, ['bold'], $this->stream);
+		$this->assertEquals("\033[31;1mtest\033[39;22m\n", $this->getStreamContents());
+	}
+
+	public function testErrorIterables()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->error($this->yieldIterables(), 'red', null, [], $this->stream);
+		$this->assertEquals(
+			"\033[31mfoo\033[39m\n\033[31mbar\033[39m\n\033[31mbaz\033[39m\n",
+			$this->getStreamContents()
+		);
+	}
+
+	public function testStrlen()
+	{
+		$output = new CLIOutput($this->stream, true);
+		$this->assertEquals(0, CLIOutput::strlen(null));
+		$this->assertEquals(4, CLIOutput::strlen($output->color('test', 'red', 'yellow')));
+		$this->assertEquals(20, mb_strlen($output->color('test', 'red', 'yellow')));
+	}
+
+	public function testShowProgress()
+	{
+		$output = new CLIOutput($this->stream, true);
+
+		$output->write('first.');
+		$output->showProgress(1, 20);
+		$output->showProgress(10, 20);
+		$output->showProgress(20, 20);
+		$output->write('second.');
+		$output->showProgress(1, 20);
+		$output->showProgress(10, 20);
+		$output->showProgress(20, 20);
+		$output->write('third.');
+		$output->showProgress(1, 20);
+
+		$expected = <<<EOT
+first.
+[\033[32m#.........\033[39m]   5% Complete
+\033[1A[\033[32m#####.....\033[39m]  50% Complete
+\033[1A[\033[32m##########\033[39m] 100% Complete
+second.
+[\033[32m#.........\033[39m]   5% Complete
+\033[1A[\033[32m#####.....\033[39m]  50% Complete
+\033[1A[\033[32m##########\033[39m] 100% Complete
+third.
+[\033[32m#.........\033[39m]   5% Complete
+
+EOT;
+		$this->assertEquals($expected, $this->getStreamContents());
+	}
+
+	public function testShowProgressWithoutBar()
+	{
+		$output = new CLIOutput($this->stream, true);
+
+		$output->write('first.');
+		$output->showProgress(false, 20);
+		$output->showProgress(false, 20);
+		$output->showProgress(false, 20);
+
+		$expected = <<<EOT
+first.
+\007\007\007
+EOT;
+		$this->assertEquals($expected, $this->getStreamContents());
+	}
+
+	/**
+	 * @dataProvider tableProvider
+	 */
+	public function testTable($tbody, $thead, $expected)
+	{
+		$output = new CLIOutput($this->stream, true);
+		$output->table($tbody, $thead);
+		$this->assertEquals($this->getStreamContents(), $expected);
+	}
+
+	public function tableProvider()
+	{
+		$head      = [
+			'ID',
+			'Title',
+		];
+		$one_row   = [
+			[
+				'id'  => 1,
+				'foo' => 'bar',
+			],
+		];
+		$many_rows = [
+			[
+				'id'  => 1,
+				'foo' => 'bar',
+			],
+			[
+				'id'  => 2,
+				'foo' => 'bar * 2',
+			],
+			[
+				'id'  => 3,
+				'foo' => 'bar + bar + bar',
+			],
+		];
+
+		return [
+			[
+				$one_row,
+				[],
+				"+---+-----+\n" .
+				"| 1 | bar |\n" .
+				"+---+-----+\n\n",
+			],
+			[
+				$one_row,
+				$head,
+				"+----+-------+\n" .
+				"| ID | Title |\n" .
+				"+----+-------+\n" .
+				"| 1  | bar   |\n" .
+				"+----+-------+\n\n",
+			],
+			[
+				$many_rows,
+				[],
+				"+---+-----------------+\n" .
+				"| 1 | bar             |\n" .
+				"| 2 | bar * 2         |\n" .
+				"| 3 | bar + bar + bar |\n" .
+				"+---+-----------------+\n\n",
+			],
+			[
+				$many_rows,
+				$head,
+				"+----+-----------------+\n" .
+				"| ID | Title           |\n" .
+				"+----+-----------------+\n" .
+				"| 1  | bar             |\n" .
+				"| 2  | bar * 2         |\n" .
+				"| 3  | bar + bar + bar |\n" .
+				"+----+-----------------+\n\n",
+			],
+		];
+	}
+}

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -1,30 +1,9 @@
 <?php namespace CodeIgniter\CLI;
 
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\CIUnitTestCase;
 
-class CLITest extends \CodeIgniter\Test\CIUnitTestCase
+class CLITest extends CIUnitTestCase
 {
-
-	private $stream_filter;
-
-	protected function setUp(): void
-	{
-		parent::setUp();
-
-		CITestStreamFilter::$buffer = '';
-		$this->stream_filter        = stream_filter_append(STDOUT, 'CITestStreamFilter');
-	}
-
-	public function tearDown(): void
-	{
-		stream_filter_remove($this->stream_filter);
-	}
-
-	public function testNew()
-	{
-		$actual = new CLI();
-		$this->assertInstanceOf(CLI::class, $actual);
-	}
 
 	public function testBeep()
 	{
@@ -38,203 +17,18 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 		CLI::beep(4);
 	}
 
-	public function testWait()
-	{
-		$time = time();
-		CLI::wait(1, true);
-		$this->assertCloseEnough(1, time() - $time);
-
-		$time = time();
-		CLI::wait(1);
-		$this->assertCloseEnough(1, time() - $time);
-
-		// Leaving the code fragment below in, to remind myself (or others)
-		// of what appears to be the most likely path to test this last
-		// bit of wait() functionality.
-		// The problem: if the block below is enabled, the phpunit tests
-		// go catatonic when it is executed, presumably because of
-		// the CLI::input() waiting for a key press
-		//      // test the press any key to continue...
-		//      stream_filter_register('CLITestKeyboardFilter', 'CodeIgniter\CLI\CLITestKeyboardFilter');
-		//      $spoofer = stream_filter_append(STDIN, 'CLITestKeyboardFilter');
-		//      $time = time();
-		//      CLITestKeyboardFilter::$spoofed = ' ';
-		//      CLI::wait(0);
-		//      stream_filter_remove($spoofer);
-		//      $this->assertEquals(0, time() - $time);
-	}
-
 	public function testIsWindows()
 	{
 		$this->assertEquals(('\\' === DIRECTORY_SEPARATOR), CLI::isWindows());
 		$this->assertEquals(defined('PHP_WINDOWS_VERSION_MAJOR'), CLI::isWindows());
 	}
 
-	public function testNewLine()
-	{
-		$this->expectOutputString('');
-		CLI::newLine();
-	}
-
-	public function testColorExceptionForeground()
-	{
-		$this->expectException('RuntimeException');
-		$this->expectExceptionMessage('Invalid foreground color: Foreground');
-
-		CLI::color('test', 'Foreground');
-	}
-
-	public function testColorExceptionBackground()
-	{
-		$this->expectException('RuntimeException');
-		$this->expectExceptionMessage('Invalid background color: Background');
-
-		CLI::color('test', 'white', 'Background');
-	}
-
-	public function testColor()
-	{
-		$this->assertEquals("\033[1;37m\033[42m\033[4mtest\033[0m", CLI::color('test', 'white', 'green', 'underline'));
-	}
-
-	public function testPrint()
-	{
-		CLI::print('test');
-		$expected = 'test';
-
-		$this->assertEquals($expected, CITestStreamFilter::$buffer);
-	}
-
-	public function testPrintForeground()
-	{
-		CLI::print('test', 'red');
-		$expected = "\033[0;31mtest\033[0m";
-
-		$this->assertEquals($expected, CITestStreamFilter::$buffer);
-	}
-
-	public function testPrintBackground()
-	{
-		CLI::print('test', 'red', 'green');
-		$expected = "\033[0;31m\033[42mtest\033[0m";
-
-		$this->assertEquals($expected, CITestStreamFilter::$buffer);
-	}
-
-	public function testWrite()
-	{
-		CLI::write('test');
-		$expected = <<<EOT
-
-test
-
-EOT;
-		$this->assertEquals($expected, CITestStreamFilter::$buffer);
-	}
-
-	public function testWriteForeground()
-	{
-		CLI::write('test', 'red');
-		$expected = <<<EOT
-\033[0;31mtest\033[0m
-
-EOT;
-		$this->assertEquals($expected, CITestStreamFilter::$buffer);
-	}
-
-	public function testWriteBackground()
-	{
-		CLI::write('test', 'red', 'green');
-		$expected = <<<EOT
-\033[0;31m\033[42mtest\033[0m
-
-EOT;
-		$this->assertEquals($expected, CITestStreamFilter::$buffer);
-	}
-
-	public function testError()
-	{
-		$this->stream_filter = stream_filter_append(STDERR, 'CITestStreamFilter');
-		CLI::error('test');
-		// red expected cuz stderr
-		$expected = <<<EOT
-\033[1;31mtest\033[0m
-
-EOT;
-		$this->assertEquals($expected, CITestStreamFilter::$buffer);
-	}
-
-	public function testErrorForeground()
-	{
-		$this->stream_filter = stream_filter_append(STDERR, 'CITestStreamFilter');
-		CLI::error('test', 'purple');
-		$expected = <<<EOT
-\033[0;35mtest\033[0m
-
-EOT;
-		$this->assertEquals($expected, CITestStreamFilter::$buffer);
-	}
-
-	public function testErrorBackground()
-	{
-		$this->stream_filter = stream_filter_append(STDERR, 'CITestStreamFilter');
-		CLI::error('test', 'purple', 'green');
-		$expected = <<<EOT
-\033[0;35m\033[42mtest\033[0m
-
-EOT;
-		$this->assertEquals($expected, CITestStreamFilter::$buffer);
-	}
-
-	public function testShowProgress()
-	{
-		CLI::write('first.');
-		CLI::showProgress(1, 20);
-		CLI::showProgress(10, 20);
-		CLI::showProgress(20, 20);
-		CLI::write('second.');
-		CLI::showProgress(1, 20);
-		CLI::showProgress(10, 20);
-		CLI::showProgress(20, 20);
-		CLI::write('third.');
-		CLI::showProgress(1, 20);
-
-		$expected = <<<EOT
-first.
-[\033[32m#.........\033[0m]   5% Complete
-\033[1A[\033[32m#####.....\033[0m]  50% Complete
-\033[1A[\033[32m##########\033[0m] 100% Complete
-second.
-[\033[32m#.........\033[0m]   5% Complete
-\033[1A[\033[32m#####.....\033[0m]  50% Complete
-\033[1A[\033[32m##########\033[0m] 100% Complete
-third.
-[\033[32m#.........\033[0m]   5% Complete
-
-EOT;
-		$this->assertEquals($expected, CITestStreamFilter::$buffer);
-	}
-
-	public function testShowProgressWithoutBar()
-	{
-		CLI::write('first.');
-		CLI::showProgress(false, 20);
-		CLI::showProgress(false, 20);
-		CLI::showProgress(false, 20);
-
-		$expected = <<<EOT
-first.
-\007\007\007
-EOT;
-		$this->assertEquals($expected, CITestStreamFilter::$buffer);
-	}
-
 	public function testWrap()
 	{
 		$this->assertEquals('', CLI::wrap(''));
-		$this->assertEquals('1234' . PHP_EOL . ' 5678' . PHP_EOL . ' 90' . PHP_EOL . ' abc' . PHP_EOL . ' de' . PHP_EOL . ' fghij' . PHP_EOL . ' 0987654321', CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 5, 1));
-		$this->assertEquals('1234 5678 90' . PHP_EOL . '  abc de fghij' . PHP_EOL . '  0987654321', CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 999, 2));
-		$this->assertEquals('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321'));
+		$this->assertEquals("1234\n 5678\n 90\n abc\n de\n fghij\n 0987654321", CLI::wrap("1234 5678 90\nabc de fghij\n0987654321", 5, 1));
+		$this->assertEquals("1234 5678 90\n  abc de fghij\n  0987654321", CLI::wrap("1234 5678 90\nabc de fghij\n0987654321", 999, 2));
+		$this->assertEquals("1234 5678 90\nabc de fghij\n0987654321", CLI::wrap("1234 5678 90\nabc de fghij\n0987654321"));
 	}
 
 	public function testParseCommand()
@@ -319,92 +113,5 @@ EOT;
 	{
 		$this->assertTrue(is_int(CLI::getHeight()));
 		$this->assertTrue(is_int(CLI::getWidth()));
-	}
-
-	/**
-	 * @dataProvider tableProvider
-	 *
-	 * @param array $tbody
-	 * @param array $thead
-	 * @param array $expected
-	 */
-	public function testTable($tbody, $thead, $expected)
-	{
-		CLI::table($tbody, $thead);
-		$this->assertEquals(CITestStreamFilter::$buffer, $expected);
-	}
-
-	public function tableProvider()
-	{
-		$head      = [
-			'ID',
-			'Title',
-		];
-		$one_row   = [
-			[
-				'id'  => 1,
-				'foo' => 'bar',
-			],
-		];
-		$many_rows = [
-			[
-				'id'  => 1,
-				'foo' => 'bar',
-			],
-			[
-				'id'  => 2,
-				'foo' => 'bar * 2',
-			],
-			[
-				'id'  => 3,
-				'foo' => 'bar + bar + bar',
-			],
-		];
-
-		return [
-			[
-				$one_row,
-				[],
-				"+---+-----+\n" .
-				"| 1 | bar |\n" .
-				"+---+-----+\n\n",
-			],
-			[
-				$one_row,
-				$head,
-				"+----+-------+\n" .
-				"| ID | Title |\n" .
-				"+----+-------+\n" .
-				"| 1  | bar   |\n" .
-				"+----+-------+\n\n",
-			],
-			[
-				$many_rows,
-				[],
-				"+---+-----------------+\n" .
-				"| 1 | bar             |\n" .
-				"| 2 | bar * 2         |\n" .
-				"| 3 | bar + bar + bar |\n" .
-				"+---+-----------------+\n\n",
-			],
-			[
-				$many_rows,
-				$head,
-				"+----+-----------------+\n" .
-				"| ID | Title           |\n" .
-				"+----+-----------------+\n" .
-				"| 1  | bar             |\n" .
-				"| 2  | bar * 2         |\n" .
-				"| 3  | bar + bar + bar |\n" .
-				"+----+-----------------+\n\n",
-			],
-		];
-	}
-
-	public function testStrlen()
-	{
-		$this->assertEquals(18, mb_strlen(CLI::color('success', 'green')));
-		$this->assertEquals(7, CLI::strlen(CLI::color('success', 'green')));
-		$this->assertEquals(0, CLI::strlen(null));
 	}
 }

--- a/user_guide_src/source/cli/cli_library.rst
+++ b/user_guide_src/source/cli/cli_library.rst
@@ -17,7 +17,7 @@ CodeIgniter's CLI library makes creating interactive command-line scripts simple
 Initializing the Class
 ======================
 
-You do not need to create an instance of the CLI library, since all of it's methods are static. Instead, you simply
+You do not need to create an instance of the CLI library, since all of its methods are static. Instead, you simply
 need to ensure your controller can locate it via a ``use`` statement above your class::
 
 	<?php namespace App\Controllers;
@@ -58,6 +58,9 @@ Finally, you can pass validation rules to the answer input as the third paramete
 Providing Feedback
 ==================
 
+.. note:: For more choices in formatting options and available foreground and background colors, you may try the
+ new and improved :doc:`CLI Output Library </cli/cli_output>`.
+
 **write()**
 
 Several methods are provided for you to provide feedback to your users. This can be as simple as a single status update
@@ -80,7 +83,6 @@ The following foreground colors are available:
 * black
 * dark_gray
 * blue
-* dark_blue
 * light_blue
 * green
 * light_green

--- a/user_guide_src/source/cli/cli_output.rst
+++ b/user_guide_src/source/cli/cli_output.rst
@@ -1,0 +1,323 @@
+##################
+CLI Output Library
+##################
+
+CodeIgniter's CLI Output library is the dedicated class for providing output
+to the command line.
+
+Originally, the methods here are from the :doc:`CLI library </cli/cli_library>`
+but moved to incorporate new and improved features, which include:
+
+* Automatic detection for ANSI color support for your favorite terminal.
+* Enforce/disable ANSI-colored output.
+* Foreground and background colors available are expanded to include the colors in the ECMA-48 Standard.
+* Additional formatting options besides from ``underline``.
+* Choice of other streams for output aside from ``STDOUT`` and ``STDERR``.
+
+.. contents::
+	:local:
+	:depth: 2
+
+Initializing the Class
+======================
+
+First, create an instance of ``CLIOutput``::
+
+	$output = new CLIOutput();
+
+Optionally you may supply the stream to use in the first argument (defaults to
+``STDOUT``) and whether to enforce color support in the second argument (defaults
+to ``null``). If ``null`` is provided in the second argument, automatic detection for
+ANSI color support will be made::
+
+	$output = new CLIOutput(STDERR, true);
+
+Colors and Options Available
+============================
+
+The following available foreground and background colors and other formatting options are
+specified in the `ECMA-48 Standard <https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-048.pdf>`_
+and summarized in this Wikipedia article: `ANSI escape code <https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters>`_
+
+=================== =================== ===========
+ Foreground colors   Background colors   Options
+=================== =================== ===========
+ black               black               reset
+ red                 red                 bold
+ green               green               italic
+ yellow              yellow              underline
+ blue                blue                blink
+ magenta             magenta             inverse
+ cyan                cyan                conceal
+ white               white               strike
+ bright_black        bright_black
+ bright_red          bright_red
+ bright_green        bright_green
+ bright_yellow       bright_yellow
+ bright_blue         bright_blue
+ bright_magenta      bright_magenta
+ bright_cyan         bright_cyan
+ bright_white        bright_white
+=================== =================== ===========
+
+Providing Feedback
+==================
+
+**write()**
+
+Several methods are provided for you to provide feedback to your users. This can be as simple as a single status update
+or a complex table of information that wraps to the user's terminal window. At the core of this is the ``write()``
+method which takes the string to output as the first parameter::
+
+	$output->write('The rain in Spain falls mainly on the plains.');
+
+You can change the color of the text by passing in a color name as the second parameter::
+
+	$output->write('File created.', 'green');
+
+This could be used to differentiate messages by status, or create 'headers' by using a different color. You can
+even set background colors by passing the color name in as the third parameter::
+
+	$output->write('File overwritten.', 'bright_red', 'white');
+
+If you need to write multiple items at once, pass an array or iterable in the first parameter::
+
+	$messages = [
+		'Deleting file...',
+		'File successfully deleted.',
+	];
+	$output->write($messages, 'bright_red');
+
+**print()**
+
+Print functions identically to the ``write()`` method, except that it does not force a newline either before or after.
+Instead it prints it to the screen wherever the cursor is currently. This allows you to print multiple items all on
+the same line, from different calls. This is especially helpful when you want to show a status, do something, then
+print "Done" on the same line::
+
+    for ($i = 0; $i <= 10; $i++)
+    {
+        $output->print($i);
+    }
+
+**color()**
+
+While the ``write()`` command will write a single line to the terminal, ending it with an EOL character, you can
+use the ``color()`` method to make a string fragment that can be used in the same way, except that it will not force
+an EOL after printing. This allows you to create multiple outputs on the same row. Or, more commonly, you can use
+it inside of a ``write()`` method to create a string of a different color inside::
+
+	$output->write("fileA \t" . $output->color('/path/to/file', 'white'), 'yellow');
+
+This example would write a single line to the window, with ``fileA`` in yellow, followed by a tab, and then
+``/path/to/file`` in white text.
+
+**error()**
+
+If you need to output errors, you should use the appropriately named ``error()`` method. This writes bright-red text
+to ``STDERR``, instead of ``STDOUT``, like ``write()`` and ``color()`` do. This can be useful if you have scripts watching
+for errors so they don't have to sift through all of the information, only the actual error messages. You use it
+exactly as you would the ``write()`` method::
+
+	$output->error('Cannot write to file: ' . $file);
+
+**newLine()**
+
+The ``newLine()`` method displays a blank line to the user. It does not take any parameters::
+
+	$output->newLine();
+
+**clearScreen()**
+
+You can clear the current terminal window with the ``clearScreen()`` method. In most versions of Windows, this will
+simply insert 40 blank lines since Windows doesn't support this feature. Windows 10 bash integration should change
+this::
+
+	$output->clearScreen();
+
+**showProgress()**
+
+If you have a long-running task that you would like to keep the user updated with the progress, you can use the
+``showProgress()`` method which displays something like the following:
+
+.. code-block:: none
+
+	[####......] 40% Complete
+
+This block is animated in place for a very nice effect.
+
+To use it, pass in the current step as the first parameter, and the total number of steps as the second parameter.
+The percent complete and the length of the display will be determined based on that number. When you are done,
+pass ``false`` as the first parameter and the progress bar will be removed.
+::
+
+	$totalSteps = count($tasks);
+	$currStep   = 1;
+
+	foreach ($tasks as $task)
+	{
+		$output->showProgress($currStep++, $totalSteps);
+		$task->run();
+	}
+
+	// Done, so erase it...
+	$output->showProgress(false);
+
+**table()**
+
+::
+
+	$thead = ['ID', 'Title', 'Updated At', 'Active'];
+	$tbody = [
+		[7, 'A great item title', '2017-11-15 10:35:02', 1],
+		[8, 'Another great item title', '2017-11-16 13:46:54', 0]
+	];
+
+	$output->table($tbody, $thead);
+
+.. code-block:: none
+
+	+----+--------------------------+---------------------+--------+
+	| ID | Title                    | Updated At          | Active |
+	+----+--------------------------+---------------------+--------+
+	| 7  | A great item title       | 2017-11-16 10:35:02 | 1      |
+	| 8  | Another great item title | 2017-11-16 13:46:54 | 0      |
+	+----+--------------------------+---------------------+--------+
+
+**wait()**
+
+Waits a certain number of seconds, optionally showing a wait message and
+waiting for a key press.
+
+::
+
+        // wait for specified interval, with countdown displayed
+        $output->wait($seconds, true);
+
+        // show continuation message and wait for input
+        $output->wait(0, false);
+
+        // wait for specified interval
+        $output->wait($seconds, false);
+
+Class Reference
+===============
+
+.. php:class:: CodeIgniter\\CLI\\CLIOutput
+
+	.. php:method:: __construct([$stream = STDOUT[, $enforceColors = null]])
+
+		:param resource $stream: A valid CLI output stream. Defaults to use STDOUT.
+		:param bool|null $enforceColors: Whether to enforce color output. Use null for auto-detection.
+
+	.. php:method:: setStream($resource)
+
+		:param resource $stream: A valid CLI output stream
+
+	.. php:method:: getStream()
+
+		:returns: Returns the current output stream
+		:rtype: resource
+
+	.. php:method:: setEnforceColors($enforceColors)
+
+		:param bool $enforceColors: Whether to enforce colored output to terminals
+
+	.. php:method:: isColored()
+
+		:returns: Returns true if output is to be colored
+		:rtype: bool
+
+	.. php:method:: hasColorSupport()
+
+		:returns: Returns true if output stream supports colors.
+		:rtype: bool
+
+		If the second argument in ``__construct()`` is passed as ``null``, this method is invoked to
+		check if the current terminal supports ANSI colors by using a number of heuristics and
+		checking the environment.
+
+	.. php:method:: wait($seconds[, $countdown = false])
+
+		:param int $seconds: Number of seconds
+		:param bool $countdown: Show a countdown timer or not
+
+		This waits for a certain number of ``$seconds``, optionally showing a wait message
+		and waiting for a key press.
+
+	.. php:method:: print([$texts = ''[, $foreground = null[, $background = null[, $options = []]]]])
+
+		:param string|array|Traversable $texts: The text (or array of texts) to output
+		:param string|null $foreground: The foreground color
+		:param string|null $background: The background color
+		:param array $options: Other formatting options
+
+		This outputs a string (or series of strings) to the CLI without any surrounding newlines.
+		This is useful for showing repeating elements on a single line.
+
+	.. php:method:: write([$texts = ''[, $foreground = null[, $background = null[, $options = []]]]])
+
+		:param string|array|Traversable $texts: The text (or array of texts) to output
+		:param string|null $foreground: The foreground color
+		:param string|null $background: The background color
+		:param array $options: Other formatting options
+
+		This method outputs a string to the CLI on its own line.
+
+	.. php:method:: error($texts[, $foreground = 'bright_red'[, $background = null[, $options = [][, $stream = STDERR]]]])
+
+		:param string|array|Traversable $texts: The error text to output, or array of errors
+		:param string $foreground: The foreground color
+		:param string|null $background: The background color
+		:param array $options: Other formatting options
+		:param resource $stream: Error stream to use. Defaults to ``STDERR``
+
+		This method outputs an error to the CLI using ``STDERR`` instead of ``STDOUT``.
+
+	.. php:method:: newLine([$num = 1])
+
+		:param int $num: Number of lines to output
+
+		This method enters empty lines in multiple of ``$num``
+
+	.. php:method:: clearScreen()
+
+		Clears the screen of output.
+
+	.. php:method:: color($text[, $foreground = null[, $background = null[, $options = []]]])
+
+		:param string $text: The text to color
+		:param string|null $foreground: The foreground color
+		:param string|null $background: The background color
+		:param array $options: Other formatting options
+		:returns: The color coded text, or a plain text if color support is disabled.
+		:rtype: string
+
+		This returns the given text with the correct color codes for a foreground and
+		optionally a background color and other options
+
+	.. php:method:: strlen($string)
+
+		:param string|null $string: The string to get the length
+		:returns: An integer length, or 0 if ``null`` is given
+		:rtype: int
+
+		This gets the number of characters in string having encoded characters
+		and ignores styles set by the ``color()`` function.
+
+		.. note:: This is a static method. You may use this without having an instance of ``CLIOutput``.
+
+	.. php:method:: showProgress([$thisStep = 1[, $totalSteps = 10]])
+
+		:param int|bool $thisStep: Current step
+		:param int $totalSteps: Total steps
+
+		This displays a progress bar on the CLI. You must call it repeatedly to update it.
+		Set ``$thisStep`` to ``false`` to erase the progress bar.
+
+	.. php:method:: table($tbody[, $thead = []])
+
+		:param array $tbody: List of rows
+		:param array $thead: List of columns
+
+		This returns a well-formatted table.

--- a/user_guide_src/source/cli/index.rst
+++ b/user_guide_src/source/cli/index.rst
@@ -10,4 +10,5 @@ CodeIgniter 4 can also be used with command line programs.
     cli
     cli_commands
     cli_library
+    cli_output
     cli_request


### PR DESCRIPTION
This is in relation to issue #2849 .

**Description**
This PR improves the current `CLI` library with regard to the output by utilizing a new class `CLIOutput`. The original methods in `CLI` have been retained for BC.

Changes made are the following:
- Automatic detection for ANSI color support for your favorite terminal.
- Enforce/disable ANSI-colored output.
- Foreground and background colors available are expanded to include the colors in the ECMA-48 Standard.
- Additional formatting options besides from underline.
- Choice of other streams for output aside from STDOUT and STDERR.

For the documentation, I do not know how to properly tell users to use the new class. If you have suggestions, I'll gladly incorporate.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
