### PR TITLE
Clarify model find* event data

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -393,10 +393,17 @@ class Model
 	 */
 	public function find($id = null)
 	{
+		$singleton = is_numeric($id) || is_string($id);
+
 		if ($this->tempAllowCallbacks)
 		{
 			// Call the before event and check for a return
-			$eventData = $this->trigger('beforeFind', ['id' => $id, 'method' => 'find']);
+			$eventData = $this->trigger('beforeFind', [
+				'id'        => $id,
+				'method'    => 'find',
+				'singleton' => $singleton,
+			]);
+
 			if (! empty($eventData['returnData']))
 			{
 				return $eventData['data'];
@@ -415,7 +422,7 @@ class Model
 					->get();
 			$row = $row->getResult($this->tempReturnType);
 		}
-		elseif (is_numeric($id) || is_string($id))
+		elseif ($singleton)
 		{
 			$row = $builder->where($this->table . '.' . $this->primaryKey, $id)
 					->get();
@@ -430,9 +437,10 @@ class Model
 		}
 
 		$eventData = [
-			'id'     => $id,
-			'data'   => $row,
-			'method' => 'find',
+			'id'        => $id,
+			'data'      => $row,
+			'method'    => 'find',
+			'singleton' => $singleton,
 		];
 		if ($this->tempAllowCallbacks)
 		{
@@ -486,7 +494,12 @@ class Model
 		if ($this->tempAllowCallbacks)
 		{
 			// Call the before event and check for a return
-			$eventData = $this->trigger('beforeFind', ['method' => 'findAll', 'limit' => $limit, 'offset' => $offset]);
+			$eventData = $this->trigger('beforeFind', [
+				'method'    => 'findAll',
+				'limit'     => $limit,
+				'offset'    => $offset,
+				'singleton' => false,
+			]);
 			if (! empty($eventData['returnData']))
 			{
 				return $eventData['data'];
@@ -506,10 +519,11 @@ class Model
 		$row = $row->getResult($this->tempReturnType);
 
 		$eventData = [
-			'data'   => $row,
-			'limit'  => $limit,
-			'offset' => $offset,
-			'method' => 'findAll',
+			'data'      => $row,
+			'limit'     => $limit,
+			'offset'    => $offset,
+			'method'    => 'findAll',
+			'singleton' => false,
 		];
 		if ($this->tempAllowCallbacks)
 		{
@@ -536,7 +550,11 @@ class Model
 		if ($this->tempAllowCallbacks)
 		{
 			// Call the before event and check for a return
-			$eventData = $this->trigger('beforeFind', ['method' => 'first']);
+			$eventData = $this->trigger('beforeFind', [
+				'method'    => 'first',
+				'singleton' => true,
+			]);
+
 			if (! empty($eventData['returnData']))
 			{
 				return $eventData['data'];
@@ -570,8 +588,9 @@ class Model
 		$row = $row->getFirstRow($this->tempReturnType);
 
 		$eventData = [
-			'data'   => $row,
-			'method' => 'first',
+			'data'      => $row,
+			'method'    => 'first',
+			'singleton' => true,
 		];
 		if ($this->tempAllowCallbacks)
 		{

--- a/system/Model.php
+++ b/system/Model.php
@@ -430,8 +430,9 @@ class Model
 		}
 
 		$eventData = [
-			'id'   => $id,
-			'data' => $row,
+			'id'     => $id,
+			'data'   => $row,
+			'method' => 'find',
 		];
 		if ($this->tempAllowCallbacks)
 		{
@@ -508,6 +509,7 @@ class Model
 			'data'   => $row,
 			'limit'  => $limit,
 			'offset' => $offset,
+			'method' => 'findAll',
 		];
 		if ($this->tempAllowCallbacks)
 		{
@@ -567,7 +569,10 @@ class Model
 
 		$row = $row->getFirstRow($this->tempReturnType);
 
-		$eventData = ['data' => $row];
+		$eventData = [
+			'data'   => $row,
+			'method' => 'first',
+		];
 		if ($this->tempAllowCallbacks)
 		{
 			$eventData = $this->trigger('afterFind', $eventData);

--- a/tests/_support/Models/EventModel.php
+++ b/tests/_support/Models/EventModel.php
@@ -28,6 +28,9 @@ class EventModel extends Model
 	protected $beforeFind   = ['beforeFindMethod'];
 	protected $afterFind    = ['afterFindMethod'];
 
+	// Cache of the most recent eventData from a trigger
+	public $eventData;
+
 	// Testing directive to set $returnData on beforeFind event
 	public $beforeFindReturnData = false;
 
@@ -36,49 +39,56 @@ class EventModel extends Model
 
 	protected function beforeInsertMethod(array $data)
 	{
-		$this->tokens[] = 'beforeInsert';
+		$this->tokens[]  = 'beforeInsert';
+		$this->eventData = $data;
 
 		return $data;
 	}
 
 	protected function afterInsertMethod(array $data)
 	{
-		$this->tokens[] = 'afterInsert';
+		$this->tokens[]  = 'afterInsert';
+		$this->eventData = $data;
 
 		return $data;
 	}
 
 	protected function beforeUpdateMethod(array $data)
 	{
-		$this->tokens[] = 'beforeUpdate';
+		$this->tokens[]  = 'beforeUpdate';
+		$this->eventData = $data;
 
 		return $data;
 	}
 
 	protected function afterUpdateMethod(array $data)
 	{
-		$this->tokens[] = 'afterUpdate';
+		$this->tokens[]  = 'afterUpdate';
+		$this->eventData = $data;
 
 		return $data;
 	}
 
 	protected function beforeDeleteMethod(array $data)
 	{
-		$this->tokens[] = 'beforeDelete';
+		$this->tokens[]  = 'beforeDelete';
+		$this->eventData = $data;
 
 		return $data;
 	}
 
 	protected function afterDeleteMethod(array $data)
 	{
-		$this->tokens[] = 'afterDelete';
+		$this->tokens[]  = 'afterDelete';
+		$this->eventData = $data;
 
 		return $data;
 	}
 
 	protected function beforeFindMethod(array $data)
 	{
-		$this->tokens[] = 'beforeFind';
+		$this->tokens[]  = 'beforeFind';
+		$this->eventData = $data;
 
 		if ($this->beforeFindReturnData)
 		{
@@ -91,7 +101,8 @@ class EventModel extends Model
 
 	protected function afterFindMethod(array $data)
 	{
-		$this->tokens[] = 'afterFind';
+		$this->tokens[]  = 'afterFind';
+		$this->eventData = $data;
 
 		return $data;
 	}

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1130,6 +1130,39 @@ class ModelTest extends CIDatabaseTestCase
 		$this->assertFalse($model->hasToken('afterFind'));
 	}
 
+	public function testFindEventSingletons()
+	{
+		$model = new EventModel();
+
+		// afterFind
+		$model->first();
+		$this->assertEquals(true, $model->eventData['singleton']);
+
+		$model->find(1);
+		$this->assertEquals(true, $model->eventData['singleton']);
+
+		$model->find();
+		$this->assertEquals(false, $model->eventData['singleton']);
+
+		$model->findAll();
+		$this->assertEquals(false, $model->eventData['singleton']);
+
+		// beforeFind
+		$model->beforeFindReturnData = true;
+
+		$model->first();
+		$this->assertEquals(true, $model->eventData['singleton']);
+
+		$model->find(1);
+		$this->assertEquals(true, $model->eventData['singleton']);
+
+		$model->find();
+		$this->assertEquals(false, $model->eventData['singleton']);
+
+		$model->findAll();
+		$this->assertEquals(false, $model->eventData['singleton']);
+	}
+
 	//--------------------------------------------------------------------
 
 	public function testAllowCallbacksFalsePreventsTriggers()

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -795,7 +795,7 @@ beforeUpdate      **id** = the array of primary keys of the rows being updated.
 afterUpdate       **id** = the array of primary keys of the rows being updated.
                   **data** = the key/value pairs being updated.
                   **result** = the results of the update() method used through the Query Builder.
-beforeFind        The name of the calling **method**, with these additional fields:
+beforeFind        The name of the calling **method**, whether a **singleton** was requested, and these additional fields:
 - first()         No additional fields
 - find()          **id** = the primary key of the row being searched for.
 - findAll()       **limit** = the number of rows to find.

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -795,14 +795,12 @@ beforeUpdate      **id** = the array of primary keys of the rows being updated.
 afterUpdate       **id** = the array of primary keys of the rows being updated.
                   **data** = the key/value pairs being updated.
                   **result** = the results of the update() method used through the Query Builder.
-afterFind         Varies by find* method. See the following:
+beforeFind        The name of the calling **method**, with these additional fields:
+- first()         No additional fields
 - find()          **id** = the primary key of the row being searched for.
-                  **data** = The resulting row of data, or null if no result found.
-- findAll()       **data** = the resulting rows of data, or null if no result found.
-                  **limit** = the number of rows to find.
+- findAll()       **limit** = the number of rows to find.
                   **offset** = the number of rows to skip during the search.
-- first()         **data** = the resulting row found during the search, or null if none found.
-beforeFind        Same as **afterFind** but with the name of the calling **$method** instead of **$data**.
+afterFind         Same as **beforeFind** but including the resulting row(s) of data, or null if no result found.
 beforeDelete      Varies by delete* method. See the following:
 - delete()        **id** = primary key of row being deleted.
                   **purge** = boolean whether soft-delete rows should be hard deleted.


### PR DESCRIPTION
**Description**
Currently the `beforeFind` and `afterFind` events can be triggered by three different methods, each of which has different data conditions which are difficult for the event recipient to parse. For example, if `$eventData['data']` contains an array is it an array of results or a single result array?

This PR defines "singletons" - model `find*` methods intended to return a single result array - and adds the boolean value to the event data. Additionally this adds the calling method to `trigger()`'s event data for `afterFind`, same as is currently available for `beforeFind`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
