### PR TITLE
Fix tutorial news section HTML tag

### DIFF
--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -265,7 +265,7 @@ The only thing left to do is create the corresponding view at
 ::
 
     <h2><?= esc($news['title']); ?></h2>
-    <?= esc($news['body']); ?>
+    <p><?= esc($news['body']); ?></p>
 
 Routing
 -------------------------------------------------------


### PR DESCRIPTION
**Description**
It is better that body in the `<p>` tag.
Current code shows body and footer without line breaks.

**Checklist:**
- [x] Securely signed commits
- [n/a] Component(s) with PHPdocs
- [n/a] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
