### PR TITLE
Add simple command list format

### DIFF
--- a/system/Commands/ListCommands.php
+++ b/system/Commands/ListCommands.php
@@ -22,7 +22,6 @@ use CodeIgniter\CLI\CLI;
  */
 class ListCommands extends BaseCommand
 {
-
 	/**
 	 * The group the command is lumped under
 	 * when listing commands.
@@ -64,7 +63,9 @@ class ListCommands extends BaseCommand
 	 *
 	 * @var array
 	 */
-	protected $options = [];
+	protected $options = [
+		'--simple' => 'Prints a list of the commands with no other info',
+	];
 
 	//--------------------------------------------------------------------
 
@@ -76,9 +77,21 @@ class ListCommands extends BaseCommand
 	public function run(array $params)
 	{
 		$commands = $this->commands->getCommands();
-
 		ksort($commands);
 
+		// Check for 'simple' format
+		return array_key_exists('simple', $params) || CLI::getOption('simple')
+			? $this->listSimple($commands)
+			: $this->listFull($commands);
+	}
+
+	/**
+	 * Lists the commands with accompanying info.
+	 *
+	 * @param array $commands
+	 */
+	protected function listFull(array $commands)
+	{
 		// Sort into buckets by group
 		$groups = [];
 
@@ -117,6 +130,19 @@ class ListCommands extends BaseCommand
 			{
 				CLI::newLine();
 			}
+		}
+	}
+
+	/**
+	 * Lists the commands only.
+	 *
+	 * @param array $commands
+	 */
+	protected function listSimple(array $commands)
+	{
+		foreach ($commands as $title => $command)
+		{
+			CLI::write($title);
 		}
 	}
 }

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -44,6 +44,14 @@ class CommandTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertStringContainsString('Displays basic usage information.', $this->getBuffer());
 	}
 
+	public function testListCommandsSimple()
+	{
+		command('list --simple');
+
+		$this->assertStringContainsString('db:seed', $this->getBuffer());
+		$this->assertStringNotContainsString('Lists the available commands.', $this->getBuffer());
+	}
+
 	public function testCustomCommand()
 	{
 		command('app:info');

--- a/user_guide_src/source/cli/cli_commands.rst
+++ b/user_guide_src/source/cli/cli_commands.rst
@@ -61,6 +61,9 @@ You can get help about any CLI command using the help command as follows::
 
     > php spark help db:seed
 
+Use the **list** command to get a list of available commands and their descriptions, sorted by categories.
+You may also use ``spark list --simple`` to get a raw list of all available commands, sorted alphabetically.
+
 *********************
 Creating New Commands
 *********************


### PR DESCRIPTION
**Description**
This adds a new command list format "simple" that is a parsable list of commands, e.g.:
```

CodeIgniter v4.0.4 Command Line Tool - Server Time: 2020-11-09 10:42:28 UTC-05:00

cache:clear
cache:info
db:create
db:seed
debugbar:clear
...
```

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [x] User guide updated
- [X] Conforms to style guide
