### PR TITLE
Make short HTTP protocol version acceptable

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -604,7 +604,7 @@ class CURLRequest extends Request
 			}
 			else if (strpos($header, 'HTTP') === 0)
 			{
-				preg_match('#^HTTP\/([12]\.[01]) ([0-9]+) (.+)#', $header, $matches);
+				preg_match('#^HTTP\/([12](?:\.[01])?) ([0-9]+) (.+)#', $header, $matches);
 
 				if (isset($matches[1]))
 				{

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -380,7 +380,7 @@ class Message
 		}
 
 		// Make sure that version is in the correct format
-		$version = number_format($version, 1);
+		$version = number_format((float) $version, 1);
 
 		if (! in_array($version, $this->validProtocolVersions, true))
 		{

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -379,6 +379,9 @@ class Message
 			$version = substr($version, strpos($version, '/') + 1);
 		}
 
+		// Make sure that version is in the correct format
+		$version = number_format($version, 1);
+
 		if (! in_array($version, $this->validProtocolVersions, true))
 		{
 			throw HTTPException::forInvalidHTTPProtocol(implode(', ', $this->validProtocolVersions));

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -814,6 +814,20 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
 		$this->assertEquals(234, $response->getStatusCode());
 	}
 
+	public function testResponseHeadersShortProtocol()
+	{
+		$request = $this->getRequest([
+			'base_uri' => 'http://www.foo.com/api/v1/',
+			'delay'    => 1000,
+		]);
+
+		$request->setOutput("HTTP/2 235 Ohoh\x0d\x0aAccept: text/html\x0d\x0a\x0d\x0aHi there shortie");
+		$response = $request->get('bogus');
+
+		$this->assertEquals('2.0', $response->getProtocolVersion());
+		$this->assertEquals(235, $response->getStatusCode());
+	}
+
 	//--------------------------------------------------------------------
 
 	public function testPostFormEncoded()


### PR DESCRIPTION
**Description**
This PR fix issue where the short HTTP protocol version is not acceptable.

Thanks to @JanZelenka for the regex update.

Fixes #3586

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
