### PR TITLE
Use DocBlocks to document Config classes' properties

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -1,278 +1,434 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 
 class App extends BaseConfig
 {
-
-	/*
-	|--------------------------------------------------------------------------
-	| Base Site URL
-	|--------------------------------------------------------------------------
-	|
-	| URL to your CodeIgniter root. Typically this will be your base URL,
-	| WITH a trailing slash:
-	|
-	|	http://example.com/
-	|
-	| If this is not set then CodeIgniter will try guess the protocol, domain
-	| and path to your installation. However, you should always configure this
-	| explicitly and never rely on auto-guessing, especially in production
-	| environments.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Base Site URL
+	 * --------------------------------------------------------------------------
+	 *
+	 * URL to your CodeIgniter root. Typically this will be your base URL,
+	 * WITH a trailing slash:
+	 *
+	 *    http://example.com/
+	 *
+	 * If this is not set then CodeIgniter will try guess the protocol, domain
+	 * and path to your installation. However, you should always configure this
+	 * explicitly and never rely on auto-guessing, especially in production
+	 * environments.
+	 *
+	 * @var string
+	 */
 	public $baseURL = 'http://localhost:8080/';
 
-	/*
-	|--------------------------------------------------------------------------
-	| Index File
-	|--------------------------------------------------------------------------
-	|
-	| Typically this will be your index.php file, unless you've renamed it to
-	| something else. If you are using mod_rewrite to remove the page set this
-	| variable so that it is blank.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Index File
+	 * --------------------------------------------------------------------------
+	 *
+	 * Typically this will be your index.php file, unless you've renamed it to
+	 * something else. If you are using mod_rewrite to remove the page set this
+	 * variable so that it is blank.
+	 *
+	 * @var string
+	 */
 	public $indexPage = 'index.php';
 
-	/*
-	|--------------------------------------------------------------------------
-	| URI PROTOCOL
-	|--------------------------------------------------------------------------
-	|
-	| This item determines which getServer global should be used to retrieve the
-	| URI string.  The default setting of 'REQUEST_URI' works for most servers.
-	| If your links do not seem to work, try one of the other delicious flavors:
-	|
-	| 'REQUEST_URI'    Uses $_SERVER['REQUEST_URI']
-	| 'QUERY_STRING'   Uses $_SERVER['QUERY_STRING']
-	| 'PATH_INFO'      Uses $_SERVER['PATH_INFO']
-	|
-	| WARNING: If you set this to 'PATH_INFO', URIs will always be URL-decoded!
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * URI PROTOCOL
+	 * --------------------------------------------------------------------------
+	 *
+	 * This item determines which getServer global should be used to retrieve the
+	 * URI string.  The default setting of 'REQUEST_URI' works for most servers.
+	 * If your links do not seem to work, try one of the other delicious flavors:
+	 *
+	 * 'REQUEST_URI'    Uses $_SERVER['REQUEST_URI']
+	 * 'QUERY_STRING'   Uses $_SERVER['QUERY_STRING']
+	 * 'PATH_INFO'      Uses $_SERVER['PATH_INFO']
+	 *
+	 * WARNING: If you set this to 'PATH_INFO', URIs will always be URL-decoded!
+	 *
+	 * @var string
+	 */
 	public $uriProtocol = 'REQUEST_URI';
 
-	/*
-	|--------------------------------------------------------------------------
-	| Default Locale
-	|--------------------------------------------------------------------------
-	|
-	| The Locale roughly represents the language and location that your visitor
-	| is viewing the site from. It affects the language strings and other
-	| strings (like currency markers, numbers, etc), that your program
-	| should run under for this request.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Default Locale
+	 * --------------------------------------------------------------------------
+	 *
+	 * The Locale roughly represents the language and location that your visitor
+	 * is viewing the site from. It affects the language strings and other
+	 * strings (like currency markers, numbers, etc), that your program
+	 * should run under for this request.
+	 *
+	 * @var string
+	 */
 	public $defaultLocale = 'en';
 
-	/*
-	|--------------------------------------------------------------------------
-	| Negotiate Locale
-	|--------------------------------------------------------------------------
-	|
-	| If true, the current Request object will automatically determine the
-	| language to use based on the value of the Accept-Language header.
-	|
-	| If false, no automatic detection will be performed.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Negotiate Locale
+	 * --------------------------------------------------------------------------
+	 *
+	 * If true, the current Request object will automatically determine the
+	 * language to use based on the value of the Accept-Language header.
+	 *
+	 * If false, no automatic detection will be performed.
+	 *
+	 * @var boolean
+	 */
 	public $negotiateLocale = false;
 
-	/*
-	|--------------------------------------------------------------------------
-	| Supported Locales
-	|--------------------------------------------------------------------------
-	|
-	| If $negotiateLocale is true, this array lists the locales supported
-	| by the application in descending order of priority. If no match is
-	| found, the first locale will be used.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Supported Locales
+	 * --------------------------------------------------------------------------
+	 *
+	 * If $negotiateLocale is true, this array lists the locales supported
+	 * by the application in descending order of priority. If no match is
+	 * found, the first locale will be used.
+	 *
+	 * @var string[]
+	 */
 	public $supportedLocales = ['en'];
 
-	/*
-	|--------------------------------------------------------------------------
-	| Application Timezone
-	|--------------------------------------------------------------------------
-	|
-	| The default timezone that will be used in your application to display
-	| dates with the date helper, and can be retrieved through app_timezone()
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Application Timezone
+	 * --------------------------------------------------------------------------
+	 *
+	 * The default timezone that will be used in your application to display
+	 * dates with the date helper, and can be retrieved through app_timezone()
+	 *
+	 * @var string
+	 */
 	public $appTimezone = 'America/Chicago';
 
-	/*
-	|--------------------------------------------------------------------------
-	| Default Character Set
-	|--------------------------------------------------------------------------
-	|
-	| This determines which character set is used by default in various methods
-	| that require a character set to be provided.
-	|
-	| See http://php.net/htmlspecialchars for a list of supported charsets.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Default Character Set
+	 * --------------------------------------------------------------------------
+	 *
+	 * This determines which character set is used by default in various methods
+	 * that require a character set to be provided.
+	 *
+	 * @see http://php.net/htmlspecialchars for a list of supported charsets.
+	 *
+	 * @var string
+	 */
 	public $charset = 'UTF-8';
 
-	/*
-	|--------------------------------------------------------------------------
-	| URI PROTOCOL
-	|--------------------------------------------------------------------------
-	|
-	| If true, this will force every request made to this application to be
-	| made via a secure connection (HTTPS). If the incoming request is not
-	| secure, the user will be redirected to a secure version of the page
-	| and the HTTP Strict Transport Security header will be set.
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * URI PROTOCOL
+	 * --------------------------------------------------------------------------
+	 *
+	 * If true, this will force every request made to this application to be
+	 * made via a secure connection (HTTPS). If the incoming request is not
+	 * secure, the user will be redirected to a secure version of the page
+	 * and the HTTP Strict Transport Security header will be set.
+	 *
+	 * @var boolean
+	 */
 	public $forceGlobalSecureRequests = false;
 
-	/*
-	|--------------------------------------------------------------------------
-	| Session Variables
-	|--------------------------------------------------------------------------
-	|
-	| 'sessionDriver'
-	|
-	|	The storage driver to use: files, database, redis, memcached
-	|       - CodeIgniter\Session\Handlers\FileHandler
-	|       - CodeIgniter\Session\Handlers\DatabaseHandler
-	|       - CodeIgniter\Session\Handlers\MemcachedHandler
-	|       - CodeIgniter\Session\Handlers\RedisHandler
-	|
-	| 'sessionCookieName'
-	|
-	|	The session cookie name, must contain only [0-9a-z_-] characters
-	|
-	| 'sessionExpiration'
-	|
-	|	The number of SECONDS you want the session to last.
-	|	Setting to 0 (zero) means expire when the browser is closed.
-	|
-	| 'sessionSavePath'
-	|
-	|	The location to save sessions to, driver dependent.
-	|
-	|	For the 'files' driver, it's a path to a writable directory.
-	|	WARNING: Only absolute paths are supported!
-	|
-	|	For the 'database' driver, it's a table name.
-	|	Please read up the manual for the format with other session drivers.
-	|
-	|	IMPORTANT: You are REQUIRED to set a valid save path!
-	|
-	| 'sessionMatchIP'
-	|
-	|	Whether to match the user's IP address when reading the session data.
-	|
-	|	WARNING: If you're using the database driver, don't forget to update
-	|	         your session table's PRIMARY KEY when changing this setting.
-	|
-	| 'sessionTimeToUpdate'
-	|
-	|	How many seconds between CI regenerating the session ID.
-	|
-	| 'sessionRegenerateDestroy'
-	|
-	|	Whether to destroy session data associated with the old session ID
-	|	when auto-regenerating the session ID. When set to FALSE, the data
-	|	will be later deleted by the garbage collector.
-	|
-	| Other session cookie settings are shared with the rest of the application,
-	| except for 'cookie_prefix' and 'cookie_httponly', which are ignored here.
-	|
-	*/
-	public $sessionDriver            = 'CodeIgniter\Session\Handlers\FileHandler';
-	public $sessionCookieName        = 'ci_session';
-	public $sessionExpiration        = 7200;
-	public $sessionSavePath          = WRITEPATH . 'session';
-	public $sessionMatchIP           = false;
-	public $sessionTimeToUpdate      = 300;
+	/**
+	 * --------------------------------------------------------------------------
+	 * Session Driver
+	 * --------------------------------------------------------------------------
+	 *
+	 * The session storage driver to use:
+	 * - `CodeIgniter\Session\Handlers\FileHandler`
+	 * - `CodeIgniter\Session\Handlers\DatabaseHandler`
+	 * - `CodeIgniter\Session\Handlers\MemcachedHandler`
+	 * - `CodeIgniter\Session\Handlers\RedisHandler`
+	 *
+	 * @var string
+	 */
+	public $sessionDriver = 'CodeIgniter\Session\Handlers\FileHandler';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Session Cookie Name
+	 * --------------------------------------------------------------------------
+	 *
+	 * The session cookie name, must contain only [0-9a-z_-] characters
+	 *
+	 * @var string
+	 */
+	public $sessionCookieName = 'ci_session';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Session Expiration
+	 * --------------------------------------------------------------------------
+	 *
+	 * The number of SECONDS you want the session to last.
+	 * Setting to 0 (zero) means expire when the browser is closed.
+	 *
+	 * @var integer
+	 */
+	public $sessionExpiration = 7200;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Session Save Path
+	 * --------------------------------------------------------------------------
+	 *
+	 * The location to save sessions to and is driver dependent.
+	 *
+	 * For the 'files' driver, it's a path to a writable directory.
+	 * WARNING: Only absolute paths are supported!
+	 *
+	 * For the 'database' driver, it's a table name.
+	 * Please read up the manual for the format with other session drivers.
+	 *
+	 * IMPORTANT: You are REQUIRED to set a valid save path!
+	 *
+	 * @var string
+	 */
+	public $sessionSavePath = WRITEPATH . 'session';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Session Match IP
+	 * --------------------------------------------------------------------------
+	 *
+	 * Whether to match the user's IP address when reading the session data.
+	 *
+	 * WARNING: If you're using the database driver, don't forget to update
+	 *          your session table's PRIMARY KEY when changing this setting.
+	 *
+	 * @var boolean
+	 */
+	public $sessionMatchIP = false;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Session Time to Update
+	 * --------------------------------------------------------------------------
+	 *
+	 * How many seconds between CI regenerating the session ID.
+	 *
+	 * @var integer
+	 */
+	public $sessionTimeToUpdate = 300;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Session Regenerate Destroy
+	 * --------------------------------------------------------------------------
+	 *
+	 * Whether to destroy session data associated with the old session ID
+	 * when auto-regenerating the session ID. When set to FALSE, the data
+	 * will be later deleted by the garbage collector.
+	 *
+	 * @var boolean
+	 */
 	public $sessionRegenerateDestroy = false;
 
-	/*
-	|--------------------------------------------------------------------------
-	| Cookie Related Variables
-	|--------------------------------------------------------------------------
-	|
-	| 'cookiePrefix'   = Set a cookie name prefix if you need to avoid collisions
-	| 'cookieDomain'   = Set to .your-domain.com for site-wide cookies
-	| 'cookiePath'     = Typically will be a forward slash
-	| 'cookieSecure'   = Cookie will only be set if a secure HTTPS connection exists.
-	| 'cookieHTTPOnly' = Cookie will only be accessible via HTTP(S) (no javascript)
-	| 'cookieSameSite' = Configure cookie SameSite setting. Allowed values are 'None',
-	|                    'Strict', 'Lax' or ''. Defaults to 'Lax' for compatibility
-	|                    with modern browsers. '' means no SameSite attribute is set on
-	|                    cookies. If set to 'None', cookieSecure must also be set.
-	|
-	| Note: These settings (with the exception of 'cookie_prefix' and
-	|       'cookie_httponly') will also affect sessions.
-	|
-	*/
-	public $cookiePrefix   = '';
-	public $cookieDomain   = '';
-	public $cookiePath     = '/';
-	public $cookieSecure   = false;
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie Prefix
+	 * --------------------------------------------------------------------------
+	 *
+	 * Set a cookie name prefix if you need to avoid collisions.
+	 *
+	 * @var string
+	 */
+	public $cookiePrefix = '';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie Domain
+	 * --------------------------------------------------------------------------
+	 *
+	 * Set to `.your-domain.com` for site-wide cookies.
+	 *
+	 * @var string
+	 */
+	public $cookieDomain = '';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie Path
+	 * --------------------------------------------------------------------------
+	 *
+	 * Typically will be a forward slash.
+	 *
+	 * @var string
+	 */
+	public $cookiePath = '/';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie Secure
+	 * --------------------------------------------------------------------------
+	 *
+	 * Cookie will only be set if a secure HTTPS connection exists.
+	 *
+	 * @var boolean
+	 */
+	public $cookieSecure = false;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie HTTP Only
+	 * --------------------------------------------------------------------------
+	 *
+	 * Cookie will only be accessible via HTTP(S) (no JavaScript).
+	 *
+	 * @var boolean
+	 */
 	public $cookieHTTPOnly = false;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie SameSite
+	 * --------------------------------------------------------------------------
+	 *
+	 * Configure cookie SameSite setting. Allowed values are:
+	 * - None
+	 * - Lax
+	 * - Strict
+	 * - ''
+	 *
+	 * Defaults to `Lax` for compatibility with modern browsers. Setting `''`
+	 * (empty string) means no SameSite attribute will be set on cookies. If
+	 * set to `None`, `$cookieSecure` must also be set.
+	 *
+	 * @var string
+	 */
 	public $cookieSameSite = 'Lax';
 
-	/*
-	|--------------------------------------------------------------------------
-	| Reverse Proxy IPs
-	|--------------------------------------------------------------------------
-	|
-	| If your server is behind a reverse proxy, you must whitelist the proxy
-	| IP addresses from which CodeIgniter should trust headers such as
-	| HTTP_X_FORWARDED_FOR and HTTP_CLIENT_IP in order to properly identify
-	| the visitor's IP address.
-	|
-	| You can use both an array or a comma-separated list of proxy addresses,
-	| as well as specifying whole subnets. Here are a few examples:
-	|
-	| Comma-separated:	'10.0.1.200,192.168.5.0/24'
-	| Array:		array('10.0.1.200', '192.168.5.0/24')
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Reverse Proxy IPs
+	 * --------------------------------------------------------------------------
+	 *
+	 * If your server is behind a reverse proxy, you must whitelist the proxy
+	 * IP addresses from which CodeIgniter should trust headers such as
+	 * HTTP_X_FORWARDED_FOR and HTTP_CLIENT_IP in order to properly identify
+	 * the visitor's IP address.
+	 *
+	 * You can use both an array or a comma-separated list of proxy addresses,
+	 * as well as specifying whole subnets. Here are a few examples:
+	 *
+	 * Comma-separated:	'10.0.1.200,192.168.5.0/24'
+	 * Array: ['10.0.1.200', '192.168.5.0/24']
+	 *
+	 * @var string|string[]
+	 */
 	public $proxyIPs = '';
 
-	/*
-	|--------------------------------------------------------------------------
-	| Cross Site Request Forgery
-	|--------------------------------------------------------------------------
-	| Enables a CSRF cookie token to be set. When set to TRUE, token will be
-	| checked on a submitted form. If you are accepting user data, it is strongly
-	| recommended CSRF protection be enabled.
-	|
-	| CSRFTokenName   = The token name
-	| CSRFHeaderName  = The header name
-	| CSRFCookieName  = The cookie name
-	| CSRFExpire      = The number in seconds the token should expire.
-	| CSRFRegenerate  = Regenerate token on every submission
-	| CSRFRedirect    = Redirect to previous page with error on failure
-	| CSRFSameSite    = Setting for the SameSite CSRF cookie token. Default setting
-	|                   'Lax' as recommended in:
-	|                   https://portswigger.net/web-security/csrf/samesite-cookies
-	|                   Allowed values are: 'None', 'Strict', 'Lax' or ''.
-	*/
-	public $CSRFTokenName  = 'csrf_test_name';
-	public $CSRFHeaderName = 'X-CSRF-TOKEN';
-	public $CSRFCookieName = 'csrf_cookie_name';
-	public $CSRFExpire     = 7200;
-	public $CSRFRegenerate = true;
-	public $CSRFRedirect   = true;
-	public $CSRFSameSite   = 'Lax';
+	/**
+	 * --------------------------------------------------------------------------
+	 * CSRF Token Name
+	 * --------------------------------------------------------------------------
+	 *
+	 * The token name.
+	 *
+	 * @var string
+	 */
+	public $CSRFTokenName = 'csrf_test_name';
 
-	/*
-	|--------------------------------------------------------------------------
-	| Content Security Policy
-	|--------------------------------------------------------------------------
-	| Enables the Response's Content Secure Policy to restrict the sources that
-	| can be used for images, scripts, CSS files, audio, video, etc. If enabled,
-	| the Response object will populate default values for the policy from the
-	| ContentSecurityPolicy.php file. Controllers can always add to those
-	| restrictions at run time.
-	|
-	| For a better understanding of CSP, see these documents:
-	|   - http://www.html5rocks.com/en/tutorials/security/content-security-policy/
-	|   - http://www.w3.org/TR/CSP/
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * CSRF Header Name
+	 * --------------------------------------------------------------------------
+	 *
+	 * The header name.
+	 *
+	 * @var string
+	 */
+	public $CSRFHeaderName = 'X-CSRF-TOKEN';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * CSRF Cookie Name
+	 * --------------------------------------------------------------------------
+	 *
+	 * The cookie name.
+	 *
+	 * @var string
+	 */
+	public $CSRFCookieName = 'csrf_cookie_name';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * CSRF Expire
+	 * --------------------------------------------------------------------------
+	 *
+	 * The number in seconds the token should expire.
+	 *
+	 * @var integer
+	 */
+	public $CSRFExpire = 7200;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * CSRF Regenerate
+	 * --------------------------------------------------------------------------
+	 *
+	 * Regenerate token on every submission?
+	 *
+	 * @var boolean
+	 */
+	public $CSRFRegenerate = true;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * CSRF Redirect
+	 * --------------------------------------------------------------------------
+	 *
+	 * Redirect to previous page with error on failure?
+	 *
+	 * @var boolean
+	 */
+	public $CSRFRedirect = true;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * CSRF SameSite
+	 * --------------------------------------------------------------------------
+	 *
+	 * Setting for CSRF SameSite cookie token. Allowed values are:
+	 * - None
+	 * - Lax
+	 * - Strict
+	 * - ''
+	 *
+	 * Defaults to `Lax` as recommended in this link:
+	 *
+	 * @see https://portswigger.net/web-security/csrf/samesite-cookies
+	 *
+	 * @var string
+	 */
+	public $CSRFSameSite = 'Lax';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Content Security Policy
+	 * --------------------------------------------------------------------------
+	 *
+	 * Enables the Response's Content Secure Policy to restrict the sources that
+	 * can be used for images, scripts, CSS files, audio, video, etc. If enabled,
+	 * the Response object will populate default values for the policy from the
+	 * `ContentSecurityPolicy.php` file. Controllers can always add to those
+	 * restrictions at run time.
+	 *
+	 * For a better understanding of CSP, see these documents:
+	 *
+	 * @see http://www.html5rocks.com/en/tutorials/security/content-security-policy/
+	 * @see http://www.w3.org/TR/CSP/
+	 *
+	 * @var boolean
+	 */
 	public $CSPEnabled = false;
 }

