### PR TITLE
Supply Xdebug 3 mode

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -13,6 +13,7 @@ on:
       - composer.json
       - spark
       - '**.php'
+      - phpunit.xml.dist
       - .github/workflows/test-phpunit.yml
   pull_request:
     branches:
@@ -26,6 +27,7 @@ on:
       - composer.json
       - spark
       - '**.php'
+      - phpunit.xml.dist
       - .github/workflows/test-phpunit.yml
 
 jobs:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -41,6 +41,7 @@
 	</logging>
 
 	<php>
+		<env name="XDEBUG_MODE" value="coverage"/>
 		<server name="app.baseURL" value="http://example.com/"/>
 
 		<!-- Directory containing phpunit.xml -->


### PR DESCRIPTION
**Description**
Enables `coverage` mode for Xdebug 3, should have no affect on Xdebug 2.x

**Checklist:**
- [X] Securely signed commits
- n/a Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- n/a User guide updated
- [x] Conforms to style guide
