### PR TITLE
Fix extra slash in URI

### DIFF
--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -283,7 +283,7 @@ trait FeatureTestTrait
 	protected function setupRequest(string $method, string $path = null): IncomingRequest
 	{
 		$config = config(App::class);
-		$uri    = new URI($config->baseURL . '/' . trim($path, '/ '));
+		$uri    = new URI(rtrim($config->baseURL, '/') . '/' . trim($path, '/ '));
 
 		$request      = new IncomingRequest($config, clone($uri), null, new UserAgent());
 		$request->uri = $uri;


### PR DESCRIPTION
**Description**
Using `FeatureTestCase::get('/')` currently results in a URI of `//` due to an extra slash in the URI. This resolves fine during auto-routing but circumvents explicit route definitions such as `$routes->get('/', 'Foo::index');`.

This PR ensures the slashes are correct going into the URI regardless of `baseUrl` and `$path`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
