### PR TITLE
Fix Model::first() only use orderBy() when group by is not empty

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -103,7 +103,7 @@ class BaseBuilder
 	 *
 	 * @var array
 	 */
-	protected $QBGroupBy = [];
+	public $QBGroupBy = [];
 
 	/**
 	 * QB HAVING data

--- a/system/Model.php
+++ b/system/Model.php
@@ -479,7 +479,7 @@ class Model
 		}
 
 		// Some databases, like PostgreSQL, need order
-		// information to consistently return correct results
+		// information to consistently return correct results.
 		if (! empty($builder->QBGroupBy) && empty($builder->QBOrderBy) && ! empty($this->primaryKey))
 		{
 			$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');

--- a/system/Model.php
+++ b/system/Model.php
@@ -472,8 +472,8 @@ class Model
 		}
 
 		// Some databases, like PostgreSQL, need order
-		// information to consistently return correct results.
-		if (empty($builder->QBOrderBy) && ! empty($this->primaryKey))
+		// information to consistently return correct results when there is group by
+		if (! empty($this->QBGroupBy) && empty($builder->QBOrderBy) && ! empty($this->primaryKey))
 		{
 			$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');
 		}

--- a/system/Model.php
+++ b/system/Model.php
@@ -472,7 +472,7 @@ class Model
 		}
 		else
 		{
-			if (empty($builder->QBGroupBy) && ! empty($this->primaryKey))
+			if ($this->useSoftDeletes === true && empty($builder->QBGroupBy) && ! empty($this->primaryKey))
 			{
 				$builder->groupBy($this->table . '.' . $this->primaryKey);
 			}

--- a/system/Model.php
+++ b/system/Model.php
@@ -471,15 +471,18 @@ class Model
 			$builder->where($this->table . '.' . $this->deletedField, null);
 		}
 
-		// Some databases, like PostgreSQL, need order
-		// information to consistently return correct results when there is group by
-		if (! empty($this->QBGroupBy) && empty($builder->QBOrderBy) && ! empty($this->primaryKey))
+		preg_match('/(MAX\(.+\))|(MIN\(.+\))|(AVG\(.+\))|(SUM\(.+\))|(COUNT\(.+\))/', $builder->getCompiledSelect(false), $matches);
+		if ($matches)
 		{
-			$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');
+			// Some databases, like PostgreSQL, need order
+			// information to consistently return correct results.
+			if (! empty($builder->QBGroupBy) && empty($builder->QBOrderBy) && ! empty($this->primaryKey))
+			{
+				$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');
+			}
 		}
 
-		$row = $builder->limit(1, 0)
-				->get();
+		$row = $builder->limit(1, 0)->get();
 
 		$row = $row->getFirstRow($this->tempReturnType);
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -473,13 +473,9 @@ class Model
 
 		// Some databases, like PostgreSQL, need order
 		// information to consistently return correct results when there is group by
-		// except when soft delete is enabled
-		if (empty($builder->QBOrderBy) && ! empty($this->primaryKey))
+		if (! empty($this->QBGroupBy) && empty($builder->QBOrderBy) && ! empty($this->primaryKey))
 		{
-			if (! empty($this->QBGroupBy) || $this->tempUseSoftDeletes === true)
-			{
-				$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');
-			}
+			$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');
 		}
 
 		$row = $builder->limit(1, 0)

--- a/system/Model.php
+++ b/system/Model.php
@@ -470,19 +470,23 @@ class Model
 		{
 			$builder->where($this->table . '.' . $this->deletedField, null);
 		}
-
-		preg_match('/(MAX\(.+\))|(MIN\(.+\))|(AVG\(.+\))|(SUM\(.+\))|(COUNT\(.+\))/', $builder->getCompiledSelect(false), $matches);
-		if ($matches)
+		else
 		{
-			// Some databases, like PostgreSQL, need order
-			// information to consistently return correct results.
-			if (! empty($builder->QBGroupBy) && empty($builder->QBOrderBy) && ! empty($this->primaryKey))
+			if (empty($builder->QBGroupBy) && ! empty($this->primaryKey))
 			{
-				$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');
+				$builder->groupBy($this->table . '.' . $this->primaryKey);
 			}
 		}
 
-		$row = $builder->limit(1, 0)->get();
+		// Some databases, like PostgreSQL, need order
+		// information to consistently return correct results
+		if (! empty($builder->QBGroupBy) && empty($builder->QBOrderBy) && ! empty($this->primaryKey))
+		{
+			$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');
+		}
+
+		$row = $builder->limit(1, 0)
+					   ->get();
 
 		$row = $row->getFirstRow($this->tempReturnType);
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -473,9 +473,13 @@ class Model
 
 		// Some databases, like PostgreSQL, need order
 		// information to consistently return correct results when there is group by
-		if (! empty($this->QBGroupBy) && empty($builder->QBOrderBy) && ! empty($this->primaryKey))
+		// except when soft delete is enabled
+		if (empty($builder->QBOrderBy) && ! empty($this->primaryKey))
 		{
-			$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');
+			if (! empty($this->QBGroupBy) || $this->tempUseSoftDeletes === true)
+			{
+				$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');
+			}
 		}
 
 		$row = $builder->limit(1, 0)

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -276,23 +276,47 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testFirstRespectsSoftDeletes()
+	public function provideGroupBy()
+	{
+		return [
+			[true],
+			[false],
+		];
+	}
+
+	/**
+	 * @dataProvider provideGroupBy
+	 */
+	public function testFirstRespectsSoftDeletes($groupBy)
 	{
 		$this->db->table('user')
 				 ->where('id', 1)
 				 ->update(['deleted_at' => date('Y-m-d H:i:s')]);
 
 		$model = new UserModel();
-
-		$user = $model->first();
+		if ($groupBy)
+		{
+			$user = $model->groupBy('id')->first();
+		}
+		else
+		{
+			$user = $model->first();
+		}
 
 		// fix for PHP7.2
 		$count = is_array($user) ? count($user) : 1;
 		$this->assertEquals(1, $count);
 		$this->assertEquals(2, $user->id);
 
-		$user = $model->withDeleted()
-					  ->first();
+		$user = $model->withDeleted();
+		if ($groupBy)
+		{
+			$user = $model->groupBy('id')->first();
+		}
+		else
+		{
+			$user = $model->first();
+		}
 
 		$this->assertEquals(1, $user->id);
 	}
