### PR TITLE
report coveralls only in specific php version

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -124,8 +124,7 @@ jobs:
     needs: [tests]
     runs-on: ubuntu-latest
     steps:
-      - if: matrix.php-versions == '7.4'
-        name: Coveralls Finished
+      - name: Coveralls Finished
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -119,3 +119,14 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: PHP ${{ matrix.php-versions }} ${{matrix.db-plaftorms}}
+
+  coveralls-finish:
+    needs: [tests]
+    runs-on: ubuntu-latest
+    steps:
+      - if: matrix.php-versions == '7.4'
+        name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -110,7 +110,8 @@ jobs:
           DB: ${{ matrix.db-platforms }}
           TERM: xterm-256color
 
-      - name: Run Coveralls
+      - if: matrix.php-versions == '7.4'
+        name: Run Coveralls
         run: |
           composer global require php-coveralls/php-coveralls:^2.4
           php-coveralls --coverage_clover=build/logs/clover.xml -v
@@ -118,13 +119,3 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: PHP ${{ matrix.php-versions }}
-
-  coveralls-finish:
-    needs: [tests]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.github_token }}
-          parallel-finished: true

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -118,4 +118,4 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
-          COVERALLS_FLAG_NAME: PHP ${{ matrix.php-versions }}
+          COVERALLS_FLAG_NAME: PHP ${{ matrix.php-versions }} ${{matrix.db-plaftorms}}


### PR DESCRIPTION
@michalsn I think report coveralls can be only in specific php version to handle false positive decreased coverage.

As I see, it seems the stable report in php <strike>7.3</strike> 7.4. I added if php version check to handle it. Please verify if it is ok.

**Checklist:**
- [x] Securely signed commits