### PR TITLE
Factory instance basenames

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
 		}
 	},
 	"autoload-dev": {
-                "psr-4": {
-                        "Utils\\": "utils"
-                }
-        },
+		"psr-4": {
+			"Utils\\": "utils"
+		}
+	},
 	"scripts": {
 		"post-update-cmd": [
 			"@composer dump-autoload",

--- a/tests/system/Database/ModelFactoryTest.php
+++ b/tests/system/Database/ModelFactoryTest.php
@@ -2,37 +2,56 @@
 
 use CodeIgniter\Test\CIDatabaseTestCase;
 use Tests\Support\Models\JobModel;
+use Tests\Support\Models\UserModel;
 
 class ModelFactoryTest extends CIDatabaseTestCase
 {
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		ModelFactory::reset();
+	}
 
 	public function testCreateSeparateInstances()
 	{
-		$model          = ModelFactory::get('JobModel', false);
+		$basenameModel  = ModelFactory::get('JobModel', false);
 		$namespaceModel = ModelFactory::get('Tests\\Support\\Models\\JobModel', false);
 
-		$this->assertInstanceOf(JobModel::class, $model);
+		$this->assertInstanceOf(JobModel::class, $basenameModel);
 		$this->assertInstanceOf(JobModel::class, $namespaceModel);
-		$this->assertNotSame($model, $namespaceModel);
+		$this->assertNotSame($basenameModel, $namespaceModel);
 	}
 
 	public function testCreateSharedInstance()
 	{
-		$model          = ModelFactory::get('JobModel', true);
+		$basenameModel  = ModelFactory::get('JobModel', true);
 		$namespaceModel = ModelFactory::get('Tests\\Support\\Models\\JobModel', true);
 
-		$this->assertSame($model, $namespaceModel);
+		$this->assertSame($basenameModel, $namespaceModel);
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState  disabled
-	 */
 	public function testInjection()
 	{
-		ModelFactory::reset();
-		ModelFactory::injectMock('Banana', '\stdClass');
-		$this->assertNotNull(ModelFactory::get('Banana'));
+		ModelFactory::injectMock('Banana', new JobModel());
+		$this->assertInstanceOf(JobModel::class, ModelFactory::get('Banana'));
 	}
 
+	public function testReset()
+	{
+		ModelFactory::injectMock('Banana', new JobModel());
+
+		ModelFactory::reset();
+
+		$this->assertNull(ModelFactory::get('Banana'));
+	}
+
+	public function testBasenameReturnsExistingNamespaceInstance()
+	{
+		ModelFactory::injectMock(UserModel::class, new JobModel());
+
+		$basenameModel = ModelFactory::get('UserModel');
+
+		$this->assertInstanceOf(JobModel::class, $basenameModel);
+	}
 }


### PR DESCRIPTION
**Description**
This addresses a bug I've been working around for a while. Consider this scenario: a `WidgetModel` in the `App` namespace, and an unrelated third-party module with its own `WidgetModel`.

Currently, `ModelFactory` stores shared instances solely by their "base name" (class without the namespace). This creates a problem for our scenario, because even supplying the full namespace will only compare the base names:
```
$appModel = model('App\Models\WidgetModel');
$modModel = model('Module\Org\Models\WidgetModel');
get_class($modModel); // App\Models\WidgetModel
```
This PR changes `ModelFactory` to tracks base names separately from the full class name so a developer can choose between `model($fullClassName)` (which will always return the intended class) or `model($baseClassName)` (which lets the `FileLocator` determine the best match).
***
If these changes seem appropriate to all, the same structure should be applied to `Config`, or maybe even abstracted to a `Components` class that functions similar to `Services` but for distinct components (models, config, entities(?), some thing?).

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
