### PR TITLE
Update 3rd parameter of memcachedHandler::save() call on MemcachedHandlerTest::testGet() to ensure no random failure at Travis 

### DIFF
--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -48,12 +48,12 @@ class MemcachedHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testGet()
 	{
-		$this->memcachedHandler->save(self::$key1, 'value', 1);
+		$this->memcachedHandler->save(self::$key1, 'value', 2);
 
 		$this->assertSame('value', $this->memcachedHandler->get(self::$key1));
 		$this->assertNull($this->memcachedHandler->get(self::$dummy));
 
-		\CodeIgniter\CLI\CLI::wait(2);
+		\CodeIgniter\CLI\CLI::wait(3);
 		$this->assertNull($this->memcachedHandler->get(self::$key1));
 	}
 


### PR DESCRIPTION
Updated 3rd parameter from 1 to 2.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage