### PR TITLE
docs: add table of contents in 2 libs

### DIFF
--- a/user_guide_src/source/libraries/pagination.rst
+++ b/user_guide_src/source/libraries/pagination.rst
@@ -5,6 +5,10 @@ Pagination
 CodeIgniter provides a very simple, but flexible pagination library that is simple to theme, works with the model,
 and capable of supporting multiple paginators on a single page.
 
+.. contents::
+    :local:
+    :depth: 2
+
 *******************
 Loading the Library
 *******************

--- a/user_guide_src/source/libraries/typography.rst
+++ b/user_guide_src/source/libraries/typography.rst
@@ -5,6 +5,10 @@ Typography
 The Typography library contains methods that help you format text
 in semantically relevant ways.
 
+.. contents::
+    :local:
+    :depth: 2
+
 *******************
 Loading the Library
 *******************


### PR DESCRIPTION
**Description**
TOC is missing in Typography and Pagination.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
