### PR TITLE
Avoid required arguments after typed nullable arguments.

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -374,13 +374,13 @@ class CodeIgniter
 	 * Handles the main request logic and fires the controller.
 	 *
 	 * @param RouteCollectionInterface|null $routes
-	 * @param Cache                         $cacheConfig
+	 * @param Cache|null                    $cacheConfig
 	 * @param boolean                       $returnResponse
 	 *
 	 * @return RequestInterface|ResponseInterface|mixed
 	 * @throws RedirectException
 	 */
-	protected function handleRequest(RouteCollectionInterface $routes = null, Cache $cacheConfig, bool $returnResponse = false)
+	protected function handleRequest(RouteCollectionInterface $routes = null, Cache $cacheConfig = null, bool $returnResponse = false)
 	{
 		$routeFilter = $this->tryToRouteIt($routes);
 

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1319,15 +1319,15 @@ class BaseBuilder
 	/**
 	 * Platform independent LIKE statement builder.
 	 *
-	 * @param string  $prefix
-	 * @param string  $column
-	 * @param string  $not
-	 * @param string  $bind
-	 * @param boolean $insensitiveSearch
+	 * @param string|null  $prefix
+	 * @param string|null  $column
+	 * @param string|null  $not
+	 * @param string|null  $bind
+	 * @param boolean      $insensitiveSearch
 	 *
 	 * @return string     $like_statement
 	 */
-	protected function _like_statement(string $prefix = null, string $column, string $not = null, string $bind, bool $insensitiveSearch = false): string
+	protected function _like_statement(string $prefix = null, string $column = null, string $not = null, string $bind = null, bool $insensitiveSearch = false): string
 	{
 		$likeStatement = "{$prefix} {$column} {$not} LIKE :{$bind}:";
 

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -361,15 +361,15 @@ class Builder extends BaseBuilder
 	 *
 	 * @see https://www.postgresql.org/docs/9.2/static/functions-matching.html
 	 *
-	 * @param string  $prefix
-	 * @param string  $column
-	 * @param string  $not
-	 * @param string  $bind
-	 * @param boolean $insensitiveSearch
+	 * @param string|null  $prefix
+	 * @param string|null  $column
+	 * @param string|null  $bind
+	 * @param string|null  $not
+	 * @param boolean      $insensitiveSearch
 	 *
 	 * @return string     $like_statement
 	 */
-	public function _like_statement(string $prefix = null, string $column, string $not = null, string $bind, bool $insensitiveSearch = false): string
+	public function _like_statement(string $prefix = null, string $column = null, string $not = null, string $bind = null, bool $insensitiveSearch = false): string
 	{
 		$op = $insensitiveSearch === true ? 'ILIKE' : 'LIKE';
 

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -123,12 +123,12 @@ class IncomingRequest extends Request
 	/**
 	 * Constructor
 	 *
-	 * @param object      $config
-	 * @param URI         $uri
-	 * @param string|null $body
-	 * @param UserAgent   $userAgent
+	 * @param object         $config
+	 * @param URI|null       $uri
+	 * @param string         $body
+	 * @param UserAgent|null $userAgent
 	 */
-	public function __construct($config, URI $uri = null, $body = 'php://input', UserAgent $userAgent)
+	public function __construct($config, URI $uri = null, $body = 'php://input', UserAgent $userAgent = null)
 	{
 		// Get our body from php://input
 		if ($body === 'php://input')

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -657,12 +657,12 @@ abstract class BaseHandler implements ImageHandlerInterface
 	 *
 	 * @param integer|float      $width
 	 * @param integer|float|null $height
-	 * @param integer|float      $origWidth
-	 * @param integer|float      $origHeight
+	 * @param integer|float|null $origWidth
+	 * @param integer|float|null $origHeight
 	 *
 	 * @return array
 	 */
-	protected function calcAspectRatio($width, $height = null, $origWidth, $origHeight): array
+	protected function calcAspectRatio($width, $height = null, $origWidth = null, $origHeight = null): array
 	{
 		// If $height is null, then we have it easy.
 		// Calc based on full image size and be done.

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -115,16 +115,16 @@ class Pager implements PagerInterface
 	 * Allows for a simple, manual, form of pagination where all of the data
 	 * is provided by the user. The URL is the current URI.
 	 *
-	 * @param integer $page
-	 * @param integer $perPage
-	 * @param integer $total
-	 * @param string  $template The output template alias to render.
-	 * @param integer $segment  (if page number is provided by URI segment)
+	 * @param integer      $page
+	 * @param integer|null $perPage
+	 * @param integer|null $total
+	 * @param string       $template The output template alias to render.
+	 * @param integer      $segment  (if page number is provided by URI segment)
+	 * @param  string|null $group    optional group (i.e. if we'd like to define custom path)
 	 *
-	 * @param  string  $group    optional group (i.e. if we'd like to define custom path)
 	 * @return string
 	 */
-	public function makeLinks(int $page, int $perPage = null, int $total, string $template = 'default_full', int $segment = 0, ?string $group = 'default'): string
+	public function makeLinks(int $page, int $perPage = null, int $total = null, string $template = 'default_full', int $segment = 0, ?string $group = 'default'): string
 	{
 		$group = $group === '' ? 'default' : $group;
 
@@ -163,15 +163,15 @@ class Pager implements PagerInterface
 	 * Stores a set of pagination data for later display. Most commonly used
 	 * by the model to automate the process.
 	 *
-	 * @param string  $group
-	 * @param integer $page
-	 * @param integer $perPage
-	 * @param integer $total
-	 * @param integer $segment
+	 * @param string       $group
+	 * @param integer      $page
+	 * @param integer|null $perPage
+	 * @param integer|null $total
+	 * @param integer      $segment
 	 *
 	 * @return $this
 	 */
-	public function store(string $group, int $page, int $perPage = null, int $total, int $segment = 0)
+	public function store(string $group, int $page, int $perPage = null, int $total = null, int $segment = 0)
 	{
 		if ($segment)
 		{

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -218,12 +218,13 @@ class DOMParser
 	/**
 	 * Search the DOM using an XPath expression.
 	 *
-	 * @param  string $search
-	 * @param  string $element
-	 * @param  array  $paths
+	 * @param  string|null $search
+	 * @param  string|null $element
+	 * @param  array       $paths
+	 *
 	 * @return DOMNodeList
 	 */
-	protected function doXPath(string $search = null, string $element, array $paths = [])
+	protected function doXPath(string $search = null, string $element = null, array $paths = [])
 	{
 		// Otherwise, grab any elements that match
 		// the selector

--- a/system/Validation/CreditCardRules.php
+++ b/system/Validation/CreditCardRules.php
@@ -172,12 +172,12 @@ class CreditCardRules
 	 *      'cc_num' => 'valid_cc_number[visa]'
 	 *  ];
 	 *
-	 * @param string $ccNumber
-	 * @param string $type
+	 * @param string|null $ccNumber
+	 * @param string|null $type
 	 *
 	 * @return boolean
 	 */
-	public function valid_cc_number(string $ccNumber = null, string $type): bool
+	public function valid_cc_number(string $ccNumber = null, string $type = null): bool
 	{
 		$type = strtolower($type);
 		$info = null;

--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -49,12 +49,12 @@ class FileRules
 	/**
 	 * Verifies that $name is the name of a valid uploaded file.
 	 *
-	 * @param string $blank
-	 * @param string $name
+	 * @param string|null $blank
+	 * @param string|null $name
 	 *
 	 * @return boolean
 	 */
-	public function uploaded(string $blank = null, string $name): bool
+	public function uploaded(string $blank = null, string $name = null): bool
 	{
 		if (! ($files = $this->request->getFileMultiple($name)))
 		{
@@ -96,11 +96,11 @@ class FileRules
 	 * Verifies if the file's size in Kilobytes is no larger than the parameter.
 	 *
 	 * @param string|null $blank
-	 * @param string      $params
+	 * @param string|null $params
 	 *
 	 * @return boolean
 	 */
-	public function max_size(string $blank = null, string $params): bool
+	public function max_size(string $blank = null, string $params = null): bool
 	{
 		// Grab the file name off the top of the $params
 		// after we split it.
@@ -145,11 +145,11 @@ class FileRules
 	 * which for our purposes basically means that it's a raster image or svg.
 	 *
 	 * @param string|null $blank
-	 * @param string      $params
+	 * @param string|null $params
 	 *
 	 * @return boolean
 	 */
-	public function is_image(string $blank = null, string $params): bool
+	public function is_image(string $blank = null, string $params = null): bool
 	{
 		// Grab the file name off the top of the $params
 		// after we split it.
@@ -192,11 +192,11 @@ class FileRules
 	 * Checks to see if an uploaded file's mime type matches one in the parameter.
 	 *
 	 * @param string|null $blank
-	 * @param string      $params
+	 * @param string|null $params
 	 *
 	 * @return boolean
 	 */
-	public function mime_in(string $blank = null, string $params): bool
+	public function mime_in(string $blank = null, string $params = null): bool
 	{
 		// Grab the file name off the top of the $params
 		// after we split it.
@@ -235,11 +235,11 @@ class FileRules
 	 * Checks to see if an uploaded file's extension matches one in the parameter.
 	 *
 	 * @param string|null $blank
-	 * @param string      $params
+	 * @param string|null $params
 	 *
 	 * @return boolean
 	 */
-	public function ext_in(string $blank = null, string $params): bool
+	public function ext_in(string $blank = null, string $params = null): bool
 	{
 		// Grab the file name off the top of the $params
 		// after we split it.
@@ -279,11 +279,11 @@ class FileRules
 	 * a specified allowable dimension.
 	 *
 	 * @param string|null $blank
-	 * @param string      $params
+	 * @param string|null $params
 	 *
 	 * @return boolean
 	 */
-	public function max_dims(string $blank = null, string $params): bool
+	public function max_dims(string $blank = null, string $params = null): bool
 	{
 		// Grab the file name off the top of the $params
 		// after we split it.

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -187,12 +187,12 @@ class FormatRules
 	/**
 	 * Compares value against a regular expression pattern.
 	 *
-	 * @param string $str
-	 * @param string $pattern
+	 * @param string|null $str
+	 * @param string|null $pattern
 	 *
 	 * @return boolean
 	 */
-	public function regex_match(string $str = null, string $pattern): bool
+	public function regex_match(string $str = null, string $pattern = null): bool
 	{
 		if (strpos($pattern, '/') !== 0)
 		{

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -23,13 +23,13 @@ class Rules
 	/**
 	 * The value does not match another field in $data.
 	 *
-	 * @param string $str
-	 * @param string $field
-	 * @param array  $data  Other field/value pairs
+	 * @param string|null $str
+	 * @param string|null $field
+	 * @param array       $data  Other field/value pairs
 	 *
 	 * @return boolean
 	 */
-	public function differs(string $str = null, string $field, array $data): bool
+	public function differs(string $str = null, string $field = null, array $data = []): bool
 	{
 		if (strpos($field, '.') !== false)
 		{
@@ -44,12 +44,12 @@ class Rules
 	/**
 	 * Equals the static value provided.
 	 *
-	 * @param string $str
-	 * @param string $val
+	 * @param string|null $str
+	 * @param string|null $val
 	 *
 	 * @return boolean
 	 */
-	public function equals(string $str = null, string $val): bool
+	public function equals(string $str = null, string $val = null): bool
 	{
 		return $str === $val;
 	}
@@ -60,12 +60,12 @@ class Rules
 	 * Returns true if $str is $val characters long.
 	 * $val = "5" (one) | "5,8,12" (multiple values)
 	 *
-	 * @param string $str
-	 * @param string $val
+	 * @param string|null $str
+	 * @param string|null $val
 	 *
 	 * @return boolean
 	 */
-	public function exact_length(string $str = null, string $val): bool
+	public function exact_length(string $str = null, string $val = null): bool
 	{
 		$val = explode(',', $val);
 		foreach ($val as $tmp)
@@ -84,12 +84,12 @@ class Rules
 	/**
 	 * Greater than
 	 *
-	 * @param string $str
-	 * @param string $min
+	 * @param string|null $str
+	 * @param string|null $min
 	 *
 	 * @return boolean
 	 */
-	public function greater_than(string $str = null, string $min): bool
+	public function greater_than(string $str = null, string $min = null): bool
 	{
 		return is_numeric($str) && $str > $min;
 	}
@@ -99,12 +99,12 @@ class Rules
 	/**
 	 * Equal to or Greater than
 	 *
-	 * @param string $str
-	 * @param string $min
+	 * @param string|null $str
+	 * @param string|null $min
 	 *
 	 * @return boolean
 	 */
-	public function greater_than_equal_to(string $str = null, string $min): bool
+	public function greater_than_equal_to(string $str = null, string $min = null): bool
 	{
 		return is_numeric($str) && $str >= $min;
 	}
@@ -120,13 +120,13 @@ class Rules
 	 *    is_not_unique[table.field,where_field,where_value]
 	 *    is_not_unique[menu.id,active,1]
 	 *
-	 * @param string $str
-	 * @param string $field
-	 * @param array  $data
+	 * @param string|null $str
+	 * @param string|null $field
+	 * @param array       $data
 	 *
 	 * @return boolean
 	 */
-	public function is_not_unique(string $str = null, string $field, array $data): bool
+	public function is_not_unique(string $str = null, string $field = null, array $data = []): bool
 	{
 		// Grab any data for exclusion of a single row.
 		list($field, $whereField, $whereValue) = array_pad(explode(',', $field), 3, null);
@@ -157,12 +157,12 @@ class Rules
 	/**
 	 * Value should be within an array of values
 	 *
-	 * @param string $value
-	 * @param string $list
+	 * @param string|null $value
+	 * @param string|null $list
 	 *
 	 * @return boolean
 	 */
-	public function in_list(string $value = null, string $list): bool
+	public function in_list(string $value = null, string $list = null): bool
 	{
 		$list = array_map('trim', explode(',', $list));
 		return in_array($value, $list, true);
@@ -179,13 +179,13 @@ class Rules
 	 *    is_unique[table.field,ignore_field,ignore_value]
 	 *    is_unique[users.email,id,5]
 	 *
-	 * @param string $str
-	 * @param string $field
-	 * @param array  $data
+	 * @param string|null $str
+	 * @param string|null $field
+	 * @param array       $data
 	 *
 	 * @return boolean
 	 */
-	public function is_unique(string $str = null, string $field, array $data): bool
+	public function is_unique(string $str = null, string $field = null, array $data = []): bool
 	{
 		// Grab any data for exclusion of a single row.
 		list($field, $ignoreField, $ignoreValue) = array_pad(explode(',', $field), 3, null);
@@ -216,12 +216,12 @@ class Rules
 	/**
 	 * Less than
 	 *
-	 * @param string $str
-	 * @param string $max
+	 * @param string|null $str
+	 * @param string|null $max
 	 *
 	 * @return boolean
 	 */
-	public function less_than(string $str = null, string $max): bool
+	public function less_than(string $str = null, string $max = null): bool
 	{
 		return is_numeric($str) && $str < $max;
 	}
@@ -231,12 +231,12 @@ class Rules
 	/**
 	 * Equal to or Less than
 	 *
-	 * @param string $str
-	 * @param string $max
+	 * @param string|null $str
+	 * @param string|null $max
 	 *
 	 * @return boolean
 	 */
-	public function less_than_equal_to(string $str = null, string $max): bool
+	public function less_than_equal_to(string $str = null, string $max = null): bool
 	{
 		return is_numeric($str) && $str <= $max;
 	}
@@ -246,13 +246,13 @@ class Rules
 	/**
 	 * Matches the value of another field in $data.
 	 *
-	 * @param string $str
-	 * @param string $field
-	 * @param array  $data  Other field/value pairs
+	 * @param string|null $str
+	 * @param string|null $field
+	 * @param array       $data  Other field/value pairs
 	 *
 	 * @return boolean
 	 */
-	public function matches(string $str = null, string $field, array $data): bool
+	public function matches(string $str = null, string $field = null, array $data = []): bool
 	{
 		if (strpos($field, '.') !== false)
 		{
@@ -267,12 +267,12 @@ class Rules
 	/**
 	 * Returns true if $str is $val or fewer characters in length.
 	 *
-	 * @param string $str
-	 * @param string $val
+	 * @param string|null $str
+	 * @param string|null $val
 	 *
 	 * @return boolean
 	 */
-	public function max_length(string $str = null, string $val): bool
+	public function max_length(string $str = null, string $val = null): bool
 	{
 		return (is_numeric($val) && $val >= mb_strlen($str));
 	}
@@ -282,12 +282,12 @@ class Rules
 	/**
 	 * Returns true if $str is at least $val length.
 	 *
-	 * @param string $str
-	 * @param string $val
+	 * @param string|null $str
+	 * @param string|null $val
 	 *
 	 * @return boolean
 	 */
-	public function min_length(string $str = null, string $val): bool
+	public function min_length(string $str = null, string $val = null): bool
 	{
 		return (is_numeric($val) && $val <= mb_strlen($str));
 	}
@@ -297,12 +297,12 @@ class Rules
 	/**
 	 * Does not equal the static value provided.
 	 *
-	 * @param string $str
-	 * @param string $val
+	 * @param string|null $str
+	 * @param string|null $val
 	 *
 	 * @return boolean
 	 */
-	public function not_equals(string $str = null, string $val): bool
+	public function not_equals(string $str = null, string $val = null): bool
 	{
 		return $str !== $val;
 	}
@@ -312,12 +312,12 @@ class Rules
 	/**
 	 * Value should not be within an array of values.
 	 *
-	 * @param string $value
-	 * @param string $list
+	 * @param string|null $value
+	 * @param string|null $list
 	 *
 	 * @return boolean
 	 */
-	public function not_in_list(string $value = null, string $list): bool
+	public function not_in_list(string $value = null, string $list = null): bool
 	{
 		return ! $this->in_list($value, $list);
 	}
@@ -352,12 +352,12 @@ class Rules
 	 *     required_with[password]
 	 *
 	 * @param string|null $str
-	 * @param string      $fields List of fields that we should check if present
+	 * @param string|null $fields List of fields that we should check if present
 	 * @param array       $data   Complete list of fields from the form
 	 *
 	 * @return boolean
 	 */
-	public function required_with($str = null, string $fields, array $data): bool
+	public function required_with($str = null, string $fields = null, array $data = []): bool
 	{
 		$fields = explode(',', $fields);
 
@@ -404,12 +404,12 @@ class Rules
 	 *     required_without[id,email]
 	 *
 	 * @param string|null $str
-	 * @param string      $fields
+	 * @param string|null $fields
 	 * @param array       $data
 	 *
 	 * @return boolean
 	 */
-	public function required_without($str = null, string $fields, array $data): bool
+	public function required_without($str = null, string $fields = null, array $data = []): bool
 	{
 		$fields = explode(',', $fields);
 

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -376,12 +376,12 @@ class Validation implements ValidationInterface
 	 *
 	 * @param string      $field
 	 * @param string|null $label
-	 * @param string      $rules
+	 * @param string|null $rules
 	 * @param array       $errors
 	 *
 	 * @return $this
 	 */
-	public function setRule(string $field, string $label = null, string $rules, array $errors = [])
+	public function setRule(string $field, string $label = null, string $rules = null, array $errors = [])
 	{
 		$this->rules[$field] = [
 			'label' => $label,

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -72,7 +72,7 @@ class FormatRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 	/**
 	 * @dataProvider urlProvider
 	 */
-	public function testValidURL(string $url = null, bool $expected)
+	public function testValidURL(string $url = null, bool $expected = false)
 	{
 		$data = [
 			'foo' => $url,


### PR DESCRIPTION
Extends #3938 and related to #3957.

**Description**
This PR adds default values for all function arguments that follow an optional argument.
Interestingly, while such argument arrangement triggers a depracation notice in PHP8 if the first optional argument is not typed, it does not as long as the optional parameter is typed and its default value is `null`.

E.g., the following function definitions are incorrect and will trigger the PHP8 warning:
`function test(string $param1 = 'hi' string $param2)`
`function test($param1 = null, string $param2)`

This definition does not trigger the warning, but is still incorrect:
`function test(string $param1 = null, string $param2)`


**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Conforms to style guide