### PR TITLE
Write console long options using '--'

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -1017,9 +1017,12 @@ class CLI
 	 * Returns the options as a string, suitable for passing along on
 	 * the CLI to other commands.
 	 *
+	 * @param boolean $useLongOpts Use '--' for long options?
+	 * @param boolean $trim        Trim final string output?
+	 *
 	 * @return string
 	 */
-	public static function getOptionString(): string
+	public static function getOptionString(bool $useLongOpts = false, bool $trim = false): string
 	{
 		if (empty(static::$options))
 		{
@@ -1030,17 +1033,28 @@ class CLI
 
 		foreach (static::$options as $name => $value)
 		{
+			if ($useLongOpts && mb_strlen($name) > 1)
+			{
+				$out .= "--{$name} ";
+			}
+			else
+			{
+				$out .= "-{$name} ";
+			}
+
 			// If there's a space, we need to group
 			// so it will pass correctly.
 			if (mb_strpos($value, ' ') !== false)
 			{
-				$value = '"' . $value . '"';
+				$out .= '"' . $value . '" ';
 			}
-
-			$out .= "-{$name} $value ";
+			elseif ($value !== null)
+			{
+				$out .= "{$value} ";
+			}
 		}
 
-		return $out;
+		return $trim ? trim($out) : $out;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/CLI/GeneratorCommand.php
+++ b/system/CLI/GeneratorCommand.php
@@ -73,8 +73,8 @@ abstract class GeneratorCommand extends BaseCommand
 	 * @var array
 	 */
 	private $defaultOptions = [
-		'-n'     => 'Set root namespace. Defaults to APP_NAMESPACE.',
-		'-force' => 'Force overwrite existing files.',
+		'-n'      => 'Set root namespace. Defaults to APP_NAMESPACE.',
+		'--force' => 'Force overwrite existing files.',
 	];
 
 	/**

--- a/system/Commands/Database/Migrate.php
+++ b/system/Commands/Database/Migrate.php
@@ -92,9 +92,9 @@ class Migrate extends BaseCommand
 	 * @var array
 	 */
 	protected $options = [
-		'-n'   => 'Set migration namespace',
-		'-g'   => 'Set database group',
-		'-all' => 'Set for all namespaces, will ignore (-n) option',
+		'-n'    => 'Set migration namespace',
+		'-g'    => 'Set database group',
+		'--all' => 'Set for all namespaces, will ignore (-n) option',
 	];
 
 	/**

--- a/system/Commands/Database/MigrateRefresh.php
+++ b/system/Commands/Database/MigrateRefresh.php
@@ -93,10 +93,10 @@ class MigrateRefresh extends BaseCommand
 	 * @var array
 	 */
 	protected $options = [
-		'-n'   => 'Set migration namespace',
-		'-g'   => 'Set database group',
-		'-all' => 'Set latest for all namespace, will ignore (-n) option',
-		'-f'   => 'Force command - this option allows you to bypass the confirmation question when running this command in a production environment',
+		'-n'    => 'Set migration namespace',
+		'-g'    => 'Set database group',
+		'--all' => 'Set latest for all namespace, will ignore (-n) option',
+		'-f'    => 'Force command - this option allows you to bypass the confirmation question when running this command in a production environment',
 	];
 
 	/**

--- a/system/Commands/Encryption/GenerateKey.php
+++ b/system/Commands/Encryption/GenerateKey.php
@@ -83,10 +83,10 @@ class GenerateKey extends BaseCommand
 	 * @var array
 	 */
 	protected $options = [
-		'-force'  => 'Force overwrite existing key in `.env` file.',
-		'-length' => 'The length of the random string that should be returned in bytes. Defaults to 32.',
-		'-prefix' => 'Prefix to prepend to encoded key (either hex2bin or base64). Defaults to hex2bin.',
-		'-show'   => 'Shows the generated key in the terminal instead of storing in the `.env` file.',
+		'--force'  => 'Force overwrite existing key in `.env` file.',
+		'--length' => 'The length of the random string that should be returned in bytes. Defaults to 32.',
+		'--prefix' => 'Prefix to prepend to encoded key (either hex2bin or base64). Defaults to hex2bin.',
+		'--show'   => 'Shows the generated key in the terminal instead of storing in the `.env` file.',
 	];
 
 	/**

--- a/system/Commands/Generators/CreateCommand.php
+++ b/system/Commands/Generators/CreateCommand.php
@@ -80,9 +80,9 @@ class CreateCommand extends GeneratorCommand
 	 * @var array
 	 */
 	protected $options = [
-		'-command' => 'The command name. Defaults to "command:name"',
-		'-group'   => 'The group of command. Defaults to "CodeIgniter" for basic commands, and "Generators" for generator commands.',
-		'-type'    => 'Type of command. Whether a basic command or a generator command. Defaults to "basic".',
+		'--command' => 'The command name. Defaults to "command:name"',
+		'--group'   => 'The group of command. Defaults to "CodeIgniter" for basic commands, and "Generators" for generator commands.',
+		'--type'    => 'Type of command. Whether a basic command or a generator command. Defaults to "basic".',
 	];
 
 	/**

--- a/system/Commands/Generators/CreateController.php
+++ b/system/Commands/Generators/CreateController.php
@@ -83,8 +83,8 @@ class CreateController extends GeneratorCommand
 	 * @var array
 	 */
 	protected $options = [
-		'-bare'    => 'Extends from CodeIgniter\\Controller instead of BaseController',
-		'-restful' => 'Extends from a RESTful resource. Options are \'controller\' or \'presenter\'.',
+		'--bare'    => 'Extends from CodeIgniter\\Controller instead of BaseController',
+		'--restful' => 'Extends from a RESTful resource. Options are \'controller\' or \'presenter\'.',
 	];
 
 	/**

--- a/system/Commands/Generators/CreateModel.php
+++ b/system/Commands/Generators/CreateModel.php
@@ -83,9 +83,9 @@ class CreateModel extends GeneratorCommand
 	 * @var array
 	 */
 	protected $options = [
-		'-dbgroup' => 'Database group to use. Defaults to "default".',
-		'-entity'  => 'Use an Entity as return type.',
-		'-table'   => 'Supply a different table name. Defaults to the pluralized name.',
+		'--dbgroup' => 'Database group to use. Defaults to "default".',
+		'--entity'  => 'Use an Entity as return type.',
+		'--table'   => 'Supply a different table name. Defaults to the pluralized name.',
 	];
 
 	/**

--- a/system/Commands/Generators/CreateScaffold.php
+++ b/system/Commands/Generators/CreateScaffold.php
@@ -88,12 +88,12 @@ class CreateScaffold extends BaseCommand
 	 * @var array
 	 */
 	protected $options = [
-		'-bare'    => 'Add the \'-bare\' option to controller scaffold.',
-		'-restful' => 'Add the \'-restful\' option to controller scaffold.',
-		'-dbgroup' => 'Add the \'-dbgroup\' option to model scaffold.',
-		'-table'   => 'Add the \'-table\' option to the model scaffold.',
-		'-n'       => 'Set root namespace. Defaults to APP_NAMESPACE.',
-		'-force'   => 'Force overwrite existing files.',
+		'--bare'    => 'Add the \'-bare\' option to controller scaffold.',
+		'--restful' => 'Add the \'-restful\' option to controller scaffold.',
+		'--dbgroup' => 'Add the \'-dbgroup\' option to model scaffold.',
+		'--table'   => 'Add the \'-table\' option to the model scaffold.',
+		'-n'        => 'Set root namespace. Defaults to APP_NAMESPACE.',
+		'--force'   => 'Force overwrite existing files.',
 	];
 
 	/**

--- a/system/Commands/Generators/MigrateCreate.php
+++ b/system/Commands/Generators/MigrateCreate.php
@@ -96,8 +96,8 @@ class MigrateCreate extends BaseCommand
 	 * @var array
 	 */
 	protected $options = [
-		'-n'     => 'Set root namespace. Defaults to APP_NAMESPACE',
-		'-force' => 'Force overwrite existing files.',
+		'-n'      => 'Set root namespace. Defaults to APP_NAMESPACE',
+		'--force' => 'Force overwrite existing files.',
 	];
 
 	/**

--- a/system/Commands/Housekeeping/ClearLogs.php
+++ b/system/Commands/Housekeeping/ClearLogs.php
@@ -82,7 +82,7 @@ class ClearLogs extends BaseCommand
 	 * @var array
 	 */
 	protected $options = [
-		'-force' => 'Force delete of all logs files without prompting.',
+		'--force' => 'Force delete of all logs files without prompting.',
 	];
 
 	/**

--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -115,9 +115,9 @@ class Serve extends BaseCommand
 	 * @var array
 	 */
 	protected $options = [
-		'-php'  => 'The PHP Binary [default: "PHP_BINARY"]',
-		'-host' => 'The HTTP Host [default: "localhost"]',
-		'-port' => 'The HTTP Host Port [default: "8080"]',
+		'--php'  => 'The PHP Binary [default: "PHP_BINARY"]',
+		'--host' => 'The HTTP Host [default: "localhost"]',
+		'--port' => 'The HTTP Host Port [default: "8080"]',
 	];
 
 	/**

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CodeIgniter
  *
@@ -52,12 +53,9 @@ use Config\App;
  * originally made available under.
  *
  * http://fuelphp.com
- *
- * @package CodeIgniter\HTTP
  */
 class CLIRequest extends Request
 {
-
 	/**
 	 * Stores the segments of our cli "URI" command.
 	 *
@@ -79,8 +77,6 @@ class CLIRequest extends Request
 	 */
 	protected $method = 'cli';
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Constructor
 	 *
@@ -95,8 +91,6 @@ class CLIRequest extends Request
 
 		$this->parseCommand();
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Returns the "path" of the request script so that it can be used
@@ -120,8 +114,6 @@ class CLIRequest extends Request
 		return empty($path) ? '' : $path;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Returns an associative array of all CLI options found, with
 	 * their values.
@@ -133,8 +125,6 @@ class CLIRequest extends Request
 		return $this->options;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Returns the path segments.
 	 *
@@ -144,8 +134,6 @@ class CLIRequest extends Request
 	{
 		return $this->segments;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Returns the value for a single CLI option that was passed in.
@@ -159,8 +147,6 @@ class CLIRequest extends Request
 		return $this->options[$key] ?? null;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Returns the options as a string, suitable for passing along on
 	 * the CLI to other commands.
@@ -173,9 +159,11 @@ class CLIRequest extends Request
 	 *
 	 *      getOptionString() = '-foo bar -baz "queue some stuff"'
 	 *
+	 * @param boolean $useLongOpts
+	 *
 	 * @return string
 	 */
-	public function getOptionString(): string
+	public function getOptionString(bool $useLongOpts = false): string
 	{
 		if (empty($this->options))
 		{
@@ -186,14 +174,25 @@ class CLIRequest extends Request
 
 		foreach ($this->options as $name => $value)
 		{
-			// If there's a space, we need to group
-			// so it will pass correctly.
-			if (strpos($value, ' ') !== false)
+			if ($useLongOpts && mb_strlen($name) > 1)
 			{
-				$value = '"' . $value . '"';
+				$out .= "--{$name} ";
+			}
+			else
+			{
+				$out .= "-{$name} ";
 			}
 
-			$out .= "-{$name} $value ";
+			// If there's a space, we need to group
+			// so it will pass correctly.
+			if (mb_strpos($value, ' ') !== false)
+			{
+				$out .= '"' . $value . '" ';
+			}
+			elseif ($value !== null)
+			{
+				$out .= "{$value} ";
+			}
 		}
 
 		return trim($out);

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -280,12 +280,12 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 			'b',
 			'c',
 			'd',
-			'-parm',
+			'--parm',
 			'pvalue',
 			'd2',
 			'da-sh',
-			'-fix',
-			'-opt-in',
+			'--fix',
+			'--opt-in',
 			'sure',
 		];
 		CLI::init();
@@ -295,6 +295,10 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('d', CLI::getSegment(3));
 		$this->assertEquals(['b', 'c', 'd', 'd2', 'da-sh'], CLI::getSegments());
 		$this->assertEquals(['parm' => 'pvalue', 'fix' => null, 'opt-in' => 'sure'], CLI::getOptions());
+		$this->assertEquals('-parm pvalue -fix -opt-in sure ', CLI::getOptionString());
+		$this->assertEquals('-parm pvalue -fix -opt-in sure', CLI::getOptionString(false, true));
+		$this->assertEquals('--parm pvalue --fix --opt-in sure ', CLI::getOptionString(true));
+		$this->assertEquals('--parm pvalue --fix --opt-in sure', CLI::getOptionString(true, true));
 	}
 
 	public function testParseCommandOption()
@@ -303,7 +307,7 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 			'ignored',
 			'b',
 			'c',
-			'-parm',
+			'--parm',
 			'pvalue',
 			'd',
 		];
@@ -311,6 +315,9 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(['parm' => 'pvalue'], CLI::getOptions());
 		$this->assertEquals('pvalue', CLI::getOption('parm'));
 		$this->assertEquals('-parm pvalue ', CLI::getOptionString());
+		$this->assertEquals('-parm pvalue', CLI::getOptionString(false, true));
+		$this->assertEquals('--parm pvalue ', CLI::getOptionString(true));
+		$this->assertEquals('--parm pvalue', CLI::getOptionString(true, true));
 		$this->assertNull(CLI::getOption('bogus'));
 		$this->assertEquals(['b', 'c', 'd'], CLI::getSegments());
 	}
@@ -321,17 +328,20 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 			'ignored',
 			'b',
 			'c',
-			'-parm',
+			'--parm',
 			'pvalue',
 			'd',
-			'-p2',
-			'-p3',
+			'--p2',
+			'--p3',
 			'value 3',
 		];
 		CLI::init();
 		$this->assertEquals(['parm' => 'pvalue', 'p2' => null, 'p3' => 'value 3'], CLI::getOptions());
 		$this->assertEquals('pvalue', CLI::getOption('parm'));
-		$this->assertEquals('-parm pvalue -p2  -p3 "value 3" ', CLI::getOptionString());
+		$this->assertEquals('-parm pvalue -p2 -p3 "value 3" ', CLI::getOptionString());
+		$this->assertEquals('-parm pvalue -p2 -p3 "value 3"', CLI::getOptionString(false, true));
+		$this->assertEquals('--parm pvalue --p2 --p3 "value 3" ', CLI::getOptionString(true));
+		$this->assertEquals('--parm pvalue --p2 --p3 "value 3"', CLI::getOptionString(true, true));
 		$this->assertEquals(['b', 'c', 'd'], CLI::getSegments());
 	}
 

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -59,9 +59,9 @@ class CLIRequestTest extends CIUnitTestCase
 			'users',
 			'21',
 			'profile',
