### PR TITLE
Model beforeFind

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -386,13 +386,15 @@ class Model
 	 */
 	public function find($id = null)
 	{
-		// Call the before event and check for a return
-		$eventData = $this->trigger('beforeFind', ['id' => $id, 'method' => 'find']);
-		if (! empty($eventData['returnData']))
+		if ($this->tempAllowCallbacks)
 		{
-			return $eventData['data'];
+			// Call the before event and check for a return
+			$eventData = $this->trigger('beforeFind', ['id' => $id, 'method' => 'find']);
+			if (! empty($eventData['returnData']))
+			{
+				return $eventData['data'];
+			}
 		}
-
 		$builder = $this->builder();
 
 		if ($this->tempUseSoftDeletes === true)
@@ -420,10 +422,18 @@ class Model
 			$row = $row->getResult($this->tempReturnType);
 		}
 
-		$eventData = $this->trigger('afterFind', ['id' => $id, 'data' => $row]);
+		$eventData = [
+			'id'   => $id,
+			'data' => $row,
+		];
+		if ($this->tempAllowCallbacks)
+		{
+			$eventData = $this->trigger('afterFind', $eventData);
+		}
 
 		$this->tempReturnType     = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
+		$this->tempAllowCallbacks = $this->allowCallbacks;
 
 		return $eventData['data'];
 	}
@@ -465,11 +475,14 @@ class Model
 	 */
 	public function findAll(int $limit = 0, int $offset = 0)
 	{
-		// Call the before event and check for a return
-		$eventData = $this->trigger('beforeFind', ['method' => 'findAll', 'limit' => $limit, 'offset' => $offset]);
-		if (! empty($eventData['returnData']))
+		if ($this->tempAllowCallbacks)
 		{
-			return $eventData['data'];
+			// Call the before event and check for a return
+			$eventData = $this->trigger('beforeFind', ['method' => 'findAll', 'limit' => $limit, 'offset' => $offset]);
+			if (! empty($eventData['returnData']))
+			{
+				return $eventData['data'];
+			}
 		}
 
 		$builder = $this->builder();
@@ -484,10 +497,19 @@ class Model
 
 		$row = $row->getResult($this->tempReturnType);
 
-		$eventData = $this->trigger('afterFind', ['data' => $row, 'limit' => $limit, 'offset' => $offset]);
+		$eventData = [
+			'data'   => $row,
+			'limit'  => $limit,
+			'offset' => $offset,
+		];
+		if ($this->tempAllowCallbacks)
+		{
+			$eventData = $this->trigger('afterFind', $eventData);
+		}
 
 		$this->tempReturnType     = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
+		$this->tempAllowCallbacks = $this->allowCallbacks;
 
 		return $eventData['data'];
 	}
@@ -502,11 +524,14 @@ class Model
 	 */
 	public function first()
 	{
-		// Call the before event and check for a return
-		$eventData = $this->trigger('beforeFind', ['method' => 'first']);
-		if (! empty($eventData['returnData']))
+		if ($this->tempAllowCallbacks)
 		{
-			return $eventData['data'];
+			// Call the before event and check for a return
+			$eventData = $this->trigger('beforeFind', ['method' => 'first']);
+			if (! empty($eventData['returnData']))
+			{
+				return $eventData['data'];
+			}
 		}
 
 		$builder = $this->builder();
@@ -535,10 +560,15 @@ class Model
 
 		$row = $row->getFirstRow($this->tempReturnType);
 
-		$eventData = $this->trigger('afterFind', ['data' => $row]);
+		$eventData = ['data' => $row];
+		if ($this->tempAllowCallbacks)
+		{
+			$eventData = $this->trigger('afterFind', $eventData);
+		}
 
 		$this->tempReturnType     = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
+		$this->tempAllowCallbacks = $this->allowCallbacks;
 
 		return $eventData['data'];
 	}
@@ -775,7 +805,11 @@ class Model
 			$data[$this->updatedField] = $date;
 		}
 
-		$eventData = $this->trigger('beforeInsert', ['data' => $data]);
+		$eventData = ['data' => $data];
+		if ($this->tempAllowCallbacks)
+		{
+			$eventData = $this->trigger('beforeInsert', $eventData);
+		}
 
 		// Must use the set() method to ensure objects get converted to arrays
 		$result = $this->builder()
