### PR TITLE
Correct parameter type

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -360,8 +360,8 @@ class Entity implements JsonSerializable
 	 *      $this->my_property = $p;
 	 *      $this->setMyProperty() = $p;
 	 *
-	 * @param string $key
-	 * @param null   $value
+	 * @param string     $key
+	 * @param mixed|null $value
 	 *
 	 * @return $this
 	 * @throws Exception


### PR DESCRIPTION
Each pull request should address a single issue and have a meaningful title.

**Description**

`Entity::__set()` has the wrong parameter type specified which prevents it from being successfully declared as a `universalObjectCratesClasses`.

https://github.com/phpstan/phpstan/issues/3938

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
