### PR TITLE
mysql connection throw correct  Exception type as per function comments

### DIFF
--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -222,7 +222,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 			$msg = str_replace($this->username, '****', $msg);
 			$msg = str_replace($this->password, '****', $msg);
 
-			throw new \mysqli_sql_exception($msg, $e->getCode(), $e);
+			throw new DatabaseException($msg, $e->getCode(), $e);
 		}
 
 		return false;


### PR DESCRIPTION
**Description**
Throw correct exceptin type as per function comments
Was linked to this pull request
https://github.com/codeigniter4/CodeIgniter4/pull/3364
but had a fork/git version issue and redid fork and made sure develop branch is now in line

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
