### PR TITLE
Get redirect URL from FeatureResponse

### DIFF
--- a/system/Test/FeatureResponse.php
+++ b/system/Test/FeatureResponse.php
@@ -128,6 +128,30 @@ class FeatureResponse extends TestCase
 	}
 
 	/**
+	 * Returns the URL set for redirection.
+	 *
+	 * @return string|null
+	 */
+	public function getRedirectUrl(): ?string
+	{
+		if (! $this->isRedirect())
+		{
+			return null;
+		}
+
+		if ($this->response->hasHeader('Location'))
+		{
+			return $this->response->getHeaderLine('Location');
+		}
+		elseif ($this->response->hasHeader('Refresh'))
+		{
+			return str_replace('0;url=', '', $this->response->getHeaderLine('Refresh'));
+		}
+
+		return null;
+	}
+
+	/**
 	 * Asserts that the status is a specific value.
 	 *
 	 * @param integer $code

--- a/tests/system/Test/FeatureResponseTest.php
+++ b/tests/system/Test/FeatureResponseTest.php
@@ -122,6 +122,22 @@ class FeatureResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->feature->assertRedirect();
 	}
 
+	public function testGetRedirectUrlReturnsUrl()
+	{
+		$this->getFeatureResponse('<h1>Hello World</h1>');
+		$this->feature->response = new RedirectResponse(new Config\App());
+		$this->feature->response->redirect('foo/bar');
+
+		$this->assertEquals('foo/bar', $this->feature->getRedirectUrl());
+	}
+
+	public function testGetRedirectUrlReturnsNull()
+	{
+		$this->getFeatureResponse('<h1>Hello World</h1>');
+
+		$this->assertNull($this->feature->getRedirectUrl());
+	}
+
 	public function testAssertStatus()
 	{
 		$this->getFeatureResponse('<h1>Hello World</h1>', ['statusCode' => 201]);

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -156,6 +156,14 @@ Asserts that the Response is an instance of RedirectResponse.
 
     $this->assertRedirect();
 
+**getRedirectUrl()**
+
+Returns the URL set for a RedirectResponse, or null for failure.
+::
+
+    $url = $result->getRedirectUrl();
+    $this->assertEquals(site_url('foo/bar'), $url);
+
 **assertStatus(int $code)**
 
 Asserts that the HTTP status code returned matches $code.


### PR DESCRIPTION
**Description**
Often validating that a response is a redirect is not enough to determine what happened during a controller method, as there may be multiple redirect routes. This PR adds `getRedirectUrl()` to make it easy to acquire the actual URL to verify HTTP test results.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
