### PR TITLE
Add url_to() URL helper function

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -648,7 +648,9 @@ if (! function_exists('url_to'))
 	 */
 	function url_to(string $controller, ...$args): string
 	{
-		if (! class_exists($controller))
+		$class = explode('::', $controller)[0];
+
+		if (! class_exists($class))
 		{
 			$controller = service('routes')->getDefaultNamespace() . $controller;
 		}

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -650,18 +650,23 @@ if (! function_exists('url_to'))
 	 */
 	function url_to(string $controller, ...$args): string
 	{
-		if (strpos($controller, '::') !== false)
-		{
-			$class = explode('::', $controller)[0];
-
-			if (! class_exists($class))
-			{
-				$controller = service('routes')->getDefaultNamespace() . $controller;
-			}
-		}
-
 		if (! $route = route_to($controller, ...$args))
 		{
+			if (strpos($controller, '::') !== false)
+			{
+				$class = explode('::', $controller)[0];
+
+				if (! class_exists($class))
+				{
+					$controller = service('routes')->getDefaultNamespace() . $controller;
+				}
+			}
+
+			if ($route = route_to($controller, ...$args))
+			{
+				return site_url($route);
+			}
+
 			$explode = explode('::', $controller);
 
 			if (isset($explode[1]))

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -650,11 +650,6 @@ if (! function_exists('url_to'))
 	 */
 	function url_to(string $controller, ...$args): string
 	{
-		if (! $route = route_to($controller, ...$args))
-		{
-			throw new \CodeIgniter\Router\Exceptions\RouterException(lang('HTTP.invalidRoute', [$controller]));
-		}
-
 		if (strpos($controller, '::') !== false)
 		{
 			$class = explode('::', $controller)[0];
@@ -663,6 +658,11 @@ if (! function_exists('url_to'))
 			{
 				$controller = service('routes')->getDefaultNamespace() . $controller;
 			}
+		}
+
+		if (! $route = route_to($controller, ...$args))
+		{
+			throw new \CodeIgniter\Router\Exceptions\RouterException(lang('HTTP.invalidRoute', [$controller]));
 		}
 
 		return site_url($route);

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -648,11 +648,14 @@ if (! function_exists('url_to'))
 	 */
 	function url_to(string $controller, ...$args): string
 	{
-		$class = explode('::', $controller)[0];
-
-		if (! class_exists($class))
+		if (strpos($controller, '::') !== false)
 		{
-			$controller = service('routes')->getDefaultNamespace() . $controller;
+			$class = explode('::', $controller)[0];
+
+			if (! class_exists($class))
+			{
+				$controller = service('routes')->getDefaultNamespace() . $controller;
+			}
 		}
 
 		return site_url(route_to($controller, ...$args));

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -644,13 +644,15 @@ if (! function_exists('url_to'))
 	 * @param string $controller
 	 * @param mixed  ...$args
 	 *
+	 * @throws \CodeIgniter\Router\Exceptions\RouterException
+	 *
 	 * @return string
 	 */
 	function url_to(string $controller, ...$args): string
 	{
-		if (empty($controller))
+		if (! $route = route_to($controller, ...$args))
 		{
-			return site_url();
+			throw new \CodeIgniter\Router\Exceptions\RouterException(lang('HTTP.invalidRoute', [$controller]));
 		}
 
 		if (strpos($controller, '::') !== false)
@@ -663,6 +665,6 @@ if (! function_exists('url_to'))
 			}
 		}
 
-		return site_url(route_to($controller, ...$args));
+		return site_url($route);
 	}
 }

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -664,7 +664,14 @@ if (! function_exists('url_to'))
 		{
 			$explode = explode('::', $controller);
 
-			throw new \CodeIgniter\Router\Exceptions\RouterException(lang('HTTP.controllerNotFound', [$explode[0], $explode[1]]));
+			if (isset($explode[1]))
+			{
+				throw new \CodeIgniter\Router\Exceptions\RouterException(lang('HTTP.controllerNotFound', [$explode[0], $explode[1]]));
+			}
+			else
+			{
+				throw new \CodeIgniter\Router\Exceptions\RouterException(lang('HTTP.invalidRoute', [$controller]));
+			}
 		}
 
 		return site_url($route);

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -648,6 +648,11 @@ if (! function_exists('url_to'))
 	 */
 	function url_to(string $controller, ...$args): string
 	{
+		if (empty($controller))
+		{
+			return site_url();
+		}
+
 		if (strpos($controller, '::') !== false)
 		{
 			$class = explode('::', $controller)[0];

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -655,6 +655,6 @@ if (! function_exists('url_to'))
 			$controller = service('routes')->getDefaultNamespace() . $controller;
 		}
 
-		return base_url(route_to($controller, ...$args));
+		return site_url(route_to($controller, ...$args));
 	}
 }

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -652,16 +652,7 @@ if (! function_exists('url_to'))
 	{
 		if (! $route = route_to($controller, ...$args))
 		{
-			$explode = explode('::', $controller);
-
-			if (isset($explode[1]))
-			{
-				throw new \CodeIgniter\Router\Exceptions\RouterException(lang('HTTP.controllerNotFound', [$explode[0], $explode[1]]));
-			}
-			else
-			{
-				throw new \CodeIgniter\Router\Exceptions\RouterException(lang('HTTP.invalidRoute', [$controller]));
-			}
+			throw new \CodeIgniter\Router\Exceptions\RouterException(lang('HTTP.invalidRoute', [$controller]));
 		}
 
 		return site_url($route);

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -652,6 +652,13 @@ if (! function_exists('url_to'))
 	{
 		if (! $route = route_to($controller, ...$args))
 		{
+			$explode = explode('::', $controller);
+
+			if (isset($explode[1]))
+			{
+				throw new \CodeIgniter\Router\Exceptions\RouterException(lang('HTTP.controllerNotFound', [$explode[0], $explode[1]]));
+			}
+
 			throw new \CodeIgniter\Router\Exceptions\RouterException(lang('HTTP.invalidRoute', [$controller]));
 		}
 

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -662,7 +662,9 @@ if (! function_exists('url_to'))
 
 		if (! $route = route_to($controller, ...$args))
 		{
-			throw new \CodeIgniter\Router\Exceptions\RouterException(lang('HTTP.invalidRoute', [$controller]));
+			$explode = explode('::', $controller);
+
+			throw new \CodeIgniter\Router\Exceptions\RouterException(lang('HTTP.controllerNotFound', [$explode[0], $explode[1]]));
 		}
 
 		return site_url($route);

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -652,21 +652,6 @@ if (! function_exists('url_to'))
 	{
 		if (! $route = route_to($controller, ...$args))
 		{
-			if (strpos($controller, '::') !== false)
-			{
-				$class = explode('::', $controller)[0];
-
-				if (! class_exists($class))
-				{
-					$controller = service('routes')->getDefaultNamespace() . $controller;
-				}
-			}
-
-			if ($route = route_to($controller, ...$args))
-			{
-				return site_url($route);
-			}
-
 			$explode = explode('::', $controller);
 
 			if (isset($explode[1]))

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -634,3 +634,25 @@ if (! function_exists('mb_url_title'))
 }
 
 //--------------------------------------------------------------------
+
+if (! function_exists('url_to'))
+{
+	/**
+	 * Get the full, absolute URL to a controller method
+	 * (with additional arguments)
+	 *
+	 * @param string $controller
+	 * @param mixed  ...$args
+	 *
+	 * @return string
+	 */
+	function url_to(string $controller, ...$args): string
+	{
+		if (! class_exists($controller))
+		{
+			$controller = service('routes')->getDefaultNamespace() . $controller;
+		}
+
+		return base_url(route_to($controller, ...$args));
+	}
+}

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1250,4 +1250,14 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $config));
 	}
 
+	public function testCreateAbsoluteUrlWithUrlTo()
+	{
+		$_SERVER['HTTP_HOST'] = 'example.com';
+
+		$routes = service('routes');
+		$routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2');
+
+		$this->assertEquals('http://example.com/path/string/to/13', url_to('myController::goto', 'string', 13));
+	}
+
 }

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1260,18 +1260,20 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('http://example.com/index.php/path/string/to/13', url_to('myController::goto', 'string', 13));
 	}
 
