### PR TITLE
Enforce platform requirements

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -189,7 +189,13 @@ class CodeIgniter
 		// Setup Exception Handling
 		Services::exceptions()->initialize();
 
-		$this->resolvePlatformExtensions();
+		// Run this check for manual installations
+		if (! is_file(COMPOSER_PATH))
+		{
+			// @codeCoverageIgnoreStart
+			$this->resolvePlatformExtensions();
+			// @codeCoverageIgnoreEnd
+		}
 
 		// Set default locale on the server
 		locale_set_default($this->config->defaultLocale ?? 'en');

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CodeIgniter
  *
@@ -41,6 +42,7 @@ namespace CodeIgniter;
 use Closure;
 use CodeIgniter\Debug\Timer;
 use CodeIgniter\Events\Events;
+use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\DownloadResponse;
@@ -180,19 +182,20 @@ class CodeIgniter
 	 */
 	public function initialize()
 	{
-		// Set default locale on the server
-		locale_set_default($this->config->defaultLocale ?? 'en');
-
-		// Set default timezone on the server
-		date_default_timezone_set($this->config->appTimezone ?? 'UTC');
-
 		// Define environment variables
 		$this->detectEnvironment();
 		$this->bootstrapEnvironment();
 
 		// Setup Exception Handling
-		Services::exceptions()
-				->initialize();
+		Services::exceptions()->initialize();
+
+		$this->resolvePlatformExtensions();
+
+		// Set default locale on the server
+		locale_set_default($this->config->defaultLocale ?? 'en');
+
+		// Set default timezone on the server
+		date_default_timezone_set($this->config->appTimezone ?? 'UTC');
 
 		$this->initializeKint();
 
@@ -201,6 +204,41 @@ class CodeIgniter
 			// @codeCoverageIgnoreStart
 			\Kint::$enabled_mode = false;
 			// @codeCoverageIgnoreEnd
+		}
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Checks system for missing required PHP extensions.
+	 *
+	 * @return void
+	 * @throws FrameworkException
+	 *
+	 * @codeCoverageIgnore
+	 */
+	protected function resolvePlatformExtensions()
+	{
+		$requiredExtensions = [
+			'curl',
+			'intl',
+			'json',
+			'mbstring',
+			'xml',
+		];
+		$missingExtensions  = [];
+
+		foreach ($requiredExtensions as $extension)
+		{
+			if (! extension_loaded($extension))
+			{
+				$missingExtensions[] = $extension;
+			}
+		}
+
+		if ($missingExtensions)
+		{
+			throw FrameworkException::forMissingExtension(implode(', ', $missingExtensions));
 		}
 	}
 

--- a/system/Language/en/Core.php
+++ b/system/Language/en/Core.php
@@ -18,6 +18,6 @@ return [
    'copyError'                    => 'An error was encountered while attempting to replace the file ({0}). Please make sure your file directory is writable.',
    'enabledZlibOutputCompression' => 'Your zlib.output_compression ini directive is turned on. This will not work well with output buffers.',
    'invalidFile'                  => 'Invalid file: {0}',
-   'missingExtension'             => '{0} extension is not loaded.',
+   'missingExtension'             => 'The framework needs the following extension(s) installed and loaded: {0}.',
    'noHandlers'                   => '{0} must provide at least one Handler.',
 ];

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -218,10 +218,9 @@ class LanguageTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testPrioritizedLocator()
 	{
-		$language = Services::language('en', false);
 		// this should load the replacement bundle of messages
 		$message = lang('Core.missingExtension', [], 'en');
-		$this->assertEquals('{0} extension is not loaded.', $message);
+		$this->assertEquals('The framework needs the following extension(s) installed and loaded: {0}.', $message);
 		// and we should have our new message too
 		$this->assertEquals('billions and billions', lang('Core.bazillion', [], 'en'));
 	}


### PR DESCRIPTION
**Description**
Reading through the forums, many users, especially those manual installation users, are complaining undefined functions, such as `locale_set_default`, which can be resolved by installing the required PHP extensions. I think if we can warn them beforehand that their systems are missing these extensions and enforce them to install these then we'll have fewer problems along the road. I think this is much better than suggesting to comment out those undefined functions.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
