### PR TITLE
Optional pretty SQL syntax in toolbar

### DIFF
--- a/system/Debug/Toolbar/Views/_database.tpl
+++ b/system/Debug/Toolbar/Views/_database.tpl
@@ -1,3 +1,4 @@
+{! hljsCss !}
 <table>
     <thead>
         <tr>


### PR DESCRIPTION
**Description**
I think this is hidden feature. Works (only) if [highlightjs.php](https://github.com/scrivo/highlight.php) installed in vendor dir.

Light mode:

![before_light](https://user-images.githubusercontent.com/42541162/90672024-b1353680-e27f-11ea-932a-2441e0a538d8.png)

![after_light](https://user-images.githubusercontent.com/42541162/90672023-b1353680-e27f-11ea-9ccc-a9666613ba5c.png)

Dark mode:

![before_dark](https://user-images.githubusercontent.com/42541162/90672037-b4302700-e27f-11ea-8649-f7b5c3f806c5.png)

![after_dark](https://user-images.githubusercontent.com/42541162/90672047-b7c3ae00-e27f-11ea-8193-01b0da53e760.png)

Tested with ``myth/auth`` and ``tatter/relations``.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
