### PR TITLE
Reset data cache after SQLite3 table modifications

### DIFF
--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -158,6 +158,7 @@ class Table
 	 * Called after `fromTable` and any actions, like `dropColumn`, etc,
 	 * to finalize the action. It creates a temp table, creates the new
 	 * table with modifications, and copies the data over to the new table.
+	 * Resets the connection dataCache to be sure changes are collected.
 	 *
 	 * @return boolean
 	 */
@@ -180,6 +181,8 @@ class Table
 		$success = $this->db->transComplete();
 
 		$this->db->query('PRAGMA foreign_keys = ON');
+
+		$this->db->resetDataCache();
 
 		return $success;
 	}


### PR DESCRIPTION
**Description**
Resets the connection `dataCache` after SQLite modified table structures to ensure that the new structures are rediscovered. This is a bit of a "blast" fix but should be performance-safe because of when Forge is actually used.

Fixes #3752.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
