### PR TITLE
Add STL mime support

### DIFF
--- a/app/Config/Mimes.php
+++ b/app/Config/Mimes.php
@@ -474,6 +474,11 @@ class Mimes
 			'image/x-ico',
 			'image/vnd.microsoft.icon',
 		],
+		'stl'   => [
+			'application/sla',
+			'application/vnd.ms-pki.stl',
+			'application/x-navistyle',
+		],
 	];
 
 	/**
@@ -511,7 +516,7 @@ class Mimes
 
 		if ($proposedExtension !== '')
 		{
-			if(array_key_exists($proposedExtension, static::$mimes) && in_array($type, is_string(static::$mimes[$proposedExtension]) ? [static::$mimes[$proposedExtension]] : static::$mimes[$proposedExtension], true))
+			if (array_key_exists($proposedExtension, static::$mimes) && in_array($type, is_string(static::$mimes[$proposedExtension]) ? [static::$mimes[$proposedExtension]] : static::$mimes[$proposedExtension], true))
 			{
 				// The detected mime type matches with the proposed extension.
 				return $proposedExtension;


### PR DESCRIPTION
**Description**
STL files are a common 3D model file format. I've been using my own MIME config to support them but they are so standard these days we really should have this centrally.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
