### PR TITLE
Implement getTotal item on pager

### DIFF
--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -263,6 +263,22 @@ class Pager implements PagerInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Returns the total number of items in data store.
+	 *
+	 * @param string $group
+	 *
+	 * @return integer
+	 */
+	public function getTotal(string $group = 'default'): int
+	{
+		$this->ensureGroup($group);
+
+		return $this->groups[$group]['total'];
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Returns the total number of pages.
 	 *
 	 * @param string $group

--- a/system/Pager/PagerInterface.php
+++ b/system/Pager/PagerInterface.php
@@ -112,6 +112,17 @@ interface PagerInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Returns the total number of items in data store.
+	 *
+	 * @param string $group
+	 *
+	 * @return integer
+	 */
+	public function getTotal(string $group = 'default'): int;
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Returns the total number of pages.
 	 *
 	 * @param string $group

--- a/system/Pager/PagerInterface.php
+++ b/system/Pager/PagerInterface.php
@@ -112,17 +112,6 @@ interface PagerInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * Returns the total number of items in data store.
-	 *
-	 * @param string $group
-	 *
-	 * @return integer
-	 */
-	public function getTotal(string $group = 'default'): int;
-
-	//--------------------------------------------------------------------
-
-	/**
 	 * Returns the total number of pages.
 	 *
 	 * @param string $group

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -205,6 +205,13 @@ class PagerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(1, $this->pager->getPageCount());
 	}
 
+	public function testGetTotalCorrectValue()
+	{
+		$this->pager->store('foo', 3, 12, 70);
+
+		$this->assertEquals(70, $this->pager->getTotal('foo'));
+	}
+
 	public function testGetTotalPagesCalcsCorrectValue()
 	{
 		$this->pager->store('foo', 3, 12, 70);


### PR DESCRIPTION
**Description**
This PR implement getTotal() item on pager.
Example:
```php
$model = new SampleModel();

$data = $model->paginate();
$total = $model->pager->getTotal();
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  
 