### PR TITLE
fixed missing ) after statement

### DIFF
--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -240,7 +240,7 @@ and uses best practices to minimize any security risks.
     $files = $request->getFiles();
 
     // Grab the file by name given in HTML form
-    if ($files->hasFile('uploadedFile')
+    if ($files->hasFile('uploadedFile'))
     {
         $file = $files->getFile('uploadedfile');
 


### PR DESCRIPTION
There was no closing parenthesis on #579 in `user_guide_src/source/incoming/incomingrequest.rst:243`. I've added the missing `)` to the line.