### PR TITLE
phpstan update: no longer need ignore error on isset($_SESSION)

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -1115,7 +1115,7 @@ class CodeIgniter
 			$uri = new URI($uri);
 		}
 
-		if (isset($_SESSION)) // @phpstan-ignore-line
+		if (isset($_SESSION))
 		{
 			$_SESSION['_ci_previous_url'] = (string) $uri;
 		}

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -458,7 +458,7 @@ class Logger implements LoggerInterface
 			}
 		}
 
-		if (isset($_SESSION)) // @phpstan-ignore-line
+		if (isset($_SESSION))
 		{
 			$replace['{session_vars}'] = '$_SESSION: ' . print_r($_SESSION, true);
 		}

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -758,7 +758,6 @@ class Validation implements ValidationInterface
 		// passed along from a redirect_with_input request.
 		if (empty($this->errors) && ! is_cli())
 		{
-			// @phpstan-ignore-next-line
 			if (isset($_SESSION, $_SESSION['_ci_validation_errors']))
 			{
 				$this->errors = unserialize($_SESSION['_ci_validation_errors']);


### PR DESCRIPTION
phpstan 0.12.43 handle $_SESSION always exists check. ref https://github.com/phpstan/phpstan/releases/tag/0.12.43

**Checklist:**
- [x] Securely signed commits