### PR TITLE
Bug #4174 FIX. Exclude CURRENT_TIMESTAMP from being escaped

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1144,6 +1144,11 @@ class Forge
 				$attributes['NULL'] = true;
 				$field['null']      = empty($this->null) ? '' : ' ' . $this->null;
 			}
+			// CURRENT_TIMESTAMP can not be escaped
+			else if ($attributes['DEFAULT'] === 'CURRENT_TIMESTAMP')
+			{
+				$field['default'] = $this->default . $attributes['DEFAULT'];
+			}
 			else
 			{
 				$field['default'] = $this->default . $this->db->escape($attributes['DEFAULT']);


### PR DESCRIPTION
Signed-off-by: Jozef Botka <52993808+xbotkaj@users.noreply.github.com>

Fixes #4174 

**Description**
Excluded CURRENT_TIMESTAMP from being escaped. This is only HotFix. It must be considered to rework this part of forge. Default value can contain complex values and cannot be escapes by defualt. It will make breaking change in the future after rework.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide