### PR TITLE
Allow string for parameter $obj in ReflectionHelper::getAccessibleRefProperty()

### DIFF
--- a/system/Test/ReflectionHelper.php
+++ b/system/Test/ReflectionHelper.php
@@ -72,8 +72,8 @@ trait ReflectionHelper
 	/**
 	 * Find an accessible property.
 	 *
-	 * @param object $obj
-	 * @param string $property
+	 * @param object|string $obj
+	 * @param string        $property
 	 *
 	 * @return \ReflectionProperty
 	 * @throws \ReflectionException


### PR DESCRIPTION
There is `is_object($obj)` check and its otherwise condition using `ReflectionClass`, that make it possible to pass a string parameter.

**Checklist:**
- [x] Securely signed commits
