### PR TITLE
Fix restriction on command group

### DIFF
--- a/system/Commands/Generators/CommandGenerator.php
+++ b/system/Commands/Generators/CommandGenerator.php
@@ -101,7 +101,6 @@ class CommandGenerator extends BaseCommand
 		$type    = $this->getOption('type');
 
 		$command = is_string($command) ? $command : 'command:name';
-		$group   = is_string($group) ? $group : 'CodeIgniter';
 		$type    = is_string($type) ? $type : 'basic';
 
 		if (! in_array($type, ['basic', 'generator'], true))
@@ -112,9 +111,9 @@ class CommandGenerator extends BaseCommand
 			// @codeCoverageIgnoreEnd
 		}
 
-		if ($type === 'generator')
+		if (! is_string($group))
 		{
-			$group = 'Generators';
+			$group = $type === 'generator' ? 'Generators' : 'CodeIgniter';
 		}
 
 		return $this->parseTemplate(


### PR DESCRIPTION
**Description**
The original `CreateCommand` class allows custom command generators to be grouped under anything. This is especially useful for external libraries creating their own commands. However, the refactor made this impossible as it checks if the command type is `generator` then force set the group under `Generators`. This PR fixes and returns the old behavior.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide
