### PR TITLE
Allow Common Datatypes for Table creation between Drivers

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -570,7 +570,7 @@ class Forge
 	 */
 	protected function _postDropTableStatements(string $table)
 	{
-		  return array();
+		  return [];
 	}
 
 	//--------------------------------------------------------------------
@@ -584,7 +584,7 @@ class Forge
 	 */
 	protected function _preCreateAlterStatements(string $table,array $fields)
 	{
-		  return array();
+		  return [];
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -531,6 +531,12 @@ class Forge
 				return false;
 			}
 		}
+		$preStatements = $this->_preCreateAlterStatements($table,$this->_processFields(true));
+		foreach($preStatements as $statement) 
+		{
+			 //Run without concern of result as with indexes below
+			 $this->db->query($statement); 
+		}
 
 		if (($result = $this->db->query($sql)) !== false)
 		{
@@ -552,6 +558,20 @@ class Forge
 		$this->reset();
 
 		return $result;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Pre - Create or Alter Table statements to be run
+	 *
+	 * @param string  $table         Table name
+	 * @param array   $fields        List of Fields
+	 * @return array
+	 */
+	protected function _preCreateAlterStatements(string $table,array $fields)
+	{
+		  return array();
 	}
 
 	//--------------------------------------------------------------------
@@ -585,7 +605,7 @@ class Forge
 		for ($i = 0, $c = count($columns); $i < $c; $i++)
 		{
 			$columns[$i] = ($columns[$i]['_literal'] !== false) ? "\n\t" . $columns[$i]['_literal']
-				: "\n\t" . $this->_processColumn($columns[$i]);
+				: "\n\t" . $this->_processColumn($columns[$i],$table);
 		}
 
 		$columns = implode(',', $columns);
@@ -801,6 +821,11 @@ class Forge
 
 			return false;
 		}
+		$preStatements = $this->_preCreateAlterStatements($table,$this->_processFields());
+		foreach($preStatements as $statement) 
+		{
+			 $this->db->query($statement); 
+		}
 
 		for ($i = 0, $c = count($sqls); $i < $c; $i++)
 		{
@@ -877,6 +902,11 @@ class Forge
 
 			return false;
 		}
+		$preStatements = $this->_preCreateAlterStatements($table,$this->_processFields());
+		foreach($preStatements as $statement) 
+		{
+			 $this->db->query($statement); 
+		}
 
 		if ($sqls !== null)
 		{
@@ -928,7 +958,7 @@ class Forge
 		foreach ($fields as $data)
 		{
 			$sqls[] = $sql
-					  . ($data['_literal'] !== false ? $data['_literal'] : $this->_processColumn($data));
+					  . ($data['_literal'] !== false ? $data['_literal'] : $this->_processColumn($data,$table));
 		}
 
 		return $sqls;
@@ -1040,10 +1070,11 @@ class Forge
 	 * Process column
 	 *
 	 * @param array $field
+	 * @param string $table
 	 *
 	 * @return string
 	 */
-	protected function _processColumn(array $field): string
+	protected function _processColumn(array $field,string $table): string
 	{
 		return $this->db->escapeIdentifiers($field['name'])
 			   . ' ' . $field['type'] . $field['length']

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -563,6 +563,19 @@ class Forge
 	//--------------------------------------------------------------------
 
 	/**
+	 * Post - Drop Table statements to be run
+	 *
+	 * @param string  $table         Table name
+	 * @return array
+	 */
+	protected function _postDropTableStatements(string $table)
+	{
+		  return array();
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Pre - Create or Alter Table statements to be run
 	 *
 	 * @param string  $table         Table name
@@ -704,6 +717,12 @@ class Forge
 			{
 				unset($this->db->dataCache['table_names'][$key]);
 			}
+		}
+		$preStatements = $this->_postDropTableStatements($tableName);
+		foreach($preStatements as $statement) 
+		{
+			 //Run without concern of result as with indexes below
+			 $this->db->query($statement); 
 		}
 
 		return $query;

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -195,7 +195,7 @@ class Forge extends \CodeIgniter\Database\Forge
 					$field[$i]['_literal'] = empty($data['new_name']) ? "\n\tMODIFY " : "\n\tCHANGE ";
 				}
 
-				$field[$i] = $field[$i]['_literal'] . $this->_processColumn($field[$i]);
+				$field[$i] = $field[$i]['_literal'] . $this->_processColumn($field[$i],$table);
 			}
 		}
 
