### PR TITLE
form_helper - Allow arrays as default and return values in set_value method

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -713,13 +713,13 @@ if (! function_exists('set_value'))
 	 * Grabs a value from the POST array for the specified field so you can
 	 * re-populate an input field or textarea
 	 *
-	 * @param string  $field      Field name
-	 * @param string  $default    Default value
-	 * @param boolean $htmlEscape Whether to escape HTML special characters or not
+	 * @param string          $field      Field name
+	 * @param string|string[] $default    Default value
+	 * @param boolean         $htmlEscape Whether to escape HTML special characters or not
 	 *
-	 * @return string
+	 * @return string|string[]
 	 */
-	function set_value(string $field, string $default = '', bool $htmlEscape = true): string
+	function set_value(string $field, $default = '', bool $htmlEscape = true)
 	{
 		$request = Services::request();
 


### PR DESCRIPTION
**Description**
When array type form fields are used like multiple select it is needed to pass back multiple values as array

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
