### PR TITLE
[4.1] Fixes #4114 Cannot declare class Config\App error on running PHPUnit

### DIFF
--- a/admin/framework/phpunit.xml.dist
+++ b/admin/framework/phpunit.xml.dist
@@ -27,7 +27,7 @@
 		</report>
 	</coverage>
 	<testsuites>
-		<testsuite name="app">
+		<testsuite name="App">
 			<directory>./tests</directory>
 		</testsuite>
 	</testsuites>

--- a/admin/module/phpunit.xml.dist
+++ b/admin/module/phpunit.xml.dist
@@ -27,7 +27,7 @@
 		</report>
 	</coverage>
 	<testsuites>
-		<testsuite name="app">
+		<testsuite name="App">
 			<directory>./tests</directory>
 		</testsuite>
 	</testsuites>

--- a/admin/starter/phpunit.xml.dist
+++ b/admin/starter/phpunit.xml.dist
@@ -27,7 +27,7 @@
 		</report>
 	</coverage>
 	<testsuites>
-		<testsuite name="app">
+		<testsuite name="App">
 			<directory>./tests</directory>
 		</testsuite>
 	</testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,11 +31,11 @@
 		</report>
 	</coverage>
 	<testsuites>
-		<testsuite name="system">
+		<testsuite name="System">
 			<directory>./tests/system</directory>
 			<exclude>./tests/system/Database</exclude>
 		</testsuite>
-		<testsuite name="database">
+		<testsuite name="Database">
 			<directory>./tests/system/Database</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
Fixes #4114 on Xdebug 3, changed test suite name in phpunit.xml.dist from "app" to "App" seems fixed it, changed the "system" and "database" to uppercase first char for consistency.

**Description**
Explain what you have changed, and why.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage