### PR TITLE
Refresh Composer files

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -11,16 +11,16 @@
 		"ext-json": "*",
 		"ext-mbstring": "*",
 		"kint-php/kint": "^3.3",
-		"psr/log": "^1.1",
-		"laminas/laminas-escaper": "^2.6"
+		"laminas/laminas-escaper": "^2.6",
+		"psr/log": "^1.1"
 	},
 	"require-dev": {
 		"codeigniter4/codeigniter4-standard": "^1.0",
 		"fzaninotto/faker": "^1.9@dev",
 		"mikey179/vfsstream": "1.6.*",
 		"phpunit/phpunit": "^8.5",
-		"squizlabs/php_codesniffer": "^3.3",
-		"predis/predis": "^1.1"
+		"predis/predis": "^1.1",
+		"squizlabs/php_codesniffer": "^3.3"
 	},
 	"autoload": {
 		"psr-4": {
@@ -28,11 +28,11 @@
 		}
 	},
 	"scripts": {
-		"test": "phpunit",
 		"post-update-cmd": [
 			"@composer dump-autoload",
 			"CodeIgniter\\ComposerScripts::postUpdate"
-		]
+		],
+		"test": "phpunit"
 	},
 	"support": {
 		"forum": "http://forum.codeigniter.com/",

--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -1,42 +1,42 @@
 {
-    "name": "codeigniter4/framework",
-    "type": "project",
-    "description": "The CodeIgniter framework v4",
-    "homepage": "https://codeigniter.com",
-    "license": "MIT",
-    "require": {
-        "php": ">=7.2",
-        "ext-curl": "*",
-        "ext-intl": "*",
-        "ext-json": "*",
-        "ext-mbstring": "*",
-        "kint-php/kint": "^3.3",
-        "psr/log": "^1.1",
-        "laminas/laminas-escaper": "^2.6"
-    },
-    "require-dev": {
-        "codeigniter4/codeigniter4-standard": "^1.0",
-        "fzaninotto/faker": "^1.9@dev",
-        "mikey179/vfsstream": "1.6.*",
-        "phpunit/phpunit": "^8.5",
-        "squizlabs/php_codesniffer": "^3.3",
-        "predis/predis": "^1.1"
-    },
-    "autoload": {
-        "psr-4": {
-            "CodeIgniter\\": "system/"
-        }
-    },
-    "scripts": {
+	"name": "codeigniter4/framework",
+	"type": "project",
+	"description": "The CodeIgniter framework v4",
+	"homepage": "https://codeigniter.com",
+	"license": "MIT",
+	"require": {
+		"php": ">=7.2",
+		"ext-curl": "*",
+		"ext-intl": "*",
+		"ext-json": "*",
+		"ext-mbstring": "*",
+		"kint-php/kint": "^3.3",
+		"psr/log": "^1.1",
+		"laminas/laminas-escaper": "^2.6"
+	},
+	"require-dev": {
+		"codeigniter4/codeigniter4-standard": "^1.0",
+		"fzaninotto/faker": "^1.9@dev",
+		"mikey179/vfsstream": "1.6.*",
+		"phpunit/phpunit": "^8.5",
+		"squizlabs/php_codesniffer": "^3.3",
+		"predis/predis": "^1.1"
+	},
+	"autoload": {
+		"psr-4": {
+			"CodeIgniter\\": "system/"
+		}
+	},
+	"scripts": {
 		"test": "phpunit",
-        "post-update-cmd": [
-            "@composer dump-autoload",
-            "CodeIgniter\\ComposerScripts::postUpdate"
-        ]
-    },
-    "support": {
-        "forum": "http://forum.codeigniter.com/",
-        "source": "https://github.com/codeigniter4/CodeIgniter4",
-        "slack": "https://codeigniterchat.slack.com"
-    }
+		"post-update-cmd": [
+			"@composer dump-autoload",
+			"CodeIgniter\\ComposerScripts::postUpdate"
+		]
+	},
+	"support": {
+		"forum": "http://forum.codeigniter.com/",
+		"source": "https://github.com/codeigniter4/CodeIgniter4",
+		"slack": "https://codeigniterchat.slack.com"
+	}
 }

--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "codeigniter4/codeigniter4",
+    "name": "codeigniter4/framework",
     "type": "project",
     "description": "The CodeIgniter framework v4",
     "homepage": "https://codeigniter.com",
@@ -16,9 +16,11 @@
     },
     "require-dev": {
         "codeigniter4/codeigniter4-standard": "^1.0",
+        "fzaninotto/faker": "^1.9@dev",
         "mikey179/vfsstream": "1.6.*",
         "phpunit/phpunit": "^8.5",
-        "squizlabs/php_codesniffer": "^3.3"
+        "squizlabs/php_codesniffer": "^3.3",
+        "predis/predis": "^1.1"
     },
     "autoload": {
         "psr-4": {
@@ -26,10 +28,10 @@
         }
     },
     "scripts": {
+		"test": "phpunit",
         "post-update-cmd": [
             "@composer dump-autoload",
-            "CodeIgniter\\ComposerScripts::postUpdate",
-            "bash admin/setup.sh"
+            "CodeIgniter\\ComposerScripts::postUpdate"
         ]
     },
     "support": {

--- a/admin/module/composer.json
+++ b/admin/module/composer.json
@@ -3,32 +3,32 @@
 	"description": "CodeIgniter4 starter module",
 	"homepage": "https://codeigniter.com",
 	"license": "MIT",
-	"minimum-stability": "dev",
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/codeigniter4/codeigniter4"
-		}
-	],
 	"require": {
 		"php": ">=7.2"
 	},
 	"require-dev": {
+		"codeigniter4/codeigniter4": "dev-develop",
 		"fzaninotto/faker": "^1.9@dev",
 		"mikey179/vfsstream": "1.6.*",
-		"phpunit/phpunit": "^8.5",
-		"codeigniter4/codeigniter4": "dev-develop"
+		"phpunit/phpunit": "^8.5"
 	},
 	"autoload-dev": {
 		"psr-4": {
 			"Tests\\Support\\": "tests/_support"
 		}
 	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/codeigniter4/codeigniter4"
+		}
+	],
+	"minimum-stability": "dev",
 	"scripts": {
-		"test": "phpunit",
 		"post-update-cmd": [
 			"@composer dump-autoload"
-		]
+		],
+		"test": "phpunit"
 	},
 	"support": {
 		"forum": "http://forum.codeigniter.com/",

--- a/admin/module/composer.json
+++ b/admin/module/composer.json
@@ -14,9 +14,9 @@
 		"php": ">=7.2"
 	},
 	"require-dev": {
-        "fzaninotto/faker": "^1.9@dev",
-        "mikey179/vfsstream": "1.6.*",
-        "phpunit/phpunit": "^8.5",
+		"fzaninotto/faker": "^1.9@dev",
+		"mikey179/vfsstream": "1.6.*",
+		"phpunit/phpunit": "^8.5",
 		"codeigniter4/codeigniter4": "dev-develop"
 	},
 	"autoload-dev": {

--- a/admin/module/composer.json
+++ b/admin/module/composer.json
@@ -14,8 +14,9 @@
 		"php": ">=7.2"
 	},
 	"require-dev": {
-		"mikey179/vfsstream": "1.6.*",
-		"phpunit/phpunit": "8.5.*",
+        "fzaninotto/faker": "^1.9@dev",
+        "mikey179/vfsstream": "1.6.*",
+        "phpunit/phpunit": "^8.5",
 		"codeigniter4/codeigniter4": "dev-develop"
 	},
 	"autoload-dev": {

--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -9,8 +9,9 @@
 		"codeigniter4/framework": "^4"
 	},
 	"require-dev": {
-		"mikey179/vfsstream": "1.6.*",
-		"phpunit/phpunit": "8.5.*"
+        "fzaninotto/faker": "^1.9@dev",
+        "mikey179/vfsstream": "1.6.*",
+        "phpunit/phpunit": "^8.5"
 	},
 	"autoload-dev": {
 		"psr-4": {

--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -19,10 +19,10 @@
 		}
 	},
 	"scripts": {
-		"test": "phpunit",
 		"post-update-cmd": [
 			"@composer dump-autoload"
-		]
+		],
+		"test": "phpunit"
 	},
 	"support": {
 		"forum": "http://forum.codeigniter.com/",

--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -9,9 +9,9 @@
 		"codeigniter4/framework": "^4"
 	},
 	"require-dev": {
-        "fzaninotto/faker": "^1.9@dev",
-        "mikey179/vfsstream": "1.6.*",
-        "phpunit/phpunit": "^8.5"
+		"fzaninotto/faker": "^1.9@dev",
+		"mikey179/vfsstream": "1.6.*",
+		"phpunit/phpunit": "^8.5"
 	},
 	"autoload-dev": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
 		"ext-json": "*",
 		"ext-mbstring": "*",
 		"kint-php/kint": "^3.3",
