### PR TITLE
Replace Core Services

### DIFF
--- a/app/Config/Services.php
+++ b/app/Config/Services.php
@@ -2,7 +2,7 @@
 
 namespace Config;
 
-use CodeIgniter\Config\Services as CoreServices;
+use CodeIgniter\Config\BaseService;
 
 /**
  * Services Configuration file.
@@ -17,7 +17,7 @@ use CodeIgniter\Config\Services as CoreServices;
  * method format you should use for your service methods. For more examples,
  * see the core Services file at system/Config/Services.php.
  */
-class Services extends CoreServices
+class Services extends BaseService
 {
 	// public static function example($getShared = true)
 	// {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -37,6 +37,7 @@ parameters:
 		- '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::supportsForeignKeys\(\)#'
 		- '#Call to an undefined method CodeIgniter\\Database\\ConnectionInterface::(tableExists|protectIdentifiers|setAliasedTables|escapeIdentifiers|affectedRows|addTableAlias|getIndexData)\(\)#'
 		- '#Call to an undefined method CodeIgniter\\Router\\RouteCollectionInterface::(getDefaultNamespace|isFiltered|getFilterForRoute|getRoutesOptions)\(\)#'
+		- '#Call to an undefined static method Config\\Services::[a-z]+\(\)#'
 		- '#Cannot access property [\$a-z_]+ on ((bool\|)?object\|resource)#'
 		- '#Cannot call method [a-zA-Z_]+\(\) on ((bool\|)?object\|resource)#'
 		- '#Method CodeIgniter\\Database\\ConnectionInterface::query\(\) invoked with 3 parameters, 1-2 required#'

--- a/system/Common.php
+++ b/system/Common.php
@@ -907,7 +907,7 @@ if (! function_exists('redirect'))
 	 */
 	function redirect(string $uri = null): RedirectResponse
 	{
-		$response = Services::redirectResponse(null, true);
+		$response = Services::redirectresponse(null, true);
 
 		if (! empty($uri))
 		{

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -182,7 +182,7 @@ class BaseService
 	public static function serviceExists(string $name): ?string
 	{
 		static::buildServicesCache();
-		$services = array_merge([Services::class], self::$serviceNames);
+		$services = array_merge(self::$serviceNames, [Services::class]);
 		$name     = strtolower($name);
 
 		foreach ($services as $service)

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -600,11 +600,11 @@ class Services extends BaseService
 	 *
 	 * @return RedirectResponse
 	 */
-	public static function redirectResponse(App $config = null, bool $getShared = true)
+	public static function redirectresponse(App $config = null, bool $getShared = true)
 	{
 		if ($getShared)
 		{
-			return static::getSharedInstance('redirectResponse', $config);
+			return static::getSharedInstance('redirectresponse', $config);
 		}
 
 		$config   = $config ?? config('App');

--- a/tests/_support/Config/Services.php
+++ b/tests/_support/Config/Services.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Support\Config;
 
+use CodeIgniter\HTTP\URI;
 use Config\Services as BaseServices;
 use RuntimeException;
 

--- a/tests/_support/Config/Services.php
+++ b/tests/_support/Config/Services.php
@@ -3,13 +3,13 @@
 namespace Tests\Support\Config;
 
 use Config\Services as BaseServices;
-use Tatter\Https\ServerRequest;
+use RuntimeException;
 
 /**
  * Services Class
  *
- * Defines our version of the HTTP services to override
- * the framework defaults.
+ * Provides a replacement uri Service
+ * to demonstrate overriding core services.
  */
 class Services extends BaseServices
 {
@@ -23,9 +23,10 @@ class Services extends BaseServices
 	 */
 	public static function uri(string $uri = null, bool $getShared = true)
 	{
+		// Intercept our test case
 		if ($uri === 'testCanReplaceFrameworkServices')
 		{
-			$_SESSION['testCanReplaceFrameworkServices'] = true;
+			throw new RuntimeException('Service originated from ' . static::class);
 		}
 
 		if ($getShared)

--- a/tests/_support/Config/Services.php
+++ b/tests/_support/Config/Services.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Support\Config;
+
+use Config\Services as BaseServices;
+use Tatter\Https\ServerRequest;
+
+/**
+ * Services Class
+ *
+ * Defines our version of the HTTP services to override
+ * the framework defaults.
+ */
+class Services extends BaseServices
+{
+	/**
+	 * The URI class provides a way to model and manipulate URIs.
+	 *
+	 * @param string  $uri
+	 * @param boolean $getShared
+	 *
+	 * @return URI
+	 */
+	public static function uri(string $uri = null, bool $getShared = true)
+	{
+		if ($uri === 'testCanReplaceFrameworkServices')
+		{
+			$_SESSION['testCanReplaceFrameworkServices'] = true;
+		}
+
+		if ($getShared)
+		{
+			return static::getSharedInstance('uri', $uri);
+		}
+
+		return new URI($uri);
+	}
+}

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -352,4 +352,13 @@ class ServicesTest extends CIUnitTestCase
 		rename(COMPOSER_PATH . '.backup', COMPOSER_PATH);
 	}
 
+	public function testCanReplaceFrameworkServices()
+	{
+		$this->assertArrayNotHasKey('testCanReplaceFrameworkServices', $_SESSION);
+
+		Services::uri('testCanReplaceFrameworkServices');
+
+		$this->assertArrayHasKey('testCanReplaceFrameworkServices', $_SESSION);		
+		unset($_SESSION['testCanReplaceFrameworkServices']);
+	}
 }

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -25,6 +25,14 @@ class ServicesTest extends CIUnitTestCase
 		Services::reset();
 	}
 
+	public function testCanReplaceFrameworkServices()
+	{
+		$this->expectException('RuntimeException');
+		$this->expectExceptionMessage('Service originated from Tests\Support\Config\Services');
+
+		Services::uri('testCanReplaceFrameworkServices');
+	}
+
 	public function testNewAutoloader()
 	{
 		$actual = Services::autoloader();
@@ -350,15 +358,5 @@ class ServicesTest extends CIUnitTestCase
 		rename(COMPOSER_PATH, COMPOSER_PATH . '.backup');
 		$this->assertInstanceOf(\Config\Services::class, new \Config\Services());
 		rename(COMPOSER_PATH . '.backup', COMPOSER_PATH);
-	}
-
-	public function testCanReplaceFrameworkServices()
-	{
-		$this->assertArrayNotHasKey('testCanReplaceFrameworkServices', $_SESSION);
-
-		Services::uri('testCanReplaceFrameworkServices');
-
-		$this->assertArrayHasKey('testCanReplaceFrameworkServices', $_SESSION);		
-		unset($_SESSION['testCanReplaceFrameworkServices']);
 	}
 }

--- a/user_guide_src/source/changelogs/v4.0.5.rst
+++ b/user_guide_src/source/changelogs/v4.0.5.rst
@@ -23,6 +23,7 @@ Bugs Fixed:
 
 - Fixed a bug in ``Entity`` class where declaring class parameters was preventing data propagation to the ``attributes`` array.
 - Handling for the environment variable ``encryption.key`` has changed. Previously, explicit function calls, like ``getenv('encryption.key')`` or ``env('encryption.key')`` where the value has the special prefix ``hex2bin:`` returns an automatically converted binary string. This is now changed to just return the character string with the prefix. This change was due to incompatibility with handling binary strings in environment variables on Windows platforms. However, accessing ``$key`` using ``Encryption`` class config remains unchanged and still returns a binary string.
+- ``Config\Services`` (in **app/Config/Services.php**) now extends ``CodeIgniter\Config\BaseService`` to allow proper discovery of third-party services.
 
 Deprecations:
 

--- a/user_guide_src/source/installation/upgrade_405.rst
+++ b/user_guide_src/source/installation/upgrade_405.rst
@@ -57,3 +57,8 @@ updated requirements. These methods are as follows:
 
 To facilitate use of this interface these methods have been moved from the framework's ``Response`` into a ``ResponseTrait``
 which you may use, and ``DownloadResponse`` now extends ``Response`` directly to ensure maximum compatibility.
+
+**Config\Services**
+
+Service discovery has been updated to allow third-party services (when enabled via Modules) to take precedence over core services. Update
+**app/Config/Services.php** so the class extends ``CodeIgniter\Config\BaseService`` to allow proper discovery of third-party services.


### PR DESCRIPTION
Right now the only way to replace a core service is to create a new version in the extended version **app/Config/Services.php**. This means that modules and other namespaces cannot offer service replacements.

The problem is twofold:
1. All the system static methods are public which means they will match without using `__callStatic`’s lookup
2. The Services config discovery appends classes and then match the first instance, so the default system class will always match first

~~This PR provides a test case demonstrating the failure. If we want this as a "feature" (namespace replacement of core services) I could come back later and add it to this PR.~~

***

EDIT: This PR now applies the changes necessary to replace core services from any namespace. I took a different approach than outlined above because `method_exists()` is still `true` for protected static methods yet `is_callable()` is *always* true when there is a `__callStatic()` definition. This PR changes `Config\Services` to extend `BaseServices` which will skip anything defined in `CodeIgniter\Config\Services` and thus force discovery. Class precedence (number 2 above) has also been reworked to this priority: `App`, any other namespace, `CodeIgniter` (**system**).
