### PR TITLE
Fix `@var` in SessionTestCase.

### DIFF
--- a/admin/module/tests/_support/SessionTestCase.php
+++ b/admin/module/tests/_support/SessionTestCase.php
@@ -1,13 +1,14 @@
 <?php namespace Tests\Support;
 
 use CodeIgniter\Session\Handlers\ArrayHandler;
+use CodeIgniter\Session\SessionInterface;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockSession;
 
 class SessionTestCase extends CIUnitTestCase
 {
 	/**
-	 * @var SessionHandler
+	 * @var SessionInterface
 	 */
 	protected $session;
 

--- a/admin/starter/tests/_support/SessionTestCase.php
+++ b/admin/starter/tests/_support/SessionTestCase.php
@@ -1,13 +1,14 @@
 <?php namespace Tests\Support;
 
 use CodeIgniter\Session\Handlers\ArrayHandler;
+use CodeIgniter\Session\SessionInterface;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockSession;
 
 class SessionTestCase extends CIUnitTestCase
 {
 	/**
-	 * @var SessionHandler
+	 * @var SessionInterface
 	 */
 	protected $session;
 


### PR DESCRIPTION
**Description**
Fix `@var` in SessionTestCase.
`MockSession` is not `SessionHandler`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

