### PR TITLE
Cache remember

### DIFF
--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -11,6 +11,8 @@
 
 namespace CodeIgniter\Cache;
 
+use Closure;
+
 /**
  * Cache interface
  */
@@ -31,6 +33,19 @@ interface CacheInterface
 	 * @return mixed
 	 */
 	public function get(string $key);
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Get an item from the cache, or execute the given Closure and store the result.
+	 *
+	 * @param string  $key      Cache item name
+	 * @param integer $ttl      Time to live
+	 * @param Closure $callback Callback return value
+	 *
+	 * @return mixed
+	 */
+	public function remember(string $key, int $ttl, Closure $callback);
 
 	//--------------------------------------------------------------------
 

--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -37,19 +37,6 @@ interface CacheInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * Get an item from the cache, or execute the given Closure and store the result.
-	 *
-	 * @param string  $key      Cache item name
-	 * @param integer $ttl      Time to live
-	 * @param Closure $callback Callback return value
-	 *
-	 * @return mixed
-	 */
-	public function remember(string $key, int $ttl, Closure $callback);
-
-	//--------------------------------------------------------------------
-
-	/**
 	 * Saves an item to the cache store.
 	 *
 	 * @param string  $key   Cache item name

--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -11,8 +11,6 @@
 
 namespace CodeIgniter\Cache;
 
-use Closure;
-
 /**
  * Cache interface
  */

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Cache\Handlers;
+
+use Closure;
+use CodeIgniter\Cache\CacheInterface;
+
+/**
+ * Base class for cache handling
+ */
+abstract class BaseHandler implements CacheInterface
+{
+	/**
+	 * Get an item from the cache, or execute the given Closure and store the result.
+	 *
+	 * @param string  $key      Cache item name
+	 * @param integer $ttl      Time to live
+	 * @param Closure $callback Callback return value
+	 *
+	 * @return mixed
+	 */
+	public function remember(string $key, int $ttl, Closure $callback)
+	{
+		$value = $this->get($key);
+
+		if (! is_null($value))
+		{
+			return $value;
+		}
+
+		$this->save($key, $value = $callback(), $ttl);
+
+		return $value;
+	}
+}

--- a/system/Cache/Handlers/DummyHandler.php
+++ b/system/Cache/Handlers/DummyHandler.php
@@ -11,13 +11,12 @@
 
 namespace CodeIgniter\Cache\Handlers;
 
-use CodeIgniter\Cache\CacheInterface;
 use Closure;
 
 /**
  * Dummy cache handler
  */
