### PR TITLE
[Feature] Robust code scaffolder commands

### DIFF
--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -105,8 +105,8 @@ abstract class BaseCommand
 	protected $logger;
 
 	/**
-	 * Instance of the CommandRunner controller
-	 * so commands can call other commands.
+	 * Instance of Commands so
+	 * commands can call other commands.
 	 *
 	 * @var \CodeIgniter\CLI\Commands
 	 */
@@ -149,10 +149,6 @@ abstract class BaseCommand
 	 */
 	protected function call(string $command, array $params = [])
 	{
-		// The CommandRunner will grab the first element
-		// for the command name.
-		array_unshift($params, $command);
-
 		return $this->commands->run($command, $params);
 	}
 

--- a/system/Commands/Generators/CreateCommand.php
+++ b/system/Commands/Generators/CreateCommand.php
@@ -1,0 +1,260 @@
+<?php
+
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace CodeIgniter\Commands\Generators;
+
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\CLI\GeneratorCommand;
+
+class CreateCommand extends GeneratorCommand
+{
+	/**
+	 * The Command's name
+	 *
+	 * @var string
+	 */
+	protected $name = 'make:command';
+
+	/**
+	 * The Command's short description
+	 *
+	 * @var string
+	 */
+	protected $description = 'Creates a new spark command.';
+
+	/**
+	 * The Command's usage
+	 *
+	 * @var string
+	 */
+	protected $usage = 'make:command <name> [options]';
+
+	/**
+	 * The Command's arguments
+	 *
+	 * @var array
+	 */
+	protected $arguments = [
+		'name' => 'The command class name',
+	];
+
+	/**
+	 * The Command's options
+	 *
+	 * @var array
+	 */
+	protected $options = [
+		'-command' => 'The command name. Defaults to "command:name"',
+		'-group'   => 'The group of command. Defaults to "CodeIgniter" for basic commands, and "Generators" for generator commands.',
+		'-type'    => 'Type of command. Whether a basic command or a generator command. Defaults to "basic".',
+	];
+
+	protected function getClassName(): string
+	{
+		$className = parent::getClassName();
+
+		if (empty($className))
+		{
+			$className = CLI::prompt(lang('CLI.generateClassName'), null, 'required'); // @codeCoverageIgnore
+		}
+
+		return $className;
+	}
+
+	protected function getNamespacedClass(string $rootNamespace, string $class): string
+	{
+		return $rootNamespace . '\\Commands\\' . $class;
+	}
+
+	protected function getTemplate(): string
+	{
+		$template = view('CodeIgniter\\Commands\\Generators\\Views\\command.tpl.php', [], ['debug' => false]);
+
+		return str_replace('<@php', '<?php', $template);
+	}
+
+	protected function setReplacements(string $template, string $class): string
+	{
+		// Get options
+		$commandName  = $this->params['command'] ?? CLI::getOption('command');
+		$commandGroup = $this->params['group'] ?? CLI::getOption('group');
+		$commandType  = $this->params['type'] ?? CLI::getOption('type');
+
+		// Resolve options
+		if (! is_string($commandName))
+		{
+			$commandName = 'command:name';
+		}
+
+		if (! is_string($commandType))
+		{
+			$commandType = 'basic';
+		}
+		// @codeCoverageIgnoreStart
+		elseif (! in_array($commandType, ['basic', 'generator'], true))
+		{
+			$commandType = CLI::prompt('Command type', ['basic', 'generator'], 'required');
+		}
+		// @codeCoverageIgnoreEnd
+
+		if ($commandType === 'generator')
+		{
+			$useStatement = 'use CodeIgniter\\CLI\\GeneratorCommand;';
+			$extends      = 'extends GeneratorCommand';
+		}
+		else
+		{
+			$useStatement = 'use CodeIgniter\\CLI\\BaseCommand;';
+			$extends      = 'extends BaseCommand';
+		}
+
+		if (! is_string($commandGroup))
+		{
+			$commandGroup = $commandType === 'generator' ? 'Generators' : 'CodeIgniter';
+		}
+		$commandGroup = $this->getCommandGroupProperty($commandType, $commandGroup);
+
+		$commandAbstractMethodsToImplement = $this->getRequiredAbstractMethodsToImplement($commandType);
+
+		// Do the replacements
+		$template = parent::setReplacements($template, $class);
+		$template = str_replace([
+			'{useStatement}',
+			'{extends}',
+			'{commandGroup}',
+			'{commandName}',
+			'{commandAbstractMethodsToImplement}',
+		], [
+			$useStatement,
+			$extends,
+			$commandGroup,
+			$commandName,
+			$commandAbstractMethodsToImplement,
+		],
+			$template
+		);
+
+		return $template;
+	}
+
+	/**
+	 * Gets the proper class property for group name.
+	 *
+	 * @param string $type
+	 *
+	 * @return string
+	 */
+	protected function getCommandGroupProperty(string $type, string $group): string
+	{
+		if ($type === 'generator' && $group === 'Generators')
+		{
+			// Assume it is already extending from Generator Command
+			// so this is really redundant.
+			return '';
+		}
+
+		return <<<EOF
+
+	/**
+	 * The group the command is lumped under
+	 * when listing commands.
+	 *
+	 * @var string
+	 */
+	protected \$group = '{$group}';
+
+EOF;
+	}
+
+	/**
+	 * Gets the required abstract methods.
+	 *
+	 * @param string $type
+	 *
+	 * @return string
+	 */
+	protected function getRequiredAbstractMethodsToImplement(string $type): string
+	{
+		if ($type !== 'generator')
+		{
+			return <<<'EOF'
+
+	/**
+	 * Actually execute a command.
+	 *
+	 * @param array $params
+	 */
+	public function run(array $params)
+	{
+		//
+	}
+
+EOF;
+		}
+
+		return <<<'EOF'
+
+	protected function getClassName(): string
+	{
+		// If the class name is required you need to have this.
+		// Otherwise, you can safely remove this method.
+
+		$className = parent::getClassName();
+
+		if (empty($className))
+		{
+			$className = CLI::prompt(lang('CLI.generateClassName'), null, 'required');
+		}
+
+		return $className;
+	}
+
+	protected function getNamespacedClass(string $rootNamespace, string $class): string
+	{
+		return '';
+	}
+
+	protected function getTemplate(): string
+	{
+		return '';
+	}
+
+EOF;
+	}
+}

--- a/system/Commands/Generators/CreateController.php
+++ b/system/Commands/Generators/CreateController.php
@@ -1,0 +1,254 @@
+<?php
+
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace CodeIgniter\Commands\Generators;
+
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\CLI\GeneratorCommand;
+
+/**
+ * Creates a skeleton controller file.
+ */
+class CreateController extends GeneratorCommand
+{
+	/**
+	 * The Command's name
+	 *
+	 * @var string
+	 */
+	protected $name = 'make:controller';
+
+	/**
+	 * The Command's short description
+	 *
+	 * @var string
+	 */
+	protected $description = 'Creates a new controller file.';
+
+	/**
+	 * The Command's usage
+	 *
+	 * @var string
+	 */
+	protected $usage = 'make:controller <name> [options]';
+
+	/**
+	 * The Command's arguments
+	 *
+	 * @var array
+	 */
+	protected $arguments = [
+		'name' => 'The controller class name',
+	];
+
+	/**
+	 * The Command's options
+	 *
+	 * @var array
+	 */
+	protected $options = [
+		'-base'    => 'Extends from BaseController instead of CodeIgniter\\Controller.',
+		'-restful' => 'Extends from a RESTful resource. Options are \'controller\' or \'presenter\'.',
+	];
+
+	protected function getClassName(): string
+	{
+		$className = parent::getClassName();
+
+		if (empty($className))
+		{
+			$className = CLI::prompt(lang('CLI.generateClassName'), null, 'required'); // @codeCoverageIgnore
+		}
+
+		return $className;
+	}
+
+	protected function getNamespacedClass(string $rootNamespace, string $class): string
+	{
+		return $rootNamespace . '\\Controllers\\' . $class;
+	}
+
+	protected function getTemplate(): string
+	{
+		$base = $this->params['base'] ?? CLI::getOption('base');
+		$rest = $this->params['restful'] ?? CLI::getOption('restful');
+
+		[
+			$useStatement,
+			$extends,
+			$restfulMethods,
+		] = $this->getParentClass($base, $rest);
+
+		$template = view('CodeIgniter\\Commands\\Generators\\Views\\controller.tpl.php', [], ['debug' => false]);
+		$template = str_replace([
+			'{useStatement}',
+			'{extends}',
+			'{restfulMethods}',
+			'<@php',
+		], [
+			$useStatement,
+			$extends,
+			$restfulMethods,
+			'<?php',
+		],
+			$template
+		);
+
+		return $template;
+	}
+
+	/**
+	 * Gets the appropriate parent class to extend.
+	 *
+	 * @param boolean|null        $base
+	 * @param string|boolean|null $rest
+	 *
+	 * @return array
+	 */
+	private function getParentClass(?bool $base, $rest): array
+	{
+		$restfulMethods = '';
+
+		if (! $base && ! $rest)
+		{
+			$useStatement = 'use CodeIgniter\\Controller;';
+			$extends      = 'extends Controller';
+		}
+		elseif ($base)
+		{
+			$appNamespace = trim(APP_NAMESPACE, '\\');
+			$useStatement = "use {$appNamespace}\\Controllers\\BaseController;";
+			$extends      = 'extends BaseController';
+		}
+		else
+		{
+			if ($rest === true)
+			{
+				$type = 'controller';
+			}
+			elseif (in_array($rest, ['controller', 'presenter'], true))
+			{
+				$type = $rest;
+			}
+			else
+			{
+				$type = CLI::prompt(lang('CLI.generateParentClass'), ['controller', 'presenter'], 'required');
+			}
+
+			$restfulMethods = $this->getAdditionalRestfulMethods();
+
+			$type         = ucfirst($type);
+			$useStatement = "use CodeIgniter\\RESTful\\Resource{$type};";
+			$extends      = "extends Resource{$type}";
+		}
+
+		return [
+			$useStatement,
+			$extends,
+			$restfulMethods,
+		];
+	}
+
+	private function getAdditionalRestfulMethods(): string
+	{
+		return <<<EOF
+
+	/**
+	 * Return the properties of a resource object
+	 *
+	 * @return array
+	 */
+	public function show(\$id = null)
+	{
+		//
+	}
+
+	/**
+	 * Return a new resource object, with default properties
+	 *
+	 * @return array
+	 */
+	public function new()
+	{
+		//
+	}
+
+	/**
+	 * Create a new resource object, from "posted" parameters
+	 *
+	 * @return array
+	 */
+	public function create()
+	{
+		//
+	}
+
+	/**
+	 * Return the editable properties of a resource object
+	 *
+	 * @return array
+	 */
+	public function edit(\$id = null)
+	{
+		//
+	}
+
+	/**
+	 * Add or update a model resource, from "posted" properties
+	 *
+	 * @return array
+	 */
+	public function update(\$id = null)
+	{
+		//
+	}
+
+	/**
+	 * Delete the designated resource object from the model
+	 *
+	 * @return array
+	 */
+	public function delete(\$id = null)
+	{
+		//
+	}
+
+EOF;
+	}
+}

