### PR TITLE
Failover realpath

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -354,16 +354,16 @@ class FileLocator
 	 */
 	public function findQualifiedNameFromPath(string $path)
 	{
-		$path = realpath($path);
+		$path = realpath($path) ?: $path;
 
-		if (! $path)
+		if (! is_file($path))
 		{
 			return false;
 		}
 
 		foreach ($this->getNamespaces() as $namespace)
 		{
-			$namespace['path'] = realpath($namespace['path']);
+			$namespace['path'] = realpath($namespace['path']) ?: $namespace['path'];
 
 			if (empty($namespace['path']))
 			{
@@ -412,7 +412,8 @@ class FileLocator
 
 		foreach ($this->getNamespaces() as $namespace)
 		{
-			$fullPath = realpath($namespace['path'] . $path);
+			$fullPath = $namespace['path'] . $path;
+			$fullPath = realpath($fullPath) ?: $fullPath;
 
 			if (! is_dir($fullPath))
 			{
@@ -454,7 +455,8 @@ class FileLocator
 		// autoloader->getNamespace($prefix) returns an array of paths for that namespace
 		foreach ($this->autoloader->getNamespace($prefix) as $namespacePath)
 		{
-			$fullPath = realpath(rtrim($namespacePath, '/') . '/' . $path);
+			$fullPath = rtrim($namespacePath, '/') . '/' . $path;
+			$fullPath = realpath($fullPath) ?: $fullPath;
 
 			if (! is_dir($fullPath))
 			{
@@ -485,7 +487,8 @@ class FileLocator
 	 */
 	protected function legacyLocate(string $file, string $folder = null)
 	{
-		$path = realpath(APPPATH . (empty($folder) ? $file : $folder . '/' . $file));
+		$path = APPPATH . (empty($folder) ? $file : $folder . '/' . $file);
+		$path = realpath($path) ?: $path;
 
 		if (is_file($path))
 		{

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -444,7 +444,7 @@ class FileHandler implements CacheInterface
 			if ($_recursion === false)
 			{
 				$_filedata = [];
-				$sourceDir = rtrim(realpath($sourceDir), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+				$sourceDir = rtrim(realpath($sourceDir) ?: $sourceDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 			}
 
 			// Used to be foreach (scandir($source_dir, 1) as $file), but scandir() is simply not as fast

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -152,7 +152,7 @@ class File extends SplFileInfo
 		}
 
 		$finfo    = finfo_open(FILEINFO_MIME_TYPE);
-		$mimeType = finfo_file($finfo, $this->getRealPath());
+		$mimeType = finfo_file($finfo, $this->getRealPath() ?: $this->__toString());
 		finfo_close($finfo);
 		return $mimeType;
 	}
@@ -189,7 +189,7 @@ class File extends SplFileInfo
 		$name        = $name ?? $this->getBaseName();
 		$destination = $overwrite ? $targetPath . $name : $this->getDestination($targetPath . $name);
 
-		$oldName = empty($this->getRealPath()) ? $this->getPath() : $this->getRealPath();
+		$oldName = $this->getRealPath() ?: $this->__toString();
 
 		if (! @rename($oldName, $destination))
 		{

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -666,9 +666,9 @@ class CURLRequest extends Request
 		{
 			if (is_string($config['verify']))
 			{
-				$file = realpath($config['ssl_key']);
+				$file = realpath($config['ssl_key']) ?: $config['ssl_key'];
 
-				if (! $file)
+				if (! is_file($file))
 				{
 					throw HTTPException::forInvalidSSLKey($config['ssl_key']);
 				}

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -335,7 +335,9 @@ class CIUnitTestCase extends TestCase
 	 */
 	protected function createApplication()
 	{
-		return require realpath(__DIR__ . '/../') . '/bootstrap.php';
+		$path = __DIR__ . '/../bootstrap.php';
+		$path = realpath($path) ?: $path;
+		return require $path;
 	}
 
 	/**


### PR DESCRIPTION
**Description**
I'm a fan of virtual filesystems for testing (like vfsStream) but the biggest failure is always that `realpath()` fails to resolve resource stream references to a file. The framework has been made mostly "virtual-safe" but these are a few lingering references.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
