### PR TITLE
Fix: CLI::strlen() does not handle mutibyte letters correctly

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -581,7 +581,7 @@ class CLI
 
 		$string = strtr($string, ["\033[4m" => '', "\033[0m" => '']);
 
-		return mb_strlen($string);
+		return mb_strwidth($string);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -435,6 +435,24 @@ class CLITest extends \CodeIgniter\Test\CIUnitTestCase
 				'| 3  | bar + bar + bar |' . PHP_EOL .
 				'+----+-----------------+' . PHP_EOL . PHP_EOL,
 			],
+			// Multibyte letters
+			[
+				[
+					[
+						'id'  => 'ほげ',
+						'foo' => 'bar',
+					],
+				],
+				[
+					'ID',
+					'タイトル',
+				],
+				'+------+----------+' . PHP_EOL .
+				'| ID   | タイトル |' . PHP_EOL .
+				'+------+----------+' . PHP_EOL .
+				'| ほげ | bar      |' . PHP_EOL .
+				'+------+----------+' . PHP_EOL . PHP_EOL,
+			],
 		];
 	}
 


### PR DESCRIPTION
**Description**
CLI::strlen() does not handle mutibyte letters correctly.

Before:
<img width="1001" alt="screenshot before" src="https://user-images.githubusercontent.com/87955/102179704-edee0300-3eea-11eb-9bfe-1f4c93b32208.png">

After:
<img width="1001" alt="screenshot after" src="https://user-images.githubusercontent.com/87955/102179711-f1818a00-3eea-11eb-8fb3-09cd89e1f549.png">

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [n/a] User guide updated
- [x] Conforms to style guide

