### PR TITLE
Bug: CURLRequest lib doesn't set correct headers with digest auth

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -459,7 +459,7 @@ class CURLRequest extends Request
 		 // If request and response have Digest
 		if (isset($this->config['auth'][2]) && $this->config['auth'][2] === 'digest' && strpos($output, 'WWW-Authenticate: Digest') !== false)
 		{
-				$output = substr($output, strpos($output, $breakString) + 5);
+				$output = substr($output, strpos($output, $breakString) + 4);
 		}
 
 

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -471,7 +471,8 @@ class CURLRequest extends Request
 		{	
 			$break = strpos($output, $break_string, $first_carriage_return + strlen($break_string));
 
-		} else 
+		} 
+		else 
 		{
 			$break = strpos($output, "\r\n\r\n");
 

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -447,37 +447,24 @@ class CURLRequest extends Request
 		}
 
 		$output = $this->sendRequest($curl_options);
+		
+		// Set the string we want to break our response from
+		$breakString = "\r\n\r\n";
 
 		if (strpos($output, 'HTTP/1.1 100 Continue') === 0)
 		{
 			$output = substr($output, strpos($output, "\r\n\r\n") + 4);
 		}
 		
-		// Set the string we want to break our response from
-		$break_string = "\r\n\r\n";
-		$second_carriage_return = false;
-		
-		// If auth is digest and we have headers in the curl response
-		if(isset($this->config['auth'][2]) && $this->config['auth'][2] === 'digest' && $curl_options[CURLOPT_HEADER] === true)
+		// If request and response have Digest
+		if (isset($this->config['auth'][2]) && $this->config['auth'][2] === 'digest' && strpos($output, 'WWW-Authenticate: Digest') !== false)
 		{
-				// check if we have one or two carriage return
-				// we can have two because of digest auth double call
-				$first_carriage_return = strpos($output, $break_string);
-				$second_carriage_return = strpos($output, $break_string, $first_carriage_return + strlen($break_string));
-		} 
-
-		// Split out our headers and body at the right carriage return
-		if($second_carriage_return !== false)
-		{	
-			$break = strpos($output, $break_string, $first_carriage_return + strlen($break_string));
-
-		} 
-		else 
-		{
-			$break = strpos($output, "\r\n\r\n");
-
+				$output = substr($output, strpos($output, $breakString) + 4);
 		}
 
