### PR TITLE
PHP 8 Actions

### DIFF
--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -20,8 +20,12 @@ on:
 
 jobs:
   build:
-    name: Analyze code (PHPStan)
+    name: PHP ${{ matrix.php-versions }} Static Analysis
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.4', '8.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -29,7 +33,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php-versions }}
           extensions: intl
 
       - name: Use latest Composer

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -40,13 +40,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-<<<<<<< HEAD
-        php-versions: ['7.2', '7.3', '7.4']
-        db-platforms: ['MySQLi', 'Postgre', 'SQLite3', 'SQLSRV']
-=======
         php-versions: ['7.2', '7.3', '7.4', '8.0']
-        db-platforms: ['MySQLi', 'Postgre', 'SQLite3', 'Sqlsrv']
->>>>>>> 62fd6fe3b... Include PHP8 in Actions
+        db-platforms: ['MySQLi', 'Postgre', 'SQLite3', 'SQLSRV']
 
     services:
       mysql:
@@ -93,7 +88,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer, pecl
-          extensions: imagick, sqlsrv
+          extensions: imagick, sqlsrv-beta
           coverage: xdebug
         env:
           update: true

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -40,8 +40,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+<<<<<<< HEAD
         php-versions: ['7.2', '7.3', '7.4']
         db-platforms: ['MySQLi', 'Postgre', 'SQLite3', 'SQLSRV']
+=======
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        db-platforms: ['MySQLi', 'Postgre', 'SQLite3', 'Sqlsrv']
+>>>>>>> 62fd6fe3b... Include PHP8 in Actions
 
     services:
       mysql:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"fakerphp/faker": "^1.9",
 		"mikey179/vfsstream": "^1.6",
 		"phpstan/phpstan": "^0.12",
-		"phpunit/phpunit": "^8.5",
+		"phpunit/phpunit": "^8.5 || ^9.1",
 		"predis/predis": "^1.1",
 		"rector/rector": "^0.8",
 		"squizlabs/php_codesniffer": "^3.3"


### PR DESCRIPTION
*Supercedes #3932*

**Description**
Adds PHP 8 to the testing and analysis workflows. This will give some idea of the work left to do for `4.0.5` to support PHP 8, and any conflicts among dependencies for supporting both `7.2` and `8.0`

**Checklist:**
- [X] Securely signed commits
- n/a Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
