### PR TITLE
Validation - Handle required_with and required_without on permit_empty

### DIFF
--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -284,6 +284,66 @@ class RulesTest extends CIDatabaseTestCase
 				['foo' => 0.0],
 				true,
 			],
+			[
+				['foo' => 'permit_empty|required_with[bar]'],
+				['foo' => ''],
+				true,
+			],
+			[
+				['foo' => 'permit_empty|required_with[bar]'],
+				['foo' => 0],
+				true,
+			],
+			[
+				[
+					'foo' => 'permit_empty|required_with[bar]',
+				],
+				[
+					'foo' => 0.0,
+					'bar' => 1,
+				],
+				true,
+			],
+			[
+				[
+					'foo' => 'permit_empty|required_with[bar]',
+				],
+				[
+					'foo' => '',
+					'bar' => 1,
+				],
+				false,
+			],
+			[
+				['foo' => 'permit_empty|required_without[bar]'],
+				['foo' => ''],
+				false,
+			],
+			[
+				['foo' => 'permit_empty|required_without[bar]'],
+				['foo' => 0],
+				true,
+			],
+			[
+				[
+					'foo' => 'permit_empty|required_without[bar]',
+				],
+				[
+					'foo' => 0.0,
+					'bar' => 1,
+				],
+				true,
+			],
+			[
+				[
+					'foo' => 'permit_empty|required_without[bar]',
+				],
+				[
+					'foo' => '',
+					'bar' => 1,
+				],
+				true,
+			],
 		];
 	}
 


### PR DESCRIPTION
**Description**
Fixes #2953

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
  
