### PR TITLE
Bug #4035 FIX. Close session write stream when targeting the same server

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -797,8 +797,20 @@ class CURLRequest extends Request
 
 		curl_setopt_array($ch, $curlOptions);
 
+		// Stop session to avoid deadlock if target is the same server
+		if(isset($_SESSION) && strstr($curlOptions[CURLOPT_URL], base_url()))
+		{
+			session_write_close();
+		}
+
 		// Send the request and wait for a response.
 		$output = curl_exec($ch);
+
+		// Resume session
+		if(isset($_SESSION) && strstr($curlOptions[CURLOPT_URL], base_url()))
+		{
+			session_start();
+		}
 
 		if ($output === false)
 		{


### PR DESCRIPTION
Signed-off-by: Jozef Botka <52993808+xbotkaj@users.noreply.github.com>

Fixes #4035 

**Description**
If we use sessions and in the same time making CURL request for the same machine, it will make deadlock. We need close session write stream, execute CURL and resume session.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide