### PR TITLE
add test for CommandRunner::_remap() with empty first params

### DIFF
--- a/tests/system/CLI/CommandRunnerTest.php
+++ b/tests/system/CLI/CommandRunnerTest.php
@@ -125,4 +125,13 @@ class CommandRunnerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertStringContainsString('Command "bogus" not found', $result);
 	}
 
+	public function testRemapEmptyFirstParams()
+	{
+		$this->runner->_remap('anyvalue', null, 'list');
+		$result = CITestStreamFilter::$buffer;
+
+		// make sure the result looks like a command list
+		$this->assertStringContainsString('Lists the available commands.', $result);
+	}
+
 }


### PR DESCRIPTION
By this, `CLI`'s CommandRunner class will have 100% test coverage.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage