### PR TITLE
Timezone is a single word

### DIFF
--- a/system/Debug/Toolbar/Views/_config.tpl
+++ b/system/Debug/Toolbar/Views/_config.tpl
@@ -33,7 +33,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td>TimeZone:</td>
+			<td>Timezone:</td>
 			<td>{ timezone }</td>
 		</tr>
 		<tr>

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -575,6 +575,13 @@ class GDHandler extends BaseHandler
 		imagealphablending($src, true);
 
 		$color = $isShadow ? $options['shadowColor'] : $options['color'];
+
+		// shorthand hex, #f00
+		if (strlen($color) === 3)
+		{
+			$color = implode('', array_map('str_repeat', str_split($color), [2, 2, 2]));
+		}
+
 		$color = str_split(substr($color, 0, 6), 2);
 		$color = imagecolorclosestalpha($src, hexdec($color[0]), hexdec($color[1]), hexdec($color[2]), $opacity);
 


### PR DESCRIPTION
**Description**
`Timezone` is a single word. It is not written `TimeZone`.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
