### PR TITLE
Add post-migration event

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -39,6 +39,7 @@
 namespace CodeIgniter\Database;
 
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\ConfigException;
 use Config\Migrations as MigrationsConfig;
 use Config\Services;
@@ -246,6 +247,10 @@ class MigrationRunner
 			}
 		}
 
+		$data           = get_object_vars($this);
+		$data['method'] = 'latest';
+		Events::trigger('migrate', $data);
+
 		return true;
 	}
 
@@ -368,6 +373,10 @@ class MigrationRunner
 				throw new \RuntimeException($message);
 			}
 		}
+
+		$data           = get_object_vars($this);
+		$data['method'] = 'regress';
+		Events::trigger('migrate', $data);
 
 		// Restore the namespace
 		$this->namespace = $tmpNamespace;

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -1,5 +1,6 @@
 <?php namespace CodeIgniter\Database;
 
+use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Test\CIDatabaseTestCase;
 use Config\Migrations;

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -255,7 +255,7 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 		$this->assertFalse($this->db->tableExists('foo'));
 	}
 
-	public function testProgressSuccess()
+	public function testLatestSuccess()
 	{
 		$config = $this->config;
 		$runner = new MigrationRunner($config);
@@ -292,6 +292,34 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 		$history = $runner->getHistory();
 		$this->assertEmpty($history);
+	}
+
+	public function testLatestTriggersEvent()
+	{
+		$result = null;
+
+		Events::on('migrate', function ($arg) use (&$result) {
+			$result = $arg;
+		});
+
+		$this->testLatestSuccess();
+
+		$this->assertIsArray($result);
+		$this->assertEquals('latest', $result['method']);
+	}
+
+	public function testRegressTriggersEvent()
+	{
+		$result = null;
+
+		Events::on('migrate', function ($arg) use (&$result) {
+			$result = $arg;
+		});
+
+		$this->testRegressSuccess();
+
+		$this->assertIsArray($result);
+		$this->assertEquals('regress', $result['method']);
 	}
 
 	public function testHistoryRecordsBatches()

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -258,12 +258,10 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testLatestSuccess()
 	{
-		$config = $this->config;
-		$runner = new MigrationRunner($config);
-		$runner->setSilent(false);
-		$runner->clearHistory();
-
-		$runner = $runner->setNamespace('Tests\Support\MigrationTestMigrations');
+		$runner = new MigrationRunner($this->config);
+		$runner->setSilent(false)
+			->setNamespace('Tests\Support\MigrationTestMigrations')
+			->clearHistory();
 
 		$runner->latest();
 		$version = $runner->getBatchEnd($runner->getLastBatch());
@@ -278,14 +276,14 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testRegressSuccess()
 	{
-		$config = $this->config;
-		$runner = new MigrationRunner($config);
-		$runner->setSilent(false);
+		$runner = new MigrationRunner($this->config);
+		$runner->setSilent(false)
+			->setNamespace('Tests\Support\MigrationTestMigrations')
+			->clearHistory();
 
-		$runner = $runner->setNamespace('Tests\Support\MigrationTestMigrations');
 		$runner->latest();
-
 		$runner->regress();
+
 		$version = $runner->getBatchEnd($runner->getLastBatch());
 
 		$this->assertEquals(0, $version);
@@ -297,13 +295,17 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testLatestTriggersEvent()
 	{
-		$result = null;
+		$runner = new MigrationRunner($this->config);
+		$runner->setSilent(false)
+			->setNamespace('Tests\Support\MigrationTestMigrations')
+			->clearHistory();
 
+		$result = null;
 		Events::on('migrate', function ($arg) use (&$result) {
 			$result = $arg;
 		});
 
-		$this->testLatestSuccess();
+		$runner->latest();
 
 		$this->assertIsArray($result);
 		$this->assertEquals('latest', $result['method']);
@@ -311,13 +313,18 @@ class MigrationRunnerTest extends CIDatabaseTestCase
 
 	public function testRegressTriggersEvent()
 	{
-		$result = null;
+		$runner = new MigrationRunner($this->config);
+		$runner->setSilent(false)
+			->setNamespace('Tests\Support\MigrationTestMigrations')
+			->clearHistory();
 
+		$result = null;
 		Events::on('migrate', function ($arg) use (&$result) {
 			$result = $arg;
 		});
 
-		$this->testRegressSuccess();
+		$runner->latest();
+		$runner->regress();
 
 		$this->assertIsArray($result);
 		$this->assertEquals('regress', $result['method']);

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -21,6 +21,11 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 		Events::removeAllListeners();
 	}
 
+	protected function tearDown(): void
+	{
+		Events::simulate(false);
+	}
+
 	//--------------------------------------------------------------------
 
 	/**

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -109,3 +109,5 @@ The following is a list of available event points within the CodeIgniter core co
 * **post_controller_constructor** Called immediately after your controller is instantiated, but prior to any method calls happening.
 * **post_system** Called after the final rendered page is sent to the browser, at the end of system execution after the finalized data is sent to the browser.
 * **email** Called after an email sent successfully from ``CodeIgniter\Email\Email``. Receives an array of the ``Email`` class's properties as a parameter.
+* **DBQuery** Called after a successfully-completed database query. Receives the ``Query`` object.
+* **migrate** Called after a successful migration call to ``latest()`` or ``regress()``. Receives the current properties of ``MigrationRunner`` as well as the name of the method.


### PR DESCRIPTION
**Description**
Adds an event after running migration `latest` or `regress`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [x] User guide updated
- [X] Conforms to style guide
