### PR TITLE
Add Fabricator model error

### DIFF
--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -132,6 +132,11 @@ class Fabricator
 			$model = model($model, false);
 		}
 
+		if (! is_object($model))
+		{
+			throw new \InvalidArgumentException(lang('Fabricator.invalidModel'));
+		}
+
 		$this->model = $model;
 
 		// If no locale was specified then use the App default

--- a/tests/system/Test/FabricatorTest.php
+++ b/tests/system/Test/FabricatorTest.php
@@ -46,6 +46,14 @@ class FabricatorTest extends CIUnitTestCase
 		$this->assertInstanceOf(Fabricator::class, $fabricator);
 	}
 
+	public function testConstructorWithInvalid()
+	{
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage(lang('Fabricator.invalidModel'));
+
+		$fabricator = new Fabricator('SillyRabbit\Models\AreForKids');
+	}
+
 	public function testConstructorSetsFormatters()
 	{
 		$fabricator = new Fabricator(UserModel::class, $this->formatters);


### PR DESCRIPTION
**Description**
When I expended `Fabricator` to allow non-framework models (https://github.com/codeigniter4/CodeIgniter4/commit/e93fcce48207ef8735e44f9f59123302fbb13769) I removed the exception thrown for an invalid model. This was a little too lenient as now `model()` can return `null` yet the fabricator instance remains intact, causing weird errors when using it that are hard to track down.

This PR ensures that `Fabricator` receives input that is valid for `model()`, throwing otherwise. Also bonus: a test.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
