### PR TITLE
Fix strict checking for SQLite3 memory filename

### DIFF
--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -102,7 +102,7 @@ class CreateDatabase extends BaseCommand
 					$ext = CLI::prompt('Please choose a valid file extension', ['db', 'sqlite']); // @codeCoverageIgnore
 				}
 
-				if (strpos($name, ':memory:') === false)
+				if ($name !== ':memory:')
 				{
 					$name = str_replace(['.db', '.sqlite'], '', $name) . ".{$ext}";
 				}
@@ -110,7 +110,7 @@ class CreateDatabase extends BaseCommand
 				$config->{$group}['DBDriver'] = 'SQLite3';
 				$config->{$group}['database'] = $name;
 
-				if (strpos($name, ':memory:') === false)
+				if ($name !== ':memory:')
 				{
 					$dbName = strpos($name, DIRECTORY_SEPARATOR) === false ? WRITEPATH . $name : $name;
 
@@ -131,7 +131,7 @@ class CreateDatabase extends BaseCommand
 				$db->connect();
 				Factories::reset('config');
 
-				if (! is_file($db->getDatabase()) && strpos($name, ':memory:') === false)
+				if (! is_file($db->getDatabase()) && $name !== ':memory:')
 				{
 					// @codeCoverageIgnoreStart
 					CLI::error('Database creation failed.', 'light_gray', 'red');


### PR DESCRIPTION
**Description**
According to the [SQLite documentation](https://sqlite.org/inmemorydb.html),

> Note that in order for the special ":memory:" name to apply and to create a pure in-memory database, there must be no additional text in the filename. Thus, a disk-based database can be created in a file by prepending a pathname, like this: "./:memory:".

Thus, we need to be strictly checking if the name is `:memory:` rather than checking if it is part of the name.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
