### PR TITLE
Revamp Email archive

### DIFF
--- a/system/Test/Mock/MockEmail.php
+++ b/system/Test/Mock/MockEmail.php
@@ -16,17 +16,14 @@ class MockEmail extends Email
 	{
 		if ($this->returnValue)
 		{
-			// Determine the correct properties to archive
-			$archive = array_merge(get_object_vars($this), $this->archive);
-			unset($archive['archive']);
+			$this->setArchiveValues();
 
 			if ($autoClear)
 			{
 				$this->clear();
 			}
 
-			Events::trigger('email', $archive);
-			$this->archive = $archive;
+			Events::trigger('email', $this->archive);
 		}
 
 		return $this->returnValue;

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -68,6 +68,23 @@ class EmailTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertNotEmpty($email->archive);
 	}
 
+	public function testEmailSendRepeatUpdatesArchive()
+	{
+		$config = config('Email');
+		$email  = new \CodeIgniter\Test\Mock\MockEmail($config);
+		$email->setTo('foo@foo.com');
+		$email->setFrom('bar@foo.com');
+
+		$this->assertTrue($email->send());
+
+		$email->setFrom('');
+		$email->setSubject('Archive Test');
+		$this->assertTrue($email->send());
+
+		$this->assertEquals('', $email->archive['fromEmail']);
+		$this->assertEquals('Archive Test', $email->archive['subject']);
+	}
+
 	public function testSuccessDoesTriggerEvent()
 	{
 		$config           = config('Email');


### PR DESCRIPTION
**Description**
Real sorry to do this fam - more issues with the new Email archive functionality. I added a test this time that will fail under the current conditions - basically repeated email sends with the same instance will overwrite archive values with blanks sometimes. This PR addresses it by using the `$tmpArchive` property instead of trying to bundle it all onto `$archive`. I've also consolidated the functionality to a new method to make it cleaner.

Hopefully the last on Email from me for a bit. :)

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
