### PR TITLE
Add __wakeup method to Time

### DIFF
--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -1371,4 +1371,14 @@ class Time extends DateTime
 		return method_exists($this, $method);
 	}
 
+	//--------------------------------------------------------------------
+
+	/**
+	 * This is called when we unserialize the Time object.
+	 */
+	public function __wakeup()
+	{
+		$this->timezone = new DateTimeZone($this->timezone);
+		parent::__construct($this->date, $this->timezone);
+	}
 }

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -56,10 +56,11 @@ use Locale;
  * Requires the intl PHP extension.
  *
  * @package CodeIgniter\I18n
+ *
+ * @property string $date
  */
 class Time extends DateTime
 {
-
 	/**
 	 * @var \DateTimeZone
 	 */
@@ -1378,7 +1379,14 @@ class Time extends DateTime
 	 */
 	public function __wakeup()
 	{
-		$this->timezone = new DateTimeZone($this->timezone);
+		/**
+		 * Prior to unserialization, this is a string.
+		 *
+		 * @var string $timezone
+		 */
+		$timezone = $this->timezone;
+
+		$this->timezone = new DateTimeZone($timezone);
 		parent::__construct($this->date, $this->timezone);
 	}
 }

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1008,4 +1008,14 @@ class TimeTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertNull($time->weekOfWeek);
 	}
 
+	public function testUnserializeTimeObject()
+	{
+		$time1     = new Time('August 28, 2020 10:04:00pm', 'Asia/Manila', 'en');
+		$timeCache = serialize($time1);
+		$time2     = unserialize($timeCache);
+
+		$this->assertInstanceOf(Time::class, $time2);
+		$this->assertTrue($time2->equals($time1));
+		$this->assertEquals($time1, $time2);
+	}
 }


### PR DESCRIPTION
**Description**
Fixes #3553 

Little side note on `__wakeup()`.
- Simple fix for the problem is just provide an empty `__wakeup` method to `Time` for the sake of overriding `DateTime::__wakeup()`. However, with that, we cannot initialize the parent, `DateTime`. With this fix, we can get an "equal" Time object (but not the "same" since they are not referencing to the same object).

Continuing on the controller code:
```php
        public function index()
	{
		// return view('welcome_message');

		$web = new Web();
		$web->url = 123;
		$web->created_at = date('Y-m-d H:i:s');
		var_dump($web->created_at);

		$cache = Services::cache();
		$cache->save('webname', $web, 300);

		$web = $cache->get('webname');
		var_dump($web->created_at);
	}
```

we will get this:
```php
C:\Users\P\Desktop\Web Dev\CodeIgniter4\app\Controllers\Home.php:15:
object(CodeIgniter\I18n\Time)[65]
  protected 'timezone' => 
    object(DateTimeZone)[66]
      public 'timezone_type' => int 3
      public 'timezone' => string 'America/Chicago' (length=15)
  protected 'locale' => string 'en' (length=2)
  protected 'toStringFormat' => string 'yyyy-MM-dd HH:mm:ss' (length=19)
  public 'date' => string '2020-08-28 10:35:45.000000' (length=26)
  public 'timezone_type' => int 3
  public 'timezone' => string 'America/Chicago' (length=15)

C:\Users\P\Desktop\Web Dev\CodeIgniter4\app\Controllers\Home.php:21:
object(CodeIgniter\I18n\Time)[68]
  protected 'timezone' => 
    object(DateTimeZone)[69]
      public 'timezone_type' => int 3
      public 'timezone' => string 'America/Chicago' (length=15)
  protected 'locale' => string 'en' (length=2)
  protected 'toStringFormat' => string 'yyyy-MM-dd HH:mm:ss' (length=19)
  public 'date' => string '2020-08-28 10:35:45.000000' (length=26)
  public 'timezone_type' => int 3
  public 'timezone' => string 'America/Chicago' (length=15)
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
