### PR TITLE
Eliminate 'App' in migrate:status if different from APP_NAMESPACE

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -47,3 +47,4 @@ parameters:
   dynamicConstantNames:
     - ENVIRONMENT
     - CI_DEBUG
+    - APP_NAMESPACE

--- a/system/Commands/Database/MigrateStatus.php
+++ b/system/Commands/Database/MigrateStatus.php
@@ -50,7 +50,6 @@ use Config\Services;
  */
 class MigrateStatus extends BaseCommand
 {
-
 	/**
 	 * The group the command is lumped under
 	 * when listing commands.
@@ -141,6 +140,11 @@ class MigrateStatus extends BaseCommand
 				continue;
 			}
 
+			if (APP_NAMESPACE !== 'App' && $namespace === 'App')
+			{
+				continue; // @codeCoverageIgnore
+			}
+
 			$runner->setNamespace($namespace);
 			$migrations = $runner->findMigrations();
 
@@ -170,6 +174,7 @@ class MigrateStatus extends BaseCommand
 			foreach ($migrations as $uid => $migration)
 			{
 				$date = '';
+
 				foreach ($history as $row)
 				{
 					if ($runner->getObjectUid($row) !== $uid)
@@ -179,8 +184,11 @@ class MigrateStatus extends BaseCommand
 
 					$date = date('Y-m-d H:i:s', $row->time);
 				}
-				CLI::write(str_pad('  ' . $migration->name, $max + 6) . ($date ? $date : '---'));
+
+				CLI::write(str_pad('  ' . $migration->name, $max + 6) . ($date ?: '---'));
 			}
+
+			CLI::newLine();
 		}
 
 		if (! $found)
@@ -188,5 +196,4 @@ class MigrateStatus extends BaseCommand
 			CLI::error(lang('Migrations.noneFound'));
 		}
 	}
-
 }


### PR DESCRIPTION
**Description**
If I have set the value of `APP_NAMESPACE` to a value other than the default `App`, then I would not want `App` to be listed in the `migrate:status` as it would be practically redundant with the value in `APP_NAMESPACE`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
