### PR TITLE
Improvements to Image Manipulation Class

### DIFF
--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -181,26 +181,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 	/**
 	 * Make the image resource object if needed
 	 */
-	protected function ensureResource()
-	{
-		if ($this->resource === null)
-		{
-			$path = $this->image()->getPathname();
-			// if valid image type, make corresponding image resource
-			switch ($this->image()->imageType)
-			{
-				case IMAGETYPE_GIF:
-					$this->resource = imagecreatefromgif($path);
-					break;
-				case IMAGETYPE_JPEG:
-					$this->resource = imagecreatefromjpeg($path);
-					break;
-				case IMAGETYPE_PNG:
-					$this->resource = imagecreatefrompng($path);
-					break;
-			}
-		}
-	}
+	protected abstract function ensureResource();
 
 	//--------------------------------------------------------------------
 
@@ -264,6 +245,21 @@ abstract class BaseHandler implements ImageHandlerInterface
 	{
 		$this->ensureResource();
 		return $this->resource;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Load the temporary image used during the image processing.
+	 * Some functions e.g. save() will only copy and not compress
+	 * your image otherwise.
+	 *
+	 * @return $this
+	 */
+	public function withResource()
+	{
+		$this->ensureResource();
+		return $this;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -320,6 +320,16 @@ class GDHandler extends BaseHandler
 	{
 		$target = empty($target) ? $this->image()->getPathname() : $target;
 
+		// If no new resource has been created, then we're
+		// simply copy the existing one.
+		if (empty($this->resource))
+		{
+			$name = basename($target);
+			$path = pathinfo($target, PATHINFO_DIRNAME);
+
+			return $this->image()->copy($path, $name);
+		}
+
 		switch ($this->image()->imageType)
 		{
 			case IMAGETYPE_GIF:
@@ -421,6 +431,32 @@ class GDHandler extends BaseHandler
 				return imagecreatefrompng($path);
 			default:
 				throw ImageException::forInvalidImageCreate('Ima');
+		}
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Make the image resource object if needed
+	 */
+	protected function ensureResource()
+	{
+		if ($this->resource === null)
+		{
+			$path = $this->image()->getPathname();
+			// if valid image type, make corresponding image resource
+			switch ($this->image()->imageType)
+			{
+				case IMAGETYPE_GIF:
+					$this->resource = imagecreatefromgif($path);
+					break;
+				case IMAGETYPE_JPEG:
+					$this->resource = imagecreatefromjpeg($path);
+					break;
+				case IMAGETYPE_PNG:
+					$this->resource = imagecreatefrompng($path);
+					break;
+			}
 		}
 	}
 

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -341,6 +341,18 @@ class ImageMagickHandler extends BaseHandler
 	//--------------------------------------------------------------------
 
 	/**
+	 * Make the image resource object if needed
+	 *
+	 * @throws \Exception
+	 */
+	protected function ensureResource()
+	{
+		$this->getResourcePath();
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Handler-specific method for overlaying text on an image.
 	 *
 	 * @param string $text

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -321,7 +321,22 @@ class GDHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testImageSave()
+	public function testImageCopy()
+	{
+		foreach (['gif', 'jpeg', 'png'] as $type)
+		{
+			$this->handler->withFile($this->origin . 'ci-logo.' . $type);
+			$this->handler->save($this->start . 'work/ci-logo.' . $type);
+			$this->assertTrue($this->root->hasChild('work/ci-logo.' . $type));
+
+			$this->assertEquals(
+				file_get_contents($this->origin . 'ci-logo.' . $type),
+				$this->root->getChild('work/ci-logo.' . $type)->getContent()
+			);
+		}
+	}
+
+	public function testImageCompressionGetResource()
 	{
 		foreach (['gif', 'jpeg', 'png'] as $type)
 		{
@@ -329,6 +344,28 @@ class GDHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 			$this->handler->getResource(); // make sure resource is loaded
 			$this->handler->save($this->start . 'work/ci-logo.' . $type);
 			$this->assertTrue($this->root->hasChild('work/ci-logo.' . $type));
+
+			$this->assertNotEquals(
+				file_get_contents($this->origin . 'ci-logo.' . $type),
+				$this->root->getChild('work/ci-logo.' . $type)->getContent()
+			);
+		}
+	}
+
+	public function testImageCompressionWithResource()
+	{
+		foreach (['gif', 'jpeg', 'png'] as $type)
+		{
+			$this->handler->withFile($this->origin . 'ci-logo.' . $type)
+				->withResource() // make sure resource is loaded
+				->save($this->start . 'work/ci-logo.' . $type);
+
+			$this->assertTrue($this->root->hasChild('work/ci-logo.' . $type));
+
+			$this->assertNotEquals(
+				file_get_contents($this->origin . 'ci-logo.' . $type),
+				$this->root->getChild('work/ci-logo.' . $type)->getContent()
+			);
 		}
 	}
 

--- a/user_guide_src/source/libraries/images.rst
+++ b/user_guide_src/source/libraries/images.rst
@@ -98,9 +98,18 @@ only applies to JPEG images and will be ignored otherwise::
 
 	$image = \Config\Services::image()
 		->withFile('/path/to/image/mypic.jpg')
+		// processing methods
 		->save('/path/to/image/my_low_quality_pic.jpg', 10);
 
 .. note:: Higher quality will result in larger file sizes. See also https://www.php.net/manual/en/function.imagejpeg.php
+
+If you are only interested in changing the image quality without doing any processing.
+You will need to include the image resource or you will end up with an exact copy::
+
+	$image = \Config\Services::image()
+		->withFile('/path/to/image/mypic.jpg')
+		->withResource()
+		->save('/path/to/image/my_low_quality_pic.jpg', 10);
 
 Processing Methods
 ==================
@@ -324,4 +333,3 @@ The possible options that are recognized are as follows:
 
 .. note:: The ImageMagick driver does not recognize full server path for fontPath. Instead, simply provide the
 		name of one of the installed system fonts that you wish to use, i.e. Calibri.
-


### PR DESCRIPTION
If you tried to re-compress an image with GD it failed as it where required to have an image resource, and that's only set when you for e.g. flip an image. I have copied the code from ImageMagick, so that it will just copy your image to the new location.

```php
$image = \Config\Services::image()
	->withFile('/path/to/image/mypic.jpg')
	->save('/path/to/image/my_low_quality_pic.jpg', 10);
```

Implemented a `withResource()` so that you can use method chaning instead of using the provided `getResource()` (used in tests). To just compress your image.
```php
$image = \Config\Services::image()
	->withFile('/path/to/image/mypic.jpg')
	->withResource()
	->save('/path/to/image/my_low_quality_pic.jpg', 10);
```

Made `ensureResource()` an abstract function and copied the original code into GDHandlar, as those function can only be used by GD. And a similar function have been created (just an alias) for ImageMagick.

Wrote new test to make sure the images are beeing compressed / copied in GD.

No tests have been written for ImageMagick, as I don't have it installed at the moment.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide