### PR TITLE
Run the toolbar filter as the last one

### DIFF
--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -240,6 +240,16 @@ class Filters
 		$this->processMethods();
 		$this->processFilters($uri);
 
+		// Set the toolbar filter to the last position to be executed
+		if (in_array('toolbar', $this->filters['after']) &&
+			($count = count($this->filters['after'])) > 1 &&
+			$this->filters['after'][$count - 1] !== 'toolbar'
+		)
+		{
+			array_splice($this->filters['after'], array_search('toolbar', $this->filters['after']), 1);
+			$this->filters['after'][] = 'toolbar';
+		}
+
 		$this->initialized = true;
 
 		return $this;

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -241,7 +241,7 @@ class Filters
 		$this->processFilters($uri);
 
 		// Set the toolbar filter to the last position to be executed
-		if (in_array('toolbar', $this->filters['after']) &&
+              if (in_array('toolbar', $this->filters['after'], true) &&
 			($count = count($this->filters['after'])) > 1 &&
 			$this->filters['after'][$count - 1] !== 'toolbar'
 		)

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -284,6 +284,43 @@ class FiltersTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testProcessMethodProcessesCombinedAfterForToolbar()
+	{
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		$config  = [
+			'globals' => [
+				'after' => [
+					'toolbar',
+					'bazg',
+				],
+			],
+			'methods' => [
+				'get' => ['bar'],
+			],
+			'filters' => [
+				'foof' => [
+					'after' => ['admin/*'],
+				],
+			],
+		];
+		$filters = new Filters((object) $config, $this->request, $this->response);
+		$uri     = 'admin/foo/bar';
+
+		$expected = [
+			'before' => ['bar'],
+			'after'  => [
+				'bazg',
+				'foof',
+				'toolbar',
+			],
+		];
+
+		$this->assertEquals($expected, $filters->initialize($uri)->getFilters());
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testRunThrowsWithInvalidAlias()
 	{
 		$_SERVER['REQUEST_METHOD'] = 'GET';

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -192,4 +192,6 @@ In this example, the array ``['dual', 'noreturn']`` will be passed in ``$argumen
 Provided Filters
 ****************
 
-Three filters are bundled with CodeIgniter4: Honeypot, Security, and DebugToolbar.
+Three filters are bundled with CodeIgniter4: ``Honeypot``, ``Security``, and ``DebugToolbar``.
+
+.. note:: The filters are executed in the declared order  that is defined in the config file, but there is one exception to this and it concerns the ``DebugToolbar``, which is always executed last. This is because ``DebugToolbar`` should be able to register everything that happens in other filters.


### PR DESCRIPTION
**Description**
The `toolbar` filter should be run as the last one since in other case it can't register all things are happening in other filters.

See: #3470

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
