### PR TITLE
Remove underscore in UG build path

### DIFF
--- a/.github/workflows/docs_nightly.yml
+++ b/.github/workflows/docs_nightly.yml
@@ -29,13 +29,13 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: HTML Documentation
-        path: user_guide_src/_build/html/
+        path: user_guide_src/build/html/
 
     # Commit changes to the gh-pages branch
     - name: Commit documentation changes
       run: |
         git clone https://github.com/codeigniter4/CodeIgniter4.git --branch gh-pages --single-branch gh-pages
-        cp -r user_guide_src/_build/html/* gh-pages/
+        cp -r user_guide_src/build/html/* gh-pages/
         cd gh-pages
         git config --local user.email "action@github.com"
         git config --local user.name "${GITHUB_ACTOR}"


### PR DESCRIPTION
**Description**
In [comment to #3167 ](https://github.com/codeigniter4/CodeIgniter4/pull/3167#issuecomment-653716546), docs still fails the build process. Done a little checking and found that we used the build path as `_build` instead of `build` used in the `Makefile`.

Checked this locally for a green build: https://github.com/paulbalandan/CodeIgniter4/actions/runs/157521660

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
