### PR TITLE
URI class update for better handling of URLs with sub-folders

### DIFF
--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -596,11 +596,11 @@ class URI
 		// If hosted in a sub-folder, we will have additional
 		// segments that show up prior to the URI path we just
 		// grabbed from the request, so add it on if necessary.
-		$baseUri  = new URI(config(\Config\App::class)->baseURL);
-		$basePath = trim($baseUri->getPath(), '/') . '/';
+		$baseUri  = new self(config(\Config\App::class)->baseURL);
+		$basePath = rtrim($baseUri->getPath(), '/') . '/';
 		$path     = $this->getPath();
 
-		if ($basePath !== '/' && strpos($path, $basePath) !== 0)
+		if (! empty($basePath) && $basePath !== '/' && strpos($path, $basePath) !== 0)
 		{
 			$path = $basePath . $path;
 		}

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -600,7 +600,7 @@ class URI
 		$basePath = rtrim($baseUri->getPath(), '/') . '/';
 		$path     = $this->getPath();
 
-		if (! empty($basePath) && $basePath !== '/' && strpos($path, $basePath) !== 0)
+              if ($basePath !== '/' && strpos($path, $basePath) !== 0)
 		{
 			$path = $basePath . $path;
 		}

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -593,8 +593,20 @@ class URI
 	 */
 	public function __toString(): string
 	{
+		// If hosted in a sub-folder, we will have additional
+		// segments that show up prior to the URI path we just
+		// grabbed from the request, so add it on if necessary.
+		$baseUri  = new URI(config(\Config\App::class)->baseURL);
+		$basePath = trim($baseUri->getPath(), '/') . '/';
+		$path     = $this->getPath();
+
+		if ($basePath !== '/' && strpos($path, $basePath) !== 0)
+		{
+			$path = $basePath . $path;
+		}
+
 		return static::createURIString(
-						$this->getScheme(), $this->getAuthority(), $this->getPath(), // Absolute URIs should use a "/" for an empty path
+						$this->getScheme(), $this->getAuthority(), $path, // Absolute URIs should use a "/" for an empty path
 						$this->getQuery(), $this->getFragment()
 		);
 	}

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -163,16 +163,6 @@ if (! function_exists('current_url'))
 	{
 		$uri = clone \Config\Services::request()->uri;
 
-		// If hosted in a sub-folder, we will have additional
-		// segments that show up prior to the URI path we just
-		// grabbed from the request, so add it on if necessary.
-		$baseUri = new \CodeIgniter\HTTP\URI(config(\Config\App::class)->baseURL);
-
-		if (! empty($baseUri->getPath()))
-		{
-			$uri->setHost($baseUri->getHost() . rtrim($baseUri->getPath(), '/ ') . '/');
-		}
-
 		// Since we're basing off of the IncomingRequest URI,
 		// we are guaranteed to have a host based on our own configs.
 		return $returnObject ? $uri : (string) $uri->setQuery('');


### PR DESCRIPTION
**Description**
This PR fixes some issues with `URI` class when `baseURL` contains a sub-folder.

Now we get the same results as when we would get when calling `Services::request()`. Before, the results were polluted with `baseURI` path.

Also fixes #3603

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide