### PR TITLE
Fix Session phpdoc

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -479,7 +479,7 @@ class Session implements SessionInterface
 	 * to be set as session properties.
 	 *
 	 * @param string|array $data  Property name or associative array of properties
-	 * @param string|array $value Property value if single key provided
+	 * @param mixed        $value Property value if single key provided
 	 */
 	public function set($data, $value = null)
 	{
@@ -514,8 +514,8 @@ class Session implements SessionInterface
 	 *
 	 * Replaces the legacy method $session->userdata();
 	 *
-	 * @param  string $key Identifier of the session property to retrieve
-	 * @return array|null	The property value(s)
+	 * @param  string|null $key Identifier of the session property to retrieve
+	 * @return mixed	The property value(s)
 	 */
 	public function get(string $key = null)
 	{

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -697,7 +697,7 @@ class Session implements SessionInterface
 	 * If the item key is null, return all flashdata.
 	 *
 	 * @param  string $key Property identifier
-	 * @return array|null	The requested property value, or an associative array  of them
+	 * @return array|null	The requested property value, or an associative array of them
 	 */
 	public function getFlashdata(string $key = null)
 	{

--- a/system/Session/SessionInterface.php
+++ b/system/Session/SessionInterface.php
@@ -42,7 +42,7 @@ interface SessionInterface
 	 * to be set as session properties.
 	 *
 	 * @param string|array $data  Property name or associative array of properties
-	 * @param string|array $value Property value if single key provided
+	 * @param mixed        $value Property value if single key provided
 	 */
 	public function set($data, $value = null);
 
@@ -59,7 +59,7 @@ interface SessionInterface
 	 *
 	 * @param string $key Identifier of the session property to retrieve
 	 *
-	 * @return array|null    The property value(s)
+	 * @return mixed The property value(s)
 	 */
 	public function get(string $key = null);
 


### PR DESCRIPTION
**Description**
You can set not only `string|array`, but also int, bool, object in the Session.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

