### PR TITLE
remove useless "raw html"

### DIFF
--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -17,10 +17,6 @@ include migrations from all namespaces.
 .. contents::
   :local:
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 ********************
 Migration file names
 ********************

--- a/user_guide_src/source/helpers/cookie_helper.rst
+++ b/user_guide_src/source/helpers/cookie_helper.rst
@@ -8,10 +8,6 @@ cookies.
 .. contents::
   :local:
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 Loading this Helper
 ===================
 

--- a/user_guide_src/source/helpers/date_helper.rst
+++ b/user_guide_src/source/helpers/date_helper.rst
@@ -8,10 +8,6 @@ dates.
 .. contents::
   :local:
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 Loading this Helper
 ===================
 

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -8,10 +8,6 @@ directories.
 .. contents::
   :local:
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 Loading this Helper
 ===================
 

--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -8,10 +8,6 @@ forms.
 .. contents::
   :local:
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 Loading this Helper
 ===================
 

--- a/user_guide_src/source/helpers/inflector_helper.rst
+++ b/user_guide_src/source/helpers/inflector_helper.rst
@@ -8,10 +8,6 @@ The Inflector Helper file contains functions that permit you to change
 .. contents::
   :local:
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 Loading this Helper
 ===================
 

--- a/user_guide_src/source/helpers/number_helper.rst
+++ b/user_guide_src/source/helpers/number_helper.rst
@@ -8,10 +8,6 @@ numeric data in a locale-aware manner.
 .. contents::
   :local:
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 Loading this Helper
 ===================
 

--- a/user_guide_src/source/helpers/test_helper.rst
+++ b/user_guide_src/source/helpers/test_helper.rst
@@ -7,10 +7,6 @@ The Test Helper file contains functions that assist in testing your project.
 .. contents::
   :local:
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 Loading this Helper
 ===================
 

--- a/user_guide_src/source/helpers/text_helper.rst
+++ b/user_guide_src/source/helpers/text_helper.rst
@@ -7,10 +7,6 @@ The Text Helper file contains functions that assist in working with Text.
 .. contents::
   :local:
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 Loading this Helper
 ===================
 

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -7,10 +7,6 @@ The URL Helper file contains functions that assist in working with URLs.
 .. contents::
   :local:
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 Loading this Helper
 ===================
 

--- a/user_guide_src/source/helpers/xml_helper.rst
+++ b/user_guide_src/source/helpers/xml_helper.rst
@@ -8,10 +8,6 @@ data.
 .. contents::
   :local:
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 Loading this Helper
 ===================
 

--- a/user_guide_src/source/libraries/email.rst
+++ b/user_guide_src/source/libraries/email.rst
@@ -20,10 +20,6 @@ CodeIgniter's robust Email Class supports the following features:
     :local:
     :depth: 2
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 ***********************
 Using the Email Library
 ***********************

--- a/user_guide_src/source/libraries/encryption.rst
+++ b/user_guide_src/source/libraries/encryption.rst
@@ -33,10 +33,6 @@ A more comprehensive package like `Halite <https://github.com/paragonie/halite>`
 .. contents::
   :local:
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 .. _usage:
 
 ****************************

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -12,10 +12,6 @@ in the last section of the table of contents:
     :local:
     :depth: 2
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 Using the Session Class
 *********************************************************************
 

--- a/user_guide_src/source/outgoing/table.rst
+++ b/user_guide_src/source/outgoing/table.rst
@@ -8,10 +8,6 @@ tables from arrays or database result sets.
 .. contents::
   :local:
 
-.. raw:: html
-
-  <div class="custom-index container"></div>
-
 *********************
 Using the Table Class
 *********************


### PR DESCRIPTION
**Description**
I think it's useless,
```
.. raw:: html	

  <div class="custom-index container"></div>
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
