### PR TITLE
Fixes missing regex delimiter at Toolbar

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -395,7 +395,7 @@ class Toolbar
 
 			if (strpos($response->getBody(), '<head>') !== false)
 			{
-				$response->setBody(preg_replace('<head>', '<head>' . $script, $response->getBody(), 1));
+				$response->setBody(preg_replace('/<head>/', '<head>' . $script, $response->getBody(), 1));
 				return;
 			}
 


### PR DESCRIPTION
@MGatner this is fixes missing regex delimiter at Toolbar at https://github.com/codeigniter4/CodeIgniter4/pull/3804#issuecomment-716097763

**Checklist:**
- [x] Securely signed commits
