### PR TITLE
Allow array file uploads to be validated also by 'uploaded'. Fixes #3018

### DIFF
--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -84,22 +84,38 @@ class FileRules
 	 */
 	public function uploaded(string $blank = null, string $name): bool
 	{
-		$file = $this->request->getFile($name);
-
-		if (is_null($file))
+		if (! ($files = $this->request->getFileMultiple($name)))
 		{
-			return false;
+			$files = [$this->request->getFile($name)];
 		}
 
-		if (ENVIRONMENT === 'testing')
+		foreach ($files as $file)
 		{
-			return $file->getError() === 0;
+			if (is_null($file))
+			{
+				return false;
+			}
+
+			if (ENVIRONMENT === 'testing')
+			{
+				if ($file->getError() !== 0)
+				{
+					return false;
+				}
+			}
+			else
+			{
+				// Note: cannot unit test this; no way to over-ride ENVIRONMENT?
+				// @codeCoverageIgnoreStart
+				if (! $file->isValid())
+				{
+					return false;
+				}
+				// @codeCoverageIgnoreEnd
+			}
 		}
 
-		// Note: cannot unit test this; no way to over-ride ENVIRONMENT?
-		// @codeCoverageIgnoreStart
-		return $file->isValid();
-		// @codeCoverageIgnoreEnd
+		return true;
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -61,6 +61,66 @@ class FileRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 				'width'    => 640,
 				'height'   => 400,
 			],
+			'images'  => [
+				'tmp_name' => [
+					TESTPATH . '_support/Validation/uploads/phpUxc0ty',
+					TESTPATH . '_support/Validation/uploads/phpUxc0ty',
+				],
+				'name'     => [
+					'my_avatar.png',
+					'my_bigfile.png',
+				],
+				'size'     => [
+					4614,
+					1024000,
+				],
+				'type'     => [
+					'image/png',
+					'image/png',
+				],
+				'error'    => [
+					0,
+					0,
+				],
+				'width'    => [
+					640,
+					640,
+				],
+				'height'   => [
+					400,
+					400,
+				],
+			],
+			'photos'  => [
+				'tmp_name' => [
+					TESTPATH . '_support/Validation/uploads/phpUxc0ty',
+					TESTPATH . '_support/Validation/uploads/phpUxc0ty',
+				],
+				'name'     => [
+					'my_avatar.png',
+					'my_bigfile.png',
+				],
+				'size'     => [
+					4614,
+					1024000,
+				],
+				'type'     => [
+					'image/png',
+					'image/png',
+				],
+				'error'    => [
+					1,
+					0,
+				],
+				'width'    => [
+					640,
+					640,
+				],
+				'height'   => [
+					400,
+					400,
+				],
+			],
 		];
 	}
 
@@ -79,6 +139,24 @@ class FileRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 	{
 		$this->validation->setRules([
 			'avatar' => 'uploaded[userfile]',
+		]);
+
+		$this->assertFalse($this->validation->run([]));
+	}
+
+	public function testUploadedArrayReturnsTrue()
+	{
+		$this->validation->setRules([
+			'images' => 'uploaded[images]',
+		]);
+
+		$this->assertTrue($this->validation->run([]));
+	}
+
+	public function testUploadedArrayReturnsFalse()
+	{
+		$this->validation->setRules([
+			'photos' => 'uploaded[photos]',
 		]);
 
 		$this->assertFalse($this->validation->run([]));


### PR DESCRIPTION
**Description**
Currently, all validation checks of `FileRules` allows validating array file uploads, except for `uploaded`. This PR adds that functionality. The documentation had already said that **all** file validation rules check for both single and multiple file uploads.

Fixes #3018 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
