### PR TITLE
HealthTest BaseUrl property being called wrong

### DIFF
--- a/admin/starter/tests/unit/HealthTest.php
+++ b/admin/starter/tests/unit/HealthTest.php
@@ -26,7 +26,7 @@ class HealthTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		// Then check the actual config file
 		$reader = new \Tests\Support\Libraries\ConfigReader();
-		$config = ! empty($reader->baseUrl);
+		$config = ! empty($reader->baseURL);
 
 		$this->assertTrue($env || $config);
 	}


### PR DESCRIPTION
**Description**
Fixed the call to the reader baseURL in HealthTest.php.

**Checklist:**
- [x] Securely signed commits
- [ ] N/A Component(s) with PHPdocs
- [ ] N/A Unit testing, with >80% coverage
- [ ] N/A User guide updated
- [x] Conforms to style guide
