### PR TITLE
4.1: Change deprecated assertFileNotExists

### DIFF
--- a/tests/system/Commands/ClearDebugbarTest.php
+++ b/tests/system/Commands/ClearDebugbarTest.php
@@ -43,7 +43,7 @@ class ClearDebugbarTest extends CIUnitTestCase
 	public function testClearDebugbarWorks()
 	{
 		// test clean debugbar dir
-		$this->assertFileNotExists(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . "debugbar_{$this->time}.json");
+		$this->assertFileDoesNotExist(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . "debugbar_{$this->time}.json");
 
 		// test dir is now populated with json
 		$this->createDummyDebugbarJson();
@@ -52,7 +52,7 @@ class ClearDebugbarTest extends CIUnitTestCase
 		command('debugbar:clear');
 		$result = CITestStreamFilter::$buffer;
 
-		$this->assertFileNotExists(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . "debugbar_{$this->time}.json");
+		$this->assertFileDoesNotExist(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . "debugbar_{$this->time}.json");
 		$this->assertFileExists(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . '.gitkeep');
 		$this->assertStringContainsString('Debugbar cleared.', $result);
 	}

--- a/tests/system/Commands/ClearLogsTest.php
+++ b/tests/system/Commands/ClearLogsTest.php
@@ -47,7 +47,7 @@ class ClearLogsTest extends CIUnitTestCase
 	public function testClearLogsWorks()
 	{
 		// test clean logs dir
-		$this->assertFileNotExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
+		$this->assertFileDoesNotExist(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
 
 		// test dir is now populated with logs
 		$this->createDummyLogFiles();
@@ -56,7 +56,7 @@ class ClearLogsTest extends CIUnitTestCase
 		command('logs:clear -force');
 		$result = CITestStreamFilter::$buffer;
 
-		$this->assertFileNotExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
+		$this->assertFileDoesNotExist(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
 		$this->assertFileExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . 'index.html');
 		$this->assertStringContainsString('Logs cleared.', $result);
 	}


### PR DESCRIPTION
**Description**
With PHPUnit 9, `assertFileNotExists` is renamed to `assertFileDoesNotExist`.

**Checklist:**
- [x] Securely signed commits
