### PR TITLE
apply phpstan level 1

### DIFF
--- a/.github/workflows/static-analysis-check.yml
+++ b/.github/workflows/static-analysis-check.yml
@@ -25,4 +25,4 @@ jobs:
       - name: "Install dependencies"
         run: "composer install"
       - name: "Static analysis Check"
-        run: "vendor/bin/phpstan analyze --level=0 app system"
+        run: "vendor/bin/phpstan analyze --level=1 app system"

--- a/.github/workflows/static-analysis-check.yml
+++ b/.github/workflows/static-analysis-check.yml
@@ -2,6 +2,12 @@ name: "Static Analysis Check"
 
 on:
   pull_request:
+    branches:
+      - 'develop'
+      - '4.1'
+    paths:
+      - 'app/**'
+      - 'system/**'
   push:
     branches:
       - 'develop'
@@ -20,9 +26,12 @@ jobs:
         with:
           extensions: intl
           php-version: "7.4"
+
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: "Install dependencies"
         run: "composer install"
+
       - name: "Static analysis Check"
         run: "vendor/bin/phpstan analyze --level=1 app system"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,10 +10,13 @@ parameters:
         - app/Config/*
         - app/Database/*
         - app/Views/*
+        - system/Commands/Generators/Views/migration.tpl.php
+        - system/Config/Routes.php
+        - system/Debug/Toolbar/Views/toolbar.tpl.php
+        - system/Validation/Views/single.php
     ignoreErrors:
         - '#Unsafe usage of new static\(\)*#'
         - '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::_(disable|enable)ForeignKeyChecks\(\)#'
         - '#Access to an undefined property CodeIgniter\\Config\\AutoloadConfig::(\$psr4|\$classmap)#'
-        - '#Call to protected method renderTimeline\(\) of class CodeIgniter\\Debug\\Toolbar#'
         - '#Access to an undefined property CodeIgniter\\Database\\Forge::\$dropConstraintStr#'
         - '#Access to an undefined property CodeIgniter\\Config\\View::(\$filters|\$plugins)#'

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -1136,7 +1136,7 @@ class CLI
 			$table .= '| ' . implode(' | ', $table_rows[$row]) . ' |' . PHP_EOL;
 
 			// Set the thead and table borders-bottom
-			if ($row === 0 && ! empty($thead) || $row + 1 === $total_rows)
+			if (isset($cols) && ($row === 0 && ! empty($thead) || $row + 1 === $total_rows))
 			{
 				$table .= $cols . PHP_EOL;
 			}

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -528,7 +528,7 @@ class FileHandler implements CacheInterface
 			}
 		}
 
-		return $fileInfo;
+		return $fileInfo; // @phpstan-ignore-line
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -215,7 +215,7 @@ class MemcachedHandler implements CacheInterface
 			}
 		}
 
-		return is_array($data) ? $data[0] : $data;
+		return is_array($data) ? $data[0] : $data; // @phpstan-ignore-line
 	}
 
 	//--------------------------------------------------------------------

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -1112,7 +1112,7 @@ class CodeIgniter
 			$uri = new URI($uri);
 		}
 
-		if (isset($_SESSION))
+		if (isset($_SESSION)) // @phpstan-ignore-line
 		{
 			$_SESSION['_ci_previous_url'] = (string) $uri;
 		}

--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -147,7 +147,7 @@ class Serve extends BaseCommand
 		CLI::write('Press Control-C to stop.');
 
 		// Set the Front Controller path as Document Root.
-		$docroot = escapeshellarg(FCPATH);
+		$docroot = escapeshellarg(FCPATH); // @phpstan-ignore-line
 
 		// Mimic Apache's mod_rewrite functionality with user settings.
 		$rewrite = escapeshellarg(__DIR__ . '/rewrite.php');

--- a/system/Common.php
+++ b/system/Common.php
@@ -134,7 +134,8 @@ if (! function_exists('clean_path'))
 				return 'APPPATH' . DIRECTORY_SEPARATOR . substr($path, strlen(APPPATH));
 			case strpos($path, SYSTEMPATH) === 0:
 				return 'SYSTEMPATH' . DIRECTORY_SEPARATOR . substr($path, strlen(SYSTEMPATH));
-			case strpos($path, FCPATH) === 0:
+			case strpos($path, FCPATH) === 0: // @phpstan-ignore-line
+				// @phpstan-ignore-next-line
 				return 'FCPATH' . DIRECTORY_SEPARATOR . substr($path, strlen(FCPATH));
 			case defined('VENDORPATH') && strpos($path, VENDORPATH) === 0:
 				return 'VENDORPATH' . DIRECTORY_SEPARATOR . substr($path, strlen(VENDORPATH));

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -102,7 +102,7 @@ class AutoloadConfig
 	{
 		if (isset($_SERVER['CI_ENVIRONMENT']) && $_SERVER['CI_ENVIRONMENT'] === 'testing')
 		{
-			$this->psr4['Tests\Support']                  = SUPPORTPATH;
+			$this->psr4['Tests\Support']                  = SUPPORTPATH; // @phpstan-ignore-line
 			$this->classmap['CodeIgniter\Log\TestLogger'] = SYSTEMPATH . 'Test/TestLogger.php';
 			$this->classmap['CIDatabaseTestCase']         = SYSTEMPATH . 'Test/CIDatabaseTestCase.php';
 		}

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1958,7 +1958,7 @@ class BaseBuilder
 		// If we've previously reset the QBOrderBy values, get them back
 		elseif (! isset($this->QBOrderBy))
 		{
-			$this->QBOrderBy = $orderBy ?? [];
+			$this->QBOrderBy = $orderBy ?: [];
 		}
 
 		// Restore the LIMIT setting
@@ -2789,7 +2789,7 @@ class BaseBuilder
 	{
 		$table = $this->QBFrom[0];
 
-		$sql = $this->delete($table, null, $reset, true);
+		$sql = $this->delete($table, null, $reset);
 
 		return $this->compileFinalQuery($sql);
 	}

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1958,7 +1958,7 @@ class BaseBuilder
 		// If we've previously reset the QBOrderBy values, get them back
 		elseif (! isset($this->QBOrderBy))
 		{
-			$this->QBOrderBy = $orderBy ?: [];
+			$this->QBOrderBy = $orderBy;
 		}
 
 		// Restore the LIMIT setting

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1673,13 +1673,11 @@ abstract class BaseConnection implements ConnectionInterface
 	 * Returns an object with field data
 	 *
 	 * @param  string $table the table name
-	 * @return array|false
+	 * @return array
 	 */
 	public function getFieldData(string $table)
 	{
-		$fields = $this->_fieldData($this->protectIdentifiers($table, true, false, false));
-
-		return $fields ?: false;
+		return $this->_fieldData($this->protectIdentifiers($table, true, false, false));
 	}
 
 	//--------------------------------------------------------------------
@@ -1688,13 +1686,11 @@ abstract class BaseConnection implements ConnectionInterface
 	 * Returns an object with key data
 	 *
 	 * @param  string $table the table name
-	 * @return array|false
+	 * @return array
 	 */
 	public function getIndexData(string $table)
 	{
-		$fields = $this->_indexData($this->protectIdentifiers($table, true, false, false));
-
-		return $fields ?: false;
+		return $this->_indexData($this->protectIdentifiers($table, true, false, false));
 	}
 
 	//--------------------------------------------------------------------
@@ -1703,13 +1699,11 @@ abstract class BaseConnection implements ConnectionInterface
 	 * Returns an object with foreign key data
 	 *
 	 * @param  string $table the table name
-	 * @return array|false
+	 * @return array
 	 */
 	public function getForeignKeyData(string $table)
 	{
-		$fields = $this->_foreignKeyData($this->protectIdentifiers($table, true, false, false));
-
-		return $fields ?: false;
+		return $this->_foreignKeyData($this->protectIdentifiers($table, true, false, false));
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1679,7 +1679,7 @@ abstract class BaseConnection implements ConnectionInterface
 	{
 		$fields = $this->_fieldData($this->protectIdentifiers($table, true, false, false));
 
-		return $fields ?? false;
+		return $fields ?: false;
 	}
 
 	//--------------------------------------------------------------------
@@ -1694,7 +1694,7 @@ abstract class BaseConnection implements ConnectionInterface
 	{
 		$fields = $this->_indexData($this->protectIdentifiers($table, true, false, false));
 
-		return $fields ?? false;
+		return $fields ?: false;
 	}
 
 	//--------------------------------------------------------------------
@@ -1709,7 +1709,7 @@ abstract class BaseConnection implements ConnectionInterface
 	{
 		$fields = $this->_foreignKeyData($this->protectIdentifiers($table, true, false, false));
 
-		return $fields ?? false;
+		return $fields ?: false;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -331,7 +331,7 @@ class Builder extends BaseBuilder
 		}
 
 		$cases = '';
-		foreach ($final as $k => $v)
+		foreach ($final as $k => $v) // @phpstan-ignore-line
 		{
 			$cases .= "{$k} = (CASE {$index}\n"
 					. implode("\n", $v)

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -86,7 +86,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 */
 	public function connect(bool $persistent = false)
 	{
-		if ($persistent && $this->db->DBDebug)
+		if ($persistent && $this->DBDebug)
 		{
 			throw new DatabaseException('SQLite3 doesn\'t support persistent connections.');
 		}

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -305,7 +305,7 @@ class Exceptions
 		}
 
 		ob_start();
-		include $viewFile;
+		include $viewFile; // @phpstan-ignore-line
 		$buffer = ob_get_contents();
 		ob_end_clean();
 		echo $buffer;
@@ -360,7 +360,7 @@ class Exceptions
 		}
 
 		return [
-			$statusCode ?? 500,
+			$statusCode ?: 500,
 			$exitStatus,
 		];
 	}