--- a/system/Commands/Generators/CreateController.php
+++ b/system/Commands/Generators/CreateController.php
@@ -83,7 +83,7 @@ class CreateController extends GeneratorCommand
 	 * @var array
 	 */
 	protected $options = [
-		'-base'    => 'Extends from BaseController instead of CodeIgniter\\Controller.',
+		'-bare'    => 'Extends from CodeIgniter\\Controller instead of BaseController',
 		'-restful' => 'Extends from a RESTful resource. Options are \'controller\' or \'presenter\'.',
 	];
 
@@ -106,14 +106,16 @@ class CreateController extends GeneratorCommand
 
 	protected function getTemplate(): string
 	{
-		$base = $this->params['base'] ?? CLI::getOption('base');
-		$rest = $this->params['restful'] ?? CLI::getOption('restful');
+		$bare = array_key_exists('bare', $this->params) || CLI::getOption('bare');
+		$rest = array_key_exists('restful', $this->params)
+			? $this->params['restful'] ?? true
+			: CLI::getOption('restful');
 
 		[
 			$useStatement,
 			$extends,
 			$restfulMethods,
-		] = $this->getParentClass($base, $rest);
+		] = $this->getParentClass($bare, $rest);
 
 		$template = view('CodeIgniter\\Commands\\Generators\\Views\\controller.tpl.php', [], ['debug' => false]);
 		$template = str_replace([
@@ -136,25 +138,25 @@ class CreateController extends GeneratorCommand
 	/**
 	 * Gets the appropriate parent class to extend.
 	 *
-	 * @param boolean|null        $base
+	 * @param boolean|null        $bare
 	 * @param string|boolean|null $rest
 	 *
 	 * @return array
 	 */
-	private function getParentClass(?bool $base, $rest): array
+	protected function getParentClass(?bool $bare, $rest): array
 	{
 		$restfulMethods = '';
 
-		if (! $base && ! $rest)
-		{
-			$useStatement = 'use CodeIgniter\\Controller;';
-			$extends      = 'extends Controller';
-		}
-		elseif ($base)
+		if (! $bare && ! $rest)
 		{
 			$appNamespace = trim(APP_NAMESPACE, '\\');
 			$useStatement = "use {$appNamespace}\\Controllers\\BaseController;";
 			$extends      = 'extends BaseController';
+		}
+		elseif ($bare)
+		{
+			$useStatement = 'use CodeIgniter\\Controller;';
+			$extends      = 'extends Controller';
 		}
 		else
 		{
@@ -168,7 +170,7 @@ class CreateController extends GeneratorCommand
 			}
 			else
 			{
-				$type = CLI::prompt(lang('CLI.generateParentClass'), ['controller', 'presenter'], 'required');
+				$type = CLI::prompt(lang('CLI.generateParentClass'), ['controller', 'presenter'], 'required'); // @codeCoverageIgnore
 			}
 
 			$restfulMethods = $this->getAdditionalRestfulMethods();
@@ -185,16 +187,16 @@ class CreateController extends GeneratorCommand
 		];
 	}
 
-	private function getAdditionalRestfulMethods(): string
+	protected function getAdditionalRestfulMethods(): string
 	{
-		return <<<EOF
+		return <<<'EOF'
 
 	/**
 	 * Return the properties of a resource object
 	 *
 	 * @return array
 	 */
-	public function show(\$id = null)
+	public function show($id = null)
 	{
 		//
 	}
@@ -224,7 +226,7 @@ class CreateController extends GeneratorCommand
 	 *
 	 * @return array
 	 */
-	public function edit(\$id = null)
+	public function edit($id = null)
 	{
 		//
 	}
@@ -234,7 +236,7 @@ class CreateController extends GeneratorCommand
 	 *
 	 * @return array
 	 */
-	public function update(\$id = null)
+	public function update($id = null)
 	{
 		//
 	}
@@ -244,7 +246,7 @@ class CreateController extends GeneratorCommand
 	 *
 	 * @return array
 	 */
-	public function delete(\$id = null)
+	public function delete($id = null)
 	{
 		//
 	}

--- a/system/Commands/Generators/CreateController.php
+++ b/system/Commands/Generators/CreateController.php
@@ -106,6 +106,14 @@ class CreateController extends GeneratorCommand
 
 	protected function getTemplate(): string
 	{
+		$template = view('CodeIgniter\\Commands\\Generators\\Views\\controller.tpl.php', [], ['debug' => false]);
+		$template = str_replace('<@php', '<?php', $template);
+
+		return $template;
+	}
+
+	protected function setReplacements(string $template, string $class): string
+	{
 		$bare = array_key_exists('bare', $this->params) || CLI::getOption('bare');
 		$rest = array_key_exists('restful', $this->params)
 			? $this->params['restful'] ?? true
@@ -117,17 +125,15 @@ class CreateController extends GeneratorCommand
 			$restfulMethods,
 		] = $this->getParentClass($bare, $rest);
 
-		$template = view('CodeIgniter\\Commands\\Generators\\Views\\controller.tpl.php', [], ['debug' => false]);
+		$template = parent::setReplacements($template, $class);
 		$template = str_replace([
 			'{useStatement}',
 			'{extends}',
 			'{restfulMethods}',
-			'<@php',
 		], [
 			$useStatement,
 			$extends,
 			$restfulMethods,
-			'<?php',
 		],
 			$template
 		);

--- a/system/Commands/Generators/CreateEntity.php
+++ b/system/Commands/Generators/CreateEntity.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace CodeIgniter\Commands\Generators;
+
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\CLI\GeneratorCommand;
+
+class CreateEntity extends GeneratorCommand
+{
+	/**
+	 * The Command's name
+	 *
+	 * @var string
+	 */
+	protected $name = 'make:entity';
+
+	/**
+	 * The Command's short description
+	 *
+	 * @var string
+	 */
+	protected $description = 'Creates a new entity file.';
+
+	/**
+	 * The Command's usage
+	 *
+	 * @var string
+	 */
+	protected $usage = 'make:entity <name> [options]';
+
+	/**
+	 * The Command's arguments
+	 *
+	 * @var array
+	 */
+	protected $arguments = [
+		'name' => 'The model class name',
+	];
+
+	protected function getClassName(): string
+	{
+		$className = parent::getClassName();
+
+		if (empty($className))
+		{
+			$className = CLI::prompt(lang('CLI.generateClassName'), null, 'required'); // @codeCoverageIgnore
+		}
+
+		return $className;
+	}
+
+	protected function getNamespacedClass(string $rootNamespace, string $class): string
+	{
+		return $rootNamespace . '\\Entities\\' . $class;
+	}
+
+	protected function getTemplate(): string
+	{
+		$template = view('CodeIgniter\\Commands\\Generators\\Views\\entity.tpl.php', [], ['debug' => false]);
+		return str_replace('<@php', '<?php', $template);
+	}
+}

--- a/system/Commands/Generators/CreateEntity.php
+++ b/system/Commands/Generators/CreateEntity.php
@@ -94,6 +94,7 @@ class CreateEntity extends GeneratorCommand
 	protected function getTemplate(): string
 	{
 		$template = view('CodeIgniter\\Commands\\Generators\\Views\\entity.tpl.php', [], ['debug' => false]);
+
 		return str_replace('<@php', '<?php', $template);
 	}
 }

--- a/system/Commands/Generators/CreateFilter.php
+++ b/system/Commands/Generators/CreateFilter.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace CodeIgniter\Commands\Generators;
+
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\CLI\GeneratorCommand;
+
+class CreateFilter extends GeneratorCommand
+{
+	/**
+	 * The Command's name
+	 *
+	 * @var string
+	 */
+	protected $name = 'make:filter';
+
+	/**
+	 * The Command's short description
+	 *
+	 * @var string
+	 */
+	protected $description = 'Creates a new filter file.';
+
+	/**
+	 * The Command's usage
+	 *
+	 * @var string
+	 */
+	protected $usage = 'make:filter <name> [options]';
+
+	/**
+	 * The Command's arguments
+	 *
+	 * @var array
+	 */
+	protected $arguments = [
+		'name' => 'The filter class name',
+	];
+
+	protected function getClassName(): string
+	{
+		$className = parent::getClassName();
+
+		if (empty($className))
+		{
+			$className = CLI::prompt(lang('CLI.generateClassName'), null, 'required'); // @codeCoverageIgnore
+		}
+
+		return $className;
+	}
+
+	protected function getNamespacedClass(string $rootNamespace, string $class): string
+	{
+		return $rootNamespace . '\\Filters\\' . $class;
+	}
+
+	protected function getTemplate(): string
+	{
+		$template = view('CodeIgniter\\Commands\\Generators\\Views\\filter.tpl.php', [], ['debug' => false]);
+
+		return str_replace('<@php', '<?php', $template);
+	}
+}

--- a/system/Commands/Generators/CreateModel.php
+++ b/system/Commands/Generators/CreateModel.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace CodeIgniter\Commands\Generators;
+
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\CLI\GeneratorCommand;
+
+class CreateModel extends GeneratorCommand
+{
+	/**
+	 * The Command's name
+	 *
+	 * @var string
+	 */
+	protected $name = 'make:model';
+
+	/**
+	 * The Command's short description
+	 *
+	 * @var string
+	 */
+	protected $description = 'Creates a new model file.';
+
+	/**
+	 * The Command's usage
+	 *
+	 * @var string
+	 */
+	protected $usage = 'make:model <name> [options]';
+
+	/**
+	 * The Command's arguments
+	 *
+	 * @var array
+	 */
+	protected $arguments = [
+		'name' => 'The model class name',
+	];
+
+	/**
+	 * The Command's options
+	 *
+	 * @var array
+	 */
+	protected $options = [
+		'-dbgroup' => 'Database group to use. Defaults to "default".',
+		'-entity'  => 'Use an Entity as return type.',
+	];
+
+	protected function getClassName(): string
+	{
+		$className = parent::getClassName();
+
+		if (empty($className))
+		{
+			$className = CLI::prompt(lang('CLI.generateClassName'), null, 'required'); // @codeCoverageIgnore
+		}
+
+		return $className;
+	}
+
+	protected function getNamespacedClass(string $rootNamespace, string $class): string
+	{
+		return $rootNamespace . '\\Models\\' . $class;
+	}
+
+	protected function getTemplate(): string
+	{
+		$dbgroup = $this->params['dbgroup'] ?? CLI::getOption('dbgroup');
+		if (! is_string($dbgroup))
+		{
+			$dbgroup = 'default';
+		}
+
+		$template = view('CodeIgniter\\Commands\\Generators\\Views\\model.tpl.php', [], ['debug' => false]);
+		$template = str_replace(['<@php', '{dbgroup}'], ['<?php', $dbgroup], $template);
+
+		return $template;
+	}
+
+	protected function setReplacements(string $template, string $class): string
+	{
+		$template = parent::setReplacements($template, $class);
+
+		$entity = array_key_exists('entity', $this->params) || CLI::getOption('entity');
+		if (! $entity)
+		{
+			$entity = 'array'; // default to array return
+		}
+		else
+		{
+			$entity = str_replace('\\Models', '\\Entities', $class);
+			if ($pos = strripos($entity, 'Model'))
+			{
+				// Strip 'Model' from name
+				$entity = substr($entity, 0, $pos);
+			}
+		}
+		$template = str_replace('{return}', $entity, $template);
+
+		// transform class name to lowercased plural for table name
+		$table = str_replace($this->getNamespace($class) . '\\', '', $class);
+		if ($pos = strripos($table, 'Model'))
+		{
+			$table = substr($table, 0, $pos);
+		}
+		$table = strtolower(plural($table));
+		return str_replace('{table}', $table, $template);
+	}
+}

--- a/system/Commands/Generators/CreateModel.php
+++ b/system/Commands/Generators/CreateModel.php
@@ -82,6 +82,7 @@ class CreateModel extends GeneratorCommand
 	protected $options = [
 		'-dbgroup' => 'Database group to use. Defaults to "default".',
 		'-entity'  => 'Use an Entity as return type.',
+		'-table'   => 'Supply a different table name. Defaults to the pluralized name.',
 	];
 
 	protected function getClassName(): string
@@ -135,13 +136,20 @@ class CreateModel extends GeneratorCommand
 		}
 		$template = str_replace('{return}', $entity, $template);
 
-		// transform class name to lowercased plural for table name
-		$table = str_replace($this->getNamespace($class) . '\\', '', $class);
+		$table = $this->params['table'] ?? CLI::getOption('table');
+		if (! is_string($table))
+		{
+			$table = str_replace($this->getNamespace($class) . '\\', '', $class);
+		}
+
 		if ($pos = strripos($table, 'Model'))
 		{
 			$table = substr($table, 0, $pos);
 		}
+
+		// transform class name to lowercased plural for table name
 		$table = strtolower(plural($table));
+
 		return str_replace('{table}', $table, $template);
 	}
 }

--- a/system/Commands/Generators/CreateScaffold.php
+++ b/system/Commands/Generators/CreateScaffold.php
@@ -83,10 +83,10 @@ class CreateScaffold extends BaseCommand
 	];
 
 	protected $options = [
-		'-base'    => 'Add the \'-base\' option to controller scaffold.',
+		'-bare'    => 'Add the \'-bare\' option to controller scaffold.',
 		'-restful' => 'Add the \'-restful\' option to controller scaffold.',
-		'-dbgroup' => 'Add the \'-dbgroup\' option to model and session migration scaffold.',
-		'-t'       => 'Add the \'-t\' option for the session migration scaffold.',
+		'-dbgroup' => 'Add the \'-dbgroup\' option to model scaffold.',
+		'-table'   => 'Add the \'-table\' option to the model scaffold.',
 		'-n'       => 'Set root namespace. Defaults to APP_NAMESPACE.',
 		'-force'   => 'Force overwrite existing files.',
 	];
@@ -94,12 +94,16 @@ class CreateScaffold extends BaseCommand
 	public function run(array $params)
 	{
 		// Resolve options
-		$base         = $params['base'] ?? CLI::getOption('base');
-		$rest         = $params['restful'] ?? CLI::getOption('restful');
-		$group        = $params['dbgroup'] ?? CLI::getOption('dbgroup');
-		$tableSession = $params['t'] ?? CLI::getOption('t') ?? 'ci_sessions';
-		$namespace    = $params['n'] ?? CLI::getOption('n');
-		$force        = array_key_exists('force', $params) ?? CLI::getOption('force');
+		$bare       = array_key_exists('bare', $params) || CLI::getOption('bare');
+		$rest       = array_key_exists('restful', $params)
+						? ($params['restful'] ?? true)
+						: CLI::getOption('restful');
+		$group      = array_key_exists('dbgroup', $params)
+						? ($params['dbgroup'] ?? 'default')
+						: CLI::getOption('dbgroup');
+		$tableModel = $params['table'] ?? CLI::getOption('table');
+		$namespace  = $params['n'] ?? CLI::getOption('n');
+		$force      = array_key_exists('force', $params) || CLI::getOption('force');
 
 		// Sets additional options
 		$genOptions = ['n' => $namespace];
@@ -109,22 +113,19 @@ class CreateScaffold extends BaseCommand
 		}
 
 		$controllerOpts = [];
