### PR TITLE
Account for shorthand hex format in GDHandler::textOverlay

### DIFF
--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -575,6 +575,13 @@ class GDHandler extends BaseHandler
 		imagealphablending($src, true);
 
 		$color = $isShadow ? $options['shadowColor'] : $options['color'];
+
+		// shorthand hex, #f00
+		if (strlen($color) === 3)
+		{
+			$color = implode('', array_map('str_repeat', str_split($color), [2, 2, 2]));
+		}
+
 		$color = str_split(substr($color, 0, 6), 2);
 		$color = imagecolorclosestalpha($src, hexdec($color[0]), hexdec($color[1]), hexdec($color[2]), $opacity);
 


### PR DESCRIPTION
**Description**
While trying to reproduce #3356 , I encountered an `ErrorException: Undefined offset 2` using the details provided. This was because, the user was using the shorthand hex format `'color' => '#fff'` so when that was split into 3 groups of 2, index 2 was missing. This PR changes shorthand hex `fff` to its long form `ffffff`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