@@ -1900,13 +1924,31 @@ class ModelTest extends CIDatabaseTestCase
 			->getBindings();
 	}
 
-	public function testFirstRecoverTempUseSoftDeletes()
+	/**
+	 * @dataProvider provideGroupBy
+	 */
+	public function testFirstRecoverTempUseSoftDeletes($groupBy)
 	{
 		$model = new UserModel($this->db);
 		$model->delete(1);
-		$user = $model->withDeleted()->first();
+		if ($groupBy)
+		{
+			$user = $model->groupBy('id')->withDeleted()->first();
+		}
+		else
+		{
+			$user = $model->withDeleted()->first();
+		}
 		$this->assertEquals(1, $user->id);
 		$user2 = $model->first();
+		if ($groupBy)
+		{
+			$user2 = $model->groupBy('id')->first();
+		}
+		else
+		{
+			$user2 = $model->first();
+		}
 		$this->assertEquals(2, $user2->id);
 	}
 

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -258,10 +258,10 @@ class ModelTest extends CIDatabaseTestCase
 				true,
 				3,
 			],
-			/*[
+			[
 				false,
 				7,
-			],*/
+			],
 		];
 	}
 
@@ -1969,15 +1969,7 @@ class ModelTest extends CIDatabaseTestCase
 		}
 
 		$user = $model->withDeleted()->first();
-
-		if (! $aggregate || $groupBy)
-		{
-			$this->assertEquals(1, $user->id);
-		}
-		else
-		{
-			$this->assertEquals(10, $user->id);
-		}
+		$this->assertEquals(1, $user->id);
 
 		$user2 = $model->first();
 		$this->assertEquals(2, $user2->id);

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -258,10 +258,10 @@ class ModelTest extends CIDatabaseTestCase
 				true,
 				3,
 			],
-			[
+			/*[
 				false,
 				7,
-			],
+			],*/
 		];
 	}
 

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -342,8 +342,8 @@ class ModelTest extends CIDatabaseTestCase
 			$this->assertEquals(9, $user->id);
 		}
 
