### PR TITLE
Write migrate status in tabular format

### DIFF
--- a/system/Language/en/Migrations.php
+++ b/system/Language/en/Migrations.php
@@ -45,13 +45,17 @@ return [
    'toVersion'         => 'Migrating to current version...',
    'rollingBack'       => 'Rolling back migrations to batch: ',
    'noneFound'         => 'No migrations were found.',
-   'on'                => 'Migrated On: ',
    'migSeeder'         => 'Seeder name',
    'migMissingSeeder'  => 'You must provide a seeder name.',
    'nameSeeder'        => 'Name the seeder file',
    'removed'           => 'Rolling back: ',
    'added'             => 'Running: ',
 
-   'version'           => 'Version',
+   // Migrate Status
+   'namespace'         => 'Namespace',
    'filename'          => 'Filename',
+   'version'           => 'Version',
+   'group'             => 'Group',
+   'on'                => 'Migrated On: ',
+   'batch'             => 'Batch',
 ];


### PR DESCRIPTION
**Description**
For beautiful and more verbose output of `migrate:status`.

`Before`
![image](https://user-images.githubusercontent.com/51850998/93113110-5c080b80-f6eb-11ea-82b5-cdc63873a759.png)

`After`
![image](https://user-images.githubusercontent.com/51850998/93113147-67f3cd80-f6eb-11ea-861d-2457b0b697b9.png)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
