### PR TITLE
DX: Use composer update

### DIFF
--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -63,7 +63,7 @@ jobs:
           restore-keys: ${{ runner.os }}-phpstan-
 
       - name: Install dependencies
-        run: composer install --ansi --no-progress --no-suggest --no-interaction
+        run: composer update --ansi --no-interaction
 
       - name: Run static analysis
         run: vendor/bin/phpstan analyse

--- a/.github/workflows/test-rector.yml
+++ b/.github/workflows/test-rector.yml
@@ -57,7 +57,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: composer install --ansi --no-progress --no-suggest --no-interaction
+        run: composer update --ansi --no-interaction
 
       - name: Run static analysis
         run: vendor/bin/rector process --dry-run


### PR DESCRIPTION
**Description**
As of Composer v2, `composer update` is preferred over `composer install` if installing from without a lock file. Also removes deprecated option.

**Checklist:**
- [x] Securely signed commits
