### PR TITLE
Autoloading Aliases

### DIFF
--- a/app/Config/Autoload.php
+++ b/app/Config/Autoload.php
@@ -63,4 +63,22 @@ class Autoload extends AutoloadConfig
 	 * @var array<string, string>
 	 */
 	public $classmap = [];
+
+	/**
+	 * -------------------------------------------------------------------
+	 * Aliases
+	 * -------------------------------------------------------------------
+	 * Class aliasing allows you to "intercept" a class by providing your
+	 * own (compatible) class instead. Be sure you understand the way
+	 * class_alias() works and its limitations before using this.
+	 *
+	 * Prototype:
+	 *
+	 *   $aliases = [
+	 *       'CodeIgniter\Honeypot\Honeypot' => 'App\ThirdParty\CompatibleHoneypotReplacement',
+	 *   ];
+	 *
+	 * @var array<string, string>
+	 */
+	public $aliases = [];
 }

--- a/tests/_support/Autoloader/Foobar1.php
+++ b/tests/_support/Autoloader/Foobar1.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Support\Autoloader;
+
+class Foobar1
+{
+	public $isFoobar = true;
+}

--- a/tests/_support/Autoloader/Foobar2.php
+++ b/tests/_support/Autoloader/Foobar2.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Support\Autoloader;
+
+class Foobar2
+{
+	public $isFoobar = true;
+}

--- a/tests/_support/Autoloader/Replacement.php
+++ b/tests/_support/Autoloader/Replacement.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Support\Autoloader;
+
+class Replacement
+{
+	public $isFoobar = false;
+}

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -252,4 +252,76 @@ class AutoloaderTest extends CIUnitTestCase
 		$namespaces = $this->loader->getNamespace();
 		$this->assertArrayNotHasKey('Laminas\\Escaper', $namespaces);
 	}
+
+	public function testAliasReplaceesOriginalClass()
+	{
+		$config  = new Autoload();
+		$modules = new Modules();
+
+		$config->aliases = [
+			'Tests\Support\Autoloader\Foobar1' => 'Tests\Support\Autoloader\Replacement',
+		];
+
+		$this->loader = new Autoloader();
+		$this->loader->initialize($config, $modules)->register();
+
+		// Try to load the class
+		$instance = new \Tests\Support\Autoloader\Foobar1();
+
+		$this->assertFalse($instance->isFoobar);
+	}
+
+	public function testAliasReplacementNotFoundUsesFallback()
+	{
+		$config  = new Autoload();
+		$modules = new Modules();
+
+		$config->aliases = [
+			'Tests\Support\Autoloader\Foobar2' => 'Tests\Support\Autoloader\Nonexistant',
+		];
+
+		$this->loader = new Autoloader();
+		$this->loader->initialize($config, $modules)->register();
+
+		// Try to load the class
+		$instance = new \Tests\Support\Autoloader\Foobar2();
+
+		$this->assertTrue($instance->isFoobar);
+	}
+
+	public function testAliasNonexistantStillReplaces()
+	{
+		$config  = new Autoload();
+		$modules = new Modules();
+
+		$config->aliases = [
+			'Tests\Support\Autoloader\Foobar3' => 'Tests\Support\Autoloader\Replacement',
+		];
+
+		$this->loader = new Autoloader();
+		$this->loader->initialize($config, $modules)->register();
+
+		// Try to load the class
+		$instance = new \Tests\Support\Autoloader\Foobar3();
+
+		$this->assertFalse($instance->isFoobar);
+	}
+
+	public function testAliasNeitherFoundFails()
+	{
+		$config  = new Autoload();
+		$modules = new Modules();
+
+		$config->aliases = [
+			'Tests\Support\Autoloader\Foobar4' => 'Tests\Support\Autoloader\Nonexistant',
+		];
+
+		$this->loader = new Autoloader();
+		$this->loader->initialize($config, $modules)->register();
+
+		// Check for the class
+		$result = class_exists('Tests\Support\Autoloader\Foobar4');
+
+		$this->assertFalse($result);
+	}
 }

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -76,6 +76,26 @@ third-party libraries that are not namespaced::
 
 The key of each row is the name of the class that you want to locate. The value is the path to locate it at.
 
+Aliasing
+========
+
+A third property of your Autoload Config Class may specify class aliases. This provides a powerful way
+to "intercept" requests for an unloaded class and alias it to an alternate name. This option should
+only be used if you know how `class aliasing <https://www.php.net/manual/en/function.class-alias.php>`_
+works and the limitations of autoloading priority.
+
+Classes in this array are defined with the alias as the key and the original as the value.
+Another way to think of this is the key is the class you want to "replace" and the value is
+your new class to use instead of it::
+
+	$aliases = [
+		'CodeIgniter\Honeypot\Honeypot' => 'App\ThirdParty\CompatibleHoneypotReplacement',
+	];
+
+Aliases are "lazy loaded" by the Autoloader instead of processed all at once to increase performance.
+Keep this in mind when writing tests or other Autoloaders to ensure your classes get aliased
+properly, since ``Autoloader::loadClass()`` will only be called when a class is not known.
+
 Legacy Support
 ==============
 


### PR DESCRIPTION
**Description**
This PR adds a new `Autoloader` property to the config file: `$aliases`. Aliasing will allow the autoloader to intercept a class request and return an aliased version instead on-the-fly. This will make it easier to transition framework classes with user intervention as well as to replace core classes with user-defined versions.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
