### PR TITLE
docs: fix cli indentation

### DIFF
--- a/user_guide_src/source/cli/cli.rst
+++ b/user_guide_src/source/cli/cli.rst
@@ -38,42 +38,42 @@ Let's create a simple controller so you can see it in action. Using your
 text editor, create a file called Tools.php, and put the following code
 in it::
 
-	<?php namespace App\Controllers;
+    <?php namespace App\Controllers;
 
-        use CodeIgniter\Controller;
+    use CodeIgniter\Controller;
 
-	class Tools extends Controller {
-
-		public function message($to = 'World')
-		{
-			echo "Hello {$to}!".PHP_EOL;
-		}
-	}
+    class Tools extends Controller
+    {
+        public function message($to = 'World')
+        {
+            echo "Hello {$to}!".PHP_EOL;
+        }
+    }
 
 Then save the file to your **app/Controllers/** directory.
 
 Now normally you would visit your site using a URL similar to this::
 
-	example.com/index.php/tools/message/to
+    example.com/index.php/tools/message/to
 
 Instead, we are going to open Terminal in Mac/Linux or go to Run > "cmd"
 in Windows and navigate to our CodeIgniter project's web root.
 
 .. code-block:: bash
 
-	$ cd /path/to/project/public
-	$ php index.php tools message
+    $ cd /path/to/project/public
+    $ php index.php tools message
 
 If you did it right, you should see *Hello World!* printed.
 
 .. code-block:: bash
 
-	$ php index.php tools message "John Smith"
+    $ php index.php tools message "John Smith"
 
 Here we are passing it an argument in the same way that URL parameters
 work. "John Smith" is passed as an argument and output is::
 
-	Hello John Smith!
+    Hello John Smith!
 
 That's the basics!
 ==================

--- a/user_guide_src/source/cli/cli_commands.rst
+++ b/user_guide_src/source/cli/cli_commands.rst
@@ -204,7 +204,7 @@ be familiar with when creating your own commands. It also has a :doc:`Logger </g
             $pad = $this->getPad($this->options, 6);
             foreach ($this->options as $option => $description)
             {
-                    CLI::write($tab . CLI::color(str_pad($option, $pad), 'green') . $description, 'yellow');
+                CLI::write($tab . CLI::color(str_pad($option, $pad), 'green') . $description, 'yellow');
             }
 
             // Output will be

--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -6,8 +6,8 @@ CodeIgniter4 now comes equipped with generators to ease the creation of stock co
 etc. You can also scaffold a complete set of files with just one command.
 
 .. contents::
-	:local:
-	:depth: 2
+    :local:
+    :depth: 2
 
 ************
 Introduction
@@ -16,7 +16,7 @@ Introduction
 All built-in generators reside under the ``Generators`` namespace when listed using ``php spark list``.
 To view the full description and usage information on a particular generator, use the command::
 
-	> php spark help <generator_command>
+    > php spark help <generator_command>
 
 where ``<generator_command>`` will be replaced with the command to check.
 
@@ -35,7 +35,7 @@ Usage:
 ======
 .. code-block:: none
 
-	make:command <name> [options]
+    make:command <name> [options]
 
 Argument:
 =========
@@ -58,7 +58,7 @@ Usage:
 ======
 .. code-block:: none
 
-	make:controller <name> [options]
+    make:controller <name> [options]
 
 Argument:
 =========
@@ -80,7 +80,7 @@ Usage:
 ======
 .. code-block:: none
 
-	make:entity <name> [options]
+    make:entity <name> [options]
 
 Argument:
 =========
@@ -100,7 +100,7 @@ Usage:
 ======
 .. code-block:: none
 
-	make:filter <name> [options]
+    make:filter <name> [options]
 
 Argument:
 =========
@@ -120,7 +120,7 @@ Usage:
 ======
 .. code-block:: none
 
-	make:model <name> [options]
+    make:model <name> [options]
 
 Argument:
 =========
@@ -143,7 +143,7 @@ Usage:
 ======
 .. code-block:: none
 
-	make:seeder <name> [options]
+    make:seeder <name> [options]
 
 Argument:
 =========
@@ -163,7 +163,7 @@ Usage:
 ======
 .. code-block:: none
 
-	make:migration <name> [options]
+    make:migration <name> [options]
 
 Argument:
 =========
@@ -183,7 +183,7 @@ Usage:
 ======
 .. code-block:: none
 
-	session:migration [options]
+    session:migration [options]
 
 Options:
 ========
@@ -193,24 +193,24 @@ Options:
 * ``--force``: Set this flag to overwrite existing files on destination.
 
 .. note:: When running ``php spark help session:migration``, you will see that it has the argument ``name`` listed.
-	This argument is not used as the class name is derived from the table name passed to the ``-t`` option.
+    This argument is not used as the class name is derived from the table name passed to the ``-t`` option.
 
 .. note:: Do you need to have the generated code in a subfolder? Let's say if you want to create a controller
-	class to reside in the ``Admin`` subfolder of the main ``Controllers`` folder, you will just need
-	to prepend the subfolder to the class name, like this: ``php spark make:controller admin/login``. This
-	command will create the ``Login`` controller in the ``Controllers/Admin`` subfolder with
-	a namespace of ``App\Controllers\Admin``.
+    class to reside in the ``Admin`` subfolder of the main ``Controllers`` folder, you will just need
+    to prepend the subfolder to the class name, like this: ``php spark make:controller admin/login``. This
+    command will create the ``Login`` controller in the ``Controllers/Admin`` subfolder with
+    a namespace of ``App\Controllers\Admin``.
 
 .. note:: Working on modules? Code generation will set the root namespace to a default of ``APP_NAMESPACE``.
-	Should you need to have the generated code elsewhere in your module namespace, make sure to set
-	the ``-n`` option in your command, e.g. ``php spark make:model blog -n Acme\Blog``.
+    Should you need to have the generated code elsewhere in your module namespace, make sure to set
+    the ``-n`` option in your command, e.g. ``php spark make:model blog -n Acme\Blog``.
 
 .. warning:: Make sure when setting the ``-n`` option that the supplied namespace is a valid namespace
-	defined in your ``$psr4`` array in ``Config\Autoload`` or defined in your composer autoload file.
-	Otherwise, a ``RuntimeException`` will be thrown.
+    defined in your ``$psr4`` array in ``Config\Autoload`` or defined in your composer autoload file.
+    Otherwise, a ``RuntimeException`` will be thrown.
 
 .. warning:: Use of ``migrate:create`` to create migration files is now deprecated. It will be removed in
-	future releases. Please use ``make:migration`` as replacement.
+    future releases. Please use ``make:migration`` as replacement.
 
 ****************************************
 Scaffolding a Complete Set of Stock Code
@@ -228,7 +228,7 @@ generator command are recognized by the scaffold command.
 
 Running this in your terminal::
 
-	php spark make:scaffold user
+    php spark make:scaffold user
 
 will create the following classes:
 
@@ -249,107 +249,107 @@ which is public and need not be overridden as it is essentially complete.
 
 .. php:class:: CodeIgniter\\CLI\\GeneratorCommand
 
-	.. php:method:: getClassName()
+    .. php:method:: getClassName()
 
-		:rtype: string
+        :rtype: string
 
-		Gets the class name from input. This can be overridden if name is really
-		required by providing a prompt.
+        Gets the class name from input. This can be overridden if name is really
+        required by providing a prompt.
 
-	.. php:method:: sanitizeClassName(string $class)
+    .. php:method:: sanitizeClassName(string $class)
 
-		:param string $class: Class name.
-		:rtype: string
+        :param string $class: Class name.
+        :rtype: string
 
-		Trims input, normalize separators, and ensures all paths are in Pascal case.
+        Trims input, normalize separators, and ensures all paths are in Pascal case.
 
-	.. php:method:: qualifyClassName(string $class)
+    .. php:method:: qualifyClassName(string $class)
 
-		:param string $class: Class name.
-		:rtype: string
+        :param string $class: Class name.
+        :rtype: string
 
-		Parses the class name and checks if it is already fully qualified.
+        Parses the class name and checks if it is already fully qualified.
 
-	.. php:method:: getRootNamespace()
+    .. php:method:: getRootNamespace()
 
-		:rtype: string
+        :rtype: string
 
-		Gets the root namespace from input. Defaults to value of ``APP_NAMESPACE``.
+        Gets the root namespace from input. Defaults to value of ``APP_NAMESPACE``.
 
-	.. php:method:: getNamespacedClass(string $rootNamespace, string $class)
+    .. php:method:: getNamespacedClass(string $rootNamespace, string $class)
 
-		:param string $rootNamespace: The root namespace of the class.
-		:param string $class: Class name
-		:returns: The fully qualified class name
-		:rtype: string
+        :param string $rootNamespace: The root namespace of the class.
+        :param string $class: Class name
+        :returns: The fully qualified class name
+        :rtype: string
 
-		Gets the qualified class name. This should be implemented.
+        Gets the qualified class name. This should be implemented.
 
-	.. php:method:: buildPath(string $class)
+    .. php:method:: buildPath(string $class)
 
-		:param string $class: The fully qualified class name
-		:returns: The absolute path to where the class will be saved.
-		:rtype: string
-		:throws: RuntimeException
+        :param string $class: The fully qualified class name
+        :returns: The absolute path to where the class will be saved.
+        :rtype: string
+        :throws: RuntimeException
 
-		Builds the file path from the class name.
+        Builds the file path from the class name.
 
-	.. php:method:: modifyBasename(string $filename)
+    .. php:method:: modifyBasename(string $filename)
 
-		:param string $filename: The basename of the file path.
-		:returns: A modified basename for the file.
-		:rtype: string
+        :param string $filename: The basename of the file path.
+        :returns: A modified basename for the file.
+        :rtype: string
 
-		Provides last chance for child generators to change the file's basename before saving.
-		This is useful for migration files where the basename has a date component.
+        Provides last chance for child generators to change the file's basename before saving.
+        This is useful for migration files where the basename has a date component.
 
-	.. php:method:: buildClassContents(string $class)
+    .. php:method:: buildClassContents(string $class)
 
-		:param string $class: The fully qualified class name.
-		:rtype: string
+        :param string $class: The fully qualified class name.
+        :rtype: string
 
-		Builds the contents for class being generated, doing all the replacements necessary in the template.
+        Builds the contents for class being generated, doing all the replacements necessary in the template.
 
-	.. php:method:: getTemplate()
+    .. php:method:: getTemplate()
 
-		:rtype: string
+        :rtype: string
 
-		Gets the template for the class being generated. This must be implemented.
+        Gets the template for the class being generated. This must be implemented.
 
-	.. php:method:: getNamespace(string $class)
+    .. php:method:: getNamespace(string $class)
 
-		:param string $class: The fully qualified class name.
-		:rtype: string
+        :param string $class: The fully qualified class name.
+        :rtype: string
 
-		Retrieves the namespace part from the fully qualified class name.
+        Retrieves the namespace part from the fully qualified class name.
 
-	.. php:method:: setReplacements(string $template, string $class)
+    .. php:method:: setReplacements(string $template, string $class)
 
-		:param string $template: The template string to use.
-		:param string $class: The fully qualified class name.
-		:returns: The template string with all annotations replaced.
-		:rtype: string
+        :param string $template: The template string to use.
+        :param string $class: The fully qualified class name.
+        :returns: The template string with all annotations replaced.
+        :rtype: string
 
-		Performs all the necessary replacements.
+        Performs all the necessary replacements.
 
-	.. php:method:: sortImports(string $template)
+    .. php:method:: sortImports(string $template)
 
-		:param string $template: The template file.
-		:returns: The template file with all imports already sorted.
-		:rtype: string
+        :param string $template: The template file.
+        :returns: The template file with all imports already sorted.
+        :rtype: string
 
-		Alphabetically sorts the imports for a given template.
+        Alphabetically sorts the imports for a given template.
 
 .. warning:: Child generators should make sure to implement ``GeneratorCommand``'s two abstract methods:
-	``getNamespacedClass`` and ``getTemplate``, or else you will get a PHP fatal error.
+    ``getNamespacedClass`` and ``getTemplate``, or else you will get a PHP fatal error.
 
 .. note:: ``GeneratorCommand`` has the default argument of ``['name' => 'Class name']``. You can
-	override the description by supplying the name in your ``$arguments`` property, e.g. ``['name' => 'Module class name']``.
+    override the description by supplying the name in your ``$arguments`` property, e.g. ``['name' => 'Module class name']``.
 
 .. note:: ``GeneratorCommand`` has the default options of ``-n`` and ``--force``. Child classes cannot override
-	these two properties as they are crucial in the implementation of the code generation.
+    these two properties as they are crucial in the implementation of the code generation.
 
 .. note:: Generators are default listed under the ``Generators`` namespace because it is the default group
-	name in ``GeneratorCommand``. If you want to have your own generator listed elsewhere under a different
-	namespace, you will just need to provide the ``$group`` property in your child generator,
-	e.g. ``protected $group = 'CodeIgniter';``.
+    name in ``GeneratorCommand``. If you want to have your own generator listed elsewhere under a different
+    namespace, you will just need to provide the ``$group`` property in your child generator,
+    e.g. ``protected $group = 'CodeIgniter';``.

--- a/user_guide_src/source/cli/cli_library.rst
+++ b/user_guide_src/source/cli/cli_library.rst
@@ -20,14 +20,14 @@ Initializing the Class
 You do not need to create an instance of the CLI library, since all of it's methods are static. Instead, you simply
 need to ensure your controller can locate it via a ``use`` statement above your class::
 
-	<?php namespace App\Controllers;
+    <?php namespace App\Controllers;
 
-	use CodeIgniter\CLI\CLI;
+    use CodeIgniter\CLI\CLI;
 
-	class MyController extends \CodeIgniter\Controller
-	{
-		. . .
-	}
+    class MyController extends \CodeIgniter\Controller
+    {
+        . . .
+    }
 
 The class is automatically initialized when the file is loaded the first time.
 
@@ -40,20 +40,20 @@ handled with the ``prompt()`` method.
 
 You can provide a question by passing it in as the first parameter::
 
-	$color = CLI::prompt('What is your favorite color?');
+    $color = CLI::prompt('What is your favorite color?');
 
 You can provide a default answer that will be used if the user just hits enter by passing the default in the
 second parameter::
 
-	$color = CLI::prompt('What is your favorite color?', 'blue');
+    $color = CLI::prompt('What is your favorite color?', 'blue');
 
 You can restrict the acceptable answers by passing in an array of allowed answers as the second parameter::
 
-	$overwrite = CLI::prompt('File exists. Overwrite?', ['y','n']);
+    $overwrite = CLI::prompt('File exists. Overwrite?', ['y','n']);
 
 Finally, you can pass validation rules to the answer input as the third parameter::
 
-	$email = CLI::prompt('What is your email?', null, 'required|valid_email');
+    $email = CLI::prompt('What is your email?', null, 'required|valid_email');
 
 Providing Feedback
 ==================
@@ -64,16 +64,16 @@ Several methods are provided for you to provide feedback to your users. This can
 or a complex table of information that wraps to the user's terminal window. At the core of this is the ``write()``
 method which takes the string to output as the first parameter::
 
-	CLI::write('The rain in Spain falls mainly on the plains.');
+    CLI::write('The rain in Spain falls mainly on the plains.');
 
 You can change the color of the text by passing in a color name as the second parameter::
 
-	CLI::write('File created.', 'green');
+    CLI::write('File created.', 'green');
 
 This could be used to differentiate messages by status, or create 'headers' by using a different color. You can
 even set background colors by passing the color name in as the third parameter::
 
-	CLI::write('File overwritten.', 'light_red', 'dark_gray');
+    CLI::write('File overwritten.', 'light_red', 'dark_gray');
 
 The following foreground colors are available:
 
@@ -125,7 +125,7 @@ use the ``color()`` method to make a string fragment that can be used in the sam
 an EOL after printing. This allows you to create multiple outputs on the same row. Or, more commonly, you can use
 it inside of a ``write()`` method to create a string of a different color inside::
 
-	CLI::write("fileA \t". CLI::color('/path/to/file', 'white'), 'yellow');
+    CLI::write("fileA \t". CLI::color('/path/to/file', 'white'), 'yellow');
 
 This example would write a single line to the window, with ``fileA`` in yellow, followed by a tab, and then
 ``/path/to/file`` in white text.
@@ -137,7 +137,7 @@ to STDERR, instead of STDOUT, like ``write()`` and ``color()`` do. This can be u
 for errors so they don't have to sift through all of the information, only the actual error messages. You use it
 exactly as you would the ``write()`` method::
 
-	CLI::error('Cannot write to file: ' . $file);
+    CLI::error('Cannot write to file: ' . $file);
 
 **wrap()**
 
@@ -145,8 +145,8 @@ This command will take a string, start printing it on the current line, and wrap
 This might be useful when displaying a list of options with descriptions that you want to wrap in the current
 window and not go off screen::
 
-	CLI::color("task1\t", 'yellow');
-	CLI::wrap("Some long description goes here that might be longer than the current window.");
+    CLI::color("task1\t", 'yellow');
+    CLI::wrap("Some long description goes here that might be longer than the current window.");
 
 By default, the string will wrap at the terminal width. Windows currently doesn't provide a way to determine
 the window size, so we default to 80 characters. If you want to restrict the width to something shorter that
@@ -154,29 +154,29 @@ you can be pretty sure fits within the window, pass the maximum line-length as t
 will break the string at the nearest word barrier so that words are not broken.
 ::
 
-	// Wrap the text at max 20 characters wide
-	CLI::wrap($description, 20);
+    // Wrap the text at max 20 characters wide
+    CLI::wrap($description, 20);
 
 You may find that you want a column on the left of titles, files, or tasks, while you want a column of text
 on the right with their descriptions. By default, this will wrap back to the left edge of the window, which
 doesn't allow things to line up in columns. In cases like this, you can pass in a number of spaces to pad
 every line after the first line, so that you will have a crisp column edge on the left::
 
-	// Determine the maximum length of all titles
-	// to determine the width of the left column
-	$maxlen = max(array_map('strlen', $titles));
+    // Determine the maximum length of all titles
+    // to determine the width of the left column
+    $maxlen = max(array_map('strlen', $titles));
 
-	for ($i=0; $i < count($titles); $i++)
-	{
-		CLI::write(
-			// Display the title on the left of the row
-			$titles[$i] . '   ' .
-			// Wrap the descriptions in a right-hand column
-			// with its left side 3 characters wider than
-			// the longest item on the left.
-			CLI::wrap($descriptions[$i], 40, $maxlen + 3)
-		);
-	}
+    for ($i=0; $i < count($titles); $i++)
+    {
+        CLI::write(
+            // Display the title on the left of the row
+            $titles[$i] . '   ' .
+            // Wrap the descriptions in a right-hand column
+            // with its left side 3 characters wider than
+            // the longest item on the left.
+            CLI::wrap($descriptions[$i], 40, $maxlen + 3)
+        );
+    }
 
 Would create something like this:
 
@@ -192,7 +192,7 @@ Would create something like this:
 
 The ``newLine()`` method displays a blank line to the user. It does not take any parameters::
 
-	CLI::newLine();
+    CLI::newLine();
 
 **clearScreen()**
 
@@ -200,7 +200,7 @@ You can clear the current terminal window with the ``clearScreen()`` method. In 
 simply insert 40 blank lines since Windows doesn't support this feature. Windows 10 bash integration should change
 this::
 
-	CLI::clearScreen();
+    CLI::clearScreen();
 
 **showProgress()**
 
@@ -209,7 +209,7 @@ If you have a long-running task that you would like to keep the user updated wit
 
 .. code-block:: none
 
-	[####......] 40% Complete
+    [####......] 40% Complete
 
 This block is animated in place for a very nice effect.
 
@@ -218,38 +218,38 @@ The percent complete and the length of the display will be determined based on t
 pass ``false`` as the first parameter and the progress bar will be removed.
 ::
 
-	$totalSteps = count($tasks);
-	$currStep   = 1;
+    $totalSteps = count($tasks);
+    $currStep   = 1;
 
-	foreach ($tasks as $task)
-	{
-		CLI::showProgress($currStep++, $totalSteps);
-		$task->run();
-	}
+    foreach ($tasks as $task)
+    {
+        CLI::showProgress($currStep++, $totalSteps);
+        $task->run();
+    }
 
-	// Done, so erase it...
-	CLI::showProgress(false);
+    // Done, so erase it...
+    CLI::showProgress(false);
 
 **table()**
 
 ::
 
-	$thead = ['ID', 'Title', 'Updated At', 'Active'];
-	$tbody = [
-		[7, 'A great item title', '2017-11-15 10:35:02', 1],
-		[8, 'Another great item title', '2017-11-16 13:46:54', 0]
-	];
+    $thead = ['ID', 'Title', 'Updated At', 'Active'];
+    $tbody = [
+        [7, 'A great item title', '2017-11-15 10:35:02', 1],
+        [8, 'Another great item title', '2017-11-16 13:46:54', 0]
+    ];
 
-	CLI::table($tbody, $thead);
+    CLI::table($tbody, $thead);
 
 .. code-block:: none
 
-	+----+--------------------------+---------------------+--------+
-	| ID | Title                    | Updated At          | Active |
-	+----+--------------------------+---------------------+--------+
-	| 7  | A great item title       | 2017-11-16 10:35:02 | 1      |
-	| 8  | Another great item title | 2017-11-16 13:46:54 | 0      |
-	+----+--------------------------+---------------------+--------+
+    +----+--------------------------+---------------------+--------+
+    | ID | Title                    | Updated At          | Active |
+    +----+--------------------------+---------------------+--------+
+    | 7  | A great item title       | 2017-11-16 10:35:02 | 1      |
+    | 8  | Another great item title | 2017-11-16 13:46:54 | 0      |
+    +----+--------------------------+---------------------+--------+
 
 **wait()**
 


### PR DESCRIPTION
**Description**
- Replace tab indentation with space.
  - A tab is converted to 8 spaces. So it is better to use only spaces for indentation.
- Fix sample code coding stye.

**Checklist:**
- [x] Securely signed commits
- [n/a] Component(s) with PHPdocs
- [n/a] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