-		$user = $model->withDeleted();
-		$user = $model->first();
+		$user = $model->withDeleted()
+					  ->first();
 
 		$this->assertEquals(1, $user->id);
 	}

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -251,31 +251,6 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testFirstWithoutGroupBy()
-	{
-		$model = new UserModel();
-
-		$user = $model->select('SUM(id) as total')
-					  ->where('id >', 2)
-					  ->first();
-		$this->assertEquals(7, $user->total);
-	}
-
-	//--------------------------------------------------------------------
-
-	public function testFirstWithGroupBy()
-	{
-		$model = new UserModel();
-
-		$user = $model->select('SUM(id) as total')
-						->where('id >', 2)
-						->groupBy('id')
-						->first();
-		$this->assertEquals(3, $user->total);
-	}
-
-	//--------------------------------------------------------------------
-
 	public function provideGroupBy()
 	{
 		return [
@@ -283,6 +258,32 @@ class ModelTest extends CIDatabaseTestCase
 			[false],
 		];
 	}
+
+	/**
+	 * @dataProvider provideGroupBy
+	 */
+	public function testFirstAggregate($groupBy)
+	{
+		$model = new UserModel();
+
+		if ($groupBy)
+		{
+			$user = $model->select('SUM(id) as total')
+						->where('id >', 2)
+						->groupBy('id')
+						->first();
+			$this->assertEquals(3, $user->total);
+		}
+		else
+		{
+			$user = $model->select('SUM(id) as total')
+						->where('id >', 2)
+						->first();
+			$this->assertEquals(7, $user->total);
+		}
+	}
+
+	//--------------------------------------------------------------------
 
 	/**
 	 * @dataProvider provideGroupBy

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -285,39 +285,71 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function provideAggregateAndGroupBy()
+	{
+		return [
+			[
+				true,
+				true,
+			],
+			[
+				false,
+				false,
+			],
+			[
+				true,
+				false,
+			],
+			[
+				false,
+				true,
+			],
+		];
+	}
+
 	/**
-	 * @dataProvider provideGroupBy
+	 * @dataProvider provideAggregateAndGroupBy
 	 */
-	public function testFirstRespectsSoftDeletes($groupBy)
+	public function testFirstRespectsSoftDeletes($aggregate, $groupBy)
 	{
 		$this->db->table('user')
 				 ->where('id', 1)
 				 ->update(['deleted_at' => date('Y-m-d H:i:s')]);
 
 		$model = new UserModel();
+		if ($aggregate)
+		{
+			$model->select('SUM(id) as id');
+		}
+
 		if ($groupBy)
 		{
-			$user = $model->groupBy('id')->first();
+			$model->groupBy('id');
+		}
+
+		$user = $model->first();
+
+		if (! $aggregate)
+		{
+			// fix for PHP7.2
+			$count = is_array($user) ? count($user) : 1;
+			$this->assertEquals(1, $count);
+			$this->assertEquals(2, $user->id);
 		}
 		else
 		{
-			$user = $model->first();
+			if ($groupBy)
+			{
+				$this->assertEquals(2, $user->id);
+			}
+			else
+			{
+				$this->assertEquals(9, $user->id);
+			}
 		}
-
-		// fix for PHP7.2
-		$count = is_array($user) ? count($user) : 1;
-		$this->assertEquals(1, $count);
-		$this->assertEquals(2, $user->id);
 
 		$user = $model->withDeleted();
-		if ($groupBy)
-		{
-			$user = $model->groupBy('id')->first();
-		}
-		else
-		{
-			$user = $model->first();
-		}
+		$user = $model->first();
 
 		$this->assertEquals(1, $user->id);
 	}
@@ -1926,30 +1958,41 @@ class ModelTest extends CIDatabaseTestCase
 	}
 
 	/**
-	 * @dataProvider provideGroupBy
+	 * @dataProvider provideAggregateAndGroupBy
 	 */
-	public function testFirstRecoverTempUseSoftDeletes($groupBy)
+	public function testFirstRecoverTempUseSoftDeletes($aggregate, $groupBy)
 	{
 		$model = new UserModel($this->db);
 		$model->delete(1);
+		if ($aggregate)
+		{
+			$model->select('sum(id) as id');
+		}
+
 		if ($groupBy)
 		{
-			$user = $model->groupBy('id')->withDeleted()->first();
+			$model->groupBy('id');
+		}
+
+		$user = $model->withDeleted()->first();
+
+		if (! $aggregate)
+		{
+			$this->assertEquals(1, $user->id);
 		}
 		else
 		{
-			$user = $model->withDeleted()->first();
+			if ($groupBy)
+			{
+				$this->assertEquals(1, $user->id);
+			}
+			else
+			{
+				$this->assertEquals(10, $user->id);
+			}
 		}
-		$this->assertEquals(1, $user->id);
+
 		$user2 = $model->first();
-		if ($groupBy)
-		{
-			$user2 = $model->groupBy('id')->first();
-		}
-		else
-		{
-			$user2 = $model->first();
-		}
 		$this->assertEquals(2, $user2->id);
 	}
 

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -251,6 +251,31 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testFirstWithoutGroupBy()
+	{
+		$model = new UserModel();
+
+		$user = $model->select('SUM(id) as total')
+					  ->where('id >', 2)
+					  ->first();
+		$this->assertEquals(7, $user->total);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testFirstWithGroupBy()
+	{
+		$model = new UserModel();
+
+		$user = $model->select('SUM(id) as total')
+						->where('id >', 2)
+						->groupBy('id')
+						->first();
+		$this->assertEquals(3, $user->total);
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testFirstRespectsSoftDeletes()
 	{
 		$this->db->table('user')

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -330,7 +330,7 @@ class ModelTest extends CIDatabaseTestCase
 
 		$user = $model->first();
 
-		if (! $aggregate)
+		if (! $aggregate || $groupBy)
 		{
 			// fix for PHP7.2
 			$count = is_array($user) ? count($user) : 1;
@@ -339,14 +339,7 @@ class ModelTest extends CIDatabaseTestCase
 		}
 		else
 		{
-			if ($groupBy)
-			{
-				$this->assertEquals(2, $user->id);
-			}
-			else
-			{
-				$this->assertEquals(9, $user->id);
-			}
+			$this->assertEquals(9, $user->id);
 		}
 
 		$user = $model->withDeleted();
@@ -1977,20 +1970,13 @@ class ModelTest extends CIDatabaseTestCase
 
 		$user = $model->withDeleted()->first();
 
-		if (! $aggregate)
+		if (! $aggregate || $groupBy)
 		{
 			$this->assertEquals(1, $user->id);
 		}
 		else
 		{
-			if ($groupBy)
-			{
-				$this->assertEquals(1, $user->id);
-			}
-			else
-			{
-				$this->assertEquals(10, $user->id);
-			}
+			$this->assertEquals(10, $user->id);
 		}
 
 		$user2 = $model->first();

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -254,33 +254,34 @@ class ModelTest extends CIDatabaseTestCase
 	public function provideGroupBy()
 	{
 		return [
-			[true],
-			[false],
+			[
+				true,
+				3,
+			],
+			[
+				false,
+				7,
+			],
 		];
 	}
 
 	/**
 	 * @dataProvider provideGroupBy
 	 */
-	public function testFirstAggregate($groupBy)
+	public function testFirstAggregate($groupBy, $total)
 	{
 		$model = new UserModel();
 
 		if ($groupBy)
 		{
-			$user = $model->select('SUM(id) as total')
-						->where('id >', 2)
-						->groupBy('id')
-						->first();
-			$this->assertEquals(3, $user->total);
+			$model->groupBy('id');
 		}
-		else
-		{
-			$user = $model->select('SUM(id) as total')
-						->where('id >', 2)
-						->first();
-			$this->assertEquals(7, $user->total);
-		}
+
+		$user = $model->select('SUM(id) as total')
+					  ->where('id >', 2)
+					  ->first();
+
+		$this->assertEquals($total, $user->total);
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
This fix the condition, eg: in Postgresql when we can supply sql like:

```sql
SELECT SUM(id) as total FROM "user" WHERE 1 = 1 LIMIT 1 ;
```

without group by, and followed order by. So, make order by only when there is a group by.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
