### PR TITLE
Fix "$cache::save()" return type in the documentation

### DIFF
--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -100,7 +100,7 @@ Class Reference
 	:param	int	$ttl: Time To Live, in seconds (default 60)
 	:param	bool	$raw: Whether to store the raw value
 	:returns:	TRUE on success, FALSE on failure
-	:rtype:	string
+	:rtype:	bool
 
 	This method will save an item to the cache store. If saving fails, the
 	method will return FALSE.


### PR DESCRIPTION
**Description**
$cache::save() returns a `bool`, not a `string`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
