### PR TITLE
add phpunit.xml.dist to .gitattributes for admin/framework

### DIFF
--- a/admin/framework/.gitattributes
+++ b/admin/framework/.gitattributes
@@ -6,3 +6,4 @@
 /app export-ignore
 /public export-ignore
 /writable export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
when using --prefer-dist, it is not needed to be included.

**Checklist:**
- [x] Securely signed commits

