### PR TITLE
fix. Time::setTimezone can't work

### DIFF
--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -773,7 +773,7 @@ class Time extends DateTime
 	/**
 	 * Returns a new instance with the revised timezone.
 	 *
-	 * @param \DateTimeZone $timezone
+	 * @param string|\DateTimeZone $timezone
 	 *
 	 * @return \CodeIgniter\I18n\Time
 	 * @throws \Exception

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -780,7 +780,8 @@ class Time extends DateTime
 	 */
 	public function setTimezone($timezone)
 	{
-		return Time::parse($this->toDateTimeString(), $timezone, $this->locale);
+		$timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone);
+		return Time::instance($this->toDateTime()->setTimezone($timezone), $this->locale);
 	}
 
 	/**

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -974,6 +974,14 @@ class TimeTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('Just now', $time->humanize());
 	}
 
+	public function testSetTimezoneDate()
+	{
+		$time  = Time::parse('13 May 2020 10:00', 'GMT');
+		$time2 = $time->setTimezone('GMT+8');
+		$this->assertEquals('2020-05-13 10:00:00', $time->toDateTimeString());
+		$this->assertEquals('2020-05-13 18:00:00', $time2->toDateTimeString());
+	}
+
 	//--------------------------------------------------------------------
 	// Missing tests
 

--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -347,12 +347,15 @@ setTimezone()
 
 Converts the time from it's current timezone into the new one::
 
-    $time  = Time::parse('May 10, 2017', 'America/Chicago');
+    $time  = Time::parse('13 May 2020 10:00', 'America/Chicago');
     $time2 = $time->setTimezone('Europe/London');           // Returns new instance converted to new timezone
 
-    echo $time->timezoneName;   // American/Chicago
-    echo $time2->timezoneName;  // Europe/London
+    echo $time->getTimezoneName();   // American/Chicago
+    echo $time2->getTimezoneName();  // Europe/London
 
+    echo $time->toDateTimeString();   // 2020-05-13 10:00:00
+    echo $time2->toDateTimeString();   // 2020-05-13 18:00:00
+    
 setTimestamp()
 --------------
 


### PR DESCRIPTION
Fix #2989
`Time::setTimezone` shuold same `DateTime::setTimezone`
**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

