### PR TITLE
Fix Message return types

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,50 +1,49 @@
 parameters:
-  tmpDir: build/phpstan
-  level: 5
-  paths:
-    - app
-    - system
-  treatPhpDocTypesAsCertain: false
-  bootstrapFiles:
-    - system/Test/bootstrap.php
-  excludes_analyse:
-    - app/Views/errors/cli/*
-    - app/Views/errors/html/*
-    - system/Commands/Generators/Views/*
-    - system/Config/Routes.php
-    - system/Debug/Toolbar/Views/toolbar.tpl.php
-    - system/Validation/Views/single.php
-    - system/ThirdParty/*
-  ignoreErrors:
-    - '#Unsafe usage of new static\(\)*#'
-    - '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::_(disable|enable)ForeignKeyChecks\(\)#'
-    - '#Access to an undefined property CodeIgniter\\Database\\Forge::\$dropConstraintStr#'
-    - '#Access to protected property CodeIgniter\\Database\\BaseConnection::(\$DBDebug|\$DBPrefix|\$swapPre|\$charset|\$DBCollat)#'
-    - '#Access to an undefined property CodeIgniter\\Database\\BaseConnection::\$mysqli#'
-    - '#Access to an undefined property CodeIgniter\\Database\\ConnectionInterface::(\$DBDriver|\$connID|\$likeEscapeStr|\$likeEscapeChar|\$escapeChar|\$protectIdentifiers)#'
-    - '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::supportsForeignKeys\(\)#'
-    - '#Cannot call method [a-zA-Z_]+\(\) on ((bool\|)?object\|resource)#'
-    - '#Cannot access property [\$a-z_]+ on ((bool\|)?object\|resource)#'
-    - '#Call to an undefined method CodeIgniter\\HTTP\\Request::(getPath|getSegments|getMethod|setLocale|getPost)\(\)#'
-    - '#Access to an undefined property CodeIgniter\\HTTP\\Request::\$uri#'
-    - '#Call to an undefined method CodeIgniter\\HTTP\\Message::setStatusCode\(\)#'
-    - '#Call to an undefined method CodeIgniter\\Database\\ConnectionInterface::(tableExists|protectIdentifiers|setAliasedTables|escapeIdentifiers|affectedRows|addTableAlias)\(\)#'
-    - '#Method CodeIgniter\\Database\\ConnectionInterface::query\(\) invoked with 3 parameters, 1-2 required#'
-    - '#Return type \(bool\) of method CodeIgniter\\Test\\TestLogger::log\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::log\(\)#'
-    - '#Call to an undefined method CodeIgniter\\Router\\RouteCollectionInterface::(getDefaultNamespace|isFiltered|getFilterForRoute|getRoutesOptions)\(\)#'
-    - '#Method CodeIgniter\\Router\\RouteCollectionInterface::getRoutes\(\) invoked with 1 parameter, 0 required#'
-    - '#Call to an undefined method CodeIgniter\\Validation\\ValidationInterface::loadRuleGroup\(\)#'
-    - '#Method CodeIgniter\\Validation\\ValidationInterface::run\(\) invoked with 3 parameters, 0-2 required#'
-    - '#Return type \(bool\) of method CodeIgniter\\Log\\Logger::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\)#'
-    - '#Return type \(bool\) of method CodeIgniter\\HTTP\\Files\\UploadedFile::move\(\) should be compatible with return type \(CodeIgniter\\Files\\File\) of method CodeIgniter\\Files\\File::move\(\)#'
-    - '#Call to function is_null\(\) with mysqli_stmt\|resource will always evaluate to false#'
-    - '#Negated boolean expression is always (true|false)#'
-    - '#Parameter \#1 \$db of class CodeIgniter\\Database\\SQLite3\\Table constructor expects CodeIgniter\\Database\\SQLite3\\Connection, CodeIgniter\\Database\\BaseConnection given#'
-  parallel:
-    processTimeout: 300.0
-  scanDirectories:
-    - system/Helpers
-  dynamicConstantNames:
-    - ENVIRONMENT
-    - CI_DEBUG
-    - APP_NAMESPACE
+	tmpDir: build/phpstan
+	level: 5
+	paths:
+		- app
+		- system
+	treatPhpDocTypesAsCertain: false
+	bootstrapFiles:
+		- system/Test/bootstrap.php
+	excludes_analyse:
+		- app/Views/errors/cli/*
+		- app/Views/errors/html/*
+		- system/Commands/Generators/Views/*
+		- system/Config/Routes.php
+		- system/Debug/Toolbar/Views/toolbar.tpl.php
+		- system/ThirdParty/*
+		- system/Validation/Views/single.php
+	ignoreErrors:
+		- '#Access to an undefined property CodeIgniter\\Database\\Forge::\$dropConstraintStr#'
+		- '#Access to an undefined property CodeIgniter\\Database\\BaseConnection::\$mysqli#'
+		- '#Access to an undefined property CodeIgniter\\Database\\ConnectionInterface::(\$DBDriver|\$connID|\$likeEscapeStr|\$likeEscapeChar|\$escapeChar|\$protectIdentifiers)#'
+		- '#Access to an undefined property CodeIgniter\\HTTP\\Request::\$uri#'
+		- '#Access to protected property CodeIgniter\\Database\\BaseConnection::(\$DBDebug|\$DBPrefix|\$swapPre|\$charset|\$DBCollat)#'
+		- '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::_(disable|enable)ForeignKeyChecks\(\)#'
+		- '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::supportsForeignKeys\(\)#'
+		- '#Call to an undefined method CodeIgniter\\Database\\ConnectionInterface::(tableExists|protectIdentifiers|setAliasedTables|escapeIdentifiers|affectedRows|addTableAlias)\(\)#'
+		- '#Call to an undefined method CodeIgniter\\HTTP\\Request::(getPath|getSegments|getMethod|setLocale|getPost)\(\)#'
+		- '#Call to an undefined method CodeIgniter\\Router\\RouteCollectionInterface::(getDefaultNamespace|isFiltered|getFilterForRoute|getRoutesOptions)\(\)#'
+		- '#Call to an undefined method CodeIgniter\\Validation\\ValidationInterface::loadRuleGroup\(\)#'
+		- '#Call to function is_null\(\) with mysqli_stmt\|resource will always evaluate to false#'
+		- '#Cannot access property [\$a-z_]+ on ((bool\|)?object\|resource)#'
+		- '#Cannot call method [a-zA-Z_]+\(\) on ((bool\|)?object\|resource)#'
+		- '#Method CodeIgniter\\Database\\ConnectionInterface::query\(\) invoked with 3 parameters, 1-2 required#'
+		- '#Method CodeIgniter\\Router\\RouteCollectionInterface::getRoutes\(\) invoked with 1 parameter, 0 required#'
+		- '#Method CodeIgniter\\Validation\\ValidationInterface::run\(\) invoked with 3 parameters, 0-2 required#'
+		- '#Negated boolean expression is always (true|false)#'
+		- '#Parameter \#1 \$db of class CodeIgniter\\Database\\SQLite3\\Table constructor expects CodeIgniter\\Database\\SQLite3\\Connection, CodeIgniter\\Database\\BaseConnection given#'
+		- '#Return type \(bool\) of method CodeIgniter\\Log\\Logger::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\)#'
+		- '#Return type \(bool\) of method CodeIgniter\\HTTP\\Files\\UploadedFile::move\(\) should be compatible with return type \(CodeIgniter\\Files\\File\) of method CodeIgniter\\Files\\File::move\(\)#'
+		- '#Return type \(bool\) of method CodeIgniter\\Test\\TestLogger::log\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::log\(\)#'
+		- '#Unsafe usage of new static\(\)*#'
+	parallel:
+		processTimeout: 300.0
+	scanDirectories:
+		- system/Helpers
+	dynamicConstantNames:
+		- APP_NAMESPACE
+		- CI_DEBUG
+		- ENVIRONMENT

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -46,7 +46,6 @@ use CodeIgniter\HTTP\Exceptions\HTTPException;
  */
 class Message
 {
-
 	/**
 	 * List of all HTTP request headers.
 	 *
@@ -89,7 +88,6 @@ class Message
 	protected $body;
 
 	//--------------------------------------------------------------------
-	//--------------------------------------------------------------------
 	// Body
 	//--------------------------------------------------------------------
 
@@ -103,32 +101,28 @@ class Message
 		return $this->body;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Sets the body of the current message.
 	 *
 	 * @param mixed $data
 	 *
-	 * @return Message|Response
+	 * @return $this
 	 */
-	public function setBody($data)
+	public function setBody($data): self
 	{
 		$this->body = $data;
 
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Appends data to the body of the current message.
 	 *
 	 * @param mixed $data
 	 *
-	 * @return Message|Response
+	 * @return $this
 	 */
-	public function appendBody($data)
+	public function appendBody($data): self
 	{
 		$this->body .= (string) $data;
 
@@ -136,14 +130,13 @@ class Message
 	}
 
 	//--------------------------------------------------------------------
-	//--------------------------------------------------------------------
 	// Headers
 	//--------------------------------------------------------------------
 
 	/**
 	 * Populates the $headers array with any headers the getServer knows about.
 	 */
-	public function populateHeaders()
+	public function populateHeaders(): void
 	{
 		$contentType = $_SERVER['CONTENT_TYPE'] ?? getenv('CONTENT_TYPE');
 		if (! empty($contentType))
@@ -168,8 +161,6 @@ class Message
 		}
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Returns an array containing all headers.
 	 *
@@ -188,15 +179,13 @@ class Message
 		return $this->headers;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Returns a single header object. If multiple headers with the same
 	 * name exist, then will return an array of header objects.
 	 *
 	 * @param string $name
 	 *
-	 * @return array|\CodeIgniter\HTTP\Header|null
+	 * @return array|Header|null
 	 */
 	public function getHeader(string $name)
 	{
@@ -209,8 +198,6 @@ class Message
 
 		return $this->headers[$orig_name];
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Determines whether a header exists.
@@ -225,8 +212,6 @@ class Message
 
 		return isset($this->headers[$orig_name]);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Retrieves a comma-separated string of the values for a single header.
@@ -255,17 +240,15 @@ class Message
 		return $this->headers[$orig_name]->getValueLine();
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Sets a header and it's value.
 	 *
 	 * @param string            $name
 	 * @param array|null|string $value
 	 *
-	 * @return Message|Response
+	 * @return $this
 	 */
-	public function setHeader(string $name, $value)
+	public function setHeader(string $name, $value): self
 	{
 		$origName = $this->getHeaderName($name);
 
@@ -290,16 +273,14 @@ class Message
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Removes a header from the list of headers we track.
 	 *
 	 * @param string $name
 	 *
-	 * @return Message
+	 * @return $this
 	 */
-	public function removeHeader(string $name)
+	public function removeHeader(string $name): self
 	{
 		$orig_name = $this->getHeaderName($name);
 
@@ -309,8 +290,6 @@ class Message
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Adds an additional header value to any headers that accept
 	 * multiple values (i.e. are an array or implement ArrayAccess)
@@ -318,9 +297,9 @@ class Message
 	 * @param string      $name
 	 * @param string|null $value
 	 *
-	 * @return Message
+	 * @return $this
 	 */
-	public function appendHeader(string $name, ?string $value)
+	public function appendHeader(string $name, ?string $value): self
 	{
 		$orig_name = $this->getHeaderName($name);
 
@@ -331,8 +310,6 @@ class Message
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Adds an additional header value to any headers that accept
 	 * multiple values (i.e. are an array or implement ArrayAccess)
@@ -340,15 +317,30 @@ class Message
 	 * @param string $name
 	 * @param string $value
 	 *
-	 * @return Message
+	 * @return $this
 	 */
-	public function prependHeader(string $name, string $value)
+	public function prependHeader(string $name, string $value): self
 	{
 		$orig_name = $this->getHeaderName($name);
 
 		$this->headers[$orig_name]->prependValue($value);
 
 		return $this;
+	}
+
+	/**
+	 * Takes a header name in any case, and returns the
+	 * normal-case version of the header.
+	 *
+	 * @param string $name
+	 *
+	 * @return string
+	 */
+	protected function getHeaderName(string $name): string
+	{
+		$lower_name = strtolower($name);
+
+		return $this->headerMap[$lower_name] ?? $name;
 	}
 
 	//--------------------------------------------------------------------
@@ -363,16 +355,14 @@ class Message
 		return $this->protocolVersion ?? '1.1';
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Sets the HTTP protocol version.
 	 *
 	 * @param string $version
 	 *
-	 * @return Message
+	 * @return $this
 	 */
-	public function setProtocolVersion(string $version)
+	public function setProtocolVersion(string $version): self
 	{
 		if (! is_numeric($version))
 		{
@@ -391,23 +381,4 @@ class Message
 
 		return $this;
 	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Takes a header name in any case, and returns the
-	 * normal-case version of the header.
-	 *
-	 * @param string $name
-	 *
-	 * @return string
-	 */
-	protected function getHeaderName(string $name): string
-	{
-		$lower_name = strtolower($name);
-
-		return $this->headerMap[$lower_name] ?? $name;
-	}
-
-	//--------------------------------------------------------------------
 }

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -338,12 +338,8 @@ class Message
 	 */
 	protected function getHeaderName(string $name): string
 	{
-		$lower_name = strtolower($name);
-
-		return $this->headerMap[$lower_name] ?? $name;
+		return $this->headerMap[strtolower($name)] ?? $name;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Returns the HTTP Protocol Version.


### PR DESCRIPTION
**Description**
A number of `Message` methods have docblocks for `@return Message` which makes static analysis angry when a child class is returned. This PR switches to `$this` and specifies a `self` return type on the function. I also cleaned up the file a bit but nothing that would affect code.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
