### PR TITLE
Fabricator: Update model errors on implode

### DIFF
--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -43,7 +43,7 @@ class Fabricator
 	/**
 	 * Model instance (can be non-framework if it follows framework design)
 	 *
-	 * @var CodeIgniter\Model|object
+	 * @var \CodeIgniter\Model|object
 	 */
 	protected $model;
 
@@ -549,7 +549,7 @@ class Fabricator
 				continue;
 			}
 
-			throw FrameworkException::forFabricatorCreateFailed($this->model->table, implode(' ', $this->model->errors() ?? []));
+			throw FrameworkException::forFabricatorCreateFailed($this->model->table, implode(' ', (array)$this->model->errors()));
 		}
 
 		// If the model defines a "withDeleted" method for handling soft deletes then use it


### PR DESCRIPTION
**Description**
For a strange reason the method `$this->model->errors()` returns a string.

BEFORE (implode error):
```
/home/natanfelles/CodeIgniter/se/vendor/codeigniter4/framework/system/Test/Fabricator.php:553:
string(52) "Duplicate entry '16-14' for key 'product_id_user_id'"
An uncaught Exception was encountered

Type:        ErrorException
Message:     implode(): Invalid arguments passed
Filename:    /home/natanfelles/CodeIgniter/se/vendor/codeigniter4/framework/system/Test/Fabricator.php
Line Number: 554
```
Note the error in the `implode` function.

AFTER (implode without error):
```
/home/natanfelles/CodeIgniter/se/vendor/codeigniter4/framework/system/Test/Fabricator.php:553:
string(48) "Duplicate entry '44-10' for key 'post_id_tag_id'"
An uncaught Exception was encountered

Type:        CodeIgniter\Exceptions\FrameworkException
Message:     Fabricator falhou ao inserir na tabela blog_posts_with_tags: Duplicate entry '44-10' for key 'post_id_tag_id'.
Filename:    /home/natanfelles/CodeIgniter/se/vendor/codeigniter4/framework/system/Test/Fabricator.php
Line Number: 554
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] Conforms to style guide


  
- [ ] User guide updated
