### PR TITLE
Add img_data() helper

### DIFF
--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -1,10 +1,21 @@
 <?php
 namespace CodeIgniter\Helpers;
 
+use CodeIgniter\Files\Exceptions\FileNotFoundException;
+
 final class HTMLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 {
-
 	private $tracks;
+
+	/**
+	 * @var string Path to the test file for img_data
+	 */
+	private $imgPath = SUPPORTPATH . 'Images' . DIRECTORY_SEPARATOR . 'ci-logo.gif';
+
+	/**
+	 * @var string Expected base64 encoding of $imgPath
+	 */
+	private $imgData = 'R0lGODlhmwDIAOcAAAAAAAEBAQICAgMDAwQEBAUFBQYGBgcHBwgICAkJCQoKCgsLCwwMDA0NDQ4ODg8PDxAQEBERERISEhMTExQUFBUVFRYWFhcXFxgYGBkZGRoaGhsbGxwcHB0dHR4eHh8fHyAgICEhISIiIiMjIyQkJCUlJSYmJicnJygoKCkpKSoqKisrKywsLC0tLS4uLi8vLzAwMDExMTIyMjMzMzQ0NDU1NTY2Njc3Nzg4ODk5OTo6Ojs7Ozw8PD09PT4+Pj8/P0BAQEFBQUJCQkNDQ0REREVFRUZGRkdHR0hISElJSUpKSktLS0xMTE1NTU5OTk9PT1BQUFFRUVJSUlNTU1RUVFVVVVZWVldXV1hYWFlZWVpaWltbW1xcXF1dXV5eXl9fX2BgYGFhYWJiYmNjY2RkZGVlZWZmZmdnZ2hoaGlpaWpqamtra2xsbG1tbW5ubm9vb3BwcHFxcXJycnNzc3R0dHV1dXZ2dnd3d3h4eHl5eXp6ent7e3x8fH19fX5+fn9/f4CAgIGBgYKCgoODg4SEhIWFhYaGhoeHh4iIiImJiYqKiouLi4yMjI2NjY6Ojo+Pj5CQkJGRkZKSkpOTk5SUlJWVlZaWlpeXl5iYmJmZmZqampubm5ycnJ2dnZ6enp+fn6CgoKGhoaKioqOjo6SkpKWlpaampqenp6ioqKmpqaqqqqurq6ysrK2tra6urq+vr7CwsLGxsbKysrOzs7S0tLW1tba2tre3t7i4uLm5ubq6uru7u7y8vL29vb6+vr+/v8DAwMHBwcLCwsPDw8TExMXFxcbGxsfHx8jIyMnJycrKysvLy8zMzM3Nzc7Ozs/Pz9DQ0NHR0dLS0tPT09TU1NXV1dbW1tfX19jY2NnZ2dra2tvb29zc3N3d3d7e3t/f3+Dg4OHh4eLi4uPj4+Tk5OXl5ebm5ufn5+jo6Onp6erq6uvr6+zs7O3t7e7u7u/v7/Dw8PHx8fLy8vPz8/T09PX19fb29vf39/j4+Pn5+fr6+vv7+/z8/P39/f7+/v///yH5BAEKAP8ALAAAAACbAMgAAAj+AP8JHEiwoMGDCBMqXMiwocOHECNKnEhRIoCKGDNq3MixIYCLHUOKHEkS4UeQJVOqXAnxJEqWMGPCdCmzpk2SLl/e3MnTIs2eQIMuzKlTqNGgRIseXWozqVKmUFc6jUo1ptOnVbNqvPpRq9eOXLF+HeswrFiyaE2aTcvW49q2cA+aPRm37sC5Xe3GxUtXb1u+ef2mBRxY8FfChQ1rRXxWsVHGiR1DhdxYMk/KlS3fxJxZs1XOno9yjhx65+jOpUueJp165mrUrcG+jt30NWzaGG2zxi1S927eHH3/Bp5R+HDiFY3fRs5Q+XLmCZ0/h25Q+nTqd61jz239OvXux7f+ywXvHTn58sTPo+etfj3t9u5bwxdfdj79ofDjh84f/jt//Zb91x9zAg6YXoEAGoZggoItyKBfDt5HkIMP1kWhhAJRWCFcGm7IVoceogViiGONSKJXJp6YVYoqUsVii5O96B+L0L1ooEIwFmfjen0dtiOPPa74441q/VTVkESOl9ORSKJ3VYxNehfWUlEaOdFbQlUZZER8IaXllg8B1tOXS3JJmGlkllkfYpvx949wblFW038ZGhfdaZ/ll12UrulZZ5VSubknoCkJOiihI9E5YZqJGroomb05eqiWsvlZXZpJKmmfpl9uJCCOmG4l6aWhJqcoqKVeeSqqkKq6Kqv+nfr0KqyIhvlpS4ziOmtzua45apyU+rorr7ESe6urfBp7LLJNKjusrcnS+qusQ+IXoahISvsstTZqOy1F2XK6YKTdiotgozKaey66KZLaoWo0FtQuvCO6+26h9co7L773TtovvRf6C2KgAf8ZL8HrGnywStcqvDC/BQpsYp6nNtunoNGydGutCLfn8I8yYcxxx+R9DHLIHr/pJ2hzqmeydipj1mbJMZ8nsZgt05zyyzjn3B3PcD4q88ww26wvy0Q7B7Rt6p6JZtE/N91z0nbWrLTUXV4GtXR3Iv20ckuPZi1kWV7N9diMlV211b4567SXQYdNNrBvw932zV6jnfX+Y3GzvZqZU6utm9CzcTslU337LTazU7k4OOF4cpfUYo9DnndslVs+NHtM23v5e4UfHfmBo3sup3l/F/k56KWLvjnpq+ONV42tm84mgYt7Gzhwues+F3axu3477afTXTfsaUObPO5z6zo86s0rfzzv0Tu/O+fPAz499ttLPzvx11v/PfTha7839eUbjiX64weXfmndm3o+bvFL3j7rvwO8Pubzs3s4/ffTH1cAmL+LDRB/B0TZ/jwTQAM2Dn4L9NmTIJjAMUVQQf+z2wMlc0GtVRCDE4RSCBv0QRFOjoQbFFIK9zJCH53QQiskSwxl+EIWEoVDNwShlUqkJsfUUIUVYOJgDx0XxP0UUXAzQlymGCiaqgQEADs=';
 
 	protected function setUp(): void
 	{
@@ -179,6 +190,37 @@ EOH;
 		$target   = 'assets/mugshot.jpg';
 		$expected = '<img src="http://example.com/index.php/assets/mugshot.jpg" alt="" />';
 		$this->assertEquals($expected, img($target, true));
+	}
+
+	// ------------------------------------------------------------------------
+
+	public function testImgData()
+	{
+		$expected = 'data:image/gif;base64,' . $this->imgData;
+
+		$this->assertEquals($expected, img_data($this->imgPath));
+	}
+
+	public function testImgDataWithMime()
+	{
+		$expected = 'data:image/png;base64,' . $this->imgData;
+
+		$this->assertEquals($expected, img_data($this->imgPath, 'image/png'));
+	}
+
+	public function testImgDataUnknownMime()
+	{
+		$path   = SUPPORTPATH . 'Validation' . DIRECTORY_SEPARATOR . 'uploads' . DIRECTORY_SEPARATOR . 'phpUxc0ty';
+		$result = img_data($path);
+
+		$this->assertEquals(0, strpos($result, 'data:image/jpg'));
+	}
+
+	public function testImgDataNoFile()
+	{
+		$this->expectException(FileNotFoundException::class);
+
+		img_data($this->imgPath . 'gobbledygook');
 	}
 
 	// ------------------------------------------------------------------------

--- a/user_guide_src/source/helpers/html_helper.rst
+++ b/user_guide_src/source/helpers/html_helper.rst
@@ -26,9 +26,9 @@ The following functions are available:
 
 .. php:function:: img([$src = ''[, $indexPage = false[, $attributes = '']]])
 
-    :param  mixed  $src:        Image source data
+    :param  string|array  $src:  Image source URI, or array of attributes and values
     :param  bool    $indexPage:  Whether to treat $src as a routed URI string
-    :param  mixed   $attributes: HTML attributes
+    :param  mixed   $attributes: Additional HTML attributes
     :returns:   HTML image tag
     :rtype: string
 
@@ -64,6 +64,28 @@ The following functions are available:
 
         img($imageProperties);
         // <img src="http://site.com/index.php/images/picture.jpg" alt="Me, demonstrating how to eat 4 slices of pizza at one time" class="post_images" width="200" height="200" title="That was quite a night" rel="lightbox" />
+
+.. php:function:: img_data([$src = ''[, $indexPage = false[, $attributes = '']]])
+
+    :param  string  $path:     Path to the image file
+    :param  string|null $mime  MIME type to use, or null to guess
+    :returns: base64 encoded binary image string
+    :rtype: string
+
+    Generates a src-ready string from an image using the "data:" protocol.
+    Example::
+
+        $src = img_data('public/images/picture.jpg'); // data:image/jpg;base64,R0lGODl...
+        echo img($src);
+
+    There is an optional second parameter to specify the MIME type, otherwise the
+    function will use your Mimes config to guess.
+
+        $src = img_data('path/img_without_extension', 'image/png'); // data:image/png;base64,HT5A822...
+
+    Note that $path must exist and be a readable image format supported by the ``data:`` protocol.
+    This function is not recommended for very large files, but it provides a convenient way
+    of serving images from your app that are not web-accessible (e.g. in **public/**).
 
 .. php:function:: link_tag([$href = ''[, $rel = 'stylesheet'[, $type = 'text/css'[, $title = ''[, $media = ''[, $indexPage = false[, $hreflang = '']]]]]]])
 


### PR DESCRIPTION
**Description**
Adds an image helper function to create a data tag from a file path.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
