### PR TITLE
Fixes paths to run static analysis check on develop and 4.1 branch

### DIFF
--- a/.github/workflows/static-analysis-check.yml
+++ b/.github/workflows/static-analysis-check.yml
@@ -7,8 +7,8 @@ on:
       - 'develop'
       - '4.1'
     paths:
-      - 'app'
-      - 'system'
+      - 'app/**'
+      - 'system/**'
 
 jobs:
   build:


### PR DESCRIPTION
when merging to develop, it seems the static analysis didn't run. I updated it to use paths : 

```
      - 'app/**'
      - 'system/**'
```

**Checklist:**
- [x] Securely signed commits
