### PR TITLE
Fix PHP Docblock of Debug\Timer

### DIFF
--- a/system/Debug/Timer.php
+++ b/system/Debug/Timer.php
@@ -45,10 +45,7 @@ namespace CodeIgniter\Debug;
  * Provides a simple way to measure the amount of time
  * that elapses between two points.
  *
- * NOTE: All methods are static since the class is intended
- * to measure throughout an entire application's life cycle.
- *
- * @package CodeIgniter\Benchmark
+ * @package CodeIgniter\Debug
  */
 class Timer
 {


### PR DESCRIPTION
**Description**
Trivial PR to adjust the Doc Block of `Debug\Timer`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
