### PR TITLE
Refactor and beautify error_exception.php for CLI

### DIFF
--- a/app/Views/errors/cli/error_exception.php
+++ b/app/Views/errors/cli/error_exception.php
@@ -1,17 +1,72 @@
-An uncaught Exception was encountered
+<?php
 
-Type:        <?= get_class($exception), "\n"; ?>
-Message:     <?= $message, "\n"; ?>
-Filename:    <?= $exception->getFile(), "\n"; ?>
-Line Number: <?= $exception->getLine(); ?>
+use CodeIgniter\CLI\CLI;
 
-<?php if (defined('SHOW_DEBUG_BACKTRACE') && SHOW_DEBUG_BACKTRACE === true): ?>
+// The main Exception
+CLI::newLine();
+CLI::write('[' . get_class($exception) . ']', 'light_gray', 'red');
+CLI::newLine();
+CLI::write($message);
+CLI::newLine();
+CLI::write('at ' . CLI::color(clean_path($exception->getFile()) . ':' . $exception->getLine(), 'green'));
+CLI::newLine();
 
-	Backtrace:
-	<?php foreach ($exception->getTrace() as $error): ?>
-		<?php if (isset($error['file'])): ?>
-			<?= trim('-' . $error['line'] . ' - ' . $error['file'] . '::' . $error['function']) . "\n" ?>
-		<?php endif ?>
-	<?php endforeach ?>
+// The backtrace
+if (defined('SHOW_DEBUG_BACKTRACE') && SHOW_DEBUG_BACKTRACE)
+{
+	$backtraces = $exception->getTrace();
 
-<?php endif ?>
+	if ($backtraces)
+	{
+		CLI::write('Backtrace:', 'green');
+	}
+
+	foreach ($backtraces as $i => $error)
+	{
+		$padFile  = '    '; // 4 spaces
+		$padClass = '       '; // 7 spaces
+		$c        = str_pad($i + 1, 3, ' ', STR_PAD_LEFT);
+
+		if (isset($error['file']))
+		{
+			$filepath = clean_path($error['file']) . ':' . $error['line'];
+
+			CLI::write($c . $padFile . CLI::color($filepath, 'yellow'));
+		}
+		else
+		{
+			CLI::write($c . $padFile . CLI::color('[internal function]', 'yellow'));
+		}
+
+		$function = '';
+
+		if (isset($error['class']))
+		{
+			$type      = ($error['type'] === '->') ? '()' . $error['type'] : $error['type'];
+			$function .= $padClass . $error['class'] . $type . $error['function'];
+		}
+		elseif (! isset($error['class']) && isset($error['function']))
+		{
+			$function .= $padClass . $error['function'];
+		}
+
+		$args = implode(', ', array_map(function ($value) {
+			switch (true)
+			{
+				case is_object($value):
+					return 'Object(' . get_class($value) . ')';
+				case is_array($value):
+					return '[]';
+				case is_null($value):
+					return 'null'; // return the lowercased version
+				default:
+					return var_export($value, true);
+			}
+		}, array_values($error['args'])));
+
+		$function .= '(' . $args . ')';
+
+		CLI::write($function);
+		CLI::newLine();
+	}
+}


### PR DESCRIPTION
**Description**
Refactor and improve the exception output for the terminal.

Before:
![image](https://user-images.githubusercontent.com/51850998/87954896-8ec4c780-cadf-11ea-8a49-3b3af835c077.png)

After:
![image](https://user-images.githubusercontent.com/51850998/87955031-c469b080-cadf-11ea-86e2-070bf7de0690.png)

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
