### PR TITLE
more tests for RedirectResponse class

### DIFF
--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -229,6 +229,20 @@ class RedirectResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertTrue($response->hasCookie('foo', 'bar'));
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState  disabled
+	 */
+	public function testWithCookiesWithEmptyCookies()
+	{
+		$_SESSION = [];
+
+		$response = new RedirectResponse(new App());
+		$response = $response->withCookies();
+
+		$this->assertEmpty($response->getCookies());
+	}
+
 	public function testWithHeaders()
 	{
 		$_SESSION = [];
@@ -246,5 +260,21 @@ class RedirectResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 			$this->assertTrue($response->hasHeader($name));
 			$this->assertEquals($header->getValue(), $response->getHeader($name)->getValue());
 		}
+	}
+
+	public function testWithHeadersWithEmptyHeaders()
+	{
+		$_SESSION = [];
+
+		$baseResponse = service('response');
+		foreach ($baseResponse->getHeaders() as $key => $val)
+		{
+			$baseResponse->removeHeader($key);
+		}
+
+		$response = new RedirectResponse(new App());
+		$response = $response->withHeaders();
+
+		$this->assertEmpty($baseResponse->getHeaders());
 	}
 }


### PR DESCRIPTION
Added tests for `withHeaders()` and `withCookies()` with empty headers and empty cookies. By this, the `HTTP\RedirectResponse` will have 100% test coverage.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
