### PR TITLE
4.1.0 : remove deprecated Model::fillPlaceholders()

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -1708,66 +1708,6 @@ class Model
 		return $rules;
 	}
 
-	/**
-	 * Replace any placeholders within the rules with the values that
-	 * match the 'key' of any properties being set. For example, if
-	 * we had the following $data array:
-	 *
-	 * [ 'id' => 13 ]
-	 *
-	 * and the following rule:
-	 *
-	 *  'required|is_unique[users,email,id,{id}]'
-	 *
-	 * The value of {id} would be replaced with the actual id in the form data:
-	 *
-	 *  'required|is_unique[users,email,id,13]'
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @deprecated use fillPlaceholders($rules, $data) from Validation instead
-	 *
-	 * @param array $rules
-	 * @param array $data
-	 *
-	 * @return array
-	 */
-	protected function fillPlaceholders(array $rules, array $data): array
-	{
-		$replacements = [];
-
-		foreach ($data as $key => $value)
-		{
-			$replacements["{{$key}}"] = $value;
-		}
-
-		if (! empty($replacements))
-		{
-			foreach ($rules as &$rule)
-			{
-				if (is_array($rule))
-				{
-					foreach ($rule as &$row)
-					{
-						// Should only be an `errors` array
-						// which doesn't take placeholders.
-						if (is_array($row))
-						{
-							continue;
-						}
-
-						$row = strtr($row, $replacements);
-					}
-					continue;
-				}
-
-				$rule = strtr($rule, $replacements);
-			}
-		}
-
-		return $rules;
-	}
-
 	//--------------------------------------------------------------------
 
 	/**

--- a/user_guide_src/source/changelogs/v4.1.0.rst
+++ b/user_guide_src/source/changelogs/v4.1.0.rst
@@ -8,3 +8,4 @@ Release Date: Not released
 Removed:
 
 - `Autoloader::loadLegacy()` method was previously used for migration of non-namespaced classes in transition to CodeIgniter v4. Since `4.1.0`, this support was removed.
+- Deprecated `Model::fillPlaceholders(array $rules, array $data)` method, use `fillPlaceholders(array $rules, array $data)` from Validation instead.


### PR DESCRIPTION
I think for 4.1.0, deprecated `Model::fillPlaceholders` can be removed. 

**Checklist:**
- [x] Securely signed commits
