### PR TITLE
Feature Tests & forceSecure

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -400,7 +400,7 @@ if (! function_exists('force_https'))
 			$response = Services::response(null, true);
 		}
 
-		if (ENVIRONMENT !== 'testing' && (is_cli() || $request->isSecure()))
+		if ((ENVIRONMENT !== 'testing' && (is_cli() || $request->isSecure())) || (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'test'))
 		{
 			// @codeCoverageIgnoreStart
 			return;

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -279,6 +279,11 @@ trait FeatureTestTrait
 		$request->setMethod($method);
 		$request->setProtocolVersion('1.1');
 
+		if ($config->forceGlobalSecureRequests)
+		{
+			$_SERVER['HTTPS'] = 'test';
+		}
+
 		return $request;
 	}
 


### PR DESCRIPTION
**Description**
Currently `FeatureTest` initiates an insecure request, which means if `forceGlobalSecureRequests` is activated then every status will be `302`. This PR has `FeatureTestTrait::setupRequest` check for that configuration and notify the app to make a special exemption so requests will be both a) secure and b) not redirected.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
