### PR TITLE
Make encryption HMAC digest configurable

### DIFF
--- a/app/Config/Encryption.php
+++ b/app/Config/Encryption.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
@@ -12,25 +13,32 @@ use CodeIgniter\Config\BaseConfig;
 class Encryption extends BaseConfig
 {
 	/*
-	  |--------------------------------------------------------------------------
-	  | Encryption Key Starter
-	  |--------------------------------------------------------------------------
-	  |
-	  | If you use the Encryption class you must set an encryption key (seed).
-	  | You need to ensure it is long enough for the cipher and mode you plan to use.
-	  | See the user guide for more info.
+	 |--------------------------------------------------------------------------
+	 | Encryption Key Starter
+	 |--------------------------------------------------------------------------
+	 |
+	 | If you use the Encryption class you must set an encryption key (seed).
+	 | You need to ensure it is long enough for the cipher and mode you plan to use.
+	 | See the user guide for more info.
 	 */
-
 	public $key = '';
 
 	/*
-	  |--------------------------------------------------------------------------
-	  | Encryption driver to use
-	  |--------------------------------------------------------------------------
-	  |
-	  | One of the supported drivers, eg 'OpenSSL' or 'Sodium'.
-	  | The default driver, if you don't specify one, is 'OpenSSL'.
+	 |--------------------------------------------------------------------------
+	 | Encryption driver to use
+	 |--------------------------------------------------------------------------
+	 |
+	 | One of the supported drivers, e.g. 'OpenSSL' or 'Sodium'.
+	 | The default driver, if you don't specify one, is 'OpenSSL'.
 	 */
 	public $driver = 'OpenSSL';
 
+	/*
+	 |--------------------------------------------------------------------------
+	 | Encryption digest
+	 |--------------------------------------------------------------------------
+	 |
+	 | HMAC digest to use, e.g. 'SHA512' or 'SHA256'. Default value is 'SHA512'.
+	 */
+	public $digest = 'SHA512';
 }

--- a/env
+++ b/env
@@ -87,8 +87,9 @@
 # ENCRYPTION
 #--------------------------------------------------------------------
 
-# encryption.key = 
+# encryption.key =
 # encryption.driver = OpenSSL
+# encryption.digest = SHA512
 
 #--------------------------------------------------------------------
 # HONEYPOT

--- a/system/Encryption/EncrypterInterface.php
+++ b/system/Encryption/EncrypterInterface.php
@@ -50,8 +50,9 @@ interface EncrypterInterface
 	/**
 	 * Encrypt - convert plaintext into ciphertext
 	 *
-	 * @param  string $data   Input data
-	 * @param  array  $params Over-ridden parameters, specifically the key
+	 * @param string $data   Input data
+	 * @param array  $params Over-ridden parameters, specifically the key
+	 *
 	 * @return string
 	 */
 	public function encrypt($data, $params = null);
@@ -59,8 +60,9 @@ interface EncrypterInterface
 	/**
 	 * Decrypt - convert ciphertext into plaintext
 	 *
-	 * @param  string $data   Encrypted data
-	 * @param  array  $params Over-ridden parameters, specifically the key
+	 * @param string $data   Encrypted data
+	 * @param array  $params Over-ridden parameters, specifically the key
+	 *
 	 * @return string
 	 */
 	public function decrypt($data, $params = null);

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -103,7 +103,7 @@ class Encryption
 
 		$this->key    = $config->key;
 		$this->driver = $config->driver;
