### PR TITLE
Add Interface to Security Component

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -380,7 +380,7 @@ class CodeIgniter
 	 * @return RequestInterface|ResponseInterface|mixed
 	 * @throws RedirectException
 	 */
-	protected function handleRequest(RouteCollectionInterface $routes = null, Cache $cacheConfig, bool $returnResponse = false)
+	protected function handleRequest(?RouteCollectionInterface $routes, Cache $cacheConfig, bool $returnResponse = false)
 	{
 		$routeFilter = $this->tryToRouteIt($routes);
 

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1319,15 +1319,15 @@ class BaseBuilder
 	/**
 	 * Platform independent LIKE statement builder.
 	 *
-	 * @param string  $prefix
-	 * @param string  $column
-	 * @param string  $not
-	 * @param string  $bind
-	 * @param boolean $insensitiveSearch
+	 * @param string|null  $prefix
+	 * @param string       $column
+	 * @param string|null  $not
+	 * @param string       $bind
+	 * @param boolean      $insensitiveSearch
 	 *
 	 * @return string     $like_statement
 	 */
-	protected function _like_statement(string $prefix = null, string $column, string $not = null, string $bind, bool $insensitiveSearch = false): string
+	protected function _like_statement(?string $prefix, string $column, ?string $not, string $bind, bool $insensitiveSearch = false): string
 	{
 		$likeStatement = "{$prefix} {$column} {$not} LIKE :{$bind}:";
 
@@ -1679,12 +1679,12 @@ class BaseBuilder
 	/**
 	 * LIMIT
 	 *
-	 * @param integer $value  LIMIT value
-	 * @param integer $offset OFFSET value
+	 * @param integer|null $value  LIMIT value
+	 * @param integer|null $offset OFFSET value
 	 *
 	 * @return $this
 	 */
-	public function limit(int $value = null, ?int $offset = 0)
+	public function limit(?int $value = null, ?int $offset = 0)
 	{
 		if (! is_null($value))
 		{

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -361,15 +361,15 @@ class Builder extends BaseBuilder
 	 *
 	 * @see https://www.postgresql.org/docs/9.2/static/functions-matching.html
 	 *
-	 * @param string  $prefix
-	 * @param string  $column
-	 * @param string  $not
-	 * @param string  $bind
-	 * @param boolean $insensitiveSearch
+	 * @param string|null  $prefix
+	 * @param string       $column
+	 * @param string|null  $not
+	 * @param string       $bind
+	 * @param boolean      $insensitiveSearch
 	 *
 	 * @return string     $like_statement
 	 */
-	public function _like_statement(string $prefix = null, string $column, string $not = null, string $bind, bool $insensitiveSearch = false): string
+	public function _like_statement(?string $prefix, string $column, ?string $not, string $bind, bool $insensitiveSearch = false): string
 	{
 		$op = $insensitiveSearch === true ? 'ILIKE' : 'LIKE';
 

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -277,7 +277,8 @@ class Connection extends BaseConnection
 		return 'SELECT "column_name"
 			FROM "information_schema"."columns"
 			WHERE LOWER("table_name") = '
-				. $this->escape($this->DBPrefix . strtolower($table));
+				. $this->escape($this->DBPrefix . strtolower($table))
+				. ' ORDER BY "ordinal_position"';
 	}
 
 	//--------------------------------------------------------------------
@@ -294,7 +295,8 @@ class Connection extends BaseConnection
 		$sql = 'SELECT "column_name", "data_type", "character_maximum_length", "numeric_precision", "column_default"
 			FROM "information_schema"."columns"
 			WHERE LOWER("table_name") = '
-				. $this->escape(strtolower($table));
+				. $this->escape(strtolower($table))
+				. ' ORDER BY "ordinal_position"';
 
 		if (($query = $this->query($sql)) === false)
 		{

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -115,16 +115,16 @@ class Pager implements PagerInterface
 	 * Allows for a simple, manual, form of pagination where all of the data
 	 * is provided by the user. The URL is the current URI.
 	 *
-	 * @param integer $page
-	 * @param integer $perPage
-	 * @param integer $total
-	 * @param string  $template The output template alias to render.
-	 * @param integer $segment  (if page number is provided by URI segment)
+	 * @param integer      $page
+	 * @param integer|null $perPage
+	 * @param integer      $total
+	 * @param string       $template The output template alias to render.
+	 * @param integer      $segment  (whether page number is provided by URI segment)
+	 * @param string|null  $group    optional group (i.e. if we'd like to define custom path)
 	 *
-	 * @param  string  $group    optional group (i.e. if we'd like to define custom path)
 	 * @return string
 	 */
-	public function makeLinks(int $page, int $perPage = null, int $total, string $template = 'default_full', int $segment = 0, ?string $group = 'default'): string
+	public function makeLinks(int $page, ?int $perPage, int $total, string $template = 'default_full', int $segment = 0, ?string $group = 'default'): string
 	{
 		$group = $group === '' ? 'default' : $group;
 
@@ -163,15 +163,15 @@ class Pager implements PagerInterface
 	 * Stores a set of pagination data for later display. Most commonly used
 	 * by the model to automate the process.
 	 *
-	 * @param string  $group
-	 * @param integer $page
-	 * @param integer $perPage
-	 * @param integer $total
-	 * @param integer $segment
+	 * @param string       $group
+	 * @param integer      $page
+	 * @param integer|null $perPage
+	 * @param integer      $total
+	 * @param integer      $segment
 	 *
 	 * @return $this
 	 */
-	public function store(string $group, int $page, int $perPage = null, int $total, int $segment = 0)
+	public function store(string $group, int $page, ?int $perPage, int $total, int $segment = 0)
 	{
 		if ($segment)
 		{

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -15,7 +15,6 @@ use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use Config\App;
-use Exception;
 
 /**
  * Class Security
@@ -23,7 +22,7 @@ use Exception;
  * Provides methods that help protect your site against
  * Cross-Site Request Forgery attacks.
  */
-class Security
+class Security implements SecurityInterface
 {
 	/**
 	 * CSRF Hash
@@ -41,7 +40,7 @@ class Security
 	 *
 	 * @var string
 	 */
-	protected $tokenName = 'CSRFToken';
+	protected $tokenName = 'csrf_token_name';
 
 	/**
 	 * CSRF Header Name
@@ -50,7 +49,7 @@ class Security
 	 *
 	 * @var string
 	 */
-	protected $headerName = 'CSRFToken';
+	protected $headerName = 'X-CSRF-TOKEN';
 
 	/**
 	 * CSRF Cookie Name
@@ -59,7 +58,7 @@ class Security
 	 *
 	 * @var string
 	 */
-	protected $cookieName = 'CSRFToken';
+	protected $cookieName = 'csrf_cookie_name';
 
 	/**
 	 * CSRF Expires
@@ -148,6 +147,7 @@ class Security
 	 * @param RequestInterface $request
 	 *
 	 * @return $this|false
+	 * 
 	 * @throws SecurityException
 	 *
 	 * @deprecated Use `CodeIgniter\Security\Security::verify()` instead of using this method.
@@ -193,6 +193,7 @@ class Security
 	 * @param RequestInterface $request
 	 *
 	 * @return $this|false
+	 * 
 	 * @throws SecurityException
 	 */
 	public function verify(RequestInterface $request)

--- a/system/Security/SecurityInterface.php
+++ b/system/Security/SecurityInterface.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Security;
+
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\Security\Exceptions\SecurityException;
+
+/**
+ * Expected behavior of a Security.
+ */
+interface SecurityInterface
+{
+	/**
+	 * CSRF Verify
+	 *
+	 * @param RequestInterface $request
+	 *
+	 * @return $this|false
+	 * 
+	 * @throws SecurityException
+	 */
+	public function verify(RequestInterface $request);
+
+	/**
+	 * Returns the CSRF Hash.
+	 *
+	 * @return string|null
+	 */
+	public function getHash(): ?string;
+
+	/**
+	 * Returns the CSRF Token Name.
+	 *
+	 * @return string
+	 */
+	public function getTokenName(): string;
+
+	/**
+	 * Returns the CSRF Header Name.
+	 *
+	 * @return string
+	 */
+	public function getHeaderName(): string;
+
+	/**
+	 * Returns the CSRF Cookie Name.
+	 *
+	 * @return string
+	 */
+	public function getCookieName(): string;
+
+	/**
+	 * Check if CSRF cookie is expired.
+	 *
+	 * @return boolean
+	 */
+	public function isExpired(): bool;
+
+	/**
+	 * Check if request should be redirect on failure.
+	 *
+	 * @return boolean
+	 */
+	public function shouldRedirect(): bool;
+
+	/**
+	 * Sanitize Filename
+	 *
+	 * Tries to sanitize filenames in order to prevent directory traversal attempts
+	 * and other security threats, which is particularly useful for files that
+	 * were supplied via user input.
+	 *
+	 * If it is acceptable for the user input to include relative paths,
+	 * e.g. file/in/some/approved/folder.txt, you can set the second optional
+	 * parameter, $relative_path to TRUE.
+	 *
+	 * @param string  $str          Input file name
+	 * @param boolean $relativePath Whether to preserve paths
+	 *
+	 * @return string
+	 */
+	public function sanitizeFilename(string $str, bool $relativePath = false): string;
+}

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -218,12 +218,13 @@ class DOMParser
 	/**
 	 * Search the DOM using an XPath expression.
 	 *
-	 * @param  string $search
-	 * @param  string $element
-	 * @param  array  $paths
+	 * @param  string|null $search
+	 * @param  string      $element
+	 * @param  array       $paths
+	 *
 	 * @return DOMNodeList
 	 */
-	protected function doXPath(string $search = null, string $element, array $paths = [])
+	protected function doXPath(?string $search, string $element, array $paths = [])
 	{
 		// Otherwise, grab any elements that match
 		// the selector

--- a/system/Validation/CreditCardRules.php
+++ b/system/Validation/CreditCardRules.php
@@ -172,12 +172,12 @@ class CreditCardRules
 	 *      'cc_num' => 'valid_cc_number[visa]'
 	 *  ];
 	 *
-	 * @param string $ccNumber
-	 * @param string $type
+	 * @param string|null $ccNumber
+	 * @param string      $type
 	 *
 	 * @return boolean
 	 */
-	public function valid_cc_number(string $ccNumber = null, string $type): bool
+	public function valid_cc_number(?string $ccNumber, string $type): bool
 	{
 		$type = strtolower($type);
 		$info = null;

--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -49,12 +49,12 @@ class FileRules
 	/**
 	 * Verifies that $name is the name of a valid uploaded file.
 	 *
-	 * @param string $blank
-	 * @param string $name
+	 * @param string|null $blank
+	 * @param string      $name
 	 *
 	 * @return boolean
 	 */
-	public function uploaded(string $blank = null, string $name): bool
+	public function uploaded(?string $blank, string $name): bool
 	{
 		if (! ($files = $this->request->getFileMultiple($name)))
 		{
@@ -100,7 +100,7 @@ class FileRules
 	 *
 	 * @return boolean
 	 */
-	public function max_size(string $blank = null, string $params): bool
+	public function max_size(?string $blank, string $params): bool
 	{
 		// Grab the file name off the top of the $params
 		// after we split it.
@@ -149,7 +149,7 @@ class FileRules
 	 *
 	 * @return boolean
 	 */
-	public function is_image(string $blank = null, string $params): bool
+	public function is_image(?string $blank, string $params): bool
 	{
 		// Grab the file name off the top of the $params
 		// after we split it.
@@ -196,7 +196,7 @@ class FileRules
 	 *
 	 * @return boolean
 	 */
-	public function mime_in(string $blank = null, string $params): bool
+	public function mime_in(?string $blank, string $params): bool
 	{
 		// Grab the file name off the top of the $params
 		// after we split it.
@@ -239,7 +239,7 @@ class FileRules
 	 *
 	 * @return boolean
 	 */
-	public function ext_in(string $blank = null, string $params): bool
+	public function ext_in(?string $blank, string $params): bool
 	{
 		// Grab the file name off the top of the $params
 		// after we split it.
@@ -283,7 +283,7 @@ class FileRules
 	 *
 	 * @return boolean
 	 */
-	public function max_dims(string $blank = null, string $params): bool
+	public function max_dims(?string $blank, string $params): bool
 	{
 		// Grab the file name off the top of the $params
 		// after we split it.

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -21,11 +21,11 @@ class FormatRules
 	/**
 	 * Alpha
 	 *
-	 * @param string $str
+	 * @param string|null $str
 	 *
 	 * @return boolean
 	 */
-	public function alpha(string $str = null): bool
+	public function alpha(?string $str = null): bool
 	{
 		return ctype_alpha($str);
 	}
@@ -33,11 +33,11 @@ class FormatRules
 	/**
 	 * Alpha with spaces.
 	 *
-	 * @param string $value Value.
+	 * @param string|null $value Value.
 	 *
 	 * @return boolean True if alpha with spaces, else false.
 	 */
-	public function alpha_space(string $value = null): bool
+	public function alpha_space(?string $value = null): bool
 	{
 		if ($value === null)
 		{
@@ -50,11 +50,11 @@ class FormatRules
 	/**
 	 * Alphanumeric with underscores and dashes
 	 *
-	 * @param string $str
+	 * @param string|null $str
 	 *
 	 * @return boolean
 	 */
-	public function alpha_dash(string $str = null): bool
+	public function alpha_dash(?string $str = null): bool
 	{
 			return (bool) preg_match('/^[a-z0-9_-]+$/i', $str);
 	}
@@ -78,11 +78,11 @@ class FormatRules
 	/**
 	 * Alphanumeric
 	 *
-	 * @param string $str
+	 * @param string|null $str
 	 *
 	 * @return boolean
 	 */
-	public function alpha_numeric(string $str = null): bool
+	public function alpha_numeric(?string $str = null): bool
 	{
 		return ctype_alnum($str);
 	}
@@ -90,11 +90,11 @@ class FormatRules
 	/**
 	 * Alphanumeric w/ spaces
 	 *
-	 * @param string $str
+	 * @param string|null $str
 	 *
 	 * @return boolean
 	 */
-	public function alpha_numeric_space(string $str = null): bool
+	public function alpha_numeric_space(?string $str = null): bool
 	{
 		return (bool) preg_match('/^[A-Z0-9 ]+$/i', $str);
 	}
@@ -117,11 +117,11 @@ class FormatRules
 	/**
 	 * Decimal number
 	 *
-	 * @param string $str
+	 * @param string|null $str
 	 *
 	 * @return boolean
 	 */
-	public function decimal(string $str = null): bool
+	public function decimal(?string $str = null): bool
 	{
 		return (bool) preg_match('/^[-+]?[0-9]{0,}\.?[0-9]+$/', $str);
 	}
@@ -129,11 +129,11 @@ class FormatRules
 	/**
 	 * String of hexidecimal characters
 	 *
-	 * @param string $str
+	 * @param string|null $str
 	 *
 	 * @return boolean
 	 */
-	public function hex(string $str = null): bool
+	public function hex(?string $str = null): bool
 	{
 		return ctype_xdigit($str);
 	}
@@ -141,11 +141,11 @@ class FormatRules
 	/**
 	 * Integer
 	 *
-	 * @param string $str
+	 * @param string|null $str
 	 *
 	 * @return boolean
 	 */
-	public function integer(string $str = null): bool
+	public function integer(?string $str = null): bool
 	{
 		return (bool) preg_match('/^[\-+]?[0-9]+$/', $str);
 	}
@@ -153,10 +153,10 @@ class FormatRules
 	/**
 	 * Is a Natural number  (0,1,2,3, etc.)
 	 *
-	 * @param  string $str
+	 * @param  string|null $str
 	 * @return boolean
 	 */
-	public function is_natural(string $str = null): bool
+	public function is_natural(?string $str = null): bool
 	{
 		return ctype_digit($str);
 	}
@@ -164,10 +164,10 @@ class FormatRules
 	/**
 	 * Is a Natural number, but not a zero  (1,2,3, etc.)
 	 *
-	 * @param  string $str
+	 * @param  string|null $str
 	 * @return boolean
 	 */
-	public function is_natural_no_zero(string $str = null): bool
+	public function is_natural_no_zero(?string $str = null): bool
 	{
 		return ($str !== '0' && ctype_digit($str));
 	}
@@ -175,11 +175,11 @@ class FormatRules
 	/**
 	 * Numeric
 	 *
-	 * @param string $str
+	 * @param string|null $str
 	 *
 	 * @return boolean
 	 */
-	public function numeric(string $str = null): bool
+	public function numeric(?string $str = null): bool
 	{
 		return (bool) preg_match('/^[\-+]?[0-9]*\.?[0-9]+$/', $str);
 	}
@@ -187,12 +187,12 @@ class FormatRules
 	/**
 	 * Compares value against a regular expression pattern.
 	 *
-	 * @param string $str
-	 * @param string $pattern
+	 * @param string|null $str
+	 * @param string      $pattern
 	 *
 	 * @return boolean
 	 */
-	public function regex_match(string $str = null, string $pattern): bool
+	public function regex_match(?string $str, string $pattern): bool
 	{
 		if (strpos($pattern, '/') !== 0)
 		{

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -72,7 +72,7 @@ class FormatRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 	/**
 	 * @dataProvider urlProvider
 	 */
-	public function testValidURL(string $url = null, bool $expected)
+	public function testValidURL(?string $url, bool $expected)
 	{
 		$data = [
 			'foo' => $url,


### PR DESCRIPTION
While Security Class is one of core system classes and it might be replaced by user Security class, it should have it's own interface for more flexibility.

- [x] Securely signed commits
- [x] Component(s) with PHPdocs