### PR TITLE
Fix FeatureTestCase paramater

### DIFF
--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -298,7 +298,7 @@ class FeatureTestCase extends CIDatabaseTestCase
 		$config = config(App::class);
 		$uri    = new URI($config->baseURL . '/' . trim($path, '/ '));
 
-		$request      = new IncomingRequest($config, clone($uri), $params, new UserAgent());
+		$request      = new IncomingRequest($config, clone($uri), $params ?? 'php://input', new UserAgent());
 		$request->uri = $uri;
 
 		$request->setMethod($method);


### PR DESCRIPTION
if $params is NULL, then it should work with default values
