### PR TITLE
[ci skip] prefer composer installation over manual in menu documentation

### DIFF
--- a/user_guide_src/source/installation/index.rst
+++ b/user_guide_src/source/installation/index.rst
@@ -15,8 +15,8 @@ Which is right for you?
 .. toctree::
     :titlesonly:
 
-    installing_manual
     installing_composer
+    installing_manual
     running
     upgrading
     troubleshooting


### PR DESCRIPTION
By sort menu with `composer` first, it may make people more use composer. Manual composer make some more and more questions like : got error `undefined function locale_set_default` because new user don't read the requirement. via composer, the error for it is more verbose : ext-intl must be enabled.

**Checklist:**
- [x] Securely signed commits