### PR TITLE
FieldData -> add typeName field and length field 

### DIFF
--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -87,6 +87,42 @@ class Result extends BaseResult implements ResultInterface
 	 */
 	public function getFieldData(): array
 	{
+		static $data_types = [
+			MYSQLI_TYPE_DECIMAL     => 'decimal',
+			MYSQLI_TYPE_NEWDECIMAL  => 'newdecimal',
+			MYSQLI_TYPE_FLOAT       => 'float',
+			MYSQLI_TYPE_DOUBLE      => 'double',
+			
+			MYSQLI_TYPE_BIT         => 'bit',
+			MYSQLI_TYPE_TINY        => 'tiny',
+			MYSQLI_TYPE_SHORT       => 'short',
+			MYSQLI_TYPE_LONG        => 'long',
+			MYSQLI_TYPE_LONGLONG    => 'longlong',
+			MYSQLI_TYPE_INT24       => 'int24',
+			
+			MYSQLI_TYPE_YEAR        => 'year',
+			
+			MYSQLI_TYPE_TIMESTAMP   => 'timestamp',
+			MYSQLI_TYPE_DATE        => 'date',
+			MYSQLI_TYPE_TIME        => 'time',
+			MYSQLI_TYPE_DATETIME    => 'datetime',
+			MYSQLI_TYPE_NEWDATE     => 'newdate',
+			
+			MYSQLI_TYPE_INTERVAL    => 'interval',
+			MYSQLI_TYPE_SET         => 'set',
+			MYSQLI_TYPE_ENUM        => 'enum',
+			
+			MYSQLI_TYPE_VAR_STRING  => 'var_string',
+			MYSQLI_TYPE_STRING      => 'string',
+			MYSQLI_TYPE_CHAR        => 'char',
+			
+			MYSQLI_TYPE_GEOMETRY    => 'geometry',
+			MYSQLI_TYPE_TINY_BLOB   => 'tiny_blob',
+			MYSQLI_TYPE_MEDIUM_BLOB => 'medium_blob',
+			MYSQLI_TYPE_LONG_BLOB   => 'long_blob',
+			MYSQLI_TYPE_BLOB        => 'blob',
+		];
+		
 		$retVal    = [];
 		$fieldData = $this->resultID->fetch_fields();
 
@@ -95,8 +131,10 @@ class Result extends BaseResult implements ResultInterface
 			$retVal[$i]              = new \stdClass();
 			$retVal[$i]->name        = $data->name;
 			$retVal[$i]->type        = $data->type;
+			$retVal[$i]->type_name   = isset($data_types[$data->type]) ? $data_types[$data->type] : null;
 			$retVal[$i]->max_length  = $data->max_length;
 			$retVal[$i]->primary_key = (int) ($data->flags & 2);
+			$retVal[$i]->length      = $data->length;
 			$retVal[$i]->default     = $data->def;
 		}
 

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -92,8 +92,10 @@ class Result extends BaseResult implements ResultInterface
 		{
 			$retVal[$i]             = new \stdClass();
 			$retVal[$i]->name       = pg_field_name($this->resultID, $i);
-			$retVal[$i]->type       = pg_field_type($this->resultID, $i);
+			$retVal[$i]->type       = pg_field_type_oid($this->resultID, $i);
+			$retVal[$i]->type_name   = pg_field_type($this->resultID, $i);
 			$retVal[$i]->max_length = pg_field_size($this->resultID, $i);
+			$retVal[$i]->length     = $retVal[$i]->max_length;
 			// $retVal[$i]->primary_key = (int)($fieldData[$i]->flags & 2);
 			// $retVal[$i]->default     = $fieldData[$i]->def;
 		}

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -101,8 +101,10 @@ class Result extends BaseResult implements ResultInterface
 			$retVal[$i]             = new \stdClass();
 			$retVal[$i]->name       = $this->resultID->columnName($i);
 			$type                   = $this->resultID->columnType($i);
-			$retVal[$i]->type       = isset($data_types[$type]) ? $data_types[$type] : $type;
+			$retVal[$i]->type       = $type;
+			$retVal[$i]->type_name  = isset($data_types[$type]) ? $data_types[$type] : null;
 			$retVal[$i]->max_length = null;
+			$retVal[$i]->length     = null;
 		}
 
 		return $retVal;


### PR DESCRIPTION
As per pull request
https://github.com/codeigniter4/CodeIgniter4/pull/3287
added field type name.
had to redo it as I had to re-fork the repo and that broke the previous pull request.

Will return NULL if mapped field type name not found

the DB version of the type returned by driver is stored in the type column

Where applicable length is stored or made equal to max_length as in for example MySQL the max_length is based on
the data returned and not the DB schema where length is closer to the truth but still not 100%
cant think of a alternative that wont be affect the performance of the procedure. Is a need if want to build schema
from this data in the future

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide