### PR TITLE
Fix PHPDocs for HTTP

### DIFF
--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -285,7 +285,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addBaseURI($uri, ?bool $explicitReporting = null)
+	public function addBaseURI($uri, bool $explicitReporting = null)
 	{
 		$this->addOption($uri, 'baseURI', $explicitReporting ?? $this->reportOnly);
 
@@ -309,7 +309,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addChildSrc($uri, ?bool $explicitReporting = null)
+	public function addChildSrc($uri, bool $explicitReporting = null)
 	{
 		$this->addOption($uri, 'childSrc', $explicitReporting ?? $this->reportOnly);
 
@@ -332,7 +332,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addConnectSrc($uri, ?bool $explicitReporting = null)
+	public function addConnectSrc($uri, bool $explicitReporting = null)
 	{
 		$this->addOption($uri, 'connectSrc', $explicitReporting ?? $this->reportOnly);
 
@@ -355,7 +355,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function setDefaultSrc($uri, ?bool $explicitReporting = null)
+	public function setDefaultSrc($uri, bool $explicitReporting = null)
 	{
 		$this->defaultSrc = [(string) $uri => $explicitReporting ?? $this->reportOnly];
 
@@ -377,7 +377,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addFontSrc($uri, ?bool $explicitReporting = null)
+	public function addFontSrc($uri, bool $explicitReporting = null)
 	{
 		$this->addOption($uri, 'fontSrc', $explicitReporting ?? $this->reportOnly);
 
@@ -397,7 +397,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addFormAction($uri, ?bool $explicitReporting = null)
+	public function addFormAction($uri, bool $explicitReporting = null)
 	{
 		$this->addOption($uri, 'formAction', $explicitReporting ?? $this->reportOnly);
 
@@ -417,7 +417,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addFrameAncestor($uri, ?bool $explicitReporting = null)
+	public function addFrameAncestor($uri, bool $explicitReporting = null)
 	{
 		$this->addOption($uri, 'frameAncestors', $explicitReporting ?? $this->reportOnly);
 
@@ -437,7 +437,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addImageSrc($uri, ?bool $explicitReporting = null)
+	public function addImageSrc($uri, bool $explicitReporting = null)
 	{
 		$this->addOption($uri, 'imageSrc', $explicitReporting ?? $this->reportOnly);
 
@@ -457,7 +457,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addMediaSrc($uri, ?bool $explicitReporting = null)
+	public function addMediaSrc($uri, bool $explicitReporting = null)
 	{
 		$this->addOption($uri, 'mediaSrc', $explicitReporting ?? $this->reportOnly);
 
@@ -477,7 +477,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addManifestSrc($uri, ?bool $explicitReporting = null)
+	public function addManifestSrc($uri, bool $explicitReporting = null)
 	{
 		$this->addOption($uri, 'manifestSrc', $explicitReporting ?? $this->reportOnly);
 
@@ -497,7 +497,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addObjectSrc($uri, ?bool $explicitReporting = null)
+	public function addObjectSrc($uri, bool $explicitReporting = null)
 	{
 		$this->addOption($uri, 'objectSrc', $explicitReporting ?? $this->reportOnly);
 
@@ -517,7 +517,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addPluginType($mime, ?bool $explicitReporting = null)
+	public function addPluginType($mime, bool $explicitReporting = null)
 	{
 		$this->addOption($mime, 'pluginTypes', $explicitReporting ?? $this->reportOnly);
 
@@ -556,7 +556,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addSandbox($flags, ?bool $explicitReporting = null)
+	public function addSandbox($flags, bool $explicitReporting = null)
 	{
 		$this->addOption($flags, 'sandbox', $explicitReporting ?? $this->reportOnly);
 		return $this;
@@ -575,7 +575,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addScriptSrc($uri, ?bool $explicitReporting = null)
+	public function addScriptSrc($uri, bool $explicitReporting = null)
 	{
 		$this->addOption($uri, 'scriptSrc', $explicitReporting ?? $this->reportOnly);
 
@@ -595,7 +595,7 @@ class ContentSecurityPolicy
 	 *
 	 * @return $this
 	 */
-	public function addStyleSrc($uri, ?bool $explicitReporting = null)
+	public function addStyleSrc($uri, bool $explicitReporting = null)
 	{
 		$this->addOption($uri, 'styleSrc', $explicitReporting ?? $this->reportOnly);
 
@@ -630,7 +630,7 @@ class ContentSecurityPolicy
 	 * @param string       $target
 	 * @param boolean|null $explicitReporting
 	 */
-	protected function addOption($options, string $target, ?bool $explicitReporting = null)
+	protected function addOption($options, string $target, bool $explicitReporting = null)
 	{
 		// Ensure we have an array to work with...
 		if (is_string($this->{$target}))

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -58,7 +58,7 @@ class DownloadResponse extends Message implements ResponseInterface
 	/**
 	 * Download for file
 	 *
-	 * @var File?
+	 * @var File
 	 */
 	private $file;
 
@@ -263,7 +263,18 @@ class DownloadResponse extends Message implements ResponseInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * {@inheritDoc}
+	 * Return an instance with the specified status code and, optionally, reason phrase.
+	 *
+	 * If no reason phrase is specified, will default recommended reason phrase for
+	 * the response's status code.
+	 *
+	 * @see http://tools.ietf.org/html/rfc7231#section-6
+	 * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+	 *
+	 * @param integer $code   The 3-digit integer result code to set.
+	 * @param string  $reason The reason phrase to use with the
+	 *                        provided status code; if none is provided, will
+	 *                        default to the IANA name.
 	 *
 	 * @throws DownloadException
 	 */
@@ -275,7 +286,12 @@ class DownloadResponse extends Message implements ResponseInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * {@inheritDoc}
+	 * Gets the response response phrase associated with the status code.
+	 *
+	 * @see http://tools.ietf.org/html/rfc7231#section-6
+	 * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+	 *
+	 * @return string
 	 */
 	public function getReason(): string
 	{
@@ -288,7 +304,11 @@ class DownloadResponse extends Message implements ResponseInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * {@inheritDoc}
+	 * Sets the date header
+	 *
+	 * @param \DateTime $date
+	 *
+	 * @return ResponseInterface
 	 */
 	public function setDate(\DateTime $date)
 	{
@@ -302,7 +322,13 @@ class DownloadResponse extends Message implements ResponseInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * {@inheritDoc}
+	 * Sets the Content Type header for this response with the mime type
+	 * and, optionally, the charset.
+	 *
+	 * @param string $mime
+	 * @param string $charset
+	 *
+	 * @return ResponseInterface
 	 */
 	public function setContentType(string $mime, string $charset = 'UTF-8')
 	{
@@ -323,7 +349,8 @@ class DownloadResponse extends Message implements ResponseInterface
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * Sets the appropriate headers to ensure this response
+	 * is not cached by the browsers.
 	 */
 	public function noCache(): self
 	{
@@ -337,7 +364,30 @@ class DownloadResponse extends Message implements ResponseInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * {@inheritDoc}
+	 * A shortcut method that allows the developer to set all of the
+	 * cache-control headers in one method call.
+	 *
+	 * The options array is used to provide the cache-control directives
+	 * for the header. It might look something like:
+	 *
+	 *      $options = [
+	 *          'max-age'  => 300,
+	 *          's-maxage' => 900
+	 *          'etag'     => 'abcde',
+	 *      ];
+	 *
+	 * Typical options are:
+	 *  - etag
+	 *  - last-modified
+	 *  - max-age
+	 *  - s-maxage
+	 *  - private
+	 *  - public
+	 *  - must-revalidate
+	 *  - proxy-revalidate
+	 *  - no-transform
+	 *
+	 * @param array $options
 	 *
 	 * @throws DownloadException
 	 */

--- a/system/HTTP/Exceptions/HTTPException.php
+++ b/system/HTTP/Exceptions/HTTPException.php
@@ -50,9 +50,8 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 	/**
 	 * For CurlRequest
 	 *
-	 * @return             \CodeIgniter\HTTP\Exceptions\HTTPException
+	 * @return \CodeIgniter\HTTP\Exceptions\HTTPException
 	 *
-	 * Not testable with travis-ci
 	 * @codeCoverageIgnore
 	 */
 	public static function forMissingCurl()
@@ -250,6 +249,10 @@ class HTTPException extends FrameworkException implements ExceptionInterface
 
 	/**
 	 * For Uploaded file move
+	 *
+	 * @param string $source
+	 * @param string $target
+	 * @param string $error
 	 *
 	 * @return \CodeIgniter\HTTP\Exceptions\HTTPException
 	 */

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * CodeIgniter
  *
@@ -67,7 +66,7 @@ class Negotiate
 	/**
 	 * Constructor
 	 *
-	 * @param \CodeIgniter\HTTP\RequestInterface $request
+	 * @param \CodeIgniter\HTTP\RequestInterface|null $request
 	 */
 	public function __construct(RequestInterface $request = null)
 	{
@@ -418,14 +417,10 @@ class Negotiate
 	 */
 	public function matchTypes(array $acceptable, array $supported): bool
 	{
-		[
-			$aType,
-			$aSubType,
-		] = explode('/', $acceptable['value']);
-		[
-			$sType,
-			$sSubType,
-		] = explode('/', $supported['value']);
+		// PHPDocumentor v2 cannot parse yet the shorter list syntax,
+		// causing no API generation for the file.
+		list($aType, $aSubType) = explode('/', $acceptable['value']);
+		list($sType, $sSubType) = explode('/', $supported['value']);
 
 		// If the types don't match, we're done.
 		if ($aType !== $sType)

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * CodeIgniter
  *
@@ -231,7 +230,7 @@ class Response extends Message implements ResponseInterface
 	/**
 	 * Constructor
 	 *
-	 * @param App $config
+	 * @param \Config\App $config
 	 */
 	public function __construct($config)
 	{
@@ -442,6 +441,7 @@ class Response extends Message implements ResponseInterface
 	 * Converts the $body into JSON and sets the Content Type header.
 	 *
 	 * @param array|string $body
+	 * @param boolean      $name
 	 *
 	 * @return $this
 	 */
@@ -810,14 +810,14 @@ class Response extends Message implements ResponseInterface
 	 * Accepts an arbitrary number of binds (up to 7) or an associative
 	 * array in the first parameter containing all the values.
 	 *
-	 * @param string|array  $name     Cookie name or array containing binds
-	 * @param string        $value    Cookie value
-	 * @param string        $expire   Cookie expiration time in seconds
-	 * @param string        $domain   Cookie domain (e.g.: '.yourdomain.com')
-	 * @param string        $path     Cookie path (default: '/')
-	 * @param string        $prefix   Cookie name prefix
-	 * @param boolean|false $secure   Whether to only transfer cookies via SSL
-	 * @param boolean|false $httponly Whether only make the cookie accessible via HTTP (no javascript)
+	 * @param string|array $name     Cookie name or array containing binds
+	 * @param string       $value    Cookie value
+	 * @param string       $expire   Cookie expiration time in seconds
+	 * @param string       $domain   Cookie domain (e.g.: '.yourdomain.com')
+	 * @param string       $path     Cookie path (default: '/')
+	 * @param string       $prefix   Cookie name prefix
+	 * @param boolean      $secure   Whether to only transfer cookies via SSL
+	 * @param boolean      $httponly Whether only make the cookie accessible via HTTP (no javascript)
 	 *
 	 * @return $this
 	 */


### PR DESCRIPTION
**Description**
Fix PHPDoc compilation errors for HTTP lib.

Most of the errors for the lib are the parse errors on the `?` nullable typehint which PHPDoc v2 can't handle yet. Since we have given a default value of `null` to these affected parameters and similar codes within the codebase remove the `?` typehint, I also removed it as temporary fix.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Conforms to style guide
