### PR TITLE
Fix for XMLFormatter class to produce a valid XML

### DIFF
--- a/system/Format/XMLFormatter.php
+++ b/system/Format/XMLFormatter.php
@@ -91,19 +91,21 @@ class XMLFormatter implements FormatterInterface
 		{
 			if (is_array($value))
 			{
-				if (! is_numeric($key))
+				if (is_numeric($key))
 				{
-					$subnode = $output->addChild("$key");
-					$this->arrayToXML($value, $subnode);
+					$key = "item{$key}";
 				}
-				else
-				{
-					$subnode = $output->addChild("item{$key}");
-					$this->arrayToXML($value, $subnode);
-				}
+
+				$subnode = $output->addChild("$key");
+				$this->arrayToXML($value, $subnode);
 			}
 			else
 			{
+				if (is_numeric($key))
+				{
+					$key = "item{$key}";
+				}
+
 				$output->addChild("$key", htmlspecialchars("$value"));
 			}
 		}

--- a/tests/system/Format/XMLFormatterTest.php
+++ b/tests/system/Format/XMLFormatterTest.php
@@ -33,7 +33,7 @@ EOH;
 
 		$expected = <<<EOH
 <?xml version="1.0"?>
-<response><foo><0>bar</0></foo></response>
+<response><foo><item0>bar</item0></foo></response>
 
 EOH;
 
@@ -48,7 +48,7 @@ EOH;
 
 		$expected = <<<EOH
 <?xml version="1.0"?>
-<response><item0><0>foo</0></item0></response>
+<response><item0><item0>foo</item0></item0></response>
 
 EOH;
 
@@ -60,7 +60,7 @@ EOH;
 		$data     = ['Something'];
 		$expected = <<<EOH
 <?xml version="1.0"?>
-<response><0>Something</0></response>
+<response><item0>Something</item0></response>
 
 EOH;
 


### PR DESCRIPTION
**Description**
XMLFormatter in some cases produce not valid XML.

Ref: #3092

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
