### PR TITLE
Remove dump-autoload in post-update-cmd

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -29,7 +29,6 @@
 	},
 	"scripts": {
 		"post-update-cmd": [
-			"@composer dump-autoload",
 			"CodeIgniter\\ComposerScripts::postUpdate"
 		],
 		"test": "phpunit"

--- a/admin/module/composer.json
+++ b/admin/module/composer.json
@@ -25,9 +25,6 @@
 	],
 	"minimum-stability": "dev",
 	"scripts": {
-		"post-update-cmd": [
-			"@composer dump-autoload"
-		],
 		"test": "phpunit"
 	},
 	"support": {

--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -25,9 +25,6 @@
 		}
 	},
 	"scripts": {
-		"post-update-cmd": [
-			"@composer dump-autoload"
-		],
 		"test": "phpunit"
 	},
 	"support": {

--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,12 @@
 		}
 	},
 	"autoload-dev": {
-                "psr-4": {
-                        "Utils\\": "utils"
-                }
-        },
+		"psr-4": {
+			"Utils\\": "utils"
+		}
+	},
 	"scripts": {
 		"post-update-cmd": [
-			"@composer dump-autoload",
 			"CodeIgniter\\ComposerScripts::postUpdate",
 			"bash admin/setup.sh"
 		],


### PR DESCRIPTION
**Description**
I don't know the original intent for this but `composer dump-autoload` is already called after every `install`, `update`, `remove` operation, so there's no need to call it again. If there's a reasoning behind this, please correct me. 😊

**Checklist:**
- [x] Securely signed commits
