### PR TITLE
Catch DateTime failure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"codeigniter4/codeigniter4-standard": "^1.0",
 		"fakerphp/faker": "^1.9",
 		"mikey179/vfsstream": "^1.6",
-		"phpstan/phpstan": "^0.12",
+		"phpstan/phpstan": "0.12.65",
 		"phpunit/phpunit": "^8.5 || ^9.1",
 		"predis/predis": "^1.1",
 		"rector/rector": "^0.8",

--- a/system/I18n/Exceptions/I18nException.php
+++ b/system/I18n/Exceptions/I18nException.php
@@ -19,6 +19,19 @@ use CodeIgniter\Exceptions\FrameworkException;
 class I18nException extends FrameworkException
 {
 	/**
+	 * Thrown when createFromFormat fails to receive a valid
+	 * DateTime back from DateTime::createFromFormat.
+	 *
+	 * @param string $format
+	 *
+	 * @return static
+	 */
+	public static function forInvalidFormat(string $format)
+	{
+		return new static(lang('Time.invalidFormat', [$format]));
+	}
+
+	/**
 	 * Thrown when the numeric representation of the month falls
 	 * outside the range of allowed months.
 	 *

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -277,7 +277,10 @@ class Time extends DateTime
 	 */
 	public static function createFromFormat($format, $datetime, $timeZone = null)
 	{
-		$date = parent::createFromFormat($format, $datetime);
+		if (! $date = parent::createFromFormat($format, $datetime))
+		{
+			throw I18nException::forInvalidFormat($format);
+		}
 
 		return new Time($date->format('Y-m-d H:i:s'), $timeZone);
 	}

--- a/system/Language/en/Time.php
+++ b/system/Language/en/Time.php
@@ -11,6 +11,7 @@
 
 // Time language settings
 return [
+	'invalidFormat'  => '"{0}" is not a valid datetime format',
 	'invalidMonth'   => 'Months must be between 1 and 12. Given: {0}',
 	'invalidDay'     => 'Days must be between 1 and 31. Given: {0}',
 	'invalidOverDay' => 'Days must be between 1 and {0}. Given: {1}',

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace CodeIgniter\I18n;
 
+use CodeIgniter\I18n\Exceptions\I18nException;
 use DateTime;
 use DateTimeZone;
 use IntlDateFormatter;
@@ -195,6 +196,16 @@ class TimeTest extends \CodeIgniter\Test\CIUnitTestCase
 		$time = Time::createFromFormat('F j, Y', 'January 15, 2017', $tz);
 
 		$this->assertCloseEnoughString(date('2017-01-15 H:i:s'), $time->toDateTimeString());
+	}
+
+	public function testCreateFromFormatWithInvalidFormat()
+	{
+		$format = 'foobar';
+
+		$this->expectException(I18nException::class);
+		$this->expectExceptionMessage(lang('Time.invalidFormat', [$format]));
+
+		$time = Time::createFromFormat($format, 'America/Chicago');
 	}
 
 	public function testCreateFromTimestamp()


### PR DESCRIPTION
**Description**
If `DateTime::createFromFormat` fails then it causes unexpected behavior in our own `createFromFormat`. This checks for failure (return `false`) and throws an exception.

See: https://www.php.net/manual/en/datetime.createfromformat.php

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
