### PR TITLE
more test Files\File class

### DIFF
--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -144,7 +144,9 @@ class File extends SplFileInfo
 	{
 		if (! function_exists('finfo_open'))
 		{
+			// @codeCoverageIgnoreStart
 			return $this->originalMimeType ?? 'application/octet-stream';
+			// @codeCoverageIgnoreEnd
 		}
 
 		$finfo    = finfo_open(FILEINFO_MIME_TYPE);

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -61,6 +61,13 @@ class FileTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($size, $file->getSizeByUnit('mb'));
 	}
 
+	public function testGetSizeReturnsBytes()
+	{
+		$file = new File(SYSTEMPATH . 'Common.php');
+		$size = filesize(SYSTEMPATH . 'Common.php');
+		$this->assertEquals($size, $file->getSizeByUnit('b'));
+	}
+
 	public function testThrowsExceptionIfNotAFile()
 	{
 		$this->expectException('CodeIgniter\Files\Exceptions\FileNotFoundException');


### PR DESCRIPTION
more test `Files\File` class, for `getSizeByUnit('b')`. 

For `function_exists('finfo_open')` check in `getMimeType()` function. I added `@codeCoverageIgnoreStart` and `@codeCoverageIgnoreEnd` as will not never hit in tests.

By this, the `Files\File` class will have 100% test coverage.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage