### PR TITLE
Removing unused --dev and autoload on PHPUnit workflow

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -74,9 +74,15 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: composer install --no-progress --no-suggest --no-interaction --prefer-dist --optimize-autoloader
+        run: |
+          composer install --no-progress --no-suggest --no-interaction --prefer-dist --optimize-autoloader
+          composer remove --dev phpstan/phpstan
+          composer remove --dev rector/rector
+          composer remove --dev codeigniter4/codeigniter4-standard
+          composer remove --dev squizlabs/php_codesniffer
+          php -r 'file_put_contents("vendor/laminas/laminas-zendframework-bridge/src/autoload.php", "");'
         env:
-          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}     
+          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
       - name: Test with PHPUnit
         run: script -e -c "vendor/bin/phpunit -v"


### PR DESCRIPTION
Try make PHPUnit workflow faster.

**Checklist:**
- [x] Securely signed commits