### PR TITLE
Add insertBatch test using timestamp data type

### DIFF
--- a/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
+++ b/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
@@ -1,304 +1,159 @@
-<?php namespace Tests\Support\Database\Migrations;
+<?php
 
-class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
+namespace Tests\Support\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class Migration_Create_test_tables extends Migration
 {
 	public function up()
 	{
 		// User Table
-		$this->forge->addField([
-			'id'         => [
-				'type'           => 'INTEGER',
-				'constraint'     => 3,
-				'auto_increment' => true,
-			],
-			'name'       => [
-				'type'       => 'VARCHAR',
-				'constraint' => 80,
-			],
-			'email'      => [
-				'type'       => 'VARCHAR',
-				'constraint' => 100,
-			],
-			'country'    => [
-				'type'       => 'VARCHAR',
-				'constraint' => 40,
-			],
-			'created_at' => [
-				'type' => 'DATETIME',
-				'null' => true,
-			],
-			'updated_at' => [
-				'type' => 'DATETIME',
-				'null' => true,
-			],
-			'deleted_at' => [
-				'type' => 'DATETIME',
-				'null' => true,
-			],
-		]);
-		$this->forge->addKey('id', true);
-		$this->forge->createTable('user', true);
+		$this->forge
+			->addField([
+				'id'         => ['type' => 'INTEGER', 'constraint' => 3, 'auto_increment' => true],
+				'name'       => ['type' => 'VARCHAR', 'constraint' => 80],
+				'email'      => ['type' => 'VARCHAR', 'constraint' => 100],
+				'country'    => ['type' => 'VARCHAR', 'constraint' => 40],
+				'created_at' => ['type' => 'DATETIME', 'null' => true],
+				'updated_at' => ['type' => 'DATETIME', 'null' => true],
+				'deleted_at' => ['type' => 'DATETIME', 'null' => true],
+			])
+			->addKey('id', true)
+			->createTable('user', true);
 
 		// Job Table
-		$this->forge->addField([
-			'id'          => [
-				'type'           => 'INTEGER',
-				'constraint'     => 3,
-				'auto_increment' => true,
-			],
-			'name'        => [
-				'type'       => 'VARCHAR',
-				'constraint' => 40,
-			],
-			'description' => [
-				'type'       => 'VARCHAR',
-				'constraint' => 400,
-				'null'       => true,
-			],
-			'created_at'  => [
-				'type'       => 'INTEGER',
-				'constraint' => 11,
-				'null'       => true,
-			],
-			'updated_at'  => [
-				'type'       => 'INTEGER',
-				'constraint' => 11,
-				'null'       => true,
-			],
-			'deleted_at'  => [
-				'type'       => 'INTEGER',
-				'constraint' => 11,
-				'null'       => true,
-			],
-		]);
-		$this->forge->addKey('id', true);
-		$this->forge->createTable('job', true);
+		$this->forge
+			->addField([
+				'id'          => ['type' => 'INTEGER', 'constraint' => 3, 'auto_increment' => true],
+				'name'        => ['type' => 'VARCHAR', 'constraint' => 40],
+				'description' => ['type' => 'VARCHAR', 'constraint' => 400, 'null' => true],
+				'created_at'  => ['type' => 'INTEGER', 'constraint' => 11, 'null' => true],
+				'updated_at'  => ['type' => 'INTEGER', 'constraint' => 11, 'null' => true],
+				'deleted_at'  => ['type' => 'INTEGER', 'constraint' => 11, 'null' => true],
+			])
+			->addKey('id', true)
+			->createTable('job', true);
 
 		// Misc Table
-		$this->forge->addField([
-			'id'    => [
-				'type'           => 'INTEGER',
-				'constraint'     => 3,
-				'auto_increment' => true,
-			],
-			'key'   => [
-				'type'       => 'VARCHAR',
-				'constraint' => 40,
-			],
-			'value' => [
-				'type'       => 'VARCHAR',
-				'constraint' => 400,
-				'null'       => true,
-			],
-		]);
-		$this->forge->addKey('id', true);
-		$this->forge->createTable('misc', true);
+		$this->forge
+			->addField([
+				'id'    => ['type' => 'INTEGER', 'constraint' => 3, 'auto_increment' => true],
+				'key'   => ['type' => 'VARCHAR', 'constraint' => 40],
+				'value' => ['type' => 'VARCHAR', 'constraint' => 400, 'null' => true],
+			])
+			->addKey('id', true)
+			->createTable('misc', true);
 
-		//Database Type test table
-		//missing types :
-		//TINYINT,MEDIUMINT,BIT,YEAR,BINARY , VARBINARY, TINYTEXT,LONGTEXT,YEAR,JSON,Spatial data types
-		$data_type_fields = [
-			'id'              => [
-				'type'           => 'INTEGER', //must be interger else SQLite3 error on not null for autoinc field
-				'constraint'     => 20,
-				'auto_increment' => true,
-			],
-			'type_varchar'    => [
-				'type'       => 'VARCHAR',
-				'constraint' => 40,
-				'null'       => true,
-			],
-			'type_char'       => [
-				'type'       => 'CHAR',
-				'constraint' => 10,
-				'null'       => true,
-			],
-			'type_text'       => [
-				'type' => 'TEXT',
-				'null' => true,
-			],
-			'type_smallint'   => [
-				'type' => 'SMALLINT',
-				'null' => true,
-			],
-			'type_integer'    => [
-				'type' => 'INTEGER',
-				'null' => true,
-			],
-			'type_float'      => [
-				'type' => 'FLOAT',
-				'null' => true,
-			],
-			'type_numeric'    => [
-				'type'       => 'NUMERIC',
-				'constraint' => '18,2',
-				'null'       => true,
-			],
-			'type_date'       => [
-				'type' => 'DATE',
-				'null' => true,
-			],
-			'type_time'       => [
-				'type' => 'TIME',
-				'null' => true,
-			],
-			'type_datetime'   => [
-				'type' => 'DATETIME',
-				'null' => true,
-			],
-			'type_timestamp'  => [
-				'type' => 'TIMESTAMP',
-				'null' => true,
-			],
-			'type_bigint'     => [
-				'type' => 'BIGINT',
-				'null' => true,
-			],
-			'type_real'       => [
-				'type' => 'REAL',
-				'null' => true,
-			],
-			'type_enum'       => [
-				'type'       => 'ENUM',
-				'constraint' => [
-					'appel',
-					'pears',
-					'bananas',
-				],
-				'null'       => true,
-			],
-			'type_set'        => [
-				'type'       => 'SET',
-				'constraint' => [
-					'one',
-					'two',
-				],
-				'null'       => true,
-			],
-			'type_mediumtext' => [
-				'type' => 'MEDIUMTEXT',
-				'null' => true,
-			],
-			'type_double'     => [
-				'type' => 'DOUBLE',
-				'null' => true,
-			],
-			'type_decimal'    => [
-				'type'       => 'DECIMAL',
-				'constraint' => '18,4',
-				'null'       => true,
-			],
-			'type_blob'       => [
-				'type' => 'BLOB',
-				'null' => true,
-			],
-
+		// Database Type test table
+		// missing types :
+		// TINYINT,MEDIUMINT,BIT,YEAR,BINARY , VARBINARY, TINYTEXT,LONGTEXT,YEAR,JSON,Spatial data types
+		$dataTypeFields = [
+			'id'              => ['type' => 'INTEGER', 'constraint' => 20, 'auto_increment' => true],
+			'type_varchar'    => ['type' => 'VARCHAR', 'constraint' => 40, 'null' => true],
+			'type_char'       => ['type' => 'CHAR', 'constraint' => 10, 'null' => true],
+			'type_text'       => ['type' => 'TEXT', 'null' => true],
+			'type_smallint'   => ['type' => 'SMALLINT', 'null' => true],
+			'type_integer'    => ['type' => 'INTEGER', 'null' => true],
+			'type_float'      => ['type' => 'FLOAT', 'null' => true],
+			'type_numeric'    => ['type' => 'NUMERIC', 'constraint' => '18,2', 'null' => true],
+			'type_date'       => ['type' => 'DATE', 'null' => true],
+			'type_time'       => ['type' => 'TIME', 'null' => true],
+			'type_datetime'   => ['type' => 'DATETIME', 'null' => true],
+			'type_timestamp'  => ['type' => 'TIMESTAMP', 'null' => true],
+			'type_bigint'     => ['type' => 'BIGINT', 'null' => true],
+			'type_real'       => ['type' => 'REAL', 'null' => true],
+			'type_enum'       => ['type' => 'ENUM', 'constraint' => ['appel', 'pears', 'bananas'], 'null' => true],
+			'type_set'        => ['type' => 'SET', 'constraint' => ['one', 'two'], 'null' => true],
+			'type_mediumtext' => ['type' => 'MEDIUMTEXT', 'null' => true],
+			'type_double'     => ['type' => 'DOUBLE', 'null' => true],
+			'type_decimal'    => ['type' => 'DECIMAL', 'constraint' => '18,4', 'null' => true],
+			'type_blob'       => ['type' => 'BLOB', 'null' => true],
 		];
 
 		if ($this->db->DBDriver === 'Postgre')
 		{
 			unset(
-				$data_type_fields['type_real'],
-				$data_type_fields['type_decimal']
+				$dataTypeFields['type_real'],
+				$dataTypeFields['type_decimal']
 			);
 		}
 
 		if ($this->db->DBDriver === 'Sqlsrv')
 		{
-			unset($data_type_fields['type_timestamp']);
+			unset($dataTypeFields['type_timestamp']);
 		}
 
 		if ($this->db->DBDriver === 'Postgre' || $this->db->DBDriver === 'Sqlsrv')
 		{
 			unset(
-				$data_type_fields['type_enum'],
-				$data_type_fields['type_set'],
-				$data_type_fields['type_mediumtext'],
-				$data_type_fields['type_double'],
-				$data_type_fields['type_blob']
+				$dataTypeFields['type_enum'],
+				$dataTypeFields['type_set'],
+				$dataTypeFields['type_mediumtext'],
+				$dataTypeFields['type_double'],
+				$dataTypeFields['type_blob']
 			);
 		}
 
-		$this->forge->addField($data_type_fields);
-		$this->forge->addKey('id', true);
-		$this->forge->createTable('type_test', true);
+		$this->forge
+			->addField($dataTypeFields)
+			->addKey('id', true)
+			->createTable('type_test', true);
 
 		// Empty Table
-		$this->forge->addField([
-			'id'         => [
-				'type'           => 'INTEGER',
-				'constraint'     => 3,
-				'auto_increment' => true,
-			],
-			'name'       => [
-				'type'       => 'VARCHAR',
-				'constraint' => 40,
-			],
-			'created_at' => [
-				'type' => 'DATE',
-				'null' => true,
-			],
-			'updated_at' => [
-				'type' => 'DATE',
-				'null' => true,
-			],
-		]);
-		$this->forge->addKey('id', true);
-		$this->forge->createTable('empty', true);
+		$this->forge
+			->addField([
+				'id'         => ['type' => 'INTEGER', 'constraint' => 3, 'auto_increment' => true],
+				'name'       => ['type' => 'VARCHAR', 'constraint' => 40],
+				'created_at' => ['type' => 'DATE', 'null' => true],
+				'updated_at' => ['type' => 'DATE', 'null' => true],
+			])
+			->addKey('id', true)
+			->createTable('empty', true);
 
 		// Secondary Table
-		$this->forge->addField([
-			'id'    => [
-				'type'           => 'INTEGER',
-				'constraint'     => 3,
-				'auto_increment' => true,
-			],
-			'key'   => [
-				'type'       => 'VARCHAR',
-				'constraint' => 40,
-			],
-			'value' => [
-				'type'       => 'VARCHAR',
-				'constraint' => 400,
-				'null'       => true,
-			],
-		]);
-		$this->forge->addKey('id', true);
-		$this->forge->createTable('secondary', true);
+		$this->forge
+			->addField([
+				'id'    => ['type' => 'INTEGER', 'constraint' => 3, 'auto_increment' => true],
+				'key'   => ['type' => 'VARCHAR', 'constraint' => 40],
+				'value' => ['type' => 'VARCHAR', 'constraint' => 400, 'null' => true],
+			])
+			->addKey('id', true)
+			->createTable('secondary', true);
 
 		// Stringify Primary key Table
-		$this->forge->addField([
-			'id'    => [
-				'type'       => 'VARCHAR',
-				'constraint' => 3,
-			],
-			'value' => [
-				'type'       => 'VARCHAR',
-				'constraint' => 400,
-				'null'       => true,
-			],
-		]);
-		$this->forge->addKey('id', true);
-		$this->forge->createTable('stringifypkey', true);
+		$this->forge
+			->addField([
+				'id'    => ['type' => 'VARCHAR', 'constraint' => 3],
+				'value' => ['type' => 'VARCHAR', 'constraint' => 400, 'null' => true],
+			])
+			->addKey('id', true)
+			->createTable('stringifypkey', true);
 
-		// Table without auto increment field
-		$this->forge->addField([
-			'key'   => [
-				'type'       => 'VARCHAR',
-				'constraint' => 40,
-				'unique'     => true,
-			],
-			'value' => [
-				'type'       => 'VARCHAR',
-				'constraint' => 400,
-				'null'       => true,
-			],
-		]);
-		$this->forge->addKey('key', true);
-		$this->forge->createTable('without_auto_increment', true);
+		// Table without auto-increment field
+		$this->forge
+			->addField([
+				'key'   => ['type' => 'VARCHAR', 'constraint' => 40, 'unique' => true],
+				'value' => ['type' => 'VARCHAR', 'constraint' => 400, 'null' => true],
+			])
+			->addKey('key', true)
+			->createTable('without_auto_increment', true);
+
+		if ($this->db->DBDriver !== 'Sqlsrv')
+		{
+			$this->forge
+				->addField([
+					'id'          => ['type' => 'INTEGER', 'constraint' => 11, 'auto_increment' => true],
+					'name'        => ['type' => 'VARCHAR', 'constraint' => 40],
+					'description' => ['type' => 'VARCHAR', 'constraint' => 100],
+					'created_at'  => ['type' => 'TIMESTAMP'],
+					'updated_at'  => ['type' => 'TIMESTAMP'],
+					'deleted_at'  => ['type' => 'TIMESTAMP'],
+				])
+				->addPrimaryKey('id')
+				->createTable('groups', true);
+		}
 	}
-
-	//--------------------------------------------------------------------
 
 	public function down()
 	{
@@ -310,8 +165,10 @@ class Migration_Create_test_tables extends \CodeIgniter\Database\Migration
 		$this->forge->dropTable('secondary', true);
 		$this->forge->dropTable('stringifypkey', true);
 		$this->forge->dropTable('without_auto_increment', true);
+
+		if ($this->db->DBDriver !== 'Sqlsrv')
+		{
+			$this->forge->dropTable('groups', true);
+		}
 	}
-
-	//--------------------------------------------------------------------
-
 }

--- a/tests/_support/Database/Seeds/CITestSeeder.php
+++ b/tests/_support/Database/Seeds/CITestSeeder.php
@@ -1,10 +1,13 @@
-<?php namespace Tests\Support\Database\Seeds;
+<?php
 
-class CITestSeeder extends \CodeIgniter\Database\Seeder
+namespace Tests\Support\Database\Seeds;
+
+use CodeIgniter\Database\Seeder;
+
+class CITestSeeder extends Seeder
 {
 	public function run()
 	{
-		// Job Data
 		$data = [
 			'user'                   => [
 				[
@@ -95,27 +98,35 @@ class CITestSeeder extends \CodeIgniter\Database\Seeder
 					'type_bigint'     => 2342342,
 				],
 			],
+			'groups'                 => [
+				[
+					'name'        => 'Admin',
+					'description' => 'Administrative group.',
+				],
+			],
 		];
 
-		//set SQL times to more correct format
+		// set SQL times to more correct format
 		if ($this->db->DBDriver === 'SQLite3')
 		{
-			 $data['type_test'][0]['type_date']      = '2020/01/11';
-			 $data['type_test'][0]['type_time']      = '15:22:00';
-			 $data['type_test'][0]['type_datetime']  = '2020/06/18 05:12:24';
-			 $data['type_test'][0]['type_timestamp'] = '2019/07/18 21:53:21';
+			$data['type_test'][0]['type_date']      = '2020/01/11';
+			$data['type_test'][0]['type_time']      = '15:22:00';
+			$data['type_test'][0]['type_datetime']  = '2020/06/18 05:12:24';
+			$data['type_test'][0]['type_timestamp'] = '2019/07/18 21:53:21';
 		}
 
 		if ($this->db->DBDriver === 'Postgre')
 		{
 			$data['type_test'][0]['type_time'] = '15:22:00';
-			unset($data['type_test'][0]['type_enum']);
-			unset($data['type_test'][0]['type_set']);
-			unset($data['type_test'][0]['type_mediumtext']);
-			unset($data['type_test'][0]['type_real']);
-			unset($data['type_test'][0]['type_double']);
-			unset($data['type_test'][0]['type_decimal']);
-			unset($data['type_test'][0]['type_blob']);
+			unset(
+				$data['type_test'][0]['type_enum'],
+				$data['type_test'][0]['type_set'],
+				$data['type_test'][0]['type_mediumtext'],
+				$data['type_test'][0]['type_real'],
+				$data['type_test'][0]['type_double'],
+				$data['type_test'][0]['type_decimal'],
+				$data['type_test'][0]['type_blob']
+			);
 		}
 
 		if ($this->db->DBDriver === 'Sqlsrv')
@@ -123,25 +134,25 @@ class CITestSeeder extends \CodeIgniter\Database\Seeder
 			$data['type_test'][0]['type_date']     = '2020-01-11';
 			$data['type_test'][0]['type_time']     = '15:22:00.000';
 			$data['type_test'][0]['type_datetime'] = '2020-06-18 05:12:24.000';
-			unset($data['type_test'][0]['type_timestamp']);
-			unset($data['type_test'][0]['type_enum']);
-			unset($data['type_test'][0]['type_set']);
-			unset($data['type_test'][0]['type_mediumtext']);
-			unset($data['type_test'][0]['type_double']);
-			unset($data['type_test'][0]['type_blob']);
+
+			unset(
+				$data['type_test'][0]['type_timestamp'],
+				$data['type_test'][0]['type_enum'],
+				$data['type_test'][0]['type_set'],
+				$data['type_test'][0]['type_mediumtext'],
+				$data['type_test'][0]['type_double'],
+				$data['type_test'][0]['type_blob']
+			);
 		}
 
-		foreach ($data as $table => $dummy_data)
+		foreach ($data as $table => $dummyData)
 		{
 			$this->db->table($table)->truncate();
 
-			foreach ($dummy_data as $single_dummy_data)
+			foreach ($dummyData as $singleDummyData)
 			{
-				$this->db->table($table)->insert($single_dummy_data);
+				$this->db->table($table)->insert($singleDummyData);
 			}
 		}
 	}
-
-	//--------------------------------------------------------------------
-
 }

--- a/tests/_support/Models/GroupsModel.php
+++ b/tests/_support/Models/GroupsModel.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Support\Models;
+
+use CodeIgniter\Model;
+
+class GroupsModel extends Model
+{
+	protected $table = 'groups';
+
+	protected $returnType = 'object';
+
+	protected $useTimestamps = true;
+
+	protected $dateFormat = 'datetime';
+
+	protected $allowedFields = [
+		'name',
+		'description',
+	];
+}


### PR DESCRIPTION
**Description**
In addition to the current tests to insertBatch particular on time functions, this PR adds a test to check the behavior using `TIMESTAMP` data type in migration and `datetime` format in `Model::$dateFormat`.

Ancillarily this reduces some lines to make code more compact.

Ref: #3838 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
