### PR TITLE
Remove the autoinc logic as it dont

### DIFF
--- a/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
+++ b/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
@@ -4,15 +4,12 @@ class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
 {
 	public function up()
 	{
-		// SQLite3 uses auto increment different
-		$unique_or_auto = $this->db->DBDriver === 'SQLite3' ? 'unique' : 'auto_increment';
-
 		// User Table
 		$this->forge->addField([
 			'id'         => [
 				'type'          => 'INTEGER',
 				'constraint'    => 3,
-				$unique_or_auto => true,
+				'auto_increment'=> true,
 			],
 			'name'       => [
 				'type'       => 'VARCHAR',
@@ -47,7 +44,7 @@ class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
 			'id'          => [
 				'type'          => 'INTEGER',
 				'constraint'    => 3,
-				$unique_or_auto => true,
+				'auto_increment'=> true,
 			],
 			'name'        => [
 				'type'       => 'VARCHAR',
@@ -81,7 +78,7 @@ class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
 			'id'    => [
 				'type'          => 'INTEGER',
 				'constraint'    => 3,
-				$unique_or_auto => true,
+				'auto_increment'=> true,
 			],
 			'key'   => [
 				'type'       => 'VARCHAR',
@@ -99,7 +96,7 @@ class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
 			'id'             => [
 				'type'          => 'INTEGER', //must be interger else SQLite3 error on not null for autoinc field
 				'constraint'    => 20,
-				$unique_or_auto => true,
+				'auto_increment'=> true,
 			],
 			'type_varchar'   => [
 				'type'       => 'VARCHAR',
@@ -208,7 +205,7 @@ class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
 			'id'         => [
 				'type'          => 'INTEGER',
 				'constraint'    => 3,
-				$unique_or_auto => true,
+				'auto_increment'=> true,
 			],
 			'name'       => [
 				'type'       => 'VARCHAR',
@@ -231,7 +228,7 @@ class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
 			'id'    => [
 				'type'          => 'INTEGER',
 				'constraint'    => 3,
-				$unique_or_auto => true,
+				'auto_increment'=> true,
 			],
 			'key'   => [
 				'type'       => 'VARCHAR',


### PR DESCRIPTION
seem to work, it creates a constraint that is not autoinc
each time. By doing it the same way as the other databases
one can use it now as a autoinc and not get
not null errors when inserting data

This is how definition looks after change
![prent](https://user-images.githubusercontent.com/33496470/93045955-dd628e00-f658-11ea-924d-c7fe6f27d72a.png)

Data is inserted with seeder still correctly

![prent](https://user-images.githubusercontent.com/33496470/93045977-eeab9a80-f658-11ea-87a9-9702819408ca.png)


The table without auto inc looks like all the others did before change
![prent](https://user-images.githubusercontent.com/33496470/93046030-1a2e8500-f659-11ea-9108-96763760ece4.png)
![prent](https://user-images.githubusercontent.com/33496470/93046043-2286c000-f659-11ea-94e3-bafce6080876.png)


**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

