### PR TITLE
Add altPath to choose in Exceptions::render

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -104,7 +104,7 @@ class Exceptions
 	{
 		$this->ob_level = ob_get_level();
 
-		$this->viewPath = realpath(trim($config->errorViewPath)) . DIRECTORY_SEPARATOR;
+		$this->viewPath = rtrim($config->errorViewPath, '\\/ ') . DIRECTORY_SEPARATOR;
 
 		$this->config = $config;
 
@@ -241,7 +241,7 @@ class Exceptions
 	{
 		// Production environments should have a custom exception file.
 		$view          = 'production.php';
-		$template_path = realpath(trim($template_path)) . DIRECTORY_SEPARATOR;
+		$template_path = rtrim($template_path, '\\/ ') . DIRECTORY_SEPARATOR;
 
 		if (str_ireplace(['off', 'none', 'no', 'false', 'null'], '', ini_get('display_errors')))
 		{
@@ -275,7 +275,7 @@ class Exceptions
 	{
 		// Determine possible directories of error views
 		$path    = $this->viewPath;
-		$altPath = realpath((new Paths())->viewDirectory) . DIRECTORY_SEPARATOR . 'errors' . DIRECTORY_SEPARATOR;
+		$altPath = rtrim((new Paths())->viewDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'errors' . DIRECTORY_SEPARATOR;
 
 		$path    .= (is_cli() ? 'cli' : 'html') . DIRECTORY_SEPARATOR;
 		$altPath .= (is_cli() ? 'cli' : 'html') . DIRECTORY_SEPARATOR;

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -339,7 +339,7 @@ class Exceptions
 	 *
 	 * @param \Throwable $exception
 	 *
-	 * @return integer[]
+	 * @return array
 	 */
 	protected function determineCodes(Throwable $exception): array
 	{

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -104,7 +104,7 @@ class Exceptions
 	{
 		$this->ob_level = ob_get_level();
 
-		$this->viewPath = rtrim($config->errorViewPath, '/ ') . '/';
+		$this->viewPath = realpath(trim($config->errorViewPath)) . DIRECTORY_SEPARATOR;
 
 		$this->config = $config;
 
@@ -139,13 +139,15 @@ class Exceptions
 	 * and fire an event that allows custom actions to be taken at this point.
 	 *
 	 * @param \Throwable $exception
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function exceptionHandler(Throwable $exception)
 	{
-		// @codeCoverageIgnoreStart
-		$codes      = $this->determineCodes($exception);
-		$statusCode = $codes[0];
-		$exitCode   = $codes[1];
+		[
+			$statusCode,
+			$exitCode,
+		] = $this->determineCodes($exception);
 
 		// Log it
 		if ($this->config->log === true && ! in_array($statusCode, $this->config->ignoreCodes))
@@ -172,7 +174,6 @@ class Exceptions
 		$this->render($exception, $statusCode);
 
 		exit($exitCode);
-		// @codeCoverageIgnoreEnd
 	}
 
 	//--------------------------------------------------------------------
@@ -240,7 +241,7 @@ class Exceptions
 	{
 		// Production environments should have a custom exception file.
 		$view          = 'production.php';
-		$template_path = rtrim($template_path, '/ ') . '/';
+		$template_path = realpath(trim($template_path)) . DIRECTORY_SEPARATOR;
 
 		if (str_ireplace(['off', 'none', 'no', 'false', 'null'], '', ini_get('display_errors')))
 		{
@@ -254,7 +255,7 @@ class Exceptions
 		}
 
 		// Allow for custom views based upon the status code
-		else if (is_file($template_path . 'error_' . $exception->getCode() . '.php'))
+		if (is_file($template_path . 'error_' . $exception->getCode() . '.php'))
 		{
 			return 'error_' . $exception->getCode() . '.php';
 		}
@@ -272,18 +273,26 @@ class Exceptions
 	 */
 	protected function render(Throwable $exception, int $statusCode)
 	{
-		// Determine directory with views
-		$path = $this->viewPath;
-		if (empty($path))
+		// Determine possible directories of error views
+		$path    = $this->viewPath;
+		$altPath = realpath((new Paths())->viewDirectory) . DIRECTORY_SEPARATOR . 'errors' . DIRECTORY_SEPARATOR;
+
+		$path    .= (is_cli() ? 'cli' : 'html') . DIRECTORY_SEPARATOR;
+		$altPath .= (is_cli() ? 'cli' : 'html') . DIRECTORY_SEPARATOR;
+
+		// Determine the views
+		$view    = $this->determineView($exception, $path);
+		$altView = $this->determineView($exception, $altPath);
+
+		// Check if the view exists
+		if (is_file($path . $view))
 		{
-			$paths = new Paths();
-			$path  = $paths->viewDirectory . '/errors/';
+			$file = $path . $view;
 		}
-
-		$path = is_cli() ? $path . 'cli/' : $path . 'html/';
-
-		// Determine the vew
-		$view = $this->determineView($exception, $path);
+		elseif (is_file($altPath . $altView))
+		{
+			$file = $altPath . $altView;
+		}
 
 		// Prepare the vars
 		$vars = $this->collectVars($exception, $statusCode);
@@ -296,7 +305,7 @@ class Exceptions
 		}
 
 		ob_start();
-		include($path . $view);
+		include $file;
 		$buffer = ob_get_contents();
 		ob_end_clean();
 		echo $buffer;
@@ -330,7 +339,7 @@ class Exceptions
 	 *
 	 * @param \Throwable $exception
 	 *
-	 * @return array
+	 * @return integer[]
 	 */
 	protected function determineCodes(Throwable $exception): array
 	{
@@ -383,7 +392,7 @@ class Exceptions
 			case strpos($file, FCPATH) === 0:
 				$file = 'FCPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(FCPATH));
 				break;
-			case defined('VENDORPATH') && strpos($file, VENDORPATH) === 0;
+			case defined('VENDORPATH') && strpos($file, VENDORPATH) === 0:
 				$file = 'VENDORPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(VENDORPATH));
 				break;
 		}


### PR DESCRIPTION
**Description**
In `Exceptions::render()`, added `$altPath` and `$altView` so that if the path configured in `Config\Exceptions` does not exist or the view does not exist either, then it will look for the error view file provided as default by the framework.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