@@ -788,8 +822,17 @@ class Model
 			$this->insertID = $this->db->insertID();
 		}
 
-		// Trigger afterInsert events with the inserted data and new ID
-		$this->trigger('afterInsert', ['id' => $this->insertID, 'data' => $eventData['data'], 'result' => $result]);
+		$eventData = [
+			'id'     => $this->insertID,
+			'data'   => $eventData['data'],
+			'result' => $result,
+		];
+		if ($this->tempAllowCallbacks)
+		{
+			// Trigger afterInsert events with the inserted data and new ID
+			$this->trigger('afterInsert', $eventData);
+		}
+		$this->tempAllowCallbacks = $this->allowCallbacks;
 
 		// If insertion failed, get out of here
 		if (! $result)
@@ -902,7 +945,14 @@ class Model
 			$data[$this->updatedField] = $this->setDate();
 		}
 
-		$eventData = $this->trigger('beforeUpdate', ['id' => $id, 'data' => $data]);
+		$eventData = [
+			'id'   => $id,
+			'data' => $data,
+		];
+		if ($this->tempAllowCallbacks)
+		{
+			$eventData = $this->trigger('beforeUpdate', $eventData);
+		}
 
 		$builder = $this->builder();
 
@@ -916,7 +966,16 @@ class Model
 				->set($eventData['data'], '', $escape)
 				->update();
 
-		$this->trigger('afterUpdate', ['id' => $id, 'data' => $eventData['data'], 'result' => $result]);
+		$eventData = [
+			'id'     => $id,
+			'data'   => $eventData['data'],
+			'result' => $result,
+		];
+		if ($this->tempAllowCallbacks)
+		{
+			$this->trigger('afterUpdate', $eventData);
+		}
+		$this->tempAllowCallbacks = $this->allowCallbacks;
 
 		return $result;
 	}
@@ -977,7 +1036,14 @@ class Model
 			$builder = $builder->whereIn($this->primaryKey, $id);
 		}
 
-		$this->trigger('beforeDelete', ['id' => $id, 'purge' => $purge]);
+		$eventData = [
+			'id'    => $id,
+			'purge' => $purge,
+		];
+		if ($this->tempAllowCallbacks)
+		{
+			$this->trigger('beforeDelete', $eventData);
+		}
 
 		if ($this->useSoftDeletes && ! $purge)
 		{
@@ -1005,7 +1071,17 @@ class Model
 			$result = $builder->delete();
 		}
 
-		$this->trigger('afterDelete', ['id' => $id, 'purge' => $purge, 'result' => $result, 'data' => null]);
+		$eventData = [
+			'id'     => $id,
+			'purge'  => $purge,
+			'result' => $result,
+			'data'   => null,
+		];
+		if ($this->tempAllowCallbacks)
+		{
+			$this->trigger('afterDelete', $eventData);
+		}
+		$this->tempAllowCallbacks = $this->allowCallbacks;
 
 		return $result;
 	}

--- a/tests/_support/Models/EventModel.php
+++ b/tests/_support/Models/EventModel.php
@@ -23,8 +23,13 @@ class EventModel extends Model
 	protected $afterInsert  = ['afterInsertMethod'];
 	protected $beforeUpdate = ['beforeUpdateMethod'];
 	protected $afterUpdate  = ['afterUpdateMethod'];
-	protected $afterFind    = ['afterFindMethod'];
+	protected $beforeDelete = ['beforeDeleteMethod'];
 	protected $afterDelete  = ['afterDeleteMethod'];
+	protected $beforeFind   = ['beforeFindMethod'];
+	protected $afterFind    = ['afterFindMethod'];
+
+	// Testing directive to set $returnData on beforeFind event
+	public $beforeFindReturnData = false;
 
 	// Holds stuff for testing events
 	protected $tokens = [];
@@ -57,9 +62,9 @@ class EventModel extends Model
 		return $data;
 	}
 
-	protected function afterFindMethod(array $data)
+	protected function beforeDeleteMethod(array $data)
 	{
-		$this->tokens[] = 'afterFind';
+		$this->tokens[] = 'beforeDelete';
 
 		return $data;
 	}
