### PR TITLE
make form_hidden based on form_input

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -158,7 +158,7 @@ if (! function_exists('form_hidden'))
 
 		if (! is_array($value))
 		{
-			$form .= '<input type="hidden" name="' . $name . '" value="' . esc($value) . "\" style=\"display:none;\" />\n";
+			$form .= form_input($name, $value, '', 'hidden');
 		}
 		else
 		{

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -170,8 +170,8 @@ EOH;
 			$Name     = csrf_token();
 			$expected = <<<EOH
 <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
-<input type="hidden" name="foo" value="bar" style="display:none;" />
-<input type="hidden" name="$Name" value="$Value" style="display:none;" />
+<input type="hidden" name="foo" value="bar"  />
+<input type="hidden" name="$Name" value="$Value"  />
 
 EOH;
 		}
@@ -180,7 +180,7 @@ EOH;
 			$expected = <<<EOH
 <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
 
-<input type="hidden" name="foo" value="bar" style="display:none;" />
+<input type="hidden" name="foo" value="bar"  />
 
 EOH;
 		}
@@ -242,7 +242,7 @@ EOH;
 	{
 		$expected = <<<EOH
 
-<input type="hidden" name="username" value="johndoe" style="display:none;" />\n
+<input type="hidden" name="username" value="johndoe"  />\n
 EOH;
 		$this->assertEquals($expected, form_hidden('username', 'johndoe'));
 	}
@@ -255,7 +255,7 @@ EOH;
 		];
 		$expected = <<<EOH
 
-<input type="hidden" name="foo" value="bar" style="display:none;" />
+<input type="hidden" name="foo" value="bar"  />
 
 EOH;
 		$this->assertEquals($expected, form_hidden($data, null));
@@ -269,7 +269,7 @@ EOH;
 		];
 		$expected = <<<EOH
 
-<input type="hidden" name="name[foo]" value="bar" style="display:none;" />
+<input type="hidden" name="name[foo]" value="bar"  />
 
 EOH;
 		$this->assertEquals($expected, form_hidden('name', $data));


### PR DESCRIPTION
**Description**
As far as I know, hidden fields do not require additional styles.
And with this, make form_input the basis for creating form_hidden.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