-	public function testUrlToWithEmptyString()
+	/**
+	 * @dataProvider urlToProvider
+	 */
+	public function testUrlToMakesHomeUrl($input)
 	{
-		$_SERVER['HTTP_HOST'] = 'example.com';
-
-		$this->assertEquals('http://example.com/index.php', url_to(''));
+		$this->assertEquals('http://example.com/index.php', url_to($input));
 	}
 
-	public function testUrlToWithSlash()
+	public function urlToProvider()
 	{
-		$_SERVER['HTTP_HOST'] = 'example.com';
-
-		$this->assertEquals('http://example.com/index.php', url_to('/'));
+		return [
+			[''],
+			['/'],
+		];
 	}
 
 }

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1264,17 +1264,19 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($expected, url_to($input, ...$args));
 	}
 
+	/**
+	 * @dataProvider urlToMissingRoutesProvider
+	 */
+	public function testUrlToThrowsOnEmptyOrMissingRoute(string $route)
+	{
+		$this->expectException(\CodeIgniter\Router\Exceptions\RouterException::class);
+
+		url_to($route);
+	}
+
 	public function urlToProvider()
 	{
 		return [
-			[
-				'http://example.com/index.php',
-				'',
-			],
-			[
-				'http://example.com/index.php',
-				'/',
-			],
 			[
 				'http://example.com/index.php/path/string/to/13',
 				'gotoPage',
@@ -1286,6 +1288,18 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 				'myOtherController::goto',
 				'string',
 				13,
+			],
+		];
+	}
+
+	public function urlToMissingRoutesProvider()
+	{
+		return [
+			[
+				'',
+			],
+			[
+				'Nope::doesNotExist',
 			],
 		];
 	}

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1276,15 +1276,21 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function urlToProvider()
 	{
+		if (config('App')->indexPage != '') {
+			$page = config('App')->indexPage . '/';
+		} else {
+			$page = '';
+		}
+
 		return [
 			[
-				'http://example.com/index.php/path/string/to/13',
+				"http://example.com/{$page}path/string/to/13",
 				'gotoPage',
 				'string',
 				13,
 			],
 			[
-				'http://example.com/index.php/route/string/to/13',
+				"http://example.com/{$page}route/string/to/13",
 				'myOtherController::goto',
 				'string',
 				13,

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1260,4 +1260,18 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('http://example.com/index.php/path/string/to/13', url_to('myController::goto', 'string', 13));
 	}
 
+	public function testUrlToWithEmptyString()
+	{
+		$_SERVER['HTTP_HOST'] = 'example.com';
+
+		$this->assertEquals('http://example.com/index.php', url_to(''));
+	}
+
+	public function testUrlToWithSlash()
+	{
+		$_SERVER['HTTP_HOST'] = 'example.com';
+
+		$this->assertEquals('http://example.com/index.php', url_to('/'));
+	}
+
 }

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1276,9 +1276,12 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function urlToProvider()
 	{
-		if (config('App')->indexPage != '') {
+		if (config('App')->indexPage !== '')
+		{
 			$page = config('App')->indexPage . '/';
-		} else {
+		}
+		else
+		{
 			$page = '';
 		}
 

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1260,6 +1260,16 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('http://example.com/index.php/path/string/to/13', url_to('myController::goto', 'string', 13));
 	}
 
+	public function testUrlToWithNamedRoutes()
+	{
+		$_SERVER['HTTP_HOST'] = 'example.com';
+
+		$routes = service('routes');
+		$routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'gotoPage']);
+
+		$this->assertEquals('http://example.com/index.php/path/string/to/13', url_to('gotoPage', 'string', 13));
+	}
+
 	/**
 	 * @dataProvider urlToProvider
 	 */

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1257,7 +1257,7 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$routes = service('routes');
 		$routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2');
 
-		$this->assertEquals('http://example.com/path/string/to/13', url_to('myController::goto', 'string', 13));
+		$this->assertEquals('http://example.com/index.php/path/string/to/13', url_to('myController::goto', 'string', 13));
 	}
 
 }

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1250,39 +1250,43 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $config));
 	}
 
-	public function testCreateAbsoluteUrlWithUrlTo()
-	{
-		$_SERVER['HTTP_HOST'] = 'example.com';
-
-		$routes = service('routes');
-		$routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2');
-
-		$this->assertEquals('http://example.com/index.php/path/string/to/13', url_to('myController::goto', 'string', 13));
-	}
-
-	public function testUrlToWithNamedRoutes()
+	/**
+	 * @dataProvider urlToProvider
+	 */
+	public function testUrlTo(string $expected, string $input, ...$args)
 	{
 		$_SERVER['HTTP_HOST'] = 'example.com';
 
 		$routes = service('routes');
 		$routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'gotoPage']);
+		$routes->add('route/(:any)/to/(:num)', 'myOtherController::goto/$1/$2');
 
-		$this->assertEquals('http://example.com/index.php/path/string/to/13', url_to('gotoPage', 'string', 13));
-	}
-
-	/**
-	 * @dataProvider urlToProvider
-	 */
-	public function testUrlToMakesHomeUrl($input)
-	{
-		$this->assertEquals('http://example.com/index.php', url_to($input));
+		$this->assertEquals($expected, url_to($input, ...$args));
 	}
 
 	public function urlToProvider()
 	{
 		return [
-			[''],
-			['/'],
+			[
+				'http://example.com/index.php',
+				'',
+			],
+			[
+				'http://example.com/index.php',
+				'/',
+			],
+			[
+				'http://example.com/index.php/path/string/to/13',
+				'gotoPage',
+				'string',
+				13,
+			],
+			[
+				'http://example.com/index.php/route/string/to/13',
+				'myOtherController::goto',
+				'string',
+				13,
+			],
 		];
 	}
 

--- a/user_guide_src/source/changelogs/v4.0.5.rst
+++ b/user_guide_src/source/changelogs/v4.0.5.rst
@@ -5,6 +5,10 @@ Release Date: Not released
 
 **4.0.5 release of CodeIgniter4**
 
+Enhancements:
+
+- New URL helper function ``url_to()`` which creates absolute URLs based on controllers.
+
 Bugs Fixed:
 
 - Fixed a bug in ``Entity`` class where declaring class parameters was preventing data propagation to the ``attributes`` array.

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -361,7 +361,7 @@ The following functions are available:
 
         $url = prep_url('example.com');
 
-.. php:function:: url_to([$controller[, ...$args]])
+.. php:function:: url_to($controller[, ...$args])
 
     :param  string  $controller: The controller class and method
     :param  mixed   ...$args: Additional arguments to be injected into the route

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -360,3 +360,25 @@ The following functions are available:
     Pass the URL string to the function like this::
 
         $url = prep_url('example.com');
+
+.. php:function:: url_to([$controller[, ...$args]])
+
+    :param  string  $controller: The controller class and method
+    :param  mixed   ...$args: Additional arguments to be injected into the route
+    :returns: Absolute URL
+    :rtype: string
+
+    Builds an absolute URL to a controller method in your app. Example::
+
+        echo url_to('Home::index');
+
+    You can also add arguments to the route.
+    Here is an example::
+
+        echo url_to('Page::index', 'home');
+
+    The above example would return something like:
+    *http://example.com/page/home*
+
+    This is useful because you can still change your routes after putting links
+    into your views.


### PR DESCRIPTION
This PR adds a URL helper function called `url_to()`.

**Description**
I added a URL helper called `url_to()`. It creates absolute URLs based on controllers. I'm commonly using this function in basically all of my CodeIgniter projects. Here is an example:

```php
service('routes')->get('/welcome', 'Pages::welcome');
echo url_to('Pages::welcome'); # => http://example.com/welcome

service('routes')->get('/page/(:segment)', 'Pages::view/$1');
echo url_to('Pages::view', 'home'); # => http://example.com/page/home
```

It is meant to be used inside of views to generate links. The main advantage of this function is that you can change your routes later on, but not having to change your links across all your views.

This is the first time I'm contributing code to CodeIgniter, I hope I didn't miss something.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide