### PR TITLE
Apply phpstan level 4

### DIFF
--- a/.github/workflows/static-analysis-check.yml
+++ b/.github/workflows/static-analysis-check.yml
@@ -34,4 +34,4 @@ jobs:
         run: "composer install"
 
       - name: "Static analysis Check"
-        run: "vendor/bin/phpstan analyze --level=3 app system"
+        run: "vendor/bin/phpstan analyze --level=4 app system"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,5 @@
-includes:
-        - vendor/phpstan/phpstan/conf/bleedingEdge.neon
-
 parameters:
+    treatPhpDocTypesAsCertain: false
     bootstrapFiles:
         - qa-bootstrap.php
     excludes_analyse:
@@ -37,5 +35,10 @@ parameters:
         - '#Method CodeIgniter\\Validation\\ValidationInterface::run\(\) invoked with 3 parameters, 0-2 required#'
         - '#Return type \(bool\) of method CodeIgniter\\Log\\Logger::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\)#'
         - '#Return type \(bool\) of method CodeIgniter\\HTTP\\Files\\UploadedFile::move\(\) should be compatible with return type \(CodeIgniter\\Files\\File\) of method CodeIgniter\\Files\\File::move\(\)#'
+        - '#Call to function is_null\(\) with mysqli_stmt\|resource will always evaluate to false#'
+        - '#Negated boolean expression is always (true|false)#'
     scanDirectories:
       - system/Helpers
+    dynamicConstantNames:
+        - ENVIRONMENT
+        - CI_DEBUG

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -150,7 +150,7 @@ class Autoloader
 		spl_autoload_register([$this, 'loadClass'], true, true);
 
 		// Now prepend another loader for the files in our class map.
-		$config = is_array($this->classmap) ? $this->classmap : [];
+		$config = $this->classmap;
 
 		spl_autoload_register(function ($class) use ($config) {
 			if (empty($config[$class]))

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -150,14 +150,14 @@ class CLI
 	/**
 	 * Height of the CLI window
 	 *
-	 * @var integer
+	 * @var integer|null
 	 */
 	protected static $height;
 
 	/**
 	 * Width of the CLI window
 	 *
-	 * @var integer
+	 * @var integer|null
 	 */
 	protected static $width;
 

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -252,6 +252,7 @@ class MemcachedHandler implements CacheInterface
 			return $this->memcached->set($key, $value, 0, $ttl);
 		}
 
+		// @phpstan-ignore-next-line
 		return false;
 	}
 

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -99,7 +99,7 @@ class RedisHandler implements CacheInterface
 	 */
 	public function __destruct()
 	{
-		if ($this->redis)
+		if ($this->redis) // @phpstan-ignore-line
 		{
 			$this->redis->close();
 		}

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -159,7 +159,7 @@ class WincacheHandler implements CacheInterface
 		$success = false;
 		$value   = wincache_ucache_inc($key, $offset, $success);
 
-		return ($success === true) ? $value : false;
+		return ($success === true) ? $value : false; // @phpstan-ignore-line
 	}
 
 	//--------------------------------------------------------------------
@@ -181,7 +181,7 @@ class WincacheHandler implements CacheInterface
 		$success = false;
 		$value   = wincache_ucache_dec($key, $offset, $success);
 
-		return ($success === true) ? $value : false;
+		return ($success === true) ? $value : false; // @phpstan-ignore-line
 	}
 
 	//--------------------------------------------------------------------

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -602,6 +602,7 @@ class CodeIgniter
 			return;
 		}
 
+		// @phpstan-ignore-next-line
 		if (is_cli() && ENVIRONMENT !== 'testing')
 		{
 			// @codeCoverageIgnoreStart
@@ -814,7 +815,7 @@ class CodeIgniter
 	 * @param RouteCollectionInterface|null $routes An collection interface to use in place
 	 *                                         of the config file.
 	 *
-	 * @return string
+	 * @return string|null
 	 * @throws \CodeIgniter\Router\Exceptions\RedirectException
 	 */
 	protected function tryToRouteIt(RouteCollectionInterface $routes = null)
@@ -1092,7 +1093,7 @@ class CodeIgniter
 	 *
 	 * This helps provider safer, more reliable previous_url() detection.
 	 *
-	 * @param \CodeIgniter\HTTP\URI $uri
+	 * @param \CodeIgniter\HTTP\URI|string $uri
 	 */
 	public function storePreviousURL($uri)
 	{

--- a/system/Commands/Database/MigrateRefresh.php
+++ b/system/Commands/Database/MigrateRefresh.php
@@ -111,7 +111,7 @@ class MigrateRefresh extends BaseCommand
 
 		if (ENVIRONMENT === 'production')
 		{
-			$force = array_key_exists('f', $params) || CLI::getOption('f');
+			$force = CLI::getOption('f');
 			if (is_null($force) && CLI::prompt(lang('Migrations.refreshConfirm'), ['y', 'n']) === 'n')
 			{
 				return;

--- a/system/Commands/Database/MigrateRollback.php
+++ b/system/Commands/Database/MigrateRollback.php
@@ -103,6 +103,7 @@ class MigrateRollback extends BaseCommand
 		if (ENVIRONMENT === 'production')
 		{
 			$force = array_key_exists('f', $params) || CLI::getOption('f');
+			// @phpstan-ignore-next-line
 			if (is_null($force) && CLI::prompt(lang('Migrations.rollBackConfirm'), ['y', 'n']) === 'n')
 			{
 				return;

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -996,12 +996,12 @@ class BaseBuilder
 	 * @used-by whereNotIn()
 	 * @used-by orWhereNotIn()
 	 *
-	 * @param  string        $key    The field to search
-	 * @param  array|Closure $values The values searched on, or anonymous function with subquery
-	 * @param  boolean       $not    If the statement would be IN or NOT IN
-	 * @param  string        $type
-	 * @param  boolean       $escape
-	 * @param  string        $clause (Internal use only)
+	 * @param  string             $key    The field to search
+	 * @param  array|Closure|null $values The values searched on, or anonymous function with subquery
+	 * @param  boolean            $not    If the statement would be IN or NOT IN
+	 * @param  string             $type
+	 * @param  boolean            $escape
+	 * @param  string             $clause (Internal use only)
 	 * @throws \InvalidArgumentException
 	 *
 	 * @return BaseBuilder
@@ -1048,7 +1048,7 @@ class BaseBuilder
 		}
 		else
 		{
-			$whereIn = is_array($values) ? array_values($values) : $values;
+			$whereIn = array_values($values);
 			$ok      = $this->setBind($ok, $whereIn, $escape);
 		}
 
@@ -1846,7 +1846,7 @@ class BaseBuilder
 	 * @param integer $offset The offset clause
 	 * @param boolean $reset  Are we want to clear query builder values?
 	 *
-	 * @return ResultInterface
+	 * @return ResultInterface|false
 	 */
 	public function get(int $limit = null, int $offset = 0, bool $reset = true)
 	{
@@ -2040,7 +2040,7 @@ class BaseBuilder
 	 * @param boolean $escape    Whether to escape values and identifiers
 	 * @param integer $batchSize Batch size
 	 *
-	 * @return integer Number of rows inserted or FALSE on failure
+	 * @return integer|false Number of rows inserted or FALSE on failure
 	 * @throws DatabaseException
 	 */
 	public function insertBatch(array $set = null, bool $escape = null, int $batchSize = 100)

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -236,7 +236,7 @@ abstract class BaseConnection implements ConnectionInterface
 	/**
 	 * Identifier escape character
 	 *
-	 * @var string
+	 * @var string|array
 	 */
 	public $escapeChar = '"';
 
@@ -1790,9 +1790,9 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * @param boolean $constrainByPrefix
 	 *
-	 * @return string
+	 * @return string|false
 	 */
-	abstract protected function _listTables(bool $constrainByPrefix = false): string;
+	abstract protected function _listTables(bool $constrainByPrefix = false);
 
 	//--------------------------------------------------------------------
 
@@ -1801,9 +1801,9 @@ abstract class BaseConnection implements ConnectionInterface
 	 *
 	 * @param string $table
 	 *
-	 * @return string
+	 * @return string|false
 	 */
-	abstract protected function _listColumns(string $table = ''): string;
+	abstract protected function _listColumns(string $table = '');
 
 	//--------------------------------------------------------------------
 

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -99,7 +99,7 @@ abstract class BaseResult implements ResultInterface
 	/**
 	 * Row data
 	 *
-	 * @var array
+	 * @var array|null
 	 */
 	public $rowData;
 
@@ -202,6 +202,7 @@ abstract class BaseResult implements ResultInterface
 			$this->customResultObject[$className][] = $row;
 		}
 
+		// @phpstan-ignore-next-line
 		return $this->customResultObject[$className];
 	}
 
@@ -293,6 +294,7 @@ abstract class BaseResult implements ResultInterface
 			$this->resultObject[] = $row;
 		}
 
+		// @phpstan-ignore-next-line
 		return $this->resultObject;
 	}
 

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -59,7 +59,7 @@ class Config extends BaseConfig
 	 * The main instance used to manage all of
 	 * our open database connections.
 	 *
-	 * @var \CodeIgniter\Database\Database
+	 * @var \CodeIgniter\Database\Database|null
 	 */
 	static protected $factory;
 

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -101,7 +101,7 @@ class Forge
 	/**
 	 * CREATE DATABASE statement
 	 *
-	 * @var string
+	 * @var string|false
 	 */
 	protected $createDatabaseStr = 'CREATE DATABASE %s';
 
@@ -122,7 +122,7 @@ class Forge
 	/**
 	 * DROP DATABASE statement
 	 *
-	 * @var string
+	 * @var string|false
 	 */
 	protected $dropDatabaseStr = 'DROP DATABASE %s';
 
@@ -160,7 +160,7 @@ class Forge
 	/**
 	 * RENAME TABLE statement
 	 *
-	 * @var string
+	 * @var string|false
 	 */
 	protected $renameTableStr = 'ALTER TABLE %s RENAME TO %s;';
 
@@ -181,7 +181,7 @@ class Forge
 	/**
 	 * DEFAULT value representation in CREATE/ALTER TABLE statements
 	 *
-	 * @var string
+	 * @var string|false
 	 */
 	protected $default = ' DEFAULT ';
 
@@ -477,7 +477,7 @@ class Forge
 		$sql = sprintf($this->dropConstraintStr, $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
 			$this->db->escapeIdentifiers($this->db->DBPrefix . $foreignName));
 
-		if ($sql === false)
+		if ($sql === false) // @phpstan-ignore-line
 		{
 			if ($this->db->DBDebug)
 			{
@@ -783,7 +783,7 @@ class Forge
 	public function addColumn(string $table, $field): bool
 	{
 		// Work-around for literal column definitions
-		is_array($field) || $field = [$field];
+		is_array($field) || $field = [$field]; // @phpstan-ignore-line
 
 		foreach (array_keys($field) as $k)
 		{
@@ -854,7 +854,7 @@ class Forge
 	public function modifyColumn(string $table, $field): bool
 	{
 		// Work-around for literal column definitions
-		is_array($field) || $field = [$field];
+		is_array($field) || $field = [$field]; // @phpstan-ignore-line
 
 		foreach (array_keys($field) as $k)
 		{
@@ -901,7 +901,7 @@ class Forge
 	 * @param string $table      Table name
 	 * @param mixed  $fields     Column definition
 	 *
-	 * @return string|string[]
+	 * @return string|string[]|false
 	 */
 	protected function _alterTable(string $alter_type, string $table, $fields)
 	{
@@ -962,6 +962,7 @@ class Forge
 				continue;
 			}
 
+			// @phpstan-ignore-next-line
 			isset($attributes['TYPE']) && $this->_attributeType($attributes);
 
 			$field = [
@@ -977,6 +978,7 @@ class Forge
 				'_literal'       => false,
 			];
 
+			// @phpstan-ignore-next-line
 			isset($attributes['TYPE']) && $this->_attributeUnsigned($attributes, $field);
 
 			if ($create_table === false)

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -132,7 +132,7 @@ class MigrationRunner
 	/**
 	 * The database Group filter.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	protected $groupFilter;
 
@@ -808,7 +808,7 @@ class MigrationRunner
 						  ->orderBy('id', 'ASC')
 						  ->get();
 
-		return $query ? $query->getResultObject() : [];
+		return ! empty($query) ? $query->getResultObject() : [];
 	}
 
 	//--------------------------------------------------------------------
@@ -829,7 +829,7 @@ class MigrationRunner
 						  ->orderBy('id', $order)
 						  ->get();
 
-		return $query ? $query->getResultObject() : [];
+		return ! empty($query) ? $query->getResultObject() : [];
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -386,11 +386,6 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 */
 	protected function _escapeString(string $str): string
 	{
-		if (is_bool($str))
-		{
-			return $str;
-		}
-
 		if (! $this->connID)
 		{
 			$this->initialize();

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -262,6 +262,7 @@ class Forge extends \CodeIgniter\Database\Forge
 				continue;
 			}
 
+			// @phpstan-ignore-next-line
 			is_array($this->keys[$i]) || $this->keys[$i] = [$this->keys[$i]];
 
 			$unique = in_array($i, $this->uniqueKeys) ? 'UNIQUE ' : '';

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -106,7 +106,7 @@ class Builder extends BaseBuilder
 		$direction = strtoupper(trim($direction));
 		if ($direction === 'RANDOM')
 		{
-			if (! is_float($orderBy) && ctype_digit($orderBy))
+			if (ctype_digit($orderBy))
 			{
 				$orderBy = (float) ($orderBy > 1 ? "0.{$orderBy}" : $orderBy);
 			}

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -172,6 +172,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 			return $this->dataCache['version'];
 		}
 
+		// @phpstan-ignore-next-line
 		if (! $this->connID || ( $pgVersion = pg_version($this->connID)) === false)
 		{
 			$this->initialize();
@@ -530,7 +531,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 */
 	protected function buildDSN()
 	{
-		$this->DSN === '' || $this->DSN = '';
+		$this->DSN === '' || $this->DSN = ''; // @phpstan-ignore-line
 
 		// If UNIX sockets are used, we shouldn't set a port
 		if (strpos($this->hostname, '/') !== false)

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -274,15 +274,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 			$this->initialize();
 		}
 
-		if (false === ($sql = $this->_listColumns($table)))
-		{
-			if ($this->DBDebug)
-			{
-				throw new DatabaseException(lang('Database.featureUnavailable'));
-			}
-
-			return false;
-		}
+		$sql = $this->_listColumns($table);
 
 		$query                                  = $this->query($sql);
 		$this->dataCache['field_names'][$table] = [];

--- a/system/Debug/Toolbar/Collectors/Logs.php
+++ b/system/Debug/Toolbar/Collectors/Logs.php
@@ -127,7 +127,7 @@ class Logs extends BaseCollector
 	 */
 	protected function collectLogs()
 	{
-		if (! is_null($this->data))
+		if (! empty($this->data))
 		{
 			return $this->data;
 		}

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -253,7 +253,7 @@ class Email
 	/**
 	 * SMTP Connection socket placeholder
 	 *
-	 * @var resource
+	 * @var resource|null
 	 */
 	protected $SMTPConnect;
 	/**
@@ -284,7 +284,7 @@ class Email
 	/**
 	 * Recipients
 	 *
-	 * @var array
+	 * @var array|string
 	 */
 	protected $recipients = [];
 	/**
@@ -849,7 +849,7 @@ class Email
 	protected function getProtocol()
 	{
 		$this->protocol                                                      = strtolower($this->protocol);
-		in_array($this->protocol, $this->protocols, true) || $this->protocol = 'mail';
+		in_array($this->protocol, $this->protocols, true) || $this->protocol = 'mail'; // @phpstan-ignore-line
 		return $this->protocol;
 	}
 	//--------------------------------------------------------------------
@@ -860,7 +860,7 @@ class Email
 	 */
 	protected function getEncoding()
 	{
-		in_array($this->encoding, $this->bitDepths) || $this->encoding = '8bit';
+		in_array($this->encoding, $this->bitDepths) || $this->encoding = '8bit'; // @phpstan-ignore-line
 		foreach ($this->baseCharsets as $charset)
 		{
 			if (strpos($this->charset, $charset) === 0)
@@ -2112,7 +2112,7 @@ class Email
 		$msg = implode('', $this->debugMessage);
 		// Determine which parts of our raw data needs to be printed
 		$raw_data                                         = '';
-		is_array($include) || $include                    = [$include];
+		is_array($include) || $include                    = [$include]; // @phpstan-ignore-line
 		in_array('headers', $include, true) && $raw_data  = htmlspecialchars($this->headerStr) . "\n";
 		in_array('subject', $include, true) && $raw_data .= htmlspecialchars($this->subject) . "\n";
 		in_array('body', $include, true) && $raw_data    .= htmlspecialchars($this->finalBody);

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -97,12 +97,7 @@ class File extends SplFileInfo
 	 */
 	public function getSize()
 	{
-		if (is_null($this->size))
-		{
-			$this->size = parent::getSize();
-		}
-
-		return $this->size;
+		return $this->size ?? ($this->size = parent::getSize());
 	}
 
 	/**

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -543,7 +543,7 @@ class CURLRequest extends Request
 		$size = strlen($this->body);
 
 		// Have content?
-		if ($size === null || $size > 0)
+		if ($size > 0)
 		{
 			return $this->applyBody($curl_options);
 		}

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -72,7 +72,7 @@ class DownloadResponse extends Message implements ResponseInterface
 	/**
 	 * Download for binary
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	private $binary;
 

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -252,12 +252,7 @@ class UploadedFile extends File implements UploadedFileInterface
 	 */
 	public function getError(): int
 	{
-		if (is_null($this->error))
-		{
-			return UPLOAD_ERR_OK;
-		}
-
-		return $this->error;
+		return $this->error ?? UPLOAD_ERR_OK;
 	}
 
 	//--------------------------------------------------------------------
@@ -280,7 +275,7 @@ class UploadedFile extends File implements UploadedFileInterface
 			UPLOAD_ERR_EXTENSION  => lang('HTTP.uploadErrExtension'),
 		];
 
-		$error = is_null($this->error) ? UPLOAD_ERR_OK : $this->error;
+		$error = $this->error ?? UPLOAD_ERR_OK;
 
 		return sprintf($errors[$error] ?? lang('HTTP.uploadErrUnknown'), $this->getName());
 	}

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -93,14 +93,14 @@ class IncomingRequest extends Request
 	/**
 	 * File collection
 	 *
-	 * @var Files\FileCollection
+	 * @var Files\FileCollection|null
 	 */
 	protected $files;
 
 	/**
 	 * Negotiator
 	 *
-	 * @var \CodeIgniter\HTTP\Negotiate
+	 * @var \CodeIgniter\HTTP\Negotiate|null
 	 */
 	protected $negotiator;
 

--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -125,9 +125,7 @@ class RedirectResponse extends Response
 		$session = $this->ensureSession();
 
 		$input = [
-			// @phpstan-ignore-next-line
 			'get'  => $_GET ?? [],
-			// @phpstan-ignore-next-line
 			'post' => $_POST ?? [],
 		];
 

--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -154,6 +154,7 @@ class Request extends Message implements RequestInterface
 					}
 
 					// We have a subnet ... now the heavy lifting begins
+					// // @phpstan-ignore-next-line
 					isset($separator) || $separator = $this->isValidIP($this->ipAddress, 'ipv6') ? ':' : '.';
 
 					// If the proxy entry doesn't match the IP protocol - skip it
@@ -420,6 +421,7 @@ class Request extends Message implements RequestInterface
 			$value = $this->globals[$method][$index] ?? null;
 		}
 
+		// @phpstan-ignore-next-line
 		if (is_array($value) && ($filter !== null || $flags !== null))
 		{
 			// Iterate over array and append filter and flags

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -442,7 +442,7 @@ class URI
 	 */
 	public function getPath(): string
 	{
-		return (is_null($this->path)) ? '' : $this->path;
+		return $this->path ?? '';
 	}
 
 	//--------------------------------------------------------------------
@@ -502,7 +502,7 @@ class URI
 	 */
 	public function getFragment(): string
 	{
-		return is_null($this->fragment) ? '' : $this->fragment;
+		return $this->fragment ?? '';
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -245,7 +245,7 @@ if (! function_exists('form_password'))
 	 */
 	function form_password($data = '', string $value = '', $extra = ''): string
 	{
-		is_array($data) || $data = ['name' => $data];
+		is_array($data) || $data = ['name' => $data]; // @phpstan-ignore-line
 		$data['type']            = 'password';
 
 		return form_input($data, $value, $extra);
@@ -273,7 +273,7 @@ if (! function_exists('form_upload'))
 			'type' => 'file',
 			'name' => '',
 		];
-		is_array($data) || $data = ['name' => $data];
+		is_array($data) || $data = ['name' => $data]; // @phpstan-ignore-line
 		$data['type']            = 'file';
 
 		return '<input ' . parse_form_attributes($data, $defaults) . stringify_attributes($extra) . " />\n";
@@ -389,8 +389,8 @@ if (! function_exists('form_dropdown'))
 			$defaults = ['name' => $data];
 		}
 
-		is_array($selected) || $selected = [$selected];
-		is_array($options) || $options   = [$options];
+		is_array($selected) || $selected = [$selected]; // @phpstan-ignore-line
+		is_array($options) || $options   = [$options]; // @phpstan-ignore-line
 
 		// If no selected state was submitted we will attempt to set it automatically
 		if (empty($selected))
@@ -508,7 +508,7 @@ if (! function_exists('form_radio'))
 	 */
 	function form_radio($data = '', string $value = '', bool $checked = false, $extra = ''): string
 	{
-		is_array($data) || $data = ['name' => $data];
+		is_array($data) || $data = ['name' => $data]; // @phpstan-ignore-line
 		$data['type']            = 'radio';
 
 		return form_checkbox($data, $value, $checked, $extra);

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -464,9 +464,6 @@ if (! function_exists('word_wrap'))
 	 */
 	function word_wrap(string $str, int $charlim = 76): string
 	{
-		// Set the character limit
-		is_numeric($charlim) || $charlim = 76;
-
 		// Reduce multiple spaces
 		$str = preg_replace('| +|', ' ', $str);
 

--- a/system/Honeypot/Honeypot.php
+++ b/system/Honeypot/Honeypot.php
@@ -68,7 +68,7 @@ class Honeypot
 	{
 		$this->config = $config;
 
-		if ($this->config->hidden === '')
+		if (! $this->config->hidden)
 		{
 			throw HoneypotException::forNoHiddenValue();
 		}

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -85,7 +85,7 @@ class Time extends DateTime
 	protected static $relativePattern = '/this|next|last|tomorrow|yesterday|midnight|today|[+-]|first|last|ago/i';
 
 	/**
-	 * @var \CodeIgniter\I18n\Time|null
+	 * @var \CodeIgniter\I18n\Time|DateTime|null
 	 */
 	protected static $testNow;
 
@@ -370,9 +370,9 @@ class Time extends DateTime
 	 * Creates an instance of Time that will be returned during testing
 	 * when calling 'Time::now' instead of the current time.
 	 *
-	 * @param \CodeIgniter\I18n\Time|string|null $datetime
-	 * @param \DateTimeZone|string|null          $timezone
-	 * @param string|null                        $locale
+	 * @param \CodeIgniter\I18n\Time|DateTime|string|null $datetime
+	 * @param \DateTimeZone|string|null                   $timezone
+	 * @param string|null                                 $locale
 	 *
 	 * @throws \Exception
 	 */

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -366,7 +366,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 			270,
 		];
 
-		if ($angle === '' || ! in_array($angle, $degs))
+		if (! in_array($angle, $degs))
 		{
 			throw ImageException::forMissingAngle();
 		}

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -60,7 +60,7 @@ class ImageMagickHandler extends BaseHandler
 	/**
 	 * Stores image resource in memory.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	protected $resource;
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -108,7 +108,7 @@ class Model
 	/**
 	 * Last insert ID
 	 *
-	 * @var integer
+	 * @var integer|string
 	 */
 	protected $insertID = 0;
 
@@ -220,7 +220,7 @@ class Model
 	/**
 	 * Query Builder object
 	 *
-	 * @var BaseBuilder
+	 * @var BaseBuilder|null
 	 */
 	protected $builder;
 
@@ -229,7 +229,7 @@ class Model
 	 * The array must match the format of data passed to the Validation
 	 * library.
 	 *
-	 * @var array
+	 * @var array|string
 	 */
 	protected $validationRules = [];
 
@@ -1700,13 +1700,6 @@ class Model
 		if (is_object($data))
 		{
 			$data = (array) $data;
-		}
-
-		// ValidationRules can be either a string, which is the group name,
-		// or an array of rules.
-		if (is_string($rules))
-		{
-			$rules = $this->validation->loadRuleGroup($rules);
 		}
 
 		$rules = $this->cleanValidationRules

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -186,14 +186,14 @@ class RouteCollection implements RouteCollectionInterface
 	/**
 	 * The name of the current group, if any.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	protected $group;
 
 	/**
 	 * The current subdomain.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	protected $currentSubdomain;
 

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -606,6 +606,7 @@ class Router implements RouterInterface
 	protected function validateRequest(array $segments): array
 	{
 		$segments = array_filter($segments, function ($segment) {
+			// @phpstan-ignore-next-line
 			return ! empty($segment) || ($segment !== '0' || $segment !== 0);
 		});
 		$segments = array_values($segments);

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -166,7 +166,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 		}
 
 		// Needed by write() to detect session_regenerate_id() calls
-		if (is_null($this->sessionID))
+		if (is_null($this->sessionID)) // @phpstan-ignore-line
 		{
 			$this->sessionID = $sessionID;
 		}

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -195,7 +195,7 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 			}
 
 			// Needed by write() to detect session_regenerate_id() calls
-			if (is_null($this->sessionID))
+			if (is_null($this->sessionID)) // @phpstan-ignore-line
 			{
 				$this->sessionID = $sessionID;
 			}

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -184,7 +184,7 @@ class MemcachedHandler extends BaseHandler implements \SessionHandlerInterface
 		if (isset($this->memcached) && $this->lockSession($sessionID))
 		{
 			// Needed by write() to detect session_regenerate_id() calls
-			if (is_null($this->sessionID))
+			if (is_null($this->sessionID)) // @phpstan-ignore-line
 			{
 				$this->sessionID = $sessionID;
 			}

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -103,6 +103,7 @@ class RedisHandler extends BaseHandler implements \SessionHandlerInterface
 		}
 		elseif (preg_match('#(?:tcp://)?([^:?]+)(?:\:(\d+))?(\?.+)?#', $this->savePath, $matches))
 		{
+			// @phpstan-ignore-next-line
 			isset($matches[3]) || $matches[3] = ''; // Just to avoid undefined index notices below
 
 			$this->savePath = [
@@ -187,7 +188,7 @@ class RedisHandler extends BaseHandler implements \SessionHandlerInterface
 		if (isset($this->redis) && $this->lockSession($sessionID))
 		{
 			// Needed by write() to detect session_regenerate_id() calls
-			if (is_null($this->sessionID))
+			if (is_null($this->sessionID)) // @phpstan-ignore-line
 			{
 				$this->sessionID = $sessionID;
 			}
@@ -271,6 +272,7 @@ class RedisHandler extends BaseHandler implements \SessionHandlerInterface
 			try
 			{
 				$ping_reply = $this->redis->ping();
+				// @phpstan-ignore-next-line
 				if (($ping_reply === true) || ($ping_reply === '+PONG'))
 				{
 					isset($this->lockKey) && $this->redis->del($this->lockKey);

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -540,7 +540,6 @@ class Session implements SessionInterface
 	 */
 	public function get(string $key = null)
 	{
-		// @phpstan-ignore-next-line
 		if (! empty($key) && (! is_null($value = isset($_SESSION[$key]) ? $_SESSION[$key] : null) || ! is_null($value = dot_array_search($key, $_SESSION ?? []))))
 		{
 			return $value;
@@ -804,7 +803,7 @@ class Session implements SessionInterface
 			return;
 		}
 
-		is_array($key) || $key = [$key];
+		is_array($key) || $key = [$key]; // @phpstan-ignore-line
 
 		foreach ($key as $k)
 		{
@@ -979,7 +978,7 @@ class Session implements SessionInterface
 			return;
 		}
 
-		is_array($key) || $key = [$key];
+		is_array($key) || $key = [$key]; // @phpstan-ignore-line
 
 		foreach ($key as $k)
 		{

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -94,7 +94,7 @@ class CIUnitTestCase extends TestCase
 	{
 		parent::setUp();
 
-		if (! $this->app)
+		if (! $this->app) // @phpstan-ignore-line
 		{
 			$this->app = $this->createApplication();
 		}

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -376,15 +376,10 @@ class Fabricator
 			{
 				case 'datetime':
 					return 'date';
-				break;
-
 				case 'date':
 					return 'date';
-				break;
-
 				case 'int':
 					return 'unixTime';
-				break;
 			}
 		}
 		elseif ($field === $this->model->primaryKey)

--- a/system/Test/FeatureResponse.php
+++ b/system/Test/FeatureResponse.php
@@ -182,8 +182,8 @@ class FeatureResponse extends TestCase
 	/**
 	 * Asserts that an SESSION key has been set and, optionally, test it's value.
 	 *
-	 * @param string $key
-	 * @param null   $value
+	 * @param string      $key
+	 * @param string|null $value
 	 *
 	 * @throws \Exception
 	 */
@@ -216,8 +216,8 @@ class FeatureResponse extends TestCase
 	/**
 	 * Asserts that the Response contains a specific header.
 	 *
-	 * @param string $key
-	 * @param null   $value
+	 * @param string      $key
+	 * @param string|null $value
 	 *
 	 * @throws \Exception
 	 */

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -167,7 +167,7 @@ trait FeatureTestTrait
 		$request = $this->populateGlobals($method, $request, $params);
 
 		// Make sure the RouteCollection knows what method we're using...
-		$routes = $this->routes ?: Services::routes();
+		$routes = $this->routes ?: Services::routes(); // @phpstan-ignore-line
 		$routes->setHTTPVerb($method);
 
 		// Make sure any other classes that might call the request

--- a/system/Test/Filters/CITestStreamFilter.php
+++ b/system/Test/Filters/CITestStreamFilter.php
@@ -71,6 +71,8 @@ class CITestStreamFilter extends \php_user_filter
 			static::$buffer .= $bucket->data;
 			$consumed       += $bucket->datalen;
 		}
+
+		// @phpstan-ignore-next-line
 		return PSFS_PASS_ON;
 	}
 }

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -344,7 +344,7 @@ class Validation implements ValidationInterface
 				}
 
 				$this->errors[$field] = is_null($error) ? $this->getErrorMessage($rule, $field, $label, $param, $value)
-					: $error;
+					: $error; // @phpstan-ignore-line
 
 				return false;
 			}

--- a/system/View/Table.php
+++ b/system/View/Table.php
@@ -280,7 +280,7 @@ class Table
 
 		foreach ($args as $key => $val)
 		{
-			is_array($val) || $args[$key] = ['data' => $val];
+			is_array($val) || $args[$key] = ['data' => $val]; // @phpstan-ignore-line
 		}
 
 		return $args;


### PR DESCRIPTION
Fixes the following things:

- remove unneeded `is_*` check on exact types (by type hinted or returned functions)
- remove unreacheable statements
- missing docblock declaration as possible return value in methods
- fix return declaration when there is possible multiple return types
- fix wrong exact type comparison
- remove unnecessary break after return statement

**Checklist:**
- [x] Securely signed commits