### PR TITLE
add app and app/Config to autoload composer.json for app starter

### DIFF
--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -13,6 +13,12 @@
 		"mikey179/vfsstream": "1.6.*",
 		"phpunit/phpunit": "^8.5"
 	},
+	"autoload": {
+		"psr-4": {
+			"App\\": "app",
+			"Config\\": "app/Config"
+		}
+	},
 	"autoload-dev": {
 		"psr-4": {
 			"Tests\\Support\\": "tests/_support"


### PR DESCRIPTION
The starter app is mostly installed via composer create-project. I think it is better to use composer autoload for it.

**Checklist:**
- [x] Securely signed commits