### PR TITLE
Implement Email archive

### DIFF
--- a/system/Test/Mock/MockEmail.php
+++ b/system/Test/Mock/MockEmail.php
@@ -6,13 +6,6 @@ use CodeIgniter\Events\Events;
 class MockEmail extends Email
 {
 	/**
-	 * Record of mock emails sent.
-	 *
-	 * @var array
-	 */
-	public $archive = [];
-
-	/**
 	 * Value to return from mocked send().
 	 *
 	 * @var boolean
@@ -21,16 +14,19 @@ class MockEmail extends Email
 
 	public function send($autoClear = true)
 	{
-		$this->archive = get_object_vars($this);
-
 		if ($this->returnValue)
 		{
+			// Determine the correct properties to archive
+			$archive = array_merge(get_object_vars($this), $this->archive);
+			unset($archive['archive']);
+
 			if ($autoClear)
 			{
 				$this->clear();
 			}
 
-			Events::trigger('email', $this->archive);
+			Events::trigger('email', $archive);
+			$this->archive = $archive;
 		}
 
 		return $this->returnValue;

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -39,6 +39,35 @@ class EmailTest extends \CodeIgniter\Test\CIUnitTestCase
 		}
 	}
 
+	public function testEmailSendStoresArchive()
+	{
+		$config           = config('Email');
+		$config->validate = true;
+		$email            = new \CodeIgniter\Test\Mock\MockEmail($config);
+		$email->setTo('foo@foo.com');
+		$email->setFrom('bar@foo.com');
+		$email->setSubject('Archive Test');
+
+		$this->assertTrue($email->send());
+
+		$this->assertNotEmpty($email->archive);
+		$this->assertEquals(['foo@foo.com'], $email->archive['recipients']);
+		$this->assertEquals('bar@foo.com', $email->archive['fromEmail']);
+		$this->assertEquals('Archive Test', $email->archive['subject']);
+	}
+
+	public function testAutoClearLeavesArchive()
+	{
+		$config           = config('Email');
+		$config->validate = true;
+		$email            = new \CodeIgniter\Test\Mock\MockEmail($config);
+		$email->setTo('foo@foo.com');
+
+		$this->assertTrue($email->send(true));
+
+		$this->assertNotEmpty($email->archive);
+	}
+
 	public function testSuccessDoesTriggerEvent()
 	{
 		$config           = config('Email');

--- a/user_guide_src/source/libraries/email.rst
+++ b/user_guide_src/source/libraries/email.rst
@@ -80,6 +80,13 @@ Email properties. Then save the file and it will be used automatically.
 You will NOT need to use the ``$email->initialize()`` method if
 you set your preferences in the config file.
 
+Reviewing Preferences
+---------------------
+
+The settings used for the last successful send are available from the
+instance property ``$archive``. This is helpful for testing and debugging
+to determine that actual values at the time of the ``send()`` call.
+
 Email Preferences
 =================
 


### PR DESCRIPTION
**Description**
My last PR on this subject (#3141) both missed some other properties that are set only into headers and had a logical error in that class properties without autoClear can persist and override values on next send. Oops. This PR moves all the gathering of "last successful send" data into a dedicated property, modeled after `MockEmail`'s way of doing it, and uses that to track header-only values.

Side note, it's clear to me that `Email` is in sore need of updating. I know this was a temporary port of CI3 but it really would benefit from some attention soon, especially splitting out the handlers.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
