### PR TITLE
Loosen return type docs

### DIFF
--- a/system/RESTful/ResourceController.php
+++ b/system/RESTful/ResourceController.php
@@ -84,7 +84,7 @@ class ResourceController extends Controller
 	/**
 	 * Return an array of resource objects, themselves in array format
 	 *
-	 * @return array	an array
+	 * @return mixed
 	 */
 	public function index()
 	{
@@ -94,7 +94,7 @@ class ResourceController extends Controller
 	/**
 	 * Return the properties of a resource object
 	 *
-	 * @return array	an array
+	 * @return mixed
 	 */
 	public function show($id = null)
 	{
@@ -104,7 +104,7 @@ class ResourceController extends Controller
 	/**
 	 * Return a new resource object, with default properties
 	 *
-	 * @return array	an array
+	 * @return mixed
 	 */
 	public function new()
 	{
@@ -114,7 +114,7 @@ class ResourceController extends Controller
 	/**
 	 * Create a new resource object, from "posted" parameters
 	 *
-	 * @return array	an array
+	 * @return mixed
 	 */
 	public function create()
 	{
@@ -124,7 +124,7 @@ class ResourceController extends Controller
 	/**
 	 * Return the editable properties of a resource object
 	 *
-	 * @return array	an array
+	 * @return mixed
 	 */
 	public function edit($id = null)
 	{
@@ -134,7 +134,7 @@ class ResourceController extends Controller
 	/**
 	 * Add or update a model resource, from "posted" properties
 	 *
-	 * @return array	an array
+	 * @return mixed
 	 */
 	public function update($id = null)
 	{
@@ -144,7 +144,7 @@ class ResourceController extends Controller
 	/**
 	 * Delete the designated resource object from the model
 	 *
-	 * @return array	an array
+	 * @return mixed
 	 */
 	public function delete($id = null)
 	{

--- a/system/RESTful/ResourcePresenter.php
+++ b/system/RESTful/ResourcePresenter.php
@@ -79,7 +79,7 @@ class ResourcePresenter extends Controller
 	/**
 	 * Present a view of resource objects
 	 *
-	 * @return string
+	 * @return mixed
 	 */
 	public function index()
 	{
@@ -90,7 +90,7 @@ class ResourcePresenter extends Controller
 	 * Present a view to present a specific resource object
 	 *
 	 * @param  mixed $id
-	 * @return string
+	 * @return mixed
 	 */
 	public function show($id = null)
 	{
@@ -100,7 +100,7 @@ class ResourcePresenter extends Controller
 	/**
 	 * Present a view to present a new single resource object
 	 *
-	 * @return string
+	 * @return mixed
 	 */
 	public function new()
 	{
@@ -111,7 +111,7 @@ class ResourcePresenter extends Controller
 	 * Process the creation/insertion of a new resource object.
 	 * This should be a POST.
 	 *
-	 * @return string
+	 * @return mixed
 	 */
 	public function create()
 	{
@@ -133,7 +133,7 @@ class ResourcePresenter extends Controller
 	 * Process the deletion of a specific resource object
 	 *
 	 * @param  mixed $id
-	 * @return string
+	 * @return mixed
 	 */
 	public function delete($id = null)
 	{
@@ -144,7 +144,7 @@ class ResourcePresenter extends Controller
 	 * Present a view to edit the properties of a specific resource object
 	 *
 	 * @param  mixed $id
-	 * @return string
+	 * @return mixed
 	 */
 	public function edit($id = null)
 	{
@@ -156,7 +156,7 @@ class ResourcePresenter extends Controller
 	 * This should be a POST.
 	 *
 	 * @param  mixed $id
-	 * @return string
+	 * @return mixed
 	 */
 	public function update($id = null)
 	{


### PR DESCRIPTION
**Description**
Return types are not specified on the RESTful controllers but they are in the doc blocks. Frequently an endpoint will need to return a RedirectResponse or ResponseInterface which will cause static analysis complaints. This PR loosens the return type doc completely to allow developers to set their own.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
