### PR TITLE
Add `db:create` Command to Create Database

### DIFF
--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CodeIgniter
  *

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -128,28 +128,34 @@ class CreateDatabase extends BaseCommand
 			try
 			{
 				$connect = \Config\Database::connect();
+
+				if($connect->hostname != NULL && $connect->username != NULL)
+				{
+					if($_SERVER['CI_ENVIRONMENT'] != "development")
+					{
+						CLI::write('Make sure your environment configuration are ' . CLI::color('development', 'yellow') . '.');
+						die();
+					}
+					
+					try
+					{
+						$forge = \Config\Database::forge();
+						$forge->createDatabase($name);
+						return CLI::write('Create database ' . CLI::color($name, 'green') . ' successfully');
+					}
+					catch (\Exception $e)
+					{
+						return CLI::write('Database ' . CLI::color($name, 'red') . ' exists');
+					}
+				}
+				else
+				{
+					CLI::write('Please check your database configuration in' . CLI::color(' .env', 'yellow') . ' or' . CLI::color(' app/Config/Database.php', 'yellow') . ' file.');
+				}
 			}
 			catch (\Exception $e)
 			{
 				$this->showError($e);
-			}
-
-			if($connect->hostname != NULL && $connect->username != NULL)
-			{
-				try
-				{
-					$forge = \Config\Database::forge();
-					$forge->createDatabase($name);
-					return CLI::write('Create database ' . CLI::color($name, 'green') . ' successfully');
-				}
-				catch (\Exception $e)
-				{
-					return CLI::write('Database ' . CLI::color($name, 'red') . ' exists');
-				}
-			}
-			else
-			{
-				CLI::write('Please check your database configuration in' . CLI::color(' .env', 'red') . ' file or' . CLI::color(' app/Config/Database.php', 'red'));
 			}
 		}
 	}

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -96,13 +96,6 @@ class CreateDatabase extends BaseCommand
 	protected $options = [];
 
 	/**
-	 * the Database Connection
-	 *
-	 * @var array
-	 */
-	protected $connect = [];
-
-	/**
 	 * Creates a new database.
 	 *
 	 * @param array $params
@@ -125,39 +118,22 @@ class CreateDatabase extends BaseCommand
 
 		if(!empty($name))
 		{
+			if(ENVIRONMENT != "development")
+			{
+				CLI::write('Before use this feature please set your ' . CLI::color('database connection', 'yellow') . ' and' . CLI::color(' environment', 'yellow') . ', make sure your environment configuration are ' . CLI::color('development', 'yellow') . '.');
+				die();
+			}
+
 			try
 			{
-				$connect = \Config\Database::connect();
-
-				if($connect->hostname != NULL && $connect->username != NULL)
-				{
-					if($_SERVER['CI_ENVIRONMENT'] != "development")
-					{
-						CLI::write('Make sure your environment configuration are ' . CLI::color('development', 'yellow') . '.');
-						die();
-					}
-					
-					try
-					{
-						$forge = \Config\Database::forge();
-						$forge->createDatabase($name);
-						return CLI::write('Create database ' . CLI::color($name, 'green') . ' successfully');
-					}
-					catch (\Exception $e)
-					{
-						return CLI::write('Database ' . CLI::color($name, 'red') . ' exists');
-					}
-				}
-				else
-				{
-					CLI::write('Please check your database configuration in' . CLI::color(' .env', 'yellow') . ' or' . CLI::color(' app/Config/Database.php', 'yellow') . ' file.');
-				}
+				$forge = \Config\Database::forge();
+				$forge->createDatabase($name);
+				return CLI::write('Create database ' . CLI::color($name, 'green') . ' successfully');
 			}
 			catch (\Exception $e)
 			{
-				$this->showError($e);
+				return CLI::write('Database ' . CLI::color($name, 'red') . ' exists');
 			}
 		}
 	}
-
 }

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -125,7 +125,8 @@ class CreateDatabase extends BaseCommand
 			{
 				$forge = \Config\Database::forge();
 				$forge->createDatabase($name);
-				return CLI::write('Create database ' . CLI::color($name, 'green') . ' successfully');
+
+				return CLI::write("Database \"{$name}\" created successfully.", 'green');
 			}
 			catch (\Exception $e)
 			{

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -75,7 +75,7 @@ class CreateDatabase extends BaseCommand
 	 *
 	 * @var string
 	 */
