### PR TITLE
[4.1] Fixes #4114 Cannot declare class Config\App when running vendor/bin/phpunit

### DIFF
--- a/admin/framework/phpunit.xml.dist
+++ b/admin/framework/phpunit.xml.dist
@@ -11,7 +11,7 @@
 		stopOnIncomplete="false"
 		stopOnSkipped="false"
 		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-	<coverage includeUncoveredFiles="true" processUncoveredFiles="true">
+	<coverage includeUncoveredFiles="true">
 		<include>
 			<directory suffix=".php">./app</directory>
 		</include>

--- a/admin/module/phpunit.xml.dist
+++ b/admin/module/phpunit.xml.dist
@@ -11,7 +11,7 @@
 		stopOnIncomplete="false"
 		stopOnSkipped="false"
 		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-	<coverage includeUncoveredFiles="true" processUncoveredFiles="true">
+	<coverage includeUncoveredFiles="true">
 		<include>
 			<directory suffix=".php">./src</directory>
 		</include>

--- a/admin/starter/phpunit.xml.dist
+++ b/admin/starter/phpunit.xml.dist
@@ -11,7 +11,7 @@
 		stopOnIncomplete="false"
 		stopOnSkipped="false"
 		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-	<coverage includeUncoveredFiles="true" processUncoveredFiles="true">
+	<coverage includeUncoveredFiles="true">
 		<include>
 			<directory suffix=".php">./app</directory>
 		</include>


### PR DESCRIPTION
For 4.1 branch.

**Checklist:**
- [x] Securely signed commits
