### PR TITLE
Skip session_destroy() in testing

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -448,6 +448,11 @@ class Session implements SessionInterface
 	 */
 	public function destroy()
 	{
+		if (ENVIRONMENT === 'testing')
+		{
+			return;
+		}
+
 		session_destroy();
 	}
 


### PR DESCRIPTION
**Description**
To avoid `ErrorException : session_destroy(): Trying to destroy uninitialized session`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

