### PR TITLE
Handle errors() null return

### DIFF
--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -550,7 +550,7 @@ class Fabricator
 				continue;
 			}
 
-			throw FrameworkException::forFabricatorCreateFailed($this->model->table, implode(' ', $this->model->errors()));
+			throw FrameworkException::forFabricatorCreateFailed($this->model->table, implode(' ', $this->model->errors() ?? []));
 		}
 
 		// If the model defines a "withDeleted" method for handling soft deletes then use it


### PR DESCRIPTION
**Description**
An addendum to #3866 where I failed to account for `Model::errors()` returning `null` instead of an empty array.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
