### PR TITLE
Add the upload artifact action

### DIFF
--- a/.github/workflows/docs_nightly.yml
+++ b/.github/workflows/docs_nightly.yml
@@ -25,6 +25,12 @@ jobs:
       with:
         docs-folder: "user_guide_src/"
 
+    # Create an artifact of the html output
+    - uses: actions/upload-artifact@v2
+      with:
+        name: HTML Documentation
+        path: user_guide_src/_build/html/
+
     # Commit changes to the gh-pages branch
     - name: Commit documentation changes
       run: |


### PR DESCRIPTION
**Description**
Docs action still fails because it cannot `cp` the user guide folder. This adds the `actions/upload-artifact`. This is also referenced in [`ammaraskar/sphinx-action-test` default workflow](https://github.com/ammaraskar/sphinx-action-test/blob/master/.github/workflows/default.yml).

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide