### PR TITLE
Fix filtering for fetchGlobal() method

### DIFF
--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -420,6 +420,16 @@ class Request extends Message implements RequestInterface
 			$value = $this->globals[$method][$index] ?? null;
 		}
 
+		if (is_array($value) && ($filter !== null || $flags !== null))
+		{
+			// Iterate over array and append filter and flags
+			array_walk_recursive($value, function (&$val) use ($filter, $flags) {
+				$val = filter_var($val, $filter, $flags);
+			});
+
+			return $value;
+		}
+
 		// Cannot filter these types of data automatically...
 		if (is_array($value) || is_object($value) || is_null($value))
 		{

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -290,6 +290,246 @@ class RequestTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testFetchGlobalFiltersWithNull()
+	{
+		$expected = [
+			'foo'     => false,
+			'number'  => 5,
+			'address' => [
+				'street'  => false,
+				'zipcode' => 91210,
+			],
+			'people'  => [
+				[
+					'name' => false,
+					'age'  => 26,
+					'pets' => [
+						'cats' => [
+							'name' => false,
+							'age'  => 3,
+						],
+					],
+				],
+				[
+					'name' => false,
+					'age'  => 23,
+					'pets' => [
+						'fishes' => [
+							'name' => false,
+							'age'  => 1,
+						],
+					],
+				],
+			],
+		];
+		$post     = [
+			'foo'     => 'bar',
+			'number'  => '5',
+			'address' => [
+				'street'  => 'Beverly Hills',
+				'zipcode' => '91210',
+			],
+			'people'  => [
+				[
+					'name' => 'Brandon',
+					'age'  => '26',
+					'pets' => [
+						'cats' => [
+							'name' => 'Simon',
+							'age'  => '3',
+						],
+					],
+				],
+				[
+					'name' => 'Brenda',
+					'age'  => '23',
+					'pets' => [
+						'fishes' => [
+							'name' => 'Nemo',
+							'age'  => '1',
+						],
+					],
+				],
+			],
+		];
+		$this->request->setGlobal('post', $post);
+
+		$this->assertEquals($expected, $this->request->fetchGlobal('post', null, FILTER_VALIDATE_INT));
+	}
+
+	public function testFetchGlobalFiltersWithValue()
+	{
+		$expected = [
+			[
+				'name' => false,
+				'age'  => 26,
+				'pets' => [
+					'cats' => [
+						'name' => false,
+						'age'  => 3,
+					],
+				],
+			],
+			[
+				'name' => false,
+				'age'  => 23,
+				'pets' => [
+					'fishes' => [
+						'name' => false,
+						'age'  => 1,
+					],
+				],
+			],
+		];
+		$post     = [
+			'foo'     => 'bar',
+			'number'  => '5',
+			'address' => [
+				'street'  => 'Beverly Hills',
+				'zipcode' => '91210',
+			],
+			'people'  => [
+				[
+					'name' => 'Brandon',
+					'age'  => '26',
+					'pets' => [
+						'cats' => [
+							'name' => 'Simon',
+							'age'  => '3',
+						],
+					],
+				],
+				[
+					'name' => 'Brenda',
+					'age'  => '23',
+					'pets' => [
+						'fishes' => [
+							'name' => 'Nemo',
+							'age'  => '1',
+						],
+					],
+				],
+			],
+		];
+		$this->request->setGlobal('post', $post);
+
+		$this->assertEquals($expected, $this->request->fetchGlobal('post', 'people', FILTER_VALIDATE_INT));
+	}
+
+	public function testFetchGlobalFiltersWithValues()
+	{
+		$expected = [
+			'address' => [
+				'street'  => false,
+				'zipcode' => 91210,
+			],
+			'people'  => [
+				[
+					'name' => false,
+					'age'  => 26,
+					'pets' => [
+						'cats' => [
+							'name' => false,
+							'age'  => 3,
+						],
+					],
+				],
+				[
+					'name' => false,
+					'age'  => 23,
+					'pets' => [
+						'fishes' => [
+							'name' => false,
+							'age'  => 1,
+						],
+					],
+				],
+			],
+		];
+		$post     = [
+			'foo'     => 'bar',
+			'number'  => '5',
+			'address' => [
+				'street'  => 'Beverly Hills',
+				'zipcode' => '91210',
+			],
+			'people'  => [
+				[
+					'name' => 'Brandon',
+					'age'  => '26',
+					'pets' => [
+						'cats' => [
+							'name' => 'Simon',
+							'age'  => '3',
+						],
+					],
+				],
+				[
+					'name' => 'Brenda',
+					'age'  => '23',
+					'pets' => [
+						'fishes' => [
+							'name' => 'Nemo',
+							'age'  => '1',
+						],
+					],
+				],
+			],
+		];
+		$this->request->setGlobal('post', $post);
+
+		$this->assertEquals($expected, $this->request->fetchGlobal('post', ['address', 'people'], FILTER_VALIDATE_INT));
+	}
+
+	public function testFetchGlobalFiltersWithArrayChildElement()
+	{
+		$expected = [
+			'name' => false,
+			'age'  => 26,
+			'pets' => [
+				'cats' => [
+					'name' => false,
+					'age'  => 3,
+				],
+			],
+		];
+		$post     = [
+			'foo'     => 'bar',
+			'number'  => '5',
+			'address' => [
+				'street'  => 'Beverly Hills',
+				'zipcode' => '91210',
+			],
+			'people'  => [
+				[
+					'name' => 'Brandon',
+					'age'  => '26',
+					'pets' => [
+						'cats' => [
+							'name' => 'Simon',
+							'age'  => '3',
+						],
+					],
+				],
+				[
+					'name' => 'Brenda',
+					'age'  => '23',
+					'pets' => [
+						'fishes' => [
+							'name' => 'Nemo',
+							'age'  => '1',
+						],
+					],
+				],
+			],
+		];
+		$this->request->setGlobal('post', $post);
+
+		$this->assertEquals($expected, $this->request->fetchGlobal('post', 'people[0]', FILTER_VALIDATE_INT));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function ipAddressChecks()
 	{
 		return [


### PR DESCRIPTION
**Description**
This PR fixes the issue with `fetchGlobal()` method in Request class. Right now, when using a filter or flag, these will be applied only to the first level of input data.

Ref: #3128

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide