### PR TITLE
Fix for multicolored strings in CLI

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -516,6 +516,37 @@ class CLI
 			$string .= "\033[4m";
 		}
 
+		// Detect if color method was already in use with this text
+		if (strpos($text, "\033[0m") !== false)
+		{
+			// Split the text into parts so that we can see
+			// if any part missing the color definition
+			$chunks = mb_split("\\033\[0m", $text);
+			// Reset text
+			$text = '';
+
+			foreach ($chunks as $chunk)
+			{
+				if (empty($chunk))
+				{
+					continue;
+				}
+
+				// If chunk doesn't have colors defined we need to add them
+				if (strpos($chunk, "\033[") === false)
+				{
+					$chunk = static::color($chunk, $foreground, $background, $format);
+
+					// Add color reset before chunk and clear end of the string
+					$text .= rtrim("\033[0m" . $chunk, "\033[0m");
+				}
+				else
+				{
+					$text .= $chunk;
+				}
+			}
+		}
+
 		return $string . ($text . "\033[0m");
 	}
 

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -527,7 +527,7 @@ class CLI
 
 			foreach ($chunks as $chunk)
 			{
-				if (empty($chunk))
+				if ($chunk === '')
 				{
 					continue;
 				}
@@ -536,7 +536,6 @@ class CLI
 				if (strpos($chunk, "\033[") === false)
 				{
 					$chunk = static::color($chunk, $foreground, $background, $format);
-
 					// Add color reset before chunk and clear end of the string
 					$text .= rtrim("\033[0m" . $chunk, "\033[0m");
 				}

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -159,6 +159,20 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($expected, CITestStreamFilter::$buffer);
 	}
 
+	public function testWriteForegroundWithColorBefore()
+	{
+		CLI::write(CLI::color('green', 'green') . ' red', 'red');
+		$expected = "\033[0;31m\033[0;32mgreen\033[0m\033[0;31m red\033[0m" . PHP_EOL;
+		$this->assertEquals($expected, CITestStreamFilter::$buffer);
+	}
+
+	public function testWriteForegroundWithColorAfter()
+	{
+		CLI::write('red ' . CLI::color('green', 'green'), 'red');
+		$expected = "\033[0;31mred \033[0;32mgreen\033[0m" . PHP_EOL;
+		$this->assertEquals($expected, CITestStreamFilter::$buffer);
+	}
+
 	public function testWriteBackground()
 	{
 		CLI::write('test', 'red', 'green');


### PR DESCRIPTION
**Description**
This PR fixes multicolored strings in CLI. See: #3173

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide