### PR TITLE
Implement caching of phpstan result cache

### DIFF
--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -35,5 +35,15 @@ jobs:
       - name: Install dependencies
         run: composer install --no-progress --no-suggest --no-interaction
 
+      - name: Create PHPStan result cache directory
+        run: mkdir -p build/phpstan
+
+      - name: Cache PHPStan result cache directory
+        uses: actions/cache@v2
+        with:
+          path: build/phpstan
+          key: ${{ runner.os }}-phpstan-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-phpstan-
+
       - name: Run static analysis
         run: vendor/bin/phpstan analyse

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 parameters:
+  tmpDir: build/phpstan
   level: 5
   paths:
     - app


### PR DESCRIPTION
I used `build/phpstan` since `build/` is already ignored in `.gitignore` and is used by `phpunit`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
