### PR TITLE
Bug fix: ensure to use autoload = false in class_exists() in low-hanging fruit in Factories::locateClass()

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -98,10 +98,10 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --no-progress --no-suggest --no-interaction --prefer-dist --optimize-autoloader
-          composer remove --dev phpstan/phpstan
-          composer remove --dev rector/rector
-          composer remove --dev codeigniter4/codeigniter4-standard
-          composer remove --dev squizlabs/php_codesniffer
+          composer remove --dev rector/rector --update-with-dependencies
+          composer remove --dev phpstan/phpstan --update-with-dependencies
+          composer remove --dev codeigniter4/codeigniter4-standard --update-with-dependencies
+          composer remove --dev squizlabs/php_codesniffer --update-with-dependencies
           composer update
           php -r 'file_put_contents("vendor/laminas/laminas-zendframework-bridge/src/autoload.php", "");'
         env:

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -156,7 +156,7 @@ class Factories
 	protected static function locateClass(array $config, string $name): ?string
 	{
 		// Check for low-hanging fruit
-		if (class_exists($name) && self::verifyPrefersApp($config, $name) && self::verifyInstanceOf($config, $name))
+		if (class_exists($name, false) && self::verifyPrefersApp($config, $name) && self::verifyInstanceOf($config, $name))
 		{
 			return $name;
 		}


### PR DESCRIPTION
I tried latest `dev-develop` when running test in a codeigniter4 module and without set `autoload=false` in 2nd parameter of `class_exists()` in `Factories::locateClass()`, I got the error:

```bash
Cannot declare class Config\App, because the name is already in use

at APPPATH/Config/App.php:7

Backtrace:
  1    [internal function]
       CodeIgniter\Debug\Exceptions()->shutdownHandler()


Fatal error: Cannot declare class Config\App, because the name is already in use in /Users/samsonasik/www/codeigniter4-files/vendor/codeigniter4/codeigniter4/app/Config/App.php on line 7
```

This patch fixed the issue.

**Checklist:**
- [x] Securely signed commits
