### PR TITLE
Fix fill() method in Entity class

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -124,7 +124,7 @@ class Entity implements \JsonSerializable
 
 		foreach ($data as $key => $value)
 		{
-			$this->$key = $value;
+			$this->__set($key, $value);
 		}
 
 		return $this;

--- a/user_guide_src/source/changelogs/v4.0.5.rst
+++ b/user_guide_src/source/changelogs/v4.0.5.rst
@@ -1,0 +1,11 @@
+Version 4.0.5
+====================================================
+
+Release Date: Not released
+
+**4.0.5 release of CodeIgniter4**
+
+Enhancements
+------------
+
+- Fixed a bug in ``Entity`` class where declaring class parameters was preventing data propagation to the ``attributes`` array.


### PR DESCRIPTION
**Description**
When we declare class properties for Entity class then `__set()` method won't be called.

> __set() is run when writing data to inaccessible (protected or private) or non-existing properties

See: #3368

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
