### PR TITLE
bug fix: ensure "BIGINT" to correctly applied to Postgresql Forge

### DIFF
--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -205,10 +205,6 @@ class Forge extends \CodeIgniter\Database\Forge
 				$attributes['TYPE']     = 'INTEGER';
 				$attributes['UNSIGNED'] = false;
 				break;
-			case 'BIGINT':
-				$attributes['TYPE']     = 'BIGINT';
-				$attributes['UNSIGNED'] = false;
-				break;
 			case 'DATETIME':
 				$attributes['TYPE'] = 'TIMESTAMP';
 				break;
@@ -231,7 +227,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	{
 		if (! empty($attributes['AUTO_INCREMENT']) && $attributes['AUTO_INCREMENT'] === true)
 		{
-			$field['type'] = $field['type'] === 'BIGINT' ? 'BIGSERIAL' : 'SERIAL';
+			$field['type'] = $field['type'] === 'NUMERIC' || $field['type'] === 'BIGINT' ? 'BIGSERIAL' : 'SERIAL';
 		}
 	}
 

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -205,6 +205,10 @@ class Forge extends \CodeIgniter\Database\Forge
 				$attributes['TYPE']     = 'INTEGER';
 				$attributes['UNSIGNED'] = false;
 				break;
+			case 'BIGINT':
+				$attributes['TYPE']     = 'BIGINT';
+				$attributes['UNSIGNED'] = false;
+				break;
 			case 'DATETIME':
 				$attributes['TYPE'] = 'TIMESTAMP';
 				break;
@@ -227,7 +231,7 @@ class Forge extends \CodeIgniter\Database\Forge
 	{
 		if (! empty($attributes['AUTO_INCREMENT']) && $attributes['AUTO_INCREMENT'] === true)
 		{
-			$field['type'] = $field['type'] === 'NUMERIC' ? 'BIGSERIAL' : 'SERIAL';
+			$field['type'] = $field['type'] === 'BIGINT' ? 'BIGSERIAL' : 'SERIAL';
 		}
 	}
 

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -165,6 +165,8 @@ class ForgeTest extends CIDatabaseTestCase
 		{
 			$this->assertEquals(strtolower($fieldsData[0]->type), 'integer');
 		}
+
+		$this->forge->dropTable('forge_test_table', true);
 	}
 
 	public function testCreateTableWithAttributes()

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -137,6 +137,36 @@ class ForgeTest extends CIDatabaseTestCase
 		$this->assertTrue($exist);
 	}
 
+	public function testCreateTableApplyBigInt()
+	{
+		$this->forge->dropTable('forge_test_table', true);
+
+		$this->forge->addField([
+			'id' => [
+				'type'           => 'BIGINT',
+				'unsigned'       => true,
+				'auto_increment' => true,
+			],
+		]);
+
+		$this->forge->addPrimaryKey('id');
+		$this->forge->createTable('forge_test_table', true);
+
+		$fieldsData = $this->db->getFieldData('forge_test_table');
+		if ($this->db->DBDriver === 'MySQLi')
+		{
+			$this->assertEquals(strtolower($fieldsData[0]->type), 'bigint');
+		}
+		elseif ($this->db->DBDriver === 'Postgre')
+		{
+			$this->assertEquals(strtolower($fieldsData[0]->type), 'bigint');
+		}
+		elseif ($this->db->DBDriver === 'SQLite3')
+		{
+			$this->assertEquals(strtolower($fieldsData[0]->type), 'integer');
+		}
+	}
+
 	public function testCreateTableWithAttributes()
 	{
 		if ($this->db->DBDriver === 'SQLite3')


### PR DESCRIPTION
Previously, On calling Forge at PostgreSQL, like the following:

```php
<?php
$this->forge->addField([
	'id'     => [
	    'type'           => 'BIGINT',
	    'unsigned'       => true,
	    'auto_increment' => true,
	],
]);
```

It previously converted to integer instead of bigint. By this chage, it ensure correctly make bigint when we define "BIGINT".

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage