### PR TITLE
PHPStan Ignore File

### DIFF
--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'app/**'
       - 'system/**'
+      - phpstan.neon.dist
   push:
     branches:
       - 'develop'
@@ -17,6 +18,7 @@ on:
     paths:
       - 'app/**'
       - 'system/**'
+      - phpstan.neon.dist
 
 jobs:
   build:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,6 +25,7 @@ parameters:
 		- system/Config/Routes.php
 		- system/Debug/Toolbar/Views/toolbar.tpl.php
 		- system/Images/Handlers/GDHandler.php
+		- system/Test/Filters/CITestStreamFilter.php
 		- system/ThirdParty/*
 		- system/Validation/Views/single.php
 	ignoreErrors:

--- a/system/Test/Filters/CITestStreamFilter.php
+++ b/system/Test/Filters/CITestStreamFilter.php
@@ -46,7 +46,6 @@ class CITestStreamFilter extends php_user_filter
 			$consumed += $bucket->datalen;
 		}
 
-		// @phpstan-ignore-next-line
 		return PSFS_PASS_ON;
 	}
 }


### PR DESCRIPTION
**Description**
We’ve run into our first PHP 7/8 PHPStan issue: https://github.com/codeigniter4/CodeIgniter4/runs/1650630303

For whatever reason this line in **CITestStreamFilter** is no longer an issue in PHP 8, but persists in PHP 7:
```
	public function filter($in, $out, &$consumed, $closing)
	{
		while ($bucket = stream_bucket_make_writeable($in))
		{
			static::$buffer .= $bucket->data;

			$consumed += $bucket->datalen;
		}

		// @phpstan-ignore-next-line
		return PSFS_PASS_ON;
	}
```
Ondre is considering work on how to improve this split handling (https://github.com/phpstan/phpstan/issues/4223 by our own @paulbalandan, https://github.com/phpstan/phpstan/issues/4060#issuecomment-723559902) but the current solution is to have different config files for each version.

Given that the problem currently is just single, small, test file I propose we ignore it for all versions and postpone dealing with this issue until we see what Ondre does upstream.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