-		if ($base)
+		if ($bare)
 		{
-			$controllerOpts['base'] = $base;
+			$controllerOpts['bare'] = null;
 		}
 		elseif ($rest)
 		{
 			$controllerOpts['restful'] = $rest;
 		}
 
-		$modelOpts   = [
+		$modelOpts = [
 			'dbgroup' => $group,
 			'entity'  => null,
-		];
-		$sessionOpts = [
-			'g' => $group,
-			't' => $tableSession,
+			'table'   => $tableModel,
 		];
 
 		// Call those commands!
@@ -134,6 +135,5 @@ class CreateScaffold extends BaseCommand
 		$this->call('make:entity', array_merge([$class], $genOptions));
 		$this->call('migrate:create', array_merge([$class], $genOptions));
 		$this->call('make:seeder', array_merge([$class], $genOptions));
-		$this->call('session:migration', array_merge([$class], $sessionOpts, $genOptions));
 	}
 }

--- a/system/Commands/Generators/CreateScaffold.php
+++ b/system/Commands/Generators/CreateScaffold.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace CodeIgniter\Commands\Generators;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+
+class CreateScaffold extends BaseCommand
+{
+	/**
+	 * The group the command is lumped under
+	 * when listing commands.
+	 *
+	 * @var string
+	 */
+	protected $group = 'Generators';
+
+	/**
+	 * The Command's name
+	 *
+	 * @var string
+	 */
+	protected $name = 'make:scaffold';
+
+	/**
+	 * The Command's short description
+	 *
+	 * @var string
+	 */
+	protected $description = 'Creates a complete set of scaffold files.';
+
+	/**
+	 * The Command's usage
+	 *
+	 * @var string
+	 */
+	protected $usage = 'make:scaffold <name> [options]';
+
+	/**
+	 * The Command's arguments
+	 *
+	 * @var array
+	 */
+	protected $arguments = [
+		'name' => 'The class name',
+	];
+
+	protected $options = [
+		'-base'    => 'Add the \'-base\' option to controller scaffold.',
+		'-restful' => 'Add the \'-restful\' option to controller scaffold.',
+		'-dbgroup' => 'Add the \'-dbgroup\' option to model and session migration scaffold.',
+		'-t'       => 'Add the \'-t\' option for the session migration scaffold.',
+		'-n'       => 'Set root namespace. Defaults to APP_NAMESPACE.',
+		'-force'   => 'Force overwrite existing files.',
+	];
+
+	public function run(array $params)
+	{
+		// Resolve options
+		$base         = $params['base'] ?? CLI::getOption('base');
+		$rest         = $params['restful'] ?? CLI::getOption('restful');
+		$group        = $params['dbgroup'] ?? CLI::getOption('dbgroup');
+		$tableSession = $params['t'] ?? CLI::getOption('t') ?? 'ci_sessions';
+		$namespace    = $params['n'] ?? CLI::getOption('n');
+		$force        = array_key_exists('force', $params) ?? CLI::getOption('force');
+
+		// Sets additional options
+		$genOptions = ['n' => $namespace];
+		if ($force)
+		{
+			$genOptions['force'] = null;
+		}
+
+		$controllerOpts = [];
+		if ($base)
+		{
+			$controllerOpts['base'] = $base;
+		}
+		elseif ($rest)
+		{
+			$controllerOpts['restful'] = $rest;
+		}
+
+		$modelOpts   = [
+			'dbgroup' => $group,
+			'entity'  => null,
+		];
+		$sessionOpts = [
+			'g' => $group,
+			't' => $tableSession,
+		];
+
+		// Call those commands!
+		$class = $params[0] ?? CLI::getOption(0);
+		$this->call('make:controller', array_merge([$class], $controllerOpts, $genOptions));
+		$this->call('make:model', array_merge([$class], $modelOpts, $genOptions));
+		$this->call('make:entity', array_merge([$class], $genOptions));
+		$this->call('migrate:create', array_merge([$class], $genOptions));
+		$this->call('make:seeder', array_merge([$class], $genOptions));
+		$this->call('session:migration', array_merge([$class], $sessionOpts, $genOptions));
+	}
+}

--- a/system/Commands/Generators/Views/command.tpl.php
+++ b/system/Commands/Generators/Views/command.tpl.php
@@ -1,0 +1,46 @@
+<@php
+
+namespace {namespace};
+
+use CodeIgniter\CLI\CLI;
+{useStatement}
+
+class {class} {extends}
+{
+	{commandGroup}
+	/**
+	 * The Command's name
+	 *
+	 * @var string
+	 */
+	protected $name = '{commandName}';
+
+	/**
+	 * The Command's short description
+	 *
+	 * @var string
+	 */
+	protected $description = '';
+
+	/**
+	 * The Command's usage
+	 *
+	 * @var string
+	 */
+	protected $usage = '{commandName} [arguments] [options]';
+
+	/**
+	 * The Command's arguments.
+	 *
+	 * @var array
+	 */
+	protected $arguments = [];
+
+	/**
+	 * The Command's options.
+	 *
+	 * @var array
+	 */
+	protected $options = [];
+	{commandAbstractMethodsToImplement}
+}

--- a/system/Commands/Generators/Views/controller.tpl.php
+++ b/system/Commands/Generators/Views/controller.tpl.php
@@ -1,0 +1,14 @@
+<@php
+
+namespace {namespace};
+
+{useStatement}
+
+class {class} {extends}
+{
+	public function index()
+	{
+		//
+	}
+	{restfulMethods}
+}

--- a/system/Commands/Generators/Views/entity.tpl.php
+++ b/system/Commands/Generators/Views/entity.tpl.php
@@ -1,0 +1,18 @@
+<@php
+
+namespace {namespace};
+
+use CodeIgniter\Entity;
+
+class {class} extends Entity
+{
+	protected $datamap = [];
+
+	protected $dates = [
+		'created_at',
+		'updated_at',
+		'deleted_at',
+	];
+
+	protected $casts = [];
+}

--- a/system/Commands/Generators/Views/filter.tpl.php
+++ b/system/Commands/Generators/Views/filter.tpl.php
@@ -1,0 +1,26 @@
+<@php
+
+namespace {namespace};
+
+use CodeIgniter\Filters\FilterInterface;
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
+
+class {class} implements FilterInterface
+{
+	/**
+	 * {@inheritdoc}
+	 */
+	public function before(RequestInterface $request, $arguments = null)
+	{
+		//
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
+	{
+		//
+	}
+}

--- a/system/Commands/Generators/Views/model.tpl.php
+++ b/system/Commands/Generators/Views/model.tpl.php
@@ -8,6 +8,7 @@ class {class} extends Model
 {
 	protected $table      = '{table}';
 	protected $primaryKey = 'id';
+	protected $useAutoIncrement = true;
 
 	protected $insertID = 0;
 	protected $DBGroup  = '{dbgroup}';

--- a/system/Commands/Generators/Views/model.tpl.php
+++ b/system/Commands/Generators/Views/model.tpl.php
@@ -1,0 +1,43 @@
+<@php
+
+namespace {namespace};
+
+use CodeIgniter\Model;
+
+class {class} extends Model
+{
+	protected $table      = '{table}';
+	protected $primaryKey = 'id';
+
+	protected $insertID = 0;
+	protected $DBGroup  = '{dbgroup}';
+
+	protected $returnType     = '{return}';
+	protected $useSoftDeletes = false;
+	protected $allowedFields  = [];
+
+	// Dates
+	protected $useTimestamps = false;
+	protected $dateFormat    = 'datetime';
+	protected $createdField  = 'created_at';
+	protected $updatedField  = 'updated_at';
+	protected $deletedField  = 'deleted_at';
+	protected $protectFields = true;
+
+	// Validation
+	protected $validationRules      = [];
+	protected $validationMessages   = [];
+	protected $skipValidation       = false;
+	protected $cleanValidationRules = true;
+
+	// Callbacks
+	protected $allowCallbacks = true;
+	protected $beforeInsert   = [];
+	protected $afterInsert    = [];
+	protected $beforeUpdate   = [];
+	protected $afterUpdate    = [];
+	protected $beforeFind     = [];
+	protected $afterFind      = [];
+	protected $beforeDelete   = [];
+	protected $afterDelete    = [];
+}

--- a/system/Language/en/CLI.php
+++ b/system/Language/en/CLI.php
@@ -25,6 +25,8 @@ return [
    'invalidColor'        => 'Invalid {0} color: {1}.',
 
    // Generators
+   'generateClassName'   => 'Name of class',
+   'generateParentClass' => 'Name of parent class to extend from',
    'generateFileExists'  => '{0} already exists.',
    'generateFileSuccess' => 'Created file: ',
    'generateFileError'   => 'Error in creating file: ',

--- a/tests/system/Commands/CreateCommandTest.php
+++ b/tests/system/Commands/CreateCommandTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+class CreateCommandTest extends CIUnitTestCase
+{
+	protected $streamFilter;
+
+	protected function setUp(): void
+	{
+		CITestStreamFilter::$buffer = '';
+		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
+		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+	}
+
+	protected function tearDown(): void
+	{
+		stream_filter_remove($this->streamFilter);
+
+		$result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+		$file   = trim(substr($result, 14));
+		$file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $file);
+		$dir    = dirname($file);
+		file_exists($file) && unlink($file);
+		is_dir($dir) && rmdir($dir);
+	}
+
+	protected function getBuffer(): string
+	{
+		return CITestStreamFilter::$buffer;
+	}
+
+	protected function getFileContents(string $filepath): string
+	{
+		if (! file_exists($filepath))
+		{
+			return '';
+		}
+
+		$contents = file_get_contents($filepath);
+
+		return $contents ?: '';
+	}
+
+	public function testCreateCommandWithDefaults()
+	{
+		command('make:command deliver');
+
+		$file = APPPATH . 'Commands/Deliver.php';
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+		$this->assertFileExists($file);
+
+		$contents = $this->getFileContents($file);
+		$this->assertStringContainsString('use CodeIgniter\\CLI\\BaseCommand;', $contents);
+		$this->assertStringContainsString('extends BaseCommand', $contents);
+		$this->assertStringContainsString('protected $group = \'CodeIgniter\';', $contents);
+		$this->assertStringContainsString('protected $name = \'command:name\';', $contents);
+		$this->assertStringContainsString('protected $usage = \'command:name [arguments] [options]\';', $contents);
+		$this->assertStringContainsString('public function run(array $params)', $contents);
+	}
+
+	public function testCreateCommandWithGivenOptions()
+	{
+		command('make:command deliver -command make:deliver -type generator');
+		$file = APPPATH . 'Commands/Deliver.php';
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+		$this->assertFileExists($file);
+
+		$contents = $this->getFileContents($file);
+		$this->assertStringContainsString('use CodeIgniter\\CLI\\GeneratorCommand;', $contents);
+		$this->assertStringContainsString('extends GeneratorCommand', $contents);
+		$this->assertStringNotContainsString('protected $group = \'Generators\';', $contents);
+		$this->assertStringContainsString('protected $name = \'make:deliver\';', $contents);
+		$this->assertStringContainsString('protected $usage = \'make:deliver [arguments] [options]\';', $contents);
+		$this->assertStringContainsString('protected function getTemplate(): string', $contents);
+	}
+
+	public function testCreateCommandWithOverridingGroupGiven()
+	{
+		command('make:command deliver -command make:deliver -type generator -group Deliverables');
+		$file = APPPATH . 'Commands/Deliver.php';
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+		$this->assertFileExists($file);
+
+		$contents = $this->getFileContents($file);
+		$this->assertStringContainsString('use CodeIgniter\\CLI\\GeneratorCommand;', $contents);
+		$this->assertStringContainsString('extends GeneratorCommand', $contents);
+		$this->assertStringContainsString('protected $group = \'Deliverables\';', $contents);
+		$this->assertStringContainsString('protected $name = \'make:deliver\';', $contents);
+		$this->assertStringContainsString('protected $usage = \'make:deliver [arguments] [options]\';', $contents);
+		$this->assertStringContainsString('protected function getTemplate(): string', $contents);
+	}
+}

--- a/tests/system/Commands/CreateControllerTest.php
+++ b/tests/system/Commands/CreateControllerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+class CreateControllerTest extends CIUnitTestCase
+{
+	protected $streamFilter;
+
+	protected function setUp(): void
+	{
+		CITestStreamFilter::$buffer = '';
+		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
+		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+	}
+
+	protected function tearDown(): void
+	{
+		stream_filter_remove($this->streamFilter);
+
+		$result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+		$file   = trim(substr($result, 14));
+		$file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $file);
+		file_exists($file) && unlink($file);
+	}
+
+	protected function getBuffer(): string
+	{
+		return CITestStreamFilter::$buffer;
+	}
+
+	protected function getFileContents(string $filepath): string
+	{
+		if (! file_exists($filepath))
+		{
+			return '';
+		}
+
+		$contents = file_get_contents($filepath);
+
+		return $contents ?: '';
+	}
+
+	public function testCreateControllerThatUsesBaseController()
+	{
+		command('make:controller user');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+		$this->assertStringContainsString('User.php', $this->getBuffer());
+		$this->assertFileExists(APPPATH . 'Controllers/User.php');
+		$this->assertStringContainsString('BaseController', $this->getFileContents(APPPATH . 'Controllers/User.php'));
+	}
+
+	public function testCreateControllerThatUsesCodeigniterController()
+	{
+		command('make:controller blog -bare');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+		$this->assertStringContainsString('Blog.php', $this->getBuffer());
+		$this->assertFileExists(APPPATH . 'Controllers/Blog.php');
+		$this->assertStringContainsString('use CodeIgniter\Controller;', $this->getFileContents(APPPATH . 'Controllers/Blog.php'));
+	}
+
+	public function testCreateControllerThatUsesDefaultRestfulResource()
+	{
+		command('make:controller api -restful');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+		$this->assertStringContainsString('Api.php', $this->getBuffer());
+		$this->assertFileExists(APPPATH . 'Controllers/Api.php');
+		$this->assertStringContainsString('use CodeIgniter\RESTful\ResourceController;', $this->getFileContents(APPPATH . 'Controllers/Api.php'));
+	}
+
+	public function testCreateControllerThatUsesAGivenRestfulResource()
+	{
+		command('make:controller api -restful presenter');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+		$this->assertStringContainsString('Api.php', $this->getBuffer());
+		$this->assertFileExists(APPPATH . 'Controllers/Api.php');
+		$this->assertStringContainsString('use CodeIgniter\RESTful\ResourcePresenter;', $this->getFileContents(APPPATH . 'Controllers/Api.php'));
+	}
+
+	public function testCreateRestfulControllerHasRestfulMethods()
+	{
+		command('make:controller pay -restful');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+		$this->assertStringContainsString('Pay.php', $this->getBuffer());
+		$this->assertFileExists(APPPATH . 'Controllers/Pay.php');
+		$this->assertStringContainsString('public function new()', $this->getFileContents(APPPATH . 'Controllers/Pay.php'));
+	}
+
+	public function testCreateControllerCanCreateControllersInSubfolders()
+	{
+		command('make:controller admin/user');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+		$this->assertStringContainsString('User.php', $this->getBuffer());
+		$this->assertDirectoryExists(APPPATH . 'Controllers/Admin');
+		$this->assertFileExists(APPPATH . 'Controllers/Admin/User.php');
+
+		// cleanup
+		unlink(APPPATH . 'Controllers/Admin/User.php');
+		rmdir(APPPATH . 'Controllers/Admin');
+	}
+}

--- a/tests/system/Commands/CreateEntityTest.php
+++ b/tests/system/Commands/CreateEntityTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+class CreateEntityTest extends CIUnitTestCase
+{
+	protected $streamFilter;
+
+	protected function setUp(): void
+	{
+		CITestStreamFilter::$buffer = '';
+		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
+		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+	}
+
+	protected function tearDown(): void
+	{
+		stream_filter_remove($this->streamFilter);
+	}
+
+	protected function getBuffer(): string
+	{
+		return CITestStreamFilter::$buffer;
+	}
+
+	protected function getFileContents(string $filepath): string
+	{
+		if (! file_exists($filepath))
+		{
+			return '';
+		}
+
+		$contents = file_get_contents($filepath);
+
+		return $contents ?: '';
+	}
+
+	public function testCreateEntityCreatesASkeletonEntityFile()
+	{
+		command('make:entity user');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+		$this->assertStringContainsString('User.php', $this->getBuffer());
+		$this->assertFileExists(APPPATH . 'Entities/User.php');
+		$this->assertStringContainsString('use CodeIgniter\\Entity;', $this->getFileContents(APPPATH . 'Entities/User.php'));
+
+		// cleanup
+		unlink(APPPATH . 'Entities/User.php');
+		rmdir(APPPATH . 'Entities');
+	}
+
+	public function testCreateEntityCreatesInOtherNamespace()
+	{
+		command('make:entity user -n CodeIgniter');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+		$this->assertStringContainsString('User.php', $this->getBuffer());
+		$this->assertFileExists(SYSTEMPATH . 'Entities/User.php');
+		$this->assertStringContainsString('use CodeIgniter\\Entity;', $this->getFileContents(SYSTEMPATH . 'Entities/User.php'));
+
+		// cleanup
+		unlink(SYSTEMPATH . 'Entities/User.php');
+		rmdir(SYSTEMPATH . 'Entities');
+	}
+}

--- a/tests/system/Commands/CreateFilterTest.php
+++ b/tests/system/Commands/CreateFilterTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+class CreateFilterTest extends CIUnitTestCase
+{
+	protected $streamFilter;
+
+	protected function setUp(): void
+	{
+		CITestStreamFilter::$buffer = '';
+		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
+		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+	}
+
+	protected function tearDown(): void
+	{
+		stream_filter_remove($this->streamFilter);
+
+		$result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+		$file   = trim(substr($result, 14));
+		$file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $file);
+		file_exists($file) && unlink($file);
+	}
+
+	protected function getBuffer(): string
+	{
+		return CITestStreamFilter::$buffer;
+	}
+
+	public function testCreateFilterWorks()
+	{
+		command('make:filter admin');
+
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+		$this->assertFileExists(APPPATH . 'Filters/Admin.php');
+	}
+}

