### PR TITLE
Allow fallback when make:scaffold's argument is missing

### DIFF
--- a/system/Commands/Generators/CreateScaffold.php
+++ b/system/Commands/Generators/CreateScaffold.php
@@ -129,7 +129,7 @@ class CreateScaffold extends BaseCommand
 		];
 
 		// Call those commands!
-		$class = $params[0];
+		$class = $params[0] ?? CLI::getSegment(2);
 		$this->call('make:controller', array_merge([$class], $controllerOpts, $genOptions));
 		$this->call('make:model', array_merge([$class], $modelOpts, $genOptions));
 		$this->call('make:entity', array_merge([$class], $genOptions));


### PR DESCRIPTION
**Description**
Without the fallback, we'll get the Error `Undefined offset: 0`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
