### PR TITLE
update PHP Compatibility

### DIFF
--- a/contributing/guidelines.rst
+++ b/contributing/guidelines.rst
@@ -74,7 +74,7 @@ be highlighted in the next release after it has been merged.
 PHP Compatibility
 =================
 
-CodeIgniter4 requires PHP 7.2.
+CodeIgniter4 requires PHP 7.3.
 
 Backwards Compatibility
 =======================


### PR DESCRIPTION
**Description**
Now, CI4 requires PHP 7.3

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
