### PR TITLE
Update CLI getHeight and getWidth

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -606,8 +606,8 @@ class CLI
 			// @codeCoverageIgnoreStart
 			if (($shell = getenv('SHELL')) && preg_match('/(?:bash|zsh)(?:\.exe)?$/', $shell) || getenv('TERM'))
 			{
-				static::$height = (int) exec('tput cols');
-				static::$width  = (int) exec('tput lines');
+				static::$height = (int) exec('tput lines');
+				static::$width  = (int) exec('tput cols');
 			}
 			else
 			{
@@ -621,8 +621,8 @@ class CLI
 					// Searching for "Columns:" or "Lines:" will fail on non-English locales
 					if (preg_match('/:\s*(\d+)\n[^:]+:\s*(\d+)\n/', implode("\n", $output), $matches))
 					{
-						static::$height = (int) $matches[2];
-						static::$width  = (int) $matches[1];
+						static::$height = (int) $matches[1];
+						static::$width  = (int) $matches[2];
 					}
 				}
 			}
@@ -632,13 +632,13 @@ class CLI
 		{
 			if (($size = exec('stty size')) && preg_match('/(\d+)\s+(\d+)/', $size, $matches))
 			{
-				static::$height = (int) $matches[2];
-				static::$width  = (int) $matches[1];
+				static::$height = (int) $matches[1];
+				static::$width  = (int) $matches[2];
 			}
 			else
 			{
-				static::$height = (int) exec('tput cols');
-				static::$width  = (int) exec('tput lines');
+				static::$height = (int) exec('tput lines');
+				static::$width  = (int) exec('tput cols');
 			}
 		}
 	}

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -147,6 +147,20 @@ class CLI
 	 */
 	protected static $lastWrite;
 
+	/**
+	 * Height of the CLI window
+	 *
+	 * @var integer
+	 */
+	protected static $height;
+
+	/**
+	 * Width of the CLI window
+	 *
+	 * @var integer
+	 */
+	protected static $width;
+
 	//--------------------------------------------------------------------
 
 	/**
@@ -542,8 +556,6 @@ class CLI
 
 	/**
 	 * Attempts to determine the width of the viewable CLI window.
-	 * This only works on *nix-based systems, so return a sane default
-	 * for Windows environments.
 	 *
 	 * @param integer $default
 	 *
@@ -551,22 +563,18 @@ class CLI
 	 */
 	public static function getWidth(int $default = 80): int
 	{
-		if (static::isWindows() || (int) shell_exec('tput cols') === 0)
+		if (\is_null(static::$width))
 		{
-			// @codeCoverageIgnoreStart
-			return $default;
-			// @codeCoverageIgnoreEnd
+			static::generateDimensions();
 		}
 
-		return (int) shell_exec('tput cols');
+		return static::$width ?: $default;
 	}
 
 	//--------------------------------------------------------------------
 
 	/**
 	 * Attempts to determine the height of the viewable CLI window.
-	 * This only works on *nix-based systems, so return a sane default
-	 * for Windows environments.
 	 *
 	 * @param integer $default
 	 *
@@ -574,14 +582,65 @@ class CLI
 	 */
 	public static function getHeight(int $default = 32): int
 	{
-		if (static::isWindows())
+		if (\is_null(static::$height))
 		{
-			// @codeCoverageIgnoreStart
-			return $default;
-			// @codeCoverageIgnoreEnd
+			static::generateDimensions();
 		}
 
-		return (int) shell_exec('tput lines');
+		return static::$height ?: $default;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Populates the CLI's dimensions.
+	 *
+	 * @return void
+	 */
+	public static function generateDimensions()
+	{
+		if (static::isWindows())
+		{
+			// Shells such as `Cygwin` and `Git bash` returns incorrect values
+			// when executing `mode CON`, so we use `tput` instead
+			// @codeCoverageIgnoreStart
+			if (($shell = getenv('SHELL')) && preg_match('/(?:bash|zsh)(?:\.exe)?$/', $shell) || getenv('TERM'))
+			{
+				static::$height = (int) exec('tput cols');
+				static::$width  = (int) exec('tput lines');
+			}
+			else
+			{
+				$return = -1;
+				$output = [];
+				exec('mode CON', $output, $return);
+
+				if ($return === 0 && $output)
+				{
+					// Look for the next lines ending in ": <number>"
+					// Searching for "Columns:" or "Lines:" will fail on non-English locales
+					if (preg_match('/:\s*(\d+)\n[^:]+:\s*(\d+)\n/', implode("\n", $output), $matches))
+					{
+						static::$height = (int) $matches[2];
+						static::$width  = (int) $matches[1];
+					}
+				}
+			}
+			// @codeCoverageIgnoreEnd
+		}
+		else
+		{
+			if (($size = exec('stty size')) && preg_match('/(\d+)\s+(\d+)/', $size, $matches))
+			{
+				static::$height = (int) $matches[2];
+				static::$width  = (int) $matches[1];
+			}
+			else
+			{
+				static::$height = (int) exec('tput cols');
+				static::$width  = (int) exec('tput lines');
+			}
+		}
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
At present, actual checking of terminal height and width happens only for *nix systems. For Windows, only default values are given.

This PR uses [`mode CON`](https://www.computerhope.com/modehlp.htm) to get the actual lines and columns for Windows systems. However, there were reports that Cygwin and GitBash returns incorrect values when using `mode CON` so, as fallback, `tput` was used.

As for Unix systems, added `stty size` as primary check before fallback to `tput`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide