### PR TITLE
Fixes Autoloader::loadLegacy() always called

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -280,14 +280,14 @@ class Autoloader
 	{
 		if (strpos($class, '\\') === false)
 		{
-			return false;
+			$class = 'Config\\' . $class;
 		}
 
 		foreach ($this->prefixes as $namespace => $directories)
 		{
 			foreach ($directories as $directory)
 			{
-				$directory = rtrim($directory, DIRECTORY_SEPARATOR);
+				$directory = rtrim($directory, '\\/');
 
 				if (strpos($class, $namespace) === 0)
 				{

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -280,7 +280,16 @@ class Autoloader
 	{
 		if (strpos($class, '\\') === false)
 		{
-			$class = 'Config\\' . $class;
+			$class    = 'Config\\' . $class;
+			$filePath = APPPATH . str_replace('\\', '/', $class) . '.php';
+			$filename = $this->requireFile($filePath);
+
+			if ($filename)
+			{
+				return $filename;
+			}
+
+			return false;
 		}
 
 		foreach ($this->prefixes as $namespace => $directories)

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -281,7 +281,7 @@ class Autoloader
 		if (strpos($class, '\\') === false)
 		{
 			$class    = 'Config\\' . $class;
-			$filePath = APPPATH . str_replace('\\', '/', $class) . '.php';
+			$filePath = APPPATH . str_replace('\\', DIRECTORY_SEPARATOR, $class) . '.php';
 			$filename = $this->requireFile($filePath);
 
 			if ($filename)
@@ -341,7 +341,7 @@ class Autoloader
 			APPPATH . 'Models/',
 		];
 
-		$class = str_replace('\\', '/', $class) . '.php';
+		$class = str_replace('\\', DIRECTORY_SEPARATOR, $class) . '.php';
 
 		foreach ($paths as $path)
 		{

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -287,7 +287,7 @@ class Autoloader
 		{
 			foreach ($directories as $directory)
 			{
-				$directory = rtrim($directory, '\\/');
+				$directory = rtrim($directory, DIRECTORY_SEPARATOR);
 
 				if (strpos($class, $namespace) === 0)
 				{

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -186,6 +186,17 @@ class AutoloaderTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testloadClassConfig()
+	{
+		$this->loader->addNamespace('Config', APPPATH . 'Config');
+		$this->assertSame(
+			APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'Modules.php',
+			$this->loader->loadClass('Modules')
+		);
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testLoadLegacy()
 	{
 		// should not be able to find a folder

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -186,13 +186,21 @@ class AutoloaderTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testloadClassConfig()
+	public function testloadClassConfigFound()
 	{
 		$this->loader->addNamespace('Config', APPPATH . 'Config');
 		$this->assertSame(
 			APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'Modules.php',
 			$this->loader->loadClass('Modules')
 		);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testloadClassConfigNotFound()
+	{
+		$this->loader->addNamespace('Config', APPPATH . 'Config');
+		$this->assertFalse($this->loader->loadClass('NotFound'));
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
The `loadLegacy()` function was always called in `Autoloader::loadClass()` function for just normal `Home` Controller accessing `/` page, while there is no legacy class. /cc @paulbalandan if you can verify.

Tested in MacOS.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
