### PR TITLE
Allow dashes in the CLI segment

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -868,7 +868,7 @@ class CLI
 		{
 			// If there's no '-' at the beginning of the argument
 			// then add it to our segments.
-			if (mb_strpos($_SERVER['argv'][$i], '-') === false)
+			if (mb_strpos($_SERVER['argv'][$i], '-') !== 0)
 			{
 				static::$segments[] = $_SERVER['argv'][$i];
 				continue;

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -223,7 +223,7 @@ class CLIRequest extends Request
 		{
 			// If there's no '-' at the beginning of the argument
 			// then add it to our segments.
-			if (! $options_found && strpos($argv[$i], '-') === false)
+			if (! $options_found && strpos($argv[$i], '-') !== 0)
 			{
 				$this->segments[] = filter_var($argv[$i], FILTER_SANITIZE_STRING);
 				continue;

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -283,14 +283,15 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 			'-parm',
 			'pvalue',
 			'd2',
+			'da-sh',
 		];
-		$_SERVER['argc'] = 7;
+		$_SERVER['argc'] = 8;
 		CLI::init();
 		$this->assertEquals(null, CLI::getSegment(7));
 		$this->assertEquals('b', CLI::getSegment(1));
 		$this->assertEquals('c', CLI::getSegment(2));
 		$this->assertEquals('d', CLI::getSegment(3));
-		$this->assertEquals(['b', 'c', 'd', 'd2'], CLI::getSegments());
+		$this->assertEquals(['b', 'c', 'd', 'd2', 'da-sh'], CLI::getSegments());
 	}
 
 	public function testParseCommandOption()

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -164,7 +164,7 @@ class CLIRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->request = new CLIRequest(new App());
 
 		$expectedOptions = '-foo bar -baz "queue some stuff"';
-		$expectedPath    = 'users/21';
+		$expectedPath    = 'users/21/pro-file';
 		$this->assertEquals($expectedOptions, $this->request->getOptionString());
 		$this->assertEquals($expectedPath, $this->request->getPath());
 	}


### PR DESCRIPTION
**Description**
This PR fixes the use of strings with dashes in CLI.

See: #3205

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
