### PR TITLE
Standardize types casting

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -783,7 +783,7 @@ class CLI
 			$thisStep   = abs($thisStep);
 			$totalSteps = $totalSteps < 1 ? 1 : $totalSteps;
 
-			$percent = intval(($thisStep / $totalSteps) * 100);
+			$percent = (int) (($thisStep / $totalSteps) * 100);
 			$step    = (int) round($percent / 10);
 
 			// Write the progress bar

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -461,7 +461,7 @@ class CodeIgniter
 
 		// Save our current URI as the previous URI in the session
 		// for safer, more accurate use with `previous_url()` helper function.
-		$this->storePreviousURL((string)current_url(true));
+		$this->storePreviousURL((string) current_url(true));
 
 		unset($uri);
 

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -333,7 +333,7 @@ class Forge
 	{
 		if ($primary === true)
 		{
-			foreach ((array)$key as $one)
+			foreach ((array) $key as $one)
 			{
 				$this->primaryKeys[] = $one;
 			}
@@ -981,7 +981,7 @@ class Forge
 				}
 				elseif (isset($attributes['FIRST']))
 				{
-					$field['first'] = (bool)$attributes['FIRST'];
+					$field['first'] = (bool) $attributes['FIRST'];
 				}
 			}
 
@@ -1235,7 +1235,7 @@ class Forge
 
 		for ($i = 0, $c = count($this->keys); $i < $c; $i++)
 		{
-			$this->keys[$i] = (array)$this->keys[$i];
+			$this->keys[$i] = (array) $this->keys[$i];
 
 			for ($i2 = 0, $c2 = count($this->keys[$i]); $i2 < $c2; $i2++)
 			{

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -867,7 +867,7 @@ class MigrationRunner
 			? end($batch)->batch
 			: 0;
 
-		return (int)$batch;
+		return (int) $batch;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -474,7 +474,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 
 			$retVal[$i]->nullable    = $query[$i]->Null === 'YES';
 			$retVal[$i]->default     = $query[$i]->Default;
-			$retVal[$i]->primary_key = (int)($query[$i]->Key === 'PRI');
+			$retVal[$i]->primary_key = (int) ($query[$i]->Key === 'PRI');
 		}
 
 		return $retVal;

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -304,8 +304,8 @@ class Connection extends BaseConnection implements ConnectionInterface
 			$retVal[$i]->type        = $query[$i]->type;
 			$retVal[$i]->max_length  = null;
 			$retVal[$i]->default     = $query[$i]->dflt_value;
-			$retVal[$i]->primary_key = isset($query[$i]->pk) && (bool)$query[$i]->pk;
-			$retVal[$i]->nullable    = isset($query[$i]->notnull) && ! (bool)$query[$i]->notnull;
+			$retVal[$i]->primary_key = isset($query[$i]->pk) && (bool) $query[$i]->pk;
+			$retVal[$i]->nullable    = isset($query[$i]->notnull) && ! (bool) $query[$i]->notnull;
 		}
 
 		return $retVal;
