### PR TITLE
Separate getFormatter function from config

### DIFF
--- a/app/Config/Format.php
+++ b/app/Config/Format.php
@@ -1,8 +1,10 @@
-<?php namespace Config;
+<?php
 
-use CodeIgniter\Config\BaseConfig;
+namespace Config;
 
-class Format extends BaseConfig
+use CodeIgniter\Format\Formatter;
+
+class Format extends Formatter
 {
 	/*
 	|--------------------------------------------------------------------------
@@ -18,7 +20,7 @@ class Format extends BaseConfig
 	| method is an array.
 	|
 	*/
-	public $supportedResponseFormats = [
+	public $responseFormats = [
 		'application/json',
 		'application/xml', // machine-readable XML
 		'text/xml', // human-readable XML
@@ -39,33 +41,4 @@ class Format extends BaseConfig
 		'application/xml'  => \CodeIgniter\Format\XMLFormatter::class,
 		'text/xml'         => \CodeIgniter\Format\XMLFormatter::class,
 	];
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * A Factory method to return the appropriate formatter for the given mime type.
-	 *
-	 * @param string $mime
-	 *
-	 * @return \CodeIgniter\Format\FormatterInterface
-	 */
-	public function getFormatter(string $mime)
-	{
-		if (! array_key_exists($mime, $this->formatters))
-		{
-			throw new \InvalidArgumentException('No Formatter defined for mime type: ' . $mime);
-		}
-
-		$class = $this->formatters[$mime];
-
-		if (! class_exists($class))
-		{
-			throw new \BadMethodCallException($class . ' is not a valid Formatter.');
-		}
-
-		return new $class();
-	}
-
-	//--------------------------------------------------------------------
-
 }

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -386,13 +386,13 @@ trait ResponseTrait
 			return $data;
 		}
 
-		$config = new Format();
+		$formatter = new Format();
 		$format = "application/$this->format";
 
 		// Determine correct response type through content negotiation if not explicitly declared
 		if (empty($this->format) || ! in_array($this->format, ['json', 'xml']))
 		{
-			$format = $this->request->negotiate('media', $config->supportedResponseFormats, false);
+			$format = $this->request->negotiate('media', $formatter->responseFormats;
 		}
 
 		$this->response->setContentType($format);
@@ -401,7 +401,7 @@ trait ResponseTrait
 		if (! isset($this->formatter))
 		{
 			// if no formatter, use the default
-			$this->formatter = $config->getFormatter($format);
+			$this->formatter = $formatter->get($format);
 		}
 
 		if ($format !== 'application/json')

--- a/system/Format/Formatter.php
+++ b/system/Format/Formatter.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+ 
+ namespace CodeIgniter\Format;
+
+use BadMethodCallException;
+use CodeIgniter\Config\BaseConfig;
+use InvalidArgumentException;
+
+class Formatter extends BaseConfig
+{
+	/**
+	* List of supported mime types that your application can automatically format
+	* the response when perform content negotiation with the request.
+	*
+	* @var array
+	*/
+	public $responseFormats = [];
+
+	/**
+	* Lists of classes to use to format responses with of a particular type
+	* for each mime type.
+	*
+	* @var array
+	*/
+	public $formatters = [];
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * A Factory method to return the appropriate formatter for the given mime type.
+	 *
+	 * @param string $mime
+	 *
+	 * @throws \InvalidArgumentException If formatter not found.
+	 * @throws \BadMethodCallException If formatter not valid.
+	 *
+	 * @return \CodeIgniter\Format\FormatterInterface
+	 */
+	public function get(string $mime): FormatterInterface
+	{
+		if (! array_key_exists($mime, $this->formatters))
+		{
+			throw new InvalidArgumentException("No Formatter defined for mime type: {$mime}");
+		}
+
+		if (! class_exists($class = $this->formatters[$mime]))
+		{
+			throw new BadMethodCallException("{$class} is not a valid Formatter.");
+		}
+
+		return new $class();
+	}
+}

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -43,6 +43,7 @@ namespace CodeIgniter\HTTP;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Pager\PagerInterface;
 use Config\App;
+use Config\ContentSecurityPolicy();
 use Config\Format;
 
 /**
@@ -156,6 +157,13 @@ class Response extends Message implements ResponseInterface
 	protected $statusCode = 200;
 
 	/**
+	 * Response Formatter
+	 *
+	 * @var \Config\Format
+	 */
+	public $formatter;
+
+	/**
 	 * Whether Content Security Policy is being enforced.
 	 *
 	 * @var boolean
@@ -239,8 +247,10 @@ class Response extends Message implements ResponseInterface
 		// Also ensures that a Cache-control header exists.
 		$this->noCache();
 
+		$this->formatter = new Format();
+		
 		// We need CSP object even if not enabled to avoid calls to non existing methods
-		$this->CSP = new ContentSecurityPolicy(new \Config\ContentSecurityPolicy());
+		$this->CSP = new ContentSecurityPolicy(new ContentSecurityPolicy());
 
 		$this->CSPEnabled     = $config->CSPEnabled;
 		$this->cookiePrefix   = $config->cookiePrefix;
@@ -467,11 +477,7 @@ class Response extends Message implements ResponseInterface
 
 		if ($this->bodyFormat !== 'json')
 		{
-			/**
-			 * @var Format $config
-			 */
-			$config    = config(Format::class);
-			$formatter = $config->getFormatter('application/json');
+			$formatter = $this->formatter->get('application/json');
 
 			$body = $formatter->format($body);
 		}
@@ -509,11 +515,7 @@ class Response extends Message implements ResponseInterface
 
 		if ($this->bodyFormat !== 'xml')
 		{
-			/**
-			 * @var Format $config
-			 */
-			$config    = config(Format::class);
-			$formatter = $config->getFormatter('application/xml');
+			$formatter = $this->formatter->get('application/xml');
 
 			$body = $formatter->format($body);
 		}
@@ -542,11 +544,7 @@ class Response extends Message implements ResponseInterface
 		// Nothing much to do for a string...
 		if (! is_string($body) || $format === 'json-unencoded')
 		{
-			/**
-			 * @var Format $config
-			 */
-			$config    = config(Format::class);
-			$formatter = $config->getFormatter($mime);
+			$formatter = $this->formatter->get($mime);
 
 			$body = $formatter->format($body);
 		}


### PR DESCRIPTION
Separate getFormatter function from config and adding it in a new \CodeIgniter\Format\Formatter class under method name get()

I think this will help to avoid messing with core runtime functions throw the app configs