### PR TITLE
feat: make migration/seed settings flexible on database testing

### DIFF
--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -174,6 +174,17 @@ abstract class CIDatabaseTestCase extends CIUnitTestCase
 
 		$this->loadDependencies();
 
+		$this->setUpMigrate();
+		$this->setUpSeed();
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Migrate on setUp
+	 */
+	protected function setUpMigrate()
+	{
 		if ($this->migrateOnce === false || self::$doneMigration === false)
 		{
 			if ($this->refresh === true)
@@ -186,7 +197,15 @@ abstract class CIDatabaseTestCase extends CIUnitTestCase
 
 			$this->migrateDatabase();
 		}
+	}
 
+	//--------------------------------------------------------------------
+
+	/**
+	 * Seed on setUp
+	 */
+	protected function setUpSeed()
+	{
 		if ($this->seedOnce === false || self::$doneSeed === false)
 		{
 			$this->runSeeds();

--- a/system/Test/CIDatabaseTestCase.php
+++ b/system/Test/CIDatabaseTestCase.php
@@ -60,8 +60,7 @@ abstract class CIDatabaseTestCase extends CIUnitTestCase
 	private static $doneSeed = false;
 
 	/**
-	 * Should the db be refreshed before
-	 * each test?
+	 * Should the db be refreshed before test?
 	 *
 	 * @var boolean
 	 */

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
@@ -1,0 +1,62 @@
+<?php namespace CodeIgniter\Database\DatabaseTestCase;
+
+use CodeIgniter\Test\CIDatabaseTestCase;
+use Config\Database;
+use Config\Services;
+
+/**
+ * DatabaseTestCaseMigrationOnce1Test and DatabaseTestCaseMigrationOnce2Test
+ * show $migrateOnce applies per test case file.
+ *
+ * @group DatabaseLive
+ */
+class DatabaseTestCaseMigrationOnce1Test extends CIDatabaseTestCase
+{
+	/**
+	 * Should run db migration only once?
+	 *
+	 * @var boolean
+	 */
+	protected $migrateOnce = true;
+
+	/**
+	 * Should the db be refreshed before test?
+	 *
+	 * @var boolean
+	 */
+	protected $refresh = true;
+
+	/**
+	 * The namespace(s) to help us find the migration classes.
+	 * Empty is equivalent to running `spark migrate -all`.
+	 * Note that running "all" runs migrations in date order,
+	 * but specifying namespaces runs them in namespace order (then date)
+	 *
+	 * @var string|array|null
+	 */
+	protected $namespace = [
+		'Tests\Support\MigrationTestMigrations',
+	];
+
+	public function setUp(): void
+	{
+		Services::autoloader()->addNamespace('Tests\Support\MigrationTestMigrations', SUPPORTPATH . 'MigrationTestMigrations');
+
+		parent::setUp();
+	}
+
+	public function testMigrationDone()
+	{
+		$this->seeInDatabase('foo', ['key' => 'foobar']);
+
+		// Drop table to make sure there is no foo table when
+		// DatabaseTestCaseMigrationOnce2Test runs
+		$this->dropTableFoo();
+	}
+
+	private function dropTableFoo()
+	{
+		$forge = Database::forge();
+		$forge->dropTable('foo', true);
+	}
+}

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
@@ -1,0 +1,51 @@
+<?php namespace CodeIgniter\Database\DatabaseTestCase;
+
+use CodeIgniter\Test\CIDatabaseTestCase;
+use Config\Services;
+
+/**
+ * DatabaseTestCaseMigrationOnce1Test and DatabaseTestCaseMigrationOnce2Test
+ * show $migrateOnce applies per test case file.
+ *
+ * @group DatabaseLive
+ */
+class DatabaseTestCaseMigrationOnce2Test extends CIDatabaseTestCase
+{
+	/**
+	 * Should run db migration only once?
+	 *
+	 * @var boolean
+	 */
+	protected $migrateOnce = true;
+
+	/**
+	 * Should the db be refreshed before test?
+	 *
+	 * @var boolean
+	 */
+	protected $refresh = true;
+
+	/**
+	 * The namespace(s) to help us find the migration classes.
+	 * Empty is equivalent to running `spark migrate -all`.
+	 * Note that running "all" runs migrations in date order,
+	 * but specifying namespaces runs them in namespace order (then date)
+	 *
+	 * @var string|array|null
+	 */
+	protected $namespace = [
+		'Tests\Support\MigrationTestMigrations',
+	];
+
+	public function setUp(): void
+	{
+		Services::autoloader()->addNamespace('Tests\Support\MigrationTestMigrations', SUPPORTPATH . 'MigrationTestMigrations');
+
+		parent::setUp();
+	}
+
+	public function testMigrationDone()
+	{
+		$this->seeInDatabase('foo', ['key' => 'foobar']);
+	}
+}

--- a/user_guide_src/source/testing/database.rst
+++ b/user_guide_src/source/testing/database.rst
@@ -82,16 +82,33 @@ by adding a couple of class properties to your test.
         protected $basePath = 'path/to/database/files';
     }
 
+**$migrate**
+
+This boolean value determines whether the database migration runs before test.
+By default, the database is always migrated to the latest available state as defined by ``$namespace``.
+If false, migration never runs. If you want to disable migration, set false.
+
+**$migrateOnce**
+
+This boolean value determines whether the database migration runs only once. If you want
+to run migration once before the first test, set true. If not present or false, migration
+runs before each test.
+
 **$refresh**
 
-This boolean value determines whether the database is completely refreshed before every test. If true,
-all migrations are rolled back to version 0. The database is always migrated to the latest available
-state as defined by ``$namespace``.
+This boolean value determines whether the database is completely refreshed before test. If true,
+all migrations are rolled back to version 0.
 
 **$seed**
 
 If present and not empty, this specifies the name of a Seed file that is used to populate the database with
-test data prior to every test running.
+test data prior to test running.
+
+**$seedOnce**
+
+This boolean value determines whether the database seeding runs only once. If you want
+to run database seeding once before the first test, set true. If not present or false, database seeding
+runs before each test.
 
 **$basePath**
 


### PR DESCRIPTION
**Description**
Now you can't disable migration on database testing if you want.
And running migration/seed on each test may slow tests.

- You can disable migration: `$migrate = false`
- You can run migration only once: `$migrateOnce = true`
- You can run seed only once: `$seedOnce = true`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
