### PR TITLE
Use explicit Routes in feature testing

### DIFF
--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -146,10 +146,8 @@ trait FeatureTestTrait
 		$request = $this->populateGlobals($method, $request, $params);
 
 		// Make sure the RouteCollection knows what method we're using...
-		if (! empty($this->routes))
-		{
-			$this->routes->setHTTPVerb($method);
-		}
+		$routes = $this->routes ?: Services::routes();
+		$routes->setHTTPVerb($method);
 
 		// Make sure any other classes that might call the request
 		// instance get the right one.
@@ -157,7 +155,7 @@ trait FeatureTestTrait
 
 		$response = $this->app
 				->setRequest($request)
-				->run($this->routes, true);
+				->run($routes, true);
 
 		$output = \ob_get_contents();
 		if (empty($response->getBody()) && ! empty($output))


### PR DESCRIPTION
**Description**
Currently two separate test cases will cause a conflict in the resulting `$routes` used in the simulated application. I think this ultimately has to do with re-requiring **Routes.php** in `tryToRouteIt()`:
```
if (empty($routes) || ! $routes instanceof RouteCollectionInterface)
{
	require APPPATH . 'Config/Routes.php';
}
```

This PR forces `FeatureTestTrait::call()` to load `$routes` from Services (if none were specified) to prevent the corruption. See also #3105 for symptoms.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
