### PR TITLE
fix the missing / hidden userguide

### DIFF
--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -19,16 +19,16 @@ The following example shows a common usage pattern within your controllers.
 
 ::
 
-	if (! $foo = cache('foo'))
-	{
-		echo 'Saving to the cache!<br />';
-		$foo = 'foobarbaz!';
+    if (! $foo = cache('foo'))
+    {
+        echo 'Saving to the cache!<br />';
+        $foo = 'foobarbaz!';
 
-		// Save into the cache for 5 minutes
-		cache()->save('foo', $foo, 300);
-	}
+        // Save into the cache for 5 minutes
+        cache()->save('foo', $foo, 300);
+    }
 
-	echo $foo;
+    echo $foo;
 
 You can grab an instance of the cache engine directly through the Services class::
 
@@ -77,133 +77,133 @@ Class Reference
 
 .. php:method:: isSupported()
 
-	:returns: ``true`` if supported, ``false`` if not
-	:rtype:	bool
+    :returns: ``true`` if supported, ``false`` if not
+    :rtype: bool
 
 .. php:method:: get($key): mixed
 
-	:param string $key: Cache item name
-	:returns: Item value or ``null`` if not found
-	:rtype:	mixed
+    :param string $key: Cache item name
+    :returns: Item value or ``null`` if not found
+    :rtype: mixed
 
-	This method will attempt to fetch an item from the cache store. If the
-	item does not exist, the method will return NULL.
+    This method will attempt to fetch an item from the cache store. If the
+    item does not exist, the method will return NULL.
 
-	Example::
+    Example::
 
-		$foo = $cache->get('my_cached_item');
+        $foo = $cache->get('my_cached_item');
 
 .. php:method:: remember(string $key, int $ttl, Closure $callback)
 
-	:param string $key: Cache item name
-	:param int $ttl: Time to live in seconds
-	:param Closure $callback: Callback to invoke when the cache item returns null
-	:returns: The value of the cache item
-	:rtype: mixed
-	
-	Gets an item from the cache. If ``null`` was returned, this will invoke the callback
-	and save the result. Either way, this will return the value.
+    :param string $key: Cache item name
+    :param int $ttl: Time to live in seconds
+    :param Closure $callback: Callback to invoke when the cache item returns null
+    :returns: The value of the cache item
+    :rtype: mixed
+    
+    Gets an item from the cache. If ``null`` was returned, this will invoke the callback
+    and save the result. Either way, this will return the value.
 
 .. php:method:: save(string $key, $data[, int $ttl = 60[, $raw = false]])
 
-	:param string $key: Cache item name
-	:param mixed $data: the data to save
-	:param int $ttl: Time To Live, in seconds (default 60)
-	:param bool $raw: Whether to store the raw value
-	:returns: ``true`` on success, ``false`` on failure
-	:rtype:	bool
+    :param string $key: Cache item name
+    :param mixed $data: the data to save
+    :param int $ttl: Time To Live, in seconds (default 60)
+    :param bool $raw: Whether to store the raw value
+    :returns: ``true`` on success, ``false`` on failure
+    :rtype: bool
 
-	This method will save an item to the cache store. If saving fails, the
-	method will return ``false``.
+    This method will save an item to the cache store. If saving fails, the
+    method will return ``false``.
 
-	Example::
+    Example::
 
-		$cache->save('cache_item_id', 'data_to_cache');
+        $cache->save('cache_item_id', 'data_to_cache');
 
 .. note:: The ``$raw`` parameter is only utilized by Memcache,
-		  in order to allow usage of ``increment()`` and ``decrement()``.
+    in order to allow usage of ``increment()`` and ``decrement()``.
 
 .. php:method:: delete($key): bool
 
-	:param string $key: name of cached item
-	:returns: ``true`` on success, ``false`` on failure
-	:rtype:	bool
+    :param string $key: name of cached item
+    :returns: ``true`` on success, ``false`` on failure
+    :rtype: bool
 
-	This method will delete a specific item from the cache store. If item
-	deletion fails, the method will return FALSE.
+    This method will delete a specific item from the cache store. If item
+    deletion fails, the method will return FALSE.
 
-	Example::
+    Example::
 
-		$cache->delete('cache_item_id');
+        $cache->delete('cache_item_id');
 
 .. php:method:: increment($key[, $offset = 1]): mixed
 
-	:param string $key: Cache ID
-	:param int $offset: Step/value to add
-	:returns: New value on success, ``false`` on failure
-   	:rtype:	mixed
+    :param string $key: Cache ID
+    :param int $offset: Step/value to add
+    :returns: New value on success, ``false`` on failure
+    :rtype: mixed
 
-	Performs atomic incrementation of a raw stored value.
+    Performs atomic incrementation of a raw stored value.
 
-	Example::
+    Example::
 
-		// 'iterator' has a value of 2
-		$cache->increment('iterator'); // 'iterator' is now 3
-		$cache->increment('iterator', 3); // 'iterator' is now 6
+        // 'iterator' has a value of 2
+        $cache->increment('iterator');    // 'iterator' is now 3
+        $cache->increment('iterator', 3); // 'iterator' is now 6
 
 .. php:method:: decrement($key[, $offset = 1]): mixed
 
