### PR TITLE
Fix class collision "PageNotFound" error

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -287,11 +287,11 @@ class Exceptions
 		// Check if the view exists
 		if (is_file($path . $view))
 		{
-			$file = $path . $view;
+			$renderFilePath = $path . $view;
 		}
 		elseif (is_file($altPath . $altView))
 		{
-			$file = $altPath . $altView;
+			$renderFilePath = $altPath . $altView;
 		}
 
 		// Prepare the vars
@@ -305,7 +305,7 @@ class Exceptions
 		}
 
 		ob_start();
-		include $file;
+		include $renderFilePath;
 		$buffer = ob_get_contents();
 		ob_end_clean();
 		echo $buffer;


### PR DESCRIPTION
**Description**
 #2958 allowed more robust testing for fallback paths on exception display, but the use of `extract()` caused a collision in some cases between the actual file to include and the variable `$file` to display. This PR sets a more unique name of the include path to avoid collision.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
