### PR TITLE
Fix inconsistent capitalization for request->getIPAddress()

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -760,7 +760,7 @@ class Services extends BaseService
 		$logger = static::logger();
 
 		$driverName = $config->sessionDriver;
-		$driver     = new $driverName($config, static::request()->getIpAddress());
+		$driver     = new $driverName($config, static::request()->getIPAddress());
 		$driver->setLogger($logger);
 
 		$session = new Session($driver, $config);


### PR DESCRIPTION
**Description**
Minor change. Fixed a case in which getIPAddress is called with inconsistent capitalization. Makes code more easily searchable.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
