### PR TITLE
Dynamically fill arguments for single service

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -1036,7 +1036,6 @@ if (! function_exists('service'))
 if (! function_exists('single_service'))
 {
 	/**
-	 * Allow cleaner access to a Service.
 	 * Always returns a new instance of the class.
 	 *
 	 * @param string     $name
@@ -1046,10 +1045,36 @@ if (! function_exists('single_service'))
 	 */
 	function single_service(string $name, ...$params)
 	{
-		// Ensure it's NOT a shared instance
-		array_push($params, false);
+		$service = Services::serviceExists($name);
 
-		return Services::$name(...$params);
+		if ($service === null)
+		{
+			// The service is not defined anywhere so just return.
+			return null;
+		}
+
+		$method = new ReflectionMethod($service, $name);
+		$count  = $method->getNumberOfParameters();
+		$mParam = $method->getParameters();
+		$params = $params ?? [];
+
+		if ($count === 1)
+		{
+			// This service needs only one argument, which is the shared
+			// instance flag, so let's wrap up and pass false here.
+			return $service::$name(false);
+		}
+
+		// Fill in the params with the defaults, but stop before the last
+		for ($startIndex = count($params); $startIndex <= $count - 2; $startIndex++)
+		{
+			$params[$startIndex] = $mParam[$startIndex]->getDefaultValue();
+		}
+
+		// Ensure the last argument will not create a shared instance
+		$params[$count - 1] = false;
+
+		return $service::$name(...$params);
 	}
 }
 

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -7,6 +7,7 @@ use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Router\RouteCollection;
 use CodeIgniter\Session\Handlers\FileHandler;
+use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockIncomingRequest;
 use CodeIgniter\Test\Mock\MockSession;
 use CodeIgniter\Test\TestLogger;
@@ -18,11 +19,8 @@ use Tests\Support\Models\JobModel;
 /**
  * @backupGlobals enabled
  */
