### PR TITLE
add JSON_NUMERIC_CHECK to json encode options

### DIFF
--- a/app/Config/Format.php
+++ b/app/Config/Format.php
@@ -52,7 +52,7 @@ class Format extends BaseConfig
 	|
 	*/
 	public $formatterOptions  = [
-		'application/json' => JSON_NUMERIC_CHECK,
+		'application/json' => null,
 		'application/xml'  => null,
 		'text/xml'         => null,
 	];	

--- a/app/Config/Format.php
+++ b/app/Config/Format.php
@@ -52,9 +52,9 @@ class Format extends BaseConfig
 	|
 	*/
 	public $formatterOptions  = [
-		'application/json' => JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ,
-		'application/xml'  => null,
-		'text/xml'         => null,
+		'application/json' => JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES,
+		'application/xml'  => 0,
+		'text/xml'         => 0,
 	];	
 	//--------------------------------------------------------------------
 

--- a/app/Config/Format.php
+++ b/app/Config/Format.php
@@ -52,7 +52,7 @@ class Format extends BaseConfig
 	|
 	*/
 	public $formatterOptions  = [
-		'application/json' => null,
+		'application/json' => JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ,
 		'application/xml'  => null,
 		'text/xml'         => null,
 	];	

--- a/app/Config/Format.php
+++ b/app/Config/Format.php
@@ -47,8 +47,6 @@ class Format extends BaseConfig
 	|
 	| Additional Options to adjust default formatters behaviour.
 	| For each mime type, list the additional options that should be used. 
-	| Set to null by default
-	| Note this will  add to the default options not replace it.
 	|
 	*/
 	public $formatterOptions  = [

--- a/app/Config/Format.php
+++ b/app/Config/Format.php
@@ -39,7 +39,23 @@ class Format extends BaseConfig
 		'application/xml'  => \CodeIgniter\Format\XMLFormatter::class,
 		'text/xml'         => \CodeIgniter\Format\XMLFormatter::class,
 	];
