### PR TITLE
Add Interface to Security Component

### DIFF
--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -15,7 +15,6 @@ use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use Config\App;
-use Exception;
 
 /**
  * Class Security
@@ -23,7 +22,7 @@ use Exception;
  * Provides methods that help protect your site against
  * Cross-Site Request Forgery attacks.
  */
-class Security
+class Security implements SecurityInterface
 {
 	/**
 	 * CSRF Hash
@@ -41,7 +40,7 @@ class Security
 	 *
 	 * @var string
 	 */
-	protected $tokenName = 'CSRFToken';
+	protected $tokenName = 'csrf_token_name';
 
 	/**
 	 * CSRF Header Name
@@ -50,7 +49,7 @@ class Security
 	 *
 	 * @var string
 	 */
-	protected $headerName = 'CSRFToken';
+	protected $headerName = 'X-CSRF-TOKEN';
 
 	/**
 	 * CSRF Cookie Name
@@ -59,7 +58,7 @@ class Security
 	 *
 	 * @var string
 	 */
-	protected $cookieName = 'CSRFToken';
+	protected $cookieName = 'csrf_cookie_name';
 
 	/**
 	 * CSRF Expires
@@ -148,6 +147,7 @@ class Security
 	 * @param RequestInterface $request
 	 *
 	 * @return $this|false
+	 * 
 	 * @throws SecurityException
 	 *
 	 * @deprecated Use `CodeIgniter\Security\Security::verify()` instead of using this method.
@@ -193,6 +193,7 @@ class Security
 	 * @param RequestInterface $request
 	 *
 	 * @return $this|false
+	 * 
 	 * @throws SecurityException
 	 */
 	public function verify(RequestInterface $request)

--- a/system/Security/SecurityInterface.php
+++ b/system/Security/SecurityInterface.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Security;
+
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\Security\Exceptions\SecurityException;
+
+/**
+ * Expected behavior of a Security.
+ */
+interface SecurityInterface
+{
+	/**
+	 * CSRF Verify
+	 *
+	 * @param RequestInterface $request
+	 *
+	 * @return $this|false
+	 * 
+	 * @throws SecurityException
+	 */
+	public function verify(RequestInterface $request);
+
+	/**
+	 * Returns the CSRF Hash.
+	 *
+	 * @return string|null
+	 */
+	public function getHash(): ?string;
+
+	/**
+	 * Returns the CSRF Token Name.
+	 *
+	 * @return string
+	 */
+	public function getTokenName(): string;
+
+	/**
+	 * Returns the CSRF Header Name.
+	 *
+	 * @return string
+	 */
+	public function getHeaderName(): string;
+
+	/**
+	 * Returns the CSRF Cookie Name.
+	 *
+	 * @return string
+	 */
+	public function getCookieName(): string;
+
+	/**
+	 * Check if CSRF cookie is expired.
+	 *
+	 * @return boolean
+	 */
+	public function isExpired(): bool;
+
+	/**
+	 * Check if request should be redirect on failure.
+	 *
+	 * @return boolean
+	 */
+	public function shouldRedirect(): bool;
+
+	/**
+	 * Sanitize Filename
+	 *
+	 * Tries to sanitize filenames in order to prevent directory traversal attempts
+	 * and other security threats, which is particularly useful for files that
+	 * were supplied via user input.
+	 *
+	 * If it is acceptable for the user input to include relative paths,
+	 * e.g. file/in/some/approved/folder.txt, you can set the second optional
+	 * parameter, $relative_path to TRUE.
+	 *
+	 * @param string  $str          Input file name
+	 * @param boolean $relativePath Whether to preserve paths
+	 *
+	 * @return string
+	 */
+	public function sanitizeFilename(string $str, bool $relativePath = false): string;
+}


### PR DESCRIPTION
While Security Class is one of core system classes and it might be replaced by user Security class, it should have it's own interface for more flexibility.

closes #4013 

- [x] Securely signed commits
- [x] Component(s)