### PR TITLE
Make command() mimic getopt parsing

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -169,6 +169,11 @@ if (! function_exists('command'))
 		$length = strlen($command);
 		$cursor = 0;
 
+		/**
+		 * Adopted from Symfony's `StringInput::tokenize()` with few changes.
+		 *
+		 * @see https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Input/StringInput.php
+		 */
 		while ($cursor < $length)
 		{
 			if (preg_match('/\s+/A', $command, $match, null, $cursor))

--- a/system/Common.php
+++ b/system/Common.php
@@ -161,30 +161,59 @@ if (! function_exists('command'))
 	 */
 	function command(string $command)
 	{
-		$runner = service('commands');
+		$runner      = service('commands');
+		$regexString = '([^\s]+?)(?:\s|(?<!\\\\)"|(?<!\\\\)\'|$)';
+		$regexQuoted = '(?:"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"|\'([^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\')';
 
-		$args    = explode(' ', $command);
-		$command = array_shift($args);
+		$args   = [];
+		$length = strlen($command);
+		$cursor = 0;
 
+		while ($cursor < $length)
+		{
+			if (preg_match('/\s+/A', $command, $match, null, $cursor))
+			{
+				// nothing to do
+			}
+			elseif (preg_match('/' . $regexQuoted . '/A', $command, $match, null, $cursor))
+			{
+				$args[] = stripcslashes(substr($match[0], 1, strlen($match[0]) - 2));
+			}
+			elseif (preg_match('/' . $regexString . '/A', $command, $match, null, $cursor))
+			{
+				$args[] = stripcslashes($match[1]);
+			}
+			else
+			{
+				// @codeCoverageIgnoreStart
+				throw new InvalidArgumentException(sprintf('Unable to parse input near "... %s ...".', substr($command, $cursor, 10)));
+				// @codeCoverageIgnoreEnd
+			}
+
+			$cursor += strlen($match[0]);
+		}
+
+		$command     = array_shift($args);
 		$params      = [];
 		$optionValue = false;
 
 		foreach ($args as $i => $arg)
 		{
-			// add to segments if not starting with '-'
-			// and not an option value
-			if (mb_strpos($arg, '-') !== 0 && ! $optionValue)
-			{
-				$params[] = $arg;
-				continue;
-			}
-
-			// if this was an option value, it was already
-			// included in the previous iteration, so
-			// reset the process
 			if (mb_strpos($arg, '-') !== 0)
 			{
-				$optionValue = false;
+				if ($optionValue)
+				{
+					// if this was an option value, it was already
+					// included in the previous iteration
+					$optionValue = false;
+				}
+				else
+				{
+					// add to segments if not starting with '-'
+					// and not an option value
+					$params[] = $arg;
+				}
+
 				continue;
 			}
 

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -173,6 +173,23 @@ class CommandTest extends \CodeIgniter\Test\CIUnitTestCase
 					'cv',
 				],
 			],
+			[
+				'reveal as -df "some stuff" -jk 12 -sd "Some longer stuff" -fg \'using single quotes\'',
+				[
+					'as',
+					'df' => 'some stuff',
+					'jk' => 12,
+					'sd' => 'Some longer stuff',
+					'fg' => 'using single quotes',
+				],
+			],
+			[
+				'reveal as -df "using mixed \'quotes\'\" here\""',
+				[
+					'as',
+					'df' => 'using mixed \'quotes\'" here"'
+				],
+			],
 		];
 	}
 }


### PR DESCRIPTION
**Description**
While making tests for my generators PR, I've noticed that we cannot pass in a multi-worded option value to `command()` simply because we are making an `explode` on the string input using the spaces. With this, `command('command -d "some value"')` will be broken into `array(0 => 'command', '-d' => '"some', 1 => 'value"')`, instead of the expected `array(0 => 'command', '-d' => 'some value')` just like how getopt will give it.

After searching the net, I came across this solution from Symfony's `StringInput::tokenize` which perfectly did the job right.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
