### PR TITLE
Remove cilexer from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,9 +71,6 @@ php_errors.log
 # User Guide Temp Files
 #-------------------------
 user_guide_src/build/*
-user_guide_src/cilexer/build/*
-user_guide_src/cilexer/dist/*
-user_guide_src/cilexer/pycilexer.egg-info/*
 
 #-------------------------
 # Test Files


### PR DESCRIPTION
**Description**
Since we removed cilexer as dependency in #2671 , I updated `.gitignore` to remove that also.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide