### PR TITLE
Clarify non-framework Fabricator model use

### DIFF
--- a/system/Test/Interfaces/FabricatorModel.php
+++ b/system/Test/Interfaces/FabricatorModel.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace CodeIgniter\Test\Interfaces;
+
+use Faker\Generator;
+
+/**
+ * FabricatorModel
+ *
+ * An interface defining the required methods and properties
+ * needed for a model to qualify for use with the Fabricator class.
+ * While interfaces cannot enforce properties, the following
+ * are required for use with Fabricator:
+ *
+ * @property string $returnType
+ * @property string $primaryKey
+ * @property string $dateFormat
+ */
+interface FabricatorModel
+{
+	/**
+	 * Fetches the row of database from $this->table with a primary key
+	 * matching $id.
+	 *
+	 * @param mixed|array|null $id One primary key or an array of primary keys
+	 *
+	 * @return array|object|null    The resulting row of data, or null.
+	 */
+	public function find($id = null);
+
+	/**
+	 * Inserts data into the current table. If an object is provided,
+	 * it will attempt to convert it to an array.
+	 *
+	 * @param array|object $data
+	 * @param boolean      $returnID Whether insert ID should be returned or not.
+	 *
+	 * @return integer|string|boolean
+	 * @throws \ReflectionException
+	 */
+	public function insert($data = null, bool $returnID = true);
+
+	/**
+	 * The following properties and methods are optional, but if present should
+	 * adhere to their definitions.
+	 *
+	 * @property array  $allowedFields
+	 * @property string $useSoftDeletes
+	 * @property string $useTimestamps
+	 * @property string $createdField
+	 * @property string $updatedField
+	 * @property string $deletedField
+	 */
+
+	/*
+	 * Sets $useSoftDeletes value so that we can temporarily override
+	 * the softdeletes settings. Can be used for all find* methods.
+	 *
+	 * @param boolean $val
+	 *
+	 * @return Model
+	 */
+	// public function withDeleted($val = true);
+
+	/**
+	 * Faked data for Fabricator.
+	 *
+	 * @param Generator $faker
+	 *
+	 * @return array|object
+	 */
+	// public function fake(Generator &$faker);
+}

--- a/user_guide_src/source/testing/fabricator.rst
+++ b/user_guide_src/source/testing/fabricator.rst
@@ -6,6 +6,16 @@ Often you will need sample data for your application to run its tests. The ``Fab
 uses fzaninotto's `Faker <https://github.com/fzaninotto/Faker//>`_ to turn models into generators
 of random data. Use fabricators in your seeds or test cases to stage fake data for your unit tests.
 
+Supported Models
+================
+
+``Fabricator`` supports any model that extends the framework's core model, ``CodeIgniter\Model``.
+You may use your own custom models by ensuring they implement ``CodeIgniter\Test\Interfaces\FabricatorModel``::
+
+	class MyModel implements CodeIgniter\Test\Interfaces\FabricatorModel
+
+.. note:: In addition to methods, the interface outlines some necessary properties for the target model. Please see the interface code for details.
+
 Loading Fabricators
 ===================
 


### PR DESCRIPTION
**Description**
`Fabricator` supports core framework models, but also allows for non-framework models if users want to craft their own. This PR tries to lighten and clarify what requirements exist on the model class in order for it to function with `Fabricator`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