--- a/app/Config/Autoload.php
+++ b/app/Config/Autoload.php
@@ -8,6 +8,7 @@ use CodeIgniter\Config\AutoloadConfig;
  * -------------------------------------------------------------------
  * AUTO-LOADER
  * -------------------------------------------------------------------
+ *
  * This file defines the namespaces and class maps so the Autoloader
  * can find the files as needed.
  *
@@ -36,7 +37,7 @@ class Autoload extends AutoloadConfig
 	 *       'App'	       => APPPATH
 	 *   ];
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	public $psr4 = [
 		APP_NAMESPACE => APPPATH, // For custom app namespace
@@ -59,7 +60,7 @@ class Autoload extends AutoloadConfig
 	 *       'MyClass'   => '/path/to/class/file.php'
 	 *   ];
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	public $classmap = [];
 }

--- a/app/Config/Boot/development.php
+++ b/app/Config/Boot/development.php
@@ -1,32 +1,32 @@
 <?php
+
 /*
-  |--------------------------------------------------------------------------
-  | ERROR DISPLAY
-  |--------------------------------------------------------------------------
-  | In development, we want to show as many errors as possible to help
-  | make sure they don't make it to production. And save us hours of
-  | painful debugging.
+ |--------------------------------------------------------------------------
+ | ERROR DISPLAY
+ |--------------------------------------------------------------------------
+ | In development, we want to show as many errors as possible to help
+ | make sure they don't make it to production. And save us hours of
+ | painful debugging.
  */
 error_reporting(-1);
 ini_set('display_errors', '1');
 
 /*
-  |--------------------------------------------------------------------------
-  | DEBUG BACKTRACES
-  |--------------------------------------------------------------------------
-  | If true, this constant will tell the error screens to display debug
-  | backtraces along with the other error information. If you would
-  | prefer to not see this, set this value to false.
+ |--------------------------------------------------------------------------
+ | DEBUG BACKTRACES
+ |--------------------------------------------------------------------------
+ | If true, this constant will tell the error screens to display debug
+ | backtraces along with the other error information. If you would
+ | prefer to not see this, set this value to false.
  */
 defined('SHOW_DEBUG_BACKTRACE') || define('SHOW_DEBUG_BACKTRACE', true);
 
 /*
-  |--------------------------------------------------------------------------
-  | DEBUG MODE
-  |--------------------------------------------------------------------------
-  | Debug mode is an experimental flag that can allow changes throughout
-  | the system. This will control whether Kint is loaded, and a few other
-  | items. It can always be used within your own application too.
+ |--------------------------------------------------------------------------
+ | DEBUG MODE
+ |--------------------------------------------------------------------------
+ | Debug mode is an experimental flag that can allow changes throughout
+ | the system. This will control whether Kint is loaded, and a few other
+ | items. It can always be used within your own application too.
  */
