### PR TITLE
[4.1][Static Analysis] Using PhpVersion::PHP_73 constant in rector ^0.9

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -1,6 +1,7 @@
 <?php
 
 use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
 use Rector\CodeQuality\Rector\Return_\SimplifyUselessVariableRector;
 use Rector\Performance\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\SOLID\Rector\If_\RemoveAlwaysElseRector;
@@ -30,7 +31,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 	// auto import fully qualified class names
 	$parameters->set(Option::AUTO_IMPORT_NAMES, true);
 	$parameters->set(Option::ENABLE_CACHE, true);
-	$parameters->set(Option::PHP_VERSION_FEATURES, '7.3');
+	$parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_73);
 
 	$services = $containerConfigurator->services();
 	$services->set(UnderscoreToCamelCaseVariableNameRector::class);


### PR DESCRIPTION
As documented at rector's readme https://github.com/rectorphp/rector/tree/fe639838d5ba70b716a3caa66d40ef21f9185ab1#full-config-configuration

**Checklist:**
- [x] Securely signed commits