### PR TITLE
Use Throwable in catch block of filesystem helper

### DIFF
--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -94,7 +94,7 @@ if (! function_exists('directory_map'))
 			closedir($fp);
 			return $fileData;
 		}
-		catch (\Exception $fe)
+		catch (\Throwable $e)
 		{
 			return [];
 		}
@@ -138,7 +138,7 @@ if (! function_exists('write_file'))
 
 			return is_int($result);
 		}
-		catch (\Exception $fe)
+		catch (\Throwable $e)
 		{
 			return false;
 		}
@@ -320,7 +320,7 @@ if (! function_exists('get_dir_file_info'))
 				return $fileData;
 			}
 		}
-		catch (\Exception $fe)
+		catch (\Throwable $fe)
 		{
 			return [];
 		}


### PR DESCRIPTION
**Description**
Replace `Exception` with `Throwable` in catch blocks of other filesystem helpers. Others are using `Throwable` while these are not. Seems odd to me.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide