### PR TITLE
Bug fix Pager Segment parameter out of bound fallback set current page = 1

### DIFF
--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -206,10 +206,14 @@ class Pager implements PagerInterface
 
 		$this->ensureGroup($group, $perPage);
 
+		if ($segment > 0 && $this->groups[$group]['currentPage'] > 0)
+		{
+			$page = $this->groups[$group]['currentPage'];
+		}
+
 		$perPage                             = $perPage ?? $this->config->perPage;
 		$pageCount                           = (int)ceil($total / $perPage);
-		$page                                = $page > $pageCount ? $pageCount : $page;
-		$this->groups[$group]['currentPage'] = $page;
+		$this->groups[$group]['currentPage'] = $page > $pageCount ? $pageCount : $page;
 		$this->groups[$group]['perPage']     = $perPage;
 		$this->groups[$group]['total']       = $total;
 		$this->groups[$group]['pageCount']   = $pageCount;

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -425,4 +425,10 @@ class PagerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(10, $this->pager->getCurrentPage());
 	}
 
+	public function testSegmentOutOfBound()
+	{
+		$this->pager->store('default', 10, 1, 10, 1000);
+		$this->assertEquals(1, $this->pager->getCurrentPage());
+	}
+
 }


### PR DESCRIPTION
Handle when segment parameter out of bound fallback set current page = 1 at https://github.com/codeigniter4/CodeIgniter4/blob/a063f14e62b36531f52afa0bf71b8e54c00f6399/system/Pager/Pager.php#L536-L543

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage

By this, the `Pager` also will have 100% test coverage.