@@ -389,8 +389,8 @@ class Exceptions
 			case strpos($file, SYSTEMPATH) === 0:
 				$file = 'SYSTEMPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(SYSTEMPATH));
 				break;
-			case strpos($file, FCPATH) === 0:
-				$file = 'FCPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(FCPATH));
+			case strpos($file, FCPATH) === 0: // @phpstan-ignore-line
+				$file = 'FCPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(FCPATH)); // @phpstan-ignore-line
 				break;
 			case defined('VENDORPATH') && strpos($file, VENDORPATH) === 0:
 				$file = 'VENDORPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(VENDORPATH));

--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -127,7 +127,7 @@ class Routes extends BaseCollector
 				'method'     => $router->methodName(),
 				'paramCount' => count($router->params()),
 				'truePCount' => count($params),
-				'params'     => $params ?? [],
+				'params'     => $params ?: [],
 			],
 		];
 

--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -127,7 +127,7 @@ class Routes extends BaseCollector
 				'method'     => $router->methodName(),
 				'paramCount' => count($router->params()),
 				'truePCount' => count($params),
-				'params'     => $params ?: [],
+				'params'     => $params,
 			],
 		];
 

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -1187,7 +1187,7 @@ class Email
 				}
 				if ($this->sendMultipart !== false)
 				{
-					$this->finalBody .= '--' . $boundary . '--';
+					$this->finalBody .= '--' . $boundary . '--'; // @phpstan-ignore-line
 				}
 			return;
 			case 'plain-attach':
@@ -1515,7 +1515,7 @@ class Email
 		// We might already have this set for UTF-8
 		isset($chars) || $chars = static::strlen($str);
 		$output                 = '=?' . $this->charset . '?Q?';
