### PR TITLE
Run apidocs action only when system files are changed

### DIFF
--- a/.github/workflows/apidocs-action.yml
+++ b/.github/workflows/apidocs-action.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'develop'
+    paths:
+      - 'system/**'
 
 jobs:
 


### PR DESCRIPTION
**Description**
Currently, `apidocs-action` runs on every push to `develop` regardless if there are changes to system files. So this PR adds a `paths` to the action's syntax. This is consistent with our `phpdoc.dist.xml` which transforms only files in the `system` directory.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide