### PR TITLE
remove deprecated  --update-with-dependencies in composer remove command

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -98,10 +98,10 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --no-progress --no-suggest --no-interaction --prefer-dist --optimize-autoloader
-          composer remove --dev rector/rector --update-with-dependencies
-          composer remove --dev phpstan/phpstan --update-with-dependencies
-          composer remove --dev codeigniter4/codeigniter4-standard --update-with-dependencies
-          composer remove --dev squizlabs/php_codesniffer --update-with-dependencies
+          composer remove --dev rector/rector
+          composer remove --dev phpstan/phpstan
+          composer remove --dev codeigniter4/codeigniter4-standard
+          composer remove --dev squizlabs/php_codesniffer
           composer update
           php -r 'file_put_contents("vendor/laminas/laminas-zendframework-bridge/src/autoload.php", "");'
         env:

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -98,10 +98,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --no-progress --no-suggest --no-interaction --prefer-dist --optimize-autoloader
-          composer remove --dev rector/rector
-          composer remove --dev phpstan/phpstan
-          composer remove --dev codeigniter4/codeigniter4-standard
-          composer remove --dev squizlabs/php_codesniffer
+          composer remove --dev rector/rector phpstan/phpstan codeigniter4/codeigniter4-standard squizlabs/php_codesniffer
           composer update
           php -r 'file_put_contents("vendor/laminas/laminas-zendframework-bridge/src/autoload.php", "");'
         env:


### PR DESCRIPTION
`composer remove` error that tried to be fixed at commit https://github.com/codeigniter4/CodeIgniter4/pull/3772/commits/b263bac61e48fd0f1b114ac2fa00e0098f987a28  actually can be solved by only re-sort order of command of removing between `rector` and `phpstan`. 

The `--update-with-dependencies` actually already handle by default.

**Checklist:**
- [x] Securely signed commits
