### PR TITLE
feat: add property accessor to PagerRenderer

### DIFF
--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -113,7 +113,7 @@ class PagerRenderer
 			return $this->$key;
 		}
 
-		throw new InvalidArgumentException('No such a property: ' . $key);
+		throw new InvalidArgumentException('No such property: ' . $key);
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -11,6 +11,8 @@
 
 namespace CodeIgniter\Pager;
 
+use InvalidArgumentException;
+
 /**
  * Class PagerRenderer
  *
@@ -93,6 +95,25 @@ class PagerRenderer
 		$this->pageCount    = $details['pageCount'];
 		$this->segment      = $details['segment'] ?? 0;
 		$this->pageSelector = $details['pageSelector'] ?? 'page';
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Accessor for properties if they exist.
+	 *
+	 * @param string $key
+	 *
+	 * @return mixed
+	 */
+	public function __get(string $key)
+	{
+		if (property_exists($this, $key))
+		{
+			return $this->$key;
+		}
+
+		throw new InvalidArgumentException('No such a property: ' . $key);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -582,7 +582,7 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testPropertyAccessorGetPropertyThatDoesNotExists()
 	{
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('No such a property: properyNeverEverExists');
+		$this->expectExceptionMessage('No such property: properyNeverEverExists');
 
 		$uri     = $this->uri;
 		$details = [

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -3,6 +3,7 @@
 namespace CodeIgniter\Pager;
 
 use CodeIgniter\HTTP\URI;
+use InvalidArgumentException;
 
 class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 {
@@ -559,5 +560,40 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$pager = new PagerRenderer($details);
 		$this->assertEquals('http://example.com/foo/4', $pager->getNextPage());
+	}
+
+	public function testPropertyAccessorGetProperties()
+	{
+		$uri     = $this->uri;
+		$details = [
+			'uri'         => $uri,
+			'pageCount'   => 10,
+			'currentPage' => 3,
+			'total'       => 100,
+			'segment'     => 2,
+		];
+		$pager   = new PagerRenderer($details);
+
+		$this->assertEquals(1, $pager->first);
+		$this->assertEquals(3, $pager->current);
+		$this->assertEquals(10, $pager->last);
+	}
+
+	public function testPropertyAccessorGetPropertyThatDoesNotExists()
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('No such a property: properyNeverEverExists');
+
+		$uri     = $this->uri;
+		$details = [
+			'uri'         => $uri,
+			'pageCount'   => 10,
+			'currentPage' => 3,
+			'total'       => 100,
+			'segment'     => 2,
+		];
+		$pager   = new PagerRenderer($details);
+
+		$pager->properyNeverEverExists;
 	}
 }


### PR DESCRIPTION
**Description**
Add property accessor to PagerRenderer.
To generate Pager HTML that is the same as CI3's.
The template would be like this:
```php
    <?php if ($pager->hasPreviousPage()) : ?>
    <a href="<?= $pager->getFirst() ?>" data-ci-pagination-page="<?= $pager->first ?>" rel="start">&laquo;First</a>
    <a href="<?= $pager->getPreviousPage() ?>" data-ci-pagination-page="<?= $pager->current - 1 ?>" rel="prev">&lt;</a>
    <?php endif ?>
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
