### PR TITLE
Throttle: allow removal of throttler buckets

### DIFF
--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -150,12 +150,19 @@ class Throttler implements ThrottlerInterface
 		return false;
 	}
 
-	public function remove(string $key) : void
+	/**
+	 * @param string $key The name of the bucket
+	 *
+	 * @return $this
+	 */
+	public function remove(string $key): self
 	{
 		$tokenName = $this->prefix . $key;
 
 		$this->cache->delete($tokenName);
 		$this->cache->delete($tokenName . 'Time');
+
+		return $this;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -150,6 +150,14 @@ class Throttler implements ThrottlerInterface
 		return false;
 	}
 
+	public function remove(string $key) : void
+	{
+		$tokenName = $this->prefix . $key;
+
+		$this->cache->delete($tokenName);
+		$this->cache->delete($tokenName . 'Time');
+	}
+
 	//--------------------------------------------------------------------
 
 	/**

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -39,6 +39,19 @@ class ThrottleTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(59, $this->cache->get('throttler_127.0.0.1'));
 	}
 
+	public function testRemove()
+	{
+		$throttler = new Throttler($this->cache);
+
+		$this->assertTrue($throttler->check('127.0.0.1', 1, MINUTE));
+		$this->assertFalse($throttler->check('127.0.0.1', 1, MINUTE));
+
+		$throttler->remove('127.0.0.1');
+
+		$this->assertNull($this->cache->get('throttler_127.0.0.1'));
+		$this->assertTrue($throttler->check('127.0.0.1', 1, MINUTE));
+	}
+
 	/**
 	 * @group single
 	 */
@@ -120,5 +133,4 @@ class ThrottleTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertTrue($throttler->check('127.0.0.1', $rate, MINUTE, 0));
 		$this->assertEquals(10, round($this->cache->get('throttler_127.0.0.1')));
 	}
-
 }

--- a/user_guide_src/source/libraries/throttler.rst
+++ b/user_guide_src/source/libraries/throttler.rst
@@ -154,3 +154,12 @@ Class Reference
     After ``check()`` has been run and returned FALSE, this method can be used
     to determine the time until a new token should be available and the action can be
     tried again. In this case, the minimum enforced wait time is one second.
+
+.. php:method:: remove(string $key) : self
+
+    :param string $key: The name of the bucket
+    :returns: $this
+    :rtype: self
+
+    Removes & resets the bucket.
+    Won't fail if the bucket doesn't exist.


### PR DESCRIPTION
This allows to manual remove throttler buckets manually.
E.g. after paying a plan or a successful login.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide  
