### PR TITLE
Update on PR event for phpstan workflow

### DIFF
--- a/.github/workflows/static-analysis-check.yml
+++ b/.github/workflows/static-analysis-check.yml
@@ -2,6 +2,12 @@ name: "Static Analysis Check"
 
 on:
   pull_request:
+    branches:
+      - 'develop'
+      - '4.1'
+    paths:
+      - 'app/**'
+      - 'system/**'
   push:
     branches:
       - 'develop'
@@ -20,9 +26,12 @@ jobs:
         with:
           extensions: intl
           php-version: "7.4"
+
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: "Install dependencies"
         run: "composer install"
+
       - name: "Static analysis Check"
         run: "vendor/bin/phpstan analyze --level=0 app system"


### PR DESCRIPTION
**Description**
Update the `on pull_request` event of the phpstan workflow to run only on the same conditions as the `push` event. Currently on PRs, it also runs on user guide updates.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
