### PR TITLE
Don't escape unicode characters when saving JSON from Entities. Fixes #3059

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -372,7 +372,7 @@ class Entity
 			// back to the database.
 			if (($castTo === 'json' || $castTo === 'json-array') && function_exists('json_encode'))
 			{
-				$value = json_encode($value);
+				$value = json_encode($value, JSON_UNESCAPED_UNICODE);
 
 				if (json_last_error() !== JSON_ERROR_NONE)
 				{


### PR DESCRIPTION
See #3059 