-		for ($i = 0, $length = static::strlen($output); $i < $chars; $i ++)
+		for ($i = 0, $length = static::strlen($output); $i < $chars; $i ++) // @phpstan-ignore-line
 		{
 			$chr = ($this->charset === 'UTF-8' && extension_loaded('iconv')) ? '=' . implode('=', str_split(strtoupper(bin2hex(iconv_substr($str, $i, 1, $this->charset))), 2)) : '=' . strtoupper(bin2hex($str[$i]));
 			// RFC 2045 sets a limit of 76 characters per line.
@@ -1955,7 +1955,7 @@ class Email
 		}
 		$reply                = $this->getSMTPData();
 		$this->debugMessage[] = '<pre>' . $cmd . ': ' . $reply . '</pre>';
-		if ((int) static::substr($reply, 0, 3) !== $resp)
+		if ((int) static::substr($reply, 0, 3) !== $resp) // @phpstan-ignore-line
 		{
 			$this->setErrorMessage(lang('Email.SMTPError', [$reply]));
 			return false;
@@ -2051,7 +2051,7 @@ class Email
 				$timestamp = 0;
 			}
 		}
-		if ($result === false)
+		if ($result === false) // @phpstan-ignore-line
 		{
 			$this->setErrorMessage(lang('Email.SMTPDataFailure', $data));
 			return false;

--- a/system/Encryption/Handlers/OpenSSLHandler.php
+++ b/system/Encryption/Handlers/OpenSSLHandler.php
@@ -57,6 +57,13 @@ class OpenSSLHandler extends BaseHandler
 	 */
 	protected $cipher = 'AES-256-CTR';
 
+	/**
+	 * Starter key
+	 *
+	 * @var string
+	 */
+	protected $key = '';
+
 	// --------------------------------------------------------------------
 
 	/**

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -244,7 +244,7 @@ class DownloadResponse extends Message implements ResponseInterface
 
 		$result = sprintf('attachment; filename="%s"', $download_filename);
 
-		if (isset($utf8_filename))
+		if ($utf8_filename)
 		{
 			$result .= '; filename*=UTF-8\'\'' . rawurlencode($utf8_filename);
 		}

--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -310,16 +310,23 @@ class FileCollection
 	 */
 	protected function getValueDotNotationSyntax(array $index, array $value)
 	{
-		if (! empty($index))
+		if (empty($index))
 		{
-			$current_index = array_shift($index);
+			return null;
 		}
-		if (is_array($index) && $index && is_array($value[$current_index]) && $value[$current_index])
+
+		$current_index = array_shift($index);
+		if (! isset($value[$current_index]))
+		{
+			return null;
+		}
+
+		if (is_array($value[$current_index]) && $value[$current_index])
 		{
 			return $this->getValueDotNotationSyntax($index, $value[$current_index]);
 		}
 
-		return (isset($value[$current_index])) ? $value[$current_index] : null;
+		return $value[$current_index];
 	}
 
 }

--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -310,23 +310,16 @@ class FileCollection
 	 */
 	protected function getValueDotNotationSyntax(array $index, array $value)
 	{
-		if (empty($index))
+		if (! empty($index))
 		{
-			return null;
+			$current_index = array_shift($index);
 		}
-
-		$current_index = array_shift($index);
-		if (! isset($value[$current_index]))
-		{
-			return null;
-		}
-
-		if (is_array($value[$current_index]) && $value[$current_index])
+		if (isset($current_index) && is_array($index) && $index && is_array($value[$current_index]) && $value[$current_index])
 		{
 			return $this->getValueDotNotationSyntax($index, $value[$current_index]);
 		}
 
-		return $value[$current_index];
+		return (isset($current_index) && isset($value[$current_index])) ? $value[$current_index] : null;
 	}
 
 }

--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -125,8 +125,8 @@ class RedirectResponse extends Response
 		$session = $this->ensureSession();
 
 		$input = [
-			'get'  => $_GET ?: [],
-			'post' => $_POST ?: [],
+			'get'  => $_GET,
+			'post' => $_POST,
 		];
 
 		$session->setFlashdata('_ci_old_input', $input);

--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -125,8 +125,8 @@ class RedirectResponse extends Response
 		$session = $this->ensureSession();
 
 		$input = [
-			'get'  => $_GET ?? [],
-			'post' => $_POST ?? [],
+			'get'  => $_GET ?: [],
+			'post' => $_POST ?: [],
 		];
 
 		$session->setFlashdata('_ci_old_input', $input);

--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -125,8 +125,10 @@ class RedirectResponse extends Response
 		$session = $this->ensureSession();
 
 		$input = [
-			'get'  => $_GET,
-			'post' => $_POST,
+			// @phpstan-ignore-next-line
+			'get'  => $_GET ?? [],
+			// @phpstan-ignore-next-line
+			'post' => $_POST ?? [],
 		];
 
 		$session->setFlashdata('_ci_old_input', $input);

--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -157,7 +157,7 @@ class Request extends Message implements RequestInterface
 					isset($separator) || $separator = $this->isValidIP($this->ipAddress, 'ipv6') ? ':' : '.';
 
 					// If the proxy entry doesn't match the IP protocol - skip it
-					if (strpos($proxy_ip, $separator) === false)
+					if (strpos($proxy_ip, $separator) === false) // @phpstan-ignore-line
 					{
 						continue;
 					}
@@ -165,7 +165,7 @@ class Request extends Message implements RequestInterface
 					// Convert the REMOTE_ADDR IP address to binary, if needed
 					if (! isset($ip, $sprintf))
 					{
-						if ($separator === ':')
+						if ($separator === ':') // @phpstan-ignore-line
 						{
 							// Make sure we're have the "full" IPv6 format
 							$ip = explode(':', str_replace('::', str_repeat(':', 9 - substr_count($this->ipAddress, ':')), $this->ipAddress
@@ -192,7 +192,7 @@ class Request extends Message implements RequestInterface
 					sscanf($proxy_ip, '%[^/]/%d', $netaddr, $masklen);
 
 					// Again, an IPv6 address is most likely in a compressed form
-					if ($separator === ':')
+					if ($separator === ':') // @phpstan-ignore-line
 					{
 						$netaddr = explode(':', str_replace('::', str_repeat(':', 9 - substr_count($netaddr, ':')), $netaddr));
 						for ($i = 0; $i < 8; $i ++)

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -386,7 +386,7 @@ if (! function_exists('get_file_info'))
 			}
 		}
 
-		return $fileInfo;
+		return $fileInfo; // @phpstan-ignore-line
 	}
 }
 

--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -323,12 +323,12 @@ if (! function_exists('number_to_roman'))
 					$return = $key2 . str_repeat($key1, $n - 5);
 					break;
 				case 9:
-					$return = $key1 . $key_f;
+					$return = $key1 . $key_f; // @phpstan-ignore-line
 					break;
 			}
 			switch ($num) {
 				case 10:
-					$return = $key_f;
+					$return = $key_f; // @phpstan-ignore-line
 					break;
 			}
 			if ($num > 10)

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -751,6 +751,7 @@ if (! function_exists('random_string'))
 						break;
 				}
 
+				// @phpstan-ignore-next-line
 				return substr(str_shuffle(str_repeat($pool, ceil($len / strlen($pool)))), 0, $len);
 			case 'md5':
 				return md5(uniqid(mt_rand(), true));
@@ -847,8 +848,8 @@ if (! function_exists('excerpt'))
 			$phraseLen = 1;
 		}
 
-		$pre = explode(' ', substr($text, 0, $phrasePos));
-		$pos = explode(' ', substr($text, $phrasePos + $phraseLen));
+		$pre = explode(' ', substr($text, 0, $phrasePos)); // @phpstan-ignore-line
+		$pos = explode(' ', substr($text, $phrasePos + $phraseLen)); // @phpstan-ignore-line
 
 		$prev  = ' ';
 		$post  = ' ';

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -446,7 +446,7 @@ if (! function_exists('safe_mailto'))
 				}
 
 				$temp[] = $ordinal;
