### PR TITLE
Fix @param at URI::stripQuery(...$params)

### DIFF
--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -876,7 +876,7 @@ class URI
 	/**
 	 * Removes one or more query vars from the URI.
 	 *
-	 * @param array ...$params
+	 * @param string ...$params
 	 *
 	 * @return $this
 	 */
@@ -884,7 +884,7 @@ class URI
 	{
 		foreach ($params as $param)
 		{
-			unset($this->query[$param]); // @phpstan-ignore-line
+			unset($this->query[$param]);
 		}
 
 		return $this;


### PR DESCRIPTION
Fixed `@param` at `URI::stripQuery(...$params)`, make  no need `// @phpstan-ignore-line` on `unset($this->query[$param]);`

**Checklist:**
- [x] Securely signed commits