-		$this->digest = $config->digest;
+              $this->digest = $config->digest ?? 'SHA512';
 
 		// determine what is installed
 		$this->handlers = [

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -99,12 +99,11 @@ class Encryption
 	 */
 	public function __construct(BaseConfig $config = null)
 	{
-		if (empty($config))
-		{
-			$config = new \Config\Encryption();
-		}
-		$this->driver = $config->driver;
+		$config = $config ?? new \Config\Encryption();
+
 		$this->key    = $config->key;
+		$this->driver = $config->driver;
+		$this->digest = $config->digest;
 
 		// determine what is installed
 		$this->handlers = [
@@ -132,10 +131,11 @@ class Encryption
 	public function initialize(BaseConfig $config = null)
 	{
 		// override config?
-		if (! empty($config))
+		if ($config)
 		{
-			$this->driver = $config->driver;
 			$this->key    = $config->key;
+			$this->driver = $config->driver;
+			$this->digest = $config->digest;
 		}
 
 		// Insist on a driver

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -135,7 +135,7 @@ class Encryption
 		{
 			$this->key    = $config->key;
 			$this->driver = $config->driver;
-			$this->digest = $config->digest;
+                      $this->digest = $config->digest ?? 'SHA512';
 		}
 
 		// Insist on a driver

--- a/system/Encryption/Handlers/BaseHandler.php
+++ b/system/Encryption/Handlers/BaseHandler.php
@@ -40,20 +40,13 @@
 namespace CodeIgniter\Encryption\Handlers;
 
 use CodeIgniter\Config\BaseConfig;
+use CodeIgniter\Encryption\EncrypterInterface;
 
 /**
  * Base class for encryption handling
  */
-abstract class BaseHandler implements \CodeIgniter\Encryption\EncrypterInterface
+abstract class BaseHandler implements EncrypterInterface
 {
-
-	/**
-	 * Configuraiton passed from encryption manager
-	 *
-	 * @var string
-	 */
-	protected $config;
-
 	/**
 	 * Logger instance to record error messages and warnings.
 	 *
@@ -66,14 +59,11 @@ abstract class BaseHandler implements \CodeIgniter\Encryption\EncrypterInterface
 	/**
 	 * Constructor
 	 *
-	 * @param BaseConfig $config
+	 * @param \CodeIgniter\Config\BaseConfig|null $config
 	 */
 	public function __construct(BaseConfig $config = null)
 	{
-		if (empty($config))
-		{
-			$config = new \Config\Encryption();
-		}
+		$config = $config ?? new \Config\Encryption();
 
 		// make the parameters conveniently accessible
 		foreach ($config as $pkey => $value)

--- a/system/Encryption/Handlers/OpenSSLHandler.php
+++ b/system/Encryption/Handlers/OpenSSLHandler.php
@@ -62,7 +62,7 @@ class OpenSSLHandler extends BaseHandler
 	/**
 	 * Initialize OpenSSL, remembering parameters
 	 *
-	 * @param BaseConfig $config
+	 * @param \CodeIgniter\Config\BaseConfig|null $config
 	 *
 	 * @throws \CodeIgniter\Encryption\Exceptions\EncryptionException
 	 */
@@ -74,15 +74,16 @@ class OpenSSLHandler extends BaseHandler
 	/**
 	 * Encrypt plaintext, with optional HMAC and base64 encoding
 	 *
-	 * @param  string $data   Input data
-	 * @param  array  $params Over-ridden parameters, specifically the key
+	 * @param string $data   Input data
+	 * @param array  $params Over-ridden parameters, specifically the key
+	 *
 	 * @return string
 	 * @throws \CodeIgniter\Encryption\Exceptions\EncryptionException
 	 */
 	public function encrypt($data, $params = null)
 	{
-		// Allow key over-ride
-		if (! empty($params))
+		// Allow key override
+		if ($params)
 		{
 			if (isset($params['key']))
 			{
@@ -93,6 +94,7 @@ class OpenSSLHandler extends BaseHandler
 				$this->key = $params;
 			}
 		}
+
 		if (empty($this->key))
 		{
 			throw EncryptionException::forNeedsStarterKey();
@@ -123,15 +125,16 @@ class OpenSSLHandler extends BaseHandler
 	/**
 	 * Decrypt ciphertext, with optional HMAC and base64 encoding
 	 *
-	 * @param  string $data   Encrypted data
-	 * @param  array  $params Over-ridden parameters, specifically the key
+	 * @param string $data   Encrypted data
+	 * @param array  $params Over-ridden parameters, specifically the key
+	 *
 	 * @return string
 	 * @throws \CodeIgniter\Encryption\Exceptions\EncryptionException
 	 */
 	public function decrypt($data, $params = null)
 	{
-		// Allow key over-ride
-		if (! empty($params))
+		// Allow key override
+		if ($params)
 		{
 			if (isset($params['key']))
 			{
@@ -142,6 +145,7 @@ class OpenSSLHandler extends BaseHandler
 				$this->key = $params;
 			}
 		}
+
 		if (empty($this->key))
 		{
 			throw EncryptionException::forNeedsStarterKey();


### PR DESCRIPTION
**Description**
Make `HMAC digest` configurable through `Config\Encryption` or through `.env` file. Also optimized some code in the Encryption library.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
