### PR TITLE
Introducing new URL helper method called this_url().

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -130,7 +130,7 @@ if (! function_exists('current_url'))
 	 * Returns the full URL (including segments) of the page where this
 	 * function is placed
 	 *
-	 * @param boolean $returnObject True to return an object instead of a strong
+	 * @param boolean $returnObject True to return an object instead of a string
 	 *
 	 * @return string|URI
 	 */
@@ -140,6 +140,37 @@ if (! function_exists('current_url'))
 
 		// Since we're basing off of the IncomingRequest URI,
 		// we are guaranteed to have a host based on our own configs.
+		return $returnObject ? $uri : (string) $uri->setQuery('');
+	}
+}
+
+//--------------------------------------------------------------------
+
+if (! function_exists('this_url'))
+{
+	/**
+	 * This method is pretty much the same as current_url().
+	 * The only difference is this method is based on the site_url() instead of base_url().
+	 *
+	 * @param boolean $returnObject True to return an object instead of a string
+	 *
+	 * @return string|\CodeIgniter\HTTP\URI
+	 */
+	function this_url(bool $returnObject = false)
+	{
+		$uriCopy = clone Services::request()->uri;
+		$path    = $uriCopy->getPath();
+
+		$url = site_url('/');
+
+		if (! empty($path)) 
+		{
+			$url .= $path;
+		}
+
+		$uri = new URI($url);
+		$uri->setQuery($uriCopy->getQuery());
+		
 		return $returnObject ? $uri : (string) $uri->setQuery('');
 	}
 }

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -447,6 +447,99 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	}
 
 	//--------------------------------------------------------------------
+	// Test this_url
+
+	public function testThisURLReturnsBasicURL()
+	{
+		// Since we're on a CLI, we must provide our own URI
+		$this->config->baseURL = 'http://example.com/public';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/public/index.php/test');
+
+		Services::injectMock('request', $request);
+
+		$this->assertEquals('http://example.com/public/index.php/test', this_url());
+	}
+
+	public function testThisURLReturnsObject()
+	{
+		// Since we're on a CLI, we must provide our own URI
+		$this->config->baseURL = 'http://example.com/public';
+		$request               = Services::request($this->config);
+		$request->uri          = new URI('http://example.com/public/index.php/test');
+
+		Services::injectMock('request', $request);
+
+		$url = this_url(true);
+
+		$this->assertInstanceOf(URI::class, $url);
+		$this->assertEquals('http://example.com/public/index.php/test', (string) $url);
+	}
+
+	public function testThisURLEquivalence()
+	{
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/public';
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
+
+		// Since we're on a CLI, we must provide our own URI
+		Config::injectMock('App', $this->config);
+
+		$request = Services::request($this->config);
+		Services::injectMock('request', $request);
+
+		$this->assertEquals(site_url(uri_string()), this_url());
+	}
+
+	public function testThisURLInSubfolder()
+	{
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/foo/public/bar?baz=quip';
+		$_SERVER['SCRIPT_NAME'] = '/foo/public/index.php';
+
+		// Since we're on a CLI, we must provide our own URI
+		$this->config->baseURL = 'http://example.com/foo/public';
+		Config::injectMock('App', $this->config);
+
+		$request = Services::request($this->config);
+		Services::injectMock('request', $request);
+
+		$this->assertEquals('http://example.com/foo/public/index.php/bar', this_url());
+		$this->assertEquals('http://example.com/foo/public/index.php/bar?baz=quip', (string) this_url(true));
+
+		$uri = this_url(true);
+		$this->assertEquals(['bar'], $uri->getSegments());
+		$this->assertEquals('bar', $uri->getSegment(1));
+		$this->assertEquals('example.com', $uri->getHost());
+		$this->assertEquals('http', $uri->getScheme());
+	}
+
+	public function testThisURLWithPortInSubfolder()
+	{
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['SERVER_PORT'] = '8080';
+		$_SERVER['REQUEST_URI'] = '/foo/public/bar?baz=quip';
+		$_SERVER['SCRIPT_NAME'] = '/foo/public/index.php';
+
+		// Since we're on a CLI, we must provide our own URI
+		$this->config->baseURL = 'http://example.com:8080/foo/public';
+		Config::injectMock('App', $this->config);
+
+		$request = Services::request($this->config);
+		Services::injectMock('request', $request);
+
+		$this->assertEquals('http://example.com:8080/foo/public/index.php/bar', this_url());
+		$this->assertEquals('http://example.com:8080/foo/public/index.php/bar?baz=quip', (string) this_url(true));
+
+		$uri = this_url(true);
+		$this->assertEquals(['bar'], $uri->getSegments());
+		$this->assertEquals('bar', $uri->getSegment(1));
+		$this->assertEquals('example.com', $uri->getHost());
+		$this->assertEquals('http', $uri->getScheme());
+		$this->assertEquals('8080', $uri->getPort());
+	}
+
+	//--------------------------------------------------------------------
 	// Test previous_url
 
 	public function testPreviousURLUsesSessionFirst()


### PR DESCRIPTION
This PR address #4116 issue.

A new method that mostly same as the current_url(). But based on the site_url() instead of base_url().

Thanks.