@@ -67,6 +72,26 @@ class EventModel extends Model
 	protected function afterDeleteMethod(array $data)
 	{
 		$this->tokens[] = 'afterDelete';
+
+		return $data;
+	}
+
+	protected function beforeFindMethod(array $data)
+	{
+		$this->tokens[] = 'beforeFind';
+
+		if ($this->beforeFindReturnData)
+		{
+			$data['data']       = 'foobar';
+			$data['returnData'] = true;
+		}
+
+		return $data;
+	}
+
+	protected function afterFindMethod(array $data)
+	{
+		$this->tokens[] = 'afterFind';
 
 		return $data;
 	}

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1084,24 +1084,47 @@ class ModelTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testFindEvent()
-	{
-		$model = new EventModel();
-
-		$model->find(1);
-
-		$this->assertTrue($model->hasToken('afterFind'));
-	}
-
-	//--------------------------------------------------------------------
-
 	public function testDeleteEvent()
 	{
 		$model = new EventModel();
 
 		$model->delete(1);
 
+		$this->assertTrue($model->hasToken('beforeDelete'));
 		$this->assertTrue($model->hasToken('afterDelete'));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testFindEvent()
+	{
+		$model = new EventModel();
+
+		$model->find(1);
+
+		$this->assertTrue($model->hasToken('beforeFind'));
+		$this->assertTrue($model->hasToken('afterFind'));
+	}
+
+	public function testBeforeFindReturnsData()
+	{
+		$model                       = new EventModel();
+		$model->beforeFindReturnData = true;
+
+		$result = $model->find(1);
+
+		$this->assertTrue($model->hasToken('beforeFind'));
+		$this->assertEquals($result, 'foobar');
+	}
+
+	public function testBeforeFindReturnDataPreventsAfterFind()
+	{
+		$model                       = new EventModel();
+		$model->beforeFindReturnData = true;
+
+		$model->find(1);
+
+		$this->assertFalse($model->hasToken('afterFind'));
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1682,9 +1682,9 @@ class ModelTest extends CIDatabaseTestCase
 
 	public function testSetTable()
 	{
-		$model = new JobModel();
+		$model = new SecondaryModel();
 
-		$model->setTable('db_job');
+		$model->setTable('job');
 
 		$data = [
 			'name'        => 'Apprentice',

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -790,7 +790,9 @@ afterFind         Varies by find* method. See the following:
                   **limit** = the number of rows to find.
                   **offset** = the number of rows to skip during the search.
 - first()         **data** = the resulting row found during the search, or null if none found.
-beforeDelete      **id** = primary key of row being deleted.
+beforeFind        Same as **afterFind** but with the name of the calling **$method** instead of **$data**.
+beforeDelete      Varies by delete* method. See the following:
+- delete()        **id** = primary key of row being deleted.
                   **purge** = boolean whether soft-delete rows should be hard deleted.
 afterDelete       **id** = primary key of row being deleted.
                   **purge** = boolean whether soft-delete rows should be hard deleted.
@@ -798,6 +800,26 @@ afterDelete       **id** = primary key of row being deleted.
                   **data** = unused.
 ================ =========================================================================================================
 
+Modifying Find* Data
+--------------------
+
+The ``beforeFind`` and ``afterFind`` methods can both return a modified set of data to override the normal response
+from the model. For ``afterFind`` any changes made to ``data`` in the return array will automatically be passed back
+to the calling context. In order for ``beforeFind`` to intercept the find workflow it must also return an additional
+boolean, ``returnData``::
+
+    protected $beforeFind = ['checkCache'];
+    ...
+	protected function checkCache(array $data)
+	{
+		// Check if the requested item is already in our cache
+		if (isset($data['id']) && $item = $this->getCachedItem($data['id']]))
+		{
+			$data['data']       = $item;
+			$data['returnData'] = true;
+
+			return $data;
+	...
 
 Manual Model Creation
 =====================


### PR DESCRIPTION
**Description**
This one grew a bit. Original intent was to define the `beforeModel` callback event. That's done but I also discovered I had a logic error with `allowCallbacks` resetting during `trigger()`, because most (now all) methods that use triggers actually call `trigger()` twice - fixed. I discovered a Model test that should not have been passing (`db_job` is not a valid table) - fixed. And also there were no tests for `beforeDelete` - added.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
