### PR TITLE
Abstraction for cookies and cookie collections

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -309,7 +309,7 @@ class App extends BaseConfig
 	 * (empty string) means default SameSite attribute set by browsers (`Lax`)
 	 * will be set on cookies. If set to `None`, `$cookieSecure` must also be set.
 	 *
-	 * @var string 'Lax'|'None'|'Strict'
+	 * @var string
 	 */
 	public $cookieSameSite = 'Lax';
 

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -3,6 +3,7 @@
 namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
+use DateTimeInterface;
 
 class App extends BaseConfig
 {
@@ -279,14 +280,14 @@ class App extends BaseConfig
 
 	/**
 	 * --------------------------------------------------------------------------
-	 * Cookie HTTP Only
+	 * Cookie HttpOnly
 	 * --------------------------------------------------------------------------
 	 *
 	 * Cookie will only be accessible via HTTP(S) (no JavaScript).
 	 *
 	 * @var boolean
 	 */
-	public $cookieHTTPOnly = false;
+	public $cookieHTTPOnly = true;
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -299,13 +300,49 @@ class App extends BaseConfig
 	 * - Strict
 	 * - ''
 	 *
-	 * Defaults to `Lax` for compatibility with modern browsers. Setting `''`
-	 * (empty string) means no SameSite attribute will be set on cookies. If
-	 * set to `None`, `$cookieSecure` must also be set.
+	 * Alternatively, you can use the constant names:
+	 * - `Cookie::SAMESITE_NONE`
+	 * - `Cookie::SAMESITE_LAX`
+	 * - `Cookie::SAMESITE_STRICT`
 	 *
-       * @var string 'Lax'|'None'|'Strict'
+	 * Defaults to `Lax` for compatibility with modern browsers. Setting `''`
+	 * (empty string) means default SameSite attribute set by browsers (`Lax`)
+	 * will be set on cookies. If set to `None`, `$cookieSecure` must also be set.
+	 *
+	 * @var string 'Lax'|'None'|'Strict'
 	 */
 	public $cookieSameSite = 'Lax';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie Raw
+	 * --------------------------------------------------------------------------
+	 *
+	 * This flag allows setting a "raw" cookie, i.e., its name and value are
+	 * not URL encoded using `rawurlencode()`.
+	 *
+	 * If this is set to `true`, cookie names should be compliant of RFC 2616's
+	 * list of allowed characters.
+	 *
+	 * @var boolean
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes
+	 * @see https://tools.ietf.org/html/rfc2616#section-2.2
+	 */
+	public $cookieRaw = false;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie Expires Timestamp
+	 * --------------------------------------------------------------------------
+	 *
+	 * Default expires timestamp for cookies. Setting this to `0` will mean the
+	 * cookie will not have the `Expires` attribute and will behave as a session
+	 * cookie.
+	 *
+	 * @var DateTimeInterface|integer|string
+	 */
+	public $cookieExpires = 0;
 
 	/**
 	 * --------------------------------------------------------------------------

--- a/app/Config/Security.php
+++ b/app/Config/Security.php
@@ -84,9 +84,12 @@ class Security extends BaseConfig
 	 * Allowed values are: None - Lax - Strict - ''.
 	 *
 	 * Defaults to `Lax` as recommended in this link:
+	 *
 	 * @see https://portswigger.net/web-security/csrf/samesite-cookies
 	 *
-       * @var string 'Lax'|'None'|'Strict'
+	 * @var string
+	 *
+	 * @deprecated
 	 */
 	public $samesite = 'Lax';
 }

--- a/system/Common.php
+++ b/system/Common.php
@@ -15,6 +15,9 @@ use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\ConnectionInterface;
 use CodeIgniter\Debug\Timer;
 use CodeIgniter\Files\Exceptions\FileNotFoundException;
+use CodeIgniter\HTTP\Cookie\Cookie;
+use CodeIgniter\HTTP\Cookie\CookieStore;
+use CodeIgniter\HTTP\Exceptions\CookieException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
@@ -223,6 +226,46 @@ if (! function_exists('config'))
 	function config(string $name, bool $getShared = true)
 	{
 		return Factories::config($name, ['getShared' => $getShared]);
+	}
+}
+
+if (! function_exists('cookie'))
+{
+	/**
+	 * Simpler way to create a new Cookie instance.
+	 *
+	 * @param string $name    Name of the cookie
+	 * @param string $value   Value of the cookie
+	 * @param array  $options Array of options to be passed to the cookie
+	 *
+	 * @throws CookieException
+	 *
+	 * @return Cookie
+	 */
+	function cookie(string $name, string $value = '', array $options = []): Cookie
+	{
+		return Cookie::create($name, $value, $options);
+	}
+}
+
+if (! function_exists('cookies'))
+{
+	/**
+	 * Fetches the global `CookieStore` instance held by `Response`.
+	 *
+	 * @param Cookie[] $cookies   If `getGlobal` is false, this is passed to CookieStore's constructor
+	 * @param boolean  $getGlobal If false, creates a new instance of CookieStore
+	 *
+	 * @return CookieStore
+	 */
+	function cookies(array $cookies = [], bool $getGlobal = true): CookieStore
+	{
+		if ($getGlobal)
+		{
+			return Services::response()->getCookieStore();
+		}
+
+		return new CookieStore($cookies);
 	}
 }
 

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -677,7 +677,7 @@ class Services extends BaseService
 			return static::getSharedInstance('security', $config);
 		}
 
-		$config = $config ?? config('Security') ?? config('App');
+		$config = $config ?? config('App');
 
 		return new Security($config);
 	}

--- a/system/HTTP/Cookie/ClonableCookieInterface.php
+++ b/system/HTTP/Cookie/ClonableCookieInterface.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP\Cookie;
+
+use DateTimeInterface;
+
+/**
+ * Interface for a fresh Cookie instance with selected attribute(s)
+ * only changed from the original instance.
+ */
+interface ClonableCookieInterface extends CookieInterface
+{
+	/**
+	 * Creates a new Cookie with URL encoding option updated.
+	 *
+	 * @param boolean $raw
+	 *
+	 * @return static
+	 */
+	public function withRaw(bool $raw = true);
+
+	/**
+	 * Creates a new Cookie with a new cookie prefix.
+	 *
+	 * @param string $prefix
+	 *
+	 * @return static
+	 */
+	public function withPrefix(string $prefix = '');
+
+	/**
+	 * Creates a new Cookie with a new name.
+	 *
+	 * @param string $name
+	 *
+	 * @return static
+	 */
+	public function withName(string $name);
+
+	/**
+	 * Creates a new Cookie with new value.
+	 *
+	 * @param string $value
+	 *
+	 * @return static
+	 */
+	public function withValue(string $value);
+
+	/**
+	 * Creates a new Cookie with a new cookie expires time.
+	 *
+	 * @param DateTimeInterface|integer|string $expires
+	 *
+	 * @return static
+	 */
+	public function withExpiresAt($expires = 0);
+
+	/**
+	 * Creates a new Cookie that will expire the cookie from the browser.
+	 *
+	 * @return static
+	 */
+	public function withExpired();
+
+	/**
+	 * Creates a new Cookie that will virtually never expire from the browser.
+	 *
+	 * @return static
+	 */
+	public function withNeverExpiring();
+
+	/**
+	 * Creates a new Cookie with a new domain the cookie is available.
+	 *
+	 * @param string|null $domain
+	 *
+	 * @return static
+	 */
+	public function withDomain(?string $domain);
+
+	/**
+	 * Creates a new Cookie with a new path on the server the cookie is available.
+	 *
+	 * @param string|null $path
+	 *
+	 * @return static
+	 */
+	public function withPath(?string $path);
+
+	/**
+	 * Creates a new Cookie with a new "Secure" attribute.
+	 *
+	 * @param boolean $secure
+	 *
+	 * @return static
+	 */
+	public function withSecure(bool $secure = true);
+
+	/**
+	 * Creates a new Cookie with a new "HttpOnly" attribute
+	 *
+	 * @param boolean $httpOnly
+	 *
+	 * @return static
+	 */
+	public function withHttpOnly(bool $httpOnly = true);
+
+	/**
+	 * Creates a new Cookie with a new "SameSite" attribute.
+	 *
+	 * @param string $sameSite
+	 *
+	 * @return static
+	 */
+	public function withSameSite(string $sameSite);
+}

--- a/system/HTTP/Cookie/CloneableCookieInterface.php
+++ b/system/HTTP/Cookie/CloneableCookieInterface.php
@@ -17,7 +17,7 @@ use DateTimeInterface;
  * Interface for a fresh Cookie instance with selected attribute(s)
  * only changed from the original instance.
  */
