### PR TITLE
Fix testing docs indentation

### DIFF
--- a/user_guide_src/source/testing/benchmark.rst
+++ b/user_guide_src/source/testing/benchmark.rst
@@ -25,23 +25,23 @@ the ``start()`` and ``stop()`` methods.
 The ``start()`` methods takes a single parameter: the name of this timer. You can use any string as the name
 of the timer. It is only used for you to reference later to know which measurement is which::
 
-	$benchmark = \Config\Services::timer();
-	$benchmark->start('render view');
+    $benchmark = \Config\Services::timer();
+    $benchmark->start('render view');
 
 The ``stop()`` method takes the name of the timer that you want to stop as the only parameter, also::
 
-	$benchmark->stop('render view');
+    $benchmark->stop('render view');
 
 The name is not case-sensitive, but otherwise must match the name you gave it when you started the timer.
 
 Alternatively, you can use the :doc:`global function </general/common_functions>` ``timer()`` to start
 and stop timers::
 
-	// Start the timer
-	timer('render view');
-	// Stop a running timer,
-	// if one of this name has been started
-	timer('render view');
+    // Start the timer
+    timer('render view');
+    // Stop a running timer,
+    // if one of this name has been started
+    timer('render view');
 
 Viewing Your Benchmark Points
 =============================
@@ -50,21 +50,21 @@ When your application runs, all of the timers that you have set are collected by
 not automatically display them, though. You can retrieve all of your timers by calling the ``getTimers()`` method.
 This returns an array of benchmark information, including start, end, and duration::
 
-	$timers = $benchmark->getTimers();
+    $timers = $benchmark->getTimers();
 
-	// Timers =
-	[
-		'render view'  => [
-			'start'    => 1234567890,
-			'end'      => 1345678920,
-			'duration' => 15.4315      // number of seconds
-		]
-	]
+    // Timers =
+    [
+        'render view'  => [
+            'start'    => 1234567890,
+            'end'      => 1345678920,
+            'duration' => 15.4315      // number of seconds
+        ]
+    ]
 
 You can change the precision of the calculated duration by passing in the number of decimal places you want to be shown as
 the only parameter. The default value is 4 numbers behind the decimal point::
 
-	$timers = $benchmark->getTimers(6);
+    $timers = $benchmark->getTimers(6);
 
 The timers are automatically displayed in the :doc:`Debub Toolbar </testing/debugging>`.
 
@@ -75,8 +75,8 @@ While the ``getTimers()`` method will give you the raw data for all of the timer
 the duration of a single timer, in seconds, with the `getElapsedTime()` method. The first parameter is the name of
 the timer to display. The second is the number of decimal places to display. This defaults to 4::
 
-	echo timer()->getElapsedTime('render view');
-	// Displays: 0.0234
+    echo timer()->getElapsedTime('render view');
+    // Displays: 0.0234
 
 ==================
 Using the Iterator
@@ -94,21 +94,21 @@ Tasks are defined within Closures. Any output the task creates will be discarded
 added to the Iterator class through the `add()` method. The first parameter is a name you want to refer to
 this test by. The second parameter is the Closure, itself::
 
-	$iterator = new \CodeIgniter\Benchmark\Iterator();
+    $iterator = new \CodeIgniter\Benchmark\Iterator();
 
-	// Add a new task
-	$iterator->add('single_concat', function()
-		{
-			$str = 'Some basic'.'little'.'string concatenation test.';
-		}
-	);
+    // Add a new task
+    $iterator->add('single_concat', function()
+        {
+            $str = 'Some basic'.'little'.'string concatenation test.';
+        }
+    );
 
-	// Add another task
-	$iterator->add('double', function($a='little')
-		{
-			$str = "Some basic {$little} string test.";
-		}
-	);
+    // Add another task
+    $iterator->add('double', function($a='little')
+        {
+            $str = "Some basic {$little} string test.";
+        }
+    );
 
 Running the Tasks
 =================
@@ -117,11 +117,11 @@ Once you've added the tasks to run, you can use the ``run()`` method to loop ove
 By default, it will run each task 1000 times. This is probably sufficient for most simple tests. If you need
 to run the tests more times than that, you can pass the number as the first parameter::
 
-	// Run the tests 3000 times.
-	$iterator->run(3000);
+    // Run the tests 3000 times.
+    $iterator->run(3000);
 
 Once it has run, it will return an HTML table with the results of the test. If you don't want the results
 displayed, you can pass in `false` as the second parameter::
 
-	// Don't display the results.
-	$iterator->run(1000, false);
+    // Don't display the results.
+    $iterator->run(1000, false);

--- a/user_guide_src/source/testing/debugging.rst
+++ b/user_guide_src/source/testing/debugging.rst
@@ -74,16 +74,16 @@ CodeIgniter ships with several Collectors that, as the name implies, collect dat
 can easily make your own to customize the toolbar. To determine which collectors are shown, again head over to
 the **app/Config/Toolbar.php** configuration file::
 
-	public $collectors = [
-		\CodeIgniter\Debug\Toolbar\Collectors\Timers::class,
-		\CodeIgniter\Debug\Toolbar\Collectors\Database::class,
-		\CodeIgniter\Debug\Toolbar\Collectors\Logs::class,
-		\CodeIgniter\Debug\Toolbar\Collectors\Views::class,
- 		\CodeIgniter\Debug\Toolbar\Collectors\Cache::class,
-		\CodeIgniter\Debug\Toolbar\Collectors\Files::class,
-		\CodeIgniter\Debug\Toolbar\Collectors\Routes::class,
-		\CodeIgniter\Debug\Toolbar\Collectors\Events::class,
-	];
+    public $collectors = [
+        \CodeIgniter\Debug\Toolbar\Collectors\Timers::class,
+        \CodeIgniter\Debug\Toolbar\Collectors\Database::class,
+        \CodeIgniter\Debug\Toolbar\Collectors\Logs::class,
+        \CodeIgniter\Debug\Toolbar\Collectors\Views::class,
+         \CodeIgniter\Debug\Toolbar\Collectors\Cache::class,
+        \CodeIgniter\Debug\Toolbar\Collectors\Files::class,
+        \CodeIgniter\Debug\Toolbar\Collectors\Routes::class,
+        \CodeIgniter\Debug\Toolbar\Collectors\Events::class,
+    ];
 
 Comment out any collectors that you do not want to show. Add custom Collectors here by providing the fully-qualified
 class name. The exact collectors that appear here will affect which tabs are shown, as well as what information is
@@ -119,20 +119,20 @@ that you can override, and has four required class properties that you must corr
 the Collector to work
 ::
 
-	<?php namespace MyNamespace;
+    <?php namespace MyNamespace;
 
-	use CodeIgniter\Debug\Toolbar\Collectors\BaseCollector;
+    use CodeIgniter\Debug\Toolbar\Collectors\BaseCollector;
 
-	class MyCollector extends BaseCollector
-	{
-		protected $hasTimeline   = false;
+    class MyCollector extends BaseCollector
+    {
+        protected $hasTimeline   = false;
 
-		protected $hasTabContent = false;
+        protected $hasTabContent = false;
 
-		protected $hasVarData    = false;
+        protected $hasVarData    = false;
 
-		protected $title         = '';
-	}
+        protected $title         = '';
+    }
 
 **$hasTimeline** should be set to ``true`` for any Collector that wants to display information in the toolbar's
 timeline. If this is true, you will need to implement the ``formatTimelineData()`` method to format and return the
@@ -176,12 +176,12 @@ To provide information to be displayed in the Timeline you must:
 The ``formatTimelineData()`` method must return an array of arrays formatted in a way that the timeline can use
 it to sort it correctly and display the correct information. The inner arrays must include the following information::
 
-	$data[] = [
-		'name'      => '',     // Name displayed on the left of the timeline
-		'component' => '',     // Name of the Component listed in the middle of timeline
-		'start'     => 0.00,   // start time, like microtime(true)
-		'duration'  => 0.00    // duration, like mircrotime(true) - microtime(true)
-	];
+    $data[] = [
+        'name'      => '',     // Name displayed on the left of the timeline
+        'component' => '',     // Name of the Component listed in the middle of timeline
+        'start'     => 0.00,   // start time, like microtime(true)
+        'duration'  => 0.00    // duration, like mircrotime(true) - microtime(true)
+    ];
 
 Providing Vars
 --------------
@@ -194,13 +194,13 @@ To add data to the Vars tab you must:
 The ``getVarData()`` method should return an array containing arrays of key/value pairs to display. The name of the
 outer array's key is the name of the section on the Vars tab::
 
-	$data = [
-		'section 1' => [
-		    'foo' => 'bar',
-		    'bar' => 'baz'
-		],
-		'section 2' => [
-		    'foo' => 'bar',
-		    'bar' => 'baz'
-		]
-	 ];
+    $data = [
+        'section 1' => [
+            'foo' => 'bar',
+            'bar' => 'baz'
+        ],
+        'section 2' => [
+            'foo' => 'bar',
+            'bar' => 'baz'
+        ]
+     ];

--- a/user_guide_src/source/testing/fabricator.rst
+++ b/user_guide_src/source/testing/fabricator.rst
@@ -277,4 +277,3 @@ you deleted a fake item but wanted to track the change.
 
 Resets all counts. Good idea to call this between test cases (though using
 ``CIDatabaseTestCase::$refresh = true`` does it automatically).
-

--- a/user_guide_src/source/testing/fabricator.rst
+++ b/user_guide_src/source/testing/fabricator.rst
@@ -12,7 +12,7 @@ Supported Models
 ``Fabricator`` supports any model that extends the framework's core model, ``CodeIgniter\Model``.
 You may use your own custom models by ensuring they implement ``CodeIgniter\Test\Interfaces\FabricatorModel``::
 
-	class MyModel implements CodeIgniter\Test\Interfaces\FabricatorModel
+    class MyModel implements CodeIgniter\Test\Interfaces\FabricatorModel
 
 .. note:: In addition to methods, the interface outlines some necessary properties for the target model. Please see the interface code for details.
 
