### PR TITLE
Cast currentPage value to integer in Pager class

### DIFF
--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -559,7 +559,7 @@ class Pager implements PagerInterface
 		{
 			try
 			{
-				$this->groups[$group]['currentPage'] = (int) $this->groups[$group]['uri']->getSegment($this->segment[$group]);
+				$this->groups[$group]['currentPage'] = (int) $this->groups[$group]['uri']->setSilent(false)->getSegment($this->segment[$group]);
 			}
 			catch (\CodeIgniter\HTTP\Exceptions\HTTPException $e)
 			{

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -559,7 +559,7 @@ class Pager implements PagerInterface
 		{
 			try
 			{
-				$this->groups[$group]['currentPage'] = $this->groups[$group]['uri']->getSegment($this->segment[$group]);
+				$this->groups[$group]['currentPage'] = (int) $this->groups[$group]['uri']->getSegment($this->segment[$group]);
 			}
 			catch (\CodeIgniter\HTTP\Exceptions\HTTPException $e)
 			{

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -369,6 +369,12 @@ class PagerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertStringContainsString(
 			'?page_custom=1', $this->pager->makeLinks(1, null, 1, 'default_full', 0, 'custom')
 		);
+		$this->assertStringContainsString(
+			'/1', $this->pager->makeLinks(1, 10, 1, 'default_full', 1)
+		);
+		$this->assertStringContainsString(
+			'<li class="active">', $this->pager->makeLinks(1, 10, 1, 'default_full', 1)
+		);
 	}
 
 	public function testHeadLinks()


### PR DESCRIPTION
**Description**
This PR fixes lack of casting for `currentPage` when using segments.

See: https://github.com/codeigniter4/CodeIgniter4/pull/3194#issuecomment-653206930

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide
