### PR TITLE
docs: fix general indentation

### DIFF
--- a/user_guide_src/source/general/caching.rst
+++ b/user_guide_src/source/general/caching.rst
@@ -24,7 +24,7 @@ expired, it will be deleted and refreshed before being sent to the
 browser.
 
 .. note:: The Benchmark tag is not cached so you can still view your page
-	load speed when caching is enabled.
+    load speed when caching is enabled.
 
 Enabling Caching
 ================
@@ -32,7 +32,7 @@ Enabling Caching
 To enable caching, put the following tag in any of your controller
 methods::
 
-	$this->cachePage($n);
+    $this->cachePage($n);
 
 Where ``$n`` is the number of **seconds** you wish the page to remain
 cached between refreshes.
@@ -42,10 +42,10 @@ the order that it appears, so place it wherever it seems most logical to
 you. Once the tag is in place, your pages will begin being cached.
 
 .. important:: If you change configuration options that might affect
-	your output, you have to manually delete your cache files.
+    your output, you have to manually delete your cache files.
 
 .. note:: Before the cache files can be written you must set the cache
-	engine up by editing **app/Config/Cache.php**.
+    engine up by editing **app/Config/Cache.php**.
 
 Deleting Caches
 ===============
@@ -54,4 +54,4 @@ If you no longer wish to cache a file you can remove the caching tag and
 it will no longer be refreshed when it expires.
 
 .. note:: Removing the tag will not delete the cache immediately. It will
-	have to expire normally.
+    have to expire normally.

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -29,57 +29,57 @@ Service Accessors
 
     Examples::
 
-     	$foo = cache('foo');
-    	$cache = cache();
+        $foo = cache('foo');
+        $cache = cache();
 
 .. php:function:: env ( $key[, $default=null])
 
-	:param string $key: The name of the environment variable to retrieve
-	:param mixed  $default: The default value to return if no value is found.
-	:returns: The environment variable, the default value, or null.
-	:rtype: mixed
+    :param string $key: The name of the environment variable to retrieve
+    :param mixed  $default: The default value to return if no value is found.
+    :returns: The environment variable, the default value, or null.
+    :rtype: mixed
 
-	Used to retrieve values that have previously been set to the environment,
-	or return a default value if it is not found. Will format boolean values
-	to actual booleans instead of string representations.
+    Used to retrieve values that have previously been set to the environment,
+    or return a default value if it is not found. Will format boolean values
+    to actual booleans instead of string representations.
 
-	Especially useful when used in conjunction with .env files for setting
-	values that are specific to the environment itself, like database
-	settings, API keys, etc.
+    Especially useful when used in conjunction with .env files for setting
+    values that are specific to the environment itself, like database
+    settings, API keys, etc.
 
 .. php:function:: esc ( $data, $context='html' [, $encoding])
 
-	:param   string|array   $data: The information to be escaped.
-	:param   string   $context: The escaping context. Default is 'html'.
-	:param   string   $encoding: The character encoding of the string.
-	:returns: The escaped data.
-	:rtype: mixed
+    :param   string|array   $data: The information to be escaped.
+    :param   string   $context: The escaping context. Default is 'html'.
+    :param   string   $encoding: The character encoding of the string.
+    :returns: The escaped data.
+    :rtype: mixed
 
-	Escapes data for inclusion in web pages, to help prevent XSS attacks.
-	This uses the Laminas Escaper library to handle the actual filtering of the data.
+    Escapes data for inclusion in web pages, to help prevent XSS attacks.
+    This uses the Laminas Escaper library to handle the actual filtering of the data.
 
-	If $data is a string, then it simply escapes and returns it.
-	If $data is an array, then it loops over it, escaping each 'value' of the key/value pairs.
+    If $data is a string, then it simply escapes and returns it.
+    If $data is an array, then it loops over it, escaping each 'value' of the key/value pairs.
 
-	Valid context values: html, js, css, url, attr, raw, null
+    Valid context values: html, js, css, url, attr, raw, null
 
 .. php:function:: helper( $filename )
 
-	:param   string|array  $filename: The name of the helper file to load, or an array of names.
+    :param   string|array  $filename: The name of the helper file to load, or an array of names.
 
