### PR TITLE
Timezone is a single word

### DIFF
--- a/system/Debug/Toolbar/Views/_config.tpl
+++ b/system/Debug/Toolbar/Views/_config.tpl
@@ -33,7 +33,7 @@
 			</td>
 		</tr>
 		<tr>
-			<td>TimeZone:</td>
+			<td>Timezone:</td>
 			<td>{ timezone }</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
**Description**
`Timezone` is a single word. It is not written `TimeZone`.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
