### PR TITLE
Fixes #3125 : add ability to override existing translation en in system language from App

### DIFF
--- a/app/Language/en/Validation.php
+++ b/app/Language/en/Validation.php
@@ -1,0 +1,4 @@
+<?php
+
+// override core en language system validation or define your own en language validation message
+return [];

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -244,15 +244,19 @@ class FileLocator
 			if (isset($namespace['path']) && is_file($namespace['path'] . $path))
 			{
 				$fullPath = $namespace['path'] . $path;
-				if ($prioritizeApp || strpos($fullPath, APPPATH) !== 0)
+				if ($prioritizeApp)
 				{
 					$foundPaths[] = $fullPath;
 				}
 				else
 				{
-					if (! in_array($fullPath, $appPaths, true) && strpos($fullPath, APPPATH) === 0)
+					if (strpos($fullPath, APPPATH) === 0)
 					{
 						$appPaths[] = $fullPath;
+					}
+					else
+					{
+						$foundPaths[] = $fullPath;
 					}
 				}
 			}
@@ -263,7 +267,7 @@ class FileLocator
 
 		if (! $prioritizeApp && ! empty($appPaths))
 		{
-			$foundPaths = array_merge($foundPaths, $appPaths);
+			$foundPaths = array_merge($foundPaths, array_unique($appPaths));
 		}
 
 		return $foundPaths;

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -226,27 +226,42 @@ class FileLocator
 	 *      'app/Modules/bar/Config/Routes.php',
 	 *  ]
 	 *
-	 * @param string $path
-	 * @param string $ext
+	 * @param string  $path
+	 * @param string  $ext
+	 * @param boolean $prioritizeApp
 	 *
 	 * @return array
 	 */
-	public function search(string $path, string $ext = 'php'): array
+	public function search(string $path, string $ext = 'php', bool $prioritizeApp = true): array
 	{
 		$path = $this->ensureExt($path, $ext);
 
 		$foundPaths = [];
+		$appPaths   = [];
 
 		foreach ($this->getNamespaces() as $namespace)
 		{
 			if (isset($namespace['path']) && is_file($namespace['path'] . $path))
 			{
-				$foundPaths[] = $namespace['path'] . $path;
+				$fullPath = $namespace['path'] . $path;
+				if ($prioritizeApp || strpos($fullPath, APPPATH) !== 0)
+				{
+					$foundPaths[] = $fullPath;
+				}
+				else
+				{
+					$appPaths[] = $fullPath;
+				}
 			}
 		}
 
 		// Remove any duplicates
 		$foundPaths = array_unique($foundPaths);
+
+		if (! $prioritizeApp && ! empty($appPaths))
+		{
+			$foundPaths = array_merge($foundPaths, array_unique($appPaths));
+		}
 
 		return $foundPaths;
 	}

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -262,13 +262,13 @@ class FileLocator
 			}
 		}
 
-		// Remove any duplicates
-		$foundPaths = array_unique($foundPaths);
-
 		if (! $prioritizeApp && ! empty($appPaths))
 		{
-			$foundPaths = array_merge($foundPaths, array_unique($appPaths));
+			$foundPaths = array_merge($foundPaths, $appPaths);
 		}
+
+		// Remove any duplicates
+		$foundPaths = array_unique($foundPaths);
 
 		return $foundPaths;
 	}

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -250,7 +250,10 @@ class FileLocator
 				}
 				else
 				{
-					$appPaths[] = $fullPath;
+					if (! in_array($fullPath, $appPaths, true) && strpos($fullPath, APPPATH) === 0)
+					{
+						$appPaths[] = $fullPath;
+					}
 				}
 			}
 		}
@@ -260,7 +263,7 @@ class FileLocator
 
 		if (! $prioritizeApp && ! empty($appPaths))
 		{
-			$foundPaths = array_merge($foundPaths, array_unique($appPaths));
+			$foundPaths = array_merge($foundPaths, $appPaths);
 		}
 
 		return $foundPaths;

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -338,7 +338,16 @@ class Language
 	 */
 	protected function requireFile(string $path): array
 	{
-		$files   = Services::locator()->search($path);
+		$files = Services::locator()->search($path);
+		$files = array_merge(
+			array_filter($files, function ($value) {
+				return strpos($value, APPPATH) === false;
+			}),
+			array_filter($files, function ($value) {
+				return strpos($value, APPPATH) === 0;
+			})
+		);
+
 		$strings = [];
 
 		foreach ($files as $file)

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -338,16 +338,7 @@ class Language
 	 */
 	protected function requireFile(string $path): array
 	{
-		$files = Services::locator()->search($path);
-		$files = array_merge(
-			array_filter($files, function ($value) {
-				return strpos($value, APPPATH) === false;
-			}),
-			array_filter($files, function ($value) {
-				return strpos($value, APPPATH) === 0;
-			})
-		);
-
+		$files   = Services::locator()->search($path, 'php', false);
 		$strings = [];
 
 		foreach ($files as $file)

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -191,6 +191,22 @@ class FileLocatorTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertArrayNotHasKey(0, $foundFiles);
 	}
 
+	//--------------------------------------------------------------------
+
+	public function testSearchPrioritizeSystemOverApp()
+	{
+		$foundFiles = $this->locator->search('Language/en/Validation.php', 'php', false);
+
+		$this->assertEquals([
+			SYSTEMPATH . 'Language/en/Validation.php',
+			APPPATH . 'Language/en/Validation.php',
+		],
+			$foundFiles
+		);
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testListNamespaceFilesEmptyPrefixAndPath()
 	{
 		$this->assertEmpty($this->locator->listNamespaceFiles('', ''));


### PR DESCRIPTION
Alternative of #3126 to allow override existing translation validation.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage