### PR TITLE
Fix HealthTest::testBaseUrlHasBeenSet()

### DIFF
--- a/admin/starter/tests/unit/HealthTest.php
+++ b/admin/starter/tests/unit/HealthTest.php
@@ -21,7 +21,7 @@ class HealthTest extends \CodeIgniter\Test\CIUnitTestCase
 		// First check in .env
 		if (is_file(HOMEPATH . '.env'))
 		{
-			$env = (bool) preg_grep("/^app\.baseURL = './", file(HOMEPATH . '.env'));
+			$env = (bool) preg_grep('/^app\.baseURL = ./', file(HOMEPATH . '.env'));
 		}
 
 		// Then check the actual config file

--- a/admin/starter/tests/unit/HealthTest.php
+++ b/admin/starter/tests/unit/HealthTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Config\Services;
+
 class HealthTest extends \CodeIgniter\Test\CIUnitTestCase
 {
 	public function setUp(): void
@@ -16,18 +18,35 @@ class HealthTest extends \CodeIgniter\Test\CIUnitTestCase
 
 	public function testBaseUrlHasBeenSet()
 	{
-		$env = $config = false;
+		$validation = Services::validation();
+		$env = false;
 
-		// First check in .env
+		// Check the baseURL in .env
 		if (is_file(HOMEPATH . '.env'))
 		{
 			$env = (bool) preg_grep('/^app\.baseURL = ./', file(HOMEPATH . '.env'));
 		}
 
-		// Then check the actual config file
-		$reader = new \Tests\Support\Libraries\ConfigReader();
-		$config = ! empty($reader->baseURL);
+		if ($env)
+		{
+			// BaseURL in .env is a valid URL?
+			// phpunit.xml.dist sets app.baseURL in $_SERVER
+			// So if you set app.baseURL in .env, it takes precedence
+			$config = new Config\App();
+			$this->assertTrue(
+				$validation->check($config->baseURL, 'valid_url'),
+				'baseURL "' . $config->baseURL . '" in .env is not valid URL'
+			);
+		}
 
-		$this->assertTrue($env || $config);
+		// Get the baseURL in app/Config/App.php
+		// Don't forget phpunit.xml.dist sets app.baseURL
+		$reader = new \Tests\Support\Libraries\ConfigReader();
+
+		// BaseURL in app/Config/App.php is a valid URL?
+		$this->assertTrue(
+			$validation->check($reader->baseURL, 'valid_url'),
+			'baseURL "' . $reader->baseURL . '" in app/Config/App.php is not valid URL'
+		);
 	}
 }

--- a/admin/starter/tests/unit/HealthTest.php
+++ b/admin/starter/tests/unit/HealthTest.php
@@ -19,7 +19,7 @@ class HealthTest extends \CodeIgniter\Test\CIUnitTestCase
 	public function testBaseUrlHasBeenSet()
 	{
 		$validation = Services::validation();
-		$env = false;
+		$env        = false;
 
 		// Check the baseURL in .env
 		if (is_file(HOMEPATH . '.env'))
@@ -40,7 +40,7 @@ class HealthTest extends \CodeIgniter\Test\CIUnitTestCase
 		}
 
 		// Get the baseURL in app/Config/App.php
-		// Don't forget phpunit.xml.dist sets app.baseURL
+		// You can't use Config\App, because phpunit.xml.dist sets app.baseURL
 		$reader = new \Tests\Support\Libraries\ConfigReader();
 
 		// BaseURL in app/Config/App.php is a valid URL?


### PR DESCRIPTION
**Description**
Fixes #3977

Tests about `baseURL`:
- `baseURL` is a valid URL
- Set it in `.env` or `app/Config/App.php`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
