### PR TITLE
docs: fix concepts indentation

### DIFF
--- a/user_guide_src/source/concepts/factories.rst
+++ b/user_guide_src/source/concepts/factories.rst
@@ -24,22 +24,22 @@ by using the magic static method of the Factories class, ``Factories::models()``
 the common path structure for namespaces and folders, Factories know that the model files
 and classes are found within **Models**, so you can request a model by its shorthand base name::
 
-	use CodeIgniter\Config\Factories;
+    use CodeIgniter\Config\Factories;
 
-	$users = Factories::models('UserModel');
+    $users = Factories::models('UserModel');
 
 Or you could also request a specific class::
 
-	$widgets = Factories::models('Some\Namespace\Models\WidgetModel');
+    $widgets = Factories::models('Some\Namespace\Models\WidgetModel');
 
 Next time you ask for the same class anywhere in your code, ``Factories`` will be sure
 you get back the instance as before::
 
-	class SomeOtherClass
-	{
-		$widgets = Factories::models('WidgetModel');
-		...
-	}
+    class SomeOtherClass
+    {
+        $widgets = Factories::models('WidgetModel');
+        ...
+    }
 
 Factory Parameters
 ==================
@@ -52,8 +52,8 @@ constructor, making it easy to configure your class instance on-the-fly. For exa
 your app uses a separate database for authentication and you want to be sure that any attempts
 to access user records always go through that connection::
 
-	$conn  = db_connect('AuthDatabase');
-	$users = Factories::models('UserModel', [], $conn);
+    $conn  = db_connect('AuthDatabase');
+    $users = Factories::models('UserModel', [], $conn);
 
 Now any time the ``UserModel`` is loaded from ``Factories`` it will in fact be returning a
 class instance that uses the alternate database connection.
@@ -92,17 +92,17 @@ that supplies options as an array property that matches the name of the componen
 if you wanted to ensure that all Filters used by your app were valid framework instances,
 your **Factories.php** file might look like this::
 
-	<?php namespace Config;
+    <?php namespace Config;
 
-	use CodeIgniter\Config\Factory as BaseFactory;
-	use CodeIgniter\Filters\FilterInterface;
+    use CodeIgniter\Config\Factory as BaseFactory;
+    use CodeIgniter\Filters\FilterInterface;
 
-	class Factories extends BaseFactory
-	{
-		public $filters = [
-			'instanceOf' => FilterInterface::class,
-		];
-	}
+    class Factories extends BaseFactory
+    {
+        public $filters = [
+            'instanceOf' => FilterInterface::class,
+        ];
+    }
 
 This would prevent conflict of an unrelated third-party module which happened to have an
 unrelated "Filters" path in its namespace.
@@ -114,10 +114,10 @@ The ``Factories`` class has a static method to allow runtime option configuratio
 supply the desired array of options using the ``setOptions()`` method and they will be
 merged with the default values and stored for the next call::
 
-	Factories::setOptions('filters', [
-		'instanceOf' => FilterInterface::class,
-		'prefersApp' => false,
-	]);
+    Factories::setOptions('filters', [
+        'instanceOf' => FilterInterface::class,
+        'prefersApp' => false,
+    ]);
 
 Parameter Options
 -----------------
@@ -131,5 +131,5 @@ For example, by default ``Factories`` assumes that you want to locate a shared i
 a component. By adding a second parameter to the magic static call, you can control whether
 that single call will return a new or shared instance::
 
-	$users = Factories::models('UserModel', ['getShared' => true]); // Default; will always be the same instance
-	$other = Factories::models('UserModel', ['getShared' => false]); // Will always create a new instance
+    $users = Factories::models('UserModel', ['getShared' => true]); // Default; will always be the same instance
+    $other = Factories::models('UserModel', ['getShared' => false]); // Will always create a new instance

--- a/user_guide_src/source/concepts/http.rst
+++ b/user_guide_src/source/concepts/http.rst
@@ -28,10 +28,10 @@ to the server and waits for a response.
 
 The request would look something like this::
 
-	GET / HTTP/1.1
-	Host codeigniter.com
-	Accept: text/html
-	User-Agent: Chrome/46.0.2490.80
+    GET / HTTP/1.1
+    Host codeigniter.com
+    Accept: text/html
+    User-Agent: Chrome/46.0.2490.80
 
 This message displays all of the information necessary to know what the client is requesting. It tells the
 method for the request (GET, POST, DELETE, etc), and the version of HTTP it supports.
@@ -48,14 +48,14 @@ Once the server receives the request, your application will take that informatio
 The server will bundle your output as part of its response to the client. This is also represented as
 a simple text message that looks something like this::
 
-	HTTP/1.1 200 OK
-	Server: nginx/1.8.0
-	Date: Thu, 05 Nov 2015 05:33:22 GMT
-	Content-Type: text/html; charset=UTF-8
+    HTTP/1.1 200 OK
+    Server: nginx/1.8.0
+    Date: Thu, 05 Nov 2015 05:33:22 GMT
+    Content-Type: text/html; charset=UTF-8
 
-	<html>
-		. . .
-	</html>
+    <html>
+        . . .
+    </html>
 
 The response tells the client what version of the HTTP specification that it's using and, probably most
 importantly, the status code (200). The status code is one of a number of codes that have been standardized
@@ -70,32 +70,32 @@ While PHP provides ways to interact with the request and response headers, CodeI
 abstracts them so that you have a consistent, simple interface to them. The :doc:`IncomingRequest class </incoming/incomingrequest>`
 is an object-oriented representation of the HTTP request. It provides everything you need::
 
-	use CodeIgniter\HTTP\IncomingRequest;
+    use CodeIgniter\HTTP\IncomingRequest;
 
-	$request = service('request');
+    $request = service('request');
 
-	// the URI being requested (i.e. /about)
-	$request->uri->getPath();
+    // the URI being requested (i.e. /about)
+    $request->uri->getPath();
 
-	// Retrieve $_GET and $_POST variables
-	$request->getGet('foo');
-	$request->getPost('foo');
+    // Retrieve $_GET and $_POST variables
+    $request->getGet('foo');
+    $request->getPost('foo');
 
-	// Retrieve from $_REQUEST which should include
-	// both $_GET and $_POST contents
-	$request->getVar('foo');
+    // Retrieve from $_REQUEST which should include
+    // both $_GET and $_POST contents
+    $request->getVar('foo');
 
-	// Retrieve JSON from AJAX calls
-	$request->getJSON();
+    // Retrieve JSON from AJAX calls
+    $request->getJSON();
 
-	// Retrieve server variables
-	$request->getServer('Host');
+    // Retrieve server variables
+    $request->getServer('Host');
 
-	// Retrieve an HTTP Request header, with case-insensitive names
-	$request->getHeader('host');
-	$request->getHeader('Content-Type');
+    // Retrieve an HTTP Request header, with case-insensitive names
+    $request->getHeader('host');
+    $request->getHeader('Content-Type');
 
-	$request->getMethod();  // GET, POST, PUT, etc
+    $request->getMethod();  // GET, POST, PUT, etc
 
 The request class does a lot of work in the background for you, that you never need to worry about.
 The `isAJAX()` and `isSecure()` methods check several different methods to determine the correct answer.

--- a/user_guide_src/source/concepts/index.rst
+++ b/user_guide_src/source/concepts/index.rst
@@ -5,12 +5,12 @@ CodeIgniter4 Overview
 The following pages describe the architectural concepts behind CodeIgniter4:
 
 .. toctree::
-	:titlesonly:
+    :titlesonly:
 
-	structure
-	mvc
-	autoloader
-	services
-	factories
-	http
-	security
+    structure
+    mvc
+    autoloader
+    services
+    factories
+    http
+    security

--- a/user_guide_src/source/concepts/services.rst
+++ b/user_guide_src/source/concepts/services.rst
@@ -16,7 +16,7 @@ configuration file. This file acts as a type of factory to create new instances 
 A quick example will probably make things clearer, so imagine that you need to pull in an instance
 of the Timer class. The simplest method would simply be to create a new instance of that class::
 
-	$timer = new \CodeIgniter\Debug\Timer();
+    $timer = new \CodeIgniter\Debug\Timer();
 
 And this works great. Until you decide that you want to use a different timer class in its place.
 Maybe this one has some advanced reporting the default timer does not provide. In order to do this,
@@ -30,7 +30,7 @@ class for us. This class is kept very simple. It only contains a method for each
 to use as a service. The method typically returns a shared instance of that class, passing any dependencies
 it might have into it. Then, we would replace our timer creation code with code that calls this new class::
 
-	$timer = \Config\Services::timer();
+    $timer = \Config\Services::timer();
 
 When you need to change the implementation used, you can modify the services configuration file, and
 the change happens automatically throughout your application without you having to do anything. Now
