### PR TITLE
New command: cache:clear

### DIFF
--- a/system/Commands/Cache/ClearCache.php
+++ b/system/Commands/Cache/ClearCache.php
@@ -1,5 +1,6 @@
 <?php namespace CodeIgniter\Commands\Cache;
 
+use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 
@@ -49,6 +50,24 @@ class ClearCache extends BaseCommand
 	 */
 	public function run(array $params = [])
 	{
-		dd($params);
+		$config = config('Cache');
+
+		$handler = $params[0] ?? $config->handler;
+		if (! array_key_exists($handler, $config->validHandlers))
+		{
+			CLI::error($handler . ' is not a valid cache handler.');
+			return;
+		}
+
+		$config->handler = $handler;
+		$cache           = CacheFactory::getHandler($config);
+
+		if (! $cache->clean())
+		{
+			CLI::error('Error while clearing the cache.');
+			return;
+		}
+
+		CLI::write(CLI::color('Done', 'green'));
 	}
 }

--- a/system/Commands/Cache/ClearCache.php
+++ b/system/Commands/Cache/ClearCache.php
@@ -1,0 +1,54 @@
+<?php namespace CodeIgniter\Commands\Cache;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+
+class ClearCache extends BaseCommand
+{
+	/**
+	 * Command grouping.
+	 *
+	 * @var string
+	 */
+	protected $group = 'Cache';
+
+	/**
+	 * The Command's name
+	 *
+	 * @var string
+	 */
+	protected $name = 'cache:clear';
+
+	/**
+	 * the Command's short description
+	 *
+	 * @var string
+	 */
+	protected $description = 'Clears the current system caches.';
+
+	/**
+	 * the Command's usage
+	 *
+	 * @var string
+	 */
+	protected $usage = 'cache:clear [driver]';
+
+	/**
+	 * the Command's Arguments
+	 *
+	 * @var array
+	 */
+	protected $arguments = [
+		'driver' => 'The cache driver to use',
+	];
+
+	/**
+	 * Creates a new migration file with the current timestamp.
+	 *
+	 * @param array $params
+	 */
+	public function run(array $params = [])
+	{
+		dd($params);
+	}
+}

--- a/tests/system/Commands/ClearCacheTest.php
+++ b/tests/system/Commands/ClearCacheTest.php
@@ -1,0 +1,69 @@
+<?php namespace CodeIgniter\Commands;
+
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\CLI\CommandRunner;
+use CodeIgniter\Config\Config;
+use CodeIgniter\HTTP\UserAgent;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\Mock\MockAppConfig;
+use Config\Services;
+
+class ClearCacheTest extends CIUnitTestCase
+{
+	protected $streamFilter;
+	protected $result;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		CITestStreamFilter::$buffer = '';
+		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
+
+		$this->env = new \CodeIgniter\Config\DotEnv(ROOTPATH);
+		$this->env->load();
+
+		// Set environment values that would otherwise stop the framework from functioning during tests.
+		if (! isset($_SERVER['app.baseURL']))
+		{
+			$_SERVER['app.baseURL'] = 'http://example.com';
+		}
+
+		$_SERVER['argv'] = [
+			'spark',
+			'list',
+		];
+		$_SERVER['argc'] = 2;
+		CLI::init();
+
+		$this->config   = new MockAppConfig();
+		$this->request  = new \CodeIgniter\HTTP\IncomingRequest($this->config, new \CodeIgniter\HTTP\URI('https://somwhere.com'), null, new UserAgent());
+		$this->response = new \CodeIgniter\HTTP\Response($this->config);
+		$this->logger   = Services::logger();
+		$this->runner   = new CommandRunner();
+		$this->runner->initController($this->request, $this->response, $this->logger);
+	}
+
+	public function tearDown(): void
+	{
+		if (! $this->result)
+		{
+			return;
+		}
+
+		stream_filter_remove($this->streamFilter);
+	}
+
+	public function testClearCacheInvalidHandler()
+	{
+		$config          = config('Cache');
+		$config->handler = 'junk';
+		Config::injectMock('Cache', $config);
+
+		$this->runner->index(['cache:clear']);
+		$result = CITestStreamFilter::$buffer;
+
+		$this->assertStringContainsString('junk is not a valid cache handler.', $result);
+	}
+}

--- a/tests/system/Commands/ClearCacheTest.php
+++ b/tests/system/Commands/ClearCacheTest.php
@@ -20,29 +20,7 @@ class ClearCacheTest extends CIUnitTestCase
 
 		CITestStreamFilter::$buffer = '';
 		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
-
-		$this->env = new \CodeIgniter\Config\DotEnv(ROOTPATH);
-		$this->env->load();
-
-		// Set environment values that would otherwise stop the framework from functioning during tests.
-		if (! isset($_SERVER['app.baseURL']))
-		{
-			$_SERVER['app.baseURL'] = 'http://example.com';
-		}
-
-		$_SERVER['argv'] = [
-			'spark',
-			'list',
-		];
-		$_SERVER['argc'] = 2;
-		CLI::init();
-
-		$this->config   = new MockAppConfig();
-		$this->request  = new \CodeIgniter\HTTP\IncomingRequest($this->config, new \CodeIgniter\HTTP\URI('https://somwhere.com'), null, new UserAgent());
-		$this->response = new \CodeIgniter\HTTP\Response($this->config);
-		$this->logger   = Services::logger();
-		$this->runner   = new CommandRunner();
-		$this->runner->initController($this->request, $this->response, $this->logger);
+		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
 	}
 
 	public function tearDown(): void
@@ -57,13 +35,23 @@ class ClearCacheTest extends CIUnitTestCase
 
 	public function testClearCacheInvalidHandler()
 	{
-		$config          = config('Cache');
-		$config->handler = 'junk';
-		Config::injectMock('Cache', $config);
-
-		$this->runner->index(['cache:clear']);
+		command('cache:clear junk');
 		$result = CITestStreamFilter::$buffer;
 
 		$this->assertStringContainsString('junk is not a valid cache handler.', $result);
+	}
+
+	public function testClearCacheWorks()
+	{
+		cache()->save('foo', 'bar');
+
+		$this->assertEquals('bar', cache('foo'));
+
+		command('cache:clear');
+		$result = CITestStreamFilter::$buffer;
+
+		$this->assertNull(cache('foo'));
+
+		$this->assertStringContainsString('Done', $result);
 	}
 }


### PR DESCRIPTION
Implements a new command `cache:clear` that will destroy all content on the current cache from the CLI.