### PR TITLE
Add samesite attribute for debug-bar related cookies

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -579,7 +579,7 @@ var ciDebugBar = {
 			var expires = "";
 		}
 
-		document.cookie = name + "=" + value + expires + "; path=/";
+		document.cookie = name + "=" + value + expires + "; path=/; samesite=Lax";
 	},
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
This PR adds samesite attribute when setting cookies in the toolbar.js. I'm going with `Lex` since it's the most reasonable choice.

> Cookie “debug-bar-state” will be soon rejected because it has the “sameSite” attribute set to “none” or an invalid value, without the “secure” attribute.

https://developer.mozilla.org/pl/docs/Web/HTTP/Headers/Set-Cookie/SameSite

**Checklist:**
- [x] Securely signed commits
