### PR TITLE
Pass filter arguments to after() and before() methods

### DIFF
--- a/system/Filters/CSRF.php
+++ b/system/Filters/CSRF.php
@@ -57,6 +57,7 @@ use Config\Services;
  */
 class CSRF implements FilterInterface
 {
+
 	/**
 	 * Do whatever processing this filter needs to do.
 	 * By default it should not return anything during
@@ -68,11 +69,12 @@ class CSRF implements FilterInterface
 	 * redirects, etc.
 	 *
 	 * @param RequestInterface|\CodeIgniter\HTTP\IncomingRequest $request
+	 * @param array|null                                         $arguments
 	 *
 	 * @return mixed
 	 * @throws \CodeIgniter\Security\Exceptions\SecurityException
 	 */
-	public function before(RequestInterface $request)
+	public function before(RequestInterface $request, $arguments = null)
 	{
 		if ($request->isCLI())
 		{
@@ -103,10 +105,11 @@ class CSRF implements FilterInterface
 	 *
 	 * @param RequestInterface|\CodeIgniter\HTTP\IncomingRequest $request
 	 * @param ResponseInterface|\CodeIgniter\HTTP\Response       $response
+	 * @param array|null                                         $arguments
 	 *
 	 * @return mixed
 	 */
-	public function after(RequestInterface $request, ResponseInterface $response)
+	public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
 	{
 	}
 

--- a/system/Filters/CSRF.php
+++ b/system/Filters/CSRF.php
@@ -72,7 +72,7 @@ class CSRF implements FilterInterface
 	 * @param array|null                                         $arguments
 	 *
 	 * @return mixed
-	 * @throws \Exception
+	 * @throws \CodeIgniter\Security\Exceptions\SecurityException
 	 */
 	public function before(RequestInterface $request, $arguments = null)
 	{

--- a/system/Filters/DebugToolbar.php
+++ b/system/Filters/DebugToolbar.php
@@ -48,14 +48,16 @@ use Config\Services;
  */
 class DebugToolbar implements FilterInterface
 {
+
 	/**
 	 * We don't need to do anything here.
 	 *
 	 * @param RequestInterface|\CodeIgniter\HTTP\IncomingRequest $request
+	 * @param array|null                                         $arguments
 	 *
 	 * @return void
 	 */
-	public function before(RequestInterface $request)
+	public function before(RequestInterface $request, $arguments = null)
 	{
 	}
 
@@ -67,10 +69,11 @@ class DebugToolbar implements FilterInterface
 	 *
 	 * @param RequestInterface|\CodeIgniter\HTTP\IncomingRequest $request
 	 * @param ResponseInterface|\CodeIgniter\HTTP\Response       $response
+	 * @param array|null                                         $arguments
 	 *
 	 * @return void
 	 */
-	public function after(RequestInterface $request, ResponseInterface $response)
+	public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
 	{
 		Services::toolbar()->prepare($request, $response);
 	}

--- a/system/Filters/FilterInterface.php
+++ b/system/Filters/FilterInterface.php
@@ -59,10 +59,11 @@ interface FilterInterface
 	 * redirects, etc.
 	 *
 	 * @param \CodeIgniter\HTTP\RequestInterface $request
+	 * @param null                               $arguments
 	 *
 	 * @return mixed
 	 */
-	public function before(RequestInterface $request);
+	public function before(RequestInterface $request, $arguments = null);
 
 	//--------------------------------------------------------------------
 
@@ -74,10 +75,11 @@ interface FilterInterface
 	 *
 	 * @param \CodeIgniter\HTTP\RequestInterface  $request
 	 * @param \CodeIgniter\HTTP\ResponseInterface $response
+	 * @param null                                $arguments
 	 *
 	 * @return mixed
 	 */
-	public function after(RequestInterface $request, ResponseInterface $response);
+	public function after(RequestInterface $request, ResponseInterface $response, $arguments = null);
 
 	//--------------------------------------------------------------------
 }

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -196,7 +196,7 @@ class Filters
 				}
 				elseif ($position === 'after')
 				{
-					$result = $class->after($this->request, $this->response);
+					$result = $class->after($this->request, $this->response, $this->arguments[$alias] ?? null);
 
 					if ($result instanceof ResponseInterface)
 					{

--- a/system/Filters/Honeypot.php
+++ b/system/Filters/Honeypot.php
@@ -55,11 +55,11 @@ class Honeypot implements FilterInterface
 	 * then the requester is a bot
 	 *
 	 * @param \CodeIgniter\HTTP\RequestInterface $request
+	 * @param array|null                         $arguments
 	 *
 	 * @return void
-	 * @throws \CodeIgniter\Honeypot\Exceptions\HoneypotException
 	 */
-	public function before(RequestInterface $request)
+	public function before(RequestInterface $request, $arguments = null)
 	{
 		$honeypot = Services::honeypot(new \Config\Honeypot());
 		if ($honeypot->hasContent($request))
@@ -73,10 +73,11 @@ class Honeypot implements FilterInterface
 	 *
 	 * @param \CodeIgniter\HTTP\RequestInterface  $request
 	 * @param \CodeIgniter\HTTP\ResponseInterface $response
+	 * @param array|null                          $arguments
 	 *
 	 * @return void
 	 */
-	public function after(RequestInterface $request, ResponseInterface $response)
+	public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
 	{
 		$honeypot = Services::honeypot(new \Config\Honeypot());
 		$honeypot->attachHoneypot($response);

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -12,6 +12,7 @@ require_once __DIR__ . '/fixtures/GoogleCurious.php';
 require_once __DIR__ . '/fixtures/InvalidClass.php';
 require_once __DIR__ . '/fixtures/Multiple1.php';
 require_once __DIR__ . '/fixtures/Multiple2.php';
+require_once __DIR__ . '/fixtures/Role.php';
 
 /**
  * @backupGlobals enabled
@@ -25,6 +26,7 @@ class FiltersTest extends \CodeIgniter\Test\CIUnitTestCase
 	protected function setUp(): void
 	{
 		parent::setUp();
+		Services::reset();
 
 		$this->request  = Services::request();
 		$this->response = Services::response();
@@ -623,17 +625,54 @@ class FiltersTest extends \CodeIgniter\Test\CIUnitTestCase
 			],
 		];
 
-		$filters = new Filters((object) $config, $this->request, $this->response);
+		$filters = new Filters((object)$config, $this->request, $this->response);
 
 		$filters = $filters->initialize('admin/foo/bar');
 
 		$filters->enableFilter('role:admin , super', 'before');
+		$filters->enableFilter('role:admin , super', 'after');
 
 		$found = $filters->getFilters();
 
 		$this->assertTrue(in_array('role', $found['before']));
 		$this->assertEquals(['admin', 'super'], $filters->getArguments('role'));
 		$this->assertEquals(['role' => ['admin', 'super']], $filters->getArguments());
+
+		$response = $filters->run('admin/foo/bar', 'before');
+		$this->assertEquals('admin;super', $response);
+
+		$response = $filters->run('admin/foo/bar', 'after');
+		$this->assertEquals('admin;super', $response->getBody());
+	}
+
+	public function testEnableFilterWithNoArguments()
+	{
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		$config = [
+			'aliases' => ['role' => 'CodeIgniter\Filters\fixtures\Role'],
+			'globals' => [
+				'before' => [],
+				'after'  => [],
+			],
+		];
+
+		$filters = new Filters((object)$config, $this->request, $this->response);
+
+		$filters = $filters->initialize('admin/foo/bar');
+
+		$filters->enableFilter('role', 'before');
+		$filters->enableFilter('role', 'after');
+
+		$found = $filters->getFilters();
+
+		$this->assertTrue(in_array('role', $found['before']));
+
+		$response = $filters->run('admin/foo/bar', 'before');
+		$this->assertEquals('Is null', $response);
+
+		$response = $filters->run('admin/foo/bar', 'after');
+		$this->assertEquals('Is null', $response->getBody());
 	}
 
 	public function testEnableNonFilter()

--- a/tests/system/Filters/fixtures/GoogleCurious.php
+++ b/tests/system/Filters/fixtures/GoogleCurious.php
@@ -7,12 +7,12 @@ use CodeIgniter\HTTP\ResponseInterface;
 class GoogleCurious implements FilterInterface
 {
 
-	public function before(RequestInterface $request)
+	public function before(RequestInterface $request, $arguments = null)
 	{
 				return 'This is curious';
 	}
 
-	public function after(RequestInterface $request, ResponseInterface $response)
+	public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
 	{
 	}
 

--- a/tests/system/Filters/fixtures/GoogleEmpty.php
+++ b/tests/system/Filters/fixtures/GoogleEmpty.php
@@ -7,13 +7,13 @@ use CodeIgniter\HTTP\ResponseInterface;
 class GoogleEmpty implements FilterInterface
 {
 
-	public function before(RequestInterface $request)
+	public function before(RequestInterface $request, $arguments = null)
 	{
 		$request = '';
 		return $request;
 	}
 
-	public function after(RequestInterface $request, ResponseInterface $response)
+	public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
 	{
 	}
 

--- a/tests/system/Filters/fixtures/GoogleMe.php
+++ b/tests/system/Filters/fixtures/GoogleMe.php
@@ -6,7 +6,7 @@ use CodeIgniter\HTTP\ResponseInterface;
 
 class GoogleMe implements FilterInterface
 {
-	public function before(RequestInterface $request)
+	public function before(RequestInterface $request, $arguments = null)
 	{
 		$request->url = 'http://google.com';
 
@@ -15,7 +15,7 @@ class GoogleMe implements FilterInterface
 
 	//--------------------------------------------------------------------
 
-	public function after(RequestInterface $request, ResponseInterface $response)
+	public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
 	{
 		$response->csp = 'http://google.com';
 

--- a/tests/system/Filters/fixtures/GoogleYou.php
+++ b/tests/system/Filters/fixtures/GoogleYou.php
@@ -8,14 +8,14 @@ use CodeIgniter\HTTP\ResponseInterface;
 class GoogleYou implements FilterInterface
 {
 
-	public function before(RequestInterface $request)
+	public function before(RequestInterface $request, $arguments = null)
 	{
 		$response      = Services::response();
 		$response->csp = 'http://google.com';
 		return $response;
 	}
 
-	public function after(RequestInterface $request, ResponseInterface $response)
+	public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
 	{
 	}
 

--- a/tests/system/Filters/fixtures/Multiple1.php
+++ b/tests/system/Filters/fixtures/Multiple1.php
@@ -7,13 +7,13 @@ use CodeIgniter\HTTP\ResponseInterface;
 class Multiple1 implements FilterInterface
 {
 
-	public function before(RequestInterface $request)
+	public function before(RequestInterface $request, $arguments = null)
 	{
 		$request->csp = 'http://exampleMultipleCSP.com';
 		return $request;
 	}
 
-	public function after(RequestInterface $request, ResponseInterface $response)
+	public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
 	{
 	}
 

--- a/tests/system/Filters/fixtures/Multiple2.php
+++ b/tests/system/Filters/fixtures/Multiple2.php
@@ -7,13 +7,13 @@ use CodeIgniter\HTTP\ResponseInterface;
 class Multiple2 implements FilterInterface
 {
 
-	public function before(RequestInterface $request)
+	public function before(RequestInterface $request, $arguments = null)
 	{
 		$request->url = 'http://exampleMultipleURL.com';
 		return $request;
 	}
 
-	public function after(RequestInterface $request, ResponseInterface $response)
+	public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
 	{
 	}
 

--- a/tests/system/Filters/fixtures/Role.php
+++ b/tests/system/Filters/fixtures/Role.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace CodeIgniter\Filters\fixtures;
+
+use CodeIgniter\Filters\FilterInterface;
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
+
+class Role implements FilterInterface
+{
+
+	public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
+	{
+		if (is_array($arguments))
+		{
+			$response->setBody(join(';', $arguments));
+		}
+		elseif (is_null($arguments))
+		{
+			$response->setBody('Is null');
+		}
+		else
+		{
+			$response->setBody('Something else');
+		}
+		return $response;
+	}
+
+	public function before(RequestInterface $request, $arguments = null)
+	{
+		if (is_array($arguments))
+		{
+			return join(';', $arguments);
+		}
+		elseif (is_null($arguments))
+		{
+			return 'Is null';
+		}
+		else
+		{
+			return 'Something else';
+		}
+	}
+
+}

--- a/user_guide_src/source/changelogs/v4.0.4.rst
+++ b/user_guide_src/source/changelogs/v4.0.4.rst
@@ -52,7 +52,7 @@ Bugs Fixed:
 - Fixed bug in Image GD handler that would try to compress images twice in certain cases
 - Ensure get translation output logic work on selected locale, dashed locale, and fallback "en"
 - Fix is_unique/is_not_unique validation called on POST/PUT via API in Postgresql
-- Added ``$arguments`` parameter to after() and before() in FilterInterface
+- Added ``$arguments`` parameter to after() and before() in FilterInterface. This is a breaking change, so all code implementing the FilterInterface must be updated
 - Fixed a bug where filter arguments were not passed to after()
 
 

--- a/user_guide_src/source/changelogs/v4.0.4.rst
+++ b/user_guide_src/source/changelogs/v4.0.4.rst
@@ -52,6 +52,8 @@ Bugs Fixed:
 - Fixed bug in Image GD handler that would try to compress images twice in certain cases
 - Ensure get translation output logic work on selected locale, dashed locale, and fallback "en"
 - Fix is_unique/is_not_unique validation called on POST/PUT via API in Postgresql
+- Added ``$arguments`` parameter to after() and before() in FilterInterface
+- Fixed a bug where filter arguments were not passed to after()
 
 
 

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -35,14 +35,14 @@ but may leave the methods empty if they are not needed. A skeleton filter class 
 
     class MyFilter implements FilterInterface
     {
-        public function before(RequestInterface $request)
+        public function before(RequestInterface $request, $arguments = null)
         {
             // Do something here
         }
 
         //--------------------------------------------------------------------
 
-        public function after(RequestInterface $request, ResponseInterface $response)
+        public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
         {
             // Do something here
         }
@@ -58,7 +58,7 @@ Since before filters are executed prior to your controller being executed, you m
 actions in the controller from happening. You can do this by passing back anything that is not the request object.
 This is typically used to perform redirects, like in this example::
 
-    public function before(RequestInterface $request)
+    public function before(RequestInterface $request, $arguments = null)
     {
         $auth = service('auth');
 
@@ -178,6 +178,15 @@ a list of URI patterns that filter should apply to::
         'foo' => ['before' => ['admin/*'], 'after' => ['users/*']],
         'bar' => ['before' => ['api/*', 'admin/*']]
     ];
+
+Filter arguments
+=================
+
+When configuring filters, additional arguments may be passed to a filter when setting up the route::
+
+    $routes->add('users/delete/(:segment)', 'AdminController::index', ['filter' => 'admin-auth:dual,noreturn']);
+
+In this example, the array ``['dual', 'noreturn']`` will be passed in ``$arguments`` to the filter's ``before()`` and ``after()`` implementation methods.
 
 ****************
 Provided Filters

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -336,7 +336,7 @@ You can alter the behavior of specific routes by supplying a filter to run befor
 
     $routes->add('admin',' AdminController::index', ['filter' => 'admin-auth']);
 
-The value for the filter must match one of the aliases defined within ``app/Config/Filters.php``. You may also supply parameters to be passed to the filter's ``before()`` and ``after()`` methods::
+The value for the filter must match one of the aliases defined within ``app/Config/Filters.php``. You may also supply arguments to be passed to the filter's ``before()`` and ``after()`` methods::
 
     $routes->add('users/delete/(:segment)', 'AdminController::index', ['filter' => 'admin-auth:dual,noreturn']);
 

--- a/user_guide_src/source/libraries/throttler.rst
+++ b/user_guide_src/source/libraries/throttler.rst
@@ -66,10 +66,11 @@ along the lines of::
              * to implement rate limiting for your application.
              *
              * @param RequestInterface|\CodeIgniter\HTTP\IncomingRequest $request
+             * @param array|null                                         $arguments
              *
              * @return mixed
              */
-            public function before(RequestInterface $request)
+            public function before(RequestInterface $request, $arguments = null)
             {
                     $throttler = Services::throttler();
 
@@ -89,10 +90,11 @@ along the lines of::
              *
              * @param RequestInterface|\CodeIgniter\HTTP\IncomingRequest $request
              * @param ResponseInterface|\CodeIgniter\HTTP\Response       $response
+             * @param array|null                                         $arguments
              *
              * @return mixed
              */
-            public function after(RequestInterface $request, ResponseInterface $response)
+            public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
             {
             }
     }


### PR DESCRIPTION
**Description**
Fixing #3216 by changing the FilterInterface::after() and before() to contain the arguments from the routing setup.
Updating core classes implementing FilterInterface, tests and docs.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
