### PR TITLE
docs: fix installation indentation

### DIFF
--- a/user_guide_src/source/installation/troubleshooting.rst
+++ b/user_guide_src/source/installation/troubleshooting.rst
@@ -36,11 +36,11 @@ alternate settings. If it still doesn't work after you've tried this
 you'll need to force CodeIgniter to add a question mark to your URLs. To
 do this open your *app/Config/App.php* file and change this::
 
-	public $indexPage = 'index.php';
+    public $indexPage = 'index.php';
 
 To this::
 
-	public $indexPage = 'index.php?';
+    public $indexPage = 'index.php?';
 
 The tutorial gives 404 errors everywhere :(
 -------------------------------------------

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -10,4 +10,4 @@ upgrading from.
 
     Upgrading from 4.0.4 to 4.0.5 <upgrade_405>
     Upgrading from 4.0.x to 4.0.4 <upgrade_404>
-	Upgrading from 3.x to 4.x <upgrade_4xx>
+    Upgrading from 3.x to 4.x <upgrade_4xx>


### PR DESCRIPTION
**Description**
Replace tab indentation with space.

**Checklist:**
- [x] Securely signed commits
- [n/a] Component(s) with PHPdocs
- [n/a] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
