### PR TITLE
Fix "100 Continue" header handling in CURLRequest class

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -448,10 +448,9 @@ class CURLRequest extends Request
 
 		$output = $this->sendRequest($curl_options);
 
-		$continueStr = "HTTP/1.1 100 Continue\x0d\x0a\x0d\x0a";
-		if (strpos($output, $continueStr) === 0)
+		if (strpos($output, 'HTTP/1.1 100 Continue') === 0)
 		{
-			$output = substr($output, strlen($continueStr));
+			$output = substr($output, strpos($output, "\r\n\r\n") + 4);
 		}
 
 		// Split out our headers and body


### PR DESCRIPTION
**Description**
This PR fixes "HTTP/1.1 100 Continue" header handling. 
Optional headers are allowed with 1xx statuses: https://tools.ietf.org/html/rfc2616#section-10.1

Ref: #3261

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide
