### PR TITLE
Keep development docs up to date

### DIFF
--- a/.github/workflows/docs_nightly.yml
+++ b/.github/workflows/docs_nightly.yml
@@ -1,0 +1,39 @@
+# When changes are pushed to the develop branch,
+# build the current version of the docs and
+# deploy to gh-pages so that our development
+# docs are always up to date.
+name: "Update development docs"
+on:
+  push:
+    branches:
+      - 'develop'
+    paths:
+      - 'user_guide_src/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+      steps:
+      - name: Build docs
+        - uses: actions/checkout@v2
+        - uses: ammaraskar/sphinx-action@master
+          with:
+            docs-folder: "user_guide_src/"
+      - name: Commit documentation changes
+          run: |
+            git clone https://github.com/codeigniter4/CodeIgniter4.git --branch gh-pages --single-branch gh-pages
+            cp -r user_guide_src/_build/html/* gh-pages/
+            cd gh-pages
+            git config --local user.email "action@github.com"
+            git config --local user.name "${GITHUB_ACTOR}"
+            git add .
+            git commit -m "Update documentation" -a || true
+            # The above command will fail if no changes were present, so we ignore
+            # that.
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: gh-pages
+          directory: gh-pages
+          github_token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
Added workflow to build userguide changes when pushed to develop branh and commit to gh-pages so dev docs are always up to date.

See: https://github.com/ammaraskar/sphinx-action