### PR TITLE
Fix for custom validation message defined via config file

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -624,7 +624,7 @@ class Validation implements ValidationInterface
 			throw ValidationException::forGroupNotArray($group);
 		}
 
-		$this->rules = $this->config->$group;
+		$this->setRules($this->config->$group);
 
 		// If {group}_errors exists in the config file,
 		// then override our custom errors with them.

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -306,6 +306,20 @@ class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testRunGroupWithCustomErrorMessage()
+	{
+		$this->validation->reset();
+		$this->validation->run([
+			'username' => 'codeigniter',
+		], 'login');
+
+		$this->assertEquals([
+			'password' => 'custom password required error msg.',
+		], $this->validation->getErrors());
+	}
+
+	//--------------------------------------------------------------------
+
 	/**
 	 * @dataProvider rulesSetupProvider
 	 */


### PR DESCRIPTION
**Description**
See: #3097

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
