### PR TITLE
Prevent events duplication on initialisation

### DIFF
--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -1,14 +1,17 @@
 <?php
+
 namespace CodeIgniter\Events;
 
-use CodeIgniter\Config\Config;
+use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockEvents;
+use Config\Modules;
 
-class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
+class EventsTest extends CIUnitTestCase
 {
-
 	/**
 	 * Accessible event manager instance
+	 *
+	 * @var MockEvents
 	 */
 	protected $manager;
 
@@ -26,38 +29,36 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 		Events::simulate(false);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState  disabled
 	 */
 	public function testInitialize()
 	{
-		$config                  = config('Modules');
-		$config->activeExplorers = [];
-		Config::injectMock('Modules', $config);
+		/**
+		 * @var Modules
+		 */
+		$config          = config('Modules');
+		$config->aliases = [];
 
 		// it should start out empty
-		$default = [APPPATH . 'Config/Events.php'];
-		$this->manager->setFiles([]);
+		MockEvents::setFiles([]);
 		$this->assertEmpty($this->manager->getFiles());
 
 		// make sure we have a default events file
+		$default = [APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'Events.php'];
 		$this->manager->unInitialize();
-		$this->manager::initialize();
+		MockEvents::initialize();
 		$this->assertEquals($default, $this->manager->getFiles());
 
 		// but we should be able to change it through the backdoor
-		$this->manager::setFiles(['/peanuts']);
+		MockEvents::setFiles(['/peanuts']);
 		$this->assertEquals(['/peanuts'], $this->manager->getFiles());
 
 		// re-initializing should have no effect
-		Events::initialize();
+		MockEvents::initialize();
 		$this->assertEquals(['/peanuts'], $this->manager->getFiles());
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testPerformance()
 	{
@@ -72,8 +73,6 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertGreaterThan(0, count($logged));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testListeners()
 	{
 		$callback1 = function () {
@@ -87,8 +86,6 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals([$callback2, $callback1], Events::listeners('foo'));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testHandleEvent()
 	{
 		$result = null;
@@ -101,8 +98,6 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$this->assertEquals('bar', $result);
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testCancelEvent()
 	{
@@ -122,8 +117,6 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(1, $result);
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testPriority()
 	{
 		$result = 0;
@@ -142,8 +135,6 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertFalse(Events::trigger('foo', 'bar'));
 		$this->assertEquals(2, $result);
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testPriorityWithMultiple()
 	{
@@ -169,8 +160,6 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(['c', 'd', 'a', 'b'], $result);
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testRemoveListener()
 	{
 		$result = false;
@@ -190,8 +179,6 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 		Events::trigger('foo');
 		$this->assertFalse($result);
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testRemoveListenerTwice()
 	{
@@ -214,8 +201,6 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertFalse($result);
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testRemoveUnknownListener()
 	{
 		$result = false;
@@ -236,8 +221,6 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertTrue($result);
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testRemoveAllListenersWithSingleEvent()
 	{
 		$result = false;
@@ -254,8 +237,6 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$this->assertEquals([], $listeners);
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testRemoveAllListenersWithMultipleEvents()
 	{
@@ -274,24 +255,16 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals([], Events::listeners('bar'));
 	}
 
-	//--------------------------------------------------------------------
-
 	// Basically if it doesn't crash this should be good...
 	public function testHandleEventCallableInternalFunc()
 	{
-		$result = null;
-
 		Events::on('foo', 'strlen');
 
 		$this->assertTrue(Events::trigger('foo', 'bar'));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testHandleEventCallableClass()
 	{
-		$result = null;
-
 		$box = new class() {
 			public $logged;
 
@@ -307,8 +280,6 @@ class EventsTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$this->assertEquals('bar', $box->logged);
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testSimulate()
 	{


### PR DESCRIPTION
**Description**
I have always been wondering why on `appstarter` the `pre_system` event is called twice, as shown in the toolbar. Then, this [forum thread](https://forum.codeigniter.com/thread-77765.html) emerged also discussing this *duplication*. It turns out, as pointed by OP, that on events discovery the `Config\Events` file is included twice even though they are referencing the same file. This PR attempts to filter `Events::$files` to have only unique found files to `include`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
