### PR TITLE
Add mb_url_title() function

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -613,4 +613,28 @@ if (! function_exists('url_title'))
 	}
 }
 
+// ------------------------------------------------------------------------
+
+if (! function_exists('mb_url_title'))
+{
+	/**
+	 * Create URL Title that takes into account accented characters
+	 *
+	 * Takes a "title" string as input and creates a
+	 * human-friendly URL string with a "separator" string
+	 * as the word separator.
+	 *
+	 * @param  string  $str       Input string
+	 * @param  string  $separator Word separator (usually '-' or '_')
+	 * @param  boolean $lowercase Whether to transform the output string to lowercase
+	 * @return string
+	 */
+	function mb_url_title(string $str, string $separator = '-', bool $lowercase = false): string
+	{
+		helper('text');
+
+		return url_title(convert_accented_characters($str), $separator, $lowercase);
+	}
+}
+
 //--------------------------------------------------------------------

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -16,7 +16,7 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		parent::setUp();
 
 		helper('url');
-		Services::reset();
+		Services::reset(true);
 	}
 
 	public function tearDown(): void
@@ -1139,6 +1139,43 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		foreach ($words as $in => $out)
 		{
 			$this->assertEquals($out, url_title($in, '_'));
+		}
+	}
+
+	//--------------------------------------------------------------------
+	// Test mb_url_title
+
+	public function testMbUrlTitle()
+	{
+		helper('text');
+
+		$words = [
+			'foo bar /'       => 'foo-bar',
+			'\  testing 12'   => 'testing-12',
+			'Éléphant de PHP' => 'elephant-de-php',
+			'ä ö ü Ĝ β ę'     => 'ae-oe-ue-g-v-e',
+		];
+
+		foreach ($words as $in => $out)
+		{
+			$this->assertEquals($out, mb_url_title($in, '-', true));
+		}
+	}
+
+	public function testMbUrlTitleExtraDashes()
+	{
+		helper('text');
+
+		$words = [
+			'_foo bar_'                 => 'foo_bar',
+			'_What\'s wrong with CSS?_' => 'Whats_wrong_with_CSS',
+			'Éléphant de PHP'           => 'Elephant_de_PHP',
+			'ä ö ü Ĝ β ę'               => 'ae_oe_ue_G_v_e',
+		];
+
+		foreach ($words as $in => $out)
+		{
+			$this->assertEquals($out, mb_url_title($in, '_'));
 		}
 	}
 

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -337,6 +337,17 @@ The following functions are available:
         $url_title = url_title($title, '-', TRUE);
         // Produces: whats-wrong-with-css
 
+.. php:function:: mb_url_title($str[, $separator = '-'[, $lowercase = FALSE]])
+
+    :param  string  $str: Input string
+    :param  string  $separator: Word separator (usually '-' or '_')
+    :param  bool    $lowercase: Whether to transform the output string to lowercase
+    :returns: URL-formatted string
+    :rtype: string
+
+    This function works the same as :php:func:`url_title()` but it converts all
+    accented characters automatically.
+
 .. php:function:: prep_url($str = '')
 
     :param  string  $str: URL string


### PR DESCRIPTION
**Description**
This PR adds a new function: `mb_url_title()` that supports accented characters.
Ref: #3038

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
