### PR TITLE
Add Fabricator counts

### DIFF
--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -194,6 +194,9 @@ class CIDatabaseTestCase extends CIUnitTestCase
 					$this->migrations->latest('tests');
 				}
 			}
+
+			// Reset counts on faked items
+			Fabricator::resetCounts();
 		}
 
 		if (! empty($this->seed))

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -51,6 +51,13 @@ use Faker\Generator;
 class Fabricator
 {
 	/**
+	 * Array of counts for fabricated items
+	 *
+	 * @var array
+	 */
+	protected static $tableCounts = [];
+
+	/**
 	 * Locale-specific Faker instance
 	 *
 	 * @var \Faker\Generator
@@ -152,20 +159,64 @@ class Fabricator
 		$this->setFormatters($formatters);
 	}
 
+	//--------------------------------------------------------------------
+
 	/**
-	 * Reset state to defaults
-	 *
-	 * @return $this
+	 * Reset internal counts
 	 */
-	public function reset(): self
+	public static function resetCounts()
 	{
-		$this->setFormatters();
+		self::$tableCounts = [];
+	}
 
-		$this->overrides = $this->tempOverrides = [];
-		$this->locale    = config('App')->defaultLocale;
-		$this->faker     = Factory::create($this->locale);
+	/**
+	 * Get the count for a specific table
+	 *
+	 * @param string $table Name of the target table
+	 *
+	 * @return integer
+	 */
+	public static function getCount(string $table): int
+	{
+		return empty(self::$tableCounts[$table]) ? 0 : self::$tableCounts[$table];
+	}
 
-		return $this;
+	/**
+	 * Set the count for a specific table
+	 *
+	 * @param string  $table Name of the target table
+	 * @param integer $count Count value
+	 *
+	 * @return integer  The new count value
+	 */
+	public static function setCount(string $table, int $count): int
+	{
+		self::$tableCounts[$table] = $count;
+		return $count;
+	}
+
+	/**
+	 * Increment the count for a table
+	 *
+	 * @param string $table Name of the target table
+	 *
+	 * @return integer  The new count value
+	 */
+	public static function upCount(string $table): int
+	{
+		return self::setCount($table, self::getCount($table) + 1);
+	}
+
+	/**
+	 * Decrement the count for a table
+	 *
+	 * @param string $table Name of the target table
+	 *
+	 * @return integer  The new count value
+	 */
+	public static function downCount(string $table): int
+	{
+		return self::setCount($table, self::getCount($table) - 1);
 	}
 
 	//--------------------------------------------------------------------
@@ -515,7 +566,11 @@ class Fabricator
 		// Iterate over new entities and insert each one, storing insert IDs
 		foreach ($this->make($count ?? 1) as $result)
 		{
-			$ids[] = $this->model->insert($result, true);
+			if ($id = $this->model->insert($result, true))
+			{
+				$ids[] = $id;
+				self::upCount($this->model->table);
+			}
 		}
 
 		// If the model defines a "withDeleted" method for handling soft deletes then use it

--- a/tests/system/Database/Live/FabricatorLiveTest.php
+++ b/tests/system/Database/Live/FabricatorLiveTest.php
@@ -45,4 +45,25 @@ class FabricatorLiveTest extends CIDatabaseTestCase
 
 		$this->seeInDatabase('user', ['name' => $result->name]);
 	}
+
+	public function testCreateIncrementsCount()
+	{
+		$fabricator = new Fabricator(UserModel::class);
+		$fabricator->setOverrides(['country' => 'China']);
+
+		$count = Fabricator::getCount('user');
+
+		$fabricator->create();
+
+		$this->assertEquals($count + 1, Fabricator::getCount('user'));
+	}
+
+	public function testHelperIncrementsCount()
+	{
+		$count = Fabricator::getCount('user');
+
+		fake(UserModel::class, ['country' => 'Italy']);
+
+		$this->assertEquals($count + 1, Fabricator::getCount('user'));
+	}
 }

--- a/tests/system/Test/FabricatorTest.php
+++ b/tests/system/Test/FabricatorTest.php
@@ -21,6 +21,13 @@ class FabricatorTest extends CIUnitTestCase
 		'deleted_at' => 'date',
 	];
 
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+
+		Fabricator::resetCounts();
+	}
+
 	//--------------------------------------------------------------------
 
 	public function testConstructorWithString()
