### PR TITLE
Set default locale on initialization

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -180,6 +180,9 @@ class CodeIgniter
 	 */
 	public function initialize()
 	{
+		// Set default locale on the server
+		locale_set_default($this->config->defaultLocale ?? 'en');
+
 		// Set default timezone on the server
 		date_default_timezone_set($this->config->appTimezone ?? 'UTC');
 


### PR DESCRIPTION
**Description**

Added a default locale setting during application initialization.
When I tried to create a Time object without additional parameters, it turned out that the time zone is set by default, but the locale is not.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
