### PR TITLE
Load a JSON request into Validator 

### DIFF
--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -383,7 +383,7 @@ class Message
 	 *
 	 * @return boolean
 	 */
-	public function isJson()
+	public function isJSON()
 	{
 		return $this->hasHeader('Content-Type')
 			&& $this->getHeader('Content-Type')->getValue() === 'application/json';

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -377,4 +377,15 @@ class Message
 
 		return $this;
 	}
+
+	/**
+	 * Determines if this is a json message based on the Content-Type header
+	 *
+	 * @return boolean
+	 */
+	public function isJson()
+	{
+		return $this->hasHeader('Content-Type')
+			&& $this->getHeader('Content-Type')->getValue() === 'application/json';
+	}
 }

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -364,7 +364,7 @@ class Validation implements ValidationInterface
 	 */
 	public function withRequest(RequestInterface $request): ValidationInterface
 	{
-		if ($request->hasHeader('Content-Type') && $request->getHeader('Content-Type')->getValue() === 'application/json')
+		if ($request->isJson())
 		{
 			$this->data = $request->getJSON(true);
 			return $this;

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -364,6 +364,12 @@ class Validation implements ValidationInterface
 	 */
 	public function withRequest(RequestInterface $request): ValidationInterface
 	{
+		if ($request->hasHeader('Content-Type') && $request->getHeader('Content-Type')->getValue() === 'application/json')
+		{
+			$this->data = $request->getJSON(true);
+			return $this;
+		}
+
 		if (in_array($request->getMethod(), ['put', 'patch', 'delete'], true))
 		{
 			$this->data = $request->getRawInput();

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -364,7 +364,7 @@ class Validation implements ValidationInterface
 	 */
 	public function withRequest(RequestInterface $request): ValidationInterface
 	{
-		if ($request->isJson())
+		if ($request->isJSON())
 		{
 			$this->data = $request->getJSON(true);
 			return $this;

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -334,19 +334,19 @@ class MessageTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testIsJsonReturnsFalseWithNoHeader()
 	{
-		$this->assertFalse($this->message->isJson());
+		$this->assertFalse($this->message->isJSON());
 	}
 
 	public function testIsJsonReturnsFalseWithWrongContentType()
 	{
 		$this->message->setHeader('Content-Type', 'application/xml');
-		$this->assertFalse($this->message->isJson());
+		$this->assertFalse($this->message->isJSON());
 	}
 
 	public function testIsJsonReturnsTrue()
 	{
 		$this->message->setHeader('Content-Type', 'application/json');
-		$this->assertTrue($this->message->isJson());
+		$this->assertTrue($this->message->isJSON());
 	}
 
 }

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -332,4 +332,21 @@ class MessageTest extends \CodeIgniter\Test\CIUnitTestCase
 		$_SERVER = $original; // restore so code coverage doesn't break
 	}
 
+	public function testIsJsonReturnsFalseWithNoHeader()
+	{
+		$this->assertFalse($this->message->isJson());
+	}
+
+	public function testIsJsonReturnsFalseWithWrongContentType()
+	{
+		$this->message->setHeader('Content-Type', 'application/xml');
+		$this->assertFalse($this->message->isJson());
+	}
+
+	public function testIsJsonReturnsTrue()
+	{
+		$this->message->setHeader('Content-Type', 'application/json');
+		$this->assertTrue($this->message->isJson());
+	}
+
 }

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -457,6 +457,39 @@ class ValidationTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testJsonInput()
+	{
+		$data = [
+			'username' => 'admin001',
+			'role'     => 'administrator',
+			'usepass'  => 0,
+		];
+		$json = json_encode($data);
+
+		$_SERVER['CONTENT_TYPE'] = 'application/json';
+
+		$config          = new App();
+		$config->baseURL = 'http://example.com/';
+
+		$request = new IncomingRequest($config, new URI(), $json, new UserAgent());
+		$request->setMethod('patch');
+
+		$rules     = [
+			'role' => 'required|min_length[5]',
+		];
+		$validated = $this->validation
+			->withRequest($request)
+			->setRules($rules)
+			->run();
+
+		$this->assertTrue($validated);
+		$this->assertEquals([], $this->validation->getErrors());
+
+		unset($_SERVER['CONTENT_TYPE']);
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testHasRule()
 	{
 		$this->validation->setRuleGroup('groupA');


### PR DESCRIPTION
fixes #3719 

**Description**
Adjusted Validation::withRequest so that it recognizes when the request is a json request and loads the data appropriately.
This allows someone who is building a JSON API to be able to validate their incoming JSON's using the Controller::validate function.

**Checklist:**
- [x] Securely signed commits
- [ ] (N/A) Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] (N/A) User guide updated n/a
- [x] Conforms to style guide