+		// Split out our headers and body
+		$break = strpos($output, $breakString);
+		
 		if ($break !== false)
 		{
 			// Our headers

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -453,25 +453,27 @@ class CURLRequest extends Request
 
 		if (strpos($output, 'HTTP/1.1 100 Continue') === 0)
 		{
-			$output = substr($output, strpos($output, "\r\n\r\n") + 4);
+			$output = substr($output, strpos($output, $breakString) + 4);
 		}
 		
-		// If request and response have Digest
+		 // If request and response have Digest
 		if (isset($this->config['auth'][2]) && $this->config['auth'][2] === 'digest' && strpos($output, 'WWW-Authenticate: Digest') !== false)
 		{
-				$output = substr($output, strpos($output, $breakString) + 4);
+				$output = substr($output, strpos($output, $breakString) + 5);
 		}
+
 
 		// Split out our headers and body
 		$break = strpos($output, $breakString);
+
 		
 		if ($break !== false)
 		{
 			// Our headers
 			$headers = explode("\n", substr($output, 0, $break));
-
+			
 			$this->setResponseHeaders($headers);
-
+			
 			// Our body
 			$body = substr($output, $break + 4);
 			$this->response->setBody($body);

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -452,9 +452,30 @@ class CURLRequest extends Request
 		{
 			$output = substr($output, strpos($output, "\r\n\r\n") + 4);
 		}
+		
+		// Set the string we want to break our response from
+		$break_string = "\r\n\r\n";
+		$second_carriage_return = false;
+		
+		// If auth is digest and we have headers in the curl response
+		if(isset($this->config['auth'][2]) && $this->config['auth'][2] === 'digest' && $curl_options[CURLOPT_HEADER] === true)
+		{
+				// check if we have one or two carriage return
+				// we can have two because of digest auth double call
+				$first_carriage_return = strpos($output, $break_string);
+				$second_carriage_return = strpos($output, $break_string, $first_carriage_return + strlen($break_string));
+		} 
 
-		// Split out our headers and body
-		$break = strpos($output, "\r\n\r\n");
+		// Split out our headers and body at the right carriage return
+		if($second_carriage_return !== false)
+		{	
+			$break = strpos($output, $break_string, $first_carriage_return + strlen($break_string));
+
+		} else 
+		{
+			$break = strpos($output, "\r\n\r\n");
+
+		}
 
 		if ($break !== false)
 		{

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -67,7 +67,7 @@ class CURLRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 		$output = 'Howdy Stranger.';
 
 		$response = $this->request->setOutput($output)
-				->send('get', 'http://example.com');
+			->send('get', 'http://example.com');
 
 		$this->assertInstanceOf('CodeIgniter\\HTTP\\Response', $response);
 		$this->assertEquals($output, $response->getBody());
@@ -373,7 +373,26 @@ class CURLRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testAuthDigestOption()
 	{
-		$this->request->request('get', 'http://example.com', [
+		$output = "HTTP/1.1 401 Unauthorized
+		Server: ddos-guard
+		Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
+		WWW-Authenticate: Digest\x0d\x0a\x0d\x0aHTTP/1.1 200 OK
+		Server: ddos-guard
+		Connection: keep-alive
+		Keep-Alive: timeout=60
+		Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
+		Date: Tue, 07 Jul 2020 15:13:14 GMT
+		Expires: Thu, 19 Nov 1981 08:52:00 GMT
+		Cache-Control: no-store, no-cache, must-revalidate
+		Pragma: no-cache
+		Set-Cookie: PHPSESSID=80pd3hlg38mvjnelpvokp9lad0; path=/
+		Content-Type: application/xml; charset=utf-8
+		Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>";
+
+
+		$this->request->setOutput($output);
+
+		$response = $this->request->request('get', 'http://example.com', [
 			'auth' => [
 				'username',
 				'password',
@@ -382,6 +401,9 @@ class CURLRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 		]);
 
 		$options = $this->request->curl_options;
+
+		$this->assertEquals('<title>Update success! config</title>', $response->getBody());
+		$this->assertEquals(200, $response->getStatusCode());
 
 		$this->assertArrayHasKey(CURLOPT_USERPWD, $options);
 		$this->assertEquals('username:password', $options[CURLOPT_USERPWD]);
@@ -407,9 +429,31 @@ class CURLRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testSetAuthDigest()
 	{
-		$this->request->setAuth('username', 'password', 'digest')->get('http://example.com');
+
+		$output = "HTTP/1.1 401 Unauthorized
+		Server: ddos-guard
+		Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
+		WWW-Authenticate: Digest\x0d\x0a\x0d\x0aHTTP/1.1 200 OK
+		Server: ddos-guard
+		Connection: keep-alive
+		Keep-Alive: timeout=60
+		Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
+		Date: Tue, 07 Jul 2020 15:13:14 GMT
+		Expires: Thu, 19 Nov 1981 08:52:00 GMT
+		Cache-Control: no-store, no-cache, must-revalidate
+		Pragma: no-cache
+		Set-Cookie: PHPSESSID=80pd3hlg38mvjnelpvokp9lad0; path=/
+		Content-Type: application/xml; charset=utf-8
+		Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>";
+
+		$this->request->setOutput($output);
+
+		$response = $this->request->setAuth('username', 'password', 'digest')->get('http://example.com');
 
 		$options = $this->request->curl_options;
+
+		$this->assertEquals('<title>Update success! config</title>', $response->getBody());
+		$this->assertEquals(200, $response->getStatusCode());
 
 		$this->assertArrayHasKey(CURLOPT_USERPWD, $options);
 		$this->assertEquals('username:password', $options[CURLOPT_USERPWD]);
@@ -924,5 +968,4 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
 		$this->assertArrayHasKey(CURLOPT_COOKIEFILE, $options);
 		$this->assertEquals($holder, $options[CURLOPT_COOKIEFILE]);
 	}
-
 }


### PR DESCRIPTION
**Description**
CURLRequest library makes a curl request and parse the result to set headers and body content to the correct objects. This parsing checks the first double carriage return and put the first part of the curl result as headers and the rest as body.
Problem is when using digest auth we get 2 headers in the curl response causing response headers being falsy and body containing a header.
This pull request handle this case by skipping the first headers generated by the first digest http call and start splitting for body and headers at the second double carriage return when having a successful digest auth.

Forum threads here : https://forum.codeigniter.com/thread-77046.html

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

  
