### PR TITLE
Fix set_checkbox() and set_radio() when default is set to true

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -843,7 +843,7 @@ if (! function_exists('set_checkbox'))
 		}
 
 		// Unchecked checkbox and radio inputs are not even submitted by browsers ...
-		if (intval($input) === 0 || ! empty($request->getPost()) || ! empty(old($field)))
+		if ((string) $input === '0' || ! empty($request->getPost()) || ! empty(old($field)))
 		{
 			return ($input === $value) ? ' checked="checked"' : '';
 		}
@@ -895,7 +895,7 @@ if (! function_exists('set_radio'))
 
 		// Unchecked checkbox and radio inputs are not even submitted by browsers ...
 		$result = '';
-		if (intval($input) === 0 || ! empty($input = $request->getPost($field)) || ! empty($input = old($field)))
+		if ((string) $input === '0' || ! empty($input = $request->getPost($field)) || ! empty($input = old($field)))
 		{
 			$result = ($input === $value) ? ' checked="checked"' : '';
 		}

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -745,6 +745,9 @@ EOH;
 
 		$_SESSION = [];
 		$this->assertEquals('', set_checkbox('foo', 'bar'));
+
+		$_SESSION = [];
+		$this->assertEquals(' checked="checked"', set_checkbox('foo', 'bar', true));
 	}
 
 	// ------------------------------------------------------------------------
@@ -772,6 +775,9 @@ EOH;
 
 		$_SESSION = [];
 		$this->assertEquals('', set_checkbox('foo', 'bar'));
+
+		$_SESSION = [];
+		$this->assertEquals(' checked="checked"', set_checkbox('foo', '0', true));
 	}
 
 	// ------------------------------------------------------------------------
@@ -803,6 +809,7 @@ EOH;
 		$_POST['bar'] = 'baz';
 		$this->assertEquals(' checked="checked"', set_radio('bar', 'baz'));
 		$this->assertEquals('', set_radio('bar', 'boop'));
+		$this->assertEquals(' checked="checked"', set_radio('bar', 'boop', true));
 	}
 
 	/**
@@ -814,6 +821,9 @@ EOH;
 		$_POST['bar'] = 0;
 		$this->assertEquals(' checked="checked"', set_radio('bar', '0'));
 		$this->assertEquals('', set_radio('bar', 'boop'));
+
+		$_POST = [];
+		$this->assertEquals(' checked="checked"', set_radio('bar', '0', true));
 	}
 
 	public function testSetRadioFromPostArray()


### PR DESCRIPTION
**Description**
This PR fixes `set_checkbox()` and `set_radio()` when the `$default` parameter is set to `true`.

See: #3228 and https://github.com/codeigniter4/CodeIgniter4/pull/2729#commitcomment-39947798

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide