### PR TITLE
Set validation rules for model dynamically

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -1381,6 +1381,37 @@ class Model
 	//--------------------------------------------------------------------
 
 	/**
+	 * Allows to set validation rules.
+	 * It could be used when you have to change default or override current validate rules.
+	 *
+	 * @param array $validationRules
+	 *
+	 * @return void
+	 */
+	public function setValidationRules(array $validationRules)
+	{
+		$this->validationRules = $validationRules;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Allows to set field wise validation rules.
+	 * It could be used when you have to change default or override current validate rules.
+	 *
+	 * @param string       $field
+	 * @param string|array $fieldRules
+	 *
+	 * @return void
+	 */
+	public function setValidationRule(string $field, $fieldRules)
+	{
+		$this->validationRules[$field] = $fieldRules;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Should validation rules be removed before saving?
 	 * Most handy when doing updates.
 	 *

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -667,6 +667,65 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testValidationWithSetValidationRule()
+	{
+		$model = new ValidModel($this->db);
+
+		$data = [
+			'name'        => 'some name',
+			'description' => 'some great marketing stuff',
+		];
+
+		$model->setValidationRule('description', [
+			'required',
+			'min_length[50]',
+			'errors' => [
+				'min_length' => 'Description is too short baby.',
+			],
+		]);
+		$this->assertFalse($model->insert($data));
+
+		$errors = $model->errors();
+
+		$this->assertEquals('Description is too short baby.', $errors['description']);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testValidationWithSetValidationRules()
+	{
+		$model = new ValidModel($this->db);
+
+		$data = [
+			'name'        => '',
+			'description' => 'some great marketing stuff',
+		];
+
+		$model->setValidationRules([
+			'name'        => [
+				'required',
+				'errors' => [
+					'required' => 'Give me a name baby.',
+				],
+			],
+			'description' => [
+				'required',
+				'min_length[50]',
+				'errors' => [
+					'min_length' => 'Description is too short baby.',
+				],
+			],
+		]);
+		$this->assertFalse($model->insert($data));
+
+		$errors = $model->errors();
+
+		$this->assertEquals('Give me a name baby.', $errors['name']);
+		$this->assertEquals('Description is too short baby.', $errors['description']);
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testValidationWithSetValidationMessage()
 	{
 		$model = new ValidModel($this->db);

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -677,8 +677,7 @@ class ModelTest extends CIDatabaseTestCase
 		];
 
 		$model->setValidationRule('description', [
-			'required',
-			'min_length[50]',
+			'rules'  => 'required|min_length[50]',
 			'errors' => [
 				'min_length' => 'Description is too short baby.',
 			],
@@ -703,14 +702,13 @@ class ModelTest extends CIDatabaseTestCase
 
 		$model->setValidationRules([
 			'name'        => [
-				'required',
+				'rules'  => 'required',
 				'errors' => [
 					'required' => 'Give me a name baby.',
 				],
 			],
 			'description' => [
-				'required',
-				'min_length[50]',
+				'rules'  => 'required|min_length[50]',
 				'errors' => [
 					'min_length' => 'Description is too short baby.',
 				],

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -480,6 +480,42 @@ be applied. If you have custom error message that you want to use, place them in
         ];
     }
 
+The other way to set the validation rules to fields by functions,
+
+.. php:function:: setValidationRule($field, $fieldRules)
+
+    :param  string  $field:
+    :param  array   $fieldRules:
+
+    This function will set the field validation rules.
+
+    Usage example::
+
+        $fieldName = 'username';
+        $fieldRules = [
+            'required', 'alpha_numeric_space', 'min_length[3]',
+        ];
+        $model->setValidationRule($fieldName, $fieldRules);
+
+.. php:function:: setValidationRules($validationRules)
+
+    :param  array   $validationRules:
+
+    This function will set the validation rules.
+
+    Usage example::
+
+        $validationRules = [
+            'username' => 'required|alpha_numeric_space|min_length[3]',
+            'email' => [
+                'required', 'valid_email', 'is_unique[users.email]',
+                'errors' => [
+                    'required' => 'We really need your email.',
+                ],
+            ],
+        ];
+        $model->setValidationRules($validationRules);
+
 The other way to set the validation message to fields by functions,
 
 .. php:function:: setValidationMessage($field, $fieldMessages)

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -492,9 +492,8 @@ The other way to set the validation rules to fields by functions,
     Usage example::
 
         $fieldName = 'username';
-        $fieldRules = [
-            'required|alpha_numeric_space|min_length[3]',
-        ];
+        $fieldRules = 'required|alpha_numeric_space|min_length[3]';
+        
         $model->setValidationRule($fieldName, $fieldRules);
 
 .. php:function:: setValidationRules($validationRules)

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -493,7 +493,7 @@ The other way to set the validation rules to fields by functions,
 
         $fieldName = 'username';
         $fieldRules = [
-            'required', 'alpha_numeric_space', 'min_length[3]',
+            'required|alpha_numeric_space|min_length[3]',
         ];
         $model->setValidationRule($fieldName, $fieldRules);
 
@@ -508,7 +508,7 @@ The other way to set the validation rules to fields by functions,
         $validationRules = [
             'username' => 'required|alpha_numeric_space|min_length[3]',
             'email' => [
-                'required', 'valid_email', 'is_unique[users.email]',
+                'rules'  => 'required|valid_email|is_unique[users.email]',
                 'errors' => [
                     'required' => 'We really need your email.',
                 ],


### PR DESCRIPTION
**Description**
This PR adds the ability to set validation rules for model dynamically via methods: `$model->setValidationRules($rules)` or `$model->setValidationRule($field, $rules)`. This can be very useful when working on applications that have many configuration options.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
