### PR TITLE
Fix mime types for .srt and .vtt.

### DIFF
--- a/app/Config/Mimes.php
+++ b/app/Config/Mimes.php
@@ -462,10 +462,12 @@ class Mimes
 		'srt'   => [
 			'text/srt',
 			'text/plain',
+			'application/octet-stream',
 		],
 		'vtt'   => [
 			'text/vtt',
 			'text/plain',
+			'application/octet-stream',
 		],
 		'ico'   => [
 			'image/x-icon',


### PR DESCRIPTION
Fixes #3921.
Came across this when trying to upload `.vtt` files.


**Checklist:**
- [x] Securely signed commits