### PR TITLE
Fix help command on inexistent commands

### DIFF
--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -87,26 +87,8 @@ class Commands
 	{
 		$this->discoverCommands();
 
-		if (! isset($this->commands[$command]))
+		if (! $this->verifyCommand($command, $this->commands))
 		{
-			$message = lang('CLI.commandNotFound', [$command]);
-
-			if ($alternatives = $this->getCommandAlternatives($command, $this->commands))
-			{
-				if (count($alternatives) === 1)
-				{
-					$message .= "\n\n" . lang('CLI.altCommandSingular') . "\n    ";
-				}
-				else
-				{
-					$message .= "\n\n" . lang('CLI.altCommandPlural') . "\n    ";
-				}
-
-				$message .= implode("\n    ", $alternatives);
-			}
-
-			CLI::error($message);
-			CLI::newLine();
 			return;
 		}
 
@@ -195,6 +177,43 @@ class Commands
 		}
 
 		asort($this->commands);
+	}
+
+	/**
+	 * Verifies if the command being sought is found
+	 * in the commands list.
+	 *
+	 * @param string $command
+	 * @param array  $commands
+	 *
+	 * @return boolean
+	 */
+	public function verifyCommand(string $command, array $commands): bool
+	{
+		if (! isset($commands[$command]))
+		{
+			$message = lang('CLI.commandNotFound', [$command]);
+
+			if ($alternatives = $this->getCommandAlternatives($command, $commands))
+			{
+				if (count($alternatives) === 1)
+				{
+					$message .= "\n\n" . lang('CLI.altCommandSingular') . "\n    ";
+				}
+				else
+				{
+					$message .= "\n\n" . lang('CLI.altCommandPlural') . "\n    ";
+				}
+
+				$message .= implode("\n    ", $alternatives);
+			}
+
+			CLI::error($message);
+			CLI::newLine();
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -190,30 +190,31 @@ class Commands
 	 */
 	public function verifyCommand(string $command, array $commands): bool
 	{
-		if (! isset($commands[$command]))
+		if (isset($commands[$command]))
 		{
-			$message = lang('CLI.commandNotFound', [$command]);
-
-			if ($alternatives = $this->getCommandAlternatives($command, $commands))
-			{
-				if (count($alternatives) === 1)
-				{
-					$message .= "\n\n" . lang('CLI.altCommandSingular') . "\n    ";
-				}
-				else
-				{
-					$message .= "\n\n" . lang('CLI.altCommandPlural') . "\n    ";
-				}
-
-				$message .= implode("\n    ", $alternatives);
-			}
-
-			CLI::error($message);
-			CLI::newLine();
-			return false;
+			return true;
 		}
 
-		return true;
+		$message = lang('CLI.commandNotFound', [$command]);
+
+		if ($alternatives = $this->getCommandAlternatives($command, $commands))
+		{
+			if (count($alternatives) === 1)
+			{
+				$message .= "\n\n" . lang('CLI.altCommandSingular') . "\n    ";
+			}
+			else
+			{
+				$message .= "\n\n" . lang('CLI.altCommandPlural') . "\n    ";
+			}
+
+			$message .= implode("\n    ", $alternatives);
+		}
+
+		CLI::error($message);
+		CLI::newLine();
+
+		return false;
 	}
 
 	/**

--- a/system/Commands/Help.php
+++ b/system/Commands/Help.php
@@ -100,21 +100,22 @@ class Help extends BaseCommand
 	//--------------------------------------------------------------------
 
 	/**
-	 * Displays the help for the spark cli script itself.
+	 * Displays the help for spark commands.
 	 *
 	 * @param array $params
 	 */
 	public function run(array $params)
 	{
-		$command = array_shift($params);
-		if (is_null($command))
+		$command  = array_shift($params);
+		$command  = $command ?? 'help';
+		$commands = $this->commands->getCommands();
+
+		if (! $this->commands->verifyCommand($command, $commands))
 		{
-			$command = 'help';
+			return;
 		}
 
-		$commands = $this->commands->getCommands();
-		$class    = new $commands[$command]['class']($this->logger, $this->commands);
-
+		$class = new $commands[$command]['class']($this->logger, $this->commands);
 		$class->showHelp();
 	}
 

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -35,15 +35,6 @@ class CommandTest extends \CodeIgniter\Test\CIUnitTestCase
 		return CITestStreamFilter::$buffer;
 	}
 
-	public function testHelpCommand()
-	{
-		command('help');
-
-		// make sure the result looks like a command list
-		$this->assertStringContainsString('Displays basic usage information.', $this->getBuffer());
-		$this->assertStringContainsString('command_name', $this->getBuffer());
-	}
-
 	public function testListCommands()
 	{
 		command('list');

--- a/tests/system/Commands/HelpCommandTest.php
+++ b/tests/system/Commands/HelpCommandTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+class HelpCommandTest extends CIUnitTestCase
+{
+	private $streamFilter;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		CITestStreamFilter::$buffer = '';
+		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
+		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+	}
+
+	protected function tearDown(): void
+	{
+		stream_filter_remove($this->streamFilter);
+	}
+
+	protected function getBuffer()
+	{
+		return CITestStreamFilter::$buffer;
+	}
+
+	public function testHelpCommand()
+	{
+		command('help');
+
+		// make sure the result looks like a command list
+		$this->assertStringContainsString('Displays basic usage information.', $this->getBuffer());
+		$this->assertStringContainsString('command_name', $this->getBuffer());
+	}
+
+	public function testHelpCommandOnSpecificCommand()
+	{
+		command('help cache:clear');
+		$this->assertStringContainsString('Clears the current system caches.', $this->getBuffer());
+	}
+
+	public function testHelpCommandOnInexistentCommand()
+	{
+		command('help fixme');
+		$this->assertStringContainsString('Command "fixme" not found', $this->getBuffer());
+	}
+
+	public function testHelpCommandOnInexistentCommandButWithAlternatives()
+	{
+		command('help clear');
+		$this->assertStringContainsString('Command "clear" not found.', $this->getBuffer());
+		$this->assertStringContainsString('Did you mean one of these?', $this->getBuffer());
+	}
+}


### PR DESCRIPTION
**Description**
We have made spark give suggestions when possible for inexistent commands but failed to account for cases when we use the `help` command to get info on a command, which can be inexistent too.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
