### PR TITLE
Base URL trailing slash

### DIFF
--- a/admin/framework/phpunit.xml.dist
+++ b/admin/framework/phpunit.xml.dist
@@ -36,7 +36,7 @@
 	</logging>
 
 	<php>
-		<server name="app.baseURL" value="http://example.com"/>
+		<server name="app.baseURL" value="http://example.com/"/>
 
 		<!-- Directory containing phpunit.xml -->
 		<const name="HOMEPATH" value="./"/>

--- a/admin/module/phpunit.xml.dist
+++ b/admin/module/phpunit.xml.dist
@@ -36,7 +36,7 @@
 	</logging>
 
 	<php>
-		<server name="app.baseURL" value="http://example.com"/>
+		<server name="app.baseURL" value="http://example.com/"/>
 
 		<!-- Directory containing phpunit.xml -->
 		<const name="HOMEPATH" value="./"/>

--- a/admin/starter/phpunit.xml.dist
+++ b/admin/starter/phpunit.xml.dist
@@ -36,7 +36,7 @@
 	</logging>
 
 	<php>
-		<server name="app.baseURL" value="http://example.com"/>
+		<server name="app.baseURL" value="http://example.com/"/>
 
 		<!-- Directory containing phpunit.xml -->
 		<const name="HOMEPATH" value="./"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -41,7 +41,7 @@
 	</logging>
 
 	<php>
-		<server name="app.baseURL" value="http://example.com"/>
+		<server name="app.baseURL" value="http://example.com/"/>
 
 		<!-- Directory containing phpunit.xml -->
 		<const name="HOMEPATH" value="./"/>

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -614,8 +614,8 @@ class URI
 		}
 
 		return static::createURIString(
-						$this->getScheme(), $this->getAuthority(), $path, // Absolute URIs should use a "/" for an empty path
-						$this->getQuery(), $this->getFragment()
+			$this->getScheme(), $this->getAuthority(), $path, // Absolute URIs should use a "/" for an empty path
+			$this->getQuery(), $this->getFragment()
 		);
 	}
 

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -205,11 +205,26 @@ if (! function_exists('uri_string'))
 	 *
 	 * Returns the path part of the current URL
 	 *
+	 * @param boolean $relative Whether the resulting path should be relative to baseURL
+	 *
 	 * @return string
 	 */
-	function uri_string(): string
+	function uri_string(bool $relative = false): string
 	{
-		return \Config\Services::request()->uri->getPath();
+		$request = \Config\Services::request();
+		$uri     = $request->uri;
+
+		// An absolute path is equivalent to getPath()
+		if (! $relative)
+		{
+			return $uri->getPath();
+		}
+
+		// Remove the baseURL from the entire URL
+		$url     = (string) $uri->__toString();
+		$baseURL = rtrim($request->config->baseURL, '/ ') . '/';
+
+		return substr($url, strlen($baseURL));
 	}
 }
 
@@ -675,7 +690,7 @@ if (! function_exists('url_is'))
 	{
 		// Setup our regex to allow wildcards
 		$path        = '/' . trim(str_replace('*', '(\S)*', $path), '/ ');
-		$currentPath = '/' . trim(service('request')->uri->getPath(), '/ ');
+		$currentPath = '/' . trim(uri_string(true), '/ ');
 
 		return (bool)preg_match("|^{$path}$|", $currentPath, $matches);
 	}

--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -131,7 +131,7 @@ trait ControllerTester
 
 		if (! $this->uri instanceof URI)
 		{
-			$this->uri = new URI($this->appConfig->baseURL ?? 'http://example.com');
+			$this->uri = new URI($this->appConfig->baseURL ?? 'http://example.com/');
 		}
 
 		if (empty($this->request))

