### PR TITLE
fix(Router): reset filter info before get defined filters

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -127,7 +127,7 @@ class Router implements RouterInterface
 	 * The filter info from Route Collection
 	 * if the matched route should be filtered.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	protected $filterInfo;
 

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -175,6 +175,9 @@ class Router implements RouterInterface
 		// Decode URL-encoded string
 		$uri = urldecode($uri);
 
+		// Restart filterInfo
+		$this->filterInfo = null;
+
 		if ($this->checkRoutes($uri))
 		{
 			if ($this->collection->isFiltered($this->matchedRoute[0]))


### PR DESCRIPTION
**Description**
Fix [#3591](https://github.com/codeigniter4/CodeIgniter4/issues/3591)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  
