### PR TITLE
BaseConnection - Added automatic handling of query class for 3rd party drivers

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -289,6 +289,13 @@ abstract class BaseConnection implements ConnectionInterface
 	 */
 	protected $aliasedTables = [];
 
+	/**
+	 * Query Class
+	 *
+	 * @var string
+	 */
+	protected $queryClass = 'CodeIgniter\\Database\\Query';
+
 	//--------------------------------------------------------------------
 
 	/**
@@ -301,6 +308,13 @@ abstract class BaseConnection implements ConnectionInterface
 		foreach ($params as $key => $value)
 		{
 			$this->$key = $value;
+		}
+
+		$queryClass = str_replace('Connection', 'Query', static::class);
+
+		if (class_exists($queryClass))
+		{
+			$this->queryClass = $queryClass;
 		}
 	}
 
@@ -594,9 +608,13 @@ abstract class BaseConnection implements ConnectionInterface
 	 * @param string  $queryClass
 	 *
 	 * @return BaseResult|Query|false
+	 *
+	 * @todo BC set $queryClass default as null in 4.1
 	 */
-	public function query(string $sql, $binds = null, bool $setEscapeFlags = true, string $queryClass = 'CodeIgniter\\Database\\Query')
+	public function query(string $sql, $binds = null, bool $setEscapeFlags = true, string $queryClass = '')
 	{
+		$queryClass = $queryClass ?: $this->queryClass;
+
 		if (empty($this->connID))
 		{
 			$this->initialize();

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -54,7 +54,7 @@ class MockConnection extends BaseConnection
 	 */
 	public function query(string $sql, $binds = null, bool $setEscapeFlags = true, string $queryClass = '')
 	{
-		$queryClass = str_replace('Connection', 'Query', get_class($this));
+		$queryClass = str_replace('Connection', 'Query', static::class);
 
 		$query = new $queryClass($this);
 

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -49,8 +49,10 @@ class MockConnection extends BaseConnection
 	 * @param string  $queryClass
 	 *
 	 * @return BaseResult|Query|false
+	 *
+	 * @todo BC set $queryClass default as null in 4.1
 	 */
-	public function query(string $sql, $binds = null, bool $setEscapeFlags = true, string $queryClass = 'CodeIgniter\\Database\\Query')
+	public function query(string $sql, $binds = null, bool $setEscapeFlags = true, string $queryClass = '')
 	{
 		$queryClass = str_replace('Connection', 'Query', get_class($this));
 


### PR DESCRIPTION
**Description**
If there is a driver specific query class defined it will be automatically used by the BaseConnection

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide