### PR TITLE
fix undefined class 'CodeIgniter'

### DIFF
--- a/user_guide_src/source/cli/cli_commands.rst
+++ b/user_guide_src/source/cli/cli_commands.rst
@@ -129,7 +129,7 @@ Our demo command might have a ``run`` method something like::
     public function run(array $params)
     {
         CLI::write('PHP Version: '. CLI::color(phpversion(), 'yellow'));
-        CLI::write('CI Version: '. CLI::color(CodeIgniter::CI_VERSION, 'yellow'));
+        CLI::write('CI Version: '. CLI::color(\CodeIgniter\CodeIgniter::CI_VERSION, 'yellow'));
         CLI::write('APPPATH: '. CLI::color(APPPATH, 'yellow'));
         CLI::write('SYSTEMPATH: '. CLI::color(SYSTEMPATH, 'yellow'));
         CLI::write('ROOTPATH: '. CLI::color(ROOTPATH, 'yellow'));


### PR DESCRIPTION
**Description**
forgot import the class

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
