### PR TITLE
Allow Exceptions config to extend BaseConfig

### DIFF
--- a/app/Config/Exceptions.php
+++ b/app/Config/Exceptions.php
@@ -1,12 +1,13 @@
 <?php namespace Config;
 
+use CodeIgniter\Config\BaseConfig;
+
 /**
  * Setup how the exception handler works.
  *
  * @package Config
  */
-
-class Exceptions
+class Exceptions extends BaseConfig
 {
 	/*
 	 |--------------------------------------------------------------------------


### PR DESCRIPTION
**Description**
Allow `Config\Exceptions` to extend the `BaseConfig` so that user-defined modules or external modules may supply their own registrars to populate the properties to their specific needs. Or users may use `.env` for the same purpose.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

  
