### PR TITLE
Deprecate redundant HTTP keys

### DIFF
--- a/system/HTTP/Exceptions/HTTPException.php
+++ b/system/HTTP/Exceptions/HTTPException.php
@@ -241,6 +241,6 @@ class HTTPException extends FrameworkException
 	 */
 	public static function forInvalidSameSiteSetting(string $samesite)
 	{
-		return new static(lang('HTTP.invalidSameSiteSetting', [$samesite]));
+		return new static(lang('Security.invalidSameSiteSetting', [$samesite]));
 	}
 }

--- a/system/Language/en/HTTP.php
+++ b/system/Language/en/HTTP.php
@@ -54,6 +54,7 @@ return [
 	'methodNotFound'             => 'Controller method is not found: {0}',
 
 	// CSRF
+	// @deprecated use `Security.disallowedAction`
 	'disallowedAction'           => 'The action you requested is not allowed.',
 
 	// Uploaded file moving
@@ -72,5 +73,6 @@ return [
 	'uploadErrUnknown'           => 'The file "%s" was not uploaded due to an unknown error.',
 
 	// SameSite setting
+	// @deprecated use `Security.invalidSameSiteSetting`
 	'invalidSameSiteSetting'     => 'The SameSite setting must be None, Lax, Strict, or a blank string. Given: {0}',
 ];

--- a/tests/system/HTTP/ResponseCookieTest.php
+++ b/tests/system/HTTP/ResponseCookieTest.php
@@ -308,7 +308,7 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 		$response = new Response($config);
 
 		$this->expectException(HTTPException::class);
-		$this->expectExceptionMessage(lang('HTTP.invalidSameSiteSetting', ['Invalid']));
+		$this->expectExceptionMessage(lang('Security.invalidSameSiteSetting', ['Invalid']));
 
 		$response->setCookie([
 			'name'     => 'bar',

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -2,17 +2,17 @@
 
 namespace CodeIgniter\HTTP;
 
-use CodeIgniter\Config\Config;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
+use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockResponse;
 use Config\App;
 use Config\Services;
 use DateTime;
 use DateTimeZone;
 
-class ResponseTest extends \CodeIgniter\Test\CIUnitTestCase
+class ResponseTest extends CIUnitTestCase
 {
-
 	protected $server;
 
 	protected function setUp(): void
@@ -24,7 +24,7 @@ class ResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function tearDown(): void
 	{
 		$_SERVER = $this->server;
-		Config::reset();
+		Factories::reset('config');
 	}
 
 	public function testCanSetStatusCode()
@@ -65,7 +65,7 @@ class ResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$response->setStatusCode(200);
 
-		$this->assertEquals('OK', $response->getReason());
+		$this->assertEquals('OK', $response->getReasonPhrase());
 	}
 
 	//--------------------------------------------------------------------
@@ -76,7 +76,7 @@ class ResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$response->setStatusCode(200, 'Not the mama');
 
-		$this->assertEquals('Not the mama', $response->getReason());
+		$this->assertEquals('Not the mama', $response->getReasonPhrase());
 	}
 
 	//--------------------------------------------------------------------
@@ -120,7 +120,7 @@ class ResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$response->setStatusCode(300);
 
-		$this->assertEquals('Multiple Choices', $response->getReason());
+		$this->assertEquals('Multiple Choices', $response->getReasonPhrase());
 	}
 
 	//--------------------------------------------------------------------
@@ -131,7 +131,7 @@ class ResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$response->setStatusCode(300, 'My Little Pony');
 
-		$this->assertEquals('My Little Pony', $response->getReason());
+		$this->assertEquals('My Little Pony', $response->getReasonPhrase());
 	}
 
 	//--------------------------------------------------------------------
@@ -140,7 +140,7 @@ class ResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 	{
 		$response = new Response(new App());
 
-		$this->assertEquals('OK', $response->getReason());
+		$this->assertEquals('OK', $response->getReasonPhrase());
 	}
 
 	//--------------------------------------------------------------------
@@ -166,7 +166,7 @@ class ResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 		// Ensure our URL is not getting overridden
 		$config          = new App();
 		$config->baseURL = 'http://example.com/test/';
-		Config::injectMock('App', $config);
+		Factories::injectMock('config', 'App', $config);
 
 		$response = new Response($config);
 		$pager    = \Config\Services::pager();
@@ -552,7 +552,7 @@ class ResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 		$config->cookieSameSite = 'Invalid';
 
 		$this->expectException(HTTPException::class);
-		$this->expectExceptionMessage(lang('HTTP.invalidSameSiteSetting', ['Invalid']));
+		$this->expectExceptionMessage(lang('Security.invalidSameSiteSetting', ['Invalid']));
 		new Response($config);
 	}
 }

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -141,7 +141,7 @@ final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		];
 
 		$this->expectException(HTTPException::class);
-		$this->expectExceptionMessage(lang('HTTP.invalidSameSiteSetting', ['Invalid']));
+		$this->expectExceptionMessage(lang('Security.invalidSameSiteSetting', ['Invalid']));
 
 		set_cookie($cookieAttr);
 	}


### PR DESCRIPTION
**Description**
With the merge of the refactored Security class, the redundant `HTTP.disallowedAction` and `HTTP.invalidSamSiteSetting` can be removed in favor of the `Security` counterpart.

**Checklist:**
- [x] Securely signed commits
