### PR TITLE
CSRFVerify - json-cookie-value  compar correction

### DIFF
--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -240,7 +240,8 @@ class Security
 					null));
 
 		// Do the tokens exist in both the _POST/POSTed JSON and _COOKIE arrays?
-		if (! isset($CSRFTokenValue, $_COOKIE[$this->CSRFCookieName]) || $CSRFTokenValue !== $_COOKIE[$this->CSRFCookieName]
+		if (isset($CSRFTokenValue, $_COOKIE[$this->CSRFCookieName],$json->{$this->CSRFTokenName}) && $CSRFTokenValue == $_COOKIE[$this->CSRFCookieName]
+			&& $json->{$this->CSRFTokenName} == $CSRFTokenValue
 		) // Do the tokens match?
 		{
 			throw SecurityException::forDisallowedAction();


### PR DESCRIPTION
The CSRFVerify  has a test to see if the value exist in the cookie and json at same time and is the same
but the previous IF basically made a forDisallowedAction exception to be thrown if the cookie did not exist for example
it did not take the json into account for the compare. Thus basically if with a first POST the value came in, it threw the exception
and never set the cookie for all following calls to it, thus the CSRF cookie never set then.
```
		// Do the tokens exist in both the _POST/POSTed JSON and _COOKIE arrays?
		if (! isset($CSRFTokenValue, $_COOKIE[$this->CSRFCookieName]) || $CSRFTokenValue !== $_COOKIE[$this->CSRFCookieName]
		) // Do the tokens match?
		{

```

The change will see if the cookie and json exist and if both is equal to the same value, if they are then  the exception is thrown.,
i wanted to add the post array also but dunno if that really must be taken into account here or not ?

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
