### PR TITLE
If CSRFExpire specifies 0, set 0 as it is

### DIFF
--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -288,7 +288,11 @@ class Security
 	 */
 	public function CSRFSetCookie(RequestInterface $request)
 	{
-		$expire        = time() + $this->CSRFExpire;
+		if ($this->CSRFExpire !== 0) {
+			$expire        = time() + $this->CSRFExpire;
+		} else {
+			$expire        = $this->CSRFExpire;
+		}
 		$secure_cookie = (bool) $this->cookieSecure;
 
 		if ($secure_cookie && ! $request->isSecure())

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -288,11 +288,7 @@ class Security
 	 */
 	public function CSRFSetCookie(RequestInterface $request)
 	{
-		if ($this->CSRFExpire !== 0) {
-			$expire        = time() + $this->CSRFExpire;
-		} else {
-			$expire        = $this->CSRFExpire;
-		}
+		$expire        = $this->CSRFExpire === 0 ? $this->CSRFExpire : time() + $this->CSRFExpire;
 		$secure_cookie = (bool) $this->cookieSecure;
 
 		if ($secure_cookie && ! $request->isSecure())


### PR DESCRIPTION
**Description**
If CSRFExpire specifies 0, set 0 as it is.

fix: #3655

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  
