### PR TITLE
Created checks for row and col attributes specified in the $extra par…

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -311,7 +311,8 @@ if (! function_exists('form_textarea'))
 		}
 
 		// Unsets default rows and cols if defined in extra field as array or string.
-		if ((is_array($extra) && array_key_exists('rows', $extra)) || (is_string($extra) && strpos(strtolower(preg_replace('/\s+/', '', $extra)), 'rows=') !== FALSE)) {
+		if ((is_array($extra) && array_key_exists('rows', $extra)) || (is_string($extra) && strpos(strtolower(preg_replace('/\s+/', '', $extra)), 'rows=') !== FALSE))
+		{
 			unset($defaults['rows']);
 		}
 

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -319,7 +319,7 @@ if (! function_exists('form_textarea'))
 			unset($defaults['cols']);
 		}
 
-		return '<textarea ' . parse_form_attributes($data, $defaults) . stringify_attributes($extra) . '>'
+		return '<textarea ' . parse_form_attributes($data, $defaults) . ltrim(stringify_attributes($extra)) . '>'
 				. htmlspecialchars($val)
 				. "</textarea>\n";
 	}

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -310,6 +310,15 @@ if (! function_exists('form_textarea'))
 			unset($data['value']); // textareas don't use the value attribute
 		}
 
+		// Unsets default rows and cols if defined in extra field as array or string.
+		if ((is_array($extra) && array_key_exists('rows', $extra)) || (is_string($extra) && strpos(strtolower(preg_replace('/\s+/', '', $extra)), 'rows=') !== FALSE)) {
+			unset($defaults['rows']);
+		}
+
+		if ((is_array($extra) && array_key_exists('cols', $extra)) || (is_string($extra) && strpos(strtolower(preg_replace('/\s+/', '', $extra)), 'cols=') !== FALSE)) {
+			unset($defaults['cols']);
+		}
+
 		return '<textarea ' . parse_form_attributes($data, $defaults) . stringify_attributes($extra) . '>'
 				. htmlspecialchars($val)
 				. "</textarea>\n";

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -319,7 +319,7 @@ if (! function_exists('form_textarea'))
 			unset($defaults['cols']);
 		}
 
-		return '<textarea ' . parse_form_attributes($data, $defaults) . ltrim(stringify_attributes($extra)) . '>'
+		return '<textarea ' . rtrim(parse_form_attributes($data, $defaults)) . stringify_attributes($extra) . '>'
 				. htmlspecialchars($val)
 				. "</textarea>\n";
 	}

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -316,7 +316,8 @@ if (! function_exists('form_textarea'))
 			unset($defaults['rows']);
 		}
 
-		if ((is_array($extra) && array_key_exists('cols', $extra)) || (is_string($extra) && strpos(strtolower(preg_replace('/\s+/', '', $extra)), 'cols=') !== FALSE)) {
+		if ((is_array($extra) && array_key_exists('cols', $extra)) || (is_string($extra) && strpos(strtolower(preg_replace('/\s+/', '', $extra)), 'cols=') !== FALSE))
+		{
 			unset($defaults['cols']);
 		}
 

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -311,8 +311,7 @@ EOH;
 	}
 
 	// ------------------------------------------------------------------------
-	public function testForm
-		()
+	public function testFormTextarea()
 	{
 		$expected = <<<EOH
 <textarea name="notes" cols="40" rows="10">Notes</textarea>\n

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -311,7 +311,8 @@ EOH;
 	}
 
 	// ------------------------------------------------------------------------
-	public function testFormTextarea()
+	public function testForm
+		()
 	{
 		$expected = <<<EOH
 <textarea name="notes" cols="40" rows="10" >Notes</textarea>\n
@@ -331,6 +332,29 @@ EOH;
 
 EOH;
 		$this->assertEquals($expected, form_textarea($data));
+	}
+
+	// ------------------------------------------------------------------------
+	public function testFormTextareaExtraRowsColsArray()
+	{
+		$extra     = [
+			'cols' => '30',
+			'rows'  => '5',
+		];
+		$expected = <<<EOH
+<textarea name="notes" cols="30" rows="5" >Notes</textarea>\n
+EOH;
+		$this->assertEquals($expected, form_textarea('notes', 'Notes', $extra));
+	}
+
+	// ------------------------------------------------------------------------
+	public function testFormTextareaExtraRowsColsString()
+	{
+		$extra = 'cols="30" rows="5"';
+		$expected = <<<EOH
+<textarea name="notes" cols="30" rows="5" >Notes</textarea>\n
+EOH;
+		$this->assertEquals($expected, form_textarea('notes', 'Notes', $extra));
 	}
 
 	// ------------------------------------------------------------------------

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -315,7 +315,7 @@ EOH;
 		()
 	{
 		$expected = <<<EOH
-<textarea name="notes" cols="40" rows="10" >Notes</textarea>\n
+<textarea name="notes" cols="40" rows="10">Notes</textarea>\n
 EOH;
 		$this->assertEquals($expected, form_textarea('notes', 'Notes'));
 	}
@@ -328,7 +328,7 @@ EOH;
 			'value' => 'bar',
 		];
 		$expected = <<<EOH
-<textarea name="foo" cols="40" rows="10" >bar</textarea>
+<textarea name="foo" cols="40" rows="10">bar</textarea>
 
 EOH;
 		$this->assertEquals($expected, form_textarea($data));
@@ -342,7 +342,7 @@ EOH;
 			'rows'  => '5',
 		];
 		$expected = <<<EOH
-<textarea name="notes" cols="30" rows="5" >Notes</textarea>\n
+<textarea name="notes" cols="30" rows="5">Notes</textarea>\n
 EOH;
 		$this->assertEquals($expected, form_textarea('notes', 'Notes', $extra));
 	}
@@ -352,7 +352,7 @@ EOH;
 	{
 		$extra = 'cols="30" rows="5"';
 		$expected = <<<EOH
-<textarea name="notes" cols="30" rows="5" >Notes</textarea>\n
+<textarea name="notes" cols="30" rows="5">Notes</textarea>\n
 EOH;
 		$this->assertEquals($expected, form_textarea('notes', 'Notes', $extra));
 	}


### PR DESCRIPTION
Fixes #3412 

Created checks for row and col attributes specified in the $extra parameter for the form_textarea form helper.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide