### PR TITLE
Add withSession null case

### DIFF
--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -90,13 +90,13 @@ trait FeatureTestTrait
 	/**
 	 * Sets any values that should exist during this session.
 	 *
-	 * @param array $values
+	 * @param array|null Array of values, or null to use the current $_SESSION
 	 *
 	 * @return $this
 	 */
-	public function withSession(array $values)
+	public function withSession(array $values = null)
 	{
-		$this->session = $values;
+		$this->session = is_null($values) ? $_SESSION : $values;
 
 		return $this;
 	}

--- a/tests/system/Test/FeatureTestCaseTest.php
+++ b/tests/system/Test/FeatureTestCaseTest.php
@@ -171,6 +171,27 @@ class FeatureTestCaseTest extends FeatureTestCase
 		$response->assertSessionMissing('popcorn');
 	}
 
+	public function testWithSessionNull()
+	{
+		$_SESSION = [
+			'fruit'    => 'apple',
+			'greeting' => 'hello',
+		];
+
+		$response = $this->withRoutes([
+			[
+				'get',
+				'home',
+				function () {
+					return 'Home';
+				},
+			],
+		])->withSession()->get('home');
+
+		$response->assertSessionHas('fruit', 'apple');
+		$response->assertSessionMissing('popcorn');
+	}
+
 	public function testReturns()
 	{
 		$this->withRoutes([

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -88,8 +88,8 @@ Setting Session Values
 ----------------------
 
 You can set custom session values to use during a single test with the ``withSession()`` method. This takes an array
-of key/value pairs that should exist within the $_SESSION variable when this request is made. This is handy for testing
-authentication and more.
+of key/value pairs that should exist within the $_SESSION variable when this request is made, or ``null` to indicate
+that the current values of ``$_SESSION`` should be used. This is handy for testing authentication and more.
 ::
 
     $values = [
@@ -98,6 +98,12 @@ authentication and more.
 
     $result = $this->withSession($values)
         ->get('admin');
+    
+    // Or...
+    
+    $_SESSION['logged_in'] = 123;
+    
+    $result = $this->withSession()->get('admin');
 
 Bypassing Events
 ----------------


### PR DESCRIPTION
**Description**
Currently, running a Feature Test will start with a fresh Session when you make the call(). While this helps ensure that each test is contained it means you cannot prep anything in the Session, such as logging a user in.

This PR is solution "Plan B" which overloads `withSession()` to default to use the current Session values. This still requires calling `withSession()` on every feature test, but allows the session to prepared by all the usual means by the test case.

See also #3077.

Ref. https://forum.codeigniter.com/thread-76673.html

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
