### PR TITLE
clean up public/index.php : remove unneeded $pathsPath var

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,11 +11,6 @@ unset($minPHPVersion);
 // Path to the front controller (this file)
 define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);
 
-// Location of the Paths config file.
-// This is the line that might need to be changed, depending on your folder structure.
-$pathsPath = realpath(FCPATH . '../app/Config/Paths.php') ?: FCPATH . '../app/Config/Paths.php';
-// ^^^ Change this if you move your application folder
-
 /*
  *---------------------------------------------------------------
  * BOOTSTRAP THE APPLICATION
@@ -29,7 +24,10 @@ $pathsPath = realpath(FCPATH . '../app/Config/Paths.php') ?: FCPATH . '../app/Co
 chdir(__DIR__);
 
 // Load our paths config file
-require $pathsPath;
+// This is the line that might need to be changed, depending on your folder structure.
+require realpath(FCPATH . '../app/Config/Paths.php') ?: FCPATH . '../app/Config/Paths.php';
+// ^^^ Change this if you move your application folder
+
 $paths = new Config\Paths();
 
 // Location of the framework bootstrap file.


### PR DESCRIPTION
I think `$pathsPath` can be removed and use its value to require directly.

**Checklist:**
- [x] Securely signed commits
