### PR TITLE
[ci skip] remove awkward note at admin/framework/README.md and admin/starter/README.md

### DIFF
--- a/admin/framework/README.md
+++ b/admin/framework/README.md
@@ -2,17 +2,17 @@
 
 ## What is CodeIgniter?
 
-CodeIgniter is a PHP full-stack web framework that is light, fast, flexible, and secure. 
+CodeIgniter is a PHP full-stack web framework that is light, fast, flexible, and secure.
 More information can be found at the [official site](http://codeigniter.com).
 
 This repository holds the distributable version of the framework,
-including the user guide. It has been built from the 
+including the user guide. It has been built from the
 [development repository](https://github.com/codeigniter4/CodeIgniter4).
 
 More information about the plans for version 4 can be found in [the announcement](http://forum.codeigniter.com/thread-62615.html) on the forums.
 
 The user guide corresponding to this version of the framework can be found
-[here](https://codeigniter4.github.io/userguide/). 
+[here](https://codeigniter4.github.io/userguide/).
 
 
 ## Important Change with index.php
@@ -25,7 +25,6 @@ not to the project root. A better practice would be to configure a virtual host 
 framework are exposed.
 
 **Please** read the user guide for a better explanation of how CI4 works!
-The user guide updating and deployment is a bit awkward at the moment, but we are working on it!
 
 ## Repository Management
 
@@ -33,7 +32,7 @@ We use Github issues, in our main repository, to track **BUGS** and to track app
 We use our [forum](http://forum.codeigniter.com) to provide SUPPORT and to discuss
 FEATURE REQUESTS.
 
-This repository is a "distribution" one, built by our release preparation script. 
+This repository is a "distribution" one, built by our release preparation script.
 Problems with it can be raised on our forum, or as issues in the main repository.
 
 ## Contributing
@@ -44,7 +43,7 @@ Please read the [*Contributing to CodeIgniter*](https://github.com/codeigniter4/
 
 ## Server Requirements
 
-PHP version 7.2 or higher is required, with the following extensions installed: 
+PHP version 7.2 or higher is required, with the following extensions installed:
 
 - [intl](http://php.net/manual/en/intl.requirements.php)
 - [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library

--- a/admin/starter/README.md
+++ b/admin/starter/README.md
@@ -2,17 +2,17 @@
 
 ## What is CodeIgniter?
 
-CodeIgniter is a PHP full-stack web framework that is light, fast, flexible, and secure. 
+CodeIgniter is a PHP full-stack web framework that is light, fast, flexible, and secure.
 More information can be found at the [official site](http://codeigniter.com).
 
 This repository holds a composer-installable app starter.
-It has been built from the 
+It has been built from the
 [development repository](https://github.com/codeigniter4/CodeIgniter4).
 
 More information about the plans for version 4 can be found in [the announcement](http://forum.codeigniter.com/thread-62615.html) on the forums.
 
 The user guide corresponding to this version of the framework can be found
-[here](https://codeigniter4.github.io/userguide/). 
+[here](https://codeigniter4.github.io/userguide/).
 
 ## Installation & updates
 
@@ -38,7 +38,6 @@ not to the project root. A better practice would be to configure a virtual host 
 framework are exposed.
 
 **Please** read the user guide for a better explanation of how CI4 works!
-The user guide updating and deployment is a bit awkward at the moment, but we are working on it!
 
 ## Repository Management
 
@@ -46,12 +45,12 @@ We use Github issues, in our main repository, to track **BUGS** and to track app
 We use our [forum](http://forum.codeigniter.com) to provide SUPPORT and to discuss
 FEATURE REQUESTS.
 
-This repository is a "distribution" one, built by our release preparation script. 
+This repository is a "distribution" one, built by our release preparation script.
 Problems with it can be raised on our forum, or as issues in the main repository.
 
 ## Server Requirements
 
-PHP version 7.2 or higher is required, with the following extensions installed: 
+PHP version 7.2 or higher is required, with the following extensions installed:
 
 - [intl](http://php.net/manual/en/intl.requirements.php)
 - [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library


### PR DESCRIPTION
Clean up the following note : 

```
The user guide updating and deployment is a bit awkward at the moment, but we are working on it!
```

at admin/framework/README.md and admin/starter/README.md

**Checklist:**
- [x] Securely signed commits
- [x] User guide updated
