### PR TITLE
BaseModel/Model - Removed $escape from doUpdate

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -377,13 +377,12 @@ abstract class BaseModel
 	 * Updates a single record in the database.
 	 * This methods works only with dbCalls
 	 *
-	 * @param integer|array|string|null $id     ID
-	 * @param array|null                $data   Data
-	 * @param boolean|null              $escape Escape
+	 * @param integer|array|string|null $id   ID
+	 * @param array|null                $data Data
 	 *
 	 * @return boolean
 	 */
-	abstract protected function doUpdate($id = null, $data = null, ?bool $escape = null): bool;
+	abstract protected function doUpdate($id = null, $data = null): bool;
 
 	/**
 	 * Compiles an update and runs the query

--- a/system/Model.php
+++ b/system/Model.php
@@ -321,13 +321,12 @@ class Model extends BaseModel
 	 * Updates a single record in $this->table.
 	 * This methods works only with dbCalls
 	 *
-	 * @param integer|array|string|null $id     ID
-	 * @param array|null                $data   Data
-	 * @param boolean|null              $escape Escape
+	 * @param integer|array|string|null $id   ID
+	 * @param array|null                $data Data
 	 *
 	 * @return boolean
 	 */
-	protected function doUpdate($id = null, $data = null, ?bool $escape = null): bool
+	protected function doUpdate($id = null, $data = null): bool
 	{
 		$escape       = $this->escape;
 		$this->escape = null;


### PR DESCRIPTION
**Description**
This is additional fix on top of #4072 since $escape is not needed anymore in the doUpdate method

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
  
