### PR TITLE
Update max_size validation rule to check also upload_max_filesize

### DIFF
--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -136,6 +136,11 @@ class FileRules
 				return true;
 			}
 
+			if ($file->getError() === UPLOAD_ERR_INI_SIZE)
+			{
+				return false;
+			}
+
 			if ($file->getSize() / 1024 > $params[0])
 			{
 				return false;

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -52,6 +52,15 @@ class FileRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 				'width'    => 640,
 				'height'   => 400,
 			],
+			'photo'   => [
+				'tmp_name' => TESTPATH . '_support/Validation/uploads/phpUxc0ty',
+				'name'     => 'my-photo.png',
+				'size'     => 4614,
+				'type'     => 'image/png',
+				'error'    => 1, // upload_max_filesize exceeded
+				'width'    => 640,
+				'height'   => 400,
+			],
 		];
 	}
 
@@ -99,6 +108,14 @@ class FileRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 	{
 		$this->validation->setRules([
 			'avatar' => 'max_size[avatar,4]',
+		]);
+		$this->assertFalse($this->validation->run([]));
+	}
+
+	public function testMaxSizeFailDueToUploadMaxFilesizeExceededInPhpIni()
+	{
+		$this->validation->setRules([
+			'photo' => 'max_size[photo,100]',
 		]);
 		$this->assertFalse($this->validation->run([]));
 	}

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -830,7 +830,7 @@ Rule                    Parameter   Description                                 
 uploaded                Yes         Fails if the name of the parameter does not match the name of any uploaded files.               uploaded[field_name]
 max_size                Yes         Fails if the uploaded file named in the parameter is larger than the second parameter in        max_size[field_name,2048]
                                     kilobytes (kb). Or if the file is larger than allowed maximum size declared in 
-                                    php.ini config file - ``upload_max_filesize``.
+                                    php.ini config file - ``upload_max_filesize`` directive.
 max_dims                Yes         Fails if the maximum width and height of an uploaded image exceed values. The first parameter   max_dims[field_name,300,150]
                                     is the field name. The second is the width, and the third is the height. Will also fail if
                                     the file cannot be determined to be an image.

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -829,7 +829,8 @@ Rule                    Parameter   Description                                 
 ======================= =========== =============================================================================================== ========================================
 uploaded                Yes         Fails if the name of the parameter does not match the name of any uploaded files.               uploaded[field_name]
 max_size                Yes         Fails if the uploaded file named in the parameter is larger than the second parameter in        max_size[field_name,2048]
-                                    kilobytes (kb).
+                                    kilobytes (kb). Or if the file is larger than allowed maximum size declared in 
+                                    php.ini config file - ``upload_max_filesize``.
 max_dims                Yes         Fails if the maximum width and height of an uploaded image exceed values. The first parameter   max_dims[field_name,300,150]
                                     is the field name. The second is the width, and the third is the height. Will also fail if
                                     the file cannot be determined to be an image.


### PR DESCRIPTION
**Description**
In general, when the uploaded file exceeds the `upload_max_filesize` from php.ini, we should also return `false`. Right now, developers can be confused about what is going on. With this change, we can at least direct them to the problem.

Ref: #3032

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