-	Loads a helper file.
+    Loads a helper file.
 
-	For full details, see the :doc:`helpers` page.
+    For full details, see the :doc:`helpers` page.
 
 .. php:function:: lang($line[, $args[, $locale ]])
 
-	:param string $line: The line of text to retrieve
-	:param array  $args: An array of data to substitute for placeholders.
-	:param string $locale: Specify a different locale to be used instead of default one.
+    :param string $line: The line of text to retrieve
+    :param array  $args: An array of data to substitute for placeholders.
+    :param string $locale: Specify a different locale to be used instead of default one.
 
-	Retrieves a locale-specific file based on an alias string.
+    Retrieves a locale-specific file based on an alias string.
 
-	For more information, see the :doc:`Localization </outgoing/localization>` page.
+    For more information, see the :doc:`Localization </outgoing/localization>` page.
 
 .. php:function:: model($name [, $getShared = true [, &$conn = null ]])
 
@@ -91,88 +91,88 @@ Service Accessors
 
 .. php:function:: old( $key[, $default = null, [, $escape = 'html' ]] )
 
-	:param string $key: The name of the old form data to check for.
-	:param mixed  $default: The default value to return if $key doesn't exist.
-	:param mixed  $escape: An `escape <#esc>`_ context or false to disable it.
-	:returns: The value of the defined key, or the default value.
-	:rtype: mixed
+    :param string $key: The name of the old form data to check for.
+    :param mixed  $default: The default value to return if $key doesn't exist.
+    :param mixed  $escape: An `escape <#esc>`_ context or false to disable it.
+    :returns: The value of the defined key, or the default value.
+    :rtype: mixed
 
-	Provides a simple way to access "old input data" from submitting a form.
+    Provides a simple way to access "old input data" from submitting a form.
 
-	Example::
+    Example::
 
-		// in controller, checking form submittal
-		if (! $model->save($user))
-		{
-			// 'withInput' is what specifies "old data"
-			// should be saved.
-			return redirect()->back()->withInput();
-		}
+        // in controller, checking form submittal
+        if (! $model->save($user))
+        {
+            // 'withInput' is what specifies "old data"
+            // should be saved.
+            return redirect()->back()->withInput();
+        }
 
-		// In the view
-		<input type="email" name="email" value="<?= old('email') ?>">
-		// Or with arrays
-		<input type="email" name="user[email]" value="<?= old('user.email') ?>">
+        // In the view
+        <input type="email" name="email" value="<?= old('email') ?>">
+        // Or with arrays
+        <input type="email" name="user[email]" value="<?= old('user.email') ?>">
 
 .. note:: If you are using the :doc:`form helper </helpers/form_helper>`, this feature is built-in. You only
-		need to use this function when not using the form helper.
+        need to use this function when not using the form helper.
 
 .. php:function:: session( [$key] )
 
-	:param string $key: The name of the session item to check for.
-	:returns: An instance of the Session object if no $key, the value found in the session for $key, or null.
-	:rtype: mixed
+    :param string $key: The name of the session item to check for.
+    :returns: An instance of the Session object if no $key, the value found in the session for $key, or null.
+    :rtype: mixed
 
-	Provides a convenient way to access the session class and to retrieve a
-	stored value. For more information, see the :doc:`Sessions </libraries/sessions>` page.
+    Provides a convenient way to access the session class and to retrieve a
+    stored value. For more information, see the :doc:`Sessions </libraries/sessions>` page.
 
 .. php:function:: timer( [$name] )
 
-	:param string $name: The name of the benchmark point.
-	:returns: The Timer instance
-	:rtype: CodeIgniter\Debug\Timer
+    :param string $name: The name of the benchmark point.
+    :returns: The Timer instance
+    :rtype: CodeIgniter\Debug\Timer
 
-	A convenience method that provides quick access to the Timer class. You can pass in the name
-	of a benchmark point as the only parameter. This will start timing from this point, or stop
-	timing if a timer with this name is already running.
+    A convenience method that provides quick access to the Timer class. You can pass in the name
+    of a benchmark point as the only parameter. This will start timing from this point, or stop
+    timing if a timer with this name is already running.
 
-	Example::
+    Example::
 
