### PR TITLE
Update cache commands

### DIFF
--- a/system/Commands/Cache/ClearCache.php
+++ b/system/Commands/Cache/ClearCache.php
@@ -1,9 +1,51 @@
-<?php namespace CodeIgniter\Commands\Cache;
+<?php
+
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace CodeIgniter\Commands\Cache;
 
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 
+/**
+ * Clears current cache.
+ */
 class ClearCache extends BaseCommand
 {
 	/**
@@ -50,12 +92,13 @@ class ClearCache extends BaseCommand
 	 */
 	public function run(array $params)
 	{
-		$config = config('Cache');
-
+		$config  = config('Cache');
 		$handler = $params[0] ?? $config->handler;
+
 		if (! array_key_exists($handler, $config->validHandlers))
 		{
 			CLI::error($handler . ' is not a valid cache handler.');
+
 			return;
 		}
 
@@ -64,10 +107,13 @@ class ClearCache extends BaseCommand
 
 		if (! $cache->clean())
 		{
+			// @codeCoverageIgnoreStart
 			CLI::error('Error while clearing the cache.');
+
 			return;
+			// @codeCoverageIgnoreEnd
 		}
 
-		CLI::write(CLI::color('Done', 'green'));
+		CLI::write(CLI::color('Cache cleared.', 'green'));
 	}
 }

--- a/system/Commands/Cache/InfoCache.php
+++ b/system/Commands/Cache/InfoCache.php
@@ -1,10 +1,52 @@
-<?php namespace CodeIgniter\Commands\Cache;
+<?php
+
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace CodeIgniter\Commands\Cache;
 
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
 
+/**
+ * Shows information on the cache.
+ */
 class InfoCache extends BaseCommand
 {
 	/**
@@ -26,7 +68,7 @@ class InfoCache extends BaseCommand
 	 *
 	 * @var string
 	 */
-	protected $description = 'Show info cache in the current system.';
+	protected $description = 'Shows file cache information in the current system.';
 
 	/**
 	 * the Command's usage
@@ -48,20 +90,19 @@ class InfoCache extends BaseCommand
 		if ($config->handler !== 'file')
 		{
 			CLI::error('This command only supports the file cache handler.');
+
 			return;
 		}
 
-		$cache = CacheFactory::getHandler($config);
-
+		$cache  = CacheFactory::getHandler($config);
 		$caches = $cache->getCacheInfo();
-
-		$tbody = [];
+		$tbody  = [];
 
 		foreach ($caches as $key => $field)
 		{
 			$tbody[] = [
 				$key,
-				$field['server_path'],
+				clean_path($field['server_path']),
 				number_to_size($field['size']),
 				Time::createFromTimestamp($field['date']),
 			];

--- a/tests/system/Commands/ClearCacheTest.php
+++ b/tests/system/Commands/ClearCacheTest.php
@@ -8,7 +8,6 @@ use Config\Services;
 class ClearCacheTest extends CIUnitTestCase
 {
 	protected $streamFilter;
-	protected $result;
 
 	protected function setUp(): void
 	{
@@ -24,33 +23,24 @@ class ClearCacheTest extends CIUnitTestCase
 
 	public function tearDown(): void
 	{
-		if (! $this->result)
-		{
-			return;
-		}
-
 		stream_filter_remove($this->streamFilter);
 	}
 
 	public function testClearCacheInvalidHandler()
 	{
 		command('cache:clear junk');
-		$result = CITestStreamFilter::$buffer;
 
-		$this->assertStringContainsString('junk is not a valid cache handler.', $result);
+		$this->assertStringContainsString('junk is not a valid cache handler.', CITestStreamFilter::$buffer);
 	}
 
 	public function testClearCacheWorks()
 	{
 		cache()->save('foo', 'bar');
-
 		$this->assertEquals('bar', cache('foo'));
 
 		command('cache:clear');
-		$result = CITestStreamFilter::$buffer;
 
 		$this->assertNull(cache('foo'));
-
-		$this->assertStringContainsString('Done', $result);
+		$this->assertStringContainsString('Cache cleared.', CITestStreamFilter::$buffer);
 	}
 }


### PR DESCRIPTION
**Description**
- Adds file-level header docblocks to cache commands.
- Adds class-level docblocks.
- Adds test for uncovered lines
- Adds `// @codeCoverageIgnore` for untestable lines
- Removes unnecessary variables

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