-	protected $usage = 'db:create [db_name]';
+	protected $usage = 'db:create <db_name>';
 
 	/**
 	 * the Command's Arguments

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -44,9 +44,7 @@ use CodeIgniter\CLI\CLI;
 use Config\Services;
 
 /**
- * Creates a new database migration file.
- *
- * @package CodeIgniter\Commands
+ * Creates a new database.
  */
 class CreateDatabase extends BaseCommand
 {

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -104,13 +104,7 @@ class CreateDatabase extends BaseCommand
 
 		if (empty($name))
 		{
-			$name = CLI::prompt('Database name');
-		}
-
-		if (empty($name))
-		{
-			CLI::write('You must provide a ' . CLI::color('database name', 'red') . '.');
-			return;
+			$name = CLI::prompt('Database name', null, 'required');
 		}
 
 		if(!empty($name))

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -100,7 +100,6 @@ class CreateDatabase extends BaseCommand
 	 */
 	public function run(array $params = [])
 	{
-		helper('inflector');
 		$name = array_shift($params);
 
 		if (empty($name))

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -63,7 +63,7 @@ class CreateDatabase extends BaseCommand
 	 *
 	 * @var string
 	 */
-	protected $name = 'db:go';
+	protected $name = 'db:create';
 
 	/**
 	 * the Command's short description
@@ -77,7 +77,7 @@ class CreateDatabase extends BaseCommand
 	 *
 	 * @var string
 	 */
-	protected $usage = 'db:go [db_name]';
+	protected $usage = 'db:create [db_name]';
 
 	/**
 	 * the Command's Arguments

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -83,7 +83,7 @@ class CreateDatabase extends BaseCommand
 	 * @var array
 	 */
 	protected $arguments = [
-		'db_name' => 'The database name to create new database',
+		'db_name' => 'The database name to use',
 	];
 
 	/**

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -48,7 +48,6 @@ use Config\Services;
  */
 class CreateDatabase extends BaseCommand
 {
-
 	/**
 	 * The group the command is lumped under
 	 * when listing commands.

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace App\Commands;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+use Config\Services;
+
+/**
+ * Creates a new database migration file.
+ *
+ * @package CodeIgniter\Commands
+ */
+class CreateDatabase extends BaseCommand
+{
+
+	/**
+	 * The group the command is lumped under
+	 * when listing commands.
+	 *
+	 * @var string
+	 */
+	protected $group = 'Database';
+
+	/**
+	 * The Command's name
+	 *
+	 * @var string
+	 */
+	protected $name = 'db:go';
+
+	/**
+	 * the Command's short description
+	 *
+	 * @var string
+	 */
+	protected $description = 'Create a new database.';
+
+	/**
+	 * the Command's usage
+	 *
+	 * @var string
+	 */
+	protected $usage = 'db:go [db_name]';
+
+	/**
+	 * the Command's Arguments
+	 *
+	 * @var array
+	 */
+	protected $arguments = [
+		'db_name' => 'The database name',
+	];
+
+	/**
+	 * the Command's Options
+	 *
+	 * @var array
+	 */
+	protected $options = [];
+
+	/**
+	 * Creates a new database migration file with the current timestamp.
+	 *
+	 * @param array $params
+	 */
+	public function run(array $params = [])
+	{
+		helper('inflector');
+		$name = array_shift($params);
+
+		if (empty($name))
+		{
+			$name = CLI::prompt('Database name');
+		}
+
+		if (empty($name))
+		{
+			CLI::write('You must provide a ' . CLI::color('database name', 'red') . '.');
+			return;
+		}
+
+		if(!empty($name))
+		{
+			try
+			{
+				$connect = \Config\Database::connect();
+			}
+			catch (\Exception $e)
+			{
+				$this->showError($e);
+			}
+
+			if($connect->hostname != NULL && $connect->username != NULL)
+			{
+				try
+				{
+					$forge = \Config\Database::forge();
+					$forge->createDatabase($name);
+					return CLI::write('Create database ' . CLI::color($name, 'green') . ' successfully');
+				}
+				catch (\Exception $e)
+				{
+					return CLI::write('Database ' . CLI::color($name, 'red') . ' exists');
+				}
+			}
+			else
+			{
+				CLI::write('Please check your database configuration in' . CLI::color(' .env', 'red') . ' file or' . CLI::color(' app/Config/Database.php', 'red'));
+			}
+		}
+	}
+
+}

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -128,7 +128,7 @@ class CreateDatabase extends BaseCommand
 
 				return CLI::write("Database \"{$name}\" created successfully.", 'green');
 			}
-			catch (\Exception $e)
+			catch (\Throwable $e)
 			{
 				return CLI::write('Database ' . CLI::color($name, 'red') . ' exists');
 			}

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -85,7 +85,7 @@ class CreateDatabase extends BaseCommand
 	 * @var array
 	 */
 	protected $arguments = [
-		'db_name' => 'The database name',
+		'db_name' => 'The database name to create new database',
 	];
 
 	/**
@@ -96,7 +96,7 @@ class CreateDatabase extends BaseCommand
 	protected $options = [];
 
 	/**
-	 * Creates a new database migration file with the current timestamp.
+	 * Creates a new database.
 	 *
 	 * @param array $params
 	 */

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -36,7 +36,7 @@
  * @filesource
  */
 
-namespace App\Commands;
+namespace CodeIgniter\Commands\Database;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -96,6 +96,13 @@ class CreateDatabase extends BaseCommand
 	protected $options = [];
 
 	/**
+	 * the Database Connection
+	 *
+	 * @var array
+	 */
+	protected $connect = [];
+
+	/**
 	 * Creates a new database.
 	 *
 	 * @param array $params


### PR DESCRIPTION
**Description**
Create database using `php spark db:create <db_name>`

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide