### PR TITLE
Model: support returning array indexed by a specified column

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -195,6 +195,11 @@ class Model
 	protected $tempReturnType;
 
 	/**
+	 * Used by indexed() to return array indexed by a specified key
+	 */
+	protected $tempReturnIndexed = false;
+
+	/**
 	 * Whether we should limit fields in inserts
 	 * and updates to those available in $allowedFields or not.
 	 *
@@ -446,10 +451,16 @@ class Model
 
 		$row = $row->getResult($this->tempReturnType);
 
+		if ($this->tempReturnIndexed)
+		{
+			$row = array_column($row, null, $this->tempReturnIndexed);
+		}
+
 		$eventData = $this->trigger('afterFind', ['data' => $row, 'limit' => $limit, 'offset' => $offset]);
 
 		$this->tempReturnType     = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
+		$this->tempReturnIndexed  = false;
 
 		return $eventData['data'];
 	}
@@ -487,6 +498,7 @@ class Model
 
 		$this->tempReturnType     = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
+		$this->tempReturnIndexed  = false;
 
 		return $eventData['data'];
 	}
@@ -1062,6 +1074,22 @@ class Model
 	public function asObject(string $class = 'object')
 	{
 		$this->tempReturnType = $class;
+
+		return $this;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Sets the return to be array indexed by a specific key (column table).
+	 *
+	 * @param string $key Column to use for indexing (defaults to $primaryKey)
+	 *
+	 * @return Model
+	 */
+	public function indexed($key = null)
+	{
+		$this->tempReturnIndexed = $key ?? $this->primaryKey;
 
 		return $this;
 	}


### PR DESCRIPTION
```
This allows Model users to get array or results indexed with a specific
column, $primaryKey by default. It can be simply used as:

$model->indexed()->findAll()

It may be useful e.g. for generating array to be used with
form_dropdown().

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```

**Description**
I personally use it for `form_dropdown()` and found someone else requesting for it as well in forum thread [ Query result as an indexed array or object by index of choice ](https://forum.codeigniter.com/thread-76215.html). I was told to submit a Pull Request, so I share my code.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide