### PR TITLE
Allow disabling the --suffix option

### DIFF
--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -60,6 +60,15 @@ trait GeneratorTrait
 	private $sortImports = true;
 
 	/**
+	 * Whether the `--suffix` option has any effect.
+	 *
+	 * @internal
+	 *
+	 * @var boolean
+	 */
+	private $enabledSuffixing = true;
+
+	/**
 	 * The params array for easy access by other methods.
 	 *
 	 * @internal
@@ -206,7 +215,7 @@ trait GeneratorTrait
 		$class     = strtolower($class);
 		$class     = strpos($class, $component) !== false ? str_replace($component, ucfirst($component), $class) : $class;
 
-		if ($this->getOption('suffix') && ! strripos($class, $component))
+		if ($this->enabledSuffixing && $this->getOption('suffix') && ! strripos($class, $component))
 		{
 			$class .= ucfirst($component);
 		}
@@ -308,12 +317,10 @@ trait GeneratorTrait
 
 		if (! $base = reset($base))
 		{
-			// @codeCoverageIgnoreStart
 			CLI::error(lang('CLI.namespaceNotDefined', [$namespace]), 'light_gray', 'red');
 			CLI::newLine();
 
 			return '';
-			// @codeCoverageIgnoreEnd
 		}
 
 		$base = realpath($base) ?: $base;
@@ -346,6 +353,20 @@ trait GeneratorTrait
 	protected function setSortImports(bool $sortImports)
 	{
 		$this->sortImports = $sortImports;
+
+		return $this;
+	}
+
+	/**
+	 * Allows child generators to modify the internal `$enabledSuffixing` flag.
+	 *
+	 * @param boolean $enabledSuffixing
+	 *
+	 * @return $this
+	 */
+	protected function setEnabledSuffixing(bool $enabledSuffixing)
+	{
+		$this->enabledSuffixing = $enabledSuffixing;
 
 		return $this;
 	}

--- a/tests/_support/Commands/Unsuffixable.php
+++ b/tests/_support/Commands/Unsuffixable.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Support\Commands;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\GeneratorTrait;
+
+class Unsuffixable extends BaseCommand
+{
+	use GeneratorTrait;
+
+	/**
+	 * The Command's Group
+	 *
+	 * @var string
+	 */
+	protected $group = 'Generators';
+
+	/**
+	 * The Command's Name
+	 *
+	 * @var string
+	 */
+	protected $name = 'make:foo';
+
+	/**
+	 * The Command's Description
+	 *
+	 * @var string
+	 */
+	protected $description = '';
+
+	/**
+	 * The Command's Usage
+	 *
+	 * @var string
+	 */
+	protected $usage = 'make:foo [arguments] [options]';
+
+	/**
+	 * The Command's Arguments
+	 *
+	 * @var array
+	 */
+	protected $arguments = [
+		'name' => 'Class name',
+	];
+
+	/**
+	 * The Command's Options
+	 *
+	 * @var array
+	 */
+	protected $options = [];
+
+	/**
+	 * Actually execute a command.
+	 *
+	 * @param array $params
+	 */
+	public function run(array $params)
+	{
+		$this->component = 'Command';
+		$this->directory = 'Commands';
+		$this->template  = 'command.tpl.php';
+
+		$this->setEnabledSuffixing(false);
+		$this->execute($params);
+	}
+}

--- a/tests/system/Commands/GeneratorsTest.php
+++ b/tests/system/Commands/GeneratorsTest.php
@@ -83,4 +83,19 @@ class GeneratorsTest extends CIUnitTestCase
 		is_file($file) && unlink($file);
 		is_dir($dir) && rmdir($dir);
 	}
+
+	public function testSuffixingHasNoEffect(): void
+	{
+		command('make:foo bar --suffix');
+		$file1 = APPPATH . 'Commands/Bar.php';
+		$file2 = APPPATH . 'Commands/BarCommand.php';
+		$dir   = dirname($file1);
+
+		$this->assertFileExists($file1);
+		$this->assertFileDoesNotExist($file2);
+
+		is_file($file1) && unlink($file1);
+		is_file($file2) && unlink($file2);
+		is_dir($dir) && rmdir($dir);
+	}
 }


### PR DESCRIPTION
**Description**
The `--suffix` option was added in the refactor to allow classes to be suffixed by their corresponding component name. Although this flag is optional, there is no way to totally disregard this in other generators where the suffix is not desired. Intercepting the `$params` parsing is not possible as there is a separate route where this is processed. That said, if a user passes the `--suffix` option even if it is not in the list of allowed options, the `GeneratorTrait` will still process the suffixing.

This PR adds an internal flag to enable/disable this behavior.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide
