### PR TITLE
Implement model callback overrides

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -1681,7 +1681,7 @@ class Model
 	 *
 	 * @return Model
 	 */
-	public function allowCallbacks($val = true)
+	public function allowCallbacks(bool $val = true)
 	{
 		$this->tempAllowCallbacks = $val;
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -267,45 +267,60 @@ class Model
 	 */
 
 	/**
+	 * Whether to trigger the defined callbacks
+	 *
+	 * @var boolean
+	 */
+	protected $allowCallbacks = true;
+
+	/**
+	 * Used by allowCallbacks() to override the
+	 * model's allowCallbacks setting.
+	 *
+	 * @var boolean
+	 */
+	protected $tempAllowCallbacks;
+
+	/**
 	 * Callbacks for beforeInsert
 	 *
-	 * @var type
+	 * @var array
 	 */
 	protected $beforeInsert = [];
 	/**
 	 * Callbacks for afterInsert
 	 *
-	 * @var type
+	 * @var array
 	 */
 	protected $afterInsert = [];
 	/**
 	 * Callbacks for beforeUpdate
 	 *
-	 * @var type
+	 * @var array
 	 */
 	protected $beforeUpdate = [];
 	/**
 	 * Callbacks for afterUpdate
 	 *
-	 * @var type
+	 * @var array
 	 */
 	protected $afterUpdate = [];
 	/**
 	 * Callbacks for afterFind
 	 *
-	 * @var type
+	 * @var array
 	 */
 	protected $afterFind = [];
 	/**
 	 * Callbacks for beforeDelete
 	 *
-	 * @var type
+	 * @var array
 	 */
 	protected $beforeDelete = [];
 	/**
 	 * Callbacks for afterDelete
 	 *
-	 * @var type
+	 * @var array
 	 */
 	protected $afterDelete = [];
 
@@ -339,6 +354,7 @@ class Model
 
 		$this->tempReturnType     = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
+		$this->tempAllowCallbacks = $this->allowCallbacks;
 
 		if (is_null($validation))
 		{
@@ -1658,6 +1674,21 @@ class Model
 	}
 
 	/**
+	 * Sets $tempAllowCallbacks value so that we can temporarily override
+	 * the setting. Resets after the next trigger.
+	 *
+	 * @param boolean $val
+	 *
+	 * @return Model
+	 */
+	public function allowCallbacks($val = true)
+	{
+		$this->tempAllowCallbacks = $val;
+
+		return $this;
+	}
+
+	/**
 	 * A simple event trigger for Model Events that allows additional
 	 * data manipulation within the model. Specifically intended for
 	 * usage by child models this can be used to format data,
@@ -1670,6 +1701,8 @@ class Model
 	 * data for callback methods (like an array of key/value pairs to insert
 	 * or update, an array of results, etc)
 	 *
+	 * If callbacks are not allowed then returns $eventData immediately.
+	 *
 	 * @param string $event
 	 * @param array  $eventData
 	 *
@@ -1678,6 +1711,14 @@ class Model
 	 */
 	protected function trigger(string $event, array $eventData)
 	{
+		$allowed                  = $this->tempAllowCallbacks;
+		$this->tempAllowCallbacks = $this->allowCallbacks;
+
+		if (! $allowed)
+		{
+			return $eventData;
+		}
+
 		// Ensure it's a valid event
 		if (! isset($this->{$event}) || empty($this->{$event}))
 		{

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1106,6 +1106,57 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testAllowCallbacksFalsePreventsTriggers()
+	{
+		$model = new EventModel();
+
+		$model->allowCallbacks(false)->find(1);
+
+		$this->assertFalse($model->hasToken('afterFind'));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testAllowCallbacksTrueFiresTriggers()
+	{
+		$model = new EventModel();
+		$this->setPrivateProperty($model, 'allowCallbacks', false);
+
+		$model->allowCallbacks(true)->find(1);
+
+		$this->assertTrue($model->hasToken('afterFind'));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testAllowCallbacksResetsAfterTrigger()
+	{
+		$model = new EventModel();
+
+		$model->allowCallbacks(false)->find(1);
+		$model->delete(1);
+
+		$this->assertFalse($model->hasToken('afterFind'));
+		$this->assertTrue($model->hasToken('afterDelete'));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testAllowCallbacksUsesModelProperty()
+	{
+		$model = new EventModel();
+		$this->setPrivateProperty($model, 'allowCallbacks', false);
+		$this->setPrivateProperty($model, 'tempAllowCallbacks', false); // Was already set by the constructor
+
+		$model->find(1);
+		$model->delete(1);
+
+		$this->assertFalse($model->hasToken('afterFind'));
+		$this->assertFalse($model->hasToken('afterDelete'));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testSetWorksWithInsert()
 	{
 		$model = new EventModel();

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -218,6 +218,10 @@ this model will never validate.
 These arrays allow you to specify callback methods that will be run on the data at the
 time specified in the property name.
 
+**$allowCallbacks**
+
+Whether the callbacks defined above should be used.
+
 Working With Data
 =================
 
@@ -749,6 +753,15 @@ use the same callback in multiple events::
 
     protected $beforeInsert = ['hashPassword'];
     protected $beforeUpdate = ['hashPassword'];
+
+Additionally, each model may allow (default) or deny callbacks class-wide by setting its $allowCallbacks property::
+
+	protected $allowCallbacks = false;
+
+You may also change this setting temporarily for a single model call sing the ``allowCallbacks()`` method::
+
+	$model->allowCallbacks(false)->find(1); // No callbacks triggered
+	$model->find(1);                        // Callbacks subject to original property value
 
 Event Parameters
 ----------------


### PR DESCRIPTION
**Description**
This PR adds additional functionality to `Model` to allow/deny callbacks via a property (`$allowCallbacks`) or a per-execution method (`allowCallbacks(bool)`). This will help for testing, for extending models, or for unique situations where a developer needs a "safe mode" of model execution.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
