### PR TITLE
Refactor use of $params

### DIFF
--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -93,7 +93,7 @@ class Console
 	 */
 	public function showHeader()
 	{
-		CLI::write(sprintf('CodeIgniter v%s Command Line Tool - Server Time: %s UTC %s', CodeIgniter::CI_VERSION, date('Y-m-d H:i:s'), date('P')), 'light_blue');
+		CLI::write(sprintf('CodeIgniter v%s Command Line Tool - Server Time: %s UTC%s', CodeIgniter::CI_VERSION, date('Y-m-d H:i:s'), date('P')), 'blue');
 		CLI::newLine();
 	}
 }

--- a/system/Commands/Database/Migrate.php
+++ b/system/Commands/Database/Migrate.php
@@ -109,13 +109,13 @@ class Migrate extends BaseCommand
 
 		CLI::write(lang('Migrations.latest'), 'yellow');
 
-		$namespace = $params['-n'] ?? CLI::getOption('n');
-		$group     = $params['-g'] ?? CLI::getOption('g');
+		$namespace = $params['n'] ?? CLI::getOption('n');
+		$group     = $params['g'] ?? CLI::getOption('g');
 
 		try
 		{
 			// Check for 'all' namespaces
-			if ($this->isAllNamespace($params))
+			if (array_key_exists('all', $params) || CLI::getOption('all'))
 			{
 				$runner->setNamespace(null);
 			}
@@ -136,32 +136,11 @@ class Migrate extends BaseCommand
 				CLI::write($message);
 			}
 
-			CLI::write('Done');
+			CLI::write('Done migrations.', 'green');
 		}
-		catch (\Exception $e)
+		catch (\Throwable $e)
 		{
 			$this->showError($e);
 		}
 	}
-
-	/**
-	 * To migrate all namespaces to the latest migration
-	 *
-	 * Demo:
-	 *  1. command line: php spark migrate:latest -all
-	 *  2. command file: $this->call('migrate:latest', ['-g' => 'test','-all']);
-	 *
-	 * @param  array $params
-	 * @return boolean
-	 */
-	private function isAllNamespace(array $params): bool
-	{
-		if (array_search('-all', $params) !== false)
-		{
-			return true;
-		}
-
-		return ! is_null(CLI::getOption('all'));
-	}
-
 }

--- a/system/Commands/Database/MigrateRefresh.php
+++ b/system/Commands/Database/MigrateRefresh.php
@@ -107,17 +107,17 @@ class MigrateRefresh extends BaseCommand
 	 */
 	public function run(array $params)
 	{
-		$params = ['-b' => 0];
+		$params = ['b' => 0];
 
 		if (ENVIRONMENT === 'production')
 		{
-			$force = $params['-f'] ?? CLI::getOption('f');
+			$force = array_key_exists('f', $params) || CLI::getOption('f');
 			if (is_null($force) && CLI::prompt(lang('Migrations.refreshConfirm'), ['y', 'n']) === 'n')
 			{
 				return;
 			}
 
-			$params['-f'] = '';
+			$params['f'] = null;
 		}
 
 		$this->call('migrate:rollback', $params);

--- a/system/Commands/Database/MigrateRollback.php
+++ b/system/Commands/Database/MigrateRollback.php
@@ -45,7 +45,7 @@ use Config\Services;
 
 /**
  * Runs all of the migrations in reverse order, until they have
- * all been un-applied.
+ * all been unapplied.
  *
  * @package CodeIgniter\Commands
  */
@@ -79,14 +79,7 @@ class MigrateRollback extends BaseCommand
 	 *
 	 * @var string
 	 */
-	protected $usage = 'migrate:rollback [Options]';
-
-	/**
-	 * the Command's Arguments
-	 *
-	 * @var array
-	 */
-	protected $arguments = [];
+	protected $usage = 'migrate:rollback [options]';
 
 	/**
 	 * the Command's Options
@@ -109,7 +102,7 @@ class MigrateRollback extends BaseCommand
 	{
 		if (ENVIRONMENT === 'production')
 		{
-			$force = $params['-f'] ?? CLI::getOption('f');
+			$force = array_key_exists('f', $params) || CLI::getOption('f');
 			if (is_null($force) && CLI::prompt(lang('Migrations.rollBackConfirm'), ['y', 'n']) === 'n')
 			{
 				return;
@@ -118,7 +111,7 @@ class MigrateRollback extends BaseCommand
 
 		$runner = Services::migrations();
 
-		$group = $params['-g'] ?? CLI::getOption('g');
+		$group = $params['g'] ?? CLI::getOption('g');
 
 		if (! is_null($group))
 		{
@@ -127,7 +120,7 @@ class MigrateRollback extends BaseCommand
 
 		try
 		{
-			$batch = $params['-b'] ?? CLI::getOption('b') ?? $runner->getLastBatch() - 1;
+			$batch = $params['b'] ?? CLI::getOption('b') ?? $runner->getLastBatch() - 1;
 			CLI::write(lang('Migrations.rollingBack') . ' ' . $batch, 'yellow');
 
 			if (! $runner->regress($batch))
@@ -143,7 +136,7 @@ class MigrateRollback extends BaseCommand
 
 			CLI::write('Done');
 		}
-		catch (\Exception $e)
+		catch (\Throwable $e)
 		{
 			$this->showError($e);
 		}

--- a/system/Commands/Database/MigrateStatus.php
+++ b/system/Commands/Database/MigrateStatus.php
@@ -78,7 +78,7 @@ class MigrateStatus extends BaseCommand
 	 *
 	 * @var string
 	 */
-	protected $usage = 'migrate:status [Options]';
+	protected $usage = 'migrate:status [options]';
 
 	/**
 	 * the Command's Arguments
@@ -120,7 +120,7 @@ class MigrateStatus extends BaseCommand
 	{
 		$runner = Services::migrations();
 
-		$group = $params['-g'] ?? CLI::getOption('g');
+		$group = $params['g'] ?? CLI::getOption('g');
 
 		if (! is_null($group))
 		{

--- a/system/Commands/Database/Seed.php
+++ b/system/Commands/Database/Seed.php
@@ -110,23 +110,16 @@ class Seed extends BaseCommand
 
 		if (empty($seedName))
 		{
-			$seedName = CLI::prompt(lang('Migrations.migSeeder'), 'DatabaseSeeder');
-		}
-
-		if (empty($seedName))
-		{
-			CLI::error(lang('Migrations.migMissingSeeder'));
-			return;
+			$seedName = CLI::prompt(lang('Migrations.migSeeder'), null, 'required');
 		}
 
 		try
 		{
 			$seeder->call($seedName);
 		}
-		catch (\Exception $e)
+		catch (\Throwable $e)
 		{
 			$this->showError($e);
 		}
 	}
-
 }


### PR DESCRIPTION
**Description**
Currently, `CLI::parseCommandLine`, `CLIRequest::parseCommand`, and `command()` parses CLI options stripping away the beginning `-`. If we are making programmatic calls, we should do the same when providing the options.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
