### PR TITLE
Set default logging threshold to 4

### DIFF
--- a/app/Config/Logger.php
+++ b/app/Config/Logger.php
@@ -32,7 +32,7 @@ class Logger extends BaseConfig
 	| your log files will fill up very fast.
 	|
 	*/
-	public $threshold = 3;
+	public $threshold = 4;
 
 	/*
 	|--------------------------------------------------------------------------

--- a/tests/system/Commands/ClearLogsTest.php
+++ b/tests/system/Commands/ClearLogsTest.php
@@ -17,7 +17,10 @@ class ClearLogsTest extends CIUnitTestCase
 		CITestStreamFilter::$buffer = '';
 		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
 		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
-		$this->date                 = date('Y-m-d');
+
+		// test runs on other tests may log errors since default threshold
+		// is now 4, so set this to a safe distance
+		$this->date = date('Y-m-d', strtotime('+1 year'));
 	}
 
 	protected function tearDown(): void
@@ -33,7 +36,7 @@ class ClearLogsTest extends CIUnitTestCase
 		// create 10 dummy log files
 		for ($i = 0; $i < 10; $i++)
 		{
-			$newDate = date('Y-m-d', strtotime("-{$i} day"));
+			$newDate = date('Y-m-d', strtotime("+1 year -{$i} day"));
 			$path    = str_replace($date, $newDate, $path);
 			file_put_contents($path, 'Lorem ipsum');
 


### PR DESCRIPTION
**Description**
Looking through the forums, I've realized that developers' dilemma of `Unable to connect to database` exceptions can be known its root cause by logging the errors also. The default is set to `3` which logs only critical errors and higher. This PR suggests increasing the threshold to `4` to make errors logged too.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
