### PR TITLE
Correct misc build errors in user guide

### DIFF
--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -16,6 +16,7 @@ Release Date: Not Released
         :titlesonly:
 
         next
+        v4.0.3
         v4.0.0
         v4.0.0-rc.4
         v4.0.0-rc.3

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -433,6 +433,7 @@ The methods provided by the parent classes that are available are:
 			your configured ``$config['cookie_prefix']`` value.
 
 	.. php:method:: getServer([$index = null[, $filter = null[, $flags = null]]])
+		:noindex:
 
 		:param	mixed	$index: Value name
 		:param  int     $filter: The type of filter to apply. A list of filters can be found `here <https://www.php.net/manual/en/filter.filters.php>`__.

--- a/user_guide_src/source/incoming/message.rst
+++ b/user_guide_src/source/incoming/message.rst
@@ -69,7 +69,7 @@ Class Reference
         This is used by the :doc:`IncomingRequest Class </incoming/incomingrequest>` to make
         the current request's headers available.
 
-                The headers are any SERVER data that starts with ``HTTP_``, like ``HTTP_HOST``. Each message
+        The headers are any SERVER data that starts with ``HTTP_``, like ``HTTP_HOST``. Each message
         is converted from it's standard uppercase and underscore format to a ucwords and dash format.
         The preceding ``HTTP_`` is removed from the string. So ``HTTP_ACCEPT_LANGUAGE`` becomes
         ``Accept-Language``.

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -81,13 +81,13 @@ available to you::
 While the ``request()`` method is the most flexible, you can also use the following shortcut methods. They
 each take the URL as the first parameter and an array of options as the second::
 
-* $client->get('http://example.com');
-* $client->delete('http://example.com');
-* $client->head('http://example.com');
-* $client->options('http://example.com');
-* $client->patch('http://example.com');
-* $client->put('http://example.com');
-* $client->post('http://example.com');
+    $client->get('http://example.com');
+    $client->delete('http://example.com');
+    $client->head('http://example.com');
+    $client->options('http://example.com');
+    $client->patch('http://example.com');
+    $client->put('http://example.com');
+    $client->post('http://example.com');
 
 Base URI
 --------
@@ -112,7 +112,7 @@ with the baseURI according to the rules described by
 examples of how the combinations are resolved.
 
 	=====================   ================   ========================
-	baseURI                URI                Result
+	baseURI                 URI                Result
 	=====================   ================   ========================
 	`http://foo.com`        /bar               `http://foo.com/bar`
 	`http://foo.com/foo`    /bar               `http://foo.com/bar`

--- a/user_guide_src/source/libraries/email.rst
+++ b/user_guide_src/source/libraries/email.rst
@@ -251,6 +251,7 @@ Class Reference
 		and strip the tags.
 
 	.. php:method:: setHeader($header, $value)
+		:noindex:
 
 		:param	string	$header: Header name
 		:param	string	$value: Header value


### PR DESCRIPTION
Sphinx outputted error messages when trying to rebuild the userguide from scratch. Some parts did not render (like the baseURL) table, rendering quality and the rest about duplicated functions.

**Checklist:**
- [X] Securely signed commits
- [X] User guide updated
- [X] Conforms to style guide