### PR TITLE
SQLite3 escapeChar fix

### DIFF
--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -48,13 +48,6 @@ class Builder extends BaseBuilder
 {
 
 	/**
-	 * Identifier escape character
-	 *
-	 * @var string
-	 */
-	protected $escapeChar = '`';
-
-	/**
 	 * Default installs of SQLite typically do not
 	 * support limiting delete clauses.
 	 *

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -56,7 +56,14 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 */
 	public $DBDriver = 'SQLite3';
 
-	// --------------------------------------------------------------------
+	/**
+	 * Identifier escape character
+	 *
+	 * @var string
+	 */
+	public $escapeChar = '`';
+
+	//--------------------------------------------------------------------
 
 	/**
 	 * ORDER BY random keyword


### PR DESCRIPTION
**Description**
This PR fixes `escapeChar` for the SQLite database. The `escapeChar` variable was placed in the wrong file. Incorrect escape char may cause unpredictable behavior in some cases.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
