### PR TITLE
[UG] a comma after use: i.e., and e.g.,

### DIFF
--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -203,7 +203,7 @@ Options:
 
 .. note:: Working on modules? Code generation will set the root namespace to a default of ``APP_NAMESPACE``.
     Should you need to have the generated code elsewhere in your module namespace, make sure to set
-    the ``-n`` option in your command, e.g. ``php spark make:model blog -n Acme\Blog``.
+    the ``-n`` option in your command, e.g., ``php spark make:model blog -n Acme\Blog``.
 
 .. warning:: Make sure when setting the ``-n`` option that the supplied namespace is a valid namespace
     defined in your ``$psr4`` array in ``Config\Autoload`` or defined in your composer autoload file.
@@ -344,7 +344,7 @@ which is public and need not be overridden as it is essentially complete.
     ``getNamespacedClass`` and ``getTemplate``, or else you will get a PHP fatal error.
 
 .. note:: ``GeneratorCommand`` has the default argument of ``['name' => 'Class name']``. You can
-    override the description by supplying the name in your ``$arguments`` property, e.g. ``['name' => 'Module class name']``.
+    override the description by supplying the name in your ``$arguments`` property, e.g., ``['name' => 'Module class name']``.
 
 .. note:: ``GeneratorCommand`` has the default options of ``-n`` and ``--force``. Child classes cannot override
     these two properties as they are crucial in the implementation of the code generation.
@@ -352,4 +352,4 @@ which is public and need not be overridden as it is essentially complete.
 .. note:: Generators are default listed under the ``Generators`` namespace because it is the default group
     name in ``GeneratorCommand``. If you want to have your own generator listed elsewhere under a different
     namespace, you will just need to provide the ``$group`` property in your child generator,
-    e.g. ``protected $group = 'CodeIgniter';``.
+    e.g., ``protected $group = 'CodeIgniter';``.

--- a/user_guide_src/source/concepts/factories.rst
+++ b/user_guide_src/source/concepts/factories.rst
@@ -16,7 +16,7 @@ anywhere. This is a great way to reuse object states and reduce memory load from
 multiple instances loaded across your app.
 
 Anything can be loaded by Factories, but the best examples are those classes that are used
-to work on or transmit common data. The framework itself uses Factories internally, e.g. to
+to work on or transmit common data. The framework itself uses Factories internally, e.g., to
 make sure the correct configuration is loaded when using the ``Config`` class. 
 
 Take a look at ``Models`` as an example. You can access the Factory specific to ``Models``

--- a/user_guide_src/source/concepts/http.rst
+++ b/user_guide_src/source/concepts/http.rst
@@ -74,7 +74,7 @@ is an object-oriented representation of the HTTP request. It provides everything
 
     $request = service('request');
 
-    // the URI being requested (i.e. /about)
+    // the URI being requested (i.e., /about)
     $request->uri->getPath();
 
     // Retrieve $_GET and $_POST variables
@@ -100,7 +100,7 @@ is an object-oriented representation of the HTTP request. It provides everything
 The request class does a lot of work in the background for you, that you never need to worry about.
 The `isAJAX()` and `isSecure()` methods check several different methods to determine the correct answer.
 
-.. note:: The ``isAJAX()`` method depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e. fetch). See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
+.. note:: The ``isAJAX()`` method depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e., fetch). See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
 
 CodeIgniter also provides a :doc:`Response class </outgoing/response>` that is an object-oriented representation
 of the HTTP response. This gives you an easy and powerful way to construct your response to the client::

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -65,7 +65,7 @@ add the config variables as a query string::
 	// Postgre
 	$default['DSN'] = 'Postgre://username:password@hostname:5432/database?charset=utf8&connect_timeout=5&sslmode=1';
 