-
+	
+	/*
+	|--------------------------------------------------------------------------
+	| Formatters Options
+	|--------------------------------------------------------------------------
+	|
+	| Additional Options to adjust default formatters behaviour.
+	| For each mime type, list the additional options that should be used. 
+	| Set to null by default
+	| Note this will  add to the default options not replace it.
+	|
+	*/
+	public $formatterOptions  = [
+		'application/json' => JSON_NUMERIC_CHECK,
+		'application/xml'  => null,
+		'text/xml'         => null,
+	];	
 	//--------------------------------------------------------------------
 
 	/**

--- a/system/Format/JSONFormatter.php
+++ b/system/Format/JSONFormatter.php
@@ -57,7 +57,7 @@ class JSONFormatter implements FormatterInterface
 	public function format($data)
 	{
 		$options = $config->formatterOptions['application/json'] ?? JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
-		$options = $options | JSON_PARTIAL_OUTPUT_ON_ERROR ;
+		$options = $options | JSON_PARTIAL_OUTPUT_ON_ERROR;
 
 		$options = ENVIRONMENT === 'production' ? $options : $options | JSON_PRETTY_PRINT;
 

--- a/system/Format/JSONFormatter.php
+++ b/system/Format/JSONFormatter.php
@@ -40,6 +40,7 @@
 namespace CodeIgniter\Format;
 
 use CodeIgniter\Format\Exceptions\FormatException;
+use Config\Format;
 
 /**
  * JSON data formatter
@@ -56,6 +57,8 @@ class JSONFormatter implements FormatterInterface
 	 */
 	public function format($data)
 	{
+		$config  = new Format();
+		
 		$options = $config->formatterOptions['application/json'] ?? JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
 		$options = $options | JSON_PARTIAL_OUTPUT_ON_ERROR;
 

--- a/system/Format/JSONFormatter.php
+++ b/system/Format/JSONFormatter.php
@@ -57,7 +57,7 @@ class JSONFormatter implements FormatterInterface
 	public function format($data)
 	{
 		$options = $config->formatterOptions['application/json'] ?? 0;
-		$options = $options | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR ;
+		$options = $options | JSON_PARTIAL_OUTPUT_ON_ERROR ;
 
 		$options = ENVIRONMENT === 'production' ? $options : $options | JSON_PRETTY_PRINT;
 

--- a/system/Format/JSONFormatter.php
+++ b/system/Format/JSONFormatter.php
@@ -56,7 +56,8 @@ class JSONFormatter implements FormatterInterface
 	 */
 	public function format($data)
 	{
-		$options = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_NUMERIC_CHECK;
+		$options = $config->formatterOptions['application/json'] ?? 0;
+		$options = $options | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR ;
 
 		$options = ENVIRONMENT === 'production' ? $options : $options | JSON_PRETTY_PRINT;
 

--- a/system/Format/JSONFormatter.php
+++ b/system/Format/JSONFormatter.php
@@ -56,7 +56,7 @@ class JSONFormatter implements FormatterInterface
 	 */
 	public function format($data)
 	{
-		$options = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR;
+		$options = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_NUMERIC_CHECK;
 
 		$options = ENVIRONMENT === 'production' ? $options : $options | JSON_PRETTY_PRINT;
 

--- a/system/Format/JSONFormatter.php
+++ b/system/Format/JSONFormatter.php
@@ -56,7 +56,7 @@ class JSONFormatter implements FormatterInterface
 	 */
 	public function format($data)
 	{
-		$options = $config->formatterOptions['application/json'] ?? 0;
+		$options = $config->formatterOptions['application/json'] ?? JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
 		$options = $options | JSON_PARTIAL_OUTPUT_ON_ERROR ;
 
 		$options = ENVIRONMENT === 'production' ? $options : $options | JSON_PRETTY_PRINT;

--- a/system/Format/XMLFormatter.php
+++ b/system/Format/XMLFormatter.php
@@ -66,7 +66,8 @@ class XMLFormatter implements FormatterInterface
 			// @codeCoverageIgnoreEnd
 		}
 
-		$output = new \SimpleXMLElement('<?xml version="1.0"?><response></response>');
+		$options = $config->formatterOptions['application/xml'] ?? 0;
+		$output = new \SimpleXMLElement('<?xml version="1.0"?><response></response>',$options);
 
 		$this->arrayToXML((array)$data, $output);
 

--- a/system/Format/XMLFormatter.php
+++ b/system/Format/XMLFormatter.php
@@ -67,7 +67,7 @@ class XMLFormatter implements FormatterInterface
 		}
 
 		$options = $config->formatterOptions['application/xml'] ?? 0;
-		$output = new \SimpleXMLElement('<?xml version="1.0"?><response></response>',$options);
+		$output = new \SimpleXMLElement('<?xml version="1.0"?><response></response>', $options);
 
 		$this->arrayToXML((array)$data, $output);
 

--- a/system/Format/XMLFormatter.php
+++ b/system/Format/XMLFormatter.php
@@ -40,6 +40,7 @@
 namespace CodeIgniter\Format;
 
 use CodeIgniter\Format\Exceptions\FormatException;
+use Config\Format;
 
 /**
  * XML data formatter
@@ -56,6 +57,8 @@ class XMLFormatter implements FormatterInterface
 	 */
 	public function format($data)
 	{
+		$config  = new Format();
+		
 		// SimpleXML is installed but default
 		// but best to check, and then provide a fallback.
 		if (! extension_loaded('simplexml'))


### PR DESCRIPTION
linked to 
https://github.com/codeigniter4/CodeIgniter4/pull/3286

This allows encoding to make numeric data more true to its type (not enclose them with "", making the receiving system identify
the types easier.

Note making the options variable configurable might be handy in the future depending on the needs of the users
people they interface with they might need additional options added here

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
