### PR TITLE
Change console header color

### DIFF
--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -93,7 +93,7 @@ class Console
 	 */
 	public function showHeader()
 	{
-		CLI::write(sprintf('CodeIgniter v%s Command Line Tool - Server Time: %s UTC%s', CodeIgniter::CI_VERSION, date('Y-m-d H:i:s'), date('P')), 'blue');
+		CLI::write(sprintf('CodeIgniter v%s Command Line Tool - Server Time: %s UTC%s', CodeIgniter::CI_VERSION, date('Y-m-d H:i:s'), date('P')), 'green');
 		CLI::newLine();
 	}
 }


### PR DESCRIPTION
**Description**
Mini change. Change `Console`'s header color to `green` for comfort in dark terminals. IMHO, `blue` is an eye strain.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
