### PR TITLE
Remove close brace, add missing colon and text format

### DIFF
--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -8,7 +8,7 @@ Database Configuration
 
 CodeIgniter has a config file that lets you store your database
 connection values (username, password, database name, etc.). The config
-file is located at app/Config/Database.php. You can also set
+file is located at **app/Config/Database.php**. You can also set
 database connection values in the .env file. See below for more details.
 
 The config settings are stored in a class property that is an array with this

--- a/user_guide_src/source/database/examples.rst
+++ b/user_guide_src/source/database/examples.rst
@@ -16,8 +16,8 @@ your :doc:`configuration <configuration>` settings::
 
 Once loaded the class is ready to be used as described below.
 
-Note: If all your pages require database access you can connect
-automatically. See the :doc:`connecting <connecting>` page for details.
+.. note:: If all your pages require database access you can connect
+	automatically. See the :doc:`connecting <connecting>` page for details.
 
 Standard Query With Multiple Results (Object Version)
 =====================================================

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -27,7 +27,7 @@ above it instead has a product ID. To overcome this, CodeIgniter allows you to r
 Setting your own routing rules
 ==============================
 
-Routing rules are defined in the **app/config/Routes.php** file. In it you'll see that
+Routing rules are defined in the **app/Config/Routes.php** file. In it you'll see that
 it creates an instance of the RouteCollection class that permits you to specify your own routing criteria.
 Routes can be specified using placeholders or Regular Expressions.
 

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -528,7 +528,7 @@ The methods provided by the parent class that are available are:
 
     .. php:method:: getCookies()
 
-        :rtype array
+        :rtype: array
 
         Returns all cookies currently set within the Response instance.
         These are any cookies that you have specifically specified to set during the current

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -696,7 +696,7 @@ Class Reference
 
 .. php:class:: CodeIgniter\\View\\Parser
 
-	.. php:method:: render($view[, $options[, $saveData=false]]])
+	.. php:method:: render($view[, $options[, $saveData=false]])
 
 		:param  string  $view: File name of the view source
 		:param  array   $options: Array of options, as key/value pairs
@@ -720,7 +720,7 @@ Class Reference
 		Any conditional substitutions are performed first, then remaining
 		substitutions are performed for each data pair.
 
-	.. php:method:: renderString($template[, $options[, $saveData=false]]])
+	.. php:method:: renderString($template[, $options[, $saveData=false]])
 
 		:param  string  $template: View source provided as a string
     		:param  array   $options: Array of options, as key/value pairs

--- a/user_guide_src/source/outgoing/view_renderer.rst
+++ b/user_guide_src/source/outgoing/view_renderer.rst
@@ -107,7 +107,7 @@ Class Reference
 
 .. php:class:: CodeIgniter\\View\\View
 
-	.. php:method:: render($view[, $options[, $saveData=false]]])
+	.. php:method:: render($view[, $options[, $saveData=false]])
                 :noindex:
 
 		:param  string  $view: File name of the view source
@@ -120,7 +120,7 @@ Class Reference
 
 			echo $view->render('myview');
 
-	.. php:method:: renderString($view[, $options[, $saveData=false]]])
+	.. php:method:: renderString($view[, $options[, $saveData=false]])
                 :noindex:
 
 		:param  string  $view: Contents of the view to render, for instance content retrieved from a database


### PR DESCRIPTION
Remove excess close brace in optional parameters.
Add missing colon for return type.
Add formatted note.
Change directory name config into Config.
Format file location as bold.
