### PR TITLE
Fix phpstan issue with PreparedQuery classes' statement property

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -33,7 +33,6 @@ parameters:
 		- '#Call to an undefined method CodeIgniter\\Database\\ConnectionInterface::(tableExists|protectIdentifiers|setAliasedTables|escapeIdentifiers|affectedRows|addTableAlias|getIndexData)\(\)#'
 		- '#Call to an undefined method CodeIgniter\\HTTP\\Request::(getPath|getSegments|getMethod|setLocale|getPost)\(\)#'
 		- '#Call to an undefined method CodeIgniter\\Router\\RouteCollectionInterface::(getDefaultNamespace|isFiltered|getFilterForRoute|getRoutesOptions)\(\)#'
-		- '#Call to function is_null\(\) with mysqli_stmt\|resource will always evaluate to false#'
 		- '#Cannot access property [\$a-z_]+ on ((bool\|)?object\|resource)#'
 		- '#Cannot call method [a-zA-Z_]+\(\) on ((bool\|)?object\|resource)#'
 		- '#Method CodeIgniter\\Database\\ConnectionInterface::query\(\) invoked with 3 parameters, 1-2 required#'

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -48,7 +48,6 @@ use CodeIgniter\Database\PreparedQueryInterface;
  */
 class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 {
-
 	/**
 	 * Prepares the query against the database, and saves the connection
 	 * info necessary to execute the query later.
@@ -77,8 +76,6 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Takes a new set of data and runs it against the currently
 	 * prepared query. Upon success, will return a Results object.
@@ -89,7 +86,7 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 	 */
 	public function _execute(array $data): bool
 	{
-		if (is_null($this->statement))
+		if (! isset($this->statement))
 		{
 			throw new BadMethodCallException('You must call prepare before trying to execute a prepared statement.');
 		}
@@ -120,8 +117,6 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 		return $this->statement->execute();
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Returns the result object for the prepared query.
 	 *
@@ -131,6 +126,4 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 	{
 		return $this->statement->get_result();
 	}
-
-	//--------------------------------------------------------------------
 }

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -49,7 +49,6 @@ use Exception;
  */
 class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 {
-
 	/**
 	 * Stores the name this query can be
 	 * used under by postgres. Only used internally.
@@ -65,8 +64,6 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 	 * @var Result|boolean
 	 */
 	protected $result;
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Prepares the query against the database, and saves the connection
@@ -101,8 +98,6 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Takes a new set of data and runs it against the currently
 	 * prepared query. Upon success, will return a Results object.
@@ -113,7 +108,7 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 	 */
 	public function _execute(array $data): bool
 	{
-		if (is_null($this->statement))
+		if (! isset($this->statement))
 		{
 			throw new BadMethodCallException('You must call prepare before trying to execute a prepared statement.');
 		}
@@ -122,8 +117,6 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 
 		return (bool) $this->result;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Returns the result object for the prepared query.
@@ -134,8 +127,6 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 	{
 		return $this->result;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Replaces the ? placeholders with $1, $2, etc parameters for use
@@ -155,6 +146,4 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 			return "\${$count}";
 		}, $sql);
 	}
-
-	//--------------------------------------------------------------------
 }

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -49,15 +49,12 @@ use CodeIgniter\Database\PreparedQueryInterface;
 
 class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 {
-
 	/**
 	 * The SQLite3Result resource, or false.
 	 *
 	 * @var Result|boolean
 	 */
 	protected $result;
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Prepares the query against the database, and saves the connection
@@ -74,17 +71,14 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 	 */
 	public function _prepare(string $sql, array $options = [])
 	{
-		// @phpstan-ignore-next-line
 		if (! ($this->statement = $this->db->connID->prepare($sql)))
 		{
-			$this->errorCode   = $this->db->connID->lastErrorCode(); // @phpstan-ignore-line
-			$this->errorString = $this->db->connID->lastErrorMsg(); // @phpstan-ignore-line
+			$this->errorCode   = $this->db->connID->lastErrorCode();
+			$this->errorString = $this->db->connID->lastErrorMsg();
 		}
 
 		return $this;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Takes a new set of data and runs it against the currently
@@ -98,7 +92,7 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 	 */
 	public function _execute(array $data): bool
 	{
-		if (is_null($this->statement))
+		if (! isset($this->statement))
 		{
 			throw new BadMethodCallException('You must call prepare before trying to execute a prepared statement.');
 		}
@@ -128,8 +122,6 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 		return $this->result !== false;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Returns the result object for the prepared query.
 	 *
@@ -139,7 +131,4 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 	{
 		return $this->result;
 	}
-
-	//--------------------------------------------------------------------
-
 }

--- a/system/Database/Sqlsrv/PreparedQuery.php
+++ b/system/Database/Sqlsrv/PreparedQuery.php
@@ -49,7 +49,6 @@ use Exception;
  */
 class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 {
-
 	/**
 	 * Parameters array used to store the dynamic variables.
 	 *
@@ -64,7 +63,6 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 	 */
 	protected $result;
 
-	//--------------------------------------------------------------------
 	/**
 	 * Prepares the query against the database, and saves the connection
 	 * info necessary to execute the query later.
@@ -108,7 +106,7 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 	 */
 	public function _execute(array $data): bool
 	{
-		if (is_null($this->statement))
+		if (! isset($this->statement))
 		{
 			throw new BadMethodCallException('You must call prepare before trying to execute a prepared statement.');
 		}
@@ -154,5 +152,4 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 
 		return $params;
 	}
-
 }


### PR DESCRIPTION
**Description**
Fixes the ignoredError `#Call to function is_null\(\) with mysqli_stmt\|resource will always evaluate to false#`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
