### PR TITLE
no more ( -_ | -_- | _- ) in the result of url_title()

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -571,19 +571,27 @@ if (! function_exists('url_title'))
 	 */
 	function url_title(string $str, string $separator = '-', bool $lowercase = false): string
 	{
-		$qSeparator = preg_quote($separator, '#');
+		$qSeparator = preg_quote($separator);
 
 		$trans = [
-			'&.+?;'                  => '',
-			'[^\w\d\pL\pM _-]'       => '',
-			'\s+'                    => $separator,
-			'(' . $qSeparator . ')+' => $separator,
+			'![^' . $qSeparator . '\pL\pM\pN\s]+!u' => '', // remove all chars are not the separator, letters, numbers, whitespace or another character (e.g. accents, umlauts, enclosing boxes, etc.)
+			'![' . $qSeparator . '\s]+!u'        => $separator, // replace all separator chars with $separator
 		];
+
+		// make all dashes/underscores into separator
+		if ($separator === '-')
+		{
+			$str = str_replace('_', '-', $str);
+		}
+		else if ($separator === '_')
+		{
+			$str = str_replace('-', '_', $str);
+		}
 
 		$str = strip_tags($str);
 		foreach ($trans as $key => $val)
 		{
-			$str = preg_replace('#' . $key . '#iu', $val, $str);
+			$str = preg_replace($key, $val, $str);
 		}
 
 		if ($lowercase === true)

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Helpers;
 
 use CodeIgniter\Config\Config;
@@ -1237,69 +1238,128 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 	//--------------------------------------------------------------------
 	// Test url_title
 
-	public function testUrlTitle()
+	public function urlTitleProvider()
 	{
-		$words = [
-			'foo bar /'       => 'foo-bar',
-			'\  testing 12'   => 'testing-12',
-			'Éléphant de PHP' => 'éléphant-de-php',
+		// input, expected, separator, lowercase
+		return [
+			[
+				'foo bar /',
+				'foo-bar',
+			],
+			[
+				'\  testing 12',
+				'testing-12',
+			],
+			[
+				'Éléphant de PHP',
+				'éléphant-de-php',
+				'-',
+				true,
+			],
+			[
+				'_foo bar_',
+				'foo_bar',
+				'_',
+			],
+			[
+				'_What\'s wrong with CSS?_',
+				'Whats_wrong_with_CSS',
+				'_',
+			],
+			[
+				'Éléphant de PHP',
+				'Éléphant_de_PHP',
+				'_',
+			],
+			[
+				'How to use url_title() function?',
+				'how-to-use-url-title-function',
+				'-',
+				true,
+			],
+			[
+				'Welcome to the chat-room',
+				'welcome_to_the_chat_room',
+				'_',
+				true,
+			],
+			[
+				'মশিউর রহমান', // see #3180, #3427
+				'মশিউর-রহমান',
+				'-',
+				true,
+			],
+			[
+				'Example: with dash (-) and underscore ( _ )',
+				'Example-with-dash-and-underscore',
+			],
 		];
-
-		foreach ($words as $in => $out)
-		{
-			$this->assertEquals($out, url_title($in, '-', true));
-		}
 	}
 
-	public function testUrlTitleExtraDashes()
+	/**
+	 * @dataProvider urlTitleProvider
+	 */
+	public function testUrlTitle(string $input, string $expected, string $separator = '-', bool $lowercase = false)
 	{
-		$words = [
-			'_foo bar_'                 => 'foo_bar',
-			'_What\'s wrong with CSS?_' => 'Whats_wrong_with_CSS',
-			'Éléphant de PHP'           => 'Éléphant_de_PHP',
-		];
-
-		foreach ($words as $in => $out)
-		{
-			$this->assertEquals($out, url_title($in, '_'));
-		}
+		$this->assertSame($expected, url_title($input, $separator, $lowercase));
 	}
 
 	//--------------------------------------------------------------------
-	// Test mb_url_title
+	// Test
 
-	public function testMbUrlTitle()
+	public function mbUrlTitleProvider()
 	{
-		helper('text');
-
-		$words = [
-			'foo bar /'       => 'foo-bar',
-			'\  testing 12'   => 'testing-12',
-			'Éléphant de PHP' => 'elephant-de-php',
-			'ä ö ü Ĝ β ę'     => 'ae-oe-ue-g-v-e',
+		// input, expected, separator, lowercase
+		return [
+			[
+				'foo bar /',
+				'foo-bar',
+			],
+			[
+				'\  testing 12',
+				'testing-12',
+			],
+			[
+				'Éléphant de PHP',
+				'elephant-de-php',
+				'-',
+				true,
+			],
+			[
+				'ä ö ü Ĝ β ę',
+				'ae-oe-ue-g-v-e',
+				'-',
+				true,
+			],
+			[
+				'foo bar /',
+				'foo-bar',
+			],
+			[
+				'\  testing 12',
+				'testing-12',
+			],
+			[
+				'Éléphant de PHP',
+				'elephant-de-php',
+				'-',
+				true,
+			],
+			[
+				'ä ö ü Ĝ β ę',
+				'ae-oe-ue-g-v-e',
+				'-',
+				true,
+			],
 		];
-
-		foreach ($words as $in => $out)
-		{
-			$this->assertEquals($out, mb_url_title($in, '-', true));
-		}
 	}
 
-	public function testMbUrlTitleExtraDashes()
+	/**
+	 * @dataProvider mbUrlTitleProvider
+	 */
+	public function testMbUrlTitle(string $input, string $expected, string $separator = '-', bool $lowercase = false)
 	{
-		helper('text');
-
-		$words = [
-			'_foo bar_'                 => 'foo_bar',
-			'_What\'s wrong with CSS?_' => 'Whats_wrong_with_CSS',
-			'Éléphant de PHP'           => 'Elephant_de_PHP',
-			'ä ö ü Ĝ β ę'               => 'ae_oe_ue_G_v_e',
-		];
-
-		foreach ($words as $in => $out)
-		{
-			$this->assertEquals($out, mb_url_title($in, '_'));
-		}
+		$this->assertSame($expected, mb_url_title($input, $separator, $lowercase));
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
Result of `"url_title()"` has a dash and an underscore even though it is set as underscore, and appears on the other hand as well.
here the example:

```
url_title('make file read-only', '_')
// result: make_file_read-only

// now: make_file_read_only
```
or

```
url_title('underscore_ and dash-')
// result: underscore_-and-dash

// now: underscore-and-dash
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

