### PR TITLE
Fix PHPStan notice in latest develop

### DIFF
--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -63,9 +63,9 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 	/**
 	 * Constructor.
 	 *
-	 * @param ConnectionInterface $db
+	 * @param BaseConnection $db
 	 */
-	public function __construct(ConnectionInterface $db)
+	public function __construct(BaseConnection $db)
 	{
 		$this->db = &$db;
 	}

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -165,9 +165,9 @@ class Forge
 	/**
 	 * Constructor.
 	 *
-	 * @param ConnectionInterface $db
+	 * @param BaseConnection $db
 	 */
-	public function __construct(ConnectionInterface $db)
+	public function __construct(BaseConnection $db)
 	{
 		$this->db = &$db;
 	}

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -11,7 +11,7 @@
 
 namespace CodeIgniter\Database\SQLite3;
 
-use CodeIgniter\Database\ConnectionInterface;
+use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 
 /**
@@ -39,9 +39,9 @@ class Forge extends \CodeIgniter\Database\Forge
 	/**
 	 * Constructor.
 	 *
-	 * @param ConnectionInterface $db
+	 * @param BaseConnection $db
 	 */
-	public function __construct(ConnectionInterface $db)
+	public function __construct(BaseConnection $db)
 	{
 		parent::__construct($db);
 


### PR DESCRIPTION
`BaseConnection` is already implementing `ConnectionInterface` and the `$db` used is an instanceof `BaseConnection`

**Checklist:**
- [x] Securely signed commits