### PR TITLE
Array_helper: Add function array_sort_by_multiple_keys.

### DIFF
--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -123,7 +123,7 @@ if (! function_exists('array_deep_search'))
 	}
 }
 
-if (!function_exists('array_sort_by_multiple_keys'))
+if (! function_exists('array_sort_by_multiple_keys'))
 {
 	/**
 	 * Sorts a multidimensional array by its elements values. The array

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -196,11 +196,7 @@ if (!function_exists('array_sort_by_multiple_keys'))
 		// Append the array as reference
 		$tempArray[] = &$array;
 
-		// The array_multisort method accepts all sorting arrays and
-		// flags as an argument list. As we have those stored in a
-		// dynamically sized array, we use the call_user_func_array
-		// function, which parses the array to a list and then passes
-		// it to array_multisort.
-		return call_user_func_array('array_multisort', $tempArray);
+		// Pass sorting arrays and flags as an argument list.
+		return array_multisort(...$tempArray);
 	}
 }

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -143,7 +143,7 @@ if (!function_exists('sort_by_multiple_keys'))
 	 * object level. In principle, any number of sublevels could be used,
 	 * as long as the level and column exist in every array element.
 	 *
-	 * @param array &$array the reference of the array to be sorted
+	 * @param array $array the reference of the array to be sorted
 	 * @param array $sortColumns an associative array of columns to sort
 	 *              after and their sorting flags
 	 *
@@ -154,7 +154,7 @@ if (!function_exists('sort_by_multiple_keys'))
 		// Check if there really are columns to sort after
 		if (empty($sortColumns) || empty($array))
 		{
-			return $array;
+			return false;
 		}
 
 		// Group sorting indexes and data

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -134,15 +134,19 @@ if (!function_exists('array_sort_by_multiple_keys'))
 	 *
 	 * Example:
 	 * 	array_sort_by_multiple_keys($players,
-	 * 			[
-	 * 				'team.hierarchy' => SORT_ASC,
-	 * 				'position'       => SORT_ASC,
-	 * 				'name'           => SORT_STRING,
-	 * 			]
-	 * 		);
+	 * 		[
+	 * 			'team.hierarchy' => SORT_ASC,
+	 * 			'position'       => SORT_ASC,
+	 * 			'name'           => SORT_STRING,
+	 * 		]
+	 * 	);
+	 *
 	 * The '.' dot operator in the column name indicates a deeper array or
 	 * object level. In principle, any number of sublevels could be used,
 	 * as long as the level and column exist in every array element.
+	 *
+	 * For information on multi-level array sorting, refer to Example #3 here:
+	 * https://www.php.net/manual/de/function.array-multisort.php
 	 *
 	 * @param array $array       the reference of the array to be sorted
 	 * @param array $sortColumns an associative array of columns to sort
@@ -189,9 +193,14 @@ if (!function_exists('array_sort_by_multiple_keys'))
 			$tempArray[] = $sortFlag;
 		}
 
-		// Append the array reference
+		// Append the array as reference
 		$tempArray[] = &$array;
 
+		// The array_multisort method accepts all sorting arrays and
+		// flags as an argument list. As we have those stored in a
+		// dynamically sized array, we use the call_user_func_array
+		// function, which parses the array to a list and then passes
+		// it to array_multisort.
 		return call_user_func_array('array_multisort', $tempArray);
 	}
 }

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -123,16 +123,17 @@ if (! function_exists('array_deep_search'))
 	}
 }
 
-if (!function_exists('sort_by_multiple_keys'))
+if (!function_exists('array_sort_by_multiple_keys'))
 {
 	/**
-	 * Sorts an associative multidimensional array by the values of the
-	 * passed columns names. The sorting params represent an associative
-	 * array of column names and sorting flags.
+	 * Sorts a multidimensional array by its elements values. The array
+	 * columns to be used for sorting are passed as an associative
+	 * array of key names and sorting flags.
+	 *
 	 * Both arrays of objects and arrays of array can be sorted.
 	 *
 	 * Example:
-	 * 	sort_by_multiple_keys($players,
+	 * 	array_sort_by_multiple_keys($players,
 	 * 			[
 	 * 				'team.hierarchy' => SORT_ASC,
 	 * 				'position'       => SORT_ASC,
@@ -143,9 +144,9 @@ if (!function_exists('sort_by_multiple_keys'))
 	 * object level. In principle, any number of sublevels could be used,
 	 * as long as the level and column exist in every array element.
 	 *
-	 * @param array $array the reference of the array to be sorted
+	 * @param array $array       the reference of the array to be sorted
 	 * @param array $sortColumns an associative array of columns to sort
-	 *              after and their sorting flags
+	 *                           after and their sorting flags
 	 *
 	 * @return boolean
 	 */
@@ -167,36 +168,30 @@ if (!function_exists('sort_by_multiple_keys'))
 			// The '.' operator separates nested elements
 			foreach (explode('.', $key) as $keySegment)
 			{
-				// Distinguish array of objects and arrays of arrays
-				if (is_object(reset($carry)) ?? false)
+				// Loop elements if they are objects
+				if (is_object(reset($carry)))
 				{
 					// Extract the object attribute
 					foreach ($carry as $index => $object)
 					{
 						$carry[$index] = $object->$keySegment;
 					}
+					
+					continue;
 				}
-				else
-				{
-					// Extract
-					$carry = array_column($carry, $keySegment);
-				}
+
+				// Extract the target column if elements are arrays
+				$carry = array_column($carry, $keySegment);
 			}
 
-			// Store this iterations sorting paramters
-			$tempArray[$key][0] = $carry;
-			$tempArray[$key][1] = $sortFlag;
+			// Store the collected sorting parameters
+			$tempArray[] = $carry;
+			$tempArray[] = $sortFlag;
 		}
 
-		// Prepare sorting array
-		$sortArray = [];
-		foreach ($sortColumns as $index => $sortFlag)
-		{
-			$sortArray[] = &$tempArray[$index][0];
-			$sortArray[] = &$tempArray[$index][1];
-		}
-		$sortArray[] = &$array;
+		// Append the array reference
+		$tempArray[] = &$array;
 
-		return call_user_func_array('array_multisort', $sortArray);
+		return call_user_func_array('array_multisort', $tempArray);
 	}
 }

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -125,7 +125,6 @@ if (! function_exists('array_deep_search'))
 
 if (!function_exists('sort_by_multiple_keys'))
 {
-
 	/**
 	 * Sorts an associative multidimensional array by the values of the
 	 * passed columns names. The sorting params represent an associative

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -154,6 +154,76 @@ class ArrayHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertNull(array_deep_search('key644', $data));
 	}
 
+	/**
+	 * @dataProvider sortByMultipleKeysProvider
+	 */
+	public function testArraySortByMultipleKeysWithArray($sortColumns, $expected)
+	{
+		$data = $this->sortByMultipleKeysSeeder();
+
+		$success = array_sort_by_multiple_keys($data, $sortColumns);
+
+		$this->assertTrue($success);
+		$this->assertEquals($expected, array_column($data, 'name'));
+	}
+
+	/**
+	 * @dataProvider sortByMultipleKeysProvider
+	 */
+	public function testArraySortByMultipleKeysWithObjects($sortColumns, $expected)
+	{
+		$data = $this->sortByMultipleKeysSeeder();
+
+		// Morph to objects
+		foreach($data as $index => $dataSet){
+			$data[$index] = (object) $dataSet;
+		}
+
+		$success = array_sort_by_multiple_keys($data, $sortColumns);
+
+		$this->assertTrue($success);
+		$this->assertEquals($expected, array_column((array) $data, 'name'));
+	}
+
+	/**
+	 * @dataProvider sortByMultipleKeysProvider
+	 */
+	public function testArraySortByMultipleKeysFailsEmptyParameter($sortColumns, $expected)
+	{
+		$data = $this->sortByMultipleKeysSeeder();
+
+		// Both filled
+		$success = array_sort_by_multiple_keys($data, $sortColumns);
+
+		$this->assertTrue($success);
+
+		// Empty $sortColumns
+		$success = array_sort_by_multiple_keys($data, []);
+
+		$this->assertFalse($success);
+
+		// Empty &$array
+		$data    = [];
+		$success = array_sort_by_multiple_keys($data, $sortColumns);
+
+		$this->assertFalse($success);
+	}
+
+	public function testArraySortByMultipleKeysFailsInconsistentArraySizes()
+	{
+		$this->expectException('ErrorException');
+		$this->expectExceptionMessage('Array sizes are inconsistent');
+
+		$data = $this->sortByMultipleKeysSeeder();
+
+		$sortColumns = [
+			'team.orders' => SORT_ASC,
+			'positions'   => SORT_ASC,
+		];
+
+		$success = array_sort_by_multiple_keys($data, $sortColumns);
+	}
+
 	//--------------------------------------------------------------------
 
 	public function deepSearchProvider()
@@ -178,6 +248,60 @@ class ArrayHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 			[
 				'',
 				null,
+			],
+		];
+	}
+
+	public function sortByMultipleKeysProvider()
+	{
+		return [
+			[
+				[
+					'name' => SORT_STRING,
+				],
+				[
+					'Frank',
+					'John',
+					'Maria',
+				],
+			],
+			[
+				[
+					'team.order' => SORT_ASC,
+					'position'   => SORT_ASC,
+				],
+				[
+					'Frank',
+					'Maria',
+					'John',
+				],
+			],
+		];
+	}
+
+	public function sortByMultipleKeysSeeder()
+	{
+		return [
+			0 => [
+				'name'     => 'John',
+				'position' => 3,
+				'team'     => [
+					'order' => 2,
+				],
+			],
+			1 => [
+				'name'     => 'Maria',
+				'position' => 4,
+				'team'     => [
+					'order' => 1,
+				],
+			],
+			2 => [
+				'name'     => 'Frank',
+				'position' => 1,
+				'team'     => [
+					'order' => 1,
+				],
 			],
 		];
 	}

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -157,10 +157,8 @@ class ArrayHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	/**
 	 * @dataProvider sortByMultipleKeysProvider
 	 */
