### PR TITLE
Add additional empty checks after field protection for update/insert.

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -728,6 +728,13 @@ abstract class BaseModel
 		// strip out created_at values.
 		$data = $this->doProtectFields($data);
 
+		// doProtectFields() can further remove elements from
+		// $data so we need to check for empty dataset again
+		if (empty($data))
+		{
+			throw DataException::forEmptyDataset('insert');
+		}
+
 		// Set created_at and updated_at with same time
 		$date = $this->setDate();
 
@@ -865,6 +872,13 @@ abstract class BaseModel
 		// Must be called first so we don't
 		// strip out updated_at values.
 		$data = $this->doProtectFields($data);
+
+		// doProtectFields() can further remove elements from
+		// $data so we need to check for empty dataset again
+		if (empty($data))
+		{
+			throw DataException::forEmptyDataset('update');
+		}
 
 		if ($this->useTimestamps && $this->updatedField && ! array_key_exists($this->updatedField, $data))
 		{

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -178,7 +178,7 @@ final class InsertModelTest extends LiveModelTestCase
 		$this->assertSame(2, $this->model->insertBatch([$entity, $entity]));
 	}
 
-	public function testInsertArrayWithDataException(): void
+	public function testInsertArrayWithNoDataException(): void
 	{
 		$this->expectException(DataException::class);
 		$this->expectExceptionMessage('There is no data to insert.');
@@ -191,6 +191,45 @@ final class InsertModelTest extends LiveModelTestCase
 		$this->expectException(DataException::class);
 		$this->expectExceptionMessage('There is no data to insert.');
 		$this->createModel(UserModel::class)->insert($data);
+	}
+
+	public function testInsertArrayWithNoDataExceptionNoAllowedData(): void
+	{
+		$this->expectException(DataException::class);
+		$this->expectExceptionMessage('There is no data to insert.');
+		$this->createModel(UserModel::class)->insert(['thisKeyIsNotAllowed' => 'Bar']);
+	}
+
+	public function testInsertEntityWithNoDataExceptionNoAllowedData(): void
+	{
+		$this->createModel(UserModel::class);
+
+		$entity = new class extends Entity
+		{
+			protected $id;
+			protected $name;
+			protected $email;
+			protected $country;
+			protected $deleted;
+			protected $created_at;
+			protected $updated_at;
+
+			protected $_options = [
+				'datamap' => [],
+				'dates'   => [
+					'created_at',
+					'updated_at',
+					'deleted_at',
+				],
+				'casts'   => [],
+			];
+		};
+
+		$entity->fill(['thisKeyIsNotAllowed' => 'Bar']);
+
+		$this->expectException(DataException::class);
+		$this->expectExceptionMessage('There is no data to insert.');
+		$this->model->insert($entity);
 	}
 
 	public function testUseAutoIncrementSetToFalseInsertException(): void

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -260,11 +260,11 @@ final class UpdateModelTest extends LiveModelTestCase
 		$this->createModel(EventModel::class);
 
 		$data = (object) [
-							 'name'    => 'Foo',
-							 'email'   => 'foo@example.com',
-							 'country' => 'US',
-							 'deleted' => 0,
-						 ];
+			'name'    => 'Foo',
+			'email'   => 'foo@example.com',
+			'country' => 'US',
+			'deleted' => 0,
+		];
 
 		$id = $this->model->insert($data);
 

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -260,11 +260,11 @@ final class UpdateModelTest extends LiveModelTestCase
 		$this->createModel(EventModel::class);
 
 		$data = (object) [
-			'name'    => 'Foo',
-			'email'   => 'foo@example.com',
-			'country' => 'US',
-			'deleted' => 0,
-		];
+							 'name'    => 'Foo',
+							 'email'   => 'foo@example.com',
+							 'country' => 'US',
+							 'deleted' => 0,
+						 ];
 
 		$id = $this->model->insert($data);
 
@@ -273,6 +273,65 @@ final class UpdateModelTest extends LiveModelTestCase
 		$this->expectException(DataException::class);
 		$this->expectExceptionMessage('There is no data to update.');
 		$this->model->update($id, $data);
+	}
+
+	public function testUpdateArrayWithDataExceptionNoAllowedFields(): void
+	{
+		$this->createModel(EventModel::class);
+
+		$data = [
+			'name'    => 'Foo',
+			'email'   => 'foo@example.com',
+			'country' => 'US',
+			'deleted' => 0,
+		];
+
+		$id = $this->model->insert($data);
+
+		$this->expectException(DataException::class);
+		$this->expectExceptionMessage('There is no data to update.');
+		$this->model->update($id, ['thisKeyIsNotAllowed' => 'Bar']);
+	}
+
+	public function testUpdateWithEntityNoAllowedFields(): void
+	{
+		$this->createModel(UserModel::class);
+
+		$entity = new class extends Entity
+		{
+			protected $id;
+			protected $name;
+			protected $email;
+			protected $country;
+			protected $deleted;
+			protected $created_at;
+			protected $updated_at;
+
+			protected $_options = [
+				'datamap' => [],
+				'dates'   => [
+					'created_at',
+					'updated_at',
+					'deleted_at',
+				],
+				'casts'   => [],
+			];
+		};
+
+		$entity->id      = 1;
+		$entity->name    = 'Jones Martin';
+		$entity->country = 'India';
+		$entity->deleted = 0;
+
+		$id = $this->model->insert($entity);
+
+		$entity->syncOriginal();
+
+		$entity->fill(['thisKeyIsNotAllowed' => 'Bar']);
+
+		$this->expectException(DataException::class);
+		$this->expectExceptionMessage('There is no data to update.');
+		$this->model->update($id, $entity);
 	}
 
 	public function testUseAutoIncrementSetToFalseUpdate(): void
@@ -301,9 +360,9 @@ final class UpdateModelTest extends LiveModelTestCase
 		$this->assertTrue($this->model->set('country', '2+2', false)->set('email', '1+1')->update(1, $userData));
 
 		$this->seeInDatabase('user', [
-			'name' => 'Scott',
+			'name'    => 'Scott',
 			'country' => '4',
-			'email' => '1+1',
+			'email'   => '1+1',
 		]);
 	}
 }


### PR DESCRIPTION
Fixes #3896.

**Description**
This PR adds additional empty data checks to the `Model` `update` and `insert` methods.
These are needed because `doProtectFields` is currently called after the last empty dataset check, but can further remove elements from the `data` array.
See linked issue for details.

Will add tests later today.

**Checklist:**
- [x] Securely signed commits
- [ ] Unit testing, with >80% coverage
- [x] Conforms to style guide