@@ -50,16 +50,16 @@ required parameter is the service name. This is the same as the method name with
 file always returns a SHARED instance of the class, so calling the function multiple times should
 always return the same instance::
 
-	$logger = service('logger');
+    $logger = service('logger');
 
 If the creation method requires additional parameters, they can be passed after the service name::
 
-	$renderer = service('renderer', APPPATH.'views/');
+    $renderer = service('renderer', APPPATH.'views/');
 
 The second function, ``single_service()`` works just like ``service()`` but returns a new instance of
 the class::
 
-	$logger = single_service('logger');
+    $logger = single_service('logger');
 
 Defining Services
 =================
@@ -74,18 +74,18 @@ For example, the ``RouterCollection`` class implements the ``RouterCollectionInt
 want to create a replacement that provides a different way to create routes, you just need to
 create a new class that implements the ``RouterCollectionInterface``::
 
-	class MyRouter implements \CodeIgniter\Router\RouteCollectionInterface
-	{
-		// Implement required methods here.
-	}
+    class MyRouter implements \CodeIgniter\Router\RouteCollectionInterface
+    {
+        // Implement required methods here.
+    }
 
 Finally, modify **/app/Config/Services.php** to create a new instance of ``MyRouter``
 instead of ``CodeIgniter\Router\RouterCollection``::
 
-	public static function routes()
-	{
-		return new \App\Router\MyRouter();
-	}
+    public static function routes()
+    {
+        return new \App\Router\MyRouter();
+    }
 
 Allowing Parameters
 -------------------
@@ -98,15 +98,15 @@ to find the views at ``APPPATH.views/``. We want the developer to have the optio
 changing that path, though, if their needs require it. So the class accepts the ``$viewPath``
 as a constructor parameter. The service method looks like this::
 
-	public static function renderer($viewPath=APPPATH.'views/')
-	{
-		return new \CodeIgniter\View\View($viewPath);
-	}
+    public static function renderer($viewPath=APPPATH.'views/')
+    {
+        return new \CodeIgniter\View\View($viewPath);
+    }
 
 This sets the default path in the constructor method, but allows for easily changing
 the path it uses::
 
-	$renderer = \Config\Services::renderer('/shared/views');
+    $renderer = \Config\Services::renderer('/shared/views');
 
 Shared Classes
 -----------------

--- a/user_guide_src/source/concepts/structure.rst
+++ b/user_guide_src/source/concepts/structure.rst
@@ -19,17 +19,17 @@ structure that works well for many applications. The following folders make up t
 
 .. code-block:: none
 
-	/app
-		/Config         Stores the configuration files
-		/Controllers    Controllers determine the program flow
-		/Database       Stores the database migrations and seeds files
-		/Filters        Stores filter classes that can run before and after controller
-		/Helpers        Helpers store collections of standalone functions
-		/Language       Multiple language support reads the language strings from here
-		/Libraries      Useful classes that don't fit in another category
-		/Models         Models work with the database to represent the business entities.
-		/ThirdParty     ThirdParty libraries that can be used in application
-		/Views          Views make up the HTML that is displayed to the client.
+    /app
+        /Config         Stores the configuration files
+        /Controllers    Controllers determine the program flow
+        /Database       Stores the database migrations and seeds files
+        /Filters        Stores filter classes that can run before and after controller
+        /Helpers        Helpers store collections of standalone functions
+        /Language       Multiple language support reads the language strings from here
+        /Libraries      Useful classes that don't fit in another category
+        /Models         Models work with the database to represent the business entities.
+        /ThirdParty     ThirdParty libraries that can be used in application
+        /Views          Views make up the HTML that is displayed to the client.
 
 Because the ``app`` directory is already namespaced, you should feel free to modify the structure
 of this directory to suit your application's needs. For example, you might decide to start using the Repository
@@ -37,7 +37,7 @@ pattern and Entity Models to work with your data. In this case, you could rename
 ``Repositories``, and add a new ``Entities`` directory.
 
 .. note:: If you rename the ``Controllers`` directory, though, you will not be able to use the automatic method of
-		routing to controllers, and will need to define all of your routes in the routes file.
+        routing to controllers, and will need to define all of your routes in the routes file.
 
 All files in this directory live under the ``App`` namespace, though you are free to change that in
 **app/Config/Constants.php**.


### PR DESCRIPTION
**Description**
Replace tab indentation with space. 
See #3988

**Checklist:**
- [x] Securely signed commits
- [n/a] Component(s) with PHPdocs
- [n/a] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
