### PR TITLE
Use Composer v2 for workflow

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -32,9 +32,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
     name: PHP ${{ matrix.php-versions }} - ${{ matrix.db-platforms }}
 
     strategy:
@@ -87,7 +85,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: composer:v2, pecl
+          tools: composer, pecl
           extensions: imagick, sqlsrv
           coverage: xdebug
         env:
@@ -109,9 +107,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer install --no-progress --no-suggest --no-interaction --prefer-dist --optimize-autoloader
-          composer remove --dev rector/rector phpstan/phpstan codeigniter4/codeigniter4-standard squizlabs/php_codesniffer
-          composer update
+          composer update --ansi --no-interaction
+          composer remove --ansi --dev --unused rector/rector phpstan/phpstan codeigniter4/codeigniter4-standard squizlabs/php_codesniffer
           php -r 'file_put_contents("vendor/laminas/laminas-zendframework-bridge/src/autoload.php", "");'
         env:
           COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,8 @@
 		"squizlabs/php_codesniffer": "^3.3"
 	},
 	"config": {
+		"optimize-autoloader": true,
+		"preferred-install": "dist",
 		"sort-packages": true
 	},
 	"autoload": {


### PR DESCRIPTION
**Description**
Composer v2 is now released. `ammaraskar/setup-php` is now by default using v2 so no need to add the `v2` tag.
Other changes:
- Used `composer update` instead of `composer install` because no lock file is present
- `--no-suggest` is deprecated so no need to include
- `--no-progress` does not actually hide the installation progress
- moved options `--optimize-autoloader` and `--prefer-dist` to `composer.json` so these will be used both by `update` and `remove` operations
- add `--unused` option to `remove` to make sure unused packages are removed (available as of v2)
- `--ansi` for colored output 😁

**Checklist:**
- [x] Securely signed commits
