### PR TITLE
clean up: remove unneeded require_once in app/Config/Services.php

### DIFF
--- a/app/Config/Services.php
+++ b/app/Config/Services.php
@@ -2,8 +2,6 @@
 
 use CodeIgniter\Config\Services as CoreServices;
 
-require_once SYSTEMPATH . 'Config/Services.php';
-
 /**
  * Services Configuration file.
  *

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -329,4 +329,11 @@ class ServicesTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertInstanceOf(\CodeIgniter\Typography\Typography::class, $result);
 	}
 
+	public function testServiceInstance()
+	{
+		rename(COMPOSER_PATH, COMPOSER_PATH . '.backup');
+		$this->assertInstanceOf(\Config\Services::class, new \Config\Services());
+		rename(COMPOSER_PATH . '.backup', COMPOSER_PATH);
+	}
+
 }


### PR DESCRIPTION
It is unneded since the Autoloading already handle it in `system/bootstrap.php`. 

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage