### PR TITLE
Fix volatile time comparison in insert batch testing

### DIFF
--- a/tests/system/Database/Live/ModelTest.php
+++ b/tests/system/Database/Live/ModelTest.php
@@ -1396,10 +1396,10 @@ class ModelTest extends CIDatabaseTestCase
 	{
 		$job_data = [
 			[
-				'name'        => 'Philosopher',
+				'name' => 'Philosopher',
 			],
 			[
-				'name'        => 'Laborer',
+				'name' => 'Laborer',
 			],
 		];
 
@@ -1409,7 +1409,7 @@ class ModelTest extends CIDatabaseTestCase
 
 		$result = $model->where('name', 'Philosopher')->first();
 
-		$this->assertEquals(time(), $result->created_at);
+		$this->assertCloseEnough(time(), $result->created_at);
 	}
 
 	public function testInsertBatchSetsDatetimeTimestamps()
@@ -1433,7 +1433,7 @@ class ModelTest extends CIDatabaseTestCase
 
 		$result = $model->where('name', 'Lou')->first();
 
-		$this->assertEquals(time(), strtotime($result->created_at));
+		$this->assertCloseEnough(time(), strtotime($result->created_at));
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
This changes the test from `assertEquals` to `assertCloseEnough` for time comparisons to mitigate failures due to a second difference.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
