### PR TITLE
Don't add params to IncomingRequest in FeatureTestCase, per discussion in #2946

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -166,7 +166,7 @@ class IncomingRequest extends Request
 			$body = file_get_contents('php://input');
 		}
 
-		$this->body      = $body;
+		$this->body      = ! empty($body) ? $body : null;
 		$this->config    = $config;
 		$this->userAgent = $userAgent;
 

--- a/tests/_support/Controllers/Popcorn.php
+++ b/tests/_support/Controllers/Popcorn.php
@@ -51,7 +51,7 @@ class Popcorn extends Controller
 
 	public function canyon()
 	{
-		echo 'Hello-o-o';
+		echo 'Hello-o-o ' . $this->request->getGet('foo');
 	}
 
 	public function cat()

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -455,4 +455,12 @@ class IncomingRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($_GET, $this->request->getGetPost());
 	}
 
+	public function testWithFalseBody()
+	{
+		// Use `false` here to simulate file_get_contents returning a false value
+		$request = new IncomingRequest(new App(), new URI(), false, new UserAgent());
+
+		$this->assertTrue($request->getBody() !== false);
+		$this->assertTrue($request->getBody() === null);
+	}
 }

--- a/tests/system/Test/FeatureTestCaseTest.php
+++ b/tests/system/Test/FeatureTestCaseTest.php
@@ -72,6 +72,22 @@ class FeatureTestCaseTest extends FeatureTestCase
 		$response->assertSee('Hello Mars');
 	}
 
+	public function testCallPostWithBody()
+	{
+		$this->withRoutes([
+			[
+				'post',
+				'home',
+				function () {
+					return 'Hello ' . service('request')->getPost('foo') . '!';
+				},
+			],
+		]);
+		$response = $this->post('home', ['foo' => 'Mars']);
+
+		$response->assertSee('Hello Mars!');
+	}
+
 	public function testCallPut()
 	{
 		$this->withRoutes([
@@ -181,7 +197,7 @@ class FeatureTestCaseTest extends FeatureTestCase
 		$response->assertEmpty($response->response->getBody());
 	}
 
-	public function testEchoes()
+	public function testEchoesWithParams()
 	{
 		$this->withRoutes([
 			[
@@ -191,8 +207,22 @@ class FeatureTestCaseTest extends FeatureTestCase
 			],
 		]);
 		ob_start();
-		$response = $this->get('home');
-		$response->assertSee('Hello-o-o');
+		$response = $this->get('home', ['foo' => 'bar']);
+		$response->assertSee('Hello-o-o bar');
+	}
+
+	public function testEchoesWithQuery()
+	{
+		$this->withRoutes([
+			[
+				'get',
+				'home',
+				'\Tests\Support\Controllers\Popcorn::canyon',
+			],
+		]);
+		ob_start();
+		$response = $this->get('home?foo=bar');
+		$response->assertSee('Hello-o-o bar');
 	}
 
 	public function testCallZeroAsPathGot404()


### PR DESCRIPTION
`$params` from GET and POST requests were being passed as the body to the `IncomingRequest`, which doesn't match up with how things actually work. Since `$params` were already being set in the globals correctly,this tweaks it all to work better and work with `$params` for GET requests in either `$params` or in the URI itself (i.e. `/home?foo=bar`). 