### PR TITLE
Fix PHPDoc for Autoloader

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -210,7 +210,7 @@ class Autoloader
 	 *
 	 * If a prefix param is set, returns only paths to the given prefix.
 	 *
-	 * @var string|null $prefix
+	 * @param string|null $prefix
 	 *
 	 * @return array
 	 */


### PR DESCRIPTION
**Description**
Fix PHPDoc compilation error of Autoloader.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Conforms to style guide
