### PR TITLE
Allow cURL user agent

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -771,6 +771,12 @@ class CURLRequest extends Request
 			$curlOptions[CURLOPT_COOKIEFILE] = $config['cookie'];
 		}
 
+		// User Agent
+		if (isset($config['user_agent']))
+		{
+			$curlOptions[CURLOPT_USERAGENT] = $config['user_agent'];
+		}
+
 		return $curlOptions;
 	}
 

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -983,4 +983,18 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
 		$this->assertArrayHasKey(CURLOPT_COOKIEFILE, $options);
 		$this->assertEquals($holder, $options[CURLOPT_COOKIEFILE]);
 	}
+
+	public function testUserAgentOption()
+	{
+		$agent = 'CodeIgniter Framework';
+
+		$this->request->request('POST', '/post', [
+			'user_agent' => $agent,
+		]);
+
+		$options = $this->request->curl_options;
+
+		$this->assertArrayHasKey(CURLOPT_USERAGENT, $options);
+		$this->assertEquals($agent, $options[CURLOPT_USERAGENT]);
+	}
 }

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -360,6 +360,13 @@ option. The value should be the number of seconds you want the functions to exec
 
 	$response->request('GET', 'http://example.com', ['timeout' => 5]);
 
+user_agent
+==========
+
+Allows specifying the User Agent for requests::
+
+	$response->request('GET', 'http://example.com', ['user_agent' => 'CodeIgniter Framework v4']);
+
 verify
 ======
 


### PR DESCRIPTION
**Description**
Adds support for the `user_agent` option for cURL headers.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
