### PR TITLE
Fix PHPDocBlock of Images library

### DIFF
--- a/app/Config/Images.php
+++ b/app/Config/Images.php
@@ -22,7 +22,7 @@ class Images extends BaseConfig
 	/**
 	 * The available handler classes.
 	 *
-	 * @var array
+	 * @var \CodeIgniter\Images\Handlers\BaseHandler[]
 	 */
 	public $handlers = [
 		'gd'      => \CodeIgniter\Images\Handlers\GDHandler::class,

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -357,9 +357,9 @@ class Services extends BaseService
 	 * Acts as a factory for ImageHandler classes and returns an instance
 	 * of the handler. Used like Services::image()->withFile($path)->rotate(90)->save();
 	 *
-	 * @param string  $handler
-	 * @param mixed   $config
-	 * @param boolean $getShared
+	 * @param string|null         $handler
+	 * @param \Config\Images|null $config
+	 * @param boolean             $getShared
 	 *
 	 * @return \CodeIgniter\Images\Handlers\BaseHandler
 	 */

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -41,6 +41,7 @@ namespace CodeIgniter\Images\Handlers;
 use CodeIgniter\Images\Exceptions\ImageException;
 use CodeIgniter\Images\Image;
 use CodeIgniter\Images\ImageHandlerInterface;
+use Config\Images;
 
 /**
  * Base image handling implementation
@@ -86,7 +87,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 	/**
 	 * File permission mask.
 	 *
-	 * @var type
+	 * @var integer
 	 */
 	protected $filePermissions = 0644;
 
@@ -143,11 +144,11 @@ abstract class BaseHandler implements ImageHandlerInterface
 	/**
 	 * Constructor.
 	 *
-	 * @param type $config
+	 * @param \Config\Images|null $config
 	 */
 	public function __construct($config = null)
 	{
-		$this->config = $config;
+		$this->config = $config ?? new Images();
 	}
 
 	//--------------------------------------------------------------------
@@ -199,9 +200,9 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 * Verifies that a file has been supplied and it is an image.
 	 *
 	 * @return Image  The image instance
-	 * @throws type ImageException
+	 * @throws ImageException
 	 */
-	protected function image(): ?Image
+	protected function image(): Image
 	{
 		if ($this->verified)
 		{
@@ -308,7 +309,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 * @param boolean      $maintainRatio
 	 * @param string       $masterDim
 	 *
-	 * @return mixed
+	 * @return $this
 	 */
 	public function crop(int $width = null, int $height = null, int $x = null, int $y = null, bool $maintainRatio = false, string $masterDim = 'auto')
 	{
@@ -354,7 +355,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 *
 	 * @param float $angle
 	 *
-	 * @return mixed
+	 * @return $this
 	 */
 	public function rotate(float $angle)
 	{
@@ -396,7 +397,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 * @param integer $green
 	 * @param integer $blue
 	 *
-	 * @return mixed
+	 * @return $this
 	 */
 	public function flatten(int $red = 255, int $green = 255, int $blue = 255)
 	{
@@ -415,8 +416,8 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 * @param integer $green
 	 * @param integer $blue
 	 *
-	 * @return   mixed
-	 * @internal param int $angle
+	 * @return   $this
+	 * @internal
 	 */
 	protected abstract function _flatten(int $red = 255, int $green = 255, int $blue = 255);
 
@@ -460,7 +461,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 *
 	 * @param string $direction
 	 *
-	 * @return mixed
+	 * @return $this
 	 */
 	protected abstract function _flip(string $direction);
 
@@ -556,7 +557,6 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 * EXIF data is only supported fr JPEG & TIFF formats.
 	 *
 	 * @param string|null $key    If specified, will only return this piece of EXIF data.
-	 *
 	 * @param boolean     $silent If true, will not throw our own exceptions.
 	 *
 	 * @return mixed
@@ -606,7 +606,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 * @param integer $height
 	 * @param string  $position
 	 *
-	 * @return boolean
+	 * @return $this
 	 */
 	public function fit(int $width, int $height = null, string $position = 'center')
 	{
@@ -631,10 +631,10 @@ abstract class BaseHandler implements ImageHandlerInterface
 	/**
 	 * Calculate image aspect ratio.
 	 *
-	 * @param $width
-	 * @param null       $height
-	 * @param $origWidth
-	 * @param $origHeight
+	 * @param integer|float      $width
+	 * @param integer|float|null $height
+	 * @param integer|float      $origWidth
+	 * @param integer|float      $origHeight
 	 *
 	 * @return array
 	 */
@@ -675,11 +675,11 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 * Based on the position, will determine the correct x/y coords to
 	 * crop the desired portion from the image.
 	 *
-	 * @param $width
-	 * @param $height
-	 * @param $origWidth
-	 * @param $origHeight
-	 * @param $position
+	 * @param integer|float $width
+	 * @param integer|float $height
+	 * @param integer|float $origWidth
+	 * @param integer|float $origHeight
+	 * @param string        $position
 	 *
 	 * @return array
 	 */
@@ -752,10 +752,10 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 *    $image->resize(100, 200, true)
 	 *          ->save($target);
 	 *
-	 * @param string  $target
-	 * @param integer $quality
+	 * @param string|null $target
+	 * @param integer     $quality
 	 *
-	 * @return mixed
+	 * @return boolean
 	 */
 	public abstract function save(string $target = null, int $quality = 90);
 
@@ -866,7 +866,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 *
 	 * accessor for testing; not part of interface
 	 *
-	 * @return type
+	 * @return integer
 	 */
 	public function getHeight()
 	{

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -49,8 +49,8 @@ class GDHandler extends BaseHandler
 	/**
 	 * Constructor.
 	 *
-	 * @param  type $config
-	 * @throws type
+	 * @param  \Config\Images|null $config
+	 * @throws ImageException
 	 */
 	public function __construct($config = null)
 	{
@@ -184,7 +184,7 @@ class GDHandler extends BaseHandler
 	/**
 	 * Resizes the image.
 	 *
-	 * @return boolean|\CodeIgniter\Images\Handlers\GDHandler
+	 * @return \CodeIgniter\Images\Handlers\GDHandler
 	 */
 	public function _resize()
 	{
@@ -196,7 +196,7 @@ class GDHandler extends BaseHandler
 	/**
 	 * Crops the image.
 	 *
-	 * @return boolean|\CodeIgniter\Images\Handlers\GDHandler
+	 * @return \CodeIgniter\Images\Handlers\GDHandler
 	 */
 	public function _crop()
 	{
@@ -210,7 +210,7 @@ class GDHandler extends BaseHandler
 	 *
 	 * @param string $action
 	 *
-	 * @return $this|bool
+	 * @return $this
 	 */
 	protected function process(string $action)
 	{
@@ -404,8 +404,8 @@ class GDHandler extends BaseHandler
 	 * @param string  $path      Image path
 	 * @param integer $imageType Image type
 	 *
-	 * @return resource
-	 * @throws type ImageException
+	 * @return resource|boolean
+	 * @throws ImageException
 	 */
 	protected function getImageResource(string $path, int $imageType)
 	{
@@ -549,6 +549,8 @@ class GDHandler extends BaseHandler
 	 * @param string  $text
 	 * @param array   $options
 	 * @param boolean $isShadow Whether we are drawing the dropshadow or actual text
+	 *
+	 * @return void
 	 */
 	protected function textOverlay(string $text, array $options = [], bool $isShadow = false)
 	{

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -60,7 +60,7 @@ class ImageMagickHandler extends BaseHandler
 	/**
 	 * Stores image resource in memory.
 	 *
-	 * @var
+	 * @var string
 	 */
 	protected $resource;
 
@@ -69,8 +69,8 @@ class ImageMagickHandler extends BaseHandler
 	/**
 	 * Constructor.
 	 *
-	 * @param  type $config
-	 * @throws type
+	 * @param  \Config\Images $config
+	 * @throws ImageException
 	 */
 	public function __construct($config = null)
 	{
@@ -496,7 +496,7 @@ class ImageMagickHandler extends BaseHandler
 	/**
 	 * Return the width of an image.
 	 *
-	 * @return type
+	 * @return integer
 	 */
 	public function _getWidth()
 	{
@@ -506,7 +506,7 @@ class ImageMagickHandler extends BaseHandler
 	/**
 	 * Return the height of an image.
 	 *
-	 * @return type
+	 * @return integer
 	 */
 	public function _getHeight()
 	{

--- a/system/Images/Image.php
+++ b/system/Images/Image.php
@@ -51,14 +51,14 @@ class Image extends File
 	/**
 	 * The original image width in pixels.
 	 *
-	 * @var
+	 * @var integer|float
 	 */
 	public $origWidth;
 
 	/**
 	 * The original image height in pixels.
 	 *
-	 * @var
+	 * @var integer|float
 	 */
 	public $origHeight;
 
@@ -131,7 +131,7 @@ class Image extends File
 	 *
 	 * @param boolean $return
 	 *
-	 * @return mixed
+	 * @return array|boolean
 	 */
 	public function getProperties(bool $return = false)
 	{

--- a/system/Images/ImageHandlerInterface.php
+++ b/system/Images/ImageHandlerInterface.php
@@ -52,6 +52,8 @@ interface ImageHandlerInterface
 	 * @param integer $height
 	 * @param boolean $maintainRatio If true, will get the closest match possible while keeping aspect ratio true.
 	 * @param string  $masterDim
+	 *
+	 * @return $this
 	 */
 	public function resize(int $width, int $height, bool $maintainRatio = false, string $masterDim = 'auto');
 
@@ -69,7 +71,7 @@ interface ImageHandlerInterface
 	 * @param boolean      $maintainRatio
 	 * @param string       $masterDim
 	 *
-	 * @return mixed
+	 * @return $this
 	 */
 	public function crop(int $width = null, int $height = null, int $x = null, int $y = null, bool $maintainRatio = false, string $masterDim = 'auto');
 
@@ -92,7 +94,7 @@ interface ImageHandlerInterface
 	 *
 	 * @param float $angle
 	 *
-	 * @return mixed
+	 * @return $this
 	 */
 	public function rotate(float $angle);
 
@@ -105,9 +107,10 @@ interface ImageHandlerInterface
 	 * @param integer $green
 	 * @param integer $blue
 	 *
-	 * @return mixed
+	 * @return $this
 	 */
 	public function flatten(int $red = 255, int $green = 255, int $blue = 255);
+
 	//--------------------------------------------------------------------
 
 	/**
@@ -137,7 +140,7 @@ interface ImageHandlerInterface
 	 *
 	 * @param string $dir Direction to flip, either 'vertical' or 'horizontal'
 	 *
-	 * @return mixed
+	 * @return $this
 	 */
 	public function flip(string $dir = 'vertical');
 
@@ -161,7 +164,7 @@ interface ImageHandlerInterface
 	 * @param integer $height
 	 * @param string  $position
 	 *
-	 * @return boolean
+	 * @return $this
 	 */
 	public function fit(int $width, int $height, string $position);
 
@@ -201,7 +204,7 @@ interface ImageHandlerInterface
 	 * @param string  $target
 	 * @param integer $quality
 	 *
-	 * @return mixed
+	 * @return boolean
 	 */
 	public function save(string $target = null, int $quality = 90);
 }


### PR DESCRIPTION
**Description**
Fixes doc blocks of the Images library. Basis for this was the actual usage.

Fixes #3249 too.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
