### PR TITLE
Don't instantiate Faker on Seeder constructor

### DIFF
--- a/tests/system/Database/DatabaseSeederTest.php
+++ b/tests/system/Database/DatabaseSeederTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace CodeIgniter\Database;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Database;
+use Faker\Generator;
+
+class DatabaseSeederTest extends CIUnitTestCase
+{
+	public function testInstantiateNoSeedPath()
+	{
+		$this->expectException('InvalidArgumentException');
+
+		$config            = new Database();
+		$config->filesPath = '';
+		new Seeder($config);
+	}
+
+	public function testInstantiateNotDirSeedPath()
+	{
+		$this->expectException('InvalidArgumentException');
+
+		$config            = new Database;
+		$config->filesPath = APPPATH . 'Foo';
+		new Seeder($config);
+	}
+
+	public function testFakerGet()
+	{
+		$this->assertInstanceOf(Generator::class, Seeder::faker());
+	}
+
+	public function testCallOnEmptySeeder()
+	{
+		$this->expectException('InvalidArgumentException');
+
+		$seeder = new Seeder(new Database());
+		$seeder->call('');
+	}
+}

--- a/user_guide_src/source/dbmgmt/seeds.rst
+++ b/user_guide_src/source/dbmgmt/seeds.rst
@@ -7,15 +7,19 @@ you need to populate the database with sample data that you can develop against,
 Seeds can contain static data that you don't want to include in a migration, like countries, or geo-coding tables,
 event or setting information, and more.
 
-Database seeds are simple classes that must have a **run()** method, and extend **CodeIgniter\Database\Seeder**.
+Database seeds are simple classes that must have a **run()** method, and extend ``CodeIgniter\Database\Seeder``.
 Within the **run()** the class can create any form of data that it needs to. It has access to the database
 connection and the forge through ``$this->db`` and ``$this->forge``, respectively. Seed files must be
 stored within the **app/Database/Seeds** directory. The name of the file must match the name of the class.
 ::
 
-        <?php namespace App\Database\Seeds;
+	<?php
 
-	class SimpleSeeder extends \CodeIgniter\Database\Seeder
+	namespace App\Database\Seeds;
+
+	use CodeIgniter\Database\Seeder;
+
+	class SimpleSeeder extends Seeder
 	{
 		public function run()
 		{
@@ -25,9 +29,7 @@ stored within the **app/Database/Seeds** directory. The name of the file must ma
 			];
 
 			// Simple Queries
-			$this->db->query("INSERT INTO users (username, email) VALUES(:username:, :email:)",
-				$data
-			);
+			$this->db->query("INSERT INTO users (username, email) VALUES(:username:, :email:)", $data);
 
 			// Using Query Builder
 			$this->db->table('users')->insert($data);
@@ -40,9 +42,13 @@ Nesting Seeders
 Seeders can call other seeders, with the **call()** method. This allows you to easily organize a central seeder,
 but organize the tasks into separate seeder files::
 
-        <?php namespace App\Database\Seeds;
+	<?php
 
-	class TestSeeder extends \CodeIgniter\Database\Seeder
+	namespace App\Database\Seeds;
+
+	use CodeIgniter\Database\Seeder;
+
+	class TestSeeder extends Seeder
 	{
 		public function run()
 		{
@@ -61,6 +67,41 @@ anywhere the autoloader can find them. This is great for more modular code bases
 		$this->call('My\Database\Seeds\CountrySeeder');
 	}
 
+Using Faker
+===========
+
+If you want to automate the generation of seed data, you can use
+the `Faker library <https://github.com/fzaninotto/faker>`_.
+
+To install Faker into your project::
+
+	> composer require --dev fzaninotto/faker
+
+After installation, an instance of ``Faker\Generator`` is available in the main ``Seeder``
+class and is accessible by all child seeders. You must use the static method ``faker()``
+to access the instance.
+
+::
+
+	<?php
+
+	namespace App\Database\Seeds;
+
+	use CodeIgniter\Database\Seeder;
+
+	class UserSeeder extends Seeder
+	{
+		public function run()
+		{
+			$model = model('UserModel');
+
+			$model->insert([
+				'email'      => static::faker()->email,
+				'ip_address' => static::faker()->ipv4,
+			]);
+		}
+	}
+
 Using Seeders
 =============
 
@@ -77,3 +118,22 @@ a dedicated controller::
 
 	> php spark db:seed TestSeeder
 
+Creating Seed Files
+-------------------
+
+Using the command line, you can easily generate seed files.
+
+::
+
+	// This command will create a UserSeeder seed file
+	// located at app/Database/Seeds/ directory.
+	> php spark make:seeder UserSeeder
+
+You can supply the **root** namespace where the seed file will be stored by supplying the ``-n`` option::
+
+	> php spark make:seeder MySeeder -n Acme\Blog
+
+If ``Acme\Blog`` is mapped to ``app/Blog`` directory, then this command will save the
+seed file to ``app/Blog/Database/Seeds/``.
+
+Supplying the ``--force`` option will overwrite existing files in destination.


### PR DESCRIPTION
**Description**
This attempts to hasten database live tests by extracting `Faker` instantiation from `Seeder`'s constructor to a new static method and using a static property so that it will persist across instances. I've added tests for uncovered lines.

My only worry for this is that the `use` statement for `Faker\Factory` may break if the library is not installed for manual installations. @samsonasik I've tried using `@noRector` but still it imports them. Any ideas?

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