-				if (count($temp) === $count)
+				if (count($temp) === $count) // @phpstan-ignore-line
 				{
 					$number = ($count === 3) ? (($temp[0] % 16) * 4096) + (($temp[1] % 64) * 64) + ($temp[2] % 64) : (($temp[0] % 32) * 64) + ($temp[1] % 64);
 					$x[]    = '|' . $number;

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -292,7 +292,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 			$this->reproportion();
 		}
 
-		return $this->_resize($maintainRatio);
+		return $this->_resize($maintainRatio); // @phpstan-ignore-line
 	}
 
 	//--------------------------------------------------------------------
@@ -324,7 +324,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 			$this->reproportion();
 		}
 
-		$result = $this->_crop();
+		$result = $this->_crop(); // @phpstan-ignore-line
 
 		$this->xAxis = null;
 		$this->yAxis = null;
@@ -858,6 +858,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 */
 	public function getWidth()
 	{
+		// @phpstan-ignore-next-line
 		return ($this->resource !== null) ? $this->_getWidth() : $this->width;
 	}
 
@@ -870,6 +871,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 */
 	public function getHeight()
 	{
+		// @phpstan-ignore-next-line
 		return ($this->resource !== null) ? $this->_getHeight() : $this->height;
 	}
 

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -292,7 +292,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 			$this->reproportion();
 		}
 
-		return $this->_resize($maintainRatio); // @phpstan-ignore-line
+		return $this->_resize($maintainRatio);
 	}
 
 	//--------------------------------------------------------------------
@@ -324,7 +324,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 			$this->reproportion();
 		}
 
-		$result = $this->_crop(); // @phpstan-ignore-line
+		$result = $this->_crop();
 
 		$this->xAxis = null;
 		$this->yAxis = null;
@@ -507,6 +507,44 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 * @param array  $options
 	 */
 	protected abstract function _text(string $text, array $options = []);
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Handles the actual resizing of the image.
+	 *
+	 * @param boolean $maintainRatio
+	 *
+	 * @return $this
+	 */
+	public abstract function _resize(bool $maintainRatio = false);
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Crops the image.
+	 *
+	 * @return $this
+	 */
+	public abstract function _crop();
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Return image width.
+	 *
+	 * @return integer
+	 */
+	public abstract function _getWidth();
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Return the height of an image.
+	 *
+	 * @return integer
+	 */
+	public abstract function _getHeight();
 
 	//--------------------------------------------------------------------
 
@@ -858,7 +896,6 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 */
 	public function getWidth()
 	{
-		// @phpstan-ignore-next-line
 		return ($this->resource !== null) ? $this->_getWidth() : $this->width;
 	}
 
@@ -871,7 +908,6 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 */
 	public function getHeight()
 	{
-		// @phpstan-ignore-next-line
 		return ($this->resource !== null) ? $this->_getHeight() : $this->height;
 	}
 

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -186,7 +186,7 @@ class GDHandler extends BaseHandler
 	 *
 	 * @return \CodeIgniter\Images\Handlers\GDHandler
 	 */
-	public function _resize()
+	public function _resize(bool $maintainRatio = false)
 	{
 		return $this->process('resize');
 	}

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -278,7 +278,7 @@ class ImageMagickHandler extends BaseHandler
 			throw ImageException::forImageProcessFailed();
 		}
 
-		return $output;
+		return $output; // @phpstan-ignore-line
 	}
 
 	//--------------------------------------------------------------------
@@ -468,10 +468,10 @@ class ImageMagickHandler extends BaseHandler
 					break;
 			}
 
-			$xAxis = $xAxis >= 0 ? '+' . $xAxis : $xAxis;
-			$yAxis = $yAxis >= 0 ? '+' . $yAxis : $yAxis;
+			$xAxis = $xAxis >= 0 ? '+' . $xAxis : $xAxis; // @phpstan-ignore-line
+			$yAxis = $yAxis >= 0 ? '+' . $yAxis : $yAxis; // @phpstan-ignore-line
 
-			$cmd .= " -gravity {$gravity} -geometry {$xAxis}{$yAxis}";
+			$cmd .= " -gravity {$gravity} -geometry {$xAxis}{$yAxis}"; // @phpstan-ignore-line
 		}
 
 		// Color

