### PR TITLE
Clarify Renderer discrepancy

### DIFF
--- a/system/Config/View.php
+++ b/system/Config/View.php
@@ -17,6 +17,14 @@ namespace CodeIgniter\Config;
 class View extends BaseConfig
 {
 	/**
+	 * When false, the view method will clear the data between each
+	 * call.
+	 *
+	 * @var boolean
+	 */
+	public $saveData = true;
+
+	/**
 	 * Parser Filters map a filter name with any PHP callable. When the
 	 * Parser prepares a variable for display, it will chain it
 	 * through the filters in the order defined, inserting any parameters.

--- a/system/View/RendererInterface.php
+++ b/system/View/RendererInterface.php
@@ -26,9 +26,7 @@ interface RendererInterface
 	 * @param array   $options  Reserved for 3rd-party uses since
 	 *                          it might be needed to pass additional info
 	 *                          to other template engines.
-	 * @param boolean $saveData If true, will save data for use with any other calls,
-	 *                          if false, will clean the data after displaying the view,
-	 *                             if not specified, use the config setting.
+	 * @param boolean $saveData Whether to save data for subsequent calls
 	 *
 	 * @return string
 	 */
@@ -44,9 +42,7 @@ interface RendererInterface
 	 * @param array   $options  Reserved for 3rd-party uses since
 	 *                          it might be needed to pass additional info
 	 *                          to other template engines.
-	 * @param boolean $saveData If true, will save data for use with any other calls,
-	 *                          if false, will clean the data after displaying the view,
-	 *                             if not specified, use the config setting.
+	 * @param boolean $saveData Whether to save data for subsequent calls
 	 *
 	 * @return string
 	 */

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -155,7 +155,7 @@ class View implements RendererInterface
 	 *  - cache      Number of seconds to cache for
 	 *  - cache_name Name to use for cache
 	 *
-	 * @param string       $view     The view contents
+	 * @param string       $view     File name of the view source
 	 * @param array        $options  Reserved for 3rd-party uses since
 	 *                               it might be needed to pass additional info
 	 *                               to other template engines.

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -152,12 +152,16 @@ class View implements RendererInterface
 	 * data that has already been set.
 	 *
 	 * Valid $options:
-	 *     - cache 		number of seconds to cache for
-	 *  - cache_name	Name to use for cache
+	 *  - cache      Number of seconds to cache for
+	 *  - cache_name Name to use for cache
 	 *
-	 * @param string       $view
-	 * @param array|null   $options
-	 * @param boolean|null $saveData
+	 * @param string       $view     The view contents
+	 * @param array        $options  Reserved for 3rd-party uses since
+	 *                               it might be needed to pass additional info
+	 *                               to other template engines.
+	 * @param boolean|null $saveData If true, saves data for subsequent calls,
+	 *                               if false, cleans the data after displaying,
+	 *                               if null, uses the config setting.
 	 *
 	 * @return string
 	 */
@@ -272,13 +276,13 @@ class View implements RendererInterface
 	 * data that has already been set.
 	 * Cache does not apply, because there is no "key".
 	 *
-	 * @param string  $view     The view contents
-	 * @param array   $options  Reserved for 3rd-party uses since
-	 *                          it might be needed to pass additional info
-	 *                          to other template engines.
-	 * @param boolean $saveData If true, will save data for use with any other calls,
-	 *                          if false, will clean the data after displaying the view,
-	 *                             if not specified, use the config setting.
+	 * @param string       $view     The view contents
+	 * @param array        $options  Reserved for 3rd-party uses since
+	 *                               it might be needed to pass additional info
+	 *                               to other template engines.
+	 * @param boolean|null $saveData If true, saves data for subsequent calls,
+	 *                               if false, cleans the data after displaying,
+	 *                               if null, uses the config setting.
 	 *
 	 * @return string
 	 */

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -142,7 +142,7 @@ class View implements RendererInterface
 		$this->loader   = $loader ?? Services::locator();
 		$this->logger   = $logger ?? Services::logger();
 		$this->debug    = $debug ?? CI_DEBUG;
-		$this->saveData = $config->saveData ?? null;
+		$this->saveData = (bool) $config->saveData;
 	}
 
 	//--------------------------------------------------------------------