--- a/system/Test/Mock/MockAppConfig.php
+++ b/system/Test/Mock/MockAppConfig.php
@@ -2,7 +2,7 @@
 
 class MockAppConfig
 {
-	public $baseURL = 'http://example.com';
+	public $baseURL = 'http://example.com/';
 
 	public $uriProtocol = 'REQUEST_URI';
 

--- a/system/Test/Mock/MockCLIConfig.php
+++ b/system/Test/Mock/MockCLIConfig.php
@@ -2,7 +2,7 @@
 
 class MockCLIConfig extends \Config\App
 {
-	public $baseURL = 'http://example.com';
+	public $baseURL = 'http://example.com/';
 
 	public $uriProtocol = 'REQUEST_URI';
 

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -47,7 +47,7 @@ require_once SYSTEMPATH . 'Common.php';
 // Set environment values that would otherwise stop the framework from functioning during tests.
 if (! isset($_SERVER['app.baseURL']))
 {
-	$_SERVER['app.baseURL'] = 'http://example.com';
+	$_SERVER['app.baseURL'] = 'http://example.com/';
 }
 
 // Load necessary components

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -29,7 +29,7 @@ class ResponseTraitTest extends \CodeIgniter\Test\CIUnitTestCase
 	protected function makeController(array $userConfig = [], string $uri = 'http://example.com', array $userHeaders = [])
 	{
 		$config = [
-			'baseURL'          => 'http://example.com',
+			'baseURL'          => 'http://example.com/',
 			'uriProtocol'      => 'REQUEST_URI',
 			'defaultLocale'    => 'en',
 			'negotiateLocale'  => false,
@@ -466,7 +466,7 @@ EOH;
 	public function testFormatByRequestNegotiateIfFormatIsNotJsonOrXML()
 	{
 		$config = [
-			'baseURL'          => 'http://example.com',
+			'baseURL'          => 'http://example.com/',
 			'uriProtocol'      => 'REQUEST_URI',
 			'defaultLocale'    => 'en',
 			'negotiateLocale'  => false,

--- a/tests/system/CLI/CommandRunnerTest.php
+++ b/tests/system/CLI/CommandRunnerTest.php
@@ -30,7 +30,7 @@ class CommandRunnerTest extends \CodeIgniter\Test\CIUnitTestCase
 		// Set environment values that would otherwise stop the framework from functioning during tests.
 		if (! isset($_SERVER['app.baseURL']))
 		{
-			$_SERVER['app.baseURL'] = 'http://example.com';
+			$_SERVER['app.baseURL'] = 'http://example.com/';
 		}
 
 		$_SERVER['argv'] = [

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -27,7 +27,7 @@ class ConsoleTest extends CIUnitTestCase
 		// Set environment values that would otherwise stop the framework from functioning during tests.
 		if (! isset($_SERVER['app.baseURL']))
 		{
-			$_SERVER['app.baseURL'] = 'http://example.com';
+			$_SERVER['app.baseURL'] = 'http://example.com/';
 		}
 
 		$_SERVER['argv'] = [

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -281,7 +281,7 @@ class CodeIgniterTest extends \CodeIgniter\Test\CIUnitTestCase
 		$codeigniter->useSafeOutput(true)->run();
 		$output = ob_get_clean();
 
-		$this->assertEquals('https://example.com', $response->getHeader('Location')->getValue());
+		$this->assertEquals('https://example.com/', $response->getHeader('Location')->getValue());
 	}
 
 	public function testRunRedirectionWithNamed()

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -457,7 +457,7 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		force_https();
 
-		$this->assertEquals('https://example.com', Services::response()->getHeader('Location')->getValue());
+		$this->assertEquals('https://example.com/', Services::response()->getHeader('Location')->getValue());
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -298,7 +298,7 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 
 		$this->config          = new App();
-		$this->config->baseURL = 'http://example.com';
+		$this->config->baseURL = 'http://example.com/';
 
 		$this->routes = new RouteCollection(Services::locator(), new \Config\Modules());
 		Services::injectMock('routes', $this->routes);
@@ -334,7 +334,7 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 
 		$this->config          = new App();
-		$this->config->baseURL = 'http://example.com';
+		$this->config->baseURL = 'http://example.com/';
 
 		$this->routes = new RouteCollection(Services::locator(), new \Config\Modules());
 		Services::injectMock('routes', $this->routes);

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -176,7 +176,7 @@ class IncomingRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 			'es',
 		];
 		$config->defaultLocale    = 'es';
-		$config->baseURL          = 'http://example.com';
+		$config->baseURL          = 'http://example.com/';
 
 		$request = new IncomingRequest($config, new URI(), null, new UserAgent());
 
@@ -192,7 +192,7 @@ class IncomingRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 			'es',
 		];
 		$config->defaultLocale    = 'es';
-		$config->baseURL          = 'http://example.com';
+		$config->baseURL          = 'http://example.com/';
 
 		$request = new IncomingRequest($config, new URI(), null, new UserAgent());
 
@@ -215,7 +215,7 @@ class IncomingRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 			'fr',
 			'en',
 		];
-		$config->baseURL          = 'http://example.com';
+		$config->baseURL          = 'http://example.com/';
 
 		$request = new IncomingRequest($config, new URI(), null, new UserAgent());
 
@@ -233,7 +233,7 @@ class IncomingRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 			'fr',
 			'en',
 		];
-		$config->baseURL          = 'http://example.com';
+		$config->baseURL          = 'http://example.com/';
 
 		$request = new IncomingRequest($config, new URI(), null, new UserAgent());
 
@@ -291,7 +291,7 @@ class IncomingRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 		];
 
 		$config          = new App();
-		$config->baseURL = 'http://example.com';
+		$config->baseURL = 'http://example.com/';
 
 		$request = new IncomingRequest($config, new URI(), $json, new UserAgent());
 
@@ -309,7 +309,7 @@ class IncomingRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 		];
 
 		$config          = new App();
-		$config->baseURL = 'http://example.com';
+		$config->baseURL = 'http://example.com/';
 
 		$request = new IncomingRequest($config, new URI(), $rawstring, new UserAgent());
 

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -26,7 +26,7 @@ class RedirectResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 
 		$this->config          = new App();
-		$this->config->baseURL = 'http://example.com';
+		$this->config->baseURL = 'http://example.com/';
 
 		$this->routes = new RouteCollection(Services::locator(), new \Config\Modules());
 		Services::injectMock('routes', $this->routes);

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -165,7 +165,7 @@ class ResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 	{
 		// Ensure our URL is not getting overridden
 		$config          = new App();
-		$config->baseURL = 'http://example.com/test';
+		$config->baseURL = 'http://example.com/test/';
 		Config::injectMock('App', $config);
 
 		$response = new Response($config);

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -452,18 +452,7 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	//--------------------------------------------------------------------
 	// Test uri_string
 
-	public function testUriString()
-	{
-		$request      = Services::request($this->config);
-		$request->uri = new URI('http://example.com/');
-
-		Services::injectMock('request', $request);
-
-		$url = current_url();
-		$this->assertEquals('/', uri_string());
-	}
-
-	public function testUriStringExample()
+	public function testUriStringAbsolute()
 	{
 		$_SERVER['HTTP_HOST']   = 'example.com';
 		$_SERVER['REQUEST_URI'] = '/assets/image.jpg';
@@ -475,6 +464,103 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$url = current_url();
 		$this->assertEquals('/assets/image.jpg', uri_string());
+	}
+
+	public function testUriStringRelative()
+	{
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/assets/image.jpg';
+
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/assets/image.jpg');
+
+		Services::injectMock('request', $request);
+
+		$url = current_url();
+		$this->assertEquals('assets/image.jpg', uri_string(true));
+	}
+
+	public function testUriStringNoTrailingSlashAbsolute()
+	{
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/assets/image.jpg';
+
+		$this->config->baseURL = 'http://example.com';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/assets/image.jpg');
+
+		Services::injectMock('request', $request);
+
+		$url = current_url();
+		$this->assertEquals('/assets/image.jpg', uri_string());
+	}
+
+	public function testUriStringNoTrailingSlashRelative()
+	{
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/assets/image.jpg';
+
+		$this->config->baseURL = 'http://example.com';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/assets/image.jpg');
+
+		Services::injectMock('request', $request);
+
+		$url = current_url();
+		$this->assertEquals('assets/image.jpg', uri_string(true));
+	}
+
+	public function testUriStringEmptyAbsolute()
+	{
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
+
+		Services::injectMock('request', $request);
+
+		$url = current_url();
+		$this->assertEquals('/', uri_string());
+	}
+
+	public function testUriStringEmptyRelative()
+	{
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
+
+		Services::injectMock('request', $request);
+
+		$url = current_url();
+		$this->assertEquals('', uri_string(true));
+	}
+
+	public function testUriStringSubfolderAbsolute()
+	{
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/subfolder/assets/image.jpg';
+
+		$this->config->baseURL = 'http://example.com/subfolder/';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/subfolder/assets/image.jpg');
+
+		Services::injectMock('request', $request);
+
+		$url = current_url();
+		$this->assertEquals('/subfolder/assets/image.jpg', uri_string());
+	}
+
+	public function testUriStringSubfolderRelative()
+	{
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/assets/image.jpg';
+		$_SERVER['REQUEST_URI'] = '/subfolder/assets/image.jpg';
+
+		$this->config->baseURL = 'http://example.com/subfolder/';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/subfolder/assets/image.jpg');
+
+		Services::injectMock('request', $request);
+
+		$url = current_url();
+		$this->assertEquals('assets/image.jpg', uri_string(true));
 	}
 
 	//--------------------------------------------------------------------
@@ -1320,10 +1406,10 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testUrlIsWithSubfolder(string $currentPath, string $testPath, bool $expected)
 	{
 		$_SERVER['HTTP_HOST']  = 'example.com';
-		$this->config->baseUrl = 'http://example.com/foobar/';
+		$this->config->baseURL = 'http://example.com/subfolder/';
 
 		$request      = Services::request($this->config);
-		$request->uri = new URI('http://example.com/foobar/' . $currentPath);
+		$request->uri = new URI('http://example.com/subfolder/' . $currentPath);
 		Services::injectMock('request', $request);
 
 		$this->assertEquals($expected, url_is($testPath));

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -11,6 +11,10 @@ use Config\App;
  */
 class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 {
+	/**
+	 * @var App
+	 */
+	protected $config;
 
 	protected function setUp(): void
 	{
@@ -19,6 +23,15 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		helper('url');
 		Services::reset(true);
 		Config::reset();
+
+		// Set a common base configuration (overriden by individual tests)
+		$this->config            = new App();
+		$this->config->baseURL   = 'http://example.com/';
+		$this->config->indexPage = 'index.php';
+		$_SERVER['HTTP_HOST']    = 'example.com';
+		$_SERVER['REQUEST_URI']  = '/';
+
+		//Config::injectMock('App', $this->config);
 	}
 
 	public function tearDown(): void
@@ -33,147 +46,108 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testSiteURLBasics()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('http://example.com/index.php', site_url('', null, $config));
+		$this->assertEquals('http://example.com/index.php', site_url('', null, $this->config));
 	}
 
 	public function testSiteURLHTTPS()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-		$_SERVER['HTTPS']       = 'on';
+		$_SERVER['HTTPS'] = 'on';
 
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('https://example.com/index.php', site_url('', null, $config));
+		$this->assertEquals('https://example.com/index.php', site_url('', null, $this->config));
+	}
+
+	public function testSiteURLNoTrailingSlash()
+	{
+		$this->config->baseURL = 'http://example.com';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/index.php');
+
+		Services::injectMock('request', $request);
+
+		$this->assertEquals('http://example.com/index.php', site_url('', null, $this->config));
 	}
 
 	public function testSiteURLNoIndex()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = '';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$this->config->indexPage = '';
+		$request                 = Services::request($this->config);
+		$request->uri            = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('http://example.com/', site_url('', null, $config));
+		$this->assertEquals('http://example.com/', site_url('', null, $this->config));
 	}
 
 	public function testSiteURLDifferentIndex()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'banana.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$this->config->indexPage = 'banana.php';
+		$request                 = Services::request($this->config);
+		$request->uri            = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('http://example.com/banana.php', site_url('', null, $config));
+		$this->assertEquals('http://example.com/banana.php', site_url('', null, $this->config));
 	}
 
 	public function testSiteURLNoIndexButPath()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = '';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$this->config->indexPage = '';
