### PR TITLE
add test for Filters with empty except

### DIFF
--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -143,14 +143,29 @@ class FiltersTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testProcessMethodProcessGlobalsWithExcept()
+	public function provideExcept()
+	{
+		return [
+			[
+				['admin/*'],
+			],
+			[
+				[],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider provideExcept
+	 */
+	public function testProcessMethodProcessGlobalsWithExcept(array $except)
 	{
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 
 		$config  = [
 			'globals' => [
 				'before' => [
-					'foo' => ['except' => ['admin/*']],
+					'foo' => ['except' => $except],
 					'bar'
 				],
 				'after'  => [


### PR DESCRIPTION
Added test for filter with empty array except. Use dataprovider as it will result with same except data found. By this, Filters class will have 100% test coverage.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
