### PR TITLE
Prefer app translations

### DIFF
--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -338,7 +338,12 @@ class Language
 	 */
 	protected function requireFile(string $path): array
 	{
-		$files   = Services::locator()->search($path);
+		// since the locator uses the namespaces to lookup
+		// the files (where the App and the Config namespace
+		// is preferred) we can simply turn around the array
+		// to have the most important file as the last file
+		// (which then overrides the files before)
+		$files   = array_reverse(Services::locator()->search($path));
 		$strings = [];
 
 		foreach ($files as $file)


### PR DESCRIPTION
This closes #3125

**Description**
Since the namespaces are sorted "most preferred first" and the locator searches and returns files in these order we can simply rotate the array to get the most preferred as overrides.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  
