### PR TITLE
Check color support for STDERR for CLI::error

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -375,12 +375,19 @@ class CLI
 	 */
 	public static function error(string $text, string $foreground = 'light_red', string $background = null)
 	{
+		// Check color support for STDERR
+		$stdout            = static::$isColored;
+		static::$isColored = static::hasColorSupport(STDERR);
+
 		if ($foreground || $background)
 		{
 			$text = static::color($text, $foreground, $background);
 		}
 
 		fwrite(STDERR, $text . PHP_EOL);
+
+		// return STDOUT color support
+		static::$isColored = $stdout;
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
Since `CLI::error` uses `STDERR` as stream, this PR attempts to check if the stream supports terminal colors by modifying the `$isColored` variable used by `CLI::color`. Afterwards, this returns the variable to its previous state.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide