### PR TITLE
Filters: Fix route filters running twice

### DIFF
--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -509,6 +509,7 @@ class Filters
 	/**
 	 * Maps filter aliases to the equivalent filter classes
 	 *
+	 * @param  string $position
 	 * @throws FilterException
 	 *
 	 * @return void
@@ -536,6 +537,11 @@ class Filters
 				$this->filtersClass[$position][] = $this->config->aliases[$alias];
 			}
 		}
+
+		// when using enableFilter() we already write the class name in ->filtersClass as well as the
+		// alias in ->filters. This leads to duplicates when using route filters.
+		// Since some filters like rate limiters rely on being executed once a request we filter em here.
+		$this->filtersClass[$position] = array_unique($this->filtersClass[$position]);
 	}
 
 	/**


### PR DESCRIPTION
This fixes #3902

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide