### PR TITLE
Add support for frame-src to CSP

### DIFF
--- a/app/Config/ContentSecurityPolicy.php
+++ b/app/Config/ContentSecurityPolicy.php
@@ -35,6 +35,7 @@ class ContentSecurityPolicy extends BaseConfig
 	public $fontSrc        = null;
 	public $formAction     = 'self';
 	public $frameAncestors = null;
+	public $frameSrc       = null;
 	public $mediaSrc       = null;
 	public $objectSrc      = 'self';
 	public $manifestSrc    = null;

--- a/env
+++ b/env
@@ -78,6 +78,7 @@
 # contentsecuritypolicy.fontSrc = null
 # contentsecuritypolicy.formAction = null
 # contentsecuritypolicy.frameAncestors = null
+# contentsecuritypolicy.frameSrc = null
 # contentsecuritypolicy.mediaSrc = null
 # contentsecuritypolicy.objectSrc = null
 # contentsecuritypolicy.pluginTypes = null

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -80,6 +80,13 @@ class ContentSecurityPolicy
 	 *
 	 * @var array|string
 	 */
+	protected $frameSrc = [];
+
+	/**
+	 * Used for security enforcement
+	 *
+	 * @var array|string
+	 */
 	protected $imageSrc = [];
 
 	/**
@@ -399,6 +406,26 @@ class ContentSecurityPolicy
 	//--------------------------------------------------------------------
 
 	/**
+	 * Adds a new valid endpoint for valid frame sources. Can be either
+	 * a URI class or a simple string.
+	 *
+	 * @see http://www.w3.org/TR/CSP/#directive-frame-src
+	 *
+	 * @param string|array $uri
+	 * @param boolean|null $explicitReporting
+	 *
+	 * @return $this
+	 */
+	public function addFrameSrc($uri, bool $explicitReporting = null)
+	{
+		$this->addOption($uri, 'frameSrc', $explicitReporting ?? $this->reportOnly);
+
+		return $this;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Adds a new valid endpoint for valid image sources. Can be either
 	 * a URI class or a simple string.
 	 *
@@ -698,6 +725,7 @@ class ContentSecurityPolicy
 			'font-src'        => 'fontSrc',
 			'form-action'     => 'formAction',
 			'frame-ancestors' => 'frameAncestors',
+			'frame-src'       => 'frameSrc',
 			'img-src'         => 'imageSrc',
 			'media-src'       => 'mediaSrc',
 			'object-src'      => 'objectSrc',


### PR DESCRIPTION
Each pull request should address a single issue and have a meaningful title.

Add support for the frame-src directive in the Content Security Policy as per the W3 https://www.w3.org/TR/CSP/#directive-frame-src. While frame-src was deprecated in CSP 2 it was undeprecated in CSP 3 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
