### PR TITLE
Fix: Removed type hint from documentation for closures from database queries

### DIFF
--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -300,7 +300,7 @@ methods:
 
     ::
 
-        $builder->where('advance_amount <', function(BaseBuilder $builder) {
+        $builder->where('advance_amount <', function($builder) {
             return $builder->select('MAX(advance_amount)', false)->from('orders')->where('id >', 2);
         });
         // Produces: WHERE "advance_amount" < (SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2)
@@ -330,7 +330,7 @@ You can use subqueries instead of an array of values.
 
     ::
 
-        $builder->whereIn('id', function(BaseBuilder $builder) {
+        $builder->whereIn('id', function($builder) {
             return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
         });
         // Produces: WHERE "id" IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
@@ -350,7 +350,7 @@ You can use subqueries instead of an array of values.
 
     ::
 
-        $builder->orWhereIn('id', function(BaseBuilder $builder) {
+        $builder->orWhereIn('id', function($builder) {
             return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
         });
 
@@ -371,7 +371,7 @@ You can use subqueries instead of an array of values.
 
     ::
 
-        $builder->whereNotIn('id', function(BaseBuilder $builder) {
+        $builder->whereNotIn('id', function($builder) {
             return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
         });
 
@@ -393,7 +393,7 @@ You can use subqueries instead of an array of values.
 
     ::
 
-        $builder->orWhereNotIn('id', function(BaseBuilder $builder) {
+        $builder->orWhereNotIn('id', function($builder) {
             return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
         });
 
@@ -531,7 +531,7 @@ You can use subqueries instead of an array of values.
 
     ::
 
-        $builder->havingIn('id', function(BaseBuilder $builder) {
+        $builder->havingIn('id', function($builder) {
             return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
         });
         // Produces: HAVING "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
@@ -551,7 +551,7 @@ You can use subqueries instead of an array of values.
 
     ::
 
-        $builder->orHavingIn('id', function(BaseBuilder $builder) {
+        $builder->orHavingIn('id', function($builder) {
             return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
         });
 
@@ -572,7 +572,7 @@ You can use subqueries instead of an array of values.
 
     ::
 
-        $builder->havingNotIn('id', function(BaseBuilder $builder) {
+        $builder->havingNotIn('id', function($builder) {
             return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
         });
 
@@ -594,7 +594,7 @@ You can use subqueries instead of an array of values.
 
     ::
 
-        $builder->orHavingNotIn('id', function(BaseBuilder $builder) {
+        $builder->orHavingNotIn('id', function($builder) {
             return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
         });
 


### PR DESCRIPTION
Based on http://forum.codeigniter.com/thread-74714.html
Using an example from the documentation, the developer might not understand that the BaseBuilder type hint in the closure is a reference to the Codeigniter\Database\BaseBuilder class.
By specifying a BaseBuilder type hint without using "use Codeigniter\Database\BaseBuilder", a developer will receive a type error.

**Checklist:**
- [x] User guide updated