-		"psr/log": "^1.1",
-		"laminas/laminas-escaper": "^2.6"
+		"laminas/laminas-escaper": "^2.6",
+		"psr/log": "^1.1"
 	},
 	"require-dev": {
 		"codeigniter4/codeigniter4-standard": "^1.0",
 		"fzaninotto/faker": "^1.9@dev",
 		"mikey179/vfsstream": "1.6.*",
 		"phpunit/phpunit": "^8.5",
-		"squizlabs/php_codesniffer": "^3.3",
-		"predis/predis": "^1.1"
+		"predis/predis": "^1.1",
+		"squizlabs/php_codesniffer": "^3.3"
 	},
 	"autoload": {
 		"psr-4": {
@@ -28,12 +28,12 @@
 		}
 	},
 	"scripts": {
-		"test": "phpunit",
 		"post-update-cmd": [
 			"@composer dump-autoload",
 			"CodeIgniter\\ComposerScripts::postUpdate",
 			"bash admin/setup.sh"
-		]
+		],
+		"test": "phpunit"
 	},
 	"support": {
 		"forum": "http://forum.codeigniter.com/",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         }
     },
     "scripts": {
+		"test": "phpunit",
         "post-update-cmd": [
             "@composer dump-autoload",
             "CodeIgniter\\ComposerScripts::postUpdate",

--- a/composer.json
+++ b/composer.json
@@ -1,43 +1,43 @@
 {
-    "name": "codeigniter4/codeigniter4",
-    "type": "project",
-    "description": "The CodeIgniter framework v4",
-    "homepage": "https://codeigniter.com",
-    "license": "MIT",
-    "require": {
-        "php": ">=7.2",
-        "ext-curl": "*",
-        "ext-intl": "*",
-        "ext-json": "*",
-        "ext-mbstring": "*",
-        "kint-php/kint": "^3.3",
-        "psr/log": "^1.1",
-        "laminas/laminas-escaper": "^2.6"
-    },
-    "require-dev": {
-        "codeigniter4/codeigniter4-standard": "^1.0",
-        "fzaninotto/faker": "^1.9@dev",
-        "mikey179/vfsstream": "1.6.*",
-        "phpunit/phpunit": "^8.5",
-        "squizlabs/php_codesniffer": "^3.3",
-        "predis/predis": "^1.1"
-    },
-    "autoload": {
-        "psr-4": {
-            "CodeIgniter\\": "system/"
-        }
-    },
-    "scripts": {
+	"name": "codeigniter4/codeigniter4",
+	"type": "project",
+	"description": "The CodeIgniter framework v4",
+	"homepage": "https://codeigniter.com",
+	"license": "MIT",
+	"require": {
+		"php": ">=7.2",
+		"ext-curl": "*",
+		"ext-intl": "*",
+		"ext-json": "*",
+		"ext-mbstring": "*",
+		"kint-php/kint": "^3.3",
+		"psr/log": "^1.1",
+		"laminas/laminas-escaper": "^2.6"
+	},
+	"require-dev": {
+		"codeigniter4/codeigniter4-standard": "^1.0",
+		"fzaninotto/faker": "^1.9@dev",
+		"mikey179/vfsstream": "1.6.*",
+		"phpunit/phpunit": "^8.5",
+		"squizlabs/php_codesniffer": "^3.3",
+		"predis/predis": "^1.1"
+	},
+	"autoload": {
+		"psr-4": {
+			"CodeIgniter\\": "system/"
+		}
+	},
+	"scripts": {
 		"test": "phpunit",
-        "post-update-cmd": [
-            "@composer dump-autoload",
-            "CodeIgniter\\ComposerScripts::postUpdate",
-            "bash admin/setup.sh"
-        ]
-    },
-    "support": {
-        "forum": "http://forum.codeigniter.com/",
-        "source": "https://github.com/codeigniter4/CodeIgniter4",
-        "slack": "https://codeigniterchat.slack.com"
-    }
+		"post-update-cmd": [
+			"@composer dump-autoload",
+			"CodeIgniter\\ComposerScripts::postUpdate",
+			"bash admin/setup.sh"
+		]
+	},
+	"support": {
+		"forum": "http://forum.codeigniter.com/",
+		"source": "https://github.com/codeigniter4/CodeIgniter4",
+		"slack": "https://codeigniterchat.slack.com"
+	}
 }


### PR DESCRIPTION
**Description**
This repo holds the master copies of **composer.json** for the other CodeIgniter 4 repositories and project launchers. A few fo them have become out of sync. This PR cleans them up and updates versions and names to be consistent.

Issues addressed:
* Incorrect project name for **framework**
* Missing `dev` requirements added since last release (`faker`, `predis`)
* Missing script command "test"
* Inconsistent PHPUnit version scheme (`8.5.*` standardized to `^8.5`)
* Inconsistent tabs/spaces standardized to tabs

**Checklist:**
- [X] Securely signed commits
- n/a Component(s) with PHPdocs
- n/a Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
