### PR TITLE
feat: add methods to get page numbers in PagerRenderer

### DIFF
--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -42,14 +42,14 @@ class PagerRenderer
 	protected $current;
 
 	/**
-	 * Total number of pages? unused?
+	 * Total number of items.
 	 *
 	 * @var integer
 	 */
 	protected $total;
 
 	/**
-	 * Page count?
+	 * Total number of pages.
 	 *
 	 * @var integer
 	 */

--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -401,4 +401,34 @@ class PagerRenderer
 
 		return (string) $uri;
 	}
+
+	/**
+	 * Returns the page number of the first page.
+	 *
+	 * @return integer
+	 */
+	public function getPageNumberFirst(): int
+	{
+		return $this->first;
+	}
+
+	/**
+	 * Returns the page number of the current page.
+	 *
+	 * @return integer
+	 */
+	public function getPageNumberCurrent(): int
+	{
+		return $this->current;
+	}
+
+	/**
+	 * Returns the page number of the last page.
+	 *
+	 * @return integer
+	 */
+	public function getPageNumberLast(): int
+	{
+		return $this->last;
+	}
 }

--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -431,4 +431,24 @@ class PagerRenderer
 	{
 		return $this->last;
 	}
+
+	/**
+	 * Returns the previous page number.
+	 *
+	 * @return integer|null
+	 */
+	public function getPreviousPageNumber(): ?int
+	{
+		return ($this->current === 1) ? null : $this->current - 1;
+	}
+
+	/**
+	 * Returns the next page number.
+	 *
+	 * @return integer|null
+	 */
+	public function getNextPageNumber(): ?int
+	{
+		return ($this->current === $this->pageCount) ? null : $this->current + 1;
+	}
 }

--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -407,7 +407,7 @@ class PagerRenderer
 	 *
 	 * @return integer
 	 */
-	public function getPageNumberFirst(): int
+	public function getFirstPageNumber(): int
 	{
 		return $this->first;
 	}
@@ -417,7 +417,7 @@ class PagerRenderer
 	 *
 	 * @return integer
 	 */
-	public function getPageNumberCurrent(): int
+	public function getCurrentPageNumber(): int
 	{
 		return $this->current;
 	}
@@ -427,7 +427,7 @@ class PagerRenderer
 	 *
 	 * @return integer
 	 */
-	public function getPageNumberLast(): int
+	public function getLastPageNumber(): int
 	{
 		return $this->last;
 	}

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -573,9 +573,9 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 		];
 		$pager   = new PagerRenderer($details);
 
-		$this->assertEquals(1, $pager->getPageNumberFirst());
-		$this->assertEquals(3, $pager->getPageNumberCurrent());
-		$this->assertEquals(10, $pager->getPageNumberLast());
+		$this->assertEquals(1, $pager->getFirstPageNumber());
+		$this->assertEquals(3, $pager->getCurrentPageNumber());
+		$this->assertEquals(10, $pager->getLastPageNumber());
 	}
 
 	public function testGetPageNumberSetSurroundCount()
@@ -591,8 +591,8 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 		$pager   = new PagerRenderer($details);
 		$pager->setSurroundCount(2);
 
-		$this->assertEquals(3, $pager->getPageNumberFirst());
-		$this->assertEquals(5, $pager->getPageNumberCurrent());
-		$this->assertEquals(7, $pager->getPageNumberLast());
+		$this->assertEquals(3, $pager->getFirstPageNumber());
+		$this->assertEquals(5, $pager->getCurrentPageNumber());
+		$this->assertEquals(7, $pager->getLastPageNumber());
 	}
 }

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -657,6 +657,6 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 		$pager   = new PagerRenderer($details);
 		$pager->setSurroundCount(2);
 
-		$this->assertEquals(null, $pager->getNextPageNumber());
+		$this->assertNull($pager->getNextPageNumber());
 	}
 }

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -625,7 +625,7 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 		$pager   = new PagerRenderer($details);
 		$pager->setSurroundCount(2);
 
-		$this->assertEquals(null, $pager->getPreviousPageNumber());
+		$this->assertNull($pager->getPreviousPageNumber());
 	}
 
 	public function testGetNextPageNumber()

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -560,4 +560,21 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 		$pager = new PagerRenderer($details);
 		$this->assertEquals('http://example.com/foo/4', $pager->getNextPage());
 	}
+
+	public function testGetPageNumber()
+	{
+		$uri     = $this->uri;
+		$details = [
+			'uri'         => $uri,
+			'pageCount'   => 10,
+			'currentPage' => 3,
+			'total'       => 100,
+			'segment'     => 2,
+		];
+		$pager   = new PagerRenderer($details);
+
+		$this->assertEquals(1, $pager->getPageNumberFirst());
+		$this->assertEquals(3, $pager->getPageNumberCurrent());
+		$this->assertEquals(10, $pager->getPageNumberLast());
+	}
 }

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -595,4 +595,68 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(5, $pager->getCurrentPageNumber());
 		$this->assertEquals(7, $pager->getLastPageNumber());
 	}
+
+	public function testGetPreviousPageNumber()
+	{
+		$uri     = $this->uri;
+		$details = [
+			'uri'         => $uri,
+			'pageCount'   => 10,
+			'currentPage' => 5,
+			'total'       => 100,
+			'segment'     => 2,
+		];
+		$pager   = new PagerRenderer($details);
+		$pager->setSurroundCount(2);
+
+		$this->assertEquals(4, $pager->getPreviousPageNumber());
+	}
+
+	public function testGetPreviousPageNumberNull()
+	{
+		$uri     = $this->uri;
+		$details = [
+			'uri'         => $uri,
+			'pageCount'   => 10,
+			'currentPage' => 1,
+			'total'       => 100,
+			'segment'     => 2,
+		];
+		$pager   = new PagerRenderer($details);
+		$pager->setSurroundCount(2);
+
+		$this->assertEquals(null, $pager->getPreviousPageNumber());
+	}
+
+	public function testGetNextPageNumber()
+	{
+		$uri     = $this->uri;
+		$details = [
+			'uri'         => $uri,
+			'pageCount'   => 10,
+			'currentPage' => 5,
+			'total'       => 100,
+			'segment'     => 2,
+		];
+		$pager   = new PagerRenderer($details);
+		$pager->setSurroundCount(2);
+
+		$this->assertEquals(6, $pager->getNextPageNumber());
+	}
+
+	public function testGetNextPageNumberNull()
+	{
+		$uri     = $this->uri;
+		$details = [
+			'uri'         => $uri,
+			'pageCount'   => 10,
+			'currentPage' => 10,
+			'total'       => 100,
+			'segment'     => 2,
+		];
+		$pager   = new PagerRenderer($details);
+		$pager->setSurroundCount(2);
+
+		$this->assertEquals(null, $pager->getNextPageNumber());
+	}
 }

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -577,4 +577,22 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(3, $pager->getPageNumberCurrent());
 		$this->assertEquals(10, $pager->getPageNumberLast());
 	}
+
+	public function testGetPageNumberSetSurroundCount()
+	{
+		$uri     = $this->uri;
+		$details = [
+			'uri'         => $uri,
+			'pageCount'   => 10,
+			'currentPage' => 5,
+			'total'       => 100,
+			'segment'     => 2,
+		];
+		$pager   = new PagerRenderer($details);
+		$pager->setSurroundCount(2);
+
+		$this->assertEquals(3, $pager->getPageNumberFirst());
+		$this->assertEquals(5, $pager->getPageNumberCurrent());
+		$this->assertEquals(7, $pager->getPageNumberLast());
+	}
 }


### PR DESCRIPTION
**Description**
Supersedes #4141

Add methods to get page numbers in PagerRenderer.
To generate Pager HTML that is the same as CI3's.

- getFirstPageNumber()
- getCurrentPageNumber()
- getLastPageNumber()
- getPreviousPageNumber()
- getNextPageNumber()

The template would be like this:
```php
<?php if ($pager->hasPreviousPage()) : ?>
<a href="<?= $pager->getFirst() ?>" data-ci-pagination-page="<?= $pager->getPageNumberFirst() ?>" rel="start">&laquo;First</a>
<a href="<?= $pager->getPreviousPage() ?>" data-ci-pagination-page="<?= $pager->getPreviousPageNumber() ?>" rel="prev">&lt;</a>
<?php endif ?>
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
