### PR TITLE
Use fully-qualified namespace for PHP in Session

### DIFF
--- a/system/Session/Handlers/BaseHandler.php
+++ b/system/Session/Handlers/BaseHandler.php
@@ -158,7 +158,7 @@ abstract class BaseHandler implements \SessionHandlerInterface
 	 */
 	protected function destroyCookie(): bool
 	{
-		return setcookie(
+		return \setcookie(
 				$this->cookieName, null, 1, $this->cookiePath, $this->cookieDomain, $this->cookieSecure, true
 		);
 	}
@@ -211,7 +211,7 @@ abstract class BaseHandler implements \SessionHandlerInterface
 	 */
 	protected function fail(): bool
 	{
-		ini_set('session.save_path', $this->savePath);
+		\ini_set('session.save_path', $this->savePath);
 
 		return false;
 	}

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -111,12 +111,12 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 		$this->db = Database::connect($this->DBGroup);
 
 		// Determine Database type
-		$driver = strtolower(get_class($this->db));
-		if (strpos($driver, 'mysql') !== false)
+		$driver = \strtolower(\get_class($this->db));
+		if (\strpos($driver, 'mysql') !== false)
 		{
 			$this->platform = 'mysql';
 		}
-		elseif (strpos($driver, 'postgre') !== false)
+		elseif (\strpos($driver, 'postgre') !== false)
 		{
 			$this->platform = 'postgre';
 		}
@@ -160,12 +160,12 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 	{
 		if ($this->lockSession($sessionID) === false)
 		{
-			$this->fingerprint = md5('');
+			$this->fingerprint = \md5('');
 			return '';
 		}
 
 		// Needed by write() to detect session_regenerate_id() calls
-		if (is_null($this->sessionID))
+		if (\is_null($this->sessionID))
 		{
 			$this->sessionID = $sessionID;
 		}
@@ -187,7 +187,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 			// ID regeneration, so we need to explicitly set this to
 			// FALSE instead of relying on the default ...
 			$this->rowExists   = false;
-			$this->fingerprint = md5('');
+			$this->fingerprint = \md5('');
 
 			return '';
 		}
@@ -195,16 +195,16 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 		// PostgreSQL's variant of a BLOB datatype is Bytea, which is a
 		// PITA to work with, so we use base64-encoded data in a TEXT
 		// field instead.
-		if (is_bool($result))
+		if (\is_bool($result))
 		{
 			$result = '';
 		}
 		else
 		{
-			$result = ($this->platform === 'postgre') ? base64_decode(rtrim($result->data)) : $result->data;
+			$result = ($this->platform === 'postgre') ? \base64_decode(\rtrim($result->data)) : $result->data;
 		}
 
-		$this->fingerprint = md5($result);
+		$this->fingerprint = \md5($result);
 		$this->rowExists   = true;
 
 		return $result;
@@ -241,8 +241,8 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 			$insertData = [
 				'id'         => $sessionID,
 				'ip_address' => $this->ipAddress,
-				'timestamp'  => time(),
-				'data'       => $this->platform === 'postgre' ? base64_encode($sessionData) : $sessionData,
+				'timestamp'  => \time(),
+				'data'       => $this->platform === 'postgre' ? \base64_encode($sessionData) : $sessionData,
 			];
 
 			if (! $this->db->table($this->table)->insert($insertData))
@@ -250,7 +250,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 				return $this->fail();
 			}
 
-			$this->fingerprint = md5($sessionData);
+			$this->fingerprint = \md5($sessionData);
 			$this->rowExists   = true;
 
 			return true;
@@ -264,12 +264,12 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 		}
 
 		$updateData = [
-			'timestamp' => time(),
+			'timestamp' => \time(),
 		];
 
-		if ($this->fingerprint !== md5($sessionData))
+		if ($this->fingerprint !== \md5($sessionData))
 		{
-			$updateData['data'] = ($this->platform === 'postgre') ? base64_encode($sessionData) : $sessionData;
+			$updateData['data'] = ($this->platform === 'postgre') ? \base64_encode($sessionData) : $sessionData;
 		}
 
 		if (! $builder->update($updateData))
@@ -277,7 +277,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 			return $this->fail();
 		}
 
-		$this->fingerprint = md5($sessionData);
+		$this->fingerprint = \md5($sessionData);
 
 		return true;
 	}
@@ -347,7 +347,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 	 */
 	public function gc($maxlifetime): bool
 	{
-		return ($this->db->table($this->table)->delete('timestamp < ' . (time() - $maxlifetime))) ? true : $this->fail();
+		return ($this->db->table($this->table)->delete('timestamp < ' . (\time() - $maxlifetime))) ? true : $this->fail();
 	}
 
 	//--------------------------------------------------------------------
