### PR TITLE
Remove unused code in CIUnitTestCase

### DIFF
--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -40,7 +40,6 @@
 namespace CodeIgniter\Test;
 
 use CodeIgniter\Events\Events;
-use Config\Paths;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -245,8 +245,6 @@ class CIUnitTestCase extends TestCase
 	 */
 	protected function createApplication()
 	{
-		$paths = new Paths();
-
 		return require realpath(__DIR__ . '/../') . '/bootstrap.php';
 	}
 


### PR DESCRIPTION
**Description**
In the `createApplication` method of `CIUnitTestCase`, the `$paths` variable was not used (or forgotten to be used?) so there's no need to retain that.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide