### PR TITLE
Fix default location for SQLite3 database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ writable/session/*
 writable/uploads/*
 !writable/uploads/index.html
 
+writable/data/*
+!writable/data/index.html
+
 writable/debugbar/*
 
 php_errors.log

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -85,6 +85,12 @@ class Connection extends BaseConnection implements ConnectionInterface
 		}
 		try
 		{
+			$this->database = ($this->database === ':memory:')
+				? $this->database
+				: (strpos($this->database, DIRECTORY_SEPARATOR) === false
+					? WRITEPATH . 'data' . DIRECTORY_SEPARATOR . $this->database
+					: $this->database);
+
 			return (! $this->password)
 				? new \SQLite3($this->database)
 				: new \SQLite3($this->database, SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, $this->password);

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -16,6 +16,7 @@ Release Date: Not Released
         :titlesonly:
 
         next
+        v4.0.4
         v4.0.3
         v4.0.0
         v4.0.0-rc.4

--- a/user_guide_src/source/changelogs/v4.0.4.rst
+++ b/user_guide_src/source/changelogs/v4.0.4.rst
@@ -1,0 +1,15 @@
+Version 4.0.4
+====================================================
+
+Release Date: Unreleased
+
+**4.0.4 release of CodeIgniter4**
+
+The location for the SQLite3 database has changed and by default will be now located in a ``writable/data`` folder instead of the ``public`` folder.
+
+Enhancements:
+
+
+Bugs Fixed:
+
+- Fixed location for the SQLite3 database which by default will be now located in a ``writable/data`` folder instead of the ``public`` folder.

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -38,6 +38,9 @@ prototype::
 The name of the class property is the connection name, and can be used
 while connecting to specify a group name.
 
+.. note:: The default location of the SQLite3 database is in the ``writable/data/`` folder.
+	If you want to change the location, you must set the full path to the new folder.
+
 Some database drivers (such as PDO, PostgreSQL, Oracle, ODBC) might
 require a full DSN string to be provided. If that is the case, you
 should use the 'DSN' configuration setting, as if you're using the

--- a/writable/data/index.html
+++ b/writable/data/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>


### PR DESCRIPTION
**Description**
We should make it very clear in the release notes that the default location has changed. I know this is more a bugfix, but it also may break "things" for some people.

See: #3113 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
