### PR TITLE
Reverse if condition in CLI::fwrite

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -1148,18 +1148,20 @@ class CLI
 	 *
 	 * @param resource $handle
 	 * @param string   $string
+	 *
+	 * @return void
 	 */
 	protected static function fwrite($handle, string $string)
 	{
-		if (is_cli())
+		if (! is_cli())
 		{
-			fwrite($handle, $string);
+			// @codeCoverageIgnoreStart
+			echo $string;
 			return;
+			// @codeCoverageIgnoreEnd
 		}
 
-		// @codeCoverageIgnoreStart
-		echo $string;
-		// @codeCoverageIgnoreEnd
+		fwrite($handle, $string);
 	}
 }
 


### PR DESCRIPTION
**Description**
Use the negated if condition for `CLI::fwrite` to achieve 100% test coverage for the class.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide
