### PR TITLE
Use verbose DB output for errors

### DIFF
--- a/app/Views/errors/html/error_404.php
+++ b/app/Views/errors/html/error_404.php
@@ -74,7 +74,7 @@
 
 		<p>
 			<?php if (! empty($message) && $message !== '(null)') : ?>
-				<?= esc($message) ?>
+				<?= esc(nl2br($message)) ?>
 			<?php else : ?>
 				Sorry! Cannot seem to find the page you were looking for.
 			<?php endif ?>

--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -21,7 +21,7 @@
 		<div class="container">
 			<h1><?= esc($title), esc($exception->getCode() ? ' #' . $exception->getCode() : '') ?></h1>
 			<p>
-				<?= esc($exception->getMessage()) ?>
+				<?= esc(nl2br($exception->getMessage())) ?>
 				<a href="https://www.duckduckgo.com/?q=<?= urlencode($title . ' ' . preg_replace('#\'.*\'|".*"#Us', '', $exception->getMessage())) ?>"
 				   rel="noreferrer" target="_blank">search &rarr;</a>
 			</p>

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -1,8 +1,13 @@
-<?php namespace CodeIgniter\Database;
+<?php
 
+namespace CodeIgniter\Database;
+
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use Throwable;
 
-class BaseConnectionTest extends \CodeIgniter\Test\CIUnitTestCase
+class BaseConnectionTest extends CIUnitTestCase
 {
 	protected $options = [
 		'DSN'      => '',
@@ -42,8 +47,6 @@ class BaseConnectionTest extends \CodeIgniter\Test\CIUnitTestCase
 		'failover' => [],
 	];
 
-	//--------------------------------------------------------------------
-
 	public function testSavesConfigOptions()
 	{
 		$db = new MockConnection($this->options);
@@ -64,36 +67,30 @@ class BaseConnectionTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertSame([], $db->failover);
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testConnectionThrowExceptionWhenCannotConnect()
 	{
-		$db = new MockConnection($this->options);
-
-		$this->expectException('\CodeIgniter\Database\Exceptions\DatabaseException');
-		$this->expectExceptionMessage('Unable to connect to the database.');
-
-		$db->shouldReturn('connect', false)
-			->initialize();
+		try
+		{
+			$db = new MockConnection($this->options);
+			$db->shouldReturn('connect', false)->initialize();
+		}
+		catch (Throwable $e)
+		{
+			$this->assertInstanceOf(DatabaseException::class, $e);
+			$this->assertStringContainsString('Unable to connect to the database.', $e->getMessage());
+		}
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testCanConnectAndStoreConnection()
 	{
 		$db = new MockConnection($this->options);
-
-		$db->shouldReturn('connect', 123)
-			->initialize();
+		$db->shouldReturn('connect', 123)->initialize();
 
 		$this->assertSame(123, $db->getConnection());
 	}
 
-	//--------------------------------------------------------------------
-
 	/**
-	 * @throws \CodeIgniter\Database\Exceptions\DatabaseException
-	 * @group  single
+	 * @group single
 	 */
 	public function testCanConnectToFailoverWhenNoConnectionAvailable()
 	{
@@ -101,29 +98,22 @@ class BaseConnectionTest extends \CodeIgniter\Test\CIUnitTestCase
 		$options['failover'] = [$this->failoverOptions];
 
 		$db = new MockConnection($options);
-
-		$db->shouldReturn('connect', [false, 345])
-		   ->initialize();
+		$db->shouldReturn('connect', [false, 345])->initialize();
 
 		$this->assertSame(345, $db->getConnection());
 		$this->assertSame('failover', $db->username);
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testStoresConnectionTimings()
 	{
 		$start = microtime(true);
 
 		$db = new MockConnection($this->options);
-
 		$db->initialize();
 
 		$this->assertGreaterThan($start, $db->getConnectStart());
 		$this->assertGreaterThan(0.0, $db->getConnectDuration());
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testMagicIssetTrue()
 	{
@@ -132,8 +122,6 @@ class BaseConnectionTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertTrue(isset($db->charset));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testMagicIssetFalse()
 	{
 		$db = new MockConnection($this->options);
@@ -141,16 +129,12 @@ class BaseConnectionTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertFalse(isset($db->foobar));
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testMagicGet()
 	{
 		$db = new MockConnection($this->options);
 
-		$this->assertEquals('utf8', $db->charset);
+		$this->assertSame('utf8', $db->charset);
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testMagicGetMissing()
 	{


### PR DESCRIPTION
**Description**
This PR changes the error output for DB connections to be more verbose than the generic `Unable to connect to the database.`. This is an attempt to reduce questions on the forum regarding this despite raising the logging threshold to `4`.

`php spark migrate --all`

![image](https://user-images.githubusercontent.com/51850998/107846056-9d782080-6e1b-11eb-93ec-61032756313d.png)

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide
