### PR TITLE
Use MockCache during testing

### DIFF
--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -41,6 +41,7 @@ namespace CodeIgniter\Test;
 
 use CodeIgniter\Events\Events;
 use CodeIgniter\Session\Handlers\ArrayHandler;
+use CodeIgniter\Test\Mock\MockCache;
 use CodeIgniter\Test\Mock\MockEmail;
 use CodeIgniter\Test\Mock\MockSession;
 use Config\Services;
@@ -65,6 +66,7 @@ class CIUnitTestCase extends TestCase
 	 * @var array of methods
 	 */
 	protected $setUpMethods = [
+		'mockCache',
 		'mockEmail',
 		'mockSession',
 	];
@@ -120,6 +122,22 @@ class CIUnitTestCase extends TestCase
 	//--------------------------------------------------------------------
 
 	/**
+	 * Injects the mock Cache driver to prevent filesystem collisions
+	 */
+	protected function mockCache()
+	{
+		Services::injectMock('cache', new MockCache());
+	}
+
+	/**
+	 * Injects the mock email driver so no emails really send
+	 */
+	protected function mockEmail()
+	{
+		Services::injectMock('email', new MockEmail(config('Email')));
+	}
+
+	/**
 	 * Injects the mock session driver into Services
 	 */
 	protected function mockSession()
@@ -130,14 +148,6 @@ class CIUnitTestCase extends TestCase
 		$session = new MockSession(new ArrayHandler($config, '0.0.0.0'), $config);
 
 		Services::injectMock('session', $session);
-	}
-
-	/**
-	 * Injects the mock email driver so no emails really send
-	 */
-	protected function mockEmail()
-	{
-		Services::injectMock('email', new MockEmail(config('Email')));
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Commands/ClearCacheTest.php
+++ b/tests/system/Commands/ClearCacheTest.php
@@ -1,7 +1,9 @@
 <?php namespace CodeIgniter\Commands;
 
+use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Config\Services;
 
 class ClearCacheTest extends CIUnitTestCase
 {
@@ -15,6 +17,9 @@ class ClearCacheTest extends CIUnitTestCase
 		CITestStreamFilter::$buffer = '';
 		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
 		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+
+		// Make sure we are testing with the correct handler (override injections)
+		Services::injectMock('cache', CacheFactory::getHandler(config('Cache')));
 	}
 
 	public function tearDown(): void


### PR DESCRIPTION
**Description**
The default Cache driver is `FileHandler` which can create unwanted files on the local filesystem during testing, especially for the CLI user has permissions that differ from a web user. This PR adds a `mockCache()` method to `CIUnitTestCase` and includes it in the array of `setUpMethods` by default.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
