### PR TITLE
Specifically exclude migrations from class mapping

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -28,7 +28,10 @@
 	"autoload": {
 		"psr-4": {
 			"CodeIgniter\\": "system/"
-		}
+		},
+		"exclude-from-classmap": [
+			"**/Database/Migrations/**"
+		]
 	},
 	"scripts": {
 		"post-update-cmd": [

--- a/admin/module/composer.json
+++ b/admin/module/composer.json
@@ -4,7 +4,7 @@
 	"homepage": "https://codeigniter.com",
 	"license": "MIT",
 	"require": {
-		"php": "^7.2 || ^8.0",
+		"php": "^7.2 || ^8.0"
 	},
 	"require-dev": {
 		"codeigniter4/codeigniter4": "dev-develop",

--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -20,7 +20,10 @@
 		"psr-4": {
 			"App\\": "app",
 			"Config\\": "app/Config"
-		}
+		},
+		"exclude-from-classmap": [
+			"**/Database/Migrations/**"
+		]
 	},
 	"autoload-dev": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,10 @@
 	"autoload": {
 		"psr-4": {
 			"CodeIgniter\\": "system/"
-		}
+		},
+		"exclude-from-classmap": [
+			"**/Database/Migrations/**"
+		]
 	},
 	"autoload-dev": {
 		"psr-4": {


### PR DESCRIPTION
**Description**
With Composer 2, user classes with filenames not conforming to PSR4 will not be autoloaded anymore giving a warning message in the terminal. Since migrations do not need autoloading per se, we can safely dismiss this warning by specifically excluding them in the class map.

Fixes #3195 

**Checklist:**
- [x] Securely signed commits
