### PR TITLE
Fixes #2932 : Fix Translation key separated by dot

### DIFF
--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -163,6 +163,13 @@ class Language
 			}
 		}
 
+		if ($output === null)
+		{
+			$row    = current(explode('.', $parsedLine));
+			$key    = substr($parsedLine, strlen($row) + 1);
+			$output = $this->language[$this->locale][$file][$row][$key] ?? null;
+		}
+
 		if ($output === null && strpos($this->locale, '-'))
 		{
 			[$locale] = explode('-', $this->locale, 2);

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -321,4 +321,12 @@ class LanguageTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('e', $lang->getLine('Nested.a.b.c.d'));
 	}
 
+	public function testLanguageKeySeparatedByDot()
+	{
+		$lang = new SecondMockLanguage('en');
+		$lang->loadem('Foo', 'en');
+
+		$this->assertEquals('The fieldname field is very short.', $lang->getLine('Foo.bar.min_length1', ['field' => 'fieldname']));
+	}
+
 }


### PR DESCRIPTION
Fixes #2932 : Fix Translation key may separated by dot.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage