### PR TITLE
4.1.0: remove Autoloader::loadLegacy() method

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -255,16 +255,7 @@ class Autoloader
 		$class = trim($class, '\\');
 		$class = str_ireplace('.php', '', $class);
 
-		$mapped_file = $this->loadInNamespace($class);
-
-		// Nothing? One last chance by looking
-		// in common CodeIgniter folders.
-		if (! $mapped_file)
-		{
-			$mapped_file = $this->loadLegacy($class);
-		}
-
-		return $mapped_file;
+		return $this->loadInNamespace($class);
 	}
 
 	//--------------------------------------------------------------------
@@ -312,45 +303,6 @@ class Autoloader
 		}
 
 		// never found a mapped file
-		return false;
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Attempts to load the class from common locations in previous
-	 * version of CodeIgniter, namely 'app/Libraries', and
-	 * 'app/Models'.
-	 *
-	 * @param string $class The class name. This typically should NOT have a namespace.
-	 *
-	 * @return mixed    The mapped file name on success, or boolean false on failure
-	 */
-	protected function loadLegacy(string $class)
-	{
-		// If there is a namespace on this class, then
-		// we cannot load it from traditional locations.
-		if (strpos($class, '\\') !== false)
-		{
-			return false;
-		}
-
-		$paths = [
-			APPPATH . 'Controllers/',
-			APPPATH . 'Libraries/',
-			APPPATH . 'Models/',
-		];
-
-		$class = str_replace('\\', DIRECTORY_SEPARATOR, $class) . '.php';
-
-		foreach ($paths as $path)
-		{
-			if ($file = $this->requireFile($path . $class))
-			{
-				return $file;
-			}
-		}
-
 		return false;
 	}
 

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -205,21 +205,6 @@ class AutoloaderTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testLoadLegacy()
-	{
-		// should not be able to find a folder
-		$this->assertFalse((bool) $this->loader->loadClass(__DIR__));
-		// should be able to find these because we said so in the Autoloader
-		$this->assertTrue((bool) $this->loader->loadClass('Home'));
-		// should not be able to find these - don't exist
-		$this->assertFalse((bool) $this->loader->loadClass('anotherLibrary'));
-		$this->assertFalse((bool) $this->loader->loadClass('\nester\anotherLibrary'));
-		// should not be able to find these legacy classes - namespaced
-		$this->assertFalse($this->loader->loadClass('Controllers\Home'));
-	}
-
-	//--------------------------------------------------------------------
-
 	public function testSanitizationSimply()
 	{
 		$test     = '${../path}!#/to/some/file.php_';

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -16,6 +16,7 @@ Release Date: Not Released
         :titlesonly:
 
         next
+        v4.1.0
         v4.0.5
         v4.0.4
         v4.0.3

--- a/user_guide_src/source/changelogs/v4.1.0.rst
+++ b/user_guide_src/source/changelogs/v4.1.0.rst
@@ -1,0 +1,10 @@
+Version 4.1.0
+====================================================
+
+Release Date: Not released
+
+**4.1.0 release of CodeIgniter4**
+
+Removed:
+
+- `Autoloader::loadLegacy()` method was previously used for migration non-namespaced classes transition to CodeIgniter v4. Since `4.1.0`, this support removed.

--- a/user_guide_src/source/changelogs/v4.1.0.rst
+++ b/user_guide_src/source/changelogs/v4.1.0.rst
@@ -7,4 +7,4 @@ Release Date: Not released
 
 Removed:
 
-- `Autoloader::loadLegacy()` method was previously used for migration non-namespaced classes transition to CodeIgniter v4. Since `4.1.0`, this support removed.
+- `Autoloader::loadLegacy()` method was previously used for migration of non-namespaced classes in transition to CodeIgniter v4. Since `4.1.0`, this support was removed.

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -76,15 +76,6 @@ third-party libraries that are not namespaced::
 
 The key of each row is the name of the class that you want to locate. The value is the path to locate it at.
 
-Legacy Support
-==============
-
-If neither of the above methods finds the class, and the class is not namespaced, the autoloader will look in the
-**/app/Libraries** and **/app/Models** directories to attempt to locate the files. This provides
-a measure to help ease the transition from previous versions.
-
-There are no configuration options for legacy support.
-
 Composer Support
 ================
 


### PR DESCRIPTION
`Autoloader::loadLegacy()` method was previously used for migration non-namespaced classes transition to CodeIgniter v4. Since `4.1.0`, I think this can be removed.

**Checklist:**
- [x] Securely signed commits