+		$request                 = Services::request($this->config);
+		$request->uri            = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('http://example.com/abc', site_url('abc', null, $config));
+		$this->assertEquals('http://example.com/abc', site_url('abc', null, $this->config));
 	}
 
 	public function testSiteURLAttachesPath()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('http://example.com/index.php/foo', site_url('foo', null, $config));
+		$this->assertEquals('http://example.com/index.php/foo', site_url('foo', null, $this->config));
 	}
 
 	public function testSiteURLAttachesScheme()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('ftp://example.com/index.php/foo', site_url('foo', 'ftp', $config));
+		$this->assertEquals('ftp://example.com/index.php/foo', site_url('foo', 'ftp', $this->config));
 	}
 
 	public function testSiteURLExample()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('http://example.com/index.php/news/local/123', site_url('news/local/123', null, $config));
+		$this->assertEquals('http://example.com/index.php/news/local/123', site_url('news/local/123', null, $this->config));
 	}
 
 	public function testSiteURLSegments()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('http://example.com/index.php/news/local/123', site_url(['news', 'local', '123'], null, $config));
+		$this->assertEquals('http://example.com/index.php/news/local/123', site_url(['news', 'local', '123'], null, $this->config));
 	}
 
 	/**
@@ -185,10 +159,8 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['REQUEST_URI'] = '/test';
 
 		// Since we're on a CLI, we must provide our own URI
-		$config          = new App();
-		$config->baseURL = 'http://example.com/';
-		$request         = Services::request($config, false);
-		$request->uri    = new URI('http://example.com/test');
+		$request      = Services::request($this->config, false);
+		$request->uri = new URI('http://example.com/test');
 
 		Services::injectMock('request', $request);
 
@@ -204,10 +176,8 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['REQUEST_URI'] = '/test/page';
 
 		// Since we're on a CLI, we must provide our own URI
-		$config          = new App();
-		$config->baseURL = 'http://example.com';
-		$request         = Services::request($config, false);
-		$request->uri    = new URI('http://example.com/test/page');
+		$request      = Services::request($this->config, false);
+		$request->uri = new URI('http://example.com/test/page');
 
 		Services::injectMock('request', $request);
 
@@ -220,57 +190,50 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testBaseURLBasics()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
 		$this->assertEquals('http://example.com', base_url());
 	}
 
 	public function testBaseURLAttachesPath()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
 		$this->assertEquals('http://example.com/foo', base_url('foo'));
 	}
 
 	public function testBaseURLAttachesPathArray()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
 		$this->assertEquals('http://example.com/foo/bar', base_url(['foo', 'bar']));
 	}
 
 	public function testBaseURLAttachesScheme()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
 		$this->assertEquals('https://example.com/foo', base_url('foo', 'https'));
 	}
 
 	public function testBaseURLHeedsBaseURL()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
 		// Since we're on a CLI, we must provide our own URI
-		$config          = new App();
-		$config->baseURL = 'http://example.com/public';
-		$request         = Services::request($config);
-		$request->uri    = new URI('http://example.com/public');
+		$this->config->baseURL = 'http://example.com/public';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/public');
 
 		Services::injectMock('request', $request);
 
 		$this->assertEquals('http://example.com/public', base_url());
 	}
 
+	public function testBaseURLNoTrailingSlash()
+	{
+		// Since we're on a CLI, we must provide our own URI
+		$this->config->baseURL = 'http://example.com';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/foobar');
+
+		Services::injectMock('request', $request);
+
+		$this->assertEquals('http://example.com', base_url());
+	}
+
 	public function testBaseURLExample()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
 		$this->assertEquals('http://example.com/blog/post/123', base_url('blog/post/123'));
 	}
 
@@ -283,10 +246,8 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['REQUEST_URI'] = '/test';
 
 		// Since we're on a CLI, we must provide our own URI
-		$config          = new App();
-		$config->baseURL = 'http://example.com/';
-		$request         = Services::request($config, false);
-		$request->uri    = new URI('http://example.com/test');
+		$request      = Services::request($this->config, false);
+		$request->uri = new URI('http://example.com/test');
 
 		Services::injectMock('request', $request);
 
@@ -298,9 +259,7 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	 */
 	public function testBaseURLHTTPS()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-		$_SERVER['HTTPS']       = 'on';
+		$_SERVER['HTTPS'] = 'on';
 
 		$this->assertEquals('https://example.com/blog/post/123', base_url('blog/post/123'));
 	}
@@ -314,10 +273,8 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['REQUEST_URI'] = '/test/page';
 
 		// Since we're on a CLI, we must provide our own URI
-		$config          = new App();
-		$config->baseURL = 'http://example.com';
-		$request         = Services::request($config, false);
-		$request->uri    = new URI('http://example.com/test/page');
+		$request      = Services::request($this->config, false);
+		$request->uri = new URI('http://example.com/test/page');
 
 		Services::injectMock('request', $request);
 
@@ -332,11 +289,27 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['SCRIPT_NAME'] = '/subfolder/index.php';
 
 		// Since we're on a CLI, we must provide our own URI
-		$config          = new App();
-		$config->baseURL = 'http://example.com/subfolder';
-		Config::injectMock('App', $config);
+		$this->config->baseURL = 'http://example.com/subfolder/';
+		Config::injectMock('App', $this->config);
 
-		$request = Services::request($config, false);
+		$request = Services::request($this->config, false);
+		Services::injectMock('request', $request);
+
+		$this->assertEquals('http://example.com/subfolder/foo', base_url('foo'));
+		$this->assertEquals('http://example.com/subfolder', base_url());
+	}
+
+	public function testBaseURLNoTrailingSlashHasSubfolder()
+	{
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/subfolder/test';
+		$_SERVER['SCRIPT_NAME'] = '/subfolder/index.php';
+
+		// Since we're on a CLI, we must provide our own URI
+		$this->config->baseURL = 'http://example.com/subfolder';
+		Config::injectMock('App', $this->config);
+
+		$request = Services::request($this->config, false);
 		Services::injectMock('request', $request);
 
 		$this->assertEquals('http://example.com/subfolder/foo', base_url('foo'));
@@ -348,14 +321,10 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testCurrentURLReturnsBasicURL()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
 		// Since we're on a CLI, we must provide our own URI
-		$config          = new App();
-		$config->baseURL = 'http://example.com/public';
-		$request         = Services::request($config);
-		$request->uri    = new URI('http://example.com/public');
+		$this->config->baseURL = 'http://example.com/public';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/public');
 
 		Services::injectMock('request', $request);
 
@@ -364,14 +333,10 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testCurrentURLReturnsObject()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
 		// Since we're on a CLI, we must provide our own URI
-		$config          = new App();
-		$config->baseURL = 'http://example.com/public';
-		$request         = Services::request($config);
-		$request->uri    = new URI('http://example.com/public');
+		$this->config->baseURL = 'http://example.com/public';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/public');
 
 		Services::injectMock('request', $request);
 
@@ -388,11 +353,9 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
 		// Since we're on a CLI, we must provide our own URI
-		$config          = new App();
-		$config->baseURL = 'http://example.com/';
-		Config::injectMock('App', $config);
+		Config::injectMock('App', $this->config);
 
-		$request = Services::request($config);
+		$request = Services::request($this->config);
 		Services::injectMock('request', $request);
 
 		$this->assertEquals(base_url(uri_string()), current_url());
@@ -405,11 +368,10 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['SCRIPT_NAME'] = '/foo/public/index.php';
 
 		// Since we're on a CLI, we must provide our own URI
-		$config          = new App();
-		$config->baseURL = 'http://example.com/foo/public';
-		Config::injectMock('App', $config);
+		$this->config->baseURL = 'http://example.com/foo/public';
+		Config::injectMock('App', $this->config);
 
-		$request = Services::request($config);
+		$request = Services::request($this->config);
 		Services::injectMock('request', $request);
 
 		$this->assertEquals('http://example.com/foo/public/bar', current_url());
@@ -430,11 +392,10 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['SCRIPT_NAME'] = '/foo/public/index.php';
 
 		// Since we're on a CLI, we must provide our own URI
-		$config          = new App();
-		$config->baseURL = 'http://example.com:8080/foo/public';
-		Config::injectMock('App', $config);
+		$this->config->baseURL = 'http://example.com:8080/foo/public';
+		Config::injectMock('App', $this->config);
 
-		$request = Services::request($config);
+		$request = Services::request($this->config);
 		Services::injectMock('request', $request);
 
 		$this->assertEquals('http://example.com:8080/foo/public/bar', current_url());
@@ -456,16 +417,13 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$uri1 = 'http://example.com/one?two';
 		$uri2 = 'http://example.com/two?foo';
 
-		$_SERVER['HTTP_HOST']         = 'example.com';
-		$_SERVER['REQUEST_URI']       = '/';
 		$_SERVER['HTTP_REFERER']      = $uri1;
 		$_SESSION['_ci_previous_url'] = $uri2;
 
 		// Since we're on a CLI, we must provide our own URI
-		$config          = new App();
-		$config->baseURL = 'http://example.com/public';
-		$request         = Services::request($config);
-		$request->uri    = new URI('http://example.com/public');
+		$this->config->baseURL = 'http://example.com/public';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/public');
 
 		Services::injectMock('request', $request);
 
@@ -479,15 +437,12 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$uri1 = 'http://example.com/one?two';
 		$uri2 = 'http://example.com/two?foo';
 
-		$_SERVER['HTTP_HOST']    = 'example.com';
-		$_SERVER['REQUEST_URI']  = '/';
 		$_SERVER['HTTP_REFERER'] = $uri1;
 
 		// Since we're on a CLI, we must provide our own URI
-		$config          = new App();
-		$config->baseURL = 'http://example.com/public';
-		$request         = Services::request($config);
-		$request->uri    = new URI('http://example.com/public');
+		$this->config->baseURL = 'http://example.com/public';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/public');
 
 		Services::injectMock('request', $request);
 
@@ -499,14 +454,8 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testUriString()
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
@@ -519,11 +468,8 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['HTTP_HOST']   = 'example.com';
 		$_SERVER['REQUEST_URI'] = '/assets/image.jpg';
 
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/assets/image.jpg');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/assets/image.jpg');
 
 		Services::injectMock('request', $request);
 
