### PR TITLE
Builder Tables

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -186,6 +186,15 @@ class BaseBuilder
 	protected $db;
 
 	/**
+	 * Name of the primary table for this instance.
+	 * Tracked separately because $QBFrom gets escaped
+	 * and prefixed.
+	 *
+	 * @var string
+	 */
+	protected $tableName;
+
+	/**
 	 * ORDER BY random keyword
 	 *
 	 * @var array
@@ -286,6 +295,7 @@ class BaseBuilder
 
 		$this->db = $db;
 
+		$this->tableName = $tableName;
 		$this->from($tableName);
 
 		if (! empty($options))
@@ -326,6 +336,18 @@ class BaseBuilder
 		$this->testMode = $mode;
 
 		return $this;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Gets the name of the primary table.
+	 *
+	 * @return string
+	 */
+	public function getTable(): string
+	{
+		return $this->tableName;
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Builder/BaseTest.php
+++ b/tests/system/Database/Builder/BaseTest.php
@@ -26,4 +26,32 @@ class BaseTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$this->assertInstanceOf(MockConnection::class, $result);
 	}
+
+	//--------------------------------------------------------------------
+
+	public function testGetTableReturnsTable()
+	{
+		$builder = $this->db->table('jobs');
+
+		$result = $builder->getTable();
+		$this->assertEquals('jobs', $result);
+	}
+
+	public function testGetTableIgnoresFrom()
+	{
+		$builder = $this->db->table('jobs');
+
+		$builder->from('foo');
+		$result = $builder->getTable();
+		$this->assertEquals('jobs', $result);
+	}
+
+	public function testGetTableRespectsFrom()
+	{
+		$builder = $this->db->table('jobs');
+
+		$builder->from('foo', true);
+		$result = $builder->getTable();
+		$this->assertEquals('foo', $result);
+	}
 }

--- a/tests/system/Database/Builder/BaseTest.php
+++ b/tests/system/Database/Builder/BaseTest.php
@@ -45,13 +45,4 @@ class BaseTest extends \CodeIgniter\Test\CIUnitTestCase
 		$result = $builder->getTable();
 		$this->assertEquals('jobs', $result);
 	}
-
-	public function testGetTableRespectsFrom()
-	{
-		$builder = $this->db->table('jobs');
-
-		$builder->from('foo', true);
-		$result = $builder->getTable();
-		$this->assertEquals('foo', $result);
-	}
 }

--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -2487,19 +2487,6 @@ class ModelTest extends CIDatabaseTestCase
 		$model->undefinedMethodCall();
 	}
 
-	public function testUndefinedMethodInBuilder()
-	{
-		$model = new JobModel($this->db);
-
-		$model->find(1);
-
-		$this->expectException(BadMethodCallException::class);
-		$this->expectExceptionMessage('Call to undefined method Tests\Support\Models\JobModel::getBindings');
-
-		$binds = $model->builder()
-			->getBindings();
-	}
-
 	/**
 	 * @dataProvider provideAggregateAndGroupBy
 	 */
@@ -2642,5 +2629,38 @@ class ModelTest extends CIDatabaseTestCase
 
 		$model->setAllowedFields($allowed2);
 		$this->assertSame($allowed2, $this->getPrivateProperty($model, 'allowedFields'));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testBuilderUsesModelTable()
+	{
+		$model   = new UserModel($this->db);
+		$builder = $model->builder();
+
+		$this->assertEquals('user', $builder->getTable());
+	}
+
+	public function testBuilderRespectsTableParameter()
+	{
+		$model    = new UserModel($this->db);
+		$builder1 = $model->builder('jobs');
+		$builder2 = $model->builder();
+
+		$this->assertEquals('jobs', $builder1->getTable());
+		$this->assertEquals('user', $builder2->getTable());
+	}
+
+	public function testBuilderWithParameterIgnoresShared()
+	{
+		$model = new UserModel($this->db);
+
+		$builder1 = $model->builder();
+		$builder2 = $model->builder('jobs');
+		$builder3 = $model->builder();
+
+		$this->assertEquals('user', $builder1->getTable());
+		$this->assertEquals('jobs', $builder2->getTable());
+		$this->assertEquals('user', $builder3->getTable());
 	}
 }

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -670,7 +670,10 @@ need it::
 
 	$builder = $userModel->builder();
 
-This builder is already set up with the model's $table.
+This builder is already set up with the model's $table. If you need access to another table
+you can pass it in as a parameter, but be aware that this will not return a shared instance::
+
+	$groupBuilder = $userModel->builder('groups');
 
 You can also use Query Builder methods and the Model's CRUD methods in the same chained call, allowing for
 very elegant use::


### PR DESCRIPTION
**Description**

*See #3793 for the underlying issue*

This one might be controversial, but there's a bug and I have not found a simpler fix. `Model::builder($tableName)` will return an existing shared instance of the `Builder` regardless of `$tableName`'s value. This is for a couple reasons:

* `builder()` is protected and the `__call()` method that loads it in turn does not pass on parameters
* If `builder()` detects a existing shared instance it will return it immediately, regardless of the table name

This PR attempts to fix the issue by:
1. Defining a `$tableName` property for `Builder`, assigned during initialization
2. Providing a getter to access this property
3. Adjusting `Model::builder()` to be public (also cleans up some unnecessary `__call()` steps)
4. Using `Builder::getTable()` to check the table against a requested name in the parameter

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
