### PR TITLE
Use null coalescing to routes resolution in FeatureTestTrait::call

### DIFF
--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -167,7 +167,7 @@ trait FeatureTestTrait
 		$request = $this->populateGlobals($method, $request, $params);
 
 		// Make sure the RouteCollection knows what method we're using...
-		$routes = $this->routes ?: Services::routes(); // @phpstan-ignore-line
+		$routes = $this->routes ?? Services::routes();
 		$routes->setHTTPVerb($method);
 
 		// Make sure any other classes that might call the request

--- a/tests/system/HomeTest.php
+++ b/tests/system/HomeTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CodeIgniter;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\FeatureTestTrait;
+
+class HomeTest extends CIUnitTestCase
+{
+	use FeatureTestTrait;
+
+	public function testPageLoadsSuccessfully()
+	{
+		$response = $this->get('/');
+		$this->assertTrue($response->isOK());
+	}
+}

--- a/tests/system/HomeTest.php
+++ b/tests/system/HomeTest.php
@@ -11,7 +11,16 @@ class HomeTest extends CIUnitTestCase
 
 	public function testPageLoadsSuccessfully()
 	{
-		$response = $this->get('/');
+		$this->withRoutes([
+			[
+				'get',
+				'home',
+				'\App\Controllers\Home::index',
+			],
+		]);
+
+		$response = $this->get('home');
+		$this->assertInstanceOf('CodeIgniter\Test\FeatureResponse', $response);
 		$this->assertTrue($response->isOK());
 	}
 }


### PR DESCRIPTION
**Description**
This change will allow us to not be constrained in using `FeatureTestTrait` within the context only of `FeatureResponse`. We can also use this on other test cases, like `CIUnitTestCase`. This also resolves phpstan's error "Ternary operation always return true."

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