@@ -62,13 +62,13 @@ method where you can define exactly what the faked data should look like::
     {
         public function fake(Generator &$faker)
         {
-        	return [
-        	    'first'  => $faker->firstName,
-        	    'email'  => $faker->email,
-        	    'phone'  => $faker->phoneNumber,
-        	    'avatar' => Faker\Provider\Image::imageUrl(800, 400),
-        	    'login'  => config('Auth')->allowRemembering ? date('Y-m-d') : null,
-        	];
+            return [
+                'first'  => $faker->firstName,
+                'email'  => $faker->email,
+                'phone'  => $faker->phoneNumber,
+                'avatar' => Faker\Provider\Image::imageUrl(800, 400),
+                'login'  => config('Auth')->allowRemembering ? date('Y-m-d') : null,
+            ];
         }
 
 Notice in this example how the first three values are equivalent to the formatters from before. However for ``avatar``
@@ -215,8 +215,8 @@ Test Helper
 Often all you will need is a one-and-done fake object for testing. The Test Helper provides
 the ``fake($model, $overrides)`` function to do just this::
 
-	helper('test');
-	$user = fake('App\Models\UserModel', ['name' => 'Gerry']);
+    helper('test');
+    $user = fake('App\Models\UserModel', ['name' => 'Gerry']);
 
 This is equivalent to::
 
@@ -242,11 +242,11 @@ Your model's fake method could look like this::
 
         public function fake(Generator &$faker)
         {
-        	return [
+            return [
                 'first'    => $faker->firstName,
                 'email'    => $faker->email,
                 'group_id' => rand(1, Fabricator::getCount('groups')),
-        	];
+            ];
         }
 
 Now creating a new user will ensure it is a part of a valid group: ``$user = fake(UserModel::class);``

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -107,44 +107,44 @@ Staging
 Most tests require some preparation in order to run correctly. PHPUnit's ``TestCase`` provides four methods
 to help with staging and clean up::
 
-	public static function setUpBeforeClass(): void
-	public static function tearDownAfterClass(): void
-	public function setUp(): void
-	public function tearDown(): void
+    public static function setUpBeforeClass(): void
+    public static function tearDownAfterClass(): void
+    public function setUp(): void
+    public function tearDown(): void
 
 The static methods run before and after the entire test case, whereas the local methods run
 between each test. If you implement any of these special functions make sure you run their
 parent as well so extended test cases do not interfere with staging::
 
-	public function setUp(): void
-	{
-		parent::setUp();
-		helper('text');
-	}
+    public function setUp(): void
+    {
+        parent::setUp();
+        helper('text');
+    }
 
 In addition to these methods, ``CIUnitTestCase`` also comes with a convenience property for
 parameter-free methods you want run during set up and tear down::
 
-	protected $setUpMethods = [
-		'mockEmail',
-		'mockSession',
-	];
-	
-	protected $tearDownMethods = [];
+    protected $setUpMethods = [
+        'mockEmail',
+        'mockSession',
+    ];
+
+    protected $tearDownMethods = [];
 
 You can see by default these handle the mocking of intrusive services, but your class may override
 that or provide their own::
 
-	class OneOfMyModelsTest extends CIUnitTestCase
-	{
-		protected $tearDownMethods = [
-			'purgeRows',
-		];
-		
-		protected function purgeRows()
-		{
-			$this->model->purgeDeleted()
-		}
+    class OneOfMyModelsTest extends CIUnitTestCase
+    {
+        protected $tearDownMethods = [
+            'purgeRows',
+        ];
+
+        protected function purgeRows()
+        {
+            $this->model->purgeDeleted()
+        }
 
 Additional Assertions
 ---------------------
@@ -245,10 +245,10 @@ parameter is an instance of the class to test. The second parameter is the name 
     $obj = new Foo();
 
     // Get the invoker for the 'privateMethod' method.
-	$method = $this->getPrivateMethodInvoker($obj, 'privateMethod');
+    $method = $this->getPrivateMethodInvoker($obj, 'privateMethod');
 
     // Test the results
-	$this->assertEquals('bar', $method('param1', 'param2'));
+    $this->assertEquals('bar', $method('param1', 'param2'));
 
 **getPrivateProperty($instance, $property)**
 
@@ -319,12 +319,12 @@ component name::
 
     protected function setUp()
     {
-    	parent::setUp();
+        parent::setUp();
 
-		$model = new MockUserModel();
-		Factories::injectMock('models', 'App\Models\UserModel', $model);
-	}
-		
+        $model = new MockUserModel();
+        Factories::injectMock('models', 'App\Models\UserModel', $model);
+    }
+
 .. note:: All component Factories are reset by default between each test. Modify your test case's ``$setUpMethods`` if you need instances to persist.
 
 Stream Filters


### PR DESCRIPTION
**Description**
A tab is converted to 8 spaces. So it is better to use only spaces for indentation.

<img width="726" alt="screenshot" src="https://user-images.githubusercontent.com/87955/102072664-89c53380-3e45-11eb-823b-037a45cfb33f.png">

**Checklist:**
- [x] Securely signed commits
- [n/a] Component(s) with PHPdocs
- [n/a] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