-	:param string $key: Cache ID
-	:param int $offset: Step/value to reduce by
-	:returns: New value on success, ``false`` on failure
-	:rtype:	mixed
+    :param string $key: Cache ID
+    :param int $offset: Step/value to reduce by
+    :returns: New value on success, ``false`` on failure
+    :rtype: mixed
 
-	Performs atomic decrementation of a raw stored value.
+    Performs atomic decrementation of a raw stored value.
 
-	Example::
+    Example::
 
-		// 'iterator' has a value of 6
-		$cache->decrement('iterator'); // 'iterator' is now 5
-		$cache->decrement('iterator', 2); // 'iterator' is now 3
+        // 'iterator' has a value of 6
+        $cache->decrement('iterator');    // 'iterator' is now 5
+        $cache->decrement('iterator', 2); // 'iterator' is now 3
 
 .. php:method:: clean()
 
-	:returns: ``true`` on success, ``false`` on failure
-	:rtype:	bool
+    :returns: ``true`` on success, ``false`` on failure
+    :rtype: bool
 
-	This method will 'clean' the entire cache. If the deletion of the
-	cache files fails, the method will return FALSE.
+    This method will 'clean' the entire cache. If the deletion of the
+    cache files fails, the method will return FALSE.
 
-	Example::
+    Example::
 
-			$cache->clean();
+        $cache->clean();
 
 .. php:method:: getCacheInfo()
 
-	:returns: Information on the entire cache database
-	:rtype:	mixed
+    :returns: Information on the entire cache database
+    :rtype: mixed
 
-	This method will return information on the entire cache.
+    This method will return information on the entire cache.
 
-	Example::
+    Example::
 
-		var_dump($cache->getCacheInfo());
+        var_dump($cache->getCacheInfo());
 
 .. note:: The information returned and the structure of the data is dependent
-		  on which adapter is being used.
+    on which adapter is being used.
 
 .. php:method:: getMetadata(string $key)
 
-	:param string $key: Cache item name
-	:returns: Metadata for the cached item
-	:rtype:	mixed
+    :param string $key: Cache item name
+    :returns: Metadata for the cached item
+    :rtype: mixed
 
-	This method will return detailed information on a specific item in the
-	cache.
+    This method will return detailed information on a specific item in the
+    cache.
 
-	Example::
+    Example::
 
-		var_dump($cache->getMetadata('my_cached_item'));
+        var_dump($cache->getMetadata('my_cached_item'));
 
 .. note:: The information returned and the structure of the data is dependent
           on which adapter is being used.
@@ -228,12 +228,12 @@ Memcached Caching
 
 Memcached servers can be specified in the cache configuration file. Available options are::
 
-	public $memcached = [
-		'host'   => '127.0.0.1',
-		'port'   => 11211,
-		'weight' => 1,
-		'raw'    => false,
-	];
+    public $memcached = [
+        'host'   => '127.0.0.1',
+        'port'   => 11211,
+        'weight' => 1,
+        'raw'    => false,
+    ];
 
 For more information on Memcached, please see
 `https://www.php.net/memcached <https://www.php.net/memcached>`_.
@@ -256,13 +256,13 @@ To use it, you need `Redis server and phpredis PHP extension <https://github.com
 
 Config options to connect to redis server stored in the cache configuration file. Available options are::
 
-	public $redis = [
-		'host'     => '127.0.0.1',
-		'password' => null,
-		'port'     => 6379,
-		'timeout'  => 0,
-		'database' => 0,
-	];
+    public $redis = [
+        'host'     => '127.0.0.1',
+        'password' => null,
+        'port'     => 6379,
+        'timeout'  => 0,
+        'database' => 0,
+    ];
 
 For more information on Redis, please see
 `https://redis.io <https://redis.io>`_.

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -95,7 +95,7 @@ Class Reference
 
 .. php:method:: remember(string $key, int $ttl, Closure $callback)
 
-	:param string $key: Ccahe item name
+	:param string $key: Cache item name
 	:param int $ttl: Time to live in seconds
 	:param Closure $callback: Callback to invoke when the cache item returns null
 	:returns: The value of the cache item

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -104,7 +104,7 @@ Class Reference
 	Gets an item from the cache. If ``null`` was returned, this will invoke the callback
 	and save the result. Either way, this will return the value.
 
-.. php:method::⠀save(string $key, $data[, int $ttl = 60[, $raw = false]])
+.. php:method:: save(string $key, $data[, int $ttl = 60[, $raw = false]])
 
 	:param string $key: Cache item name
 	:param mixed $data: the data to save


### PR DESCRIPTION
**Description**
- fix guide not showing up after #4107
- fix typo
- convert indentation from tabs to spaces

before (#4107)
![image](https://user-images.githubusercontent.com/2387514/106181319-0c286d80-61d0-11eb-9fa1-49689714dcf3.png)

after (this PR)
![image](https://user-images.githubusercontent.com/2387514/106181454-337f3a80-61d0-11eb-9ea6-746350b725cc.png)



**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide

  
