### PR TITLE
[ci skip] added varning about .env and phpinfo()

### DIFF
--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -113,6 +113,8 @@ overwritten. The loaded Environment variables are accessed using any of the foll
 	$s3_bucket = $_ENV['S3_BUCKET'];
 	$s3_bucket = $_SERVER['S3_BUCKET'];
 
+.. important:: Note that your settings from the **.env** file are added to Environment Variables. As a side effect, this means that if your CodeIgniter application is (for example) generating a ``var_dump($_ENV)`` or ``phpinfo()`` (for debugging or other valid reasons) **your secure credentials are publicly exposed**.
+
 Nesting Variables
 =================
 


### PR DESCRIPTION
**Description**
Updated documentation to remind users that information from .env is available in the output from phpinfo() and other commands dumping Environment Variables.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