-			'-foo',
+			'--foo',
 			'bar',
-			'-foo-bar',
+			'--foo-bar',
 			'yes',
 		];
 
@@ -82,7 +82,7 @@ class CLIRequestTest extends CIUnitTestCase
 			'users',
 			'21',
 			'profile',
-			'-foo',
+			'--foo',
 			'bar',
 		];
 
@@ -100,17 +100,17 @@ class CLIRequestTest extends CIUnitTestCase
 			'users',
 			'21',
 			'profile',
-			'-foo',
+			'--foo',
 			'bar',
-			'-baz',
+			'--baz',
 			'queue some stuff',
 		];
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
 
-		$expected = '-foo bar -baz "queue some stuff"';
-		$this->assertEquals($expected, $this->request->getOptionString());
+		$this->assertEquals('-foo bar -baz "queue some stuff"', $this->request->getOptionString());
+		$this->assertEquals('--foo bar --baz "queue some stuff"', $this->request->getOptionString(true));
 	}
 
 	public function testParsingNoOptions()
@@ -136,15 +136,14 @@ class CLIRequestTest extends CIUnitTestCase
 			'users',
 			'21',
 			'profile',
-			'-foo',
+			'--foo',
 			'bar',
 		];
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
 
-		$expected = 'users/21/profile';
-		$this->assertEquals($expected, $this->request->getPath());
+		$this->assertEquals('users/21/profile', $this->request->getPath());
 	}
 
 	public function testParsingMalformed()
@@ -154,19 +153,18 @@ class CLIRequestTest extends CIUnitTestCase
 			'users',
 			'21',
 			'pro-file',
-			'-foo',
+			'--foo',
 			'bar',
-			'-baz',
+			'--baz',
 			'queue some stuff',
 		];
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
 
-		$expectedOptions = '-foo bar -baz "queue some stuff"';
-		$expectedPath    = 'users/21/pro-file';
-		$this->assertEquals($expectedOptions, $this->request->getOptionString());
-		$this->assertEquals($expectedPath, $this->request->getPath());
+		$this->assertEquals('-foo bar -baz "queue some stuff"', $this->request->getOptionString());
+		$this->assertEquals('--foo bar --baz "queue some stuff"', $this->request->getOptionString(true));
+		$this->assertEquals('users/21/pro-file', $this->request->getPath());
 	}
 
 	public function testParsingMalformed2()
@@ -176,19 +174,18 @@ class CLIRequestTest extends CIUnitTestCase
 			'users',
 			'21',
 			'profile',
-			'-foo',
+			'--foo',
 			'oops-bar',
-			'-baz',
+			'--baz',
 			'queue some stuff',
 		];
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
 
-		$expectedOptions = '-foo oops-bar -baz "queue some stuff"';
-		$expectedPath    = 'users/21/profile';
-		$this->assertEquals($expectedOptions, $this->request->getOptionString());
-		$this->assertEquals($expectedPath, $this->request->getPath());
+		$this->assertEquals('-foo oops-bar -baz "queue some stuff"', $this->request->getOptionString());
+		$this->assertEquals('--foo oops-bar --baz "queue some stuff"', $this->request->getOptionString(true));
+		$this->assertEquals('users/21/profile', $this->request->getPath());
 	}
 
 	public function testParsingMalformed3()
