### PR TITLE
pre-commit hook does not work with alias

### DIFF
--- a/admin/pre-commit
+++ b/admin/pre-commit
@@ -35,7 +35,7 @@ if [ "$FILES" != "" ]
 then
 	echo "Running PHPStan..."
 	# Run on whole codebase
-	./vendor/bin/phpstan analyse
+	php ./vendor/bin/phpstan analyse
 
 	if [ $? != 0 ]
 	then
@@ -47,7 +47,7 @@ fi
 if [ "$FILES" != "" ]
 then
 	echo "Running Code Sniffer..."
-	./vendor/bin/phpcbf --standard=./vendor/codeigniter4/codeigniter4-standard/CodeIgniter4 --encoding=utf-8 -n -p $FILES
+	php ./vendor/bin/phpcbf --standard=./vendor/codeigniter4/codeigniter4-standard/CodeIgniter4 --encoding=utf-8 -n -p $FILES
 fi
 
 exit $?


### PR DESCRIPTION
**Description**
In some workflows like  MAMP on OSX default php version is set using alias in bash profile

```
alias php='/Applications/MAMP/bin/php/php7.4.2/bin/php -c "/Library/Application Support/appsolute/MAMP PRO/conf/php7.4.2.ini"'
```

In such case when phpstan and codesniffer are executed via git hoot it will run them using the default system php instead of using the alias.

Prefixing the method call with php triggers the alias and solves the issue.
**Checklist:**
- [x ] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide