### PR TITLE
Fix phpstan error on database

### DIFF
--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -12,20 +12,17 @@
 namespace CodeIgniter\Database;
 
 use BadMethodCallException;
-use CodeIgniter\Database\MySQLi\Connection;
 use CodeIgniter\Events\Events;
-use mysqli_stmt;
 
 /**
  * Base prepared query
  */
 abstract class BasePreparedQuery implements PreparedQueryInterface
 {
-
 	/**
 	 * The prepared statement itself.
 	 *
-	 * @var resource|mysqli_stmt
+	 * @var object|resource
 	 */
 	protected $statement;
 
@@ -54,7 +51,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 	/**
 	 * A reference to the db connection to use.
 	 *
-	 * @var BaseConnection|Connection
+	 * @var BaseConnection
 	 */
 	protected $db;
 
@@ -63,9 +60,9 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 	/**
 	 * Constructor.
 	 *
-	 * @param ConnectionInterface $db
+	 * @param BaseConnection $db
 	 */
-	public function __construct(ConnectionInterface $db)
+	public function __construct(BaseConnection $db)
 	{
 		$this->db = &$db;
 	}
@@ -180,7 +177,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 	/**
 	 * Explicitly closes the statement.
 	 *
-	 * @return null|void
+	 * @return void
 	 */
 	public function close()
 	{

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -17,11 +17,11 @@ use RuntimeException;
 use Throwable;
 
 /**
- * Class Forge
+ * The Forge class transforms migrations to executable
+ * SQL statements.
  */
 class Forge
 {
-
 	/**
 	 * The active database connection.
 	 *
@@ -165,9 +165,9 @@ class Forge
 	/**
 	 * Constructor.
 	 *
-	 * @param ConnectionInterface $db
+	 * @param BaseConnection $db
 	 */
-	public function __construct(ConnectionInterface $db)
+	public function __construct(BaseConnection $db)
 	{
 		$this->db = &$db;
 	}

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -11,7 +11,7 @@
 
 namespace CodeIgniter\Database\SQLite3;
 
-use CodeIgniter\Database\ConnectionInterface;
+use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 
 /**
@@ -39,9 +39,9 @@ class Forge extends \CodeIgniter\Database\Forge
 	/**
 	 * Constructor.
 	 *
-	 * @param ConnectionInterface $db
+	 * @param BaseConnection $db
 	 */
-	public function __construct(ConnectionInterface $db)
+	public function __construct(BaseConnection $db)
 	{
 		parent::__construct($db);
 

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -86,7 +86,7 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
 			}
 
 			// Bind it
-			$this->statement->bindValue($key + 1, $item, $bindType); // @phpstan-ignore-line
+			$this->statement->bindValue($key + 1, $item, $bindType);
 		}
 
 		$this->result = $this->statement->execute();


### PR DESCRIPTION
**Description**
This one needs arbitration.

PHPStan flags the requirement of docblock using `BaseConnection` but constructor accepts `ConnectionInterface`. `BaseConnection` implements `ConnectionInterface` so it should not pose a problem but maybe phpstan flags this as error because there may be utility methods in `BaseConnection` that are not present in the interface.

This PR changes requirement to `BaseConnection` altogether as it meets the `ConnectionInterface` requirement and may cover the methods unique to BaseConnection. I think this should not be a BC as users would be using the configured DB drivers which already extends `BaseConnection`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
