### PR TITLE
Factory parameter options

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -256,7 +256,7 @@ if (! function_exists('config'))
 	 */
 	function config(string $name, bool $getShared = true)
 	{
-		return Factories::config($name, $getShared);
+		return Factories::config($name, ['getShared' => $getShared]);
 	}
 }
 
@@ -884,7 +884,7 @@ if (! function_exists('model'))
 	 */
 	function model(string $name, bool $getShared = true, ConnectionInterface &$conn = null)
 	{
-		return Factories::models($name, $getShared, $conn);
+		return Factories::models($name, ['getShared' => $getShared], $conn);
 	}
 }
 

--- a/system/Config/Config.php
+++ b/system/Config/Config.php
@@ -57,7 +57,7 @@ class Config
 	 */
 	public static function get(string $name, bool $getShared = true)
 	{
-		return Factories::config($name, $getShared);
+		return Factories::config($name, ['getShared' => $getShared]);
 	}
 
 	/**

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -71,8 +71,8 @@ class Factories
 	private static $configOptions = [
 		'component'  => 'config',
 		'path'       => 'Config',
-		'getShared'  => true,
 		'instanceOf' => null,
+		'getShared'  => true,
 		'preferApp'  => true,
 	];
 

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -55,24 +55,25 @@ use Config\Services;
 class Factories
 {
 	/**
-	 * Store of component configurations, usually
+	 * Store of component-specific options, usually
 	 * from CodeIgniter\Config\Factory.
 	 *
 	 * @var array<string, array>
 	 */
-	protected static $configs = [];
+	protected static $options = [];
 
 	/**
-	 * Explicit configuration for the Config
+	 * Explicit options for the Config
 	 * component to prevent logic loops.
 	 *
 	 * @var array<string, mixed>
 	 */
-	private static $configValues = [
+	private static $optionsOptions = [
 		'component'  => 'config',
 		'path'       => 'Config',
+		'getShared'  => true,
 		'instanceOf' => null,
-		'prefersApp' => true,
+		'preferApp'  => true,
 	];
 
 	/**
@@ -85,7 +86,7 @@ class Factories
 
 	/**
 	 * Store for instances of any component that
-	 * has been requested as a "shared".
+	 * has been requested as "shared".
 	 * A multi-dimensional array with components as
 	 * keys to the array of name-indexed instances.
 	 *
@@ -106,8 +107,8 @@ class Factories
 	 */
 	public static function __callStatic(string $component, array $arguments)
 	{
-		// Load the component-specific configuration
-		$config = self::getConfig(strtolower($component));
+		// Load the component-specific options
+		$options = self::getOptions(strtolower($component));
 
 		// First argument is the name, second is whether to use a shared instance
 		$name      = trim(array_shift($arguments), '\\ ');
@@ -115,7 +116,7 @@ class Factories
 
 		if (! $getShared)
 		{
-			if ($class = self::locateClass($config, $name))
+			if ($class = self::locateClass($options, $name))
 			{
 				return new $class(...$arguments);
 			}
@@ -126,55 +127,55 @@ class Factories
 		$basename = self::getBasename($name);
 
 		// Check for an existing instance
-		if (isset(self::$basenames[$config['component']][$basename]))
+		if (isset(self::$basenames[$options['component']][$basename]))
 		{
-			$class = self::$basenames[$config['component']][$basename];
+			$class = self::$basenames[$options['component']][$basename];
 		}
 		else
 		{
 			// Try to locate the class
-			if (! $class = self::locateClass($config, $name))
+			if (! $class = self::locateClass($options, $name))
 			{
 				return null;
 			}
 
-			self::$instances[$config['component']][$class]    = new $class(...$arguments);
-			self::$basenames[$config['component']][$basename] = $class;
+			self::$instances[$options['component']][$class]    = new $class(...$arguments);
+			self::$basenames[$options['component']][$basename] = $class;
 		}
 
-		return self::$instances[$config['component']][$class];
+		return self::$instances[$options['component']][$class];
 	}
 
 	/**
 	 * Finds a component class
 	 *
-	 * @param array  $config The array of component-specific directives
-	 * @param string $name   Class name, namespace optional
+	 * @param array  $options The array of component-specific directives
+	 * @param string $name    Class name, namespace optional
 	 *
 	 * @return string|null
 	 */
-	protected static function locateClass(array $config, string $name): ?string
+	protected static function locateClass(array $options, string $name): ?string
 	{
 		// Check for low-hanging fruit
-		if (class_exists($name, false) && self::verifyPrefersApp($config, $name) && self::verifyInstanceOf($config, $name))
+		if (class_exists($name, false) && self::verifypreferApp($options, $name) && self::verifyInstanceOf($options, $name))
 		{
 			return $name;
 		}
 
 		// Determine the relative class names we need
 		$basename = self::getBasename($name);
-		$appname  = $config['component'] === 'config'
+		$appname  = $options['component'] === 'config'
 			? 'Config\\' . $basename
-			: rtrim(APP_NAMESPACE, '\\') . '\\' . $config['path'] . '\\' . $basename;
+			: rtrim(APP_NAMESPACE, '\\') . '\\' . $options['path'] . '\\' . $basename;
 
 		// If an App version was requested see if it verifies
-		if ($config['prefersApp'] && class_exists($appname) && self::verifyInstanceOf($config, $name))
+		if ($options['preferApp'] && class_exists($appname) && self::verifyInstanceOf($options, $name))
 		{
 			return $appname;
 		}
 
 		// If we have ruled out an App version and the class exists then try it
-		if (class_exists($name) && self::verifyInstanceOf($config, $name))
+		if (class_exists($name) && self::verifyInstanceOf($options, $name))
 		{
 			return $name;
 		}
@@ -185,7 +186,7 @@ class Factories
 		// Check if the class was namespaced
 		if (strpos($name, '\\') !== false)
 		{
-			if (! $file = $locator->locateFile($name, $config['path']))
+			if (! $file = $locator->locateFile($name, $options['path']))
 			{
 				return null;
 			}
@@ -196,7 +197,7 @@ class Factories
 		else
 		{
 			// Check all namespaces, prioritizing App and modules
-			if (! $files = $locator->search($config['path'] . DIRECTORY_SEPARATOR . $name))
+			if (! $files = $locator->search($options['path'] . DIRECTORY_SEPARATOR . $name))
 			{
 				return null;
 			}
@@ -207,7 +208,7 @@ class Factories
 		{
 			$class = $locator->getClassname($file);
 
-			if ($class && self::verifyInstanceOf($config, $class))
+			if ($class && self::verifyInstanceOf($options, $class))
 			{
 				return $class;
 			}
@@ -219,23 +220,23 @@ class Factories
 	//--------------------------------------------------------------------
 
 	/**
-	 * Verifies that a class & config satisfy the "prefersApp" option
+	 * Verifies that a class & config satisfy the "preferApp" option
 	 *
-	 * @param array  $config The array of component-specific directives
-	 * @param string $name   Class name, namespace optional
+	 * @param array  $options The array of component-specific directives
+	 * @param string $name    Class name, namespace optional
 	 *
 	 * @return boolean
 	 */
-	protected static function verifyPrefersApp(array $config, string $name): bool
+	protected static function verifypreferApp(array $options, string $name): bool
 	{
 		// Anything without that restriction passes
-		if (! $config['prefersApp'])
+		if (! $options['preferApp'])
 		{
 			return true;
 		}
 
 		// Special case for Config since its App namespace is actually \Config
-		if ($config['component'] === 'config')
+		if ($options['component'] === 'config')
 		{
 			return strpos($name, 'Config') === 0;
 		}
@@ -246,20 +247,20 @@ class Factories
 	/**
 	 * Verifies that a class & config satisfy the "instanceOf" option
 	 *
-	 * @param array  $config The array of component-specific directives
-	 * @param string $name   Class name, namespace optional
+	 * @param array  $options The array of component-specific directives
+	 * @param string $name    Class name, namespace optional
 	 *
 	 * @return boolean
 	 */
-	protected static function verifyInstanceOf(array $config, string $name): bool
+	protected static function verifyInstanceOf(array $options, string $name): bool
 	{
 		// Anything without that restriction passes
-		if (! $config['instanceOf'])
+		if (! $options['instanceOf'])
 		{
 			return true;
 		}
 
-		return is_a($name, $config['instanceOf'], true);
+		return is_a($name, $options['instanceOf'], true);
 	}
 
 	//--------------------------------------------------------------------
@@ -271,20 +272,20 @@ class Factories
 	 *
 	 * @return array<string, mixed>
 	 */
-	public static function getConfig(string $component): array
+	public static function getOptions(string $component): array
 	{
 		$component = strtolower($component);
 
 		// Check for a stored version
-		if (isset(self::$configs[$component]))
+		if (isset(self::$options[$component]))
 		{
-			return self::$configs[$component];
+			return self::$options[$component];
 		}
 
 		// Handle Config as a special case to prevent logic loops
 		if ($component === 'config')
 		{
-			$values = self::$configValues;
+			$values = self::$optionsOptions;
 		}
 		// Load values from the best Factory configuration (will include Registrars)
 		else
@@ -292,7 +293,7 @@ class Factories
 			$values = config('Factory')->$component ?? [];
 		}
 
-		return self::setConfig($component, $values);
+		return self::setOptions($component, $values);
 	}
 
 	/**
@@ -303,7 +304,7 @@ class Factories
 	 *
 	 * @return array<string, mixed> The result after applying defaults and normalization
 	 */
-	public static function setConfig(string $component, array $values): array
+	public static function setOptions(string $component, array $values): array
 	{
 		// Allow the config to replace the component name, to support "aliases"
 		$values['component'] = strtolower($values['component'] ?? $component);
@@ -318,8 +319,8 @@ class Factories
 		$values = array_merge(Factory::$default, $values);
 
 		// Store the result to the supplied name and potential alias
-		self::$configs[$component]           = $values;
-		self::$configs[$values['component']] = $values;
+		self::$options[$component]           = $values;
+		self::$options[$values['component']] = $values;
 
 		return $values;
 	}
@@ -333,14 +334,14 @@ class Factories
 	{
 		if ($component)
 		{
-			unset(static::$configs[$component]);
+			unset(static::$options[$component]);
 			unset(static::$basenames[$component]);
 			unset(static::$instances[$component]);
 
 			return;
 		}
 
-		static::$configs   = [];
+		static::$options   = [];
 		static::$basenames = [];
 		static::$instances = [];
 	}
@@ -356,7 +357,7 @@ class Factories
 	{
 		// Force a configuration to exist for this component
 		$component = strtolower($component);
-		self::getConfig($component);
+		self::getOptions($component);
 
 		$class    = get_class($instance);
 		$basename = self::getBasename($name);

--- a/system/Config/Factory.php
+++ b/system/Config/Factory.php
@@ -59,6 +59,7 @@ class Factory extends BaseConfig
 	public static $default = [
 		'component'  => null,
 		'path'       => null,
+		'getShared'  => true,
 		'instanceOf' => null,
 		'preferApp'  => true,
 	];

--- a/system/Config/Factory.php
+++ b/system/Config/Factory.php
@@ -59,8 +59,8 @@ class Factory extends BaseConfig
 	public static $default = [
 		'component'  => null,
 		'path'       => null,
-		'getShared'  => true,
 		'instanceOf' => null,
+		'getShared'  => true,
 		'preferApp'  => true,
 	];
 

--- a/system/Config/Factory.php
+++ b/system/Config/Factory.php
@@ -51,8 +51,8 @@ namespace CodeIgniter\Config;
 class Factory extends BaseConfig
 {
 	/**
-	 * Supplies a default configuration to merge for
-	 * all unspecified factory configuration values.
+	 * Supplies a default set of options to merge for
+	 * all unspecified factory components.
 	 *
 	 * @var array
 	 */
@@ -60,7 +60,7 @@ class Factory extends BaseConfig
 		'component'  => null,
 		'path'       => null,
 		'instanceOf' => null,
-		'prefersApp' => true,
+		'preferApp'  => true,
 	];
 
 	/**

--- a/system/Database/ModelFactory.php
+++ b/system/Database/ModelFactory.php
@@ -21,7 +21,7 @@ class ModelFactory
 	 */
 	public static function get(string $name, bool $getShared = true, ConnectionInterface $connection = null)
 	{
-		return Factories::models($name, $getShared, $connection);
+		return Factories::models($name, ['getShared' => $getShared], $connection);
 	}
 
 	/**

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -38,44 +38,44 @@ class FactoriesTest extends CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testGetsConfigValues()
+	public function testGetsOptions()
 	{
-		$result = Factories::getConfig('models');
+		$result = Factories::getOptions('models');
 
-		$this->assertTrue($result['prefersApp']);
+		$this->assertTrue($result['preferApp']);
 	}
 
-	public function testGetsConfigDefaults()
+	public function testGetsDefaultOptions()
 	{
-		$result = Factories::getConfig('blahblahs');
+		$result = Factories::getOptions('blahblahs');
 
-		$this->assertTrue($result['prefersApp']);
+		$this->assertTrue($result['preferApp']);
 		$this->assertEquals('Blahblahs', $result['path']);
 	}
 
-	public function testSetsConfigValues()
+	public function testSetsOptions()
 	{
-		Factories::setConfig('widgets', ['foo' => 'bar']);
+		Factories::setOptions('widgets', ['foo' => 'bar']);
 
-		$result = Factories::getConfig('widgets');
+		$result = Factories::getOptions('widgets');
 
 		$this->assertEquals('bar', $result['foo']);
-		$this->assertEquals(true, $result['prefersApp']);
+		$this->assertEquals(true, $result['preferApp']);
 	}
 
-	public function testUsesConfigFileValues()
+	public function testUsesConfigOptions()
 	{
 		// Simulate having a $widgets property in App\Config\Factory
 		$config          = new Factory();
 		$config->widgets = ['bar' => 'bam'];
 		Factories::injectMock('config', Factory::class, $config);
 
-		$result = Factories::getConfig('widgets');
+		$result = Factories::getOptions('widgets');
 
 		$this->assertEquals('bam', $result['bar']);
 	}
 
-	public function testSetConfigResets()
+	public function testSetOptionsResets()
 	{
 		Factories::injectMock('widgets', 'Banana', new stdClass());
 
@@ -83,7 +83,7 @@ class FactoriesTest extends CIUnitTestCase
 		$this->assertIsArray($result);
 		$this->assertArrayHasKey('widgets', $result);
 
-		Factories::setConfig('widgets', []);
+		Factories::setOptions('widgets', []);
 
 		$result = $this->getFactoriesStaticProperty('instances');
 		$this->assertIsArray($result);
@@ -92,22 +92,22 @@ class FactoriesTest extends CIUnitTestCase
 
 	public function testResetsAll()
 	{
-		Factories::setConfig('widgets', ['foo' => 'bar']);
+		Factories::setOptions('widgets', ['foo' => 'bar']);
 
 		Factories::reset();
 
-		$result = $this->getFactoriesStaticProperty('configs');
+		$result = $this->getFactoriesStaticProperty('options');
 		$this->assertEquals([], $result);
 	}
 
 	public function testResetsComponentOnly()
 	{
-		Factories::setConfig('widgets', ['foo' => 'bar']);
-		Factories::setConfig('spigots', ['bar' => 'bam']);
+		Factories::setOptions('widgets', ['foo' => 'bar']);
+		Factories::setOptions('spigots', ['bar' => 'bam']);
 
 		Factories::reset('spigots');
 
-		$result = $this->getFactoriesStaticProperty('configs');
+		$result = $this->getFactoriesStaticProperty('options');
 		$this->assertIsArray($result);
 		$this->assertArrayHasKey('widgets', $result);
 	}
@@ -192,7 +192,7 @@ class FactoriesTest extends CIUnitTestCase
 
 	public function testRespectsComponentAlias()
 	{
-		Factories::setConfig('tedwigs', ['component' => 'widgets']);
+		Factories::setOptions('tedwigs', ['component' => 'widgets']);
 
 		$result = Factories::tedwigs('SomeWidget');
 		$this->assertInstanceOf(SomeWidget::class, $result);
@@ -200,7 +200,7 @@ class FactoriesTest extends CIUnitTestCase
 
 	public function testRespectsPath()
 	{
-		Factories::setConfig('models', ['path' => 'Widgets']);
+		Factories::setOptions('models', ['path' => 'Widgets']);
 
 		$result = Factories::models('SomeWidget');
 		$this->assertInstanceOf(SomeWidget::class, $result);
@@ -208,7 +208,7 @@ class FactoriesTest extends CIUnitTestCase
 
 	public function testRespectsInstanceOf()
 	{
-		Factories::setConfig('widgets', ['instanceOf' => stdClass::class]);
+		Factories::setOptions('widgets', ['instanceOf' => stdClass::class]);
 
 		$result = Factories::widgets('SomeWidget');
 		$this->assertInstanceOf(SomeWidget::class, $result);
@@ -230,7 +230,7 @@ class FactoriesTest extends CIUnitTestCase
 		$this->assertInstanceOf(SomeWidget::class, $result);
 	}
 
-	public function testPrefersAppOverridesClassname()
+	public function testpreferAppOverridesClassname()
 	{
 		// Create a fake class in App
 		$class = 'App\Widgets\OtherWidget';
@@ -242,7 +242,7 @@ class FactoriesTest extends CIUnitTestCase
 		$result = Factories::widgets(OtherWidget::class);
 		$this->assertInstanceOf(SomeWidget::class, $result);
 
-		Factories::setConfig('widgets', ['prefersApp' => false]);
+		Factories::setOptions('widgets', ['preferApp' => false]);
 
 		$result = Factories::widgets(OtherWidget::class);
 		$this->assertInstanceOf(OtherWidget::class, $result);

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -138,35 +138,35 @@ class FactoriesTest extends CIUnitTestCase
 
 	public function testCreatesByBasename()
 	{
-		$result = Factories::widgets('SomeWidget', false);
+		$result = Factories::widgets('SomeWidget', ['getShared' => false]);
 
 		$this->assertInstanceOf(SomeWidget::class, $result);
 	}
 
 	public function testCreatesByClassname()
 	{
-		$result = Factories::widgets(SomeWidget::class, false);
+		$result = Factories::widgets(SomeWidget::class, ['getShared' => false]);
 
 		$this->assertInstanceOf(SomeWidget::class, $result);
 	}
 
 	public function testCreatesByAbsoluteClassname()
 	{
-		$result = Factories::models('\Tests\Support\Models\UserModel', false);
+		$result = Factories::models('\Tests\Support\Models\UserModel', ['getShared' => false]);
 
 		$this->assertInstanceOf('Tests\Support\Models\UserModel', $result);
 	}
 
 	public function testCreatesInvalid()
 	{
-		$result = Factories::widgets('gfnusvjai', false);
+		$result = Factories::widgets('gfnusvjai', ['getShared' => false]);
 
 		$this->assertNull($result);
 	}
 
 	public function testIgnoresNonClass()
 	{
-		$result = Factories::widgets('NopeWidget', false);
+		$result = Factories::widgets('NopeWidget', ['getShared' => false]);
 
 		$this->assertNull($result);
 	}
@@ -215,6 +215,14 @@ class FactoriesTest extends CIUnitTestCase
 
 		$result = Factories::widgets('OtherWidget');
 		$this->assertNull($result);
+	}
+
+	public function testPrioritizesParameterOptions()
+	{
+		Factories::setOptions('widgets', ['instanceOf' => stdClass::class]);
+
+		$result = Factories::widgets('OtherWidget', ['instanceOf' => null]);
+		$this->assertInstanceOf(OtherWidget::class, $result);
 	}
 
 	public function testFindsAppFirst()

--- a/user_guide_src/source/concepts/factories.rst
+++ b/user_guide_src/source/concepts/factories.rst
@@ -41,43 +41,29 @@ you get back the instance as before::
 		...
 	}
 
-Factories Behavior
+Factory Parameters
 ==================
 
-The default behavior might not work for every component. For example, say your component
-name and its path do not align, or you need limit returns to a certain type of class, or
-your component classes require additional parameters to their constructor. This section
-covers configuring behavior for a specific Factories component.
+``Factories`` takes as a second parameter an array of option values (described below).
+These directives will override the default options configured for each component.
 
-Factory Parameters
-------------------
-
-By default, ``Factories`` assumes that you want to locate a shared instance of a component
-with the provided name. The convenience of ``Factories`` for locating classes is sometimes
-desirable without using its shared instance storage. By adding a second parameter to the
-magic static call, you can control whether ``Factories`` will return a new or shared instance
-each time::
-
-	$users = Factories::models('UserModel', true); // Default; will always be the same instance
-	$other = Factories::models('UserModel', false); // Will always create a new instance
-
-Additionally, any more parameters passed at the same time will be forwarded on to the class
-constructor, making it easy to configure your shared instance on-the-fly. For example, say
+Any more parameters passed at the same time will be forwarded on to the class
+constructor, making it easy to configure your class instance on-the-fly. For example, say
 your app uses a separate database for authentication and you want to be sure that any attempts
 to access user records always go through that connection::
 
 	$conn  = db_connect('AuthDatabase');
-	$users = Factories::models('UserModel', true, $conn);
+	$users = Factories::models('UserModel', [], $conn);
 
-Now any time the ``UserModel`` is loaded from ``Factories`` it will in fact be returning the
-shared instance that uses the alternate database connection.
+Now any time the ``UserModel`` is loaded from ``Factories`` it will in fact be returning a
+class instance that uses the alternate database connection.
 
-Factory Configuration
----------------------
+Factories Options
+==================
 
-What works for one component may not work for all. ``Factories`` supports alternate behavior
-at the component level via configurations. A configuration consists of any of the settings,
-which will fall back on the default if not provided.
+The default behavior might not work for every component. For example, say your component
+name and its path do not align, or you need to limit instances to a certain type of class.
+Each component takes a set of options to direct discovery and instantiation.
 
 ========== ============== ==================================================================================================================== ===================================================
 Key        Type           Description                                                                                                          Default
@@ -85,14 +71,26 @@ Key        Type           Description                                           
 component  string or null The name of the component (if different than the static method). This can be used to alias one component to another. ``null`` (defaults to the component name)
 path       string or null The relative path within the namespace/folder to look for classes.                                                   ``null`` (defaults to the component name)
 instanceOf string or null A required class name to match on the returned instance.                                                             ``null`` (no filtering)
-prefersApp boolean        Whether a class with the same basename in the App namespace overrides other explicit class requests.                 ``true``
+getShared  boolean        Whether to return a shared instance of the class or load a fresh one.                                                ``true``
+preferApp  boolean        Whether a class with the same basename in the App namespace overrides other explicit class requests.                 ``true``
 ========== ============== ==================================================================================================================== ===================================================
 
-Configurations can be applied in one of two ways: through a configuration file or at runtime.
-To use the file, create a new configuration at **app/Config/Factory.php** that supplies
-configuration settings in a property matching the configuration name. For example, if you
-wanted to ensure that all Filters used by your app were really valid your **Factories.php**
-file might look like this::
+Factories Behavior
+==================
+
+Options can be applied in one of three ways (listed in ascending priority):
+
+* A configuration file ``Factory`` with a component property.
+* The static method ``Factories::setOptions``.
+* Passing options directly at call time with a parameter.
+
+Configurations
+--------------
+
+To set default component options, create a new COnfig files at **app/Config/Factory.php**
+that supplies options as an array property that matches the name of the component. For example,
+if you wanted to ensure that all Filters used by your app were valid framework instances,
+your **Factories.php** file might look like this::
 
 	<?php namespace Config;
 
@@ -109,11 +107,29 @@ file might look like this::
 This would prevent conflict of an unrelated third-party module which happened to have an
 unrelated "Filters" path in its namespace.
 
-Runtime configuration is even easier: simply supply the desired configuration values to
-``Factories`` using the ``setConfig()`` method and they will be merged with the default
-values and stored for the next call::
+setOptions Method
+-----------------
+
+The ``Factories`` class has a static method to allow runtime option configuration: simply
+supply the desired array of options using the ``setConfig()`` method and they will be
+merged with the default values and stored for the next call::
 
 	Factories::setConfig('filters', [
 		'instanceOf' => FilterInterface::class,
 		'prefersApp' => false,
 	]);
+
+Parameter Options
+-----------------
+
+``Factories``'s magic static call takes as a second parameter an array of option values.
+These directives will override the stored options configured for each component and can be
+used at call time to get exactly what you need. The input should be an array with option
+names as keys to each overriding value.
+
+For example, by default ``Factories`` assumes that you want to locate a shared instance of
+a component. By adding a second parameter to the magic static call, you can control whether
+that single call will return a new or shared instance::
+
+	$users = Factories::models('UserModel', ['getShared' => true]); // Default; will always be the same instance
+	$other = Factories::models('UserModel', ['getShared' => false]); // Will always create a new instance

--- a/user_guide_src/source/concepts/factories.rst
+++ b/user_guide_src/source/concepts/factories.rst
@@ -87,7 +87,7 @@ Options can be applied in one of three ways (listed in ascending priority):
 Configurations
 --------------
 
-To set default component options, create a new COnfig files at **app/Config/Factory.php**
+To set default component options, create a new Config files at **app/Config/Factory.php**
 that supplies options as an array property that matches the name of the component. For example,
 if you wanted to ensure that all Filters used by your app were valid framework instances,
 your **Factories.php** file might look like this::
@@ -111,10 +111,10 @@ setOptions Method
 -----------------
 
 The ``Factories`` class has a static method to allow runtime option configuration: simply
-supply the desired array of options using the ``setConfig()`` method and they will be
+supply the desired array of options using the ``setOptions()`` method and they will be
 merged with the default values and stored for the next call::
 
-	Factories::setConfig('filters', [
+	Factories::setOptions('filters', [
 		'instanceOf' => FilterInterface::class,
 		'prefersApp' => false,
 	]);


### PR DESCRIPTION
**Description**
After using `Factories` for a bit I've found some of the functionality to be a bit awkward. The classes that `Factories` replaced had a single option, `getShared`, which I gave undue prominence to in the abstracted class. But with the limit on passable parameters this forced other directives to come from the configuration.

This PR renames factory "configurations" to "options" to help distinguish them from actual `Config` classes. It moves `getShared` to be another option and changes `__callStatic` to take a set of options as the second parameter, which allows full customization by each call.

An example of what this enables... Say an `Authentication` services needs to look up a user via its `UserModel`. By using `Factories`'s `preferApp`, it can allow a developer to provide a different model to use simply by creating `App\Models\UserModel`. However, if the Service wants to enforce certain restrictions it could provide an `instanceOf` directive to make sure it was finding something it could use:
```
$model = Factories::models('UserModel', [
	'preferApp'  => true,
	'instanceOf' => 'Auth\Interfaces\UserModelInterface'
]);
```

Another example, if a developer wants to leverage the shared instance functionality but wants to be sure to get a specific class that can be handled without changing the entire component's options:
```
$widget = Factories::widgets('Org\Widgets\ColorWidget', [
	'getShared' => true,
	'preferApp' => false,
]);
```

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
