### PR TITLE
Fix - throw an exception on insert for an empty object

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -695,6 +695,11 @@ class Model
 			$data = (array) $data;
 		}
 
+		if (empty($data))
+		{
+			throw DataException::forEmptyDataset('insert');
+		}
+
 		// Validate data before saving.
 		if ($this->skipValidation === false)
 		{
@@ -1439,7 +1444,7 @@ class Model
 	public function validate($data): bool
 	{
 		$rules = $this->getValidationRules();
-		
+
 		if ($this->skipValidation === true || empty($rules) || empty($data))
 		{
 			return true;
@@ -1580,7 +1585,7 @@ class Model
 	public function getValidationRules(array $options = []): array
 	{
 		$rules = $this->validationRules;
-		
+
 		// ValidationRules can be either a string, which is the group name,
 		// or an array of rules.
 		if (is_string($rules))

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1798,7 +1798,7 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testInsertWithNoDataException()
+	public function testInsertArrayWithNoDataException()
 	{
 		$model = new UserModel();
 		$data  = [];
@@ -1809,7 +1809,7 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testUpdateWithNoDataException()
+	public function testUpdateArrayWithNoDataException()
 	{
 		$model = new EventModel();
 
@@ -1823,6 +1823,40 @@ class ModelTest extends CIDatabaseTestCase
 		$id = $model->insert($data);
 
 		$data = [];
+
+		$this->expectException(DataException::class);
+		$this->expectExceptionMessage('There is no data to update.');
+
+		$model->update($id, $data);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testInsertObjectWithNoDataException()
+	{
+		$model = new UserModel();
+		$data  = new \stdClass();
+		$this->expectException(DataException::class);
+		$this->expectExceptionMessage('There is no data to insert.');
+		$model->insert($data);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testUpdateObjectWithNoDataException()
+	{
+		$model = new EventModel();
+
+		$data = (object) [
+							 'name'    => 'Foo',
+							 'email'   => 'foo@example.com',
+							 'country' => 'US',
+							 'deleted' => 0,
+						 ];
+
+		$id = $model->insert($data);
+
+		$data = new \stdClass();
 
 		$this->expectException(DataException::class);
 		$this->expectExceptionMessage('There is no data to update.');


### PR DESCRIPTION
**Description**
This PR fixes the lack of exception when we add an empty object to `insert()` method.

Ref: #2998

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
