### PR TITLE
Model/BaseModel - Fix primary key and  add @throws for builder method

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1675,13 +1675,6 @@ abstract class BaseModel
 		if (method_exists($data, 'toRawArray'))
 		{
 			$properties = $data->toRawArray($onlyChanged, $recursive);
-
-			// Always grab the primary key otherwise updates will fail.
-			if (! empty($properties) && ! empty($this->primaryKey) && ! in_array($this->primaryKey, $properties, true)
-				&& ! empty($data->{$this->primaryKey}))
-			{
-				$properties[$this->primaryKey] = $data->{$this->primaryKey};
-			}
 		}
 		else
 		{

--- a/system/Model.php
+++ b/system/Model.php
@@ -560,6 +560,7 @@ class Model extends BaseModel
 	 * @param string|null $table Table name
 	 *
 	 * @return BaseBuilder
+	 * @throws ModelException
 	 */
 	public function builder(?string $table = null)
 	{


### PR DESCRIPTION
**Description**
This fixes the issue with primaryKey property which was unintentionally left inside base model. This also ads @throws for builder() method

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide


