### PR TITLE
New common function: clean_path

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -112,6 +112,40 @@ if (! function_exists('cache'))
 	}
 }
 
+if (! function_exists('clean_path'))
+{
+	/**
+	 * A convenience method to clean paths for
+	 * a nicer looking output. Useful for exception
+	 * handling, error logging, etc.
+	 *
+	 * @param string $path
+	 *
+	 * @return string
+	 */
+	function clean_path(string $path): string
+	{
+		// Resolve relative paths
+		$path = realpath($path) ?: $path;
+
+		switch (true)
+		{
+			case strpos($path, APPPATH) === 0:
+				return 'APPPATH' . DIRECTORY_SEPARATOR . substr($path, strlen(APPPATH));
+			case strpos($path, SYSTEMPATH) === 0:
+				return 'SYSTEMPATH' . DIRECTORY_SEPARATOR . substr($path, strlen(SYSTEMPATH));
+			case strpos($path, FCPATH) === 0:
+				return 'FCPATH' . DIRECTORY_SEPARATOR . substr($path, strlen(FCPATH));
+			case defined('VENDORPATH') && strpos($path, VENDORPATH) === 0:
+				return 'VENDORPATH' . DIRECTORY_SEPARATOR . substr($path, strlen(VENDORPATH));
+			case strpos($path, ROOTPATH) === 0:
+				return 'ROOTPATH' . DIRECTORY_SEPARATOR . substr($path, strlen(ROOTPATH));
+			default:
+				return $path;
+		}
+	}
+}
+
 if (! function_exists('command'))
 {
 	/**

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -455,4 +455,41 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('https://example.com', Services::response()->getHeader('Location')->getValue());
 	}
 
+	//--------------------------------------------------------------------
+
+	/**
+	 * @dataProvider dirtyPathsProvider
+	 */
+	public function testCleanPathActuallyCleaningThePaths($input, $expected)
+	{
+		$this->assertEquals($expected, clean_path($input));
+	}
+
+	public function dirtyPathsProvider()
+	{
+		$ds = DIRECTORY_SEPARATOR;
+
+		return [
+			[
+				ROOTPATH . 'spark',
+				'ROOTPATH' . $ds . 'spark',
+			],
+			[
+				APPPATH . 'Config' . $ds . 'App.php',
+				'APPPATH' . $ds . 'Config' . $ds . 'App.php',
+			],
+			[
+				SYSTEMPATH . 'CodeIgniter.php',
+				'SYSTEMPATH' . $ds . 'CodeIgniter.php',
+			],
+			[
+				VENDORPATH . 'autoload.php',
+				'VENDORPATH' . $ds . 'autoload.php',
+			],
+			[
+				FCPATH . 'index.php',
+				'FCPATH' . $ds . 'index.php',
+			],
+		];
+	}
 }


### PR DESCRIPTION
**Description**
Use a common function `clean_path` as a means for nicer looking output instead of defining it as a method for class that needs it, e.g. `Exceptions`, `Logger`, `BaseCollector`, etc. With this, we can dispense use of redundant methods like `Exceptions::cleanPath` in favor of a global function.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
