### PR TITLE
Allow ignoring *.db inside folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,8 @@ writable/uploads/*
 
 writable/debugbar/*
 
-writable/*.db
-writable/*.sqlite
+writable/**/*.db
+writable/**/*.sqlite
 
 php_errors.log
 


### PR DESCRIPTION
**Description**
Since we are ignoring sqlite DBs inside the `writable` folder, might as well ignore db files inside folders within the `writable`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
