### PR TITLE
Limit toolbar to initial head tag

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -395,10 +395,7 @@ class Toolbar
 
 			if (strpos($response->getBody(), '<head>') !== false)
 			{
-				$response->setBody(
-						str_replace('<head>', '<head>' . $script, $response->getBody())
-				);
-
+				$response->setBody(preg_replace('<head>', '<head>' . $script, $response->getBody(), 1));
 				return;
 			}
 


### PR DESCRIPTION
**Description**
I have a form to edit email content, the body of which includes a `<head>` tag. The toolbar filter is injecting itself into the form to edit this content because it matches `<head>`. This PR limits the toolbar replacement to the first instance of the head tag.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
