### PR TITLE
Codeigniter\Entity - Fix ToArray datamap

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -179,14 +179,23 @@ class Entity implements \JsonSerializable
 			}
 		}
 
+		//Filter processing already mapped properties
+		$datamap = array_filter($this->datamap, function ($key) {
+			return ! in_array($key, array_keys($this->attributes));
+		}, ARRAY_FILTER_USE_KEY);
+
 		// Loop over our mapped properties and add them to the list...
-		if (is_array($this->datamap))
+		if (is_array($datamap))
 		{
-			foreach ($this->datamap as $from => $to)
+			foreach ($datamap as $from => $to)
 			{
 				if (array_key_exists($to, $return))
 				{
-					$return[$from] = $this->__get($to);
+					$return[$from] = $this->__get($from);
+					if (! in_array($to, array_keys($this->datamap)))
+					{
+						unset($return[$to]);
+					}
 
 					if ($recursive)
 					{

--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -628,11 +628,10 @@ class EntityTest extends \CodeIgniter\Test\CIUnitTestCase
 		$result = $entity->toArray();
 
 		$this->assertEquals($result, [
-			'foo'        => null,
-			'bar'        => ':bar',
-			'default'    => 'sumfin',
-			'created_at' => null,
-			'createdAt'  => null,
+			'foo'       => null,
+			'bar'       => ':bar',
+			'default'   => 'sumfin',
+			'createdAt' => null,
 		]);
 	}
 
@@ -644,17 +643,15 @@ class EntityTest extends \CodeIgniter\Test\CIUnitTestCase
 		$result = $entity->toArray(false, true, true);
 
 		$this->assertEquals($result, [
-			'foo'        => null,
-			'bar'        => ':bar',
-			'default'    => 'sumfin',
-			'created_at' => null,
-			'createdAt'  => null,
-			'entity'     => [
-				'foo'        => null,
-				'bar'        => ':bar',
-				'default'    => 'sumfin',
-				'created_at' => null,
-				'createdAt'  => null,
+			'foo'       => null,
+			'bar'       => ':bar',
+			'default'   => 'sumfin',
+			'createdAt' => null,
+			'entity'    => [
+				'foo'       => null,
+				'bar'       => ':bar',
+				'default'   => 'sumfin',
+				'createdAt' => null,
 			],
 		]);
 	}
@@ -666,10 +663,21 @@ class EntityTest extends \CodeIgniter\Test\CIUnitTestCase
 		$result = $entity->toArray();
 
 		$this->assertEquals($result, [
-			'foo'    => null,
-			'simple' => ':oo',
-			'bar'    => null,
-			'orig'   => ':oo',
+			'bar'  => null,
+			'orig' => ':oo',
+		]);
+	}
+
+	public function testAsArraySwapped()
+	{
+		$entity = $this->getSwappedEntity();
+
+		$result = $entity->toArray();
+
+		$this->assertEquals($result, [
+			'bar'          => 'foo',
+			'foo'          => 'bar',
+			'original_bar' => 'bar',
 		]);
 	}
 
@@ -913,6 +921,28 @@ class EntityTest extends \CodeIgniter\Test\CIUnitTestCase
 			{
 				return $this->attributes['simple'] . ':oo';
 			}
+		};
+	}
+
+	protected function getSwappedEntity() : Entity
+	{
+		return new class extends Entity
+		{
+			protected $attributes = [
+				'foo' => 'foo',
+				'bar' => 'bar',
+			];
+
+			protected $_original = [
+				'foo' => 'foo',
+				'bar' => 'bar',
+			];
+
+			protected $datamap = [
+				'bar'          => 'foo',
+				'foo'          => 'bar',
+				'original_bar' => 'bar',
+			];
 		};
 	}
 


### PR DESCRIPTION
**Description**

There are couple of issues with the way datamap works 

- It keeps doubles the values original and mapped where only mapped should be kept
- If datamap is used on existing attribute it will not work properly as value is already processed through data map in the getter
- When unsetting the key we need to double check if there is not another map that uses the key in $to map as if unset it won't be accessible in the next loop

I've added the getSwappedEntity() method which returns the entity which is affected by all those issues. 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
