### PR TITLE
New line for License copyright 

### DIFF
--- a/user_guide_src/source/license.rst
+++ b/user_guide_src/source/license.rst
@@ -2,8 +2,8 @@
 The MIT License (MIT)
 #####################
 
-Copyright (c) 2014-2019 British Columbia Institute of Technology
-Copyright (c) 2019-2020 CodeIgniter Foundation
+| Copyright (c) 2014-2019 British Columbia Institute of Technology 
+| Copyright (c) 2019-2020 CodeIgniter Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
**Description**
I didn't render before, and the result is like below: (https://codeigniter4.github.io/CodeIgniter4/license.html)
![image](https://user-images.githubusercontent.com/2387514/103149220-25d23180-479a-11eb-8dbc-0b9fd0af47ad.png)

And now, the expected is: 
![image](https://user-images.githubusercontent.com/2387514/103149226-2f5b9980-479a-11eb-8f0e-48a0cc930099.png)


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
