### PR TITLE
Force devs to turn off zlib.output_compression ini in 'pre-system' event

### DIFF
--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -1,6 +1,7 @@
 <?php namespace Config;
 
 use CodeIgniter\Events\Events;
+use CodeIgniter\Exceptions\FrameworkException;
 
 /*
  * --------------------------------------------------------------------
@@ -22,12 +23,17 @@ use CodeIgniter\Events\Events;
 Events::on('pre_system', function () {
 	if (ENVIRONMENT !== 'testing')
 	{
-		while (\ob_get_level() > 0)
+		if (ini_get('zlib.output_compression'))
 		{
-			\ob_end_flush();
+			throw FrameworkException::forEnabledZlibOutputCompression();
 		}
 
-		\ob_start(function ($buffer) {
+		while (ob_get_level() > 0)
+		{
+			ob_end_flush();
+		}
+
+		ob_start(function ($buffer) {
 			return $buffer;
 		});
 	}

--- a/system/Exceptions/FrameworkException.php
+++ b/system/Exceptions/FrameworkException.php
@@ -11,6 +11,10 @@
 
 class FrameworkException extends \RuntimeException implements ExceptionInterface
 {
+	public static function forEnabledZlibOutputCompression()
+	{
+		return new static(lang('Core.enabledZlibOutputCompression'));
+	}
 
 	public static function forInvalidFile(string $path)
 	{
@@ -31,5 +35,4 @@ class FrameworkException extends \RuntimeException implements ExceptionInterface
 	{
 		return new static(lang('Core.noHandlers', [$class]));
 	}
-
 }

--- a/system/Language/en/Core.php
+++ b/system/Language/en/Core.php
@@ -15,8 +15,9 @@
  */
 
 return [
-   'invalidFile'      => 'Invalid file: {0}',
-   'copyError'        => 'An error was encountered while attempting to replace the file({0}). Please make sure your file directory is writable.',
-   'missingExtension' => '{0} extension is not loaded.',
-   'noHandlers'       => '{0} must provide at least one Handler.',
+   'copyError'                    => 'An error was encountered while attempting to replace the file({0}). Please make sure your file directory is writable.',
+   'enabledZlibOutputCompression' => 'Your zlib.output_compression ini directive is turned on. This will not work well with output buffers.',
+   'invalidFile'                  => 'Invalid file: {0}',
+   'missingExtension'             => '{0} extension is not loaded.',
+   'noHandlers'                   => '{0} must provide at least one Handler.',
 ];


### PR DESCRIPTION
**Description**
This answers issue #2980 and is related to #2182. 

In the 'pre-system' event, added a check if `zlib.output_compression` ini is turned on. If it does, pages will be blank so this check warns devs for this scenario. The exception thrown will be managed by the exception_handler, resulting to these snippets:

// browser
![image](https://user-images.githubusercontent.com/51850998/81810186-1d075500-9555-11ea-81cd-672e8f252773.png)

// terminal
![image](https://user-images.githubusercontent.com/51850998/81810547-b8002f00-9555-11ea-9017-5c892288eee4.png)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