@@ -198,20 +195,19 @@ class CLIRequestTest extends CIUnitTestCase
 			'users',
 			'21',
 			'profile',
-			'-foo',
+			'--foo',
 			'oops',
 			'bar',
-			'-baz',
+			'--baz',
 			'queue some stuff',
 		];
 
 		// reinstantiate it to force parsing
 		$this->request = new CLIRequest(new App());
 
-		$expectedOptions = '-foo oops -baz "queue some stuff"';
-		$expectedPath    = 'users/21/profile/bar';
-		$this->assertEquals($expectedOptions, $this->request->getOptionString());
-		$this->assertEquals($expectedPath, $this->request->getPath());
+		$this->assertEquals('-foo oops -baz "queue some stuff"', $this->request->getOptionString());
+		$this->assertEquals('--foo oops --baz "queue some stuff"', $this->request->getOptionString(true));
+		$this->assertEquals('users/21/profile/bar', $this->request->getPath());
 	}
 
 	//--------------------------------------------------------------------

--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -43,11 +43,11 @@ Argument:
 
 Options:
 ========
-* ``-command``: The command name to run in spark. Defaults to ``command:name``.
-* ``-group``: The group/namespace of the command. Defaults to ``CodeIgniter`` for basic commands, and ``Generators`` for generator commands.
-* ``-type``: The type of command, whether a ``basic`` command or a ``generator`` command. Defaults to ``basic``.
+* ``--command``: The command name to run in spark. Defaults to ``command:name``.
+* ``--group``: The group/namespace of the command. Defaults to ``CodeIgniter`` for basic commands, and ``Generators`` for generator commands.
+* ``--type``: The type of command, whether a ``basic`` command or a ``generator`` command. Defaults to ``basic``.
 * ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
