### PR TITLE
prep_url() with https://

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -522,26 +522,31 @@ if (! function_exists('auto_link'))
 if (! function_exists('prep_url'))
 {
 	/**
-	 * Prep URL - Simply adds the http:// part if no scheme is included.
+	 * Prep URL - Simply adds the http:// or https:// part if no scheme is included.
 	 *
 	 * Formerly used URI, but that does not play nicely with URIs missing
 	 * the scheme.
 	 *
-	 * @param  string $str the URL
+	 * @param  string  $str    the URL
+	 * @param  boolean $secure set true if you want to force https://
 	 * @return string
 	 */
-	function prep_url(string $str = ''): string
+	function prep_url(string $str = '', bool $secure = false): string
 	{
-		if ($str === 'http://' || $str === '')
+		if (in_array($str, ['http://', 'https://', '//', ''], true))
 		{
 			return '';
 		}
 
-		$url = parse_url($str);
-
-		if (! $url || ! isset($url['scheme']))
+		if (parse_url($str, PHP_URL_SCHEME) === null)
 		{
-			return 'http://' . $str;
+			$str = 'http://' . ltrim($str, '/');
+		}
+
+		// force replace http:// with https://
+		if ($secure)
+		{
+			$str = preg_replace('/^(?:http):/i', 'https:', $str);
 		}
 
 		return $str;

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1149,12 +1149,89 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	//--------------------------------------------------------------------
 	// Test prep_url
 
-	public function testPrepUrl()
+	public function prepUrlProvider()
 	{
-		$this->assertEquals('http://codeigniter.com', prep_url('codeigniter.com'));
-		$this->assertEquals('http://www.codeigniter.com', prep_url('www.codeigniter.com'));
-		$this->assertEquals('', prep_url());
-		$this->assertEquals('http://www.codeigniter.com', prep_url('http://www.codeigniter.com'));
+		// input, expected, secure
+		return [
+			[
+				'',
+				'',
+				false,
+			],
+			[
+				'//',
+				'',
+				false,
+			],
+			[
+				'//codeigniter.com',
+				'http://codeigniter.com',
+				false,
+			],
+			[
+				'codeigniter.com',
+				'http://codeigniter.com',
+				false,
+			],
+			[
+				'www.codeigniter.com',
+				'http://www.codeigniter.com',
+				false,
+			],
+			[
+				'http://www.codeigniter.com',
+				'http://www.codeigniter.com',
+				false,
+			],
+			[
+				'https://www.codeigniter.com',
+				'https://www.codeigniter.com',
+				false,
+			],
+			[
+				'',
+				'',
+				true,
+			],
+			[
+				'//',
+				'',
+				true,
+			],
+			[
+				'//codeigniter.com',
+				'https://codeigniter.com',
+				true,
+			],
+			[
+				'codeigniter.com',
+				'https://codeigniter.com',
+				true,
+			],
+			[
+				'www.codeigniter.com',
+				'https://www.codeigniter.com',
+				true,
+			],
+			[
+				'http://www.codeigniter.com',
+				'https://www.codeigniter.com',
+				true,
+			],
+			[
+				'https://www.codeigniter.com',
+				'https://www.codeigniter.com',
+				true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider prepUrlProvider
+	 */
+	public function testPrepUrl(string $input, string $expected, bool $secure)
+	{
+		$this->assertSame($expected, prep_url($input, $secure));
 	}
 
 	//--------------------------------------------------------------------

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -356,13 +356,14 @@ The following functions are available:
     This function works the same as :php:func:`url_title()` but it converts all
     accented characters automatically.
 
-.. php:function:: prep_url($str = '')
+.. php:function:: prep_url([$str = ''[, $secure = false]])
 
-    :param  string  $str: URL string
+    :param  string   $str: URL string
+    :param  boolean  $secure: TRUE for https://
     :returns: Protocol-prefixed URL string
     :rtype: string
 
-    This function will add *http://* in the event that a protocol prefix
+    This function will add *http://* or *https://* in the event that a protocol prefix
     is missing from a URL.
 
     Pass the URL string to the function like this::


### PR DESCRIPTION
**Description**
Add parameter to force https in `prep_url()`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