-		// Get an instance
-		$timer = timer();
+        // Get an instance
+        $timer = timer();
 
-		// Set timer start and stop points
-		timer('controller_loading');    // Will start the timer
-		. . .
-		timer('controller_loading');    // Will stop the running timer
+        // Set timer start and stop points
+        timer('controller_loading');    // Will start the timer
+        . . .
+        timer('controller_loading');    // Will stop the running timer
 
 .. php:function:: view ($name [, $data [, $options ]])
 
-	:param   string   $name: The name of the file to load
-	:param   array    $data: An array of key/value pairs to make available within the view.
-	:param   array    $options: An array of options that will be passed to the rendering class.
-	:returns: The output from the view.
-	:rtype: string
+    :param   string   $name: The name of the file to load
+    :param   array    $data: An array of key/value pairs to make available within the view.
+    :param   array    $options: An array of options that will be passed to the rendering class.
+    :returns: The output from the view.
+    :rtype: string
 
-	Grabs the current RendererInterface-compatible class
-	and tells it to render the specified view. Simply provides
-	a convenience method that can be used in Controllers,
-	libraries, and routed closures.
+    Grabs the current RendererInterface-compatible class
+    and tells it to render the specified view. Simply provides
+    a convenience method that can be used in Controllers,
+    libraries, and routed closures.
 
-	Currently, only one option is available for use within the `$options` array, `saveData` which specifies
-	that data will persistent between multiple calls to `view()` within the same request. By default, the
-	data for that view is forgotten after displaying that single view file.
+    Currently, only one option is available for use within the `$options` array, `saveData` which specifies
+    that data will persistent between multiple calls to `view()` within the same request. By default, the
+    data for that view is forgotten after displaying that single view file.
 
-	The $option array is provided primarily to facilitate third-party integrations with
-	libraries like Twig.
+    The $option array is provided primarily to facilitate third-party integrations with
+    libraries like Twig.
 
-	Example::
+    Example::
 
-		$data = ['user' => $user];
+        $data = ['user' => $user];
 
-		echo view('user_profile', $data);
+        echo view('user_profile', $data);
 
-	For more details, see the :doc:`Views </outgoing/views>` page.
+    For more details, see the :doc:`Views </outgoing/views>` page.
 
 .. php:function:: view_cell ( $library [, $params = null [, $ttl = 0 [, $cacheName = null]]] )
 
@@ -197,53 +197,53 @@ Miscellaneous Functions
 
 .. php:function:: csrf_token ()
 
-	:returns: The name of the current CSRF token.
-	:rtype: string
+    :returns: The name of the current CSRF token.
+    :rtype: string
 
-	Returns the name of the current CSRF token.
+    Returns the name of the current CSRF token.
 
 .. php:function:: csrf_header ()
 
-	:returns: The name of the header for current CSRF token.
-	:rtype: string
+    :returns: The name of the header for current CSRF token.
+    :rtype: string
 
-	The name of the header for current CSRF token.
+    The name of the header for current CSRF token.
 
 .. php:function:: csrf_hash ()
 
-	:returns: The current value of the CSRF hash.
-	:rtype: string
+    :returns: The current value of the CSRF hash.
+    :rtype: string
 
-	Returns the current CSRF hash value.
+    Returns the current CSRF hash value.
 
 .. php:function:: csrf_field ()
 
-	:returns: A string with the HTML for hidden input with all required CSRF information.
-	:rtype: string
+    :returns: A string with the HTML for hidden input with all required CSRF information.
+    :rtype: string
 
-	Returns a hidden input with the CSRF information already inserted::
+    Returns a hidden input with the CSRF information already inserted::
 
-		<input type="hidden" name="{csrf_token}" value="{csrf_hash}">
+        <input type="hidden" name="{csrf_token}" value="{csrf_hash}">
 
 .. php:function:: csrf_meta ()
 
-	:returns: A string with the HTML for meta tag with all required CSRF information.
-	:rtype: string
+    :returns: A string with the HTML for meta tag with all required CSRF information.
+    :rtype: string
 
-	Returns a meta tag with the CSRF information already inserted::
+    Returns a meta tag with the CSRF information already inserted::
 
-		<meta name="{csrf_header}" content="{csrf_hash}">
+        <meta name="{csrf_header}" content="{csrf_hash}">
 
 .. php:function:: force_https ( $duration = 31536000 [, $request = null [, $response = null]] )
 
-	:param  int  $duration: The number of seconds browsers should convert links to this resource to HTTPS.
-	:param  RequestInterface $request: An instance of the current Request object.
-	:param  ResponseInterface $response: An instance of the current Response object.
+    :param  int  $duration: The number of seconds browsers should convert links to this resource to HTTPS.
+    :param  RequestInterface $request: An instance of the current Request object.
+    :param  ResponseInterface $response: An instance of the current Response object.
 
-	Checks to see if the page is currently being accessed via HTTPS. If it is, then
-	nothing happens. If it is not, then the user is redirected back to the current URI
-	but through HTTPS. Will set the HTTP Strict Transport Security header, which instructs
-	modern browsers to automatically modify any HTTP requests to HTTPS requests for the $duration.
+    Checks to see if the page is currently being accessed via HTTPS. If it is, then
+    nothing happens. If it is not, then the user is redirected back to the current URI
+    but through HTTPS. Will set the HTTP Strict Transport Security header, which instructs
+    modern browsers to automatically modify any HTTP requests to HTTPS requests for the $duration.
 
 .. php:function:: function_usable ( $function_name )
 
@@ -253,8 +253,8 @@ Miscellaneous Functions
 
 .. php:function:: is_cli ()
 
-	:returns: TRUE if the script is being executed from the command line or FALSE otherwise.
-	:rtype: bool
+    :returns: TRUE if the script is being executed from the command line or FALSE otherwise.
+    :rtype: bool
 
 .. php:function:: is_really_writable ( $file )
 
@@ -264,104 +264,104 @@ Miscellaneous Functions
 
 .. php:function:: log_message ($level, $message [, $context])
 
-	:param   string   $level: The level of severity
-	:param   string   $message: The message that is to be logged.
-	:param   array    $context: An associative array of tags and their values that should be replaced in $message
-	:returns: TRUE if was logged successfully or FALSE if there was a problem logging it
-	:rtype: bool
+    :param   string   $level: The level of severity
+    :param   string   $message: The message that is to be logged.
+    :param   array    $context: An associative array of tags and their values that should be replaced in $message
+    :returns: TRUE if was logged successfully or FALSE if there was a problem logging it
+    :rtype: bool
 
-	Logs a message using the Log Handlers defined in **app/Config/Logger.php**.
+    Logs a message using the Log Handlers defined in **app/Config/Logger.php**.
 
-	Level can be one of the following values: **emergency**, **alert**, **critical**, **error**, **warning**,
-	**notice**, **info**, or **debug**.
+    Level can be one of the following values: **emergency**, **alert**, **critical**, **error**, **warning**,
+    **notice**, **info**, or **debug**.
 
-	Context can be used to substitute values in the message string. For full details, see the
-	:doc:`Logging Information <logging>` page.
+    Context can be used to substitute values in the message string. For full details, see the
+    :doc:`Logging Information <logging>` page.
 
 .. php:function:: redirect( string $uri )
 
-	:param  string  $uri: The URI to redirect the user to.
+    :param  string  $uri: The URI to redirect the user to.
 
-	Returns a RedirectResponse instance allowing you to easily create redirects::
+    Returns a RedirectResponse instance allowing you to easily create redirects::
 
-		// Go back to the previous page
-		return redirect()->back();
+        // Go back to the previous page
+        return redirect()->back();
 
-		// Go to specific UI
-		return redirect()->to('/admin');
+        // Go to specific UI
+        return redirect()->to('/admin');
 
-		// Go to a named/reverse-routed URI
-		return redirect()->route('named_route');
+        // Go to a named/reverse-routed URI
+        return redirect()->route('named_route');
 
-		// Keep the old input values upon redirect so they can be used by the `old()` function
-		return redirect()->back()->withInput();
+        // Keep the old input values upon redirect so they can be used by the `old()` function
+        return redirect()->back()->withInput();
 
-		// Set a flash message
-		return redirect()->back()->with('foo', 'message');
+        // Set a flash message
+        return redirect()->back()->with('foo', 'message');
 
