### PR TITLE
Group routes without a prefix.

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -713,7 +713,7 @@ class RouteCollection implements RouteCollectionInterface
 
 		// To register a route, we'll set a flag so that our router
 		// so it will see the group name.
-		// If the group name is null, we go on using the previously built group name.
+		// If the group name is empty, we go on using the previously built group name.
 		$this->group = $name ? ltrim($oldGroup . '/' . $name, '/') : $oldGroup;
 
 		$callback = array_pop($params);

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -701,12 +701,12 @@ class RouteCollection implements RouteCollectionInterface
 	 *            $route->resource('users');
 	 *     });
 	 *
-	 * @param string|null    $name      The name to group/prefix the routes with.
+	 * @param string         $name      The name to group/prefix the routes with.
 	 * @param array|callable ...$params
 	 *
 	 * @return void
 	 */
-	public function group(?string $name, ...$params)
+	public function group(string $name, ...$params)
 	{
 		$oldGroup   = $this->group;
 		$oldOptions = $this->currentOptions;

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -701,19 +701,20 @@ class RouteCollection implements RouteCollectionInterface
 	 *            $route->resource('users');
 	 *     });
 	 *
-	 * @param string         $name      The name to group/prefix the routes with.
+	 * @param string|null    $name      The name to group/prefix the routes with.
 	 * @param array|callable ...$params
 	 *
 	 * @return void
 	 */
-	public function group(string $name, ...$params)
+	public function group(?string $name, ...$params)
 	{
 		$oldGroup   = $this->group;
 		$oldOptions = $this->currentOptions;
 
 		// To register a route, we'll set a flag so that our router
 		// so it will see the group name.
-		$this->group = ltrim($oldGroup . '/' . $name, '/');
+		// If the group name is null, we go on using the previously built group name.
+		$this->group = $name ? ltrim($oldGroup . '/' . $name, '/') : $oldGroup;
 
 		$callback = array_pop($params);
 

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -308,12 +308,12 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testGroupingWorksWithNullPrefix()
+	public function testGroupingWorksWithEmptyStringPrefix()
 	{
 		$routes = $this->getCollector();
 
 		$routes->group(
-				null, function ($routes) {
+				'', function ($routes) {
 					$routes->add('users/list', '\Users::list');
 				}
 		);
@@ -327,7 +327,7 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testNestedGroupingWorksWithNullPrefix()
+	public function testNestedGroupingWorksWithEmptyPrefix()
 	{
 		$routes = $this->getCollector();
 
@@ -335,7 +335,7 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$routes->group('admin', function ($routes) {
 			$routes->group(
-				null, function ($routes) {
+				'', function ($routes) {
 					$routes->add('users/list', '\Users::list');
 					
 					$routes->group('delegate', function ($routes) {

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -308,6 +308,53 @@ class RouteCollectionTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testGroupingWorksWithNullPrefix()
+	{
+		$routes = $this->getCollector();
+
+		$routes->group(
+				null, function ($routes) {
+					$routes->add('users/list', '\Users::list');
+				}
+		);
+
+		$expected = [
+			'users/list' => '\Users::list',
+		];
+
+		$this->assertEquals($expected, $routes->getRoutes());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testNestedGroupingWorksWithNullPrefix()
+	{
+		$routes = $this->getCollector();
+
+		$routes->add('verify/begin', '\VerifyController::begin');
+
+		$routes->group('admin', function ($routes) {
+			$routes->group(
+				null, function ($routes) {
+					$routes->add('users/list', '\Users::list');
+					
+					$routes->group('delegate', function ($routes) {
+						$routes->add('foo', '\Users::foo');
+					});
+			});
+		});
+
+		$expected = [
+			'verify/begin'       => '\VerifyController::begin',
+			'admin/users/list'   => '\Users::list',
+			'admin/delegate/foo' => '\Users::foo'
+		];
+
+		$this->assertEquals($expected, $routes->getRoutes());
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testHostnameOption()
 	{
 		$_SERVER['HTTP_HOST'] = 'example.com';

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -257,7 +257,7 @@ The value for the filter must match one of the aliases defined within ``app/Conf
 
 At some point, you may want to group routes for the purpose of applying filters or other route 
 config options like namespace, subdomain, etc. Without necessarily needing to add a prefix to the group, you can pass 
-``null`` in place of the prefix and the routes in the group will be routed as though the group never existed but with the 
+an empty string in place of the prefix and the routes in the group will be routed as though the group never existed but with the 
 given route config options.
 
 Environment Restrictions

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -255,6 +255,11 @@ run the filter before or after the controller. This is especially handy during a
 
 The value for the filter must match one of the aliases defined within ``app/Config/Filters.php``.
 
+At some point, you may want to group routes for the purpose of applying filters or other route 
+config options like namespace, subdomain, etc. Without necessarily needing to add a prefix to the group, you can pass 
+``null`` in place of the prefix and the routes in the group will be routed as though the group never existed but with the 
+given route config options.
+
 Environment Restrictions
 ========================
 


### PR DESCRIPTION
Each pull request should address a single issue and have a meaningful title.

**Description**
I ran into bit of an issue while grouping my routes and wanted to achieve something like the below.
```
$routes->group('v1', ['namespace' => 'App\Controllers\V1'], function ($routes) {
    $routes->post('verify/begin', 'VerificationController::generateVerificationCode');
    $routes->post('verify/code', 'VerificationController::verifyCode');
    $routes->post('users', 'UserController::createUser');
    $routes->post('auth', 'AuthController::authenticateUser');
    
    $routes->group(null, ['filter' => 'api-auth', 'namespace' => 'App\Controllers\V1'], function($routes) {
        $routes->put('users', 'UserController::updateUser');
    });
});
```
In essence i wanted to group some routes without a prefix but have them run under certain filters. I realized that when i hit the below end point
```
PUT /v1/users
```
I basically get a 404.

So  i made some changes to make this possible.

These changes could help one group routes under a subdomain for instance without the need for a route prefix, apply security filters on certain routes like i did above, without the need for a prefix, and so on.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide