### PR TITLE
mb_url_title are not working correctly

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -590,7 +590,7 @@ if (! function_exists('url_title'))
 
 		$trans = [
 			'&.+?;'                   => '',
-			'[^\w\d _-]'              => '',
+			'[^\w\d\pL\pM _-]'              => '',
 			'\s+'                     => $separator,
 			'(' . $q_separator . ')+' => $separator,
 		];


### PR DESCRIPTION
mb_url_title()  function are not working correctly for Bengali language. So I fixed it. Now it's working.

I expect : মশিউর-রহমান-তন্ময়

It gives outputs me before: মশউর-রহমন-তনময
See it the sentence meaning are changed.
I solved this bug and fixed it.

**Checklist:**
- [√ ] Securely signed commits
- [√ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [√ ] Conforms to style guide