### PR TITLE
Get JSON Variable

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -348,9 +348,10 @@ class IncomingRequest extends Request
 	/**
 	 * Get a specific variable from a JSON input stream
 	 *
-	 * @param  string  $index The variable that you want which can use dot syntax for getting specific values.
-	 * @param  boolean $assoc If TRUE return the result as an associative array.
-	 * @return array|mixed|null|object
+	 * @param string  $index The variable that you want which can use dot syntax for getting specific values.
+	 * @param boolean $assoc If true, return the result as an associative array.
+	 *
+	 * @return mixed
 	 */
 	public function getJsonVar(string $index, bool $assoc = false)
 	{

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -140,7 +140,7 @@ class Message implements MessageInterface
 	 *
 	 * @deprecated Use header calls directly
 	 */
-	public function isJSON()
+	public function isJSON(): bool
 	{
 		if (! $this->hasHeader('Content-Type'))
 		{

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -140,7 +140,7 @@ class Message implements MessageInterface
 	 *
 	 * @deprecated Use header calls directly
 	 */
-	public function isJSON(): bool
+      public function isJSON()
 	{
 		if (! $this->hasHeader('Content-Type'))
 		{

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -298,6 +298,77 @@ class IncomingRequestTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals($expected, $request->getJSON(true));
 	}
 
+	public function testCanGetAVariableFromJson()
+	{
+		$jsonObj = [
+			'foo' => 'bar',
+			'baz' => [
+				'fizz' => 'buzz',
+			],
+		];
+		$json    = json_encode($jsonObj);
+
+		$config          = new App();
+		$config->baseURL = 'http://example.com/';
+
+		$request = new IncomingRequest($config, new URI(), $json, new UserAgent());
+
+		$this->assertEquals('bar', $request->getJsonVar('foo'));
+		$jsonVar = $request->getJsonVar('baz');
+		$this->assertIsObject($jsonVar);
+		$this->assertEquals('buzz', $jsonVar->fizz);
+		$this->assertEquals('buzz', $request->getJsonVar('baz.fizz'));
+	}
+
+	public function testGetJsonVarAsArray()
+	{
+		$jsonObj = [
+			'baz' => [
+				'fizz' => 'buzz',
+				'foo'  => 'bar',
+			],
+		];
+		$json    = json_encode($jsonObj);
+
+		$config          = new App();
+		$config->baseURL = 'http://example.com/';
+
+		$request = new IncomingRequest($config, new URI(), $json, new UserAgent());
+
+		$jsonVar = $request->getJsonVar('baz', true);
+		$this->assertIsArray($jsonVar);
+		$this->assertEquals('buzz', $jsonVar['fizz']);
+		$this->assertEquals('bar', $jsonVar['foo']);
+	}
+
+	public function testGetVarWorksWithJson()
+	{
+		$jsonObj = [
+			'foo'  => 'bar',
+			'fizz' => 'buzz',
+		];
+		$json    = json_encode($jsonObj);
+
+		$config          = new App();
+		$config->baseURL = 'http://example.com/';
+
+		$request = new IncomingRequest($config, new URI(), $json, new UserAgent());
+		$request->setHeader('Content-Type', 'application/json');
+
+		$this->assertEquals('bar', $request->getVar('foo'));
+		$this->assertEquals('buzz', $request->getVar('fizz'));
+
+		$multiple = $request->getVar(['foo', 'fizz']);
+		$this->assertIsArray($multiple);
+		$this->assertEquals('bar', $multiple['foo']);
+		$this->assertEquals('buzz', $multiple['fizz']);
+
+		$all = $request->getVar();
+		$this->assertIsObject($all);
+		$this->assertEquals('bar', $all->foo);
+		$this->assertEquals('buzz', $all->fizz);
+	}
+
 	public function testCanGrabGetRawInput()
 	{
 		$rawstring = 'username=admin001&role=administrator&usepass=0';

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -141,6 +141,45 @@ arrays, pass in ``true`` as the first parameter.
 The second and third parameters match up to the ``depth`` and ``options`` arguments of the
 `json_decode <https://www.php.net/manual/en/function.json-decode.php>`_ PHP function.
 
+If the incoming request has a ``CONTENT_TYPE`` header set to "application/json", you can also use ``getVar()`` to get
+the JSON stream. Using ``getVar()`` in this way will always return an object.
+
+**Get Specific Data from JSON**
+
+You can get a specific piece of data from a JSON stream by passing a variable name into ``getVar()`` for the
+data that you want or you can use "dot" notation to dig into the JSON to get data that is not on the root level.
+
+::
+
+    //With a request body of:
+    {
+        "foo": "bar",
+        "fizz": {
+            "buzz": "baz"
+        }
+    }
+    $data = $request->getVar('foo');
+    //$data = "bar"
+
+    $data = $request->getVar('fizz.buzz');
+    //$data = "baz"
+
+
+If you want the result to be an associative array instead of an object, you can use ``getJsonVar()`` instead and pass
+true in the second parameter. This function can also be used if you can't guarantee that the incoming request will have the
+correct ``CONTENT_TYPE`` header.
+
+::
+
+    //With the same request as above
+    $data = $request->getJsonVar('fizz');
+    //$data->buzz = "baz"
+
+    $data = $request->getJsonVar('fizz', true);
+    //$data = ["buzz" => "baz"]
+
+.. note:: See the documentation for ``dot_array_search()`` in the ``Array`` helper for more information on "dot" notation.
+
 **Retrieving Raw data (PUT, PATCH, DELETE)**
 
 Finally, you can grab the contents of php://input as a raw stream with ``getRawInput()``::


### PR DESCRIPTION
**Description**
This pull request gives more options when building a JSON API for accessing data in the JSON of a request. This was done by making getVar() smart enough to know when it is a JSON request and grab the data accordingly. This also allows for using "dot" notation for getting data outside of the root level. For more control this PR also gives a new function called getJsonVar() which allows the developer to control the format of the returned data.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
