### PR TITLE
4.1.0 remove FileLocator::legacyLocate() method

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -376,7 +376,7 @@ class Autoloader
 
 		if (is_file($file))
 		{
-			$requiredFiles[$file] = $file;
+			$requiredFiles[$file] = true;
 			require_once $file;
 
 			return $file;

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -366,10 +366,17 @@ class Autoloader
 	 */
 	protected function requireFile(string $file)
 	{
+		static $requiredFiles = [];
+
 		$file = $this->sanitizeFilename($file);
+		if (isset($requiredFiles[$file]))
+		{
+			return $file;
+		}
 
 		if (is_file($file))
 		{
+			$requiredFiles[$file] = $file;
 			require_once $file;
 
 			return $file;

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -90,10 +90,10 @@ class FileLocator
 			$file = substr($file, strlen($folder . '/'));
 		}
 
-		// Is not namespaced? Try the application folder.
+		// Is not namespaced? Returns false immediately
 		if (strpos($file, '\\') === false)
 		{
-			return $this->legacyLocate($file, $folder);
+			return false;
 		}
 
 		// Standardize slashes to handle nested directories.
@@ -470,28 +470,5 @@ class FileLocator
 		}
 
 		return $files;
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Checks the app folder to see if the file can be found.
-	 * Only for use with filenames that DO NOT include namespacing.
-	 *
-	 * @param string      $file
-	 * @param string|null $folder
-	 *
-	 * @return string|false The path to the file, or false if not found.
-	 */
-	protected function legacyLocate(string $file, string $folder = null)
-	{
-		$path = realpath(APPPATH . (empty($folder) ? $file : $folder . '/' . $file));
-
-		if (is_file($path))
-		{
-			return $path;
-		}
-
-		return false;
 	}
 }

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -90,10 +90,10 @@ class FileLocator
 			$file = substr($file, strlen($folder . '/'));
 		}
 
