### PR TITLE
Fix insert Entity object on postgres

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -584,7 +584,7 @@ class Model
 			$properties = $data->toRawArray($onlyChanged);
 
 			// Always grab the primary key otherwise updates will fail.
-			if (! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties))
+			if (! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties) && ! empty($data->{$primaryKey}))
 			{
 				$properties[$primaryKey] = $data->{$primaryKey};
 			}


### PR DESCRIPTION
I add check that $data->{$primaryKey} is set, before add it to $data. Otherwise we get error on insert:
> pg_query(): Query failed: ERROR: null value in column "id" violates not-null constraint

because sql:
> INSERT INTO table (key, id) VALUES('value', NULL)