### PR TITLE
Fix 'exit code 23' in apidocs action

### DIFF
--- a/.github/workflows/apidocs-action.yml
+++ b/.github/workflows/apidocs-action.yml
@@ -1,15 +1,15 @@
 name: API Documentation
 
-on: [push]
-  # push:
-  #   branches:
-  #     - 'develop'
+on:
+  push:
+    branches:
+      - 'develop'
 
 jobs:
 
   build:
     name: Generate API Docs
-    # if: (github.repository == 'codeigniter4/CodeIgniter4')
+    if: (github.repository == 'codeigniter4/CodeIgniter4')
     runs-on: ubuntu-latest
 
     steps:
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout api
         uses: actions/checkout@v2
         with:
-          repository: paulbalandan/api
+          repository: codeigniter4/api
           token: ${{ secrets.ACCESS_TOKEN }}
           path: api
 

--- a/.github/workflows/apidocs-action.yml
+++ b/.github/workflows/apidocs-action.yml
@@ -1,15 +1,15 @@
 name: API Documentation
 
-on:
-  push:
-    branches:
-      - 'develop'
+on: [push]
+  # push:
+  #   branches:
+  #     - 'develop'
 
 jobs:
 
   build:
     name: Generate API Docs
-    if: (github.repository == 'codeigniter4/CodeIgniter4')
+    # if: (github.repository == 'codeigniter4/CodeIgniter4')
     runs-on: ubuntu-latest
 
     steps:
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout api
         uses: actions/checkout@v2
         with:
-          repository: codeigniter4/api
+          repository: paulbalandan/api
           token: ${{ secrets.ACCESS_TOKEN }}
           path: api
 
@@ -43,6 +43,7 @@ jobs:
 
       - name: Download phpDocumentor
         run: |
+          cd ./source
           curl \
             -L https://github.com/phpDocumentor/phpDocumentor/releases/download/v2.9.1/phpDocumentor.phar \
             -o admin/phpDocumentor.phar


### PR DESCRIPTION
**Description**
In [#3183 (comment)](https://github.com/codeigniter4/CodeIgniter4/pull/3183#issuecomment-653798106), the action exits on `Download phpDocumentor` step with code 23. I must admit that there was an oversight when I copied the working version of the action in my test branch to that PR branch. I have overlooked adding `cd ./source` before calling `curl`.

Green build is on this PR's first commit.
[Test fix for apidocs locally](https://github.com/paulbalandan/CodeIgniter4/actions/runs/157961164)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide