### PR TITLE
Fix. toodebug disabled, view debug comment is show.

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -15,11 +15,16 @@ class Filters extends BaseConfig
 	// Always applied before every request
 	public $globals = [
 		'before' => [
+			'toolbar' => [
+				'except' => 'api/*',
+			],
 			//'honeypot'
 			// 'csrf',
 		],
 		'after'  => [
-			'toolbar',
+			'toolbar' => [
+				'except' => 'api/*',
+			],
 			//'honeypot'
 		],
 	];

--- a/app/Config/Toolbar.php
+++ b/app/Config/Toolbar.php
@@ -16,6 +16,9 @@ class Toolbar extends BaseConfig
 	| toolbarMaxHistory = Number of history files, 0 for none or -1 for unlimited
 	|
 	*/
+
+	public $enabled = false;
+
 	public $collectors = [
 		\CodeIgniter\Debug\Toolbar\Collectors\Timers::class,
 		\CodeIgniter\Debug\Toolbar\Collectors\Database::class,

--- a/system/Filters/DebugToolbar.php
+++ b/system/Filters/DebugToolbar.php
@@ -57,6 +57,7 @@ class DebugToolbar implements FilterInterface
 	 */
 	public function before(RequestInterface $request)
 	{
+		config('toolbar')->enabled = true;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -261,9 +261,9 @@ class View implements RendererInterface
 
 		if ($this->debug && (! isset($options['debug']) || $options['debug'] === true))
 		{
-			$toolbarCollectors = config(\Config\Toolbar::class)->collectors;
+			$toolbarConfig = config('toolbar');
 
-			if (in_array(\CodeIgniter\Debug\Toolbar\Collectors\Views::class, $toolbarCollectors))
+			if ($toolbarConfig->enabled && in_array(\CodeIgniter\Debug\Toolbar\Collectors\Views::class, $toolbarConfig->collectors))
 			{
 				// Clean up our path names to make them a little cleaner
 				foreach (['APPPATH', 'SYSTEMPATH', 'ROOTPATH'] as $path)

--- a/tests/system/Filters/DebugToolbarTest.php
+++ b/tests/system/Filters/DebugToolbarTest.php
@@ -23,6 +23,16 @@ class DebugToolbarTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testDebugToolbarFilterExcept()
+	{
+		$data     = [
+			'testString' => 'bar',
+			'bar'        => 'baz',
+		];
+		$expected = '<h1>bar</h1>';
+		$this->assertEquals($expected, view('\Tests\Support\View\Views\simple', $data, []));
+	}
+
 	public function testDebugToolbarFilter()
 	{
 		$_SERVER['REQUEST_METHOD'] = 'GET';
@@ -45,6 +55,18 @@ class DebugToolbarTest extends \CodeIgniter\Test\CIUnitTestCase
 		// nothing should change here, since we are running in the CLI
 		$filter->after($this->request, $this->response);
 		$this->assertEquals($expectedAfter, $this->response);
+	}
+
+	public function testDebugToolbarFilterView()
+	{
+		$filter = new DebugToolbar();
+		$filter->before($this->request);
+		$data     = [
+			'testString' => 'bar',
+			'bar'        => 'baz',
+		];
+		$expected = 'DEBUG-VIEW';
+		$this->assertStringContainsString($expected, view('\Tests\Support\View\Views\simple', $data, []));
 	}
 
 }

--- a/user_guide_src/source/testing/debugging.rst
+++ b/user_guide_src/source/testing/debugging.rst
@@ -64,7 +64,7 @@ constant CI_DEBUG is defined and it's value is positive. This is defined in the 
 app/Config/Boot/development.php) and can be modified there to determine what environments it shows
 itself in.
 
-The toolbar itself is displayed as an :doc:`After Filter </incoming/filters>`. You can stop it from ever
+The toolbar itself is displayed as an :doc:`Filter </incoming/filters>`. You can stop it from ever
 running by removing it from the ``$globals`` property of **app/Config/Filters.php**.
 
 Choosing What to Show


### PR DESCRIPTION
- fix #3002 tooldebug except, but view debug comment is show.
- add filters except example

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
