### PR TITLE
Allow to customize the request's headers in FeatureTestCase

### DIFF
--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -72,4 +72,11 @@ class FeatureTestCase extends CIDatabaseTestCase
 	 * @var boolean
 	 */
 	protected $clean = true;
+
+	/**
+	 * Custom request's headers
+	 * 
+	 * @var array
+	 */
+	protected $headers = [];
 }

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -102,6 +102,25 @@ trait FeatureTestTrait
 	}
 
 	/**
+	 * Set request's headers
+	 * 
+	 * Example of use 
+	 * withHeaders([
+	 *  'Authorization' => 'Token'
+	 * ])
+	 * 
+	 * @param array|null Array of headers
+	 * 
+	 * @return $this
+	 */
+	public function withHeaders(array $headers = null)
+	{
+		$this->headers = $headers;
+
+		return $this;
+	}
+
+	/**
 	 * Don't run any events while running this test.
 	 *
 	 * @return $this
@@ -143,6 +162,7 @@ trait FeatureTestTrait
 		$_SERVER['REQUEST_METHOD'] = $method;
 
 		$request = $this->setupRequest($method, $path);
+		$request = $this->setupHeaders($request);
 		$request = $this->populateGlobals($method, $request, $params);
 
 		// Make sure the RouteCollection knows what method we're using...
@@ -297,6 +317,26 @@ trait FeatureTestTrait
 		if ($config->forceGlobalSecureRequests)
 		{
 			$_SERVER['HTTPS'] = 'test';
+		}
+
+		return $request;
+	}
+
+	/**
+	 * Setup the custom request's headers
+	 * 
+	 * @param \CodeIgniter\HTTP\Request $request
+	 * 
+	 * @return \CodeIgniter\HTTP\IncomingRequest
+	 */
+	protected function setupHeaders(Request $request)
+	{
+		if(!empty($this->headers))
+		{
+			foreach($this->headers as $name => $value)
+			{
+				$request->setHeader($name, $value);
+			}
 		}
 
 		return $request;

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -109,11 +109,11 @@ trait FeatureTestTrait
 	 *  'Authorization' => 'Token'
 	 * ])
 	 * 
-	 * @param array|null Array of headers
+	 * @param array Array of headers
 	 * 
 	 * @return $this
 	 */
-	public function withHeaders(array $headers = null)
+	public function withHeaders(array $headers = [])
 	{
 		$this->headers = $headers;
 
@@ -331,9 +331,9 @@ trait FeatureTestTrait
 	 */
 	protected function setupHeaders(Request $request)
 	{
-		if(!empty($this->headers))
+		if (! empty($this->headers))
 		{
-			foreach($this->headers as $name => $value)
+			foreach ($this->headers as $name => $value)
 			{
 				$request->setHeader($name, $value);
 			}


### PR DESCRIPTION
**Description**
When you develop a protected api, sometimes you need to send tokens in the request header to authenticate that you can use this api. So you can create a filter that verifies that field in the header of the request.

When you want to test this API, with FeatureTestCase, you can't because it doesn't have the option to add headers to the order.

So I added this method, `withHeaders`, which before submitting the order, inserts custom headers.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide