### PR TITLE
Add round brackets in a code example

### DIFF
--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -757,10 +757,10 @@ must return the original $data array so other callbacks have the full informatio
 
     protected function hashPassword(array $data)
     {
-        if (! isset($data['data']['password']) return $data;
+        if (! isset($data['data']['password'])) return $data;
 
         $data['data']['password_hash'] = password_hash($data['data']['password'], PASSWORD_DEFAULT);
-        unset($data['data']['password'];
+        unset($data['data']['password']);
 
         return $data;
     }


### PR DESCRIPTION
Round brackets are missing in two places and cause errors if the code is just copied and pasted.