### PR TITLE
Fixing a bug in Message::isJSON

### DIFF
--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -142,7 +142,14 @@ class Message implements MessageInterface
 	 */
 	public function isJSON()
 	{
-		return $this->hasHeader('Content-Type')
-			&& $this->header('Content-Type')->getValue() === 'application/json';
+		if (! $this->hasHeader('Content-Type'))
+		{
+			return false;
+		}
+
+		$header = $this->header('Content-Type')->getValue();
+		$parts  = explode(';', $header);
+
+		return in_array('application/json', $parts);
 	}
 }

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -150,6 +150,6 @@ class Message implements MessageInterface
 		$header = $this->header('Content-Type')->getValue();
 		$parts  = explode(';', $header);
 
-		return in_array('application/json', $parts);
+		return in_array('application/json', $parts, true);
 	}
 }

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -349,4 +349,10 @@ class MessageTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertTrue($this->message->isJSON());
 	}
 
+	public function testIsJsonWorksWithExtendedContentType()
+	{
+		$this->message->setHeader('Content-Type', 'application/json;charset=UTF-8');
+		$this->assertTrue($this->message->isJSON());
+	}
+
 }


### PR DESCRIPTION
Fixes the bug pointed out in a comment on #3719.

**Description**
Fixed an issue in isJSON that was breaking it if the content type header had the encoding in it as well.

**Checklist:**
- [x] Securely signed commits
- [ ]N/A Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ]N/A User guide updated
- [x] Conforms to style guide