### PR TITLE
Fix countAllResults() when DBPrefix is defined

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1938,11 +1938,19 @@ class BaseBuilder
 		$limit         = $this->QBLimit;
 		$this->QBLimit = false;
 
-		$sql = ($this->QBDistinct === true || ! empty($this->QBGroupBy))
-			?
-			$this->countString . $this->db->protectIdentifiers('numrows') . "\nFROM (\n" . $this->compileSelect() . "\n) CI_count_all_results"
-			:
-			$this->compileSelect($this->countString . $this->db->protectIdentifiers('numrows'));
+		if ($this->QBDistinct === true || ! empty($this->QBGroupBy))
+		{
+			// We need to backup the original SELECT in case DBPrefix is used
+			$select = $this->QBSelect;
+			$sql    = $this->countString . $this->db->protectIdentifiers('numrows') . "\nFROM (\n" . $this->compileSelect() . "\n) CI_count_all_results";
+			// Restore SELECT part
+			$this->QBSelect = $select;
+			unset($select);
+		}
+		else
+		{
+			$sql = $this->compileSelect($this->countString . $this->db->protectIdentifiers('numrows'));
+		}
 
 		if ($this->testMode)
 		{

--- a/tests/system/Database/Builder/CountTest.php
+++ b/tests/system/Database/Builder/CountTest.php
@@ -59,6 +59,28 @@ class CountTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/3651
+	 */
+	public function testCountAllResultsWithGroupByAndPrefix()
+	{
+		$this->db = new MockConnection(['DBPrefix' => 'ci_']);
+
+		$builder = new BaseBuilder('jobs', $this->db);
+		$builder->select('jobs.*')->where('id >', 3)->groupBy('id')->testMode();
+
+		$expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM ( SELECT "ci_jobs".* FROM "ci_jobs" WHERE "id" > :id: GROUP BY "id" ) CI_count_all_results';
+
+		$answer1 = $builder->countAllResults(false);
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $answer1));
+
+		// We run the query one more time to make sure the DBPrefix is added only once
+		$answer2 = $builder->countAllResults(false);
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $answer2));
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testCountAllResultsWithGroupByAndHaving()
 	{
 		$builder = new BaseBuilder('jobs', $this->db);


### PR DESCRIPTION
**Description**
This PR fixes the `countAllResults()` method when `DBPrefix` is defined and additionally we use `groupBy()` or `distinct()` method with the query.

Fixes #3651

A `DBPrefix` was always added again to the next query when the `countAllResults()` method was set to not reset the SELECT part.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
