### PR TITLE
Make Redirect trailing slashes redirect with base

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -18,7 +18,8 @@ Options All -Indexes
 
 	# Redirect Trailing Slashes...
 	RewriteCond %{REQUEST_FILENAME} !-d
-	RewriteRule ^(.*)/$ $1 [L,R=301]
+	RewriteCond %{REQUEST_URI} (.+)/$
+      RewriteRule ^ %1 [L,R=301]
 
 	# Rewrite "www.example.com -> example.com"
 	RewriteCond %{HTTPS} !=on

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -18,7 +18,7 @@ Options All -Indexes
 
 	# Redirect Trailing Slashes...
 	RewriteCond %{REQUEST_FILENAME} !-d
-	RewriteRule ^(.*)/$ /$1 [L,R=301]
+	RewriteRule ^(.*)/$ $1 [L,R=301]
 
 	# Rewrite "www.example.com -> example.com"
 	RewriteCond %{HTTPS} !=on


### PR DESCRIPTION
**Description**
When using /$1 it doesn't prepend RewriteBase to the uri, so going to /sub/controller/ will redirect to /controller instead of /sub/controller