### PR TITLE
[Develop] Fixes #4114 Cannot declare class Config\App when running vendor/bin/phpunit

### DIFF
--- a/admin/framework/phpunit.xml.dist
+++ b/admin/framework/phpunit.xml.dist
@@ -16,7 +16,7 @@
 	</testsuites>
 
 	<filter>
-		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="true">
+		<whitelist addUncoveredFilesFromWhitelist="true">
 			<directory suffix=".php">./app</directory>
 			<exclude>
 				<directory suffix=".php">./app/Views</directory>

--- a/admin/module/phpunit.xml.dist
+++ b/admin/module/phpunit.xml.dist
@@ -16,7 +16,7 @@
 	</testsuites>
 
 	<filter>
-		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="true">
+		<whitelist addUncoveredFilesFromWhitelist="true">
 			<directory suffix=".php">./src</directory>
 			<exclude>
 				<directory suffix=".php">./src/Views</directory>

--- a/admin/starter/phpunit.xml.dist
+++ b/admin/starter/phpunit.xml.dist
@@ -16,7 +16,7 @@
 	</testsuites>
 
 	<filter>
-		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="true">
+		<whitelist addUncoveredFilesFromWhitelist="true">
 			<directory suffix=".php">./app</directory>
 			<exclude>
 				<directory suffix=".php">./app/Views</directory>


### PR DESCRIPTION
For develop branch.


**Checklist:**
- [x] Securely signed commits
