### PR TITLE
Bug fixing related to PR #2987 on DotEnv.php

### DIFF
--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -77,18 +77,8 @@ class DotEnv
 	public function load(): bool
 	{
 		$vars = $this->parse();
-
-		if ($vars === null)
-		{
-			return false;
-		}
-
-		foreach ($vars as $name => $value)
-		{
-			$this->setVariable($name, $value);
-		}
-
-		return true; // for success
+		
+		return ($vars === null ? false : true);
 	}
 
 	//--------------------------------------------------------------------
@@ -129,6 +119,7 @@ class DotEnv
 			{
 				list($name, $value) = $this->normaliseVariable($line);
 				$vars[$name]        = $value;
+				$this->setVariable($name, $value);
 			}
 		}
 


### PR DESCRIPTION
**Description**
Nested variables are now parsed correctedly, the previous version called the setVariable() function in a loop after all the parsing happened, returning always null for nested vars.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide