### PR TITLE
feat(router): add alternate-content option to route

### DIFF
--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -317,7 +317,7 @@ class Negotiate
 	 *
 	 * @return boolean
 	 */
-	protected function match(array $acceptable, string $supported, bool $enforceTypes = false, $matchLocales = false): bool
+	public function match(array $acceptable, string $supported, bool $enforceTypes = false, $matchLocales = false): bool
 	{
 		$supported = $this->parseHeader($supported);
 		if (is_array($supported) && count($supported) === 1)


### PR DESCRIPTION
feat(router): add alternate-content option to route

**Description**

Hey, I discussed this last week with @MGatner on slack. I was wondering if we could have the same route point to different controller methods depending on the user request. For example, a user might request a route with "application/json" to get json data or else be shown html.
Apparently, the router does not support this yet. I was invited to submit a PR, so here it is :)

With many hours trying to understand and tweak the Router, I've come up with a (debatable) solution to extend the route options. Basically, one would have to add an "alternate-content" option to any route with this format:

```php
$routes->add('bar', 'TestController::default', [
    'alternate-content' => [
        'application/json' => 'AnotherTestController::json',
        'application/activity+json' => 'ActivityPubTest::actor',
        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' => 'ActivityPubTest::actor',
    ],
]);
```
Then, when handling the route, the router would check if there is any alternate content type to match to the request's accept header. If so, before parsing out the controller and method names + params, the "TestController::default" string would be replaced by the controller method string associated with the content-type. I've injected the code were I thought it would make sense and reused some of the negotiator service logic to match the content-types.

To finish, it's my first PR here and I do not have much experience with the CodeIgniter4 code base, so any feedback would be much appreciated, whether it is about the overall solution, tests, naming, style...

Thanks!

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide