### PR TITLE
remove `else` on return/throw/continue early

### DIFF
--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -223,7 +223,8 @@ class RedisHandler implements CacheInterface
 		{
 			return false;
 		}
-		elseif ($ttl)
+
+		if ($ttl)
 		{
 			$this->redis->expireAt($key, time() + $ttl);
 		}

--- a/system/Common.php
+++ b/system/Common.php
@@ -786,7 +786,8 @@ if (! function_exists('is_really_writable'))
 
 			return true;
 		}
-		elseif (! is_file($file) || ( $fp = @fopen($file, 'ab')) === false)
+
+		if (! is_file($file) || ( $fp = @fopen($file, 'ab')) === false)
 		{
 			return false;
 		}

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3069,7 +3069,8 @@ class BaseBuilder
 				{
 					continue;
 				}
-				elseif ($qbkey['escape'] === false)
+
+				if ($qbkey['escape'] === false)
 				{
 					$qbkey = $qbkey['condition'];
 					continue;
@@ -3191,7 +3192,8 @@ class BaseBuilder
 
 			return $this->QBOrderBy = "\nORDER BY " . implode(', ', $this->QBOrderBy);
 		}
-		elseif (is_string($this->QBOrderBy))
+
+		if (is_string($this->QBOrderBy))
 		{
 			return $this->QBOrderBy;
 		}

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -853,8 +853,9 @@ abstract class BaseConnection implements ConnectionInterface
 		{
 			return false;
 		}
+
 		// When transactions are nested we only begin/commit/rollback the outermost ones
