### PR TITLE
Fix wrong method: getCacheInfo() instead of cache_info()

### DIFF
--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -171,7 +171,7 @@ Class Reference
 
 			$cache->clean();
 
-.. php:method:: ⠀cache_info()
+.. php:method:: ⠀getCacheInfo()
 
 	:returns:	Information on the entire cache database
 	:rtype:	mixed
@@ -180,7 +180,7 @@ Class Reference
 
 	Example::
 
-		var_dump($cache->cache_info());
+		var_dump($cache->getCacheInfo());
 
 .. note:: The information returned and the structure of the data is dependent
 		  on which adapter is being used.


### PR DESCRIPTION
**Description**
Fixes #3800 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
