### PR TITLE
Small correction in example code

### DIFF
--- a/user_guide_src/source/libraries/uploaded_files.rst
+++ b/user_guide_src/source/libraries/uploaded_files.rst
@@ -157,7 +157,7 @@ You can check that a file was actually uploaded via HTTP with no errors by calli
 
 	if (! $file->isValid())
 	{
-		throw new RuntimeException($file->getErrorString().'('.$file->getError().')');
+		throw new \RuntimeException($file->getErrorString().'('.$file->getError().')');
 	}
 
 As seen in this example, if a file had an upload error, you can retrieve the error code (an integer) and the error


### PR DESCRIPTION
Added "\" to code example throw new \RuntimeException... 

I copied the code block to test uploading files and got a Class not found error.  After not being able to determine the cause, I thought of adding the "\" which I understand has to do with namespace protocol.  Hope this is right!