### PR TITLE
Fix CLI option error in user guide

### DIFF
--- a/user_guide_src/source/installation/running.rst
+++ b/user_guide_src/source/installation/running.rst
@@ -57,17 +57,17 @@ The local development server can be customized with three command line options:
 
 - You can use the ``--host`` CLI option to specify a different host to run the application at::
 
-    php spark serve --host=example.dev
+    php spark serve --host example.dev
 
 - By default, the server runs on port 8080 but you might have more than one site running, or already have
   another application using that port. You can use the ``--port`` CLI option to specify a different one::
 
-    php spark serve --port=8081
+    php spark serve --port 8081
 
 - You can also specify a specific version of PHP to use, with the ``--php`` CLI option, with its value
   set to the path of the PHP executable you want to use::
 
-    php spark serve --php=/usr/bin/php7.6.5.4
+    php spark serve --php /usr/bin/php7.6.5.4
 
 Hosting with Apache
 =================================================


### PR DESCRIPTION

Fix CLI option error in user guide

**Description**
It should be a `<space>` instead of `=`

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [ ] Conforms to style guide
