### PR TITLE
Fix current_url() helper function when working with subfolders

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -170,7 +170,7 @@ if (! function_exists('current_url'))
 
 		if (! empty($baseUri->getPath()))
 		{
-			$uri->setHost($baseUri->getHost() . $baseUri->getPath());
+			$uri->setHost($baseUri->getHost() . rtrim($baseUri->getPath(), '/ ') . '/');
 		}
 
 		// Since we're basing off of the IncomingRequest URI,

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -170,7 +170,7 @@ if (! function_exists('current_url'))
 
 		if (! empty($baseUri->getPath()))
 		{
-			$uri->setPath(rtrim($baseUri->getPath(), '/ ') . '/' . $uri->getPath());
+			$uri->setHost($baseUri->getHost() . $baseUri->getPath());
 		}
 
 		// Since we're basing off of the IncomingRequest URI,

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -183,11 +183,17 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$config          = new App();
 		$config->baseURL = 'http://example.com/foo/public';
 		$request         = Services::request($config);
-		$request->uri    = new URI('http://example.com/foo/public/bar');
+		$request->uri    = (new URI())->setScheme('http://')->setHost('example.com/foo/public/')->setPath('bar');
 
 		Services::injectMock('request', $request);
 
 		$this->assertEquals('http://example.com/foo/public/bar', current_url());
+
+		$uri = current_url(true);
+		$this->assertEquals(['bar'], $uri->getSegments());
+		$this->assertEquals('bar', $uri->getSegment(1));
+		$this->assertEquals('example.com/foo/public/', $uri->getHost());
+		$this->assertEquals('http', $uri->getScheme());
 	}
 
 	/**


### PR DESCRIPTION
**Description**
This PR fixes the `current_url()` helper function to correctly propagate the `baseURL` when working in the subfolder.

Fixes #3594

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
