### PR TITLE
Fixes EncryptionException::forNoHandlerAvailable() handler parameter call

### DIFF
--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -87,6 +87,13 @@ class Encryption
 		'OpenSSL',
 	];
 
+	/**
+	 * Handlers that are to be installed
+	 *
+	 * @var array
+	 */
+	protected $handlers = [];
+
 	// --------------------------------------------------------------------
 
 	/**
@@ -115,7 +122,7 @@ class Encryption
 		{
 			// this should never happen in travis-ci
 			// @codeCoverageIgnoreStart
-			throw EncryptionException::forNoHandlerAvailable($this->driver);
+			throw EncryptionException::forNoHandlerAvailable('OpenSSL');
 			// @codeCoverageIgnoreEnd
 		}
 	}

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -87,13 +87,6 @@ class Encryption
 		'OpenSSL',
 	];
 
-	/**
-	 * Handlers that are to be installed
-	 *
-	 * @var array
-	 */
-	protected $handlers = [];
-
 	// --------------------------------------------------------------------
 
 	/**
@@ -112,17 +105,12 @@ class Encryption
 		$this->driver = $config->driver;
 		$this->digest = $config->digest ?? 'SHA512';
 
-		// determine what is installed
-		$this->handlers = [
-			'OpenSSL' => extension_loaded('openssl'),
-		];
-
 		// if any aren't there, bomb
-		if (in_array(false, $this->handlers))
+		if ($this->driver === 'OpenSSL' && ! extension_loaded('openssl'))
 		{
 			// this should never happen in travis-ci
 			// @codeCoverageIgnoreStart
-			throw EncryptionException::forNoHandlerAvailable('OpenSSL');
+			throw EncryptionException::forNoHandlerAvailable($this->driver);
 			// @codeCoverageIgnoreEnd
 		}
 	}

--- a/system/Encryption/Exceptions/EncryptionException.php
+++ b/system/Encryption/Exceptions/EncryptionException.php
@@ -14,9 +14,9 @@ class EncryptionException extends \RuntimeException implements ExceptionInterfac
 		return new static(lang('Encryption.noDriverRequested'));
 	}
 
-	public static function forNoHandlerAvailable()
+	public static function forNoHandlerAvailable(string $handler)
 	{
-		return new static(lang('Encryption.noHandlerAvailable'));
+		return new static(lang('Encryption.noHandlerAvailable', [$handler]));
 	}
 
 	public static function forUnKnownHandler(string $driver = null)


### PR DESCRIPTION
Two things:

- `EncryptionException::forNoHandlerAvailable` is for to pass handler name, it was passed driver in `Encryption::__construct()`.
- `EncryptionException::forNoHandlerAvailable()` require `$handler` parameter, it was no parameter.

**Checklist:**
- [x] Securely signed commits