### PR TITLE
Fix Parser file path in ViewException message is empty

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -117,13 +117,14 @@ class Parser extends View
 
 		if (! is_file($file))
 		{
-			$file = $this->loader->locateFile($view, 'Views');
-		}
+			$fileOrig = $file;
+			$file     = $this->loader->locateFile($view, 'Views');
 
-		// locateFile will return an empty string if the file cannot be found.
-		if (empty($file))
-		{
-			throw ViewException::forInvalidFile($file);
+			// locateFile will return an empty string if the file cannot be found.
+			if (empty($file))
+			{
+				throw ViewException::forInvalidFile($fileOrig);
+			}
 		}
 
 		if (is_null($this->tempData))

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -329,8 +329,8 @@ class Parser extends View
 		// Find all matches of space-flexible versions of {tag}{/tag} so we
 		// have something to loop over.
 		preg_match_all(
-				'#' . $this->leftDelimiter . '\s*' . preg_quote($variable) . '\s*' . $this->rightDelimiter . '(.+?)' .
-				$this->leftDelimiter . '\s*' . '/' . preg_quote($variable) . '\s*' . $this->rightDelimiter . '#s', $template, $matches, PREG_SET_ORDER
+			'#' . $this->leftDelimiter . '\s*' . preg_quote($variable) . '\s*' . $this->rightDelimiter . '(.+?)' .
+			$this->leftDelimiter . '\s*' . '/' . preg_quote($variable) . '\s*' . $this->rightDelimiter . '#s', $template, $matches, PREG_SET_ORDER
 		);
 
 		/*

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -942,6 +942,8 @@ class ParserTest extends CIUnitTestCase
 	public function testRenderCannotFindView()
 	{
 		$this->expectException(ViewException::class);
+		$this->expectExceptionMessageMatches('!/View/Views/Simplest\.php\z!');
+
 		$this->parser->setData(['testString' => 'Hello World']);
 		$this->parser->render('Simplest');
 	}


### PR DESCRIPTION
**Description**
- add invalid file path in ViewException message, so that we can see the invalid view name.
- fix indentation

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