-* ``-force``: Set this flag to overwrite existing files on destination.
+* ``--force``: Set this flag to overwrite existing files on destination.
 
 make:controller
 ---------------
@@ -66,10 +66,10 @@ Argument:
 
 Options:
 ========
-* ``-bare``: Extends from ``CodeIgniter\Controller`` instead of ``BaseController``.
-* ``-restful``: Extends from a RESTful resource. Choices are ``controller`` and ``presenter``. Defaults to ``controller``.
+* ``--bare``: Extends from ``CodeIgniter\Controller`` instead of ``BaseController``.
+* ``--restful``: Extends from a RESTful resource. Choices are ``controller`` and ``presenter``. Defaults to ``controller``.
 * ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
-* ``-force``: Set this flag to overwrite existing files on destination.
+* ``--force``: Set this flag to overwrite existing files on destination.
 
 make:entity
 -----------
@@ -109,7 +109,7 @@ Argument:
 Options:
 ========
 * ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
-* ``-force``: Set this flag to overwrite existing files on destination.
+* ``--force``: Set this flag to overwrite existing files on destination.
 
 make:model
 ----------
@@ -128,11 +128,11 @@ Argument:
 
 Options:
 ========
-* ``-dbgroup``: Database group to use. Defaults to ``default``.
-* ``-entity``: Set this flag to use an entity class as the return type.
-* ``-table``: Supply a different table name. Defaults to the pluralized class name.
+* ``--dbgroup``: Database group to use. Defaults to ``default``.
+* ``--entity``: Set this flag to use an entity class as the return type.
+* ``--table``: Supply a different table name. Defaults to the pluralized class name.
 * ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
-* ``-force``: Set this flag to overwrite existing files on destination.
+* ``--force``: Set this flag to overwrite existing files on destination.
 
 make:seeder
 -----------
@@ -152,7 +152,7 @@ Argument:
 Options:
 ========
 * ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
