### PR TITLE
Fix: Example code is not working #2993

### DIFF
--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -25,12 +25,12 @@ are called before you take your actions.
 
     class TestFoo extends FeatureTestCase
     {
-        public function setUp()
+        public function setUp(): void
         {
             parent::setUp();
         }
 
-        public function tearDown()
+        public function tearDown(): void
         {
             parent::tearDown();
         }


### PR DESCRIPTION
Fix #2993 
The example of "The Test Class“ is not working in Documets

**Description**
The example code is not working anymore with v4.0.3.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
