### PR TITLE
Add default value to getSegment() method

### DIFF
--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -498,12 +498,13 @@ class URI
 	/**
 	 * Returns the value of a specific segment of the URI path.
 	 *
-	 * @param integer $number
+	 * @param integer $number  Segment number
+	 * @param string  $default Default value
 	 *
 	 * @return string     The value of the segment. If no segment is found,
 	 *                    throws InvalidArgumentError
 	 */
-	public function getSegment(int $number): string
+	public function getSegment(int $number, string $default = ''): string
 	{
 		// The segment should treat the array as 1-based for the user
 		// but we still have to deal with a zero-based array.
@@ -514,7 +515,7 @@ class URI
 			throw HTTPException::forURISegmentOutOfRange($number);
 		}
 
-		return $this->segments[$number] ?? '';
+		return $this->segments[$number] ?? $default;
 	}
 
 	/**

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -105,7 +105,6 @@ class URITest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('', $uri->getSegment(3));
 
 		$this->assertEquals(2, $uri->getTotalSegments());
-		$this->assertEquals(['path', 'to'], $uri->getSegments());
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -74,6 +74,56 @@ class URITest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testSegmentOutOfRangeWithDefaultValue()
+	{
+		$this->expectException(HTTPException::class);
+		$url = 'http://abc.com/a123/b/c';
+		$uri = new URI($url);
+		$uri->getSegment(22, 'something');
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSegmentOutOfRangeWithSilentAndDefaultValue()
+	{
+		$url = 'http://abc.com/a123/b/c';
+		$uri = new URI($url);
+		$this->assertEquals('something', $uri->setSilent()->getSegment(22, 'something'));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSegmentsWithDefaultValueAndSilent()
+	{
+		$uri = new URI('http://hostname/path/to');
+		$uri->setSilent();
+
+		$this->assertEquals(['path', 'to'], $uri->getSegments());
+		$this->assertEquals('path', $uri->getSegment(1));
+		$this->assertEquals('to', $uri->getSegment(2, 'different'));
+		$this->assertEquals('script', $uri->getSegment(3, 'script'));
+		$this->assertEquals('', $uri->getSegment(3));
+
+		$this->assertEquals(2, $uri->getTotalSegments());
+		$this->assertEquals(['path', 'to'], $uri->getSegments());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSegmentOutOfRangeWithDefaultValuesAndSilent()
+	{
+		$uri = new URI('http://hostname/path/to/script');
+		$uri->setSilent();
+
+		$this->assertEquals('', $uri->getSegment(22));
+		$this->assertEquals('something', $uri->getSegment(33, 'something'));
+
+		$this->assertEquals(3, $uri->getTotalSegments());
+		$this->assertEquals(['path', 'to', 'script'], $uri->getSegments());
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testCanCastAsString()
 	{
 		$url = 'http://username:password@hostname:9090/path?arg=value#anchor';

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -229,31 +229,33 @@ what the values of the segments are. The segments start at 1 being the furthest 
 	// URI = http://example.com/users/15/profile
 
 	// Prints '15'
-	if ($request->uri->getSegment(1) == 'users')
+	if ($uri->getSegment(1) == 'users')
 	{
-		echo $request->uri->getSegment(2);
+		echo $uri->getSegment(2);
 	}
 
-You can also get the different default value for a given segment. Default value is set by using the second parameter of the ``getSegment()`` method.
+You can also set a different default value for a particular segment by using the second parameter of the ``getSegment()`` method. The default is empty string.
 ::
 	// URI = http://example.com/users/15/profile
 
 	// will print 'profile'
-	echo $request->uri->getSegment(3, 'foo');
+	echo $uri->getSegment(3, 'foo');
 	// will print 'bar'
-	echo $request->uri->getSegment(4, 'bar');
+	echo $uri->getSegment(4, 'bar');
 	// will throw an exception
-	echo $request->uri->getSegment(5, 'baz');
+	echo $uri->getSegment(5, 'baz');
 	// will print 'baz'
-	echo $request->uri->setSilent()->getSegment(5, 'baz');
+	echo $uri->setSilent()->getSegment(5, 'baz');
+	// will print '' (empty string)
+	echo $uri->setSilent()->getSegment(5);
 
 You can get a count of the total segments::
 
-	$total = $request->uri->getTotalSegments(); // 3
+	$total = $uri->getTotalSegments(); // 3
 
 Finally, you can retrieve an array of all of the segments::
 
-	$segments = $request->uri->getSegments();
+	$segments = $uri->getSegments();
 
 	// $segments =
 	[

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -234,6 +234,19 @@ what the values of the segments are. The segments start at 1 being the furthest 
 		echo $request->uri->getSegment(2);
 	}
 
+You can also get the different default value for a given segment. Default value is set by using the second parameter of the ``getSegment()`` method.
+::
+	// URI = http://example.com/users/15/profile
+
+	// will print 'profile'
+	echo $request->uri->getSegment(3, 'foo');
+	// will print 'bar'
+	echo $request->uri->getSegment(4, 'bar');
+	// will throw an exception
+	echo $request->uri->getSegment(5, 'baz');
+	// will print 'baz'
+	echo $request->uri->setSilent()->getSegment(5, 'baz');
+
 You can get a count of the total segments::
 
 	$total = $request->uri->getTotalSegments(); // 3


### PR DESCRIPTION
**Description**
This PR adds a second parameter to the `getSegment()` method, so we can change the default value that will be returned when there is no segment set. Usually, this feature will be used along with `setSilent()`, so that the exception will be not thrown.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide