### PR TITLE
Bug #4221  FIX Undefined offset: 0 error on getFileMultiple

### DIFF
--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -99,14 +99,14 @@ class FileCollection
 				$name         = explode('.', $name);
 				$uploadedFile = $this->getValueDotNotationSyntax($name, $this->files);
 
-				return (is_array($uploadedFile) && ($uploadedFile[0] instanceof UploadedFile)) ?
+				return (is_array($uploadedFile) && ($uploadedFile[array_key_first($uploadedFile)] instanceof UploadedFile)) ?
 					$uploadedFile : null;
 			}
 
 			if (array_key_exists($name, $this->files))
 			{
 				$uploadedFile = $this->files[$name];
-				return (is_array($uploadedFile) && ($uploadedFile[0] instanceof UploadedFile)) ?
+				return (is_array($uploadedFile) && ($uploadedFile[array_key_first($uploadedFile)] instanceof UploadedFile)) ?
 					$uploadedFile : null;
 			}
 		}


### PR DESCRIPTION
Fixes #4221 

**Description**
Change the way to obtain the first key from multiple file array. With array_key_first it does not matter if the first key is "0" or another

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
  
