### PR TITLE
Remove superfluous interface definition in classes

### DIFF
--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -12,7 +12,6 @@
 namespace CodeIgniter\Database\MySQLi;
 
 use CodeIgniter\Database\BaseConnection;
-use CodeIgniter\Database\ConnectionInterface;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use LogicException;
 use MySQLi;
@@ -23,7 +22,7 @@ use Throwable;
 /**
  * Connection for MySQLi
  */
-class Connection extends BaseConnection implements ConnectionInterface
+class Connection extends BaseConnection
 {
 	/**
 	 * Database driver

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -13,12 +13,11 @@ namespace CodeIgniter\Database\MySQLi;
 
 use BadMethodCallException;
 use CodeIgniter\Database\BasePreparedQuery;
-use CodeIgniter\Database\PreparedQueryInterface;
 
 /**
  * Prepared query for MySQLi
  */
-class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
+class PreparedQuery extends BasePreparedQuery
 {
 	/**
 	 * Prepares the query against the database, and saves the connection

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -12,16 +12,14 @@
 namespace CodeIgniter\Database\MySQLi;
 
 use CodeIgniter\Database\BaseResult;
-use CodeIgniter\Database\ResultInterface;
 use CodeIgniter\Entity;
 use stdClass;
 
 /**
  * Result for MySQLi
  */
-class Result extends BaseResult implements ResultInterface
+class Result extends BaseResult
 {
-
 	/**
 	 * Gets the number of fields in the result set.
 	 *

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -12,7 +12,6 @@
 namespace CodeIgniter\Database\Postgre;
 
 use CodeIgniter\Database\BaseConnection;
-use CodeIgniter\Database\ConnectionInterface;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use ErrorException;
 use stdClass;
@@ -20,9 +19,8 @@ use stdClass;
 /**
  * Connection for Postgre
  */
-class Connection extends BaseConnection implements ConnectionInterface
+class Connection extends BaseConnection
 {
-
 	/**
 	 * Database driver
 	 *

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -13,13 +13,12 @@ namespace CodeIgniter\Database\Postgre;
 
 use BadMethodCallException;
 use CodeIgniter\Database\BasePreparedQuery;
-use CodeIgniter\Database\PreparedQueryInterface;
 use Exception;
 
 /**
  * Prepared query for Postgre
  */
-class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
+class PreparedQuery extends BasePreparedQuery
 {
 	/**
 	 * Stores the name this query can be

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -12,16 +12,14 @@
 namespace CodeIgniter\Database\Postgre;
 
 use CodeIgniter\Database\BaseResult;
-use CodeIgniter\Database\ResultInterface;
 use CodeIgniter\Entity;
 use stdClass;
 
 /**
  * Result for Postgre
  */
-class Result extends BaseResult implements ResultInterface
+class Result extends BaseResult
 {
-
 	/**
 	 * Gets the number of fields in the result set.
 	 *

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -12,7 +12,6 @@
 namespace CodeIgniter\Database\SQLite3;
 
 use CodeIgniter\Database\BaseConnection;
-use CodeIgniter\Database\ConnectionInterface;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use ErrorException;
 use Exception;
@@ -22,9 +21,8 @@ use stdClass;
 /**
  * Connection for SQLite3
  */
-class Connection extends BaseConnection implements ConnectionInterface
+class Connection extends BaseConnection
 {
-
 	/**
 	 * Database driver
 	 *

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -13,13 +13,11 @@ namespace CodeIgniter\Database\SQLite3;
 
 use BadMethodCallException;
 use CodeIgniter\Database\BasePreparedQuery;
-use CodeIgniter\Database\PreparedQueryInterface;
 
 /**
  * Prepared query for SQLite3
  */
-
-class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
+class PreparedQuery extends BasePreparedQuery
 {
 	/**
 	 * The SQLite3Result resource, or false.

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -14,16 +14,14 @@ namespace CodeIgniter\Database\SQLite3;
 use Closure;
 use CodeIgniter\Database\BaseResult;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Database\ResultInterface;
 use CodeIgniter\Entity;
 use stdClass;
 
 /**
  * Result for SQLite3
  */
-class Result extends BaseResult implements ResultInterface
+class Result extends BaseResult
 {
-
 	/**
 	 * Gets the number of fields in the result set.
 	 *

--- a/system/Database/Sqlsrv/Connection.php
+++ b/system/Database/Sqlsrv/Connection.php
@@ -12,7 +12,6 @@
 namespace CodeIgniter\Database\Sqlsrv;
 
 use CodeIgniter\Database\BaseConnection;
-use CodeIgniter\Database\ConnectionInterface;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use Exception;
 use stdClass;
@@ -20,9 +19,8 @@ use stdClass;
 /**
  * Connection for Sqlsrv
  */
-class Connection extends BaseConnection implements ConnectionInterface
+class Connection extends BaseConnection
 {
-
 	/**
 	 * Database driver
 	 *

--- a/system/Database/Sqlsrv/PreparedQuery.php
+++ b/system/Database/Sqlsrv/PreparedQuery.php
@@ -13,13 +13,12 @@ namespace CodeIgniter\Database\Sqlsrv;
 
 use BadMethodCallException;
 use CodeIgniter\Database\BasePreparedQuery;
-use CodeIgniter\Database\PreparedQueryInterface;
 use Exception;
 
 /**
  * Prepared query for Postgre
  */
-class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
+class PreparedQuery extends BasePreparedQuery
 {
 	/**
 	 * Parameters array used to store the dynamic variables.

--- a/system/Database/Sqlsrv/Result.php
+++ b/system/Database/Sqlsrv/Result.php
@@ -12,16 +12,14 @@
 namespace CodeIgniter\Database\Sqlsrv;
 
 use CodeIgniter\Database\BaseResult;
-use CodeIgniter\Database\ResultInterface;
 use CodeIgniter\Entity;
 use stdClass;
 
 /**
  * Result for Sqlsrv
  */
-class Result extends BaseResult implements ResultInterface
+class Result extends BaseResult
 {
-
 	/**
 	 * Row offset
 	 *

--- a/system/HTTP/Exceptions/HTTPException.php
+++ b/system/HTTP/Exceptions/HTTPException.php
@@ -11,15 +11,13 @@
 
 namespace CodeIgniter\HTTP\Exceptions;
 
-use CodeIgniter\Exceptions\ExceptionInterface;
 use CodeIgniter\Exceptions\FrameworkException;
 
 /**
  * Things that can go wrong with HTTP
  */
-class HTTPException extends FrameworkException implements ExceptionInterface
+class HTTPException extends FrameworkException
 {
-
 	/**
 	 * For CurlRequest
 	 *

--- a/system/I18n/Exceptions/I18nException.php
+++ b/system/I18n/Exceptions/I18nException.php
@@ -11,13 +11,12 @@
 
 namespace CodeIgniter\I18n\Exceptions;
 
-use CodeIgniter\Exceptions\ExceptionInterface;
 use CodeIgniter\Exceptions\FrameworkException;
 
 /**
  * I18nException
  */
-class I18nException extends FrameworkException implements ExceptionInterface
+class I18nException extends FrameworkException
 {
 	/**
 	 * Thrown when the numeric representation of the month falls

--- a/system/Log/Exceptions/LogException.php
+++ b/system/Log/Exceptions/LogException.php
@@ -11,10 +11,9 @@
 
 namespace CodeIgniter\Log\Exceptions;
 
-use CodeIgniter\Exceptions\ExceptionInterface;
 use CodeIgniter\Exceptions\FrameworkException;
 
-class LogException extends FrameworkException implements ExceptionInterface
+class LogException extends FrameworkException
 {
 	public static function forInvalidLogLevel(string $level)
 	{

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -22,9 +22,8 @@ use Config\Services;
  *
  * @see https://craig.is/writing/chrome-logger
  */
-class ChromeLoggerHandler extends BaseHandler implements HandlerInterface
+class ChromeLoggerHandler extends BaseHandler
 {
-
 	/**
 	 * Version of this library - for ChromeLogger use.
 	 *

--- a/system/Log/Handlers/FileHandler.php
+++ b/system/Log/Handlers/FileHandler.php
@@ -17,9 +17,8 @@ use Exception;
 /**
  * Log error messages to file system
  */
-class FileHandler extends BaseHandler implements HandlerInterface
+class FileHandler extends BaseHandler
 {
-
 	/**
 	 * Folder to hold logs
 	 *

--- a/system/Pager/Exceptions/PagerException.php
+++ b/system/Pager/Exceptions/PagerException.php
@@ -11,10 +11,9 @@
 
 namespace CodeIgniter\Pager\Exceptions;
 
-use CodeIgniter\Exceptions\ExceptionInterface;
 use CodeIgniter\Exceptions\FrameworkException;
 
-class PagerException extends FrameworkException implements ExceptionInterface
+class PagerException extends FrameworkException
 {
 	public static function forInvalidTemplate(string $template = null)
 	{

--- a/system/Router/Exceptions/RouterException.php
+++ b/system/Router/Exceptions/RouterException.php
@@ -11,13 +11,12 @@
 
 namespace CodeIgniter\Router\Exceptions;
 
-use CodeIgniter\Exceptions\ExceptionInterface;
 use CodeIgniter\Exceptions\FrameworkException;
 
 /**
  * RouterException
  */
-class RouterException extends FrameworkException implements ExceptionInterface
+class RouterException extends FrameworkException
 {
 	/**
 	 * Thrown when the actual parameter type does not match

--- a/system/Security/Exceptions/SecurityException.php
+++ b/system/Security/Exceptions/SecurityException.php
@@ -11,10 +11,9 @@
 
 namespace CodeIgniter\Security\Exceptions;
 
-use CodeIgniter\Exceptions\ExceptionInterface;
 use CodeIgniter\Exceptions\FrameworkException;
 
-class SecurityException extends FrameworkException implements ExceptionInterface
+class SecurityException extends FrameworkException
 {
 	public static function forDisallowedAction()
 	{

--- a/system/Session/Exceptions/SessionException.php
+++ b/system/Session/Exceptions/SessionException.php
@@ -11,10 +11,9 @@
 
 namespace CodeIgniter\Session\Exceptions;
 
-use CodeIgniter\Exceptions\ExceptionInterface;
 use CodeIgniter\Exceptions\FrameworkException;
 
-class SessionException extends FrameworkException implements ExceptionInterface
+class SessionException extends FrameworkException
 {
 	public static function forMissingDatabaseTable()
 	{

--- a/system/Session/Handlers/ArrayHandler.php
+++ b/system/Session/Handlers/ArrayHandler.php
@@ -11,15 +11,13 @@
 
 namespace CodeIgniter\Session\Handlers;
 
-use Config\Database;
 use Exception;
-use SessionHandlerInterface;
 
 /**
  * Session handler using static array for storage.
  * Intended only for use during testing.
  */
-class ArrayHandler extends BaseHandler implements SessionHandlerInterface
+class ArrayHandler extends BaseHandler
 {
 	protected static $cache = [];
 

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -16,14 +16,12 @@ use CodeIgniter\Session\Exceptions\SessionException;
 use Config\App as AppConfig;
 use Config\Database;
 use Exception;
-use SessionHandlerInterface;
 
 /**
  * Session handler using current Database for storage
  */
-class DatabaseHandler extends BaseHandler implements SessionHandlerInterface
+class DatabaseHandler extends BaseHandler
 {
-
 	/**
 	 * The database group to use for storage.
 	 *

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -14,14 +14,12 @@ namespace CodeIgniter\Session\Handlers;
 use CodeIgniter\Session\Exceptions\SessionException;
 use Config\App as AppConfig;
 use Exception;
-use SessionHandlerInterface;
 
 /**
  * Session handler using file system for storage
  */
-class FileHandler extends BaseHandler implements SessionHandlerInterface
+class FileHandler extends BaseHandler
 {
-
 	/**
 	 * Where to save the session files to.
 	 *

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -14,14 +14,12 @@ namespace CodeIgniter\Session\Handlers;
 use CodeIgniter\Session\Exceptions\SessionException;
 use Config\App as AppConfig;
 use Memcached;
-use SessionHandlerInterface;
 
 /**
  * Session handler using Memcache for persistence
  */
-class MemcachedHandler extends BaseHandler implements SessionHandlerInterface
+class MemcachedHandler extends BaseHandler
 {
-
 	/**
 	 * Memcached instance
 	 *

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -16,14 +16,12 @@ use Config\App as AppConfig;
 use Exception;
 use Redis;
 use RedisException;
-use SessionHandlerInterface;
 
 /**
  * Session handler using Redis for persistence
  */
-class RedisHandler extends BaseHandler implements SessionHandlerInterface
+class RedisHandler extends BaseHandler
 {
-
 	/**
 	 * phpRedis instance
 	 *

--- a/system/Validation/Exceptions/ValidationException.php
+++ b/system/Validation/Exceptions/ValidationException.php
@@ -11,10 +11,9 @@
 
 namespace CodeIgniter\Validation\Exceptions;
 
-use CodeIgniter\Exceptions\ExceptionInterface;
 use CodeIgniter\Exceptions\FrameworkException;
 
-class ValidationException extends FrameworkException implements ExceptionInterface
+class ValidationException extends FrameworkException
 {
 	public static function forRuleNotFound(string $rule = null)
 	{

--- a/system/View/Exceptions/ViewException.php
+++ b/system/View/Exceptions/ViewException.php
@@ -11,10 +11,9 @@
 
 namespace CodeIgniter\View\Exceptions;
 
-use CodeIgniter\Exceptions\ExceptionInterface;
 use CodeIgniter\Exceptions\FrameworkException;
 
-class ViewException extends FrameworkException implements ExceptionInterface
+class ViewException extends FrameworkException
 {
 	public static function forInvalidCellMethod(string $class, string $method)
 	{


### PR DESCRIPTION
**Description**
If a parent class already implements an interface, then the extending child class need not implement again the interface in its class definition.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
