### PR TITLE
Store entity property as GZIPPED binary strings

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -348,6 +348,7 @@ class Entity implements JsonSerializable
 			$value = $this->mutateDate($value);
 		}
 
+		$castTo = false;
 		$isNullable = false;
 		$isGzipped = false;
 


### PR DESCRIPTION
With that you could store all of data types in database (BLOB) type as gzipped binnary strings.
It could save a lot of data in case of longer strings / logs. Tested with string but it should work perfectly with other types as well as nullable. 

uncompressed: 2267 
compressed with gzip: 1079


gzip is fast and should work everywhere.

If you are interested guys with it , it would be great to write docs and tests ;-)
