### PR TITLE
more test for PagerRenderer

### DIFF
--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -509,6 +509,24 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testGetPreviousPageWithSegmentHigherThanZero()
+	{
+		$uri = $this->uri;
+
+		$details = [
+			'uri'         => $uri,
+			'pageCount'   => 10,
+			'currentPage' => 3,
+			'total'       => 100,
+			'segment'     => 2,
+		];
+
+		$pager = new PagerRenderer($details);
+		$this->assertEquals('http://example.com/foo/2', $pager->getPreviousPage());
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testHasNextPageReturnsTrueWhenLastIsMoreThanCurrent()
 	{
 		$uri = $this->uri;
@@ -525,5 +543,21 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertNotNull($pager->getNextPage());
 		$this->assertTrue($pager->hasNextPage());
 		$this->assertEquals('http://example.com/foo?page=4', $pager->getNextPage());
+	}
+
+	public function testGetNextPageWithSegmentHigherThanZero()
+	{
+		$uri = $this->uri;
+
+		$details = [
+			'uri'         => $uri,
+			'pageCount'   => 10,
+			'currentPage' => 3,
+			'total'       => 100,
+			'segment'     => 2,
+		];
+
+		$pager = new PagerRenderer($details);
+		$this->assertEquals('http://example.com/foo/4', $pager->getNextPage());
 	}
 }


### PR DESCRIPTION
Added more test to PagerRenderer for testing `getPreviousPage()` and `getNextPage()` when segment > 0. By this,  `Pager\PagerRenderer` class will have 100% test coverage.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
