### PR TITLE
Fix setRules override

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -452,7 +452,7 @@ class Validation implements ValidationInterface
 			}
 		}
 
-		$this->rules = $rules;
+		$this->rules = array_merge($this->rules, $rules);
 
 		return $this;
 	}


### PR DESCRIPTION
This will allow us to use multiple setRules() together or chaining them together without override each other

multiple use;
$validation->setRules(array_of_rules[1]);
$validation->setRules(array_of_rules[2]);

or chaining together;
$validation->setRules(array_of_rules[3])->setRuleGroup('group_name');