### PR TITLE
Add command 'logs:clear'

### DIFF
--- a/system/Commands/Housekeeping/ClearLogs.php
+++ b/system/Commands/Housekeeping/ClearLogs.php
@@ -74,7 +74,16 @@ class ClearLogs extends BaseCommand
 	 *
 	 * @var string
 	 */
-	protected $usage = 'logs:clear';
+	protected $usage = 'logs:clear [option';
+
+	/**
+	 * The Command's options
+	 *
+	 * @var array
+	 */
+	protected $options = [
+		'-force' => 'Force delete of all logs files without prompting.',
+	];
 
 	/**
 	 * Actually execute a command.
@@ -83,12 +92,24 @@ class ClearLogs extends BaseCommand
 	 */
 	public function run(array $params)
 	{
+		$force = array_key_exists('force', $params) || CLI::getOption('force');
+
+		if (! $force && CLI::prompt('Are you sure you want to delete the logs?', ['n', 'y']) === 'n')
+		{
+			// @codeCoverageIgnoreStart
+			CLI::error('Deleting logs aborted.', 'light_gray', 'red');
+			CLI::error('If you want, use the "-force" option to force delete all log files.', 'light_gray', 'red');
+			CLI::newLine();
+			return;
+			// @codeCoverageIgnoreEnd
+		}
+
 		helper('filesystem');
 
 		if (! delete_files(WRITEPATH . 'logs', false, true))
 		{
 			// @codeCoverageIgnoreStart
-			CLI::error('Error in deleting the logs files.');
+			CLI::error('Error in deleting the logs files.', 'light_gray', 'red');
 			CLI::newLine();
 			return;
 			// @codeCoverageIgnoreEnd

--- a/system/Commands/Housekeeping/ClearLogs.php
+++ b/system/Commands/Housekeeping/ClearLogs.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace CodeIgniter\Commands\Housekeeping;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+
+/**
+ * ClearLogs command.
+ */
+class ClearLogs extends BaseCommand
+{
+	/**
+	 * The group the command is lumped under
+	 * when listing commands.
+	 *
+	 * @var string
+	 */
+	protected $group = 'Housekeeping';
+
+	/**
+	 * The Command's name
+	 *
+	 * @var string
+	 */
+	protected $name = 'logs:clear';
+
+	/**
+	 * The Command's short description
+	 *
+	 * @var string
+	 */
+	protected $description = 'Clears all log files.';
+
+	/**
+	 * The Command's usage
+	 *
+	 * @var string
+	 */
+	protected $usage = 'logs:clear';
+
+	/**
+	 * Actually execute a command.
+	 *
+	 * @param array $params
+	 */
+	public function run(array $params)
+	{
+		helper('filesystem');
+
+		if (! delete_files(WRITEPATH . 'logs', false, true))
+		{
+			// @codeCoverageIgnoreStart
+			CLI::error('Error in deleting the logs files.');
+			CLI::newLine();
+			return;
+			// @codeCoverageIgnoreEnd
+		}
+
+		CLI::write('Logs cleared.', 'green');
+		CLI::newLine();
+	}
+}

--- a/tests/system/Commands/ClearLogsTest.php
+++ b/tests/system/Commands/ClearLogsTest.php
@@ -50,7 +50,7 @@ class ClearLogsTest extends CIUnitTestCase
 		$this->createDummyLogFiles();
 		$this->assertFileExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
 
-		command('logs:clear');
+		command('logs:clear -force');
 		$result = CITestStreamFilter::$buffer;
 
 		$this->assertFileNotExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");

--- a/tests/system/Commands/ClearLogsTest.php
+++ b/tests/system/Commands/ClearLogsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+class ClearLogsTest extends CIUnitTestCase
+{
+	protected $streamFilter;
+	protected $date;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		CITestStreamFilter::$buffer = '';
+		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
+		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+		$this->date                 = date('Y-m-d');
+	}
+
+	protected function tearDown(): void
+	{
+		stream_filter_remove($this->streamFilter);
+	}
+
+	protected function createDummyLogFiles()
+	{
+		$date = $this->date;
+		$path = WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$date}.log";
+
+		// create 10 dummy log files
+		for ($i = 0; $i < 10; $i++)
+		{
+			$newDate = date('Y-m-d', strtotime("-{$i} day"));
+			$path    = str_replace($date, $newDate, $path);
+			file_put_contents($path, 'Lorem ipsum');
+
+			$date = $newDate;
+		}
+	}
+
+	public function testClearLogsWorks()
+	{
+		// test clean logs dir
+		$this->assertFileNotExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
+
+		// test dir is now populated with logs
+		$this->createDummyLogFiles();
+		$this->assertFileExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
+
+		command('logs:clear');
+		$result = CITestStreamFilter::$buffer;
+
+		$this->assertFileNotExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
+		$this->assertFileExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . 'index.html');
+		$this->assertStringContainsString('Logs cleared.', $result);
+	}
+}


### PR DESCRIPTION
**Description**
Addition to the `Housekeeping` department, this command will automatically delete all logs files, just like how `debugbar:clear` deletes all debugbar.json files.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
