### PR TITLE
Fix for getting database error

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -373,12 +373,12 @@ abstract class BaseConnection implements ConnectionInterface
 
 		$this->connectTime = microtime(true);
 
-		try 
+		try
 		{
 			// Connect to the database and set the connection ID
 			$this->connID = $this->connect($this->pConnect);
-		} 
-		catch (\Throwable $e) 
+		}
+		catch (\Throwable $e)
 		{
 			log_message('error', 'Error connecting to the database: ' . $e->getMessage());
 		}
@@ -401,14 +401,14 @@ abstract class BaseConnection implements ConnectionInterface
 						}
 					}
 
-					try 
+					try
 					{
 						// Try to connect
 						$this->connID = $this->connect($this->pConnect);
-					} 
-					catch (\Throwable $e) 
+					}
+					catch (\Throwable $e)
 					{
-						log_message('error', 'Error connecting to the database: '.$e->getMessage());
+						log_message('error', 'Error connecting to the database: ' . $e->getMessage());
 					}
 
 					// If a connection is made break the foreach loop
@@ -553,17 +553,6 @@ abstract class BaseConnection implements ConnectionInterface
 	public function getPrefix(): string
 	{
 		return $this->DBPrefix;
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Returns the last error encountered by this connection.
-	 *
-	 * @return mixed
-	 */
-	public function getError()
-	{
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -124,7 +124,7 @@ interface ConnectionInterface
 	 *
 	 * @return mixed
 	 */
-	public function getError();
+	public function error(): array;
 
 	//--------------------------------------------------------------------
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -1334,7 +1334,7 @@ class Model
 		}
 
 		// Still here? Grab the database-specific error, if any.
-		$error = $this->db->getError();
+		$error = $this->db->error();
 
 		return $error['message'] ?? null;
 	}


### PR DESCRIPTION
**Description**
This PR fixes a bug regarding the method used to get the database error. All DB drivers use `error()` method but in our interface, we had `getError()` which wasn't really used anywhere except for the `Model` class. 

See: #3204

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
