### PR TITLE
Add support for nested params in matches/differs rules

### DIFF
--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -61,6 +61,11 @@ class Rules
 	 */
 	public function differs(string $str = null, string $field, array $data): bool
 	{
+		if (strpos($field, '.') !== false)
+		{
+			return $str !== dot_array_search($field, $data);
+		}
+
 		return array_key_exists($field, $data) && $str !== $data[$field];
 	}
 
@@ -279,6 +284,11 @@ class Rules
 	 */
 	public function matches(string $str = null, string $field, array $data): bool
 	{
+		if (strpos($field, '.') !== false)
+		{
+			return $str === dot_array_search($field, $data);
+		}
+
 		return array_key_exists($field, $data) && $str === $data[$field];
 	}
 

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -398,6 +398,42 @@ class RulesTest extends CIDatabaseTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testMatcheNestedsTrue()
+	{
+		$data = [
+			'nested' => [
+				'foo' => 'match',
+				'bar' => 'match',
+			],
+		];
+
+		$this->validation->setRules([
+			'nested.foo' => 'matches[nested.bar]',
+		]);
+
+		$this->assertTrue($this->validation->run($data));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testMatchesNestedFalse()
+	{
+		$data = [
+			'nested' => [
+				'foo' => 'match',
+				'bar' => 'nope',
+			],
+		];
+
+		$this->validation->setRules([
+			'nested.foo' => 'matches[nested.bar]',
+		]);
+
+		$this->assertFalse($this->validation->run($data));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testDiffersNull()
 	{
 		$data = [
@@ -439,6 +475,42 @@ class RulesTest extends CIDatabaseTestCase
 
 		$this->validation->setRules([
 			'foo' => 'differs[bar]',
+		]);
+
+		$this->assertFalse($this->validation->run($data));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testDiffersNestedTrue()
+	{
+		$data = [
+			'nested' => [
+				'foo' => 'match',
+				'bar' => 'nope',
+			],
+		];
+
+		$this->validation->setRules([
+			'nested.foo' => 'differs[nested.bar]',
+		]);
+
+		$this->assertTrue($this->validation->run($data));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testDiffersNestedFalse()
+	{
+		$data = [
+			'nested' => [
+				'foo' => 'match',
+				'bar' => 'match',
+			],
+		];
+
+		$this->validation->setRules([
+			'nested.foo' => 'differs[nested.bar]',
 		]);
 
 		$this->assertFalse($this->validation->run($data));


### PR DESCRIPTION
**Description**
This PR adds support for nested params. Right now rules like `matches[nested.value]` are not supported.

See: #3492

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
