### PR TITLE
remove unnecessary foreach in RouteCollection::checkSubdomains()

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1517,15 +1517,7 @@ class RouteCollection implements RouteCollectionInterface
 			return true;
 		}
 
-		foreach ($subdomains as $subdomain)
-		{
-			if ($subdomain === $this->currentSubdomain)
-			{
-				return true;
-			}
-		}
-
-		return false;
+		return in_array($this->currentSubdomain, $subdomains, true);
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
use `in_array()` instead for check `$this->currentSubdomain` inside `$subdomains`

**Checklist:**
- [x] Securely signed commits