### PR TITLE
PHP 8 Support

### DIFF
--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -20,8 +20,12 @@ on:
 
 jobs:
   build:
-    name: Analyze code (PHPStan)
+    name: PHP ${{ matrix.php-versions }} Analysis
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.4', '8.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -29,7 +33,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php-versions }}
           extensions: intl
 
       - name: Use latest Composer

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0']
         db-platforms: ['MySQLi', 'Postgre', 'SQLite3', 'Sqlsrv']
 
     services:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -48,6 +48,8 @@ parameters:
 		- '#Return type \(bool\) of method CodeIgniter\\HTTP\\Files\\UploadedFile::move\(\) should be compatible with return type \(CodeIgniter\\Files\\File\) of method CodeIgniter\\Files\\File::move\(\)#'
 		- '#Return type \(bool\) of method CodeIgniter\\Test\\TestLogger::log\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::log\(\)#'
 		- '#Unsafe usage of new static\(\)*#'
+		- '#.GdImage.#'
+	reportUnmatchedIgnoredErrors: false
 	parallel:
 		processTimeout: 300.0
 	scanDirectories:

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -416,6 +416,11 @@ class CodeIgniter
 		{
 			$controller = $this->createController();
 
+			if (! method_exists($controller, '_remap') && ! is_callable([$controller, $this->method], false))
+			{
+				throw PageNotFoundException::forMethodNotFound($this->method);
+			}
+
 			// Is there a "post_controller_constructor" event?
 			Events::trigger('post_controller_constructor');
 
@@ -889,11 +894,6 @@ class CodeIgniter
 		if (! class_exists($this->controller, true) || $this->method[0] === '_')
 		{
 			throw PageNotFoundException::forControllerNotFound($this->controller, $this->method);
-		}
-		if (! method_exists($this->controller, '_remap') &&
-				! is_callable([$this->controller, $this->method], false))
-		{
-			throw PageNotFoundException::forMethodNotFound($this->method);
 		}
 	}
 

--- a/system/Database/Database.php
+++ b/system/Database/Database.php
@@ -42,7 +42,7 @@ class Database
 	 * @return   mixed
 	 * @internal param bool $useBuilder
 	 */
-	public function load(array $params = [], string $alias)
+	public function load(array $params, string $alias)
 	{
 		// Handle universal DSN connection string
 		if (! empty($params['DSN']) && strpos($params['DSN'], '://') !== false)

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -127,7 +127,7 @@ class Connection extends BaseConnection
 					if ($this->encrypt['ssl_verify'])
 					{
 						defined('MYSQLI_OPT_SSL_VERIFY_SERVER_CERT') &&
-						$this->mysqli->options(MYSQLI_OPT_SSL_VERIFY_SERVER_CERT, true);
+						$this->mysqli->options(MYSQLI_OPT_SSL_VERIFY_SERVER_CERT, 1);
 					}
 					// Apparently (when it exists), setting MYSQLI_OPT_SSL_VERIFY_SERVER_CERT
 					// to FALSE didn't do anything, so PHP 5.6.16 introduced yet another

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -129,7 +129,7 @@ class IncomingRequest extends Request
 	 * @param string|null $body
 	 * @param UserAgent   $userAgent
 	 */
-	public function __construct($config, URI $uri = null, $body = 'php://input', UserAgent $userAgent)
+	public function __construct($config, URI $uri = null, $body = 'php://input', UserAgent $userAgent = null)
 	{
 		// Get our body from php://input
 		if ($body === 'php://input')

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -663,7 +663,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 *
 	 * @return array
 	 */
-	protected function calcAspectRatio($width, $height = null, $origWidth, $origHeight): array
+	protected function calcAspectRatio($width, $height, $origWidth, $origHeight): array
 	{
 		// If $height is null, then we have it easy.
 		// Calc based on full image size and be done.

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -111,7 +111,7 @@ class ChromeLoggerHandler extends BaseHandler
 		$message = $this->format($message);
 
 		// Generate Backtrace info
-		$backtrace = debug_backtrace(false, $this->backtraceLevel);
+		$backtrace = debug_backtrace(0, $this->backtraceLevel);
 		$backtrace = end($backtrace);
 
 		$backtraceMessage = 'unknown';

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -462,7 +462,7 @@ class Logger implements LoggerInterface
 		];
 
 		// Generate Backtrace info
-		$trace = \debug_backtrace(false);
+		$trace = \debug_backtrace(0);
 
 		// So we search from the bottom (earliest) of the stack frames
 		$stackFrames = \array_reverse($trace);

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -988,7 +988,7 @@ class RouteCollection implements RouteCollectionInterface
 	 *
 	 * @return RouteCollectionInterface
 	 */
-	public function match(array $verbs = [], string $from, $to, array $options = null): RouteCollectionInterface
+	public function match(array $verbs = [], string $from = '', $to = '', array $options = null): RouteCollectionInterface
 	{
 		foreach ($verbs as $verb)
 		{

--- a/system/Test/Filters/CITestStreamFilter.php
+++ b/system/Test/Filters/CITestStreamFilter.php
@@ -46,7 +46,6 @@ class CITestStreamFilter extends php_user_filter
 			$consumed       += $bucket->datalen;
 		}
 
-		// @phpstan-ignore-next-line
 		return PSFS_PASS_ON;
 	}
 }

--- a/system/Test/Filters/CITestStreamFilter.php
+++ b/system/Test/Filters/CITestStreamFilter.php
@@ -46,6 +46,7 @@ class CITestStreamFilter extends php_user_filter
 			$consumed       += $bucket->datalen;
 		}
 