-class DummyHandler implements CacheInterface
+class DummyHandler extends BaseHandler
 {
 	/**
 	 * Takes care of any handler-specific setup that must be done.

--- a/system/Cache/Handlers/DummyHandler.php
+++ b/system/Cache/Handlers/DummyHandler.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\CacheInterface;
+use Closure;
 
 /**
  * Dummy cache handler
@@ -36,6 +37,22 @@ class DummyHandler implements CacheInterface
 	 * @return mixed
 	 */
 	public function get(string $key)
+	{
+		return null;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Get an item from the cache, or execute the given Closure and store the result.
+	 *
+	 * @param string  $key      Cache item name
+	 * @param integer $ttl      Time to live
+	 * @param Closure $callback Callback return value
+	 *
+	 * @return mixed
+	 */
+	public function remember(string $key, int $ttl, Closure $callback)
 	{
 		return null;
 	}

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -11,15 +11,13 @@
 
 namespace CodeIgniter\Cache\Handlers;
 
-use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Cache\Exceptions\CacheException;
 use Config\Cache;
-use Closure;
 
 /**
  * File system cache handler
  */
-class FileHandler implements CacheInterface
+class FileHandler extends BaseHandler
 {
 	/**
 	 * Prefixed to all cache names.
@@ -81,31 +79,6 @@ class FileHandler implements CacheInterface
 		$data = $this->getItem($key);
 
 		return is_array($data) ? $data['data'] : null;
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Get an item from the cache, or execute the given Closure and store the result.
-	 *
-	 * @param string  $key      Cache item name
-	 * @param integer $ttl      Time to live
-	 * @param Closure $callback Callback return value
-	 *
-	 * @return mixed
-	 */
-	public function remember(string $key, int $ttl, Closure $callback)
-	{
-		$value = $this->get($key);
-
-		if (! is_null($value))
-		{
-			return $value;
-		}
-
-		$this->save($key, $value = $callback(), $ttl);
-
-		return $value;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Cache\Handlers;
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Cache\Exceptions\CacheException;
 use Config\Cache;
+use Closure;
 
 /**
  * File system cache handler
@@ -80,6 +81,31 @@ class FileHandler implements CacheInterface
 		$data = $this->getItem($key);
 
 		return is_array($data) ? $data['data'] : null;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Get an item from the cache, or execute the given Closure and store the result.
+	 *
+	 * @param string  $key      Cache item name
+	 * @param integer $ttl      Time to live
+	 * @param Closure $callback Callback return value
+	 *
+	 * @return mixed
+	 */
+	public function remember(string $key, int $ttl, Closure $callback)
+	{
+		$value = $this->get($key);
+
+		if (! is_null($value))
+		{
+			return $value;
+		}
+
+		$this->save($key, $value = $callback(), $ttl);
+
+		return $value;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Cache\Handlers;
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Exceptions\CriticalError;
 use Config\Cache;
+use Closure;
 use Exception;
 use Memcache;
 use Memcached;
@@ -192,6 +193,31 @@ class MemcachedHandler implements CacheInterface
 		}
 
 		return is_array($data) ? $data[0] : $data; // @phpstan-ignore-line
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Get an item from the cache, or execute the given Closure and store the result.
+	 *
+	 * @param string  $key      Cache item name
+	 * @param integer $ttl      Time to live
+	 * @param Closure $callback Callback return value
+	 *
+	 * @return mixed
+	 */
+	public function remember(string $key, int $ttl, Closure $callback)
+	{
+		$value = $this->get($key);
+
+		if (! is_null($value))
+		{
+			return $value;
+		}
+
+		$this->save($key, $value = $callback(), $ttl);
+
+		return $value;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -11,10 +11,8 @@
 
 namespace CodeIgniter\Cache\Handlers;
 
-use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Exceptions\CriticalError;
 use Config\Cache;
-use Closure;
 use Exception;
 use Memcache;
 use Memcached;
@@ -22,7 +20,7 @@ use Memcached;
 /**
  * Mamcached cache handler
  */
-class MemcachedHandler implements CacheInterface
+class MemcachedHandler extends BaseHandler
 {
 	/**
 	 * Prefixed to all cache names.
@@ -193,31 +191,6 @@ class MemcachedHandler implements CacheInterface
 		}
 
 		return is_array($data) ? $data[0] : $data; // @phpstan-ignore-line
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Get an item from the cache, or execute the given Closure and store the result.
-	 *
-	 * @param string  $key      Cache item name
-	 * @param integer $ttl      Time to live
-	 * @param Closure $callback Callback return value
-	 *
-	 * @return mixed
-	 */
-	public function remember(string $key, int $ttl, Closure $callback)
-	{
-		$value = $this->get($key);
-
-		if (! is_null($value))
-		{
-			return $value;
-		}
-
-		$this->save($key, $value = $callback(), $ttl);
-
-		return $value;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -11,17 +11,15 @@
 
 namespace CodeIgniter\Cache\Handlers;
 
-use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Exceptions\CriticalError;
 use Config\Cache;
-use Closure;
 use Exception;
 use Predis\Client;
 
 /**
  * Predis cache handler
  */
-class PredisHandler implements CacheInterface
+class PredisHandler extends BaseHandler
 {
 	/**
 	 * Prefixed to all cache names.
@@ -128,31 +126,6 @@ class PredisHandler implements CacheInterface
 			default:
 				return null;
 		}
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Get an item from the cache, or execute the given Closure and store the result.
-	 *
-	 * @param string  $key      Cache item name
-	 * @param integer $ttl      Time to live
-	 * @param Closure $callback Callback return value
-	 *
-	 * @return mixed
-	 */
-	public function remember(string $key, int $ttl, Closure $callback)
-	{
-		$value = $this->get($key);
-
-		if (! is_null($value))
-		{
-			return $value;
-		}
-
-		$this->save($key, $value = $callback(), $ttl);
-
-		return $value;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Cache\Handlers;
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Exceptions\CriticalError;
 use Config\Cache;
+use Closure;
 use Exception;
 use Predis\Client;
 
@@ -127,6 +128,31 @@ class PredisHandler implements CacheInterface
 			default:
 				return null;
 		}
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Get an item from the cache, or execute the given Closure and store the result.
+	 *
+	 * @param string  $key      Cache item name
+	 * @param integer $ttl      Time to live
+	 * @param Closure $callback Callback return value
+	 *
+	 * @return mixed
+	 */
+	public function remember(string $key, int $ttl, Closure $callback)
+	{
+		$value = $this->get($key);
+
+		if (! is_null($value))
+		{
+			return $value;
+		}
+
+		$this->save($key, $value = $callback(), $ttl);
+
+		return $value;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Cache\Handlers;
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Exceptions\CriticalError;
 use Config\Cache;
+use Closure;
 use Redis;
 use RedisException;
 
@@ -159,6 +160,31 @@ class RedisHandler implements CacheInterface
 			default:
 				return null;
 		}
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Get an item from the cache, or execute the given Closure and store the result.
+	 *
+	 * @param string  $key      Cache item name
+	 * @param integer $ttl      Time to live
+	 * @param Closure $callback Callback return value
+	 *
+	 * @return mixed
+	 */
+	public function remember(string $key, int $ttl, Closure $callback)
+	{
+		$value = $this->get($key);
+
+		if (! is_null($value))
+		{
+			return $value;
+		}
+
+		$this->save($key, $value = $callback(), $ttl);
+
+		return $value;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -11,17 +11,15 @@
 
 namespace CodeIgniter\Cache\Handlers;
 
-use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Exceptions\CriticalError;
 use Config\Cache;
-use Closure;
 use Redis;
 use RedisException;
 
 /**
  * Redis cache handler
  */
-class RedisHandler implements CacheInterface
+class RedisHandler extends BaseHandler
 {
 	/**
 	 * Prefixed to all cache names.
@@ -160,31 +158,6 @@ class RedisHandler implements CacheInterface
 			default:
 				return null;
 		}
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Get an item from the cache, or execute the given Closure and store the result.
-	 *
-	 * @param string  $key      Cache item name
-	 * @param integer $ttl      Time to live
-	 * @param Closure $callback Callback return value
-	 *
-	 * @return mixed
-	 */
-	public function remember(string $key, int $ttl, Closure $callback)
-	{
-		$value = $this->get($key);
-
-		if (! is_null($value))
-		{
-			return $value;
-		}
-
-		$this->save($key, $value = $callback(), $ttl);
-
-		return $value;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -11,16 +11,14 @@
 
 namespace CodeIgniter\Cache\Handlers;
 
-use CodeIgniter\Cache\CacheInterface;
 use Config\Cache;
-use Closure;
 
 /**
  * Cache handler for WinCache from Microsoft & IIS.
  * Windows-only, so not testable on travis-ci.
  * Unusable methods flagged for code coverage ignoring.
  */
-class WincacheHandler implements CacheInterface
+class WincacheHandler extends BaseHandler
 {
 	/**
 	 * Prefixed to all cache names.
@@ -73,31 +71,6 @@ class WincacheHandler implements CacheInterface
 
 		// Success returned by reference from wincache_ucache_get()
 		return ($success) ? $data : null;
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * Get an item from the cache, or execute the given Closure and store the result.
-	 *
-	 * @param string  $key      Cache item name
-	 * @param integer $ttl      Time to live
-	 * @param Closure $callback Callback return value
-	 *
-	 * @return mixed
-	 */
-	public function remember(string $key, int $ttl, Closure $callback)
-	{
-		$value = $this->get($key);
-
-		if (! is_null($value))
-		{
-			return $value;
-		}
-
-		$this->save($key, $value = $callback(), $ttl);
-
-		return $value;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\CacheInterface;
 use Config\Cache;
+use Closure;
 
 /**
  * Cache handler for WinCache from Microsoft & IIS.
@@ -72,6 +73,31 @@ class WincacheHandler implements CacheInterface
 
 		// Success returned by reference from wincache_ucache_get()
 		return ($success) ? $data : null;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Get an item from the cache, or execute the given Closure and store the result.
+	 *
+	 * @param string  $key      Cache item name
+	 * @param integer $ttl      Time to live
+	 * @param Closure $callback Callback return value
+	 *
+	 * @return mixed
+	 */
+	public function remember(string $key, int $ttl, Closure $callback)
+	{
+		$value = $this->get($key);
+
+		if (! is_null($value))
+		{
+			return $value;
+		}
+
+		$this->save($key, $value = $callback(), $ttl);
+
+		return $value;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Test\Mock;
 
 use CodeIgniter\Cache\CacheInterface;
+use Closure;
 
 class MockCache implements CacheInterface
 {
@@ -55,6 +56,31 @@ class MockCache implements CacheInterface
 		return array_key_exists($key, $this->cache)
 			? $this->cache[$key]
 			: null;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Get an item from the cache, or execute the given Closure and store the result.
+	 *
+	 * @param string  $key      Cache item name
+	 * @param integer $ttl      Time to live
+	 * @param Closure $callback Callback return value
+	 *
+	 * @return mixed
+	 */
+	public function remember(string $key, int $ttl, Closure $callback)
+	{
+		$value = $this->get($key);
+
+		if (! is_null($value))
+		{
+			return $value;
+		}
+
+		$this->save($key, $value = $callback(), $ttl);
+
+		return $value;
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Cache/Handlers/DummyHandlerTest.php
+++ b/tests/system/Cache/Handlers/DummyHandlerTest.php
@@ -20,6 +20,15 @@ class DummyHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertNull($this->dummyHandler->get('key'));
 	}
 
+	public function testRemember()
+	{
+		$dummyHandler = $this->dummyHandler->remember('key', 2, function () {
+			return 'value';
+		});
+
+		$this->assertNull($dummyHandler);
+	}
+
 	public function testSave()
 	{
 		$this->assertTrue($this->dummyHandler->save('key', 'value'));

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -94,6 +94,19 @@ class FileHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertNull($this->fileHandler->get(self::$key1));
 	}
 
+	public function testRemember()
+	{
+		$this->fileHandler->remember(self::$key1, 2, function () {
+			return 'value';
+		});
+
+		$this->assertSame('value', $this->fileHandler->get(self::$key1));
+		$this->assertNull($this->fileHandler->get(self::$dummy));
+
+		\CodeIgniter\CLI\CLI::wait(3);
+		$this->assertNull($this->fileHandler->get(self::$key1));
+	}
+
 	public function testSave()
 	{
 		$this->assertTrue($this->fileHandler->save(self::$key1, 'value'));

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -57,6 +57,19 @@ class MemcachedHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertNull($this->memcachedHandler->get(self::$key1));
 	}
 
+	public function testRemember()
+	{
+		$this->memcachedHandler->remember(self::$key1, 2, function () {
+			return 'value';
+		});
+
+		$this->assertSame('value', $this->memcachedHandler->get(self::$key1));
+		$this->assertNull($this->memcachedHandler->get(self::$dummy));
+
+		\CodeIgniter\CLI\CLI::wait(3);
+		$this->assertNull($this->memcachedHandler->get(self::$key1));
+	}
+
 	public function testSave()
 	{
 		$this->assertTrue($this->memcachedHandler->save(self::$key1, 'value'));

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -65,6 +65,19 @@ class PredisHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertNull($this->PredisHandler->get(self::$key1));
 	}
 
+	public function testRemember()
+	{
+		$this->PredisHandler->remember(self::$key1, 2, function () {
+			return 'value';
+		});
+
+		$this->assertSame('value', $this->PredisHandler->get(self::$key1));
+		$this->assertNull($this->PredisHandler->get(self::$dummy));
+
+		\CodeIgniter\CLI\CLI::wait(3);
+		$this->assertNull($this->PredisHandler->get(self::$key1));
+	}
+
 	public function testSave()
 	{
 		$this->assertTrue($this->PredisHandler->save(self::$key1, 'value'));

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -103,15 +103,15 @@ class RedisHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testRemember()
 	{
-		$this->fileHandler->remember(self::$key1, 2, function () {
+		$this->redisHandler->remember(self::$key1, 2, function () {
 			return 'value';
 		});
 
-		$this->assertSame('value', $this->fileHandler->get(self::$key1));
-		$this->assertNull($this->fileHandler->get(self::$dummy));
+		$this->assertSame('value', $this->redisHandler->get(self::$key1));
+		$this->assertNull($this->redisHandler->get(self::$dummy));
 
 		\CodeIgniter\CLI\CLI::wait(3);
-		$this->assertNull($this->fileHandler->get(self::$key1));
+		$this->assertNull($this->redisHandler->get(self::$key1));
 	}
 
 	public function testSave()

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -101,6 +101,19 @@ class RedisHandlerTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertNull($this->redisHandler->get(self::$key1));
 	}
 
+	public function testRemember()
+	{
+		$this->fileHandler->remember(self::$key1, 2, function () {
+			return 'value';
+		});
+
+		$this->assertSame('value', $this->fileHandler->get(self::$key1));
+		$this->assertNull($this->fileHandler->get(self::$dummy));
+
+		\CodeIgniter\CLI\CLI::wait(3);
+		$this->assertNull($this->fileHandler->get(self::$key1));
+	}
+
 	public function testSave()
 	{
 		$this->assertTrue($this->redisHandler->save(self::$key1, 'value'));

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -80,7 +80,7 @@ Class Reference
 	:returns: ``true`` if supported, ``false`` if not
 	:rtype:	bool
 
-.. php:method:: get(string $key)
+.. php:method:: get($key)
 
 	:param string $key: Cache item name
 	:returns: Item value or ``null`` if not found
@@ -123,7 +123,7 @@ Class Reference
 .. note:: The ``$raw`` parameter is only utilized by Memcache,
 		  in order to allow usage of ``increment()`` and ``decrement()``.
 
-.. php:method:: delete(string $key)
+.. php:method:: delete($key)
 
 	:param string $key: name of cached item
 	:returns: ``true`` on success, ``false`` on failure
@@ -136,7 +136,7 @@ Class Reference
 
 		$cache->delete('cache_item_id');
 
-.. php:method:: increment(string $key[, int $offset = 1])
+.. php:method:: increment($key[, $offset = 1])
 
 	:param string $key: Cache ID
 	:param int $offset: Step/value to add
@@ -151,7 +151,7 @@ Class Reference
 		$cache->increment('iterator'); // 'iterator' is now 3
 		$cache->increment('iterator', 3); // 'iterator' is now 6
 
-.. php:method:: decrement(string $key[, int $offset = 1])
+.. php:method:: decrement($key[, $offset = 1])
 
 	:param string $key: Cache ID
 	:param int $offset: Step/value to reduce by

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -19,7 +19,7 @@ The following example shows a common usage pattern within your controllers.
 
 ::
 
-	if ( ! $foo = cache('foo'))
+	if (! $foo = cache('foo'))
 	{
 		echo 'Saving to the cache!<br />';
 		$foo = 'foobarbaz!';
@@ -75,15 +75,15 @@ The settings for the Redis server that you wish to use when using the ``Redis`` 
 Class Reference
 ***************
 
-.. php:method:: ⠀isSupported()
+.. php:method:: isSupported()
 
-	:returns:	TRUE if supported, FALSE if not
+	:returns: ``true`` if supported, ``false`` if not
 	:rtype:	bool
 
-.. php:method:: ⠀get($key)
+.. php:method:: get(string $key)
 
-	:param	string	$key: Cache item name
-	:returns:	Item value or NULL if not found
+	:param string $key: Cache item name
+	:returns: Item value or ``null`` if not found
 	:rtype:	mixed
 
 	This method will attempt to fetch an item from the cache store. If the
@@ -93,17 +93,28 @@ Class Reference
 
 		$foo = $cache->get('my_cached_item');
 
-.. php:method:: ⠀save($key, $data[, $ttl = 60[, $raw = FALSE]])
+.. php:method:: remember(string $key, int $ttl, Closure $callback)
 
-	:param	string	$key: Cache item name
-	:param	mixed	$data: the data to save
-	:param	int	$ttl: Time To Live, in seconds (default 60)
-	:param	bool	$raw: Whether to store the raw value
-	:returns:	TRUE on success, FALSE on failure
+	:param string $key: Ccahe item name
+	:param int $ttl: Time to live in seconds
+	:param Closure $callback: Callback to invoke when the cache item returns null
+	:returns: The value of the cache item
+	:rtype: mixed
+	
+	Gets an item from the cache. If ``null`` was returned, this will invoke the callback
+	and save the result. Either way, this will return the value.
+
+.. php:method::⠀save(string $key, $data[, int $ttl = 60[, $raw = false]])
+
+	:param string $key: Cache item name
+	:param mixed $data: the data to save
+	:param int $ttl: Time To Live, in seconds (default 60)
+	:param bool $raw: Whether to store the raw value
+	:returns: ``true`` on success, ``false`` on failure
 	:rtype:	bool
 
 	This method will save an item to the cache store. If saving fails, the
-	method will return FALSE.
+	method will return ``false``.
 
 	Example::
 
@@ -112,10 +123,10 @@ Class Reference
 .. note:: The ``$raw`` parameter is only utilized by Memcache,
 		  in order to allow usage of ``increment()`` and ``decrement()``.
 
-.. php:method:: ⠀delete($key)
+.. php:method:: delete(string $key)
 
-	:param	string	$key: name of cached item
-	:returns:	TRUE on success, FALSE on failure
+	:param string $key: name of cached item
+	:returns: ``true`` on success, ``false`` on failure
 	:rtype:	bool
 
 	This method will delete a specific item from the cache store. If item
@@ -125,11 +136,11 @@ Class Reference
 
 		$cache->delete('cache_item_id');
 
-.. php:method:: ⠀increment($key[, $offset = 1])
+.. php:method:: increment(string $key[, int $offset = 1])
 
-	:param	string	$key: Cache ID
-	:param	int	$offset: Step/value to add
-	:returns:	New value on success, FALSE on failure
+	:param string $key: Cache ID
+	:param int $offset: Step/value to add
+	:returns: New value on success, ``false`` on failure
    	:rtype:	mixed
 
 	Performs atomic incrementation of a raw stored value.
@@ -137,16 +148,14 @@ Class Reference
 	Example::
 
 		// 'iterator' has a value of 2
-
 		$cache->increment('iterator'); // 'iterator' is now 3
-
 		$cache->increment('iterator', 3); // 'iterator' is now 6
 
-.. php:method:: ⠀decrement($key[, $offset = 1])
+.. php:method:: decrement(string $key[, int $offset = 1])
 
-	:param	string	$key: Cache ID
-	:param	int	$offset: Step/value to reduce by
-	:returns:	New value on success, FALSE on failure
+	:param string $key: Cache ID
+	:param int $offset: Step/value to reduce by
+	:returns: New value on success, ``false`` on failure
 	:rtype:	mixed
 
 	Performs atomic decrementation of a raw stored value.
@@ -154,14 +163,12 @@ Class Reference
 	Example::
 
 		// 'iterator' has a value of 6
-
 		$cache->decrement('iterator'); // 'iterator' is now 5
-
 		$cache->decrement('iterator', 2); // 'iterator' is now 3
 
-.. php:method:: ⠀clean()
+.. php:method:: clean()
 
-	:returns:	TRUE on success, FALSE on failure
+	:returns: ``true`` on success, ``false`` on failure
 	:rtype:	bool
 
 	This method will 'clean' the entire cache. If the deletion of the
@@ -171,9 +178,9 @@ Class Reference
 
 			$cache->clean();
 
-.. php:method:: ⠀getCacheInfo()
+.. php:method:: getCacheInfo()
 
-	:returns:	Information on the entire cache database
+	:returns: Information on the entire cache database
 	:rtype:	mixed
 
 	This method will return information on the entire cache.
@@ -185,10 +192,10 @@ Class Reference
 .. note:: The information returned and the structure of the data is dependent
 		  on which adapter is being used.
 
-.. php:method:: ⠀getMetadata($key)
+.. php:method:: getMetadata(string $key)
 
-	:param	string	$key: Cache item name
-	:returns:	Metadata for the cached item
+	:param string $key: Cache item name
+	:returns: Metadata for the cached item
 	:rtype:	mixed
 
 	This method will return detailed information on a specific item in the

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -80,7 +80,7 @@ Class Reference
 	:returns: ``true`` if supported, ``false`` if not
 	:rtype:	bool
 
-.. php:method:: get($key)
+.. php:method:: get($key): mixed
 
 	:param string $key: Cache item name
 	:returns: Item value or ``null`` if not found
@@ -123,7 +123,7 @@ Class Reference
 .. note:: The ``$raw`` parameter is only utilized by Memcache,
 		  in order to allow usage of ``increment()`` and ``decrement()``.
 
-.. php:method:: delete($key)
+.. php:method:: delete($key): bool
 
 	:param string $key: name of cached item
 	:returns: ``true`` on success, ``false`` on failure
@@ -136,7 +136,7 @@ Class Reference
 
 		$cache->delete('cache_item_id');
 
-.. php:method:: increment($key[, $offset = 1])
+.. php:method:: increment($key[, $offset = 1]): mixed
 
 	:param string $key: Cache ID
 	:param int $offset: Step/value to add
@@ -151,7 +151,7 @@ Class Reference
 		$cache->increment('iterator'); // 'iterator' is now 3
 		$cache->increment('iterator', 3); // 'iterator' is now 6
 
-.. php:method:: decrement($key[, $offset = 1])
+.. php:method:: decrement($key[, $offset = 1]): mixed
 
 	:param string $key: Cache ID
 	:param int $offset: Step/value to reduce by


### PR DESCRIPTION
**Description**
Retrieve & Store cache
Sometimes we wish to retrieve an item from the cache, but also store a default value if the requested item doesn't exist.
Usage:
```php
$value = Service::cache->remember('sample', 3600, function () {
    return [
       'sample' => 'data',
    ];
});
``` 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  
