### PR TITLE
Better support for NoSQL drivers

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -593,11 +593,11 @@ abstract class BaseConnection implements ConnectionInterface
 	/**
 	 * Executes the query against the database.
 	 *
-	 * @param string $sql
+	 * @param mixed $sql
 	 *
 	 * @return mixed
 	 */
-	abstract protected function execute(string $sql);
+	abstract protected function execute($sql);
 
 	/**
 	 * Orchestrates a query against the database. Queries must use
@@ -607,16 +607,16 @@ abstract class BaseConnection implements ConnectionInterface
 	 * Should automatically handle different connections for read/write
 	 * queries if needed.
 	 *
-	 * @param string  $sql
-	 * @param mixed   ...$binds
-	 * @param boolean $setEscapeFlags
-	 * @param string  $queryClass
+	 * @param mixed       $sql
+	 * @param mixed       ...$binds
+	 * @param boolean     $setEscapeFlags
+	 * @param string|null $queryClass
 	 *
 	 * @return BaseResult|Query|boolean
 	 *
 	 * @todo BC set $queryClass default as null in 4.1
 	 */
-	public function query(string $sql, $binds = null, bool $setEscapeFlags = true, string $queryClass = '')
+	public function query($sql, $binds = null, bool $setEscapeFlags = true, string $queryClass = null)
 	{
 		$queryClass = $queryClass ?: $this->queryClass;
 
@@ -718,11 +718,11 @@ abstract class BaseConnection implements ConnectionInterface
 	 * is performed, nor are transactions handled. Simply takes a raw
 	 * query string and returns the database-specific result id.
 	 *
-	 * @param string $sql
+	 * @param mixed $sql
 	 *
 	 * @return mixed
 	 */
-	public function simpleQuery(string $sql)
+	public function simpleQuery($sql)
 	{
 		if (empty($this->connID))
 		{

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -75,13 +75,13 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 	 * NOTE: This version is based on SQL code. Child classes should
 	 * override this method.
 	 *
-	 * @param string $sql
+	 * @param mixed  $sql
 	 * @param array  $options    Passed to the connection's prepare statement.
 	 * @param string $queryClass
 	 *
 	 * @return mixed
 	 */
-	public function prepare(string $sql, array $options = [], string $queryClass = 'CodeIgniter\\Database\\Query')
+	public function prepare($sql, array $options = [], string $queryClass = 'CodeIgniter\\Database\\Query')
 	{
 		// We only supports positional placeholders (?)
 		// in order to work with the execute method below, so we

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -124,12 +124,12 @@ interface ConnectionInterface
 	 * Should automatically handle different connections for read/write
 	 * queries if needed.
 	 *
-	 * @param string $sql
-	 * @param mixed  ...$binds
+	 * @param mixed $sql
+	 * @param mixed ...$binds
 	 *
 	 * @return BaseResult|Query|boolean
 	 */
-	public function query(string $sql, $binds = null);
+	public function query($sql, $binds = null);
 
 	//--------------------------------------------------------------------
 
@@ -138,11 +138,11 @@ interface ConnectionInterface
 	 * is performed, nor are transactions handled. Simply takes a raw
 	 * query string and returns the database-specific result id.
 	 *
-	 * @param string $sql
+	 * @param mixed $sql
 	 *
 	 * @return mixed
 	 */
-	public function simpleQuery(string $sql);
+	public function simpleQuery($sql);
 
 	//--------------------------------------------------------------------
 	/**

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -310,11 +310,11 @@ class Connection extends BaseConnection
 	/**
 	 * Executes the query against the database.
 	 *
-	 * @param string $sql
+	 * @param mixed $sql
 	 *
 	 * @return mixed
 	 */
-	public function execute(string $sql)
+	public function execute($sql)
 	{
 		while ($this->connID->more_results())
 		{

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -26,13 +26,13 @@ class PreparedQuery extends BasePreparedQuery
 	 * NOTE: This version is based on SQL code. Child classes should
 	 * override this method.
 	 *
-	 * @param string $sql
-	 * @param array  $options Passed to the connection's prepare statement.
-	 *                        Unused in the MySQLi driver.
+	 * @param mixed $sql
+	 * @param array $options Passed to the connection's prepare statement.
+	 *                       Unused in the MySQLi driver.
 	 *
 	 * @return mixed
 	 */
-	public function _prepare(string $sql, array $options = [])
+	public function _prepare($sql, array $options = [])
 	{
 		// Mysqli driver doesn't like statements
 		// with terminating semicolons.

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -159,11 +159,11 @@ class Connection extends BaseConnection
 	/**
 	 * Executes the query against the database.
 	 *
-	 * @param string $sql
+	 * @param mixed $sql
 	 *
 	 * @return mixed
 	 */
-	public function execute(string $sql)
+	public function execute($sql)
 	{
 		try
 		{

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -43,14 +43,14 @@ class PreparedQuery extends BasePreparedQuery
 	 * NOTE: This version is based on SQL code. Child classes should
 	 * override this method.
 	 *
-	 * @param string $sql
-	 * @param array  $options Passed to the connection's prepare statement.
-	 *                        Unused in the MySQLi driver.
+	 * @param mixed $sql
+	 * @param array $options Passed to the connection's prepare statement.
+	 *                       Unused in the MySQLi driver.
 	 *
 	 * @return mixed
 	 * @throws Exception
 	 */
-	public function _prepare(string $sql, array $options = [])
+	public function _prepare($sql, array $options = [])
 	{
 		$this->name = (string) random_int(1, 10000000000000000);
 

--- a/system/Database/PreparedQueryInterface.php
+++ b/system/Database/PreparedQueryInterface.php
@@ -32,12 +32,12 @@ interface PreparedQueryInterface
 	 * Prepares the query against the database, and saves the connection
 	 * info necessary to execute the query later.
 	 *
-	 * @param string $sql
-	 * @param array  $options Passed to the connection's prepare statement.
+	 * @param mixed $sql
+	 * @param array $options Passed to the connection's prepare statement.
 	 *
 	 * @return mixed
 	 */
-	public function prepare(string $sql, array $options = []);
+	public function prepare($sql, array $options = []);
 
 	//--------------------------------------------------------------------
 

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -97,13 +97,13 @@ class Query implements QueryInterface
 	/**
 	 * Sets the raw query string to use for this statement.
 	 *
-	 * @param string  $sql
+	 * @param mixed   $sql
 	 * @param mixed   $binds
 	 * @param boolean $setEscape
 	 *
 	 * @return $this
 	 */
-	public function setQuery(string $sql, $binds = null, bool $setEscape = true)
+	public function setQuery($sql, $binds = null, bool $setEscape = true)
 	{
 		$this->originalQueryString = $sql;
 
@@ -158,9 +158,9 @@ class Query implements QueryInterface
 	 * Returns the final, processed query string after binding, etal
 	 * has been performed.
 	 *
-	 * @return string
+	 * @return mixed
 	 */
-	public function getQuery(): string
+	public function getQuery()
 	{
 		if (empty($this->finalQueryString))
 		{

--- a/system/Database/QueryInterface.php
+++ b/system/Database/QueryInterface.php
@@ -22,13 +22,13 @@ interface QueryInterface
 	/**
 	 * Sets the raw query string to use for this statement.
 	 *
-	 * @param string  $sql
+	 * @param mixed   $sql
 	 * @param mixed   $binds
 	 * @param boolean $setEscape
 	 *
 	 * @return mixed
 	 */
-	public function setQuery(string $sql, $binds = null, bool $setEscape = true);
+	public function setQuery($sql, $binds = null, bool $setEscape = true);
 
 	//--------------------------------------------------------------------
 

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -490,11 +490,11 @@ class Connection extends BaseConnection
 	/**
 	 * Executes the query against the database.
 	 *
-	 * @param string $sql
+	 * @param mixed $sql
 	 *
 	 * @return mixed
 	 */
-	public function execute(string $sql)
+	public function execute($sql)
 	{
 		$stmt = ($this->scrollable === false || $this->isWriteType($sql)) ?
 			sqlsrv_query($this->connID, $sql) :

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -41,13 +41,13 @@ class PreparedQuery extends BasePreparedQuery
 	 * NOTE: This version is based on SQL code. Child classes should
 	 * override this method.
 	 *
-	 * @param string $sql
-	 * @param array  $options Options takes an associative array;
+	 * @param mixed $sql
+	 * @param array $options Options takes an associative array;
 	 *
 	 * @return mixed
 	 * @throws Exception
 	 */
-	public function _prepare(string $sql, array $options = [])
+	public function _prepare($sql, array $options = [])
 	{
 		/* Prepare parameters for the query */
 		$queryString = $this->getQueryString();

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -134,11 +134,11 @@ class Connection extends BaseConnection
 	/**
 	 * Execute the query
 	 *
-	 * @param string $sql
+	 * @param mixed $sql
 	 *
 	 * @return mixed    \SQLite3Result object or bool
 	 */
-	public function execute(string $sql)
+	public function execute($sql)
 	{
 		try
 		{

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -33,13 +33,13 @@ class PreparedQuery extends BasePreparedQuery
 	 * NOTE: This version is based on SQL code. Child classes should
 	 * override this method.
 	 *
-	 * @param string $sql
-	 * @param array  $options Passed to the connection's prepare statement.
-	 *                        Unused in the MySQLi driver.
+	 * @param mixed $sql
+	 * @param array $options Passed to the connection's prepare statement.
+	 *                       Unused in the MySQLi driver.
 	 *
 	 * @return mixed
 	 */
-	public function _prepare(string $sql, array $options = [])
+	public function _prepare($sql, array $options = [])
 	{
 		if (! ($this->statement = $this->db->connID->prepare($sql)))
 		{

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -43,16 +43,16 @@ class MockConnection extends BaseConnection
 	 * Should automatically handle different connections for read/write
 	 * queries if needed.
 	 *
-	 * @param string  $sql
-	 * @param mixed   ...$binds
-	 * @param boolean $setEscapeFlags
-	 * @param string  $queryClass
+	 * @param mixed       $sql
+	 * @param mixed       ...$binds
+	 * @param boolean     $setEscapeFlags
+	 * @param string|null $queryClass
 	 *
 	 * @return BaseResult|Query|boolean
 	 *
 	 * @todo BC set $queryClass default as null in 4.1
 	 */
-	public function query(string $sql, $binds = null, bool $setEscapeFlags = true, string $queryClass = '')
+	public function query($sql, $binds = null, bool $setEscapeFlags = true, string $queryClass = null)
 	{
 		$queryClass = str_replace('Connection', 'Query', static::class);
 
@@ -161,11 +161,11 @@ class MockConnection extends BaseConnection
 	/**
 	 * Executes the query against the database.
 	 *
-	 * @param string $sql
+	 * @param mixed $sql
 	 *
 	 * @return mixed
 	 */
-	protected function execute(string $sql)
+	protected function execute($sql)
 	{
 		return $this->returnValues['execute'];
 	}


### PR DESCRIPTION
**Description**
 - BaseConnection - Query class determined automatically if Driver specific Query class exist
 - Removed strong type of string for $sql param in methods since NoSQL mostly use arrays 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

  