-		// Is not namespaced? Returns false immediately
+		// Is not namespaced? assume a Config class
 		if (strpos($file, '\\') === false)
 		{
-			return false;
+			return $this->autoloader->loadClass($file);
 		}
 
 		// Standardize slashes to handle nested directories.

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -197,6 +197,20 @@ class AutoloaderTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testloadClassConfigFoundRepetitivelyUseCachedRequiredFile()
+	{
+		$this->loader->addNamespace('Config', APPPATH . 'Config');
+		$this->loader->loadClass('Modules');
+		$this->loader->loadClass('Modules');
+
+		$this->assertSame(
+			APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'Modules.php',
+			$this->loader->loadClass('Modules')
+		);
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testloadClassConfigNotFound()
 	{
 		$this->loader->addNamespace('Config', APPPATH . 'Config');

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -34,55 +34,10 @@ class FileLocatorTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testLocateFileWorksWithLegacyStructure()
+	public function testLocateFileCannotFindNonNamespacedFile()
 	{
 		$file = 'Controllers/Home';
-
-		$expected = APPPATH . 'Controllers/Home.php';
-
-		$this->assertEquals($expected, $this->locator->locateFile($file));
-	}
-
-	//--------------------------------------------------------------------
-
-	public function testLocateFileWithLegacyStructureNotFound()
-	{
-		$file = 'Unknown';
-
 		$this->assertFalse($this->locator->locateFile($file));
-	}
-
-	//--------------------------------------------------------------------
-
-	public function testLocateFileWorksInApplicationDirectory()
-	{
-		$file = 'welcome_message';
-
-		$expected = APPPATH . 'Views/welcome_message.php';
-
-		$this->assertEquals($expected, $this->locator->locateFile($file, 'Views'));
-	}
-
-	//--------------------------------------------------------------------
-
-	public function testLocateFileWorksInApplicationDirectoryWithoutFolder()
-	{
-		$file = 'Common';
-
-		$expected = APPPATH . 'Common.php';
-
-		$this->assertEquals($expected, $this->locator->locateFile($file));
-	}
-
-	//--------------------------------------------------------------------
-
-	public function testLocateFileWorksInNestedApplicationDirectory()
-	{
-		$file = 'Controllers/Home';
-
-		$expected = APPPATH . 'Controllers/Home.php';
-
-		$this->assertEquals($expected, $this->locator->locateFile($file, 'Controllers'));
 	}
 
 	//--------------------------------------------------------------------
@@ -92,17 +47,6 @@ class FileLocatorTest extends \CodeIgniter\Test\CIUnitTestCase
 		$file = '\App\Views/errors/html/error_404.php';
 
 		$expected = APPPATH . 'Views/errors/html/error_404.php';
-
-		$this->assertEquals($expected, $this->locator->locateFile($file, 'Views'));
-	}
-
-	//--------------------------------------------------------------------
-
-	public function testLocateFileReplacesFolderNameLegacy()
-	{
-		$file = 'Views/welcome_message.php';
-
-		$expected = APPPATH . 'Views/welcome_message.php';
 
 		$this->assertEquals($expected, $this->locator->locateFile($file, 'Views'));
 	}

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -42,7 +42,16 @@ class FileLocatorTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testLocateFileAsConfigClass()
+	public function testLocateFileAsConfigClassNotFound()
+	{
+		$file = 'Unknown';
+
+		$this->assertFalse($this->locator->locateFile($file));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testLocateFileAsConfigClassFound()
 	{
 		$file = 'Toolbar';
 

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -42,6 +42,17 @@ class FileLocatorTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testLocateFileAsConfigClass()
+	{
+		$file = 'Toolbar';
+
+		$expected = APPPATH . 'Config/Toolbar.php';
+
+		$this->assertEquals($expected, $this->locator->locateFile($file));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testLocateFileReplacesFolderName()
 	{
 		$file = '\App\Views/errors/html/error_404.php';

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -16,6 +16,7 @@ Release Date: Not Released
         :titlesonly:
 
         next
+        v4.1.0
         v4.0.5
         v4.0.4
         v4.0.3

--- a/user_guide_src/source/changelogs/v4.1.0.rst
+++ b/user_guide_src/source/changelogs/v4.1.0.rst
@@ -7,8 +7,15 @@ Release Date: Not released
 
 Removed:
 
-- `FileLocator::legacyLocate()` method was previously used for ability to locate PSR-4 namespaced files and non-namespaced files. Since `4.1.0`, this support will only works for Config class, eg:
+- `FileLocator::legacyLocate()` method was previously used for ability to locate PSR-4 namespaced files and non-namespaced files. Since `4.1.0`, this non-namespaced support will only works for Config class, eg:
 
 ```php
-config('Toolbar'); // will locate APPPATH . 'Config/Toolbar.php'
+config('Toolbar'); // will get APPPATH . 'Config/Toolbar.php'
+```
+
+or
+
+```php
+$fileLocator = service('locator');
+$fileLocator->locateFile('Toolbar'); // will get APPPATH . 'Config/Toolbar.php'
 ```

--- a/user_guide_src/source/changelogs/v4.1.0.rst
+++ b/user_guide_src/source/changelogs/v4.1.0.rst
@@ -1,0 +1,10 @@
+Version 4.1.0
+====================================================
+
+Release Date: Not released
+
+**4.1.0 release of CodeIgniter4**
+
+Removed:
+
+- `FileLocator::legacyLocate()` method was previously used for ability to locate PSR-4 namespaced files and non-namespaced files. Since `4.1.0`, this support was removed.

--- a/user_guide_src/source/changelogs/v4.1.0.rst
+++ b/user_guide_src/source/changelogs/v4.1.0.rst
@@ -7,4 +7,8 @@ Release Date: Not released
 
 Removed:
 
-- `FileLocator::legacyLocate()` method was previously used for ability to locate PSR-4 namespaced files and non-namespaced files. Since `4.1.0`, this support was removed.
+- `FileLocator::legacyLocate()` method was previously used for ability to locate PSR-4 namespaced files and non-namespaced files. Since `4.1.0`, this support will only works for Config class, eg:
+
+```php
+config('Toolbar'); // will locate APPPATH . 'Config/Toolbar.php'
+```


### PR DESCRIPTION
`FileLocator::legacyLocate()` method was previously used for ability to locate PSR-4 namespaced files and non-namespaced files. Since `4.1.0`, I think only `psr-4` namespace locate file should be supported.

**Checklist:**
- [x] Securely signed commits