### PR TITLE
Feature Tests with a Formatted Request Body

### DIFF
--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -88,4 +88,12 @@ class FeatureTestCase extends CIDatabaseTestCase
 	 * @var string
 	 */
 	protected $bodyFormat = '';
+
+	/**
+	 * Allows for directly setting the body to what
+	 * it needs to be.
+	 *
+	 * @var mixed
+	 */
+	protected $requestBody = '';
 }

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -80,4 +80,12 @@ class FeatureTestCase extends CIDatabaseTestCase
 	 * @var array
 	 */
 	protected $headers = [];
+
+	/**
+	 * Allows for formatting the request body to what
+	 * the controller is going to expect
+	 *
+	 * @var string
+	 */
+	protected $bodyFormat = '';
 }

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -403,23 +403,26 @@ trait FeatureTestTrait
 	 */
 	protected function setRequestBody(Request $request, $params = null)
 	{
-		if (empty($params))
+		if (! empty($this->bodyFormat))
 		{
-			$params = $request->fetchGlobal('request');
-		}
-		$formatMime = '';
-		if ($this->bodyFormat === 'json')
-		{
-			$formatMime = 'application/json';
-		}
-		elseif ($this->bodyFormat === 'xml')
-		{
-			$formatMime = 'application/xml';
-		}
-		if (! empty($formatMime))
-		{
-			$formatted = Services::format()->getFormatter($formatMime)->format($params);
-			$request->setBody($formatted);
+			if (empty($params))
+			{
+				$params = $request->fetchGlobal('request');
+			}
+			$formatMime = '';
+			if ($this->bodyFormat === 'json')
+			{
+				$formatMime = 'application/json';
+			}
+			elseif ($this->bodyFormat === 'xml')
+			{
+				$formatMime = 'application/xml';
+			}
+			if (! empty($formatMime))
+			{
+				$formatted = Services::format()->getFormatter($formatMime)->format($params);
+				$request->setBody($formatted);
+			}
 		}
 
 		return $request;

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -416,13 +416,13 @@ trait FeatureTestTrait
 	 */
 	protected function setRequestBody(Request $request, array $params = null): Request
 	{
-		if ($this->requestBody !== '')
+		if (isset($this->requestBody) && $this->requestBody !== '')
 		{
 			$request->setBody($this->requestBody);
 			return $request;
 		}
 
-		if ($this->bodyFormat !== '')
+		if (isset($this->bodyFormat) && $this->bodyFormat !== '')
 		{
 			if (empty($params))
 			{

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -416,13 +416,13 @@ trait FeatureTestTrait
 	 */
 	protected function setRequestBody(Request $request, array $params = null): Request
 	{
-		if (! empty($this->requestBody))
+		if ($this->requestBody !== '')
 		{
 			$request->setBody($this->requestBody);
 			return $request;
 		}
 
-		if (! empty($this->bodyFormat))
+		if ($this->bodyFormat !== '')
 		{
 			if (empty($params))
 			{

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -135,6 +135,19 @@ trait FeatureTestTrait
 	}
 
 	/**
+	 * Set the raw body for the request
+	 *
+	 * @param  mixed $body
+	 * @return $this
+	 */
+	public function withBody($body)
+	{
+		$this->requestBody = $body;
+
+		return $this;
+	}
+
+	/**
 	 * Don't run any events while running this test.
 	 *
 	 * @return $this
@@ -399,10 +412,16 @@ trait FeatureTestTrait
 	 * @param  Request    $request
 	 * @param  null|array $params  The parameters to be formatted and put in the body. If this is empty, it will get the
 	 *                               what has been loaded into the request global of the request class.
-	 * @return mixed
+	 * @return Request
 	 */
-	protected function setRequestBody(Request $request, $params = null)
+	protected function setRequestBody(Request $request, array $params = null): Request
 	{
+		if (! empty($this->requestBody))
+		{
+			$request->setBody($this->requestBody);
+			return $request;
+		}
+
 		if (! empty($this->bodyFormat))
 		{
 			if (empty($params))
@@ -418,10 +437,11 @@ trait FeatureTestTrait
 			{
 				$formatMime = 'application/xml';
 			}
-			if (! empty($formatMime))
+			if (! empty($formatMime) && ! empty($params))
 			{
 				$formatted = Services::format()->getFormatter($formatMime)->format($params);
 				$request->setBody($formatted);
+				$request->setHeader('Content-Type', $formatMime);
 			}
 		}
 

--- a/tests/_support/Controllers/Popcorn.php
+++ b/tests/_support/Controllers/Popcorn.php
@@ -73,4 +73,8 @@ class Popcorn extends Controller
 		return redirect()->route('testing-index');
 	}
 
+	public function echoJson()
+	{
+		return $this->response->setJSON($this->request->getJSON());
+	}
 }

--- a/tests/system/Test/FeatureTestCaseTest.php
+++ b/tests/system/Test/FeatureTestCaseTest.php
@@ -313,4 +313,40 @@ class FeatureTestCaseTest extends FeatureTestCase
 		$this->assertTrue($response->isRedirect());
 		$this->assertTrue($response->isOK());
 	}
+
+	public function testCallWithJsonRequest()
+	{
+		$this->withRoutes([
+			[
+				'post',
+				'home',
+				'\Tests\Support\Controllers\Popcorn::echoJson',
+			],
+		]);
+		$response = $this->withBodyFormat('json')->call('post', 'home', ['foo' => 'bar']);
+		$response->assertOK();
+		$response->assertJSONExact(['foo' => 'bar']);
+	}
+
+	public function testSetupRequestBodyWithParams()
+	{
+		$request = $this->setupRequest('post', 'home');
+
+		$request = $this->withBodyFormat('json')->setRequestBody($request, ['foo1' => 'bar1']);
+
+		$this->assertJsonStringEqualsJsonString(json_encode(['foo1' => 'bar1']), $request->getBody());
+	}
+
+	public function testSetupRequestBodyWithXml()
+	{
+		$request = $this->setupRequest('post', 'home');
+
+		$request = $this->withBodyFormat('xml')->setRequestBody($request, ['foo' => 'bar']);
+
+		$expectedXml = '<?xml version="1.0"?>
+<response><foo>bar</foo></response>
+';
+
+		$this->assertEquals($expectedXml, $request->getBody());
+	}
 }

--- a/tests/system/Test/FeatureTestCaseTest.php
+++ b/tests/system/Test/FeatureTestCaseTest.php
@@ -335,6 +335,7 @@ class FeatureTestCaseTest extends FeatureTestCase
 		$request = $this->withBodyFormat('json')->setRequestBody($request, ['foo1' => 'bar1']);
 
 		$this->assertJsonStringEqualsJsonString(json_encode(['foo1' => 'bar1']), $request->getBody());
+		$this->assertTrue('application/json' === $request->getHeader('Content-Type')->getValue());
 	}
 
 	public function testSetupRequestBodyWithXml()
@@ -348,5 +349,15 @@ class FeatureTestCaseTest extends FeatureTestCase
 ';
 
 		$this->assertEquals($expectedXml, $request->getBody());
+		$this->assertTrue('application/xml' === $request->getHeader('Content-Type')->getValue());
+	}
+
+	public function testSetupRequestBodyWithBody()
+	{
+		$request = $this->setupRequest('post', 'home');
+
+		$request = $this->withBody('test')->setRequestBody($request);
+
+		$this->assertEquals('test', $request->getBody());
 	}
 }

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -105,6 +105,18 @@ that the current values of ``$_SESSION`` should be used. This is handy for testi
     
     $result = $this->withSession()->get('admin');
 
