### PR TITLE
simple error_log Log Handler

### DIFF
--- a/app/Config/Logger.php
+++ b/app/Config/Logger.php
@@ -136,5 +136,16 @@ class Logger extends BaseConfig
 		//          'handles' => ['critical', 'alert', 'emergency', 'debug',
 		//                        'error', 'info', 'notice', 'warning'],
 		//      ]
+
+		/**
+		 * Error Log Handler. Uncomment this block to use it.
+		 */
+		//      'CodeIgniter\Log\Handlers\ErrorlogHandler' => [
+		//          /*
+		//           * The log levels that this handler will handle.
+		//           */
+		//          'handles' => ['critical', 'alert', 'emergency', 'debug',
+		//                        'error', 'info', 'notice', 'warning'],
+		//      ]
 	];
 }

--- a/system/Log/Handlers/ErrorlogHandler.php
+++ b/system/Log/Handlers/ErrorlogHandler.php
@@ -46,6 +46,4 @@ class ErrorlogHandler extends BaseHandler
 
 		return error_log($msg);
 	}
-
-	//--------------------------------------------------------------------
 }

--- a/system/Log/Handlers/ErrorlogHandler.php
+++ b/system/Log/Handlers/ErrorlogHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Log\Handlers;
+
+/**
+ * Log error messages to PHP error log
+ */
+class ErrorlogHandler extends BaseHandler
+{
+
+	/**
+	 * Constructor
+	 *
+	 * @param array $config
+	 */
+	public function __construct(array $config = [])
+	{
+		parent::__construct($config);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Handles logging the message.
+	 * If the handler returns false, then execution of handlers
+	 * will stop. Any handlers that have not run, yet, will not
+	 * be run.
+	 *
+	 * @param string $level
+	 * @param string $message
+	 *
+	 * @return boolean
+	 */
+	public function handle($level, $message): bool
+	{
+		$msg = strtoupper($level) . ' --> ' . $message . "\n";
+
+		return error_log($msg);
+	}
+
+	//--------------------------------------------------------------------
+}

--- a/tests/system/Log/Handlers/ErrorlogHandlerTest.php
+++ b/tests/system/Log/Handlers/ErrorlogHandlerTest.php
@@ -1,16 +1,12 @@
 <?php
+
 namespace CodeIgniter\Log\Handlers;
 
+use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 
-class ErrorlogHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
+final class ErrorlogHandlerTest extends CIUnitTestCase
 {
-
-	protected function setUp(): void
-	{
-		parent::setUp();
-	}
-
 	public function testHandle()
 	{
 		$config = new LoggerConfig();
@@ -20,5 +16,4 @@ class ErrorlogHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$logger = new ErrorlogHandler($config->handlers['CodeIgniter\Log\Handlers\TestHandler']);
 		$this->assertTrue($logger->handle('warning', 'This is a test log'));
 	}
-
 }

--- a/tests/system/Log/Handlers/ErrorlogHandlerTest.php
+++ b/tests/system/Log/Handlers/ErrorlogHandlerTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace CodeIgniter\Log\Handlers;
+
+use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
+
+class ErrorlogHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
+{
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+	}
+
+	public function testHandle()
+	{
+		$config = new LoggerConfig();
+
+		$config->handlers['CodeIgniter\Log\Handlers\TestHandler']['handles'] = ['critical'];
+
+		$logger = new ErrorlogHandler($config->handlers['CodeIgniter\Log\Handlers\TestHandler']);
+		$this->assertTrue($logger->handle('warning', 'This is a test log'));
+	}
+
+}

--- a/user_guide_src/source/general/logging.rst
+++ b/user_guide_src/source/general/logging.rst
@@ -69,6 +69,7 @@ be set to handle specific levels and ignore the rest. Currently, two handlers co
 - **ChromeLogger Handler** If you have the `ChromeLogger extension <https://craig.is/writing/chrome-logger>`_
   installed in the Chrome web browser, you can use this handler to display the log information in
   Chrome's console window.
+- **Errorlog Handler** this handler will log with php error_log
 
 The handlers are configured in the main configuration file, in the ``$handlers`` property, which is simply
 an array of handlers and their configuration. Each handler is specified with the key being the fully


### PR DESCRIPTION
**Description**
A simple Log Handler for error_log.
We use this Handler to log to stdout for Docker Container.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide