### PR TITLE
DatabaseTestCase migrations

### DIFF
--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -167,37 +167,13 @@ class CIDatabaseTestCase extends CIUnitTestCase
 
 		if ($this->refresh === true)
 		{
-			// If no namespace was specified then rollback/migrate all
-			if (empty($this->namespace))
-			{
-				$this->migrations->setNamespace(null);
-
-				$this->migrations->regress(0, 'tests');
-
-				$this->migrations->latest('tests');
-			}
-
-			// Run migrations for each specified namespace
-			else
-			{
-				$namespaces = is_array($this->namespace) ? $this->namespace : [$this->namespace];
-
-				foreach ($namespaces as $namespace)
-				{
-					$this->migrations->setNamespace($namespace);
-					$this->migrations->regress(0, 'tests');
-				}
-
-				foreach ($namespaces as $namespace)
-				{
-					$this->migrations->setNamespace($namespace);
-					$this->migrations->latest('tests');
-				}
-			}
+			$this->regressDatabase();
 
 			// Reset counts on faked items
 			Fabricator::resetCounts();
 		}
+
+		$this->migrateDatabase();
 
 		if (! empty($this->seed))
 		{
@@ -236,6 +212,55 @@ class CIDatabaseTestCase extends CIUnitTestCase
 	}
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * Regress migrations as defined by the class
+	 */
+	protected function regressDatabase()
+	{
+		// If no namespace was specified then rollback all
+		if (empty($this->namespace))
+		{
+			$this->migrations->setNamespace(null);
+			$this->migrations->regress(0, 'tests');
+		}
+
+		// Regress each specified namespace
+		else
+		{
+			$namespaces = is_array($this->namespace) ? $this->namespace : [$this->namespace];
+
+			foreach ($namespaces as $namespace)
+			{
+				$this->migrations->setNamespace($namespace);
+				$this->migrations->regress(0, 'tests');
+			}
+		}
+	}
+
+	/**
+	 * Run migrations as defined by the class
+	 */
+	protected function migrateDatabase()
+	{
+		// If no namespace was specified then migrate all
+		if (empty($this->namespace))
+		{
+			$this->migrations->setNamespace(null);
+			$this->migrations->latest('tests');
+		}
+		// Run migrations for each specified namespace
+		else
+		{
+			$namespaces = is_array($this->namespace) ? $this->namespace : [$this->namespace];
+
+			foreach ($namespaces as $namespace)
+			{
+				$this->migrations->setNamespace($namespace);
+				$this->migrations->latest('tests');
+			}
+		}
+	}
 
 	/**
 	 * Seeds that database with a specific seeder.

--- a/user_guide_src/source/testing/database.rst
+++ b/user_guide_src/source/testing/database.rst
@@ -85,7 +85,8 @@ by adding a couple of class properties to your test.
 **$refresh**
 
 This boolean value determines whether the database is completely refreshed before every test. If true,
-all migrations are rolled back to version 0, then the database is migrated to the latest available migration.
+all migrations are rolled back to version 0. The database is always migrated to the latest available
+state as defined by ``$namespace``.
 
 **$seed**
 
@@ -100,14 +101,23 @@ but the path to the single directory that holds the sub-directory.
 
 **$namespace**
 
-By default, CodeIgniter will look in **tests/_support/DatabaseTestMigrations/Database/Migrations** to locate the migrations
+By default, CodeIgniter will look in **tests/_support/Database/Migrations** to locate the migrations
 that it should run during testing. You can change this location by specifying a new namespace in the ``$namespace`` properties.
 This should not include the **Database/Migrations** path, just the base namespace.
+To run migrations from all available namespaces set this property to ``null``.
 
 Helper Methods
 ==============
 
 The **CIDatabaseTestCase** class provides several helper methods to aid in testing your database.
+
+**regressDatabase()**
+
+Called during ``$refresh`` described above, this method is available if you need to reset the database manually.
+
+**migrateDatabase()**
+
+Called during ``setUp``, this method is available if you need to run migrations manually.
 
 **seed($name)**
 


### PR DESCRIPTION
**Description**
Changes `CIDatabaseTestCase` to run migrations regardless of `$refresh` status. This enables consecutive tests to set up the database without wiping it between tests, and minimizes failures from calling `seed()` where the migrations aren't in place.

This PR also exposes two new methods (used by `setUp()`) to let developers manipulate the database state on demand: `regressDatabase()` and `migrateDatabase()`.

User Guide updated with new functionality, and corrected a few mistakes left from old passes.

Ref. https://forum.codeigniter.com/thread-76921.html

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
