### PR TITLE
Fix database test case test

### DIFF
--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -5,7 +5,7 @@ use Config\Services;
 
 class DatabaseTestCaseTest extends CIDatabaseTestCase
 {
-	protected $loaded = false;
+	protected static $loaded = false;
 
 	/**
 	 * Should the db be refreshed before
@@ -41,10 +41,10 @@ class DatabaseTestCaseTest extends CIDatabaseTestCase
 
 	public function setUp(): void
 	{
-		if (! $this->loaded)
+		if (! self::$loaded)
 		{
 			Services::autoloader()->addNamespace('Tests\Support\MigrationTestMigrations', SUPPORTPATH . 'MigrationTestMigrations');
-			$this->loaded = true;
+			self::$loaded = true;
 		}
 
 		parent::setUp();

--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -3,6 +3,9 @@
 use CodeIgniter\Test\CIDatabaseTestCase;
 use Config\Services;
 
+/**
+ * @group DatabaseLive
+ */
 class DatabaseTestCaseTest extends CIDatabaseTestCase
 {
 	protected static $loaded = false;


### PR DESCRIPTION
**Description**
Properties are reset by PHPUnit, so `$this->loaded` in `setUp()` is always `false`.

```diff
--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -45,6 +47,7 @@ class DatabaseTestCaseTest extends CIDatabaseTestCase
        {
            Services::autoloader()->addNamespace('Tests\Support\MigrationTestMigrations', SUPPORTPATH . 'MigrationTestMigrations');
            $this->loaded = true;
+           echo '!!! addNamespace !!!'.PHP_EOL;
        }
 
        parent::setUp();
```

You see `!!! addNamespace !!!` twice.

```
$ vendor/bin/phpunit --no-coverage tests/system/Database/DatabaseTestCaseTest.php --debug
PHPUnit 8.5.4 by Sebastian Bergmann and contributors.

Test 'CodeIgniter\Database\DatabaseTestCaseTest::testMultipleSeeders' started
Test 'CodeIgniter\Database\DatabaseTestCaseTest::testMultipleSeeders' ended
!!! addNamespace !!!
Test 'CodeIgniter\Database\DatabaseTestCaseTest::testMultipleMigrationNamespaces' started
Test 'CodeIgniter\Database\DatabaseTestCaseTest::testMultipleMigrationNamespaces' ended
!!! addNamespace !!!


Time: 156 ms, Memory: 12.00 MB

OK (2 tests, 2 assertions)
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [n/a] User guide updated
- [x] Conforms to style guide
