### PR TITLE
Streamline gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,19 +5,27 @@
 
 # git files
 .gitattributes export-ignore
-# .gitignore
+.gitignore export-ignore
 
-# helper config files
-.travis.yml export-ignore
+# Don't give admin files
+.github/ export-ignore
+admin/ export-ignore
+contributing/ export-ignore
+.editorconfig export-ignore
+.nojekyll export-ignore export-ignore
+CODE_OF_CONDUCT.md export-ignore
+DCO.txt export-ignore
+PULL_REQUEST_TEMPLATE.md export-ignore
+stale.yml export-ignore
+Vagrantfile.dist export-ignore
+
+# They don't want our test files
+tests/system/ export-ignore
+utils/ export-ignore
+rector.php export-ignore
+phpunit.xml.dist export-ignore
+phpstan.neon.dist export-ignore
+
+# The source user guide, either
+user_guide_src/ export-ignore
 phpdoc.dist.xml export-ignore
-
-# Misc other files
-readme.rst
-
-# They don't want all of our tests...
-tests/bin/ export-ignore
-tests/codeigniter/ export-ignore
-tests/travis/ export-ignore
-
-# User Guide Source Files
-user_guide_src


### PR DESCRIPTION
**Description**
When using the development branch as dependency for a module, or just even using in `appstarter` for catching up with the latest changes, the downloaded package is always "bloated" with regard to unnecessary files and folders. This PR attempts to clean up the distributable package (when using `--prefer-dist`) by putting in `.gitattributes` (through `export-ignore`) the "unusable" files.

**Checklist:**
- [x] Securely signed commits
