### PR TITLE
Add Builder::insertID()

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3494,4 +3494,15 @@ class BaseBuilder
 	}
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * Passes through to $db insertID().
+	 *
+	 * @return integer|string
+	 */
+	public function insertID()
+	{
+		// @phpstan-ignore-next-line
+		return $this->db->insertID();
+	}
 }

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -109,4 +109,20 @@ class InsertTest extends CIDatabaseTestCase
 		$this->seeInDatabase('misc', ['value' => $hash]);
 	}
 
+	//--------------------------------------------------------------------
+
+	public function testBuilderInsertID()
+	{
+		$job_data = [
+			'name'        => 'Grocery Sales',
+			'description' => 'Discount!',
+		];
+
+		$builder = $this->db->table('job');
+		$builder->insert($job_data);
+
+		$expected = $this->db->insertID();
+
+		$this->assertEquals($expected, $builder->insertID());
+	}
 }

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -859,6 +859,8 @@ The first parameter is an object.
 
 .. note:: All values are escaped automatically producing safer queries.
 
+After a successful ``insert()`` you can use $builder->insertID() to retrieve the new ID.
+
 **$builder->ignore()**
 
 Generates an insert ignore string based on the data you supply, and runs the


### PR DESCRIPTION
**Description**
It is a source of frequent confusion that the Query Builder cannot return the last insert ID. Because `$db` is protected there is no way to access the database instance once you have instantiated a Builder. This adds a method to call the database instance's `insertID()` on behalf of the builder.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
