### PR TITLE
Bugfix: Multipart Content-Length

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -543,7 +543,7 @@ class CURLRequest extends Request
 		if ($method === 'PUT' || $method === 'POST')
 		{
 			// See http://tools.ietf.org/html/rfc7230#section-3.3.2
-			if (is_null($this->getHeader('content-length')))
+			if (is_null($this->getHeader('content-length')) && ! isset($this->config['multipart']))
 			{
 				$this->setHeader('Content-Length', '0');
 			}


### PR DESCRIPTION
**Description**
Following RFC 7230, CURL requests currently set the `Content-Length` header to `0` for every POST and PUT request, to make sure it is present. This is overwritten by the actual length for `application/x-www-form-urlencoded` requests, but left in place for `multipart/form-data` which causes some servers to close the connection early (since 0 bytes are already done).

This PR makes the `0` setting conditional on the presence of `multipart` data, so the native CURL client can set the actual `Content-Length` automatically.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