--- a/tests/system/Commands/CreateModelTest.php
+++ b/tests/system/Commands/CreateModelTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+class CreateModelTest extends CIUnitTestCase
+{
+	protected $streamFilter;
+
+	protected function setUp(): void
+	{
+		CITestStreamFilter::$buffer = '';
+		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
+		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+	}
+
+	protected function tearDown(): void
+	{
+		stream_filter_remove($this->streamFilter);
+
+		$result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+		$file   = trim(substr($result, 14));
+		$file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $file);
+		file_exists($file) && unlink($file);
+	}
+
+	protected function getBuffer(): string
+	{
+		return CITestStreamFilter::$buffer;
+	}
+
+	protected function getFileContents(string $filepath): string
+	{
+		if (! file_exists($filepath))
+		{
+			return '';
+		}
+
+		$contents = file_get_contents($filepath);
+
+		return $contents ?: '';
+	}
+
+	public function testCreateModelWithDefaults()
+	{
+		command('make:model user');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+
+		$file = APPPATH . 'Models/User.php';
+		$this->assertFileExists($file);
+		$this->assertStringContainsString('extends Model', $this->getFileContents($file));
+		$this->assertStringContainsString('protected $table      = \'users\';', $this->getFileContents($file));
+		$this->assertStringContainsString('protected $DBGroup  = \'default\';', $this->getFileContents($file));
+		$this->assertStringContainsString('protected $returnType     = \'array\';', $this->getFileContents($file));
+	}
+
+	public function testCreateModelWithDbGroup()
+	{
+		command('make:model user -dbgroup testing');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+
+		$file = APPPATH . 'Models/User.php';
+		$this->assertFileExists($file);
+		$this->assertStringContainsString('protected $DBGroup  = \'testing\';', $this->getFileContents($file));
+	}
+
+	public function testCreateModelWithEntityAsReturnType()
+	{
+		command('make:model user -entity');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+
+		$file = APPPATH . 'Models/User.php';
+		$this->assertFileExists($file);
+		$this->assertStringContainsString('protected $returnType     = \'App\\Entities\\User\';', $this->getFileContents($file));
+	}
+
+	public function testCreateModelWithDifferentModelTable()
+	{
+		command('make:model user -table utilisateur');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+
+		$file = APPPATH . 'Models/User.php';
+		$this->assertFileExists($file);
+		$this->assertStringContainsString('protected $table      = \'utilisateurs\';', $this->getFileContents($file));
+	}
+
+	public function testCreateModelWithEntityAndNameHasModelWillTrimInEntity()
+	{
+		command('make:model userModel -entity');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+
+		$file = APPPATH . 'Models/UserModel.php';
+		$this->assertFileExists($file);
+		$this->assertStringContainsString('protected $returnType     = \'App\\Entities\\User\';', $this->getFileContents($file));
+	}
+}

--- a/tests/system/Commands/CreateScaffoldTest.php
+++ b/tests/system/Commands/CreateScaffoldTest.php
@@ -43,6 +43,11 @@ class CreateScaffoldTest extends CIUnitTestCase
 		command('make:scaffold people');
 		$this->assertStringContainsString('Created file: ', $this->getBuffer());
 
+		$dir       = '\\' . DIRECTORY_SEPARATOR;
+		$migration = "APPPATH{$dir}Database{$dir}Migrations{$dir}(.*)\.php";
+		preg_match('/' . $migration . '/u', $this->getBuffer(), $matches);
+		$matches[0] = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $matches[0]);
+
 		$paths = [
 			'Controllers',
 			'Models',
@@ -53,7 +58,7 @@ class CreateScaffoldTest extends CIUnitTestCase
 		{
 			$this->assertFileExists(APPPATH . $path . '/People.php');
 		}
-		$this->assertFileExists(APPPATH . 'Database/Migrations/' . gmdate(config('Migrations')->timestampFormat) . 'People.php');
+		$this->assertFileExists($matches[0]);
 		$this->assertFileExists(APPPATH . 'Database/Seeds/People.php');
 
 		// cleanup
@@ -61,15 +66,57 @@ class CreateScaffoldTest extends CIUnitTestCase
 		{
 			unlink(APPPATH . $path . '/People.php');
 		}
-		unlink(APPPATH . 'Database/Migrations/' . gmdate(config('Migrations')->timestampFormat) . 'People.php');
+		unlink($matches[0]);
 		unlink(APPPATH . 'Database/Seeds/People.php');
+		rmdir(APPPATH . 'Entities');
+	}
+
+	public function testCreateScaffoldWithOneOptionPassed()
+	{
+		command('make:scaffold fixer -bare');
+
+		$dir       = '\\' . DIRECTORY_SEPARATOR;
+		$migration = "APPPATH{$dir}Database{$dir}Migrations{$dir}(.*)\.php";
+		preg_match('/' . $migration . '/u', $this->getBuffer(), $matches);
+		$matches[0] = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $matches[0]);
+
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+
+		// File existence check
+		$paths = [
+			'Controllers',
+			'Models',
+			'Entities',
+		];
+		foreach ($paths as $path)
+		{
+			$this->assertFileExists(APPPATH . $path . '/Fixer.php');
+		}
+		$this->assertFileExists($matches[0]);
+		$this->assertFileExists(APPPATH . 'Database/Seeds/Fixer.php');
+
+		// Options check
+		$this->assertStringContainsString('extends Controller', $this->getFileContents(APPPATH . 'Controllers/Fixer.php'));
+
+		// cleanup
+		foreach ($paths as $path)
+		{
+			unlink(APPPATH . $path . '/Fixer.php');
+		}
+		unlink($matches[0]);
+		unlink(APPPATH . 'Database/Seeds/Fixer.php');
 		rmdir(APPPATH . 'Entities');
 	}
 
 	public function testCreateScaffoldCanPassManyOptionsToCommands()
 	{
-		command('make:scaffold user -bare');
 		command('make:scaffold user -restful -dbgroup testing -force -table utilisateur');
+
+		$dir       = '\\' . DIRECTORY_SEPARATOR;
+		$migration = "APPPATH{$dir}Database{$dir}Migrations{$dir}(.*)\.php";
+		preg_match('/' . $migration . '/u', $this->getBuffer(), $matches);
+		$matches[0] = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $matches[0]);
+
 		$this->assertStringContainsString('Created file: ', $this->getBuffer());
 
 		// File existence check
@@ -82,7 +129,7 @@ class CreateScaffoldTest extends CIUnitTestCase
 		{
 			$this->assertFileExists(APPPATH . $path . '/User.php');
 		}
-		$this->assertFileExists(APPPATH . 'Database/Migrations/' . gmdate(config('Migrations')->timestampFormat) . 'User.php');
+		$this->assertFileExists($matches[0]);
 		$this->assertFileExists(APPPATH . 'Database/Seeds/User.php');
 
 		// Options check
@@ -95,7 +142,7 @@ class CreateScaffoldTest extends CIUnitTestCase
 		{
 			unlink(APPPATH . $path . '/User.php');
 		}
-		unlink(APPPATH . 'Database/Migrations/' . gmdate(config('Migrations')->timestampFormat) . 'User.php');
+		unlink($matches[0]);
 		unlink(APPPATH . 'Database/Seeds/User.php');
 		rmdir(APPPATH . 'Entities');
 	}

