### PR TITLE
Allow php3.7 installation

### DIFF
--- a/Vagrantfile.dist
+++ b/Vagrantfile.dist
@@ -87,6 +87,8 @@ Vagrant.configure("2") do |config|
     echo "Updating and Installing Required Packages"
     echo "================================================================================"
 
+    add-apt-repository ppa:ondrej/php
+
     apt-get update
 
     debconf-set-selections <<< "mysql-server mysql-server/root_password password ${MYSQL_ROOT_PASS}"


### PR DESCRIPTION
Without this change, vagrant will not install php.
It will have an error 'Unable to locate package php7.3' during `vagrant up`