### PR TITLE
Fix failover functionality for db connection

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -383,7 +383,7 @@ abstract class BaseConnection implements ConnectionInterface
 			if (! empty($this->failover) && is_array($this->failover))
 			{
 				// Go over all the failovers
-				foreach ($this->failover as $failover)
+				foreach ($this->failover as $item => $failover)
 				{
 					// Replace the current settings with those of the failover
 					foreach ($failover as $key => $val)
@@ -393,6 +393,8 @@ abstract class BaseConnection implements ConnectionInterface
 							$this->$key = $val;
 						}
 					}
+
+					unset($this->failover[$item]);
 
 					// Try to connect
 					$this->connID = $this->connect($this->pConnect);

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -216,13 +216,16 @@ class Connection extends BaseConnection implements ConnectionInterface
 		}
 		catch (\Throwable $e)
 		{
-			// Clean sensitive information from errors.
-			$msg = $e->getMessage();
+			if (empty($this->failover))
+			{
+				// Clean sensitive information from errors.
+				$msg = $e->getMessage();
 
-			$msg = str_replace($this->username, '****', $msg);
-			$msg = str_replace($this->password, '****', $msg);
+				$msg = str_replace($this->username, '****', $msg);
+				$msg = str_replace($this->password, '****', $msg);
 
-			throw new \mysqli_sql_exception($msg, $e->getCode(), $e);
+				throw new \mysqli_sql_exception($msg, $e->getCode(), $e);
+			}
 		}
 
 		return false;

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -91,7 +91,15 @@ class Connection extends BaseConnection implements ConnectionInterface
 		}
 		catch (\Exception $e)
 		{
-			throw new DatabaseException('SQLite3 error: ' . $e->getMessage());
+			if (empty($this->failover))
+			{
+				// Clean sensitive information from errors.
+				$msg = $e->getMessage();
+
+				$msg = str_replace($this->password, '****', $msg);
+
+				throw new DatabaseException('SQLite3 error: ' . $msg);
+			}
 		}
 	}
 

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -13,6 +13,8 @@ class ConnectTest extends CIDatabaseTestCase
 
 	protected $group2;
 
+	protected $tests;
+
 	protected function setUp(): void
 	{
 		parent::setUp();
@@ -21,6 +23,7 @@ class ConnectTest extends CIDatabaseTestCase
 
 		$this->group1 = $config->default;
 		$this->group2 = $config->default;
+		$this->tests  = $config->tests;
 
 		$this->group1['DBDriver'] = 'MySQLi';
 		$this->group2['DBDriver'] = 'Postgre';
@@ -76,15 +79,15 @@ class ConnectTest extends CIDatabaseTestCase
 
 	public function testConnectWithFailover()
 	{
-		$this->group1['failover'][] = $this->group1;
+		$this->tests['failover'][] = $this->tests;
 
-		unset($this->group1['failover'][0]['failover']);
+		unset($this->tests['failover'][0]['failover']);
 
-		$this->group1['username'] = 'wrong';
+		$this->tests['username'] = 'wrong';
 
-		$db1 = Database::connect($this->group1);
+		$db1 = Database::connect($this->tests);
 
-		$this->assertInstanceOf(\CodeIgniter\Database\MySQLi\Connection::class, $db1);
+		$this->assertEquals($this->tests['failover'][0]['DBDriver'], $this->getPrivateProperty($db1, 'DBDriver'));
 		$this->assertTrue(count($db1->listTables()) >= 0);
 	}
 }

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -73,4 +73,18 @@ class ConnectTest extends CIDatabaseTestCase
 		$this->assertNotInstanceOf(\CodeIgniter\Database\SQLite3\Connection::class, $db1);
 		$this->assertEquals('MySQLi', $this->getPrivateProperty($db1, 'DBDriver'));
 	}
+
+	public function testConnectWithFailover()
+	{
+		$this->group1['failover'][] = $this->group1;
+
+		unset($this->group1['failover'][0]['failover']);
+
+		$this->group1['username'] = 'wrong';
+
+		$db1 = Database::connect($this->group1);
+
+		$this->assertInstanceOf(\CodeIgniter\Database\MySQLi\Connection::class, $db1);
+		$this->assertTrue(count($db1->listTables()) >= 0);
+	}
 }


### PR DESCRIPTION
**Description**
This PR fixes the `failover` functionality for the database. Right now, even when you define the `failover` it won't be executed because we always throw an exception when there is a problem with the connection.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
