### PR TITLE
Feature: Validation: allow anonymous functions as rules

### DIFF
--- a/system/Language/en/Validation.php
+++ b/system/Language/en/Validation.php
@@ -17,6 +17,8 @@ return [
    'groupNotFound'         => '{0} is not a validation rules group.',
    'groupNotArray'         => '{0} rule group must be an array.',
    'invalidTemplate'       => '{0} is not a valid Validation template.',
+   'invalidRule'           => '{0} can\'t be used as a rule.',
+   'unnamedRule'           => '{0} has to have a name.',
 
 	// Rule Messages
    'alpha'                 => 'The {field} field may only contain alphabetical characters.',

--- a/system/Validation/Exceptions/ValidationException.php
+++ b/system/Validation/Exceptions/ValidationException.php
@@ -39,4 +39,31 @@ class ValidationException extends FrameworkException
 	{
 		return new static(lang('Validation.noRuleSets'));
 	}
+	public static function forInvalidRule($rule = null) : self
+	{
+		return new static(lang('Validation.invalidRule', [ static::convertRuleToString($rule) ]));
+	}
+
+	public static function forUnnamedRule($rule = null) : self
+	{
+		return new static(lang('Validation.unnamedRule', [ static::convertRuleToString($rule) ]));
+	}
+
+	/**
+	 * Used as a helper to convert anything else than a string to a rule (name)
+	 *
+	 * @param  mixed $rule
+	 * @return string|null
+	 */
+	protected static function convertRuleToString($rule) : ?string
+	{
+		if (! is_string($rule))
+		{
+			// Try to not confuse the developer with something like "Cannot use array as a rule."
+			// but dont leak to much
+			$rule = ENVIRONMENT !== 'production' ? '"' . var_export($rule, true) . '"' : gettype($rule);
+		}
+
+		return $rule;
+	}
 }

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -634,6 +634,23 @@ right after the name of the field the error should belong to::
 
     <?= $validation->showError('username', 'my_single') ?>
 
+Anonymous functions as rule
+************************************************
+
+You need a custom rule but creating a :ref:`global custom rule <validation-creating-custom-rules>` is not a option?
+You can use a anonymous function as rule. Therefore, your anonymous function needs to be set as the second element of an array where the first element is your rule name (``foobar``)::
+
+  $validation->setRules([
+    'name' => [
+      'required',
+      ['foobar', function(mixed $value, array $data) {
+          return (bool) $value;
+      }],
+    ],
+  ]);
+
+.. _validation-creating-custom-rules:
+
 Creating Custom Rules
 ************************************************
 


### PR DESCRIPTION
Allows to use an anonymous function with a name as a rule:
```php
$rules = [
  'max_length[191]',
  [
    'foobar',
    function(mixed $value, array $data) {
      return (bool) $value;
    },
  ],
];
```
Anonymous-function rules also require to be wrapped in an array and have a name for errors as first array item

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide