### PR TITLE
Fix reset functionality for countAllResults()

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -1634,7 +1634,15 @@ class Model
 		{
 			$this->builder()->where($this->table . '.' . $this->deletedField, null);
 		}
-		$this->tempUseSoftDeletes = $this->useSoftDeletes;
+
+		// When $reset === false, the $tempUseSoftDeletes will be
+		// dependant on $useSoftDeletes value because we don't
+		// want to add the same "where" condition for the second time
+		$this->tempUseSoftDeletes = ($reset === true)
+			? $this->useSoftDeletes
+			: ($this->useSoftDeletes === true
+				? false
+				: $this->useSoftDeletes);
 
 		return $this->builder()->testMode($test)->countAllResults($reset);
 	}

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1525,6 +1525,32 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testPaginateWithDeleted()
+	{
+		$model = new UserModel($this->db);
+		$model->delete(1);
+
+		$data = $model->withDeleted()->paginate();
+
+		$this->assertEquals(4, count($data));
+		$this->assertEquals(4, $model->pager->getDetails()['total']);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testPaginateWithoutDeleted()
+	{
+		$model = new UserModel($this->db);
+		$model->delete(1);
+
+		$data = $model->withDeleted(false)->paginate();
+
+		$this->assertEquals(3, count($data));
+		$this->assertEquals(3, $model->pager->getDetails()['total']);
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testValidationByObject()
 	{
 		$model = new ValidModel($this->db);
@@ -2072,6 +2098,90 @@ class ModelTest extends CIDatabaseTestCase
 		$model->delete(1);
 		$this->assertEquals(4, $model->withDeleted()->countAllResults());
 		$this->assertEquals(3, $model->countAllResults());
+	}
+
+	public function testcountAllResultsFalseWithDeletedTrue()
+	{
+		$model = new UserModel($this->db);
+		$model->delete(1);
+
+		$this->assertEquals(4, $model->withDeleted()->countAllResults(false));
+
+		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user"';
+		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+
+		$this->assertFalse($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
+
+		$this->assertEquals(4, $model->countAllResults());
+
+		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user"';
+		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+
+		$this->assertTrue($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
+	}
+
+	public function testcountAllResultsFalseWithDeletedFalse()
+	{
+		$model = new UserModel($this->db);
+		$model->delete(1);
+
+		$this->assertEquals(3, $model->withDeleted(false)->countAllResults(false));
+
+		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user" WHERE "db_user"."deleted_at" IS NULL';
+		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+
+		$this->assertFalse($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
+
+		$this->assertEquals(3, $model->countAllResults());
+
+		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user" WHERE "db_user"."deleted_at" IS NULL';
+		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+
+		$this->assertTrue($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
+	}
+
+	public function testcountAllResultsFalseWithDeletedTrueUseSoftDeletesFalse()
+	{
+		$model = new UserModel($this->db);
+		$model->delete(1);
+
+		$this->setPrivateProperty($model, 'useSoftDeletes', false);
+
+		$this->assertEquals(4, $model->withDeleted()->countAllResults(false));
+
+		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user"';
+		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+
+		$this->assertFalse($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
+
+		$this->assertEquals(4, $model->countAllResults());
+
+		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user"';
+		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+
+		$this->assertFalse($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
+	}
+
+	public function testcountAllResultsFalseWithDeletedFalseUseSoftDeletesFalse()
+	{
+		$model = new UserModel($this->db);
+		$model->delete(1);
+
+		$this->setPrivateProperty($model, 'useSoftDeletes', false);
+
+		$this->assertEquals(3, $model->withDeleted(false)->countAllResults(false));
+
+		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user" WHERE "db_user"."deleted_at" IS NULL';
+		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+
+		$this->assertFalse($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
+
+		$this->assertEquals(3, $model->countAllResults());
+
+		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user" WHERE "db_user"."deleted_at" IS NULL';
+		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+
+		$this->assertFalse($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
 	}
 
 }

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -2,6 +2,7 @@
 
 use BadMethodCallException;
 use CodeIgniter\Config\Config;
+use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Entity;
 use CodeIgniter\I18n\Time;
@@ -2102,46 +2103,51 @@ class ModelTest extends CIDatabaseTestCase
 
 	public function testcountAllResultsFalseWithDeletedTrue()
 	{
+		$builder     = new BaseBuilder('user', $this->db);
+		$expectedSQL = $builder->testMode()->countAllResults();
+
 		$model = new UserModel($this->db);
 		$model->delete(1);
 
 		$this->assertEquals(4, $model->withDeleted()->countAllResults(false));
 
-		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user"';
-		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+		$this->assertEquals($expectedSQL, (string)$this->db->getLastQuery());
 
 		$this->assertFalse($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
 
 		$this->assertEquals(4, $model->countAllResults());
 
-		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user"';
-		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+		$this->assertEquals($expectedSQL, (string)$this->db->getLastQuery());
 
 		$this->assertTrue($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
 	}
 
 	public function testcountAllResultsFalseWithDeletedFalse()
 	{
+		$builder     = new BaseBuilder('user', $this->db);
+		$expectedSQL = $builder->testMode()->where('user.deleted_at', null)->countAllResults();
+
 		$model = new UserModel($this->db);
 		$model->delete(1);
 
 		$this->assertEquals(3, $model->withDeleted(false)->countAllResults(false));
 
-		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user" WHERE "db_user"."deleted_at" IS NULL';
-		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+		$this->assertEquals($expectedSQL, (string)$this->db->getLastQuery());
 
 		$this->assertFalse($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
 
 		$this->assertEquals(3, $model->countAllResults());
 
-		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user" WHERE "db_user"."deleted_at" IS NULL';
-		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+		$this->assertEquals($expectedSQL, (string)$this->db->getLastQuery());
 
 		$this->assertTrue($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
 	}
 
 	public function testcountAllResultsFalseWithDeletedTrueUseSoftDeletesFalse()
 	{
+		$builder     = new BaseBuilder('user', $this->db);
+		$expectedSQL = $builder->testMode()->countAllResults();
+
 		$model = new UserModel($this->db);
 		$model->delete(1);
 
@@ -2149,21 +2155,22 @@ class ModelTest extends CIDatabaseTestCase
 
 		$this->assertEquals(4, $model->withDeleted()->countAllResults(false));
 
-		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user"';
-		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+		$this->assertEquals($expectedSQL, (string)$this->db->getLastQuery());
 
 		$this->assertFalse($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
 
 		$this->assertEquals(4, $model->countAllResults());
 
-		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user"';
-		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+		$this->assertEquals($expectedSQL, (string)$this->db->getLastQuery());
 
 		$this->assertFalse($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
 	}
 
 	public function testcountAllResultsFalseWithDeletedFalseUseSoftDeletesFalse()
 	{
+		$builder     = new BaseBuilder('user', $this->db);
+		$expectedSQL = $builder->testMode()->where('user.deleted_at', null)->countAllResults();
+
 		$model = new UserModel($this->db);
 		$model->delete(1);
 
@@ -2171,15 +2178,13 @@ class ModelTest extends CIDatabaseTestCase
 
 		$this->assertEquals(3, $model->withDeleted(false)->countAllResults(false));
 
-		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user" WHERE "db_user"."deleted_at" IS NULL';
-		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+		$this->assertEquals($expectedSQL, (string)$this->db->getLastQuery());
 
 		$this->assertFalse($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
 
 		$this->assertEquals(3, $model->countAllResults());
 
-		$expected = 'SELECT COUNT(*) AS "numrows" FROM "db_user" WHERE "db_user"."deleted_at" IS NULL';
-		$this->assertEquals($expected, str_replace("\n", ' ', (string)$this->db->getLastQuery()));
+		$this->assertEquals($expectedSQL, (string)$this->db->getLastQuery());
 
 		$this->assertFalse($this->getPrivateProperty($model, 'tempUseSoftDeletes'));
 	}


### PR DESCRIPTION
**Description**
When we set the `$reset` parameter to `false` in `countAllResults()`, the  "soft delete" method should not be reset because it affects the form of the query we want to use next time.

Ref: #3121

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
