### PR TITLE
Compress Timeline for Database Queries

### DIFF
--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -145,15 +145,21 @@ class Database extends BaseCollector
 			];
 		}
 
+		$start = 0;
+		$duration = 0;
+
 		foreach (static::$queries as $query)
 		{
-			$data[] = [
-				'name'      => 'Query',
-				'component' => 'Database',
-				'start'     => $query->getStartTime(true),
-				'duration'  => $query->getDuration(),
-			];
+			$start = $query->getStartTime(true);
+			$duration += $query->getDuration();
 		}
+
+		$data[] = [
+			'name'      => 'Queries ('.count(static::$queries).')',
+			'component' => 'Database',
+			'start'     => $start,
+			'duration'  => $duration,
+		];
 
 		return $data;
 	}

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -145,21 +145,24 @@ class Database extends BaseCollector
 			];
 		}
 
-		$start = 0;
-		$duration = 0;
-
-		foreach (static::$queries as $query)
+		if (count(static::$queries) > 0)
 		{
-			$start = $query->getStartTime(true);
-			$duration += $query->getDuration();
-		}
+			$start = 0;
+			$duration = 0;
 
-		$data[] = [
-			'name'      => 'Queries ('.count(static::$queries).')',
-			'component' => 'Database',
-			'start'     => $start,
-			'duration'  => $duration,
-		];
+			foreach (static::$queries as $query)
+			{
+				$start = $query->getStartTime(true);
+				$duration += $query->getDuration();
+			}
+
+			$data[] = [
+				'name'      => 'Queries ('.count(static::$queries).')',
+				'component' => 'Database',
+				'start'     => $start,
+				'duration'  => $duration,
+			];
+		}
 
 		return $data;
 	}


### PR DESCRIPTION
Simplified database queries component shown in timeline to decrease timeline for a hundred queries
Before:
![before](https://user-images.githubusercontent.com/59371810/81191759-ae0c8800-8fb9-11ea-909b-0a8d4f8626e8.png)
After:
![after](https://user-images.githubusercontent.com/59371810/81191777-b238a580-8fb9-11ea-96c0-353ba1449ca0.png)
