### PR TITLE
Helper cache

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -636,6 +636,8 @@ if (! function_exists('helper'))
 	 */
 	function helper($filenames)
 	{
+		static $loaded = [];
+
 		$loader = Services::locator(true);
 
 		if (! is_array($filenames))
@@ -659,6 +661,12 @@ if (! function_exists('helper'))
 				$filename .= '_helper';
 			}
 
+			// Check if this helper has already been loaded
+			if (in_array($filename, $loaded))
+			{
+				continue;
+			}
+
 			// If the file is namespaced, we'll just grab that
 			// file and not search for any others
 			if (strpos($filename, '\\') !== false)
@@ -671,6 +679,7 @@ if (! function_exists('helper'))
 				}
 
 				$includes[] = $path;
+				$loaded[]   = $filename;
 			}
 
 			// No namespaces, so search in all available locations
@@ -695,6 +704,7 @@ if (! function_exists('helper'))
 						else
 						{
 							$localIncludes[] = $path;
+							$loaded[]        = $filename;
 						}
 					}
 				}
@@ -704,6 +714,7 @@ if (! function_exists('helper'))
 				{
 					// @codeCoverageIgnoreStart
 					$includes[] = $appHelper;
+					$loaded[]   = $filename;
 					// @codeCoverageIgnoreEnd
 				}
 
@@ -714,6 +725,7 @@ if (! function_exists('helper'))
 				if (! empty($systemHelper))
 				{
 					$includes[] = $systemHelper;
+					$loaded[]   = $filename;
 				}
 			}
 		}

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -171,7 +171,7 @@ class BaseService
 				static::$instances['locator'] = new FileLocator(static::autoloader());
 			}
 
-			return static::$instances['locator'];
+			return static::$mocks['locator'] ?? static::$instances['locator'];
 		}
 
 		return new FileLocator(static::autoloader());

--- a/tests/_support/Autoloader/FatalLocator.php
+++ b/tests/_support/Autoloader/FatalLocator.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Support\Autoloader;
+
+use CodeIgniter\Autoloader\FileLocator;
+use RuntimeException;
+
+/**
+ * Class FatalLocator
+ *
+ * A locator replacement designed to throw
+ * exceptions when used to indicate when
+ * a lookup actually happens.
+ */
+class FatalLocator extends FileLocator
+{
+
+	/**
+	 * Throws.
+	 *
+	 * @param string $file   The namespaced file to locate
+	 * @param string $folder The folder within the namespace that we should look for the file.
+	 * @param string $ext    The file extension the file should have.
+	 *
+	 * @return string|false The path to the file, or false if not found.
+	 */
+	public function locateFile(string $file, string $folder = null, string $ext = 'php')
+	{
+		$folder = $folder ?? 'null';
+		throw new RuntimeException("locateFile({$file}, {$folder}, {$ext})");
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Searches through all of the defined namespaces looking for a file.
+	 * Returns an array of all found locations for the defined file.
+	 *
+	 * Example:
+	 *
+	 *  $locator->search('Config/Routes.php');
+	 *  // Assuming PSR4 namespaces include foo and bar, might return:
+	 *  [
+	 *      'app/Modules/foo/Config/Routes.php',
+	 *      'app/Modules/bar/Config/Routes.php',
+	 *  ]
+	 *
+	 * @param string  $path
+	 * @param string  $ext
+	 * @param boolean $prioritizeApp
+	 *
+	 * @return array
+	 */
+	public function search(string $path, string $ext = 'php', bool $prioritizeApp = true): array
+	{
+		$prioritizeApp = $prioritizeApp ? 'true' : 'false';
+		throw new RuntimeException("search({$path}, {$ext}, {$prioritizeApp})");
+	}
+}

--- a/tests/_support/Helpers/baguette_helper.php
+++ b/tests/_support/Helpers/baguette_helper.php
@@ -1,0 +1,2 @@
+<?php
+// You did it!

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -12,6 +12,7 @@ use CodeIgniter\Test\Mock\MockSession;
 use CodeIgniter\Test\TestLogger;
 use Config\App;
 use Config\Logger;
+use Tests\Support\Autoloader\FatalLocator;
 use Tests\Support\Models\JobModel;
 
 /**
@@ -506,5 +507,50 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 				'FCPATH' . $ds . 'index.php',
 			],
 		];
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testHelperWithFatalLocatorThrowsException()
+	{
+		// Replace the locator with one that will fail if it is called
+		$locator = new FatalLocator(Services::autoloader());
+		Services::injectMock('locator', $locator);
+
+		try
+		{
+			helper('baguette');
+			$exception = false;
+		}
+		catch (\RuntimeException $e)
+		{
+			$exception = true;
+		}
+
+		$this->assertTrue($exception);
+		Services::reset();
+	}
+
+	public function testHelperLoadsOnce()
+	{
+		// Load it the first time
+		helper('baguette');
+
+		// Replace the locator with one that will fail if it is called
+		$locator = new FatalLocator(Services::autoloader());
+		Services::injectMock('locator', $locator);
+
+		try
+		{
+			helper('baguette');
+			$exception = false;
+		}
+		catch (\RuntimeException $e)
+		{
+			$exception = true;
+		}
+
+		$this->assertFalse($exception);
+		Services::reset();
 	}
 }


### PR DESCRIPTION
**Description**
Adds a local static cache of helpers that have already been loaded, so multiple calls to the same file with `helper()` won't result in duplicate filesystem searches.

Bonus: This sped up tests on `CommonFunctionTest.php` by 7 seconds (30s -> 20s) so will likely help overall test time!

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
