### PR TITLE
RedisHandler update for sessionExpiration = 0

### DIFF
--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -125,7 +125,9 @@ class RedisHandler extends BaseHandler implements \SessionHandlerInterface
 			$this->keyPrefix .= $this->ipAddress . ':';
 		}
 
-				$this->sessionExpiration = $config->sessionExpiration;
+		$this->sessionExpiration = empty($config->sessionExpiration)
+			? (int) ini_get('session.gc_maxlifetime')
+			: (int) $config->sessionExpiration;
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
When we set `$sessionExpiration = 0` for RedisHandler, we have to actually use `ini_get('session.gc_maxlifetime')` under the hood, because otherwise, we can't save session data - `0` is not valid value for `set` method.

Setting `null` would not work either since data would be never expired. Using `ini_get('session.gc_maxlifetime')` makes it reasonable enough. CI3 handles this in the same way.

Ref: #3111 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
