### PR TITLE
Add JSON_NUMERIC_CHECK to JSON encoding

### DIFF
--- a/system/Format/JSONFormatter.php
+++ b/system/Format/JSONFormatter.php
@@ -56,7 +56,7 @@ class JSONFormatter implements FormatterInterface
 	 */
 	public function format($data)
 	{
-		$options = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR;
+		$options = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_NUMERIC_CHECK;
 
 		$options = ENVIRONMENT === 'production' ? $options : $options | JSON_PRETTY_PRINT;
 


### PR DESCRIPTION
This allows encoding to make numeric data more true to its type (not enclose them with "", making the receiving system identify
the types easier.

Note making the options variable configurable might be handy in the future depending on the needs of the users
people they interface with they might need additional options added here

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide