### PR TITLE
Email Event

### DIFF
--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -1548,13 +1548,13 @@ class Email
 		}
 		$this->buildMessage();
 		$result = $this->spoolEmail();
-		if ($result && $autoClear)
-		{
-			$this->clear();
-		}
-
 		if ($result)
 		{
+			if ($autoClear)
+			{
+				$this->clear();
+			}
+
 			Events::trigger('email', get_object_vars($this));
 		}
 

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -39,6 +39,7 @@
 
 namespace CodeIgniter\Email;
 
+use CodeIgniter\Events\Events;
 use Config\Mimes;
 
 /**
@@ -1530,8 +1531,7 @@ class Email
 		{
 			$this->setReplyTo($this->headers['From']);
 		}
-		if (empty($this->recipients) && ! isset($this->headers['To']) && empty($this->BCCArray) && ! isset($this->headers['Bcc']) && ! isset($this->headers['Cc'])
-		)
+		if (empty($this->recipients) && ! isset($this->headers['To']) && empty($this->BCCArray) && ! isset($this->headers['Bcc']) && ! isset($this->headers['Cc']))
 		{
 			$this->setErrorMessage(lang('Email.noRecipients'));
 			return false;
@@ -1552,6 +1552,12 @@ class Email
 		{
 			$this->clear();
 		}
+
+		if ($result)
+		{
+			Events::trigger('email', get_object_vars($this));
+		}
+
 		return $result;
 	}
 	//--------------------------------------------------------------------
@@ -1595,6 +1601,8 @@ class Email
 			$this->buildMessage();
 			$this->spoolEmail();
 		}
+
+		Events::trigger('email', $this->printDebugger());
 	}
 	//--------------------------------------------------------------------
 	/**

--- a/system/Test/Mock/MockEmail.php
+++ b/system/Test/Mock/MockEmail.php
@@ -1,6 +1,7 @@
 <?php namespace CodeIgniter\Test\Mock;
 
 use CodeIgniter\Email\Email;
+use CodeIgniter\Events\Events;
 
 class MockEmail extends Email
 {
@@ -11,14 +12,27 @@ class MockEmail extends Email
 	 */
 	public $archive = [];
 
+	/**
+	 * Value to return from mocked send().
+	 *
+	 * @var boolean
+	 */
+	public $returnValue = true;
+
 	public function send($autoClear = true)
 	{
+		$this->archive = get_object_vars($this);
+
 		if ($autoClear)
 		{
 			$this->clear();
 		}
 
-		$this->archive = get_object_vars($this);
-		return true;
+		if ($this->returnValue)
+		{
+			Events::trigger('email', $this->archive);
+		}
+
+		return $this->returnValue;
 	}
 }

--- a/system/Test/Mock/MockEmail.php
+++ b/system/Test/Mock/MockEmail.php
@@ -23,13 +23,13 @@ class MockEmail extends Email
 	{
 		$this->archive = get_object_vars($this);
 
-		if ($autoClear)
-		{
-			$this->clear();
-		}
-
 		if ($this->returnValue)
 		{
+			if ($autoClear)
+			{
+				$this->clear();
+			}
+
 			Events::trigger('email', $this->archive);
 		}
 

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -1,5 +1,7 @@
 <?php namespace system\Email;
 
+use CodeIgniter\Events\Events;
+
 class EmailTest extends \CodeIgniter\Test\CIUnitTestCase
 {
 	public function testEmailValidation()
@@ -35,5 +37,42 @@ class EmailTest extends \CodeIgniter\Test\CIUnitTestCase
 		{
 			$this->assertEquals('foo@foo.com', $email->archive['recipients'][0]);
 		}
+	}
+
+	public function testSuccessTriggersEvent()
+	{
+		$config           = config('Email');
+		$config->validate = true;
+		$email            = new \CodeIgniter\Test\Mock\MockEmail($config);
+		$email->setTo('foo@foo.com');
+
+		$result = null;
+
+		Events::on('email', function ($arg) use (&$result) {
+			$result = $arg;
+		});
+
+		$this->assertTrue($email->send());
+
+		$this->assertIsArray($result);
+	}
+
+	public function testFailreDoesNotTriggerEvent()
+	{
+		$config           = config('Email');
+		$config->validate = true;
+		$email            = new \CodeIgniter\Test\Mock\MockEmail($config);
+		$email->setTo('foo@foo.com');
+		$email->returnValue = false;
+
+		$result = null;
+
+		Events::on('email', function ($arg) use (&$result) {
+			$result = $arg;
+		});
+
+		$this->assertFalse($email->send());
+
+		$this->assertNull($result);
 	}
 }

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -39,7 +39,7 @@ class EmailTest extends \CodeIgniter\Test\CIUnitTestCase
 		}
 	}
 
-	public function testSuccessTriggersEvent()
+	public function testSuccessDoesTriggerEvent()
 	{
 		$config           = config('Email');
 		$config->validate = true;
@@ -58,7 +58,7 @@ class EmailTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(['foo@foo.com'], $result['recipients']);
 	}
 
-	public function testFailreDoesNotTriggerEvent()
+	public function testFailureDoesNotTriggerEvent()
 	{
 		$config           = config('Email');
 		$config->validate = true;

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -55,6 +55,7 @@ class EmailTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertTrue($email->send());
 
 		$this->assertIsArray($result);
+		$this->assertEquals(['foo@foo.com'], $result['recipients']);
 	}
 
 	public function testFailreDoesNotTriggerEvent()

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -108,3 +108,4 @@ The following is a list of available event points within the CodeIgniter core co
 * **pre_system** Called very early during system execution. Only the benchmark and events class have been loaded at this point. No routing or other processes have happened.
 * **post_controller_constructor** Called immediately after your controller is instantiated, but prior to any method calls happening.
 * **post_system** Called after the final rendered page is sent to the browser, at the end of system execution after the finalized data is sent to the browser.
+* **email** Called after an email sent successfully from ``CodeIgniter\Email\Email``. Receives an array of the ``Email`` class's properties as a parameter.


### PR DESCRIPTION
**Description**
Defines a new Event, "email", triggered on successful email send. The event receives the Email class's current set of properties so listeners can respond to email specifics.

@samsonasik Please review the move of `archive` on the MockEmail class per my other comment. If you want to review this whole PR I would appreciate it :)

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
