### PR TITLE
Backfill Parameters

### DIFF
--- a/system/Database/Database.php
+++ b/system/Database/Database.php
@@ -41,8 +41,13 @@ class Database
 	 * @return   mixed
 	 * @internal param bool $useBuilder
 	 */
-	public function load(array $params = [], string $alias)
+	public function load(array $params = [], string $alias = '')
 	{
+		if (empty($alias))
+		{
+			throw new InvalidArgumentException('You must supply the parameter: alias.');
+		}
+
 		// Handle universal DSN connection string
 		if (! empty($params['DSN']) && strpos($params['DSN'], '://') !== false)
 		{

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -16,6 +16,7 @@ use CodeIgniter\HTTP\Files\FileCollection;
 use CodeIgniter\HTTP\Files\UploadedFile;
 use Config\App;
 use Config\Services;
+use InvalidArgumentException;
 use Locale;
 
 /**
@@ -128,8 +129,13 @@ class IncomingRequest extends Request
 	 * @param string|null $body
 	 * @param UserAgent   $userAgent
 	 */
-	public function __construct($config, URI $uri = null, $body = 'php://input', UserAgent $userAgent)
+	public function __construct($config, URI $uri = null, $body = 'php://input', UserAgent $userAgent = null)
 	{
+		if (empty($uri) || empty($userAgent))
+		{
+			throw new InvalidArgumentException('You must supply the parameters: uri, userAgent.');
+		}
+
 		// Get our body from php://input
 		if ($body === 'php://input')
 		{

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -15,6 +15,7 @@ use CodeIgniter\Images\Exceptions\ImageException;
 use CodeIgniter\Images\Image;
 use CodeIgniter\Images\ImageHandlerInterface;
 use Config\Images;
+use InvalidArgumentException;
 
 /**
  * Base image handling implementation
@@ -662,8 +663,13 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 *
 	 * @return array
 	 */
-	protected function calcAspectRatio($width, $height = null, $origWidth, $origHeight): array
+	protected function calcAspectRatio($width, $height = null, $origWidth = 0, $origHeight = 0): array
 	{
+		if (empty($origWidth) || empty($origHeight))
+		{
+			throw new InvalidArgumentException('You must supply the parameters: origWidth, origHeight.');
+		}
+
 		// If $height is null, then we have it easy.
 		// Calc based on full image size and be done.
 		if (is_null($height))

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -462,7 +462,7 @@ class Logger implements LoggerInterface
 		];
 
 		// Generate Backtrace info
-		$trace = \debug_backtrace(false);
+		$trace = \debug_backtrace(0);
 
 		// So we search from the bottom (earliest) of the stack frames
 		$stackFrames = \array_reverse($trace);

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -17,6 +17,7 @@ use CodeIgniter\HTTP\Request;
 use CodeIgniter\Router\Exceptions\RouterException;
 use Config\Modules;
 use Config\Services;
+use InvalidArgumentException;
 
 /**
  * Class RouteCollection
@@ -988,8 +989,13 @@ class RouteCollection implements RouteCollectionInterface
 	 *
 	 * @return RouteCollectionInterface
 	 */
-	public function match(array $verbs = [], string $from, $to, array $options = null): RouteCollectionInterface
+	public function match(array $verbs = [], string $from = '', $to = '', array $options = null): RouteCollectionInterface
 	{
+		if (empty($from) || empty($to))
+		{
+			throw new InvalidArgumentException('You must supply the parameters: from, to.');
+		}
+
 		foreach ($verbs as $verb)
 		{
 			$verb = strtolower($verb);

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Validation;
 
 use Config\Database;
+use InvalidArgumentException;
 
 /**
  * Validation Rules.
@@ -352,13 +353,18 @@ class Rules
 	 *     required_with[password]
 	 *
 	 * @param string|null $str
-	 * @param string      $fields List of fields that we should check if present
+	 * @param string|null $fields List of fields that we should check if present
 	 * @param array       $data   Complete list of fields from the form
 	 *
 	 * @return boolean
 	 */
-	public function required_with($str = null, string $fields, array $data): bool
+	public function required_with($str = null, string $fields = null, array $data = []): bool
 	{
+		if (is_null($fields) || empty($data))
+		{
+			throw new InvalidArgumentException('You must supply the parameters: fields, data.');
+		}
+
 		$fields = explode(',', $fields);
 
 		// If the field is present we can safely assume that
@@ -404,13 +410,18 @@ class Rules
 	 *     required_without[id,email]
 	 *
 	 * @param string|null $str
-	 * @param string      $fields
+	 * @param string|null $fields
 	 * @param array       $data
 	 *
 	 * @return boolean
 	 */
-	public function required_without($str = null, string $fields, array $data): bool
+	public function required_without($str = null, string $fields = null, array $data = []): bool
 	{
+		if (is_null($fields) || empty($data))
+		{
+			throw new InvalidArgumentException('You must supply the parameters: fields, data.');
+		}
+
 		$fields = explode(',', $fields);
 
 		// If the field is present we can safely assume that

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -206,8 +206,13 @@ class Validation implements ValidationInterface
 	 *
 	 * @return boolean
 	 */
-	protected function processRules(string $field, string $label = null, $value, $rules = null, array $data): bool
+	protected function processRules(string $field, string $label = null, $value, $rules = null, array $data = null): bool
 	{
+		if (is_null($data))
+		{
+			throw new InvalidArgumentException('You must supply the parameter: data.');
+		}
+
 		// If the if_exist rule is defined...
 		if (in_array('if_exist', $rules, true))
 		{


### PR DESCRIPTION
**Description**
This PR addresses the now-deprecated(PHP 8) use of mandatory parameters following optional parameters. Split off from #3931.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
