### PR TITLE
Fix Image::save() when target value is null

### DIFF
--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -278,17 +278,25 @@ class GDHandler extends BaseHandler
 	 */
 	public function save(string $target = null, int $quality = 90): bool
 	{
-		$target = empty($target) ? $this->image()->getPathname() : $target;
+		$original = $target;
+		$target   = empty($target) ? $this->image()->getPathname() : $target;
 
 		// If no new resource has been created, then we're
 		// simply copy the existing one.
-		if (empty($this->resource))
+		if (empty($this->resource) && $quality === 100)
 		{
+			if ($original === null)
+			{
+				return true;
+			}
+
 			$name = basename($target);
 			$path = pathinfo($target, PATHINFO_DIRNAME);
 
 			return $this->image()->copy($path, $name);
 		}
+
+		$this->ensureResource();
 
 		switch ($this->image()->imageType)
 		{

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -299,17 +299,25 @@ class ImageMagickHandler extends BaseHandler
 	 */
 	public function save(string $target = null, int $quality = 90): bool
 	{
-		$target = empty($target) ? $this->image() : $target;
+		$original = $target;
+		$target   = empty($target) ? $this->image()->getPathname() : $target;
 
 		// If no new resource has been created, then we're
 		// simply copy the existing one.
-		if (empty($this->resource))
+		if (empty($this->resource) && $quality === 100)
 		{
+			if ($original === null)
+			{
+				return true;
+			}
+
 			$name = basename($target);
 			$path = pathinfo($target, PATHINFO_DIRNAME);
 
 			return $this->image()->copy($path, $name);
 		}
+
+		$this->ensureResource();
 
 		// Copy the file through ImageMagick so that it has
 		// a chance to convert file format.

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -331,6 +331,12 @@ class GDHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 	{
 		foreach (['gif', 'jpeg', 'png', 'webp'] as $type)
 		{
+			if ($type === 'webp' && ! function_exists('imagecreatefromwebp'))
+			{
+				$this->expectException(ImageException::class);
+				$this->expectExceptionMessage('Your server does not support the GD function required to process this type of image.');
+			}
+
 			$this->handler->withFile($this->origin . 'ci-logo.' . $type);
 			$this->handler->save($this->start . 'work/ci-logo.' . $type);
 			$this->assertTrue($this->root->hasChild('work/ci-logo.' . $type));

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -335,9 +335,24 @@ class GDHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 			$this->handler->save($this->start . 'work/ci-logo.' . $type);
 			$this->assertTrue($this->root->hasChild('work/ci-logo.' . $type));
 
-			$this->assertEquals(
+			$this->assertNotEquals(
 				file_get_contents($this->origin . 'ci-logo.' . $type),
 				$this->root->getChild('work/ci-logo.' . $type)->getContent()
+			);
+		}
+	}
+
+	public function testImageCopyWithNoTargetAndMaxQuality()
+	{
+		foreach (['gif', 'jpeg', 'png', 'webp'] as $type)
+		{
+			$this->handler->withFile($this->origin . 'ci-logo.' . $type);
+			$this->handler->save(null, 100);
+			$this->assertTrue(file_exists($this->origin . 'ci-logo.' . $type));
+
+			$this->assertEquals(
+				file_get_contents($this->origin . 'ci-logo.' . $type),
+				file_get_contents($this->origin . 'ci-logo.' . $type)
 			);
 		}
 	}

--- a/tests/system/Images/ImageMagickHandlerTest.php
+++ b/tests/system/Images/ImageMagickHandlerTest.php
@@ -327,13 +327,34 @@ class ImageMagickHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 	{
 		foreach (['gif', 'jpeg', 'png', 'webp'] as $type)
 		{
+			if ($type === 'webp' && ! in_array('WEBP', \Imagick::queryFormats()))
+			{
+				$this->expectException(ImageException::class);
+				$this->expectExceptionMessage('Your server does not support the GD function required to process this type of image.');
+			}
+
 			$this->handler->withFile($this->origin . 'ci-logo.' . $type);
 			$this->handler->save($this->root . 'ci-logo.' . $type);
 			$this->assertTrue(file_exists($this->root . 'ci-logo.' . $type));
 
-			$this->assertEquals(
+			$this->assertNotEquals(
 				file_get_contents($this->origin . 'ci-logo.' . $type),
 				file_get_contents($this->root . 'ci-logo.' . $type)
+			);
+		}
+	}
+
+	public function testImageCopyWithNoTargetAndMaxQuality()
+	{
+		foreach (['gif', 'jpeg', 'png', 'webp'] as $type)
+		{
+			$this->handler->withFile($this->origin . 'ci-logo.' . $type);
+			$this->handler->save(null, 100);
+			$this->assertTrue(file_exists($this->origin . 'ci-logo.' . $type));
+
+			$this->assertEquals(
+				file_get_contents($this->origin . 'ci-logo.' . $type),
+				file_get_contents($this->origin . 'ci-logo.' . $type)
 			);
 		}
 	}


### PR DESCRIPTION
**Description**
This PR fixes a bug when `$target` parameter in the `save()` method is `null`. We also take into consideration the `$quality` parameter for every case.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
