### PR TITLE
Make PostgreSQL DBDriver consistent : using Postgre instead of postgre

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1493,7 +1493,8 @@ abstract class BaseConnection implements ConnectionInterface
 	 */
 	public function callFunction(string $functionName, ...$params): bool
 	{
-		$driver = ($this->DBDriver === 'postgre' ? 'pg' : strtolower($this->DBDriver)) . '_';
+		$driver = strtolower($this->DBDriver);
+		$driver = ($driver === 'postgre' ? 'pg' : $driver) . '_';
 
 		if (false === strpos($driver, $functionName))
 		{

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -53,7 +53,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 *
 	 * @var string
 	 */
-	public $DBDriver = 'postgre';
+	public $DBDriver = 'Postgre';
 
 	//--------------------------------------------------------------------
 


### PR DESCRIPTION
In the documentation, it is named "Postgre", while in the code, it named "postgre" lower case. This change ensure to make it consistent to use "Postgre" naming in PostgreSQL Connection's DBDriver property. 

![Postgre](https://user-images.githubusercontent.com/10989147/89564298-fea8b100-d846-11ea-99b8-d2f904117434.png)

Also, on **non case sensitive** operating system, it caused an issue when we can configure `.env` as lower "postgre" and when moving to **case sensitive** operating system, it got error class not found.

This patch fixed it.

**Checklist:**
- [x] Securely signed commits
