### PR TITLE
Update phpstan.neon and resolve some errors

### DIFF
--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -36,4 +36,4 @@ jobs:
         run: composer install --no-progress --no-suggest --no-interaction
 
       - name: Run static analysis
-        run: vendor/bin/phpstan analyze --level=5 app system
+        run: vendor/bin/phpstan analyse

--- a/app/Config/Autoload.php
+++ b/app/Config/Autoload.php
@@ -16,7 +16,6 @@ use CodeIgniter\Config\AutoloadConfig;
  */
 class Autoload extends AutoloadConfig
 {
-
 	/**
 	 * -------------------------------------------------------------------
 	 * Namespaces

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,45 +1,48 @@
 parameters:
-    treatPhpDocTypesAsCertain: false
-    bootstrapFiles:
-        - qa-bootstrap.php
-    excludes_analyse:
-        - app/Views/errors/cli/error_404.php
-        - app/Views/errors/cli/error_exception.php
-        - app/Views/errors/html/error_exception.php
-        - system/Commands/Generators/Views/migration.tpl.php
-        - system/Config/Routes.php
-        - system/Debug/Toolbar/Views/toolbar.tpl.php
-        - system/Validation/Views/single.php
-        - system/ThirdParty/*
-    ignoreErrors:
-        - '#Unsafe usage of new static\(\)*#'
-        - '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::_(disable|enable)ForeignKeyChecks\(\)#'
-        - '#Access to an undefined property CodeIgniter\\Config\\AutoloadConfig::(\$psr4|\$classmap)#'
-        - '#Access to an undefined property CodeIgniter\\Database\\Forge::\$dropConstraintStr#'
-        - '#Access to an undefined property CodeIgniter\\Config\\View::(\$filters|\$plugins)#'
-        - '#Access to protected property CodeIgniter\\Database\\BaseConnection::(\$DBDebug|\$DBPrefix|\$swapPre|\$charset|\$DBCollat)#'
-        - '#Access to an undefined property CodeIgniter\\Database\\BaseConnection::\$mysqli#'
-        - '#Access to an undefined property CodeIgniter\\Database\\ConnectionInterface::(\$DBDriver|\$connID|\$likeEscapeStr|\$likeEscapeChar|\$escapeChar|\$protectIdentifiers)#'
-        - '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::supportsForeignKeys\(\)#'
-        - '#Cannot call method [a-zA-Z_]+\(\) on ((bool\|)?object\|resource)#'
-        - '#Cannot access property [\$a-z_]+ on ((bool\|)?object\|resource)#'
-        - '#Call to an undefined method CodeIgniter\\HTTP\\Request::(getPath|getSegments|getMethod|setLocale|getPost)\(\)#'
-        - '#Access to an undefined property CodeIgniter\\HTTP\\Request::\$uri#'
-        - '#Call to an undefined method CodeIgniter\\HTTP\\Message::setStatusCode\(\)#'
-        - '#Call to an undefined method CodeIgniter\\Database\\ConnectionInterface::(tableExists|protectIdentifiers|setAliasedTables|escapeIdentifiers|affectedRows|addTableAlias)\(\)#'
-        - '#Method CodeIgniter\\Database\\ConnectionInterface::query\(\) invoked with 3 parameters, 1-2 required#'
-        - '#Return type \(bool\) of method CodeIgniter\\Test\\TestLogger::log\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::log\(\)#'
-        - '#Call to an undefined method CodeIgniter\\Router\\RouteCollectionInterface::(getDefaultNamespace|isFiltered|getFilterForRoute|getRoutesOptions)\(\)#'
-        - '#Method CodeIgniter\\Router\\RouteCollectionInterface::getRoutes\(\) invoked with 1 parameter, 0 required#'
-        - '#Call to an undefined method CodeIgniter\\Validation\\ValidationInterface::loadRuleGroup\(\)#'
-        - '#Method CodeIgniter\\Validation\\ValidationInterface::run\(\) invoked with 3 parameters, 0-2 required#'
-        - '#Return type \(bool\) of method CodeIgniter\\Log\\Logger::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\)#'
-        - '#Return type \(bool\) of method CodeIgniter\\HTTP\\Files\\UploadedFile::move\(\) should be compatible with return type \(CodeIgniter\\Files\\File\) of method CodeIgniter\\Files\\File::move\(\)#'
-        - '#Call to function is_null\(\) with mysqli_stmt\|resource will always evaluate to false#'
-        - '#Negated boolean expression is always (true|false)#'
-        - '#Parameter \#1 \$db of class CodeIgniter\\Database\\SQLite3\\Table constructor expects CodeIgniter\\Database\\SQLite3\\Connection, CodeIgniter\\Database\\BaseConnection given#'
-    scanDirectories:
-      - system/Helpers
-    dynamicConstantNames:
-        - ENVIRONMENT
-        - CI_DEBUG
+  level: 5
+  paths:
+    - app
+    - system
+  treatPhpDocTypesAsCertain: false
+  bootstrapFiles:
+    - qa-bootstrap.php
+  excludes_analyse:
+    - app/Views/errors/cli/*
+    - app/Views/errors/html/*
+    - system/Commands/Generators/Views/*
+    - system/Config/Routes.php
+    - system/Debug/Toolbar/Views/toolbar.tpl.php
+    - system/Validation/Views/single.php
+    - system/ThirdParty/*
+  ignoreErrors:
+    - '#Unsafe usage of new static\(\)*#'
+    - '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::_(disable|enable)ForeignKeyChecks\(\)#'
+    - '#Access to an undefined property CodeIgniter\\Database\\Forge::\$dropConstraintStr#'
+    - '#Access to protected property CodeIgniter\\Database\\BaseConnection::(\$DBDebug|\$DBPrefix|\$swapPre|\$charset|\$DBCollat)#'
+    - '#Access to an undefined property CodeIgniter\\Database\\BaseConnection::\$mysqli#'
+    - '#Access to an undefined property CodeIgniter\\Database\\ConnectionInterface::(\$DBDriver|\$connID|\$likeEscapeStr|\$likeEscapeChar|\$escapeChar|\$protectIdentifiers)#'
+    - '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::supportsForeignKeys\(\)#'
+    - '#Cannot call method [a-zA-Z_]+\(\) on ((bool\|)?object\|resource)#'
+    - '#Cannot access property [\$a-z_]+ on ((bool\|)?object\|resource)#'
+    - '#Call to an undefined method CodeIgniter\\HTTP\\Request::(getPath|getSegments|getMethod|setLocale|getPost)\(\)#'
+    - '#Access to an undefined property CodeIgniter\\HTTP\\Request::\$uri#'
+    - '#Call to an undefined method CodeIgniter\\HTTP\\Message::setStatusCode\(\)#'
+    - '#Call to an undefined method CodeIgniter\\Database\\ConnectionInterface::(tableExists|protectIdentifiers|setAliasedTables|escapeIdentifiers|affectedRows|addTableAlias)\(\)#'
+    - '#Method CodeIgniter\\Database\\ConnectionInterface::query\(\) invoked with 3 parameters, 1-2 required#'
+    - '#Return type \(bool\) of method CodeIgniter\\Test\\TestLogger::log\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::log\(\)#'
+    - '#Call to an undefined method CodeIgniter\\Router\\RouteCollectionInterface::(getDefaultNamespace|isFiltered|getFilterForRoute|getRoutesOptions)\(\)#'
+    - '#Method CodeIgniter\\Router\\RouteCollectionInterface::getRoutes\(\) invoked with 1 parameter, 0 required#'
+    - '#Call to an undefined method CodeIgniter\\Validation\\ValidationInterface::loadRuleGroup\(\)#'
+    - '#Method CodeIgniter\\Validation\\ValidationInterface::run\(\) invoked with 3 parameters, 0-2 required#'
+    - '#Return type \(bool\) of method CodeIgniter\\Log\\Logger::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\)#'
+    - '#Return type \(bool\) of method CodeIgniter\\HTTP\\Files\\UploadedFile::move\(\) should be compatible with return type \(CodeIgniter\\Files\\File\) of method CodeIgniter\\Files\\File::move\(\)#'
+    - '#Call to function is_null\(\) with mysqli_stmt\|resource will always evaluate to false#'
+    - '#Negated boolean expression is always (true|false)#'
+    - '#Parameter \#1 \$db of class CodeIgniter\\Database\\SQLite3\\Table constructor expects CodeIgniter\\Database\\SQLite3\\Connection, CodeIgniter\\Database\\BaseConnection given#'
+  parallel:
+    processTimeout: 300.0
+  scanDirectories:
+    - system/Helpers
+  dynamicConstantNames:
+    - ENVIRONMENT
+    - CI_DEBUG

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -40,13 +40,43 @@
 namespace CodeIgniter\Config;
 
 /**
- * AUTO-LOADER
+ * AUTOLOADER
  *
  * This file defines the namespaces and class maps so the Autoloader
  * can find the files as needed.
  */
 class AutoloadConfig
 {
+	/**
+	 * -------------------------------------------------------------------
+	 * Namespaces
+	 * -------------------------------------------------------------------
+	 * This maps the locations of any namespaces in your application to
+	 * their location on the file system. These are used by the autoloader
+	 * to locate files the first time they have been instantiated.
+	 *
+	 * The '/app' and '/system' directories are already mapped for you.
+	 * you may change the name of the 'App' namespace if you wish,
+	 * but this should be done prior to creating any namespaced classes,
+	 * else you will need to modify all of those classes for this to work.
+	 *
+	 * @var array
+	 */
+	public $psr4 = [];
+
+	/**
+	 * -------------------------------------------------------------------
+	 * Class Map
+	 * -------------------------------------------------------------------
+	 * The class map provides a map of class names and their exact
+	 * location on the drive. Classes loaded in this manner will have
+	 * slightly faster performance because they will not have to be
+	 * searched for within one or more directories as they would if they
+	 * were being autoloaded through a namespace.
+	 *
+	 * @var array
+	 */
+	public $classmap = [];
 
 	/**
 	 * -------------------------------------------------------------------

--- a/system/Config/View.php
+++ b/system/Config/View.php
@@ -44,6 +44,22 @@ namespace CodeIgniter\Config;
  */
 class View extends BaseConfig
 {
+	/**
+	 * Parser Filters map a filter name with any PHP callable. When the
+	 * Parser prepares a variable for display, it will chain it
+	 * through the filters in the order defined, inserting any parameters.
+	 *
+	 * To prevent potential abuse, all filters MUST be defined here
+	 * in order for them to be available for use within the Parser.
+	 */
+	public $filters = [];
+
+	/**
+	 * Parser Plugins provide a way to extend the functionality provided
+	 * by the core Parser by creating aliases that will be replaced with
+	 * any callable. Can be single or tag pair.
+	 */
+	public $plugins = [];
 
 	/**
 	 * Built-in View filters.


### PR DESCRIPTION
**Description**
Update `phpstan.neon`
- use 2-space indent since this is yaml
- add the rule `level` to parameters
- add `paths` to check to parameters
- `excludes_analyse` will now exclude all tpl files in generator commands' views
- all error views are excluded
- add `parallel.processTimeout` to parameters for running in local machines
- add missing `$psr4` and `$classmap` properties of `AutoloadConfig`. These will be overwritten by `Config\Autoload`'s similarly named properties.
- add missing `$filters` and `$plugins` properties of `CodeIgniter\Config\Views`. These will be overwritten by `Config\Views` similarly named properties.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