-interface ClonableCookieInterface extends CookieInterface
+interface CloneableCookieInterface extends CookieInterface
 {
 	/**
 	 * Creates a new Cookie with URL encoding option updated.

--- a/system/HTTP/Cookie/Cookie.php
+++ b/system/HTTP/Cookie/Cookie.php
@@ -1,0 +1,909 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP\Cookie;
+
+use ArrayAccess;
+use CodeIgniter\HTTP\Exceptions\CookieException;
+use Config\App;
+use DateTimeInterface;
+use InvalidArgumentException;
+use LogicException;
+
+/**
+ * A `Cookie` class represents an immutable HTTP cookie value object.
+ *
+ * Being immutable, modifying one or more of its attributes will return
+ * a new `Cookie` instance, rather than modifying itself. Users should
+ * reassign this new instance to a new variable to capture it.
+ *
+ * ```php
+ * $cookie = Cookie::create('test_cookie', 'test_value');
+ * $cookie->getName(); // test_cookie
+ *
+ * $cookie->withName('prod_cookie');
+ * $cookie->getName(); // test_cookie
+ *
+ * $cookie2 = $cookie->withName('prod_cookie');
+ * $cookie2->getName(); // prod_cookie
+ * ```
+ */
+class Cookie implements ArrayAccess, ClonableCookieInterface
+{
+	/**
+	 * @var boolean
+	 */
+	protected $raw = false;
+
+	/**
+	 * @var string
+	 */
+	protected $prefix = '';
+
+	/**
+	 * @var string
+	 */
+	protected $name;
+
+	/**
+	 * @var string
+	 */
+	protected $value;
+
+	/**
+	 * @var integer
+	 */
+	protected $expires;
+
+	/**
+	 * @var string
+	 */
+	protected $path = '/';
+
+	/**
+	 * @var string
+	 */
+	protected $domain = '';
+
+	/**
+	 * @var boolean
+	 */
+	protected $secure = false;
+
+	/**
+	 * @var boolean
+	 */
+	protected $httpOnly = true;
+
+	/**
+	 * @var string
+	 */
+	protected $sameSite = self::SAMESITE_LAX;
+
+	/**
+	 * Default attributes for a Cookie object. The keys here are the
+	 * lowercase attribute names. Do not camelCase!
+	 *
+	 * @var array<string, mixed>
+	 */
+	private static $defaults = [
+		'prefix'   => '',
+		'expires'  => 0,
+		'path'     => '/',
+		'domain'   => '',
+		'secure'   => false,
+		'httponly' => true,
+		'raw'      => false,
+		'samesite' => self::SAMESITE_LAX,
+	];
+
+	/**
+	 * A cookie name can be any US-ASCII characters, except control characters,
+	 * spaces, tabs, or separator characters.
+	 *
+	 * @var string
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes
+	 * @see https://tools.ietf.org/html/rfc2616#section-2.2
+	 */
+	private static $reservedCharsList = "=,; \t\r\n\v\f()<>@:\\\"/[]?{}";
+
+	/**
+	 * Set the default attributes to a Cookie instance by injecting
+	 * the values from the `App` config or an array.
+	 *
+	 * @param App|array<string, mixed> $config
+	 *
+	 * @return array<string, mixed> The old defaults array. Useful for resetting.
+	 */
+	public static function setDefaults($config = [])
+	{
+		$oldDefaults = static::$defaults;
+		$newDefaults = [];
+
+		if ($config instanceof App)
+		{
+			$newDefaults = [
+				'prefix'   => $config->cookiePrefix,
+				'expires'  => $config->cookieExpires ?? 0,
+				'domain'   => $config->cookieDomain,
+				'path'     => $config->cookiePath,
+				'secure'   => $config->cookieSecure,
+				'httponly' => $config->cookieHTTPOnly,
+				'raw'      => $config->cookieRaw ?? false,
+				'samesite' => $config->cookieSameSite ?? self::SAMESITE_LAX,
+			];
+		}
+		elseif (is_array($config))
+		{
+			$newDefaults = $config;
+		}
+
+		// This array union ensures that even if passed `$config`
+		// is not `App` or `array`, no empty defaults will occur.
+		static::$defaults = $newDefaults + $oldDefaults;
+
+		return $oldDefaults;
+	}
+
+	//=========================================================================
+	// CONSTRUCTORS
+	//=========================================================================
+
+	/**
+	 * Create a new Cookie instance from a `Set-Cookie` header.
+	 *
+	 * @param string  $cookie
+	 * @param boolean $raw
+	 *
+	 * @throws CookieException
+	 *
+	 * @return static
+	 */
+	public static function fromHeaderString(string $cookie, bool $raw = false)
+	{
+		$data        = self::$defaults;
+		$data['raw'] = $raw;
+
+		$parts = preg_split('/\;[\s]*/', $cookie);
+		$part  = explode('=', array_shift($parts), 2);
+
+		$name  = $raw ? $part[0] : urldecode($part[0]);
+		$value = isset($part[1]) ? ($raw ? $part[1] : urldecode($part[1])) : '';
+		unset($part);
+
+		foreach ($parts as $part)
+		{
+			if (strpos($part, '=') !== false)
+			{
+				list($attr, $val) = explode('=', $part);
+			}
+			else
+			{
+				$attr = $part;
+				$val  = true;
+			}
+
+			$data[strtolower($attr)] = $val;
+		}
+
+		return static::create($name, $value, $data);
+	}
+
+	/**
+	 * Create Cookie objects on the fly.
+	 *
+	 * @param string               $name
+	 * @param string               $value
+	 * @param array<string, mixed> $options
+	 *
+	 * @throws CookieException
+	 *
+	 * @return static
+	 */
+	public static function create(string $name, string $value = '', array $options = [])
+	{
+		$options += self::$defaults;
+
+		$options['expires'] = static::convertExpiresTimestamp($options['expires']);
+
+		// If both `Expires` and `Max-Age` are set, `Max-Age` has precedence.
+		if (isset($options['max-age']) && is_numeric($options['max-age']))
+		{
+			$options['expires'] = time() + (int) $options['max-age'];
+			unset($options['max-age']);
+		}
+
+		return new static(
+			$name,
+			$value,
+			$options['expires'],
+			$options['prefix'],
+			$options['path'],
+			$options['domain'],
+			$options['secure'],
+			$options['httponly'],
+			$options['raw'],
+			$options['samesite']
+		);
+	}
+
+	/**
+	 * Construct a new Cookie instance.
+	 *
+	 * @param string                           $name     The name of the cookie
+	 * @param string                           $value    The value of the cookie
+	 * @param DateTimeInterface|integer|string $expires  The time the cookie expires
+	 * @param string|null                      $prefix   The prefix of the cookie
+	 * @param string|null                      $path     The path on the server in which the cookie is available
+	 * @param string|null                      $domain   The domain in which the cookie is available
+	 * @param boolean                          $secure   Whether to send back the cookie over HTTPS
+	 * @param boolean                          $httpOnly Whether to forbid JavaScript access to cookies
+	 * @param boolean                          $raw      Whether the cookie should be sent with no URL encoding
+	 * @param string                           $sameSite Whether the cookie will be available for cross-site requests
+	 *
+	 * @throws CookieException
+	 */
+	public function __construct(
+		string $name,
+		string $value = '',
+		$expires = 0,
+		string $prefix = null,
+		string $path = null,
+		string $domain = null,
+		bool $secure = false,
+		bool $httpOnly = true,
+		bool $raw = false,
+		string $sameSite = self::SAMESITE_LAX
+	)
+	{
+		// to retain BC
+		$prefix   = $prefix ?: self::$defaults['prefix'];
+		$path     = $path ?: self::$defaults['path'];
+		$domain   = $domain ?: self::$defaults['domain'];
+		$secure   = $secure ?: self::$defaults['secure'];
+		$httpOnly = $httpOnly ?: self::$defaults['httponly'];
+		$sameSite = $sameSite ?: self::$defaults['samesite'];
+
+		$this->validateName($name, $raw);
+		$this->validatePrefix($prefix, $secure, $domain, $path);
+		$this->validateSameSite($sameSite, $secure);
+
+		$this->name     = $name;
+		$this->value    = $value;
+		$this->expires  = static::convertExpiresTimestamp($expires);
+		$this->prefix   = $prefix;
+		$this->path     = $path;
+		$this->domain   = $domain;
+		$this->secure   = $secure;
+		$this->httpOnly = $httpOnly;
+		$this->raw      = $raw;
+		$this->sameSite = ucfirst(strtolower($sameSite));
+	}
+
+	//=========================================================================
+	// GETTERS
+	//=========================================================================
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getId(): string
+	{
+		$name   = $this->getPrefixedName();
+		$domain = $this->getDomain();
+		$path   = $this->getPath();
+
+		return implode(';', [$name, $domain, $path]);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isRaw(): bool
+	{
+		return $this->raw;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getPrefix(): string
+	{
+		return $this->prefix;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getName(): string
+	{
+		return $this->name;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getPrefixedName(): string
+	{
+		$name = $this->getPrefix();
+
+		if ($this->isRaw())
+		{
+			$name .= $this->getName();
+		}
+		else
+		{
+			$search  = str_split(self::$reservedCharsList);
+			$replace = array_map(static function (string $char): string {
+				return rawurlencode($char);
+			}, $search);
+
+			$name .= str_replace($search, $replace, $this->getName());
+		}
+
+		return $name;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getValue(): string
+	{
+		return $this->value;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getExpiresTimestamp(): int
+	{
+		return $this->expires;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getExpiresString(): string
+	{
+		return gmdate(self::EXPIRES_FORMAT, $this->expires);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isExpired(): bool
+	{
+		return $this->expires === 0 || $this->expires < time();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getMaxAge(): int
+	{
+		$maxAge = $this->expires - time();
+
+		return $maxAge >= 0 ? $maxAge : 0;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getDomain(): string
+	{
+		return $this->domain;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getPath(): string
+	{
+		return $this->path;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isSecure(): bool
+	{
+		return $this->secure;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isHttpOnly(): bool
+	{
+		return $this->httpOnly;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getSameSite(): string
+	{
+		return $this->sameSite;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getOptions(): array
+	{
+		// This is the order of options in `setcookie`. DO NOT change.
+		return [
+			'expires'  => $this->expires,
+			'path'     => $this->path,
+			'domain'   => $this->domain,
+			'secure'   => $this->secure,
+			'httponly' => $this->httpOnly,
+			'samesite' => $this->sameSite ?: ucfirst(self::SAMESITE_LAX),
+		];
+	}
+
+	//=========================================================================
+	// CLONING
+	//=========================================================================
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function withRaw(bool $raw = true)
+	{
+		$this->validateName($this->name, $raw);
+
+		$cookie = clone $this;
+
+		$cookie->raw = $raw;
+
+		return $cookie;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function withPrefix(string $prefix = '')
+	{
+		$this->validatePrefix($prefix, $this->secure, $this->domain, $this->path);
+
+		$cookie = clone $this;
+
+		$cookie->prefix = $prefix;
+
+		return $cookie;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function withName(string $name)
+	{
+		$this->validateName($name, $this->raw);
+
+		$cookie = clone $this;
+
+		$cookie->name = $name;
+
+		return $cookie;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function withValue(string $value)
+	{
+		$cookie = clone $this;
+
+		$cookie->value = $value;
+
+		return $cookie;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function withExpiresAt($expires = 0)
+	{
+		$cookie = clone $this;
+
+		$cookie->expires = static::convertExpiresTimestamp($expires);
+
+		return $cookie;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function withExpired()
+	{
+		$cookie = clone $this;
+
+		$cookie->expires = 0;
+
+		return $cookie;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function withNeverExpiring()
+	{
+		$cookie = clone $this;
+
+		$cookie->expires = time() + 5 * YEAR;
+
+		return $cookie;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function withDomain(?string $domain)
+	{
+		$domain = $domain ?? self::$defaults['domain'];
+		$this->validatePrefix($this->prefix, $this->secure, $domain, $this->path);
+
+		$cookie = clone $this;
+
+		$cookie->domain = $domain;
+
+		return $cookie;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function withPath(?string $path)
+	{
+		$path = $path ?: self::$defaults['path'];
+		$this->validatePrefix($this->prefix, $this->secure, $this->domain, $path);
+
+		$cookie = clone $this;
+
+		$cookie->path = $path;
+
+		return $cookie;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function withSecure(bool $secure = true)
+	{
+		$this->validatePrefix($this->prefix, $secure, $this->domain, $this->path);
+		$this->validateSameSite($this->sameSite, $secure);
+
+		$cookie = clone $this;
+
+		$cookie->secure = $secure;
+
+		return $cookie;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function withHttpOnly(bool $httpOnly = true)
+	{
+		$cookie = clone $this;
+
+		$cookie->httpOnly = $httpOnly;
+
+		return $cookie;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function withSameSite(string $sameSite)
+	{
+		$this->validateSameSite($sameSite, $this->secure);
+
+		$cookie = clone $this;
+
+		$cookie->sameSite = $sameSite;
+
+		return $cookie;
+	}
+
+	//=========================================================================
+	// ARRAY ACCESS FOR BC
+	//=========================================================================
+
+	/**
+	 * Whether an offset exists.
+	 *
+	 * @param string $offset
+	 *
+	 * @return boolean
+	 */
+	public function offsetExists($offset)
+	{
+		if (in_array($offset, ['expire', 'httponly', 'samesite'], true))
+		{
+			return true;
+		}
+
+		return property_exists($this, $offset);
+	}
+
+	/**
+	 * Offset to retrieve.
+	 *
+	 * @param string $offset
+	 *
+	 * @throws InvalidArgumentException
+	 *
+	 * @return mixed
+	 */
+	public function offsetGet($offset)
+	{
+		if (! $this->offsetExists($offset))
+		{
+			throw new InvalidArgumentException(sprintf('Undefined offset "%s".', $offset));
+		}
+
+		if ($offset === 'expire')
+		{
+			return $this->expires;
+		}
+
+		if ($offset === 'httponly')
+		{
+			return $this->httpOnly;
+		}
+
+		if ($offset === 'samesite')
+		{
+			return $this->sameSite;
+		}
+
+		return $this->{$offset};
+	}
+
+	/**
+	 * Offset to set.
+	 *
+	 * @param string $offset
+	 * @param mixed  $value
+	 *
+	 * @throws LogicException
+	 *
+	 * @return void
+	 */
+	public function offsetSet($offset, $value)
+	{
+		throw new LogicException(sprintf('Cannot set values of properties of %s as it is immutable.', static::class));
+	}
+
+	/**
+	 * Offset to unset.
+	 *
+	 * @param string $offset
+	 *
+	 * @throws LogicException
+	 *
+	 * @return void
+	 */
+	public function offsetUnset($offset)
+	{
+		throw new LogicException(sprintf('Cannot unset values of properties of %s as it is immutable.', static::class));
+	}
+
+	//=========================================================================
+	// CONVERTERS
+	//=========================================================================
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toHeaderString(): string
+	{
+		return $this->__toString();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function __toString()
+	{
+		$cookieHeader = [];
+
+		if ($this->getValue() === '')
+		{
+			$cookieHeader[] = $this->getPrefixedName() . '=deleted';
+			$cookieHeader[] = 'Expires=' . gmdate(self::EXPIRES_FORMAT, 0);
+			$cookieHeader[] = 'Max-Age=0';
+		}
+		else
+		{
+			$value = $this->isRaw() ? $this->getValue() : rawurlencode($this->getValue());
+
+			$cookieHeader[] = sprintf('%s=%s', $this->getPrefixedName(), $value);
+
+			if ($this->getExpiresTimestamp() !== 0)
+			{
+				$cookieHeader[] = 'Expires=' . $this->getExpiresString();
+				$cookieHeader[] = 'Max-Age=' . (string) $this->getMaxAge();
+			}
+		}
+
+		if ($this->getPath() !== '')
+		{
+			$cookieHeader[] = 'Path=' . $this->getPath();
+		}
+
+		if ($this->getDomain() !== '')
+		{
+			$cookieHeader[] = 'Domain=' . $this->getDomain();
+		}
+
+		if ($this->isSecure())
+		{
+			$cookieHeader[] = 'Secure';
+		}
+
+		if ($this->isHttpOnly())
+		{
+			$cookieHeader[] = 'HttpOnly';
+		}
+
+		$sameSite = $this->getSameSite();
+
+		if ($sameSite === '')
+		{
+			// modern browsers warn in console logs that an empty SameSite attribute
+			// will be given the `Lax` value
+			$sameSite = self::SAMESITE_LAX;
+		}
+
+		$cookieHeader[] = 'SameSite=' . ucfirst(strtolower($sameSite));
+
+		return implode('; ', $cookieHeader);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function toArray(): array
+	{
+		return [
+			'name'   => $this->name,
+			'value'  => $this->value,
+			'prefix' => $this->prefix,
+			'raw'    => $this->raw,
+		] + $this->getOptions();
+	}
+
+	/**
+	 * Converts expires time to Unix format.
+	 *
+	 * @param DateTimeInterface|integer|string $expires
+	 *
+	 * @return integer
+	 */
+	protected static function convertExpiresTimestamp($expires = 0): int
+	{
+		if ($expires instanceof DateTimeInterface)
+		{
+			$expires = $expires->format('U');
+		}
+
+		if (! is_string($expires) && ! is_int($expires))
+		{
+			throw CookieException::forInvalidExpiresTime(gettype($expires));
+		}
+
+		if (! is_numeric($expires))
+		{
+			$expires = strtotime($expires);
+
+			if ($expires === false)
+			{
+				throw CookieException::forInvalidExpiresValue();
+			}
+		}
+
+		return $expires > 0 ? (int) $expires : 0;
+	}
+
+	//=========================================================================
+	// VALIDATION
+	//=========================================================================
+
+	/**
+	 * Validates the cookie name per RFC 2616.
+	 *
+	 * If `$raw` is true, names should not contain invalid characters
+	 * as `setrawcookie()` will reject this.
+	 *
+	 * @param string  $name
+	 * @param boolean $raw
+	 *
+	 * @throws CookieException
+	 *
+	 * @return void
+	 */
+	protected function validateName(string $name, bool $raw): void
+	{
+		if ($raw && strpbrk($name, self::$reservedCharsList) !== false)
+		{
+			throw CookieException::forInvalidCookieName($name);
+		}
+
+		if ($name === '')
+		{
+			throw CookieException::forEmptyCookieName();
+		}
+	}
+
+	/**
+	 * Validates the special prefixes if some attribute requirements are met.
+	 *
+	 * @param string  $prefix
+	 * @param boolean $secure
+	 * @param string  $domain
+	 * @param string  $path
+	 *
+	 * @throws CookieException
+	 *
+	 * @return void
+	 */
+	protected function validatePrefix(string $prefix, bool $secure, string $domain, string $path): void
+	{
+		if (stripos($prefix, '__Secure-') === 0 && ! $secure)
+		{
+			throw CookieException::forInvalidSecurePrefix();
+		}
+
+		if (stripos($prefix, '__Host-') === 0 && (! $secure || $domain !== '' || $path !== '/'))
+		{
+			throw CookieException::forInvalidHostPrefix();
+		}
+	}
+
+	/**
+	 * Validates the `SameSite` to be within the allowed types.
+	 *
+	 * @param string  $sameSite
+	 * @param boolean $secure
+	 *
+	 * @throws CookieException
+	 *
+	 * @return void
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+	 */
+	protected function validateSameSite(string $sameSite, bool $secure): void
+	{
+		if ($sameSite === '')
+		{
+			$sameSite = self::$defaults['samesite'];
+		}
+
+		if ($sameSite === '')
+		{
+			$sameSite = self::SAMESITE_LAX;
+		}
+
+		if (! in_array(strtolower($sameSite), self::ALLOWED_SAMESITE_VALUES, true))
+		{
+			throw CookieException::forInvalidSameSite($sameSite);
+		}
+
+		if (strtolower($sameSite) === self::SAMESITE_NONE && ! $secure)
+		{
+			throw CookieException::forInvalidSameSiteNone();
+		}
+	}
+}

--- a/system/HTTP/Cookie/Cookie.php
+++ b/system/HTTP/Cookie/Cookie.php
@@ -36,7 +36,7 @@ use LogicException;
  * $cookie2->getName(); // prod_cookie
  * ```
  */
-class Cookie implements ArrayAccess, ClonableCookieInterface
+class Cookie implements ArrayAccess, CloneableCookieInterface
 {
 	/**
 	 * @var boolean
@@ -611,7 +611,7 @@ class Cookie implements ArrayAccess, ClonableCookieInterface
 
 		$cookie = clone $this;
 
-		$cookie->sameSite = $sameSite;
+		$cookie->sameSite = ucfirst(strtolower($sameSite));
 
 		return $cookie;
 	}

--- a/system/HTTP/Cookie/CookieInterface.php
+++ b/system/HTTP/Cookie/CookieInterface.php
@@ -1,0 +1,208 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP\Cookie;
+
+/**
+ * Interface for a value object representation of an HTTP cookie.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
+ */
+interface CookieInterface
+{
+	/**
+	 * Cookies will be sent in all contexts, i.e in responses to both
+	 * first-party and cross-origin requests. If `SameSite=None` is set,
+	 * the cookie `Secure` attribute must also be set (or the cookie will be blocked).
+	 */
+	public const SAMESITE_NONE = 'none';
+
+	/**
+	 * Cookies are not sent on normal cross-site subrequests (for example to
+	 * load images or frames into a third party site), but are sent when a
+	 * user is navigating to the origin site (i.e. when following a link).
+	 *
+	 * @var string
+	 */
+	public const SAMESITE_LAX = 'lax';
+
+	/**
+	 * Cookies will only be sent in a first-party context and not be sent
+	 * along with requests initiated by third party websites.
+	 *
+	 * @var string
+	 */
+	public const SAMESITE_STRICT = 'strict';
+
+	/**
+	 * RFC 6265 allowed values for the "SameSite" attribute.
+	 *
+	 * @var string[]
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+	 */
+	public const ALLOWED_SAMESITE_VALUES = [
+		self::SAMESITE_NONE,
+		self::SAMESITE_LAX,
+		self::SAMESITE_STRICT,
+	];
+
+	/**
+	 * Expires date format.
+	 *
+	 * @var string
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
+	 * @see https://tools.ietf.org/html/rfc7231#section-7.1.1.2
+	 */
+	public const EXPIRES_FORMAT = 'D, d-M-Y H:i:s T';
+
+	/**
+	 * Returns a unique identifier for the cookie consisting
+	 * of its name, prefix, domain, and path.
+	 *
+	 * @return string
+	 */
+	public function getId(): string;
+
+	/**
+	 * Checks if the cookie should be sent with no URL encoding.
+	 *
+	 * @return boolean
+	 */
+	public function isRaw(): bool;
+
+	/**
+	 * Gets the cookie prefix.
+	 *
+	 * @return string
+	 */
+	public function getPrefix(): string;
+
+	/**
+	 * Gets the cookie name.
+	 *
+	 * @return string
+	 */
+	public function getName(): string;
+
+	/**
+	 * Gets the cookie name prepended with the prefix, if any.
+	 *
+	 * @return string
+	 */
+	public function getPrefixedName(): string;
+
+	/**
+	 * Gets the cookie value.
+	 *
+	 * @return string
+	 */
+	public function getValue(): string;
+
+	/**
+	 * Gets the time in Unix timestamp the cookie expires.
+	 *
+	 * @return integer
+	 */
+	public function getExpiresTimestamp(): int;
+
+	/**
+	 * Gets the formatted expires time.
+	 *
+	 * @return string
+	 */
+	public function getExpiresString(): string;
+
+	/**
+	 * Checks if the cookie is expired.
+	 *
+	 * @return boolean
+	 */
+	public function isExpired(): bool;
+
+	/**
+	 * Gets the "Max-Age" cookie attribute.
+	 *
+	 * @return integer
+	 */
+	public function getMaxAge(): int;
+
+	/**
+	 * Gets the "Domain" cookie attribute.
+	 *
+	 * @return string
+	 */
+	public function getDomain(): string;
+
+	/**
+	 * Gets the "Path" cookie attribute.
+	 *
+	 * @return string
+	 */
+	public function getPath(): string;
+
+	/**
+	 * Gets the "Secure" cookie attribute.
+	 *
+	 * Checks if the cookie is only sent to the server when a request is made
+	 * with the `https:` scheme (except on `localhost`), and therefore is more
+	 * resistent to man-in-the-middle attacks.
+	 *
+	 * @return boolean
+	 */
+	public function isSecure(): bool;
+
+	/**
+	 * Gets the "HttpOnly" cookie attribute.
+	 *
+	 * Checks if JavaScript is forbidden from accessing the cookie.
+	 *
+	 * @return boolean
+	 */
+	public function isHttpOnly(): bool;
+
+	/**
+	 * Gets the "SameSite" cookie attribute.
+	 *
+	 * @return string
+	 */
+	public function getSameSite(): string;
+
+	/**
+	 * Gets the options that are passable to the `setcookie` variant
+	 * available on PHP 7.3+
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function getOptions(): array;
+
+	/**
+	 * Returns the Cookie as a header value.
+	 *
+	 * @return string
+	 */
+	public function toHeaderString(): string;
+
+	/**
+	 * Returns the string representation of the Cookie object.
+	 *
+	 * @return string
+	 */
+	public function __toString();
+
+	/**
+	 * Returns the array representation of the Cookie object.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toArray(): array;
+}

--- a/system/HTTP/Cookie/CookieStore.php
+++ b/system/HTTP/Cookie/CookieStore.php
@@ -1,0 +1,330 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP\Cookie;
+
+use ArrayIterator;
+use CodeIgniter\HTTP\Exceptions\CookieException;
+use Countable;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * The CookieStore object represents an immutable collection of `Cookie` value objects.
+ *
+ * @implements IteratorAggregate<string, Cookie>
+ */
+class CookieStore implements Countable, IteratorAggregate
+{
+	/**
+	 * The cookie collection.
+	 *
+	 * @var array<string, Cookie>
+	 */
+	protected $cookies = [];
+
+	/**
+	 * Creates a CookieStore from an array of `Set-Cookie` headers.
+	 *
+	 * @param string[] $headers
+	 * @param boolean  $raw
+	 *
+	 * @throws CookieException
+	 *
+	 * @return static
+	 */
+	public static function fromCookieHeaders(array $headers, bool $raw = false)
+	{
+		/**
+		 * @var Cookie[] $cookies
+		 */
+		$cookies = array_filter(array_map(function (string $header) use ($raw) {
+			try
+			{
+				return Cookie::fromHeaderString($header, $raw);
+			}
+			catch (CookieException $e)
+			{
+				log_message('error', $e->getMessage());
+				return false;
+			}
+		}, $headers));
+
+		return new static($cookies);
+	}
+
+	/**
+	 * @param Cookie[] $cookies
+	 *
+	 * @throws CookieException
+	 */
+	public function __construct(array $cookies)
+	{
+		$this->validateCookies($cookies);
+
+		foreach ($cookies as $cookie)
+		{
+			$this->cookies[$cookie->getId()] = $cookie;
+		}
+	}
+
+	/**
+	 * Checks if a `Cookie` object identified by name and
+	 * prefix is present in the collection.
+	 *
+	 * @param string      $name
+	 * @param string      $prefix
+	 * @param string|null $value
+	 *
+	 * @return boolean
+	 */
+	public function has(string $name, string $prefix = '', string $value = null): bool
+	{
+		$name = $prefix . $name;
+
+		foreach ($this->cookies as $cookie)
+		{
+			if ($cookie->getPrefixedName() !== $name)
+			{
+				continue;
+			}
+
+			if ($value === null)
+			{
+				return true; // for BC
+			}
+
+			return $cookie->getValue() === $value;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Retrieves an instance of `Cookie` identified by a name and prefix.
+	 * This throws an exception if not found.
+	 *
+	 * @param string $name
+	 * @param string $prefix
+	 *
+	 * @throws CookieException
+	 *
+	 * @return Cookie
+	 */
+	public function get(string $name, string $prefix = ''): Cookie
+	{
+		$name = $prefix . $name;
+
+		foreach ($this->cookies as $cookie)
+		{
+			if ($cookie->getPrefixedName() === $name)
+			{
+				return $cookie;
+			}
+		}
+
+		throw CookieException::forUnknownCookieInstance([$name, $prefix]);
+	}
+
+	/**
+	 * Store a new cookie and return a new collection. The original collection
+	 * is left unchanged.
+	 *
+	 * @param Cookie $cookie
+	 *
+	 * @return static
+	 */
+	public function put(Cookie $cookie)
+	{
+		$store = clone $this;
+
+		$store->cookies[$cookie->getId()] = $cookie;
+
+		return $store;
+	}
+
+	/**
+	 * Removes a cookie from a collection and returns an updated collection.
+	 * The original collection is left unchanged.
+	 *
+	 * Removing a cookie from the store **DOES NOT** delete it from the browser.
+	 * If you intend to delete a cookie *from the browser*, you must put an empty
+	 * value cookie with the same name to the store.
+	 *
+	 * @param string $name
+	 * @param string $prefix
+	 *
+	 * @return static
+	 */
+	public function remove(string $name, string $prefix = '')
+	{
+		$default = Cookie::setDefaults();
+		$name    = $prefix . $name;
+		$domain  = $default['domain'];
+		$path    = $default['path'];
+
+		$id = implode(';', [$name, $domain, $path]);
+
+		$store = clone $this;
+
+		foreach ($store->cookies as $index => $cookie)
+		{
+			if ($index === $id)
+			{
+				unset($store->cookies[$index]);
+			}
+		}
+
+		return $store;
+	}
+
+	/**
+	 * Dispatches all cookies in store.
+	 *
+	 * @return void
+	 */
+	public function dispatch()
+	{
+		foreach ($this->cookies as $cookie)
+		{
+			$name    = $cookie->getPrefixedName();
+			$value   = $cookie->getValue();
+			$options = $cookie->getOptions();
+
+			if ($cookie->isRaw())
+			{
+				$this->setRawCookie($name, $value, $options);
+			}
+			else
+			{
+				$this->setCookie($name, $value, $options);
+			}
+		}
+
+		$this->clear();
+	}
+
+	/**
+	 * Returns all cookie instances in store.
+	 *
+	 * @return array<string, Cookie>
+	 */
+	public function display()
+	{
+		return $this->cookies;
+	}
+
+	/**
+	 * Clears the cookie collection.
+	 *
+	 * @return void
+	 */
+	public function clear(): void
+	{
+		$this->cookies = [];
+	}
+
+	/**
+	 * Gets the Cookie count in this collection.
+	 *
+	 * @return integer
+	 */
+	public function count()
+	{
+		return count($this->cookies);
+	}
+
+	/**
+	 * Gets the iterator for the cookie collection.
+	 *
+	 * @return Traversable<string, Cookie>
+	 */
+	public function getIterator()
+	{
+		return new ArrayIterator($this->cookies);
+	}
+
+	/**
+	 * Validates all cookies passed to be instances of Cookie.
+	 *
+	 * @param array $cookies
+	 *
+	 * @throws CookieException
+	 *
+	 * @return void
+	 */
+	protected function validateCookies(array $cookies): void
+	{
+		foreach ($cookies as $index => $cookie)
+		{
+			$type = is_object($cookie) ? get_class($cookie) : gettype($cookie);
+
+			if (! $cookie instanceof Cookie)
+			{
+				throw CookieException::forInvalidCookieInstance([static::class, Cookie::class, $type, $index]);
+			}
+		}
+	}
+
+	/**
+	 * Extracted call to `setrawcookie()` in order to run unit tests on it.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @param string $name
+	 * @param string $value
+	 * @param array  $options
+	 *
+	 * @return void
+	 */
+	protected function setRawCookie(string $name, string $value, array $options)
+	{
+		if (PHP_VERSION_ID < 70300)
+		{
+			$options['path'] .= '; SameSite=' . $options['samesite'];
+			unset($options['samesite']);
+
+			$options = array_values($options);
+			setrawcookie($name, $value, ...$options);
+		}
+		else
+		{
+			setrawcookie($name, $value, $options);
+		}
+	}
+
+	/**
+	 * Extracted call to `setcookie()` in order to run unit tests on it.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @param string $name
+	 * @param string $value
+	 * @param array  $options
+	 *
+	 * @return void
+	 */
+	protected function setCookie(string $name, string $value, array $options)
+	{
+		if (PHP_VERSION_ID < 70300)
+		{
+			$options['path'] .= '; SameSite=' . $options['samesite'];
+			unset($options['samesite']);
+
+			$options = array_values($options);
+			setcookie($name, $value, ...$options);
+		}
+		else
+		{
+			setcookie($name, $value, $options);
+		}
+	}
+}

--- a/system/HTTP/Cookie/CookieStore.php
+++ b/system/HTTP/Cookie/CookieStore.php
@@ -287,18 +287,7 @@ class CookieStore implements Countable, IteratorAggregate
 	 */
 	protected function setRawCookie(string $name, string $value, array $options)
 	{
-		if (PHP_VERSION_ID < 70300)
-		{
-			$options['path'] .= '; SameSite=' . $options['samesite'];
-			unset($options['samesite']);
-
-			$options = array_values($options);
-			setrawcookie($name, $value, ...$options);
-		}
-		else
-		{
-			setrawcookie($name, $value, $options);
-		}
+		setrawcookie($name, $value, $options);
 	}
 
 	/**
@@ -314,17 +303,6 @@ class CookieStore implements Countable, IteratorAggregate
 	 */
 	protected function setCookie(string $name, string $value, array $options)
 	{
-		if (PHP_VERSION_ID < 70300)
-		{
-			$options['path'] .= '; SameSite=' . $options['samesite'];
-			unset($options['samesite']);
-
-			$options = array_values($options);
-			setcookie($name, $value, ...$options);
-		}
-		else
-		{
-			setcookie($name, $value, $options);
-		}
+		setcookie($name, $value, $options);
 	}
 }

--- a/system/HTTP/Exceptions/CookieException.php
+++ b/system/HTTP/Exceptions/CookieException.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP\Exceptions;
+
+use CodeIgniter\Exceptions\FrameworkException;
+
+/**
+ * CookieException is thrown for invalid cookies initialization and management.
+ */
+class CookieException extends FrameworkException
+{
+	/**
+	 * Thrown for invalid type given for the "Expires" attribute.
+	 *
+	 * @param string $type
+	 *
+	 * @return static
+	 */
+	public static function forInvalidExpiresTime(string $type)
+	{
+		return new static(lang('Cookie.invalidExpiresTime', [$type]));
+	}
+
+	/**
+	 * Thrown when the value provided for "Expires" is invalid.
+	 *
+	 * @return static
+	 */
+	public static function forInvalidExpiresValue()
+	{
+		return new static(lang('Cookie.invalidExpiresValue'));
+	}
+
+	/**
+	 * Thrown when the cookie name contains invalid characters per RFC 2616.
+	 *
+	 * @param string $name
+	 *
+	 * @return static
+	 */
+	public static function forInvalidCookieName(string $name)
+	{
+		return new static(lang('Cookie.invalidCookieName', [$name]));
+	}
+
+	/**
+	 * Thrown when the cookie name is empty.
+	 *
+	 * @return static
+	 */
+	public static function forEmptyCookieName()
+	{
+		return new static(lang('Cookie.emptyCookieName'));
+	}
+
+	/**
+	 * Thrown when using the `__Secure-` prefix but the `Secure` attribute
+	 * is not set to true.
+	 *
+	 * @return static
+	 */
+	public static function forInvalidSecurePrefix()
+	{
+		return new static(lang('Cookie.invalidSecurePrefix'));
+	}
+
+	/**
+	 * Thrown when using the `__Host-` prefix but the `Secure` flag is not
+	 * set, the `Domain` is set, and the `Path` is not `/`.
+	 *
+	 * @return static
+	 */
+	public static function forInvalidHostPrefix()
+	{
+		return new static(lang('Cookie.invalidHostPrefix'));
+	}
+
+	/**
+	 * Thrown when the `SameSite` attribute given is not of the valid types.
+	 *
+	 * @param string $sameSite
+	 *
+	 * @return static
+	 */
+	public static function forInvalidSameSite(string $sameSite)
+	{
+		return new static(lang('Cookie.invalidSameSite', [$sameSite]));
+	}
+
+	/**
+	 * Thrown when the `SameSite` attribute is set to `None` but the `Secure`
+	 * attribute is not set.
+	 *
+	 * @return static
+	 */
+	public static function forInvalidSameSiteNone()
+	{
+		return new static(lang('Cookie.invalidSameSiteNone'));
+	}
+
+	/**
+	 * Thrown when the `CookieStore` class is filled with invalid Cookie objects.
+	 *
+	 * @param array<string|integer> $data
+	 *
+	 * @return static
+	 */
+	public static function forInvalidCookieInstance(array $data)
+	{
+		return new static(lang('Cookie.invalidCookieInstance', $data));
+	}
+
+	/**
+	 * Thrown when the queried Cookie object does not exist in the cookie collection.
+	 *
+	 * @param string[] $data
+	 *
+	 * @return static
+	 */
+	public static function forUnknownCookieInstance(array $data)
+	{
+		return new static(lang('Cookie.unknownCookieInstance', $data));
+	}
+}

--- a/system/HTTP/Exceptions/HTTPException.php
+++ b/system/HTTP/Exceptions/HTTPException.php
@@ -238,6 +238,8 @@ class HTTPException extends FrameworkException
 	 * @param string $samesite
 	 *
 	 * @return HTTPException
+	 *
+	 * @deprecated
 	 */
 	public static function forInvalidSameSiteSetting(string $samesite)
 	{

--- a/system/HTTP/Exceptions/HTTPException.php
+++ b/system/HTTP/Exceptions/HTTPException.php
@@ -60,9 +60,8 @@ class HTTPException extends FrameworkException
 	 * @param string $errorNum
 	 * @param string $error
 	 *
-	 * @return             \CodeIgniter\HTTP\Exceptions\HTTPException
+	 * @return HTTPException
 	 *
-	 * Not testable with travis-ci; we over-ride the method which triggers it
 	 * @codeCoverageIgnore
 	 */
 	public static function forCurlError(string $errorNum, string $error)
@@ -239,7 +238,9 @@ class HTTPException extends FrameworkException
 	 *
 	 * @return HTTPException
 	 *
-	 * @deprecated
+	 * @deprecated Use `CookieException::forInvalidSameSite()` instead.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public static function forInvalidSameSiteSetting(string $samesite)
 	{

--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\HTTP\Cookie\CookieStore;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use Config\Services;
 
@@ -139,10 +140,7 @@ class RedirectResponse extends Response
 	 */
 	public function withCookies()
 	{
-		foreach (Services::response()->getCookies() as $cookie)
-		{
-			$this->cookies[] = $cookie;
-		}
+		$this->cookieStore = new CookieStore(Services::response()->getCookies());
 
 		return $this;
 	}
@@ -157,7 +155,7 @@ class RedirectResponse extends Response
 	 */
 	public function withHeaders()
 	{
-		foreach (Services::response()->getHeaders() as $name => $header)
+		foreach (Services::response()->headers() as $name => $header)
 		{
 			$this->setHeader($name, $header->getValue());
 		}

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -11,6 +11,9 @@
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\HTTP\Cookie\Cookie;
+use CodeIgniter\HTTP\Cookie\CookieStore;
+use CodeIgniter\HTTP\Exceptions\CookieException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use Config\App;
 
@@ -119,7 +122,7 @@ class Response extends Message implements MessageInterface, ResponseInterface
 	/**
 	 * The current status code for this response.
 	 * The status code is a 3-digit integer result code of the server's attempt
-     * to understand and satisfy the request.
+	 * to understand and satisfy the request.
 	 *
 	 * @var integer
 	 */
@@ -133,8 +136,6 @@ class Response extends Message implements MessageInterface, ResponseInterface
 	 * @internal Used for framework testing, should not be relied on otherwise
 	 */
 	protected $pretend = false;
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Constructor
@@ -152,24 +153,29 @@ class Response extends Message implements MessageInterface, ResponseInterface
 		// We need CSP object even if not enabled to avoid calls to non existing methods
 		$this->CSP = new ContentSecurityPolicy(new \Config\ContentSecurityPolicy());
 
-		$this->CSPEnabled     = $config->CSPEnabled;
+		$this->CSPEnabled = $config->CSPEnabled;
+
+		//---------------------------------------------------------------------
+		// DEPRECATED COOKIE MANAGEMENT
+		//---------------------------------------------------------------------
 		$this->cookiePrefix   = $config->cookiePrefix;
 		$this->cookieDomain   = $config->cookieDomain;
 		$this->cookiePath     = $config->cookiePath;
 		$this->cookieSecure   = $config->cookieSecure;
 		$this->cookieHTTPOnly = $config->cookieHTTPOnly;
-		$this->cookieSameSite = $config->cookieSameSite ?? $this->cookieSameSite;
+		$this->cookieSameSite = $config->cookieSameSite ?? Cookie::SAMESITE_LAX;
 
-		if (! in_array(strtolower($this->cookieSameSite), ['', 'none', 'lax', 'strict'], true))
+		if (! in_array(strtolower($config->cookieSameSite), array_merge(Cookie::ALLOWED_SAMESITE_VALUES, ['']), true))
 		{
-			throw HTTPException::forInvalidSameSiteSetting($this->cookieSameSite);
+			throw CookieException::forInvalidSameSite($config->cookieSameSite);
 		}
+
+		$this->cookieStore = new CookieStore([]);
+		Cookie::setDefaults($config);
 
 		// Default to an HTML Content-Type. Devs can override if needed.
 		$this->setContentType('text/html');
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Turns "pretend" mode on or off to aid in testing.
@@ -220,21 +226,22 @@ class Response extends Message implements MessageInterface, ResponseInterface
 		return $this->getReasonPhrase();
 	}
 
-    /**
-     * Gets the response reason phrase associated with the status code.
-     *
-     * Because a reason phrase is not a required element in a response
-     * status line, the reason phrase value MAY be null. Implementations MAY
-     * choose to return the default RFC 7231 recommended reason phrase (or those
-     * listed in the IANA HTTP Status Code Registry) for the response's
-     * status code.
-     *
-     * @link http://tools.ietf.org/html/rfc7231#section-6
-     * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-     * @return string Reason phrase; must return an empty string if none present.
-     */
-    public function getReasonPhrase()
-    {
+	/**
+	 * Gets the response reason phrase associated with the status code.
+	 *
+	 * Because a reason phrase is not a required element in a response
+	 * status line, the reason phrase value MAY be null. Implementations MAY
+	 * choose to return the default RFC 7231 recommended reason phrase (or those
+	 * listed in the IANA HTTP Status Code Registry) for the response's
+	 * status code.
+	 *
+	 * @link http://tools.ietf.org/html/rfc7231#section-6
+	 * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+	 *
+	 * @return string Reason phrase; must return an empty string if none present.
+	 */
+	public function getReasonPhrase()
+	{
 		if ($this->reason === '')
 		{
 			return ! empty($this->statusCode) ? static::$statusCodes[$this->statusCode] : '';

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -165,7 +165,7 @@ class Response extends Message implements MessageInterface, ResponseInterface
 		$this->cookieHTTPOnly = $config->cookieHTTPOnly;
 		$this->cookieSameSite = $config->cookieSameSite ?? Cookie::SAMESITE_LAX;
 
-		if (! in_array(strtolower($config->cookieSameSite), array_merge(Cookie::ALLOWED_SAMESITE_VALUES, ['']), true))
+		if (! in_array(strtolower($config->cookieSameSite ?: Cookie::SAMESITE_LAX), Cookie::ALLOWED_SAMESITE_VALUES, true))
 		{
 			throw CookieException::forInvalidSameSite($config->cookieSameSite);
 		}

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\HTTP\Cookie\Cookie;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Pager\PagerInterface;
 use DateTime;
@@ -185,6 +186,7 @@ interface ResponseInterface
 	 * @see http://tools.ietf.org/html/rfc5988
 	 *
 	 * @return Response
+	 *
 	 * @todo Recommend moving to Pager
 	 */
 	public function setLink(PagerInterface $pager);
@@ -358,7 +360,7 @@ interface ResponseInterface
 	 * @param string|null $name
 	 * @param string      $prefix
 	 *
-	 * @return mixed
+	 * @return Cookie[]|Cookie|null
 	 */
 	public function getCookie(string $name = null, string $prefix = '');
 
@@ -377,7 +379,7 @@ interface ResponseInterface
 	/**
 	 * Returns all cookies currently set.
 	 *
-	 * @return array
+	 * @return Cookie[]
 	 */
 	public function getCookies();
 

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -106,7 +106,7 @@ trait ResponseTrait
 	 *
 	 * @deprecated Use the dedicated Cookie class instead.
 	 */
-	protected $cookieSameSite = 'Lax';
+	protected $cookieSameSite = Cookie::SAMESITE_LAX;
 
 	/**
 	 * Stores all cookies that were set in the response.

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -11,6 +11,9 @@
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\HTTP\Cookie\Cookie;
+use CodeIgniter\HTTP\Cookie\CookieStore;
+use CodeIgniter\HTTP\Exceptions\CookieException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Pager\PagerInterface;
 use Config\Services;
@@ -23,6 +26,8 @@ use InvalidArgumentException;
  *
  * Additional methods to make a PSR-7 Response class
  * compliant with the framework's own ResponseInterface.
+ *
+ * @property array $statusCodes
  *
  * @see https://github.com/php-fig/http-message/blob/master/src/ResponseInterface.php
  */
@@ -43,9 +48,18 @@ trait ResponseTrait
 	public $CSP;
 
 	/**
+	 * CookieStore instance.
+	 *
+	 * @var CookieStore
+	 */
+	protected $cookieStore;
+
+	/**
 	 * Set a cookie name prefix if you need to avoid collisions
 	 *
 	 * @var string
+	 *
+	 * @deprecated Use the dedicated Cookie class instead.
 	 */
 	protected $cookiePrefix = '';
 
@@ -53,6 +67,8 @@ trait ResponseTrait
 	 * Set to .your-domain.com for site-wide cookies
 	 *
 	 * @var string
+	 *
+	 * @deprecated Use the dedicated Cookie class instead.
 	 */
 	protected $cookieDomain = '';
 
@@ -60,6 +76,8 @@ trait ResponseTrait
 	 * Typically will be a forward slash
 	 *
 	 * @var string
+	 *
+	 * @deprecated Use the dedicated Cookie class instead.
 	 */
 	protected $cookiePath = '/';
 
@@ -67,6 +85,8 @@ trait ResponseTrait
 	 * Cookie will only be set if a secure HTTPS connection exists.
 	 *
 	 * @var boolean
+	 *
+	 * @deprecated Use the dedicated Cookie class instead.
 	 */
 	protected $cookieSecure = false;
 
@@ -74,6 +94,8 @@ trait ResponseTrait
 	 * Cookie will only be accessible via HTTP(S) (no javascript)
 	 *
 	 * @var boolean
+	 *
+	 * @deprecated Use the dedicated Cookie class instead.
 	 */
 	protected $cookieHTTPOnly = false;
 
@@ -81,6 +103,8 @@ trait ResponseTrait
 	 * Cookie SameSite setting
 	 *
 	 * @var string
+	 *
+	 * @deprecated Use the dedicated Cookie class instead.
 	 */
 	protected $cookieSameSite = 'Lax';
 
@@ -88,6 +112,8 @@ trait ResponseTrait
 	 * Stores all cookies that were set in the response.
 	 *
 	 * @var array
+	 *
+	 * @deprecated Use the dedicated Cookie class instead.
 	 */
 	protected $cookies = [];
 
@@ -98,8 +124,6 @@ trait ResponseTrait
 	 * @var string
 	 */
 	protected $bodyFormat = 'html';
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Return an instance with the specified status code and, optionally, reason phrase.
@@ -166,8 +190,6 @@ trait ResponseTrait
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Set the Link Header
 	 *
@@ -176,7 +198,8 @@ trait ResponseTrait
 	 * @see http://tools.ietf.org/html/rfc5988
 	 *
 	 * @return Response
-	 * @todo   Recommend moving to Pager
+	 *
+	 * @todo Recommend moving to Pager
 	 */
 	public function setLink(PagerInterface $pager)
 	{
@@ -204,8 +227,6 @@ trait ResponseTrait
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Sets the Content Type header for this response with the mime type
 	 * and, optionally, the charset.
@@ -229,8 +250,6 @@ trait ResponseTrait
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Converts the $body into JSON and sets the Content Type header.
 	 *
@@ -245,8 +264,6 @@ trait ResponseTrait
 
 		return $this;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Returns the current body, converted to JSON is it isn't already.
@@ -267,8 +284,6 @@ trait ResponseTrait
 		return $body ?: null;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Converts $body into XML, and sets the correct Content-Type.
 	 *
@@ -282,8 +297,6 @@ trait ResponseTrait
 
 		return $this;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Retrieves the current body into XML and returns it.
@@ -302,8 +315,6 @@ trait ResponseTrait
 
 		return $body;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Handles conversion of the of the data into the appropriate format,
@@ -331,7 +342,6 @@ trait ResponseTrait
 	}
 
 	//--------------------------------------------------------------------
-	//--------------------------------------------------------------------
 	// Cache Control Methods
 	//
 	// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
@@ -342,19 +352,18 @@ trait ResponseTrait
 	 * is not cached by the browsers.
 	 *
 	 * @return Response
-	 * @todo   Recommend researching these directives, might need: 'private', 'no-transform', 'no-store', 'must-revalidate'
-	 * @see    DownloadResponse::noCache()
+	 *
+	 * @todo Recommend researching these directives, might need: 'private', 'no-transform', 'no-store', 'must-revalidate'
+	 *
+	 * @see DownloadResponse::noCache()
 	 */
 	public function noCache()
 	{
 		$this->removeHeader('Cache-control');
-
 		$this->setHeader('Cache-control', ['no-store', 'max-age=0', 'no-cache']);
 
 		return $this;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * A shortcut method that allows the developer to set all of the
@@ -414,8 +423,6 @@ trait ResponseTrait
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Sets the Last-Modified date header.
 	 *
@@ -441,7 +448,6 @@ trait ResponseTrait
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
 	//--------------------------------------------------------------------
 	// Output Methods
 	//--------------------------------------------------------------------
@@ -471,8 +477,6 @@ trait ResponseTrait
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Sends the headers of this HTTP request to the browser.
 	 *
@@ -494,8 +498,7 @@ trait ResponseTrait
 		}
 
 		// HTTP Status
-		header(sprintf('HTTP/%s %s %s', $this->getProtocolVersion(), $this->getStatusCode(), $this->getReason()), true,
-				$this->getStatusCode());
+		header(sprintf('HTTP/%s %s %s', $this->getProtocolVersion(), $this->getStatusCode(), $this->getReason()), true, $this->getStatusCode());
 
 		// Send all of our headers
 		foreach ($this->getHeaders() as $name => $values)
@@ -505,8 +508,6 @@ trait ResponseTrait
 
 		return $this;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Sends the Body of the message to the browser.
@@ -519,8 +520,6 @@ trait ResponseTrait
 
 		return $this;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Perform a redirect to a new URL, in two flavors: header or location.
@@ -568,8 +567,6 @@ trait ResponseTrait
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Set a cookie
 	 *
@@ -612,71 +609,37 @@ trait ResponseTrait
 			}
 		}
 
-		if ($prefix === '' && $this->cookiePrefix !== '')
+		if (is_numeric($expire))
 		{
-			$prefix = $this->cookiePrefix;
+			$expire = $expire > 0 ? time() + $expire : 0;
 		}
 
-		if ($domain === '' && $this->cookieDomain !== '')
-		{
-			$domain = $this->cookieDomain;
-		}
-
-		if ($path === '/' && $this->cookiePath !== '/')
-		{
-			$path = $this->cookiePath;
-		}
-
-		if ($secure === false && $this->cookieSecure === true)
-		{
-			$secure = $this->cookieSecure;
-		}
-
-		if ($httponly === false && $this->cookieHTTPOnly !== false)
-		{
-			$httponly = $this->cookieHTTPOnly;
-		}
-
-		if (is_null($samesite))
-		{
-			$samesite = $this->cookieSameSite ?? '';
-		}
-
-		if (! in_array(strtolower($samesite), ['', 'none', 'lax', 'strict'], true))
-		{
-			throw HTTPException::forInvalidSameSiteSetting($samesite);
-		}
-
-		if (! is_numeric($expire))
-		{
-			$expire = time() - 86500;
-		}
-		else
-		{
-			$expire = ($expire > 0) ? time() + $expire : 0;
-		}
-
-		$cookie = [
-			'name'     => $prefix . $name,
-			'value'    => $value,
-			'expires'  => $expire,
-			'path'     => $path,
+		$options = [
+			'expires'  => $expire ?: 0,
 			'domain'   => $domain,
+			'path'     => $path,
+			'prefix'   => $prefix,
 			'secure'   => $secure,
 			'httponly' => $httponly,
+			'samesite' => $samesite ?? '',
 		];
 
-		if ($samesite !== '')
-		{
-			$cookie['samesite'] = $samesite;
-		}
+		$cookie = Cookie::create($name, $value, $options);
 
-		$this->cookies[] = $cookie;
+		$this->cookieStore = $this->cookieStore->put($cookie);
 
 		return $this;
 	}
 
-	//--------------------------------------------------------------------
+	/**
+	 * Returns the `CookieStore` instance.
+	 *
+	 * @return CookieStore
+	 */
+	public function getCookieStore()
+	{
+		return $this->cookieStore;
+	}
 
 	/**
 	 * Checks to see if the Response has a specified cookie or not.
@@ -689,29 +652,9 @@ trait ResponseTrait
 	 */
 	public function hasCookie(string $name, string $value = null, string $prefix = ''): bool
 	{
-		if ($prefix === '' && $this->cookiePrefix !== '')
-		{
-			$prefix = $this->cookiePrefix;
-		}
+		$prefix = $prefix ?: Cookie::setDefaults()['prefix']; // to retain BC
 
-		$name = $prefix . $name;
-
-		foreach ($this->cookies as $cookie)
-		{
-			if ($cookie['name'] !== $name)
-			{
-				continue;
-			}
-
-			if ($value === null)
-			{
-				return true;
-			}
-
-			return $cookie['value'] === $value;
-		}
-
-		return false;
+		return $this->cookieStore->has($name, $prefix, $value);
 	}
 
 	/**
@@ -720,31 +663,26 @@ trait ResponseTrait
 	 * @param string|null $name
 	 * @param string      $prefix
 	 *
-	 * @return mixed
+	 * @return Cookie[]|Cookie|null
 	 */
 	public function getCookie(string $name = null, string $prefix = '')
 	{
-		// if no name given, return them all
-		if (empty($name))
+		if ((string) $name === '')
 		{
-			return $this->cookies;
+			return $this->cookieStore->display();
 		}
 
-		if ($prefix === '' && $this->cookiePrefix !== '')
+		try
 		{
-			$prefix = $this->cookiePrefix;
+			$prefix = $prefix ?: Cookie::setDefaults()['prefix']; // to retain BC
+
+			return $this->cookieStore->get($name, $prefix);
 		}
-
-		$name = $prefix . $name;
-
-		foreach ($this->cookies as $cookie)
+		catch (CookieException $e)
 		{
-			if ($cookie['name'] === $name)
-			{
-				return $cookie;
-			}
+			log_message('error', $e->getMessage());
+			return null;
 		}
-		return null;
 	}
 
 	/**
@@ -759,39 +697,40 @@ trait ResponseTrait
 	 */
 	public function deleteCookie(string $name = '', string $domain = '', string $path = '/', string $prefix = '')
 	{
-		if (empty($name))
+		if ($name === '')
 		{
 			return $this;
 		}
 
-		if ($prefix === '' && $this->cookiePrefix !== '')
-		{
-			$prefix = $this->cookiePrefix;
-		}
+		$prefix = $prefix ?: Cookie::setDefaults()['prefix']; // to retain BC
 
-		$prefixedName = $prefix . $name;
+		$prefixed = $prefix . $name;
+		$store    = $this->cookieStore;
+		$found    = false;
 
-		$cookieHasFlag = false;
-		foreach ($this->cookies as &$cookie)
+		foreach ($store as $cookie)
 		{
-			if ($cookie['name'] === $prefixedName)
+			if ($cookie->getPrefixedName() === $prefixed)
 			{
-				if (! empty($domain) && $cookie['domain'] !== $domain)
+				if ($domain !== $cookie->getDomain())
 				{
 					continue;
 				}
-				if (! empty($path) && $cookie['path'] !== $path)
+
+				if ($path !== $cookie->getPath())
 				{
 					continue;
 				}
-				$cookie['value']   = '';
-				$cookie['expires'] = '';
-				$cookieHasFlag     = true;
+
+				$cookie = $cookie->withValue('')->withExpired();
+				$found  = true;
+
+				$this->cookieStore = $store->put($cookie);
 				break;
 			}
 		}
 
-		if (! $cookieHasFlag)
+		if (! $found)
 		{
 			$this->setCookie($name, '', '', $domain, $path, $prefix);
 		}
@@ -802,11 +741,11 @@ trait ResponseTrait
 	/**
 	 * Returns all cookies currently set.
 	 *
-	 * @return array
+	 * @return Cookie[]
 	 */
 	public function getCookies()
 	{
-		return $this->cookies;
+		return $this->cookieStore->display();
 	}
 
 	/**
@@ -819,20 +758,7 @@ trait ResponseTrait
 			return;
 		}
 
-		foreach ($this->cookies as $params)
-		{
-			$name  = $params['name'];
-			$value = $params['value'];
-			unset($params['name'], $params['value']);
-
-			// If samesite is blank string, skip setting the attribute on the cookie
-			if (isset($params['samesite']) && $params['samesite'] === '')
-			{
-				unset($params['samesite']);
-			}
-
-			setcookie($name, $value, $params);
-		}
+		$this->cookieStore->dispatch();
 	}
 
 	/**

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -12,11 +12,10 @@
 use Config\App;
 use Config\Services;
 
-// --------------------------------------------------------------------
+//=============================================================================
+// CodeIgniter Cookie Helpers
+//=============================================================================
 
-/**
- * CodeIgniter Cookie Helpers
- */
 if (! function_exists('set_cookie'))
 {
 	/**
@@ -28,16 +27,13 @@ if (! function_exists('set_cookie'))
 	 * @param string|array $name     Cookie name or array containing binds
 	 * @param string       $value    The value of the cookie
 	 * @param string       $expire   The number of seconds until expiration
-	 * @param string       $domain   For site-wide cookie.
-	 *                                 Usually: .yourdomain.com
+	 * @param string       $domain   For site-wide cookie. Usually: .yourdomain.com
 	 * @param string       $path     The cookie path
 	 * @param string       $prefix   The cookie prefix
 	 * @param boolean      $secure   True makes the cookie secure
-	 * @param boolean      $httpOnly True makes the cookie accessible via
-	 *                                 http(s) only (no javascript)
+	 * @param boolean      $httpOnly True makes the cookie accessible via http(s) only (no javascript)
 	 * @param string|null  $sameSite The cookie SameSite value
 	 *
-	 * @see (\Config\Services::response())->setCookie()
 	 * @see \CodeIgniter\HTTP\Response::setCookie()
 	 */
 	function set_cookie(
@@ -52,47 +48,37 @@ if (! function_exists('set_cookie'))
 		string $sameSite = null
 	)
 	{
-		// The following line shows as a syntax error in NetBeans IDE
-		//(\Config\Services::response())->setcookie
 		$response = Services::response();
-		$response->setcookie($name, $value, $expire, $domain, $path, $prefix, $secure, $httpOnly, $sameSite);
+		$response->setCookie($name, $value, $expire, $domain, $path, $prefix, $secure, $httpOnly, $sameSite);
 	}
 }
-
-//--------------------------------------------------------------------
 
 if (! function_exists('get_cookie'))
 {
 	/**
-	 * Fetch an item from the COOKIE array
+	 * Fetch an item from the $_COOKIE array
 	 *
 	 * @param string  $index
 	 * @param boolean $xssClean
 	 *
 	 * @return mixed
 	 *
-	 * @see (\Config\Services::request())->getCookie()
 	 * @see \CodeIgniter\HTTP\IncomingRequest::getCookie()
 	 */
 	function get_cookie($index, bool $xssClean = false)
 	{
-		$app             = config(App::class);
-		$appCookiePrefix = $app->cookiePrefix;
-		$prefix          = isset($_COOKIE[$index]) ? '' : $appCookiePrefix;
-
+		$prefix  = isset($_COOKIE[$index]) ? '' : config(App::class)->cookiePrefix;
 		$request = Services::request();
-		$filter  = true === $xssClean ? FILTER_SANITIZE_STRING : null;
+		$filter  = $xssClean ? FILTER_SANITIZE_STRING : FILTER_DEFAULT;
 
 		return $request->getCookie($prefix . $index, $filter);
 	}
 }
 
-//--------------------------------------------------------------------
-
 if (! function_exists('delete_cookie'))
 {
 	/**
-	 * Delete a COOKIE
+	 * Delete a cookie
 	 *
 	 * @param mixed  $name
 	 * @param string $domain the cookie domain. Usually: .yourdomain.com
@@ -101,11 +87,27 @@ if (! function_exists('delete_cookie'))
 	 *
 	 * @return void
 	 *
-	 * @see (\Config\Services::response())->deleteCookie()
 	 * @see \CodeIgniter\HTTP\Response::deleteCookie()
 	 */
 	function delete_cookie($name, string $domain = '', string $path = '/', string $prefix = '')
 	{
 		Services::response()->deleteCookie($name, $domain, $path, $prefix);
+	}
+}
+
+if (! function_exists('has_cookie'))
+{
+	/**
+	 * Checks if a cookie exists by name.
+	 *
+	 * @param string      $name
+	 * @param string|null $value
+	 * @param string      $prefix
+	 *
+	 * @return boolean
+	 */
+	function has_cookie(string $name, string $value = null, string $prefix = ''): bool
+	{
+		return Services::response()->hasCookie($name, $value, $prefix);
 	}
 }

--- a/system/Language/en/Cookie.php
+++ b/system/Language/en/Cookie.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// Cookie language settings
+return [
+   'invalidExpiresTime'    => 'Invalid "{0}" type for "Expires" attribute. Expected: string, integer, DateTimeInterface object.',
+   'invalidExpiresValue'   => 'The cookie expiration time is not valid.',
+   'invalidCookieName'     => 'The cookie name "{0}" contains invalid characters.',
+   'emptyCookieName'       => 'The cookie name cannot be empty.',
+   'invalidSecurePrefix'   => 'Using the "__Secure-" prefix requires setting the "Secure" attribute.',
+   'invalidHostPrefix'     => 'Using the "__Host-" prefix must be set with the "Secure" flag, must not have a "Domain" attribute, and the "Path" is set to "/".',
+   'invalidSameSite'       => 'The SameSite value must be None, Lax, Strict or a blank string, {0} given.',
+   'invalidSameSiteNone'   => 'Using the "SameSite=None" attribute requires setting the "Secure" attribute.',
+   'invalidCookieInstance' => '"{0}" class expected cookies array to be instances of "{1}" but got "{2}" at index {3}.',
+   'unknownCookieInstance' => 'Cookie object with name "{0}" and prefix "{1}" was not found in the collection.',
+];

--- a/system/Language/en/HTTP.php
+++ b/system/Language/en/HTTP.php
@@ -73,6 +73,6 @@ return [
 	'uploadErrUnknown'           => 'The file "%s" was not uploaded due to an unknown error.',
 
 	// SameSite setting
-	// @deprecated use `Security.invalidSameSiteSetting`
+	// @deprecated
 	'invalidSameSiteSetting'     => 'The SameSite setting must be None, Lax, Strict, or a blank string. Given: {0}',
 ];

--- a/system/Language/en/Security.php
+++ b/system/Language/en/Security.php
@@ -12,5 +12,7 @@
 // Security language settings
 return [
 	'disallowedAction' => 'The action you requested is not allowed.',
+
+	// @deprecated
 	'invalidSameSite'  => 'The SameSite value must be None, Lax, Strict, or a blank string. Given: {0}',
 ];

--- a/system/Language/en/Session.php
+++ b/system/Language/en/Session.php
@@ -16,5 +16,7 @@ return [
 	'writeProtectedSavePath' => 'Session: Configured save path "{0}" is not writable by the PHP process.',
 	'emptySavePath'          => 'Session: No save path configured.',
 	'invalidSavePathFormat'  => 'Session: Invalid Redis save path format: {0}',
+
+	// @deprecated
 	'invalidSameSiteSetting' => 'Session: The SameSite setting must be None, Lax, Strict, or a blank string. Given: {0}',
 ];

--- a/system/Security/Exceptions/SecurityException.php
+++ b/system/Security/Exceptions/SecurityException.php
@@ -19,7 +19,10 @@ class SecurityException extends FrameworkException
 	{
 		return new static(lang('Security.disallowedAction'), 403);
 	}
-	
+
+	/**
+	 * @deprecated
+	 */
 	public static function forInvalidSameSite(string $samesite)
 	{
 		return new static(lang('Security.invalidSameSite', [$samesite]));

--- a/system/Security/Exceptions/SecurityException.php
+++ b/system/Security/Exceptions/SecurityException.php
@@ -21,7 +21,9 @@ class SecurityException extends FrameworkException
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated Use `CookieException::forInvalidSameSite()` instead.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public static function forInvalidSameSite(string $samesite)
 	{

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -11,9 +11,11 @@
 
 namespace CodeIgniter\Security;
 
+use CodeIgniter\HTTP\Cookie\Cookie;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use Config\App;
+use Config\Security as SecurityConfig;
 
 /**
  * Class Security
@@ -51,6 +53,13 @@ class Security implements SecurityInterface
 	protected $headerName = 'X-CSRF-TOKEN';
 
 	/**
+	 * The CSRF Cookie instance.
+	 *
+	 * @var Cookie
+	 */
+	protected $cookie;
+
+	/**
 	 * CSRF Cookie Name
 	 *
 	 * Cookie name for Cross Site Request Forgery protection cookie.
@@ -67,6 +76,8 @@ class Security implements SecurityInterface
 	 * Defaults to two hours (in seconds).
 	 *
 	 * @var integer
+	 *
+	 * @deprecated
 	 */
 	protected $expires = 7200;
 
@@ -100,10 +111,10 @@ class Security implements SecurityInterface
 	 * @see https://portswigger.net/web-security/csrf/samesite-cookies
 	 *
 	 * @var string 'Lax'|'None'|'Strict'
+	 *
+	 * @deprecated
 	 */
 	protected $samesite = 'Lax';
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Constructor.
@@ -112,34 +123,27 @@ class Security implements SecurityInterface
 	 * initial state.
 	 *
 	 * @param App $config
-	 *
-	 * @throws SecurityException
 	 */
-	public function __construct($config)
+	public function __construct(App $config)
 	{
+		/**
+		 * @var SecurityConfig
+		 */
 		$security = config('Security');
+
 		// Store CSRF-related configurations
 		$this->tokenName  = $security->tokenName ?? $config->CSRFTokenName ?? $this->tokenName;
 		$this->headerName = $security->headerName ?? $config->CSRFHeaderName ?? $this->headerName;
-		$this->cookieName = $security->cookieName ?? $config->CSRFCookieName ?? $this->cookieName;
-		$this->expires    = $security->expires ?? $config->CSRFExpire ?? $this->expires;
 		$this->regenerate = $security->regenerate ?? $config->CSRFRegenerate ?? $this->regenerate;
-		$this->samesite   = $security->samesite ?? $config->CSRFSameSite ?? $this->samesite;
+		$this->cookieName = $config->cookiePrefix . ($security->cookieName ?? $config->CSRFCookieName ?? $this->cookieName);
 
-		if (! in_array(strtolower($this->samesite), ['none', 'lax', 'strict', ''], true))
-		{
-			throw SecurityException::forInvalidSameSite($this->samesite);
-		}
+		$expires = $security->expires ?? $config->CSRFExpire ?? 7200;
 
-		if (isset($config->cookiePrefix))
-		{
-			$this->cookieName = $config->cookiePrefix . $this->cookieName;
-		}
-
-		$this->generateHash();
+		Cookie::setDefaults($config);
+		$this->cookie = Cookie::create($this->cookieName, $this->generateHash(), [
+			'expires' => $expires === 0 ? 0 : time() + $expires,
+		]);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * CSRF Verify
@@ -151,13 +155,13 @@ class Security implements SecurityInterface
 	 * @throws SecurityException
 	 *
 	 * @deprecated Use `CodeIgniter\Security\Security::verify()` instead of using this method.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function CSRFVerify(RequestInterface $request)
 	{
 		return $this->verify($request);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Returns the CSRF Hash.
@@ -165,13 +169,13 @@ class Security implements SecurityInterface
 	 * @return string|null
 	 *
 	 * @deprecated Use `CodeIgniter\Security\Security::getHash()` instead of using this method.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function getCSRFHash(): ?string
 	{
 		return $this->getHash();
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Returns the CSRF Token Name.
@@ -179,13 +183,13 @@ class Security implements SecurityInterface
 	 * @return string
 	 *
 	 * @deprecated Use `CodeIgniter\Security\Security::getTokenName()` instead of using this method.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function getCSRFTokenName(): string
 	{
 		return $this->getTokenName();
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * CSRF Verify
@@ -226,7 +230,7 @@ class Security implements SecurityInterface
 		$token = $_POST[$this->tokenName] ?? $tokenName;
 
 		// Does the tokens exist in both the POST/POSTed JSON and COOKIE arrays and match?
-		if (! isset($token, $_COOKIE[$this->cookieName]) || $token !== $_COOKIE[$this->cookieName])
+		if (! isset($token, $_COOKIE[$this->cookieName]) || ! hash_equals($token, $_COOKIE[$this->cookieName]))
 		{
 			throw SecurityException::forDisallowedAction();
 		}
@@ -244,23 +248,19 @@ class Security implements SecurityInterface
 			$request->setBody(json_encode($json));
 		}
 
-		// Regenerate on every submission?
 		if ($this->regenerate)
 		{
-			// Nothing should last forever.
 			$this->hash = null;
 			unset($_COOKIE[$this->cookieName]);
 		}
 
-		$this->generateHash();
+		$this->cookie = $this->cookie->withValue($this->generateHash());
 		$this->sendCookie($request);
 
 		log_message('info', 'CSRF token verified.');
 
 		return $this;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Returns the CSRF Hash.
@@ -272,8 +272,6 @@ class Security implements SecurityInterface
 		return $this->hash;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Returns the CSRF Token Name.
 	 *
@@ -283,8 +281,6 @@ class Security implements SecurityInterface
 	{
 		return $this->tokenName;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Returns the CSRF Header Name.
@@ -296,8 +292,6 @@ class Security implements SecurityInterface
 		return $this->headerName;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Returns the CSRF Cookie Name.
 	 *
@@ -308,20 +302,19 @@ class Security implements SecurityInterface
 		return $this->cookieName;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Check if CSRF cookie is expired.
 	 *
 	 * @return boolean
+	 *
+	 * @deprecated
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function isExpired(): bool
 	{
-		return $this->expires === 0;
+		return $this->cookie->isExpired();
 	}
-
-	//--------------------------------------------------------------------
-
 	/**
 	 * Check if request should be redirect on failure.
 	 *
@@ -331,8 +324,6 @@ class Security implements SecurityInterface
 	{
 		return $this->redirect;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Sanitize Filename
@@ -405,8 +396,6 @@ class Security implements SecurityInterface
 		return stripslashes($str);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Generates the CSRF Hash.
 	 *
@@ -434,64 +423,36 @@ class Security implements SecurityInterface
 		return $this->hash;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * CSRF Send Cookie
 	 *
 	 * @param RequestInterface $request
 	 *
-	 * @return             Security|false
-	 * @codeCoverageIgnore
+	 * @return Security|false
 	 */
 	protected function sendCookie(RequestInterface $request)
 	{
-		$config = new App();
-
-		$expires = $this->isExpired() ? $this->expires : time() + $this->expires;
-		$path    = $config->cookiePath ?? '/';
-		$domain  = $config->cookieDomain ?? '';
-		$secure  = $config->cookieSecure ?? false;
-
-		if ($secure && ! $request->isSecure())
+		if ($this->cookie->isSecure() && ! $request->isSecure())
 		{
 			return false;
 		}
 
-		if (PHP_VERSION_ID < 70300)
-		{
-			// In PHP < 7.3.0, there is a "hacky" way to set the samesite parameter
-			$samesite = '';
-
-			if (! empty($this->samesite))
-			{
-				$samesite = '; samesite=' . $this->samesite;
-			}
-
-			setcookie($this->cookieName, $this->hash, $expires, $path . $samesite, $domain, $secure, true);
-		}
-		else
-		{
-			// PHP 7.3 adds another function signature allowing setting of samesite
-			$params = [
-				'expires'  => $expires,
-				'path'     => $path,
-				'domain'   => $domain,
-				'secure'   => $secure,
-				'httponly' => true, // Enforce HTTP only cookie for security
-			];
-
-			if (! empty($this->samesite))
-			{
-				$params['samesite'] = $this->samesite;
-			}
-
-			// @phpstan-ignore-next-line @todo ignore to be removed in 4.1 with rector 0.9
-			setcookie($this->cookieName, $this->hash, $params);
-		}
-
+		$this->doSendCookie();
 		log_message('info', 'CSRF cookie sent.');
 
 		return $this;
+	}
+
+	/**
+	 * Actual dispatching of cookies.
+	 * Extracted for this to be unit tested.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return void
+	 */
+	protected function doSendCookie(): void
+	{
+		cookies([$this->cookie], false)->dispatch();
 	}
 }

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -110,11 +110,11 @@ class Security implements SecurityInterface
 	 *
 	 * @see https://portswigger.net/web-security/csrf/samesite-cookies
 	 *
-	 * @var string 'Lax'|'None'|'Strict'
+	 * @var string
 	 *
 	 * @deprecated
 	 */
-	protected $samesite = 'Lax';
+	protected $samesite = Cookie::SAMESITE_LAX;
 
 	/**
 	 * Constructor.

--- a/system/Security/SecurityInterface.php
+++ b/system/Security/SecurityInterface.php
@@ -25,7 +25,7 @@ interface SecurityInterface
 	 * @param RequestInterface $request
 	 *
 	 * @return $this|false
-	 * 
+	 *
 	 * @throws SecurityException
 	 */
 	public function verify(RequestInterface $request);
@@ -62,6 +62,8 @@ interface SecurityInterface
 	 * Check if CSRF cookie is expired.
 	 *
 	 * @return boolean
+	 *
+	 * @deprecated
 	 */
 	public function isExpired(): bool;
 

--- a/system/Session/Exceptions/SessionException.php
+++ b/system/Session/Exceptions/SessionException.php
@@ -40,6 +40,11 @@ class SessionException extends FrameworkException
 		return new static(lang('Session.invalidSavePathFormat', [$path]));
 	}
 
+	/**
+	 * @deprecated
+	 *
+	 * @codeCoverageIgnore
+	 */
 	public static function forInvalidSameSiteSetting(string $samesite)
 	{
 		return new static(lang('Session.invalidSameSiteSetting', [$samesite]));

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -11,7 +11,7 @@
 
 namespace CodeIgniter\Session;
 
-use CodeIgniter\Session\Exceptions\SessionException;
+use CodeIgniter\HTTP\Cookie\Cookie;
 use Config\App;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
@@ -64,7 +64,7 @@ class Session implements SessionInterface
 	 *
 	 * For the 'database' driver, it's a table name.
 	 *
-	 * TODO: address memcache & redis needs
+	 * @todo address memcache & redis needs
 	 *
 	 * IMPORTANT: You are REQUIRED to set a valid save path!
 	 *
@@ -99,10 +99,19 @@ class Session implements SessionInterface
 	protected $sessionRegenerateDestroy = false;
 
 	/**
+	 * The session cookie instance.
+	 *
+	 * @var Cookie
+	 */
+	protected $cookie;
+
+	/**
 	 * The domain name to use for cookies.
 	 * Set to .your-domain.com for site-wide cookies.
 	 *
 	 * @var string
+	 *
+	 * @deprecated
 	 */
 	protected $cookieDomain = '';
 
@@ -111,6 +120,8 @@ class Session implements SessionInterface
 	 * Typically will be a forward slash.
 	 *
 	 * @var string
+	 *
+	 * @deprecated
 	 */
 	protected $cookiePath = '/';
 
@@ -118,6 +129,8 @@ class Session implements SessionInterface
 	 * Cookie will only be set if a secure HTTPS connection exists.
 	 *
 	 * @var boolean
+	 *
+	 * @deprecated
 	 */
 	protected $cookieSecure = false;
 
@@ -126,6 +139,8 @@ class Session implements SessionInterface
 	 * Must be 'None', 'Lax' or 'Strict'.
 	 *
 	 * @var string 'Lax'|'None'|'Strict'
+	 *
+	 * @deprecated
 	 */
 	protected $cookieSameSite = 'Lax';
 
@@ -143,8 +158,6 @@ class Session implements SessionInterface
 	 */
 	protected $logger;
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Constructor.
 	 *
@@ -153,7 +166,7 @@ class Session implements SessionInterface
 	 * @param SessionHandlerInterface $driver
 	 * @param App                     $config
 	 */
-	public function __construct(SessionHandlerInterface $driver, $config)
+	public function __construct(SessionHandlerInterface $driver, App $config)
 	{
 		$this->driver = $driver;
 
@@ -165,20 +178,26 @@ class Session implements SessionInterface
 		$this->sessionTimeToUpdate      = $config->sessionTimeToUpdate ?? $this->sessionTimeToUpdate;
 		$this->sessionRegenerateDestroy = $config->sessionRegenerateDestroy ?? $this->sessionRegenerateDestroy;
 
+		//---------------------------------------------------------------------
+		// DEPRECATED COOKIE MANAGEMENT
+		//---------------------------------------------------------------------
 		$this->cookieDomain   = $config->cookieDomain ?? $this->cookieDomain;
 		$this->cookiePath     = $config->cookiePath ?? $this->cookiePath;
 		$this->cookieSecure   = $config->cookieSecure ?? $this->cookieSecure;
 		$this->cookieSameSite = $config->cookieSameSite ?? $this->cookieSameSite;
 
-		if (! in_array(strtolower($this->cookieSameSite), ['', 'none', 'lax', 'strict'], true))
-		{
-			throw SessionException::forInvalidSameSiteSetting($this->cookieSameSite);
-		}
+		$this->cookie = Cookie::create($this->sessionCookieName, '', [
+			'expires'  => $this->sessionExpiration === 0 ? 0 : time() + $this->sessionExpiration,
+			'raw'      => $config->cookieRaw ?? false,
+			'domain'   => $config->cookieDomain ?? '',
+			'path'     => $config->cookiePath ?? '/',
+			'secure'   => $config->cookieSecure ?? false,
+			'httponly' => true, // for security
+			'samesite' => $config->cookieSameSite ?? Cookie::SAMESITE_LAX,
+		]);
 
 		helper('array');
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Initialize the session container and starts up the session.
@@ -211,13 +230,11 @@ class Session implements SessionInterface
 		}
 
 		$this->configure();
-
 		$this->setSaveHandler();
 
 		// Sanitize the cookie, because apparently PHP doesn't do that for userspace handlers
-		if (isset($_COOKIE[$this->sessionCookieName]) && (
-				! is_string($_COOKIE[$this->sessionCookieName]) || ! preg_match('#\A' . $this->sidRegexp . '\z#', $_COOKIE[$this->sessionCookieName])
-				)
+		if (isset($_COOKIE[$this->sessionCookieName])
+			&& (! is_string($_COOKIE[$this->sessionCookieName]) || ! preg_match('#\A' . $this->sidRegexp . '\z#', $_COOKIE[$this->sessionCookieName]))
 		)
 		{
 			unset($_COOKIE[$this->sessionCookieName]);
@@ -226,8 +243,7 @@ class Session implements SessionInterface
 		$this->startSession();
 
 		// Is session ID auto-regeneration configured? (ignoring ajax requests)
-		if ((empty($_SERVER['HTTP_X_REQUESTED_WITH'])
-			|| strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) !== 'xmlhttprequest')
+		if ((empty($_SERVER['HTTP_X_REQUESTED_WITH']) || strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) !== 'xmlhttprequest')
 			&& ($regenerateTime = $this->sessionTimeToUpdate) > 0
 		)
 		{
@@ -248,13 +264,10 @@ class Session implements SessionInterface
 		}
 
 		$this->initVars();
-
 		$this->logger->info("Session: Class initialized using '" . $this->sessionDriverName . "' driver.");
 
 		return $this;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Does a full stop of the session:
@@ -266,13 +279,17 @@ class Session implements SessionInterface
 	public function stop()
 	{
 		setcookie(
-				$this->sessionCookieName, session_id(), 1, $this->cookiePath, $this->cookieDomain, $this->cookieSecure, true
+			$this->sessionCookieName,
+			session_id(),
+			1,
+			$this->cookie->getPath(),
+			$this->cookie->getDomain(),
+			$this->cookie->isSecure(),
+			true
 		);
 
 		session_regenerate_id(true);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Configuration.
@@ -290,19 +307,15 @@ class Session implements SessionInterface
 			ini_set('session.name', $this->sessionCookieName);
 		}
 
+		$sameSite = $this->cookie->getSameSite() ?: ucfirst(Cookie::SAMESITE_LAX);
+
 		if (PHP_VERSION_ID < 70300)
 		{
-			$sameSite = '';
-			if ($this->cookieSameSite !== '')
-			{
-				$sameSite = '; samesite=' . $this->cookieSameSite;
-			}
-
 			session_set_cookie_params(
 				$this->sessionExpiration,
-				$this->cookiePath . $sameSite, // Hacky way to set SameSite for PHP 7.2 and earlier
-				$this->cookieDomain,
-				$this->cookieSecure,
+				$this->cookie->getPath() . '; SameSite=' . $sameSite,
+				$this->cookie->getDomain(),
+				$this->cookie->isSecure(),
 				true // HTTP only; Yes, this is intentional and not configurable for security reasons.
 			);
 		}
@@ -311,22 +324,17 @@ class Session implements SessionInterface
 			// PHP 7.3 adds support for setting samesite in session_set_cookie_params()
 			$params = [
 				'lifetime' => $this->sessionExpiration,
-				'path'     => $this->cookiePath,
-				'domain'   => $this->cookieDomain,
-				'secure'   => $this->cookieSecure,
+				'path'     => $this->cookie->getPath(),
+				'domain'   => $this->cookie->getDomain(),
+				'secure'   => $this->cookie->isSecure(),
 				'httponly' => true, // HTTP only; Yes, this is intentional and not configurable for security reasons.
+				'samesite' => $sameSite,
 			];
 
-			if ($this->cookieSameSite !== '')
-			{
-				$params['samesite'] = $this->cookieSameSite;
-				ini_set('session.cookie_samesite', $this->cookieSameSite);
-			}
-
+			ini_set('session.cookie_samesite', $sameSite);
 			session_set_cookie_params($params);
 		}
 
-		//if (empty($this->sessionExpiration))
 		if (! isset($this->sessionExpiration))
 		{
 			$this->sessionExpiration = (int) ini_get('session.gc_maxlifetime');
@@ -349,8 +357,6 @@ class Session implements SessionInterface
 
 		$this->configureSidLength();
 	}
-
-	// ------------------------------------------------------------------------
 
 	/**
 	 * Configure session ID length
@@ -402,8 +408,6 @@ class Session implements SessionInterface
 		$this->sidRegexp .= '{' . $sidLength . '}';
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Handle temporary variables
 	 *
@@ -439,7 +443,6 @@ class Session implements SessionInterface
 	}
 
 	//--------------------------------------------------------------------
-	//--------------------------------------------------------------------
 	// Session Utility Methods
 	//--------------------------------------------------------------------
 
@@ -454,8 +457,6 @@ class Session implements SessionInterface
 		session_regenerate_id($destroy);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Destroys the current session.
 	 */
@@ -464,7 +465,6 @@ class Session implements SessionInterface
 		session_destroy();
 	}
 
-	//--------------------------------------------------------------------
 	//--------------------------------------------------------------------
 	// Basic Setters and Getters
 	//--------------------------------------------------------------------
@@ -503,8 +503,6 @@ class Session implements SessionInterface
 		$_SESSION[$data] = $value;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Get user data that has been set in the session.
 	 *
@@ -535,11 +533,10 @@ class Session implements SessionInterface
 		}
 
 		$userdata = [];
-		$_exclude = array_merge(
-			['__ci_vars'], $this->getFlashKeys(), $this->getTempKeys()
-		);
+		$_exclude = array_merge(['__ci_vars'], $this->getFlashKeys(), $this->getTempKeys());
 
 		$keys = array_keys($_SESSION);
+
 		foreach ($keys as $key)
 		{
 			if (! in_array($key, $_exclude, true))
@@ -550,8 +547,6 @@ class Session implements SessionInterface
 
 		return $userdata;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Returns whether an index exists in the session array.
@@ -564,8 +559,6 @@ class Session implements SessionInterface
 	{
 		return isset($_SESSION[$key]);
 	}
-
-	   //--------------------------------------------------------------------
 
 	/**
 	 * Push new value onto session value that is array.
@@ -582,8 +575,6 @@ class Session implements SessionInterface
 			$this->set($key, array_merge($value, $data));
 		}
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Remove one or more session properties.
@@ -609,8 +600,6 @@ class Session implements SessionInterface
 		unset($_SESSION[$key]);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Magic method to set variables in the session by simply calling
 	 *  $session->foo = bar;
@@ -622,8 +611,6 @@ class Session implements SessionInterface
 	{
 		$_SESSION[$key] = $value;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Magic method to get session variables by simply calling
@@ -650,8 +637,6 @@ class Session implements SessionInterface
 		return null;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Magic method to check for session variables.
 	 * Different from has() in that it will validate 'session_id' as well.
@@ -666,7 +651,6 @@ class Session implements SessionInterface
 		return isset($_SESSION[$key]) || ($key === 'session_id');
 	}
 
-	//--------------------------------------------------------------------
 	//--------------------------------------------------------------------
 	// Flash Data Methods
 	//--------------------------------------------------------------------
@@ -689,15 +673,14 @@ class Session implements SessionInterface
 		$this->markAsFlashdata(is_array($data) ? array_keys($data) : $data);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Retrieve one or more items of flash data from the session.
 	 *
 	 * If the item key is null, return all flashdata.
 	 *
-	 * @param  string $key Property identifier
-	 * @return array|null	The requested property value, or an associative array of them
+	 * @param string $key Property identifier
+	 *
+	 * @return array|null The requested property value, or an associative array  of them
 	 */
 	public function getFlashdata(string $key = null)
 	{
@@ -720,8 +703,6 @@ class Session implements SessionInterface
 		return $flashdata;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Keeps a single piece of flash data alive for one more request.
 	 *
@@ -731,8 +712,6 @@ class Session implements SessionInterface
 	{
 		$this->markAsFlashdata($key);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Mark a session property or properties as flashdata.
@@ -770,8 +749,6 @@ class Session implements SessionInterface
 		return true;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Unmark data in the session as flashdata.
 	 *
@@ -784,7 +761,10 @@ class Session implements SessionInterface
 			return;
 		}
 
-		is_array($key) || $key = [$key]; // @phpstan-ignore-line
+		if (! is_array($key))
+		{
+			$key = [$key];
+		}
 
 		foreach ($key as $k)
 		{
@@ -800,12 +780,10 @@ class Session implements SessionInterface
 		}
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Retrieve all of the keys for session data marked as flashdata.
 	 *
-	 * @return array	The property names of all flashdata
+	 * @return array The property names of all flashdata
 	 */
 	public function getFlashKeys(): array
 	{
@@ -824,7 +802,6 @@ class Session implements SessionInterface
 	}
 
 	//--------------------------------------------------------------------
-	//--------------------------------------------------------------------
 	// Temp Data Methods
 	//--------------------------------------------------------------------
 
@@ -841,8 +818,6 @@ class Session implements SessionInterface
 		$this->set($data, $value);
 		$this->markAsTempdata($data, $ttl);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Returns either a single piece of tempdata, or all temp data currently
@@ -872,8 +847,6 @@ class Session implements SessionInterface
 		return $tempdata;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Removes a single piece of temporary data from the session.
 	 *
@@ -885,8 +858,6 @@ class Session implements SessionInterface
 		unset($_SESSION[$key]);
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Mark one of more pieces of data as being temporary, meaning that
 	 * it has a set lifespan within the session.
@@ -894,7 +865,7 @@ class Session implements SessionInterface
 	 * @param string|array $key Property identifier or array of them
 	 * @param integer      $ttl Time to live, in seconds
 	 *
-	 * @return boolean    False if any of the properties were not set
+	 * @return boolean False if any of the properties were not set
 	 */
 	public function markAsTempdata($key, int $ttl = 300): bool
 	{
@@ -944,8 +915,6 @@ class Session implements SessionInterface
 		return true;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Unmarks temporary data in the session, effectively removing its
 	 * lifespan and allowing it to live as long as the session does.
@@ -975,8 +944,6 @@ class Session implements SessionInterface
 		}
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Retrieve the keys of all session data that have been marked as temporary data.
 	 *
@@ -998,8 +965,6 @@ class Session implements SessionInterface
 		return $keys;
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Sets the driver as the session handler in PHP.
 	 * Extracted for easier testing.
@@ -1008,8 +973,6 @@ class Session implements SessionInterface
 	{
 		session_set_save_handler($this->driver, true);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Starts the session.
@@ -1023,57 +986,19 @@ class Session implements SessionInterface
 			return;
 		}
 
-		// @codeCoverageIgnoreStart
-		session_start();
-		// @codeCoverageIgnoreEnd
+		session_start(); // @codeCoverageIgnore
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Takes care of setting the cookie on the client side.
-	 * Extracted for testing reasons.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	protected function setCookie()
 	{
-		if (PHP_VERSION_ID < 70300)
-		{
-			$sameSite = '';
-			if ($this->cookieSameSite !== '')
-			{
-				$sameSite = '; samesite=' . $this->cookieSameSite;
-			}
+		$expiration   = $this->sessionExpiration === 0 ? 0 : time() + $this->sessionExpiration;
+		$this->cookie = $this->cookie->withValue(session_id())->withExpiresAt($expiration);
 
-			setcookie(
-				$this->sessionCookieName,
-				session_id(),
-				empty($this->sessionExpiration) ? 0 : time() + $this->sessionExpiration,
-				$this->cookiePath . $sameSite, // Hacky way to set SameSite for PHP 7.2 and earlier
-				$this->cookieDomain,
-				$this->cookieSecure,
-				true
-			);
-		}
-		else
-		{
-			// PHP 7.3 adds another function signature allowing setting of samesite
-			$params = [
-				'expires'  => empty($this->sessionExpiration) ? 0 : time() + $this->sessionExpiration,
-				'path'     => $this->cookiePath,
-				'domain'   => $this->cookieDomain,
-				'secure'   => $this->cookieSecure,
-				'httponly' => true,
-			];
-
-			if ($this->cookieSameSite !== '')
-			{
-				$params['samesite'] = $this->cookieSameSite;
-			}
-
-			// @phpstan-ignore-next-line @todo ignore to be removed in 4.1 with rector 0.9
-			setcookie($this->sessionCookieName, session_id(), $params);
-		}
+		cookies([$this->cookie], false)->dispatch();
 	}
-
-	//--------------------------------------------------------------------
 }

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -138,11 +138,11 @@ class Session implements SessionInterface
 	 * Cookie SameSite setting as described in RFC6265
 	 * Must be 'None', 'Lax' or 'Strict'.
 	 *
-	 * @var string 'Lax'|'None'|'Strict'
+	 * @var string
 	 *
 	 * @deprecated
 	 */
-	protected $cookieSameSite = 'Lax';
+	protected $cookieSameSite = Cookie::SAMESITE_LAX;
 
 	/**
 	 * sid regex expression
@@ -309,31 +309,17 @@ class Session implements SessionInterface
 
 		$sameSite = $this->cookie->getSameSite() ?: ucfirst(Cookie::SAMESITE_LAX);
 
-		if (PHP_VERSION_ID < 70300)
-		{
-			session_set_cookie_params(
-				$this->sessionExpiration,
-				$this->cookie->getPath() . '; SameSite=' . $sameSite,
-				$this->cookie->getDomain(),
-				$this->cookie->isSecure(),
-				true // HTTP only; Yes, this is intentional and not configurable for security reasons.
-			);
-		}
-		else
-		{
-			// PHP 7.3 adds support for setting samesite in session_set_cookie_params()
-			$params = [
-				'lifetime' => $this->sessionExpiration,
-				'path'     => $this->cookie->getPath(),
-				'domain'   => $this->cookie->getDomain(),
-				'secure'   => $this->cookie->isSecure(),
-				'httponly' => true, // HTTP only; Yes, this is intentional and not configurable for security reasons.
-				'samesite' => $sameSite,
-			];
+		$params = [
+			'lifetime' => $this->sessionExpiration,
+			'path'     => $this->cookie->getPath(),
+			'domain'   => $this->cookie->getDomain(),
+			'secure'   => $this->cookie->isSecure(),
+			'httponly' => true, // HTTP only; Yes, this is intentional and not configurable for security reasons.
+			'samesite' => $sameSite,
+		];
 
-			ini_set('session.cookie_samesite', $sameSite);
-			session_set_cookie_params($params);
-		}
+		ini_set('session.cookie_samesite', $sameSite);
+		session_set_cookie_params($params);
 
 		if (! isset($this->sessionExpiration))
 		{

--- a/system/Test/FeatureResponse.php
+++ b/system/Test/FeatureResponse.php
@@ -252,7 +252,7 @@ class FeatureResponse extends TestCase
 	public function assertCookieExpired(string $key, string $prefix = '')
 	{
 		$this->assertTrue($this->response->hasCookie($key, null, $prefix));
-		$this->assertGreaterThan(time(), $this->response->getCookie($key, $prefix)['expires']);
+		$this->assertGreaterThan(time(), $this->response->getCookie($key, $prefix)->getExpiresTimestamp());
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Test/Mock/MockAppConfig.php
+++ b/system/Test/Mock/MockAppConfig.php
@@ -11,7 +11,9 @@
 
 namespace CodeIgniter\Test\Mock;
 
-class MockAppConfig
+use Config\App;
+
+class MockAppConfig extends App
 {
 	public $baseURL = 'http://example.com/';
 

--- a/system/Test/Mock/MockSecurityConfig.php
+++ b/system/Test/Mock/MockSecurityConfig.php
@@ -2,9 +2,14 @@
 
 namespace CodeIgniter\Test\Mock;
 
-use Config\Security as SecurityConfig;
+use Config\Security as Security;
 
-class MockSecurityConfig extends SecurityConfig
+/**
+ * @deprecated
+ *
+ * @codeCoverageIgnore
+ */
+class MockSecurityConfig extends Security
 {
 	public $tokenName   = 'csrf_test_name';
 	public $headerName  = 'X-CSRF-TOKEN';

--- a/system/Test/Mock/MockSession.php
+++ b/system/Test/Mock/MockSession.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Test\Mock;
 
+use CodeIgniter\HTTP\Cookie\Cookie;
 use CodeIgniter\Session\Session;
 
 /**
@@ -24,13 +25,11 @@ class MockSession extends Session
 	/**
 	 * Holds our "cookie" data.
 	 *
-	 * @var array
+	 * @var Cookie[]
 	 */
 	public $cookies = [];
 
 	public $didRegenerate = false;
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Sets the driver as the session handler in PHP.
@@ -38,10 +37,8 @@ class MockSession extends Session
 	 */
 	protected function setSaveHandler()
 	{
-		//        session_set_save_handler($this->driver, true);
+		// session_set_save_handler($this->driver, true);
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Starts the session.
@@ -49,11 +46,9 @@ class MockSession extends Session
 	 */
 	protected function startSession()
 	{
-		//        session_start();
+		// session_start();
 		$this->setCookie();
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Takes care of setting the cookie on the client side.
@@ -61,55 +56,15 @@ class MockSession extends Session
 	 */
 	protected function setCookie()
 	{
-		if (PHP_VERSION_ID < 70300)
-		{
-			$sameSite = '';
-			if ($this->cookieSameSite !== '')
-			{
-				$sameSite = '; samesite=' . $this->cookieSameSite;
-			}
+		$expiration   = $this->sessionExpiration === 0 ? 0 : time() + $this->sessionExpiration;
+		$this->cookie = $this->cookie->withValue(session_id())->withExpiresAt($expiration);
 
-			$this->cookies[] = [
-				$this->sessionCookieName,
-				session_id(),
-				empty($this->sessionExpiration) ? 0 : time() + $this->sessionExpiration,
-				$this->cookiePath . $sameSite, // Hacky way to set SameSite for PHP 7.2 and earlier
-				$this->cookieDomain,
-				$this->cookieSecure,
-				true,
-			];
-		}
-		else
-		{
-			// PHP 7.3 adds another function signature allowing setting of samesite
-			$params = [
-				'expires'  => empty($this->sessionExpiration) ? 0 : time() + $this->sessionExpiration,
-				'path'     => $this->cookiePath,
-				'domain'   => $this->cookieDomain,
-				'secure'   => $this->cookieSecure,
-				'httponly' => true,
-			];
-
-			if ($this->cookieSameSite !== '')
-			{
-				$params['samesite'] = $this->cookieSameSite;
-			}
-
-			$this->cookies[] = [
-				$this->sessionCookieName,
-				session_id(),
-				$params,
-			];
-		}
+		$this->cookies[] = $this->cookie;
 	}
-
-	//--------------------------------------------------------------------
 
 	public function regenerate(bool $destroy = false)
 	{
 		$this->didRegenerate              = true;
 		$_SESSION['__ci_last_regenerate'] = time();
 	}
-
-	//--------------------------------------------------------------------
 }

--- a/tests/system/HTTP/Cookie/CookieClassTest.php
+++ b/tests/system/HTTP/Cookie/CookieClassTest.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace CodeIgniter\HTTP\Cookie;
+
+use CodeIgniter\HTTP\Cookie\Cookie;
+use CodeIgniter\HTTP\Exceptions\CookieException;
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\App;
+use DateTimeImmutable;
+use DateTimeZone;
+use InvalidArgumentException;
+use LogicException;
+
+/**
+ * @internal
+ */
+final class CookieClassTest extends CIUnitTestCase
+{
+	/**
+	 * @var array
+	 */
+	private $defaults;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->defaults = Cookie::setDefaults();
+	}
+
+	protected function tearDown(): void
+	{
+		Cookie::setDefaults($this->defaults);
+	}
+
+	public function testCookieInitializationWithDefaults(): void
+	{
+		$cookie  = Cookie::create('test', 'value');
+		$options = Cookie::setDefaults();
+
+		$this->assertSame($options['prefix'] . 'test', $cookie->getPrefixedName());
+		$this->assertSame('test', $cookie->getName());
+		$this->assertSame('value', $cookie->getValue());
+		$this->assertSame($options['prefix'], $cookie->getPrefix());
+		$this->assertSame($options['raw'], $cookie->isRaw());
+		$this->assertSame($options['expires'], $cookie->getExpiresTimestamp());
+		$this->assertSame($options['domain'], $cookie->getDomain());
+		$this->assertSame($options['path'], $cookie->getPath());
+		$this->assertSame($options['secure'], $cookie->isSecure());
+		$this->assertSame($options['httponly'], $cookie->isHttpOnly());
+		$this->assertSame($options['samesite'], $cookie->getSameSite());
+	}
+
+	public function testConfigInjectionForDefaults(): void
+	{
+		/**
+		 * @var App $app
+		 */
+		$app = config('App', false);
+		$old = Cookie::setDefaults($app);
+
+		$cookie = Cookie::create('test', 'value');
+		$this->assertSame($app->cookiePrefix . 'test', $cookie->getPrefixedName());
+		$this->assertSame('test', $cookie->getName());
+		$this->assertSame('value', $cookie->getValue());
+		$this->assertSame($app->cookiePrefix, $cookie->getPrefix());
+		$this->assertSame($app->cookieRaw, $cookie->isRaw());
+		$this->assertSame($app->cookieExpires, $cookie->getExpiresTimestamp());
+		$this->assertSame($app->cookieDomain, $cookie->getDomain());
+		$this->assertSame($app->cookiePath, $cookie->getPath());
+		$this->assertSame($app->cookieSecure, $cookie->isSecure());
+		$this->assertSame($app->cookieHTTPOnly, $cookie->isHttpOnly());
+		$this->assertSame($app->cookieSameSite, $cookie->getSameSite());
+
+		Cookie::setDefaults($old);
+	}
+
+	public function testValidationOfRawCookieName(): void
+	{
+		$this->expectException(CookieException::class);
+		Cookie::create("test;\n", '', ['raw' => true]);
+	}
+
+	public function testValidationOfEmptyCookieName(): void
+	{
+		$this->expectException(CookieException::class);
+		Cookie::create('', 'value');
+	}
+
+	public function testValidationOfSecurePrefix(): void
+	{
+		$this->expectException(CookieException::class);
+		Cookie::create('test', 'value', ['prefix' => '__Secure-', 'secure' => false]);
+	}
+
+	public function testValidationOfHostPrefix(): void
+	{
+		$this->expectException(CookieException::class);
+		Cookie::create('test', 'value', ['prefix' => '__Host-', 'domain' => 'localhost']);
+	}
+
+	public function testValidationOfSameSite(): void
+	{
+		Cookie::setDefaults(['samesite' => '']);
+		$this->assertInstanceOf(Cookie::class, Cookie::create('test'));
+
+		$this->expectException(CookieException::class);
+		Cookie::create('test', '', ['samesite' => 'Yes']);
+	}
+
+	public function testValidationOfSameSiteNone(): void
+	{
+		$this->expectException(CookieException::class);
+		Cookie::create('test', '', ['samesite' => Cookie::SAMESITE_NONE, 'secure' => false]);
+	}
+
+	public function testExpirationTime(): void
+	{
+		// expires => 0
+		$cookie = Cookie::create('test', 'value');
+		$this->assertSame(0, $cookie->getExpiresTimestamp());
+		$this->assertSame('Thu, 01-Jan-1970 00:00:00 GMT', $cookie->getExpiresString());
+		$this->assertTrue($cookie->isExpired());
+		$this->assertSame(0, $cookie->getMaxAge());
+
+		$date   = new DateTimeImmutable('2021-01-10 00:00:00 GMT', new DateTimeZone('UTC'));
+		$cookie = Cookie::create('test', 'value', ['expires' => $date]);
+		$this->assertSame((int) $date->format('U'), $cookie->getExpiresTimestamp());
+		$this->assertSame('Sun, 10-Jan-2021 00:00:00 GMT', $cookie->getExpiresString());
+	}
+
+	/**
+	 * @dataProvider invalidExpiresProvider
+	 *
+	 * @param mixed $expires
+	 *
+	 * @return void
+	 */
+	public function testInvalidExpires($expires): void
+	{
+		$this->expectException(CookieException::class);
+		Cookie::create('test', 'value', ['expires' => $expires]);
+	}
+
+	public static function invalidExpiresProvider(): iterable
+	{
+		$cases = [
+			'non-numeric-string' => ['yes'],
+			'boolean'            => [true],
+			'float'              => [10.0],
+		];
+
+		foreach ($cases as $type => $case)
+		{
+			yield $type => $case;
+		}
+	}
+
+	/**
+	 * @dataProvider setCookieHeaderProvider
+	 *
+	 * @param string $header
+	 * @param array  $changed
+	 *
+	 * @return void
+	 */
+	public function testSetCookieHeaderCreation(string $header, array $changed): void
+	{
+		$cookie = Cookie::fromHeaderString($header);
+		$cookie = $cookie->toArray();
+		$this->assertEquals($changed + $cookie, $cookie);
+	}
+
+	public static function setCookieHeaderProvider(): iterable
+	{
+		yield 'basic' => [
+			'test=value',
+			['name' => 'test', 'value' => 'value'],
+		];
+
+		yield 'empty-value' => [
+			'test',
+			['name' => 'test', 'value' => ''],
+		];
+
+		yield 'with-other-attrs' => [
+			'test=value; Max-Age=3600; Path=/web',
+			['name' => 'test', 'value' => 'value', 'path' => '/web'],
+		];
+
+		yield 'with-flags' => [
+			'test=value; Secure; HttpOnly; SameSite=Lax',
+			['name' => 'test', 'value' => 'value', 'secure' => true, 'httponly' => true, 'samesite' => 'Lax'],
+		];
+	}
+
+	public function testValidNamePerRfcYieldsSameNameRegardlessOfRawParam(): void
+	{
+		$cookie1 = Cookie::create('testing', '', ['raw' => false]);
+		$cookie2 = Cookie::create('testing', '', ['raw' => true]);
+		$this->assertSame($cookie1->getPrefixedName(), $cookie2->getPrefixedName());
+	}
+
+	public function testCloningCookies(): void
+	{
+		$a = Cookie::create('dev', 'cookie');
+		$b = $a->withRaw();
+		$c = $a->withPrefix('my_');
+		$d = $a->withName('prod');
+		$e = $a->withValue('muffin');
+		$f = $a->withExpiresAt('+30 days');
+		$g = $a->withExpired();
+		$h = $a->withNeverExpiring();
+		$i = $a->withDomain('localhost');
+		$j = $a->withPath('/web');
+		$k = $a->withSecure();
+		$l = $a->withHttpOnly();
+		$m = $a->withSameSite(Cookie::SAMESITE_STRICT);
+
+		$this->assertNotSame($a, $b);
+		$this->assertNotSame($a, $c);
+		$this->assertNotSame($a, $d);
+		$this->assertNotSame($a, $e);
+		$this->assertNotSame($a, $f);
+		$this->assertNotSame($a, $g);
+		$this->assertNotSame($a, $h);
+		$this->assertNotSame($a, $i);
+		$this->assertNotSame($a, $j);
+		$this->assertNotSame($a, $k);
+		$this->assertNotSame($a, $l);
+		$this->assertNotSame($a, $m);
+	}
+
+	public function testStringCastingOfCookies(): void
+	{
+		$date = new DateTimeImmutable('2021-02-14 00:00:00 GMT', new DateTimeZone('UTC'));
+
+		$a = Cookie::create('cookie', 'lover');
+		$b = $a->withValue('monster')->withPath('/web')->withDomain('localhost')->withExpiresAt($date);
+		$c = $a->withSecure()->withHttpOnly(false)->withSameSite(Cookie::SAMESITE_STRICT);
+
+		$max = (string) $b->getMaxAge();
+		$old = Cookie::setDefaults(['samesite' => '']);
+
+		$d = $a->withValue('')->withSameSite('');
+
+		$this->assertSame(
+			'cookie=lover; Path=/; HttpOnly; SameSite=Lax',
+			$a->toHeaderString()
+		);
+		$this->assertSame(
+			"cookie=monster; Expires=Sun, 14-Feb-2021 00:00:00 GMT; Max-Age={$max}; Path=/web; Domain=localhost; HttpOnly; SameSite=Lax",
+			(string) $b
+		);
+		$this->assertSame(
+			'cookie=lover; Path=/; Secure; SameSite=Strict',
+			(string) $c
+		);
+		$this->assertSame(
+			'cookie=deleted; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/; HttpOnly; SameSite=Lax',
+			(string) $d
+		);
+
+		Cookie::setDefaults($old);
+	}
+
+	public function testArrayAccessOfCookie(): void
+	{
+		$cookie = Cookie::create('cookie', 'monster');
+
+		$this->assertTrue(isset($cookie['expire']));
+		$this->assertSame($cookie['expire'], $cookie->getExpiresTimestamp());
+		$this->assertTrue(isset($cookie['httponly']));
+		$this->assertSame($cookie['httponly'], $cookie->isHttpOnly());
+		$this->assertTrue(isset($cookie['samesite']));
+		$this->assertSame($cookie['samesite'], $cookie->getSameSite());
+		$this->assertTrue(isset($cookie['path']));
+		$this->assertSame($cookie['path'], $cookie->getPath());
+
+		$this->expectException(InvalidArgumentException::class);
+		$cookie['expiry'];
+	}
+
+	public function testCannotSetPropertyViaArrayAccess(): void
+	{
+		$this->expectException(LogicException::class);
+		Cookie::create('cookie', 'monster')['expires'] = 7200;
+	}
+
+	public function testCannotUnsetPropertyViaArrayAccess(): void
+	{
+		$this->expectException(LogicException::class);
+		unset(Cookie::create('cookie', 'monster')['path']);
+	}
+}

--- a/tests/system/HTTP/Cookie/CookieStoreTest.php
+++ b/tests/system/HTTP/Cookie/CookieStoreTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace CodeIgniter\HTTP\Cookie;
+
+use CodeIgniter\HTTP\Cookie\CookieStore;
+use CodeIgniter\HTTP\Exceptions\CookieException;
+use CodeIgniter\Test\CIUnitTestCase;
+use DateTimeImmutable;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * @internal
+ */
+final class CookieStoreTest extends CIUnitTestCase
+{
+	/**
+	 * @var array
+	 */
+	private $defaults;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->defaults = Cookie::setDefaults();
+	}
+
+	protected function tearDown(): void
+	{
+		Cookie::setDefaults($this->defaults);
+	}
+
+	public function testCookieStoreInitialization(): void
+	{
+		$cookies = [
+			Cookie::create('dev', 'cookie'),
+			Cookie::create('prod', 'cookie', ['raw' => true]),
+		];
+
+		$store = new CookieStore($cookies);
+
+		$this->assertCount(2, $store);
+		$this->assertTrue($store->has('dev'));
+		$this->assertSame($cookies[0], $store->get('dev'));
+		$this->assertTrue($store->has('prod'));
+		$this->assertTrue($store->has('prod', '', 'cookie'));
+		$this->assertSame($cookies[1], $store->get('prod'));
+		$this->assertFalse($store->has('test'));
+		$this->assertSame($cookies, array_values($store->display()));
+		$this->assertSame($cookies, array_values(iterator_to_array($store->getIterator())));
+
+		$this->expectException(CookieException::class);
+		$store->get('test');
+	}
+
+	public function testCookieStoreInitViaHeaders(): void
+	{
+		$cookies = [
+			'dev=cookie; Max-Age=3600',
+			'prod=cookie; Path=/web',
+			'test,def=cookie; SameSite=Lax',
+		];
+
+		$store = CookieStore::fromCookieHeaders($cookies, true);
+		$this->assertCount(2, $store);
+		$this->assertTrue($store->has('dev'));
+		$this->assertTrue($store->has('prod'));
+		$this->assertFalse($store->has('test,def'));
+	}
+
+	public function testInvalidCookieStored(): void
+	{
+		$this->expectException(CookieException::class);
+		new CookieStore([new DateTimeImmutable('now')]);
+	}
+
+	public function testPutRemoveCookiesInStore(): void
+	{
+		$cookies = [
+			Cookie::create('dev', 'cookie'),
+			Cookie::create('prod', 'cookie', ['raw' => true]),
+		];
+
+		$store  = new CookieStore($cookies);
+		$bottle = $store->put(Cookie::create('test', 'cookie'));
+		$jar    = $store->remove('dev');
+
+		$this->assertNotSame($store->display(), $bottle->display());
+		$this->assertFalse($store->has('test'));
+		$this->assertTrue($bottle->has('test'));
+		$this->assertTrue($store->has('dev'));
+		$this->assertFalse($jar->has('dev'));
+	}
+
+	public function testCookieDispatching(): void
+	{
+		$cookies = [
+			'dev'  => Cookie::create('dev', 'cookie'),
+			'prod' => Cookie::create('prod', 'cookie', ['raw' => true]),
+		];
+
+		$dev  = $cookies['dev']->getOptions();
+		$prod = $cookies['prod']->getOptions();
+
+		/**
+		 * @var MockObject&CookieStore
+		 */
+		$store = $this->getMockBuilder(CookieStore::class)
+			->setConstructorArgs([$cookies])
+			->onlyMethods(['setRawCookie', 'setCookie'])
+			->getMock();
+
+		$store->expects($this->once())->method('setRawCookie')->with('prod', 'cookie', $prod);
+		$store->expects($this->once())->method('setCookie')->with('dev', 'cookie', $dev);
+		$store->dispatch();
+	}
+
+	public function testCookiesFunction(): void
+	{
+		$a = cookies();
+		$b = cookies([], false);
+
+		$this->assertInstanceOf(CookieStore::class, $a);
+		$this->assertInstanceOf(CookieStore::class, $b);
+		$this->assertNotSame($a, $b);
+	}
+}

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -2,16 +2,16 @@
 
 namespace CodeIgniter\HTTP;
 
-use CodeIgniter\Config\Config;
-use CodeIgniter\Config\Services;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Router\RouteCollection;
+use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockIncomingRequest;
 use CodeIgniter\Validation\Validation;
 use Config\App;
+use Config\Services;
 
-class RedirectResponseTest extends \CodeIgniter\Test\CIUnitTestCase
+class RedirectResponseTest extends CIUnitTestCase
 {
-
 	/**
 	 * @var RouteCollection
 	 */
@@ -197,7 +197,7 @@ class RedirectResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 	{
 		$config          = new App();
 		$config->baseURL = 'http://example.com/test/';
-		Config::injectMock('App', $config);
+		Factories::injectMock('config', 'App', $config);
 
 		$request = new MockIncomingRequest($config, new URI('http://example.com/test/'), null, new UserAgent());
 		Services::injectMock('request', $request);
@@ -211,21 +211,20 @@ class RedirectResponseTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertTrue($response->hasHeader('Location'));
 		$this->assertEquals('http://example.com/test/index.php/exampleRoute', $response->getHeaderLine('Location'));
 
-		Config::reset();
+		Factories::reset('config');
 	}
 
 	public function testWithCookies()
 	{
 		$_SESSION = [];
 
-		$baseResponse = service('response');
+		$baseResponse = Services::response();
 		$baseResponse->setCookie('foo', 'bar');
 
 		$response = new RedirectResponse(new App());
 		$this->assertFalse($response->hasCookie('foo', 'bar'));
 
 		$response = $response->withCookies();
-
 		$this->assertTrue($response->hasCookie('foo', 'bar'));
 	}
 

--- a/tests/system/HTTP/ResponseCookieTest.php
+++ b/tests/system/HTTP/ResponseCookieTest.php
@@ -1,21 +1,31 @@
 <?php
 namespace CodeIgniter\HTTP;
 
-use CodeIgniter\HTTP\Exceptions\HTTPException;
+use CodeIgniter\HTTP\Cookie\Cookie;
+use CodeIgniter\HTTP\Cookie\CookieStore;
+use CodeIgniter\HTTP\Exceptions\CookieException;
+use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 
-class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
+/**
+ * @internal
+ */
+final class ResponseCookieTest extends CIUnitTestCase
 {
+	/**
+	 * @var array
+	 */
+	private $defaults;
 
 	protected function setUp(): void
 	{
 		parent::setUp();
-		$this->server = $_SERVER;
+		$this->defaults = Cookie::setDefaults();
 	}
 
-	public function tearDown(): void
+	protected function tearDown(): void
 	{
-		$_SERVER = $this->server;
+		Cookie::setDefaults($this->defaults);
 	}
 
 	public function testCookiePrefixed()
@@ -25,7 +35,7 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 		$response             = new Response($config);
 		$response->setCookie('foo', 'bar');
 
-		$this->assertTrue(is_array($response->getCookie('foo')));
+		$this->assertInstanceOf(Cookie::class, $response->getCookie('foo'));
 		$this->assertTrue($response->hasCookie('foo'));
 		$this->assertTrue($response->hasCookie('foo', 'bar'));
 		$this->assertTrue($response->hasCookie('foo', 'bar', 'mine'));
@@ -40,8 +50,7 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 		$response->setCookie('foo', 'bar');
 		$response->setCookie('bee', 'bop');
 
-		$allCookies = $response->getCookie();
-		$this->assertEquals(2, count($allCookies));
+		$this->assertCount(2, $response->getCookies());
 		$this->assertTrue($response->hasCookie('foo'));
 		$this->assertTrue($response->hasCookie('bee'));
 	}
@@ -53,9 +62,8 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 		$response->setCookie('foo', 'bar');
 		$response->setCookie('bee', 'bop');
 
-		$allCookies = $response->getCookie();
-		$this->assertEquals(2, count($allCookies));
-		$this->assertEquals(null, $response->getCookie('bogus'));
+		$this->assertCount(2, $response->getCookie());
+		$this->assertNull($response->getCookie('bogus'));
 	}
 
 	public function testCookieDomain()
@@ -65,17 +73,17 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$response->setCookie('foo', 'bar');
 		$cookie = $response->getCookie('foo');
-		$this->assertEquals('', $cookie['domain']);
+		$this->assertSame('', $cookie->getDomain());
 
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'domain' => 'somewhere.com']);
 		$cookie = $response->getCookie('bee');
-		$this->assertEquals('somewhere.com', $cookie['domain']);
+		$this->assertSame('somewhere.com', $cookie->getDomain());
 
 		$config->cookieDomain = 'mine.com';
 		$response             = new Response($config);
 		$response->setCookie('alu', 'la');
 		$cookie = $response->getCookie('alu');
-		$this->assertEquals('mine.com', $cookie['domain']);
+		$this->assertSame('mine.com', $cookie->getDomain());
 	}
 
 	public function testCookiePath()
@@ -85,17 +93,11 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$response->setCookie('foo', 'bar');
 		$cookie = $response->getCookie('foo');
-		$this->assertEquals('/', $cookie['path']);
+		$this->assertSame('/', $cookie->getPath());
 
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'path' => '/tmp/here']);
 		$cookie = $response->getCookie('bee');
-		$this->assertEquals('/tmp/here', $cookie['path']);
-
-		$config->cookiePath = '/tmp/there';
-		$response           = new Response($config);
-		$response->setCookie('alu', 'la');
-		$cookie = $response->getCookie('alu');
-		$this->assertEquals('/tmp/there', $cookie['path']);
+		$this->assertSame('/tmp/here', $cookie->getPath());
 	}
 
 	public function testCookieSecure()
@@ -105,17 +107,11 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$response->setCookie('foo', 'bar');
 		$cookie = $response->getCookie('foo');
-		$this->assertEquals(false, $cookie['secure']);
+		$this->assertFalse($cookie->isSecure());
 
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'secure' => true]);
 		$cookie = $response->getCookie('bee');
-		$this->assertEquals(true, $cookie['secure']);
-
-		$config->cookieSecure = true;
-		$response             = new Response($config);
-		$response->setCookie('alu', 'la');
-		$cookie = $response->getCookie('alu');
-		$this->assertEquals(true, $cookie['secure']);
+		$this->assertTrue($cookie->isSecure());
 	}
 
 	public function testCookieHTTPOnly()
@@ -125,17 +121,11 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$response->setCookie('foo', 'bar');
 		$cookie = $response->getCookie('foo');
-		$this->assertEquals(false, $cookie['httponly']);
+		$this->assertTrue($cookie->isHttpOnly());
 
-		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'httponly' => true]);
+		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'httponly' => false]);
 		$cookie = $response->getCookie('bee');
-		$this->assertEquals(true, $cookie['httponly']);
-
-		$config->cookieHTTPOnly = true;
-		$response               = new Response($config);
-		$response->setCookie('alu', 'la');
-		$cookie = $response->getCookie('alu');
-		$this->assertEquals(true, $cookie['httponly']);
+		$this->assertTrue($cookie->isHttpOnly());
 	}
 
 	public function testCookieExpiry()
@@ -145,22 +135,17 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$response->setCookie('foo', 'bar');
 		$cookie = $response->getCookie('foo');
-		$this->assertTrue($cookie['expires'] < time());
+		$this->assertTrue($cookie->isExpired());
 
 		$response = new Response($config);
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
 		$cookie = $response->getCookie('bee');
-		$this->assertFalse($cookie['expires'] < time());
-
-		$response = new Response($config);
-		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 'oops']);
-		$cookie = $response->getCookie('bee');
-		$this->assertTrue($cookie['expires'] < time());
+		$this->assertFalse($cookie->isExpired());
 
 		$response = new Response($config);
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => -1000]);
 		$cookie = $response->getCookie('bee');
-		$this->assertEquals(0, $cookie['expires']);
+		$this->assertSame(0, $cookie->getExpiresTimestamp());
 	}
 
 	public function testCookieDelete()
@@ -172,27 +157,27 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 		$response->setCookie('foo', 'bar');
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
 		$cookie = $response->getCookie('bee');
-		$this->assertFalse($cookie['expires'] <= time());
+		$this->assertFalse($cookie->isExpired());
 
 		// delete cookie manually
 		$response = new Response($config);
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => '']);
 		$cookie = $response->getCookie('bee');
-		$this->assertTrue($cookie['expires'] <= time(), $cookie['expires'] . ' should be less than ' . time());
+		$this->assertTrue($cookie->isExpired(), $cookie->getExpiresTimestamp() . ' should be less than ' . time());
 
 		// delete with no effect
 		$response = new Response($config);
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
 		$response->deleteCookie();
 		$cookie = $response->getCookie('bee');
-		$this->assertFalse($cookie['expires'] < time());
+		$this->assertFalse($cookie->isExpired());
 
 		// delete cookie for real
 		$response = new Response($config);
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
 		$response->deleteCookie('bee');
 		$cookie = $response->getCookie('bee');
-		$this->assertTrue($cookie['expires'] <= time(), $cookie['expires'] . ' should be less than ' . time());
+		$this->assertTrue($cookie->isExpired(), $cookie->getExpiresTimestamp() . ' should be less than ' . time());
 
 		// delete cookie for real, with prefix
 		$config->cookiePrefix = 'mine';
@@ -200,7 +185,7 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
 		$response->deleteCookie('bee');
 		$cookie = $response->getCookie('bee');
-		$this->assertEquals($cookie['expires'], '', 'Expires should be an empty string');
+		$this->assertSame($cookie->getExpiresTimestamp(), 0);
 
 		// delete cookie with wrong prefix?
 		$config->cookiePrefix = 'mine';
@@ -208,32 +193,21 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
 		$response->deleteCookie('bee', '', '', 'wrong');
 		$cookie = $response->getCookie('bee');
-		$this->assertFalse($cookie['expires'] <= time(), $cookie['expires'] . ' should be less than ' . time());
+		$this->assertFalse($cookie->isExpired(), $cookie->getExpiresTimestamp() . ' should be less than ' . time());
 		$response->deleteCookie('bee', '', '', 'mine');
 		$cookie = $response->getCookie('bee');
-		$this->assertEquals($cookie['expires'], '', 'Expires should be an empty string');
+		$this->assertSame($cookie->getExpiresTimestamp(), 0);
 
 		// delete cookie with wrong domain?
 		$config->cookieDomain = '.mine.com';
 		$response             = new Response($config);
-		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
-		$response->deleteCookie('bee', 'wrong', '', '');
-		$cookie = $response->getCookie('bee');
-		$this->assertFalse($cookie['expires'] <= time(), $cookie['expires'] . ' should be less than ' . time());
-		$response->deleteCookie('bee', '.mine.com', '', '');
-		$cookie = $response->getCookie('bee');
-		$this->assertEquals($cookie['expires'], '', 'Expires should be an empty string');
-
-		// delete cookie with wrong path?
-		$config->cookiePath = '/whoknowswhere';
-		$response           = new Response($config);
-		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
-		$response->deleteCookie('bee', '', '/wrong', '');
-		$cookie = $response->getCookie('bee');
-		$this->assertFalse($cookie['expires'] <= time(), $cookie['expires'] . ' should be less than ' . time());
-		$response->deleteCookie('bee', '', '/whoknowswhere', '');
-		$cookie = $response->getCookie('bee');
-		$this->assertEquals($cookie['expires'], '', 'Expires should be an empty string');
+		$response->setCookie(['name' => 'bees', 'value' => 'bop', 'expire' => 1000]);
+		$response->deleteCookie('bees', 'wrong', '', '');
+		$cookie = $response->getCookie('bees');
+		$this->assertFalse($cookie->isExpired(), $cookie->getExpiresTimestamp() . ' should be less than ' . time());
+		$response->deleteCookie('bees', '.mine.com', '', '');
+		$cookie = $response->getCookie('bees');
+		$this->assertSame($cookie->getExpiresTimestamp(), 0);
 	}
 
 	public function testCookieDefaultSetSameSite()
@@ -245,11 +219,10 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 			'value' => 'foo',
 		]);
 
-		$allCookies = $response->getCookie();
-		$this->assertEquals(1, count($allCookies));
-		$this->assertIsArray($allCookies[0]);
-		$this->assertArrayHasKey('samesite', $allCookies[0]);
-		$this->assertEquals('Lax', $allCookies[0]['samesite']);
+		$allCookies = $response->getCookies();
+		$this->assertCount(1, $allCookies);
+		$this->assertInstanceOf(Cookie::class, $allCookies['bar;;/']);
+		$this->assertSame('Lax', $allCookies['bar;;/']->getSameSite());
 	}
 
 	public function testCookieStrictSetSameSite()
@@ -262,11 +235,10 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 			'value' => 'foo',
 		]);
 
-		$allCookies = $response->getCookie();
-		$this->assertEquals(1, count($allCookies));
-		$this->assertIsArray($allCookies[0]);
-		$this->assertArrayHasKey('samesite', $allCookies[0]);
-		$this->assertEquals('Strict', $allCookies[0]['samesite']);
+		$allCookies = $response->getCookies();
+		$this->assertCount(1, $allCookies);
+		$this->assertInstanceOf(Cookie::class, $allCookies['bar;;/']);
+		$this->assertSame('Strict', $allCookies['bar;;/']->getSameSite());
 	}
 
 	public function testCookieBlankSetSameSite()
@@ -279,10 +251,10 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 			'value' => 'foo',
 		]);
 
-		$allCookies = $response->getCookie();
-		$this->assertEquals(1, count($allCookies));
-		$this->assertIsArray($allCookies[0]);
-		$this->assertArrayNotHasKey('samesite', $allCookies[0]);
+		$allCookies = $response->getCookies();
+		$this->assertCount(1, $allCookies);
+		$this->assertInstanceOf(Cookie::class, $allCookies['bar;;/']);
+		$this->assertSame('', $allCookies['bar;;/']->getSameSite());
 	}
 
 	public function testCookieStrictSameSite()
@@ -295,11 +267,10 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 			'samesite' => 'Strict',
 		]);
 
-		$allCookies = $response->getCookie();
-		$this->assertEquals(1, count($allCookies));
-		$this->assertIsArray($allCookies[0]);
-		$this->assertArrayHasKey('samesite', $allCookies[0]);
-		$this->assertEquals('Strict', $allCookies[0]['samesite']);
+		$allCookies = $response->getCookies();
+		$this->assertCount(1, $allCookies);
+		$this->assertInstanceOf(Cookie::class, $allCookies['bar;;/']);
+		$this->assertSame('Strict', $allCookies['bar;;/']->getSameSite());
 	}
 
 	public function testCookieInvalidSameSite()
@@ -307,8 +278,8 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 		$config   = new App();
 		$response = new Response($config);
 
-		$this->expectException(HTTPException::class);
-		$this->expectExceptionMessage(lang('Security.invalidSameSiteSetting', ['Invalid']));
+		$this->expectException(CookieException::class);
+		$this->expectExceptionMessage(lang('Cookie.invalidSameSite', ['Invalid']));
 
 		$response->setCookie([
 			'name'     => 'bar',
@@ -317,4 +288,9 @@ class ResponseCookieTest extends \CodeIgniter\Test\CIUnitTestCase
 		]);
 	}
 
+	public function testGetCookieStore()
+	{
+		$response = new Response(new App());
+		$this->assertInstanceOf(CookieStore::class, $response->getCookieStore());
+	}
 }

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -3,6 +3,7 @@
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Config\Factories;
+use CodeIgniter\HTTP\Exceptions\CookieException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockResponse;
@@ -551,8 +552,8 @@ class ResponseTest extends CIUnitTestCase
 		$config                 = new App();
 		$config->cookieSameSite = 'Invalid';
 
-		$this->expectException(HTTPException::class);
-		$this->expectExceptionMessage(lang('Security.invalidSameSiteSetting', ['Invalid']));
+		$this->expectException(CookieException::class);
+		$this->expectExceptionMessage(lang('Cookie.invalidSameSite', ['Invalid']));
 		new Response($config);
 	}
 }

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -1,17 +1,17 @@
 <?php
 namespace CodeIgniter\Helpers;
 
-use CodeIgniter\Config\Services;
-use CodeIgniter\HTTP\Exceptions\HTTPException;
+use CodeIgniter\HTTP\Exceptions\CookieException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
+use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockResponse;
 use Config\App;
+use Config\Services;
 
-final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
+final class CookieHelperTest extends CIUnitTestCase
 {
-
 	private $name;
 	private $value;
 	private $expire;
@@ -26,14 +26,12 @@ final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->expire = 9999;
 
 		Services::injectMock('response', new MockResponse(new App()));
-		$this->response = service('response');
+		$this->response = Services::response();
 		$this->request  = new IncomingRequest(new App(), new URI(), null, new UserAgent());
 		Services::injectMock('request', $this->request);
 
 		helper('cookie');
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testSetCookie()
 	{
@@ -44,7 +42,19 @@ final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		delete_cookie($this->name);
 	}
 
-	//--------------------------------------------------------------------
+	public function testHasCookie()
+	{
+		$cookieAttr = [
+			'name'   => $this->name,
+			'value'  => $this->value,
+			'expire' => $this->expire,
+		];
+		set_cookie($cookieAttr);
+
+		$this->assertTrue(has_cookie($this->name, $this->value));
+
+		delete_cookie($this->name);
+	}
 
 	public function testSetCookieByArrayParameters()
 	{
@@ -59,8 +69,6 @@ final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		delete_cookie($this->name);
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testSetCookieSecured()
 	{
@@ -81,8 +89,6 @@ final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		delete_cookie($secured);
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testDeleteCookie()
 	{
 		$this->response->setCookie($this->name, $this->value, $this->expire);
@@ -92,11 +98,9 @@ final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 		$cookie = $this->response->getCookie($this->name);
 
 		// The cookie is set to be cleared when the request is sent....
-		$this->assertEquals('', $cookie['value']);
-		$this->assertEquals('', $cookie['expires']);
+		$this->assertEquals('', $cookie->getValue());
+		$this->assertEquals(0, $cookie->getExpiresTimestamp());
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testGetCookie()
 	{
@@ -111,7 +115,7 @@ final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$cookie = $this->response->getCookie($this->name);
 		// The cookie is set to be cleared when the request is sent....
-		$this->assertEquals('', $cookie['value']);
+		$this->assertEquals('', $cookie->getValue());
 	}
 
 	public function testSameSiteDefault()
@@ -126,7 +130,7 @@ final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$this->assertTrue($this->response->hasCookie($this->name));
 		$theCookie = $this->response->getCookie($this->name);
-		$this->assertEquals('Lax', $theCookie['samesite']);
+		$this->assertEquals('Lax', $theCookie->getSameSite());
 
 		delete_cookie($this->name);
 	}
@@ -140,8 +144,8 @@ final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 			'samesite' => 'Invalid',
 		];
 
-		$this->expectException(HTTPException::class);
-		$this->expectExceptionMessage(lang('Security.invalidSameSiteSetting', ['Invalid']));
+		$this->expectException(CookieException::class);
+		$this->expectExceptionMessage(lang('Cookie.invalidSameSite', ['Invalid']));
 
 		set_cookie($cookieAttr);
 	}
@@ -159,7 +163,7 @@ final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$this->assertTrue($this->response->hasCookie($this->name));
 		$theCookie = $this->response->getCookie($this->name);
-		$this->assertEquals('Strict', $theCookie['samesite']);
+		$this->assertEquals('Strict', $theCookie->getSameSite());
 
 		delete_cookie($this->name);
 	}
@@ -170,9 +174,8 @@ final class CookieHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 
 		$this->assertTrue($this->response->hasCookie($this->name));
 		$theCookie = $this->response->getCookie($this->name);
-		$this->assertEquals('Strict', $theCookie['samesite']);
+		$this->assertEquals('Strict', $theCookie->getSameSite());
 
 		delete_cookie($this->name);
 	}
-
 }

--- a/user_guide_src/source/changelogs/v4.1.0.rst
+++ b/user_guide_src/source/changelogs/v4.1.0.rst
@@ -12,4 +12,24 @@ Changes:
 Removed:
 
 - `Autoloader::loadLegacy()` method was previously used for migration of non-namespaced classes in transition to CodeIgniter v4. Since `4.1.0`, this support was removed.
+
+Enhancements:
+
+- New HTTP classes, ``Cookie`` and ``CookieStore``, for abstracting web cookies.
+
+Changes:
+
+- ``Response::getCookie`` now returns a ``Cookie`` instance instead of an array of cookie attributes.
+- ``Response::getCookies`` now returns an array of ``Cookie`` instances instead of array of array of attributes.
+- To eliminate warnings from modern browsers' consoles, empty samesite values will be defaulted to ``Lax`` on cookie dispatch.
+
+Bugs Fixed:
+
+Deprecations:
+
 - Deprecated `Model::fillPlaceholders(array $rules, array $data)` method, use `fillPlaceholders(array $rules, array $data)` from Validation instead.
+- Language strings and exceptions on invalid cookie samesite are deprecated for the ``CookieException``'s own exception message.
+- Deprecated cookie-related properties of ``Response`` in order to use the ``Cookie`` class.
+- Deprecated cookie-related properties of ``Security`` in order to use the ``Cookie`` class.
+- Deprecated cookie-related properties of ``Session`` in order to use the ``Cookie`` class.
+- Deprecated ``Security::isExpired()`` to use the ``Cookie``'s internal expires status.

--- a/user_guide_src/source/changelogs/v4.1.0.rst
+++ b/user_guide_src/source/changelogs/v4.1.0.rst
@@ -13,23 +13,8 @@ Removed:
 
 - `Autoloader::loadLegacy()` method was previously used for migration of non-namespaced classes in transition to CodeIgniter v4. Since `4.1.0`, this support was removed.
 
-Enhancements:
-
-- New HTTP classes, ``Cookie`` and ``CookieStore``, for abstracting web cookies.
-
-Changes:
-
-- ``Response::getCookie`` now returns a ``Cookie`` instance instead of an array of cookie attributes.
-- ``Response::getCookies`` now returns an array of ``Cookie`` instances instead of array of array of attributes.
-- To eliminate warnings from modern browsers' consoles, empty samesite values will be defaulted to ``Lax`` on cookie dispatch.
-
 Bugs Fixed:
 
 Deprecations:
 
 - Deprecated `Model::fillPlaceholders(array $rules, array $data)` method, use `fillPlaceholders(array $rules, array $data)` from Validation instead.
-- Language strings and exceptions on invalid cookie samesite are deprecated for the ``CookieException``'s own exception message.
-- Deprecated cookie-related properties of ``Response`` in order to use the ``Cookie`` class.
-- Deprecated cookie-related properties of ``Security`` in order to use the ``Cookie`` class.
-- Deprecated cookie-related properties of ``Session`` in order to use the ``Cookie`` class.
-- Deprecated ``Security::isExpired()`` to use the ``Cookie``'s internal expires status.

--- a/user_guide_src/source/changelogs/v4.1.2.rst
+++ b/user_guide_src/source/changelogs/v4.1.2.rst
@@ -4,3 +4,21 @@ Version 4.1.2
 Release Date: Not released
 
 **4.1.2 release of CodeIgniter4**
+
+Enhancements:
+
+- New HTTP classes, ``Cookie`` and ``CookieStore``, for abstracting web cookies.
+
+Changes:
+
+- ``Response::getCookie`` now returns a ``Cookie`` instance instead of an array of cookie attributes.
+- ``Response::getCookies`` now returns an array of ``Cookie`` instances instead of array of array of attributes.
+- To eliminate warnings from modern browsers' consoles, empty samesite values will be defaulted to ``Lax`` on cookie dispatch.
+
+Deprecations:
+
+- Language strings and exceptions on invalid cookie samesite are deprecated for the ``CookieException``'s own exception message.
+- Deprecated cookie-related properties of ``Response`` in order to use the ``Cookie`` class.
+- Deprecated cookie-related properties of ``Security`` in order to use the ``Cookie`` class.
+- Deprecated cookie-related properties of ``Session`` in order to use the ``Cookie`` class.
+- Deprecated ``Security::isExpired()`` to use the ``Cookie``'s internal expires status.

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -17,7 +17,7 @@ Global Functions
 Service Accessors
 =================
 
-.. php:function:: cache ( [$key] )
+.. php:function:: cache([$key])
 
     :param  string $key: The cache name of the item to retrieve from cache (Optional)
     :returns: Either the cache object, or the item retrieved from the cache
@@ -32,7 +32,27 @@ Service Accessors
         $foo = cache('foo');
         $cache = cache();
 
-.. php:function:: env ( $key[, $default=null])
+.. php:function:: cookie(string $name[, string $value = ''[, array $options = []]])
+
+    :param string $name: Cookie name
+    :param string $value: Cookie value
+    :param array $options: Cookie options
+    :rtype: ``Cookie``
+    :returns: ``Cookie`` instance
+    :throws: ``CookieException``
+
+    Simpler way to create a new Cookie instance.
+
+.. php:function:: cookies([array $cookies = [][, bool $getGlobal = true]])
+
+    :param array $cookies: If ``getGlobal`` is ``false``, this is passed to ``CookieStore``'s constructor.
+    :param bool $getGlobal: If ``false``, creates a new instance of ``CookieStore``.
+    :rtype: ``CookieStore``
+    :returns: Instance of ``CookieStore`` saved in the current ``Response``, or a new ``CookieStore`` instance.
+
+    Fetches the global ``CookieStore`` instance held by ``Response``.
+
+.. php:function:: env($key[, $default = null])
 
     :param string $key: The name of the environment variable to retrieve
     :param mixed  $default: The default value to return if no value is found.
@@ -47,7 +67,7 @@ Service Accessors
     values that are specific to the environment itself, like database
     settings, API keys, etc.
 
-.. php:function:: esc ( $data, $context='html' [, $encoding])
+.. php:function:: esc($data[, $context = 'html' [, $encoding]])
 
     :param   string|array   $data: The information to be escaped.
     :param   string   $context: The escaping context. Default is 'html'.
@@ -63,7 +83,7 @@ Service Accessors
 
     Valid context values: html, js, css, url, attr, raw, null
 
-.. php:function:: helper( $filename )
+.. php:function:: helper($filename)
 
     :param   string|array  $filename: The name of the helper file to load, or an array of names.
 

--- a/user_guide_src/source/helpers/cookie_helper.rst
+++ b/user_guide_src/source/helpers/cookie_helper.rst
@@ -54,11 +54,11 @@ The following functions are available:
 
 .. php:function:: delete_cookie($name[, $domain = ''[, $path = '/'[, $prefix = '']]])
 
-    :param	string	$name: Cookie name
-    :param	string	$domain: Cookie domain (usually: .yourdomain.com)
-    :param	string	$path: Cookie path
-    :param	string	$prefix: Cookie name prefix
-    :rtype:	void
+    :param string $name: Cookie name
+    :param string $domain: Cookie domain (usually: .yourdomain.com)
+    :param string $path: Cookie path
+    :param string $prefix: Cookie name prefix
+    :rtype: void
 
     Lets you delete a cookie. Unless you've set a custom path or other
     values, only the name of the cookie is needed.
@@ -73,3 +73,12 @@ The following functions are available:
     ::
 
         delete_cookie($name, $domain, $path, $prefix);
+
+.. php:function:: has_cookie(string $name[, ?string $value = null[, string $prefix = '']])
+
+    :param string $name: Cookie name
+    :param string|null $value: Cookie value
+    :param string $prefix: Cookie prefix
+    :rtype: bool
+
+    Checks if a cookie exists by name. This is an alias of ``Response::hasCookie()``.

--- a/user_guide_src/source/libraries/cookies.rst
+++ b/user_guide_src/source/libraries/cookies.rst
@@ -2,7 +2,7 @@
 Cookies
 #######
 
-An **HTTP cookie** (_web cookie, browser cookie_) is a small piece of data that a
+An **HTTP cookie** (web cookie, browser cookie) is a small piece of data that a
 server sends to the user's web browser. The browser may store it and send it
 back with later requests to the same server. Typically, it's used to tell if
 two requests came from the same browser — keeping a user logged-in, for
@@ -316,7 +316,7 @@ To check whether a ``Cookie`` object exists in the ``CookieStore`` instance, you
     Services::response()->hasCookie('remember_token');
 
     // using the cookie helper to check the current Response
-    // not available to v4.0.5 and lower
+    // not available to v4.1.1 and lower
     helper('cookie');
     has_cookie('login_token');
 
@@ -447,18 +447,18 @@ Sane defaults are already in place inside the ``Cookie`` class to ensure the smo
 objects. However, you may wish to define your own settings by changing the following settings in the
 ``Config\App`` class in ``app/Config/App.php`` file.
 
-==================== ==================================== ========= =====================================================
-Setting              Options/ Types                       Default   Description
-==================== ==================================== ========= =====================================================
-**$cookiePrefix**    ``string``                           ``''``    Prefix to prepend to the cookie name.
-**$cookieDomain**    ``string``                           ``''``    The domain property of the cookie.
-**$cookiePath**      ``string``                           ``/``     The path property of the cookie, with trailing slash.
-**$cookieSecure**    ``true/false``                       ``false`` If to be sent over secure HTTPS.
-**$cookieHTTPOnly**  ``true/false``                       ``true``  If not accessible to JavaScript.
-**$cookieSameSite**  ``Lax|None|Strict|''``               ``Lax``   The SameSite attribute.
-**$cookieRaw**       ``true/false``                       ``false`` If to be dispatched using ``setrawcookie``.
-**$cookieExpires**   ``DateTimeInterface|string|int``     ``0``     The expires timestamp.
-==================== ==================================== ========= =====================================================
+==================== ===================================== ========= =====================================================
+Setting              Options/ Types                        Default   Description
+==================== ===================================== ========= =====================================================
+**$cookiePrefix**    ``string``                            ``''``    Prefix to prepend to the cookie name.
+**$cookieDomain**    ``string``                            ``''``    The domain property of the cookie.
+**$cookiePath**      ``string``                            ``/``     The path property of the cookie, with trailing slash.
+**$cookieSecure**    ``true/false``                        ``false`` If to be sent over secure HTTPS.
+**$cookieHTTPOnly**  ``true/false``                        ``true``  If not accessible to JavaScript.
+**$cookieSameSite**  ``Lax|None|Strict|lax|none|strict''`` ``Lax``   The SameSite attribute.
+**$cookieRaw**       ``true/false``                        ``false`` If to be dispatched using ``setrawcookie()``.
+**$cookieExpires**   ``DateTimeInterface|string|int``      ``0``     The expires timestamp.
+==================== ===================================== ========= =====================================================
 
 In runtime, you can manually supply a new default using the ``Cookie::setDefaults()`` method.
 

--- a/user_guide_src/source/libraries/cookies.rst
+++ b/user_guide_src/source/libraries/cookies.rst
@@ -1,0 +1,712 @@
+#######
+Cookies
+#######
+
+An **HTTP cookie** (_web cookie, browser cookie_) is a small piece of data that a
+server sends to the user's web browser. The browser may store it and send it
+back with later requests to the same server. Typically, it's used to tell if
+two requests came from the same browser — keeping a user logged-in, for
+example. It remembers stateful information for the stateless HTTP protocol.
+
+Cookies are mainly used for three purposes:
+
+- **Session management**: Logins, shopping carts, game scores, or anything else the server should remember
+- **Personalization**: User preferences, themes, and other settings
+- **Tracking**: Recording and analyzing user behavior
+
+To help you efficiently use cookies across browsers with your request and response,
+CodeIgniter provides the ``CodeIgniter\HTTP\Cookie\Cookie`` class to abstract the
+cookie interaction.
+
+.. contents::
+    :local:
+    :depth: 2
+
+****************
+Creating Cookies
+****************
+
+There are currently five (5) ways to create a new ``Cookie`` value object.
+
+::
+
+    use CodeIgniter\HTTP\Cookie\Cookie;
+    use DateTime;
+
+    // Providing all arguments in the constructor
+    $cookie = new Cookie(
+        'remember_token', // name
+        'f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6', // value
+        new DateTime('+2 hours'), // expires
+        '__Secure-', // prefix
+        '/', // path
+        '', // domain
+        true, // secure
+        true, // httponly
+        false, // raw
+        Cookie::SAMESITE_LAX // samesite
+    );
+
+    // Using the static constructor
+    $cookie = Cookie::create(
+        'remember_token',
+        'f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6',
+        [
+            'expires'  => new DateTime('+2 hours'),
+            'prefix'   => '__Secure-',
+            'path'     => '/',
+            'domain'   => '',
+            'secure'   => true,
+            'httponly' => true,
+            'raw'      => false,
+            'samesite' => Cookie::SAMESITE_LAX,
+        ]
+    );
+
+    // Supplying a Set-Cookie header string
+    $cookie = Cookie::fromHeaderString(
+        'remember_token=f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6; Path=/; Secure; HttpOnly; SameSite=Lax',
+        false, // raw
+    );
+
+    // Using the fluent builder interface
+    $cookie = (new Cookie('remember_token'))
+        ->withValue('f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6')
+        ->withPrefix('__Secure-')
+        ->withExpires(new DateTime('+2 hours'))
+        ->withPath('/')
+        ->withDomain('')
+        ->withSecure(true)
+        ->withHttpOnly(true)
+        ->withSameSite(Cookie::SAMESITE_LAX);
+
+    // Using the global function `cookie` which implicitly calls `Cookie::create()`
+    $cookie = cookie('remember_token', 'f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6');
+
+When constructing the ``Cookie`` object, only the ``name`` attribute is required. All other else are optional.
+If the optional attributes are not modified, their values will be filled up by the default values saved in
+the ``Cookie`` class. To override the defaults currently stored in the class, you can pass a ``Config\App``
+instance or an array of defaults to the static ``Cookie::setDefaults()`` method.
+
+::
+
+    use CodeIgniter\HTTP\Cookie\Cookie;
+    use Config\App;
+
+    // pass in an App instance before constructing a Cookie class
+    Cookie::setDefaults(new App());
+    $cookie = new Cookie('login_token');
+
+    // pass in an array of defaults
+    $myDefaults = [
+        'expires'  => 0,
+        'samesite' => Cookie::SAMESITE_STRICT,
+    ];
+    Cookie::setDefaults($myDefaults);
+    $cookie = Cookie::create('login_token');
+
+Passing the ``Config\App`` instance or an array to ``Cookie::setDefaults()`` will effectively
+overwrite your defaults and will persist until new defaults are passed. If you do not want this
+behavior but only want to change defaults for a limited time, you can take advantage of
+``Cookie::setDefaults()`` return which returns the old defaults array.
+
+::
+
+    use CodeIgniter\HTTP\Cookie\Cookie;
+    use Config\App;
+
+    $oldDefaults = Cookie::setDefaults(new App());
+    $cookie = Cookie::create('my_token', 'muffins');
+
+    // return the old defaults
+    Cookie::setDefaults($oldDefaults);
+
+*****************************
+Accessing Cookie's Attributes
+*****************************
+
+Once instantiated, you can easily access a ``Cookie``'s attribute by using one of its getter methods.
+
+::
+
+    use CodeIgniter\HTTP\Cookie\Cookie;
+    use DateTime;
+    use DateTimeZone;
+
+    $cookie = Cookie::create(
+        'remember_token',
+        'f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6',
+        [
+            'expires'  => new DateTime('2025-02-14 00:00:00', new DateTimeZone('UTC')),
+            'prefix'   => '__Secure-',
+            'path'     => '/',
+            'domain'   => '',
+            'secure'   => true,
+            'httponly' => true,
+            'raw'      => false,
+            'samesite' => Cookie::SAMESITE_LAX,
+        ]
+    );
+
+    $cookie->getName(); // 'remember_token'
+    $cookie->getPrefix(); // '__Secure-'
+    $cookie->getPrefixedName(); // '__Secure-remember_token'
+    $cookie->getExpiresTimestamp(); // Unix timestamp
+    $cookie->getExpiresString(); // 'Fri, 14-Feb-2025 00:00:00 GMT'
+    $cookie->isExpired(); // false
+    $cookie->getMaxAge(); // the difference from time() to expires
+    $cookie->isRaw(); // false
+    $cookie->isSecure(); // true
+    $cookie->getPath(); // '/'
+    $cookie->getDomain(); // ''
+    $cookie->isHttpOnly(); // true
+    $cookie->getSameSite(); // 'Lax'
+
+    // additional getter
+    $cookie->getId(); // '__Secure-remember_token;;/'
+
+    // when using `setcookie()`'s alternative signature on PHP 7.3+
+    // you can easily use the `getOptions()` method to supply the
+    // $options parameter
+    $cookie->getOptions();
+
+*****************
+Immutable Cookies
+*****************
+
+A new ``Cookie`` instance is an immutable value object representation of an HTTP cookie. Being immutable,
+modifying any of the instance's attributes will not affect the original instance. The modification **always**
+returns a new instance. You need to retain this new instance in order to use it.
+
+::
+
+    use CodeIgniter\HTTP\Cookie\Cookie;
+
+    $cookie = Cookie::create('login_token', 'admin');
+    $cookie->getName(); // 'login_token'
+
+    $cookie->withName('remember_token');
+    $cookie->getName(); // 'login_token'
+
+    $new = $cookie->withName('remember_token');
+    $new->getName(); // 'remember_token'
+
+********************************
+Validating a Cookie's Attributes
+********************************
+
+An HTTP cookie is regulated by several specifications that need to be followed in order to be
+accepted by browsers. Thus, when creating or modifying certain attributes of the ``Cookie``,
+these are validated in order to check if these follow the specifications.
+
+A ``CookieException`` is thrown if violations were reported.
+
+Validating the Name Attribute
+=============================
+
+A cookie name can be any US-ASCII character, except for the following:
+
+- control characters;
+- spaces or tabs;
+- separator characters, such as ``( ) < > @ , ; : \ " / [ ] ? = { }``
+
+If setting the ``$raw`` parameter to ``true`` this validation will be strictly made. This is because
+PHP's ``setcookie`` and ``setrawcookie`` will reject cookies with invalid names. Additionally, cookie
+names cannot be an empty string.
+
+Validating the Prefix Attribute
+===============================
+
+When using the ``__Secure-`` prefix, cookies must be set with the ``$secure`` flag set to ``true``. If
+using the ``__Host-`` prefix, cookies must exhibit the following:
+
+- ``$secure`` flag set to ``true``
+- ``$domain`` is empty
+- ``$path`` must be ``/``
+
+Validating the SameSite Attribute
+=================================
+
+The SameSite attribute only accepts three (3) values:
+
+- **Lax**: Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (*i.e.* when following a link).
+- **Strict**: Cookies will only be sent in a first-party context and not be sent along with requests initiated by third party websites.
+- **None**: Cookies will be sent in all contexts, *i.e.* in responses to both first-party and cross-origin requests.
+
+CodeIgniter, however, allows you to set the SameSite attribute to an empty string. When an empty string is
+provided, the default SameSite setting saved in the ``Cookie`` class is used. You can change the default SameSite
+by using the ``Cookie::setDefaults()`` as discussed above.
+
+Recent cookie specifications have changed such that modern browsers are being required to give a default SameSite
+if nothing was provided. This default is ``Lax``. If you have set the SameSite to be an empty string and your
+default SameSite is also an empty string, your cookie will be given the ``Lax`` value.
+
+If the SameSite is set to ``None`` you need to make sure that ``Secure`` is also set to ``true``.
+
+When writing the SameSite attribute, the ``Cookie`` class accepts any of the values case-insensitively. You can
+also take advantage of the class's constants to make it not a hassle.
+
+::
+
+    use CodeIgniter\HTTP\Cookie\Cookie;
+
+    Cookie::SAMESITE_LAX; // 'lax'
+    Cookie::SAMESITE_STRICT; // 'strict'
+    Cookie::SAMESITE_NONE; // 'none'
+
+**********************
+Using the Cookie Store
+**********************
+
+The ``CookieStore`` class represents an immutable collection of ``Cookie`` objects. The ``CookieStore``
+instance can be accessed from the current ``Response`` object.
+
+::
+
+    use Config\Services;
+
+    $cookieStore = Services::response()->getCookieStore();
+
+CodeIgniter provides three (3) other ways to create a new instance of the ``CookieStore``.
+
+::
+
+    use CodeIgniter\HTTP\Cookie\Cookie;
+    use CodeIgniter\HTTP\Cookie\CookieStore;
+
+    // Passing an array of `Cookie` objects in the constructor
+    $store = new CookieStore([
+        Cookie::create('login_token'),
+        Cookie::create('remember_token'),
+    ]);
+
+    // Passing an array of `Set-Cookie` header strings
+    $store = CookieStore::fromCookieHeaders([
+        'remember_token=me; Path=/; SameSite=Lax',
+        'login_token=admin; Path=/; SameSite=Lax',
+    ]);
+
+    // using the global `cookies` function
+    $store = cookies([Cookie::create('login_token')], false);
+
+    // retrieving the `CookieStore` instance saved in our current `Response` object
+    $store = cookies();
+
+.. note:: When using the global ``cookies()`` function, the passed ``Cookie`` array will only be considered
+    if the second argument, ``$getGlobal``, is set to ``false``.
+
+Checking Cookies in Store
+=========================
+
+To check whether a ``Cookie`` object exists in the ``CookieStore`` instance, you can use several ways::
+
+    use CodeIgniter\HTTP\Cookie\Cookie;
+    use CodeIgniter\HTTP\Cookie\CookieStore;
+    use Config\Services;
+
+    // check if cookie is in the current cookie collection
+    $store = new CookieStore([
+        Cookie::create('login_token'),
+        Cookie::create('remember_token'),
+    ]);
+    $store->has('login_token');
+
+    // check if cookie is in the current Response's cookie collection
+    cookies()->has('login_token');
+    Services::response()->hasCookie('remember_token');
+
+    // using the cookie helper to check the current Response
+    // not available to v4.0.5 and lower
+    helper('cookie');
+    has_cookie('login_token');
+
+Getting Cookies in Store
+========================
+
+Retrieving a ``Cookie`` instance in a cookie collection is very easy::
+
+    use CodeIgniter\HTTP\Cookie\Cookie;
+    use CodeIgniter\HTTP\Cookie\CookieStore;
+    use Config\Services;
+
+    // getting cookie in the current cookie collection
+    $store = new CookieStore([
+        Cookie::create('login_token'),
+        Cookie::create('remember_token'),
+    ]);
+    $store->get('login_token');
+
+    // getting cookie in the current Response's cookie collection
+    cookies()->get('login_token');
+    Services::response()->getCookie('remember_token');
+
+    // using the cookie helper to get cookie from the Response's cookie collection
+    helper('cookie');
+    get_cookie('remember_token');
+
+When getting a ``Cookie`` instance directly from a ``CookieStore``, an invalid name
+will throw a ``CookieException``.
+
+::
+
+    // throws CookieException
+    $store->get('unknown_cookie');
+
+When getting a ``Cookie`` instance from the current ``Response``'s cookie collection,
+an invalid name will just return ``null``.
+
+::
+
+    cookies()->get('unknown_cookie'); // null
+
+If no arguments are supplied in when getting cookies from the ``Response``, all ``Cookie`` objects
+in store will be displayed.
+
+::
+
+    cookies()->get(); // array of Cookie objects
+
+    // alternatively, you can use the display method
+    cookies()->display();
+
+    // or even from the Response
+    Services::response()->getCookies();
+
+.. note:: The helper function ``get_cookie()`` gets the cookie from the current ``Request`` object, not
+    from ``Response``. This function checks the `$_COOKIE` array if that cookie is set and fetches it
+    right away.
+
+Adding/Removing Cookies in Store
+================================
+
+As previously mentioned, ``CookieStore`` objects are immutable. You need to save the modified instance
+in order to work on it. The original instance is left unchanged.
+
+::
+
+    use CodeIgniter\HTTP\Cookie\Cookie;
+    use CodeIgniter\HTTP\Cookie\CookieStore;
+    use Config\Services;
+
+    $store = new CookieStore([
+        Cookie::create('login_token'),
+        Cookie::create('remember_token'),
+    ]);
+
+    // adding a new Cookie instance
+    $new = $store->put(Cookie::create('admin_token', 'yes'));
+
+    // removing a Cookie instance
+    $new = $store->remove('login_token');
+
+.. note:: Removing a cookie from the store **DOES NOT** delete it from the browser.
+    If you intend to delete a cookie *from the browser*, you must put an empty value
+    cookie with the same name to the store.
+
+When interacting with the cookies in store in the current ``Response`` object, you can safely add or delete
+cookies without worrying the immutable nature of the cookie collection. The ``Response`` object will replace
+the instance with the modified instance.
+
+::
+
+    use Config\Services;
+
+    Services::response()->setCookie('admin_token', 'yes');
+    Services::response()->deleteCookie('login_token');
+
+    // using the cookie helper
+    helper('cookie');
+    set_cookie('admin_token', 'yes');
+    delete_cookie('login_token');
+
+Dispatching Cookies in Store
+============================
+
+More often than not, you do not need to concern yourself in manually sending cookies. CodeIgniter will do this
+for you. However, if you really need to manually send cookies, you can use the ``dispatch`` method. Just like
+in sending other headers, you need to make sure the headers are not yet sent by checking the value
+of ``headers_sent()``.
+
+::
+
+    use CodeIgniter\HTTP\Cookie\Cookie;
+    use CodeIgniter\HTTP\Cookie\CookieStore;
+
+    $store = new CookieStore([
+        Cookie::create('login_token'),
+        Cookie::create('remember_token'),
+    ]);
+
+    $store->dispatch(); // After dispatch, the collection is now empty.
+
+**********************
+Cookie Personalization
+**********************
+
+Sane defaults are already in place inside the ``Cookie`` class to ensure the smooth creation of cookie
+objects. However, you may wish to define your own settings by changing the following settings in the
+``Config\App`` class in ``app/Config/App.php`` file.
+
+==================== ==================================== ========= =====================================================
+Setting              Options/ Types                       Default   Description
+==================== ==================================== ========= =====================================================
+**$cookiePrefix**    ``string``                           ``''``    Prefix to prepend to the cookie name.
+**$cookieDomain**    ``string``                           ``''``    The domain property of the cookie.
+**$cookiePath**      ``string``                           ``/``     The path property of the cookie, with trailing slash.
+**$cookieSecure**    ``true/false``                       ``false`` If to be sent over secure HTTPS.
+**$cookieHTTPOnly**  ``true/false``                       ``true``  If not accessible to JavaScript.
+**$cookieSameSite**  ``Lax|None|Strict|''``               ``Lax``   The SameSite attribute.
+**$cookieRaw**       ``true/false``                       ``false`` If to be dispatched using ``setrawcookie``.
+**$cookieExpires**   ``DateTimeInterface|string|int``     ``0``     The expires timestamp.
+==================== ==================================== ========= =====================================================
+
+In runtime, you can manually supply a new default using the ``Cookie::setDefaults()`` method.
+
+***************
+Class Reference
+***************
+
+.. php:class:: CodeIgniter\\HTTP\\Cookie\\Cookie
+
+    .. php:staticmethod:: setDefaults([$config = []])
+
+        :param App|array $config: The configuration array or instance
+        :rtype: array<string, mixed>
+        :returns: The old defaults
+
+        Set the default attributes to a Cookie instance by injecting the values from the ``App`` config or an array.
+
+    .. php:staticmethod:: fromHeaderString(string $header[, bool $raw = false])
+
+        :param string $header: The ``Set-Cookie`` header string
+        :param bool $raw: Whether this cookie is not to be URL encoded and sent via ``setrawcookie()``
+        :rtype: ``Cookie``
+        :returns: ``Cookie`` instance
+        :throws: ``CookieException``
+
+        Create a new Cookie instance from a ``Set-Cookie`` header.
+
+    .. php:staticmethod:: create(string $name[, string $value = ''[, array $options = []]])
+
+        :param string $name: The cookie name
+        :param string $value: The cookie value
+        :param aray $options: The cookie options
+        :rtype: ``Cookie``
+        :returns: ``Cookie`` instance
+        :throws: ``CookieException``
+
+        Create Cookie objects on the fly.
+
+    .. php:method:: __construct(string $name[, string $value = ''[, $expires = 0[, ?string $prefix = null[, ?string $path = null[, ?string $domain = null[, bool $secure = false[, bool $httpOnly = true[, bool $raw = false[, string $sameSite = self::SAMESITE_LAX]]]]]]]]])
+
+        :param string $name:
+        :param string $value:
+        :param DateTimeInterface|string|int $expires:
+        :param string|null $prefix:
+        :param string|null $path:
+        :param string|null $domain:
+        :param bool $secure:
+        :param bool $httpOnly:
+        :param bool $raw:
+        :param string $sameSite:
+        :rtype: ``Cookie``
+        :returns: ``Cookie`` instance
+        :throws: ``CookieException``
+
+        Construct a new Cookie instance.
+
+    .. php:method:: getId()
+
+        :rtype: string
+        :returns: The ID used in indexing in the cookie collection.
+
+    .. php:method:: isRaw(): bool
+    .. php:method:: getPrefix(): string
+    .. php:method:: getName(): string
+    .. php:method:: getPrefixedName(): string
+    .. php:method:: getValue(): string
+    .. php:method:: getExpiresTimestamp(): int
+    .. php:method:: getExpiresString(): string
+    .. php:method:: isExpired(): bool
+    .. php:method:: getMaxAge(): int
+    .. php:method:: getDomain(): string
+    .. php:method:: getPath(): string
+    .. php:method:: isSecure(): bool
+    .. php:method:: isHttpOnly(): bool
+    .. php:method:: getSameSite(): string
+    .. php:method:: getOptions(): array
+
+    .. php:method:: withRaw([bool $raw = true])
+
+        :param bool $raw:
+        :rtype: ``Cookie``
+        :returns: new ``Cookie`` instance
+
+        Creates a new Cookie with URL encoding option updated.
+
+    .. php:method:: withPrefix([string $prefix = ''])
+
+        :param string $prefix:
+        :rtype: ``Cookie``
+        :returns: new ``Cookie`` instance
+
+        Creates a new Cookie with new prefix.
+
+    .. php:method:: withName(string $name)
+
+        :param string $name:
+        :rtype: ``Cookie``
+        :returns: new ``Cookie`` instance
+
+        Creates a new Cookie with new name.
+
+    .. php:method:: withValue(string $value)
+
+        :param string $value:
+        :rtype: ``Cookie``
+        :returns: new ``Cookie`` instance
+
+        Creates a new Cookie with new value.
+
+    .. php:method:: withExpiresAt($expires)
+
+        :param DateTimeInterface|string|int $expires:
+        :rtype: ``Cookie``
+        :returns: new ``Cookie`` instance
+
+        Creates a new Cookie with new cookie expires time.
+
+    .. php:method:: withExpired()
+
+        :rtype: ``Cookie``
+        :returns: new ``Cookie`` instance
+
+        Creates a new Cookie that will expire from the browser.
+
+    .. php:method:: withNeverExpiring()
+
+        :param string $name:
+        :rtype: ``Cookie``
+        :returns: new ``Cookie`` instance
+
+        Creates a new Cookie that will virtually never expire.
+
+    .. php:method:: withDomain(?string $domain)
+
+        :param string|null $domain:
+        :rtype: ``Cookie``
+        :returns: new ``Cookie`` instance
+
+        Creates a new Cookie with new domain.
+
+    .. php:method:: withPath(?string $path)
+
+        :param string|null $path:
+        :rtype: ``Cookie``
+        :returns: new ``Cookie`` instance
+
+        Creates a new Cookie with new path.
+
+    .. php:method:: withSecure([bool $secure = true])
+
+        :param bool $secure:
+        :rtype: ``Cookie``
+        :returns: new ``Cookie`` instance
+
+        Creates a new Cookie with new "Secure" attribute.
+
+    .. php:method:: withHttpOnly([bool $httpOnly = true])
+
+        :param bool $httpOnly:
+        :rtype: ``Cookie``
+        :returns: new ``Cookie`` instance
+
+        Creates a new Cookie with new "HttpOnly" attribute.
+
+    .. php:method:: withSameSite(string $sameSite)
+
+        :param string $sameSite:
+        :rtype: ``Cookie``
+        :returns: new ``Cookie`` instance
+
+        Creates a new Cookie with new "SameSite" attribute.
+
+    .. php:method:: toHeaderString()
+
+        :rtype: string
+        :returns: Returns the string representation that can be passed as a header string.
+
+    .. php:method:: toArray()
+
+        :rtype: array
+        :returns: Returns the array representation of the Cookie instance.
+
+.. php:class:: CodeIgniter\\HTTP\\Cookie\\CookieStore
+
+    .. php:staticmethod:: fromCookieHeaders(array $headers[, bool $raw = false])
+
+        :param array $header: Array of ``Set-Cookie`` headers
+        :param bool $raw: Whether not to use URL encoding
+        :rtype: ``CookieStore``
+        :returns: ``CookieStore`` instance
+        :throws: ``CookieException``
+
+        Creates a CookieStore from an array of ``Set-Cookie`` headers.
+
+    .. php:method:: __construct(array $cookies)
+
+        :param array $cookies: Array of ``Cookie`` objects
+        :rtype: ``CookieStore``
+        :returns: ``CookieStore`` instance
+        :throws: ``CookieException``
+
+    .. php:method:: has(string $name[, string $prefix = ''[, ?string $value = null]]): bool
+
+        :param string $name: Cookie name
+        :param string $prefix: Cookie prefix
+        :param string|null $value: Cookie value
+        :rtype: bool
+        :returns: Checks if a ``Cookie`` object identified by name and prefix is present in the collection.
+
+    .. php:method:: get(string $name[, string $prefix = '']): Cookie
+
+        :param string $name: Cookie name
+        :param string $prefix: Cookie prefix
+        :rtype: ``Cookie``
+        :returns: Retrieves an instance of Cookie identified by a name and prefix.
+        :throws: ``CookieException``
+
+    .. php:method:: put(Cookie $cookie): CookieStore
+
+        :param Cookie $cookie: A Cookie object
+        :rtype: ``CookieStore``
+        :returns: new ``CookieStore`` instance
+
+        Store a new cookie and return a new collection. The original collection is left unchanged.
+
+    .. php:method:: remove(string $name[, string $prefix = '']): CookieStore
+
+        :param string $name: Cookie name
+        :param string $prefix: Cookie prefix
+        :rtype: ``CookieStore``
+        :returns: new ``CookieStore`` instance
+
+        Removes a cookie from a collection and returns an updated collection.
+        The original collection is left unchanged.
+
+    .. php:method:: dispatch(): void
+
+        :rtype: void
+
+        Dispatches all cookies in store.
+
+    .. php:method:: display(): array
+
+        :rtype: array
+        :returns: Returns all cookie instances in store.
+
+    .. php:method:: clear(): void
+
+        :rtype: void
+
+        Clears the cookie collection.

--- a/user_guide_src/source/libraries/index.rst
+++ b/user_guide_src/source/libraries/index.rst
@@ -6,6 +6,7 @@ Library Reference
     :titlesonly:
 
     caching
+    cookies
     curlrequest
     email
     encryption

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -13,10 +13,10 @@ in the last section of the table of contents:
     :depth: 2
 
 Using the Session Class
-*********************************************************************
+***********************
 
 Initializing a Session
-==================================================================
+======================
 
 Sessions will typically run globally with each page load, so the Session
 class should be magically initialized.
@@ -420,7 +420,7 @@ accessing them:
   - last_activity: Depends on the storage, no straightforward way. Sorry!
 
 Session Preferences
-*********************************************************************
+*******************
 
 CodeIgniter will usually make everything work out of the box. However,
 Sessions are a very sensitive component of any application, so some
@@ -467,7 +467,7 @@ Preference           Default         Description
 ==================== =============== ===========================================================================
 **cookieDomain**     ''              The domain for which the session is applicable
 **cookiePath**       /               The path to which the session is applicable
-**cookieSecure**     FALSE           Whether to create the session cookie only on encrypted (HTTPS) connections
+**cookieSecure**     false           Whether to create the session cookie only on encrypted (HTTPS) connections
 **cookieSameSite**   Lax             The SameSite setting for the session cookie
 ==================== =============== ===========================================================================
 
@@ -477,7 +477,7 @@ Preference           Default         Description
 	ignored.
 
 Session Drivers
-*********************************************************************
+***************
 
 As already mentioned, the Session library comes with 4 handlers, or storage
 engines, that you can use:
@@ -501,7 +501,7 @@ get yourself familiar with them (below) before you make that choice.
     a PHP array, while preventing the data from being persisted.
 
 FileHandler Driver (the default)
-==================================================================
+================================
 
 The 'FileHandler' driver uses your file system for storing session data.
 
@@ -538,7 +538,7 @@ Instead, you should do something like this, depending on your environment
 	chown www-data /<path to your application directory>/Writable/sessions/
 
 Bonus Tip
---------------------------------------------------------
+---------
 
 Some of you will probably opt to choose another session driver because
 file storage is usually slower. This is only half true.
@@ -554,7 +554,7 @@ into using `tmpfs <https://eddmann.com/posts/storing-php-sessions-file-caches-in
 (warning: external resource), which can make your sessions blazing fast.
 
 DatabaseHandler Driver
-==================================================================
+======================
 
 The 'DatabaseHandler' driver uses a relational database such as MySQL or
 PostgreSQL to store sessions. This is a popular choice among many users,
@@ -632,7 +632,7 @@ when it generates the code.
 	issues.
 
 RedisHandler Driver
-==================================================================
+===================
 
 .. note:: Since Redis doesn't have a locking mechanism exposed, locks for
 	this driver are emulated by a separate value that is kept for up
@@ -669,7 +669,7 @@ sufficient::
 	public $sessionSavePath = 'tcp://localhost:6379';
 
 MemcachedHandler Driver
-==================================================================
+=======================
 
 .. note:: Since Memcached doesn't have a locking mechanism exposed, locks
 	for this driver are emulated by a separate value that is kept for
@@ -697,7 +697,7 @@ being just a ``host:port`` pair::
 	public $sessionSavePath = 'localhost:11211';
 
 Bonus Tip
---------------------------------------------------------
+---------
 
 Multi-server configuration with an optional *weight* parameter as the
 third colon-separated (``:weight``) value is also supported, but we have

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -25,25 +25,24 @@ When you need to set the output of the script directly, and not rely on CodeIgni
 do it manually with the ``setBody`` method. This is usually used in conjunction with setting the status code of
 the response::
 
-	$this->response->setStatusCode(404)
-	               ->setBody($body);
+    $this->response->setStatusCode(404)->setBody($body);
 
 The reason phrase ('OK', 'Created', 'Moved Permanently') will be automatically added, but you can add custom reasons
 as the second parameter of the ``setStatusCode()`` method::
 
-	$this->response->setStatusCode(404, 'Nope. Not here.');
+    $this->response->setStatusCode(404, 'Nope. Not here.');
 
 You can set format an array into either JSON or XML and set the content type header to the appropriate mime with the
 ``setJSON`` and ``setXML`` methods. Typically, you will send an array of data to be converted::
 
-	$data = [
-		'success' => true,
-		'id' => 123
-	];
+    $data = [
+        'success' => true,
+        'id' => 123
+    ];
 
-	return $this->response->setJSON($data);
-		or
-	return $this->response->setXML($data);
+    return $this->response->setJSON($data);
+    // or
+    return $this->response->setXML($data);
 
 Setting Headers
 ---------------
@@ -55,22 +54,22 @@ Using these functions instead of using the native PHP functions allows you to en
 prematurely, causing errors, and makes testing possible.
 ::
 
-	$response->setHeader('Location', 'http://example.com')
-	         ->setHeader('WWW-Authenticate', 'Negotiate');
+    $response->setHeader('Location', 'http://example.com')
+             ->setHeader('WWW-Authenticate', 'Negotiate');
 
 If the header exists and can have more than one value, you may use the ``appendHeader()`` and ``prependHeader()``
 methods to add the value to the end or beginning of the values list, respectively. The first parameter is the name
 of the header, while the second is the value to append or prepend.
 ::
 
-	$response->setHeader('Cache-Control', 'no-cache')
-	         ->appendHeader('Cache-Control', 'must-revalidate');
+    $response->setHeader('Cache-Control', 'no-cache')
+             ->appendHeader('Cache-Control', 'must-revalidate');
 
 Headers can be removed from the response with the ``removeHeader()`` method, which takes the header name as the only
 parameter. This is not case-sensitive.
 ::
 
-	$response->removeHeader('Location');
+    $response->removeHeader('Location');
 
 Force File Download
 ===================
@@ -90,19 +89,19 @@ handler for that type - it can use it.
 
 Example::
 
-	$data = 'Here is some text!';
-	$name = 'mytext.txt';
-	return $response->download($name, $data);
+    $data = 'Here is some text!';
+    $name = 'mytext.txt';
+    return $response->download($name, $data);
 
 If you want to download an existing file from your server you'll need to
 pass ``null`` explicitly for the second parameter::
 
-	// Contents of photo.jpg will be automatically read
-	return $response->download('/path/to/photo.jpg', null);
+    // Contents of photo.jpg will be automatically read
+    return $response->download('/path/to/photo.jpg', null);
 
 Use the optional ``setFileName()`` method to change the filename as it is sent to the client's browser::
 
-	return $response->download('awkwardEncryptedFileName.fakeExt', null)->setFileName('expenses.csv');
+    return $response->download('awkwardEncryptedFileName.fakeExt', null)->setFileName('expenses.csv');
 
 .. note:: The response object MUST be returned for the download to be sent to the client. This allows the response
     to be passed through all **after** filters before being sent to the client.
@@ -122,12 +121,12 @@ By default, all response objects sent through CodeIgniter have HTTP caching turn
 circumstances are too varied for us to be able to create a good default other than turning it off. It's simple
 to set the Cache values to what you need, through the ``setCache()`` method::
 
-	$options = [
-		'max-age'  => 300,
-		's-maxage' => 900,
-		'etag'     => 'abcde'
-	];
-	$this->response->setCache($options);
+    $options = [
+        'max-age'  => 300,
+        's-maxage' => 900,
+        'etag'     => 'abcde'
+    ];
+    $this->response->setCache($options);
 
 The ``$options`` array simply takes an array of key/value pairs that are, with a couple of exceptions, assigned
 to the ``Cache-Control`` header. You are free to set all of the options exactly as you need for your specific
@@ -160,7 +159,7 @@ Turning CSP On
 By default, support for this is off. To enable support in your application, edit the ``CSPEnabled`` value in
 **app/Config/App.php**::
 
-	public $CSPEnabled = true;
+    public $CSPEnabled = true;
 
 When enabled, the response object will contain an instance of ``CodeIgniter\HTTP\ContentSecurityPolicy``. The
 values set in **app/Config/ContentSecurityPolicy.php** are applied to that instance, and if no changes are
@@ -185,33 +184,34 @@ class holds a number of methods that map pretty clearly to the appropriate heade
 Examples are shown below, with different combinations of parameters, though all accept either a directive
 name or an array of them.::
 
-        // specify the default directive treatment
-	$response->CSP->reportOnly(false);
+    // specify the default directive treatment
+    $response->CSP->reportOnly(false);
 
-        // specify the origin to use if none provided for a directive
-	$response->CSP->setDefaultSrc('cdn.example.com');
-        // specify the URL that "report-only" reports get sent to
-	$response->CSP->setReportURI('http://example.com/csp/reports');
-        // specify that HTTP requests be upgraded to HTTPS
-	$response->CSP->upgradeInsecureRequests(true);
+    // specify the origin to use if none provided for a directive
+    $response->CSP->setDefaultSrc('cdn.example.com');
 
-        // add types or origins to CSP directives
-        // assuming that the default treatment is to block rather than just report
-	$response->CSP->addBaseURI('example.com', true); // report only
-	$response->CSP->addChildSrc('https://youtube.com'); // blocked
-	$response->CSP->addConnectSrc('https://*.facebook.com', false); // blocked
-	$response->CSP->addFontSrc('fonts.example.com');
-	$response->CSP->addFormAction('self');
-	$response->CSP->addFrameAncestor('none', true); // report this one
-	$response->CSP->addImageSrc('cdn.example.com');
-	$response->CSP->addMediaSrc('cdn.example.com');
-	$response->CSP->addManifestSrc('cdn.example.com');
-	$response->CSP->addObjectSrc('cdn.example.com', false); // reject from here
-	$response->CSP->addPluginType('application/pdf', false); // reject this media type
-	$response->CSP->addScriptSrc('scripts.example.com', true); // allow but report requests from here
-	$response->CSP->addStyleSrc('css.example.com');
-	$response->CSP->addSandbox(['allow-forms', 'allow-scripts']);
+    // specify the URL that "report-only" reports get sent to
+    $response->CSP->setReportURI('http://example.com/csp/reports');
 
+    // specify that HTTP requests be upgraded to HTTPS
+    $response->CSP->upgradeInsecureRequests(true);
+
+    // add types or origins to CSP directives
+    // assuming that the default treatment is to block rather than just report
+    $response->CSP->addBaseURI('example.com', true); // report only
+    $response->CSP->addChildSrc('https://youtube.com'); // blocked
+    $response->CSP->addConnectSrc('https://*.facebook.com', false); // blocked
+    $response->CSP->addFontSrc('fonts.example.com');
+    $response->CSP->addFormAction('self');
+    $response->CSP->addFrameAncestor('none', true); // report this one
+    $response->CSP->addImageSrc('cdn.example.com');
+    $response->CSP->addMediaSrc('cdn.example.com');
+    $response->CSP->addManifestSrc('cdn.example.com');
+    $response->CSP->addObjectSrc('cdn.example.com', false); // reject from here
+    $response->CSP->addPluginType('application/pdf', false); // reject this media type
+    $response->CSP->addScriptSrc('scripts.example.com', true); // allow but report requests from here
+    $response->CSP->addStyleSrc('css.example.com');
+    $response->CSP->addSandbox(['allow-forms', 'allow-scripts']);
 
 The first parameter to each of the "add" methods is an appropriate string value,
 or an array of them.
@@ -234,27 +234,26 @@ been the result of user-generated content. To protect against this, CSP allows y
 life, and is most secure when generated on the fly. To make this simple, you can include a ``{csp-style-nonce}`` or
 ``{csp-script-nonce}`` placeholder in the tag and it will be handled for you automatically::
 
-	// Original
-	<script {csp-script-nonce}>
-	    console.log("Script won't run as it doesn't contain a nonce attribute");
-	</script>
+    // Original
+    <script {csp-script-nonce}>
+        console.log("Script won't run as it doesn't contain a nonce attribute");
+    </script>
 
-	// Becomes
-	<script nonce="Eskdikejidojdk978Ad8jf">
-	    console.log("Script won't run as it doesn't contain a nonce attribute");
-	</script>
+    // Becomes
+    <script nonce="Eskdikejidojdk978Ad8jf">
+        console.log("Script won't run as it doesn't contain a nonce attribute");
+    </script>
 
-	// OR
-	<style {csp-style-nonce}>
-		. . .
-	</style>
+    // OR
+    <style {csp-style-nonce}>
+        . . .
+    </style>
 
-***************
 Class Reference
-***************
+===============
 
 .. note:: In addition to the methods listed here, this class inherits the methods from the
-	:doc:`Message Class </incoming/message>`.
+    :doc:`Message Class </incoming/message>`.
 
 The methods provided by the parent class that are available are:
 
@@ -277,266 +276,258 @@ The methods provided by the parent class that are available are:
 
 .. php:class:: CodeIgniter\\HTTP\\Response
 
-	.. php:method:: getStatusCode()
+    .. php:method:: getStatusCode()
 
-		:returns: The current HTTP status code for this response
-		:rtype: int
+        :returns: The current HTTP status code for this response
+        :rtype: int
 
-		Returns the currently status code for this response. If no status code has been set, a BadMethodCallException
-		will be thrown::
+        Returns the currently status code for this response. If no status code has been set, a BadMethodCallException
+        will be thrown::
 
-			echo $response->getStatusCode();
+            echo $response->getStatusCode();
 
-	.. php:method:: setStatusCode($code[, $reason=''])
+    .. php:method:: setStatusCode($code[, $reason=''])
 
-		:param int $code: The HTTP status code
-		:param string $reason: An optional reason phrase.
-		:returns: The current Response instance
-		:rtype: CodeIgniter\\HTTP\\Response
+        :param int $code: The HTTP status code
+        :param string $reason: An optional reason phrase.
+        :returns: The current Response instance
+        :rtype: ``CodeIgniter\HTTP\Response``
 
-		Sets the HTTP status code that should be sent with this response::
+        Sets the HTTP status code that should be sent with this response::
 
-		    $response->setStatusCode(404);
+            $response->setStatusCode(404);
 
-		The reason phrase will be automatically generated based upon the official lists. If you need to set your own
-		for a custom status code, you can pass the reason phrase as the second parameter::
+        The reason phrase will be automatically generated based upon the official lists. If you need to set your own
+        for a custom status code, you can pass the reason phrase as the second parameter::
 
-			$response->setStatusCode(230, "Tardis initiated");
+            $response->setStatusCode(230, "Tardis initiated");
 
-	.. php:method:: getReasonPhrase()
+    .. php:method:: getReasonPhrase()
 
-		:returns: The current reason phrase.
-		:rtype: string
+        :returns: The current reason phrase.
+        :rtype: string
 
-		Returns the current status code for this response. If not status has been set, will return an empty string::
+        Returns the current status code for this response. If not status has been set, will return an empty string::
 
-			echo $response->getReasonPhrase();
+            echo $response->getReasonPhrase();
 
-	.. php:method:: setDate($date)
+    .. php:method:: setDate($date)
 
-		:param DateTime $date: A DateTime instance with the time to set for this response.
-		:returns: The current response instance.
-		:rtype: CodeIgniter\HTTP\Response
+        :param DateTime $date: A DateTime instance with the time to set for this response.
+        :returns: The current response instance.
+        :rtype: ``CodeIgniter\HTTP\Response``
 
-		Sets the date used for this response. The ``$date`` argument must be an instance of ``DateTime``::
+        Sets the date used for this response. The ``$date`` argument must be an instance of ``DateTime``::
 
-			$date = DateTime::createFromFormat('j-M-Y', '15-Feb-2016');
-			$response->setDate($date);
+            $date = DateTime::createFromFormat('j-M-Y', '15-Feb-2016');
+            $response->setDate($date);
 
-	.. php:method:: setContentType($mime[, $charset='UTF-8'])
+    .. php:method:: setContentType($mime[, $charset='UTF-8'])
 
-		:param string $mime: The content type this response represents.
-		:param string $charset: The character set this response uses.
-		:returns: The current response instance.
-		:rtype: CodeIgniter\HTTP\Response
+        :param string $mime: The content type this response represents.
+        :param string $charset: The character set this response uses.
+        :returns: The current response instance.
+        :rtype: ``CodeIgniter\HTTP\Response``
 
-		Sets the content type this response represents::
+        Sets the content type this response represents::
 
-			$response->setContentType('text/plain');
-			$response->setContentType('text/html');
-			$response->setContentType('application/json');
+            $response->setContentType('text/plain');
+            $response->setContentType('text/html');
+            $response->setContentType('application/json');
 
-		By default, the method sets the character set to ``UTF-8``. If you need to change this, you can
-		pass the character set as the second parameter::
+        By default, the method sets the character set to ``UTF-8``. If you need to change this, you can
+        pass the character set as the second parameter::
 
-			$response->setContentType('text/plain', 'x-pig-latin');
+            $response->setContentType('text/plain', 'x-pig-latin');
 
-	.. php:method:: noCache()
+    .. php:method:: noCache()
 
-		:returns: The current response instance.
-		:rtype: CodeIgniter\HTTP\Response
+        :returns: The current response instance.
+        :rtype: ``CodeIgniter\HTTP\Response``
 
-		Sets the ``Cache-Control`` header to turn off all HTTP caching. This is the default setting
-		of all response messages::
+        Sets the ``Cache-Control`` header to turn off all HTTP caching. This is the default setting
+        of all response messages::
 
-		    $response->noCache();
+            $response->noCache();
 
-		    // Sets the following header:
-		    Cache-Control: no-store, max-age=0, no-cache
+            // Sets the following header:
+            Cache-Control: no-store, max-age=0, no-cache
 
-	.. php:method:: setCache($options)
+    .. php:method:: setCache($options)
 
-		:param array $options: An array of key/value cache control settings
-		:returns: The current response instance.
-		:rtype: CodeIgniter\HTTP\Response
+        :param array $options: An array of key/value cache control settings
+        :returns: The current response instance.
+        :rtype: ``CodeIgniter\HTTP\Response``
 
-		Sets the ``Cache-Control`` headers, including ``ETags`` and ``Last-Modified``. Typical keys are:
+        Sets the ``Cache-Control`` headers, including ``ETags`` and ``Last-Modified``. Typical keys are:
 
-		* etag
-		* last-modified
-		* max-age
-		* s-maxage
-		* private
-		* public
-		* must-revalidate
-		* proxy-revalidate
-		* no-transform
+        * etag
+        * last-modified
+        * max-age
+        * s-maxage
+        * private
+        * public
+        * must-revalidate
+        * proxy-revalidate
+        * no-transform
 
-		When passing the last-modified option, it can be either a date string, or a DateTime object.
+        When passing the last-modified option, it can be either a date string, or a DateTime object.
 
-	.. php:method:: setLastModified($date)
+    .. php:method:: setLastModified($date)
 
-		:param string|DateTime $date: The date to set the Last-Modified header to
-		:returns: The current response instance.
-		:rtype: CodeIgniter\HTTP\Response
+        :param string|DateTime $date: The date to set the Last-Modified header to
+        :returns: The current response instance.
+        :rtype: ``CodeIgniter\HTTP\Response``
 
-		Sets the ``Last-Modified`` header. The ``$date`` object can be either a string or a ``DateTime``
-		instance::
+        Sets the ``Last-Modified`` header. The ``$date`` object can be either a string or a ``DateTime``
+        instance::
 
-			$response->setLastModified(date('D, d M Y H:i:s'));
-			$response->setLastModified(DateTime::createFromFormat('u', $time));
+            $response->setLastModified(date('D, d M Y H:i:s'));
+            $response->setLastModified(DateTime::createFromFormat('u', $time));
 
-	.. php:method:: send()
-                :noindex:
+    .. php:method:: send(): Response
 
-		:returns: The current response instance.
-		:rtype: CodeIgniter\HTTP\Response
+        :returns: The current response instance.
+        :rtype: ``CodeIgniter\HTTP\Response``
 
-		Tells the response to send everything back to the client. This will first send the headers,
-		followed by the response body. For the main application response, you do not need to call
-		this as it is handled automatically by CodeIgniter.
+        Tells the response to send everything back to the client. This will first send the headers,
+        followed by the response body. For the main application response, you do not need to call
+        this as it is handled automatically by CodeIgniter.
 
-	.. php:method:: setCookie($name = ''[, $value = ''[, $expire = ''[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = FALSE[, $httponly = FALSE[, $samesite = null]]]]]]]])
+    .. php:method:: setCookie($name = ''[, $value = ''[, $expire = ''[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = FALSE[, $httponly = FALSE[, $samesite = null]]]]]]]])
 
-		:param	mixed	$name: Cookie name or an array of parameters
-		:param	string	$value: Cookie value
-		:param	int	$expire: Cookie expiration time in seconds
-		:param	string	$domain: Cookie domain
-		:param	string	$path: Cookie path
-		:param	string	$prefix: Cookie name prefix
-		:param	bool	$secure: Whether to only transfer the cookie through HTTPS
-		:param	bool	$httponly: Whether to only make the cookie accessible for HTTP requests (no JavaScript)
-		:param	string	$samesite: The value for the SameSite cookie parameter. If set to ``''``, no SameSite attribute will be set on the cookie. If set to `null`, the default value from `config/App.php` will be used
+        :param mixed $name: Cookie name or an array of parameters
+        :param string $value: Cookie value
+        :param int $expire: Cookie expiration time in seconds
+        :param string $domain: Cookie domain
+        :param string $path: Cookie path
+        :param string $prefix: Cookie name prefix
+        :param bool $secure: Whether to only transfer the cookie through HTTPS
+        :param bool $httponly: Whether to only make the cookie accessible for HTTP requests (no JavaScript)
+        :param string $samesite: The value for the SameSite cookie parameter. If set to ``''``, no SameSite attribute will be set on the cookie. If set to `null`, the default value from `config/App.php` will be used
+        :rtype: void
 
-		:rtype:	void
+        Sets a cookie containing the values you specify. There are two ways to
+        pass information to this method so that a cookie can be set: Array
+        Method, and Discrete Parameters:
 
-		Sets a cookie containing the values you specify. There are two ways to
-		pass information to this method so that a cookie can be set: Array
-		Method, and Discrete Parameters:
+        **Array Method**
 
-		**Array Method**
+        Using this method, an associative array is passed as the first
+        parameter::
 
-		Using this method, an associative array is passed as the first
-		parameter::
+            $cookie = [
+                'name'   => 'The Cookie Name',
+                'value'  => 'The Value',
+                'expire' => '86500',
+                'domain' => '.some-domain.com',
+                'path'   => '/',
+                'prefix' => 'myprefix_',
+                'secure' => TRUE,
+                'httponly' => FALSE,
+                'samesite' => 'Lax'
+            ];
 
-			$cookie = [
-				'name'   => 'The Cookie Name',
-				'value'  => 'The Value',
-				'expire' => '86500',
-				'domain' => '.some-domain.com',
-				'path'   => '/',
-				'prefix' => 'myprefix_',
-				'secure' => TRUE,
-				'httponly' => FALSE,
-				'samesite' => 'Lax'
-			];
+            $response->setCookie($cookie);
 
-			$response->setCookie($cookie);
+        **Notes**
 
-		**Notes**
+        Only the name and value are required. To delete a cookie set it with the
+        expiration blank.
 
-		Only the name and value are required. To delete a cookie set it with the
-		expiration blank.
+        The expiration is set in **seconds**, which will be added to the current
+        time. Do not include the time, but rather only the number of seconds
+        from *now* that you wish the cookie to be valid. If the expiration is
+        set to zero the cookie will only last as long as the browser is open.
 
-		The expiration is set in **seconds**, which will be added to the current
-		time. Do not include the time, but rather only the number of seconds
-		from *now* that you wish the cookie to be valid. If the expiration is
-		set to zero the cookie will only last as long as the browser is open.
+        For site-wide cookies regardless of how your site is requested, add your
+        URL to the **domain** starting with a period, like this:
+        .your-domain.com
 
-		For site-wide cookies regardless of how your site is requested, add your
-		URL to the **domain** starting with a period, like this:
-		.your-domain.com
+        The path is usually not needed since the method sets a root path.
 
-		The path is usually not needed since the method sets a root path.
+        The prefix is only needed if you need to avoid name collisions with
+        other identically named cookies for your server.
 
-		The prefix is only needed if you need to avoid name collisions with
-		other identically named cookies for your server.
+        The secure flag is only needed if you want to make it a secure cookie
+        by setting it to ``true``.
 
-		The secure boolean is only needed if you want to make it a secure cookie
-		by setting it to TRUE.
+        The SameSite value controls how cookies are shared between domains and sub-domains.
+        Allowed values are 'None', 'Lax', 'Strict' or a blank string ``''``.
+        If set to blank string, default SameSite attribute will be set.
 
-		The SameSite value controls how cookies are shared between domains and sub-domains.
-		Allowed values are 'None', 'Lax', 'Strict' or a blank string ``''``.
-		If set to blank string, no SameSite attribute will be set on the cookie sent to the client.
-		If set to ``null``, the default from ``config/App.php`` is used.
+        **Discrete Parameters**
 
-		**Discrete Parameters**
+        If you prefer, you can set the cookie by passing data using individual
+        parameters::
 
-		If you prefer, you can set the cookie by passing data using individual
-		parameters::
+            $response->setCookie($name, $value, $expire, $domain, $path, $prefix, $secure, $httponly, $samesite);
 
-			$response->setCookie($name, $value, $expire, $domain, $path, $prefix, $secure, $httponly, $samesite);
+    .. php:method:: deleteCookie($name = ''[, $domain = ''[, $path = '/'[, $prefix = '']]])
 
-	.. php:method:: deleteCookie($name = ''[, $domain = ''[, $path = '/'[, $prefix = '']]])
+        :param mixed $name: Cookie name or an array of parameters
+        :param string $domain: Cookie domain
+        :param string $path: Cookie path
+        :param string $prefix: Cookie name prefix
+        :rtype: void
 
-		:param	mixed	$name: Cookie name or an array of parameters
-		:param	string	$domain: Cookie domain
-		:param	string	$path: Cookie path
-		:param	string	$prefix: Cookie name prefix
-		:rtype:	void
+        Delete an existing cookie by setting its expiry to ``0``.
 
-		Delete an existing cookie by setting its expiry to blank.
+        **Notes**
 
-		**Notes**
+        Only the name is required.
 
-		Only the name is required.
+        The prefix is only needed if you need to avoid name collisions with
+        other identically named cookies for your server.
 
-		The prefix is only needed if you need to avoid name collisions with
-		other identically named cookies for your server.
+        Provide a prefix if cookies should only be deleted for that subset.
+        Provide a domain name if cookies should only be deleted for that domain.
+        Provide a path name if cookies should only be deleted for that path.
 
-		Provide a prefix if cookies should only be deleted for that subset.
-                Provide a domain name if cookies should only be deleted for that domain.
-                Provide a path name if cookies should only be deleted for that path.
+        If any of the optional parameters are empty, then the same-named
+        cookie will be deleted across all that apply.
 
-                If any of the optional parameters are empty, then the same-named
-                cookie will be deleted across all that apply.
+        Example::
 
-		Example::
+            $response->deleteCookie($name);
 
-			$response->deleteCookie($name);
+    .. php:method:: hasCookie($name = ''[, $value = null[, $prefix = '']])
 
-	.. php:method:: hasCookie($name = ''[, $value = null[, $prefix = '']])
+        :param mixed $name: Cookie name or an array of parameters
+        :param string $value: cookie value
+        :param string $prefix: Cookie name prefix
+        :rtype: bool
 
-		:param	mixed	$name: Cookie name or an array of parameters
-		:param	string	$value: cookie value
-		:param	string	$prefix: Cookie name prefix
-		:rtype:	boolean
+        Checks to see if the Response has a specified cookie or not.
 
-		Checks to see if the Response has a specified cookie or not.
+        **Notes**
 
-		**Notes**
+        Only the name is required. If a prefix is specified, it will be prepended to the cookie name.
 
-		Only the name is required. If a prefix is specified, it will be
-                pre-pended to the cookie name.
+        If no value is given, the method just checks for the existence of the named cookie.
+        If a value is given, then the method checks that the cookie exists, and that it
+        has the prescribed value.
 
-                If no value is given, the method just checks for the existence
-                of the named cookie. If a value is given, then the method checks
-                that the cookie exists, and that it has the prescribed value.
+        Example::
 
-		Example::
+            if ($response->hasCookie($name)) ...
 
-			if ($response->hasCookie($name)) ...
+    .. php:method:: getCookie($name = ''[, $prefix = ''])
 
-	.. php:method:: getCookie($name = ''[, $prefix = ''])
-                :noindex:
+        :param string $name: Cookie name
+        :param string $prefix: Cookie name prefix
+        :rtype: ``Cookie|Cookie[]|null``
 
-		:param	mixed	$name: Cookie name
-		:param	string	$prefix: Cookie name prefix
-		:rtype:	boolean
+        Returns the named cookie, if found, or ``null``.
+        If no name is given, returns the array of ``Cookie`` objects.
 
-		Returns the named cookie, if found, or null.
+        Example::
 
-                If no name is given, returns the array of cookies.
-
-                Each cookie is returned as an associative array.
-
-		Example::
-
-			$cookie = $response->getCookie($name);
+            $cookie = $response->getCookie($name);
 
     .. php:method:: getCookies()
 
-        :rtype: array
+        :rtype: ``Cookie[]``
 
         Returns all cookies currently set within the Response instance.
         These are any cookies that you have specifically specified to set during the current


### PR DESCRIPTION
**Description**
This introduces a new `Cookie` class and the `CookieStore` for holding a collection of cookies.

- A `CookieInterface` defines the basic methods for all HTTP cookies.
- A `CloneableCookieInterface`, which extends `CookieInterface` defines methods of an immutable HTTP cookie.
- A `Cookie` implementing `CloneableCookieInterface` representing an immutable HTTP cookie object.
- A `CookieStore` represents an immutable collection of Cookie objects.

Supersedes #4092 .
Replaces and closes #3983 .

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
