### PR TITLE
Fixes deprecation of assertArraySubset

### DIFF
--- a/system/Test/FeatureResponse.php
+++ b/system/Test/FeatureResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CodeIgniter
  *
@@ -389,15 +390,24 @@ class FeatureResponse extends TestCase
 	/**
 	 * Test that the response contains a matching JSON fragment.
 	 *
-	 * @param array $fragment
+	 * @param array   $fragment
+	 * @param boolean $strict
 	 *
 	 * @throws \Exception
 	 */
-	public function assertJSONFragment(array $fragment)
+	public function assertJSONFragment(array $fragment, bool $strict = false)
 	{
-		$json = json_decode($this->getJSON(), true);
+		$json    = json_decode($this->getJSON(), true);
+		$patched = array_replace_recursive($json, $fragment);
 
-		$this->assertArraySubset($fragment, $json, false, 'Response does not contain a matching JSON fragment.');
+		if ($strict)
+		{
+			$this->assertSame($json, $patched, 'Response does not contain a matching JSON fragment.');
+		}
+		else
+		{
+			$this->assertEquals($json, $patched, 'Response does not contain a matching JSON fragment.');
+		}
 	}
 
 	/**

--- a/tests/system/Test/FeatureResponseTest.php
+++ b/tests/system/Test/FeatureResponseTest.php
@@ -289,6 +289,17 @@ class FeatureResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 		]);
 
 		$this->feature->assertJSONFragment(['config' => ['key-a']]);
+		$this->feature->assertJSONFragment(['config' => ['key-a']], true);
+	}
+
+	public function testAssertJSONFragmentFollowingAssertArraySubset()
+	{
+		$this->getFeatureResponse([
+			'config' => '124',
+		]);
+
+		$this->feature->assertJSONFragment(['config' => 124]); // must fail on strict
+		$this->feature->assertJSONFragment(['config' => '124'], true);
 	}
 
 	public function testJsonExact()


### PR DESCRIPTION
**Description**
Fixes #3562 

Added an optional argument to `assertJSONFragment`, `bool $strict = false` to mimic `assertArraySubset`'s third param.
To demonstrate that this replacement mimics `assertArraySubset`, in the new test method, try the following locally. It should still pass:
```diff
- $this->feature->assertJSONFragment(['config' => 124]);
+ $this->assertArraySubset(['config' => 124], json_decode($this->feature->getJSON(), true));
- $this->feature->assertJSONFragment(['config' => '124'], true);
+ $this->assertArraySubset(['config' => '124'], json_decode($this->feature->getJSON(), true), true);
```
Then on the not strict test, adding `true` must fail the assert.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
