### PR TITLE
Fixed a bug where a newline was treated as a valid value even if it was included at the end.

### DIFF
--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -44,6 +44,7 @@ class FormatRules
 			return true;
 		}
 
+		// @see https://regex101.com/r/LhqHPO/1
 		return (bool) preg_match('/\A[A-Z ]+\z/i', $value);
 	}
 
@@ -56,7 +57,8 @@ class FormatRules
 	 */
 	public function alpha_dash(?string $str = null): bool
 	{
-			return (bool) preg_match('/\A[a-z0-9_-]+\z/i', $str);
+		// @see https://regex101.com/r/XfVY3d/1
+		return (bool) preg_match('/\A[a-z0-9_-]+\z/i', $str);
 	}
 
 	/**
@@ -72,6 +74,7 @@ class FormatRules
 	 */
 	public function alpha_numeric_punct($str)
 	{
+		// @see https://regex101.com/r/6N8dDY/1
 		return (bool) preg_match('/\A[A-Z0-9 ~!#$%\&\*\-_+=|:.]+\z/i', $str);
 	}
 
@@ -96,6 +99,7 @@ class FormatRules
 	 */
 	public function alpha_numeric_space(?string $str = null): bool
 	{
+		// @see https://regex101.com/r/0AZDME/1
 		return (bool) preg_match('/\A[A-Z0-9 ]+\z/i', $str);
 	}
 
@@ -123,6 +127,7 @@ class FormatRules
 	 */
 	public function decimal(?string $str = null): bool
 	{
+		// @see https://regex101.com/r/HULifl/1/
 		return (bool) preg_match('/\A[-+]?[0-9]{0,}\.?[0-9]+\z/', $str);
 	}
 
@@ -181,6 +186,7 @@ class FormatRules
 	 */
 	public function numeric(?string $str = null): bool
 	{
+		// @see https://regex101.com/r/bb9wtr/1
 		return (bool) preg_match('/\A[\-+]?[0-9]*\.?[0-9]+\z/', $str);
 	}
 
@@ -253,6 +259,7 @@ class FormatRules
 	 */
 	public function valid_email(string $str = null): bool
 	{
+		// @see https://regex101.com/r/wlJG1t/1/
 		if (function_exists('idn_to_ascii') && defined('INTL_IDNA_VARIANT_UTS46') && preg_match('#\A([^@]+)@(.+)\z#', $str, $matches))
 		{
 			$str = $matches[1] . '@' . idn_to_ascii($matches[2], 0, INTL_IDNA_VARIANT_UTS46);

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -44,7 +44,7 @@ class FormatRules
 			return true;
 		}
 
-		return (bool) preg_match('/^[A-Z ]+$/i', $value);
+		return (bool) preg_match('/\A[A-Z ]+\z/i', $value);
 	}
 
 	/**
@@ -56,7 +56,7 @@ class FormatRules
 	 */
 	public function alpha_dash(?string $str = null): bool
 	{
-			return (bool) preg_match('/^[a-z0-9_-]+$/i', $str);
+			return (bool) preg_match('/\A[a-z0-9_-]+\z/i', $str);
 	}
 
 	/**
@@ -72,7 +72,7 @@ class FormatRules
 	 */
 	public function alpha_numeric_punct($str)
 	{
-		return (bool) preg_match('/^[A-Z0-9 ~!#$%\&\*\-_+=|:.]+$/i', $str);
+		return (bool) preg_match('/\A[A-Z0-9 ~!#$%\&\*\-_+=|:.]+\z/i', $str);
 	}
 
 	/**
@@ -96,7 +96,7 @@ class FormatRules
 	 */
 	public function alpha_numeric_space(?string $str = null): bool
 	{
-		return (bool) preg_match('/^[A-Z0-9 ]+$/i', $str);
+		return (bool) preg_match('/\A[A-Z0-9 ]+\z/i', $str);
 	}
 
 	/**
@@ -123,7 +123,7 @@ class FormatRules
 	 */
 	public function decimal(?string $str = null): bool
 	{
-		return (bool) preg_match('/^[-+]?[0-9]{0,}\.?[0-9]+$/', $str);
+		return (bool) preg_match('/\A[-+]?[0-9]{0,}\.?[0-9]+\z/', $str);
 	}
 
 	/**
@@ -147,7 +147,7 @@ class FormatRules
 	 */
 	public function integer(?string $str = null): bool
 	{
-		return (bool) preg_match('/^[\-+]?[0-9]+$/', $str);
+		return (bool) preg_match('/\A[\-+]?[0-9]+\z/', $str);
 	}
 
 	/**
@@ -181,7 +181,7 @@ class FormatRules
 	 */
 	public function numeric(?string $str = null): bool
 	{
-		return (bool) preg_match('/^[\-+]?[0-9]*\.?[0-9]+$/', $str);
+		return (bool) preg_match('/\A[\-+]?[0-9]*\.?[0-9]+\z/', $str);
 	}
 
 	/**

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -425,6 +425,10 @@ class FormatRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 				true,
 			],
 			[
+				FormatRulesTest::ALPHABET . "\n",
+				false,
+			],
+			[
 				FormatRulesTest::ALPHABET . '1',
 				false,
 			],
@@ -504,6 +508,10 @@ class FormatRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 			],
 			[
 				FormatRulesTest::ALPHANUMERIC . '`',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . "\n",
 				false,
 			],
 			[
@@ -600,6 +608,10 @@ class FormatRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 				false,
 			],
 			[
+				' ' . FormatRulesTest::ALPHANUMERIC . "\n",
+				false,
+			],
+			[
 				null,
 				false,
 			],
@@ -634,6 +646,10 @@ class FormatRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 			],
 			[
 				FormatRulesTest::ALPHANUMERIC . '-\ ',
+				false,
+			],
+			[
+				FormatRulesTest::ALPHANUMERIC . "-\n",
 				false,
 			],
 			[
@@ -723,6 +739,10 @@ class FormatRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 				true,
 			],
 			[
+				"+42\n",
+				false,
+			],
+			[
 				'123a',
 				false,
 			],
@@ -770,6 +790,10 @@ class FormatRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 			[
 				'-1',
 				true,
+			],
+			[
+				"+42\n",
+				false,
 			],
 			[
 				'123a',
@@ -823,6 +847,10 @@ class FormatRulesTest extends \CodeIgniter\Test\CIUnitTestCase
 			[
 				'0',
 				true,
+			],
+			[
+				"0\n",
+				false,
 			],
 			[
 				'1.0a',


### PR DESCRIPTION
**Description**
I want it to be false when

```php
<?php
$validation->check("0\n", 'decimal');
```

However, the regular expression validation implemented in CodeIgniter4 allowed a trailing newline code.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide