### PR TITLE
Precise exception trace

### DIFF
--- a/system/CLI/Exceptions/CLIException.php
+++ b/system/CLI/Exceptions/CLIException.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\CLI\Exceptions;
 
+use CodeIgniter\Exceptions\DebugTraceableTrait;
 use RuntimeException;
 
 /**
@@ -18,6 +19,8 @@ use RuntimeException;
  */
 class CLIException extends RuntimeException
 {
+	use DebugTraceableTrait;
+
 	/**
 	 * Thrown when `$color` specified for `$type` is not within the
 	 * allowed list of colors.

--- a/system/Cache/Exceptions/CacheException.php
+++ b/system/Cache/Exceptions/CacheException.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Cache\Exceptions;
 
+use CodeIgniter\Exceptions\DebugTraceableTrait;
 use RuntimeException;
 
 /**
@@ -18,6 +19,8 @@ use RuntimeException;
  */
 class CacheException extends RuntimeException implements ExceptionInterface
 {
+	use DebugTraceableTrait;
+
 	/**
 	 * Thrown when handler has no permission to write cache.
 	 *

--- a/system/Database/Exceptions/DataException.php
+++ b/system/Database/Exceptions/DataException.php
@@ -11,10 +11,13 @@
 
 namespace CodeIgniter\Database\Exceptions;
 
+use CodeIgniter\Exceptions\DebugTraceableTrait;
 use RuntimeException;
 
 class DataException extends RuntimeException implements ExceptionInterface
 {
+	use DebugTraceableTrait;
+
 	/**
 	 * Used by the Model's trigger() method when the callback cannot be found.
 	 *

--- a/system/Encryption/Exceptions/EncryptionException.php
+++ b/system/Encryption/Exceptions/EncryptionException.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Encryption\Exceptions;
 
+use CodeIgniter\Exceptions\DebugTraceableTrait;
 use CodeIgniter\Exceptions\ExceptionInterface;
 use RuntimeException;
 
@@ -19,6 +20,8 @@ use RuntimeException;
  */
 class EncryptionException extends RuntimeException implements ExceptionInterface
 {
+	use DebugTraceableTrait;
+
 	/**
 	 * Thrown when no driver is present in the active encryption session.
 	 *

--- a/system/Exceptions/CastException.php
+++ b/system/Exceptions/CastException.php
@@ -16,6 +16,8 @@ namespace CodeIgniter\Exceptions;
  */
 class CastException extends CriticalError
 {
+	use DebugTraceableTrait;
+
 	/**
 	 * Error code
 	 *

--- a/system/Exceptions/ConfigException.php
+++ b/system/Exceptions/ConfigException.php
@@ -16,6 +16,8 @@ namespace CodeIgniter\Exceptions;
  */
 class ConfigException extends CriticalError
 {
+	use DebugTraceableTrait;
+
 	/**
 	 * Error code
 	 *

--- a/system/Exceptions/DebugTraceableTrait.php
+++ b/system/Exceptions/DebugTraceableTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CodeIgniter\Exceptions;
+
+use Throwable;
+
+/**
+ * This trait provides framework exceptions the ability to pinpoint
+ * accurately where the exception was raised rather than instantiated.
+ *
+ * This is used primarily for factory-instantiated exceptions.
+ */
+trait DebugTraceableTrait
+{
+	/**
+	 * Tweaks the exception's constructor to assign the file/line to where
+	 * it is actually raised rather than were it is instantiated.
+	 *
+	 * @param string         $message
+	 * @param integer        $code
+	 * @param Throwable|null $previous
+	 */
+	public function __construct(string $message = '', int $code = 0, Throwable $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+
+		$trace = $this->getTrace()[0];
+
+		if (isset($trace['class']) && $trace['class'] === static::class)
+		{
+			['line' => $this->line, 'file' => $this->file] = $trace;
+		}
+	}
+}

--- a/system/Exceptions/DownloadException.php
+++ b/system/Exceptions/DownloadException.php
@@ -18,6 +18,8 @@ use RuntimeException;
  */
 class DownloadException extends RuntimeException implements ExceptionInterface
 {
+	use DebugTraceableTrait;
+
 	public static function forCannotSetFilePath(string $path)
 	{
 		return new static(lang('HTTP.cannotSetFilepath', [$path]));

--- a/system/Exceptions/FrameworkException.php
+++ b/system/Exceptions/FrameworkException.php
@@ -21,6 +21,8 @@ use RuntimeException;
  */
 class FrameworkException extends RuntimeException implements ExceptionInterface
 {
+	use DebugTraceableTrait;
+
 	public static function forEnabledZlibOutputCompression()
 	{
 		return new static(lang('Core.enabledZlibOutputCompression'));

--- a/system/Exceptions/PageNotFoundException.php
+++ b/system/Exceptions/PageNotFoundException.php
@@ -15,6 +15,8 @@ use OutOfBoundsException;
 
 class PageNotFoundException extends OutOfBoundsException implements ExceptionInterface
 {
+	use DebugTraceableTrait;
+
 	/**
 	 * Error code
 	 *

--- a/system/Files/Exceptions/FileException.php
+++ b/system/Files/Exceptions/FileException.php
@@ -11,11 +11,14 @@
 
 namespace CodeIgniter\Files\Exceptions;
 
+use CodeIgniter\Exceptions\DebugTraceableTrait;
 use CodeIgniter\Exceptions\ExceptionInterface;
 use RuntimeException;
 
 class FileException extends RuntimeException implements ExceptionInterface
 {
+	use DebugTraceableTrait;
+
 	public static function forUnableToMove(string $from = null, string $to = null, string $error = null)
 	{
 		return new static(lang('Files.cannotMove', [$from, $to, $error]));

--- a/system/Files/Exceptions/FileNotFoundException.php
+++ b/system/Files/Exceptions/FileNotFoundException.php
@@ -11,11 +11,14 @@
 
 namespace CodeIgniter\Files\Exceptions;
 
+use CodeIgniter\Exceptions\DebugTraceableTrait;
 use CodeIgniter\Exceptions\ExceptionInterface;
 use RuntimeException;
 
 class FileNotFoundException extends RuntimeException implements ExceptionInterface
 {
+	use DebugTraceableTrait;
+
 	public static function forFileNotFound(string $path)
 	{
 		return new static(lang('Files.fileNotFound', [$path]));

--- a/system/Format/Exceptions/FormatException.php
+++ b/system/Format/Exceptions/FormatException.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Format\Exceptions;
 
+use CodeIgniter\Exceptions\DebugTraceableTrait;
 use CodeIgniter\Exceptions\ExceptionInterface;
 use RuntimeException;
 
@@ -19,6 +20,8 @@ use RuntimeException;
  */
 class FormatException extends RuntimeException implements ExceptionInterface
 {
+	use DebugTraceableTrait;
+
 	/**
 	 * Thrown when the instantiated class does not exist.
 	 *

--- a/tests/system/DebugTraceableTraitTest.php
+++ b/tests/system/DebugTraceableTraitTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace CodeIgniter;
+
+use CodeIgniter\Exceptions\DebugTraceableTrait;
+use CodeIgniter\Exceptions\FrameworkException;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @covers \CodeIgniter\Exceptions\DebugTraceableTrait
+ */
+final class DebugTraceableTraitTest extends CIUnitTestCase
+{
+	public function testFactoryInstanceReturnsWhereItIsRaised(): void
+	{
+		$e1 = new FrameworkException('I am on line 16');
+		$e2 = FrameworkException::forEnabledZlibOutputCompression();
+
+		$this->assertContainsEquals(DebugTraceableTrait::class, class_uses(FrameworkException::class));
+		$this->assertSame(16, $e1->getLine());
+		$this->assertSame(__FILE__, $e1->getFile());
+		$this->assertSame(17, $e2->getLine());
+		$this->assertSame(__FILE__, $e2->getFile());
+	}
+}


### PR DESCRIPTION
**Description**
When using the normal way of instantiating exceptions, the `getLine` and `getFile` will show where it is raised:
```
// file1.php
$e = new Exception('');
var_dump($e->getFile()); // file1.php
```

However, when using the framework's way of calling exceptions, `getLine` and `getFile` will show where it is instantiated, i.e., inside the exception's factory static methods.
```
// file2.php
$e = FrameworkException::forCopyError();
var_dump($e->getFile()); // FrameworkException.php
```

This PR resolves this by assigning to the `$line` and `$file` property of the exception the `debug_backtrace` function's second array, which is the place where the exception is raised. For this purpose, this creates the `DebugTraceableTrait::trace()` which does that.

Fixes #4110 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide
