### PR TITLE
New command: 'debugbar:clear'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ writable/uploads/*
 !writable/uploads/index.html
 
 writable/debugbar/*
+!writable/debugbar/.gitkeep
 
 writable/**/*.db
 writable/**/*.sqlite

--- a/system/Commands/Housekeeping/ClearDebugbar.php
+++ b/system/Commands/Housekeeping/ClearDebugbar.php
@@ -37,7 +37,7 @@
  * @filesource
  */
 
-namespace CodeIgniter\Commands\HouseKeeping;
+namespace CodeIgniter\Commands\Housekeeping;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;

--- a/system/Commands/Housekeeping/ClearDebugbar.php
+++ b/system/Commands/Housekeeping/ClearDebugbar.php
@@ -87,16 +87,16 @@ class ClearDebugbar extends BaseCommand
 	{
 		helper('filesystem');
 
-		if (delete_files(WRITEPATH . 'debugbar'))
+		if (! delete_files(WRITEPATH . 'debugbar'))
 		{
-			CLI::write('Debugbar cleared.', 'green');
+			// @codeCoverageIgnoreStart
+			CLI::error('Error deleting the debugbar JSON files.');
 			CLI::newLine();
 			return;
+			// @codeCoverageIgnoreEnd
 		}
 
-		// @codeCoverageIgnoreStart
-		CLI::error('Error deleting the debugbar JSON files.');
+		CLI::write('Debugbar cleared.', 'green');
 		CLI::newLine();
-		// @codeCoverageIgnoreEnd
 	}
 }

--- a/system/Commands/Housekeeping/ClearDebugbar.php
+++ b/system/Commands/Housekeeping/ClearDebugbar.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace CodeIgniter\Commands\HouseKeeping;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+
+/**
+ * ClearDebugbar Command
+ */
+class ClearDebugbar extends BaseCommand
+{
+	/**
+	 * The group the command is lumped under
+	 * when listing commands.
+	 *
+	 * @var string
+	 */
+	protected $group = 'Housekeeping';
+
+	/**
+	 * The Command's name
+	 *
+	 * @var string
+	 */
+	protected $name = 'debugbar:clear';
+
+	/**
+	 * The Command's usage
+	 *
+	 * @var string
+	 */
+	protected $usage = 'debugbar:clear';
+
+	/**
+	 * The Command's short description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Clears all debugbar JSON files.';
+
+	/**
+	 * Actually runs the command.
+	 *
+	 * @param array $params
+	 *
+	 * @return void
+	 */
+	public function run(array $params = [])
+	{
+		helper('filesystem');
+
+		if (delete_files(WRITEPATH . 'debugbar'))
+		{
+			CLI::write('Debugbar cleared.', 'green');
+			CLI::newLine();
+			return;
+		}
+
+		// @codeCoverageIgnoreStart
+		CLI::error('Error deleting the debugbar JSON files.');
+		CLI::newLine();
+		// @codeCoverageIgnoreEnd
+	}
+}

--- a/tests/system/Commands/ClearDebugbarTest.php
+++ b/tests/system/Commands/ClearDebugbarTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+class ClearDebugbarTest extends CIUnitTestCase
+{
+	protected $streamFilter;
+	protected $time;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		CITestStreamFilter::$buffer = '';
+		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
+		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+		$this->time                 = time();
+	}
+
+	protected function tearDown(): void
+	{
+		stream_filter_remove($this->streamFilter);
+	}
+
+	protected function createDummyDebugbarJson()
+	{
+		$time = $this->time;
+		$path = WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . "debugbar_{$time}.json";
+
+		// create 10 dummy debugbar json files
+		for ($i = 0; $i < 10; $i++)
+		{
+			$path = str_replace($time, $time - $i, $path);
+			file_put_contents($path, "{}\n");
+
+			$time -= $i;
+		}
+	}
+
+	public function testClearDebugbarWorks()
+	{
+		// test clean debugbar dir
+		$this->assertFileNotExists(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . "debugbar_{$this->time}.json");
+
+		// test dir is now populated with json
+		$this->createDummyDebugbarJson();
+		$this->assertFileExists(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . "debugbar_{$this->time}.json");
+
+		command('debugbar:clear');
+		$result = CITestStreamFilter::$buffer;
+
+		$this->assertFileNotExists(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . "debugbar_{$this->time}.json");
+		$this->assertFileExists(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . '.gitkeep');
+		$this->assertStringContainsString('Debugbar cleared.', $result);
+	}
+}


### PR DESCRIPTION
**Description**
Adds the `debugbar:clear` command to help devs wanting to keep their `debugbar` directory tidy.
https://forum.codeigniter.com/thread-75733.html

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
