### PR TITLE
Set Email subject property

### DIFF
--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -593,6 +593,7 @@ class Email
 	 */
 	public function setSubject($subject)
 	{
+		$this->subject = $subject;
 		$subject = $this->prepQEncoding($subject);
 		$this->setHeader('Subject', $subject);
 		return $this;


### PR DESCRIPTION
**Description**
Currently `Email::$subject` is only set internally before calling `sendWithMail()`, but there are a number of cases the property can show up during testing and debugging. This PR sets the property when using `setSubject()` (which currently skips `$subject` and just sets the `header`) to make it accessible for those cases, without affecting its use during `sendWithMail()`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
