### PR TITLE
Use Throwable in BaseCommand::showError

### DIFF
--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -39,8 +39,8 @@
 
 namespace CodeIgniter\CLI;
 
-use Exception;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
  * Class BaseCommand
@@ -161,12 +161,14 @@ abstract class BaseCommand
 	/**
 	 * A simple method to display an error with line/file, in child commands.
 	 *
-	 * @param Exception $e
+	 * @param Throwable $e
 	 */
-	protected function showError(Exception $e)
+	protected function showError(Throwable $e)
 	{
-		CLI::error("Error: {$e->getMessage()}");
-		CLI::write("File : {$e->getFile()} on line {$e->getLine()}");
+		$exception = $e;
+		$message   = $e->getMessage();
+
+		require APPPATH . 'Views/errors/cli/error_exception.php';
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
While trying to induce an error in calling `php spark migrate` using incorrect DB credentials, I was expecting a good error message but instead received a `TypeError`.
```
[TypeError]

Argument 1 passed to CodeIgniter\CLI\BaseCommand::showError() must be an instance of Exception, instance of CodeIgniter\Database\Exceptions\DatabaseException given, called in C:\Users\P\Desktop\Web Dev\CodeIgniter4\system\Commands\Database\Migrate.php on line 143

at SYSTEMPATH\CLI\BaseCommand.php:166
```
`DatabaseException` is a subclass of `Error` so this does not pass the type hint. This PR changes the typehint to use the `Throwable` interface instead of the more specific `Exception`. This also changes the rendering to use the built-in pretty output of `error_exception.php`.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
