### PR TITLE
[DEV] Enhancements to dev workflows

### DIFF
--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -32,8 +32,25 @@ jobs:
           php-version: '7.4'
           extensions: intl
 
-      - name: Install dependencies
-        run: composer install --no-progress --no-suggest --no-interaction
+      - name: Use latest Composer
+        run: composer self-update
+
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Create composer cache directory
+        run: mkdir -p ${{ steps.composer-cache.outputs.dir }}
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
 
       - name: Create PHPStan result cache directory
         run: mkdir -p build/phpstan
@@ -44,6 +61,9 @@ jobs:
           path: build/phpstan
           key: ${{ runner.os }}-phpstan-${{ github.sha }}
           restore-keys: ${{ runner.os }}-phpstan-
+
+      - name: Install dependencies
+        run: composer install --ansi --no-progress --no-suggest --no-interaction
 
       - name: Run static analysis
         run: vendor/bin/phpstan analyse

--- a/admin/pre-commit
+++ b/admin/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 PROJECT=`php -r "echo dirname(dirname(dirname(realpath('$0'))));"`
-STAGED_FILES_CMD=`git diff --cached --name-only --diff-filter=ACMR HEAD | grep \\\\.php`
+STAGED_FILES_CMD=`git diff --cached --name-only --diff-filter=ACMR HEAD | grep \\\\.php$`
 
 # Determine if a file list is passed
 if [ "$#" -eq 1 ]
@@ -14,17 +14,35 @@ then
 fi
 SFILES=${SFILES:-$STAGED_FILES_CMD}
 
-echo "Checking PHP Lint..."
-for FILE in $SFILES
-do
-	php -l -d display_errors=0 "$PROJECT/$FILE"
+echo "Starting CodeIgniter precommit..."
+
+if [ "$SFILES" != "" ]
+then
+	echo "Linting PHP code..."
+	for FILE in $SFILES
+	do
+		php -l -d display_errors=0 "$PROJECT/$FILE"
+		if [ $? != 0 ]
+		then
+			echo "Fix the error(s) before commit."
+			exit 1
+		fi
+		FILES="$FILES $FILE"
+	done
+fi
+
+if [ "$FILES" != "" ]
+then
+	echo "Running PHPStan..."
+	# Run on whole codebase
+	./vendor/bin/phpstan analyse
+
 	if [ $? != 0 ]
 	then
-		echo "Fix the error before commit."
+		echo "Fix the phpstan error(s) before commit."
 		exit 1
 	fi
-	FILES="$FILES $FILE"
-done
+fi
 
 if [ "$FILES" != "" ]
 then


### PR DESCRIPTION
**Description**
- Run actions only on main repo
- Add phpstan analysis to `precommit`
- Strictly check only for PHP files ending in `.php`. Will exclude `.phpcs`, `.php_cs`, etc.
- Run linting if there are PHP files to check

**Checklist:**
- [x] Securely signed commits
