### PR TITLE
Builder Get Connection

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -271,9 +271,9 @@ class BaseBuilder
 	/**
 	 * Constructor
 	 *
-	 * @param  string|array                              $tableName
-	 * @param  \CodeIgniter\Database\ConnectionInterface $db
-	 * @param  array                                     $options
+	 * @param  string|array        $tableName
+	 * @param  ConnectionInterface $db
+	 * @param  array               $options
 	 * @throws DatabaseException
 	 */
 	public function __construct($tableName, ConnectionInterface &$db, array $options = null)
@@ -297,6 +297,18 @@ class BaseBuilder
 				}
 			}
 		}
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns the current database connection
+	 *
+	 * @return ConnectionInterface
+	 */
+	public function db(): ConnectionInterface
+	{
+		return $this->db;
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Builder/BaseTest.php
+++ b/tests/system/Database/Builder/BaseTest.php
@@ -1,0 +1,29 @@
+<?php namespace Builder;
+
+use CodeIgniter\Database\Query;
+use CodeIgniter\Test\Mock\MockConnection;
+
+class BaseTest extends \CodeIgniter\Test\CIUnitTestCase
+{
+	protected $db;
+
+	//--------------------------------------------------------------------
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->db = new MockConnection([]);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testDbReturnsConnection()
+	{
+		$builder = $this->db->table('jobs');
+
+		$result = $builder->db();
+
+		$this->assertInstanceOf(MockConnection::class, $result);
+	}
+}

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1233,6 +1233,15 @@ Class Reference
 
 .. php:class:: CodeIgniter\\Database\\BaseBuilder
 
+	.. php:method:: db()
+
+		:returns: The database connection in use
+		:rtype:	``ConnectionInterface``
+
+		Returns the current database connection from ``$db``. Useful for
+		accessing ``ConnectionInterface`` methods that are not directly
+		available to the Query Builder, like ``insertID()`` or ``errors()``.
+
 	.. php:method:: resetQuery()
 
 		:returns: ``BaseBuilder`` instance (method chaining)


### PR DESCRIPTION
**Description**
It is a source of frequent confusion that the Query Builder cannot return the last insert ID, errors, or other data related to the database connection. Because $db is protected there is no way to access the database instance once you have instantiated a Builder. This adds a method to return the `ConnectionInterface` in use on a builder.

Supersedes #3697 because I realized that `ConnectionInterface` does not specific a `insertID()` method. Not sure if that is an oversight but this is a little more flexible anyways.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