-
 defined('CI_DEBUG') || define('CI_DEBUG', true);

--- a/app/Config/Boot/production.php
+++ b/app/Config/Boot/production.php
@@ -1,22 +1,21 @@
 <?php
 
 /*
-  |--------------------------------------------------------------------------
-  | ERROR DISPLAY
-  |--------------------------------------------------------------------------
-  | Don't show ANY in production environments. Instead, let the system catch
-  | it and display a generic error message.
+ |--------------------------------------------------------------------------
+ | ERROR DISPLAY
+ |--------------------------------------------------------------------------
+ | Don't show ANY in production environments. Instead, let the system catch
+ | it and display a generic error message.
  */
 ini_set('display_errors', '0');
 error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT & ~E_USER_NOTICE & ~E_USER_DEPRECATED);
 
 /*
-  |--------------------------------------------------------------------------
-  | DEBUG MODE
-  |--------------------------------------------------------------------------
-  | Debug mode is an experimental flag that can allow changes throughout
-  | the system. It's not widely used currently, and may not survive
-  | release of the framework.
+ |--------------------------------------------------------------------------
+ | DEBUG MODE
+ |--------------------------------------------------------------------------
+ | Debug mode is an experimental flag that can allow changes throughout
+ | the system. It's not widely used currently, and may not survive
+ | release of the framework.
  */
-
 defined('CI_DEBUG') || define('CI_DEBUG', false);

--- a/app/Config/Boot/testing.php
+++ b/app/Config/Boot/testing.php
@@ -1,33 +1,32 @@
 <?php
 
 /*
-  |--------------------------------------------------------------------------
-  | ERROR DISPLAY
-  |--------------------------------------------------------------------------
-  | In development, we want to show as many errors as possible to help
-  | make sure they don't make it to production. And save us hours of
-  | painful debugging.
+ |--------------------------------------------------------------------------
+ | ERROR DISPLAY
+ |--------------------------------------------------------------------------
+ | In development, we want to show as many errors as possible to help
+ | make sure they don't make it to production. And save us hours of
+ | painful debugging.
  */
 error_reporting(-1);
 ini_set('display_errors', '1');
 
 /*
-  |--------------------------------------------------------------------------
-  | DEBUG BACKTRACES
-  |--------------------------------------------------------------------------
-  | If true, this constant will tell the error screens to display debug
-  | backtraces along with the other error information. If you would
-  | prefer to not see this, set this value to false.
+ |--------------------------------------------------------------------------
+ | DEBUG BACKTRACES
+ |--------------------------------------------------------------------------
+ | If true, this constant will tell the error screens to display debug
+ | backtraces along with the other error information. If you would
+ | prefer to not see this, set this value to false.
  */
 defined('SHOW_DEBUG_BACKTRACE') || define('SHOW_DEBUG_BACKTRACE', true);
 
 /*
-  |--------------------------------------------------------------------------
-  | DEBUG MODE
-  |--------------------------------------------------------------------------
-  | Debug mode is an experimental flag that can allow changes throughout
-  | the system. It's not widely used currently, and may not survive
-  | release of the framework.
+ |--------------------------------------------------------------------------
+ | DEBUG MODE
+ |--------------------------------------------------------------------------
+ | Debug mode is an experimental flag that can allow changes throughout
+ | the system. It's not widely used currently, and may not survive
+ | release of the framework.
  */
-
 defined('CI_DEBUG') || define('CI_DEBUG', true);

