### PR TITLE
force_https didn’t force https

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -451,7 +451,7 @@ if (! function_exists('force_https'))
 		{
 			$baseURL = (string) substr($baseURL, strlen('https://'));
 		}
-		else if (strpos($baseURL, 'http://') === 0)
+		elseif (strpos($baseURL, 'http://') === 0)
 		{
 			$baseURL = (string) substr($baseURL, strlen('http://'));
 		}

--- a/system/Common.php
+++ b/system/Common.php
@@ -447,13 +447,11 @@ if (! function_exists('force_https'))
 
 		$baseURL = config(App::class)->baseURL;
 
-		// If we already use 'https' then return immediately
 		if (strpos($baseURL, 'https://') === 0)
 		{
-			return;
+			$baseURL = (string) substr($baseURL, strlen('https://'));
 		}
-
-		if (strpos($baseURL, 'http://') === 0)
+		else if (strpos($baseURL, 'http://') === 0)
 		{
 			$baseURL = (string) substr($baseURL, strlen('http://'));
 		}


### PR DESCRIPTION
when https:// is present in a defined base URL and a user accesses the site on on an insecure protocol, it would not force them onto secure.

**Description**
just because the baseURL defines the protocol as https the user isn't necessarily forced onto https. This forces the user onto https.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

  
