### PR TITLE
Sync CLIRequest::parseCommand

### DIFF
--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -231,7 +231,7 @@ class CLIRequest extends Request
 				continue;
 			}
 
-			$arg   = ltrim($arg, '-');
+			$arg   = filter_var(ltrim($arg, '-'), FILTER_SANITIZE_STRING);
 			$value = null;
 
 			if (isset($args[$i + 1]) && mb_strpos($args[$i + 1], '-') !== 0)

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -210,40 +210,34 @@ class CLIRequest extends Request
 	 */
 	protected function parseCommand()
 	{
-		// Since we're building the options ourselves,
-		// we stop adding it to the segments array once
-		// we have found the first dash.
-		$options_found = false;
+		$args = $this->getServer('argv');
+		array_shift($args); // Scrap index.php
 
-		$argc = $this->getServer('argc', FILTER_SANITIZE_NUMBER_INT);
-		$argv = $this->getServer('argv');
+		$optionValue = false;
 
-		// We start at 1 since we never want to include index.php
-		for ($i = 1; $i < $argc; $i ++)
+		foreach ($args as $i => $arg)
 		{
-			// If there's no '-' at the beginning of the argument
-			// then add it to our segments.
-			if (! $options_found && strpos($argv[$i], '-') !== 0)
+			if (mb_strpos($arg, '-') !== 0)
 			{
-				$this->segments[] = filter_var($argv[$i], FILTER_SANITIZE_STRING);
+				if ($optionValue)
+				{
+					$optionValue = false;
+				}
+				else
+				{
+					$this->segments[] = filter_var($arg, FILTER_SANITIZE_STRING);
+				}
+
 				continue;
 			}
 
-			$options_found = true;
-
-			if (strpos($argv[$i], '-') !== 0)
-			{
-				continue;
-			}
-
-			$arg   = filter_var(str_replace('-', '', $argv[$i]), FILTER_SANITIZE_STRING);
+			$arg   = ltrim($arg, '-');
 			$value = null;
 
-			// If the next item starts with a dash it's a value
-			if (isset($argv[$i + 1]) && strpos($argv[$i + 1], '-') !== 0)
+			if (isset($args[$i + 1]) && mb_strpos($args[$i + 1], '-') !== 0)
 			{
-				$value = filter_var($argv[$i + 1], FILTER_SANITIZE_STRING);
-				$i ++;
+				$value       = filter_var($args[$i + 1], FILTER_SANITIZE_STRING);
+				$optionValue = true;
 			}
 
 			$this->options[$arg] = $value;

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -40,7 +40,6 @@ class CLIRequestTest extends CIUnitTestCase
 			'-foo',
 			'bar',
 		];
-		$_SERVER['argc'] = 6;
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
@@ -62,13 +61,17 @@ class CLIRequestTest extends CIUnitTestCase
 			'profile',
 			'-foo',
 			'bar',
+			'-foo-bar',
+			'yes',
 		];
-		$_SERVER['argc'] = 6;
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
 
-		$options = ['foo' => 'bar'];
+		$options = [
+			'foo'     => 'bar',
+			'foo-bar' => 'yes',
+		];
 		$this->assertEquals($options, $this->request->getOptions());
 	}
 
@@ -82,7 +85,6 @@ class CLIRequestTest extends CIUnitTestCase
 			'-foo',
 			'bar',
 		];
-		$_SERVER['argc'] = 6;
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
@@ -103,7 +105,6 @@ class CLIRequestTest extends CIUnitTestCase
 			'-baz',
 			'queue some stuff',
 		];
-		$_SERVER['argc'] = 8;
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
@@ -120,7 +121,6 @@ class CLIRequestTest extends CIUnitTestCase
 			'21',
 			'profile',
 		];
-		$_SERVER['argc'] = 4;
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
@@ -139,7 +139,6 @@ class CLIRequestTest extends CIUnitTestCase
 			'-foo',
 			'bar',
 		];
-		$_SERVER['argc'] = 6;
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
@@ -160,7 +159,6 @@ class CLIRequestTest extends CIUnitTestCase
 			'-baz',
 			'queue some stuff',
 		];
-		$_SERVER['argc'] = 8;
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
@@ -183,7 +181,6 @@ class CLIRequestTest extends CIUnitTestCase
 			'-baz',
 			'queue some stuff',
 		];
-		$_SERVER['argc'] = 8;
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
@@ -207,13 +204,12 @@ class CLIRequestTest extends CIUnitTestCase
 			'-baz',
 			'queue some stuff',
 		];
-		$_SERVER['argc'] = 9;
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
 
 		$expectedOptions = '-foo oops -baz "queue some stuff"';
-		$expectedPath    = 'users/21/profile';
+		$expectedPath    = 'users/21/profile/bar';
 		$this->assertEquals($expectedOptions, $this->request->getOptionString());
 		$this->assertEquals($expectedPath, $this->request->getPath());
 	}


### PR DESCRIPTION
**Description**
Sync `CLIRequest::parseCommand` with recent changes in `CLI::parseCommandLine` (#3398) and also align it with `CLI::parseCommandLine`'s current behavior, see `CLITest::testParseCommandMixed`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
