### PR TITLE
[ci skip] documentation : response->download() require getBody() to be called after send() to force download

### DIFF
--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -92,17 +92,17 @@ Example::
 
 	$data = 'Here is some text!';
 	$name = 'mytext.txt';
-	return $response->download($name, $data);
+	return $response->download($name, $data)->getBody();
 
 If you want to download an existing file from your server you'll need to
 pass ``null`` explicitly for the second parameter::
 
 	// Contents of photo.jpg will be automatically read
-	return $response->download('/path/to/photo.jpg', null);
+	return $response->download('/path/to/photo.jpg', null)->getBody();
 
 Use the optional ``setFileName()`` method to change the filename as it is sent to the client's browser::
 
-	return $response->download('awkwardEncryptedFileName.fakeExt', null)->setFileName('expenses.csv');
+	return $response->download('awkwardEncryptedFileName.fakeExt', null)->setFileName('expenses.csv')->getBody();
 
 .. note:: The response object MUST be returned for the download to be sent to the client. This allows the response
     to be passed through all **after** filters before being sent to the client.


### PR DESCRIPTION
Tried in controller, without `getBody()` call after send, it will only shows the file content, not force download.

**Checklist:**
- [x] Securely signed commits
- [x] User guide updated

**Without `getBody()` call after `send()`:**

![Screen Shot 2020-07-15 at 5 29 11 PM](https://user-images.githubusercontent.com/459648/87534818-bc190c00-c6c0-11ea-994c-09d665eb2c21.png)


**With `getBody()` call after `send()`:**

![Screen Shot 2020-07-15 at 5 26 36 PM](https://user-images.githubusercontent.com/459648/87534534-5af13880-c6c0-11ea-983b-c7677d8a0f0f.png)
