### PR TITLE
New: BaseBuilder. Added methods that implement UNION.

### DIFF
--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -661,7 +661,7 @@ class Builder extends BaseBuilder
 				$sql = 'SELECT * FROM (' . $sql . ') as wrapper_alias';
 			}
 
-			$sql .= $this->compileUnion() . $this->compileUnionOrderBy();
+			$sql .= $this->compileUnion() . $this->compileUnionFilter();
 		}
 
 		return $sql;

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -651,7 +651,17 @@ class Builder extends BaseBuilder
 		// LIMIT
 		if ($this->QBLimit)
 		{
-			return $sql = $this->_limit($sql . "\n");
+			$sql = $this->_limit($sql . "\n");
+		}
+
+		if ($this->QBUnion)
+		{
+			if ($this->QBOrderBy || $this->QBLimit)
+			{
+				$sql = 'SELECT * FROM (' . $sql . ') as wrapper_alias';
+			}
+
+			$sql .= $this->compileUnion() . $this->compileUnionOrderBy();
 		}
 
 		return $sql;

--- a/tests/system/Database/Builder/UnionTest.php
+++ b/tests/system/Database/Builder/UnionTest.php
@@ -1,0 +1,171 @@
+<?php namespace CodeIgniter\Database\Builder;
+
+use CodeIgniter\Database\BaseBuilder;
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Test\Mock\MockConnection;
+
+class UnionTest extends \CodeIgniter\Test\CIUnitTestCase
+{
+	protected $db;
+
+	//--------------------------------------------------------------------
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->db = new MockConnection([]);
+	}
+
+	public function testUnion()
+	{
+		$builder = $this->db->table('movies');
+
+		$builder->select('title, year')
+			->union(function (BaseBuilder $builder) {
+				return $builder->select('title, year')->from('top_movies');
+			});
+
+		$sql = '(SELECT "title", "year" FROM "movies") UNION (SELECT "title", "year" FROM "top_movies")';
+
+		$this->assertEquals($sql, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
+
+	public function testUnionExceptions()
+	{
+		$builder = $this->db->table('movies');
+		$builder->select('title, year');
+
+		$this->expectException(\TypeError::class);
+
+		$builder->union(1);
+
+		$this->expectException(DatabaseException::class);
+		$this->expectExceptionMessage(
+			'BaseBuilder::union(). The closure must return an instance of the BaseBuilder class'
+		);
+
+		$builder->union(function (BaseBuilder $builder) {
+			$builder->select('title, year')->from('top_movies');
+		});
+	}
+
+	public function testUnionAll()
+	{
+		$builder = $this->db->table('movies');
+
+		$builder->select('title, year')
+			->unionAll(function (BaseBuilder $builder) {
+				return $builder->select('title, year')->from('top_movies');
+			});
+
+		$sql = '(SELECT "title", "year" FROM "movies") UNION ALL (SELECT "title", "year" FROM "top_movies")';
+
+		$this->assertEquals($sql, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
+
+	public function testMultiQueryUnion()
+	{
+		$builder = $this->db->table('movies');
+
+		$builder->select('title, year')
+			->union(function (BaseBuilder $builder) {
+				return $builder->select('title, year')
+					->from('top_movies')
+					->unionAll(function (BaseBuilder $builder) {
+						return $builder->select('title, year')->from('tomato_movies');
+					});
+			});
+
+		$sql = '(SELECT "title", "year" FROM "movies") '
+				. 'UNION ((SELECT "title", "year" FROM "top_movies") '
+					. 'UNION ALL (SELECT "title", "year" FROM "tomato_movies"))';
+
+		$this->assertEquals($sql, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+		$builder->resetQuery();
+
+		$builder->select('title, year')
+			->union(function (BaseBuilder $builder) {
+				return $builder->select('title, year')->from('top_movies');
+			})->unionAll(function (BaseBuilder $builder) {
+				return $builder->select('title, year')->from('tomato_movies');
+			});
+
+		$sql = '(SELECT "title", "year" FROM "movies") '
+				. 'UNION (SELECT "title", "year" FROM "top_movies") '
+				. 'UNION ALL (SELECT "title", "year" FROM "tomato_movies")';
+
+		$this->assertEquals($sql, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+		$builder->resetQuery();
+
+		$year1 = 2000;
+		$year2 = 2010;
+		$year3 = 2020;
+
+		$builder->select('title, year')
+			->where('year', $year1)
+			->union(function (BaseBuilder $builder) use ($year2, $year3) {
+				return $builder->select('title, year')
+					->from('top_movies')
+					->where('year', $year2)
+					->unionAll(function (BaseBuilder $builder) use ($year3) {
+						return $builder->select('title, year')
+							->from('tomato_movies')
+							->where('year', $year3);
+					});
+			});
+
+		$sql = '(SELECT "title", "year" FROM "movies" WHERE "year" = 2000) '
+			. 'UNION ((SELECT "title", "year" FROM "top_movies" WHERE "year" = 2010) '
+			. 'UNION ALL (SELECT "title", "year" FROM "tomato_movies" WHERE "year" = 2020))';
+
+		$this->assertEquals($sql, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
+
+	public function testUnionOrderBy()
+	{
+		$builder = $this->db->table('movies');
+
+		$builder->select('title, year')
+			->unionAll(function (BaseBuilder $builder) {
+				return $builder->select('title, year')->from('top_movies');
+			})
+			->unionOrderBy('title', 'DESC')
+			->unionOrderBy('year', 'ASC');
+
+		$sql = '(SELECT "title", "year" FROM "movies") '
+			. 'UNION ALL (SELECT "title", "year" FROM "top_movies") ORDER BY "title" DESC, "year" ASC';
+
+		$this->assertEquals($sql, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+		$builder->resetQuery();
+
+		$builder->select('title, year')
+			->union(function (BaseBuilder $builder) {
+				return $builder->select('title, year')
+					->from('top_movies')
+					->unionAll(function (BaseBuilder $builder) {
+						return $builder->select('title, year')->from('tomato_movies');
+					})->unionOrderBy('title', 'DESC');
+			});
+
+		$sql = '(SELECT "title", "year" FROM "movies") '
+			. 'UNION ((SELECT "title", "year" FROM "top_movies") '
+			. 'UNION ALL (SELECT "title", "year" FROM "tomato_movies") ORDER BY "title" DESC)';
+
+		$this->assertEquals($sql, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
+
+	public function testIgnoreUnionOrderByWithoutUnionQuery()
+	{
+		$builder = $this->db->table('movies');
+
+		$builder->select('title, year')->unionOrderBy('year', 'ASC');
+
+		$sql = 'SELECT "title", "year" FROM "movies"';
+
+		$this->assertEquals($sql, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
+}

--- a/tests/system/Database/Builder/UnionTest.php
+++ b/tests/system/Database/Builder/UnionTest.php
@@ -2,6 +2,7 @@
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\SQLSRV\Builder as BuilderSQLSRV;
 use CodeIgniter\Test\Mock\MockConnection;
 
 class UnionTest extends \CodeIgniter\Test\CIUnitTestCase
@@ -78,8 +79,8 @@ class UnionTest extends \CodeIgniter\Test\CIUnitTestCase
 			->unionAll(function (BaseBuilder $builder) {
 				return $builder->select('title, year')->from('top_movies');
 			})
-			->unionOrderBy('title', 'DESC')
-			->unionOrderBy('year', 'ASC');
+			->orderBy('title', 'DESC')
+			->orderBy('year', 'ASC');
 
 		$sql = 'SELECT "title", "year" FROM "movies" '
 			. 'UNION ALL SELECT "title", "year" FROM "top_movies" ORDER BY "title" DESC, "year" ASC';
@@ -94,8 +95,8 @@ class UnionTest extends \CodeIgniter\Test\CIUnitTestCase
 					->from('top_movies')
 					->unionAll(function (BaseBuilder $builder) {
 						return $builder->select('title, year')->from('tomato_movies');
-					})->unionOrderBy('title', 'DESC');
-			})->unionOrderBy('title');
+					})->orderBy('title', 'DESC');
+			})->orderBy('title');
 
 		$sql = 'SELECT "title", "year" FROM "movies" '
 			. 'UNION SELECT * FROM (SELECT "title", "year" FROM "top_movies" '
@@ -111,22 +112,45 @@ class UnionTest extends \CodeIgniter\Test\CIUnitTestCase
 						return $builder->select('title, year')->from('tomato_movies');
 					})->limit(1);
 			})
-			->unionOrderBy('title');
+			->orderBy('title');
 
 		$sql = 'SELECT "title", "year" FROM "movies" '
-			. 'UNION SELECT * FROM (SELECT "title", "year" FROM "top_movies"  LIMIT 1) as wrapper_alias '
-			. 'UNION ALL SELECT "title", "year" FROM "tomato_movies" ORDER BY "title"';
+			. 'UNION SELECT * FROM (SELECT "title", "year" FROM "top_movies" '
+			. 'UNION ALL SELECT "title", "year" FROM "tomato_movies"  LIMIT 1) as wrapper_alias ORDER BY "title"';
 
 		$this->assertEquals($sql, str_replace("\n", ' ', $builder->getCompiledSelect()));
 	}
 
-	public function testIgnoreUnionOrderByWithoutUnionQuery()
+	public function testUnionLimit()
 	{
 		$builder = $this->db->table('movies');
 
-		$builder->select('title, year')->unionOrderBy('year', 'ASC');
+		$builder->select('title, year')
+			->unionAll(function (BaseBuilder $builder) {
+				return $builder->select('title, year')->from('top_movies');
+			})
+			->limit(5, 10);
 
-		$sql = 'SELECT "title", "year" FROM "movies"';
+		$sql = 'SELECT "title", "year" FROM "movies" '
+			. 'UNION ALL SELECT "title", "year" FROM "top_movies"  LIMIT 10, 5';
+
+		$this->assertEquals($sql, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
+
+	public function testUnionSQLSRV()
+	{
+		$dbc     = new MockConnection(['schema' => 'dbo', 'database' => 'test']);
+		$builder = new BuilderSQLSRV('movies', $dbc);
+
+		$builder->select('title, year')
+			->unionAll(function (BaseBuilder $builder) {
+				return $builder->select('title, year')->from('top_movies');
+			})
+			->limit(5, 10);
+
+		$sql = 'SELECT "title", "year" FROM "test"."dbo"."movies" '
+			. 'UNION ALL SELECT "title", "year" FROM "test"."dbo"."top_movies" '
+			. ' ORDER BY (SELECT NULL)  OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY ';
 
 		$this->assertEquals($sql, str_replace("\n", ' ', $builder->getCompiledSelect()));
 	}

--- a/tests/system/Database/Live/UnionTest.php
+++ b/tests/system/Database/Live/UnionTest.php
@@ -1,0 +1,39 @@
+<?php namespace CodeIgniter\Database\Live;
+
+use CodeIgniter\Database\BaseBuilder;
+use CodeIgniter\Test\CIDatabaseTestCase;
+
+/**
+ * @group DatabaseLive
+ */
+class UnionTest extends CIDatabaseTestCase
+{
+	protected $refresh = true;
+
+	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
+
+	//--------------------------------------------------------------------
+
+	public function testUnion()
+	{
+		$rows = $this->db->table('user')
+			->select('name')
+			->where('country', 'US')
+			->limit(1)
+			->orderBy('name', 'DESC')
+			->union(function (BaseBuilder $builder) {
+				return $builder->select('name')
+					->from('job')
+					->where('id >', 1)
+					->limit(2);
+			})
+			->unionOrderBy('name')
+			->get()
+			->getResult();
+
+		$this->assertEquals(3, count($rows));
+		$this->assertEquals('Accountant', $rows[0]->name);
+		$this->assertEquals('Politician', $rows[1]->name);
+		$this->assertEquals('Richard A Causey', $rows[2]->name);
+	}
+}

--- a/tests/system/Database/Live/UnionTest.php
+++ b/tests/system/Database/Live/UnionTest.php
@@ -27,7 +27,7 @@ class UnionTest extends CIDatabaseTestCase
 					->where('id >', 1)
 					->limit(2);
 			})
-			->unionOrderBy('name')
+			->orderBy('name')
 			->get()
 			->getResult();
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -845,7 +845,8 @@ Combining queries (UNION)
 
 .. note:: To understand how UNION works, it is recommended to study the documentation for the used DBMS.
 .. note:: Each separate query containing LIMIT and ORDER BY will be wrapped in a
-``SELECT * FROM (...) as wrapper_alias`` so that the DBMS will process queries correctly
+``SELECT * FROM (...) as wrapper_alias`` so that the DBMS will process queries correctly.
+
 
 **$builder->union()**
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -727,6 +727,9 @@ be ignored, unless you specify a numeric seed value.
 .. note:: Random ordering is not currently supported in Oracle and
     will default to ASC instead.
 
+.. note:: The orderBy() method called after the union()/unionAll() method will be applied to the final result
+
+
 ****************************
 Limiting or Counting Results
 ****************************
@@ -745,6 +748,7 @@ The second parameter lets you set a result offset.
     $builder->limit(10, 20);
     // Produces: LIMIT 20, 10 (in MySQL. Other databases have slightly different syntax)
 
+.. note:: The limit() method called after the union()/unionAll() method will be applied to the final result
 
 **$builder->countAllResults()**
 
@@ -890,24 +894,6 @@ The method adds ALL to UNION::
     // UNION ALL SELECT title, year FROM top_movies
 
 
-**$builder->unionOrderBy()**
-
-The method adds a sort for the final query result after combining queries using UNION [ALL].
-The principle is the same as for ``orderBy()``::
-
-    //Add the following line after the namespace keyword
-    use CodeIgniter\Database\BaseBuilder;
-
-    $builder = $db->table('movies');
-
-    $builder->select('title, year')
-        ->unionAll(function (BaseBuilder $builder) {
-            return $builder->select('title, year')->from('top_movies');
-        })
-        ->unionOrderBy('title', 'DESC')
-        ->get();
-
-    // SELECT title, year FROM movies UNION ALL SELECT title, year FROM top_movies ORDER BY title DESC
 
 **************
 Inserting Data

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -839,6 +839,100 @@ Starts a new group by adding an opening parenthesis to the HAVING clause of the 
 
 Ends the current group by adding a closing parenthesis to the HAVING clause of the query.
 
+*************************
+Combining queries (UNION)
+*************************
+
+.. note:: To understand how UNION works, it is recommended to study the documentation for the used DBMS.
+
+**$builder->union()**
+
+The method combines the results of several queries into one common one and takes a Closure as an argument.
+The Closure must return an instance of the BaseBuilder class::
+
+    //Add the following line after the namespace keyword
+    use CodeIgniter\Database\BaseBuilder;
+
+    $builder = $db->table('movies');
+
+    $builder->select('title, year')
+        ->union(function (BaseBuilder $builder) {
+            return $builder->select('title, year')->from('top_movies');
+        })
+        ->get();
+
+    // (SELECT title, year FROM movies) UNION (SELECT title, year FROM top_movies)
+
+Nested UNION and variable passing::
+
+    //Add the following line after the namespace keyword
+    use CodeIgniter\Database\BaseBuilder;
+
+    $year = 2000;
+    $yearTop = 2010;
+    $yearBad = 2020;
+
+    $builder = $db->table('movies');
+
+    $builder->select('title, year')
+        ->where('year', $year)
+        ->union(function (BaseBuilder $builder) use ($yearTop, $yearBad){
+            return $builder->select('title, year')
+                ->from('top_movies')
+                ->where('year', $yearTop)
+                ->union(function (BaseBuilder $builder) use ($yearBad){
+                    return $builder->select('title, year')
+                        ->from('bad_movies')
+                        ->where('year', $yearBad)
+                });
+        })
+        ->get();
+
+    // (SELECT title, year FROM movies WHERE year = 2000)
+    //  UNION (
+    //      (SELECT title, year FROM top_movies WHERE year = 2010)
+    //      UNION (SELECT title, year FROM bad_movies WHERE year = 2020)
+    //  )
+
+
+**$builder->unionAll()**
+
+The method adds ALL to UNION::
+
+    //Add the following line after the namespace keyword
+    use CodeIgniter\Database\BaseBuilder;
+
+    $builder = $db->table('movies');
+
+    $builder->select('title, year')
+        ->unionAll(function (BaseBuilder $builder) {
+            return $builder->select('title, year')->from('top_movies');
+        })
+        ->get();
+
+    // (SELECT title, year FROM movies) UNION ALL (SELECT title, year FROM top_movies)
+
+
+**$builder->unionOrderBy()**
+
+The method adds a sort for the final query result after combining queries using UNION [ALL].
+The principle is the same as for ``orderBy()``::
+
+    //Add the following line after the namespace keyword
+    use CodeIgniter\Database\BaseBuilder;
+
+    $builder = $db->table('movies');
+
+    $builder->select('title, year')
+        ->unionAll(function (BaseBuilder $builder) {
+            return $builder->select('title, year')->from('top_movies');
+        })
+        ->unionOrderBy('title', 'DESC')
+        ->get();
+
+    // (SELECT title, year FROM movies) UNION ALL (SELECT title, year FROM top_movies) ORDER BY title DESC
+
+
 **************
 Inserting Data
 **************


### PR DESCRIPTION
**Description**
Methods generate SQL queries using UNION [ALL] 

* BaseBuilder::union()
* BaseBuilder::unionAll()
* The orderBy() and limit() methods called after the union() / unionAll() method will be applied to the final result. 

```php
$builder = $db->table('movies');

$builder->select('title, year')
    ->unionAll(function (BaseBuilder $builder) {
        return $builder->select('title, year')->from('top_movies');
    })
    ->orderBy('title', 'DESC')
    ->get();

// SELECT title, year FROM movies UNION ALL SELECT title, year FROM top_movies ORDER BY title DESC
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
