### PR TITLE
docs: Fix double "the"

### DIFF
--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -3,7 +3,7 @@ Error Handling
 ##############
 
 CodeIgniter builds error reporting into your system through Exceptions, both the `SPL collection <https://www.php.net/manual/en/spl.exceptions.php>`_, as
-well as a few custom exceptions that are provided by the framework. Depending on your environment's setup, the
+well as a few custom exceptions that are provided by the framework. Depending on your environment's setup,
 the default action when an error or exception is thrown is to display a detailed error report unless the application
 is running under the ``production`` environment. In this case, a more generic message is displayed to
 keep the best user experience for your users.

--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -428,7 +428,7 @@ all identical::
 isBefore()
 ----------
 
-Checks if the passed in time is before the the current instance. The comparison is done against the UTC versions of
+Checks if the passed in time is before the current instance. The comparison is done against the UTC versions of
 both times::
 
     $time1 = Time::parse('January 10, 2017 21:50:00', 'America/Chicago');


### PR DESCRIPTION
**Description**
Removes unneeded `the`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
