### PR TITLE
Fix regex of fillRouteParams

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -826,7 +826,7 @@ class RouteCollection implements RouteCollectionInterface
 		// Make sure we capture back-references
 		$id = '(' . trim($id, '()') . ')';
 
-		$methods = isset($options['only']) ? is_string($options['only']) ? explode(',', $options['only']) : $options['only'] : ['index', 'show', 'create', 'update', 'delete', 'new', 'edit'];
+		$methods = isset($options['only']) ? (is_string($options['only']) ? explode(',', $options['only']) : $options['only']) : ['index', 'show', 'create', 'update', 'delete', 'new', 'edit'];
 
 		if (isset($options['except']))
 		{
@@ -941,7 +941,7 @@ class RouteCollection implements RouteCollectionInterface
 		// Make sure we capture back-references
 		$id = '(' . trim($id, '()') . ')';
 
-		$methods = isset($options['only']) ? is_string($options['only']) ? explode(',', $options['only']) : $options['only'] : ['index', 'show', 'new', 'create', 'edit', 'update', 'remove', 'delete'];
+		$methods = isset($options['only']) ? (is_string($options['only']) ? explode(',', $options['only']) : $options['only']) : ['index', 'show', 'new', 'create', 'edit', 'update', 'remove', 'delete'];
 
 		if (isset($options['except']))
 		{
@@ -1348,7 +1348,7 @@ class RouteCollection implements RouteCollectionInterface
 			// the expected param type.
 			$pos = strpos($from, $pattern);
 
-			if (preg_match("|{$pattern}|", $params[$index]))
+			if (preg_match('#' . $pattern . '#', $params[$index]))
 			{
 				$from = substr_replace($from, $params[$index], $pos, strlen($pattern));
 			}

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -940,6 +940,21 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/3048
+	 */
+	public function testNamedRoutesWithPipesInRegex()
+	{
+		$routes = $this->getCollector();
+
+		$routes->get('/system/(this|that)', 'myController::system/$1', ['as' => 'pipedRoute']);
+
+		$this->assertEquals('/system/this', $routes->reverseRoute('pipedRoute', 'this'));
+		$this->assertEquals('/system/that', $routes->reverseRoute('pipedRoute', 'that'));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testReverseRouteMatching()
 	{
 		$routes = $this->getCollector();


### PR DESCRIPTION
**Description**
Fixes #3048. 

While I'm at it, I also fixed the "Nested ternary operation" deprecation warning for PHP 7.4. 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
