### PR TITLE
DotEnv: No binary strings to environment variables

### DIFF
--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -184,20 +184,6 @@ class DotEnv
 
 		$value = $this->resolveNestedVariables($value);
 
-		if ($name === 'encryption.key')
-		{
-			// Handle hex2bin prefix
-			if (strpos($value, 'hex2bin:') === 0)
-			{
-				$value = hex2bin(substr($value, 8));
-			}
-			// Handle base64 prefix
-			elseif (strpos($value, 'base64:') === 0)
-			{
-				$value = base64_decode(substr($value, 7), true);
-			}
-		}
-
 		return [
 			$name,
 			$value,

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -57,36 +57,32 @@ class DotEnvTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState  disabled
+	 */
 	public function testLoadsHex2Bin()
 	{
 		$dotenv = new DotEnv($this->fixturesFolder, 'encryption.env');
 		$dotenv->load();
 
-		$m = new \ReflectionMethod($dotenv, 'getVariable');
-		$m->setAccessible(true);
-
-		$value = $m->invoke($dotenv, 'encryption.key');
-
-		$this->assertTrue(! empty($value));
-		$this->assertEquals('f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6', bin2hex($value));
+		$this->assertEquals('hex2bin:f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6', getenv('encryption.key'));
 		$this->assertEquals('hex2bin:f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6', getenv('different.key'));
 		$this->assertEquals('OpenSSL', getenv('encryption.driver'));
 	}
 
 	//--------------------------------------------------------------------
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState  disabled
+	 */
 	public function testLoadsBase64()
 	{
 		$dotenv = new DotEnv($this->fixturesFolder, 'base64encryption.env');
 		$dotenv->load();
 
-		$m = new \ReflectionMethod($dotenv, 'getVariable');
-		$m->setAccessible(true);
-
-		$value = $m->invoke($dotenv, 'encryption.key');
-
-		$this->assertFalse(empty($value));
-		$this->assertEquals('L40bKo6b8Nu541LeVeZ1i5RXfGgnkar42CPTfukhGhw=', base64_encode($value));
+		$this->assertEquals('base64:L40bKo6b8Nu541LeVeZ1i5RXfGgnkar42CPTfukhGhw=', getenv('encryption.key'));
 		$this->assertEquals('OpenSSL', getenv('encryption.driver'));
 	}
 

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -16,6 +16,7 @@ Release Date: Not Released
         :titlesonly:
 
         next
+        v4.0.5
         v4.0.4
         v4.0.3
         v4.0.0

--- a/user_guide_src/source/changelogs/v4.0.5.rst
+++ b/user_guide_src/source/changelogs/v4.0.5.rst
@@ -5,7 +5,7 @@ Release Date: Not released
 
 **4.0.5 release of CodeIgniter4**
 
-Enhancements
-------------
+Bugs Fixed:
 
 - Fixed a bug in ``Entity`` class where declaring class parameters was preventing data propagation to the ``attributes`` array.
+- Handling for the environment variable ``encryption.key`` has changed. Previously, explicit function calls, like ``getenv('encryption.key')`` or ``env('encryption.key')`` where the value has the special prefix ``hex2bin:`` returns an automatically converted binary string. This is now changed to just return the character string with the prefix. This change was due to incompatibility with handling binary strings in environment variables on Windows platforms. However, accessing ``$key`` using ``Encryption`` class config remains unchanged and still returns a binary string.


### PR DESCRIPTION
**Description**
Per comment by the php maintainer in my bug report [here](https://bugs.php.net/bug.php?id=79875), they presented two advice in properly dealing with binary strings in the environment. This applies only for Windows. So I'll be presenting two mutually-exclusive PRs for the CI4 maintainers to decide the appropriate approach.

This is the **first** alternative: **Do not pass binary strings to the environment variables.** `BaseConfig` already has a parser for the prefix handling so `DotEnv` can be relieved from that responsibility.

Result for DotEnvTest
```
PS C:\Users\P\Desktop\Web Dev\CodeIgniter4> vendor/bin/phpunit -v --filter DotEnvTest
PHPUnit 8.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.8 with Xdebug 2.9.4
Configuration: C:\Users\P\Desktop\Web Dev\CodeIgniter4\phpunit.xml

...............                                                   15 / 15 (100%)

Time: 54.49 seconds, Memory: 50.00 MB

OK (15 tests, 49 assertions)
```

Result for BaseConfigTest
```
PS C:\Users\P\Desktop\Web Dev\CodeIgniter4> vendor/bin/phpunit -v --filter BaseConfigTest
PHPUnit 8.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.8 with Xdebug 2.9.4
Configuration: C:\Users\P\Desktop\Web Dev\CodeIgniter4\phpunit.xml

................                                                  16 / 16 (100%)

Time: 48.13 seconds, Memory: 50.00 MB

OK (16 tests, 45 assertions)
```


**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
