### PR TITLE
Autoloader include

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -377,7 +377,7 @@ class Autoloader
 
 		if (is_file($file))
 		{
-			require_once $file;
+			include_once $file;
 
 			return $file;
 		}

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -289,7 +289,7 @@ class Autoloader
 		{
 			$class    = 'Config\\' . $class;
 			$filePath = APPPATH . str_replace('\\', DIRECTORY_SEPARATOR, $class) . '.php';
-			$filename = $this->requireFile($filePath);
+			$filename = $this->includeFile($filePath);
 
 			if ($filename)
 			{
@@ -308,7 +308,7 @@ class Autoloader
 				if (strpos($class, $namespace) === 0)
 				{
 					$filePath = $directory . str_replace('\\', DIRECTORY_SEPARATOR, substr($class, strlen($namespace))) . '.php';
-					$filename = $this->requireFile($filePath);
+					$filename = $this->includeFile($filePath);
 
 					if ($filename)
 					{
@@ -352,7 +352,7 @@ class Autoloader
 
 		foreach ($paths as $path)
 		{
-			if ($file = $this->requireFile($path . $class))
+			if ($file = $this->includeFile($path . $class))
 			{
 				return $file;
 			}
@@ -364,14 +364,13 @@ class Autoloader
 	//--------------------------------------------------------------------
 
 	/**
-	 * A central way to require a file is loaded. Split out primarily
-	 * for testing purposes.
+	 * A central way to include a file. Split out primarily for testing purposes.
 	 *
 	 * @param string $file
 	 *
 	 * @return string|false The filename on success, false if the file is not loaded
 	 */
-	protected function requireFile(string $file)
+	protected function includeFile(string $file)
 	{
 		$file = $this->sanitizeFilename($file);
 


### PR DESCRIPTION
**Description**
This issue arose with the Autoloader. I don't understand all the nuances of the difference but I thought I'd at least run it through the tests and see if anyone else here with more Autoloader experience had ideas.

See: https://github.com/phpstan/phpstan/issues/3907

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
