### PR TITLE
Deprecate Message::getHeader(s)

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -657,7 +657,7 @@ class CodeIgniter
 			$output  = $cachedResponse['output'];
 
 			// Clear all default headers
-			foreach ($this->response->getHeaders() as $key => $val)
+			foreach ($this->response->headers() as $key => $val)
 			{
 				$this->response->removeHeader($key);
 			}
@@ -704,7 +704,7 @@ class CodeIgniter
 	public function cachePage(Cache $config)
 	{
 		$headers = [];
-		foreach ($this->response->getHeaders() as $header)
+		foreach ($this->response->headers() as $header)
 		{
 			$headers[$header->getName()] = $header->getValueLine();
 		}

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -140,22 +140,9 @@ class Toolbar
 			$data['vars']['post'][esc($name)] = is_array($value) ? '<pre>' . esc(print_r($value, true)) . '</pre>' : esc($value);
 		}
 
-		foreach ($request->headers() as $value)
+		foreach ($request->headers() as $name => $header)
 		{
-			if (empty($value))
-			{
-				continue;
-			}
-
-			if (! is_array($value))
-			{
-				$value = [$value];
-			}
-
-			foreach ($value as $h)
-			{
-				$data['vars']['headers'][esc($h->getName())] = esc($h->getValueLine());
-			}
+			$data['vars']['headers'][esc($header->getName())] = esc($header->getValueLine());
 		}
 
 		foreach ($request->getCookie() as $name => $value)

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -140,7 +140,7 @@ class Toolbar
 			$data['vars']['post'][esc($name)] = is_array($value) ? '<pre>' . esc(print_r($value, true)) . '</pre>' : esc($value);
 		}
 
-		foreach ($request->getHeaders() as $value)
+		foreach ($request->headers() as $value)
 		{
 			if (empty($value))
 			{

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -473,7 +473,7 @@ class CURLRequest extends Request
 			$this->removeHeader('Accept-Encoding');
 		}
 
-		$headers = $this->getHeaders();
+		$headers = $this->headers();
 
 		if (empty($headers))
 		{
@@ -520,7 +520,7 @@ class CURLRequest extends Request
 		if ($method === 'PUT' || $method === 'POST')
 		{
 			// See http://tools.ietf.org/html/rfc7230#section-3.3.2
-			if (is_null($this->getHeader('content-length')) && ! isset($this->config['multipart']))
+			if (is_null($this->header('content-length')) && ! isset($this->config['multipart']))
 			{
 				$this->setHeader('Content-Length', '0');
 			}

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -248,7 +248,7 @@ class IncomingRequest extends Request
 	 */
 	public function isAJAX(): bool
 	{
-		return $this->hasHeader('X-Requested-With') && strtolower($this->getHeader('X-Requested-With')->getValue()) === 'xmlhttprequest';
+		return $this->hasHeader('X-Requested-With') && strtolower($this->header('X-Requested-With')->getValue()) === 'xmlhttprequest';
 	}
 
 	//--------------------------------------------------------------------
@@ -266,12 +266,12 @@ class IncomingRequest extends Request
 			return true;
 		}
 
-		if ($this->hasHeader('X-Forwarded-Proto') && $this->getHeader('X-Forwarded-Proto')->getValue() === 'https')
+		if ($this->hasHeader('X-Forwarded-Proto') && $this->header('X-Forwarded-Proto')->getValue() === 'https')
 		{
 			return true;
 		}
 
-		if ($this->hasHeader('Front-End-Https') && ! empty($this->getHeader('Front-End-Https')->getValue()) && strtolower($this->getHeader('Front-End-Https')->getValue()) !== 'off')
+		if ($this->hasHeader('Front-End-Https') && ! empty($this->header('Front-End-Https')->getValue()) && strtolower($this->header('Front-End-Https')->getValue()) !== 'off')
 		{
 			return true;
 		}

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -134,11 +134,11 @@ class Message
 	}
 
 	/**
-	 * Returns an array containing all headers.
+	 * Returns an array containing all Headers.
 	 *
-	 * @return array        An array of the request headers
+	 * @return Header[] An array of the Header objects
 	 */
-	public function getHeaders(): array
+	public function headers(): array
 	{
 		// If no headers are defined, but the user is
 		// requesting it, then it's likely they want
@@ -152,14 +152,14 @@ class Message
 	}
 
 	/**
-	 * Returns a single header object. If multiple headers with the same
+	 * Returns a single Header object. If multiple headers with the same
 	 * name exist, then will return an array of header objects.
 	 *
 	 * @param string $name
 	 *
 	 * @return array|Header|null
 	 */
-	public function getHeader(string $name)
+	public function header($name)
 	{
 		$origName = $this->getHeaderName($name);
 
@@ -169,6 +169,33 @@ class Message
 		}
 
 		return $this->headers[$origName];
+	}
+
+	/**
+	 * Returns an array containing all headers.
+	 *
+	 * @return array        An array of the request headers
+	 *
+	 * @deprecated Use Message::headers() to make room for PSR-7
+	 */
+	public function getHeaders(): array
+	{
+		return $this->headers();
+	}
+
+	/**
+	 * Returns a single header object. If multiple headers with the same
+	 * name exist, then will return an array of header objects.
+	 *
+	 * @param string $name
+	 *
+	 * @return array|Header|null
+	 *
+	 * @deprecated Use Message::header() to make room for PSR-7
+	 */
+	public function getHeader(string $name)
+	{
+		return $this->header($name);
 	}
 
 	/**
@@ -358,6 +385,6 @@ class Message
 	public function isJSON()
 	{
 		return $this->hasHeader('Content-Type')
-			&& $this->getHeader('Content-Type')->getValue() === 'application/json';
+			&& $this->header('Content-Type')->getValue() === 'application/json';
 	}
 }

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -21,7 +21,7 @@ class Message
 	/**
 	 * List of all HTTP request headers.
 	 *
-	 * @var array
+	 * @var array<string,Header>
 	 */
 	protected $headers = [];
 
