### PR TITLE
read composer.json to get minimal php version required in public/index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,12 +1,13 @@
 <?php
 
 // Valid PHP Version?
-$minPHPVersion = '7.2';
+preg_match('#(\d+(.\d+)?(.\d+)?)#', json_decode(file_get_contents(__DIR__ . '/../composer.json'))->require->php, $match);
+$minPHPVersion = current($match);
 if (version_compare(PHP_VERSION, $minPHPVersion, '<'))
 {
 	die("Your PHP version must be {$minPHPVersion} or higher to run CodeIgniter. Current version: " . PHP_VERSION);
 }
-unset($minPHPVersion);
+unset($minPHPVersion, $match);
 
 // Path to the front controller (this file)
 define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);


### PR DESCRIPTION
Read composer.json to get minimal php version required in `public/index.php`. It can reduce path to check when upgrade php requirement.

**Checklist:**
- [x] Securely signed commits
