### PR TITLE
Fabricator failure

### DIFF
--- a/system/Exceptions/FrameworkException.php
+++ b/system/Exceptions/FrameworkException.php
@@ -45,4 +45,9 @@ class FrameworkException extends RuntimeException implements ExceptionInterface
 	{
 		return new static(lang('Core.noHandlers', [$class]));
 	}
+
+	public static function forFabricatorCreateFailed(string $table, string $reason)
+	{
+		return new static(lang('Fabricator.createFailed', [$table, $reason]));
+	}
 }

--- a/system/Language/en/Fabricator.php
+++ b/system/Language/en/Fabricator.php
@@ -13,4 +13,5 @@
 return [
    'invalidModel'      => 'Invalid model supplied for fabrication.',
    'missingFormatters' => 'No valid formatters defined.',
+   'createFailed'      => 'Fabricator failed to insert on table {0}: {1}.',
 ];

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -551,9 +551,9 @@ class Fabricator
 			else
 			{
 				throw new FrameworkException(lang('Fabricator.createFailed', [
-													  $this->model->table,
-													  implode(' ', $this->model->errors()),
-												  ]));
+					$this->model->table,
+					implode(' ', $this->model->errors()),
+				]));
 			}
 		}
 

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -547,14 +547,10 @@ class Fabricator
 			{
 				$ids[] = $id;
 				self::upCount($this->model->table);
+				continue;
 			}
-			else
-			{
-				throw new FrameworkException(lang('Fabricator.createFailed', [
-					$this->model->table,
-					implode(' ', $this->model->errors()),
-				]));
-			}
+
+			throw FrameworkException::forFabricatorCreateFailed($this->model->table, implode(' ', $this->model->errors()));
 		}
 
 		// If the model defines a "withDeleted" method for handling soft deletes then use it

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Test;
 
+use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\Model;
 use Faker\Factory;
 use Faker\Generator;
@@ -526,6 +527,8 @@ class Fabricator
 	 * @param boolean      $mock  Whether to execute or mock the insertion
 	 *
 	 * @return array|object  An array or object (based on returnType), or an array of returnTypes
+	 *
+	 * @throws FrameworkException
 	 */
 	public function create(int $count = null, bool $mock = false)
 	{
@@ -544,6 +547,13 @@ class Fabricator
 			{
 				$ids[] = $id;
 				self::upCount($this->model->table);
+			}
+			else
+			{
+				throw new FrameworkException(lang('Fabricator.createFailed', [
+													  $this->model->table,
+													  implode(' ', $this->model->errors()),
+												  ]));
 			}
 		}
 

--- a/tests/system/Database/Live/FabricatorLiveTest.php
+++ b/tests/system/Database/Live/FabricatorLiveTest.php
@@ -1,8 +1,10 @@
 <?php namespace CodeIgniter\Database\Live;
 
+use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\Test\CIDatabaseTestCase;
 use CodeIgniter\Test\Fabricator;
 use Tests\Support\Models\UserModel;
+use Tests\Support\Models\ValidModel;
 
 /**
  * @group DatabaseLive
@@ -65,5 +67,13 @@ class FabricatorLiveTest extends CIDatabaseTestCase
 		fake(UserModel::class, ['country' => 'Italy']);
 
 		$this->assertEquals($count + 1, Fabricator::getCount('user'));
+	}
+
+	public function testCreateThrowsOnFailure()
+	{
+		$this->expectException(FrameworkException::class);
+		$this->expectExceptionMessage(lang('Fabricator.createFailed', ['job', 'Too short, man!']));
+
+		fake(ValidModel::class, ['name' => 'eh']);
 	}
 }

--- a/utils/PHPStan/CheckUseStatementsAfterLicenseRule.php
+++ b/utils/PHPStan/CheckUseStatementsAfterLicenseRule.php
@@ -35,7 +35,7 @@ final class CheckUseStatementsAfterLicenseRule implements Rule
 	{
 		$comments = $node->getAttribute('comments');
 
-		if ($comments === [])
+		if ($comments === [] || ! is_array($comments))
 		{
 			return [];
 		}

--- a/utils/PHPStan/CheckUseStatementsAfterLicenseRule.php
+++ b/utils/PHPStan/CheckUseStatementsAfterLicenseRule.php
@@ -33,9 +33,9 @@ final class CheckUseStatementsAfterLicenseRule implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		$comments = $node->getAttribute('comments');
+		$comments = $node->getComments();
 
-		if ($comments === [] || ! is_array($comments))
+		if ($comments === [])
 		{
 			return [];
 		}


### PR DESCRIPTION
**Description**
Fixes a bug in `Fabricator` where `create()` could fail to insert anything causing `reset($ids)` to be null and `model->find()` would then return all rows. This PR has Fabricator throw a helpfully-descriptive error message when the create call fails.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
