### PR TITLE
Factory class for Entities

### DIFF
--- a/system/EntityFactory.php
+++ b/system/EntityFactory.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 British Columbia Institute of Technology
+ * Copyright (c) 2019-2020 CodeIgniter Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package    CodeIgniter
+ * @author     CodeIgniter Dev Team
+ * @copyright  2019-2020 CodeIgniter Foundation
+ * @license    https://opensource.org/licenses/MIT	MIT License
+ * @link       https://codeigniter.com
+ * @since      Version 4.0.0
+ * @filesource
+ */
+
+namespace CodeIgniter;
+
+use Config\Services;
+
+/**
+ * EntityFactory creates instances of Entity classes.
+ */
+class EntityFactory
+{
+	/**
+	 * Cache of instances of entities that have been
+	 * requested as "shared" instances.
+	 *
+	 * @var array<string, Entity>
+	 */
+	private static $instances = [];
+
+	/**
+	 * Create a new entity instance or retrieve the shared instance.
+	 *
+	 * @param string  $name
+	 * @param array   $data
+	 * @param boolean $getShared
+	 *
+	 * @return Entity|null
+	 */
+	public static function get(string $name, array $data = [], bool $getShared = true): ?Entity
+	{
+		$class = $name;
+
+		if (($pos = strrpos($name, '\\')) !== false)
+		{
+			$class = substr($name, $pos + 1);
+		}
+
+		if (! $getShared)
+		{
+			return self::createClass($name, $data);
+		}
+
+		if (! isset(self::$instances[$class]))
+		{
+			self::$instances[$class] = self::createClass($name, $data);
+		}
+
+		return self::$instances[$class];
+	}
+
+	/**
+	 * Injects mock Entity instances for testing.
+	 *
+	 * @param string $class
+	 * @param Entity $instance
+	 *
+	 * @return void
+	 */
+	public static function injectMock(string $class, Entity $instance): void
+	{
+		self::$instances[$class] = $instance;
+	}
+
+	/**
+	 * Resets the instances array.
+	 *
+	 * @return void
+	 */
+	public static function reset(): void
+	{
+		self::$instances = [];
+	}
+
+	/**
+	 * Finds the Entity class and create an instance.
+	 *
+	 * @param string $name
+	 * @param array  $data
+	 *
+	 * @return Entity|null
+	 */
+	private static function createClass(string $name, array $data): ?Entity
+	{
+		if (class_exists($name))
+		{
+			return new $name($data);
+		}
+
+		$locator = Services::locator();
+
+		$file = $locator->locateFile($name, 'Entities');
+
+		if (! $file)
+		{
+			// Class was namespaced and cannot be found
+			if (strpos($name, '\\') !== false)
+			{
+				return null;
+			}
+
+			$files = $locator->search('Entities/' . $name);
+
+			if (empty($files))
+			{
+				return null;
+			}
+
+			$file = reset($files);
+		}
+
+		$name = $locator->getClassname($file);
+
+		if (empty($name))
+		{
+			return null; // @codeCoverageIgnore
+		}
+
+		return new $name($data);
+	}
+}

--- a/tests/_support/Entities/SupportEntity.php
+++ b/tests/_support/Entities/SupportEntity.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tests\Support\Entities;
+
+use CodeIgniter\Entity;
+
+class SupportEntity extends Entity
+{
+}

--- a/tests/system/EntityFactoryTest.php
+++ b/tests/system/EntityFactoryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace CodeIgniter;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use Tests\Support\Entities\SupportEntity;
+
+class EntityFactoryTest extends CIUnitTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+		EntityFactory::reset();
+	}
+
+	public function testCreateSingleInstance()
+	{
+		$bareEntity = EntityFactory::get('SupportEntity', [], false);
+		$namespaced = EntityFactory::get('Tests\Support\Entities\SupportEntity', [], false);
+
+		$this->assertInstanceOf('Tests\Support\Entities\SupportEntity', $bareEntity);
+		$this->assertInstanceOf('Tests\Support\Entities\SupportEntity', $namespaced);
+	}
+
+	public function testInvalidEntityInstance()
+	{
+		$this->assertNull(EntityFactory::get('foo'));
+		$this->assertNull(EntityFactory::get('Tests\Support\Entities\Foo'));
+	}
+
+	public function testCreateSharedInstances()
+	{
+		$this->assertSame(
+			EntityFactory::get('SupportEntity'),
+			EntityFactory::get('Tests\Support\Entities\SupportEntity')
+		);
+	}
+
+	public function testInjectMockGivesEntityInstance()
+	{
+		EntityFactory::injectMock('Support', new SupportEntity());
+		$this->assertInstanceOf('Tests\Support\Entities\SupportEntity', EntityFactory::get('Support'));
+	}
+
+	public function testResetInstancesGivesDifferentInstances()
+	{
+		$entity = EntityFactory::get('SupportEntity');
+		EntityFactory::reset();
+		$another = EntityFactory::get('SupportEntity');
+
+		$this->assertNotSame($entity, $another);
+	}
+
+	public function testProceduralEntityInstanceGrabbing()
+	{
+		$one = entity('SupportEntity');
+		$two = entity('Tests\Support\Entities\SupportEntity');
+
+		$this->assertInstanceOf('Tests\Support\Entities\SupportEntity', $one);
+		$this->assertInstanceOf('Tests\Support\Entities\SupportEntity', $two);
+		$this->assertSame($one, $two);
+	}
+}

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -2,7 +2,7 @@
 Working With Entities
 #####################
 
-CodeIgniter supports Entity classes as a first-class citizen in it's database layer, while keeping
+CodeIgniter supports Entity classes as a first-class citizen in its database layer, while keeping
 them completely optional to use. They are commonly used as part of the Repository pattern, but can
 be used directly with the :doc:`Model </models/model>` if that fits your needs better.
 
@@ -109,6 +109,35 @@ of what columns have changed since the object was created or pulled from the dat
 When the User is passed to the model's **save()** method, it automatically takes care of reading the  properties
 and saving any changes to columns listed in the model's **$allowedFields** property. It also knows whether to create
 a new row, or update an existing one.
+
+Accessing Entities Manually
+---------------------------
+
+While models usually takes care of instantiating the entity classes for you, you may find the need to instantiate
+them manually for your specific needs. Entities are expected to be found under the ``Entities`` sub-namespace. Thus,
+if you store them at the ``app/Entities`` directory, it is expected that the classes have the ``App\Entities``
+namespace or if you have customized the ``APP_NAMESPACE`` constant, it is found in the ``{APP_NAMESPACE}\Entities``
+namespace.
+
+Accessing entities outside your models is easy. You can instantiate them directly, or use the ``entity`` function.
+
+::
+
+    // create a class manually
+    $user = new App\Entities\UserEntity();
+
+    // create an entity class the procedural way
+    $user = entity('App\Entities\UserEntity', [], false);
+
+    // create a shared user entity instance
+    $user = entity('App\Entities\UserEntity');
+
+    // passing an array of data to the entity constructor
+    $user = entity('App\Entity\UserEntity', ['username' => 'admin']);
+
+    // if the passed entity name is not namespaced, the function will
+    // search all namespaces for a matching entity class
+    $user = entity('UserEntity');
 
 Filling Properties Quickly
 --------------------------


### PR DESCRIPTION
**Description**
This PR exposes two new API in creating new or shared instances of `Entity` classes.

Procedural: Using the `entity()` common function in creating shared/single instances of Entities.
OOP: Using `CodeIgniter\EntityFactory` in creating shared/single instances of Entities.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
