### PR TITLE
Add CSV casting

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -387,6 +387,12 @@ class Entity implements JsonSerializable
 
 		if (! $isNullable || ! is_null($value))
 		{
+			// CSV casts need to be imploded.
+			if ($castTo === 'csv')
+			{
+				$value = implode(',', $value);
+			}
+
 			// Array casting requires that we serialize the value
 			// when setting it so that it can easily be stored
 			// back to the database.
@@ -569,24 +575,27 @@ class Entity implements JsonSerializable
 		switch($type)
 		{
 			case 'int':
-			case 'integer': //alias for 'integer'
-				$value = (int)$value;
+			case 'integer': // alias for 'integer'
+				$value = (int) $value;
 				break;
 			case 'float':
-				$value = (float)$value;
+				$value = (float) $value;
 				break;
 			case 'double':
-				$value = (double)$value;
+				$value = (double) $value;
 				break;
 			case 'string':
-				$value = (string)$value;
+				$value = (string) $value;
 				break;
 			case 'bool':
-			case 'boolean': //alias for 'boolean'
-				$value = (bool)$value;
+			case 'boolean': // alias for 'boolean'
+				$value = (bool) $value;
+				break;
+			case 'csv':
+				$value = explode(',', $value);
 				break;
 			case 'object':
-				$value = (object)$value;
+				$value = (object) $value;
 				break;
 			case 'array':
 				if (is_string($value) && (strpos($value, 'a:') === 0 || strpos($value, 's:') === 0))
@@ -594,7 +603,7 @@ class Entity implements JsonSerializable
 					$value = unserialize($value);
 				}
 
-				$value = (array)$value;
+				$value = (array) $value;
 				break;
 			case 'json':
 				$value = $this->castAsJson($value);

--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -332,6 +332,26 @@ class EntityTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertFalse($entity->fifth);
 	}
 
+	public function testCastCSV()
+	{
+		$entity = $this->getCastEntity();
+
+		$data = [
+			'foo',
+			'bar',
+			'bam',
+		];
+
+		$entity->twelfth = $data;
+
+		$result = $entity->toRawArray();
+		$this->assertIsString($result['twelfth']);
+		$this->assertEquals('foo,bar,bam', $result['twelfth']);
+
+		$this->assertIsArray($entity->twelfth);
+		$this->assertEquals($data, $entity->twelfth);
+	}
+
 	public function testCastObject()
 	{
 		$entity = $this->getCastEntity();
@@ -962,6 +982,7 @@ class EntityTest extends \CodeIgniter\Test\CIUnitTestCase
 				'ninth'    => null,
 				'tenth'    => null,
 				'eleventh' => null,
+				'twelfth'  => null,
 			];
 
 			protected $_original = [
@@ -976,6 +997,7 @@ class EntityTest extends \CodeIgniter\Test\CIUnitTestCase
 				'ninth'    => null,
 				'tenth'    => null,
 				'eleventh' => null,
+				'twelfth'  => null,
 			];
 
 			// 'bar' is db column, 'foo' is internal representation
@@ -991,6 +1013,7 @@ class EntityTest extends \CodeIgniter\Test\CIUnitTestCase
 				'ninth'    => 'timestamp',
 				'tenth'    => 'json',
 				'eleventh' => 'json-array',
+				'twelfth'  => 'csv',
 			];
 
 			public function setSeventh($seventh)

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -356,9 +356,9 @@ the value whenever the property is set::
     class User extends Entity
     {
         protected $casts = [
-            'options' => 'array',
-	    'options_object' => 'json',
-	    'options_array' => 'json-array'
+            'options'        => 'array',
+	        'options_object' => 'json',
+	        'options_array'  => 'json-array'
         ];
     }
 
@@ -369,6 +369,25 @@ the value whenever the property is set::
 
     $user->options = $options;
     $userModel->save($user);
+
+CSV Casting
+-----------
+
+If you know you have a array of simple values, encoding them as a serialized or JSON string
+may be more complex than the original structure. Casting as Comma-Separated Values (CSV) is
+a simpler alternative will result in a string that uses less space and is more easily read
+by humans::
+
+    class Widget extends Entity
+    {
+        protected $casts = [
+            'colors' => 'csv',
+        ];
+    }
+
+    $widget->colors = ['red', 'yellow', 'green']; // Stored in the database as "red,yellow,green"
+
+.. note:: Casting as CSV uses PHP's internal ``implode`` and ``explode`` methods and assumes all values are string-safe and free of commas. For more complex data casts try ``array`` or ``json``.
 
 Checking for Changed Attributes
 -------------------------------

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -373,7 +373,7 @@ the value whenever the property is set::
 CSV Casting
 -----------
 
-If you know you have a array of simple values, encoding them as a serialized or JSON string
+If you know you have a flat array of simple values, encoding them as a serialized or JSON string
 may be more complex than the original structure. Casting as Comma-Separated Values (CSV) is
 a simpler alternative will result in a string that uses less space and is more easily read
 by humans::


### PR DESCRIPTION
**Description**
Adds support for Entity's `castAs` to use comma-separated values, a common "sub-collection" database storage format.
```
class Widget extends Entity
{
	protected $casts = [
		'colors' => 'csv',
	];
}

$widget->colors = ['red', 'yellow', 'green']; // Stored in the database as "red,yellow,green"
...
$widget = model(WidgetModel::class)->find(1);
var_dump($widget->colors); // ['red', 'yellow', 'green']
```

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
