### PR TITLE
Fix env search order

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -332,11 +332,7 @@ if (! function_exists('env'))
 	 */
 	function env(string $key, $default = null)
 	{
-		$value = getenv($key);
-		if ($value === false)
-		{
-			$value = $_ENV[$key] ?? $_SERVER[$key] ?? false;
-		}
+		$value = $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key);
 
 		// Not found? Return the default value
 		if ($value === false)


### PR DESCRIPTION
**Description**
The `env()` common function has a different order of searching environment variables as compared with `DotEnv` and `BaseConfig`. The latter two searches in the following order: `$_ENV, $_SERVER, getenv`. While for env() it searches this way: `getenv, $_ENV, $_SERVER`. 

While this may be trivial for some, this may impact Windows systems with regard to resolving binary strings in the environment. Pending resolutions of PRs #3361 and #3362, this may affect Windows users getting the encryption key via `env('encryption.key')` and later will get an encryption failed error because it did not match with the configured `encryption.key` in `.env` file.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