--- a/tests/system/Commands/CreateScaffoldTest.php
+++ b/tests/system/Commands/CreateScaffoldTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+class CreateScaffoldTest extends CIUnitTestCase
+{
+	protected $streamFilter;
+
+	protected function setUp(): void
+	{
+		CITestStreamFilter::$buffer = '';
+		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
+		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+	}
+
+	protected function tearDown(): void
+	{
+		stream_filter_remove($this->streamFilter);
+	}
+
+	protected function getBuffer(): string
+	{
+		return CITestStreamFilter::$buffer;
+	}
+
+	protected function getFileContents(string $filepath): string
+	{
+		if (! file_exists($filepath))
+		{
+			return '';
+		}
+
+		$contents = file_get_contents($filepath);
+
+		return $contents ?: '';
+	}
+
+	public function testCreateScaffoldProducesManyFiles()
+	{
+		command('make:scaffold people');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+
+		$paths = [
+			'Controllers',
+			'Models',
+			'Entities',
+		];
+
+		foreach ($paths as $path)
+		{
+			$this->assertFileExists(APPPATH . $path . '/People.php');
+		}
+		$this->assertFileExists(APPPATH . 'Database/Migrations/' . gmdate(config('Migrations')->timestampFormat) . 'People.php');
+		$this->assertFileExists(APPPATH . 'Database/Seeds/People.php');
+
+		// cleanup
+		foreach ($paths as $path)
+		{
+			unlink(APPPATH . $path . '/People.php');
+		}
+		unlink(APPPATH . 'Database/Migrations/' . gmdate(config('Migrations')->timestampFormat) . 'People.php');
+		unlink(APPPATH . 'Database/Seeds/People.php');
+		rmdir(APPPATH . 'Entities');
+	}
+
+	public function testCreateScaffoldCanPassManyOptionsToCommands()
+	{
+		command('make:scaffold user -bare');
+		command('make:scaffold user -restful -dbgroup testing -force -table utilisateur');
+		$this->assertStringContainsString('Created file: ', $this->getBuffer());
+
+		// File existence check
+		$paths = [
+			'Controllers',
+			'Models',
+			'Entities',
+		];
+		foreach ($paths as $path)
+		{
+			$this->assertFileExists(APPPATH . $path . '/User.php');
+		}
+		$this->assertFileExists(APPPATH . 'Database/Migrations/' . gmdate(config('Migrations')->timestampFormat) . 'User.php');
+		$this->assertFileExists(APPPATH . 'Database/Seeds/User.php');
+
+		// Options check
+		$this->assertStringContainsString('extends ResourceController', $this->getFileContents(APPPATH . 'Controllers/User.php'));
+		$this->assertStringContainsString('protected $table      = \'utilisateurs\';', $this->getFileContents(APPPATH . 'Models/User.php'));
+		$this->assertStringContainsString('protected $DBGroup  = \'testing\';', $this->getFileContents(APPPATH . 'Models/User.php'));
+
+		// cleanup
+		foreach ($paths as $path)
+		{
+			unlink(APPPATH . $path . '/User.php');
+		}
+		unlink(APPPATH . 'Database/Migrations/' . gmdate(config('Migrations')->timestampFormat) . 'User.php');
+		unlink(APPPATH . 'Database/Seeds/User.php');
+		rmdir(APPPATH . 'Entities');
+	}
+}

--- a/user_guide_src/source/cli/cli_commands.rst
+++ b/user_guide_src/source/cli/cli_commands.rst
@@ -2,8 +2,8 @@
 Custom CLI Commands
 ###################
 
-While the ability to use cli commands like any other route is convenient, you might find times where you
-need a little something different. That's where CLI Commands come in. They are simple classes that do not
+While the ability to use CLI commands like any other route is convenient, you might find times where you
+need a little something different. That's where CLI commands come in. They are simple classes that do not
 need to have routes defined for, making them perfect for building tools that developers can use to make
 their jobs simpler, whether by handling migrations or database seeding, checking cronjob status, or even
 building out custom code generators for your company.
@@ -18,7 +18,7 @@ Running Commands
 
 Commands are run from the command line, in the root directory. The same one that holds the **/app**
 and **/system** directories. A custom script, **spark** has been provided that is used to run any of the
-cli commands::
+CLI commands::
 
     > php spark
 
@@ -70,12 +70,12 @@ and must extend ``CodeIgniter\CLI\BaseCommand``, and implement the ``run()`` met
 
 The following properties should be used in order to get listed in CLI commands and to add help functionality to your command:
 
-* ($group): a string to describe the group the command is lumped under when listing commands. For example (Database)
-* ($name): a string to describe the command's name. For example (migrate:create)
-* ($description): a string to describe the command. For example (Creates a new migration file.)
-* ($usage): a string to describe the command usage. For example (migrate:create [migration_name] [Options])
-* ($arguments): an array of strings to describe each command argument. For example ('migration_name' => 'The migration file name')
-* ($options): an array of strings to describe each command option. For example ('-n' => 'Set migration namespace')
+* ``$group``: a string to describe the group the command is lumped under when listing commands. For example: ``Database``
+* ``$name``: a string to describe the command's name. For example: ``migrate:create``
+* ``$description``: a string to describe the command. For example: ``Creates a new migration file.``
+* ``$usage``: a string to describe the command usage. For example: ``migrate:create [name] [options]``
+* ``$arguments``: an array of strings to describe each command argument. For example: ``'name' => 'The migration file name'``
+* ``$options``: an array of strings to describe each command option. For example: ``'-n' => 'Set migration namespace'``
 
 **Help description will be automatically generated according to the above parameters.**
 
@@ -86,7 +86,7 @@ Commands must be stored within a directory named **Commands**. However, that dir
 that the :doc:`Autoloader </concepts/autoloader>` can locate it. This could be in **/app/Commands**, or
 a directory that you keep commands in to use in all of your project development, like **Acme/Commands**.
 
-.. note:: When the commands are executed, the full CodeIgniter cli environment has been loaded, making it
+.. note:: When the commands are executed, the full CodeIgniter CLI environment has been loaded, making it
  possible to get environment information, path information, and to use any of the tools you would use when making a Controller.
 
 An Example Command
@@ -129,7 +129,7 @@ run()
 -----
 
 The ``run()`` method is the method that is called when the command is being run. The ``$params`` array is a list of
-any cli arguments after the command name for your use. If the cli string was::
+any CLI arguments after the command name for your use. If the CLI string was::
 
     > php spark foo bar baz
 
