### PR TITLE
Refactor color detection in CLI

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -161,6 +161,13 @@ class CLI
 	 */
 	protected static $width;
 
+	/**
+	 * Whether the current stream supports colored output.
+	 *
+	 * @var boolean
+	 */
+	protected static $isColored = false;
+
 	//--------------------------------------------------------------------
 
 	/**
@@ -176,6 +183,9 @@ class CLI
 		// clear segments & options to keep testing clean
 		static::$segments = [];
 		static::$options  = [];
+
+		// Check our stream resource for color support
+		static::$isColored = static::hasColorSupport(STDOUT);
 
 		static::parseCommandLine();
 
@@ -489,7 +499,7 @@ class CLI
 	 */
 	public static function color(string $text, string $foreground, string $background = null, string $format = null): string
 	{
-		if (! static::hasColorSupport(STDOUT))
+		if (! static::$isColored)
 		{
 			return $text;
 		}
@@ -546,7 +556,7 @@ class CLI
 			}
 		}
 
-		return $string . ($text . "\033[0m");
+		return $string . $text . "\033[0m";
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -97,6 +97,7 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 		$nocolor = getenv('NO_COLOR');
 		putenv('NO_COLOR=1');
 
+		CLI::init(); // force re-check on env
 		$this->assertEquals('test', CLI::color('test', 'white', 'green'));
 		putenv($nocolor ? "NO_COLOR=$nocolor" : 'NO_COLOR');
 	}
@@ -106,6 +107,7 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 		$termProgram = getenv('TERM_PROGRAM');
 		putenv('TERM_PROGRAM=Hyper');
 
+		CLI::init(); // force re-check on env
 		$this->assertEquals("\033[1;37m\033[42m\033[4mtest\033[0m", CLI::color('test', 'white', 'green', 'underline'));
 		putenv($termProgram ? "TERM_PROGRAM=$termProgram" : 'TERM_PROGRAM');
 	}
@@ -118,6 +120,9 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testColor()
 	{
+		// After the tests on NO_COLOR and TERM_PROGRAM above,
+		// the $isColored variable is rigged. So we reset this.
+		CLI::init();
 		$this->assertEquals("\033[1;37m\033[42m\033[4mtest\033[0m", CLI::color('test', 'white', 'green', 'underline'));
 	}
 


### PR DESCRIPTION
**Description**
Refactor color support detection in CLI. Move detection in `CLI::init` rather than on every call to `CLI::color`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide