### PR TITLE
\Config\Services::response()->deleteCookie Cannot run，because class R…

### DIFF
--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -133,7 +133,7 @@ class FileHandler implements CacheInterface
 
 		if ($this->writeFile($this->path . $key, serialize($contents)))
 		{
-			chmod($this->path . $key, 0640);
+			chmod($this->path . $key, 0777);
 
 			return true;
 		}

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -118,6 +118,7 @@ if (! function_exists('delete_cookie'))
 	 */
 	function delete_cookie($name, string $domain = '', string $path = '/', string $prefix = '')
 	{
-		\Config\Services::response()->deleteCookie($name, $domain, $path, $prefix);
+		$response = \Config\Services::response();
+		$response->setcookie($name, '', '', $domain, $path, $prefix);
 	}
 }


### PR DESCRIPTION
\Config\Services::response()->deleteCookie Cannot run，because class Response:$this->cookies Not initialized，so deleteCookie、getCookie、hasCookie Cannot run。

Solution:
delete cookie，also is set cookie timeout。