### PR TITLE
Image width debug-bar has conflict

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -148,7 +148,9 @@
       clear: left;
       display: inline-block;
       float: left;
-      margin: 6px 3px 6px 0; }
+      margin: 6px 3px 6px 0; 
+      width: 16px !important;
+    }
     #debug-bar .ci-label .badge {
       border-radius: 12px;
       -moz-border-radius: 12px;


### PR DESCRIPTION
Image width debug-bar has conflict with third party css template

Each pull request should address a single issue and have a meaningful title.

**Description**
Image in debug-bar conflict with css img width 100%.
So it must defined self with !important attribute

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

---------Remove from here down in your description----------

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository
  
