### PR TITLE
Remove erroneous interface reference

### DIFF
--- a/system/Database/Exceptions/DatabaseException.php
+++ b/system/Database/Exceptions/DatabaseException.php
@@ -38,8 +38,6 @@
 
 namespace CodeIgniter\Database\Exceptions;
 
-use CodeIgniter\Exceptions\ExceptionInterface;
-
 class DatabaseException extends \Error implements ExceptionInterface
 {
 	/**


### PR DESCRIPTION
**Description**
`DatabaseException` intentionally has its own `ExceptionInterface` to allow catching database-specific errors. However, the `use` statement included on the `DatabaseException` class prevents it from using the namespaced version. Since `CodeIgniter\Database\Exceptions\ExceptionInterface` extends the core `ExceptionInterface` this should not break anything that was lumping those together, but this change will now allow catching database exceptions directly using the interface.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
