### PR TITLE
Fixe rotation direction on reorient()

### DIFF
--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -533,15 +533,15 @@ abstract class BaseHandler implements ImageHandlerInterface
 				return $this->rotate(180)
 								->flip('horizontal');
 			case 5:
-				return $this->rotate(270)
-								->flip('horizontal');
-			case 6:
-				return $this->rotate(270);
-			case 7:
 				return $this->rotate(90)
 								->flip('horizontal');
-			case 8:
+			case 6:
 				return $this->rotate(90);
+			case 7:
+				return $this->rotate(270)
+								->flip('horizontal');
+			case 8:
+				return $this->rotate(270);
 			default:
 				return $this;
 		}

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -533,15 +533,15 @@ abstract class BaseHandler implements ImageHandlerInterface
 				return $this->rotate(180)
 								->flip('horizontal');
 			case 5:
-				return $this->rotate(90)
-								->flip('horizontal');
-			case 6:
-				return $this->rotate(90);
-			case 7:
 				return $this->rotate(270)
 								->flip('horizontal');
-			case 8:
+			case 6:
 				return $this->rotate(270);
+			case 7:
+				return $this->rotate(90)
+								->flip('horizontal');
+			case 8:
+				return $this->rotate(90);
 			default:
 				return $this;
 		}

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -474,5 +474,44 @@ class ImageMagickHandler extends BaseHandler
 	{
 		return imagesy($this->resource);
 	}
+	
+	//--------------------------------------------------------------------
 
+	/**
+	 * Reads the EXIF information from the image and modifies the orientation
+	 * so that displays correctly in the browser. This is especially an issue
+	 * with images taken by smartphones who always store the image up-right,
+	 * but set the orientation flag to display it correctly.
+	 *
+	 * @param boolean $silent If true, will ignore exceptions when PHP doesn't support EXIF.
+	 *
+	 * @return $this
+	 */
+	public function reorient(bool $silent = false)
+	{
+		$orientation = $this->getEXIF('Orientation', $silent);
+
+		switch ($orientation)
+		{
+			case 2:
+				return $this->flip('horizontal');
+			case 3:
+				return $this->rotate(180);
+			case 4:
+				return $this->rotate(180)
+								->flip('horizontal');
+			case 5:
+				return $this->rotate(90)
+								->flip('horizontal');
+			case 6:
+				return $this->rotate(90);
+			case 7:
+				return $this->rotate(270)
+								->flip('horizontal');
+			case 8:
+				return $this->rotate(270);
+			default:
+				return $this;
+		}
+	}
 }


### PR DESCRIPTION


**Description**
Fixe #3006
I think the rotation from exif is not in the good direction 

Change the rotation direction on image reorient()

Maybe reorient methode should be add in the doc

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  
