### PR TITLE
Fix. the parsing method is empty

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -534,11 +534,7 @@ class Router implements RouterInterface
 		// has already been set.
 		if (! empty($segments))
 		{
-			$tempMethod = array_shift($segments);
-			if ($tempMethod !== '')
-			{
-				$this->method = $tempMethod;
-			}
+			$this->method = array_shift($segments) ?: $this->method;
 		}
 
 		if (! empty($segments))

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -534,7 +534,11 @@ class Router implements RouterInterface
 		// has already been set.
 		if (! empty($segments))
 		{
-			$this->method = array_shift($segments);
+			$tempMethod = array_shift($segments);
+			if ($tempMethod !== '')
+			{
+				$this->method = $tempMethod;
+			}
 		}
 
 		if (! empty($segments))

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -520,4 +520,15 @@ class RouterTest extends \CodeIgniter\Test\CIUnitTestCase
 		];
 		$this->assertEquals($expected, $router->params());
 	}
+
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/2965
+	 */
+	public function testAutoRouteMethodEmpty()
+	{
+		$router = new Router($this->collection, $this->request);
+		$router->handle('Home/');
+		$this->assertEquals('Home', $router->controllerName());
+		$this->assertEquals('index', $router->methodName());
+	}
 }


### PR DESCRIPTION
Fix: #2965 
**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
