### PR TITLE
Add apidocs action

### DIFF
--- a/.github/workflows/apidocs-action.yml
+++ b/.github/workflows/apidocs-action.yml
@@ -13,7 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Identify
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "${GITHUB_ACTOR}"
+
+      - name: Checkout repo
         uses: actions/checkout@v2
 
       - name: Setup PHP
@@ -27,12 +32,9 @@ jobs:
         run: |
           sudo apt-get install -yq graphviz
 
-      # I can't get curl download this correctly. The phar file has
-      # appended HTML saying it is redirected. Any clues?
-      # For now, I manually downloaded the phar
-      # - name: Download phpDocumentor
-      #   run: |
-      #     curl https://github.com/phpDocumentor/phpDocumentor/releases/download/v2.9.1/phpDocumentor.phar -o ./admin/phpDocumentor.phar
+      - name: Download phpDocumentor
+        run: |
+          curl -L https://github.com/phpDocumentor/phpDocumentor/releases/download/v2.9.1/phpDocumentor.phar -o ./admin/phpDocumentor.phar
 
       - name: Prepare source
         run: |
@@ -55,8 +57,6 @@ jobs:
       - name: Deploy API
         run: |
           cd ./build/api
-          git config --global user.email "action@github.com"
-          git config --global user.name "${GITHUB_ACTOR}"
           git add .
           git commit -m "API bot sync for ${GITHUB_SHA}"
           git push -f origin master

--- a/.github/workflows/apidocs-action.yml
+++ b/.github/workflows/apidocs-action.yml
@@ -13,13 +13,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Identify
+      - name: Setup credentials
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "${GITHUB_ACTOR}"
 
-      - name: Checkout repo
+      - name: Checkout source
         uses: actions/checkout@v2
+        with:
+          path: source
+
+      - name: Checkout api
+        uses: actions/checkout@v2
+        with:
+          repository: codeigniter4/api
+          token: ${{ secrets.ACCESS_TOKEN }}
+          path: api
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -34,29 +43,27 @@ jobs:
 
       - name: Download phpDocumentor
         run: |
-          curl -L https://github.com/phpDocumentor/phpDocumentor/releases/download/v2.9.1/phpDocumentor.phar -o ./admin/phpDocumentor.phar
+          curl \
+            -L https://github.com/phpDocumentor/phpDocumentor/releases/download/v2.9.1/phpDocumentor.phar \
+            -o admin/phpDocumentor.phar
 
-      - name: Prepare source
+      - name: Prepare API
         run: |
-          rm -rf ./build/api*
-          mkdir -p ./build/api/docs
-          cd build/api
-          git init
-          git remote add origin https://github.com/codeigniter4/api.git
-          git fetch
-          git checkout master
-          git reset --hard origin/master
-          rm -r docs/*
+          cd ./api
+          rm -rf ./api/docs*
+          mkdir -p ./api/docs
+          git reset --hard master
 
       - name: Make the new API docs
         run: |
-          chmod +x ./admin/phpDocumentor.phar
-          ./admin/phpDocumentor.phar
-          cp -R ./api/build/* ./build/api/docs
+          cd ./source
+          chmod +x admin/phpDocumentor.phar
+          admin/phpDocumentor.phar
+          cp -R ${GITHUB_WORKSPACE}/source/api/build/* ${GITHUB_WORKSPACE}/api/docs
 
       - name: Deploy API
         run: |
-          cd ./build/api
+          cd ./api
           git add .
-          git commit -m "API bot sync for ${GITHUB_SHA}"
-          git push -f origin master
+          git commit -m "API sync for ${GITHUB_SHA}"
+          git push

--- a/.github/workflows/apidocs-action.yml
+++ b/.github/workflows/apidocs-action.yml
@@ -1,0 +1,62 @@
+name: API Documentation
+
+on:
+  push:
+    branches:
+      - 'develop'
+
+jobs:
+
+  build:
+    name: Generate API Docs
+    if: (github.repository == 'codeigniter4/CodeIgniter4')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.2'
+          extensions: intl, json, mbstring, mysqlnd, xdebug, xml, sqlite3
+          coverage: xdebug
+
+      - name: Download GraphViz for phpDocumentor
+        run: |
+          sudo apt-get install -yq graphviz
+
+      # I can't get curl download this correctly. The phar file has
+      # appended HTML saying it is redirected. Any clues?
+      # For now, I manually downloaded the phar
+      # - name: Download phpDocumentor
+      #   run: |
+      #     curl https://github.com/phpDocumentor/phpDocumentor/releases/download/v2.9.1/phpDocumentor.phar -o ./admin/phpDocumentor.phar
+
+      - name: Prepare source
+        run: |
+          rm -rf ./build/api*
+          mkdir -p ./build/api/docs
+          cd build/api
+          git init
+          git remote add origin https://github.com/codeigniter4/api.git
+          git fetch
+          git checkout master
+          git reset --hard origin/master
+          rm -r docs/*
+
+      - name: Make the new API docs
+        run: |
+          chmod +x ./admin/phpDocumentor.phar
+          ./admin/phpDocumentor.phar
+          cp -R ./api/build/* ./build/api/docs
+
+      - name: Deploy API
+        run: |
+          cd ./build/api
+          git config --global user.email "action@github.com"
+          git config --global user.name "${GITHUB_ACTOR}"
+          git add .
+          git commit -m "API bot sync for ${GITHUB_SHA}"
+          git push -f origin master

--- a/admin/apibot
+++ b/admin/apibot
@@ -18,7 +18,7 @@ mkdir -p build/api/docs
 cd build/api
 git init
 git remote add origin $UPSTREAM
-git fetch 
+git fetch
 git checkout master
 git reset --hard origin/master
 rm -r docs/*


### PR DESCRIPTION
**Description**
Adds the action to update API docs. ~~I have made this barely working up to `Make the new API docs` step. The deploy step fails for the username. Perhaps it is because I don't have credentials to push to `codeigniter4/api` in my testing.~~

~~Another is the use of the phar file. I'm more inclined to download the phar file per run rather than maintain the phar in the codebase so as to save disk space. But, I cannot make the download through curl successful. But if you think otherwise, it's fine.~~

After a series of runs, had finally made this turn green.
[Workflow run](https://github.com/paulbalandan/CodeIgniter4/actions/runs/157498787)
[API push](https://github.com/paulbalandan/api)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide