### PR TITLE
Fix ternary operator for $path in Namespaces Command

### DIFF
--- a/system/Commands/Utilities/Namespaces.php
+++ b/system/Commands/Utilities/Namespaces.php
@@ -110,11 +110,11 @@ class Namespaces extends BaseCommand
 		$tbody = [];
 		foreach ($config->psr4 as $ns => $path)
 		{
-			$path = realpath($path) ?? $path;
+			$path = realpath($path) ?: $path;
 
 			$tbody[] = [
 				$ns,
-				realpath($path) ?? $path,
+				realpath($path) ?: $path,
 				is_dir($path) ? 'Yes' : 'MISSING',
 			];
 		}


### PR DESCRIPTION
**Description**
Currently, the `$path` is determined by using a `realpath` on it, or itself on failure. **BUT** this uses the `null coalescing operator`. Since `realpath` returns `false` on failure, the right-hand side of the statement will never be reached even on failure. Thus, this PR addresses this by using an `Elvis operator` instead.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
