### PR TITLE
Fixed documentation styles to widen the content frame on large screens

### DIFF
--- a/user_guide_src/source/_static/css/citheme.css
+++ b/user_guide_src/source/_static/css/citheme.css
@@ -95,6 +95,20 @@ body, p, legend {
 	background-size: 200px;
 }
 
+/* -- Breakpoint for large screens (> 900px) --------- */
+@media (min-width: 900px) and (max-width: 1100px) {
+	.wy-nav-content {
+		max-width: 1620px;
+	}
+}
+
+@media (min-width: 1100px) {
+	.wy-nav-content {
+		margin: 0 auto;
+		max-width: 1620px;
+	}
+}
+
 /* Titles ------------------------------------------------------------------- */
 
 h1, h2, h3, h4, h5, h6 {
@@ -328,19 +342,4 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
 	font-weight: lighter;
 	font-size: 9px;
 	line-height: 1;
-}
-
-
-/* -- Breakpoint for large screens (> 900px) --------- */
-@media (min-width: 900px) and (max-width: 1100px) {
-	.wy-nav-content {
-		max-width: 1620px;
-	}
-}
-
-@media (min-width: 1100px) {
-	.wy-nav-content {
-		margin: 0 auto;
-		max-width: 1620px;
-	}
 }

--- a/user_guide_src/source/_static/css/citheme.css
+++ b/user_guide_src/source/_static/css/citheme.css
@@ -329,3 +329,18 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
 	font-size: 9px;
 	line-height: 1;
 }
+
+
+/* -- Breakpoint for large screens (> 900px) --------- */
+@media (min-width: 900px) and (max-width: 1100px) {
+	.wy-nav-content {
+		max-width: 1620px;
+	}
+}
+
+@media (min-width: 1100px) {
+	.wy-nav-content {
+		margin: 0 auto;
+		max-width: 1620px;
+	}
+}


### PR DESCRIPTION
I got fed up to scroll horizontally on large tables in the Validations section of the documentation and then I added some styles to widen the page content size on large monitors (screens with more than 1100px in width and beyond) to be able to use all of my monitor size. 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs (didn't required)
- [x] Unit testing, with >80% coverage (didn't required)
- [x] User guide updated (the fix)
- [x] Conforms to style guide