-.. note:: If you provide a DSN string and it is missing some valid settings (e.g. the
+.. note:: If you provide a DSN string and it is missing some valid settings (e.g., the
 	database character set), which are present in the rest of the configuration
 	fields, CodeIgniter will append them.
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -412,7 +412,7 @@ searches.
 
 .. note:: All ``like*`` method variations can be forced to perform case-insensitive searches by passing
         a fifth parameter of ``true`` to the method. This will use platform-specific features where available
-        otherwise, will force the values to be lowercase, i.e. ``WHERE LOWER(column) LIKE '%search%'``. This
+        otherwise, will force the values to be lowercase, i.e., ``WHERE LOWER(column) LIKE '%search%'``. This
         may require indexes to be made for ``LOWER(column)`` instead of ``column`` to be effective.
 
 #. **Simple key/value method:**
@@ -609,7 +609,7 @@ searches.
 
 .. note:: All ``havingLike*`` method variations can be forced to perform case-insensitive searches by passing
         a fifth parameter of ``true`` to the method. This will use platform-specific features where available
-        otherwise, will force the values to be lowercase, i.e. ``HAVING LOWER(column) LIKE '%search%'``. This
+        otherwise, will force the values to be lowercase, i.e., ``HAVING LOWER(column) LIKE '%search%'``. This
         may require indexes to be made for ``LOWER(column)`` instead of ``column`` to be effective.
 
 #. **Simple key/value method:**

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -27,7 +27,7 @@ Migration file names
 
 Each Migration is run in numeric order forward or backwards depending on the
 method taken. Each migration is numbered using the timestamp when the migration
-was created, in **YYYYMMDDHHIISS** format (e.g. **20121031100537**). This
+was created, in **YYYYMMDDHHIISS** format (e.g., **20121031100537**). This
 helps prevent numbering conflicts when working in a team environment.
 
 Prefix your migration files with the migration number followed by an underscore
@@ -306,7 +306,7 @@ Class Reference
 
 	.. php:method:: regress($batch, $group)
 
-		:param	mixed	$batch: previous batch to migrate down to; 1+ specifies the batch, 0 reverts all, negative refers to the relative batch (e.g. -3 means "three batches back")
+		:param	mixed	$batch: previous batch to migrate down to; 1+ specifies the batch, 0 reverts all, negative refers to the relative batch (e.g., -3 means "three batches back")
 		:param	mixed	$group: database group name, if null default database group will be used.
 		:returns:	``true`` on success, ``false`` on failure or no migrations are found
 		:rtype:	bool

--- a/user_guide_src/source/extending/contributing.rst
+++ b/user_guide_src/source/extending/contributing.rst
@@ -51,11 +51,11 @@ If you've found a critical vulnerability, we'd be happy to credit you in our
 Tips for a Good Issue Report
 ****************************
 
-Use a descriptive subject line (eg parser library chokes on commas) rather than a vague one (eg. your code broke).
+Use a descriptive subject line (eg parser library chokes on commas) rather than a vague one (e.g., your code broke).
 
 Address a single issue in a report.
 
-Identify the CodeIgniter version (eg 4.0.1) and the component if you know it (eg. parser library)
+Identify the CodeIgniter version (eg 4.0.1) and the component if you know it (e.g., parser library)
 
 Explain what you expected to happen, and what did happen.
 Include error messages and stack trace, if any.

--- a/user_guide_src/source/general/ajax.rst
+++ b/user_guide_src/source/general/ajax.rst
@@ -2,7 +2,7 @@
 AJAX Requests
 ##############
 
-The ``IncomingRequest::isAJAX()`` method uses the ``X-Requested-With`` header to define whether the request is XHR or normal. However, the most recent JavaScript implementations (i.e. fetch) no longer send this header along with the request, thus the use of ``IncomingRequest::isAJAX()`` becomes less reliable, because without this header it is not possible to define whether the request is or not XHR.
+The ``IncomingRequest::isAJAX()`` method uses the ``X-Requested-With`` header to define whether the request is XHR or normal. However, the most recent JavaScript implementations (i.e., fetch) no longer send this header along with the request, thus the use of ``IncomingRequest::isAJAX()`` becomes less reliable, because without this header it is not possible to define whether the request is or not XHR.
 
 To get around this problem, the most efficient solution (so far) is to manually define the request header, forcing the information to be sent to the server, which will then be able to identify that the request is XHR.
 

--- a/user_guide_src/source/general/logging.rst
+++ b/user_guide_src/source/general/logging.rst
@@ -130,7 +130,7 @@ Several core placeholders exist that will be automatically expanded for you base
 +----------------+---------------------------------------------------+
 | {session_vars} | $_SESSION variables                               |
 +----------------+---------------------------------------------------+
-| {env}          | Current environment name, i.e. development        |
+| {env}          | Current environment name, i.e., development       |
 +----------------+---------------------------------------------------+
 | {file}         | The name of file calling the logger               |
 +----------------+---------------------------------------------------+

--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -208,7 +208,7 @@ The following functions are available:
 	:param	array	$data: Field attributes data
 	:param	string	$value: Field value
 	:param	mixed	$extra: Extra attributes to be added to the tag either as an array or a literal string
-	:param  string  $type: The type of input field. i.e. 'text', 'email', 'number', etc.
+	:param  string  $type: The type of input field. i.e., 'text', 'email', 'number', etc.
 	:returns:	An HTML text input field tag
 	:rtype:	string
 
@@ -382,7 +382,7 @@ The following functions are available:
 
     	The parameter usage is identical to using :php:func:`form_dropdown()` above,
 	except of course that the name of the field will need to use POST array
-	syntax, e.g. foo[].
+	syntax, e.g., foo[].
 
 .. php:function:: form_fieldset([$legend_text = ''[, $attributes = []]])
 
@@ -615,7 +615,7 @@ The following functions are available:
     	second (optional) parameter allows you to set a default value for the
     	form. The third (optional) parameter allows you to turn off HTML escaping
     	of the value, in case you need to use this function in combination with
-    	i.e. :php:func:`form_input()` and avoid double-escaping.
+    	i.e., :php:func:`form_input()` and avoid double-escaping.
 
 	Example::
 

--- a/user_guide_src/source/helpers/html_helper.rst
+++ b/user_guide_src/source/helpers/html_helper.rst
@@ -85,7 +85,7 @@ The following functions are available:
 
     Note that $path must exist and be a readable image format supported by the ``data:`` protocol.
     This function is not recommended for very large files, but it provides a convenient way
-    of serving images from your app that are not web-accessible (e.g. in **public/**).
+    of serving images from your app that are not web-accessible (e.g., in **public/**).
 
 .. php:function:: link_tag([$href = ''[, $rel = 'stylesheet'[, $type = 'text/css'[, $title = ''[, $media = ''[, $indexPage = false[, $hreflang = '']]]]]]])
 

--- a/user_guide_src/source/helpers/number_helper.rst
+++ b/user_guide_src/source/helpers/number_helper.rst
@@ -93,7 +93,7 @@ The following functions are available:
 .. php:function:: number_to_currency($num, $currency[, $locale = null])
 
     :param mixed $num: Number to format
-    :param string $currency: The currency type, i.e. USD, EUR, etc
+    :param string $currency: The currency type, i.e., USD, EUR, etc
     :param string $locale: The locale to use for formatting
     :param integer $fraction: Number of fraction digits after decimal point
     :returns: The number as the appropriate currency for the locale

--- a/user_guide_src/source/helpers/text_helper.rst
+++ b/user_guide_src/source/helpers/text_helper.rst
@@ -101,7 +101,7 @@ The following functions are available:
 	:rtype:	string
 
 	Converts double slashes in a string to a single slash, except those
-	found in URL protocol prefixes (e.g. http&#58;//).
+	found in URL protocol prefixes (e.g., http&#58;//).
 
 	Example::
 

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -24,7 +24,7 @@ The following functions are available:
 .. php:function:: site_url([$uri = ''[, $protocol = NULL[, $altConfig = NULL]]])
 
     :param  mixed         $uri: URI string or array of URI segments
-    :param  string        $protocol: Protocol, e.g. 'http' or 'https'
+    :param  string        $protocol: Protocol, e.g., 'http' or 'https'
     :param  \\Config\\App $altConfig: Alternate configuration to use
     :returns: Site URL
     :rtype:	string
@@ -58,7 +58,7 @@ The following functions are available:
 .. php:function:: base_url([$uri = ''[, $protocol = NULL]])
 
     :param  mixed   $uri: URI string or array of URI segments
-    :param  string  $protocol: Protocol, e.g. 'http' or 'https'
+    :param  string  $protocol: Protocol, e.g., 'http' or 'https'
     :returns: Base URL
     :rtype: string
 

--- a/user_guide_src/source/helpers/xml_helper.rst
+++ b/user_guide_src/source/helpers/xml_helper.rst
@@ -29,7 +29,7 @@ The following functions are available:
 .. php:function:: xml_convert($str[, $protect_all = FALSE])
 
 	:param string $str: the text string to convert
-	:param bool $protect_all: Whether to protect all content that looks like a potential entity instead of just numbered entities, e.g. &foo;
+	:param bool $protect_all: Whether to protect all content that looks like a potential entity instead of just numbered entities, e.g., &foo;
 	:returns: XML-converted string
 	:rtype:	string
 
@@ -42,7 +42,7 @@ The following functions are available:
 	  - Dashes: -
 
 	This function ignores ampersands if they are part of existing numbered
-	character entities, e.g. &#123;. Example::
+	character entities, e.g., &#123;. Example::
 
 		$string = '<p>Here is a paragraph & an entity (&#123;).</p>';
 		$string = xml_convert($string);

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -171,7 +171,7 @@ In addition to the standard HTTP methods, this also supports two special cases: 
 self-explanatory here, but 'cli' would apply to all requests that were run from the command line, while 'ajax'
 would apply to every AJAX request.
 
-.. note:: The AJAX requests depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e. fetch). See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
+.. note:: The AJAX requests depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e., fetch). See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
 
 $filters
 ========

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -74,14 +74,14 @@ be checked with the ``isAJAX()`` and ``isCLI()`` methods::
         // ...
     }
 
-.. note:: The ``isAJAX()`` method depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e. fetch). See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
+.. note:: The ``isAJAX()`` method depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e., fetch). See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
 
 You can check the HTTP method that this request represents with the ``method()`` method::
 
     // Returns 'post'
     $method = $request->getMethod();
 
-By default, the method is returned as a lower-case string (i.e. 'get', 'post', etc). You can get an
+By default, the method is returned as a lower-case string (i.e., 'get', 'post', etc). You can get an
 uppercase version by wrapping the call in ``str_to_upper()``::
 
     // Returns 'GET'

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -462,7 +462,7 @@ then you can change this value to save typing::
 Default Controller
 ------------------
 
-When a user visits the root of your site (i.e. example.com) the controller to use is determined by the value set by
+When a user visits the root of your site (i.e., example.com) the controller to use is determined by the value set by
 the ``setDefaultController()`` method, unless a route exists for it explicitly. The default value for this is ``Home``
 which matches the controller at ``/app/Controllers/Home.php``::
 

--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -66,7 +66,7 @@ If `--prefer-source` doesn't automatically update to pull latest framework sourc
     rm -rf vendor/codeigniter4/framework && composer update codeigniter4/framework --prefer-source
 
 If you used the "--no-dev" option when you created the project, it
-would be appropriate to do so here too, i.e. ``composer update --no-dev``.
+would be appropriate to do so here too, i.e., ``composer update --no-dev``.
 
 Read the upgrade instructions, and check designated  ``app/Config`` folders for affected changes.
 
@@ -139,7 +139,7 @@ to your project root
 Copy the ``env``, ``phpunit.xml.dist`` and ``spark`` files, from
 ``vendor/codeigniter4/framework`` to your project root
 
-You will have to adjust the system path to refer to the vendor one, e.g. ``ROOTPATH . '/vendor/codeigniter4/framework/system'``,
+You will have to adjust the system path to refer to the vendor one, e.g., ``ROOTPATH . '/vendor/codeigniter4/framework/system'``,
 - the ``$systemDirectory`` variable in ``app/Config/Paths.php``
 
 Upgrading

--- a/user_guide_src/source/installation/running.rst
+++ b/user_guide_src/source/installation/running.rst
@@ -31,7 +31,7 @@ By default, the application will run using the "production" environment. To
 take advantage of the debugging tools provided, you should set the environment
 to "development".
 
-.. note:: If you will be running your site using a web server (e.g. Apache or Nginx),
+.. note:: If you will be running your site using a web server (e.g., Apache or Nginx),
     you will need to modify the permissions for the ``writable`` folder inside
     your project, so that it is writable by the user or account used by your
     web server.
@@ -86,7 +86,7 @@ The “mod_rewrite” module enables URLs without “index.php” in them, and i
 in our user guide.
 
 Make sure that the rewrite module is enabled (uncommented) in the main
-configuration file, eg. ``apache2/conf/httpd.conf``::
+configuration file, e.g., ``apache2/conf/httpd.conf``::
 
     LoadModule rewrite_module modules/mod_rewrite.so
 
@@ -106,7 +106,7 @@ We recommend using “virtual hosting” to run your apps.
 You can set up different aliases for each of the apps you work on,
 
 Make sure that the virtual hosting module is enabled (uncommented) in the main
-configuration file, eg. ``apache2/conf/httpd.conf``::
+configuration file, e.g., ``apache2/conf/httpd.conf``::
 
     LoadModule vhost_alias_module modules/mod_vhost_alias.so
 
@@ -117,7 +117,7 @@ Add a line to the file. This could be "myproject.local" or "myproject.test", for
     127.0.0.1 myproject.local
 
 Add a <VirtualHost> element for your webapp inside the virtual hosting configuration,
-eg. ``apache2/conf/extra/httpd-vhost.conf``::
+e.g., ``apache2/conf/extra/httpd-vhost.conf``::
 
     <VirtualHost *:80>
         DocumentRoot "/opt/lamp7.2/apache2/htdocs/myproject/public"

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -53,7 +53,7 @@ subforum for an up-to-date list!
 - Classes are instantiated where needed, and components are managed
   by ``Services``
 - The class loader automatically handles PSR4 style class locating,
-  within the ``App`` (application) and ``CodeIgniter`` (i.e. system) top level
+  within the ``App`` (application) and ``CodeIgniter`` (i.e., system) top level
   namespaces; with composer autoloading support, and even using educated
   guessing to find your models and libraries if they are in the right
   folder even though not namespaced
@@ -68,7 +68,7 @@ subforum for an up-to-date list!
 - CI provides ``Request`` and ``Response`` objects for you to work with -
   more powerful than the CI3-way
 - If you want a base controller (MY_Controller in CI3), make it
-  where you like, e.g. BaseController extends Controller, and then
+  where you like, e.g., BaseController extends Controller, and then
   have your controllers extend it
 
 **Models**

--- a/user_guide_src/source/libraries/encryption.rst
+++ b/user_guide_src/source/libraries/encryption.rst
@@ -72,7 +72,7 @@ The example above uses the configuration settings found in ``app/Config/Encrypti
 Option     Possible values (default in parentheses)
 ========== ====================================================
 key        Encryption key starter
-driver     Preferred handler, e.g. OpenSSL or Sodium (``OpenSSL``)
+driver     Preferred handler, e.g., OpenSSL or Sodium (``OpenSSL``)
 blockSize  Padding length in bytes for SodiumHandler (``16``)
 digest     Message digest algorithm (``SHA512``)
 ========== ====================================================
@@ -124,7 +124,7 @@ Encoding Keys or Results
 ------------------------
 
 You'll notice that the ``createKey()`` method outputs binary data, which
-is hard to deal with (i.e. a copy-paste may damage it), so you may use
+is hard to deal with (i.e., a copy-paste may damage it), so you may use
 ``bin2hex()``, or ``base64_encode`` to work with the key in
 a more friendly manner. For example::
 

--- a/user_guide_src/source/libraries/images.rst
+++ b/user_guide_src/source/libraries/images.rst
@@ -319,7 +319,7 @@ that allow you to specify how the text should be displayed::
 
 The possible options that are recognized are as follows:
 
-- color         Text Color (hex number), i.e. #ff0000
+- color         Text Color (hex number), i.e., #ff0000
 - opacity		A number between 0 and 1 that represents the opacity of the text.
 - withShadow	Boolean value whether to display a shadow or not.
 - shadowColor   Color of the shadow (hex number)
@@ -332,4 +332,4 @@ The possible options that are recognized are as follows:
 - fontSize		The font size to use. When using the GD handler with the system font, valid values are between 1-5.
 
 .. note:: The ImageMagick driver does not recognize full server path for fontPath. Instead, simply provide the
-		name of one of the installed system fonts that you wish to use, i.e. Calibri.
+		name of one of the installed system fonts that you wish to use, i.e., Calibri.

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -112,7 +112,7 @@ you might find helpful that are not related to the CSRF protection.
 Tries to sanitize filenames in order to prevent directory traversal attempts and other security threats, which is
 particularly useful for files that were supplied via user input. The first parameter is the path to sanitize.
 
-If it is acceptable for the user input to include relative paths, e.g. file/in/some/approved/folder.txt, you can set
+If it is acceptable for the user input to include relative paths, e.g., file/in/some/approved/folder.txt, you can set
 the second optional parameter, $relative_path to true.
 ::
 

--- a/user_guide_src/source/libraries/uploaded_files.rst
+++ b/user_guide_src/source/libraries/uploaded_files.rst
@@ -239,7 +239,7 @@ Moving an uploaded file can fail, with an HTTPException, under several circumsta
 
 - the file has already been moved
 - the file did not upload successfully
-- the file move operation fails (eg. improper permissions)
+- the file move operation fails (e.g., improper permissions)
 
 Store Files
 ------------
@@ -264,4 +264,4 @@ Moving an uploaded file can fail, with an HTTPException, under several circumsta
 
 - the file has already been moved
 - the file did not upload successfully
-- the file move operation fails (eg. improper permissions)
+- the file move operation fails (e.g., improper permissions)

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -194,7 +194,7 @@ Here's an updated User entity to provide some examples of how this could be used
 
 The first thing to notice is the name of the methods we've added. For each one, the class expects the snake_case
 column name to be converted into PascalCase, and prefixed with either ``set`` or ``get``. These methods will then
-be automatically called whenever you set or retrieve the class property using the direct syntax (i.e. $user->email).
+be automatically called whenever you set or retrieve the class property using the direct syntax (i.e., $user->email).
 The methods do not need to be public unless you want them accessed from other classes. For example, the ``created_at``
 class property will be accessed through the ``setCreatedAt()`` and ``getCreatedAt()`` methods.
 
@@ -328,7 +328,7 @@ This option should be an array where the key is the name of the class property, 
 should be cast to. Casting only affects when values are read. No conversions happen that affect the permanent value in
 either the entity or the database. Properties can be cast to any of the following data types:
 **integer**, **float**, **double**, **string**, **boolean**, **object**, **array**, **datetime**, and **timestamp**.
-Add a question mark at the beginning of type to mark property as nullable, i.e. **?string**, **?integer**.
+Add a question mark at the beginning of type to mark property as nullable, i.e., **?string**, **?integer**.
 
 For example, if you had a User entity with an **is_banned** property, you can cast it as a boolean::
 

--- a/user_guide_src/source/outgoing/localization.rst
+++ b/user_guide_src/source/outgoing/localization.rst
@@ -197,7 +197,7 @@ library, the following types of data can be replaced:
 * numbers - integer, currency, percent
 * dates - short, medium, long, full
 * time - short, medium, long, full
-* spellout - spells out numbers (i.e. 34 becomes thirty-four)
+* spellout - spells out numbers (i.e., 34 becomes thirty-four)
 * ordinal
 * duration
 

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -613,7 +613,7 @@ template, the original pseudo-variable is shown in the result::
 	// Result: Hello, John {initials} Doe
 
 If you provide a string substitution parameter when an array is expected,
-i.e. for a variable pair, the substitution is done for the opening variable
+i.e., for a variable pair, the substitution is done for the opening variable
 pair tag, but the closing variable pair tag is not rendered properly::
 
 	$template = 'Hello, {firstname} {lastname} ({degrees}{degree} {/degrees})';

--- a/user_guide_src/source/testing/controllers.rst
+++ b/user_guide_src/source/testing/controllers.rst
@@ -58,7 +58,7 @@ Helper Methods
 **controller($class)**
 
 Specifies the class name of the controller to test. The first parameter must be a fully qualified class name
-(i.e. include the namespace)::
+(i.e., include the namespace)::
 
     $this->controller(\App\Controllers\ForumController::class);
 

--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -287,7 +287,7 @@ with a slug to the ``view()`` method in the ``News`` controller.
     $routes->get('news', 'News::index');
     $routes->get('(:any)', 'Pages::view/$1');
 
-Point your browser to your "news" page, i.e. ``localhost:8080/news``,
+Point your browser to your "news" page, i.e., ``localhost:8080/news``,
 you should see a list of the news items, each of which has a link
 to display just the one article.
 


### PR DESCRIPTION
**Description**
Rrecommends a comma after use: i.e., and e.g.,

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