@@ -136,7 +136,7 @@ class Message
 	/**
 	 * Returns an array containing all Headers.
 	 *
-	 * @return Header[] An array of the Header objects
+	 * @return array<string,Header> An array of the Header objects
 	 */
 	public function headers(): array
 	{
@@ -174,7 +174,7 @@ class Message
 	/**
 	 * Returns an array containing all headers.
 	 *
-	 * @return array        An array of the request headers
+	 * @return array<string,Header> An array of the request headers
 	 *
 	 * @deprecated Use Message::headers() to make room for PSR-7
 	 */

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -207,8 +207,8 @@ class Security
 
 		// Do the tokens exist in _POST, HEADER or optionally php:://input - json data
 		$CSRFTokenValue = $_POST[$this->CSRFTokenName] ??
-			(! is_null($request->getHeader($this->CSRFHeaderName)) && ! empty($request->getHeader($this->CSRFHeaderName)->getValue()) ?
-				$request->getHeader($this->CSRFHeaderName)->getValue() :
+			(! is_null($request->header($this->CSRFHeaderName)) && ! empty($request->header($this->CSRFHeaderName)->getValue()) ?
+				$request->header($this->CSRFHeaderName)->getValue() :
 				(! empty($request->getBody()) && ! empty($json = json_decode($request->getBody())) && json_last_error() === JSON_ERROR_NONE ?
 					($json->{$this->CSRFTokenName} ?? null) :
 					null));

--- a/user_guide_src/source/changelogs/v4.0.5.rst
+++ b/user_guide_src/source/changelogs/v4.0.5.rst
@@ -26,3 +26,5 @@ Deprecations:
 - Deprecated ``migrate:create`` command in favor of ``make:migration`` command.
 - Deprecated ``CodeIgniter\Database\ModelFactory`` in favor of ``CodeIgniter\Config\Factories::models()``
 - Deprecated ``CodeIgniter\Config\Config`` in favor of ``CodeIgniter\Config\Factories::config()``
+- Deprecated ``CodeIgniter\HTTP\Message::getHeader`` in favor of ``header()`` to prepare for PSR-7
+- Deprecated ``CodeIgniter\HTTP\Message::getHeaders`` in favor of ``headers()`` to prepare for PSR-7

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -170,11 +170,11 @@ exception of ``getJSON()``.
 Retrieving Headers
 ----------------------------------------------------------------------------
 
-You can get access to any header that was sent with the request with the ``getHeaders()`` method, which returns
+You can get access to any header that was sent with the request with the ``headers()`` method, which returns
 an array of all headers, with the key as the name of the header, and the value is an instance of
 ``CodeIgniter\HTTP\Header``::
 
-    var_dump($request->getHeaders());
+    var_dump($request->headers());
 
     [
         'Host'          => CodeIgniter\HTTP\Header,
@@ -182,13 +182,13 @@ an array of all headers, with the key as the name of the header, and the value i
         'Accept'        => CodeIgniter\HTTP\Header,
     ]
 
-If you only need a single header, you can pass the name into the ``getHeader()`` method. This will grab the
+If you only need a single header, you can pass the name into the ``header()`` method. This will grab the
 specified header object in a case-insensitive manner if it exists. If not, then it will return ``null``::
 
     // these are all equivalent
-    $host = $request->getHeader('host');
-    $host = $request->getHeader('Host');
-    $host = $request->getHeader('HOST');
+    $host = $request->header('host');
+    $host = $request->header('Host');
+    $host = $request->header('HOST');
 
 You can always use ``hasHeader()`` to see if the header existed in this request::
 
@@ -297,8 +297,8 @@ The methods provided by the parent classes that are available are:
 * :meth:`CodeIgniter\\HTTP\\Message::setBody`
 * :meth:`CodeIgniter\\HTTP\\Message::appendBody`
 * :meth:`CodeIgniter\\HTTP\\Message::populateHeaders`
-* :meth:`CodeIgniter\\HTTP\\Message::getHeaders`
-* :meth:`CodeIgniter\\HTTP\\Message::getHeader`
+* :meth:`CodeIgniter\\HTTP\\Message::headers`
+* :meth:`CodeIgniter\\HTTP\\Message::header`
 * :meth:`CodeIgniter\\HTTP\\Message::hasHeader`
 * :meth:`CodeIgniter\\HTTP\\Message::getHeaderLine`
 * :meth:`CodeIgniter\\HTTP\\Message::setHeader`

--- a/user_guide_src/source/incoming/message.rst
+++ b/user_guide_src/source/incoming/message.rst
@@ -74,14 +74,14 @@ Class Reference
         The preceding ``HTTP_`` is removed from the string. So ``HTTP_ACCEPT_LANGUAGE`` becomes
         ``Accept-Language``.
 
-    .. php:method:: getHeaders()
+    .. php:method:: headers()
 
         :returns: An array of all of the headers found.
         :rtype: array
 
         Returns an array of all headers found or previously set.
 
-    .. php:method:: getHeader($name)
+    .. php:method:: header($name)
 
         :param  string  $name: The name of the header you want to retrieve the value of.
         :returns: Returns a single header object. If multiple headers with the same name exist, then will return an array of header objects.
@@ -91,19 +91,19 @@ Class Reference
         While the header is converted internally as described above, you can access the header with any type of case::
 
             // These are all the same:
-            $message->getHeader('HOST');
-            $message->getHeader('Host');
-            $message->getHeader('host');
+            $message->header('HOST');
+            $message->header('Host');
+            $message->header('host');
 
         If the header has multiple values, ``getValue()`` will return as an array of values. You can use the ``getValueLine()``
         method to retrieve the values as a string::
 
-            echo $message->getHeader('Accept-Language');
+            echo $message->header('Accept-Language');
 
             // Outputs something like:
             'Accept-Language: en,en-US'
 
-            echo $message->getHeader('Accept-Language')->getValue();
+            echo $message->header('Accept-Language')->getValue();
 
             // Outputs something like:
             [
@@ -111,14 +111,14 @@ Class Reference
                 'en-US'
             ]
 
-            echo $message->getHeader('Accept-Language')->getValueLine();
+            echo $message->header('Accept-Language')->getValueLine();
 
             // Outputs something like:
             'en,en-US'
 
         You can filter the header by passing a filter value in as the second parameter::
 
-            $message->getHeader('Document-URI', FILTER_SANITIZE_URL);
+            $message->header('Document-URI', FILTER_SANITIZE_URL);
 
     .. php:method:: hasHeader($name)
 

--- a/user_guide_src/source/installation/upgrade_405.rst
+++ b/user_guide_src/source/installation/upgrade_405.rst
@@ -12,3 +12,10 @@ exists for Response cookies and for CSRF cookies.
 For additional information, see `MDN Web Docs <https://developer.mozilla.org/pl/docs/Web/HTTP/Headers/Set-Cookie/SameSite>`_.
 The SameSite specifications are described in `RFC 6265 <https://tools.ietf.org/html/rfc6265>`_
 and the `RFC 6265bis revision <https://datatracker.ietf.org/doc/draft-ietf-httpbis-rfc6265bis/?include_text=1>`_.
+
+**Message::getHeader(s)**
+
+The HTTP layer is moving towards `PSR-7 compliance <https://www.php-fig.org/psr/psr-7/>`_. Towards this end
+``Message::getHeader()`` and ``Message::getHeaders()`` are deprecated and should be replaced
+with ``Message::header()`` and ``Message::headers()`` respectively. Note that this pertains
+to all classes that extend ``Message`` as well: ``Request``, ``Response`` and their subclasses.


### PR DESCRIPTION
**Description**
In the interest of moving towards partial PSR-7 compliance this PR adds the `header()` and `headers()` methods to `Message` and deprecates the current `getHeader()` and `getHeaders()` methods which conflict with the PSR's interface.

Note that I've left tests pointing to the original methods since they call the new ones and thus should not adversely affect code coverage.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
