### PR TITLE
Use include for autoloading

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -163,7 +163,7 @@ class Autoloader
 				return false;
 			}
 
-			include $config[$class];
+			include_once $config[$class];
 		}, true, // Throw exception
 			true // Prepend
 		);

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -163,7 +163,7 @@ class Autoloader
 				return false;
 			}
 
-			include_once $config[$class];
+			include $config[$class];
 		}, true, // Throw exception
 			true // Prepend
 		);
@@ -377,7 +377,7 @@ class Autoloader
 
 		if (is_file($file))
 		{
-			include_once $file;
+			include $file;
 
 			return $file;
 		}


### PR DESCRIPTION
**Description**
Try using `include` instead of `include_once` during Autoloading, since by definition files should only be autoloader when their class does not yet exist. May grant a performance increase.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
