### PR TITLE
Add param type to constructor to force param type hint

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -43,6 +43,7 @@ use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\Router\Exceptions\RouterException;
 use Config\Services;
+use Config\Modules;
 
 /**
  * Class RouteCollection
@@ -233,7 +234,7 @@ class RouteCollection implements RouteCollectionInterface
 	 * @param \CodeIgniter\Autoloader\FileLocator $locator
 	 * @param \Config\Modules                     $moduleConfig
 	 */
-	public function __construct(FileLocator $locator, $moduleConfig)
+	public function __construct(FileLocator $locator,Modules $moduleConfig)
 	{
 		$this->fileLocator  = $locator;
 		$this->moduleConfig = $moduleConfig;


### PR DESCRIPTION
Add Config Modules param type to constructor for param type linked
picked this up when a change request was asked in
https://github.com/codeigniter4/CodeIgniter4/pull/3459
and I based my code on the routecollection constructor, thus applying the same code change as requested there
here.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

