### PR TITLE
[4.1] Remove Skip UnderscoreToCamelCaseVariableNameRector for Autoloader.php file

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -28,13 +28,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
 	// auto import fully qualified class names
 	$parameters->set(Option::AUTO_IMPORT_NAMES, true);
-
-	$parameters->set(Option::SKIP, [
-		// skipped for UnderscoreToCamelCaseVariableNameRector rule
-		// as the underscored variable removed in 4.1 branch
-		UnderscoreToCamelCaseVariableNameRector::class => [__DIR__ . '/system/Autoloader/Autoloader.php'],
-	]);
-
 	$parameters->set(Option::ENABLE_CACHE, true);
 
 	$services = $containerConfigurator->services();


### PR DESCRIPTION
Previously, in `develop`, it skipped due conflict with deprecated code. In 4.1, deprecated code is removed.

**Checklist:**
- [x] Securely signed commits
