### PR TITLE
Fix PHPDoc on RouteCollection / group

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -728,7 +728,7 @@ class RouteCollection implements RouteCollectionInterface
 	 *     });
 	 *
 	 * @param string $name      The name to group/prefix the routes with.
-	 * @param mixed|callable  ...$params
+	 * @param array|callable  ...$params
 	 *
 	 * @return void
 	 */

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -728,7 +728,7 @@ class RouteCollection implements RouteCollectionInterface
 	 *     });
 	 *
 	 * @param string $name      The name to group/prefix the routes with.
-	 * @param mixed  ...$params
+	 * @param mixed|callable  ...$params
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
**Description**
This is useful to avoid IDE warnings as this param can be a closure or an array

**Checklist:**
- [ x] Securely signed commits
- [x ] Component(s) with PHPdocs
- [ x] Unit testing, with >80% coverage
- [x ] User guide updated
- [x ] Conforms to style guide


  
