### PR TITLE
fix form dropdowns

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -383,6 +383,11 @@ if (! function_exists('form_dropdown'))
 			}
 		}
 
+		//standardize selected as strings, like  the option keys will be.
+		foreach($selected as $key => $item) {
+			$selected[$key] = (string) $item;
+		}
+
 		$extra    = stringify_attributes($extra);
 		$multiple = (count($selected) > 1 && stripos($extra, 'multiple') === false) ? ' multiple="multiple"' : '';
 		$form     = '<select ' . rtrim(parse_form_attributes($data, $defaults)) . $extra . $multiple . ">\n";

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -71,8 +71,7 @@ if (! function_exists('form_open'))
 		$form = '<form action="' . $action . '"' . $attributes . ">\n";
 
 		// Add CSRF field if enabled, but leave it out for GET requests and requests to external websites
-		$before = Services::filters()
-						  ->getFilters()['before'];
+		$before = Services::filters()->getFilters()['before'];
 
 		if ((in_array('csrf', $before, true) || array_key_exists('csrf', $before)) && strpos($action, base_url()) !== false && ! stripos($form, 'method="get"'))
 		{
@@ -383,8 +382,9 @@ if (! function_exists('form_dropdown'))
 			}
 		}
 
-		//standardize selected as strings, like  the option keys will be.
-		foreach($selected as $key => $item) {
+		// standardize selected as strings, like  the option keys will be.
+		foreach ($selected as $key => $item)
+		{
 			$selected[$key] = (string) $item;
 		}
 


### PR DESCRIPTION
**Description**
-since in_array is now being enforced as strict, and the option keys are being forced as strings, the selected items also need to be forced as strings.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
