### PR TITLE
Fixes #3028 add ability to manipulate string result of view->renderSection()

### DIFF
--- a/system/View/View.php
+++ b/system/View/View.php
@@ -493,20 +493,21 @@ class View implements RendererInterface
 	 *
 	 * @param string $sectionName
 	 */
-	public function renderSection(string $sectionName)
+	public function renderSection(string $sectionName) : string
 	{
 		if (! isset($this->sections[$sectionName]))
 		{
-			echo '';
-
-			return;
+			return '';
 		}
 
+		$result = '';
 		foreach ($this->sections[$sectionName] as $key => $contents)
 		{
-			echo $contents;
+			$result .= $contents;
 			unset($this->sections[$sectionName][$key]);
 		}
+
+		return $result;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -491,12 +491,21 @@ class View implements RendererInterface
 	/**
 	 * Renders a section's contents.
 	 *
-	 * @param string $sectionName
+	 * @param string  $sectionName
+	 * @param boolean $echoed
+	 *
+	 * @return void|string
 	 */
-	public function renderSection(string $sectionName) : string
+	public function renderSection(string $sectionName, bool $echoed = true)
 	{
 		if (! isset($this->sections[$sectionName]))
 		{
+			if ($echoed)
+			{
+				echo '';
+				return;
+			}
+
 			return '';
 		}
 
@@ -505,6 +514,12 @@ class View implements RendererInterface
 		{
 			$result .= $contents;
 			unset($this->sections[$sectionName][$key]);
+		}
+
+		if ($echoed)
+		{
+			echo $result;
+			return;
 		}
 
 		return $result;

--- a/tests/system/View/ViewTest.php
+++ b/tests/system/View/ViewTest.php
@@ -370,10 +370,20 @@ class ViewTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertStringContainsString('<h1>test</h1>', $view->render('simple', null, false));
 	}
 
-	public function testRenderSectionNotExists()
+	public function testRenderSectionNotExistsEchoed()
+	{
+		$view = new View($this->config, $this->viewsDir, $this->loader);
+		ob_start();
+		$view->renderSection('content');
+		$content = ob_get_clean();
+
+		$this->assertEquals('', $content);
+	}
+
+	public function testRenderSectionNotExistsReturnedString()
 	{
 		$view    = new View($this->config, $this->viewsDir, $this->loader);
-		$content = $view->renderSection('content');
+		$content = $view->renderSection('content', false);
 
 		$this->assertEquals('', $content);
 	}
@@ -390,7 +400,26 @@ class ViewTest extends \CodeIgniter\Test\CIUnitTestCase
 			];
 		})->bindTo($view, View::class)($view);
 
-		$content = $view->renderSection('content');
+		ob_start();
+		$view->renderSection('content');
+		$content = ob_get_clean();
+
+		$this->assertEquals('ab', $content);
+	}
+
+	public function testRenderSectionExistsReturnedString()
+	{
+		$view = new View($this->config, $this->viewsDir, $this->loader);
+		(function ($view) {
+			$view->sections = [
+				'content' => [
+					'a',
+					'b',
+				],
+			];
+		})->bindTo($view, View::class)($view);
+
+		$content = $view->renderSection('content', false);
 		$this->assertEquals('ab', $content);
 	}
 

--- a/tests/system/View/ViewTest.php
+++ b/tests/system/View/ViewTest.php
@@ -370,4 +370,28 @@ class ViewTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertStringContainsString('<h1>test</h1>', $view->render('simple', null, false));
 	}
 
+	public function testRenderSectionNotExists()
+	{
+		$view    = new View($this->config, $this->viewsDir, $this->loader);
+		$content = $view->renderSection('content');
+
+		$this->assertEquals('', $content);
+	}
+
+	public function testRenderSectionExists()
+	{
+		$view = new View($this->config, $this->viewsDir, $this->loader);
+		(function ($view) {
+			$view->sections = [
+				'content' => [
+					'a',
+					'b',
+				],
+			];
+		})->bindTo($view, View::class)($view);
+
+		$content = $view->renderSection('content');
+		$this->assertEquals('ab', $content);
+	}
+
 }


### PR DESCRIPTION
Fixes #3028 . add ability `View::renderSection()` to returns string.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage