### PR TITLE
Fix errors/html/error_exception.php

### DIFF
--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -178,7 +178,7 @@
 							<tr>
 								<td><?= htmlspecialchars($key, ENT_IGNORE, 'UTF-8') ?></td>
 								<td>
-									<?php if (! is_array($value) && ! is_object($value) && ! is_resource($value)) : ?>
+									<?php if (is_string($value)) : ?>
 										<?= htmlspecialchars($value, ENT_SUBSTITUTE, 'UTF-8') ?>
 									<?php else: ?>
 										<?= '<pre>' . print_r($value, true) ?>
@@ -253,7 +253,7 @@
 							<tr>
 								<td><?= htmlspecialchars($key, ENT_IGNORE, 'UTF-8') ?></td>
 								<td>
-									<?php if (! is_array($value) && ! is_object($value)) : ?>
+									<?php if (is_string($value)) : ?>
 										<?= htmlspecialchars($value, ENT_SUBSTITUTE, 'UTF-8') ?>
 									<?php else: ?>
 										<?= '<pre>' . print_r($value, true) ?>

--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -97,7 +97,7 @@
 										foreach ($row['args'] as $key => $value) : ?>
 											<tr>
 												<td><code><?= htmlspecialchars(isset($params[$key]) ? '$' . $params[$key]->name : "#$key", ENT_SUBSTITUTE, 'UTF-8') ?></code></td>
-												<td><pre><?= print_r($value, true) ?></pre></td>
+												<td><pre><?= htmlspecialchars(print_r($value, true), ENT_SUBSTITUTE, 'UTF-8') ?></pre></td>
 											</tr>
 										<?php endforeach ?>
 
@@ -151,7 +151,7 @@
 									<?php if (is_string($value)) : ?>
 										<?= htmlspecialchars($value, ENT_SUBSTITUTE, 'UTF-8') ?>
 									<?php else: ?>
-										<pre><?= print_r($value, true) ?></pre>
+										<pre><?= htmlspecialchars(print_r($value, true), ENT_SUBSTITUTE, 'UTF-8') ?></pre>
 									<?php endif; ?>
 								</td>
 							</tr>
@@ -181,7 +181,7 @@
 									<?php if (is_string($value)) : ?>
 										<?= htmlspecialchars($value, ENT_SUBSTITUTE, 'UTF-8') ?>
 									<?php else: ?>
-										<pre><?= print_r($value, true) ?></pre>
+										<pre><?= htmlspecialchars(print_r($value, true), ENT_SUBSTITUTE, 'UTF-8') ?></pre>
 									<?php endif; ?>
 								</td>
 							</tr>
@@ -256,7 +256,7 @@
 									<?php if (is_string($value)) : ?>
 										<?= htmlspecialchars($value, ENT_SUBSTITUTE, 'UTF-8') ?>
 									<?php else: ?>
-										<pre><?= print_r($value, true) ?></pre>
+										<pre><?= htmlspecialchars(print_r($value, true), ENT_SUBSTITUTE, 'UTF-8') ?></pre>
 									<?php endif; ?>
 								</td>
 							</tr>

--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -178,7 +178,7 @@
 							<tr>
 								<td><?= htmlspecialchars($key, ENT_IGNORE, 'UTF-8') ?></td>
 								<td>
-									<?php if (! is_array($value) && ! is_object($value)) : ?>
+									<?php if (! is_array($value) && ! is_object($value) && ! is_resource($value)) : ?>
 										<?= htmlspecialchars($value, ENT_SUBSTITUTE, 'UTF-8') ?>
 									<?php else: ?>
 										<?= '<pre>' . print_r($value, true) ?>

--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -151,7 +151,7 @@
 									<?php if (is_string($value)) : ?>
 										<?= htmlspecialchars($value, ENT_SUBSTITUTE, 'UTF-8') ?>
 									<?php else: ?>
-										<?= '<pre>' . print_r($value, true) ?>
+										<pre><?= print_r($value, true) ?></pre>
 									<?php endif; ?>
 								</td>
 							</tr>
@@ -181,7 +181,7 @@
 									<?php if (is_string($value)) : ?>
 										<?= htmlspecialchars($value, ENT_SUBSTITUTE, 'UTF-8') ?>
 									<?php else: ?>
-										<?= '<pre>' . print_r($value, true) ?>
+										<pre><?= print_r($value, true) ?></pre>
 									<?php endif; ?>
 								</td>
 							</tr>
@@ -256,7 +256,7 @@
 									<?php if (is_string($value)) : ?>
 										<?= htmlspecialchars($value, ENT_SUBSTITUTE, 'UTF-8') ?>
 									<?php else: ?>
-										<?= '<pre>' . print_r($value, true) ?>
+										<pre><?= print_r($value, true) ?></pre>
 									<?php endif; ?>
 								</td>
 							</tr>


### PR DESCRIPTION
**Description**
`errors/html/error_exception.php` throws error when constants contain resource and can't see the real exception.

```
ErrorException #1

Uncaught ErrorException: htmlspecialchars() expects parameter 1 to be string, resource given in .../app/Views/errors/html/error_exception.php:182 Stack trace: #0 [internal function]: CodeIgniter\Debug\Exceptions->errorHandler(2, 'htmlspecialchar...', '/Users/kenji/wo...', 182, Array) #1 .../app/Views/errors/html/error_exception.php(182): htmlspecialchars(Resource id #4, 8, 'UTF-8') #2 .../vendor/codeigniter4/codeigniter4/system/Debug/Exceptions.php(281): include('/Users/kenji/wo...') #3 .../vendor/codeigniter4/codeigniter4/system/Debug/Exceptions.php(147): CodeIgniter\Debug\Exceptions->render(Object(...\Exception\NotSupportedException), 500) #4 [internal function]: CodeIgniter\Debug\Exceptions->exceptionHandler(Object(...\Exception\NotSupportedException)) #5 {main} thrown 
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
