### PR TITLE
Remove extra spaces inside parentheses

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -207,7 +207,7 @@ class FileLocator
 			}
 		}
 
-		if (empty( $className ))
+		if (empty($className))
 		{
 			return '';
 		}

--- a/system/Common.php
+++ b/system/Common.php
@@ -800,7 +800,7 @@ if (! function_exists('is_really_writable'))
 			return true;
 		}
 
-		if (! is_file($file) || ( $fp = @fopen($file, 'ab')) === false)
+		if (! is_file($file) || ($fp = @fopen($file, 'ab')) === false)
 		{
 			return false;
 		}

--- a/system/ComposerScripts.php
+++ b/system/ComposerScripts.php
@@ -157,9 +157,9 @@ class ComposerScripts
 		$dir = opendir($source);
 		@mkdir($dest);
 
-		while (false !== ( $file = readdir($dir)))
+		while (false !== ($file = readdir($dir)))
 		{
-			if (( $file !== '.' ) && ( $file !== '..' ))
+			if (($file !== '.') && ($file !== '..'))
 			{
 				if (is_dir($source . '/' . $file))
 				{

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1506,7 +1506,7 @@ class BaseBuilder
 	{
 		$this->QBWhereGroupStarted = false;
 		$where                     = [
-			'condition' => str_repeat(' ', $this->QBWhereGroupCount -- ) . ')',
+			'condition' => str_repeat(' ', $this->QBWhereGroupCount--) . ')',
 			'escape'    => false,
 		];
 
@@ -2993,7 +2993,7 @@ class BaseBuilder
 		}
 		else
 		{
-			$sql = ( ! $this->QBDistinct) ? 'SELECT ' : 'SELECT DISTINCT ';
+			$sql = (! $this->QBDistinct) ? 'SELECT ' : 'SELECT DISTINCT ';
 
 			if (empty($this->QBSelect))
 			{

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1292,7 +1292,7 @@ abstract class BaseConnection implements ConnectionInterface
 		// Avoid breaking functions and literal values inside queries
 		if (ctype_digit($item)
 			|| $item[0] === "'"
-			|| ( $this->escapeChar !== '"' && $item[0] === '"')
+			|| ($this->escapeChar !== '"' && $item[0] === '"')
 			|| strpos($item, '(') !== false)
 		{
 			return $item;
@@ -1379,7 +1379,7 @@ abstract class BaseConnection implements ConnectionInterface
 			return array_map([&$this, 'escape'], $str);
 		}
 
-		if (is_string($str) || ( is_object($str) && method_exists($str, '__toString')))
+		if (is_string($str) || (is_object($str) && method_exists($str, '__toString')))
 		{
 			return "'" . $this->escapeString($str) . "'";
 		}

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -175,7 +175,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 		}
 
 		// @phpstan-ignore-next-line
-		if (! $this->connID || ( $pgVersion = pg_version($this->connID)) === false)
+		if (! $this->connID || ($pgVersion = pg_version($this->connID)) === false)
 		{
 			$this->initialize();
 		}
@@ -238,7 +238,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 			$this->initialize();
 		}
 
-		if (is_string($str) || ( is_object($str) && method_exists($str, '__toString')))
+		if (is_string($str) || (is_object($str) && method_exists($str, '__toString')))
 		{
 			return pg_escape_literal($this->connID, $str);
 		}

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -797,7 +797,7 @@ class IncomingRequest extends Request
 		$tok  = strtok($uri, '/');
 		while ($tok !== false)
 		{
-			if (( ! empty($tok) || $tok === '0') && $tok !== '..')
+			if ((! empty($tok) || $tok === '0') && $tok !== '..')
 			{
 				$uris[] = $tok;
 			}

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -439,17 +439,17 @@ if (! function_exists('symbolic_permissions'))
 		// Owner
 		$symbolic .= (($perms & 0x0100) ? 'r' : '-')
 				. (($perms & 0x0080) ? 'w' : '-')
-				. (($perms & 0x0040) ? (($perms & 0x0800) ? 's' : 'x' ) : (($perms & 0x0800) ? 'S' : '-'));
+				. (($perms & 0x0040) ? (($perms & 0x0800) ? 's' : 'x') : (($perms & 0x0800) ? 'S' : '-'));
 
 		// Group
 		$symbolic .= (($perms & 0x0020) ? 'r' : '-')
 				. (($perms & 0x0010) ? 'w' : '-')
-				. (($perms & 0x0008) ? (($perms & 0x0400) ? 's' : 'x' ) : (($perms & 0x0400) ? 'S' : '-'));
+				. (($perms & 0x0008) ? (($perms & 0x0400) ? 's' : 'x') : (($perms & 0x0400) ? 'S' : '-'));
 
 		// World
 		$symbolic .= (($perms & 0x0004) ? 'r' : '-')
 				. (($perms & 0x0002) ? 'w' : '-')
-				. (($perms & 0x0001) ? (($perms & 0x0200) ? 't' : 'x' ) : (($perms & 0x0200) ? 'T' : '-'));
+				. (($perms & 0x0001) ? (($perms & 0x0200) ? 't' : 'x') : (($perms & 0x0200) ? 'T' : '-'));
 
 		return $symbolic;
 	}

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -461,7 +461,7 @@ if (! function_exists('form_checkbox'))
 	{
 		$defaults = [
 			'type'  => 'checkbox',
-			'name'  => ( ! is_array($data) ? $data : ''),
+			'name'  => (! is_array($data) ? $data : ''),
 			'value' => $value,
 		];
 

--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -71,7 +71,7 @@ if (! function_exists('number_to_size'))
 
 		// ignore sub part
 		$generalLocale = $locale;
-		if (! empty($locale) && ( $underscorePos = strpos($locale, '_')))
+		if (! empty($locale) && ($underscorePos = strpos($locale, '_')))
 		{
 			$generalLocale = substr($locale, 0, $underscorePos);
 		}
@@ -142,7 +142,7 @@ if (! function_exists('number_to_amount'))
 
 		// ignore sub part
 		$generalLocale = $locale;
-		if (! empty($locale) && ( $underscorePos = strpos($locale, '_')))
+		if (! empty($locale) && ($underscorePos = strpos($locale, '_')))
 		{
 			$generalLocale = substr($locale, 0, $underscorePos);
 		}

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -860,7 +860,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 		if (($this->width === 0 && $this->height === 0) ||
 				$this->image()->origWidth === 0 ||
 				$this->image()->origHeight === 0 ||
-				( ! ctype_digit((string) $this->width) && ! ctype_digit((string) $this->height)) ||
+				(! ctype_digit((string) $this->width) && ! ctype_digit((string) $this->height)) ||
 				! ctype_digit((string) $this->image()->origWidth) ||
 				! ctype_digit((string) $this->image()->origHeight)
 		)

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -491,7 +491,7 @@ class Router implements RouterInterface
 					[
 						$controller,
 						$method,
-					] = explode( '::', $val );
+					] = explode('::', $val);
 
 					// Only replace slashes in the controller, not in the method.
 					$controller = str_replace('/', '\\', $controller);

--- a/system/Typography/Typography.php
+++ b/system/Typography/Typography.php
@@ -339,7 +339,7 @@ class Typography
 	 */
 	protected function formatNewLines(string $str): string
 	{
-		if ($str === '' || ( strpos($str, "\n") === false && ! in_array($this->lastBlockElement, $this->innerBlockRequired, true)))
+		if ($str === '' || (strpos($str, "\n") === false && ! in_array($this->lastBlockElement, $this->innerBlockRequired, true)))
 		{
 			return $str;
 		}

--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -150,8 +150,8 @@ class Cell
 			$output = $instance->{$method}();
 		}
 		elseif (($paramCount === 1) && (
-				( ! array_key_exists($refParams[0]->name, $paramArray)) ||
-				(array_key_exists($refParams[0]->name, $paramArray) && count($paramArray) !== 1) )
+				(! array_key_exists($refParams[0]->name, $paramArray)) ||
+				(array_key_exists($refParams[0]->name, $paramArray) && count($paramArray) !== 1))
 		)
 		{
 			$output = $instance->{$method}($paramArray);
@@ -201,7 +201,7 @@ class Cell
 	 */
 	public function prepareParams($params)
 	{
-		if (empty($params) || ( ! is_string($params) && ! is_array($params)))
+		if (empty($params) || (! is_string($params) && ! is_array($params)))
 		{
 			return [];
 		}

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -402,8 +402,9 @@ class Parser extends View
 
 						if (! empty($pair))
 						{
-							$pairs[array_keys( $pair )[0]] = true;
-							$temp                          = array_merge($temp, $pair);
+							$pairs[array_keys($pair)[0]] = true;
+
+							$temp = array_merge($temp, $pair);
 						}
 
 						continue;
@@ -423,7 +424,7 @@ class Parser extends View
 				// Now replace our placeholders with the new content.
 				foreach ($temp as $pattern => $content)
 				{
-					$out = $this->replaceSingle($pattern, $content, $out, ! isset( $pairs[$pattern] ) );
+					$out = $this->replaceSingle($pattern, $content, $out, ! isset($pairs[$pattern]));
 				}
 
 				$str .= $out;


### PR DESCRIPTION
**Description:**
Removes WordPress-style spacing inside parentheses.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
