### PR TITLE
Fixes change is_null after trim with empty string comparison

### DIFF
--- a/app/Config/Mimes.php
+++ b/app/Config/Mimes.php
@@ -510,7 +510,7 @@ class Mimes
 
 		$proposed_extension = trim(strtolower($proposed_extension));
 
-		if (! is_null($proposed_extension) && array_key_exists($proposed_extension, static::$mimes) && in_array($type, is_string(static::$mimes[$proposed_extension]) ? [static::$mimes[$proposed_extension]] : static::$mimes[$proposed_extension]))
+		if ($proposed_extension !== '' && array_key_exists($proposed_extension, static::$mimes) && in_array($type, is_string(static::$mimes[$proposed_extension]) ? [static::$mimes[$proposed_extension]] : static::$mimes[$proposed_extension]))
 		{
 			return $proposed_extension;
 		}


### PR DESCRIPTION
Fixes in `app/Config/Mimes.php`, after trim, null will always be string. I updated to compare with empty string.

```

php > var_dump(trim(strtolower(null)));

string(0) ""

```

**Checklist:**
- [x] Securely signed commits