### PR TITLE
Fix unexpected unindent

### DIFF
--- a/user_guide_src/source/helpers/html_helper.rst
+++ b/user_guide_src/source/helpers/html_helper.rst
@@ -67,8 +67,8 @@ The following functions are available:
 
 .. php:function:: img_data([$src = ''[, $indexPage = false[, $attributes = '']]])
 
-    :param  string  $path:     Path to the image file
-    :param  string|null $mime  MIME type to use, or null to guess
+    :param string $path: Path to the image file
+    :param string|null $mime: MIME type to use, or null to guess
     :returns: base64 encoded binary image string
     :rtype: string
 


### PR DESCRIPTION
**Description**
Fixes the lingering `unexpected unindent` warning of sphinx on the html helper doc.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
