### PR TITLE
fix: add dot_array_search to required_with and required_without

### DIFF
--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -422,13 +422,13 @@ class Rules
 
 		// Still here? Then we fail this test if
 		// any of the fields are not present in $data
-		foreach ($fields as $field) {
+		foreach ($fields as $field)
+		{
 			if (
-				(strpos($field, '.') !== false &&
-					empty(dot_array_search($field, $data))) ||
-				(strpos($field, '.') === false &&
-					(!array_key_exists($field, $data) || empty($data[$field])))
-			) {
+				(strpos($field, '.') !== false && empty(dot_array_search($field, $data))) ||
+				(strpos($field, '.') === false && (! array_key_exists($field, $data) || empty($data[$field])))
+			)
+			{
 				return false;
 			}
 		}

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -379,8 +379,8 @@ class Rules
 		foreach ($fields as $field)
 		{
 			if (
-				(strpos($field, '.') !== false && ! empty(dot_array_search($field, $data))) ||
-				(array_key_exists($field, $data) && ! empty($data[$field]))
+				(array_key_exists($field, $data) && ! empty($data[$field])) ||
+				(strpos($field, '.') !== false && ! empty(dot_array_search($field, $data)))	
 			)
 			{
 				$requiredFields[] = $field;
@@ -425,8 +425,8 @@ class Rules
 		foreach ($fields as $field)
 		{
 			if (
-				(strpos($field, '.') !== false && empty(dot_array_search($field, $data))) ||
-				(strpos($field, '.') === false && (! array_key_exists($field, $data) || empty($data[$field])))
+				(strpos($field, '.') === false && (! array_key_exists($field, $data) || empty($data[$field]))) ||
+				(strpos($field, '.') !== false && empty(dot_array_search($field, $data)))
 			)
 			{
 				return false;

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -376,19 +376,15 @@ class Rules
 		// as $fields is the lis
 		$requiredFields = [];
 
-		foreach ($fields as $field)
-		{
-			if (array_key_exists($field, $data))
-			{
+		foreach ($fields as $field) {
+			if (
+				(strpos($field, '.') !== false &&
+					!empty(dot_array_search($field, $data))) ||
+				(array_key_exists($field, $data) && !empty($data[$field]))
+			) {
 				$requiredFields[] = $field;
 			}
 		}
-
-		// Remove any keys with empty values since, that means they
-		// weren't truly there, as far as this is concerned.
-		$requiredFields = array_filter($requiredFields, function ($item) use ($data) {
-			return ! empty($data[$item]);
-		});
 
 		return empty($requiredFields);
 	}
@@ -425,10 +421,13 @@ class Rules
 
 		// Still here? Then we fail this test if
 		// any of the fields are not present in $data
-		foreach ($fields as $field)
-		{
-			if (! array_key_exists($field, $data))
-			{
+		foreach ($fields as $field) {
+			if (
+				(strpos($field, '.') !== false &&
+					empty(dot_array_search($field, $data))) ||
+				(strpos($field, '.') === false &&
+					(!array_key_exists($field, $data) || empty($data[$field])))
+			) {
 				return false;
 			}
 		}

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -376,12 +376,13 @@ class Rules
 		// as $fields is the lis
 		$requiredFields = [];
 
-		foreach ($fields as $field) {
+		foreach ($fields as $field)
+		{
 			if (
-				(strpos($field, '.') !== false &&
-					!empty(dot_array_search($field, $data))) ||
-				(array_key_exists($field, $data) && !empty($data[$field]))
-			) {
+				(strpos($field, '.') !== false && ! empty(dot_array_search($field, $data))) ||
+				(array_key_exists($field, $data) && ! empty($data[$field]))
+			)
+			{
 				$requiredFields[] = $field;
 			}
 		}

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -1499,7 +1499,7 @@ class RulesTest extends CIDatabaseTestCase
 			'foo' => 'bar',
 			'bar' => 'something',
 			'baz' => null,
-			'ar'  => [],// Was running into issues with array values
+			'array'  => ['nonEmptyField1'=>'value1','nonEmptyField2'=>'value2', 'emptyField1'=>null, 'emptyField2'=>null],
 		];
 
 		$this->validation->setRules([
@@ -1544,6 +1544,26 @@ class RulesTest extends CIDatabaseTestCase
 				null,
 				true,
 			],
+			[
+				'array.emptyField1',
+				'array.emptyField2',
+				true,
+			],
+			[
+				'array.nonEmptyField1',
+				'array.emptyField2',
+				true,
+			],
+			[
+				'array.emptyField1',
+				'array.nonEmptyField2',
+				false,
+			],
+			[
+				'array.nonEmptyField1',
+				'array.nonEmptyField2',
+				true,
+			],
 		];
 	}
 
@@ -1561,6 +1581,7 @@ class RulesTest extends CIDatabaseTestCase
 			'foo' => 'bar',
 			'bar' => 'something',
 			'baz' => null,
+			'array'  => ['nonEmptyField1'=>'value1','nonEmptyField2'=>'value2', 'emptyField1'=>null, 'emptyField2'=>null],
 		];
 
 		$this->validation->setRules([
@@ -1600,6 +1621,26 @@ class RulesTest extends CIDatabaseTestCase
 				null,
 				true,
 			],
+			[
+				'array.emptyField1',
+				'array.emptyField2',
+				false,
+			],
+			[
+				'array.nonEmptyField1',
+				'array.emptyField2',
+				true,
+			],
+			[
+				'array.emptyField1',
+				'array.nonEmptyField2',
+				true,
+			],
+				[
+				'array.nonEmptyField1',
+				'array.nonEmptyField2',
+				true,
+			],			
 		];
 	}
 


### PR DESCRIPTION
Closes #3965

**Description**
Added dot_array_search to required_with and required_without so that they work when using array as key in a form. 

