### PR TITLE
Fix Toolbar event collector number formatting

### DIFF
--- a/system/Debug/Toolbar/Collectors/Events.php
+++ b/system/Debug/Toolbar/Collectors/Events.php
@@ -145,15 +145,20 @@ class Events extends BaseCollector
 			{
 				$data['events'][$key] = [
 					'event'    => $key,
-					'duration' => number_format(($row['end'] - $row['start']) * 1000, 2),
+					'duration' => ($row['end'] - $row['start']) * 1000,
 					'count'    => 1,
 				];
 
 				continue;
 			}
 
-			$data['events'][$key]['duration'] += number_format(($row['end'] - $row['start']) * 1000, 2);
+			$data['events'][$key]['duration'] += ($row['end'] - $row['start']) * 1000;
 			$data['events'][$key]['count']++;
+		}
+
+		foreach ($data['events'] as &$row)
+		{
+			$row['duration'] = number_format($row['duration'], 2);
 		}
 
 		return $data;


### PR DESCRIPTION
**Description**
If event count > 1 and duration more than 1000 ms it's rise 
```
CRITICAL - 2020-09-01 10:54:24 --> A non well formed numeric value encountered
#0 vendor\codeigniter4\framework\system\Debug\Toolbar\Collectors\Events.php(155): CodeIgniter\Debug\Exceptions->errorHandler(8, 'A non well form...', 'E:\\progdev\\Proj...', 155, Array)
#1 vendor\codeigniter4\framework\system\Debug\Toolbar\Collectors\BaseCollector.php(307): CodeIgniter\Debug\Toolbar\Collectors\Events->display()
#2 vendor\codeigniter4\framework\system\Debug\Toolbar.php(128): CodeIgniter\Debug\Toolbar\Collectors\BaseCollector->getAsArray()
#3 vendor\codeigniter4\framework\system\Debug\Toolbar.php(353): CodeIgniter\Debug\Toolbar->run(1598946859.601, 4.642, Object(CodeIgniter\HTTP\IncomingRequest), Object(CodeIgniter\HTTP\Response))
#4 vendor\codeigniter4\framework\system\Filters\DebugToolbar.php(78): CodeIgniter\Debug\Toolbar->prepare(Object(CodeIgniter\HTTP\IncomingRequest), Object(CodeIgniter\HTTP\Response))
#5 vendor\codeigniter4\framework\system\Filters\Filters.php(199): CodeIgniter\Filters\DebugToolbar->after(Object(CodeIgniter\HTTP\IncomingRequest), Object(CodeIgniter\HTTP\Response), NULL)
#6 vendor\codeigniter4\framework\system\CodeIgniter.php(422): CodeIgniter\Filters\Filters->run('v1/employee_sta...', 'after')
#7 vendor\codeigniter4\framework\system\CodeIgniter.php(312): CodeIgniter\CodeIgniter->handleRequest(NULL, Object(Config\Cache), false)
#8 public\index.php(45): CodeIgniter\CodeIgniter->run()
#9 {main}
```

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide