### PR TITLE
Add PagerRenderer::getPageCount()

### DIFF
--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -433,6 +433,16 @@ class PagerRenderer
 	}
 
 	/**
+	 * Returns total number of pages.
+	 *
+	 * @return integer
+	 */
+	public function getPageCount(): int
+	{
+		return $this->pageCount;
+	}
+
+	/**
 	 * Returns the previous page number.
 	 *
 	 * @return integer|null

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -576,6 +576,7 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals(1, $pager->getFirstPageNumber());
 		$this->assertEquals(3, $pager->getCurrentPageNumber());
 		$this->assertEquals(10, $pager->getLastPageNumber());
+		$this->assertEquals(10, $pager->getPageCount());
 	}
 
 	public function testGetPageNumberSetSurroundCount()

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -563,9 +563,8 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testGetPageNumber()
 	{
-		$uri     = $this->uri;
 		$details = [
-			'uri'         => $uri,
+			'uri'         => $this->uri,
 			'pageCount'   => 10,
 			'currentPage' => 3,
 			'total'       => 100,
@@ -581,9 +580,8 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testGetPageNumberSetSurroundCount()
 	{
-		$uri     = $this->uri;
 		$details = [
-			'uri'         => $uri,
+			'uri'         => $this->uri,
 			'pageCount'   => 10,
 			'currentPage' => 5,
 			'total'       => 100,
@@ -599,9 +597,8 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testGetPreviousPageNumber()
 	{
-		$uri     = $this->uri;
 		$details = [
-			'uri'         => $uri,
+			'uri'         => $this->uri,
 			'pageCount'   => 10,
 			'currentPage' => 5,
 			'total'       => 100,
@@ -615,9 +612,8 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testGetPreviousPageNumberNull()
 	{
-		$uri     = $this->uri;
 		$details = [
-			'uri'         => $uri,
+			'uri'         => $this->uri,
 			'pageCount'   => 10,
 			'currentPage' => 1,
 			'total'       => 100,
@@ -631,9 +627,8 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testGetNextPageNumber()
 	{
-		$uri     = $this->uri;
 		$details = [
-			'uri'         => $uri,
+			'uri'         => $this->uri,
 			'pageCount'   => 10,
 			'currentPage' => 5,
 			'total'       => 100,
@@ -647,9 +642,8 @@ class PagerRendererTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testGetNextPageNumberNull()
 	{
-		$uri     = $this->uri;
 		$details = [
-			'uri'         => $uri,
+			'uri'         => $this->uri,
 			'pageCount'   => 10,
 			'currentPage' => 10,
 			'total'       => 100,


### PR DESCRIPTION
**Description**
To generate the same link as the pagination in CI3, #4188 is not enough.
I also need the `$pageCount` value.
I need `$pager->getCurrentPageNumber() < $pager->getPageCount() - $surroundCount`.

Example:
```php
/**
 * @var \CodeIgniter\Pager\PagerRenderer $pager
 */

$surroundCount = 2;
$pager->setSurroundCount($surroundCount);
?>

<p class="pagination">
<?php if ($pager->hasPreviousPage()) : ?>
    <?php if ($pager->getPreviousPageNumber() > $surroundCount) : ?>
    <a href="<?= $pager->getFirst() ?>" data-ci-pagination-page="<?= $pager->getFirstPageNumber() ?> rel="start">
    &laquo;<?= lang('Pager.first') ?></a>
    <?php endif ?>

    <a href="<?= $pager->getPreviousPage() ?>" data-ci-pagination-page="<?= $pager->getPreviousPageNumber() ?>" rel="prev">&lt;</a>
<?php endif ?>

<?php foreach ($pager->links() as $link) : ?>
<?php if ($link['active']) : ?>
    <strong><?= $link['title'] ?></strong>
<?php else : ?>
    <a href="<?= $link['uri'] ?>" data-ci-pagination-page="<?= $link['title'] ?>">
        <?= $link['title'] ?>
    </a>
<?php endif ?>
<?php endforeach ?>

<?php if ($pager->hasNextPage()) : ?>
    <a href="<?= $pager->getNextPage() ?>" data-ci-pagination-page="<?= $pager->getNextPageNumber() ?>" rel="next">&gt;</a>

    <?php if ($pager->getCurrentPageNumber() < $pager->getPageCount() - $surroundCount) : ?>
    <a href="<?= $pager->getLast() ?>" data-ci-pagination-page="<?= $pager->getLastPageNumber() ?>">
    <?= lang('Pager.last') ?>&raquo;</a>
    <?php endif ?>
<?php endif ?>
</p>
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
