### PR TITLE
Array_helper: Add missing test for _array_search_dot.

### DIFF
--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -167,7 +167,7 @@ class ArrayHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function deepSearchProvider()
+	public static function deepSearchProvider()
 	{
 		return [
 			[

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -19,6 +19,17 @@ class ArrayHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(23, dot_array_search('foo.bar', $data));
 	}
 
+	public function testArrayDotTooManyLevels()
+	{
+		$data = [
+			'foo' => [
+				'bar' => 23,
+			],
+		];
+
+		$this->assertEquals(23, dot_array_search('foo.bar.baz', $data));
+	}
+
 	public function testArrayDotReturnNullEmptyArray()
 	{
 		$data = [];


### PR DESCRIPTION
**Description**
With this PR, `array_helper` tests will have 100% coverage.

However, I am not sure, if the current behavior of `_array_search_dot` is desired.

https://github.com/codeigniter4/CodeIgniter4/blob/e6bfd328b3353e178c8b3fe852dbfcccd940501c/system/Helpers/array_helper.php#L90

This line can only be reached, if either the current index is not the last in the dot-notation search string (i.e., we want to search in a deeper level) and at the same time `$array[$currentIndex]` is not an array (i.e., there is no deeper level to search in).

So instead of failing because the search depth is smaller than the array depth, we just break the search and return the deepest level found. Is that desired?

**Checklist:**
- [ ] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide