### PR TITLE
Optimization: CLI parseCommandLine

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -881,32 +881,41 @@ class CLI
 	/**
 	 * Parses the command line it was called from and collects all
 	 * options and valid segments.
-	 *
-	 * I tried to use getopt but had it fail occasionally to find any
-	 * options but argc has always had our back. We don't have all of the power
-	 * of getopt but this does us just fine.
 	 */
 	protected static function parseCommandLine()
 	{
-		// start picking segments off from #1, ignoring the invoking program
-		for ($i = 1; $i < $_SERVER['argc']; $i ++)
+		$args = $_SERVER['argv'];
+		array_shift($args); // scrap invoking program
+		$optionValue = false;
+
+		foreach ($args as $i => $arg)
 		{
-			// If there's no '-' at the beginning of the argument
-			// then add it to our segments.
-			if (mb_strpos($_SERVER['argv'][$i], '-') !== 0)
+			// If there's no "-" at the beginning, then
+			// this is probably an argument or an option value
+			if (mb_strpos($arg, '-') !== 0)
 			{
-				static::$segments[] = $_SERVER['argv'][$i];
+				if ($optionValue)
+				{
+					// We have already included this in the previous
+					// iteration, so reset this flag
+					$optionValue = false;
+				}
+				else
+				{
+					// Yup, it's a segment
+					static::$segments[] = $arg;
+				}
+
 				continue;
 			}
 
-			$arg   = ltrim($_SERVER['argv'][$i], '-');
+			$arg   = ltrim($arg, '-');
 			$value = null;
 
-			// if there is a following segment, and it doesn't start with a dash, it's a value.
-			if (isset($_SERVER['argv'][$i + 1]) && mb_strpos($_SERVER['argv'][$i + 1], '-') !== 0)
+			if (isset($args[$i + 1]) && mb_strpos($args[$i + 1], '-') !== 0)
 			{
-				$value = $_SERVER['argv'][$i + 1];
-				$i ++;
+				$value       = $args[$i + 1];
+				$optionValue = true;
 			}
 
 			static::$options[$arg] = $value;

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -288,7 +288,6 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 			'-opt-in',
 			'sure',
 		];
-		$_SERVER['argc'] = 11;
 		CLI::init();
 		$this->assertEquals(null, CLI::getSegment(7));
 		$this->assertEquals('b', CLI::getSegment(1));
@@ -308,7 +307,6 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 			'pvalue',
 			'd',
 		];
-		$_SERVER['argc'] = 6;
 		CLI::init();
 		$this->assertEquals(['parm' => 'pvalue'], CLI::getOptions());
 		$this->assertEquals('pvalue', CLI::getOption('parm'));
@@ -330,7 +328,6 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 			'-p3',
 			'value 3',
 		];
-		$_SERVER['argc'] = 9;
 		CLI::init();
 		$this->assertEquals(['parm' => 'pvalue', 'p2' => null, 'p3' => 'value 3'], CLI::getOptions());
 		$this->assertEquals('pvalue', CLI::getOption('parm'));


### PR DESCRIPTION
**Description**
Use `foreach()` in parsing, instead of relying on `$_SERVER['argc']`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
