### PR TITLE
remove get_class() on method_exists

### DIFF
--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -286,7 +286,7 @@ class BaseService
 		// Try to find the desired service method
 		foreach (static::$services as $class)
 		{
-			if (method_exists(get_class($class), $name))
+			if (method_exists($class, $name))
 			{
 				return $class::$name(...$arguments);
 			}


### PR DESCRIPTION
`method_exists()` allow pass object to 1st parameter.

**Checklist:**
- [x] Securely signed commits