### PR TITLE
PHPStan Fixes

### DIFF
--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'app/**'
       - 'system/**'
+      - composer.json
       - phpstan.neon.dist
   push:
     branches:
@@ -18,6 +19,7 @@ on:
     paths:
       - 'app/**'
       - 'system/**'
+      - composer.json
       - phpstan.neon.dist
 
 jobs:

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -304,7 +304,7 @@ class App extends BaseConfig
 	 * set to `None`, `$cookieSecure` must also be set.
 	 *
 	 * @var string
-	 * @phpstan-var 'Lax'|'None'|'Strict'
+       * @var string 'Lax'|'None'|'Strict'
 	 */
 	public $cookieSameSite = 'Lax';
 

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -303,7 +303,7 @@ class App extends BaseConfig
 	 * (empty string) means no SameSite attribute will be set on cookies. If
 	 * set to `None`, `$cookieSecure` must also be set.
 	 *
-	 * @var string
+	 * @var 'Lax'|'None'|'Strict'
 	 */
 	public $cookieSameSite = 'Lax';
 

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -303,7 +303,6 @@ class App extends BaseConfig
 	 * (empty string) means no SameSite attribute will be set on cookies. If
 	 * set to `None`, `$cookieSecure` must also be set.
 	 *
-	 * @var string
        * @var string 'Lax'|'None'|'Strict'
 	 */
 	public $cookieSameSite = 'Lax';

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -303,7 +303,8 @@ class App extends BaseConfig
 	 * (empty string) means no SameSite attribute will be set on cookies. If
 	 * set to `None`, `$cookieSecure` must also be set.
 	 *
-	 * @var 'Lax'|'None'|'Strict'
+	 * @var string
+	 * @phpstan-var 'Lax'|'None'|'Strict'
 	 */
 	public $cookieSameSite = 'Lax';
 

--- a/app/Config/Security.php
+++ b/app/Config/Security.php
@@ -86,7 +86,7 @@ class Security extends BaseConfig
 	 * Defaults to `Lax` as recommended in this link:
 	 * @see https://portswigger.net/web-security/csrf/samesite-cookies
 	 *
-	 * @var string
+	 * @var 'Lax'|'None'|'Strict'
 	 */
 	public $samesite = 'Lax';
 }

--- a/app/Config/Security.php
+++ b/app/Config/Security.php
@@ -87,7 +87,7 @@ class Security extends BaseConfig
 	 * @see https://portswigger.net/web-security/csrf/samesite-cookies
 	 *
 	 * @var string
-	 * @phpstan-var 'Lax'|'None'|'Strict'
+       * @var string 'Lax'|'None'|'Strict'
 	 */
 	public $samesite = 'Lax';
 }

--- a/app/Config/Security.php
+++ b/app/Config/Security.php
@@ -86,7 +86,6 @@ class Security extends BaseConfig
 	 * Defaults to `Lax` as recommended in this link:
 	 * @see https://portswigger.net/web-security/csrf/samesite-cookies
 	 *
-	 * @var string
        * @var string 'Lax'|'None'|'Strict'
 	 */
 	public $samesite = 'Lax';

--- a/app/Config/Security.php
+++ b/app/Config/Security.php
@@ -86,7 +86,8 @@ class Security extends BaseConfig
 	 * Defaults to `Lax` as recommended in this link:
 	 * @see https://portswigger.net/web-security/csrf/samesite-cookies
 	 *
-	 * @var 'Lax'|'None'|'Strict'
+	 * @var string
+	 * @phpstan-var 'Lax'|'None'|'Strict'
 	 */
 	public $samesite = 'Lax';
 }

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -234,7 +234,6 @@ class CodeIgniter
 		// If we have KINT_DIR it means it's already loaded via composer
 		if (! defined('KINT_DIR'))
 		{
-			// @phpstan-ignore-next-line
 			spl_autoload_register(function ($class) {
 				$class = explode('\\', $class);
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -99,7 +99,7 @@ class Security implements SecurityInterface
 	 * Defaults to `Lax` as recommended in this link:
 	 * @see https://portswigger.net/web-security/csrf/samesite-cookies
 	 *
-	 * @var string
+	 * @var 'Lax'|'None'|'Strict'
 	 */
 	protected $samesite = 'Lax';
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -100,7 +100,7 @@ class Security implements SecurityInterface
 	 * @see https://portswigger.net/web-security/csrf/samesite-cookies
 	 *
 	 * @var string
-	 * @phpstan-var 'Lax'|'None'|'Strict'
+       * @var string 'Lax'|'None'|'Strict'
 	 */
 	protected $samesite = 'Lax';
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -99,7 +99,8 @@ class Security implements SecurityInterface
 	 * Defaults to `Lax` as recommended in this link:
 	 * @see https://portswigger.net/web-security/csrf/samesite-cookies
 	 *
-	 * @var 'Lax'|'None'|'Strict'
+	 * @var string
+	 * @phpstan-var 'Lax'|'None'|'Strict'
 	 */
 	protected $samesite = 'Lax';
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -99,7 +99,6 @@ class Security implements SecurityInterface
 	 * Defaults to `Lax` as recommended in this link:
 	 * @see https://portswigger.net/web-security/csrf/samesite-cookies
 	 *
-	 * @var string
        * @var string 'Lax'|'None'|'Strict'
 	 */
 	protected $samesite = 'Lax';

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -125,7 +125,6 @@ class Session implements SessionInterface
 	 * Cookie SameSite setting as described in RFC6265
 	 * Must be 'None', 'Lax' or 'Strict'.
 	 *
-	 * @var string
        * @var string 'Lax'|'None'|'Strict'
 	 */
 	protected $cookieSameSite = 'Lax';

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -125,7 +125,8 @@ class Session implements SessionInterface
 	 * Cookie SameSite setting as described in RFC6265
 	 * Must be 'None', 'Lax' or 'Strict'.
 	 *
-	 * @var 'Lax'|'None'|'Strict'
+	 * @var string
+	 * @phpstan-var 'Lax'|'None'|'Strict'
 	 */
 	protected $cookieSameSite = 'Lax';
 

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -126,7 +126,7 @@ class Session implements SessionInterface
 	 * Must be 'None', 'Lax' or 'Strict'.
 	 *
 	 * @var string
-	 * @phpstan-var 'Lax'|'None'|'Strict'
+       * @var string 'Lax'|'None'|'Strict'
 	 */
 	protected $cookieSameSite = 'Lax';
 

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -125,7 +125,7 @@ class Session implements SessionInterface
 	 * Cookie SameSite setting as described in RFC6265
 	 * Must be 'None', 'Lax' or 'Strict'.
 	 *
-	 * @var string
+	 * @var 'Lax'|'None'|'Strict'
 	 */
 	protected $cookieSameSite = 'Lax';
 


### PR DESCRIPTION
**Description**
* Adds **composer.json** to the path list for PHPStan Action
* Specifies the Same Site Cookie string values for PHPStan compliance
* Removes the ignore line for a now-passing check

See https://github.com/codeigniter4/CodeIgniter4/pull/4134

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
