### PR TITLE
Develop sqlsrv schema

### DIFF
--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -95,6 +95,8 @@ class Builder extends BaseBuilder
 	 */
 	protected function _insert(string $table, array $keys, array $unescapedKeys): string
 	{
+
+
 		$fullTableName = $this->getFullName($table);
 
 		// insert statement
@@ -189,11 +191,23 @@ class Builder extends BaseBuilder
 	 */
 	private function getFullName(string $table): string
 	{
+
+		$table_exploded = explode('.', $table);
+		if(count($table_exploded) === 2)
+		{
+			$this->db->schema = str_replace('"', '', $table_exploded[0]);
+			$tableName = $table_exploded[1];
+		}else
+		{
+			$tableName = $table;
+		}
+
+
 		if ($this->db->escapeChar === '"')
 		{
-			return '"' . $this->db->getDatabase() . '"."' . $this->db->schema . '"."' . str_replace('"', '', $table) . '"';
+			return '"' . $this->db->getDatabase() . '"."' . $this->db->schema . '"."' . str_replace('"', '', $tableName) . '"';
 		}
-		return '[' . $this->db->getDatabase() . '].[' . $this->db->schema . '].[' . str_replace('"', '', $table) . ']';
+		return '[' . $this->db->getDatabase() . '].[' . $this->db->schema . '].[' . str_replace('"', '', $tableName) . ']';
 	}
 
 	/**

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -95,8 +95,6 @@ class Builder extends BaseBuilder
 	 */
 	protected function _insert(string $table, array $keys, array $unescapedKeys): string
 	{
-
-
 		$fullTableName = $this->getFullName($table);
 
 		// insert statement
@@ -191,17 +189,16 @@ class Builder extends BaseBuilder
 	 */
 	private function getFullName(string $table): string
 	{
-
-		$table_exploded = explode('.', $table);
-		if(count($table_exploded) === 2)
+		$tableExploded = explode('.', $table);
+		if (count($tableExploded) === 2)
 		{
-			$this->db->schema = str_replace('"', '', $table_exploded[0]);
-			$tableName = $table_exploded[1];
-		}else
+			$this->db->schema = str_replace('"', '', $tableExploded[0]);
+			$tableName        = $tableExploded[1];
+		}
+		else
 		{
 			$tableName = $table;
 		}
-
 
 		if ($this->db->escapeChar === '"')
 		{


### PR DESCRIPTION
**Description**

In codeigniter 3 using sqlsrv handler we could use a different scheme than "dbo" for example "adm", "tools", the full name being configured as follows: [DBNAME]. [SCHEMA]. [TABLENAME] however in the version 4.1 to obtain a record the full name looks like this: [DBNAME]. [TABLENAME] and to insert or update then if you take [DBNAME]. [SCHEMA]. [TABLENAME] from the key database configuration file " schema ", then it occurs to me that the table name" schema.tableName "is used in the model for sqlsrv. If the schema is not set then it takes "dbo" by default.

`private function getFullName(string $table): string
	{
		$tableExploded = explode('.', $table);
		if (count($tableExploded) === 2)
		{
			$this->db->schema = str_replace('"', '', $tableExploded[0]);
			$tableName        = $tableExploded[1];
		}
		else
		{
			$tableName = $table;
		}

		if ($this->db->escapeChar === '"')
		{
			return '"' . $this->db->getDatabase() . '"."' . $this->db->schema . '"."' . str_replace('"', '', $tableName) . '"';
		}
		return '[' . $this->db->getDatabase() . '].[' . $this->db->schema . '].[' . str_replace('"', '', $tableName) . ']';
	}
`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide


