### PR TITLE
add fixture class for Invalid Command class that throws \ReflectionException on Commands::discoverCommands()

### DIFF
--- a/tests/_support/Commands/InvalidCommand.php
+++ b/tests/_support/Commands/InvalidCommand.php
@@ -1,0 +1,24 @@
+<?php
+namespace Tests\Support\Commands;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\CodeIgniter;
+
+class InvalidCommand extends BaseCommand
+{
+
+	protected $group       = 'demo';
+	protected $name        = 'app:invalid';
+	protected $description = '';
+
+	public function __construct()
+	{
+		throw new \ReflectionException();
+	}
+
+	public function run(array $params)
+	{
+		CLI::write('CI Version: ' . CLI::color(CodeIgniter::CI_VERSION, 'red'));
+	}
+}


### PR DESCRIPTION
By this, `CLI\Commands` class will have 100% test coverage.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage