### PR TITLE
Increase TTL for cache in testGet

### DIFF
--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -89,12 +89,12 @@ class FileHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testGet()
 	{
-		$this->fileHandler->save(self::$key1, 'value', 1);
+		$this->fileHandler->save(self::$key1, 'value', 2);
 
 		$this->assertSame('value', $this->fileHandler->get(self::$key1));
 		$this->assertNull($this->fileHandler->get(self::$dummy));
 
-		\CodeIgniter\CLI\CLI::wait(2);
+		\CodeIgniter\CLI\CLI::wait(3);
 		$this->assertNull($this->fileHandler->get(self::$key1));
 	}
 

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -56,12 +56,12 @@ class PredisHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testGet()
 	{
-		$this->PredisHandler->save(self::$key1, 'value', 1);
+		$this->PredisHandler->save(self::$key1, 'value', 2);
 
 		$this->assertSame('value', $this->PredisHandler->get(self::$key1));
 		$this->assertNull($this->PredisHandler->get(self::$dummy));
 
-		\CodeIgniter\CLI\CLI::wait(2);
+		\CodeIgniter\CLI\CLI::wait(3);
 		$this->assertNull($this->PredisHandler->get(self::$key1));
 	}
 

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -92,12 +92,12 @@ class RedisHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testGet()
 	{
-		$this->redisHandler->save(self::$key1, 'value', 1);
+		$this->redisHandler->save(self::$key1, 'value', 2);
 
 		$this->assertSame('value', $this->redisHandler->get(self::$key1));
 		$this->assertNull($this->redisHandler->get(self::$dummy));
 
-		\CodeIgniter\CLI\CLI::wait(2);
+		\CodeIgniter\CLI\CLI::wait(3);
 		$this->assertNull($this->redisHandler->get(self::$key1));
 	}
 


### PR DESCRIPTION
**Description**
These tests seem to randomly fail from time to time. Hopefully increasing TTL will help.

**Checklist:**
- [x] Securely signed commits