@@ -499,7 +499,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	 */
 	public function isWriteType($sql): bool
 	{
-		return (bool)preg_match(
+		return (bool) preg_match(
 			'/^\s*"?(SET|INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|TRUNCATE|LOAD|COPY|ALTER|RENAME|GRANT|REVOKE|LOCK|UNLOCK|REINDEX)\s/i',
 			$sql);
 	}
@@ -516,7 +516,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 	{
 		$result = $this->simpleQuery('PRAGMA foreign_keys');
 
-		return (bool)$result;
+		return (bool) $result;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -192,7 +192,7 @@ class Forge extends \CodeIgniter\Database\Forge
 
 		for ($i = 0, $c = count($this->keys); $i < $c; $i++)
 		{
-			$this->keys[$i] = (array)$this->keys[$i];
+			$this->keys[$i] = (array) $this->keys[$i];
 
 			for ($i2 = 0, $c2 = count($this->keys[$i]); $i2 < $c2; $i2++)
 			{

--- a/system/Debug/Toolbar/Collectors/History.php
+++ b/system/Debug/Toolbar/Collectors/History.php
@@ -86,7 +86,7 @@ class History extends BaseCollector
 			if (json_last_error() === JSON_ERROR_NONE)
 			{
 				preg_match_all('/\d+/', $filename, $time);
-				$time = (int)end($time[0]);
+				$time = (int) end($time[0]);
 
 				// Debugbar files shown in History Collector
 				$files[] = [

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -434,7 +434,7 @@ class DownloadResponse extends Message implements ResponseInterface
 		$this->setHeader('Content-Disposition', $this->getContentDisposition());
 		$this->setHeader('Expires-Disposition', '0');
 		$this->setHeader('Content-Transfer-Encoding', 'binary');
-		$this->setHeader('Content-Length', (string)$this->getContentLength());
+		$this->setHeader('Content-Length', (string) $this->getContentLength());
 		$this->noCache();
 	}
 

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -50,7 +50,7 @@ if (! function_exists('_array_search_dot'))
 			? array_shift($indexes)
 			: null;
 
-		if ((empty($currentIndex)  && intval($currentIndex) !== 0) || (! isset($array[$currentIndex]) && $currentIndex !== '*'))
+		if ((empty($currentIndex) && (int) $currentIndex !== 0) || (! isset($array[$currentIndex]) && $currentIndex !== '*'))
 		{
 			return null;
 		}

--- a/system/Helpers/inflector_helper.php
+++ b/system/Helpers/inflector_helper.php
@@ -27,7 +27,7 @@ if (! function_exists('singular'))
 	 */
 	function singular(string $string): string
 	{
-		$result = strval($string);
+		$result = $string;
 
 		if (! is_pluralizable($result))
 		{
@@ -94,7 +94,7 @@ if (! function_exists('plural'))
 	 */
 	function plural(string $string): string
 	{
-		$result = strval($string);
+		$result = $string;
 
 		if (! is_pluralizable($result))
 		{

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -667,6 +667,6 @@ if (! function_exists('url_is'))
 		$path        = '/' . trim(str_replace('*', '(\S)*', $path), '/ ');
 		$currentPath = '/' . trim(uri_string(true), '/ ');
 
-		return (bool)preg_match("|^{$path}$|", $currentPath, $matches);
+		return (bool) preg_match("|^{$path}$|", $currentPath, $matches);
 	}
 }

--- a/system/I18n/TimeDifference.php
+++ b/system/I18n/TimeDifference.php
@@ -162,7 +162,7 @@ class TimeDifference
 		}
 
 		$time = clone($this->currentTime);
-		return (int)($time->fieldDifference($this->testTime, IntlCalendar::FIELD_DAY_OF_YEAR) / 7);
+		return (int) ($time->fieldDifference($this->testTime, IntlCalendar::FIELD_DAY_OF_YEAR) / 7);
 	}
 
 	/**

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -186,8 +186,9 @@ class Pager implements PagerInterface
 			$page = $this->groups[$group]['currentPage'];
 		}
 
-		$perPage                             = $perPage ?? $this->config->perPage;
-		$pageCount                           = (int)ceil($total / $perPage);
+		$perPage   = $perPage ?? $this->config->perPage;
+		$pageCount = (int) ceil($total / $perPage);
+
 		$this->groups[$group]['currentPage'] = $page > $pageCount ? $pageCount : $page;
 		$this->groups[$group]['perPage']     = $perPage;
 		$this->groups[$group]['total']       = $total;
@@ -314,7 +315,7 @@ class Pager implements PagerInterface
 			return null;
 		}
 
-		return (int)ceil($this->groups[$group]['total'] / $this->groups[$group]['perPage']);
+		return (int) ceil($this->groups[$group]['total'] / $this->groups[$group]['perPage']);
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -377,13 +377,13 @@ class FileHandler extends BaseHandler implements SessionHandlerInterface
 	 */
 	protected function configureSessionIDRegex()
 	{
-		$bitsPerCharacter = (int)ini_get('session.sid_bits_per_character');
-		$SIDLength        = (int)ini_get('session.sid_length');
+		$bitsPerCharacter = (int) ini_get('session.sid_bits_per_character');
+		$SIDLength        = (int) ini_get('session.sid_length');
 
 		if (($bits = $SIDLength * $bitsPerCharacter) < 160)
 		{
 			// Add as many more characters as necessary to reach at least 160 bits
-			$SIDLength += (int)ceil((160 % $bits) / $bitsPerCharacter);
+			$SIDLength += (int) ceil((160 % $bits) / $bitsPerCharacter);
 			ini_set('session.sid_length', (string) $SIDLength);
 		}
 

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -126,7 +126,7 @@ class DOMParser
 
 		$result = $this->doXPath($search, $element);
 
-		return (bool)$result->length;
+		return (bool) $result->length;
 	}
 
 	/**
@@ -193,7 +193,7 @@ class DOMParser
 	{
 		$result = $this->doXPath(null, 'input', ["[@value=\"{$value}\"][@name=\"{$field}\"]"]);
 
-		return (bool)$result->length;
+		return (bool) $result->length;
 	}
 
 	/**
@@ -210,7 +210,7 @@ class DOMParser
 			'[@checked="checked"]',
 		]);
 
-		return (bool)$result->length;
+		return (bool) $result->length;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Validation/CreditCardRules.php
+++ b/system/Validation/CreditCardRules.php
@@ -263,7 +263,7 @@ class CreditCardRules
 	 */
 	protected function isValidLuhn(string $number = null): bool
 	{
-		settype($number, 'string');
+		$number = (string) $number;
 
 		$sumTable = [
 			[

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -70,7 +70,7 @@ class Rules
 		$val = explode(',', $val);
 		foreach ($val as $tmp)
 		{
-			if (is_numeric($tmp) && (int)$tmp === mb_strlen($str))
+			if (is_numeric($tmp) && (int) $tmp === mb_strlen($str))
 			{
 				return true;
 			}

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -357,7 +357,7 @@ class Parser extends View
 				// Otherwise, cast as an array and it will grab public properties.
 				elseif (is_object($row))
 				{
-					$row = (array)$row;
+					$row = (array) $row;
 				}
 
 				$temp  = [];
@@ -831,7 +831,7 @@ class Parser extends View
 		// Otherwise, cast as an array and it will grab public properties.
 		elseif (is_object($value))
 		{
-			$value = (array)$value;
+			$value = (array) $value;
 		}
 
 		return $value;


### PR DESCRIPTION
**Description**
Standardizes typecasting
- Cast and casted variable should have one space in between
- Use cast instead of cast functions (intval, strval, etc.) or settype
- Remove unnecessary casting

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
