### PR TITLE
Ability to create class instances inside entity.

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -368,9 +368,18 @@ class Entity implements JsonSerializable
 			// Array casting requires that we serialize the value
 			// when setting it so that it can easily be stored
 			// back to the database.
-			if ($castTo === 'array' || strpos($castTo, 'class:') === 0)
+			if ($castTo === 'array')
 			{
 				$value = serialize($value);
+			}
+
+			if (strpos($castTo, 'class:') === 0)
+			{
+				$type = substr($castTo,6);
+
+				if(class_exists($type)) {
+					$value = serialize(new $type($value));
+				}
 			}
 
 			// JSON casting requires that we JSONize the value

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -368,7 +368,7 @@ class Entity implements JsonSerializable
 			// Array casting requires that we serialize the value
 			// when setting it so that it can easily be stored
 			// back to the database.
-			if ($castTo === 'array')
+			if ($castTo === 'array' || strpos($castTo, 'class:') === 0)
 			{
 				$value = serialize($value);
 			}
@@ -542,6 +542,17 @@ class Entity implements JsonSerializable
 				return null;
 			}
 			$type = substr($type, 1);
+		}
+		
+		
+		if(strpos($type, 'class:') === 0)
+		{
+			$type = substr($type,6);
+
+			if(class_exists($type)) {
+				$value = is_array($value) ? new $type($value) : unserialize($value);
+			}
+			return $value;
 		}
 
 		switch($type)


### PR DESCRIPTION
With this you could create in your entities inner instances of other entities.

I.e.:

you have entity that you wish to contain other entity in it.... lets say you need POSCommon entity in your RequestRate class...

```
<?php

namespace App\Entities\API;

use App\Libraries\Ext\Entity;

class RequestRate extends Entity
{
	protected $casts = [
		'commission_buy'						=> '?decimal',
		'commission_sell'						=> '?decimal',
		'pos_common'							=> 'class:App\Entities\API\POSCommon'
	];


	protected $attributes = [
		'commission_buy'						=> null,
		'commission_sell'						=> null,
		'pos_common'							=> null,
	];

	protected $datamap = [
		'commissionBuy' => 'commission_buy',
		'commissionSell' => 'commission_sell',
		'r' => 'pos_common'
	];

}

```

with that change it is peace of cake ;-)




