### PR TITLE
Replace BaseCollector::cleanPath with Exceptions::cleanPath

### DIFF
--- a/system/Debug/Toolbar/Collectors/BaseCollector.php
+++ b/system/Debug/Toolbar/Collectors/BaseCollector.php
@@ -38,6 +38,8 @@
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
+use CodeIgniter\Debug\Exceptions;
+
 /**
  * Base Toolbar collector
  */
@@ -253,20 +255,7 @@ class BaseCollector
 	 */
 	public function cleanPath(string $file): string
 	{
-		if (strpos($file, APPPATH) === 0)
-		{
-			$file = 'APPPATH/' . substr($file, strlen(APPPATH));
-		}
-		elseif (strpos($file, SYSTEMPATH) === 0)
-		{
-			$file = 'SYSTEMPATH/' . substr($file, strlen(SYSTEMPATH));
-		}
-		elseif (strpos($file, FCPATH) === 0)
-		{
-			$file = 'FCPATH/' . substr($file, strlen(FCPATH));
-		}
-
-		return $file;
+		return Exceptions::cleanPath($file);
 	}
 
 	/**


### PR DESCRIPTION
**Description**
Since the method signature of `BaseCollector::cleanPath()` is essentially the same with `Exceptions::cleanPath()`, and both are doing the same thing, *i.e.* creating nicer looking paths for the error output, I think one should use the other for the code to be DRY.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
