### PR TITLE
Enable Testing Registrars

### DIFF
--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -107,13 +107,7 @@ class BaseConfig
 			}
 		}
 
-		if (defined('ENVIRONMENT') && ENVIRONMENT !== 'testing')
-		{
-			// well, this won't happen during unit testing
-			// @codeCoverageIgnoreStart
-			$this->registerProperties();
-			// @codeCoverageIgnoreEnd
-		}
+		$this->registerProperties();
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/_support/Config/TestRegistrar.php
+++ b/tests/_support/Config/TestRegistrar.php
@@ -6,7 +6,7 @@
  * Provides a basic registrar class for testing BaseConfig registration functions.
  */
 
-class Registrar
+class TestRegistrar
 {
 
 	public static function RegistrarConfig()

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -227,7 +227,7 @@ class BaseConfigTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testRegistrars()
 	{
 		$config              = new \RegistrarConfig();
-		$config::$registrars = ['\Tests\Support\Config\Registrar'];
+		$config::$registrars = ['\Tests\Support\Config\TestRegistrar'];
 		$this->setPrivateProperty($config, 'didDiscovery', true);
 		$method = $this->getPrivateMethodInvoker($config, 'registerProperties');
 		$method();

--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -229,21 +229,20 @@ Registrars
 
 A configuration file can also specify any number of "registrars", which are any
 other classes which might provide additional configuration properties.
-This is done by adding a ``registrars`` property to your configuration file,
+This is done by adding a ``$registrars`` property to your configuration file,
 holding an array of the names of candidate registrars.::
 
-    protected $registrars = [
+    public static $registrars = [
         SupportingPackageRegistrar::class
     ];
 
 In order to act as a "registrar" the classes so identified must have a
-static function named the same as the configuration class, and it should return an associative
+static function with the same name as the configuration class, and it should return an associative
 array of property settings.
 
 When your configuration object is instantiated, it will loop over the
-designated classes in ``$registrars``. For each of these classes, which contains a method name matching
-the configuration class, it will invoke that method, and incorporate any returned properties
-the same way as described for namespaced variables.
+designated classes in ``$registrars``. For each of these classes it will invoke
+the method named for the configuration class and incorporate any returned properties.
 
 A sample configuration class setup for this::
 
@@ -253,9 +252,9 @@ A sample configuration class setup for this::
 
     class MySalesConfig extends BaseConfig
     {
-        public $target        = 100;
-        public $campaign      = "Winter Wonderland";
-        protected $registrars = [
+        public $target            = 100;
+        public $campaign          = "Winter Wonderland";
+        public static $registrars = [
             '\App\Models\RegionalSales';
         ];
     }
@@ -272,9 +271,14 @@ A sample configuration class setup for this::
         }
     }
 
-With the above example, when `MySalesConfig` is instantiated, it will end up with
-the two properties declared, but the value of the `$target` property will be over-ridden
-by treating `RegionalSalesModel` as a "registrar". The resulting configuration properties::
+With the above example, when ``MySalesConfig`` is instantiated, it will end up with
+the two properties declared, but the value of the ``$target`` property will be overridden
+by treating ``RegionalSales`` as a "registrar". The resulting configuration properties::
 
     $target   = 45;
     $campaign = "Winter Wonderland";
+
+In addition to explicit registrars defined by the ``$registrars`` property, you may also
+define registrars in any namespace using the **Config/Registrars.php** file, if discovery
+is enabled in :doc:`Modules </general/modules>`. These files work the same as the classes
+described above, using methods named for each configuration class you wish to extend.


### PR DESCRIPTION
**Description**
Currently `Registrar` discovery is disabled during testing. This is an attempt to reenable it. Also fixes a fair amount of missing and incorrect info on Registrars in the docs.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
