### PR TITLE
Fix phpstan error notice after update to v0.12.40

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"codeigniter4/codeigniter4-standard": "^1.0",
 		"fzaninotto/faker": "^1.9@dev",
 		"mikey179/vfsstream": "1.6.*",
-		"phpstan/phpstan": "^0.12.37",
+		"phpstan/phpstan": "^0.12.40",
 		"phpunit/phpunit": "^8.5",
 		"predis/predis": "^1.1",
 		"squizlabs/php_codesniffer": "^3.3"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"codeigniter4/codeigniter4-standard": "^1.0",
 		"fzaninotto/faker": "^1.9@dev",
 		"mikey179/vfsstream": "1.6.*",
-		"phpstan/phpstan": "^0.12.40",
+		"phpstan/phpstan": "^0.12",
 		"phpunit/phpunit": "^8.5",
 		"predis/predis": "^1.1",
 		"squizlabs/php_codesniffer": "^3.3"

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -830,7 +830,7 @@ class Response extends Message implements ResponseInterface
 	 * @param string       $prefix   Cookie name prefix
 	 * @param boolean      $secure   Whether to only transfer cookies via SSL
 	 * @param boolean      $httponly Whether only make the cookie accessible via HTTP (no javascript)
-       * @param string|null  $samesite
+	 * @param string|null  $samesite
 	 *
 	 * @return $this
 	 */
@@ -899,7 +899,7 @@ class Response extends Message implements ResponseInterface
 		}
 		else
 		{
-			$expire = ($expire > 0) ? time() + $expire : 0; // @phpstan-ignore-line
+			$expire = ($expire > 0) ? time() + $expire : 0;
 		}
 
 		$cookie = [

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -557,7 +557,7 @@ class Time extends DateTime
 		$time = $this->getTimestamp();
 
 		// future dates have no age
-		return max(0, date('Y', $now) - date('Y', $time)); // @phpstan-ignore-line
+		return max(0, date('Y', $now) - date('Y', $time));
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
It seems new phpstan released https://github.com/phpstan/phpstan/releases/tag/0.12.40 that make we can clean up unneeded `// @phpstan-ignore-line` at 

-  `system/HTTP/Response.php` line 902
- `system/I18n/Time.php` line 560

after update to phpstan v0.12.40

**Checklist:**
- [x] Securely signed commits