-* ``-force``: Set this flag to overwrite existing files on destination.
+* ``--force``: Set this flag to overwrite existing files on destination.
 
 make:migration
 --------------
@@ -172,7 +172,7 @@ Argument:
 Options:
 ========
 * ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
-* ``-force``: Set this flag to overwrite existing files on destination.
+* ``--force``: Set this flag to overwrite existing files on destination.
 
 session:migration
 -----------------
@@ -190,7 +190,7 @@ Options:
 * ``-g``: Set the database group.
 * ``-t``: Set the table name. Defaults to ``ci_sessions``.
 * ``-n``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
-* ``-force``: Set this flag to overwrite existing files on destination.
+* ``--force``: Set this flag to overwrite existing files on destination.
 
 .. note:: When running ``php spark help session:migration``, you will see that it has the argument ``name`` listed.
 	This argument is not used as the class name is derived from the table name passed to the ``-t`` option.
@@ -346,7 +346,7 @@ which is public and need not be overridden as it is essentially complete.
 .. note:: ``GeneratorCommand`` has the default argument of ``['name' => 'Class name']``. You can
 	override the description by supplying the name in your ``$arguments`` property, e.g. ``['name' => 'Module class name']``.
 
-.. note:: ``GeneratorCommand`` has the default options of ``-n`` and ``-force``. Child classes cannot override
+.. note:: ``GeneratorCommand`` has the default options of ``-n`` and ``--force``. Child classes cannot override
 	these two properties as they are crucial in the implementation of the code generation.
 
 .. note:: Generators are default listed under the ``Generators`` namespace because it is the default group

--- a/user_guide_src/source/cli/cli_request.rst
+++ b/user_guide_src/source/cli/cli_request.rst
@@ -14,28 +14,28 @@ Additional Accessors
 
 Returns an array of the command line arguments deemed to be part of a path::
 
-    // command line: php index.php users 21 profile -foo bar
+    // command line: php index.php users 21 profile --foo bar
     echo $request->getSegments();  // ['users', '21', 'profile']
 
 **getPath()**
 
 Returns the reconstructed path as a string::
 
-    // command line: php index.php users 21 profile -foo bar
+    // command line: php index.php users 21 profile --foo bar
     echo $request->getPath();  // users/21/profile
 
 **getOptions()**
 
 Returns an array of the command line arguments deemed to be options::
 
-    // command line: php index.php users 21 profile -foo bar
+    // command line: php index.php users 21 profile --foo bar
     echo $request->getOptions();  // ['foo' => 'bar']
 
 **getOption($which)**
 
 Returns the value of a specific command line argument deemed to be an option::
 
-    // command line: php index.php users 21 profile -foo bar
+    // command line: php index.php users 21 profile --foo bar
     echo $request->getOption('foo');  // bar
     echo $request->getOption('notthere'); // NULL
 
@@ -43,5 +43,11 @@ Returns the value of a specific command line argument deemed to be an option::
 
 Returns the reconstructed command line string for the options::
 
-    // command line: php index.php users 21 profile -foo bar
-    echo $request->getOptionPath();  // -foo bar
+    // command line: php index.php users 21 profile --foo bar
+    echo $request->getOptionString();  // -foo bar
+
+Passing ``true`` to the first argument will try to write long options using two dashes::
+
+    // php index.php user 21 --foo bar -f
+    echo $request->getOptionString(); // -foo bar -f
+    echo $request->getOptionString(true); // --foo bar -f


### PR DESCRIPTION
**Description**
I just realized that we are unknowingly accepting options to be written either starting with `-` or `--`. This is because on trimming the options we are using `ltrim` which greedily trims the dashes. So:
```php
echo ltrim('-allow', '-'); // allow
echo ltrim('--allow', '-'); // allow
```

This PR suggests using the "longopts-style" for writing long options, i.e. using `--`. This change will not affect previous usages because of the `ltrim` above and `mb_strpos($arg, '-') === 0` will match for both `-` and `--`. Additionally, I intentionally did not change the unit tests for commands that uses `-` to show that it will still work as intended.

For `getOptionString`, I added optional parameters that will change the existing parsing to use the longopts style. It is default to `false` to match with current behavior. Then, I noticed that `CLI::getOptionString` and `CLIRequest::getOptionString` behaves differently in terms of trimming the final output string. The former gives it raw while the latter outputs it trimmed. Oh well.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
