### PR TITLE
Cache command info only for file cache handler

### DIFF
--- a/system/Commands/Cache/InfoCache.php
+++ b/system/Commands/Cache/InfoCache.php
@@ -33,16 +33,7 @@ class InfoCache extends BaseCommand
 	 *
 	 * @var string
 	 */
-	protected $usage = 'cache:info [driver]';
-
-	/**
-	 * the Command's Arguments
-	 *
-	 * @var array
-	 */
-	protected $arguments = [
-		'driver' => 'The cache driver to use',
-	];
+	protected $usage = 'cache:info';
 
 	/**
 	 * Clears the cache
@@ -54,15 +45,13 @@ class InfoCache extends BaseCommand
 		$config = config('Cache');
 		helper('number');
 
-		$handler = $params[0] ?? $config->handler;
-		if (! array_key_exists($handler, $config->validHandlers))
+		if ($config->handler !== 'file')
 		{
-			CLI::error($handler . ' is not a valid cache handler.');
+			CLI::error('This command only supports the file cache handler.');
 			return;
 		}
 
-		$config->handler = $handler;
-		$cache           = CacheFactory::getHandler($config);
+		$cache = CacheFactory::getHandler($config);
 
 		$caches = $cache->getCacheInfo();
 

--- a/tests/system/Commands/InfoCacheTest.php
+++ b/tests/system/Commands/InfoCacheTest.php
@@ -24,26 +24,12 @@ class InfoCacheTest extends CIUnitTestCase
 
 	public function tearDown(): void
 	{
-		if (! $this->result)
-		{
-			return;
-		}
-
 		stream_filter_remove($this->streamFilter);
 	}
 
 	protected function getBuffer()
 	{
 		return CITestStreamFilter::$buffer;
-	}
-
-	public function testInfoCacheInvalidHandler()
-	{
-		command('cache:info notfound');
-
-		$result = CITestStreamFilter::$buffer;
-
-		$this->assertStringContainsString('notfound is not a valid cache handler.', $result);
 	}
 
 	public function testInfoCacheCanSeeFoo()


### PR DESCRIPTION
**Description**
This command cache:info only supports the file cache handler.
Related discussion https://github.com/codeigniter4/CodeIgniter4/pull/3660#issuecomment-695786132

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  