-class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
+class CommonFunctionsTest extends CIUnitTestCase
 {
-
-	//--------------------------------------------------------------------
-
 	protected function setUp(): void
 	{
 		parent::setUp();
@@ -30,8 +28,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$renderer->resetData();
 		unset($_ENV['foo'], $_SERVER['foo']);
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testStringifyAttributes()
 	{
@@ -50,8 +46,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('', stringify_attributes([]));
 	}
 
-	// ------------------------------------------------------------------------
-
 	public function testStringifyJsAttributes()
 	{
 		$this->assertEquals('width=800,height=600', stringify_attributes(['width' => '800', 'height' => '600'], true));
@@ -61,8 +55,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$atts->height = 600;
 		$this->assertEquals('width=800,height=600', stringify_attributes($atts, true));
 	}
-
-	// ------------------------------------------------------------------------
 
 	public function testEnvReturnsDefault()
 	{
@@ -96,8 +88,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertNull(env('p4'));
 	}
 
-	// ------------------------------------------------------------------------
-
 	public function testRedirectReturnsRedirectResponse()
 	{
 		$_SERVER['REQUEST_METHOD'] = 'GET';
@@ -122,8 +112,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertInstanceOf(\CodeIgniter\HTTP\RedirectResponse::class, redirect());
 	}
 
-	// ------------------------------------------------------------------------
-
 	public function testView()
 	{
 		$data     = [
@@ -145,15 +133,11 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertStringContainsString($expected, view('\Tests\Support\View\Views\simple'));
 	}
 
-	// ------------------------------------------------------------------------
-
 	public function testViewCell()
 	{
 		$expected = 'Hello';
 		$this->assertEquals($expected, view_cell('\Tests\Support\View\SampleClass::hello'));
 	}
-
-	// ------------------------------------------------------------------------
 
 	public function testEscapeWithDifferentEncodings()
 	{
@@ -162,15 +146,11 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('&lt;x', esc('<x', 'html', 'windows-1251'));
 	}
 
-	// ------------------------------------------------------------------------
-
 	public function testEscapeBadContext()
 	{
 		$this->expectException(InvalidArgumentException::class);
 		esc(['width' => '800', 'height' => '600'], 'bogus');
 	}
-
-	// ------------------------------------------------------------------------
 
 	/**
 	 * @runInSeparateProcess
@@ -208,17 +188,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(null, session('notbogus'));
 	}
 
-	// ------------------------------------------------------------------------
-
-	public function testSingleService()
-	{
-		$timer1 = single_service('timer');
-		$timer2 = single_service('timer');
-		$this->assertFalse($timer1 === $timer2);
-	}
-
-	// ------------------------------------------------------------------------
-
 	public function testRouteTo()
 	{
 		// prime the pump
@@ -227,8 +196,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$this->assertEquals('/path/string/to/13', route_to('myController::goto', 'string', 13));
 	}
-
-	// ------------------------------------------------------------------------
 
 	public function testInvisible()
 	{
@@ -240,14 +207,10 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('Javascript', remove_invisible_characters('Java%0cscript', true));
 	}
 
-	// ------------------------------------------------------------------------
-
 	public function testAppTimezone()
 	{
 		$this->assertEquals('America/Chicago', app_timezone());
 	}
-
-	// ------------------------------------------------------------------------
 
 	public function testCSRFToken()
 	{
@@ -274,8 +237,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertStringContainsString('<meta name="X-CSRF-TOKEN" ', csrf_meta());
 	}
 
-	// ------------------------------------------------------------------------
-
 	public function testModelNotExists()
 	{
 		$this->assertNull(model(UnexsistenceClass::class));
@@ -295,8 +256,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 	{
 		$this->assertInstanceOf(JobModel::class, model('\Tests\Support\Models\JobModel'));
 	}
-
-	// ------------------------------------------------------------------------
 
 	/**
 	 * @runInSeparateProcess
@@ -370,15 +329,11 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($locations, old('location'));
 	}
 
-	// ------------------------------------------------------------------------
-
 	public function testReallyWritable()
 	{
 		// cannot test fully on *nix
 		$this->assertTrue(is_really_writable(WRITEPATH));
 	}
-
-	// ------------------------------------------------------------------------
 
 	public function testSlashItem()
 	{
@@ -415,7 +370,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		\CodeIgniter\Config\BaseService::injectMock('session', $session);
 	}
 
-	//--------------------------------------------------------------------
 	// Make sure cookies are set by RedirectResponse this way
 	// See https://github.com/codeigniter4/CodeIgniter4/issues/1393
 	public function testRedirectResponseCookies1()
@@ -434,8 +388,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertTrue($answer1->hasCookie('foo', 'onething'));
 		$this->assertTrue($answer1->hasCookie('login_time'));
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testTrace()
 	{
@@ -456,8 +408,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertStringContainsString('<h1>is_not</h1>', view('\Tests\Support\View\Views\simples'));
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState  disabled
@@ -470,8 +420,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$this->assertEquals('https://example.com/', Services::response()->getHeader('Location')->getValue());
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * @dataProvider dirtyPathsProvider
@@ -508,8 +456,6 @@ class CommonFunctionsTest extends \CodeIgniter\Test\CIUnitTestCase
 			],
 		];
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testHelperWithFatalLocatorThrowsException()
 	{

--- a/tests/system/CommonSingleServiceTest.php
+++ b/tests/system/CommonSingleServiceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use CodeIgniter\Config\Services;
+use CodeIgniter\Test\CIUnitTestCase;
+
+final class CommonSingleServiceTest extends CIUnitTestCase
+{
+	/**
+	 * @dataProvider serviceNamesProvider
+	 *
+	 * @param string $service
+	 *
+	 * @return void
+	 */
+	public function testSingleServiceWithNoParamsSupplied(string $service): void
+	{
+		$service1 = single_service($service);
+		$service2 = single_service($service);
+
+		$this->assertSame(get_class($service1), get_class($service2));
+		$this->assertNotSame($service1, $service2);
+	}
+
+	/**
+	 * @dataProvider serviceNamesProvider
+	 *
+	 * @param string $service
+	 *
+	 * @return void
+	 */
+	public function testSingleServiceWithAtLeastOneParamSupplied(string $service): void
+	{
+		$params = [];
+		$method = new ReflectionMethod(Services::class, $service);
+
+		if ($method->getNumberOfParameters() === 1)
+		{
+			$params[] = true;
+		}
+		else
+		{
+			$params[] = $method->getParameters()[0]->getDefaultValue();
+		}
+
+		$service1 = single_service($service, ...$params);
+		$service2 = single_service($service, ...$params);
+
+		$this->assertSame(get_class($service1), get_class($service2));
+		$this->assertNotSame($service1, $service2);
+	}
+
+	public function testSingleServiceWithAllParamsSupplied(): void
+	{
+		$cache1 = single_service('cache', null, true);
+		$cache2 = single_service('cache', null, true);
+
+		// Assert that even passing true as last param this will
+		// not create a shared instance.
+		$this->assertSame(get_class($cache1), get_class($cache2));
+		$this->assertNotSame($cache1, $cache2);
+	}
+
+	public function testSingleServiceWithGibberishGiven(): void
+	{
+		$this->assertNull(single_service('foo'));
+		$this->assertNull(single_service('bar'));
+		$this->assertNull(single_service('baz'));
+		$this->assertNull(single_service('caches'));
+		$this->assertNull(single_service('timers'));
+	}
+
+	public static function serviceNamesProvider(): iterable
+	{
+		$methods = (new ReflectionClass(Services::class))->getMethods(ReflectionMethod::IS_PUBLIC);
+
+		foreach ($methods as $method)
+		{
+			$name = $method->getName();
+			$excl = [
+				'__callStatic',
+				'serviceExists',
+				'reset',
+				'injectMock',
+				'encrypter', // Encrypter needs a starter key
+				'session', // Headers already sent
+			];
+
+			if (in_array($name, $excl, true))
+			{
+				continue;
+			}
+
+			yield [$name];
+		}
+	}
+}

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -8,7 +8,6 @@ use CodeIgniter\Test\Mock\MockResponse;
 
 class ServicesTest extends CIUnitTestCase
 {
-
 	protected $config;
 	protected $original;
 
@@ -17,15 +16,13 @@ class ServicesTest extends CIUnitTestCase
 		parent::setUp();
 
 		$this->original = $_SERVER;
-		//      $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'es; q=1.0, en; q=0.5';
-		$this->config = new App();
-		//      $this->config->negotiateLocale = true;
-		//      $this->config->supportedLocales = ['en', 'es'];
+		$this->config   = new App();
 	}
 
 	public function tearDown(): void
 	{
 		$_SERVER = $this->original;
+		Services::reset();
 	}
 
 	public function testNewAutoloader()


### PR DESCRIPTION
**Description**
Fixes #3854 .

This PR deprecates the protected `BaseService::discoverServices()` method and splitting its services discovery function into a new protected `buildServicesCache()`. The resolution of where the service might be defined is now defined in a new public static method `serviceExists()` that takes the name of service as lone argument. This returns an array of `bool $result, ?string $service`.

For the `single_service` function, this takes use of `ReflectionMethod` and `ReflectionParameter` to introspect the signature of the method requested and fills up the `$params` by the default values but also ensures that the last argument is always `false` to ensure no shared instance.

@sfadschm, please stress test this solution to find any possible regressions.

So far, the tests checks the function when:
- the service is not defined
- the params are not provided
- at least one param is given
- all possible params are provided, with the last set to `true`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
