### PR TITLE
Use explicit 'PHP_EOL' in wordwrap

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -785,7 +785,7 @@ class CLI
 
 		$max = $max - $pad_left;
 
-		$lines = wordwrap($string, $max);
+		$lines = wordwrap($string, $max, PHP_EOL);
 
 		if ($pad_left > 0)
 		{


### PR DESCRIPTION
**Description**
Running `CLITest` on Windows will likely fail on the `testWrap` method giving this error message:

![image](https://user-images.githubusercontent.com/51850998/85946586-f623a780-b977-11ea-9add-7247af34bf63.png)

Upon investigation, this was because `CLI::wrap` uses the `wordwrap` function and sets the third parameter into its default value of `\n` instead of the platform-specific `PHP_EOL`. This PR adds that.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide