### PR TITLE
Remove package tags

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -25,8 +25,6 @@ use Config\Services;
  *
  * @property IncomingRequest $request
  * @property Response        $response
- *
- * @package CodeIgniter\API
  */
 trait ResponseTrait
 {

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -50,8 +50,6 @@ use InvalidArgumentException;
  *
  *      // register the autoloader
  *      $loader->register();
- *
- * @package CodeIgniter\Autoloader
  */
 class Autoloader
 {

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -16,8 +16,6 @@ namespace CodeIgniter\Autoloader;
  *
  * Allows loading non-class files in a namespaced manner.
  * Works with Helpers, Views, etc.
- *
- * @package CodeIgniter
  */
 class FileLocator
 {

--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -17,8 +17,6 @@ use Throwable;
 
 /**
  * Class BaseCommand
- *
- * @package CodeIgniter\CLI
  */
 abstract class BaseCommand
 {

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -32,8 +32,6 @@ use Throwable;
  * The wait() method is mostly testable, as long as you don't give it
  * an argument of "0".
  * These have been flagged to ignore for code coverage purposes.
- *
- * @package CodeIgniter\CLI
  */
 class CLI
 {

--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -20,8 +20,6 @@ use ReflectionException;
  * Class Commands
  *
  * Core functionality for running, listing, etc commands.
- *
- * @package CodeIgniter\CLI
  */
 class Commands
 {

--- a/system/CLI/GeneratorCommand.php
+++ b/system/CLI/GeneratorCommand.php
@@ -20,8 +20,6 @@ use Throwable;
 /**
  * GeneratorCommand can be used as base class
  * for creating commands that generates a file.
- *
- * @package CodeIgniter\CLI
  */
 abstract class GeneratorCommand extends BaseCommand
 {

--- a/system/Cache/CacheFactory.php
+++ b/system/Cache/CacheFactory.php
@@ -19,8 +19,6 @@ use Config\Cache;
  * Class Cache
  *
  * A factory for loading the desired
- *
- * @package CodeIgniter\Cache
  */
 class CacheFactory
 {

--- a/system/Commands/Generators/CreateSeeder.php
+++ b/system/Commands/Generators/CreateSeeder.php
@@ -16,8 +16,6 @@ use CodeIgniter\CLI\GeneratorCommand;
 
 /**
  * Creates a new seeder file
- *
- * @package CodeIgniter\Commands
  */
 class CreateSeeder extends GeneratorCommand
 {

--- a/system/Commands/Generators/CreateSessionMigration.php
+++ b/system/Commands/Generators/CreateSessionMigration.php
@@ -16,8 +16,6 @@ use CodeIgniter\CLI\GeneratorCommand;
 
 /**
  * Creates a migration file for database sessions.
- *
- * @package CodeIgniter\Commands
  */
 class CreateSessionMigration extends GeneratorCommand
 {

--- a/system/Commands/Help.php
+++ b/system/Commands/Help.php
@@ -18,8 +18,6 @@ use CodeIgniter\CLI\BaseCommand;
  *
  * Lists the basic usage information for the spark script,
  * and provides a way to list help for other commands.
- *
- * @package CodeIgniter\Commands
  */
 class Help extends BaseCommand
 {

--- a/system/Commands/ListCommands.php
+++ b/system/Commands/ListCommands.php
@@ -19,8 +19,6 @@ use CodeIgniter\CLI\CLI;
  *
  * Lists the basic usage information for the spark script,
  * and provides a way to list help for other commands.
- *
- * @package CodeIgniter\Commands
  */
 class ListCommands extends BaseCommand
 {

--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -19,8 +19,6 @@ use CodeIgniter\CLI\CLI;
  *
  * Not testable, as it throws phpunit for a loop :-/
  *
- * @package CodeIgniter\Commands\Server
- *
  * @codeCoverageIgnore
  */
 class Serve extends BaseCommand

--- a/system/Commands/Utilities/Namespaces.php
+++ b/system/Commands/Utilities/Namespaces.php
@@ -19,8 +19,6 @@ use Config\Autoload;
  * Lists namespaces set in Config\Autoload with their
  * full server path. Helps you to verify that you have
  * the namespaces setup correctly.
- *
- * @package CodeIgniter\Commands
  */
 class Namespaces extends BaseCommand
 {

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -19,8 +19,6 @@ use Config\Services;
  * Lists all of the user-defined routes. This will include any Routes files
  * that can be discovered, but will NOT include any routes that are not defined
  * in a routes file, but are instead discovered through auto-routing.
- *
- * @package CodeIgniter\Commands
  */
 class Routes extends BaseCommand
 {

--- a/system/Common.php
+++ b/system/Common.php
@@ -25,14 +25,6 @@ use Config\Services;
 use Config\View;
 use Laminas\Escaper\Escaper;
 
-/**
- * Common Functions
- *
- * Several application-wide utility methods.
- *
- * @package  CodeIgniter
- * @category Common Functions
- */
 //--------------------------------------------------------------------
 // Services Convenience Functions
 //--------------------------------------------------------------------

--- a/system/ComposerScripts.php
+++ b/system/ComposerScripts.php
@@ -23,7 +23,6 @@ use ReflectionException;
  * download
  *
  * @codeCoverageIgnore
- * @package            CodeIgniter
  */
 class ComposerScripts
 {

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -21,8 +21,6 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Class Controller
- *
- * @package CodeIgniter
  */
 class Controller
 {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -23,8 +23,7 @@ use InvalidArgumentException;
  * Database-specific Builders might need to override
  * certain methods to make them work.
  *
- * @package CodeIgniter\Database
- * @mixin   \CodeIgniter\Model
+ * @mixin \CodeIgniter\Model
  */
 class BaseBuilder
 {

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -13,8 +13,6 @@ namespace CodeIgniter\Database;
 
 /**
  * Interface ConnectionInterface
- *
- * @package CodeIgniter\Database
  */
 interface ConnectionInterface
 {

--- a/system/Database/Database.php
+++ b/system/Database/Database.php
@@ -17,8 +17,6 @@ use InvalidArgumentException;
  * Database Connection Factory
  *
  * Creates and returns an instance of the appropriate DatabaseConnection
- *
- * @package CodeIgniter\Database
  */
 class Database
 {

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -13,8 +13,6 @@ namespace CodeIgniter\Database;
 
 /**
  * Query builder
- *
- * @package CodeIgniter\Database
  */
 class Query implements QueryInterface
 {

--- a/system/Database/QueryInterface.php
+++ b/system/Database/QueryInterface.php
@@ -16,8 +16,6 @@ namespace CodeIgniter\Database;
  *
  * Represents a single statement that can be executed against the database.
  * Statements are platform-specific and can handle binding of binds.
- *
- * @package CodeIgniter\Database
  */
 interface QueryInterface
 {

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -21,8 +21,6 @@ use CodeIgniter\Database\Exceptions\DataException;
  * These are needed in order to support migrations during testing
  * when another database is used as the primary engine, but
  * SQLite in memory databases are used for faster test execution.
- *
- * @package CodeIgniter\Database\SQLite3
  */
 class Table
 {

--- a/system/Debug/Timer.php
+++ b/system/Debug/Timer.php
@@ -18,8 +18,6 @@ use RuntimeException;
  *
  * Provides a simple way to measure the amount of time
  * that elapses between two points.
- *
- * @package CodeIgniter\Debug
  */
 class Timer
 {

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -29,8 +29,6 @@ use Config\Toolbar as ToolbarConfig;
  * Displays a toolbar with bits of stats to aid a developer in debugging.
  *
  * Inspiration: http://prophiler.fabfuel.de
- *
- * @package CodeIgniter\Debug
  */
 class Toolbar
 {

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -19,12 +19,6 @@ use ErrorException;
  * CodeIgniter Email Class
  *
  * Permits email to be sent using Mail, Sendmail, or SMTP.
- *
- * @package    CodeIgniter
- * @subpackage Libraries
- * @category   Libraries
- * @author     EllisLab Dev Team
- * @link       https://codeigniter.com/user_guide/libraries/email.html
  */
 class Email
 {

--- a/system/Exceptions/DownloadException.php
+++ b/system/Exceptions/DownloadException.php
@@ -15,8 +15,6 @@ use RuntimeException;
 
 /**
  * Class DownloadException
- *
- * @package CodeIgniter\Exceptions
  */
 class DownloadException extends RuntimeException implements ExceptionInterface
 {

--- a/system/Exceptions/FrameworkException.php
+++ b/system/Exceptions/FrameworkException.php
@@ -18,8 +18,6 @@ use RuntimeException;
  *
  * A collection of exceptions thrown by the framework
  * that can only be determined at run time.
- *
- * @package CodeIgniter\Exceptions
  */
 class FrameworkException extends RuntimeException implements ExceptionInterface
 {

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -18,8 +18,6 @@ use SplFileInfo;
 
 /**
  * Wrapper for PHP's built-in SplFileInfo, with goodies.
- *
- * @package CodeIgniter\Files
  */
 class File extends SplFileInfo
 {

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -20,8 +20,6 @@ use InvalidArgumentException;
  *
  * A lightweight HTTP client for sending synchronous HTTP requests
  * via cURL.
- *
- * @package CodeIgniter\HTTP
  */
 class CURLRequest extends Request
 {

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -19,11 +19,10 @@ use Config\ContentSecurityPolicy as ContentSecurityPolicyConfig;
  * Provides tools for working with the Content-Security-Policy header
  * to help defeat XSS attacks.
  *
- * @see     http://www.w3.org/TR/CSP/
- * @see     http://www.html5rocks.com/en/tutorials/security/content-security-policy/
- * @see     http://content-security-policy.com/
- * @see     https://www.owasp.org/index.php/Content_Security_Policy
- * @package CodeIgniter\HTTP
+ * @see http://www.w3.org/TR/CSP/
+ * @see http://www.html5rocks.com/en/tutorials/security/content-security-policy/
+ * @see http://content-security-policy.com/
+ * @see https://www.owasp.org/index.php/Content_Security_Policy
  */
 class ContentSecurityPolicy
 {

--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -18,8 +18,6 @@ use RecursiveIteratorIterator;
  * Class FileCollection
  *
  * Provides easy access to uploaded files for a request.
- *
- * @package CodeIgniter\HTTP\Files
  */
 class FileCollection
 {

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -24,8 +24,6 @@ use RuntimeException;
  * provide files.
  *
  * Typically, implementors will extend the SplFileInfo class.
- *
- * @package CodeIgniter\HTTP
  */
 class UploadedFile extends File implements UploadedFileInterface
 {

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -20,8 +20,6 @@ use RuntimeException;
  * provide files.
  *
  * Typically, implementors will extend the SplFileInfo class.
- *
- * @package CodeIgniter\HTTP
  */
 interface UploadedFileInterface
 {

--- a/system/HTTP/Header.php
+++ b/system/HTTP/Header.php
@@ -15,8 +15,6 @@ namespace CodeIgniter\HTTP;
  * Class Header
  *
  * Represents a single HTTP header.
- *
- * @package CodeIgniter\HTTP
  */
 class Header
 {

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -40,8 +40,6 @@ use Locale;
  * - Query string arguments (generally via $_GET, or as parsed via parse_str())
  * - Upload files, if any (as represented by $_FILES)
  * - Deserialized body binds (generally from $_POST)
- *
- * @package CodeIgniter\HTTP
  */
 class IncomingRequest extends Request
 {

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -20,8 +20,7 @@ use CodeIgniter\HTTP\Exceptions\HTTPException;
  * type match between what the application supports and what the requesting
  * getServer wants.
  *
- * @see     http://tools.ietf.org/html/rfc7231#section-5.3
- * @package CodeIgniter\HTTP
+ * @see http://tools.ietf.org/html/rfc7231#section-5.3
  */
 class Negotiate
 {

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -29,8 +29,6 @@ use InvalidArgumentException;
  * - Status code and reason phrase
  * - Headers
  * - Message body
- *
- * @package CodeIgniter\HTTP
  */
 class Response extends Message implements ResponseInterface
 {

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -25,8 +25,7 @@ use InvalidArgumentException;
  * - Headers
  * - Message body
  *
- * @package CodeIgniter\HTTP
- * @mixin   \CodeIgniter\HTTP\RedirectResponse
+ * @mixin \CodeIgniter\HTTP\RedirectResponse
  */
 interface ResponseInterface
 {

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -11,8 +11,6 @@
 
 /**
  * CodeIgniter Array Helpers
- *
- * @package CodeIgniter
  */
 
 if (! function_exists('dot_array_search'))

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -16,8 +16,6 @@ use Config\Services;
 
 /**
  * CodeIgniter Cookie Helpers
- *
- * @package CodeIgniter
  */
 if (! function_exists('set_cookie'))
 {

--- a/system/Helpers/date_helper.php
+++ b/system/Helpers/date_helper.php
@@ -11,8 +11,6 @@
 
 /**
  * CodeIgniter Date Helpers
- *
- * @package CodeIgniter
  */
 
 if (! function_exists('now'))

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -11,8 +11,6 @@
 
 /**
  * CodeIgniter File System Helpers
- *
- * @package CodeIgniter
  */
 // ------------------------------------------------------------------------
 

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -13,8 +13,6 @@ use Config\App;
 
 /**
  * CodeIgniter Form Helpers
- *
- * @package CodeIgniter
  */
 
 use Config\Services;

--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -17,8 +17,6 @@ use Config\Mimes;
 
 /**
  * CodeIgniter HTML Helpers
- *
- * @package CodeIgniter
  */
 if (! function_exists('ul'))
 {

--- a/system/Helpers/inflector_helper.php
+++ b/system/Helpers/inflector_helper.php
@@ -13,8 +13,6 @@
 
 /**
  * CodeIgniter Inflector Helpers
- *
- * @package CodeIgniter
  */
 if (! function_exists('singular'))
 {

--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -13,8 +13,6 @@ use Config\Services;
 
 /**
  * CodeIgniter Number Helpers
- *
- * @package CodeIgniter
  */
 
 if (! function_exists('number_to_size'))

--- a/system/Helpers/security_helper.php
+++ b/system/Helpers/security_helper.php
@@ -13,8 +13,6 @@ use Config\Services;
 
 /**
  * CodeIgniter Security Helpers
- *
- * @package CodeIgniter
  */
 
 if (! function_exists('sanitize_filename'))

--- a/system/Helpers/test_helper.php
+++ b/system/Helpers/test_helper.php
@@ -13,8 +13,6 @@ use CodeIgniter\Test\Fabricator;
 
 /**
  * CodeIgniter Test Helpers
- *
- * @package CodeIgniter
  */
 //--------------------------------------------------------------------
 

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -13,8 +13,6 @@ use Config\ForeignCharacters;
 
 /**
  * CodeIgniter Text Helpers
- *
- * @package CodeIgniter
  */
 //--------------------------------------------------------------------
 

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -16,8 +16,6 @@ use Config\Services;
 
 /**
  * CodeIgniter URL Helpers
- *
- * @package CodeIgniter
  */
 
 if (! function_exists('site_url'))

--- a/system/Helpers/xml_helper.php
+++ b/system/Helpers/xml_helper.php
@@ -11,8 +11,6 @@
 
 /**
  * CodeIgniter XML Helpers
- *
- * @package CodeIgniter
  */
 
 if (! function_exists('xml_convert'))

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -28,8 +28,6 @@ use Locale;
  *
  * Requires the intl PHP extension.
  *
- * @package CodeIgniter\I18n
- *
  * @property string $date
  */
 class Time extends DateTime

--- a/system/I18n/TimeDifference.php
+++ b/system/I18n/TimeDifference.php
@@ -16,8 +16,6 @@ use IntlCalendar;
 
 /**
  * Class TimeDifference
- *
- * @package CodeIgniter\I18n
  */
 class TimeDifference
 {

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -26,8 +26,6 @@ use Imagick;
  * hmm - the width & height accessors at the end use the imagick extension.
  *
  * FIXME - This needs conversion & unit testing, to use the imagick extension
- *
- * @package CodeIgniter\Images\Handlers
  */
 class ImageMagickHandler extends BaseHandler
 {

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -18,8 +18,6 @@ use MessageFormatter;
  * Handle system messages and localization.
  *
  * Locale-based, built on top of PHP internationalization.
- *
- * @package CodeIgniter\Language
  */
 class Language
 {

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -21,8 +21,6 @@ use Config\Services;
  * Requires the ChromeLogger extension installed in your browser.
  *
  * @see https://craig.is/writing/chrome-logger
- *
- * @package CodeIgniter\Log\Handlers
  */
 class ChromeLoggerHandler extends BaseHandler implements HandlerInterface
 {

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -28,8 +28,6 @@ use Throwable;
  * The context array can contain arbitrary data, the only assumption that
  * can be made by implementors is that if an Exception instance is given
  * to produce a stack trace, it MUST be in a key named "exception".
- *
- * @package CodeIgniter\Log
  */
 class Logger implements LoggerInterface
 {

--- a/system/Modules/Modules.php
+++ b/system/Modules/Modules.php
@@ -14,9 +14,7 @@ namespace CodeIgniter\Modules;
 /**
  * Modules Class
  *
- * @package CodeIgniter\Modules
- * @author  EllisLab Dev Team
- * @link    https://codeigniter.com/user_guide/general/modules.html
+ * @link https://codeigniter.com/user_guide/general/modules.html
  */
 class Modules
 {

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -23,8 +23,6 @@ use Config\Pager as PagerConfig;
  * pagination links and reading the current url's query variable, "page"
  * to determine the current page. This class can support multiple
  * paginations on a single page.
- *
- * @package CodeIgniter\Pager
  */
 class Pager implements PagerInterface
 {

--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -17,8 +17,6 @@ namespace CodeIgniter\Pager;
  * This class is passed to the view that describes the pagination,
  * and is used to get the link information and provide utility
  * methods needed to work with pagination.
- *
- * @package CodeIgniter\Pager
  */
 class PagerRenderer
 {

--- a/system/RESTful/ResourceController.php
+++ b/system/RESTful/ResourceController.php
@@ -20,8 +20,6 @@ use Psr\Log\LoggerInterface;
 
 /**
  * An extendable controller to provide a RESTful API for a resource.
- *
- * @package CodeIgniter\RESTful
  */
 class ResourceController extends Controller
 {

--- a/system/RESTful/ResourcePresenter.php
+++ b/system/RESTful/ResourcePresenter.php
@@ -19,20 +19,16 @@ use Psr\Log\LoggerInterface;
 
 /**
  * An extendable controller to help provide a UI for a resource.
- *
- * @package CodeIgniter\RESTful
  */
 class ResourcePresenter extends Controller
 {
 
 	/**
-	 *
 	 * @var string|null Name of the model class managing this resource's data
 	 */
 	protected $modelName;
 
 	/**
-	 *
 	 * @var Model|null the model holding this resource's data
 	 */
 	protected $model;

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -22,8 +22,6 @@ use Config\Services;
  * Class RouteCollection
  *
  * @todo Implement nested resource routing (See CakePHP)
- *
- * @package CodeIgniter\Router
  */
 class RouteCollection implements RouteCollectionInterface
 {

--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -22,8 +22,6 @@ use Closure;
  *
  * The RouteCollection provides the Router with the routes so that it can determine
  * which controller should be ran.
- *
- * @package CodeIgniter\Router
  */
 interface RouteCollectionInterface
 {

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -18,8 +18,6 @@ use CodeIgniter\Router\RouteCollection;
  *
  * Provides a base class with the trait for doing full HTTP testing
  * against your application.
- *
- * @package CodeIgniter\Test
  */
 class FeatureTestCase extends CIDatabaseTestCase
 {

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -27,8 +27,6 @@ use ReflectionException;
  *
  * Provides additional utilities for doing full HTTP testing
  * against your application in trait format.
- *
- * @package CodeIgniter\Test
  */
 trait FeatureTestTrait
 {

--- a/system/Test/Mock/MockEvents.php
+++ b/system/Test/Mock/MockEvents.php
@@ -11,42 +11,6 @@
 
 namespace CodeIgniter\Test\Mock;
 
-/**
- * CodeIgniter
- *
- * An open source application development framework for PHP
- *
- * This content is released under the MIT License (MIT)
- *
- * Copyright (c) 2014-2018 British Columbia Institute of Technology
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- * @package    CodeIgniter
- * @author     CodeIgniter Dev Team
- * @copyright  2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
- * @license    https://opensource.org/licenses/MIT	MIT License
- * @link       https://codeigniter.com
- * @since      Version 4.0.0
- * @filesource
- */
-
 use CodeIgniter\Events\Events;
 
 /**

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -24,8 +24,6 @@ use CodeIgniter\Cache\CacheInterface;
  * for the purposes of this implementation.
  *
  * @see https://en.wikipedia.org/wiki/Token_bucket
- *
- * @package CodeIgniter\Throttle
  */
 class Throttler implements ThrottlerInterface
 {

--- a/system/Validation/CreditCardRules.php
+++ b/system/Validation/CreditCardRules.php
@@ -17,8 +17,6 @@ namespace CodeIgniter\Validation;
  * Provides validation methods for common credit-card inputs.
  *
  * @see http://en.wikipedia.org/wiki/Credit_card_number
- *
- * @package CodeIgniter\Validation
  */
 class CreditCardRules
 {

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -15,8 +15,6 @@ use DateTime;
 
 /**
  * Format validation Rules.
- *
- * @package CodeIgniter\Validation
  */
 class FormatRules
 {

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -15,8 +15,6 @@ use Config\Database;
 
 /**
  * Validation Rules.
- *
- * @package CodeIgniter\Validation
  */
 class Rules
 {

--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -41,8 +41,6 @@ use ReflectionMethod;
  *         class Class {
  *             function method(array $params=null)
  *         }
- *
- * @package CodeIgniter\View
  */
 class Cell
 {

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -20,8 +20,6 @@ use Psr\Log\LoggerInterface;
  * Class Parser
  *
  *  ClassFormerlyKnownAsTemplateParser
- *
- * @package CodeIgniter\View
  */
 class Parser extends View
 {

--- a/system/View/RendererInterface.php
+++ b/system/View/RendererInterface.php
@@ -15,8 +15,6 @@ namespace CodeIgniter\View;
  * Interface RendererInterface
  *
  * The interface used for displaying Views and/or theme files.
- *
- * @package CodeIgniter\View
  */
 interface RendererInterface
 {

--- a/system/View/Table.php
+++ b/system/View/Table.php
@@ -17,11 +17,6 @@ use CodeIgniter\Database\BaseResult;
  * HTML Table Generating Class
  *
  * Lets you create tables manually or from database result objects, or arrays.
- *
- * @package    CodeIgniter
- * @subpackage Libraries
- * @category   HTML Tables
- * @author     EllisLab Dev Team
  */
 class Table
 {

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -22,8 +22,6 @@ use RuntimeException;
 
 /**
  * Class View
- *
- * @package CodeIgniter\View
  */
 class View implements RendererInterface
 {
@@ -431,8 +429,6 @@ class View implements RendererInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 *
-	 *
 	 * @throws RuntimeException
 	 */
 	public function endSection()


### PR DESCRIPTION
**Description**
This PR removes unnecessary `@package` tags ported from earlier CI versions.

According to the [PHPDoc website](https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/package.html#package):

> The @package tag can be used as a counterpart or supplement to Namespaces. Namespaces provide a functional subdivision of Structural Elements where the @package tag can provide a logical subdivision in which way the elements can be grouped with a different hierarchy.
>
> **If, across the board, both logical and functional subdivisions are equal is it NOT RECOMMENDED to use the @package tag to prevent maintenance overhead.**

In earlier CI versions the package tags were used as in place replacement for namespaces. Since CI4 is actively using namespaces, then usage of package tags is no longer necessary.

This PR also removes other superfluous tags ported from earlier CI versions.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
