### PR TITLE
update rector ^0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,10 @@
 		"codeigniter4/codeigniter4-standard": "^1.0",
 		"fzaninotto/faker": "^1.9@dev",
 		"mikey179/vfsstream": "1.6.*",
-		"nette/utils": "^3.1",
 		"phpstan/phpstan": "^0.12",
 		"phpunit/phpunit": "^8.5",
 		"predis/predis": "^1.1",
-		"rector/rector-prefixed": "0.8.13",
+		"rector/rector": "^0.8",
 		"squizlabs/php_codesniffer": "^3.3"
 	},
 	"autoload": {

--- a/rector.php
+++ b/rector.php
@@ -13,7 +13,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 	// is there a file you need to skip?
 	$parameters->set(Option::EXCLUDE_PATHS, [
 		__DIR__ . '/app/Views',
-		__DIR__ . '/system/Autoloader/Autoloader.php',
 		__DIR__ . '/system/Debug/Toolbar/Views/toolbar.tpl.php',
 		__DIR__ . '/system/ThirdParty',
 	]);
@@ -22,6 +21,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 	$parameters->set(Option::AUTOLOAD_PATHS, [
 		// autoload specific file
 		__DIR__ . '/system/Test/bootstrap.php',
+	]);
+
+	$parameters->set(Option::SKIP, [
+		// skipped for UnderscoreToCamelCaseVariableNameRector rule
+		// as the underscored variable removed in 4.1 branch
+		UnderscoreToCamelCaseVariableNameRector::class => [__DIR__ . '/system/Autoloader/Autoloader.php'],
 	]);
 
 	$services = $containerConfigurator->services();


### PR DESCRIPTION
Update to use rector/rector ^0.8, version 0.8.14 also enable Option::SKIP to allow skip check file(s)/directory(es) by rule.

**Checklist:**
- [x] Securely signed commits