### PR TITLE
Differentiate empty array

### DIFF
--- a/app/Views/errors/cli/error_exception.php
+++ b/app/Views/errors/cli/error_exception.php
@@ -56,7 +56,7 @@ if (defined('SHOW_DEBUG_BACKTRACE') && SHOW_DEBUG_BACKTRACE)
 				case is_object($value):
 					return 'Object(' . get_class($value) . ')';
 				case is_array($value):
-					return '[]';
+					return count($value) ? '[...]' : '[]';
 				case is_null($value):
 					return 'null'; // return the lowercased version
 				default:


### PR DESCRIPTION
**Description**
Differentiate empty array from a nonempty array in printing backtrace's `args`.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