--- a/app/Config/Cache.php
+++ b/app/Config/Cache.php
@@ -1,82 +1,90 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 
 class Cache extends BaseConfig
 {
-	/*
-	|--------------------------------------------------------------------------
-	| Primary Handler
-	|--------------------------------------------------------------------------
-	|
-	| The name of the preferred handler that should be used. If for some reason
-	| it is not available, the $backupHandler will be used in its place.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Primary Handler
+	 * --------------------------------------------------------------------------
+	 *
+	 * The name of the preferred handler that should be used. If for some reason
+	 * it is not available, the $backupHandler will be used in its place.
+	 *
+	 * @var string
+	 */
 	public $handler = 'file';
 
-	/*
-	|--------------------------------------------------------------------------
-	| Backup Handler
-	|--------------------------------------------------------------------------
-	|
-	| The name of the handler that will be used in case the first one is
-	| unreachable. Often, 'file' is used here since the filesystem is
-	| always available, though that's not always practical for the app.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Backup Handler
+	 * --------------------------------------------------------------------------
+	 *
+	 * The name of the handler that will be used in case the first one is
+	 * unreachable. Often, 'file' is used here since the filesystem is
+	 * always available, though that's not always practical for the app.
+	 *
+	 * @var string
+	 */
 	public $backupHandler = 'dummy';
 
-	/*
-	|--------------------------------------------------------------------------
-	| Cache Directory Path
-	|--------------------------------------------------------------------------
-	|
-	| The path to where cache files should be stored, if using a file-based
-	| system.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cache Directory Path
+	 * --------------------------------------------------------------------------
+	 *
+	 * The path to where cache files should be stored, if using a file-based
+	 * system.
+	 *
+	 * @var string
+	 */
 	public $storePath = WRITEPATH . 'cache/';
 
-	/*
-	|--------------------------------------------------------------------------
-	| Cache Include Query String
-	|--------------------------------------------------------------------------
-	|
-	| Whether to take the URL query string into consideration when generating
-	| output cache files. Valid options are:
-	|
-	|	false      = Disabled
-	|	true       = Enabled, take all query parameters into account.
-	|	             Please be aware that this may result in numerous cache
-	|	             files generated for the same page over and over again.
-	|	array('q') = Enabled, but only take into account the specified list
-	|	             of query parameters.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cache Include Query String
+	 * --------------------------------------------------------------------------
+	 *
+	 * Whether to take the URL query string into consideration when generating
+	 * output cache files. Valid options are:
+	 *
+	 *    false      = Disabled
+	 *    true       = Enabled, take all query parameters into account.
+	 *                 Please be aware that this may result in numerous cache
+	 *                 files generated for the same page over and over again.
+	 *    array('q') = Enabled, but only take into account the specified list
+	 *                 of query parameters.
+	 *
+	 * @var boolean|string[]
+	 */
 	public $cacheQueryString = false;
 
-	/*
-	|--------------------------------------------------------------------------
-	| Key Prefix
-	|--------------------------------------------------------------------------
-	|
-	| This string is added to all cache item names to help avoid collisions
-	| if you run multiple applications with the same cache engine.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Key Prefix
+	 * --------------------------------------------------------------------------
+	 *
+	 * This string is added to all cache item names to help avoid collisions
+	 * if you run multiple applications with the same cache engine.
+	 *
+	 * @var string
+	 */
 	public $prefix = '';
 
-	/*
-	| -------------------------------------------------------------------------
-	| Memcached settings
-	| -------------------------------------------------------------------------
-	| Your Memcached servers can be specified below, if you are using
-	| the Memcached drivers.
-	|
-	|	See: https://codeigniter.com/user_guide/libraries/caching.html#memcached
-	|
-	*/
+	/**
+	 * -------------------------------------------------------------------------
+	 * Memcached settings
+	 * -------------------------------------------------------------------------
+	 * Your Memcached servers can be specified below, if you are using
+	 * the Memcached drivers.
+	 *
+	 * @see https://codeigniter.com/user_guide/libraries/caching.html#memcached
+	 *
+	 * @var array<string, string|int|boolean>
+	 */
 	public $memcached = [
 		'host'   => '127.0.0.1',
 		'port'   => 11211,
@@ -84,14 +92,15 @@ class Cache extends BaseConfig
 		'raw'    => false,
 	];
 
-	/*
-	| -------------------------------------------------------------------------
-	| Redis settings
-	| -------------------------------------------------------------------------
-	| Your Redis server can be specified below, if you are using
-	| the Redis or Predis drivers.
-	|
-	*/
+	/**
+	 * -------------------------------------------------------------------------
+	 * Redis settings
+	 * -------------------------------------------------------------------------
+	 * Your Redis server can be specified below, if you are using
+	 * the Redis or Predis drivers.
+	 *
+	 * @var array<string, string|int|null>
+	 */
 	public $redis = [
 		'host'     => '127.0.0.1',
 		'password' => null,
@@ -100,15 +109,16 @@ class Cache extends BaseConfig
 		'database' => 0,
 	];
 
-	/*
-	|--------------------------------------------------------------------------
-	| Available Cache Handlers
-	|--------------------------------------------------------------------------
-	|
-	| This is an array of cache engine alias' and class names. Only engines
-	| that are listed here are allowed to be used.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Available Cache Handlers
+	 * --------------------------------------------------------------------------
+	 *
+	 * This is an array of cache engine alias' and class names. Only engines
+	 * that are listed here are allowed to be used.
+	 *
+	 * @var array<string, string>
+	 */
 	public $validHandlers = [
 		'dummy'     => \CodeIgniter\Cache\Handlers\DummyHandler::class,
 		'file'      => \CodeIgniter\Cache\Handlers\FileHandler::class,

--- a/app/Config/Constants.php
+++ b/app/Config/Constants.php
@@ -1,36 +1,38 @@
 <?php
 
-//--------------------------------------------------------------------
-// App Namespace
-//--------------------------------------------------------------------
-// This defines the default Namespace that is used throughout
-// CodeIgniter to refer to the Application directory. Change
-// this constant to change the namespace that all application
-// classes should use.
-//
-// NOTE: changing this will require manually modifying the
-// existing namespaces of App\* namespaced-classes.
-//
+/*
+ | --------------------------------------------------------------------
+ | App Namespace
+ | --------------------------------------------------------------------
+ |
+ | This defines the default Namespace that is used throughout
+ | CodeIgniter to refer to the Application directory. Change
+ | this constant to change the namespace that all application
+ | classes should use.
+ |
+ | NOTE: changing this will require manually modifying the
+ | existing namespaces of App\* namespaced-classes.
+ */
 defined('APP_NAMESPACE') || define('APP_NAMESPACE', 'App');
 
 /*
-|--------------------------------------------------------------------------
-| Composer Path
-|--------------------------------------------------------------------------
-|
-| The path that Composer's autoload file is expected to live. By default,
-| the vendor folder is in the Root directory, but you can customize that here.
-*/
+ | --------------------------------------------------------------------------
+ | Composer Path
+ | --------------------------------------------------------------------------
+ |
+ | The path that Composer's autoload file is expected to live. By default,
+ | the vendor folder is in the Root directory, but you can customize that here.
+ */
 defined('COMPOSER_PATH') || define('COMPOSER_PATH', ROOTPATH . 'vendor/autoload.php');
 
 /*
-|--------------------------------------------------------------------------
-| Timing Constants
-|--------------------------------------------------------------------------
-|
-| Provide simple ways to work with the myriad of PHP functions that
-| require information to be in seconds.
-*/
+ |--------------------------------------------------------------------------
+ | Timing Constants
+ |--------------------------------------------------------------------------
+ |
+ | Provide simple ways to work with the myriad of PHP functions that
+ | require information to be in seconds.
+ */
 defined('SECOND') || define('SECOND', 1);
 defined('MINUTE') || define('MINUTE', 60);
 defined('HOUR')   || define('HOUR', 3600);
@@ -41,30 +43,30 @@ defined('YEAR')   || define('YEAR', 31536000);
 defined('DECADE') || define('DECADE', 315360000);
 
 /*
-|--------------------------------------------------------------------------
-| Exit Status Codes
-|--------------------------------------------------------------------------
-|
-| Used to indicate the conditions under which the script is exit()ing.
-| While there is no universal standard for error codes, there are some
-| broad conventions.  Three such conventions are mentioned below, for
-| those who wish to make use of them.  The CodeIgniter defaults were
-| chosen for the least overlap with these conventions, while still
-| leaving room for others to be defined in future versions and user
-| applications.
-|
-| The three main conventions used for determining exit status codes
-| are as follows:
-|
-|    Standard C/C++ Library (stdlibc):
-|       http://www.gnu.org/software/libc/manual/html_node/Exit-Status.html
-|       (This link also contains other GNU-specific conventions)
-|    BSD sysexits.h:
-|       http://www.gsp.com/cgi-bin/man.cgi?section=3&topic=sysexits
-|    Bash scripting:
-|       http://tldp.org/LDP/abs/html/exitcodes.html
-|
-*/
+ | --------------------------------------------------------------------------
+ | Exit Status Codes
+ | --------------------------------------------------------------------------
+ |
+ | Used to indicate the conditions under which the script is exit()ing.
+ | While there is no universal standard for error codes, there are some
+ | broad conventions.  Three such conventions are mentioned below, for
+ | those who wish to make use of them.  The CodeIgniter defaults were
+ | chosen for the least overlap with these conventions, while still
+ | leaving room for others to be defined in future versions and user
+ | applications.
+ |
+ | The three main conventions used for determining exit status codes
+ | are as follows:
+ |
+ |    Standard C/C++ Library (stdlibc):
+ |       http://www.gnu.org/software/libc/manual/html_node/Exit-Status.html
+ |       (This link also contains other GNU-specific conventions)
+ |    BSD sysexits.h:
+ |       http://www.gsp.com/cgi-bin/man.cgi?section=3&topic=sysexits
+ |    Bash scripting:
+ |       http://tldp.org/LDP/abs/html/exitcodes.html
+ |
+ */
 defined('EXIT_SUCCESS')        || define('EXIT_SUCCESS', 0); // no errors
 defined('EXIT_ERROR')          || define('EXIT_ERROR', 1); // generic error
 defined('EXIT_CONFIG')         || define('EXIT_CONFIG', 3); // configuration error

--- a/app/Config/ContentSecurityPolicy.php
+++ b/app/Config/ContentSecurityPolicy.php
@@ -1,4 +1,6 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 
@@ -11,8 +13,6 @@ use CodeIgniter\Config\BaseConfig;
  *
  * Suggested reference for explanations:
  *    https://www.html5rocks.com/en/tutorials/security/content-security-policy/
- *
- * @package Config
  */
 class ContentSecurityPolicy extends BaseConfig
 {

--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -1,12 +1,13 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
+
+use CodeIgniter\Database\Config;
 
 /**
  * Database Configuration
- *
- * @package Config
  */
-
-class Database extends \CodeIgniter\Database\Config
+class Database extends Config
 {
 	/**
 	 * The directory that holds the Migrations
@@ -14,7 +15,7 @@ class Database extends \CodeIgniter\Database\Config
 	 *
 	 * @var string
 	 */
-	public $filesPath = APPPATH . 'Database/';
+	public $filesPath = APPPATH . 'Database' . DIRECTORY_SEPARATOR;
 
 	/**
 	 * Lets you choose which connection group to

--- a/app/Config/DocTypes.php
+++ b/app/Config/DocTypes.php
@@ -1,15 +1,15 @@
-<?php namespace Config;
+<?php
 
-/**
- * DocTypes
- *
- * @package Config
- */
+namespace Config;
 
 class DocTypes
 {
-	public $list =
-	[
+	/**
+	 * List of valid document types.
+	 *
+	 * @var array<string, string>
+	 */
+	public $list = [
 		'xhtml11'           => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">',
 		'xhtml1-strict'     => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">',
 		'xhtml1-trans'      => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">',

--- a/app/Config/Email.php
+++ b/app/Config/Email.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 
 class Email extends BaseConfig
 {
-
 	/**
 	 * @var string
 	 */

--- a/app/Config/Encryption.php
+++ b/app/Config/Encryption.php
@@ -12,33 +12,39 @@ use CodeIgniter\Config\BaseConfig;
  */
 class Encryption extends BaseConfig
 {
-	/*
-	 |--------------------------------------------------------------------------
-	 | Encryption Key Starter
-	 |--------------------------------------------------------------------------
-	 |
-	 | If you use the Encryption class you must set an encryption key (seed).
-	 | You need to ensure it is long enough for the cipher and mode you plan to use.
-	 | See the user guide for more info.
+	/**
+	 * --------------------------------------------------------------------------
+	 * Encryption Key Starter
+	 * --------------------------------------------------------------------------
+	 *
+	 * If you use the Encryption class you must set an encryption key (seed).
+	 * You need to ensure it is long enough for the cipher and mode you plan to use.
+	 * See the user guide for more info.
+	 *
+	 * @var string
 	 */
 	public $key = '';
 
-	/*
-	 |--------------------------------------------------------------------------
-	 | Encryption driver to use
-	 |--------------------------------------------------------------------------
-	 |
-	 | One of the supported drivers, e.g. 'OpenSSL' or 'Sodium'.
-	 | The default driver, if you don't specify one, is 'OpenSSL'.
+	/**
+	 * --------------------------------------------------------------------------
+	 * Encryption Driver to Use
+	 * --------------------------------------------------------------------------
+	 *
+	 * One of the supported drivers, e.g. 'OpenSSL' or 'Sodium'.
+	 * The default driver, if you don't specify one, is 'OpenSSL'.
+	 *
+	 * @var string
 	 */
 	public $driver = 'OpenSSL';
 
-	/*
-	 |--------------------------------------------------------------------------
-	 | Encryption digest
-	 |--------------------------------------------------------------------------
-	 |
-	 | HMAC digest to use, e.g. 'SHA512' or 'SHA256'. Default value is 'SHA512'.
+	/**
+	 * --------------------------------------------------------------------------
+	 * Encryption digest
+	 * --------------------------------------------------------------------------
+	 *
+	 * HMAC digest to use, e.g. 'SHA512' or 'SHA256'. Default value is 'SHA512'.
+	 *
+	 * @var string
 	 */
 	public $digest = 'SHA512';
 }

--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -1,4 +1,6 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\FrameworkException;

--- a/app/Config/Exceptions.php
+++ b/app/Config/Exceptions.php
@@ -1,42 +1,48 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 
 /**
  * Setup how the exception handler works.
- *
- * @package Config
  */
 class Exceptions extends BaseConfig
 {
-	/*
-	 |--------------------------------------------------------------------------
-	 | LOG EXCEPTIONS?
-	 |--------------------------------------------------------------------------
-	 | If true, then exceptions will be logged
-	 | through Services::Log.
-	 |
-	 | Default: true
+	/**
+	 * --------------------------------------------------------------------------
+	 * LOG EXCEPTIONS?
+	 * --------------------------------------------------------------------------
+	 * If true, then exceptions will be logged
+	 * through Services::Log.
+	 *
+	 * Default: true
+	 *
+	 * @var boolean
 	 */
 	public $log = true;
 
-	/*
-	 |--------------------------------------------------------------------------
-	 | DO NOT LOG STATUS CODES
-	 |--------------------------------------------------------------------------
-	 | Any status codes here will NOT be logged if logging is turned on.
-	 | By default, only 404 (Page Not Found) exceptions are ignored.
+	/**
+	 * --------------------------------------------------------------------------
+	 * DO NOT LOG STATUS CODES
+	 * --------------------------------------------------------------------------
+	 * Any status codes here will NOT be logged if logging is turned on.
+	 * By default, only 404 (Page Not Found) exceptions are ignored.
+	 *
+	 * @var array
 	 */
-	public $ignoreCodes = [ 404 ];
+	public $ignoreCodes = [404];
 
-	/*
-	|--------------------------------------------------------------------------
-	| Error Views Path
-	|--------------------------------------------------------------------------
-	| This is the path to the directory that contains the 'cli' and 'html'
-	| directories that hold the views used to generate errors.
-	|
-	| Default: APPPATH.'Views/errors'
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Error Views Path
+	 * --------------------------------------------------------------------------
+	 * This is the path to the directory that contains the 'cli' and 'html'
+	 * directories that hold the views used to generate errors.
+	 *
+	 * Default: APPPATH.'Views/errors'
+	 *
+	 * @var string
+	 */
 	public $errorViewPath = APPPATH . 'Views/errors';
 }

--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -1,36 +1,59 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 
 class Filters extends BaseConfig
 {
-	// Makes reading things below nicer,
-	// and simpler to change out script that's used.
+	/**
+	 * Configures aliases for Filter classes to
+	 * make reading things nicer and simpler.
+	 *
+	 * @var array
+	 */
 	public $aliases = [
 		'csrf'     => \CodeIgniter\Filters\CSRF::class,
 		'toolbar'  => \CodeIgniter\Filters\DebugToolbar::class,
 		'honeypot' => \CodeIgniter\Filters\Honeypot::class,
 	];
 
-	// Always applied before every request
+	/**
+	 * List of filter aliases that are always
+	 * applied before and after every request.
+	 *
+	 * @var array
+	 */
 	public $globals = [
 		'before' => [
-			//'honeypot'
+			// 'honeypot',
 			// 'csrf',
 		],
 		'after'  => [
 			'toolbar',
-			//'honeypot'
+			// 'honeypot',
 		],
 	];
 
-	// Works on all of a particular HTTP method
-	// (GET, POST, etc) as BEFORE filters only
-	//     like: 'post' => ['CSRF', 'throttle'],
+	/**
+	 * List of filter aliases that works on a
+	 * particular HTTP method (GET, POST, etc.).
+	 *
+	 * Example:
+	 * 'post' => ['csrf', 'throttle']
+	 *
+	 * @var array
+	 */
 	public $methods = [];
 
-	// List filter aliases and any before/after uri patterns
-	// that they should run on, like:
-	//    'isLoggedIn' => ['before' => ['account/*', 'profiles/*']],
+	/**
+	 * List of filter aliases that should run on any
+	 * before or after URI patterns.
+	 *
+	 * Example:
+	 * 'isLoggedIn' => ['before' => ['account/*', 'profiles/*']]
+	 *
+	 * @var array
+	 */
 	public $filters = [];
 }

--- a/app/Config/ForeignCharacters.php
+++ b/app/Config/ForeignCharacters.php
@@ -1,6 +1,9 @@
-<?php namespace Config;
+<?php
 
-class ForeignCharacters extends \CodeIgniter\Config\ForeignCharacters
+namespace Config;
+
+use CodeIgniter\Config\ForeignCharacters as BaseForeignCharacters;
+
+class ForeignCharacters extends BaseForeignCharacters
 {
-
 }

--- a/app/Config/Honeypot.php
+++ b/app/Config/Honeypot.php
@@ -1,10 +1,11 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 
 class Honeypot extends BaseConfig
 {
-
 	/**
 	 * Makes Honeypot visible or not to human
 	 *

--- a/app/Config/Images.php
+++ b/app/Config/Images.php
@@ -1,4 +1,6 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 
@@ -22,7 +24,7 @@ class Images extends BaseConfig
 	/**
 	 * The available handler classes.
 	 *
-	 * @var array<string, class-string>
+	 * @var array<string, string>
 	 */
 	public $handlers = [
 		'gd'      => \CodeIgniter\Images\Handlers\GDHandler::class,

--- a/app/Config/Kint.php
+++ b/app/Config/Kint.php
@@ -1,23 +1,22 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 use Kint\Renderer\Renderer;
 
+/**
+ * --------------------------------------------------------------------------
+ * Kint
+ * --------------------------------------------------------------------------
+ *
+ * We use Kint's `RichRenderer` and `CLIRenderer`. This area contains options
+ * that you can set to customize how Kint works for you.
+ *
+ * @see https://kint-php.github.io/kint/ for details on these settings.
+ */
 class Kint extends BaseConfig
 {
-	/*
-	|--------------------------------------------------------------------------
-	| Kint
-	|--------------------------------------------------------------------------
-	|
-	| We use Kint's RichRenderer and CLIRenderer. This area contains options
-	| that you can set to customize how Kint works for you.
-	|
-	| For details on these settings, see Kint's docs:
-	|	https://kint-php.github.io/kint/
-	|
-	*/
-
 	/*
 	|--------------------------------------------------------------------------
 	| Global Settings

--- a/app/Config/Logger.php
+++ b/app/Config/Logger.php
@@ -1,80 +1,88 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 
 class Logger extends BaseConfig
 {
-	/*
-	|--------------------------------------------------------------------------
-	| Error Logging Threshold
-	|--------------------------------------------------------------------------
-	|
-	| You can enable error logging by setting a threshold over zero. The
-	| threshold determines what gets logged. Any values below or equal to the
-	| threshold will be logged. Threshold options are:
-	|
-	|	0 = Disables logging, Error logging TURNED OFF
-	|	1 = Emergency Messages  - System is unusable
-	|	2 = Alert Messages      - Action Must Be Taken Immediately
-	|   3 = Critical Messages   - Application component unavailable, unexpected exception.
-	|   4 = Runtime Errors      - Don't need immediate action, but should be monitored.
-	|   5 = Warnings               - Exceptional occurrences that are not errors.
-	|   6 = Notices            - Normal but significant events.
-	|   7 = Info             - Interesting events, like user logging in, etc.
-	|   8 = Debug                - Detailed debug information.
-	|   9 = All Messages
-	|
-	| You can also pass an array with threshold levels to show individual error types
-	|
-	| 	array(1, 2, 3, 8) = Emergency, Alert, Critical, and Debug messages
-	|
-	| For a live site you'll usually enable Critical or higher (3) to be logged otherwise
-	| your log files will fill up very fast.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Error Logging Threshold
+	 * --------------------------------------------------------------------------
+	 *
+	 * You can enable error logging by setting a threshold over zero. The
+	 * threshold determines what gets logged. Any values below or equal to the
+	 * threshold will be logged.
+	 *
+	 * Threshold options are:
+	 *
+	 * - 0 = Disables logging, Error logging TURNED OFF
+	 * - 1 = Emergency Messages - System is unusable
+	 * - 2 = Alert Messages - Action Must Be Taken Immediately
+	 * - 3 = Critical Messages - Application component unavailable, unexpected exception.
+	 * - 4 = Runtime Errors - Don't need immediate action, but should be monitored.
+	 * - 5 = Warnings - Exceptional occurrences that are not errors.
+	 * - 6 = Notices - Normal but significant events.
+	 * - 7 = Info - Interesting events, like user logging in, etc.
+	 * - 8 = Debug - Detailed debug information.
+	 * - 9 = All Messages
+	 *
+	 * You can also pass an array with threshold levels to show individual error types
+	 *
+	 *     array(1, 2, 3, 8) = Emergency, Alert, Critical, and Debug messages
+	 *
+	 * For a live site you'll usually enable Critical or higher (3) to be logged otherwise
+	 * your log files will fill up very fast.
+	 *
+	 * @var integer|array
+	 */
 	public $threshold = 4;
 
-	/*
-	|--------------------------------------------------------------------------
-	| Date Format for Logs
-	|--------------------------------------------------------------------------
-	|
-	| Each item that is logged has an associated date. You can use PHP date
-	| codes to set your own date formatting
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Date Format for Logs
+	 * --------------------------------------------------------------------------
+	 *
+	 * Each item that is logged has an associated date. You can use PHP date
+	 * codes to set your own date formatting
+	 *
+	 * @var string
+	 */
 	public $dateFormat = 'Y-m-d H:i:s';
 
-	/*
-	|--------------------------------------------------------------------------
-	| Log Handlers
-	|--------------------------------------------------------------------------
-	|
-	| The logging system supports multiple actions to be taken when something
-	| is logged. This is done by allowing for multiple Handlers, special classes
-	| designed to write the log to their chosen destinations, whether that is
-	| a file on the getServer, a cloud-based service, or even taking actions such
-	| as emailing the dev team.
-	|
-	| Each handler is defined by the class name used for that handler, and it
-	| MUST implement the CodeIgniter\Log\Handlers\HandlerInterface interface.
-	|
-	| The value of each key is an array of configuration items that are sent
-	| to the constructor of each handler. The only required configuration item
-	| is the 'handles' element, which must be an array of integer log levels.
-	| This is most easily handled by using the constants defined in the
-	| Psr\Log\LogLevel class.
-	|
-	| Handlers are executed in the order defined in this array, starting with
-	| the handler on top and continuing down.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Log Handlers
+	 * --------------------------------------------------------------------------
+	 *
+	 * The logging system supports multiple actions to be taken when something
+	 * is logged. This is done by allowing for multiple Handlers, special classes
+	 * designed to write the log to their chosen destinations, whether that is
+	 * a file on the getServer, a cloud-based service, or even taking actions such
+	 * as emailing the dev team.
+	 *
+	 * Each handler is defined by the class name used for that handler, and it
+	 * MUST implement the `CodeIgniter\Log\Handlers\HandlerInterface` interface.
+	 *
+	 * The value of each key is an array of configuration items that are sent
+	 * to the constructor of each handler. The only required configuration item
+	 * is the 'handles' element, which must be an array of integer log levels.
+	 * This is most easily handled by using the constants defined in the
+	 * `Psr\Log\LogLevel` class.
+	 *
+	 * Handlers are executed in the order defined in this array, starting with
+	 * the handler on top and continuing down.
+	 *
+	 * @var array
+	 */
 	public $handlers = [
 
-		//--------------------------------------------------------------------
-		// File Handler
-		//--------------------------------------------------------------------
-
+		/*
+		 * --------------------------------------------------------------------
+		 * File Handler
+		 * --------------------------------------------------------------------
+		 */
 		'CodeIgniter\Log\Handlers\FileHandler' => [
 
 			/*

--- a/app/Config/Migrations.php
+++ b/app/Config/Migrations.php
@@ -1,50 +1,55 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 
 class Migrations extends BaseConfig
 {
-	/*
-	|--------------------------------------------------------------------------
-	| Enable/Disable Migrations
-	|--------------------------------------------------------------------------
-	|
-	| Migrations are enabled by default for security reasons.
-	| You should enable migrations whenever you intend to do a schema migration
-	| and disable it back when you're done.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Enable/Disable Migrations
+	 * --------------------------------------------------------------------------
+	 *
+	 * Migrations are enabled by default.
+	 *
+	 * You should enable migrations whenever you intend to do a schema migration
+	 * and disable it back when you're done.
+	 *
+	 * @var boolean
+	 */
 	public $enabled = true;
 
-	/*
-	|--------------------------------------------------------------------------
-	| Migrations table
-	|--------------------------------------------------------------------------
-	|
-	| This is the name of the table that will store the current migrations state.
-	| When migrations runs it will store in a database table which migration
-	| level the system is at. It then compares the migration level in this
-	| table to the $config['migration_version'] if they are not the same it
-	| will migrate up. This must be set.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Migrations Table
+	 * --------------------------------------------------------------------------
+	 *
+	 * This is the name of the table that will store the current migrations state.
+	 * When migrations runs it will store in a database table which migration
+	 * level the system is at. It then compares the migration level in this
+	 * table to the $config['migration_version'] if they are not the same it
+	 * will migrate up. This must be set.
+	 *
+	 * @var string
+	 */
 	public $table = 'migrations';
 
-	/*
-	|--------------------------------------------------------------------------
-	| Timestamp Format
-	|--------------------------------------------------------------------------
-	|
-	| This is the format that will be used when creating new migrations
-	| using the cli command:
-	|   > php spark migrate:create
-	|
-	| Typical formats:
-	|   YmdHis_
-	|   Y-m-d-His_
-	|   Y_m_d_His_
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Timestamp Format
+	 * --------------------------------------------------------------------------
+	 *
+	 * This is the format that will be used when creating new migrations
+	 * using the CLI command:
+	 *   > php spark migrate:create
+	 *
+	 * Typical formats:
+	 * - YmdHis_
+	 * - Y-m-d-His_
+	 * - Y_m_d_His_
+	 *
+	 * @var string
+	 */
 	public $timestampFormat = 'Y-m-d-His_';
-
 }

--- a/app/Config/Mimes.php
+++ b/app/Config/Mimes.php
@@ -1,18 +1,19 @@
-<?php namespace Config;
+<?php
 
-/*
-| -------------------------------------------------------------------
-| MIME TYPES
-| -------------------------------------------------------------------
-| This file contains an array of mime types.  It is used by the
-| Upload class to help identify allowed file types.
-|
-| When more than one variation for an extension exist (like jpg, jpeg, etc)
-| the most common one should be first in the array to aid the guess*
-| methods. The same applies when more than one mime-type exists for a
-| single extension.
-|
-*/
+namespace Config;
+
+/**
+ * Mimes
+ *
+ * This file contains an array of mime types.  It is used by the
+ * Upload class to help identify allowed file types.
+ *
+ * When more than one variation for an extension exist (like jpg, jpeg, etc)
+ * the most common one should be first in the array to aid the guess*
+ * methods. The same applies when more than one mime-type exists for a
+ * single extension.
+ */
+
 class Mimes
 {
 	/**
@@ -473,8 +474,6 @@ class Mimes
 		],
 	];
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Attempts to determine the best mime type for the given file extension.
 	 *
@@ -494,17 +493,15 @@ class Mimes
 		return is_array(static::$mimes[$extension]) ? static::$mimes[$extension][0] : static::$mimes[$extension];
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Attempts to determine the best file extension for a given mime type.
 	 *
-	 * @param string $type
-	 * @param string $proposed_extension - default extension (in case there is more than one with the same mime type)
+	 * @param string      $type
+	 * @param string|null $proposed_extension - default extension (in case there is more than one with the same mime type)
 	 *
 	 * @return string|null The extension determined, or null if unable to match.
 	 */
-	public static function guessExtensionFromType(string $type, ?string $proposed_extension = null)
+	public static function guessExtensionFromType(string $type, string $proposed_extension = null)
 	{
 		$type = trim(strtolower($type), '. ');
 
@@ -525,7 +522,4 @@ class Mimes
 
 		return null;
 	}
-
-	//--------------------------------------------------------------------
-
 }

--- a/app/Config/Modules.php
+++ b/app/Config/Modules.php
@@ -2,45 +2,52 @@
 
 namespace Config;
 
-use CodeIgniter\Modules\Modules as CoreModules;
+use CodeIgniter\Modules\Modules as BaseModules;
 
-class Modules extends CoreModules
+class Modules extends BaseModules
 {
-	/*
-	 |--------------------------------------------------------------------------
-	 | Auto-Discovery Enabled?
-	 |--------------------------------------------------------------------------
-	 |
-	 | If true, then auto-discovery will happen across all elements listed in
-	 | $activeExplorers below. If false, no auto-discovery will happen at all,
-	 | giving a slight performance boost.
+	/**
+	 * --------------------------------------------------------------------------
+	 * Enable Auto-Discovery?
+	 * --------------------------------------------------------------------------
+	 *
+	 * If true, then auto-discovery will happen across all elements listed in
+	 * $activeExplorers below. If false, no auto-discovery will happen at all,
+	 * giving a slight performance boost.
+	 *
+	 * @var boolean
 	 */
 	public $enabled = true;
 
-	/*
-	 |--------------------------------------------------------------------------
-	 | Auto-Discovery Within Composer Packages Enabled?
-	 |--------------------------------------------------------------------------
-	 |
-	 | If true, then auto-discovery will happen across all namespaces loaded
-	 | by Composer, as well as the namespaces configured locally.
+	/**
+	 * --------------------------------------------------------------------------
+	 * Enable Auto-Discovery Within Composer Packages?
+	 * --------------------------------------------------------------------------
+	 *
+	 * If true, then auto-discovery will happen across all namespaces loaded
+	 * by Composer, as well as the namespaces configured locally.
+	 *
+	 * @var boolean
 	 */
 	public $discoverInComposer = true;
 
-	/*
-	|--------------------------------------------------------------------------
-	| Auto-discover Rules
-	|--------------------------------------------------------------------------
-	|
-	| Aliases list of all discovery classes that will be active and used during
-	| the current application request.
-	| If it is not listed, only the base application elements will be used.
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Auto-Discovery Rules
+	 * --------------------------------------------------------------------------
+	 *
+	 * Aliases list of all discovery classes that will be active and used during
+	 * the current application request.
+	 *
+	 * If it is not listed, only the base application elements will be used.
+	 *
+	 * @var string[]
+	 */
 	public $aliases = [
 		'events',
+		'filters',
 		'registrars',
 		'routes',
 		'services',
-		'filters',
 	];
 }

--- a/app/Config/Pager.php
+++ b/app/Config/Pager.php
@@ -1,35 +1,39 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 
 class Pager extends BaseConfig
 {
-	/*
-	|--------------------------------------------------------------------------
-	| Templates
-	|--------------------------------------------------------------------------
-	|
-	| Pagination links are rendered out using views to configure their
-	| appearance. This array contains aliases and the view names to
-	| use when rendering the links.
-	|
-	| Within each view, the Pager object will be available as $pager,
-	| and the desired group as $pagerGroup;
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Templates
+	 * --------------------------------------------------------------------------
+	 *
+	 * Pagination links are rendered out using views to configure their
+	 * appearance. This array contains aliases and the view names to
+	 * use when rendering the links.
+	 *
+	 * Within each view, the Pager object will be available as $pager,
+	 * and the desired group as $pagerGroup;
+	 *
+	 * @var array<string, string>
+	 */
 	public $templates = [
 		'default_full'   => 'CodeIgniter\Pager\Views\default_full',
 		'default_simple' => 'CodeIgniter\Pager\Views\default_simple',
 		'default_head'   => 'CodeIgniter\Pager\Views\default_head',
 	];
 
-	/*
-	|--------------------------------------------------------------------------
-	| Items Per Page
-	|--------------------------------------------------------------------------
-	|
-	| The default number of results shown in a single page.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Items Per Page
+	 * --------------------------------------------------------------------------
+	 *
+	 * The default number of results shown in a single page.
+	 *
+	 * @var integer
+	 */
 	public $perPage = 20;
 }

--- a/app/Config/Paths.php
+++ b/app/Config/Paths.php
@@ -1,9 +1,14 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 /**
+ * Paths
+ *
  * Holds the paths that are used by the system to
  * locate the main directories, app, system, etc.
- * Modifying these allows you to re-structure your application,
+ *
+ * Modifying these allows you to restructure your application,
  * share a system folder between multiple applications, and more.
  *
  * All paths are relative to the project's root folder.
@@ -11,33 +16,35 @@
 
 class Paths
 {
-	/*
-	 *---------------------------------------------------------------
+	/**
+	 * ---------------------------------------------------------------
 	 * SYSTEM FOLDER NAME
-	 *---------------------------------------------------------------
+	 * ---------------------------------------------------------------
 	 *
-	 * This variable must contain the name of your "system" folder.
-	 * Include the path if the folder is not in the same directory
-	 * as this file.
+	 * This must contain the name of your "system" folder. Include
+	 * the path if the folder is not in the same directory as this file.
+	 *
+	 * @var string
 	 */
 	public $systemDirectory = __DIR__ . '/../../system';
 
-	/*
-	 *---------------------------------------------------------------
+	/**
+	 * ---------------------------------------------------------------
 	 * APPLICATION FOLDER NAME
-	 *---------------------------------------------------------------
+	 * ---------------------------------------------------------------
 	 *
 	 * If you want this front controller to use a different "app"
 	 * folder than the default one you can set its name here. The folder
 	 * can also be renamed or relocated anywhere on your getServer. If
-	 * you do, use a full getServer path. For more info please see the user guide:
-	 * http://codeigniter.com/user_guide/general/managing_apps.html
+	 * you do, use a full getServer path.
 	 *
-	 * NO TRAILING SLASH!
+	 * @see http://codeigniter.com/user_guide/general/managing_apps.html
+	 *
+	 * @var string
 	 */
 	public $appDirectory = __DIR__ . '/..';
 
-	/*
+	/**
 	 * ---------------------------------------------------------------
 	 * WRITABLE DIRECTORY NAME
 	 * ---------------------------------------------------------------
@@ -47,19 +54,23 @@ class Paths
 	 * need write permission to a single place that can be tucked away
 	 * for maximum security, keeping it out of the app and/or
 	 * system directories.
+	 *
+	 * @var string
 	 */
 	public $writableDirectory = __DIR__ . '/../../writable';
 
-	/*
+	/**
 	 * ---------------------------------------------------------------
 	 * TESTS DIRECTORY NAME
 	 * ---------------------------------------------------------------
 	 *
 	 * This variable must contain the name of your "tests" directory.
+	 *
+	 * @var string
 	 */
 	public $testsDirectory = __DIR__ . '/../../tests';
 
-	/*
+	/**
 	 * ---------------------------------------------------------------
 	 * VIEW DIRECTORY NAME
 	 * ---------------------------------------------------------------
@@ -68,6 +79,8 @@ class Paths
 	 * contains the view files used by your application. By
 	 * default this is in `app/Views`. This value
 	 * is used when no value is provided to `Services::renderer()`.
+	 *
+	 * @var string
 	 */
 	public $viewDirectory = __DIR__ . '/../Views';
 }

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -1,4 +1,6 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 // Create a new instance of our RouteCollection class.
 $routes = Services::routes();
@@ -22,7 +24,7 @@ $routes->setTranslateURIDashes(false);
 $routes->set404Override();
 $routes->setAutoRoute(true);
 
-/**
+/*
  * --------------------------------------------------------------------
  * Route Definitions
  * --------------------------------------------------------------------
@@ -32,7 +34,7 @@ $routes->setAutoRoute(true);
 // route since we don't have to scan directories.
 $routes->get('/', 'Home::index');
 
-/**
+/*
  * --------------------------------------------------------------------
  * Additional Routing
  * --------------------------------------------------------------------

--- a/app/Config/Services.php
+++ b/app/Config/Services.php
@@ -1,6 +1,8 @@
-<?php namespace Config;
+<?php
 
-use CodeIgniter\Config\Services as CoreServices;
+namespace Config;
+
+use CodeIgniter\Config\Services as BaseServices;
 
 /**
  * Services Configuration file.
@@ -15,16 +17,16 @@ use CodeIgniter\Config\Services as CoreServices;
  * method format you should use for your service methods. For more examples,
  * see the core Services file at system/Config/Services.php.
  */
-class Services extends CoreServices
+class Services extends BaseServices
 {
 
-	//    public static function example($getShared = true)
-	//    {
-	//        if ($getShared)
-	//        {
-	//            return static::getSharedInstance('example');
-	//        }
+	// public static function example($getShared = true)
+	// {
+	//     if ($getShared)
+	//     {
+	//         return static::getSharedInstance('example');
+	//     }
 	//
-	//        return new \CodeIgniter\Example();
-	//    }
+	//     return new \CodeIgniter\Example();
+	// }
 }

--- a/app/Config/Services.php
+++ b/app/Config/Services.php
@@ -2,7 +2,7 @@
 
 namespace Config;
 
-use CodeIgniter\Config\Services as BaseServices;
+use CodeIgniter\Config\Services as CoreServices;
 
 /**
  * Services Configuration file.
@@ -17,7 +17,7 @@ use CodeIgniter\Config\Services as BaseServices;
  * method format you should use for your service methods. For more examples,
  * see the core Services file at system/Config/Services.php.
  */
-class Services extends BaseServices
+class Services extends CoreServices
 {
 
 	// public static function example($getShared = true)

--- a/app/Config/Toolbar.php
+++ b/app/Config/Toolbar.php
@@ -1,21 +1,31 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 
+/**
+ * --------------------------------------------------------------------------
+ * Debug Toolbar
+ * --------------------------------------------------------------------------
+ *
+ * The Debug Toolbar provides a way to see information about the performance
+ * and state of your application during that page display. By default it will
+ * NOT be displayed under production environments, and will only display if
+ * `CI_DEBUG` is true, since if it's not, there's not much to display anyway.
+ */
 class Toolbar extends BaseConfig
 {
-	/*
-	|--------------------------------------------------------------------------
-	| Debug Toolbar
-	|--------------------------------------------------------------------------
-	| The Debug Toolbar provides a way to see information about the performance
-	| and state of your application during that page display. By default it will
-	| NOT be displayed under production environments, and will only display if
-	| CI_DEBUG is true, since if it's not, there's not much to display anyway.
-	|
-	| toolbarMaxHistory = Number of history files, 0 for none or -1 for unlimited
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Toolbar Collectors
+	 * --------------------------------------------------------------------------
+	 *
+	 * List of toolbar collectors that will be called when Debug Toolbar
+	 * fires up and collects data from.
+	 *
+	 * @var string[]
+	 */
 	public $collectors = [
 		\CodeIgniter\Debug\Toolbar\Collectors\Timers::class,
 		\CodeIgniter\Debug\Toolbar\Collectors\Database::class,
@@ -27,42 +37,44 @@ class Toolbar extends BaseConfig
 		\CodeIgniter\Debug\Toolbar\Collectors\Events::class,
 	];
 
-	/*
-	|--------------------------------------------------------------------------
-	| Max History
-	|--------------------------------------------------------------------------
-	| The Toolbar allows you to view recent requests that have been made to
-	| the application while the toolbar is active. This allows you to quickly
-	| view and compare multiple requests.
-	|
-	| $maxHistory sets a limit on the number of past requests that are stored,
-	| helping to conserve file space used to store them. You can set it to
-	| 0 (zero) to not have any history stored, or -1 for unlimited history.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Max History
+	 * --------------------------------------------------------------------------
+	 *
+	 * `$maxHistory` sets a limit on the number of past requests that are stored,
+	 * helping to conserve file space used to store them. You can set it to
+	 * 0 (zero) to not have any history stored, or -1 for unlimited history.
+	 *
+	 * @var integer
+	 */
 	public $maxHistory = 20;
 
-	/*
-	|--------------------------------------------------------------------------
-	| Toolbar Views Path
-	|--------------------------------------------------------------------------
-	| The full path to the the views that are used by the toolbar.
-	| MUST have a trailing slash.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Toolbar Views Path
+	 * --------------------------------------------------------------------------
+	 *
+	 * The full path to the the views that are used by the toolbar.
+	 * This MUST have a trailing slash.
+	 *
+	 * @var string
+	 */
 	public $viewsPath = SYSTEMPATH . 'Debug/Toolbar/Views/';
 
-	/*
-	|--------------------------------------------------------------------------
-	| Max Queries
-	|--------------------------------------------------------------------------
-	| If the Database Collector is enabled, it will log every query that the
-	| the system generates so they can be displayed on the toolbar's timeline
-	| and in the query log. This can lead to memory issues in some instances
-	| with hundreds of queries.
-	|
-	| $maxQueries defines the maximum amount of queries that will be stored.
-	|
-	*/
+	/**
+	 * --------------------------------------------------------------------------
+	 * Max Queries
+	 * --------------------------------------------------------------------------
+	 *
+	 * If the Database Collector is enabled, it will log every query that the
+	 * the system generates so they can be displayed on the toolbar's timeline
+	 * and in the query log. This can lead to memory issues in some instances
+	 * with hundreds of queries.
+	 *
+	 * `$maxQueries` defines the maximum amount of queries that will be stored.
+	 *
+	 * @var integer
+	 */
 	public $maxQueries = 100;
 }

--- a/app/Config/UserAgents.php
+++ b/app/Config/UserAgents.php
@@ -1,18 +1,28 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 
+/**
+ * -------------------------------------------------------------------
+ * User Agents
+ * -------------------------------------------------------------------
+ *
+ * This file contains four arrays of user agent data. It is used by the
+ * User Agent Class to help identify browser, platform, robot, and
+ * mobile device data. The array keys are used to identify the device
+ * and the array values are used to set the actual name of the item.
+ */
 class UserAgents extends BaseConfig
 {
-	/*
-	| -------------------------------------------------------------------
-	| USER AGENT TYPES
-	| -------------------------------------------------------------------
-	| This file contains four arrays of user agent data. It is used by the
-	| User Agent Class to help identify browser, platform, robot, and
-	| mobile device data. The array keys are used to identify the device
-	| and the array values are used to set the actual name of the item.
-	*/
+	/**
+	 * -------------------------------------------------------------------
+	 * OS Platforms
+	 * -------------------------------------------------------------------
+	 *
+	 * @var array<string, string>
+	 */
 	public $platforms = [
 		'windows nt 10.0' => 'Windows 10',
 		'windows nt 6.3'  => 'Windows 8.1',
@@ -58,8 +68,16 @@ class UserAgents extends BaseConfig
 		'symbian'         => 'Symbian OS',
 	];
 
-	// The order of this array should NOT be changed. Many browsers return
-	// multiple browser types so we want to identify the sub-type first.
+	/**
+	 * -------------------------------------------------------------------
+	 * Browsers
+	 * -------------------------------------------------------------------
+	 *
+	 * The order of this array should NOT be changed. Many browsers return
+	 * multiple browser types so we want to identify the subtype first.
+	 *
+	 * @var array<string, string>
+	 */
 	public $browsers = [
 		'OPR'               => 'Opera',
 		'Flock'             => 'Flock',
@@ -94,6 +112,13 @@ class UserAgents extends BaseConfig
 		'Vivaldi'           => 'Vivaldi',
 	];
 
+	/**
+	 * -------------------------------------------------------------------
+	 * Mobiles
+	 * -------------------------------------------------------------------
+	 *
+	 * @var array<string, string>
+	 */
 	public $mobiles = [
 		// legacy array, old values commented out
 		'mobileexplorer'       => 'Mobile Explorer',
@@ -194,7 +219,15 @@ class UserAgents extends BaseConfig
 		'cellphone'            => 'Generic Mobile',
 	];
 
-	// There are hundreds of bots but these are the most common.
+	/**
+	 * -------------------------------------------------------------------
+	 * Robots
+	 * -------------------------------------------------------------------
+	 *
+	 * There are hundred of bots but these are the most common.
+	 *
+	 * @var array<string, string>
+	 */
 	public $robots = [
 		'googlebot'            => 'Googlebot',
 		'msnbot'               => 'MSNBot',

--- a/app/Config/Validation.php
+++ b/app/Config/Validation.php
@@ -1,4 +1,6 @@
-<?php namespace Config;
+<?php
+
+namespace Config;
 
 class Validation
 {
@@ -10,7 +12,7 @@ class Validation
 	 * Stores the classes that contain the
 	 * rules that are available.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
 	public $ruleSets = [
 		\CodeIgniter\Validation\Rules::class,
@@ -23,7 +25,7 @@ class Validation
 	 * Specifies the views that are used to display the
 	 * errors.
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	public $templates = [
 		'list'   => 'CodeIgniter\Validation\Views\list',

--- a/app/Config/View.php
+++ b/app/Config/View.php
@@ -2,7 +2,7 @@
 
 namespace Config;
 
-use CodeIgniter\View\View as BaseView;
+use CodeIgniter\Config\View as BaseView;
 
 class View extends BaseView
 {

--- a/app/Config/View.php
+++ b/app/Config/View.php
@@ -1,6 +1,10 @@
-<?php namespace Config;
+<?php
 
-class View extends \CodeIgniter\Config\View
+namespace Config;
+
+use CodeIgniter\View\View as BaseView;
+
+class View extends BaseView
 {
 	/**
 	 * When false, the view method will clear the data between each
@@ -9,6 +13,8 @@ class View extends \CodeIgniter\Config\View
 	 * to each view. You might prefer to have the data stick around between
 	 * calls so that it is available to all views. If that is the case,
 	 * set $saveData to true.
+	 *
+	 * @var boolean
 	 */
 	public $saveData = true;
 
@@ -22,6 +28,8 @@ class View extends \CodeIgniter\Config\View
 	 * Examples:
 	 *  { title|esc(js) }
 	 *  { created_on|date(Y-m-d)|esc(attr) }
+	 *
+	 * @var array
 	 */
 	public $filters = [];
 
@@ -29,6 +37,8 @@ class View extends \CodeIgniter\Config\View
 	 * Parser Plugins provide a way to extend the functionality provided
 	 * by the core Parser by creating aliases that will be replaced with
 	 * any callable. Can be single or tag pair.
+	 *
+	 * @var array
 	 */
 	public $plugins = [];
 }


### PR DESCRIPTION
**Description**
In CI3, we used arrays to manage configurations. That's why we only used multiline comments (`T_COMMENT`) to document each config. However, in CI4 we have shifted to config classes. Class properties are structural elements that needs to have its documentation in DocBlocks (`T_DOC_COMMENT`). In here, we can add more information on each config variable by defining its type, adding linkable references, etc. This also helps static code analysis tools detect errors in usage by knowing the types used. Plus side also is that in IDEs the definition of the config class' properties will be shown when you hover your mouse over the property. These benefits are deprived on the use of regular comments.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