@@ -536,11 +482,8 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testIndexPage()
 	{
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
@@ -549,15 +492,13 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testIndexPageAlt()
 	{
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'banana.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$this->config->indexPage = 'banana.php';
+		$request                 = Services::request($this->config);
+		$request->uri            = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('banana.php', index_page($config));
+		$this->assertEquals('banana.php', index_page($this->config));
 	}
 
 	//--------------------------------------------------------------------
@@ -611,17 +552,11 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	 */
 	public function testAnchor($expected = '', $uri = '', $title = '', $attributes = '')
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
-		$this->assertEquals($expected, anchor($uri, $title, $attributes, $config));
+		$this->assertEquals($expected, anchor($uri, $title, $attributes, $this->config));
 	}
 
 	public function anchorNoindexPatterns()
@@ -672,17 +607,12 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	 */
 	public function testAnchorNoindex($expected = '', $uri = '', $title = '', $attributes = '')
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = '';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$this->config->indexPage = '';
+		$request                 = Services::request($this->config);
+		$request->uri            = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
-		$this->assertEquals($expected, anchor($uri, $title, $attributes, $config));
+		$this->assertEquals($expected, anchor($uri, $title, $attributes, $this->config));
 	}
 
 	public function anchorSubpagePatterns()
@@ -729,17 +659,12 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	 */
 	public function testAnchorTargetted($expected = '', $uri = '', $title = '', $attributes = '')
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = '';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$this->config->indexPage = '';
+		$request                 = Services::request($this->config);
+		$request->uri            = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
-		$this->assertEquals($expected, anchor($uri, $title, $attributes, $config));
+		$this->assertEquals($expected, anchor($uri, $title, $attributes, $this->config));
 	}
 
 	public function anchorExamplePatterns()
