### PR TITLE
docs: fix out-of-dated property name in Config/Modules.php

### DIFF
--- a/app/Config/Modules.php
+++ b/app/Config/Modules.php
@@ -12,7 +12,7 @@ class Modules extends BaseModules
 	 * --------------------------------------------------------------------------
 	 *
 	 * If true, then auto-discovery will happen across all elements listed in
-	 * $activeExplorers below. If false, no auto-discovery will happen at all,
+	 * $aliases below. If false, no auto-discovery will happen at all,
 	 * giving a slight performance boost.
 	 *
 	 * @var boolean

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -92,7 +92,7 @@ all discovery, optimizing performance, but negating the special capabilities of 
 Specify Discovery Items
 =======================
 
-With the **$activeExplorers** option, you can specify which items are automatically discovered. If the item is not
+With the **$aliases** option, you can specify which items are automatically discovered. If the item is not
 present, then no auto-discovery will happen for that item, but the others in the array will still be discovered.
 
 Discovery and Composer


### PR DESCRIPTION
**Description**
`$activeExplorers` was renamed in <https://github.com/codeigniter4/CodeIgniter4/commit/3626206ca7784bd6d63e0daecbf9484ac302319e>.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
