### PR TITLE
Command cache info to show cache in current system

### DIFF
--- a/system/Commands/Cache/InfoCache.php
+++ b/system/Commands/Cache/InfoCache.php
@@ -1,0 +1,90 @@
+<?php namespace CodeIgniter\Commands\Cache;
+
+use CodeIgniter\Cache\CacheFactory;
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\I18n\Time;
+
+class InfoCache extends BaseCommand
+{
+	/**
+	 * Command grouping.
+	 *
+	 * @var string
+	 */
+	protected $group = 'Cache';
+
+	/**
+	 * The Command's name
+	 *
+	 * @var string
+	 */
+	protected $name = 'cache:info';
+
+	/**
+	 * the Command's short description
+	 *
+	 * @var string
+	 */
+	protected $description = 'Show info cache in the current system.';
+
+	/**
+	 * the Command's usage
+	 *
+	 * @var string
+	 */
+	protected $usage = 'cache:info [driver]';
+
+	/**
+	 * the Command's Arguments
+	 *
+	 * @var array
+	 */
+	protected $arguments = [
+		'driver' => 'The cache driver to use',
+	];
+
+	/**
+	 * Clears the cache
+	 *
+	 * @param array $params
+	 */
+	public function run(array $params)
+	{
+		$config = config('Cache');
+		helper('number');
+
+		$handler = $params[0] ?? $config->handler;
+		if (! array_key_exists($handler, $config->validHandlers))
+		{
+			CLI::error($handler . ' is not a valid cache handler.');
+			return;
+		}
+
+		$config->handler = $handler;
+		$cache           = CacheFactory::getHandler($config);
+
+		$caches = $cache->getCacheInfo();
+
+		$tbody = [];
+
+		foreach ($caches as $key => $field)
+		{
+			$tbody[] = [
+				$key,
+				$field['server_path'],
+				number_to_size($field['size']),
+				Time::createFromTimestamp($field['date']),
+			];
+		}
+
+		$thead = [
+			CLI::color('Name', 'green'),
+			CLI::color('Server Path', 'green'),
+			CLI::color('Size', 'green'),
+			CLI::color('Date', 'green'),
+		];
+
+		CLI::table($tbody, $thead);
+	}
+}

--- a/tests/system/Commands/InfoCacheTest.php
+++ b/tests/system/Commands/InfoCacheTest.php
@@ -1,0 +1,76 @@
+<?php namespace CodeIgniter\Commands;
+
+use CodeIgniter\Cache\CacheFactory;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Config\Services;
+
+class InfoCacheTest extends CIUnitTestCase
+{
+	protected $streamFilter;
+	protected $result;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		CITestStreamFilter::$buffer = '';
+		$this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
+		$this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+
+		// Make sure we are testing with the correct handler (override injections)
+		Services::injectMock('cache', CacheFactory::getHandler(config('Cache')));
+	}
+
+	public function tearDown(): void
+	{
+		if (! $this->result)
+		{
+			return;
+		}
+
+		stream_filter_remove($this->streamFilter);
+	}
+
+	protected function getBuffer()
+	{
+		return CITestStreamFilter::$buffer;
+	}
+
+	public function testInfoCacheInvalidHandler()
+	{
+		command('cache:info notfound');
+
+		$result = CITestStreamFilter::$buffer;
+
+		$this->assertStringContainsString('notfound is not a valid cache handler.', $result);
+	}
+
+	public function testInfoCacheCanSeeFoo()
+	{
+		cache()->save('foo', 'bar');
+
+		command('cache:info');
+
+		$this->assertStringContainsString('foo', $this->getBuffer());
+	}
+
+	public function testInfoCacheCanSeeTable()
+	{
+		command('cache:info');
+
+		$this->assertStringContainsString('Name', $this->getBuffer());
+		$this->assertStringContainsString('Server Path', $this->getBuffer());
+		$this->assertStringContainsString('Size', $this->getBuffer());
+		$this->assertStringContainsString('Date', $this->getBuffer());
+	}
+
+	public function testInfoCacheCannotSeeFoo()
+	{
+		cache()->delete('foo');
+
+		command('cache:info');
+
+		$this->assertStringNotContainsString ('foo', $this->getBuffer());
+	}
+}


### PR DESCRIPTION
**Description**
Command cache info to show cache in the current system.
Example: 
![image](https://user-images.githubusercontent.com/10989147/93693979-cf1ce200-fb30-11ea-960e-fad47d426eaa.png)



**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  
