### PR TITLE
initial signed commit of code changes to add ResultInterface::getNumRows

### DIFF
--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -175,4 +175,16 @@ class Result extends BaseResult
 	}
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * Returns the number of rows in the resultID (i.e., mysqli_result object)
+	 *
+	 * @return int number of rows in a query result; if the number of rows is greater than PHP_INT_MAX, this will cast the number as a string which will yield PHP_INT_MAX
+	 */
+	public function getNumRows() : int
+	{
+		return intval($this->resultID->num_rows);
+	}
+
+	//--------------------------------------------------------------------
 }

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -141,4 +141,22 @@ class Result extends BaseResult
 	}
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * Returns the number of rows in the resultID (i.e., PostgreSQL query result resource)
+	 *
+	 * @return int The number of rows in the query result
+	 * @throws \Exception if an error is encountered retrieving the row count
+	 */
+	public function getNumRows() : int
+	{
+		$retval = pg_num_rows($this->resultID);
+		if ($retval < 0) {
+			throw \Exception("An error was encountered retrieving the row count");
+		} else {
+			return intval($retval);
+		}
+	}
+
+	//--------------------------------------------------------------------
 }

--- a/system/Database/ResultInterface.php
+++ b/system/Database/ResultInterface.php
@@ -232,4 +232,13 @@ interface ResultInterface
 	public function dataSeek(int $n = 0);
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * Gets the number of rows returned in the result set.
+	 *
+	 * @return integer
+	 */
+	public function getNumRows(): int;
+
+	//--------------------------------------------------------------------
 }

--- a/system/Database/SQLSRV/Result.php
+++ b/system/Database/SQLSRV/Result.php
@@ -181,4 +181,24 @@ class Result extends BaseResult
 		}
 		return sqlsrv_fetch_object($this->resultID, $className);
 	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns the number of rows in the resultID (i.e., SQLSRV query result resource)
+	 *
+	 * @return int Returns the number of rows retrieved on success
+	 * @throws \Exception if an error is encountered attempting to retrieve the count (eg if the prior select query failed)
+	 */
+	public function getNumRows() : int
+	{
+		$retval = sqlsrv_num_rows($this->resultID);
+		if ($retval === false) {
+			throw new \Exception("Error retrieving row count");
+		} else {
+			return intval($retval);
+		}
+	}
+
+	//--------------------------------------------------------------------
 }

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -180,4 +180,17 @@ class Result extends BaseResult
 	}
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * SQLite3Result class does not have a numrows function, so we throw an exception here.
+	 * NOTE: there are workarounds (e.g., looping thru results and counting) but these would alter other object states so we just encourage use of countAllResults instead
+	 *
+	 * @throws \Exception
+	 */
+	public function getNumRows() : int
+	{
+		throw new \Exception("SQLite3Result does not support a numRows method. Use Builder->countAllResults() instead.");
+	}
+
+	//--------------------------------------------------------------------
 }

--- a/tests/system/Database/Live/GetNumRowsTest.php
+++ b/tests/system/Database/Live/GetNumRowsTest.php
@@ -1,0 +1,41 @@
+<?php namespace Builder;
+
+use CodeIgniter\Test\CIDatabaseTestCase;
+
+class GetNumRowsTest extends CIDatabaseTestCase
+{
+	protected $refresh = true;
+	
+	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+
+	/**
+	 * Added as instructed at https://codeigniter4.github.io/userguide/testing/database.html#the-test-class
+	 * {@inheritDoc}
+	 * @see \CodeIgniter\Test\CIDatabaseTestCase::setUp()
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+	}
+
+	/**
+	 * Added as instructed at https://codeigniter4.github.io/userguide/testing/database.html#the-test-class
+	 * {@inheritDoc}
+	 * @see \CodeIgniter\Test\CIDatabaseTestCase::tearDown()
+	 */
+	public function tearDown(): void
+	{
+		parent::tearDown();
+	}
+
+	/**
+	 * tests newly added ResultInterface::getNumRows with a live db
+	 */
+	public function testGetRowNum()
+	{
+		$query = $this->db->table('job')->get();
+		$this->assertEquals(4, $query->getNumRows());
+	}
+
+
+}


### PR DESCRIPTION
And also to the various DBMS-specific Result classes. Added unit tests/system/Database/Live/GetNumRowsTest.php for this newly added method. Added an entry in the user docs for getNumRows method.

**Description**
Per Lonnie Ezell's [message](https://github.com/codeigniter4/CodeIgniter4/pull/109#issuecomment-752838400) in #109, I have attempted my first CodeIgniter fork/branch/pull request here. It adds a getNumRows method to the ResultInterface and the various DBMS classes that extend it. This pull request supercedes a previous messy one (for which I apologize).

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
