### PR TITLE
fix getNext and getPrevious links

### DIFF
--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -171,11 +171,11 @@ class PagerRenderer
 
 		if ($this->segment === 0)
 		{
-			$uri->addQuery($this->pageSelector, $this->first - 1);
+			$uri->addQuery($this->pageSelector, $this->current - 1);
 		}
 		else
 		{
-			$uri->setSegment($this->segment, $this->first - 1);
+			$uri->setSegment($this->segment, $this->current - 1);
 		}
 
 		return (string) $uri;
@@ -215,11 +215,11 @@ class PagerRenderer
 
 		if ($this->segment === 0)
 		{
-			$uri->addQuery($this->pageSelector, $this->last + 1);
+			$uri->addQuery($this->pageSelector, $this->current + 1);
 		}
 		else
 		{
-			$uri->setSegment($this->segment, $this->last + 1);
+			$uri->setSegment($this->segment, $this->current + 1);
 		}
 
 		return (string) $uri;


### PR DESCRIPTION
**Description**
changed getPrevious to current - 1 to get previous page instead of first -1 that gets first page. same in getNext.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide