### PR TITLE
Allow GeneratorCommand's sortImports to be configurable

### DIFF
--- a/system/CLI/GeneratorCommand.php
+++ b/system/CLI/GeneratorCommand.php
@@ -78,6 +78,15 @@ abstract class GeneratorCommand extends BaseCommand
 	];
 
 	/**
+	 * Whether to sort class imports.
+	 *
+	 * @internal
+	 *
+	 * @var boolean
+	 */
+	private $sortImports = true;
+
+	/**
 	 * The params array for easy access by other methods.
 	 *
 	 * @var array
@@ -153,6 +162,21 @@ abstract class GeneratorCommand extends BaseCommand
 
 		CLI::write(lang('CLI.generateFileSuccess') . CLI::color(clean_path($path), 'green'));
 		CLI::newLine();
+	}
+
+	/**
+	 * Allows child generators to modify
+	 * the internal `$sortImports` flag.
+	 *
+	 * @param boolean $sort
+	 *
+	 * @return $this
+	 */
+	protected function setSortImports(bool $sort)
+	{
+		$this->sortImports = $sort;
+
+		return $this;
 	}
 
 	/**
@@ -338,7 +362,7 @@ abstract class GeneratorCommand extends BaseCommand
 	 */
 	protected function sortImports(string $template): string
 	{
-		if (preg_match('/(?P<imports>(?:use [^;]+;$\n?)+)/m', $template, $match))
+		if ($this->sortImports && preg_match('/(?P<imports>(?:use [^;]+;$\n?)+)/m', $template, $match))
 		{
 			$imports = explode("\n", trim($match['imports']));
 			sort($imports);
@@ -346,7 +370,7 @@ abstract class GeneratorCommand extends BaseCommand
 			return str_replace(trim($match['imports']), implode("\n", $imports), $template);
 		}
 
-		return $template; // @codeCoverageIgnore
+		return $template;
 	}
 
 	/**

--- a/system/CLI/GeneratorCommand.php
+++ b/system/CLI/GeneratorCommand.php
@@ -362,7 +362,7 @@ abstract class GeneratorCommand extends BaseCommand
 	 */
 	protected function sortImports(string $template): string
 	{
-		if ($this->sortImports && preg_match('/(?P<imports>(?:use [^;]+;$\n?)+)/m', $template, $match))
+		if ($this->sortImports && preg_match('/(?P<imports>(?:^use [^;]+;$\n?)+)/m', $template, $match))
 		{
 			$imports = explode("\n", trim($match['imports']));
 			sort($imports);

--- a/tests/_support/Commands/Foobar.php
+++ b/tests/_support/Commands/Foobar.php
@@ -1,7 +1,11 @@
 <?php
 
+use Config\App;
+use CodeIgniter\CLI\CLI;
+
 return [
-   'foo' => 'The command use this as foo.',
-   'bar' => 'The command use this as bar.',
+   'foo' => 'The command will use this as foo.',
+   'bar' => 'The command will use this as bar.',
    'baz' => 'The baz is here.',
+   'bas' => CLI::color('bas', 'green') . (new App())->baseURL,
 ];

--- a/tests/_support/Commands/Foobar.php
+++ b/tests/_support/Commands/Foobar.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+   'foo' => 'The command use this as foo.',
+   'bar' => 'The command use this as bar.',
+   'baz' => 'The baz is here.',
+];

--- a/tests/_support/Commands/LanguageCommand.php
+++ b/tests/_support/Commands/LanguageCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Support\Commands;
+
+use CodeIgniter\CLI\GeneratorCommand;
+
+class LanguageCommand extends GeneratorCommand
+{
+	protected $name        = 'publish:language';
+	protected $description = 'Publishes a language file.';
+	protected $usage       = 'publish:language [options]';
+	protected $options     = [
+		'--lang' => 'The language folder to save the file.',
+		'--sort' => 'Turn on/off the sortImports flag.',
+	];
+
+	public function run(array $params)
+	{
+		$params[0]      = 'Foobar';
+		$params['lang'] = $params['lang'] ?? 'en';
+		$sort           = (isset($params['sort']) && $params['sort'] === 'off') ? false : true;
+
+		$this->setSortImports($sort);
+
+		parent::run($params);
+	}
+
+	protected function getNamespacedClass(string $rootNamespace, string $class): string
+	{
+		return $rootNamespace . '\\Language\\' . $this->params['lang'] . '\\' . $class;
+	}
+
+	protected function getTemplate(): string
+	{
+		return file_get_contents(__DIR__ . '/Foobar.php') ?: '';
+	}
+}

--- a/tests/system/Commands/ConfigurableSortImportsTest.php
+++ b/tests/system/Commands/ConfigurableSortImportsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+class ConfigurableSortImportsTest extends CIUnitTestCase
+{
+	protected $streamFilter;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		CITestStreamFilter::$buffer = '';
+		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
+		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		stream_filter_remove($this->streamFilter);
+
+		$result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+		$file   = trim(substr($result, 14));
+		$file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $file);
+		$dir    = dirname($file);
+		file_exists($file) && unlink($file);
+		is_dir($dir) && rmdir($dir);
+	}
+
+	public function testEnabledSortImportsWillDisruptLanguageFilePublish()
+	{
+		command('publish:language --lang es');
+
+		$file = APPPATH . 'Language/es/Foobar.php';
+		$this->assertStringContainsString('Created file: ', CITestStreamFilter::$buffer);
+		$this->assertFileExists($file);
+		$this->assertNotSame(sha1_file(SUPPORTPATH . 'Commands/Foobar.php'), sha1_file($file));
+	}
+
+	public function testDisabledSortImportsWillNotAffectLanguageFilesPublish()
+	{
+		command('publish:language --lang es --sort off');
+
+		$file = APPPATH . 'Language/es/Foobar.php';
+		$this->assertStringContainsString('Created file: ', CITestStreamFilter::$buffer);
+		$this->assertFileExists($file);
+		$this->assertSame(sha1_file(SUPPORTPATH . 'Commands/Foobar.php'), sha1_file($file));
+	}
+}


### PR DESCRIPTION
**Description**
I am making a spark command that publishes a module's language files to userland or to other language folders. The problem is the method `GeneratorCommand::sortImports` is interfering with the file created.

Initially, the idea for the sort imports method is to automatically sort the class imports a class template is using before outputting the final product. This is not a problem if the file contains classes that uses class imports. For language files, however, we are using a return array with translations defined as index-value pairs. The `sortImports` algorithm checks for word matches starting with `use blah blah`, collects those matches, sorts them, then output them. If in the translation array I have the pairs:
```php
return [
    'foo' => 'This one will use {0} on foo.',
    'bar' => 'This will use bar on {0}.',
];
```
`sortImports` will collect the `use` phrases and sorts them, destroying the array on output, something like:

```php
return [
    'foo' => 'This one will
    'bar' => 'This will
use {0} on foo.',
use bar on {0}.',
];
```

This PR tries to resolve this issue by setting an internal `$sortImports` flag variable (default to `true`). Then child generator classes not wanting to have their imports sorted or will affect the file generation (such as my case) will just have to turn off this flag and `GeneratorCommand` will return the template unscathed.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
