### PR TITLE
Fix wrong included file in exception rendering

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -287,11 +287,11 @@ class Exceptions
 		// Check if the view exists
 		if (is_file($path . $view))
 		{
-			$file = $path . $view;
+			$viewFile = $path . $view;
 		}
 		elseif (is_file($altPath . $altView))
 		{
-			$file = $altPath . $altView;
+			$viewFile = $altPath . $altView;
 		}
 
 		// Prepare the vars
@@ -305,7 +305,7 @@ class Exceptions
 		}
 
 		ob_start();
-		include $file;
+		include $viewFile;
 		$buffer = ob_get_contents();
 		ob_end_clean();
 		echo $buffer;


### PR DESCRIPTION
**Description**
Fixes #3067. Apparently, I was at fault for this bug. My apologies.

The bug occurs on line 299 of `Exceptions` upon extraction of `$vars` into the current symbol table. On lines 288 to 295, we check which of the available views to use and assign the value to `$file`. Then on line 298, we collect the exception's variables. Examining the array returned by `$this->collectVars`, we can see that there exists a `file` key corresponding to the file of the current exception.

Upon import of the `$vars`, the `$file` variable which we originally determined in lines 288 to 295 was replaced by the `file` key of `$vars`. Thus, on `include` of the `$file`, we erroneously included the exception file itself, not the supposed error view file. This resulted to the class re-declaration fatal error.

This PR renames the variable used for the view file to eliminate the name clash. 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
