### PR TITLE
Add UTC offset to spark header

### DIFF
--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -93,13 +93,13 @@ class Console
 	 */
 	public function showHeader()
 	{
-		CLI::newLine(1);
+		CLI::newLine();
 
 		CLI::write(CLI::color('CodeIgniter CLI Tool', 'green')
 				. ' - Version ' . CodeIgniter::CI_VERSION
-				. ' - Server-Time: ' . date('Y-m-d H:i:sa'));
+				. sprintf(' - Server Time: %s UTC%s', date('Y-m-d H:i:sa'), date('P')));
 
-		CLI::newLine(1);
+		CLI::newLine();
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
I know it is a bit of nitpicking but I always get confused why my local time is different from server time. I'm suggesting putting a UTC offset to the server time printed by spark.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
