### PR TITLE
Fix FeatureTest validation

### DIFF
--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -314,6 +314,8 @@ trait FeatureTestTrait
 			$request->setGlobal($method, $params);
 		}
 
+		$request->setGlobal('request', $params);
+
 		$_SESSION = $this->session ?? [];
 
 		return $request;


### PR DESCRIPTION
**Description**
Validation uses `Request::getVar()` to load input data. During feature testing, `populateGlobals()` fills the appropriate method ('post', 'get', etc) but not the super-var 'request', so validation always fails to receive any input data.

This PR adds an additional call to `setGlobal()` to fill 'request' with the same data as the method-specific version.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
