### PR TITLE
Add missing escaping in error_exception.php

### DIFF
--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -19,9 +19,9 @@
 	<!-- Header -->
 	<div class="header">
 		<div class="container">
-			<h1><?= htmlspecialchars($title, ENT_SUBSTITUTE, 'UTF-8'), ($exception->getCode() ? ' #' . $exception->getCode() : '') ?></h1>
+			<h1><?= htmlspecialchars($title, ENT_SUBSTITUTE, 'UTF-8'), esc($exception->getCode() ? ' #' . $exception->getCode() : '') ?></h1>
 			<p>
-				<?= $exception->getMessage() ?>
+				<?= esc($exception->getMessage()) ?>
 				<a href="https://www.google.com/search?q=<?= urlencode($title . ' ' . preg_replace('#\'.*\'|".*"#Us', '', $exception->getMessage())) ?>"
 				   rel="noreferrer" target="_blank">search &rarr;</a>
 			</p>
@@ -30,7 +30,7 @@
 
 	<!-- Source -->
 	<div class="container">
-		<p><b><?= static::cleanPath($file, $line) ?></b> at line <b><?= $line ?></b></p>
+		<p><b><?= esc(static::cleanPath($file, $line)) ?></b> at line <b><?= esc($line) ?></b></p>
 
 		<?php if (is_file($file)) : ?>
 			<div class="source">
@@ -66,11 +66,11 @@
 								<?php
 								if (isset($row['function']) && in_array($row['function'], ['include', 'include_once', 'require', 'require_once'], true))
 								{
-									echo $row['function'] . ' ' . static::cleanPath($row['file']);
+									echo esc($row['function'] . ' ' . static::cleanPath($row['file']));
 								}
 								else
 								{
-									echo static::cleanPath($row['file']) . ' : ' . $row['line'];
+									echo esc(static::cleanPath($row['file']) . ' : ' . $row['line']);
 								}
 								?>
 							<?php else : ?>
@@ -79,11 +79,11 @@
 
 							<!-- Class/Method -->
 							<?php if (isset($row['class'])) : ?>
-								&nbsp;&nbsp;&mdash;&nbsp;&nbsp;<?= $row['class'] . $row['type'] . $row['function'] ?>
+								&nbsp;&nbsp;&mdash;&nbsp;&nbsp;<?= esc($row['class'] . $row['type'] . $row['function']) ?>
 								<?php if (! empty($row['args'])) : ?>
 									<?php $args_id = $error_id . 'args' . $index ?>
-									( <a href="#" onclick="return toggle('<?= $args_id ?>');">arguments</a> )
-									<div class="args" id="<?= $args_id ?>">
+									( <a href="#" onclick="return toggle('<?= esc($args_id, 'attr') ?>');">arguments</a> )
+									<div class="args" id="<?= esc($args_id, 'attr') ?>">
 										<table cellspacing="0">
 
 										<?php
@@ -109,7 +109,7 @@
 							<?php endif; ?>
 
 							<?php if (! isset($row['class']) && isset($row['function'])) : ?>
-								&nbsp;&nbsp;&mdash;&nbsp;&nbsp;	<?= $row['function'] ?>()
+								&nbsp;&nbsp;&mdash;&nbsp;&nbsp;	<?= esc($row['function']) ?>()
 							<?php endif; ?>
 						</p>
 
@@ -134,7 +134,7 @@
 						continue;
 					} ?>
 
-					<h3>$<?= $var ?></h3>
+					<h3>$<?= esc($var) ?></h3>
 
 					<table>
 						<thead>
@@ -199,15 +199,15 @@
 					<tbody>
 						<tr>
 							<td style="width: 10em">Path</td>
-							<td><?= $request->uri ?></td>
+							<td><?= esc($request->uri) ?></td>
 						</tr>
 						<tr>
 							<td>HTTP Method</td>
-							<td><?= $request->getMethod(true) ?></td>
+							<td><?= esc($request->getMethod(true)) ?></td>
 						</tr>
 						<tr>
 							<td>IP Address</td>
-							<td><?= $request->getIPAddress() ?></td>
+							<td><?= esc($request->getIPAddress()) ?></td>
 						</tr>
 						<tr>
 							<td style="width: 10em">Is AJAX Request?</td>
@@ -223,7 +223,7 @@
 						</tr>
 						<tr>
 							<td>User Agent</td>
-							<td><?= $request->getUserAgent()->getAgentString() ?></td>
+							<td><?= esc($request->getUserAgent()->getAgentString()) ?></td>
 						</tr>
 
 					</tbody>
@@ -239,7 +239,7 @@
 
 					<?php $empty = false; ?>
 
-					<h3>$<?= $var ?></h3>
+					<h3>$<?= esc($var) ?></h3>
 
 					<table style="width: 100%">
 						<thead>
@@ -318,7 +318,7 @@
 				<table>
 					<tr>
 						<td style="width: 15em">Response Status</td>
-						<td><?= $response->getStatusCode() . ' - ' . $response->getReason() ?></td>
+						<td><?= esc($response->getStatusCode() . ' - ' . $response->getReason()) ?></td>
 					</tr>
 				</table>
 
@@ -366,15 +366,15 @@
 					<tbody>
 						<tr>
 							<td>Memory Usage</td>
-							<td><?= static::describeMemory(memory_get_usage(true)) ?></td>
+							<td><?= esc(static::describeMemory(memory_get_usage(true))) ?></td>
 						</tr>
 						<tr>
 							<td style="width: 12em">Peak Memory Usage:</td>
-							<td><?= static::describeMemory(memory_get_peak_usage(true)) ?></td>
+							<td><?= esc(static::describeMemory(memory_get_peak_usage(true))) ?></td>
 						</tr>
 						<tr>
 							<td>Memory Limit:</td>
-							<td><?= ini_get('memory_limit') ?></td>
+							<td><?= esc(ini_get('memory_limit')) ?></td>
 						</tr>
 					</tbody>
 				</table>
@@ -389,9 +389,9 @@
 		<div class="container">
 
 			<p>
-				Displayed at <?= date('H:i:sa') ?> &mdash;
-				PHP: <?= phpversion() ?>  &mdash;
-				CodeIgniter: <?= \CodeIgniter\CodeIgniter::CI_VERSION ?>
+				Displayed at <?= esc(date('H:i:sa')) ?> &mdash;
+				PHP: <?= esc(phpversion()) ?>  &mdash;
+				CodeIgniter: <?= esc(\CodeIgniter\CodeIgniter::CI_VERSION) ?>
 			</p>
 
 		</div>

--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 	<meta name="robots" content="noindex">
 
-	<title><?= htmlspecialchars($title, ENT_SUBSTITUTE, 'UTF-8') ?></title>
+	<title><?= esc($title) ?></title>
 	<style type="text/css">
 		<?= preg_replace('#[\r\n\t ]+#', ' ', file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'debug.css')) ?>
 	</style>
@@ -19,7 +19,7 @@
 	<!-- Header -->
 	<div class="header">
 		<div class="container">
-			<h1><?= htmlspecialchars($title, ENT_SUBSTITUTE, 'UTF-8'), esc($exception->getCode() ? ' #' . $exception->getCode() : '') ?></h1>
+			<h1><?= esc($title), esc($exception->getCode() ? ' #' . $exception->getCode() : '') ?></h1>
 			<p>
 				<?= esc($exception->getMessage()) ?>
 				<a href="https://www.google.com/search?q=<?= urlencode($title . ' ' . preg_replace('#\'.*\'|".*"#Us', '', $exception->getMessage())) ?>"
@@ -96,8 +96,8 @@
 										}
 										foreach ($row['args'] as $key => $value) : ?>
 											<tr>
-												<td><code><?= htmlspecialchars(isset($params[$key]) ? '$' . $params[$key]->name : "#$key", ENT_SUBSTITUTE, 'UTF-8') ?></code></td>
-												<td><pre><?= htmlspecialchars(print_r($value, true), ENT_SUBSTITUTE, 'UTF-8') ?></pre></td>
+												<td><code><?= esc(isset($params[$key]) ? '$' . $params[$key]->name : "#$key") ?></code></td>
+												<td><pre><?= esc(print_r($value, true)) ?></pre></td>
 											</tr>
 										<?php endforeach ?>
 
@@ -146,12 +146,12 @@
 						<tbody>
 						<?php foreach ($GLOBALS[$var] as $key => $value) : ?>
 							<tr>
-								<td><?= htmlspecialchars($key, ENT_IGNORE, 'UTF-8') ?></td>
+								<td><?= esc($key) ?></td>
 								<td>
 									<?php if (is_string($value)) : ?>
-										<?= htmlspecialchars($value, ENT_SUBSTITUTE, 'UTF-8') ?>
+										<?= esc($value) ?>
 									<?php else: ?>
-										<pre><?= htmlspecialchars(print_r($value, true), ENT_SUBSTITUTE, 'UTF-8') ?></pre>
+										<pre><?= esc(print_r($value, true)) ?></pre>
 									<?php endif; ?>
 								</td>
 							</tr>
@@ -176,12 +176,12 @@
 						<tbody>
 						<?php foreach ($constants['user'] as $key => $value) : ?>
 							<tr>
-								<td><?= htmlspecialchars($key, ENT_IGNORE, 'UTF-8') ?></td>
+								<td><?= esc($key) ?></td>
 								<td>
 									<?php if (is_string($value)) : ?>
-										<?= htmlspecialchars($value, ENT_SUBSTITUTE, 'UTF-8') ?>
+										<?= esc($value) ?>
 									<?php else: ?>
-										<pre><?= htmlspecialchars(print_r($value, true), ENT_SUBSTITUTE, 'UTF-8') ?></pre>
+										<pre><?= esc(print_r($value, true)) ?></pre>
 									<?php endif; ?>
 								</td>
 							</tr>
@@ -251,12 +251,12 @@
 						<tbody>
 						<?php foreach ($GLOBALS[$var] as $key => $value) : ?>
 							<tr>
-								<td><?= htmlspecialchars($key, ENT_IGNORE, 'UTF-8') ?></td>
+								<td><?= esc($key) ?></td>
 								<td>
 									<?php if (is_string($value)) : ?>
-										<?= htmlspecialchars($value, ENT_SUBSTITUTE, 'UTF-8') ?>
+										<?= esc($value) ?>
 									<?php else: ?>
-										<pre><?= htmlspecialchars(print_r($value, true), ENT_SUBSTITUTE, 'UTF-8') ?></pre>
+										<pre><?= esc(print_r($value, true)) ?></pre>
 									<?php endif; ?>
 								</td>
 							</tr>
@@ -354,7 +354,7 @@
 
 				<ol>
 				<?php foreach ($files as $file) :?>
-					<li><?= htmlspecialchars(static::cleanPath($file), ENT_SUBSTITUTE, 'UTF-8') ?></li>
+					<li><?= esc(static::cleanPath($file)) ?></li>
 				<?php endforeach ?>
 				</ol>
 			</div>


### PR DESCRIPTION
**Description**
- Escaping all variable and function output in `error_exception.php`.
- Use `esc()` in all places.

I can not see the message containing `<...>`.

In the current code, some variables are escaped with `ENT_IGNORE`, but 
I don't know why. It is not recommended, so I change esc()'s default.

> ENT_IGNORE
> Silently discard invalid code unit sequences instead of returning             an empty string. Using this flag is discouraged as it             » may have security implications.
https://www.php.net/manual/en/function.htmlspecialchars.php

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
