### PR TITLE
Normalize url_is test path

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -675,7 +675,7 @@ if (! function_exists('url_is'))
 	{
 		// Setup our regex to allow wildcards
 		$path        = '/' . trim(str_replace('*', '(\S)*', $path), '/ ');
-		$currentPath = rtrim(service('request')->uri->getPath(), '/ ');
+		$currentPath = '/' . trim(service('request')->uri->getPath(), '/ ');
 
 		return (bool)preg_match("|^{$path}$|", $currentPath, $matches);
 	}


### PR DESCRIPTION
**Description**
Addresses an issue where the tested path for `url_is()` could have inconsistent results based on preceding slashes.

The underlying issue should be addressed in #3672 but this will ensure `url_is()` works in the meantime, and should function as a general precaution against `URI` return values.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
