### PR TITLE
Allow dashes within CLI options

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -899,7 +899,7 @@ class CLI
 				continue;
 			}
 
-			$arg   = str_replace('-', '', $_SERVER['argv'][$i]);
+			$arg   = ltrim($_SERVER['argv'][$i], '-');
 			$value = null;
 
 			// if there is a following segment, and it doesn't start with a dash, it's a value.

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -284,14 +284,18 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 			'pvalue',
 			'd2',
 			'da-sh',
+			'-fix',
+			'-opt-in',
+			'sure',
 		];
-		$_SERVER['argc'] = 8;
+		$_SERVER['argc'] = 11;
 		CLI::init();
 		$this->assertEquals(null, CLI::getSegment(7));
 		$this->assertEquals('b', CLI::getSegment(1));
 		$this->assertEquals('c', CLI::getSegment(2));
 		$this->assertEquals('d', CLI::getSegment(3));
 		$this->assertEquals(['b', 'c', 'd', 'd2', 'da-sh'], CLI::getSegments());
+		$this->assertEquals(['parm' => 'pvalue', 'fix' => null, 'opt-in' => 'sure'], CLI::getOptions());
 	}
 
 	public function testParseCommandOption()


### PR DESCRIPTION
**Description**
#3208 fixed #3205 with regard to resolving dashes within CLI segments. However, if we have an option like `-opt-in` then `CLI::getOptions` will give `optin` as the key, removing the dash in between.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
