### PR TITLE
ArgType 'String' is not valid in MessageFormatter class (fixes #3191)

### DIFF
--- a/system/Language/en/Email.php
+++ b/system/Language/en/Email.php
@@ -23,7 +23,7 @@ return [
    'sendFailurePHPMail'   => 'Unable to send email using PHP mail(). Your server might not be configured to send mail using this method.',
    'sendFailureSendmail'  => 'Unable to send email using PHP Sendmail. Your server might not be configured to send mail using this method.',
    'sendFailureSmtp'      => 'Unable to send email using PHP SMTP. Your server might not be configured to send mail using this method.',
-   'sent'                 => 'Your message has been successfully sent using the following protocol: {0, string}',
+   'sent'                 => 'Your message has been successfully sent using the following protocol: {0}',
    'noSocket'             => 'Unable to open a socket to Sendmail. Please check settings.',
    'noHostname'           => 'You did not specify a SMTP hostname.',
    'SMTPError'            => 'The following SMTP error was encountered: {0}',

--- a/system/Language/en/HTTP.php
+++ b/system/Language/en/HTTP.php
@@ -31,7 +31,7 @@ return [
    'emptySupportedNegotiations' => 'You must provide an array of supported values to all Negotiations.',
 
 	// RedirectResponse
-   'invalidRoute'               => '{0, string} route cannot be found while reverse-routing.',
+   'invalidRoute'               => '{0} route cannot be found while reverse-routing.',
 
 	// DownloadResponse
    'cannotSetBinary'            => 'When setting filepath cannot set binary.',
@@ -42,7 +42,7 @@ return [
 
 	// Response
    'missingResponseStatus'      => 'HTTP Response is missing a status code',
-   'invalidStatusCode'          => '{0, string} is not a valid HTTP return status code',
+   'invalidStatusCode'          => '{0} is not a valid HTTP return status code',
    'unknownStatusCode'          => 'Unknown HTTP status code provided with no message: {0}',
 
 	// URI

--- a/system/Language/en/Images.php
+++ b/system/Language/en/Images.php
@@ -26,7 +26,7 @@ return [
    'unsupportedImageCreate' => 'Your server does not support the GD function required to process this type of image.',
    'jpgOrPngRequired'       => 'The image resize protocol specified in your preferences only works with JPEG or PNG image types.',
    'rotateUnsupported'      => 'Image rotation does not appear to be supported by your server.',
-   'libPathInvalid'         => 'The path to your image library is not correct. Please set the correct path in your image preferences. {0, string)',
+   'libPathInvalid'         => 'The path to your image library is not correct. Please set the correct path in your image preferences. {0}',
    'imageProcessFailed'     => 'Image processing failed. Please verify that your server supports the chosen protocol and that the path to your image library is correct.',
    'rotationAngleRequired'  => 'An angle of rotation is required to rotate the image.',
    'invalidPath'            => 'The path to the image is not correct.',


### PR DESCRIPTION
First noticed when sending an email using the Email class, a few of the language strings in System/Language/en/*.php use an argtype of "string" which isn't valid in the PHP MessageFormatter class. This causes an error to be logged, or in a production environment, an error to be shown and the script halted. Removing this argType (leaving it undefined) fixes this completely.

There was also a typo in System/Language/en/Images.php in the same place (closing bracket instead of a closing brace) which I fixed at the same time.