### PR TITLE
Deprecate BaseCommand::getPad and add more tests

### DIFF
--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -171,6 +171,7 @@ abstract class BaseCommand
 	public function showHelp()
 	{
 		CLI::write(lang('CLI.helpUsage'), 'yellow');
+
 		if (! empty($this->usage))
 		{
 			$usage = $this->usage;
@@ -184,6 +185,7 @@ abstract class BaseCommand
 				$usage .= ' [arguments]';
 			}
 		}
+
 		CLI::write($this->setPad($usage, 0, 0, 2));
 
 		if (! empty($this->description))
@@ -198,6 +200,7 @@ abstract class BaseCommand
 			CLI::newLine();
 			CLI::write(lang('CLI.helpArguments'), 'yellow');
 			$length = max(array_map('strlen', array_keys($this->arguments)));
+
 			foreach ($this->arguments as $argument => $description)
 			{
 				CLI::write(CLI::color($this->setPad($argument, $length, 2, 2), 'green') . $description);
@@ -209,6 +212,7 @@ abstract class BaseCommand
 			CLI::newLine();
 			CLI::write(lang('CLI.helpOptions'), 'yellow');
 			$length = max(array_map('strlen', array_keys($this->options)));
+
 			foreach ($this->options as $option => $description)
 			{
 				CLI::write(CLI::color($this->setPad($option, $length, 2, 2), 'green') . $description);
@@ -223,12 +227,12 @@ abstract class BaseCommand
 	 *
 	 * @param string  $item
 	 * @param integer $max
-	 * @param integer $extra  // How many extra spaces to add at the end
+	 * @param integer $extra  How many extra spaces to add at the end
 	 * @param integer $indent
 	 *
 	 * @return string
 	 */
-	protected function setPad(string $item, int $max, int $extra = 2, int $indent = 0): string
+	public function setPad(string $item, int $max, int $extra = 2, int $indent = 0): string
 	{
 		$max += $extra + $indent;
 
@@ -244,6 +248,10 @@ abstract class BaseCommand
 	 * @param integer $pad
 	 *
 	 * @return integer
+	 *
+	 * @deprecated Use setPad() instead.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function getPad(array $array, int $pad): int
 	{

--- a/tests/_support/Commands/AppInfo.php
+++ b/tests/_support/Commands/AppInfo.php
@@ -10,6 +10,7 @@ class AppInfo extends BaseCommand
 
 	protected $group       = 'demo';
 	protected $name        = 'app:info';
+	protected $arguments   = ['draft' => 'unused'];
 	protected $description = 'Displays basic application information.';
 
 	public function run(array $params)

--- a/tests/system/Commands/HelpCommandTest.php
+++ b/tests/system/Commands/HelpCommandTest.php
@@ -37,6 +37,12 @@ class HelpCommandTest extends CIUnitTestCase
 		$this->assertStringContainsString('command_name', $this->getBuffer());
 	}
 
+	public function testHelpCommandWithMissingUsage()
+	{
+		command('help app:info');
+		$this->assertStringContainsString('app:info [arguments]', $this->getBuffer());
+	}
+
 	public function testHelpCommandOnSpecificCommand()
 	{
 		command('help cache:clear');

--- a/user_guide_src/source/changelogs/v4.0.5.rst
+++ b/user_guide_src/source/changelogs/v4.0.5.rst
@@ -17,3 +17,7 @@ Bugs Fixed:
 
 - Fixed a bug in ``Entity`` class where declaring class parameters was preventing data propagation to the ``attributes`` array.
 - Handling for the environment variable ``encryption.key`` has changed. Previously, explicit function calls, like ``getenv('encryption.key')`` or ``env('encryption.key')`` where the value has the special prefix ``hex2bin:`` returns an automatically converted binary string. This is now changed to just return the character string with the prefix. This change was due to incompatibility with handling binary strings in environment variables on Windows platforms. However, accessing ``$key`` using ``Encryption`` class config remains unchanged and still returns a binary string.
+
+Deprecations:
+
+- Deprecated ``BaseCommand::getPad`` in favor of ``BaseCommand::setPad``.


### PR DESCRIPTION
**Description**
With the changes brought by #3435 , the method `BaseCommand::getPad` is not used anymore. I've checked for usage references within the codebase using VSCode and found none. This was because it was replaced by `setPad`. Since this is a public function, I'm proposing to deprecate this.

Also, with that PR's changes, some lines got uncovered by tests. So I've added a test for that.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
