### PR TITLE
Parser: Allow dashes and parentheses in parser plugin information

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -721,9 +721,7 @@ class Parser extends View
 
 	/**
 	 * Scans the template for any parser plugins, and attempts to execute them.
-	 * Plugins are notated based on {+ +} opening and closing braces.
-	 *
-	 * When encountered,
+	 * Plugins are delimited by {+ ... +}
 	 *
 	 * @param string $template
 	 *
@@ -737,7 +735,10 @@ class Parser extends View
 			$isPair   = is_array($callable);
 			$callable = $isPair ? array_shift($callable) : $callable;
 
-			$pattern = $isPair ? '#{\+\s*' . $plugin . '([\w\d=-_:\+\s()/\"@.]*)?\s*\+}(.+?){\+\s*/' . $plugin . '\s*\+}#ims' : '#{\+\s*' . $plugin . '([\w\d=-_:\+\s()/\"@.]*)?\s*\+}#ims';
+			// See https://regex101.com/r/BCBBKB/1
+			$pattern = $isPair
+				? '#\{\+\s*' . $plugin . '([\w=\-_:\+\s\(\)/"@.]*)?\s*\+\}(.+?)\{\+\s*/' . $plugin . '\s*\+\}#ims'
+				: '#\{\+\s*' . $plugin . '([\w=\-_:\+\s\(\)/"@.]*)?\s*\+\}#ims';
 
 			/**
 			 * Match tag pairs
@@ -747,9 +748,7 @@ class Parser extends View
 			 *   $matches[1] = all parameters string in opening tag
 			 *   $matches[2] = content between the tags to send to the plugin.
 			 */
-			preg_match_all($pattern, $template, $matches, PREG_SET_ORDER);
-
-			if (empty($matches))
+			if (! preg_match_all($pattern, $template, $matches, PREG_SET_ORDER))
 			{
 				continue;
 			}
@@ -759,9 +758,11 @@ class Parser extends View
 				$params = [];
 
 				preg_match_all('/([\w-]+=\"[^"]+\")|([\w-]+=[^\"\s=]+)|(\"[^"]+\")|(\S+)/', trim($match[1]), $matchesParams);
+
 				foreach ($matchesParams[0] as $item)
 				{
 					$keyVal = explode('=', $item);
+
 					if (count($keyVal) === 2)
 					{
 						$params[$keyVal[0]] = str_replace('"', '', $keyVal[1]);
@@ -772,7 +773,9 @@ class Parser extends View
 					}
 				}
 
-				$template = $isPair ? str_replace($match[0], $callable($match[2], $params), $template) : str_replace($match[0], $callable($params), $template);
+				$template = $isPair
+					? str_replace($match[0], $callable($match[2], $params), $template)
+					: str_replace($match[0], $callable($params), $template);
 			}
 		}
 

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -48,6 +48,17 @@ class ParserPluginTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(mailto('foo@example.com', 'Silly'), $this->parser->renderString($template));
 	}
 
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/3523
+	 */
+	public function testMailtoWithDashAndParenthesis()
+	{
+		helper('url');
+		$template = '{+ mailto email=foo-bar@example.com title="Scilly (the Great)" +}';
+
+		$this->assertSame(mailto('foo-bar@example.com', 'Scilly (the Great)'), $this->parser->renderString($template));
+	}
+
 	public function testSafeMailto()
 	{
 		helper('url');


### PR DESCRIPTION
**Description**
Fixes #3523 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
