### PR TITLE
Use CLI::getSegment(2) to refer to the first argument of generator command

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -947,6 +947,8 @@ class CLI
 	 *  // segment(3) is 'three', not '-f' or 'anOption'
 	 *  > php spark one two -f anOption three
 	 *
+	 * **IMPORTANT:** The index here is one-based instead of zero-based.
+	 *
 	 * @param integer $index
 	 *
 	 * @return mixed|null

--- a/system/CLI/GeneratorCommand.php
+++ b/system/CLI/GeneratorCommand.php
@@ -152,7 +152,8 @@ abstract class GeneratorCommand extends BaseCommand
 	 */
 	protected function getClassName(): string
 	{
-		$name = $this->params[0] ?? CLI::getSegment(0);
+		$name = $this->params[0] ?? CLI::getSegment(2);
+
 		return $name ?? '';
 	}
 
@@ -203,6 +204,7 @@ abstract class GeneratorCommand extends BaseCommand
 	protected function getRootNamespace(): string
 	{
 		$rootNamespace = $this->params['n'] ?? CLI::getOption('n') ?? APP_NAMESPACE;
+
 		return trim(str_replace('/', '\\', $rootNamespace), '\\');
 	}
 
@@ -238,6 +240,7 @@ abstract class GeneratorCommand extends BaseCommand
 
 		$path     = $base . DIRECTORY_SEPARATOR . str_replace('\\', DIRECTORY_SEPARATOR, $name) . '.php';
 		$filename = $this->modifyBasename(basename($path));
+
 		return implode(DIRECTORY_SEPARATOR, array_slice(explode(DIRECTORY_SEPARATOR, $path), 0, -1)) . DIRECTORY_SEPARATOR . $filename;
 	}
 
@@ -310,6 +313,7 @@ abstract class GeneratorCommand extends BaseCommand
 
 		$template = str_replace($namespaces, $this->getNamespace($class), $template);
 		$class    = str_replace($this->getNamespace($class) . '\\', '', $class);
+
 		return str_replace($classes, $class, $template);
 	}
 
@@ -326,11 +330,10 @@ abstract class GeneratorCommand extends BaseCommand
 		{
 			$imports = explode("\n", trim($match['imports']));
 			sort($imports);
+
 			return str_replace(trim($match['imports']), implode("\n", $imports), $template);
 		}
 
-		// @codeCoverageIgnoreStart
-		return $template;
-		// @codeCoverageIgnoreEnd
+		return $template; // @codeCoverageIgnore
 	}
 }


### PR DESCRIPTION
**Description**
I've noticed that `getSegment`'s code deducts 1 from the index parameter before checking which made me realize that it is one-based instead of zero-based. This PR updates `GeneratorCommand::getClassName()` to use that.

In retrospect, why was it that way?

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
