### PR TITLE
Add Custom PHPStan rule to check Use statement after license docblock

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,9 +1,16 @@
+services:
+	-
+		class: Utils\PHPStan\CheckUseStatementsAfterLicenseRule
+		tags:
+			- phpstan.rules.rule
+
 parameters:
 	tmpDir: build/phpstan
 	level: 5
 	paths:
 		- app
 		- system
+		- utils/PHPStan
 	treatPhpDocTypesAsCertain: false
 	bootstrapFiles:
 		- system/Test/bootstrap.php

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -1,11 +1,5 @@
 <?php
 
-use CodeIgniter\CodeIgniter;
-use CodeIgniter\Config\DotEnv;
-use CodeIgniter\Services;
-use Config\Autoload;
-use Config\Modules;
-
 /**
  * CodeIgniter
  *
@@ -42,6 +36,12 @@ use Config\Modules;
  * @since      Version 4.0.0
  * @filesource
  */
+
+use CodeIgniter\CodeIgniter;
+use CodeIgniter\Config\DotEnv;
+use CodeIgniter\Services;
+use Config\Autoload;
+use Config\Modules;
 
 /*
  * ---------------------------------------------------------------

--- a/utils/PHPStan/CheckUseStatementsAfterLicenseRule.php
+++ b/utils/PHPStan/CheckUseStatementsAfterLicenseRule.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Use_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+final class CheckUseStatementsAfterLicenseRule implements Rule
+{
+	/**
+	 * @var string
+	 */
+	private const ERROR_MESSAGE = 'Use statement must be located after license docblock';
+
+	public function getNodeType(): string
+	{
+		return Stmt::class;
+	}
+
+	/**
+	 * @param Stmt $node
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$comments = $node->getAttribute('comments');
+		if ($comments === [])
+		{
+			return [];
+		}
+
+		foreach ($comments as $comment)
+		{
+			if (! $comment instanceof Doc)
+			{
+				continue;
+			}
+
+			$text = $comment->getText();
+			if (! preg_match('/\* Copyright \(c\) 2019-\d{4,} CodeIgniter Foundation\n/', $text))
+			{
+				continue;
+			}
+
+			$previous = $node->getAttribute('previous');
+			while ($previous)
+			{
+				if ($previous instanceof Use_)
+				{
+					return [self::ERROR_MESSAGE];
+				}
+
+				$previous = $previous->getAttribute('previous');
+			}
+		}
+
+		return [];
+	}
+}


### PR DESCRIPTION
I created custom PHPStan rule to check Use statement after license docblock like in `system/boostrap.php` which previously use statement is missplaced before license.

**Checklist:**
- [x] Securely signed commits