@@ -775,17 +700,11 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	 */
 	public function testAnchorExamples($expected = '', $uri = '', $title = '', $attributes = '')
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
-		$this->assertEquals($expected, anchor($uri, $title, $attributes, $config));
+		$this->assertEquals($expected, anchor($uri, $title, $attributes, $this->config));
 	}
 
 	//--------------------------------------------------------------------
@@ -836,17 +755,11 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	 */
 	public function testAnchorPopup($expected = '', $uri = '', $title = '', $attributes = false)
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
-		$this->assertEquals($expected, anchor_popup($uri, $title, $attributes, $config));
+		$this->assertEquals($expected, anchor_popup($uri, $title, $attributes, $this->config));
 	}
 
 	//--------------------------------------------------------------------
@@ -878,14 +791,8 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	 */
 	public function testMailto($expected = '', $email, $title = '', $attributes = '')
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
@@ -921,14 +828,8 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	 */
 	public function testSafeMailto($expected = '', $email, $title = '', $attributes = '')
 	{
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$config            = new App();
-		$config->baseURL   = 'http://example.com';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/');
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/');
 
 		Services::injectMock('request', $request);
 
@@ -1202,23 +1103,35 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	}
 
 	//--------------------------------------------------------------------
-	// Exploratory testing, investigating https://github.com/codeigniter4/CodeIgniter4/issues/2016
 
 	public function testBasedNoIndex()
 	{
 		$_SERVER['HTTP_HOST']   = 'example.com';
 		$_SERVER['REQUEST_URI'] = '/ci/v4/x/y';
 
-		$config            = new App();
-		$config->baseURL   = 'http://example.com/ci/v4/';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/ci/v4/x/y');
+		$this->config->baseURL = 'http://example.com/ci/v4/';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/ci/v4/x/y');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('http://example.com/ci/v4/index.php/controller/method', site_url('controller/method', null, $config));
-		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $config));
+		$this->assertEquals('http://example.com/ci/v4/index.php/controller/method', site_url('controller/method', null, $this->config));
+		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $this->config));
+	}
+
+	public function testBasedNoTrailingSlash()
+	{
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/ci/v4/x/y';
+
+		$this->config->baseURL = 'http://example.com/ci/v4';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/ci/v4/x/y');
+
+		Services::injectMock('request', $request);
+
+		$this->assertEquals('http://example.com/ci/v4/index.php/controller/method', site_url('controller/method', null, $this->config));
+		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $this->config));
 	}
 
 	public function testBasedWithIndex()
@@ -1226,16 +1139,14 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['HTTP_HOST']   = 'example.com';
 		$_SERVER['REQUEST_URI'] = '/ci/v4/index.php/x/y';
 
-		$config            = new App();
-		$config->baseURL   = 'http://example.com/ci/v4/';
-		$config->indexPage = 'index.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/ci/v4/index.php/x/y');
+		$this->config->baseURL = 'http://example.com/ci/v4/';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/ci/v4/index.php/x/y');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('http://example.com/ci/v4/index.php/controller/method', site_url('controller/method', null, $config));
-		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $config));
+		$this->assertEquals('http://example.com/ci/v4/index.php/controller/method', site_url('controller/method', null, $this->config));
+		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $this->config));
 	}
 
 	public function testBasedWithoutIndex()
@@ -1243,16 +1154,15 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['HTTP_HOST']   = 'example.com';
 		$_SERVER['REQUEST_URI'] = '/ci/v4/x/y';
 
-		$config            = new App();
-		$config->baseURL   = 'http://example.com/ci/v4/';
-		$config->indexPage = '';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/ci/v4/x/y');
+		$this->config->baseURL   = 'http://example.com/ci/v4/';
+		$this->config->indexPage = '';
+		$request                 = Services::request($this->config);
+		$request->uri            = new URI('http://example.com/ci/v4/x/y');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('http://example.com/ci/v4/controller/method', site_url('controller/method', null, $config));
-		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $config));
+		$this->assertEquals('http://example.com/ci/v4/controller/method', site_url('controller/method', null, $this->config));
+		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $this->config));
 	}
 
 	public function testBasedWithOtherIndex()
@@ -1260,16 +1170,15 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER['HTTP_HOST']   = 'example.com';
 		$_SERVER['REQUEST_URI'] = '/ci/v4/x/y';
 
-		$config            = new App();
-		$config->baseURL   = 'http://example.com/ci/v4/';
-		$config->indexPage = 'fc.php';
-		$request           = Services::request($config);
-		$request->uri      = new URI('http://example.com/ci/v4/x/y');
+		$this->config->baseURL   = 'http://example.com/ci/v4/';
+		$this->config->indexPage = 'fc.php';
+		$request                 = Services::request($this->config);
+		$request->uri            = new URI('http://example.com/ci/v4/x/y');
 
 		Services::injectMock('request', $request);
 
-		$this->assertEquals('http://example.com/ci/v4/fc.php/controller/method', site_url('controller/method', null, $config));
-		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $config));
+		$this->assertEquals('http://example.com/ci/v4/fc.php/controller/method', site_url('controller/method', null, $this->config));
+		$this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null, $this->config));
 	}
 
 	/**
@@ -1383,9 +1292,38 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	{
 		$_SERVER['HTTP_HOST'] = 'example.com';
 
-		$url          = new URI('http://example.com/' . $currentPath);
-		$request      = service('request');
-		$request->uri = $url;
+		$request      = Services::request();
+		$request->uri = new URI('http://example.com/' . $currentPath);
+		Services::injectMock('request', $request);
+
+		$this->assertEquals($expected, url_is($testPath));
+	}
+
+	/**
+	 * @dataProvider urlIsProvider
+	 */
+	public function testUrlIsNoIndex(string $currentPath, string $testPath, bool $expected)
+	{
+		$_SERVER['HTTP_HOST']    = 'example.com';
+		$this->config->indexPage = '';
+
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/' . $currentPath);
+		Services::injectMock('request', $request);
+
+		$this->assertEquals($expected, url_is($testPath));
+	}
+
+	/**
+	 * @dataProvider urlIsProvider
+	 */
+	public function testUrlIsWithSubfolder(string $currentPath, string $testPath, bool $expected)
+	{
+		$_SERVER['HTTP_HOST']  = 'example.com';
+		$this->config->baseUrl = 'http://example.com/foobar/';
+
+		$request      = Services::request($this->config);
+		$request->uri = new URI('http://example.com/foobar/' . $currentPath);
 		Services::injectMock('request', $request);
 
 		$this->assertEquals($expected, url_is($testPath));

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -441,7 +441,7 @@ class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 		];
 
 		$config          = new App();
-		$config->baseURL = 'http://example.com';
+		$config->baseURL = 'http://example.com/';
 
 		$request = new IncomingRequest($config, new URI(), $rawstring, new UserAgent());
 		$request->setMethod('patch');
@@ -666,7 +666,7 @@ class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testRulesForArrayField($body, $rules, $results)
 	{
 		$config          = new App();
-		$config->baseURL = 'http://example.com';
+		$config->baseURL = 'http://example.com/';
 
 		$request = new IncomingRequest($config, new URI(), http_build_query($body), new UserAgent());
 		$request->setMethod('post');
@@ -740,7 +740,7 @@ class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testRulesForSingleRuleWithAsteriskWillReturnNoError()
 	{
 		$config          = new App();
-		$config->baseURL = 'http://example.com';
+		$config->baseURL = 'http://example.com/';
 
 		$_REQUEST = [
 			'id_user'   => [
@@ -771,7 +771,7 @@ class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testRulesForSingleRuleWithAsteriskWillReturnError()
 	{
 		$config          = new App();
-		$config->baseURL = 'http://example.com';
+		$config->baseURL = 'http://example.com/';
 
 		$_REQUEST = [
 			'id_user'   => [
@@ -805,7 +805,7 @@ class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testRulesForSingleRuleWithSingleValue()
 	{
 		$config          = new App();
-		$config->baseURL = 'http://example.com';
+		$config->baseURL = 'http://example.com/';
 
 		$_REQUEST = [
 			'id_user' => 'gh',

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -112,19 +112,27 @@ The following functions are available:
     use a known and trusted source. If the session hasn't been loaded, or is otherwise unavailable,
     then a sanitized version of HTTP_REFERER will be used.
 
-.. php:function:: uri_string()
+.. php:function:: uri_string([$relative = false])
 
-    :returns: An URI string
+    :param	boolean	$relative: True if you would like the string relative to baseURL
+    :returns: A URI string
     :rtype:	string
 
-    Returns the path part relative to **baseUrl**.
+    Returns the path part of the current URL.
     For example, if your URL was this::
 
         http://some-site.com/blog/comments/123
 
     The function would return::
 
-        blog/comments/123
+        /blog/comments/123
+
+    Or with the optional relative parameter::
+    
+        app.baseURL = http://some-site.com/subfolder/
+
+        uri_string(); // "/subfolder/blog/comments/123"
+        uri_string(true); // "blog/comments/123"
 
 .. php:function:: index_page([$altConfig = NULL])
 

--- a/user_guide_src/source/installation/running.rst
+++ b/user_guide_src/source/installation/running.rst
@@ -17,7 +17,8 @@ Initial Configuration & Set Up
 
 #. Open the **app/Config/App.php** file with a text editor and
    set your base URL. If you need more flexibility, the baseURL may
-   be set within the ``.env`` file as **app.baseURL="http://example.com"**.
+   be set within the ``.env`` file as **app.baseURL="http://example.com/"**.
+   (Always use a trailing slash on your base URL!)
 #. If you intend to use a database, open the
    **app/Config/Database.php** file with a text editor and set your
    database settings. Alternately, these could be set in your ``.env`` file.


### PR DESCRIPTION
**Description**
This PR clarifies the requirement for a trailing slash on `baseURL` configuration. Most changes are updating tests to start with a base URL that uses a trailing slash. I also fixed a few places to try to make them a little more lenient when there is no trailing slash, and added more tests to detect errors due to base URL discrepancies.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
