### PR TITLE
Fixes Entity::fill() not autoserializing/encoding

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -124,18 +124,7 @@ class Entity implements \JsonSerializable
 
 		foreach ($data as $key => $value)
 		{
-			$key = $this->mapProperty($key);
-
-			$method = 'set' . str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $key)));
-
-			if (method_exists($this, $method))
-			{
-				$this->$method($value);
-			}
-			else
-			{
-				$this->attributes[$key] = $value;
-			}
+			$this->$key = $value;
 		}
 
 		return $this;

--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -403,6 +403,48 @@ class EntityTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(['foo' => 'bar'], $entity->seventh);
 	}
 
+	public function testCastArrayByFill()
+	{
+		$entity = $this->getCastEntity();
+
+		$data = [
+			'seventh' => [
+				1,
+				2,
+				3,
+			],
+		];
+
+		$entity->fill($data);
+
+		// Check if serialiazed
+		$check = $this->getPrivateProperty($entity, 'attributes')['seventh'];
+		$this->assertEquals(serialize([1, 2, 3]), $check);
+
+		// Check if unserialized
+		$this->assertEquals([1, 2, 3], $entity->seventh);
+	}
+
+	public function testCastArrayByConstructor()
+	{
+		$data = [
+			'seventh' => [
+				1,
+				2,
+				3,
+			],
+		];
+
+		$entity = $this->getCastEntity($data);
+
+		// Check if serialiazed
+		$check = $this->getPrivateProperty($entity, 'attributes')['seventh'];
+		$this->assertEquals(serialize([1, 2, 3]), $check);
+
+		// Check if unserialized
+		$this->assertEquals([1, 2, 3], $entity->seventh);
+	}
+
 	//--------------------------------------------------------------------
 
 	public function testCastNullable()
@@ -447,6 +489,47 @@ class EntityTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('["Sun","Mon","Tue"]', $check);
 
 		$this->assertEquals($data, $entity->eleventh);
+	}
+
+	public function testCastAsJsonByFill()
+	{
+		$entity = $this->getCastEntity();
+		$data   = [
+			'eleventh' => [
+				1,
+				2,
+				3,
+			],
+		];
+
+		$entity->fill($data);
+
+		// Check if serialiazed
+		$check = $this->getPrivateProperty($entity, 'attributes')['eleventh'];
+		$this->assertEquals(json_encode([1, 2, 3]), $check);
+
+		// Check if unserialized
+		$this->assertEquals([1, 2, 3], $entity->eleventh);
+	}
+
+	public function testCastAsJsonByConstructor()
+	{
+		$data = [
+			'eleventh' => [
+				1,
+				2,
+				3,
+			],
+		];
+
+		$entity = $this->getCastEntity($data);
+
+		// Check if serialiazed
+		$check = $this->getPrivateProperty($entity, 'attributes')['eleventh'];
+		$this->assertEquals(json_encode([1, 2, 3]), $check);
+
+		// Check if unserialized
+		$this->assertEquals([1, 2, 3], $entity->eleventh);
 	}
 
 	public function testCastAsJSONErrorDepth()
@@ -789,9 +872,9 @@ class EntityTest extends \CodeIgniter\Test\CIUnitTestCase
 		};
 	}
 
-	protected function getCastEntity()
+	protected function getCastEntity($data = null)
 	{
-		return new class extends Entity
+		return new class($data) extends Entity
 		{
 			protected $attributes = [
 				'first'    => null,


### PR DESCRIPTION
**Description**
I fixed a bug (or what I think is one) in the Entity class that caused entity attributes cast as 'array', 'json' and 'json-array' not to be automatically serialized or encoded when the `fill` (and, by consequence, the constructor) is used.
I also modified the anonymous class returned by getCastEntity in EntityTests to allow for constructor arguments to be passed to it.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide


**Reproduction and other notes:**
Consider this entity

```php

<?php

namespace App\Entities;
use CodeIgniter\Entity;

class CastFillBug extends Entity
{
  
 protected $casts =[
   'field1' => 'array',
   'field2' => 'json',
   'field3' => 'json-array',
 ];

}
```

and this piece of code

```php

$entity = new \App\Entities\CastFillBug();
$data = [
    'field1' => [1,2,3],
    'field2' => [4,5,6],
    'field3' => [7,8,9]
];


$entity->fill($data);
var_dump($entity->toRawArray());
```


Right now this returns the following

```
array (size=3)
  'field1' => 
    array (size=3)
      0 => int 1
      1 => int 2
      2 => int 3
  'field2' => 
    array (size=3)
      0 => int 4
      1 => int 5
      2 => int 6
  'field3' => 
    array (size=3)
      0 => int 7
      1 => int 8
      2 => int 9
```

All fields should have either been serialized or encoded with `json_encode`

The issue seems to be on lines:  
/system/Entity.php:127-138

Here, the `fill()` method reuses some code from the `__set()` method and does not take casts into consideration.

Replacing that entire section with
```php
$this->$key = $value;
```
lets us use `__set()` to handle all the logic with solves the problem. 

Is this intended behaviour?
If this is intended maybe a note should be added in the documentation to specify that auto-serialization only works on direct assignment, not using fill or the constructor.
