### PR TITLE
docs: fix method name in sample code

### DIFF
--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -305,8 +305,8 @@ Class Reference
 		Regress can be used to roll back changes to a previous state, batch by batch.
 		::
 
-			$migration->batch(5);
-			$migration->batch(-1);
+			$migration->regress(5);
+			$migration->regress(-1);
 
 	.. php:method:: force($path, $namespace, $group)
 


### PR DESCRIPTION
**Description**
The method name is wrong.

**Checklist:**
- [x] Securely signed commits
- [n/a] Component(s) with PHPdocs
- [n/a] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