@@ -207,10 +207,12 @@ class Forge extends \CodeIgniter\Database\Forge
 	/**
 	 * Process column
 	 *
-	 * @param  array $field
+	 * @param array $field
+	 * @param string $table
+	 *
 	 * @return string
 	 */
-	protected function _processColumn(array $field): string
+	protected function _processColumn(array $field,string $table): string
 	{
 		$extra_clause = isset($field['after']) ? ' AFTER ' . $this->db->escapeIdentifiers($field['after']) : '';
 

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -214,7 +214,7 @@ class Forge extends \CodeIgniter\Database\Forge
 		  $result = array();
 		  foreach($fields as $field) 
 		  {
-				if ((strtoupper($field['type']) == 'ENUM') ||	(strtoupper($field['type']) == 'SET') ) 
+				if (isset($field['type']) && ((strtoupper($field['type']) == 'ENUM') ||	(strtoupper($field['type']) == 'SET')) ) 
 				{
 					 $result[] = 'CREATE TYPE ' . trim($table).'_'.trim($field['name']).'_'.$field['type']
 								 . ' AS ENUM '.$field['length']; //constraint types stored in length field with processing of fields
@@ -339,7 +339,6 @@ class Forge extends \CodeIgniter\Database\Forge
 		 $result = array();
 		 foreach($this->dropDatabaseEnums as $enum_entry)
 		 {
-			 					//log_message('error', print_r($enum_entry,true));
 			 $result[] = 'DROP TYPE IF EXISTS '.$enum_entry;
 		 }
 		  return $result;

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -186,10 +186,11 @@ class Forge extends \CodeIgniter\Database\Forge
 	 * Process column
 	 *
 	 * @param array $field
+	 * @param string $table
 	 *
 	 * @return string
 	 */
-	protected function _processColumn(array $field): string
+	protected function _processColumn(array $field,string $table): string
 	{
 		if ($field['type'] === 'TEXT' && strpos($field['length'], "('") === 0)
 		{

--- a/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
+++ b/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
@@ -153,52 +153,39 @@ class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
 				'type' => 'BIGINT',
 				'null' => true,
 			],
-
+			'type_enum'		=> [
+				'type'       	=> 'ENUM',
+				'constraint' 	=> ['appel','pears','bananas'],
+				'null'       	=> true,
+			],
+			'type_set'		=> [
+				'type'       	=> 'SET',
+				'constraint' 	=> ['one','two'],
+				'null'       	=> true,
+			],
+			'type_mediumtext'=> [
+				  'type'     	=> 'MEDIUMTEXT',
+				  'null'     	=> true,
+			],
+			'type_real'   	=> [
+				  'type'     	=> 'REAL',
+				  'null'     	=> true,
+			],
+			'type_double'   => [
+				  'type'     	=> 'DOUBLE',
+				  'null'     	=> true,
+			],
+			'type_decimal'  => [
+				 'type'      	=> 'DECIMAL',
+				 'constraint'	=> '18,4',
+				 'null'      	=> true,
+			],
+			'type_blob'   	=> [
+				 'type'      	=> 'BLOB',
+				 'null'      	=> true,
+			],
+			
 		];
-		if ($this->db->DBDriver !== 'Postgre')
-		{
-			$extra_fields     = [
-				'type_enum'       => [
-					'type'       => 'ENUM',
-					'constraint' => [
-						'appel',
-						'pears',
-						'bananas',
-					],
-					'null'       => true,
-				],
-				'type_set'        => [
-					'type'       => 'SET',
-					'constraint' => [
-						'one',
-						'two',
-					],
-					'null'       => true,
-				],
-				'type_mediumtext' => [
-					'type' => 'MEDIUMTEXT',
-					'null' => true,
-				],
-				'type_real'       => [
-					'type' => 'REAL',
-					'null' => true,
-				],
-				'type_double'     => [
-					'type' => 'DOUBLE',
-					'null' => true,
-				],
-				'type_decimal'    => [
-					'type'       => 'DECIMAL',
-					'constraint' => '18,4',
-					'null'       => true,
-				],
-				'type_blob'       => [
-					'type' => 'BLOB',
-					'null' => true,
-				],
-			];
-			$data_type_fields = array_merge($data_type_fields, $extra_fields);
-		}
 		$this->forge->addField($data_type_fields);
 		$this->forge->addKey('id', true);
 		$this->forge->createTable('type_test', true);
@@ -273,7 +260,7 @@ class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
 		$this->forge->dropTable('user', true);
 		$this->forge->dropTable('job', true);
 		$this->forge->dropTable('misc', true);
-		$this->forge->dropTable('type_test', true);
+		$this->forge->dropTable('type_test', true,true);
 		$this->forge->dropTable('empty', true);
 		$this->forge->dropTable('secondary', true);
 		$this->forge->dropTable('stringifypkey', true);

--- a/tests/_support/Database/Seeds/CITestSeeder.php
+++ b/tests/_support/Database/Seeds/CITestSeeder.php
@@ -106,15 +106,9 @@ class CITestSeeder extends \CodeIgniter\Database\Seeder
 		}
 		elseif ($this->db->DBDriver === 'Postgre')
 		{
-			$data['type_test'][0]['type_time'] = '15:22:00';
-			unset($data['type_test'][0]['type_enum']);
-			unset($data['type_test'][0]['type_set']);
-			unset($data['type_test'][0]['type_mediumtext']);
-			unset($data['type_test'][0]['type_real']);
-			unset($data['type_test'][0]['type_double']);
-			unset($data['type_test'][0]['type_decimal']);
-			unset($data['type_test'][0]['type_blob']);
-		}
+			$data['type_test'][0]['type_time']      = '15:22:00';
+		}			
+
 		foreach ($data as $table => $dummy_data)
 		{
 			$this->db->table($table)->truncate();

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -161,8 +161,8 @@ class GetTest extends CIDatabaseTestCase
 			$this->assertEquals('timestamp', $type_test[10]->type_name);  //DATETIME
 			$this->assertEquals('timestamp', $type_test[11]->type_name);  //TIMESTAMP
 			$this->assertEquals('int8', $type_test[12]->type_name); //BIGINT
-			$this->assertEquals('type_test_type_enum_enum', $type_test[13]->type_name);  //ENUM
-			$this->assertEquals('type_test_type_set_set', $type_test[14]->type_name);  //SET
+			$this->assertEquals($this->db->DBPrefix.'type_test_type_enum_enum', $type_test[13]->type_name);  //ENUM
+			$this->assertEquals($this->db->DBPrefix.'type_test_type_set_set', $type_test[14]->type_name);  //SET
 			$this->assertEquals('text', $type_test[15]->type_name);  //MEDIUMTEXT
 			$this->assertEquals('float4', $type_test[16]->type_name);  //REAL
 			$this->assertEquals('numeric', $type_test[17]->type_name);  //DOUBLE

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -151,7 +151,7 @@ class GetTest extends CIDatabaseTestCase
 			$this->assertEquals('int4', $type_test[0]->type_name); //INTEGER AUTOINC
 			$this->assertEquals('varchar', $type_test[1]->type_name);  //VARCHAR
 			$this->assertEquals('bpchar', $type_test[2]->type_name);  //CHAR
-			$this->assertEquals('text', $type_test[3]->type_name);  //TEXT
+			$this->assertEquals('text', $type_test[3]->type_name);  //TEXT		
 			$this->assertEquals('int2', $type_test[4]->type_name);  //SMALLINT
 			$this->assertEquals('int4', $type_test[5]->type_name);  //INTEGER
 			$this->assertEquals('float8', $type_test[6]->type_name);  //FLOAT
@@ -161,6 +161,13 @@ class GetTest extends CIDatabaseTestCase
 			$this->assertEquals('timestamp', $type_test[10]->type_name);  //DATETIME
 			$this->assertEquals('timestamp', $type_test[11]->type_name);  //TIMESTAMP
 			$this->assertEquals('int8', $type_test[12]->type_name); //BIGINT
+			$this->assertEquals('type_test_type_enum_enum', $type_test[13]->type_name);  //ENUM
+			$this->assertEquals('type_test_type_set_set', $type_test[14]->type_name);  //SET
+			$this->assertEquals('text', $type_test[15]->type_name);  //MEDIUMTEXT
+			$this->assertEquals('float4', $type_test[16]->type_name);  //REAL
+			$this->assertEquals('numeric', $type_test[17]->type_name);  //DOUBLE
+			$this->assertEquals('numeric', $type_test[18]->type_name);  //DECIMAL
+			$this->assertEquals('bytea', $type_test[19]->type_name);  //BLOB
 		}
 	}
 


### PR DESCRIPTION
**Description**
Allow common datatypes between Drivers for table creation and alters.
This allows Postgress to have ENUM,SET types (will create the type inside it for use in table).
Test cases where updated now Testing of datatypes is not driver dependant on creation of tables anymore

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide