### PR TITLE
BaseModel/Model - Attempt to rework escape parameter

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -354,12 +354,11 @@ abstract class BaseModel
 	 * Inserts data into the current database
 	 * This methods works only with dbCalls
 	 *
-	 * @param array        $data   Data
-	 * @param boolean|null $escape Escape
+	 * @param array $data Data
 	 *
 	 * @return object|integer|string|false
 	 */
-	abstract protected function doInsert(array $data, ?bool $escape = null);
+	abstract protected function doInsert(array $data);
 
 	/**
 	 * Compiles batch insert and runs the queries, validating each row prior.
@@ -708,13 +707,12 @@ abstract class BaseModel
 	 *
 	 * @param array|object|null $data     Data
 	 * @param boolean           $returnID Whether insert ID should be returned or not.
-	 * @param boolean|null      $escape   Escape
 	 *
 	 * @return BaseResult|object|integer|string|false
 	 *
 	 * @throws ReflectionException
 	 */
-	public function insert($data = null, bool $returnID = true, ?bool $escape = null)
+	public function insert($data = null, bool $returnID = true)
 	{
 		$this->insertID = 0;
 
@@ -774,7 +772,7 @@ abstract class BaseModel
 			$eventData = $this->trigger('beforeInsert', $eventData);
 		}
 
-		$result = $this->doInsert($eventData['data'], $escape);
+		$result = $this->doInsert($eventData['data']);
 
 		$eventData = [
 			'id'     => $this->insertID,
@@ -866,15 +864,14 @@ abstract class BaseModel
 	 * Updates a single record in the database. If an object is provided,
 	 * it will attempt to convert it into an array.
 	 *
-	 * @param integer|array|string|null $id     ID
-	 * @param array|object|null         $data   Data
-	 * @param boolean|null              $escape Escape
+	 * @param integer|array|string|null $id   ID
+	 * @param array|object|null         $data Data
 	 *
 	 * @return boolean
 	 *
 	 * @throws ReflectionException
 	 */
-	public function update($id = null, $data = null, ?bool $escape = null): bool
+	public function update($id = null, $data = null): bool
 	{
 		if (is_numeric($id) || is_string($id))
 		{
@@ -936,7 +933,7 @@ abstract class BaseModel
 		$eventData = [
 			'id'     => $id,
 			'data'   => $eventData['data'],
-			'result' => $this->doUpdate($id, $eventData['data'], $escape),
+			'result' => $this->doUpdate($id, $eventData['data']),
 		];
 
 		if ($this->tempAllowCallbacks)

--- a/system/Model.php
+++ b/system/Model.php
@@ -84,6 +84,13 @@ class Model extends BaseModel
 	 */
 	protected $tempData = [];
 
+	/**
+	 * Escape Parameter to be passed in do methods
+	 *
+	 * @var boolean|null
+	 */
+	protected $escape = null;
+
 	// endregion
 
 	// region Constructor
@@ -243,13 +250,15 @@ class Model extends BaseModel
 	 * Inserts data into the current table.
 	 * This methods works only with dbCalls
 	 *
-	 * @param array        $data   Data
-	 * @param boolean|null $escape Escape
+	 * @param array $data Data
 	 *
 	 * @return BaseResult|integer|string|false
 	 */
-	protected function doInsert(array $data, ?bool $escape = null)
+	protected function doInsert(array $data)
 	{
+		$escape       = $this->escape;
+		$this->escape = null;
+
 		// Require non empty primaryKey when
 		// not using auto-increment feature
 		if (! $this->useAutoIncrement && empty($data[$this->primaryKey]))
@@ -320,6 +329,9 @@ class Model extends BaseModel
 	 */
 	protected function doUpdate($id = null, $data = null, ?bool $escape = null): bool
 	{
+		$escape       = $this->escape;
+		$this->escape = null;
+
 		$builder = $this->builder();
 
 		if ($id)
@@ -654,46 +666,44 @@ class Model extends BaseModel
 	 *
 	 * @param array|object|null $data     Data
 	 * @param boolean           $returnID Whether insert ID should be returned or not.
-	 * @param boolean|null      $escape   Escape
 	 *
 	 * @return BaseResult|object|integer|string|false
 	 *
 	 * @throws ReflectionException
 	 */
-	public function insert($data = null, bool $returnID = true, ?bool $escape = null)
+	public function insert($data = null, bool $returnID = true)
 	{
 		if (empty($data))
 		{
 			$data           = $this->tempData['data'] ?? null;
-			$escape         = $this->tempData['escape'] ?? null;
+			$this->escape   = $this->tempData['escape'] ?? null;
 			$this->tempData = [];
 		}
 
-		return parent::insert($data, $returnID, $escape);
+		return parent::insert($data, $returnID);
 	}
 
 	/**
 	 * Updates a single record in the database. If an object is provided,
 	 * it will attempt to convert it into an array.
 	 *
-	 * @param integer|array|string|null $id     ID
-	 * @param array|object|null         $data   Data
-	 * @param boolean|null              $escape Escape
+	 * @param integer|array|string|null $id   ID
+	 * @param array|object|null         $data Data
 	 *
 	 * @return boolean
 	 *
 	 * @throws ReflectionException
 	 */
-	public function update($id = null, $data = null, ?bool $escape = null): bool
+	public function update($id = null, $data = null): bool
 	{
 		if (empty($data))
 		{
 			$data           = $this->tempData['data'] ?? null;
-			$escape         = $this->tempData['escape'] ?? null;
+			$this->escape   = $this->tempData['escape'] ?? null;
 			$this->tempData = [];
 		}
 
-		return parent::update($id, $data, $escape);
+		return parent::update($id, $data);
 	}
 
 	// endregion


### PR DESCRIPTION
**Description**
Here is one way of keeping escape parameter outside of method definitions. But the existing solution is much more elegant

@michalsn What's your opinion on this one ? 

Should we keep the existing implementation and just update the docs or should this one be merged

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

  
