### PR TITLE
Fix $cookie['expires'] double calculation error

### DIFF
--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -179,16 +179,7 @@ class RedirectResponse extends Response
 
 		foreach ($cookies as $cookie)
 		{
-			$this->setCookie(
-				$cookie['name'],
-				$cookie['value'],
-				$cookie['expires'],
-				$cookie['domain'],
-				$cookie['path'],
-				'', // prefix
-				$cookie['secure'],
-				$cookie['httponly']
-			);
+			$this->cookies[] = $cookie;
 		}
 
 		return $this;


### PR DESCRIPTION
**Description**
```
$this->setCookie(
				$cookie['name'],
				$cookie['value'],
				$cookie['expires'], //The expiration time will be double-counted
				$cookie['domain'],
				$cookie['path'],
				'', // prefix
				$cookie['secure'],
				$cookie['httponly']
			);
```