### PR TITLE
Remove placeholder from validarion rules when there is no matching variable

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -1524,12 +1524,16 @@ class Model
 							continue;
 						}
 
-						$row = strtr($row, $replacements);
+						$row = preg_replace_callback('/\{(\w+)\}/', function ($matches) use ($replacements) {
+							return array_key_exists($matches[0], $replacements) ? $replacements[$matches[0]] : '';
+						}, $row);
 					}
 					continue;
 				}
 
-				$rule = strtr($rule, $replacements);
+				$rule = preg_replace_callback('/\{(\w+)\}/', function ($matches) use ($replacements) {
+					return array_key_exists($matches[0], $replacements) ? $replacements[$matches[0]] : '';
+				}, $rule);
 			}
 		}
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -1524,10 +1524,22 @@ class Model
 							continue;
 						}
 
+						// Skip regex_match rule
+						if (strpos($row, 'regex_match[') !== false)
+						{
+							continue;
+						}
+
 						$row = preg_replace_callback('/\{(\w+)\}/', function ($matches) use ($replacements) {
 							return array_key_exists($matches[0], $replacements) ? $replacements[$matches[0]] : '';
 						}, $row);
 					}
+					continue;
+				}
+
+				// Skip regex_match rule
+				if (strpos($rule, 'regex_match[') !== false)
+				{
 					continue;
 				}
 

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -653,12 +653,16 @@ class Validation implements ValidationInterface
 							continue;
 						}
 
-						$row = strtr($row, $replacements);
+						$row = preg_replace_callback('/\{(\w+)\}/', function ($matches) use ($replacements) {
+							return array_key_exists($matches[0], $replacements) ? $replacements[$matches[0]] : '';
+						}, $row);
 					}
 					continue;
 				}
 
-				$rule = strtr($rule, $replacements);
+				$rule = preg_replace_callback('/\{(\w+)\}/', function ($matches) use ($replacements) {
+					return array_key_exists($matches[0], $replacements) ? $replacements[$matches[0]] : '';
+				}, $rule);
 			}
 		}
 

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -653,10 +653,22 @@ class Validation implements ValidationInterface
 							continue;
 						}
 
+						// Skip regex_match rule
+						if (strpos($row, 'regex_match[') !== false)
+						{
+							continue;
+						}
+
 						$row = preg_replace_callback('/\{(\w+)\}/', function ($matches) use ($replacements) {
 							return array_key_exists($matches[0], $replacements) ? $replacements[$matches[0]] : '';
 						}, $row);
 					}
+					continue;
+				}
+
+				// Skip regex_match rule
+				if (strpos($rule, 'regex_match[') !== false)
+				{
 					continue;
 				}
 

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -609,6 +609,67 @@ class RulesTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	/**
+	 * @group DatabaseLive
+	 */
+	public function testIsUniqueIgnoresParamsAsVariable()
+	{
+		$db   = Database::connect();
+		$user = $db->table('user')
+				   ->insert([
+					   'name'    => 'Developer A',
+					   'email'   => 'deva@example.com',
+					   'country' => 'Elbonia',
+				   ]);
+		$row  = $db->table('user')
+				   ->limit(1)
+				   ->get()
+				   ->getRow();
+
+		$data = [
+			'id'    => $row->id,
+			'email' => 'deva@example.com',
+		];
+
+		$this->validation->setRules([
+			'email' => 'is_unique[user.email,id,{id}]',
+		]);
+
+		$this->assertTrue($this->validation->run($data));
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * @group DatabaseLive
+	 */
+	public function testIsUniqueIgnoresParamsAsVariableWithEmptyPlaceholder()
+	{
+		$db   = Database::connect();
+		$user = $db->table('user')
+				   ->insert([
+					   'name'    => 'Developer A',
+					   'email'   => 'deva@example.com',
+					   'country' => 'Elbonia',
+				   ]);
+		$row  = $db->table('user')
+				   ->limit(1)
+				   ->get()
+				   ->getRow();
+
+		$data = [
+			'email' => 'deva@example.com',
+		];
+
+		$this->validation->setRules([
+			'email' => 'is_unique[user.email,id,{id}]',
+		]);
+
+		$this->assertFalse($this->validation->run($data));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testMinLengthNull()
 	{
 		$data = [

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -612,37 +612,6 @@ class RulesTest extends CIDatabaseTestCase
 	/**
 	 * @group DatabaseLive
 	 */
-	public function testIsUniqueIgnoresParamsAsVariable()
-	{
-		$db   = Database::connect();
-		$user = $db->table('user')
-				   ->insert([
-					   'name'    => 'Developer A',
-					   'email'   => 'deva@example.com',
-					   'country' => 'Elbonia',
-				   ]);
-		$row  = $db->table('user')
-				   ->limit(1)
-				   ->get()
-				   ->getRow();
-
-		$data = [
-			'id'    => $row->id,
-			'email' => 'deva@example.com',
-		];
-
-		$this->validation->setRules([
-			'email' => 'is_unique[user.email,id,{id}]',
-		]);
-
-		$this->assertTrue($this->validation->run($data));
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * @group DatabaseLive
-	 */
 	public function testIsUniqueIgnoresParamsAsVariableWithEmptyPlaceholder()
 	{
 		$db   = Database::connect();


### PR DESCRIPTION
**Description**
When we use a placeholder in validation rules and there is no data provided to replace the placeholder, we can end up with something like `{variable}` as a parameter. This can cause issues for developers like in `is_unique` validation method.

In this case, when we have rules like: `is_unique[user.email,id,{id}]` we can produce the query like:
```sql
SELECT 1
FROM "user"
WHERE "email" = 'john@smith.com'
AND "id" != '{id}'
LIMIT 1
```
In MySQL it would be a mistake we probably could live with, but in PostgreSQL this will produce an error: `invalid input syntax for integer` since this DB engine checks the field types.

Either way, I would call the current behavior a bug.

This pull request fixes this by removing placeholders that can't be replaced by provided variables.

Related to #2812

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide 
