### PR TITLE
Fix CLI::validate() usage when using dot sign

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -305,8 +305,10 @@ class CLI
 	 */
 	protected static function validate(string $field, string $value, string $rules): bool
 	{
+		$label      = $field;
+		$field      = 'temp';
 		$validation = \Config\Services::validation(null, false);
-		$validation->setRule($field, null, $rules);
+		$validation->setRule($field, $label, $rules);
 		$validation->run([$field => $value]);
 
 		if ($validation->hasError($field))


### PR DESCRIPTION
**Description**
This PR fixes `CLI::validate()` when field value in `prompt()` uses dot sign.

Ref: #3233

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
