### PR TITLE
In method find returns uniform data

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -426,7 +426,7 @@ class Model
 		{
 			$row = $builder->get();
 
-			$row = $row->getResult($this->tempReturnType);
+			$row = $row->getFirstRow($this->tempReturnType);
 		}
 
 		$eventData = [


### PR DESCRIPTION
If find is used like: `$model->where("column", "5")->find()`, the ci4 returned array like [0->["id"=>1, "column"=>5]]. But mine opinion is, that it will be better to return only the first row

Each pull request should address a single issue and have a meaningful title.

**Description**
Explain what you have changed, and why.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

---------Remove from here down in your description----------

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository
  
