### PR TITLE
DotEnv: Convert binary string to UTF-8 for Windows

### DIFF
--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -94,8 +94,27 @@ class BaseConfig
 
 			if ($shortPrefix === 'encryption' && $property === 'key')
 			{
+				// Handle values from .env already parsed by DotEnv
+				if (strpos($this->$property, 'hex2bin:') === false && strpos($this->$property, 'base64:') === false)
+				{
+					if ('\\' === DIRECTORY_SEPARATOR)
+					{
+						/**
+						 * Windows requires binary strings to be converted to UTF-8 codepage
+						 * before being stored in environment. Since DotEnv already did the conversion
+						 * and we need the original binary string, we'll just reverse the process here.
+						 *
+						 * @see https://bugs.php.net/bug.php?id=79875
+						 */
+						// @codeCoverageIgnoreStart
+						$ansi            = sapi_windows_cp_get('ansi');
+						$utf8            = sapi_windows_cp_get('utf-8');
+						$this->$property = sapi_windows_cp_conv($utf8, $ansi, $this->$property);
+						// @codeCoverageIgnoreEnd
+					}
+				}
 				// Handle hex2bin prefix
-				if (strpos($this->$property, 'hex2bin:') === 0)
+				elseif (strpos($this->$property, 'hex2bin:') === 0)
 				{
 					$this->$property = hex2bin(substr($this->$property, 8));
 				}

--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -196,6 +196,21 @@ class DotEnv
 			{
 				$value = base64_decode(substr($value, 7), true);
 			}
+
+			if ('\\' === DIRECTORY_SEPARATOR)
+			{
+				/**
+				 * Convert binary string to UTF-8 codepage before passing to environment
+				 * to preserve interoperability.
+				 *
+				 * @see https://bugs.php.net/bug.php?id=79875
+				 */
+				// @codeCoverageIgnoreStart
+				$ansi  = sapi_windows_cp_get('ansi');
+				$utf8  = sapi_windows_cp_get('utf-8');
+				$value = sapi_windows_cp_conv($ansi, $utf8, $value);
+				// @codeCoverageIgnoreEnd
+			}
 		}
 
 		return [

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -57,15 +57,21 @@ class DotEnvTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState  disabled
+	 */
 	public function testLoadsHex2Bin()
 	{
 		$dotenv = new DotEnv($this->fixturesFolder, 'encryption.env');
 		$dotenv->load();
 
-		$m = new \ReflectionMethod($dotenv, 'getVariable');
-		$m->setAccessible(true);
+		$value = getenv('encryption.key', true);
 
-		$value = $m->invoke($dotenv, 'encryption.key');
+		if ('\\' === DIRECTORY_SEPARATOR)
+		{
+			$value = sapi_windows_cp_conv(65001, 1252, $value);
+		}
 
 		$this->assertTrue(! empty($value));
 		$this->assertEquals('f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6', bin2hex($value));
@@ -75,15 +81,21 @@ class DotEnvTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState  disabled
+	 */
 	public function testLoadsBase64()
 	{
 		$dotenv = new DotEnv($this->fixturesFolder, 'base64encryption.env');
 		$dotenv->load();
 
-		$m = new \ReflectionMethod($dotenv, 'getVariable');
-		$m->setAccessible(true);
+		$value = getenv('encryption.key', true);
 
-		$value = $m->invoke($dotenv, 'encryption.key');
+		if ('\\' === DIRECTORY_SEPARATOR)
+		{
+			$value = sapi_windows_cp_conv(65001, 1252, $value);
+		}
 
 		$this->assertFalse(empty($value));
 		$this->assertEquals('L40bKo6b8Nu541LeVeZ1i5RXfGgnkar42CPTfukhGhw=', base64_encode($value));


### PR DESCRIPTION
**Description**
Per discussion in #3361 , this is **second** alternative to binary string handling. **Convert binary strings to UTF-8 codepage and convert them back on retrieval by `BaseConfig`.**

Basically, we're aiming for interoperability as what is Windows is doing right now. So for proper handling, we convert first the binary string parsed by `DotEnv` into UTF-8 using the `sapi_windows_cp_conv` function available since PHP/7.1. Afterwards, when these values will be used to populate the configuration properties, we instruct `BaseConfig` to convert it back. Conversion is thru `ANSI <=> UTF-8`.

Result for DotEnvTest
```
PS C:\Users\P\Desktop\Web Dev\CodeIgniter4> vendor/bin/phpunit -v --filter DotEnvTest
PHPUnit 8.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.8 with Xdebug 2.9.4
Configuration: C:\Users\P\Desktop\Web Dev\CodeIgniter4\phpunit.xml

...............                                                   15 / 15 (100%)

Time: 42.4 seconds, Memory: 50.00 MB

OK (15 tests, 51 assertions)
```

Result for BaseConfigTest
```
PS C:\Users\P\Desktop\Web Dev\CodeIgniter4> vendor/bin/phpunit -v --filter BaseConfigTest
PHPUnit 8.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.8 with Xdebug 2.9.4
Configuration: C:\Users\P\Desktop\Web Dev\CodeIgniter4\phpunit.xml

................                                                  16 / 16 (100%)

Time: 47.68 seconds, Memory: 50.00 MB

OK (16 tests, 45 assertions)
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