@@ -362,7 +362,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 	{
 		if ($this->platform === 'mysql')
 		{
-			$arg = md5($sessionID . ($this->matchIP ? '_' . $this->ipAddress : ''));
+			$arg = \md5($sessionID . ($this->matchIP ? '_' . $this->ipAddress : ''));
 			if ($this->db->query("SELECT GET_LOCK('{$arg}', 300) AS ci_session_lock")->getRow()->ci_session_lock)
 			{
 				$this->lock = $arg;

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -43,6 +43,10 @@ use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Session\Exceptions\SessionException;
 use Config\Database;
+use function strpos;
+use function md5;
+use function time;
+use function base64_encode;
 
 /**
  * Session handler using current Database for storage
@@ -112,11 +116,11 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 
 		// Determine Database type
 		$driver = \strtolower(\get_class($this->db));
-		if (\strpos($driver, 'mysql') !== false)
+		if (strpos($driver, 'mysql') !== false)
 		{
 			$this->platform = 'mysql';
 		}
-		elseif (\strpos($driver, 'postgre') !== false)
+		elseif (strpos($driver, 'postgre') !== false)
 		{
 			$this->platform = 'postgre';
 		}
@@ -160,7 +164,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 	{
 		if ($this->lockSession($sessionID) === false)
 		{
-			$this->fingerprint = \md5('');
+			$this->fingerprint = md5('');
 			return '';
 		}
 
@@ -187,7 +191,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 			// ID regeneration, so we need to explicitly set this to
 			// FALSE instead of relying on the default ...
 			$this->rowExists   = false;
-			$this->fingerprint = \md5('');
+			$this->fingerprint = md5('');
 
 			return '';
 		}
@@ -204,7 +208,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 			$result = ($this->platform === 'postgre') ? \base64_decode(\rtrim($result->data)) : $result->data;
 		}
 
-		$this->fingerprint = \md5($result);
+		$this->fingerprint = md5($result);
 		$this->rowExists   = true;
 
 		return $result;
@@ -241,8 +245,8 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 			$insertData = [
 				'id'         => $sessionID,
 				'ip_address' => $this->ipAddress,
-				'timestamp'  => \time(),
-				'data'       => $this->platform === 'postgre' ? \base64_encode($sessionData) : $sessionData,
+				'timestamp'  => time(),
+				'data'       => $this->platform === 'postgre' ? base64_encode($sessionData) : $sessionData,
 			];
 
 			if (! $this->db->table($this->table)->insert($insertData))
@@ -250,7 +254,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 				return $this->fail();
 			}
 
-			$this->fingerprint = \md5($sessionData);
+			$this->fingerprint = md5($sessionData);
 			$this->rowExists   = true;
 
 			return true;
@@ -264,12 +268,12 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 		}
 
 		$updateData = [
-			'timestamp' => \time(),
+			'timestamp' => time(),
 		];
 
-		if ($this->fingerprint !== \md5($sessionData))
+		if ($this->fingerprint !== md5($sessionData))
 		{
-			$updateData['data'] = ($this->platform === 'postgre') ? \base64_encode($sessionData) : $sessionData;
+			$updateData['data'] = ($this->platform === 'postgre') ? base64_encode($sessionData) : $sessionData;
 		}
 
 		if (! $builder->update($updateData))
@@ -277,7 +281,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 			return $this->fail();
 		}
 
-		$this->fingerprint = \md5($sessionData);
+		$this->fingerprint = md5($sessionData);
 
 		return true;
 	}
@@ -347,7 +351,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 	 */
 	public function gc($maxlifetime): bool
 	{
-		return ($this->db->table($this->table)->delete('timestamp < ' . (\time() - $maxlifetime))) ? true : $this->fail();
+		return ($this->db->table($this->table)->delete('timestamp < ' . (time() - $maxlifetime))) ? true : $this->fail();
 	}
 
 	//--------------------------------------------------------------------
@@ -362,7 +366,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 	{
 		if ($this->platform === 'mysql')
 		{
-			$arg = \md5($sessionID . ($this->matchIP ? '_' . $this->ipAddress : ''));
+			$arg = md5($sessionID . ($this->matchIP ? '_' . $this->ipAddress : ''));
 			if ($this->db->query("SELECT GET_LOCK('{$arg}', 300) AS ci_session_lock")->getRow()->ci_session_lock)
 			{
 				$this->lock = $arg;

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -97,12 +97,12 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 
 		if (! empty($config->sessionSavePath))
 		{
-			$this->savePath = rtrim($config->sessionSavePath, '/\\');
-			ini_set('session.save_path', $config->sessionSavePath);
+			$this->savePath = \rtrim($config->sessionSavePath, '/\\');
+			\ini_set('session.save_path', $config->sessionSavePath);
 		}
 		else
 		{
-			$sessionPath = rtrim(ini_get('session.save_path'), '/\\');
+			$sessionPath = \rtrim(\ini_get('session.save_path'), '/\\');
 
 			if (! $sessionPath)
 			{
@@ -132,14 +132,14 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 	 */
 	public function open($savePath, $name): bool
 	{
-		if (! is_dir($savePath))
+		if (! \is_dir($savePath))
 		{
-			if (! mkdir($savePath, 0700, true))
+			if (! \mkdir($savePath, 0700, true))
 			{
 				throw SessionException::forInvalidSavePath($this->savePath);
 			}
 		}
-		elseif (! is_writable($savePath))
+		elseif (! \is_writable($savePath))
 		{
 			throw SessionException::forWriteProtectedSavePath($this->savePath);
 		}
@@ -147,7 +147,7 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 		$this->savePath = $savePath;
 		$this->filePath = $this->savePath . '/'
 						  . $name // we'll use the session cookie name as a prefix to avoid collisions
-						  . ($this->matchIP ? md5($this->ipAddress) : '');
+						  . ($this->matchIP ? \md5($this->ipAddress) : '');
 
 		return true;
 	}
@@ -169,48 +169,48 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 		// which re-reads session data
 		if ($this->fileHandle === null)
 		{
-			$this->fileNew = ! is_file($this->filePath . $sessionID);
+			$this->fileNew = ! \is_file($this->filePath . $sessionID);
 
-			if (($this->fileHandle = fopen($this->filePath . $sessionID, 'c+b')) === false)
+			if (($this->fileHandle = \fopen($this->filePath . $sessionID, 'c+b')) === false)
 			{
 				$this->logger->error("Session: Unable to open file '" . $this->filePath . $sessionID . "'.");
 
 				return false;
 			}
 
-			if (flock($this->fileHandle, LOCK_EX) === false)
+			if (\flock($this->fileHandle, LOCK_EX) === false)
 			{
 				$this->logger->error("Session: Unable to obtain lock for file '" . $this->filePath . $sessionID . "'.");
-				fclose($this->fileHandle);
+				\fclose($this->fileHandle);
 				$this->fileHandle = null;
 
 				return false;
 			}
 
 			// Needed by write() to detect session_regenerate_id() calls
-			if (is_null($this->sessionID))
+			if (\is_null($this->sessionID))
 			{
 				$this->sessionID = $sessionID;
 			}
 
 			if ($this->fileNew)
 			{
-				chmod($this->filePath . $sessionID, 0600);
-				$this->fingerprint = md5('');
+				\chmod($this->filePath . $sessionID, 0600);
+				$this->fingerprint = \md5('');
 
 				return '';
 			}
 		}
 		else
 		{
-			rewind($this->fileHandle);
+			\rewind($this->fileHandle);
 		}
 
 		$session_data = '';
-		clearstatcache();    // Address https://github.com/codeigniter4/CodeIgniter4/issues/2056
-		for ($read = 0, $length = filesize($this->filePath . $sessionID); $read < $length; $read += strlen($buffer))
+		\clearstatcache();    // Address https://github.com/codeigniter4/CodeIgniter4/issues/2056
+		for ($read = 0, $length = \filesize($this->filePath . $sessionID); $read < $length; $read += \strlen($buffer))
 		{
-			if (($buffer = fread($this->fileHandle, $length - $read)) === false)
+			if (($buffer = \fread($this->fileHandle, $length - $read)) === false)
 			{
 				break;
 			}
@@ -218,7 +218,7 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 			$session_data .= $buffer;
 		}
 
-		$this->fingerprint = md5($session_data);
+		$this->fingerprint = \md5($session_data);
 
 		return $session_data;
 	}
@@ -243,41 +243,41 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 			$this->sessionID = $sessionID;
 		}
 
-		if (! is_resource($this->fileHandle))
+		if (! \is_resource($this->fileHandle))
 		{
 			return false;
 		}
-		elseif ($this->fingerprint === md5($sessionData))
+		elseif ($this->fingerprint === \md5($sessionData))
 		{
-			return ($this->fileNew) ? true : touch($this->filePath . $sessionID);
+			return ($this->fileNew) ? true : \touch($this->filePath . $sessionID);
 		}
 
 		if (! $this->fileNew)
 		{
-			ftruncate($this->fileHandle, 0);
-			rewind($this->fileHandle);
+			\ftruncate($this->fileHandle, 0);
+			\rewind($this->fileHandle);
 		}
 
-		if (($length = strlen($sessionData)) > 0)
+		if (($length = \strlen($sessionData)) > 0)
 		{
 			for ($written = 0; $written < $length; $written += $result)
 			{
-				if (($result = fwrite($this->fileHandle, substr($sessionData, $written))) === false)
+				if (($result = \fwrite($this->fileHandle, \substr($sessionData, $written))) === false)
 				{
 					break;
 				}
 			}
 
-			if (! is_int($result))
+			if (! \is_int($result))
 			{
-				$this->fingerprint = md5(substr($sessionData, 0, $written));
+				$this->fingerprint = \md5(\substr($sessionData, 0, $written));
 				$this->logger->error('Session: Unable to write data.');
 
 				return false;
 			}
 		}
 
-		$this->fingerprint = md5($sessionData);
+		$this->fingerprint = \md5($sessionData);
 
 		return true;
 	}
@@ -293,10 +293,10 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 	 */
 	public function close(): bool
 	{
-		if (is_resource($this->fileHandle))
+		if (\is_resource($this->fileHandle))
 		{
-			flock($this->fileHandle, LOCK_UN);
-			fclose($this->fileHandle);
+			\flock($this->fileHandle, LOCK_UN);
+			\fclose($this->fileHandle);
 
 			$this->fileHandle = $this->fileNew = null;
 
@@ -321,15 +321,15 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 	{
 		if ($this->close())
 		{
-			return is_file($this->filePath . $session_id)
-				? (unlink($this->filePath . $session_id) && $this->destroyCookie()) : true;
+			return \is_file($this->filePath . $session_id)
+				? (\unlink($this->filePath . $session_id) && $this->destroyCookie()) : true;
 		}
 		elseif ($this->filePath !== null)
 		{
-			clearstatcache();
+			\clearstatcache();
 
-			return is_file($this->filePath . $session_id)
-				? (unlink($this->filePath . $session_id) && $this->destroyCookie()) : true;
+			return \is_file($this->filePath . $session_id)
+				? (\unlink($this->filePath . $session_id) && $this->destroyCookie()) : true;
 		}
 
 		return false;
@@ -348,40 +348,40 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 	 */
 	public function gc($maxlifetime): bool
 	{
-		if (! is_dir($this->savePath) || ($directory = opendir($this->savePath)) === false)
+		if (! \is_dir($this->savePath) || ($directory = \opendir($this->savePath)) === false)
 		{
 			$this->logger->debug("Session: Garbage collector couldn't list files under directory '" . $this->savePath . "'.");
 
 			return false;
 		}
 
-		$ts = time() - $maxlifetime;
+		$ts = \time() - $maxlifetime;
 
 		$pattern = $this->matchIP === true
 			? '[0-9a-f]{32}'
 			: '';
 
-		$pattern = sprintf(
+		$pattern = \sprintf(
 			'#\A%s' . $pattern . $this->sessionIDRegex . '\z#',
 			preg_quote($this->cookieName)
 		);
 
-		while (($file = readdir($directory)) !== false)
+		while (($file = \readdir($directory)) !== false)
 		{
 			// If the filename doesn't match this pattern, it's either not a session file or is not ours
-			if (! preg_match($pattern, $file)
-				|| ! is_file($this->savePath . DIRECTORY_SEPARATOR . $file)
-				|| ($mtime = filemtime($this->savePath . DIRECTORY_SEPARATOR . $file)) === false
+			if (! \preg_match($pattern, $file)
+				|| ! \is_file($this->savePath . DIRECTORY_SEPARATOR . $file)
+				|| ($mtime = \filemtime($this->savePath . DIRECTORY_SEPARATOR . $file)) === false
 				|| $mtime > $ts
 			)
 			{
 				continue;
 			}
 
-			unlink($this->savePath . DIRECTORY_SEPARATOR . $file);
+			\unlink($this->savePath . DIRECTORY_SEPARATOR . $file);
 		}
 
-		closedir($directory);
+		\closedir($directory);
 
 		return true;
 	}
@@ -393,14 +393,14 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 	 */
 	protected function configureSessionIDRegex()
 	{
-		$bitsPerCharacter = (int)ini_get('session.sid_bits_per_character');
-		$SIDLength        = (int)ini_get('session.sid_length');
+		$bitsPerCharacter = (int)\ini_get('session.sid_bits_per_character');
+		$SIDLength        = (int)\ini_get('session.sid_length');
 
 		if (($bits = $SIDLength * $bitsPerCharacter) < 160)
 		{
 			// Add as many more characters as necessary to reach at least 160 bits
 			$SIDLength += (int)ceil((160 % $bits) / $bitsPerCharacter);
-			ini_set('session.sid_length', $SIDLength);
+			\ini_set('session.sid_length', $SIDLength);
 		}
 
 		// Yes, 4,5,6 are the only known possible values as of 2016-10-27

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -100,7 +100,7 @@ class MemcachedHandler extends BaseHandler implements \SessionHandlerInterface
 
 		if (! empty($this->keyPrefix))
 		{
-			ini_set('memcached.sess_prefix', $this->keyPrefix);
+			\ini_set('memcached.sess_prefix', $this->keyPrefix);
 		}
 
 		$this->sessionExpiration = $config->sessionExpiration;
@@ -130,7 +130,7 @@ class MemcachedHandler extends BaseHandler implements \SessionHandlerInterface
 			$server_list[] = $server['host'] . ':' . $server['port'];
 		}
 
-		if (! preg_match_all('#,?([^,:]+)\:(\d{1,5})(?:\:(\d+))?#', $this->savePath, $matches, PREG_SET_ORDER)
+		if (! \preg_match_all('#,?([^,:]+)\:(\d{1,5})(?:\:(\d+))?#', $this->savePath, $matches, PREG_SET_ORDER)
 		)
 		{
 			$this->memcached = null;
@@ -142,7 +142,7 @@ class MemcachedHandler extends BaseHandler implements \SessionHandlerInterface
 		foreach ($matches as $match)
 		{
 			// If Memcached already has this server (or if the port is invalid), skip it
-			if (in_array($match[1] . ':' . $match[2], $server_list, true))
+			if (\in_array($match[1] . ':' . $match[2], $server_list, true))
 			{
 				$this->logger->debug('Session: Memcached server pool already has ' . $match[1] . ':' . $match[2]);
 				continue;
@@ -184,13 +184,13 @@ class MemcachedHandler extends BaseHandler implements \SessionHandlerInterface
 		if (isset($this->memcached) && $this->lockSession($sessionID))
 		{
 			// Needed by write() to detect session_regenerate_id() calls
-			if (is_null($this->sessionID))
+			if (\is_null($this->sessionID))
 			{
 				$this->sessionID = $sessionID;
 			}
 
 			$session_data      = (string) $this->memcached->get($this->keyPrefix . $sessionID);
-			$this->fingerprint = md5($session_data);
+			$this->fingerprint = \md5($session_data);
 
 			return $session_data;
 		}
@@ -224,15 +224,15 @@ class MemcachedHandler extends BaseHandler implements \SessionHandlerInterface
 				return false;
 			}
 
-			$this->fingerprint = md5('');
+			$this->fingerprint = \md5('');
 			$this->sessionID   = $sessionID;
 		}
 
 		if (isset($this->lockKey))
 		{
-			$this->memcached->replace($this->lockKey, time(), 300);
+			$this->memcached->replace($this->lockKey, \time(), 300);
 
-			if ($this->fingerprint !== ($fingerprint = md5($sessionData)))
+			if ($this->fingerprint !== ($fingerprint = \md5($sessionData)))
 			{
 				if ($this->memcached->set($this->keyPrefix . $sessionID, $sessionData, $this->sessionExpiration))
 				{
@@ -333,7 +333,7 @@ class MemcachedHandler extends BaseHandler implements \SessionHandlerInterface
 	{
 		if (isset($this->lockKey))
 		{
-			return $this->memcached->replace($this->lockKey, time(), 300);
+			return $this->memcached->replace($this->lockKey, \time(), 300);
 		}
 
 		// 30 attempts to obtain a lock, in case another request already has it
@@ -344,11 +344,11 @@ class MemcachedHandler extends BaseHandler implements \SessionHandlerInterface
 		{
 			if ($this->memcached->get($lock_key))
 			{
-				sleep(1);
+				\sleep(1);
 				continue;
 			}
 
-			if (! $this->memcached->set($lock_key, time(), 300))
+			if (! $this->memcached->set($lock_key, \time(), 300))
 			{
 				$this->logger->error('Session: Error while trying to obtain lock for ' . $this->keyPrefix . $sessionID);
 

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -40,9 +40,9 @@ namespace CodeIgniter\Session\Handlers;
 
 use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Session\Exceptions\SessionException;
+use Memcached;
 use function md5;
 use function time;
-use function Memcached;
 
 /**
  * Session handler using Memcache for persistence

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -101,19 +101,19 @@ class RedisHandler extends BaseHandler implements \SessionHandlerInterface
 		{
 			throw SessionException::forEmptySavepath();
 		}
-		elseif (preg_match('#(?:tcp://)?([^:?]+)(?:\:(\d+))?(\?.+)?#', $this->savePath, $matches))
+		elseif (\preg_match('#(?:tcp://)?([^:?]+)(?:\:(\d+))?(\?.+)?#', $this->savePath, $matches))
 		{
 			isset($matches[3]) || $matches[3] = ''; // Just to avoid undefined index notices below
 
 			$this->savePath = [
 				'host'     => $matches[1],
 				'port'     => empty($matches[2]) ? null : $matches[2],
-				'password' => preg_match('#auth=([^\s&]+)#', $matches[3], $match) ? $match[1] : null,
-				'database' => preg_match('#database=(\d+)#', $matches[3], $match) ? (int) $match[1] : null,
-				'timeout'  => preg_match('#timeout=(\d+\.\d+)#', $matches[3], $match) ? (float) $match[1] : null,
+				'password' => \preg_match('#auth=([^\s&]+)#', $matches[3], $match) ? $match[1] : null,
+				'database' => \preg_match('#database=(\d+)#', $matches[3], $match) ? (int) $match[1] : null,
+				'timeout'  => \preg_match('#timeout=(\d+\.\d+)#', $matches[3], $match) ? (float) $match[1] : null,
 			];
 
-			preg_match('#prefix=([^\s&]+)#', $matches[3], $match) && $this->keyPrefix = $match[1];
+			\preg_match('#prefix=([^\s&]+)#', $matches[3], $match) && $this->keyPrefix = $match[1];
 		}
 		else
 		{
@@ -185,15 +185,15 @@ class RedisHandler extends BaseHandler implements \SessionHandlerInterface
 		if (isset($this->redis) && $this->lockSession($sessionID))
 		{
 			// Needed by write() to detect session_regenerate_id() calls
-			if (is_null($this->sessionID))
+			if (\is_null($this->sessionID))
 			{
 				$this->sessionID = $sessionID;
 			}
 
 			$session_data                               = $this->redis->get($this->keyPrefix . $sessionID);
-			is_string($session_data) ? $this->keyExists = true : $session_data = '';
+			\is_string($session_data) ? $this->keyExists = true : $session_data = '';
 
-			$this->fingerprint = md5($session_data);
+			$this->fingerprint = \md5($session_data);
 
 			return $session_data;
 		}
@@ -235,7 +235,7 @@ class RedisHandler extends BaseHandler implements \SessionHandlerInterface
 		{
 			$this->redis->expire($this->lockKey, 300);
 
-			if ($this->fingerprint !== ($fingerprint = md5($sessionData)) || $this->keyExists === false)
+			if ($this->fingerprint !== ($fingerprint = \md5($sessionData)) || $this->keyExists === false)
 			{
 				if ($this->redis->set($this->keyPrefix . $sessionID, $sessionData, $this->sessionExpiration))
 				{
@@ -363,11 +363,11 @@ class RedisHandler extends BaseHandler implements \SessionHandlerInterface
 		{
 			if (($ttl = $this->redis->ttl($lock_key)) > 0)
 			{
-				sleep(1);
+				\sleep(1);
 				continue;
 			}
 
-			if (! $this->redis->setex($lock_key, 300, time()))
+			if (! $this->redis->setex($lock_key, 300, \time()))
 			{
 				$this->logger->error('Session: Error while trying to obtain lock for ' . $this->keyPrefix . $sessionID);
 				return false;

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -205,13 +205,13 @@ class Session implements SessionInterface
 			return;
 			// @codeCoverageIgnoreEnd
 		}
-		elseif ((bool) ini_get('session.auto_start'))
+		elseif ((bool) \ini_get('session.auto_start'))
 		{
 			$this->logger->error('Session: session.auto_start is enabled in php.ini. Aborting.');
 
 			return;
 		}
-		elseif (session_status() === PHP_SESSION_ACTIVE)
+		elseif (\session_status() === PHP_SESSION_ACTIVE)
 		{
 			$this->logger->warning('Session: Sessions is enabled, and one exists.Please don\'t $session->start();');
 
@@ -230,7 +230,7 @@ class Session implements SessionInterface
 
 		// Sanitize the cookie, because apparently PHP doesn't do that for userspace handlers
 		if (isset($_COOKIE[$this->sessionCookieName]) && (
-				! is_string($_COOKIE[$this->sessionCookieName]) || ! preg_match('#\A' . $this->sidRegexp . '\z#', $_COOKIE[$this->sessionCookieName])
+				! \is_string($_COOKIE[$this->sessionCookieName]) || ! \preg_match('#\A' . $this->sidRegexp . '\z#', $_COOKIE[$this->sessionCookieName])
 				)
 		)
 		{
@@ -241,21 +241,21 @@ class Session implements SessionInterface
 
 		// Is session ID auto-regeneration configured? (ignoring ajax requests)
 		if ((empty($_SERVER['HTTP_X_REQUESTED_WITH']) ||
-				strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) !== 'xmlhttprequest') && ($regenerate_time = $this->sessionTimeToUpdate) > 0
+				\strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) !== 'xmlhttprequest') && ($regenerate_time = $this->sessionTimeToUpdate) > 0
 		)
 		{
 			if (! isset($_SESSION['__ci_last_regenerate']))
 			{
-				$_SESSION['__ci_last_regenerate'] = time();
+				$_SESSION['__ci_last_regenerate'] = \time();
 			}
-			elseif ($_SESSION['__ci_last_regenerate'] < (time() - $regenerate_time))
+			elseif ($_SESSION['__ci_last_regenerate'] < (\time() - $regenerate_time))
 			{
 				$this->regenerate((bool) $this->sessionRegenerateDestroy);
 			}
 		}
 		// Another work-around ... PHP doesn't seem to send the session cookie
 		// unless it is being currently created or regenerated
-		elseif (isset($_COOKIE[$this->sessionCookieName]) && $_COOKIE[$this->sessionCookieName] === session_id())
+		elseif (isset($_COOKIE[$this->sessionCookieName]) && $_COOKIE[$this->sessionCookieName] === \session_id())
 		{
 			$this->setCookie();
 		}
@@ -278,11 +278,11 @@ class Session implements SessionInterface
 	 */
 	public function stop()
 	{
-		setcookie(
-				$this->sessionCookieName, session_id(), 1, $this->cookiePath, $this->cookieDomain, $this->cookieSecure, true
+		\setcookie(
+				$this->sessionCookieName, \session_id(), 1, $this->cookiePath, $this->cookieDomain, $this->cookieSecure, true
 		);
 
-		session_regenerate_id(true);
+		\session_regenerate_id(true);
 	}
 
 	//--------------------------------------------------------------------
@@ -296,37 +296,37 @@ class Session implements SessionInterface
 	{
 		if (empty($this->sessionCookieName))
 		{
-			$this->sessionCookieName = ini_get('session.name');
+			$this->sessionCookieName = \ini_get('session.name');
 		}
 		else
 		{
-			ini_set('session.name', $this->sessionCookieName);
+			\ini_set('session.name', $this->sessionCookieName);
 		}
 
-		session_set_cookie_params(
+		\session_set_cookie_params(
 				$this->sessionExpiration, $this->cookiePath, $this->cookieDomain, $this->cookieSecure, true // HTTP only; Yes, this is intentional and not configurable for security reasons.
 		);
 
 		//if (empty($this->sessionExpiration))
 		if (! isset($this->sessionExpiration))
 		{
-			$this->sessionExpiration = (int) ini_get('session.gc_maxlifetime');
+			$this->sessionExpiration = (int) \ini_get('session.gc_maxlifetime');
 		}
 		else
 		{
-			ini_set('session.gc_maxlifetime', (int) $this->sessionExpiration);
+			\ini_set('session.gc_maxlifetime', (int) $this->sessionExpiration);
 		}
 
 		if (! empty($this->sessionSavePath))
 		{
-			ini_set('session.save_path', $this->sessionSavePath);
+			\ini_set('session.save_path', $this->sessionSavePath);
 		}
 
 		// Security is king
-		ini_set('session.use_trans_sid', 0);
-		ini_set('session.use_strict_mode', 1);
-		ini_set('session.use_cookies', 1);
-		ini_set('session.use_only_cookies', 1);
+		\ini_set('session.use_trans_sid', 0);
+		\ini_set('session.use_strict_mode', 1);
+		\ini_set('session.use_cookies', 1);
+		\ini_set('session.use_only_cookies', 1);
 
 		$this->configureSidLength();
 	}
@@ -350,18 +350,18 @@ class Session implements SessionInterface
 	 */
 	protected function configureSidLength()
 	{
-		$bits_per_character = (int) (ini_get('session.sid_bits_per_character') !== false
-			? ini_get('session.sid_bits_per_character')
+		$bits_per_character = (int) (\ini_get('session.sid_bits_per_character') !== false
+			? \ini_get('session.sid_bits_per_character')
 			: 4);
-		$sid_length         = (int) (ini_get('session.sid_length') !== false
-			? ini_get('session.sid_length')
+		$sid_length         = (int) (\ini_get('session.sid_length') !== false
+			? \ini_get('session.sid_length')
 			: 40);
 		if (($sid_length * $bits_per_character) < 160)
 		{
 			$bits = ($sid_length * $bits_per_character);
 			// Add as many more characters as necessary to reach at least 160 bits
 			$sid_length += (int) ceil((160 % $bits) / $bits_per_character);
-			ini_set('session.sid_length', $sid_length);
+			\ini_set('session.sid_length', $sid_length);
 		}
 
 		// Yes, 4,5,6 are the only known possible values as of 2016-10-27
@@ -396,7 +396,7 @@ class Session implements SessionInterface
 			return;
 		}
 
-		$current_time = time();
+		$current_time = \time();
 
 		foreach ($_SESSION['__ci_vars'] as $key => &$value)
 		{
@@ -430,8 +430,8 @@ class Session implements SessionInterface
 	 */
 	public function regenerate(bool $destroy = false)
 	{
-		$_SESSION['__ci_last_regenerate'] = time();
-		session_regenerate_id($destroy);
+		$_SESSION['__ci_last_regenerate'] = \time();
+		\session_regenerate_id($destroy);
 	}
 
 	//--------------------------------------------------------------------
@@ -441,7 +441,7 @@ class Session implements SessionInterface
 	 */
 	public function destroy()
 	{
-		session_destroy();
+		\session_destroy();
 	}
 
 	//--------------------------------------------------------------------
@@ -463,11 +463,11 @@ class Session implements SessionInterface
 	 */
 	public function set($data, $value = null)
 	{
-		if (is_array($data))
+		if (\is_array($data))
 		{
 			foreach ($data as $key => &$value)
 			{
-				if (is_int($key))
+				if (\is_int($key))
 				{
 					$_SESSION[$value] = null;
 				}
@@ -499,7 +499,7 @@ class Session implements SessionInterface
 	 */
 	public function get(string $key = null)
 	{
-		if (! empty($key) && (! is_null($value = isset($_SESSION[$key]) ? $_SESSION[$key] : null) || ! is_null($value = dot_array_search($key, $_SESSION ?? []))))
+		if (! empty($key) && (! \is_null($value = isset($_SESSION[$key]) ? $_SESSION[$key] : null) || ! \is_null($value = dot_array_search($key, $_SESSION ?? []))))
 		{
 			return $value;
 		}
@@ -514,14 +514,14 @@ class Session implements SessionInterface
 		}
 
 		$userdata = [];
-		$_exclude = array_merge(
+		$_exclude = \array_merge(
 			['__ci_vars'], $this->getFlashKeys(), $this->getTempKeys()
 		);
 
-		$keys = array_keys($_SESSION);
+		$keys = \array_keys($_SESSION);
 		foreach ($keys as $key)
 		{
-			if (! in_array($key, $_exclude, true))
+			if (! \in_array($key, $_exclude, true))
 			{
 				$userdata[$key] = $_SESSION[$key];
 			}
@@ -556,9 +556,9 @@ class Session implements SessionInterface
 	   */
 	public function push(string $key, array $data)
 	{
-		if ($this->has($key) && is_array($value = $this->get($key)))
+		if ($this->has($key) && \is_array($value = $this->get($key)))
 			   {
-			$this->set($key, array_merge($value, $data));
+			$this->set($key, \array_merge($value, $data));
 		}
 	}
 
@@ -575,7 +575,7 @@ class Session implements SessionInterface
 	 */
 	public function remove($key)
 	{
-		if (is_array($key))
+		if (\is_array($key))
 		{
 			foreach ($key as $k)
 			{
@@ -622,7 +622,7 @@ class Session implements SessionInterface
 		}
 		elseif ($key === 'session_id')
 		{
-			return session_id();
+			return \session_id();
 		}
 
 		return null;
@@ -664,7 +664,7 @@ class Session implements SessionInterface
 	public function setFlashdata($data, $value = null)
 	{
 		$this->set($data, $value);
-		$this->markAsFlashdata(is_array($data) ? array_keys($data) : $data);
+		$this->markAsFlashdata(\is_array($data) ? \array_keys($data) : $data);
 	}
 
 	//--------------------------------------------------------------------
@@ -682,7 +682,7 @@ class Session implements SessionInterface
 		if (isset($key))
 		{
 			return (isset($_SESSION['__ci_vars'], $_SESSION['__ci_vars'][$key], $_SESSION[$key]) &&
-					! is_int($_SESSION['__ci_vars'][$key])) ? $_SESSION[$key] : null;
+					! \is_int($_SESSION['__ci_vars'][$key])) ? $_SESSION[$key] : null;
 		}
 
 		$flashdata = [];
@@ -691,7 +691,7 @@ class Session implements SessionInterface
 		{
 			foreach ($_SESSION['__ci_vars'] as $key => &$value)
 			{
-				is_int($value) || $flashdata[$key] = $_SESSION[$key];
+				\is_int($value) || $flashdata[$key] = $_SESSION[$key];
 			}
 		}
 
@@ -721,7 +721,7 @@ class Session implements SessionInterface
 	 */
 	public function markAsFlashdata($key): bool
 	{
-		if (is_array($key))
+		if (\is_array($key))
 		{
 			for ($i = 0, $c = count($key); $i < $c; $i ++)
 			{
@@ -731,9 +731,9 @@ class Session implements SessionInterface
 				}
 			}
 
-			$new = array_fill_keys($key, 'new');
+			$new = \array_fill_keys($key, 'new');
 
-			$_SESSION['__ci_vars'] = isset($_SESSION['__ci_vars']) ? array_merge($_SESSION['__ci_vars'], $new) : $new;
+			$_SESSION['__ci_vars'] = isset($_SESSION['__ci_vars']) ? \array_merge($_SESSION['__ci_vars'], $new) : $new;
 
 			return true;
 		}
@@ -762,11 +762,11 @@ class Session implements SessionInterface
 			return;
 		}
 
-		is_array($key) || $key = [$key];
+		\is_array($key) || $key = [$key];
 
 		foreach ($key as $k)
 		{
-			if (isset($_SESSION['__ci_vars'][$k]) && ! is_int($_SESSION['__ci_vars'][$k]))
+			if (isset($_SESSION['__ci_vars'][$k]) && ! \is_int($_SESSION['__ci_vars'][$k]))
 			{
 				unset($_SESSION['__ci_vars'][$k]);
 			}
@@ -793,9 +793,9 @@ class Session implements SessionInterface
 		}
 
 		$keys = [];
-		foreach (array_keys($_SESSION['__ci_vars']) as $key)
+		foreach (\array_keys($_SESSION['__ci_vars']) as $key)
 		{
-			is_int($_SESSION['__ci_vars'][$key]) || $keys[] = $key;
+			\is_int($_SESSION['__ci_vars'][$key]) || $keys[] = $key;
 		}
 
 		return $keys;
@@ -834,7 +834,7 @@ class Session implements SessionInterface
 		if (isset($key))
 		{
 			return (isset($_SESSION['__ci_vars'], $_SESSION['__ci_vars'][$key], $_SESSION[$key]) &&
-					is_int($_SESSION['__ci_vars'][$key])) ? $_SESSION[$key] : null;
+					\is_int($_SESSION['__ci_vars'][$key])) ? $_SESSION[$key] : null;
 		}
 
 		$tempdata = [];
@@ -843,7 +843,7 @@ class Session implements SessionInterface
 		{
 			foreach ($_SESSION['__ci_vars'] as $key => &$value)
 			{
-				is_int($value) && $tempdata[$key] = $_SESSION[$key];
+				\is_int($value) && $tempdata[$key] = $_SESSION[$key];
 			}
 		}
 
@@ -876,30 +876,30 @@ class Session implements SessionInterface
 	 */
 	public function markAsTempdata($key, int $ttl = 300): bool
 	{
-		$ttl += time();
+		$ttl += \time();
 
-		if (is_array($key))
+		if (\is_array($key))
 		{
 			$temp = [];
 
 			foreach ($key as $k => $v)
 			{
 				// Do we have a key => ttl pair, or just a key?
-				if (is_int($k))
+				if (\is_int($k))
 				{
 					$k = $v;
 					$v = $ttl;
 				}
-				elseif (is_string($v))
+				elseif (\is_string($v))
 				{
-					$v = time() + $ttl;
+					$v = \time() + $ttl;
 				}
 				else
 				{
-					$v += time();
+					$v += \time();
 				}
 
-				if (! array_key_exists($k, $_SESSION))
+				if (! \array_key_exists($k, $_SESSION))
 				{
 					return false;
 				}
@@ -907,7 +907,7 @@ class Session implements SessionInterface
 				$temp[$k] = $v;
 			}
 
-			$_SESSION['__ci_vars'] = isset($_SESSION['__ci_vars']) ? array_merge($_SESSION['__ci_vars'], $temp) : $temp;
+			$_SESSION['__ci_vars'] = isset($_SESSION['__ci_vars']) ? \array_merge($_SESSION['__ci_vars'], $temp) : $temp;
 
 			return true;
 		}
@@ -937,11 +937,11 @@ class Session implements SessionInterface
 			return;
 		}
 
-		is_array($key) || $key = [$key];
+		\is_array($key) || $key = [$key];
 
 		foreach ($key as $k)
 		{
-			if (isset($_SESSION['__ci_vars'][$k]) && is_int($_SESSION['__ci_vars'][$k]))
+			if (isset($_SESSION['__ci_vars'][$k]) && \is_int($_SESSION['__ci_vars'][$k]))
 			{
 				unset($_SESSION['__ci_vars'][$k]);
 			}
@@ -968,9 +968,9 @@ class Session implements SessionInterface
 		}
 
 		$keys = [];
-		foreach (array_keys($_SESSION['__ci_vars']) as $key)
+		foreach (\array_keys($_SESSION['__ci_vars']) as $key)
 		{
-			is_int($_SESSION['__ci_vars'][$key]) && $keys[] = $key;
+			\is_int($_SESSION['__ci_vars'][$key]) && $keys[] = $key;
 		}
 
 		return $keys;
@@ -984,7 +984,7 @@ class Session implements SessionInterface
 	 */
 	protected function setSaveHandler()
 	{
-		session_set_save_handler($this->driver, true);
+		\session_set_save_handler($this->driver, true);
 	}
 
 	//--------------------------------------------------------------------
@@ -1002,7 +1002,7 @@ class Session implements SessionInterface
 		}
 
 		// @codeCoverageIgnoreStart
-		session_start();
+		\session_start();
 		// @codeCoverageIgnoreEnd
 	}
 
@@ -1014,8 +1014,14 @@ class Session implements SessionInterface
 	 */
 	protected function setCookie()
 	{
-		setcookie(
-				$this->sessionCookieName, session_id(), (empty($this->sessionExpiration) ? 0 : time() + $this->sessionExpiration), $this->cookiePath, $this->cookieDomain, $this->cookieSecure, true
+		\setcookie(
+			$this->sessionCookieName,
+			\session_id(),
+			(empty($this->sessionExpiration) ? 0 : \time() + $this->sessionExpiration),
+			$this->cookiePath,
+			$this->cookieDomain,
+			$this->cookieSecure,
+			true
 		);
 	}
 


### PR DESCRIPTION
**Description**

Code better optimized by calling with fully-qualified PHP function names. 
For instance, the PHP function time in the following

     $_SESSION['__ci_last_regenerate'] = \time();

It's not a giant optimization, but it's more than a micro-optimization. 

Existing unit test `SessionTest.php` unchanged and all tests pass.
User guide not affected by these changes.



  
