### PR TITLE
PHPDoc blocks unified

### DIFF
--- a/system/Language/en/Cast.php
+++ b/system/Language/en/Cast.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Cast language strings.
  *

--- a/system/Language/en/Email.php
+++ b/system/Language/en/Email.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Email language strings.
  *

--- a/system/Language/en/Encryption.php
+++ b/system/Language/en/Encryption.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Encryption language strings.
  *

--- a/system/Language/en/Files.php
+++ b/system/Language/en/Files.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Files language strings.
  *

--- a/system/Language/en/RESTful.php
+++ b/system/Language/en/RESTful.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * RESTful language strings.
  *

--- a/system/Language/en/View.php
+++ b/system/Language/en/View.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * View language strings.
  *


### PR DESCRIPTION
Blank lines harmonised.

...I tried to find guidelines or some logic in the core files, but there it's not uniformly. But there it doesn't matter... 
To visually compare translation-files accross diffferent languages, it's helpful if each file has the same code style.