@@ -156,7 +156,7 @@ class View implements RendererInterface
 	 *  - cache_name Name to use for cache
 	 *
 	 * @param string       $view     File name of the view source
-	 * @param array        $options  Reserved for 3rd-party uses since
+	 * @param array|null   $options  Reserved for 3rd-party uses since
 	 *                               it might be needed to pass additional info
 	 *                               to other template engines.
 	 * @param boolean|null $saveData If true, saves data for subsequent calls,
@@ -176,7 +176,7 @@ class View implements RendererInterface
 		$fileExt                     = pathinfo($view, PATHINFO_EXTENSION);
 		$realPath                    = empty($fileExt) ? $view . '.php' : $view; // allow Views as .html, .tpl, etc (from CI3)
 		$this->renderVars['view']    = $realPath;
-		$this->renderVars['options'] = $options;
+		$this->renderVars['options'] = $options ?? [];
 
 		// Was it cached?
 		if (isset($this->renderVars['options']['cache']))
@@ -277,7 +277,7 @@ class View implements RendererInterface
 	 * Cache does not apply, because there is no "key".
 	 *
 	 * @param string       $view     The view contents
-	 * @param array        $options  Reserved for 3rd-party uses since
+	 * @param array|null   $options  Reserved for 3rd-party uses since
 	 *                               it might be needed to pass additional info
 	 *                               to other template engines.
 	 * @param boolean|null $saveData If true, saves data for subsequent calls,

--- a/user_guide_src/source/outgoing/view_renderer.rst
+++ b/user_guide_src/source/outgoing/view_renderer.rst
@@ -102,6 +102,9 @@ Several options can be passed to the ``render()`` or ``renderString()`` methods:
 		ignored for renderString()
 -   ``saveData`` - true if the view data parameters should be retained for subsequent calls
 
+.. note:: ``saveData`` as defined by the interface must be a boolean, but implementing
+	classes (like ``View`` below) may extend this to include ``null`` values.
+
 Class Reference
 ***************
 
@@ -110,9 +113,9 @@ Class Reference
 	.. php:method:: render($view[, $options[, $saveData=false]])
                 :noindex:
 
-		:param  string  $view: File name of the view source
-		:param  array   $options: Array of options, as key/value pairs
-		:param  boolean $saveData: If true, will save data for use with any other calls, if false, will clean the data after rendering the view.
+		:param  string       $view: File name of the view source
+		:param  array        $options: Array of options, as key/value pairs
+		:param  boolean|null $saveData: If true, will save data for use with any other calls. If false, will clean the data after rendering the view. If null, uses the config setting.
 		:returns: The rendered text for the chosen view
 		:rtype: string
 
@@ -123,9 +126,9 @@ Class Reference
 	.. php:method:: renderString($view[, $options[, $saveData=false]])
                 :noindex:
 
-		:param  string  $view: Contents of the view to render, for instance content retrieved from a database
-		:param  array   $options: Array of options, as key/value pairs
-		:param  boolean $saveData: If true, will save data for use with any other calls, if false, will clean the data after rendering the view.
+		:param  string       $view: Contents of the view to render, for instance content retrieved from a database
+		:param  array        $options: Array of options, as key/value pairs
+		:param  boolean|null $saveData: If true, will save data for use with any other calls. If false, will clean the data after rendering the view. If null, uses the config setting.
 		:returns: The rendered text for the chosen view
 		:rtype: string
 


### PR DESCRIPTION
**Description**
Fixes a discrepancy between the interface docblock and the actual method definitions. Clarifies the usage in `View`.

* Fixes https://github.com/codeigniter4/CodeIgniter4/issues/4086
* Replaces https://github.com/codeigniter4/CodeIgniter4/pull/4093

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