-		// Copies all cookies from global response instance
-		return redirect()->back()->withCookies();
+        // Copies all cookies from global response instance
+        return redirect()->back()->withCookies();
 
-		// Copies all headers from the global response instance
-		return redirect()->back()->withHeaders();
+        // Copies all headers from the global response instance
+        return redirect()->back()->withHeaders();
 
-	When passing a URI into the function, it is treated as a reverse-route request, not a relative/full URI,
-	treating it the same as using redirect()->route()::
+    When passing a URI into the function, it is treated as a reverse-route request, not a relative/full URI,
+    treating it the same as using redirect()->route()::
 
-		// Go to a named/reverse-routed URI
-		return redirect('named_route');
+        // Go to a named/reverse-routed URI
+        return redirect('named_route');
 
 .. php:function:: remove_invisible_characters($str[, $urlEncoded = TRUE])
 
-	:param	string	$str: Input string
-	:param	bool	$urlEncoded: Whether to remove URL-encoded characters as well
-	:returns:	Sanitized string
-	:rtype:	string
+    :param    string    $str: Input string
+    :param    bool    $urlEncoded: Whether to remove URL-encoded characters as well
+    :returns:    Sanitized string
+    :rtype:    string
 
-	This function prevents inserting NULL characters between ASCII
-	characters, like Java\\0script.
+    This function prevents inserting NULL characters between ASCII
+    characters, like Java\\0script.
 
-	Example::
+    Example::
 
-		remove_invisible_characters('Java\\0script');
-		// Returns: 'Javascript'
+        remove_invisible_characters('Java\\0script');
+        // Returns: 'Javascript'
 
 .. php:function:: route_to ( $method [, ...$params] )
 
-	:param   string   $method: The named route alias, or name of the controller/method to match.
-	:param   mixed   $params: One or more parameters to be passed to be matched in the route.
+    :param   string  $method: The named route alias, or name of the controller/method to match.
+    :param   mixed   $params: One or more parameters to be passed to be matched in the route.
 
-	Generates a URI relative to the domain name (not **baseUrl**) for you based on either a named route alias,
-	or a controller::method combination. Will take parameters into effect, if provided.
+    Generates a URI relative to the domain name (not **baseUrl**) for you based on either a named route alias,
+    or a controller::method combination. Will take parameters into effect, if provided.
 
-	For full details, see the :doc:`/incoming/routing` page.
+    For full details, see the :doc:`/incoming/routing` page.
 
 .. php:function:: service ( $name [, ...$params] )
 
-	:param   string   $name: The name of the service to load
-	:param   mixed    $params: One or more parameters to pass to the service method.
-	:returns: An instance of the service class specified.
-	:rtype: mixed
+    :param   string   $name: The name of the service to load
+    :param   mixed    $params: One or more parameters to pass to the service method.
+    :returns: An instance of the service class specified.
+    :rtype: mixed
 
-	Provides easy access to any of the :doc:`Services <../concepts/services>` defined in the system.
-	This will always return a shared instance of the class, so no matter how many times this is called
-	during a single request, only one class instance will be created.
+    Provides easy access to any of the :doc:`Services <../concepts/services>` defined in the system.
+    This will always return a shared instance of the class, so no matter how many times this is called
+    during a single request, only one class instance will be created.
 
-	Example::
+    Example::
 
-		$logger = service('logger');
-		$renderer = service('renderer', APPPATH.'views/');
+        $logger = service('logger');
+        $renderer = service('renderer', APPPATH.'views/');
 
 .. php:function:: single_service ( $name [, ...$params] )
 
-	:param   string   $name: The name of the service to load
-	:param   mixed    $params: One or more parameters to pass to the service method.
-	:returns: An instance of the service class specified.
-	:rtype: mixed
+    :param   string   $name: The name of the service to load
+    :param   mixed    $params: One or more parameters to pass to the service method.
+    :returns: An instance of the service class specified.
+    :rtype: mixed
 
-	Identical to the **service()** function described above, except that all calls to this
-	function will return a new instance of the class, where **service** returns the same
-	instance every time.
+    Identical to the **service()** function described above, except that all calls to this
+    function will return a new instance of the class, where **service** returns the same
+    instance every time.
 
 .. php:function:: slash_item ( $item )
 
@@ -373,12 +373,12 @@ Miscellaneous Functions
 
 .. php:function:: stringify_attributes ( $attributes [, $js] )
 
-	:param   mixed    $attributes: string, array of key value pairs, or object
-	:param   boolean  $js: TRUE if values do not need quotes (Javascript-style)
-	:returns: String containing the attribute key/value pairs, comma-separated
-	:rtype: string
+    :param   mixed    $attributes: string, array of key value pairs, or object
+    :param   boolean  $js: TRUE if values do not need quotes (Javascript-style)
+    :returns: String containing the attribute key/value pairs, comma-separated
+    :rtype: string
 
-	Helper function used to convert a string, array, or object of attributes to a string.
+    Helper function used to convert a string, array, or object of attributes to a string.
 
 ================
 Global Constants
@@ -391,55 +391,55 @@ Core Constants
 
 .. php:const:: APPPATH
 
-	The path to the **app** directory.
+    The path to the **app** directory.
 
 .. php:const:: ROOTPATH
 
-	The path to the project root directory. Just above ``APPPATH``.
+    The path to the project root directory. Just above ``APPPATH``.
 
 .. php:const:: SYSTEMPATH
 
-	The path to the **system** directory.
+    The path to the **system** directory.
 
 .. php:const:: FCPATH
 
-	The path to the directory that holds the front controller.
+    The path to the directory that holds the front controller.
 
 .. php:const:: WRITEPATH
 
-	The path to the **writable** directory.
+    The path to the **writable** directory.
 
 Time Constants
 ==============
 
 .. php:const:: SECOND
 
-	Equals 1.
+    Equals 1.
 
 .. php:const:: MINUTE
 
-	Equals 60.
+    Equals 60.
 
 .. php:const:: HOUR
 
-	Equals 3600.
+    Equals 3600.
 
 .. php:const:: DAY
 
-	Equals 86400.
+    Equals 86400.
 
 .. php:const:: WEEK
 
-	Equals 604800.
+    Equals 604800.
 
 .. php:const:: MONTH
 
-	Equals 2592000.
+    Equals 2592000.
 
 .. php:const:: YEAR
 
-	Equals 31536000.
+    Equals 31536000.
 
 .. php:const:: DECADE
 
-	Equals 315360000.
+    Equals 315360000.

--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -22,25 +22,25 @@ You can access configuration files for your classes in several different ways.
 
 - By using the ``new`` keyword to create an instance::
 
-	// Creating new configuration object by hand
-	$config = new \Config\Pager();
+    // Creating new configuration object by hand
+    $config = new \Config\Pager();
 
 - By using the ``config()`` function::
 
-	// Get shared instance with config function
-	$config = config('Pager');
+    // Get shared instance with config function
+    $config = config('Pager');
 
-	// Access config class with namespace
-	$config = config( 'Config\\Pager' );
+    // Access config class with namespace
+    $config = config( 'Config\\Pager' );
 
-	// Creating a new object with config function
-	$config = config('Pager', false);
+    // Creating a new object with config function
+    $config = config('Pager', false);
 
 All configuration object properties are public, so you access the settings like any other property::
 
-        $config = config('Pager');
-	// Access settings as object properties
-	$pageSize = $config->perPage;
+    $config = config('Pager');
+    // Access settings as object properties
+    $pageSize = $config->perPage;
 
 If no namespace is provided, it will look for the file in all defined namespaces
 as well as **/app/Config/**.
@@ -101,8 +101,8 @@ application by either renaming the template to **.env**, or by making a copy of 
 Settings are stored in **.env** files as a simple a collection of name/value pairs separated by an equal sign.
 ::
 
-	S3_BUCKET = dotenv
-	SECRET_KEY = super_secret_key
+    S3_BUCKET = dotenv
+    SECRET_KEY = super_secret_key
         CI_ENVIRONMENT = development
 
 When your application runs, **.env** will be loaded automatically, and the variables put
@@ -111,9 +111,9 @@ overwritten. The loaded Environment variables are accessed using any of the foll
 ``getenv()``, ``$_SERVER``, or ``$_ENV``.
 ::
 
-	$s3_bucket = getenv('S3_BUCKET');
-	$s3_bucket = $_ENV['S3_BUCKET'];
-	$s3_bucket = $_SERVER['S3_BUCKET'];
+    $s3_bucket = getenv('S3_BUCKET');
+    $s3_bucket = $_ENV['S3_BUCKET'];
+    $s3_bucket = $_SERVER['S3_BUCKET'];
 
 .. important:: Note that your settings from the **.env** file are added to Environment Variables. As a side effect, this means that if your CodeIgniter application is (for example) generating a ``var_dump($_ENV)`` or ``phpinfo()`` (for debugging or other valid reasons) **your secure credentials are publicly exposed**.
 

--- a/user_guide_src/source/general/environments.rst
+++ b/user_guide_src/source/general/environments.rst
@@ -46,16 +46,16 @@ like:
 
 .. code-block:: nginx
 
-	server {
-	    server_name localhost;
-	    include     conf/defaults.conf;
-	    root        /var/www;
+    server {
+        server_name localhost;
+        include     conf/defaults.conf;
+        root        /var/www;
 
-	    location    ~* \.php$ {
-	        fastcgi_param CI_ENVIRONMENT "production";
-	        include conf/fastcgi-php.conf;
-	    }
-	}
+        location    ~* \.php$ {
+            fastcgi_param CI_ENVIRONMENT "production";
+            include conf/fastcgi-php.conf;
+        }
+    }
 
 Alternative methods are available for nginx and other servers, or you can
 remove this logic entirely and set the constant based on the server's IP address

--- a/user_guide_src/source/general/helpers.rst
+++ b/user_guide_src/source/general/helpers.rst
@@ -34,7 +34,7 @@ Loading a Helper
 
 Loading a helper file is quite simple using the following method::
 
-	helper('name');
+    helper('name');
 
 Where **name** is the file name of the helper, without the .php file
 extension or the "_helper" part.

--- a/user_guide_src/source/general/urls.rst
+++ b/user_guide_src/source/general/urls.rst
@@ -5,14 +5,14 @@ CodeIgniter URLs
 By default, URLs in CodeIgniter are designed to be search-engine and human-friendly. Rather than using the standard
 "query-string" approach to URLs that is synonymous with dynamic systems, CodeIgniter uses a **segment-based** approach::
 
-	example.com/news/article/my_article
+    example.com/news/article/my_article
 
 URI Segments
 ============
 
 The segments in the URL, in following with the Model-View-Controller approach, usually represent::
 
-	example.com/class/method/ID
+    example.com/class/method/ID
 
 1. The first segment represents the controller **class** that should be invoked.
 2. The second segment represents the class **method** that should be called.
@@ -27,7 +27,7 @@ Removing the index.php file
 
 By default, the **index.php** file will be included in your URLs::
 
-	example.com/index.php/news/article/my_article
+    example.com/index.php/news/article/my_article
 
 If your server supports rewriting URLs you can easily remove this file with URL rewriting. This is handled differently
 by different servers, but we will show examples for the two most common web servers here.
@@ -41,10 +41,10 @@ items:
 
 .. code-block:: apache
 
-	RewriteEngine On
-	RewriteCond %{REQUEST_FILENAME} !-f
-	RewriteCond %{REQUEST_FILENAME} !-d
-	RewriteRule ^(.*)$ index.php/$1 [L]
+    RewriteEngine On
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^(.*)$ index.php/$1 [L]
 
 In this example, any HTTP request other than those for existing directories and existing files are treated as a
 request for your index.php file.
@@ -61,9 +61,9 @@ the above Apache configuration:
 
 .. code-block:: nginx
 
-	location / {
-		try_files $uri $uri/ /index.php$is_args$args;
-	}
+    location / {
+        try_files $uri $uri/ /index.php$is_args$args;
+    }
 
 This will first look for a file or directory matching the URI (constructing the full path to each file from the
 settings of the root and alias directives), and then sends the request to the index.php file along with any arguments.


### PR DESCRIPTION
**Description**
Replace tab indentation with space.
See #3988

**Checklist:**
- [x] Securely signed commits
- [n/a] Component(s) with PHPdocs
- [n/a] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
