### PR TITLE
Bug #4235 fix. Wrong HTML code in output of "form_input" helper function

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -944,7 +944,7 @@ if (! function_exists('parse_form_attributes'))
 				{
 					continue;
 				}
-				$att .= $key . '="' . $val . '"' . ($val === end($default) ? '' : ' ');
+				$att .= $key . '="' . $val . '"' . ($key === key(array_slice($default, -1, 1, true)) ? '' : ' ');
 			}
 			else
 			{

--- a/system/ThirdParty/Escaper/Escaper.php
+++ b/system/ThirdParty/Escaper/Escaper.php
@@ -162,7 +162,7 @@ class Escaper
             return $string;
         }
 
-        $result = preg_replace_callback('/[^a-z0-9,\.\-_]/iSu', $this->htmlAttrMatcher, $string);
+        $result = preg_replace_callback('/[^a-z0-9,\.\-_ ]/iSu', $this->htmlAttrMatcher, $string);
         return $this->fromUtf8($result);
     }
 
@@ -185,7 +185,7 @@ class Escaper
             return $string;
         }
 
-        $result = preg_replace_callback('/[^a-z0-9,\._]/iSu', $this->jsMatcher, $string);
+        $result = preg_replace_callback('/[^a-z0-9,\._ ]/iSu', $this->jsMatcher, $string);
         return $this->fromUtf8($result);
     }
 
@@ -216,7 +216,7 @@ class Escaper
             return $string;
         }
 
-        $result = preg_replace_callback('/[^a-z0-9]/iSu', $this->cssMatcher, $string);
+        $result = preg_replace_callback('/[^a-z0-9 ]/iSu', $this->cssMatcher, $string);
         return $this->fromUtf8($result);
     }
 


### PR DESCRIPTION
**Description**
I fixed error number 1 as documented in my bug #4235 (file _/system/Helpers/form_helper.php_). On the other hand, error number 2 I did not fix as documented in my bug #4235, because the problem is actually in the _/system/ThirdParty/Escaper/Escaper.php_ library file, where spaces in HTML, JAVASCRIPT and CSS attributes are also incorrectly encoded.

**Checklist:**
- [*] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [*] Conforms to style guide

  
