### PR TITLE
Optimize Autoloader::loadInNamespace in getting path

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -287,12 +287,11 @@ class Autoloader
 		{
 			foreach ($directories as $directory)
 			{
-				$directory = rtrim($directory, '/');
+				$directory = rtrim($directory, '\\/');
 
 				if (strpos($class, $namespace) === 0)
 				{
-					$filePath = $directory . str_replace('\\', '/',
-							substr($class, strlen($namespace))) . '.php';
+					$filePath = $directory . str_replace('\\', DIRECTORY_SEPARATOR, substr($class, strlen($namespace))) . '.php';
 					$filename = $this->requireFile($filePath);
 
 					if ($filename)

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -64,7 +64,7 @@ class AutoloaderTest extends \CodeIgniter\Test\CIUnitTestCase
 		// $auto_loader->register();
 		// look for Home controller, as that should be in base repo
 		$actual   = $auto_loader->loadClass('App\Controllers\Home');
-		$expected = APPPATH . 'Controllers/Home.php';
+		$expected = APPPATH . 'Controllers' . DIRECTORY_SEPARATOR . 'Home.php';
 		$this->assertSame($expected, $actual);
 	}
 
@@ -78,7 +78,7 @@ class AutoloaderTest extends \CodeIgniter\Test\CIUnitTestCase
 		$auto_loader->register();
 		// look for Home controller, as that should be in base repo
 		$actual   = $auto_loader->loadClass('App\Controllers\Home');
-		$expected = APPPATH . 'Controllers/Home.php';
+		$expected = APPPATH . 'Controllers' . DIRECTORY_SEPARATOR . 'Home.php';
 		$this->assertSame($expected, $actual);
 	}
 
@@ -87,11 +87,11 @@ class AutoloaderTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testExistingFile()
 	{
 		$actual   = $this->loader->loadClass('App\Controllers\Home');
-		$expected = APPPATH . 'Controllers/Home.php';
+		$expected = APPPATH . 'Controllers' . DIRECTORY_SEPARATOR . 'Home.php';
 		$this->assertSame($expected, $actual);
 
 		$actual   = $this->loader->loadClass('CodeIgniter\Helpers\array_helper');
-		$expected = SYSTEMPATH . 'Helpers/array_helper.php';
+		$expected = SYSTEMPATH . 'Helpers' . DIRECTORY_SEPARATOR . 'array_helper.php';
 		$this->assertSame($expected, $actual);
 	}
 
@@ -100,7 +100,7 @@ class AutoloaderTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testMatchesWithPreceedingSlash()
 	{
 		$actual   = $this->loader->loadClass('\App\Controllers\Home');
-		$expected = APPPATH . 'Controllers/Home.php';
+		$expected = APPPATH . 'Controllers' . DIRECTORY_SEPARATOR . 'Home.php';
 		$this->assertSame($expected, $actual);
 	}
 
@@ -109,7 +109,7 @@ class AutoloaderTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testMatchesWithFileExtension()
 	{
 		$actual   = $this->loader->loadClass('\App\Controllers\Home.php');
-		$expected = APPPATH . 'Controllers/Home.php';
+		$expected = APPPATH . 'Controllers' . DIRECTORY_SEPARATOR . 'Home.php';
 		$this->assertSame($expected, $actual);
 	}
 
@@ -155,7 +155,7 @@ class AutoloaderTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->loader->addNamespace('My\App', __DIR__);
 
 		$actual   = $this->loader->loadClass('My\App\App');
-		$expected = APPPATH . 'Config/App.php';
+		$expected = APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'App.php';
 		$this->assertSame($expected, $actual);
 
 		$actual   = $this->loader->loadClass('My\App\AutoloaderTest');


### PR DESCRIPTION
**Description**
Currently, directory `rtrim` accounts only for forward slash but not for backward slash, which may result to the following:
```
$this->requireFile('C:\\Users\\P\\Desktop\\Web Dev\\CodeIgniter4\\system\\/Database/MySQLi/Connection.php')
```

With the new changes from this PR, the path will look like this:
```
$this->requireFile('C:\\Users\\P\\Desktop\\Web Dev\\CodeIgniter4\\system\\Database\\MySQLi\\Connection.php')
```

I know this seems for fancy output but I'm creating a custom exception handling output and the `\\/` and inconsistent directory separators looks unaesthetic.

PS. Changed the tests to change `/` to the `DIRECTORY_SEPARATOR` for it to pass on Windows.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
