### PR TITLE
Update BaseConnection.php

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -380,7 +380,7 @@ abstract class BaseConnection implements ConnectionInterface
 		} 
 		catch (\Throwable $e) 
 		{
-			log_message('error', 'connect database error: ' . $e->getMessage());
+			log_message('error', 'Error connecting to the database: ' . $e->getMessage());
 		}
 
 		// No connection resource? Check if there is a failover else throw an error
@@ -408,7 +408,7 @@ abstract class BaseConnection implements ConnectionInterface
 					} 
 					catch (\Throwable $e) 
 					{
-						log_message('error', 'connect database error: '.$e->getMessage());
+						log_message('error', 'Error connecting to the database: '.$e->getMessage());
 					}
 
 					// If a connection is made break the foreach loop

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -373,8 +373,12 @@ abstract class BaseConnection implements ConnectionInterface
 
 		$this->connectTime = microtime(true);
 
-		// Connect to the database and set the connection ID
-		$this->connID = $this->connect($this->pConnect);
+		try {
+			// Connect to the database and set the connection ID
+			$this->connID = $this->connect($this->pConnect);
+		} catch (\Exception $e) {
+			log_message('error', 'Database: '.$e->getMessage());
+		}
 
 		// No connection resource? Check if there is a failover else throw an error
 		if (! $this->connID)
@@ -394,8 +398,12 @@ abstract class BaseConnection implements ConnectionInterface
 						}
 					}
 
-					// Try to connect
-					$this->connID = $this->connect($this->pConnect);
+					try {
+						// Try to connect
+						$this->connID = $this->connect($this->pConnect);
+					} catch (\Exception $e) {
+						log_message('error', 'Database: '.$e->getMessage());
+					}
 
 					// If a connection is made break the foreach loop
 					if ($this->connID)

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -373,11 +373,14 @@ abstract class BaseConnection implements ConnectionInterface
 
 		$this->connectTime = microtime(true);
 
-		try {
+		try 
+		{
 			// Connect to the database and set the connection ID
 			$this->connID = $this->connect($this->pConnect);
-		} catch (\Exception $e) {
-			log_message('error', 'Database: '.$e->getMessage());
+		} 
+		catch (\Throwable $e) 
+		{
+			log_message('error', 'connect database error: ' . $e->getMessage());
 		}
 
 		// No connection resource? Check if there is a failover else throw an error
@@ -398,11 +401,14 @@ abstract class BaseConnection implements ConnectionInterface
 						}
 					}
 
-					try {
+					try 
+					{
 						// Try to connect
 						$this->connID = $this->connect($this->pConnect);
-					} catch (\Exception $e) {
-						log_message('error', 'Database: '.$e->getMessage());
+					} 
+					catch (\Throwable $e) 
+					{
+						log_message('error', 'connect database error: '.$e->getMessage());
 					}
 
 					// If a connection is made break the foreach loop

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -13,6 +13,8 @@ class ConnectTest extends CIDatabaseTestCase
 
 	protected $group2;
 
+	protected $tests;
+
 	protected function setUp(): void
 	{
 		parent::setUp();
@@ -21,6 +23,7 @@ class ConnectTest extends CIDatabaseTestCase
 
 		$this->group1 = $config->default;
 		$this->group2 = $config->default;
+		$this->tests  = $config->tests;
 
 		$this->group1['DBDriver'] = 'MySQLi';
 		$this->group2['DBDriver'] = 'Postgre';
@@ -72,5 +75,19 @@ class ConnectTest extends CIDatabaseTestCase
 		$db1 = Database::connect('default');
 		$this->assertNotInstanceOf(\CodeIgniter\Database\SQLite3\Connection::class, $db1);
 		$this->assertEquals('MySQLi', $this->getPrivateProperty($db1, 'DBDriver'));
+	}
+
+	public function testConnectWithFailover()
+	{
+		$this->tests['failover'][] = $this->tests;
+
+		unset($this->tests['failover'][0]['failover']);
+
+		$this->tests['username'] = 'wrong';
+
+		$db1 = Database::connect($this->tests);
+
+		$this->assertEquals($this->tests['failover'][0]['DBDriver'], $this->getPrivateProperty($db1, 'DBDriver'));
+		$this->assertTrue(count($db1->listTables()) >= 0);
 	}
 }


### PR DESCRIPTION
Configuration file app\Config\Database item "failover" Effective

**Description**
When using DBDriver = MySQLi, if I configure the failover option, but if the main configuration database connection times out, an exception will be thrown directly and execution will stop. It does not attempt to use the configuration of failover items.


