### PR TITLE
getSize() does not accept parameters like getSizeByUnit()

### DIFF
--- a/user_guide_src/source/libraries/files.rst
+++ b/user_guide_src/source/libraries/files.rst
@@ -61,12 +61,9 @@ method. This is especially useful to rename files when moving it so that the fil
 
 **getSize()**
 
-Returns the size of the uploaded file in bytes. You can pass in either 'kb' or 'mb' as the first parameter to get
-the results in kilobytes or megabytes, respectively::
+Returns the size of the uploaded file in bytes::
 
-	$bytes     = $file->getSize();      // 256901
-	$kilobytes = $file->getSize('kb');  // 250.880
-	$megabytes = $file->getSize('mb');  // 0.245
+	$size     = $file->getSize();      // 256901
 
 **getSizeByUnit()**
 


### PR DESCRIPTION
Each pull request should address a single issue and have a meaningful title.

**Description**
getSize() does not accept the unit parameter like getSizeByUnit() as stated on the user guide.
Not sure if that is suposed to be like that or it was a "copy/paste" issue on this document, but does induce into error.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