-	public function testArraySortByMultipleKeysWithArray($sortColumns, $expected)
+	public function testArraySortByMultipleKeysWithArray($data, $sortColumns, $expected)
 	{
-		$data = $this->sortByMultipleKeysSeeder();
-
 		$success = array_sort_by_multiple_keys($data, $sortColumns);
 
 		$this->assertTrue($success);
@@ -170,10 +168,8 @@ class ArrayHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	/**
 	 * @dataProvider sortByMultipleKeysProvider
 	 */
-	public function testArraySortByMultipleKeysWithObjects($sortColumns, $expected)
+	public function testArraySortByMultipleKeysWithObjects($data, $sortColumns, $expected)
 	{
-		$data = $this->sortByMultipleKeysSeeder();
-
 		// Morph to objects
 		foreach($data as $index => $dataSet){
 			$data[$index] = (object) $dataSet;
@@ -188,10 +184,8 @@ class ArrayHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	/**
 	 * @dataProvider sortByMultipleKeysProvider
 	 */
-	public function testArraySortByMultipleKeysFailsEmptyParameter($sortColumns, $expected)
+	public function testArraySortByMultipleKeysFailsEmptyParameter($data, $sortColumns, $expected)
 	{
-		$data = $this->sortByMultipleKeysSeeder();
-
 		// Both filled
 		$success = array_sort_by_multiple_keys($data, $sortColumns);
 
@@ -209,12 +203,13 @@ class ArrayHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertFalse($success);
 	}
 
-	public function testArraySortByMultipleKeysFailsInconsistentArraySizes()
+	/**
+	 * @dataProvider sortByMultipleKeysProvider
+	 */
+	public function testArraySortByMultipleKeysFailsInconsistentArraySizes($data)
 	{
 		$this->expectException('ErrorException');
 		$this->expectExceptionMessage('Array sizes are inconsistent');
-
-		$data = $this->sortByMultipleKeysSeeder();
 
 		$sortColumns = [
 			'team.orders' => SORT_ASC,
@@ -252,36 +247,9 @@ class ArrayHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		];
 	}
 
-	public function sortByMultipleKeysProvider()
+	public static function sortByMultipleKeysProvider()
 	{
-		return [
-			[
-				[
-					'name' => SORT_STRING,
-				],
-				[
-					'Frank',
-					'John',
-					'Maria',
-				],
-			],
-			[
-				[
-					'team.order' => SORT_ASC,
-					'position'   => SORT_ASC,
-				],
-				[
-					'Frank',
-					'Maria',
-					'John',
-				],
-			],
-		];
-	}
-
-	public function sortByMultipleKeysSeeder()
-	{
-		return [
+		$seed = [
 			0 => [
 				'name'     => 'John',
 				'position' => 3,
@@ -301,6 +269,32 @@ class ArrayHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 				'position' => 1,
 				'team'     => [
 					'order' => 1,
+				],
+			],
+		];
+
+		return [
+			[
+				$seed,
+				[
+					'name' => SORT_STRING,
+				],
+				[
+					'Frank',
+					'John',
+					'Maria',
+				],
+			],
+			[
+				$seed,
+				[
+					'team.order' => SORT_ASC,
+					'position'   => SORT_ASC,
+				],
+				[
+					'Frank',
+					'Maria',
+					'John',
 				],
 			],
 		];

--- a/user_guide_src/source/helpers/array_helper.rst
+++ b/user_guide_src/source/helpers/array_helper.rst
@@ -65,3 +65,92 @@ The following functions are available:
     :rtype: mixed
 
     Returns the value of an element with a key value in an array of uncertain depth
+
+..  php:function:: array_sort_by_multiple_keys(array &$array, array $sortColumns)
+
+    :param  array  $array:       The array to be sorted (passed by reference).
+    :param  array  $sortColumns: The array keys to sort after and the respective PHP
+                                 sort flags as an associative array.
+    :returns: Whether sorting was successful or not.
+    :rtype: boolean
+
+    This method sorts the elements of a multidimensonal array by the values of one or
+    more keys in a hierarchical way. Take the following array, that might be returned
+    from, e.g., the ``find()`` function of a model::
+
+        $players = [
+            0 => [
+                'name'     => 'John',
+                'team_id'  => 2,
+                'position' => 3,
+                'team'     => [
+                    'id' => 1,
+                    'order' => 2,
+                ],
+            ],
+            1 => [
+                'name'     => 'Maria',
+                'team_id'  => 5,
+                'position' => 4,
+                'team'     => [
+                    'id' => 5,
+                    'order' => 1,
+                ],
+            ],
+            2 => [
+                'name'     => 'Frank',
+                'team_id'  => 5,
+                'position' => 1,
+                'team'     => [
+                    'id' => 5,
+                    'order' => 1,
+                ],
+            ],
+        ];
+
+    Now sort this array by two keys. Note that the method supports the dot-notation
+    to access values in deeper array levels, but does not support wildcards.
+
+        array_sort_by_multiple_keys($players, [
+            'team.order' => SORT_ASC,
+            'position'   => SORT_ASC,
+        ]);
+
+    The ``$players`` array is now sorted by the ``order`` value in each players'
+    ``team`` subarray. If this value is equal for several players, these players
+    will be ordered by their ``position``. The resulting array is::
+
+        $players = [
+            0 => [
+                'name'     => 'Frank',
+                'team_id'  => 5,
+                'position' => 1,
+                'team'     => [
+                    'id' => 5,
+                    'order' => 1,
+                ],
+            ],
+            1 => [
+                'name'     => 'Maria',
+                'team_id'  => 5,
+                'position' => 4,
+                'team'     => [
+                    'id' => 5,
+                    'order' => 1,
+                ],
+            ],
+            2 => [
+                'name'     => 'John',
+                'team_id'  => 2,
+                'position' => 3,
+                'team'     => [
+                    'id' => 1,
+                    'order' => 2,
+                ],
+            ],
+        ];
+
+    In the same way, the method can also handle an array of objects. In the example
+    above it is further possible that each ``player`` is represented by an array,
+    while the ``teams`` are objects. The method will detect the type of elements in
+    each nesting level and handle it accordingly.

--- a/user_guide_src/source/helpers/array_helper.rst
+++ b/user_guide_src/source/helpers/array_helper.rst
@@ -109,16 +109,18 @@ The following functions are available:
         ];
 
     Now sort this array by two keys. Note that the method supports the dot-notation
-    to access values in deeper array levels, but does not support wildcards.
+    to access values in deeper array levels, but does not support wildcards::
 
-        array_sort_by_multiple_keys($players, [
-            'team.order' => SORT_ASC,
-            'position'   => SORT_ASC,
-        ]);
+        array_sort_by_multiple_keys($players,
+            [
+                'team.order' => SORT_ASC,
+                'position'   => SORT_ASC,
+            ]
+        );
 
-    The ``$players`` array is now sorted by the ``order`` value in each players'
-    ``team`` subarray. If this value is equal for several players, these players
-    will be ordered by their ``position``. The resulting array is::
+    The ``$players`` array is now sorted by the 'order' value in each players'
+    'team' subarray. If this value is equal for several players, these players
+    will be ordered by their 'position'. The resulting array is::
 
         $players = [
             0 => [
@@ -151,6 +153,6 @@ The following functions are available:
         ];
 
     In the same way, the method can also handle an array of objects. In the example
-    above it is further possible that each ``player`` is represented by an array,
-    while the ``teams`` are objects. The method will detect the type of elements in
+    above it is further possible that each 'player' is represented by an array,
+    while the 'teams' are objects. The method will detect the type of elements in
     each nesting level and handle it accordingly.

--- a/user_guide_src/source/helpers/array_helper.rst
+++ b/user_guide_src/source/helpers/array_helper.rst
@@ -84,7 +84,7 @@ The following functions are available:
                 'team_id'  => 2,
                 'position' => 3,
                 'team'     => [
-                    'id' => 1,
+                    'id'    => 1,
                     'order' => 2,
                 ],
             ],
@@ -93,7 +93,7 @@ The following functions are available:
                 'team_id'  => 5,
                 'position' => 4,
                 'team'     => [
-                    'id' => 5,
+                    'id'    => 5,
                     'order' => 1,
                 ],
             ],
@@ -102,7 +102,7 @@ The following functions are available:
                 'team_id'  => 5,
                 'position' => 1,
                 'team'     => [
-                    'id' => 5,
+                    'id'    => 5,
                     'order' => 1,
                 ],
             ],


### PR DESCRIPTION
**Description**
This PR adds a convenience method to CI's `array_helper` to allow sorting a multidimensional array by a list of columns contained in the array. As I find myself using this regularly, I thought maybe others would appreciate this functionality, too.

The helper function takes the reference to an array `&$array` that is to be sorted and an associative array `$sortColumns` of column names and SORT_* flags.
The referenced array is looped and a onedimensional array of values for each column defined in the `$sortColumns` array is generated. Then all of these arrays are passed to the array_multisort function together.

This results in `&$array` being sorted by all of the defined columns and flags hierarchically, which might be useful, e.g., for sorting arrays of entities returned from models.

The method works on both arrays containing sub-arrays and arrays containing objects (e.g., `Entities`).
By using the `.` separator in the column names in `$sortColumns`, deeper levels of `&$array` can be accessed for sorting (e.g., when sorting a list of entities loaded with their relations from Tatter\Relations).

Opinions and improvements very welcome :)

**Checklist:**
- [ ] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

Not sure about the style guide, but I hope it does conform.
Will update user guide if feature is considered useful.
