### PR TITLE
fix. Entity::mutateDate set empty return current time

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -495,7 +495,7 @@ class Entity implements \JsonSerializable
 			return Time::createFromTimestamp($value);
 		}
 
-		if (is_string($value))
+		if (is_string($value) && ! empty($value))
 		{
 			return Time::parse($value);
 		}

--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -799,6 +799,17 @@ class EntityTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(json_encode($entity->toArray()), json_encode($entity));
 	}
 
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/3251
+	 */
+	public function testmutateDateEmpty()
+	{
+		$entity = $this->getCastEntity();
+
+		$entity->eighth = '';
+		$this->assertEquals('', $entity->eighth);
+	}
+
 	protected function getEntity()
 	{
 		return new class extends Entity


### PR DESCRIPTION
Fix: #3251 Entity::mutateDate set empty return current time
**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