-		elseif ($this->transDepth > 0)
+		if ($this->transDepth > 0)
 		{
 			$this->transDepth ++;
 			return true;
@@ -892,8 +893,9 @@ abstract class BaseConnection implements ConnectionInterface
 		{
 			return false;
 		}
+
 		// When transactions are nested we only begin/commit/rollback the outermost ones
-		elseif ($this->transDepth > 1 || $this->_transCommit())
+		if ($this->transDepth > 1 || $this->_transCommit())
 		{
 			$this->transDepth --;
 			return true;
@@ -915,8 +917,9 @@ abstract class BaseConnection implements ConnectionInterface
 		{
 			return false;
 		}
+
 		// When transactions are nested we only begin/commit/rollback the outermost ones
-		elseif ($this->transDepth > 1 || $this->_transRollback())
+		if ($this->transDepth > 1 || $this->_transRollback())
 		{
 			$this->transDepth --;
 			return true;
@@ -1287,7 +1290,8 @@ abstract class BaseConnection implements ConnectionInterface
 		{
 			return $item;
 		}
-		elseif (is_array($item))
+
+		if (is_array($item))
 		{
 			foreach ($item as $key => $value)
 			{
@@ -1296,10 +1300,12 @@ abstract class BaseConnection implements ConnectionInterface
 
 			return $item;
 		}
+
 		// Avoid breaking functions and literal values inside queries
-		elseif (ctype_digit($item) || $item[0] === "'" || ( $this->escapeChar !== '"' && $item[0] === '"') ||
-				strpos($item, '(') !== false
-		)
+		if (ctype_digit($item)
+			|| $item[0] === "'"
+			|| ( $this->escapeChar !== '"' && $item[0] === '"')
+			|| strpos($item, '(') !== false)
 		{
 			return $item;
 		}

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -134,7 +134,8 @@ abstract class BaseResult implements ResultInterface
 		{
 			return $this->getResultArray();
 		}
-		elseif ($type === 'object')
+
+		if ($type === 'object')
 		{
 			return $this->getResultObject();
 		}
@@ -331,7 +332,8 @@ abstract class BaseResult implements ResultInterface
 		{
 			return $this->getRowObject($n);
 		}
-		elseif ($type === 'array')
+
+		if ($type === 'array')
 		{
 			return $this->getRowArray($n);
 		}
@@ -548,7 +550,8 @@ abstract class BaseResult implements ResultInterface
 		{
 			return $this->fetchAssoc();
 		}
-		elseif ($type === 'object')
+
+		if ($type === 'object')
 		{
 			return $this->fetchObject();
 		}

--- a/system/Database/BaseUtils.php
+++ b/system/Database/BaseUtils.php
@@ -104,7 +104,8 @@ abstract class BaseUtils
 		{
 			return $this->db->dataCache['db_names'];
 		}
-		elseif ($this->listDatabases === false)
+
+		if ($this->listDatabases === false)
 		{
 			if ($this->db->DBDebug)
 			{

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -240,8 +240,8 @@ class Forge
 
 			return false;
 		}
-		elseif (! $this->db->query(sprintf($ifNotExists ? $this->createDatabaseIfStr : $this->createDatabaseStr, $dbName, $this->db->charset, $this->db->DBCollat))
-		)
+
+		if (! $this->db->query(sprintf($ifNotExists ? $this->createDatabaseIfStr : $this->createDatabaseStr, $dbName, $this->db->charset, $this->db->DBCollat)))
 		{
 			if ($this->db->DBDebug)
 			{
@@ -305,7 +305,8 @@ class Forge
 
 			return false;
 		}
-		elseif (! $this->db->query(sprintf($this->dropDatabaseStr, $dbName)))
+
+		if (! $this->db->query(sprintf($this->dropDatabaseStr, $dbName)))
 		{
 			if ($this->db->DBDebug)
 			{
@@ -741,7 +742,8 @@ class Forge
 		{
 			throw new \InvalidArgumentException('A table name is required for that operation.');
 		}
-		elseif ($this->renameTableStr === false)
+
+		if ($this->renameTableStr === false)
 		{
 			if ($this->db->DBDebug)
 			{
@@ -1111,7 +1113,8 @@ class Forge
 
 					return;
 				}
-				elseif (is_string($key) && strcasecmp($attributes['TYPE'], $key) === 0)
+
+				if (is_string($key) && strcasecmp($attributes['TYPE'], $key) === 0)
 				{
 					$field['type'] = $key;
 

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -240,7 +240,8 @@ class Connection extends BaseConnection implements ConnectionInterface
 		{
 			return pg_escape_literal($this->connID, $str);
 		}
-		elseif (is_bool($str))
+
+		if (is_bool($str))
 		{
 			return $str ? 'TRUE' : 'FALSE';
 		}

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -182,7 +182,8 @@ class Result extends BaseResult implements ResultInterface
 		{
 			return false;
 		}
-		elseif ($className === 'stdClass')
+
+		if ($className === 'stdClass')
 		{
 			return (object) $row;
 		}

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -883,7 +883,8 @@ class Email
 		{
 			return empty($this->attachments) ? 'html' : 'html-attach';
 		}
-		elseif ($this->mailType === 'text' && ! empty($this->attachments))
+
+		if ($this->mailType === 'text' && ! empty($this->attachments))
 		{
 			return 'plain-attach';
 		}
@@ -1989,7 +1990,8 @@ class Email
 		{
 			return true;
 		}
-		elseif (strpos($reply, '334') !== 0)
+
+		if (strpos($reply, '334') !== 0)
 		{
 			$this->setErrorMessage(lang('Email.failedSMTPLogin', [$reply]));
 			return false;

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -97,7 +97,7 @@ class Filters
 	 * @var array
 	 */
 	protected $arguments = [];
-	
+
 	/**
 	 * Handle to the modules config.
 	 *
@@ -110,9 +110,9 @@ class Filters
 	/**
 	 * Constructor.
 	 *
-	 * @param \Config\Filters   $config
-	 * @param RequestInterface  $request
-	 * @param ResponseInterface $response
+	 * @param \Config\Filters      $config
+	 * @param RequestInterface     $request
+	 * @param ResponseInterface    $response
 	 * @param \Config\Modules|null $moduleConfig
 	 */
 	public function __construct($config, RequestInterface $request, ResponseInterface $response, Modules $moduleConfig = null)
@@ -123,22 +123,22 @@ class Filters
 
 		$this->moduleConfig = $moduleConfig ?? config('Modules');
 	}
-	
+
 	//--------------------------------------------------------------------
 
 	/**
 	 * If discoverFilters is enabled in Config then system will try to auto
-	 * Discovery custom filters files in Namespaces and allow access to 
+	 * Discovery custom filters files in Namespaces and allow access to
 	 * The config object via the variable $customfilters as with the routes file
-	 * Sample : 
+	 * Sample :
 	 * $filters->aliases['custom-auth'] = \Acme\Blob\Filters\BlobAuth::class;
-	 */	
+	 */
 	private function discoverFilters()
 	{
 		$locater = Services::locator();
-		
+
 		$filters = $this->config;
-		
+
 		$files = $locater->search('Config/Filters.php');
 
 		foreach ($files as $file)
@@ -151,7 +151,7 @@ class Filters
 
 			include $file;
 		}
-	}	
+	}
 
 	/**
 	 * Set the response explicity.
@@ -235,7 +235,8 @@ class Filters
 
 					return $result;
 				}
-				elseif ($position === 'after')
+
+				if ($position === 'after')
 				{
 					$result = $class->after($this->request, $this->response, $this->arguments[$alias] ?? null);
 
@@ -279,8 +280,8 @@ class Filters
 		if ($this->moduleConfig->shouldDiscover('filters'))
 		{
 			$this->discoverFilters();
-		}	
-		
+		}
+
 		$this->processGlobals($uri);
 		$this->processMethods();
 		$this->processFilters($uri);

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -58,7 +58,7 @@ class DownloadResponse extends Message implements ResponseInterface
 	/**
 	 * Download for file
 	 *
-	 * @var File
+	 * @var File|null
 	 */
 	private $file;
 
@@ -163,7 +163,8 @@ class DownloadResponse extends Message implements ResponseInterface
 		{
 			return strlen($this->binary);
 		}
-		elseif ($this->file instanceof File)
+
+		if ($this->file instanceof File)
 		{
 			return $this->file->getSize();
 		}
@@ -509,7 +510,8 @@ class DownloadResponse extends Message implements ResponseInterface
 		{
 			return $this->sendBodyByBinary();
 		}
-		elseif ($this->file !== null)
+
+		if ($this->file !== null)
 		{
 			return $this->sendBodyByFilePath();
 		}

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -295,11 +295,13 @@ class IncomingRequest extends Request
 		{
 			return true;
 		}
-		elseif ($this->hasHeader('X-Forwarded-Proto') && $this->getHeader('X-Forwarded-Proto')->getValue() === 'https')
+
+		if ($this->hasHeader('X-Forwarded-Proto') && $this->getHeader('X-Forwarded-Proto')->getValue() === 'https')
 		{
 			return true;
 		}
-		elseif ($this->hasHeader('Front-End-Https') && ! empty($this->getHeader('Front-End-Https')->getValue()) && strtolower($this->getHeader('Front-End-Https')->getValue()) !== 'off')
+
+		if ($this->hasHeader('Front-End-Https') && ! empty($this->getHeader('Front-End-Https')->getValue()) && strtolower($this->getHeader('Front-End-Https')->getValue()) !== 'off')
 		{
 			return true;
 		}
@@ -763,7 +765,8 @@ class IncomingRequest extends Request
 		{
 			return '';
 		}
-		elseif (strncmp($uri, '/', 1) === 0)
+
+		if (strncmp($uri, '/', 1) === 0)
 		{
 			$uri                     = explode('?', $uri, 2);
 			$_SERVER['QUERY_STRING'] = $uri[1] ?? '';

--- a/system/Model.php
+++ b/system/Model.php
@@ -1973,11 +1973,13 @@ class Model
 		{
 			return $this->{$name};
 		}
-		elseif (isset($this->db->$name))
+
+		if (isset($this->db->$name))
 		{
 			return $this->db->$name;
 		}
-		elseif (isset($this->builder()->$name))
+
+		if (isset($this->builder()->$name))
 		{
 			return $this->builder()->$name;
 		}
@@ -1998,11 +2000,13 @@ class Model
 		{
 			return true;
 		}
-		elseif (isset($this->db->$name))
+
+		if (isset($this->db->$name))
 		{
 			return true;
 		}
-		elseif (isset($this->builder()->$name))
+
+		if (isset($this->builder()->$name))
 		{
 			return true;
 		}

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -231,7 +231,7 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 		}
 
 		// Was the ID regenerated?
-		elseif ($sessionID !== $this->sessionID)
+		if ($sessionID !== $this->sessionID)
 		{
 			$this->rowExists = false;
 			$this->sessionID = $sessionID;
@@ -372,7 +372,8 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 
 			return $this->fail();
 		}
-		elseif ($this->platform === 'postgre')
+
+		if ($this->platform === 'postgre')
 		{
 			$arg = "hashtext('{$sessionID}')" . ($this->matchIP ? ", hashtext('{$this->ipAddress}')" : '');
 			if ($this->db->simpleQuery("SELECT pg_advisory_lock({$arg})"))
@@ -412,7 +413,8 @@ class DatabaseHandler extends BaseHandler implements \SessionHandlerInterface
 
 			return $this->fail();
 		}
-		elseif ($this->platform === 'postgre')
+
+		if ($this->platform === 'postgre')
 		{
 			if ($this->db->simpleQuery("SELECT pg_advisory_unlock({$this->lock})"))
 			{

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -254,7 +254,8 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 		{
 			return false;
 		}
-		elseif ($this->fingerprint === md5($sessionData))
+
+		if ($this->fingerprint === md5($sessionData))
 		{
 			return ($this->fileNew) ? true : touch($this->filePath . $sessionID);
 		}
@@ -332,7 +333,8 @@ class FileHandler extends BaseHandler implements \SessionHandlerInterface
 			return is_file($this->filePath . $session_id)
 				? (unlink($this->filePath . $session_id) && $this->destroyCookie()) : true;
 		}
-		elseif ($this->filePath !== null)
+
+		if ($this->filePath !== null)
 		{
 			clearstatcache();
 

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -216,8 +216,9 @@ class MemcachedHandler extends BaseHandler implements \SessionHandlerInterface
 		{
 			return false;
 		}
+
 		// Was the ID regenerated?
-		elseif ($sessionID !== $this->sessionID)
+		if ($sessionID !== $this->sessionID)
 		{
 			if (! $this->releaseLock() || ! $this->lockSession($sessionID))
 			{

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -101,7 +101,8 @@ class RedisHandler extends BaseHandler implements \SessionHandlerInterface
 		{
 			throw SessionException::forEmptySavepath();
 		}
-		elseif (preg_match('#(?:tcp://)?([^:?]+)(?:\:(\d+))?(\?.+)?#', $this->savePath, $matches))
+
+		if (preg_match('#(?:tcp://)?([^:?]+)(?:\:(\d+))?(\?.+)?#', $this->savePath, $matches))
 		{
 			// @phpstan-ignore-next-line
 			isset($matches[3]) || $matches[3] = ''; // Just to avoid undefined index notices below
@@ -222,8 +223,9 @@ class RedisHandler extends BaseHandler implements \SessionHandlerInterface
 		{
 			return false;
 		}
+
 		// Was the ID regenerated?
-		elseif ($sessionID !== $this->sessionID)
+		if ($sessionID !== $this->sessionID)
 		{
 			if (! $this->releaseLock() || ! $this->lockSession($sessionID))
 			{
@@ -387,7 +389,8 @@ class RedisHandler extends BaseHandler implements \SessionHandlerInterface
 			log_message('error', 'Session: Unable to obtain lock for ' . $this->keyPrefix . $sessionID . ' after 30 attempts, aborting.');
 			return false;
 		}
-		elseif ($ttl === -1)
+
+		if ($ttl === -1)
 		{
 			log_message('debug', 'Session: Lock for ' . $this->keyPrefix . $sessionID . ' had no TTL, overriding.');
 		}

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -220,13 +220,15 @@ class Session implements SessionInterface
 			return;
 			// @codeCoverageIgnoreEnd
 		}
-		elseif ((bool) ini_get('session.auto_start'))
+
+		if ((bool) ini_get('session.auto_start'))
 		{
 			$this->logger->error('Session: session.auto_start is enabled in php.ini. Aborting.');
 
 			return;
 		}
-		elseif (session_status() === PHP_SESSION_ACTIVE)
+
+		if (session_status() === PHP_SESSION_ACTIVE)
 		{
 			$this->logger->warning('Session: Sessions is enabled, and one exists.Please don\'t $session->start();');
 
@@ -544,7 +546,8 @@ class Session implements SessionInterface
 		{
 			return $value;
 		}
-		elseif (empty($_SESSION))
+
+		if (empty($_SESSION))
 		{
 			return $key === null ? [] : null;
 		}
@@ -661,7 +664,8 @@ class Session implements SessionInterface
 		{
 			return $_SESSION[$key];
 		}
-		elseif ($key === 'session_id')
+
+		if ($key === 'session_id')
 		{
 			return session_id();
 		}

--- a/system/Test/FeatureResponse.php
+++ b/system/Test/FeatureResponse.php
@@ -145,7 +145,8 @@ class FeatureResponse extends TestCase
 		{
 			return $this->response->getHeaderLine('Location');
 		}
-		elseif ($this->response->hasHeader('Refresh'))
+
+		if ($this->response->hasHeader('Refresh'))
 		{
 			return str_replace('0;url=', '', $this->response->getHeaderLine('Refresh'));
 		}

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -362,7 +362,8 @@ class FormatRules
 		{
 			return false;
 		}
-		elseif (preg_match('/^(?:([^:]*)\:)?\/\/(.+)$/', $str, $matches))
+
+		if (preg_match('/^(?:([^:]*)\:)?\/\/(.+)$/', $str, $matches))
 		{
 			if (! in_array($matches[1], ['http', 'https'], true))
 			{


### PR DESCRIPTION
When there is already `return` or `throw`  or `continue` early in previous `if`, we can remove `else`.

**Checklist:**
- [x] Securely signed commits
