### PR TITLE
Make travis build faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ before_install:
 before_script:
   - echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - composer install --prefer-source
+  - composer install --prefer-dist
+  - php -r 'file_put_contents("vendor/laminas/laminas-zendframework-bridge/src/autoload.php", "");'
 
 after_success:
   - travis_retry php tests/bin/php-coveralls.phar -v


### PR DESCRIPTION
`laminas/laminas-zendframework-bridge` is only needed when there is package prefixed with `Zend`, `Expressive`, or `Apigility`. Since package like `laminas-escaper` already uses `Laminas` prefix,  it can be removed via removing it in travis process, so hopefully phpunit run will be faster.

**Checklist:**
- [x] Securely signed commits
