### PR TITLE
FeatureTest use current session

### DIFF
--- a/system/Test/FeatureResponse.php
+++ b/system/Test/FeatureResponse.php
@@ -57,6 +57,13 @@ class FeatureResponse extends TestCase
 	public $response;
 
 	/**
+	 * State of $_SESSION after the call.
+	 *
+	 * @var array|null
+	 */
+	public $session;
+
+	/**
 	 * DOM for the body.
 	 *
 	 * @var \CodeIgniter\Test\DOMParser
@@ -77,6 +84,10 @@ class FeatureResponse extends TestCase
 		{
 			$this->domParser = (new DOMParser())->withString($body);
 		}
+
+		// Store the session and reset it
+		$this->session = $_SESSION;
+		$_SESSION      = [];
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -136,8 +136,6 @@ trait FeatureTestTrait
 		}
 		// @codeCoverageIgnoreEnd
 
-		// Simulate having a blank session
-		$_SESSION                  = [];
 		$_SERVER['REQUEST_METHOD'] = $method;
 
 		$request = $this->setupRequest($method, $path);
@@ -316,7 +314,10 @@ trait FeatureTestTrait
 
 		$request->setGlobal('request', $params);
 
-		$_SESSION = $this->session ?? [];
+		if (! empty($this->session))
+		{
+			$_SESSION = $this->session;
+		}
 
 		return $request;
 	}


### PR DESCRIPTION
**Description**
Currently, running a Feature Test will start with a fresh Session when you make the call(). While this helps ensure that each test is contained it means you cannot prep anything in the Session, such as logging a user in.

This PR is solution "Plan A" which uses the current Session (unless overriding values are passed to `withSession()`) and blanks the session *after* the call, returning the resulting session in `FeatureResponse` for examination.

Since this may entail a breaking change I'm considering this a draft PR and will submit a non-BC option as well, but note that I think this is a better solution for feature testing.

Ref. https://forum.codeigniter.com/thread-76673.html

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