+		// @phpstan-ignore-next-line
 		return PSFS_PASS_ON;
 	}
 }

--- a/system/Test/ReflectionHelper.php
+++ b/system/Test/ReflectionHelper.php
@@ -97,7 +97,6 @@ trait ReflectionHelper
 	public static function getPrivateProperty($obj, $property)
 	{
 		$refProperty = self::getAccessibleRefProperty($obj, $property);
-		return $refProperty->getValue($obj);
+		return is_string($obj) ? $refProperty->getValue() : $refProperty->getValue($obj);
 	}
-
 }

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -357,7 +357,7 @@ class Rules
 	 *
 	 * @return boolean
 	 */
-	public function required_with($str = null, string $fields, array $data): bool
+	public function required_with($str, string $fields, array $data): bool
 	{
 		$fields = explode(',', $fields);
 
@@ -409,7 +409,7 @@ class Rules
 	 *
 	 * @return boolean
 	 */
-	public function required_without($str = null, string $fields, array $data): bool
+	public function required_without($str, string $fields, array $data): bool
 	{
 		$fields = explode(',', $fields);
 

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -207,7 +207,7 @@ class Validation implements ValidationInterface
 	 *
 	 * @return boolean
 	 */
-	protected function processRules(string $field, string $label = null, $value, $rules = null, array $data): bool
+	protected function processRules(string $field, string $label = null, $value, $rules, array $data): bool
 	{
 		// If the if_exist rule is defined...
 		if (in_array('if_exist', $rules, true))

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -1,10 +1,6 @@
 <?php
 namespace CodeIgniter\Cache\Handlers;
 
-set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline, array $errcontext) {
-	//throw new \ErrorException($errstr, $errno, 0, $errfile, $errline);
-});
-
 class FileHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 {
 

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -875,7 +875,7 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	/**
 	 * @dataProvider mailtoPatterns
 	 */
-	public function testMailto($expected = '', $email, $title = '', $attributes = '')
+	public function testMailto($expected = '', $email = '', $title = '', $attributes = '')
 	{
 		$request      = Services::request($this->config);
 		$request->uri = new URI('http://example.com/');
@@ -912,7 +912,7 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	/**
 	 * @dataProvider safeMailtoPatterns
 	 */
-	public function testSafeMailto($expected = '', $email, $title = '', $attributes = '')
+	public function testSafeMailto($expected = '', $email = '', $title = '', $attributes = '')
 	{
 		$request      = Services::request($this->config);
 		$request->uri = new URI('http://example.com/');


### PR DESCRIPTION
**Description**
This is a first pass at some of the changes that need to happen for PHP 8.0 release. One significant thing this PR does not address is the change to GD return types to use `GDImage` (see https://php.watch/versions/8.0/gdimage), with will need to be addressed in **images/Handler/GDhandler.php**.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
