### PR TITLE
Enable strict param on base64_decode and array_search

### DIFF
--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -286,7 +286,7 @@ class Filters
 			$this->filters['after'][$count - 1] !== 'toolbar'
 		)
 		{
-			array_splice($this->filters['after'], array_search('toolbar', $this->filters['after']), 1);
+			array_splice($this->filters['after'], array_search('toolbar', $this->filters['after'], true), 1);
 			$this->filters['after'][] = 'toolbar';
 		}
 

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -61,12 +61,11 @@ use Throwable;
  */
 class Logger implements LoggerInterface
 {
-
 	/**
 	 * Used by the logThreshold Config setting to define
 	 * which errors to show.
 	 *
-	 * @var array
+	 * @var array<string, integer>
 	 */
 	protected $logLevels = [
 		'emergency' => 1,
@@ -160,7 +159,7 @@ class Logger implements LoggerInterface
 			$temp = [];
 			foreach ($this->loggableLevels as $level)
 			{
-				$temp[] = array_search((int) $level, $this->logLevels);
+				$temp[] = array_search((int) $level, $this->logLevels, true);
 			}
 
 			$this->loggableLevels = $temp;
@@ -331,7 +330,7 @@ class Logger implements LoggerInterface
 	{
 		if (is_numeric($level))
 		{
-			$level = array_search((int) $level, $this->logLevels);
+			$level = array_search((int) $level, $this->logLevels, true);
 		}
 
 		// Is the level a valid level?

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -426,7 +426,7 @@ class Router implements RouterInterface
 			// Are we dealing with a locale?
 			if (strpos($key, '{locale}') !== false)
 			{
-				$localeSegment = array_search('{locale}', preg_split('/[\/]*((^[a-zA-Z0-9])|\(([^()]*)\))*[\/]+/m', $key));
+				$localeSegment = array_search('{locale}', preg_split('/[\/]*((^[a-zA-Z0-9])|\(([^()]*)\))*[\/]+/m', $key), true);
 
 				// Replace it with a regex so it
 				// will actually match.

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -204,7 +204,7 @@ class DatabaseHandler extends BaseHandler implements SessionHandlerInterface
 		}
 		else
 		{
-			$result = ($this->platform === 'postgre') ? base64_decode(rtrim($result->data)) : $result->data;
+			$result = ($this->platform === 'postgre') ? base64_decode(rtrim($result->data), true) : $result->data;
 		}
 
 		$this->fingerprint = md5($result);

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -259,7 +259,7 @@ class FormatRules
 	 */
 	public function valid_base64(string $str = null): bool
 	{
-		return (base64_encode(base64_decode($str)) === $str);
+		return (base64_encode(base64_decode($str, true)) === $str);
 	}
 
 	/**

--- a/utils/Rector/PassStrictParameterToFunctionParameterRector.php
+++ b/utils/Rector/PassStrictParameterToFunctionParameterRector.php
@@ -20,7 +20,9 @@ final class PassStrictParameterToFunctionParameterRector extends AbstractRector
 {
 	private const FUNCTION_WITH_ARG_POSITION = [
 		// position start from 0
-		'in_array' => 2,
+		'array_search'  => 2,
+		'base64_decode' => 1,
+		'in_array'      => 2,
 	];
 
 	public function getDefinition(): RectorDefinition

--- a/utils/Rector/PassStrictParameterToFunctionParameterRector.php
+++ b/utils/Rector/PassStrictParameterToFunctionParameterRector.php
@@ -28,15 +28,9 @@ final class PassStrictParameterToFunctionParameterRector extends AbstractRector
 	public function getDefinition(): RectorDefinition
 	{
 		return new RectorDefinition('Pass strict to function parameter on specific position argument when no value provided', [
-			new CodeSample(
-				<<<'CODE_SAMPLE'
-in_array('a', $array);
-CODE_SAMPLE
-,
-				<<<'CODE_SAMPLE'
-in_array('a', $array, true);
-CODE_SAMPLE
-			),
+			new CodeSample('array_search($value, $array);', 'array_search($value, $array, true);'),
+			new CodeSample('base64_decode($string);', 'base64_decode($string, true);'),
+			new CodeSample("in_array('a', \$array);", "in_array('a', \$array, true);"),
 		]);
 	}
 


### PR DESCRIPTION
**Description**
This continues on #3799 to add `true` param to `base64_decode` and `array_search`, which are used in the framework. This does not change yet other functions that can be made strict (e.g., `array_keys`, `mb_detect_encoding`) as it is not yet used.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
