### PR TITLE
Load helpers directly from the initController

### DIFF
--- a/system/Controller.php
+++ b/system/Controller.php
@@ -31,7 +31,7 @@
  * @package    CodeIgniter
  * @author     CodeIgniter Dev Team
  * @copyright  2019-2020 CodeIgniter Foundation
- * @license    https://opensource.org/licenses/MIT	MIT License
+ * @license    https://opensource.org/licenses/MIT - MIT License
  * @link       https://codeigniter.com
  * @since      Version 4.0.0
  * @filesource
@@ -53,7 +53,6 @@ use Psr\Log\LoggerInterface;
  */
 class Controller
 {
-
 	/**
 	 * An array of helpers to be automatically loaded
 	 * upon class instantiation.
@@ -62,34 +61,32 @@ class Controller
 	 */
 	protected $helpers = [];
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Instance of the main Request object.
 	 *
-	 * @var RequestInterface
+	 * @var \CodeIgniter\HTTP\RequestInterface
 	 */
 	protected $request;
 
 	/**
 	 * Instance of the main response object.
 	 *
-	 * @var ResponseInterface
+	 * @var \CodeIgniter\HTTP\ResponseInterface
 	 */
 	protected $response;
 
 	/**
 	 * Instance of logger to use.
 	 *
-	 * @var LoggerInterface
+	 * @var \Psr\Log\LoggerInterface
 	 */
 	protected $logger;
 
 	/**
-	 * Whether HTTPS access should be enforced
-	 * for all methods in this controller.
+	 * Whether HTTPS access should be enforced for all
+	 * methods in this controller.
 	 *
-	 * @var integer  Number of seconds to set HSTS header
+	 * @var integer Number of seconds to set HSTS header
 	 */
 	protected $forceHTTPS = 0;
 
@@ -106,9 +103,9 @@ class Controller
 	/**
 	 * Constructor.
 	 *
-	 * @param RequestInterface         $request
-	 * @param ResponseInterface        $response
-	 * @param \Psr\Log\LoggerInterface $logger
+	 * @param \CodeIgniter\HTTP\RequestInterface  $request
+	 * @param \CodeIgniter\HTTP\ResponseInterface $response
+	 * @param \Psr\Log\LoggerInterface 	      $logger
 	 *
 	 * @throws \CodeIgniter\HTTP\Exceptions\HTTPException
 	 */
@@ -123,7 +120,11 @@ class Controller
 			$this->forceHTTPS($this->forceHTTPS);
 		}
 
-		$this->loadHelpers();
+		// Autoloading helper files.
+		if (! empty($this->helpers))
+		{
+			helper($this->helpers);
+		}
 	}
 
 	//--------------------------------------------------------------------
@@ -148,29 +149,14 @@ class Controller
 	//--------------------------------------------------------------------
 
 	/**
-	 * Provides a simple way to tie into the main CodeIgniter class
-	 * and tell it how long to cache the current page for.
+	 * Provides a simple way to tie into the main CodeIgniter class and
+	 * tell it how long to cache the current page for.
 	 *
 	 * @param integer $time
 	 */
 	protected function cachePage(int $time)
 	{
 		CodeIgniter::cache($time);
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Handles "auto-loading" helper files.
-	 */
-	protected function loadHelpers()
-	{
-		if (empty($this->helpers))
-		{
-			return;
-		}
-
-		helper($this->helpers);
 	}
 
 	//--------------------------------------------------------------------
@@ -210,11 +196,6 @@ class Controller
 			$rules = $validation->$rules;
 		}
 
-		return $this->validator
-			->withRequest($this->request)
-			->setRules($rules, $messages)
-			->run();
+		return $this->validator->withRequest($this->request)->setRules($rules, $messages)->run();
 	}
-
-	//--------------------------------------------------------------------
 }

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -118,10 +118,7 @@ class Controller
 		}
 
 		// Autoload helper files.
-		if (! empty($this->helpers))
-		{
-			helper($this->helpers);
-		}
+		helper($this->helpers);
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -54,8 +54,7 @@ use Psr\Log\LoggerInterface;
 class Controller
 {
 	/**
-	 * An array of helpers to be automatically loaded
-	 * upon class instantiation.
+	 * Helpers that will be automatically loaded on class instantiation.
 	 *
 	 * @var array
 	 */
@@ -83,16 +82,14 @@ class Controller
 	protected $logger;
 
 	/**
-	 * Whether HTTPS access should be enforced for all
-	 * methods in this controller.
+	 * Should enforce HTTPS access for all methods in this controller.
 	 *
 	 * @var integer Number of seconds to set HSTS header
 	 */
 	protected $forceHTTPS = 0;
 
 	/**
-	 * Once validation has been run,
-	 * will hold the Validation instance.
+	 * Once validation has been run, will hold the Validation instance.
 	 *
 	 * @var Validation
 	 */
@@ -120,7 +117,7 @@ class Controller
 			$this->forceHTTPS($this->forceHTTPS);
 		}
 
-		// Autoloading helper files.
+		// Autoload helper files.
 		if (! empty($this->helpers))
 		{
 			helper($this->helpers);
@@ -157,6 +154,23 @@ class Controller
 	protected function cachePage(int $time)
 	{
 		CodeIgniter::cache($time);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Handles "auto-loading" helper files.
+	 *
+	 * @deprecated Use `helper` function instead of using this method.
+	 */
+	protected function loadHelpers()
+	{
+		if (empty($this->helpers))
+		{
+			return;
+		}
+		
+		helper($this->helpers);
 	}
 
 	//--------------------------------------------------------------------

--- a/user_guide_src/source/changelogs/v4.0.5.rst
+++ b/user_guide_src/source/changelogs/v4.0.5.rst
@@ -21,5 +21,6 @@ Bugs Fixed:
 Deprecations:
 
 - Deprecated ``BaseCommand::getPad`` in favor of ``BaseCommand::setPad``.
+- Deprecated ``CodeIgniter\Controller::loadHelpers`` in favor of ``helper`` function.
 - Deprecated ``Config\Format::getFormatter`` in favor of ``CodeIgniter\Format\Format::getFormatter``
 - Deprecated ``migrate:create`` command in favor of ``make:migration`` command.


### PR DESCRIPTION
remove loadHelpers  method while it isn't used somewhere else, since we can use helper() method anywhere