--- a/system/Log/Handlers/FileHandler.php
+++ b/system/Log/Handlers/FileHandler.php
@@ -157,7 +157,7 @@ class FileHandler extends BaseHandler implements HandlerInterface
 			chmod($filepath, $this->filePermissions);
 		}
 
-		return is_int($result);
+		return is_int($result); // @phpstan-ignore-line
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -458,7 +458,7 @@ class Logger implements LoggerInterface
 			}
 		}
 
-		if (isset($_SESSION))
+		if (isset($_SESSION)) // @phpstan-ignore-line
 		{
 			$replace['{session_vars}'] = '$_SESSION: ' . print_r($_SESSION, true);
 		}
@@ -534,7 +534,7 @@ class Logger implements LoggerInterface
 		$file = str_replace(APPPATH, 'APPPATH/', $file);
 		$file = str_replace(SYSTEMPATH, 'SYSTEMPATH/', $file);
 
-		return str_replace(FCPATH, 'FCPATH/', $file);
+		return str_replace(FCPATH, 'FCPATH/', $file); // @phpstan-ignore-line
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -529,7 +529,8 @@ class RouteCollection implements RouteCollectionInterface
 		// we might need to do.
 		$this->discoverRoutes();
 
-		$routes = [];
+		$routes     = [];
+		$collection = [];
 
 		if (isset($this->routes[$verb]))
 		{
@@ -806,7 +807,7 @@ class RouteCollection implements RouteCollectionInterface
 		// In order to allow customization of the route the
 		// resources are sent to, we need to have a new name
 		// to store the values in.
-		$new_name = implode("\\", array_map('ucfirst', explode('/', $name)));
+		$new_name = implode('\\', array_map('ucfirst', explode('/', $name)));
 		// If a new controller is specified, then we replace the
 		// $name value with the name of the new controller.
 		if (isset($options['controller']))
@@ -919,7 +920,7 @@ class RouteCollection implements RouteCollectionInterface
 		// In order to allow customization of the route the
 		// resources are sent to, we need to have a new name
 		// to store the values in.
-		$newName = implode("\\", array_map('ucfirst', explode('/', $name)));
+		$newName = implode('\\', array_map('ucfirst', explode('/', $name)));
 		// If a new controller is specified, then we replace the
 		// $name value with the name of the new controller.
 		if (isset($options['controller']))

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -275,7 +275,7 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 				}
 			}
 
