### PR TITLE
Unify QA bootstrap files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
 			"CodeIgniter\\ComposerScripts::postUpdate",
 			"bash admin/setup.sh"
 		],
+		"analyze": "phpstan analyze",
 		"test": "phpunit"
 	},
 	"support": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,7 +6,7 @@ parameters:
     - system
   treatPhpDocTypesAsCertain: false
   bootstrapFiles:
-    - qa-bootstrap.php
+    - system/Test/bootstrap.php
   excludes_analyse:
     - app/Views/errors/cli/*
     - app/Views/errors/html/*

--- a/qa-bootstrap.php
+++ b/qa-bootstrap.php
@@ -1,9 +1,0 @@
-<?php
-
-define('CONFIGPATH', __DIR__ . '/app/Config/');
-define('PUBLICPATH', __DIR__ . '/app/public/');
-define('HOMEPATH', __DIR__);
-
-require 'app/Config/Paths.php';
-$paths = new Config\Paths();
-require_once 'system/bootstrap.php';

--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -148,7 +148,7 @@ class Serve extends BaseCommand
 		CLI::write('Press Control-C to stop.');
 
 		// Set the Front Controller path as Document Root.
-		$docroot = escapeshellarg(FCPATH); // @phpstan-ignore-line
+		$docroot = escapeshellarg(FCPATH);
 
 		// Mimic Apache's mod_rewrite functionality with user settings.
 		$rewrite = escapeshellarg(__DIR__ . '/rewrite.php');

--- a/system/Common.php
+++ b/system/Common.php
@@ -134,8 +134,7 @@ if (! function_exists('clean_path'))
 				return 'APPPATH' . DIRECTORY_SEPARATOR . substr($path, strlen(APPPATH));
 			case strpos($path, SYSTEMPATH) === 0:
 				return 'SYSTEMPATH' . DIRECTORY_SEPARATOR . substr($path, strlen(SYSTEMPATH));
-			case strpos($path, FCPATH) === 0: // @phpstan-ignore-line
-				// @phpstan-ignore-next-line
+			case strpos($path, FCPATH) === 0:
 				return 'FCPATH' . DIRECTORY_SEPARATOR . substr($path, strlen(FCPATH));
 			case defined('VENDORPATH') && strpos($path, VENDORPATH) === 0:
 				return 'VENDORPATH' . DIRECTORY_SEPARATOR . substr($path, strlen(VENDORPATH));

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -132,7 +132,7 @@ class AutoloadConfig
 	{
 		if (isset($_SERVER['CI_ENVIRONMENT']) && $_SERVER['CI_ENVIRONMENT'] === 'testing')
 		{
-			$this->psr4['Tests\Support']                  = SUPPORTPATH; // @phpstan-ignore-line
+			$this->psr4['Tests\Support']                  = SUPPORTPATH;
 			$this->classmap['CodeIgniter\Log\TestLogger'] = SYSTEMPATH . 'Test/TestLogger.php';
 			$this->classmap['CIDatabaseTestCase']         = SYSTEMPATH . 'Test/CIDatabaseTestCase.php';
 		}

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -389,8 +389,8 @@ class Exceptions
 			case strpos($file, SYSTEMPATH) === 0:
 				$file = 'SYSTEMPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(SYSTEMPATH));
 				break;
-			case strpos($file, FCPATH) === 0: // @phpstan-ignore-line
-				$file = 'FCPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(FCPATH)); // @phpstan-ignore-line
+			case strpos($file, FCPATH) === 0:
+				$file = 'FCPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(FCPATH));
 				break;
 			case defined('VENDORPATH') && strpos($file, VENDORPATH) === 0:
 				$file = 'VENDORPATH' . DIRECTORY_SEPARATOR . substr($file, strlen(VENDORPATH));

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -534,7 +534,7 @@ class Logger implements LoggerInterface
 		$file = str_replace(APPPATH, 'APPPATH/', $file);
 		$file = str_replace(SYSTEMPATH, 'SYSTEMPATH/', $file);
 
-		return str_replace(FCPATH, 'FCPATH/', $file); // @phpstan-ignore-line
+		return str_replace(FCPATH, 'FCPATH/', $file);
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -72,7 +72,7 @@ class CIDatabaseTestCase extends CIUnitTestCase
 	 *
 	 * @var string
 	 */
-	protected $basePath = SUPPORTPATH . 'Database'; // @phpstan-ignore-line
+	protected $basePath = SUPPORTPATH . 'Database';
 
 	/**
 	 * The namespace(s) to help us find the migration classes.

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -11,7 +11,11 @@ defined('CI_DEBUG') || define('CI_DEBUG', true);
 
 // Often these constants are pre-defined, but query the current directory structure as a fallback
 defined('HOMEPATH') || define('HOMEPATH', realpath(rtrim(getcwd(), '\\/ ')) . DIRECTORY_SEPARATOR);
-$source = is_dir(HOMEPATH . 'app') ? HOMEPATH : 'vendor/codeigniter4/codeigniter4/';
+$source = is_dir(HOMEPATH . 'app') 
+       ? HOMEPATH 
+       : (is_dir('vendor/codeigniter4/framework/') 
+               ? 'vendor/codeigniter4/framework/' 
+               : 'vendor/codeigniter4/codeigniter4/');
 defined('CONFIGPATH') || define('CONFIGPATH', realpath($source . 'app/Config') . DIRECTORY_SEPARATOR);
 defined('PUBLICPATH') || define('PUBLICPATH', realpath($source . 'app/Config') . DIRECTORY_SEPARATOR);
 unset($source);

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -11,13 +11,13 @@ defined('CI_DEBUG') || define('CI_DEBUG', true);
 
 // Often these constants are pre-defined, but query the current directory structure as a fallback
 defined('HOMEPATH') || define('HOMEPATH', realpath(rtrim(getcwd(), '\\/ ')) . DIRECTORY_SEPARATOR);
-$source = is_dir(HOMEPATH . 'app') 
-       ? HOMEPATH 
-       : (is_dir('vendor/codeigniter4/framework/') 
-               ? 'vendor/codeigniter4/framework/' 
-               : 'vendor/codeigniter4/codeigniter4/');
+$source = is_dir(HOMEPATH . 'app')
+	   ? HOMEPATH
+	   : (is_dir('vendor/codeigniter4/framework/')
+			   ? 'vendor/codeigniter4/framework/'
+			   : 'vendor/codeigniter4/codeigniter4/');
 defined('CONFIGPATH') || define('CONFIGPATH', realpath($source . 'app/Config') . DIRECTORY_SEPARATOR);
-defined('PUBLICPATH') || define('PUBLICPATH', realpath($source . 'app/Config') . DIRECTORY_SEPARATOR);
+defined('PUBLICPATH') || define('PUBLICPATH', realpath($source . 'public') . DIRECTORY_SEPARATOR);
 unset($source);
 
 // Load framework paths from their config file

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -7,6 +7,14 @@ ini_set('display_startup_errors', '1');
 // Make sure it recognizes that we're testing.
 $_SERVER['CI_ENVIRONMENT'] = 'testing';
 define('ENVIRONMENT', 'testing');
+defined('CI_DEBUG') || define('CI_DEBUG', true);
+
+// Often these constants are pre-defined, but query the current directory structure as a fallback
+defined('HOMEPATH') || define('HOMEPATH', realpath(rtrim(getcwd(), '\\/ ')) . DIRECTORY_SEPARATOR);
+$source = is_dir(HOMEPATH . 'app') ? HOMEPATH : 'vendor/codeigniter4/codeigniter4/';
+defined('CONFIGPATH') || define('CONFIGPATH', realpath($source . 'app/Config') . DIRECTORY_SEPARATOR);
+defined('PUBLICPATH') || define('PUBLICPATH', realpath($source . 'app/Config') . DIRECTORY_SEPARATOR);
+unset($source);
 
 // Load framework paths from their config file
 require CONFIGPATH . 'Paths.php';

--- a/user_guide_src/source/installation/running.rst
+++ b/user_guide_src/source/installation/running.rst
@@ -208,3 +208,15 @@ Once set up, you can then launch your webapp inside a VM, with the command::
 Your webapp will be accessible at ``http://localhost:8080``, with the code coverage
 report for your build at ``http://localhost:8081`` and the user guide for
 it at ``http://localhost:8082``.
+
+Bootstrapping the App
+=================================================
+
+In some scenarios you will want to load the framework without actually running the whole
+application. This is particularly useful for unit testing your project, but may also be
+handy for using third-party tools to analyze and modify your code. The framework comes
+with a separate bootstrap script specifically for this scenario: ``system/Test/bootstrap.php``.
+
+Most of the paths to your project are defined during the bootstrap process. You may use
+pre-defined constants to override these, but when using the defaults be sure that your
+paths align with the expected directory structure for your installation method.


### PR DESCRIPTION
**Description**
This PR adjusts our PHPUnit bootstrap file to work with PHPStan, and hopefully any other external code processor. Not only does this allow us to unify the process, but modules and projects should now be able to use the same one without needing to define their own.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
