### PR TITLE
Controller Helpers

### DIFF
--- a/system/Controller.php
+++ b/system/Controller.php
@@ -170,10 +170,7 @@ class Controller
 			return;
 		}
 
-		foreach ($this->helpers as $helper)
-		{
-			helper($helper);
-		}
+		helper($helper);
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -170,7 +170,7 @@ class Controller
 			return;
 		}
 
-		helper($helper);
+		helper($this->helpers);
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
`helper()` already prefers an array, so unpacking the names with `foreach` is just a performance cost.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