@@ -162,21 +162,21 @@ be familiar with when creating your own commands. It also has a :doc:`Logger </g
 
 .. php:class:: CodeIgniter\\CLI\\BaseCommand
 
-    .. php:method:: call(string $command[, array $params=[] ])
+    .. php:method:: call(string $command[, array $params = []])
 
         :param string $command: The name of another command to call.
-        :param array $params: Additional cli arguments to make available to that command.
+        :param array $params: Additional CLI arguments to make available to that command.
 
         This method allows you to run other commands during the execution of your current command::
 
         $this->call('command_one');
         $this->call('command_two', $params);
 
-    .. php:method:: showError(\Exception $e)
+    .. php:method:: showError(Throwable $e)
 
-        :param Exception $e: The exception to use for error reporting.
+        :param Throwable $e: The exception to use for error reporting.
 
-        A convenience method to maintain a consistent and clear error output to the cli::
+        A convenience method to maintain a consistent and clear error output to the CLI::
 
             try
             {

--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -1,0 +1,352 @@
+##############
+CLI Generators
+##############
+
+CodeIgniter4 now comes equipped with generators to ease the creation of stock controllers, models, entities,
+etc. You can also scaffold a complete set of files with just one command.
+
+.. contents::
+	:local:
+	:depth: 2
+
+************
+Introduction
+************
+
+All built-in generators reside under the ``Generators`` namespace when listed using ``php spark list``.
+To view the full description and usage information on a particular generator, use the command::
+
+	> php spark help <generator_command>
+
+where ``<generator_command>`` will be replaced with the command to check.
+
+*******************
+Built-in Generators
+*******************
+
+CodeIgniter4 ships the following generators by default.
+
+make:command
+------------
+
+Creates a new spark command.
+
+Usage:
+======
+.. code-block:: none
+
+	make:command <name> [options]
+
+Argument:
+=========
+* ``name``: The name of the command class. **[REQUIRED]**
+
+Options:
+========
+* ``-command``: The command name to run in spark. Defaults to ``command:name``.
+* ``-group``: The group/namespace of the command. Defaults to ``CodeIgniter`` for basic commands, and ``Generators`` for generator commands.
+* ``-type``: The type of command, whether a ``basic`` command or a ``generator`` command. Defaults to ``basic``.
+* ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
+* ``-force``: Set this flag to overwrite existing files on destination.
+
+make:controller
+---------------
+
+Creates a new controller file.
+
+Usage:
+======
+.. code-block:: none
+
+	make:controller <name> [options]
+
+Argument:
+=========
+* ``name``: The name of the controller class. **[REQUIRED]**
+
+Options:
+========
+* ``-bare``: Extends from ``CodeIgniter\Controller`` instead of ``BaseController``.
+* ``-restful``: Extends from a RESTful resource. Choices are ``controller`` and ``presenter``. Defaults to ``controller``.
+* ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
+* ``-force``: Set this flag to overwrite existing files on destination.
+
+make:entity
+-----------
+
+Creates a new entity file.
+
+Usage:
+======
+.. code-block:: none
+
+	make:entity <name> [options]
+
+Argument:
+=========
+* ``name``: The name of the entity class. **[REQUIRED]**
+
+Options:
+========
+* ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
+* ``-force``: Set this flag to overwrite existing files on destination.
+
+make:filter
+-----------
+
+Creates a new filter file.
+
+Usage:
+======
+.. code-block:: none
+
+	make:filter <name> [options]
+
+Argument:
+=========
+* ``name``: The name of the filter class. **[REQUIRED]**
+
+Options:
+========
+* ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
+* ``-force``: Set this flag to overwrite existing files on destination.
+
+make:model
+----------
+
+Creates a new model file.
+
+Usage:
+======
+.. code-block:: none
+
+	make:model <name> [options]
+
+Argument:
+=========
+* ``name``: The name of the model class. **[REQUIRED]**
+
+Options:
+========
+* ``-dbgroup``: Database group to use. Defaults to ``default``.
+* ``-entity``: Set this flag to use an entity class as the return type.
+* ``-table``: Supply a different table name. Defaults to the pluralized class name.
+* ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
+* ``-force``: Set this flag to overwrite existing files on destination.
+
+make:seeder
+-----------
+
+Creates a new seeder file.
+
+Usage:
+======
+.. code-block:: none
+
+	make:seeder <name> [options]
+
+Argument:
+=========
+* ``name``: The name of the seeder class. **[REQUIRED]**
+
+Options:
+========
+* ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
+* ``-force``: Set this flag to overwrite existing files on destination.
+
+migrate:create
+--------------
+
+Creates a new migration file.
+
+Usage:
+======
+.. code-block:: none
+
+	migrate:create <name> [options]
+
+Argument:
+=========
+* ``name``: The name of the migration class. **[REQUIRED]**
+
+Options:
+========
+* ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
+* ``-force``: Set this flag to overwrite existing files on destination.
+
+session:migration
+-----------------
+
+Generates the migration file for database sessions.
+
+Usage:
+======
+.. code-block:: none
+
+	session:migration [options]
+
+Options:
+========
+* ``-g``: Set the database group.
+* ``-t``: Set the table name. Defaults to ``ci_sessions``.
+* ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
+* ``-force``: Set this flag to overwrite existing files on destination.
+
+.. note:: When running ``php spark help session:migration``, you will see that it has the argument ``name`` listed.
+	This argument is not used as the class name is derived from the table name passed to the ``-t`` option.
+
+.. note:: Do you need to have the generated code in a subfolder? Let's say if you want to create a controller
+	class to reside in the ``Admin`` subfolder of the main ``Controllers`` folder, you will just need
+	to prepend the subfolder to the class name, like this: ``php spark make:controller admin/login``. This
+	command will create the ``Login`` controller in the ``Controllers/Admin`` subfolder with
+	a namespace of ``App\Controllers\Admin``.
+
+.. note:: Working on modules? Code generation will set the root namespace to a default of ``APP_NAMESPACE``.
+	Should you need to have the generated code elsewhere in your module namespace, make sure to set
+	the ``-n`` option in your command, e.g. ``php spark make:model blog -n Acme\Blog``.
+
+.. warning:: Make sure when setting the ``-n`` option that the supplied namespace is a valid namespace
+	defined in your ``$psr4`` array in ``Config\Autoload`` or defined in your composer autoload file.
+	Otherwise, a ``RuntimeException`` will be thrown.
+
+****************************************
+Scaffolding a Complete Set of Stock Code
+****************************************
+
+Sometimes in our development phase we are creating functionalities by groups, such as creating an *Admin* group.
+This group will contain its own controller, model, migration files, or even entities. You may be tempted to type
+each generator command one-by-one in the terminal and wishfully thinking it would be great to have a single generator
+command to rule them all.
+
+Fret no more! CodeIgniter4 is also shipped with a dedicated ``make:scaffold`` command that is basically a
+wrapper to the controller, model, entity, migration, and seeder generator commands. All you need is the class
+name that will be used to name all the generated classes. Also, **individual options** supported by each
+generator command is recognized by the scaffold command.
+
+Running this in your terminal::
+
+	php spark make:scaffold user
+
+will create the following classes:
+
+(1) ``App\Controllers\User``;
+(2) ``App\Models\User``;
+(3) ``App\Entities\User``;
+(4) ``App\Database\Migrations\User``; and
+(5) ``App\Database\Seeds\User``.
+
+****************
+GeneratorCommand
+****************
+
+All generator commands must extend ``GeneratorCommand`` to fully utilize its methods that are used in code
+generation. While some of the methods are already functional, you may have the need to customize or upgrade
+what each method does. You can do so as all methods have protected visibility, except for the ``run()`` method
+which is public and need not be overridden as it is essentially complete.
+
+.. php:class:: CodeIgniter\\CLI\\GeneratorCommand
+
+	.. php:method:: getClassName()
+
+		:rtype: string
+
+		Gets the class name from input. This can be overridden if name is really
+		required by providing a prompt.
+
+	.. php:method:: sanitizeClassName(string $class)
+
+		:param string $class: Class name.
+		:rtype: string
+
+		Trims input, normalize separators, and ensures all paths are in Pascal case.
+
+	.. php:method:: qualifyClassName(string $class)
+
+		:param string $class: Class name.
+		:rtype: string
+
+		Parses the class name and checks if it is already fully qualified.
+
+	.. php:method:: getRootNamespace()
+
+		:rtype: string
+
+		Gets the root namespace from input. Defaults to value of ``APP_NAMESPACE``.
+
+	.. php:method:: getNamespacedClass(string $rootNamespace, string $class)
+
+		:param string $rootNamespace: The root namespace of the class.
+		:param string $class: Class name
+		:returns: The fully qualified class name
+		:rtype: string
+
+		Gets the qualified class name. This should be implemented.
+
+	.. php:method:: buildPath(string $class)
+
+		:param string $class: The fully qualified class name
+		:returns: The absolute path to where the class will be saved.
+		:rtype: string
+		:throws: RuntimeException
+
+		Builds the file path from the class name.
+
+	.. php:method:: modifyBasename(string $filename)
+
+		:param string $filename: The basename of the file path.
+		:returns: A modified basename for the file.
+		:rtype: string
+
+		Provides last chance for child generators to change the file's basename before saving.
+		This is useful for migration files where the basename has a date component.
+
+	.. php:method:: buildClassContents(string $class)
+
+		:param string $class: The fully qualified class name.
+		:rtype: string
+
+		Builds the contents for class being generated, doing all the replacements necessary in the template.
+
+	.. php:method:: getTemplate()
+
+		:rtype: string
+
+		Gets the template for the class being generated. This must be implemented.
+
+	.. php:method:: getNamespace(string $class)
+
+		:param string $class: The fully qualified class name.
+		:rtype: string
+
+		Retrieves the namespace part from the fully qualified class name.
+
+	.. php:method:: setReplacements(string $template, string $class)
+
+		:param string $template: The template string to use.
+		:param string $class: The fully qualified class name.
+		:returns: The template string with all annotations replaced.
+		:rtype: string
+
+		Performs all the necessary replacements.
+
+	.. php:method:: sortImports(string $template)
+
+		:param string $template: The template file.
+		:returns: The template file with all imports already sorted.
+		:rtype: string
+
+		Alphabetically sorts the imports for a given template.
+
+.. warning:: Child generators should make sure to implement ``GeneratorCommand``'s two abstract methods:
+	``getNamespacedClass`` and ``getTemplate``, or else you will get a PHP fatal error.
+
+.. note:: ``GeneratorCommand`` has the default argument of ``['name' => 'Class name']``. You can
+	override the description by supplying the name in your ``$options`` property, e.g. ``['name' => 'Module class name']``.
+
+.. note:: ``GeneratorCommand`` has the default options of ``-n`` and ``-force``. Child classes cannot override
+	these two properties as they are crucial in the implementation of the code generation.
+
+.. note:: Generators are default listed under the ``Generators`` namespace because it is the default group
+	name in ``GeneratorCommand``. If you want to have your own generator listed elsewhere under a different
+	namespace, you will just need to provide the ``$group`` property in your child generator,
+	e.g. ``protected $group = 'CodeIgniter';``.

--- a/user_guide_src/source/cli/index.rst
+++ b/user_guide_src/source/cli/index.rst
@@ -9,5 +9,6 @@ CodeIgniter 4 can also be used with command line programs.
 
     cli
     cli_commands
+    cli_generators
     cli_library
     cli_request


### PR DESCRIPTION
**Description**
Add code generators that leverages the power of `GeneratorCommand`.

- `make:controller <name> [options]`
- `make:model <name> [options]`
- `make:entity <name> [options]`
- `make:scaffold <name> [options]`
- `make:command <name> [options]`
- `make:filter <name> [options]`

Tests are underway, but I would like to have a few feedback of additions or removals from current proposed.
Default property values are lifted from the respective parent class.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Conforms to style guide
- [x] Unit testing, with >80% coverage
- [x] User guide updated
