### PR TITLE
Added SameSite attribute to CSRF cookie

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -239,7 +239,7 @@ class App extends BaseConfig
 	| CSRFTokenName   = The token name
 	| CSRFHeaderName  = The header name
 	| CSRFCookieName  = The cookie name
-	| CSRFCookieSameSite  = The cookie SameSite attribute (none, Lax or Strict)
+	| CSRFCookieSameSite  = The cookie SameSite attribute (none, lax or strict)
 	| CSRFExpire      = The number in seconds the token should expire.
 	| CSRFRegenerate  = Regenerate token on every submission
 	| CSRFRedirect    = Redirect to previous page with error on failure

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -239,6 +239,7 @@ class App extends BaseConfig
 	| CSRFTokenName   = The token name
 	| CSRFHeaderName  = The header name
 	| CSRFCookieName  = The cookie name
+	| CSRFCookieSameSite  = The cookie SameSite attribute (none, Lax or Strict)
 	| CSRFExpire      = The number in seconds the token should expire.
 	| CSRFRegenerate  = Regenerate token on every submission
 	| CSRFRedirect    = Redirect to previous page with error on failure
@@ -246,6 +247,7 @@ class App extends BaseConfig
 	public $CSRFTokenName  = 'csrf_test_name';
 	public $CSRFHeaderName = 'X-CSRF-TOKEN';
 	public $CSRFCookieName = 'csrf_cookie_name';
+	public $CSRFCookieSameSite = 'strict';
 	public $CSRFExpire     = 7200;
 	public $CSRFRegenerate = true;
 	public $CSRFRedirect   = true;

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -212,71 +212,11 @@ class Controller
 
 			$rules = $validation->$rules;
 		}
-		
-        // Replace any placeholders (i.e. {id}) in the rules with
-        // the value found in $data, if exists.
-       	$rules = $this->fillPlaceholders($rules, $this->request->getVar());
 
 		return $this->validator
 			->withRequest($this->request)
 			->setRules($rules, $messages)
 			->run();
-	}
-	
-	/**
-	 * Replace any placeholders within the rules with the values that
-	 * match the 'key' of any properties being set. For example, if
-	 * we had the following $data array:
-	 *
-	 * [ 'id' => 13 ]
-	 *
-	 * and the following rule:
-	 *
-	 *  'required|is_unique[users,email,id,{id}]'
-	 *
-	 * The value of {id} would be replaced with the actual id in the form data:
-	 *
-	 *  'required|is_unique[users,email,id,13]'
-	 *
-	 * @param array $rules
-	 * @param array $data
-	 *
-	 * @return array
-	 */
-	protected function fillPlaceholders(array $rules, array $data): array
-	{
-	$replacements = [];
-
-	foreach ($data as $key => $value)
-	{
-		$replacements["{{$key}}"] = $value;
-	}
-
-	if (! empty($replacements))
-	{
-		foreach ($rules as &$rule)
-		{
-		if (is_array($rule))
-		{
-			foreach ($rule as &$row)
-			{
-			// Should only be an `errors` array
-			// which doesn't take placeholders.
-			if (is_array($row))
-			{
-				continue;
-			}
-
-			$row = strtr($row, $replacements);
-			}
-			continue;
-		}
-
-		$rule = strtr($rule, $replacements);
-		}
-	}
-
-	return $rules;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -212,11 +212,71 @@ class Controller
 
 			$rules = $validation->$rules;
 		}
+		
+        // Replace any placeholders (i.e. {id}) in the rules with
+        // the value found in $data, if exists.
+       	$rules = $this->fillPlaceholders($rules, $this->request->getVar());
 
 		return $this->validator
 			->withRequest($this->request)
 			->setRules($rules, $messages)
 			->run();
+	}
+	
+	/**
+	 * Replace any placeholders within the rules with the values that
+	 * match the 'key' of any properties being set. For example, if
+	 * we had the following $data array:
+	 *
+	 * [ 'id' => 13 ]
+	 *
+	 * and the following rule:
+	 *
+	 *  'required|is_unique[users,email,id,{id}]'
+	 *
+	 * The value of {id} would be replaced with the actual id in the form data:
+	 *
+	 *  'required|is_unique[users,email,id,13]'
+	 *
+	 * @param array $rules
+	 * @param array $data
+	 *
+	 * @return array
+	 */
+	protected function fillPlaceholders(array $rules, array $data): array
+	{
+	$replacements = [];
+
+	foreach ($data as $key => $value)
+	{
+		$replacements["{{$key}}"] = $value;
+	}
+
+	if (! empty($replacements))
+	{
+		foreach ($rules as &$rule)
+		{
+		if (is_array($rule))
+		{
+			foreach ($rule as &$row)
+			{
+			// Should only be an `errors` array
+			// which doesn't take placeholders.
+			if (is_array($row))
+			{
+				continue;
+			}
+
+			$row = strtr($row, $replacements);
+			}
+			continue;
+		}
+
+		$rule = strtr($rule, $replacements);
+		}
+	}
+
+	return $rules;
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
In order to provide an additional layer of defense against cross-site request forgery (CSRF) attacks, the SameSite attribute is added to the CSRF cookie.

**Checklist:**
- [ ] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
  