@@ -397,5 +404,83 @@ class FabricatorTest extends CIUnitTestCase
 
 		$this->assertObjectHasAttribute('deleted_at', $result);
 		$this->assertNull($result->deleted_at);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testSetCountReturnsCount()
+	{
+		$result = Fabricator::setCount('goblins', 42);
+
+		$this->assertEquals(42, $result);
+	}
+
+	public function testSetCountSetsValue()
+	{
+		Fabricator::setCount('trolls', 3);
+		$result = Fabricator::getCount('trolls');
+
+		$this->assertEquals(3, $result);
+	}
+
+	public function testGetCountNewTableReturnsZero()
+	{
+		$result = Fabricator::getCount('gremlins');
+
+		$this->assertEquals(0, $result);
+	}
+
+	public function testUpCountIncrementsValue()
+	{
+		Fabricator::setCount('orcs', 12);
+		Fabricator::upCount('orcs');
+
+		$this->assertEquals(13, Fabricator::getCount('orcs'));
+	}
+
+	public function testUpCountReturnsValue()
+	{
+		Fabricator::setCount('hobgoblins', 12);
+		$result = Fabricator::upCount('hobgoblins');
+
+		$this->assertEquals(13, $result);
+	}
+
+	public function testUpCountNewTableReturnsOne()
+	{
+		$result = Fabricator::upCount('ogres');
+
+		$this->assertEquals(1, $result);
+	}
+
+	public function testDownCountDecrementsValue()
+	{
+		Fabricator::setCount('orcs', 12);
+		Fabricator::downCount('orcs');
+
+		$this->assertEquals(11, Fabricator::getCount('orcs'));
+	}
+
+	public function testDownCountReturnsValue()
+	{
+		Fabricator::setCount('hobgoblins', 12);
+		$result = Fabricator::downCount('hobgoblins');
+
+		$this->assertEquals(11, $result);
+	}
+
+	public function testDownCountNewTableReturnsNegativeOne()
+	{
+		$result = Fabricator::downCount('ogres');
+
+		$this->assertEquals(-1, $result);
+	}
+
+	public function testResetClearsValue()
+	{
+		Fabricator::setCount('giants', 1000);
+		Fabricator::resetCounts();
+
+		$this->assertEquals(0, Fabricator::getCount('giants'));
 	}
 }

--- a/user_guide_src/source/testing/fabricator.rst
+++ b/user_guide_src/source/testing/fabricator.rst
@@ -223,3 +223,58 @@ This is equivalent to::
     $fabricator = new Fabricator('App\Models\UserModel');
     $fabricator->setOverrides(['name' => 'Gerry']);
     $user = $fabricator->create();
+
+Table Counts
+============
+
+Frequently your faked data will depend on other faked data. ``Fabricator`` provides a static
+count of the number of faked items you have created for each table. Consider the following
+example:
+
+Your project has users and groups. In your test case you want to create various scenarios
+with groups of different sizes, so you use ``Fabricator`` to create a bunch of groups.
+Now you want to create fake users but don't want to assign them to a non-existant group ID.
+Your model's fake method could look like this::
+
+    class UserModel
+    {
+        protected $table = 'users';
+
+        public function fake(Generator &$faker)
+        {
+        	return [
+                'first'    => $faker->firstName,
+                'email'    => $faker->email,
+                'group_id' => rand(1, Fabricator::getCount('users')),
+        	];
+        }
+
+Now creating a new user will ensure it is a part of a valid group: ``$user = fake(UserModel::class);``
+
+``Fabricator`` handles the counts internally but you can also access these static methods
+to assist with using them:
+
+**getCount(string $table): int**
+
+Return the current value for a specific table (default: 0).
+
+**setCount(string $table, int $count): int**
+
+Set the value for a specific table manually, for example if you create some test items
+without using a fabricator that you still wanted factored into the final counts.
+
+**upCount(string $table): int**
+
+Increment the value for a specific table by one and return the new value. (This is what is
+used internally with ``Fabricator::create()``).
+
+**downCount(string $table): int**
+
+Decrement the value for a specific table by one and return the new value, for example if
+you deleted a fake item but wanted to track the change.
+
+**resetCounts()**
+
+Resets all counts. Good idea to call this between test cases (though using
+``CIDatabaseTestCase::$refresh = true`` does it automatically).
+


### PR DESCRIPTION
**Description**
Adds counters for table items created by `Fabricator` to assist with simulated environments that have cross-referenced tables. *See the updated User Guide for example.*

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
