### PR TITLE
Fix typehints of $request in Validation

### DIFF
--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -39,7 +39,7 @@
 
 namespace CodeIgniter\Validation;
 
-use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\IncomingRequest;
 use Config\Services;
 
 /**
@@ -51,7 +51,7 @@ class FileRules
 	/**
 	 * Request instance. So we can get access to the files.
 	 *
-	 * @var \CodeIgniter\HTTP\RequestInterface
+	 * @var \CodeIgniter\HTTP\IncomingRequest
 	 */
 	protected $request;
 
@@ -60,16 +60,11 @@ class FileRules
 	/**
 	 * Constructor.
 	 *
-	 * @param RequestInterface $request
+	 * @param \CodeIgniter\HTTP\IncomingRequest|null $request
 	 */
-	public function __construct(RequestInterface $request = null)
+	public function __construct(IncomingRequest $request = null)
 	{
-		if (is_null($request))
-		{
-			$request = Services::request();
-		}
-
-		$this->request = $request;
+		$this->request = $request ?? Services::request();
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -38,7 +38,7 @@
 
 namespace CodeIgniter\Validation;
 
-use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\Validation\Exceptions\ValidationException;
 use CodeIgniter\View\RendererInterface;
 
@@ -359,11 +359,11 @@ class Validation implements ValidationInterface
 	 * Takes a Request object and grabs the input data to use from its
 	 * array values.
 	 *
-	 * @param \CodeIgniter\HTTP\RequestInterface|\CodeIgniter\HTTP\IncomingRequest $request
+	 * @param \CodeIgniter\HTTP\IncomingRequest $request
 	 *
 	 * @return \CodeIgniter\Validation\ValidationInterface
 	 */
-	public function withRequest(RequestInterface $request): ValidationInterface
+	public function withRequest(IncomingRequest $request): ValidationInterface
 	{
 		if (in_array($request->getMethod(), ['put', 'patch', 'delete']))
 		{

--- a/system/Validation/ValidationInterface.php
+++ b/system/Validation/ValidationInterface.php
@@ -39,7 +39,7 @@
 
 namespace CodeIgniter\Validation;
 
-use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\IncomingRequest;
 
 /**
  * Expected behavior of a validator
@@ -78,11 +78,11 @@ interface ValidationInterface
 	 * Takes a Request object and grabs the input data to use from its
 	 * array values.
 	 *
-	 * @param \CodeIgniter\HTTP\RequestInterface $request
+	 * @param \CodeIgniter\HTTP\IncomingRequest $request
 	 *
 	 * @return \CodeIgniter\Validation\ValidationInterface
 	 */
-	public function withRequest(RequestInterface $request): ValidationInterface;
+	public function withRequest(IncomingRequest $request): ValidationInterface;
 
 	//--------------------------------------------------------------------
 	// Rules


### PR DESCRIPTION
**Description**
Fixes typehints of the `$request` object in `Validation` and `FileRules`.

Currently, some of the methods used on `$request` do not belong to `RequestInterface` but are found in `IncomingRequest`, like `getFile`, `getFileMultiple`, `getRawInput`, etc. This causes typehinting errors in IDEs like VSCode.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