+Setting Headers
+---------------
+
+You can set header values with the ``withHeaders()`` method. This takes an array of key/value pairs that would be
+passed as a header into the call.::
+
+    $headers = [
+        'CONTENT_TYPE' => 'application/json'
+    ];
+
+    $result = $this->withHeaders($headers)->post('users');
+
 Bypassing Events
 ----------------
 
@@ -119,8 +131,8 @@ Formatting The Request
 
 You can set the format of your request's body using the ``withBodyFormat()`` method. Currently this supports either
 `json` or `xml`. This will take the parameters passed into ``call(), post(), get()...`` and assign them to the
-body of the request in the given format. This is useful when testing JSON or XML API's so that you can set the request
-in the form that the controller will expect.
+body of the request in the given format. This will also set the `Content-Type` header for your request accordingly.
+This is useful when testing JSON or XML API's so that you can set the request in the form that the controller will expect.
 ::
 
     //If your feature test contains this:
@@ -129,6 +141,13 @@ in the form that the controller will expect.
 
     //Your controller can then get the parameters passed in with:
     $userInfo = $this->request->getJson();
+
+Setting the Body
+----------------
+
+You can set the body of your request with the ``withBody()`` method. This allows you to format the body how you want
+to format it. It is recommended that you use this if you have more complicated xml's to test. This will also not set
+the Content-Type header for you so if you need that, you can set it with the ``withHeaders()`` method.
 
 Testing the Response
 ====================

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -114,6 +114,21 @@ to send out emails. You can tell the system to skip any event handling with the 
     $result = $this->skipEvents()
         ->post('users', $userInfo);
 
+Formatting The Request
+-----------------------
+
+You can set the format of your request's body using the ``withBodyFormat()`` method. Currently this supports either
+`json` or `xml`. This will take the parameters passed into ``call(), post(), get()...`` and assign them to the
+body of the request in the given format. This is useful when testing JSON or XML API's so that you can set the request
+in the form that the controller will expect.
+::
+
+    //If your feature test contains this:
+    $result = $this->withBodyFormat('json')
+        ->post('users', $userInfo);
+
+    //Your controller can then get the parameters passed in with:
+    $userInfo = $this->request->getJson();
 
 Testing the Response
 ====================


### PR DESCRIPTION
**Description**
I added the ability to set a body format on Feature Tests so that the request body can be set according to that format. This allows the Feature Tests to work on controllers that are using functions such as `$request->getJson()` or are expecting the body to contain a JSON or XML.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
