### PR TITLE
Add MockFilters for feature testing

### DIFF
--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -17,6 +17,7 @@ use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Router\Exceptions\RedirectException;
+use CodeIgniter\Test\Mock\MockFilters;
 use Config\App;
 use Config\Services;
 use Exception;
@@ -147,8 +148,12 @@ trait FeatureTestTrait
 		// instance get the right one.
 		Services::injectMock('request', $request);
 
-		// Make sure filters are reset between tests
-		Services::injectMock('filters', Services::filters(null, false));
+		// Make sure filters do not output during testing
+		Services::injectMock('filters', new MockFilters(
+			config('Filters'),
+			Services::request(),
+			Services::response()
+		));
 
 		$response = $this->app
 				->setRequest($request)

--- a/system/Test/Mock/MockFilters.php
+++ b/system/Test/Mock/MockFilters.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Test\Mock;
 
 use CodeIgniter\Filters\Filters;
 use CodeIgniter\HTTP\RedirectResponse;
+use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 
 /**
@@ -29,7 +30,6 @@ class MockFilters extends Filters
 	 * @param string $position
 	 *
 	 * @return RequestInterface|ResponseInterface|mixed
-	 * @throws FilterException
 	 */
 	public function run(string $uri, string $position = 'before')
 	{

--- a/system/Test/Mock/MockFilters.php
+++ b/system/Test/Mock/MockFilters.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Test\Mock;
+
+use CodeIgniter\Filters\Filters;
+use CodeIgniter\HTTP\RedirectResponse;
+use CodeIgniter\HTTP\ResponseInterface;
+
+/**
+ * Mock Filters handler to prevent output during
+ * unit testing (especially Feature Tests).
+ */
+class MockFilters extends Filters
+{
+	/**
+	 * Runs through all of the filters for the specified
+	 * uri and position.
+	 *
+	 * @param string $uri
+	 * @param string $position
+	 *
+	 * @return RequestInterface|ResponseInterface|mixed
+	 * @throws FilterException
+	 */
+	public function run(string $uri, string $position = 'before')
+	{
+		$result = parent::run($uri, $position);
+
+		if ($result instanceof ResponseInterface && ! $result instanceof RedirectResponse)
+		{
+			\ob_start();
+		}
+
+		return $result;
+	}
+}


### PR DESCRIPTION
**Description**
Filters can return a `ResponseInterface` directly, which bypasses feature testing's buffer handling and causes CLI output. This PR adds a new `MockFilters` which intercepts responses and starts a new buffer predictively to prevent output (the buffer will be closed shortly after by `FeatureTestTrait`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