-			if (! is_int($result))
+			if (! is_int($result)) // @phpstan-ignore-line
 			{
 				$this->fingerprint = md5(substr($sessionData, 0, $written));
 				$this->logger->error('Session: Unable to write data.');

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -499,6 +499,7 @@ class Session implements SessionInterface
 	 */
 	public function get(string $key = null)
 	{
+		// @phpstan-ignore-next-line
 		if (! empty($key) && (! is_null($value = isset($_SESSION[$key]) ? $_SESSION[$key] : null) || ! is_null($value = dot_array_search($key, $_SESSION ?? []))))
 		{
 			return $value;

--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -72,7 +72,7 @@ class CIDatabaseTestCase extends CIUnitTestCase
 	 *
 	 * @var string
 	 */
-	protected $basePath = SUPPORTPATH . 'Database';
+	protected $basePath = SUPPORTPATH . 'Database'; // @phpstan-ignore-line
 
 	/**
 	 * The namespace(s) to help us find the migration classes.

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -9,7 +9,7 @@ $_SERVER['CI_ENVIRONMENT'] = 'testing';
 define('ENVIRONMENT', 'testing');
 
 // Load framework paths from their config file
-require CONFIGPATH . 'Paths.php';
+require CONFIGPATH . 'Paths.php'; // @phpstan-ignore-line
 $paths = new Config\Paths();
 
 // Define necessary framework path constants
@@ -18,10 +18,14 @@ defined('WRITEPATH')     || define('WRITEPATH', realpath($paths->writableDirecto
 defined('SYSTEMPATH')    || define('SYSTEMPATH', realpath($paths->systemDirectory) . DIRECTORY_SEPARATOR);
 defined('ROOTPATH')      || define('ROOTPATH', realpath(APPPATH . '../') . DIRECTORY_SEPARATOR);
 defined('CIPATH')        || define('CIPATH', realpath(SYSTEMPATH . '../') . DIRECTORY_SEPARATOR);
+// @phpstan-ignore-next-line
 defined('FCPATH')        || define('FCPATH', realpath(PUBLICPATH) . DIRECTORY_SEPARATOR);
+// @phpstan-ignore-next-line
 defined('TESTPATH')      || define('TESTPATH', realpath(HOMEPATH . 'tests/') . DIRECTORY_SEPARATOR);
 defined('SUPPORTPATH')   || define('SUPPORTPATH', realpath(TESTPATH . '_support/') . DIRECTORY_SEPARATOR);
+// @phpstan-ignore-next-line
 defined('COMPOSER_PATH') || define('COMPOSER_PATH', realpath(HOMEPATH . 'vendor/autoload.php'));
+// @phpstan-ignore-next-line
 defined('VENDORPATH')    || define('VENDORPATH', realpath(HOMEPATH . 'vendor') . DIRECTORY_SEPARATOR);
 
 // Load Common.php from App then System
@@ -64,4 +68,4 @@ $loader->initialize(new Config\Autoload(), new Config\Modules());
 $loader->register();
 
 require_once APPPATH . 'Config/Routes.php';
-$routes->getRoutes('*');
+$routes->getRoutes('*'); // @phpstan-ignore-line

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -758,6 +758,7 @@ class Validation implements ValidationInterface
 		// passed along from a redirect_with_input request.
 		if (empty($this->errors) && ! is_cli())
 		{
+			// @phpstan-ignore-next-line
 			if (isset($_SESSION, $_SESSION['_ci_validation_errors']))
 			{
 				$this->errors = unserialize($_SESSION['_ci_validation_errors']);

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -173,7 +173,7 @@ class Parser extends View
 		// Should we cache?
 		if (isset($options['cache']))
 		{
-			cache()->save($cacheName, $output, (int) $options['cache']);
+			cache()->save($cacheName, $output, (int) $options['cache']); // @phpstan-ignore-line
 		}
 		$this->tempData = null;
 		return $output;

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -57,6 +57,7 @@ use Config;
  */
 if (! defined('APPPATH'))
 {
+	// @phpstan-ignore-next-line
 	define('APPPATH', realpath($paths->appDirectory) . DIRECTORY_SEPARATOR);
 }
 
@@ -73,6 +74,7 @@ if (! defined('ROOTPATH'))
  */
 if (! defined('SYSTEMPATH'))
 {
+	// @phpstan-ignore-next-line
 	define('SYSTEMPATH', realpath($paths->systemDirectory) . DIRECTORY_SEPARATOR);
 }
 
@@ -81,6 +83,7 @@ if (! defined('SYSTEMPATH'))
  */
 if (! defined('WRITEPATH'))
 {
+	// @phpstan-ignore-next-line
 	define('WRITEPATH', realpath($paths->writableDirectory) . DIRECTORY_SEPARATOR);
 }
 
@@ -89,6 +92,7 @@ if (! defined('WRITEPATH'))
  */
 if (! defined('TESTPATH'))
 {
+	// @phpstan-ignore-next-line
 	define('TESTPATH', realpath($paths->testsDirectory) . DIRECTORY_SEPARATOR);
 }
 


### PR DESCRIPTION
Apply phpstan level 1, catched various bugs:

- coalesce null that should be `?:`
- unneeded issset check
- too many parameter in method call
- undefined variable/property
- undefined index in array
- missing abstract methods in Images BaseHandler
- Fixes impossible returns false for BaseConnection::getFieldData(), getIndexData(), and getForeignKeyData()

There are ofcourse some that false positive detection that ignored.

**Checklist:**
- [x] Securely signed commits
