### PR TITLE
Enforce errors format

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1087,27 +1087,25 @@ abstract class BaseModel
 	 * Grabs the last error(s) that occurred. If data was validated,
 	 * it will first check for errors there, otherwise will try to
 	 * grab the last error from the Database connection.
+	 * The return array should be in the following format:
+	 *  ['source' => 'message']
 	 *
 	 * @param boolean $forceDB Always grab the db error, not validation
 	 *
-	 * @return array|null
+	 * @return array<string,string>
 	 */
 	public function errors(bool $forceDB = false)
 	{
 		// Do we have validation errors?
 		if (! $forceDB && ! $this->skipValidation)
 		{
-			$errors = $this->validation->getErrors();
-
-			if (! empty($errors))
+			if ($errors = $this->validation->getErrors())
 			{
 				return $errors;
 			}
 		}
 
-		$error = $this->doErrors();
-
-		return $error['message'] ?? null;
+		return $this->doErrors();
 	}
 
 	// endregion

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1097,12 +1097,9 @@ abstract class BaseModel
 	public function errors(bool $forceDB = false)
 	{
 		// Do we have validation errors?
-		if (! $forceDB && ! $this->skipValidation)
+		if (! $forceDB && ! $this->skipValidation && ($errors = $this->validation->getErrors()))
 		{
-			if ($errors = $this->validation->getErrors())
-			{
-				return $errors;
-			}
+			return $errors;
 		}
 
 		return $this->doErrors();

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -91,7 +91,11 @@ interface ConnectionInterface
 	/**
 	 * Returns the last error encountered by this connection.
 	 *
-	 * @return array
+	 * Must return an array with keys 'code' and 'message':
+	 *
+	 *  ['code' => string|int, 'message' => string);
+	 *
+	 * @return array<string,string|int>
 	 */
 	public function error(): array;
 

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -633,9 +633,9 @@ class Connection extends BaseConnection
 	 *
 	 * Must return an array with keys 'code' and 'message':
 	 *
-	 *  return ['code' => null, 'message' => null);
+	 *  ['code' => string|int, 'message' => string);
 	 *
-	 * @return array
+	 * @return array<string,string|int>
 	 */
 	public function error(): array
 	{

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -439,15 +439,15 @@ class Connection extends BaseConnection
 	 *
 	 * Must return an array with keys 'code' and 'message':
 	 *
-	 *  return ['code' => null, 'message' => null);
+	 *  ['code' => string|int, 'message' => string);
 	 *
-	 * @return array
+	 * @return array<string,string|int>
 	 */
 	public function error(): array
 	{
 		return [
 			'code'    => '',
-			'message' => pg_last_error($this->connID),
+			'message' => pg_last_error($this->connID) ?: '',
 		];
 	}
 

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -401,9 +401,9 @@ class Connection extends BaseConnection
 	 *
 	 * Must return an array with keys 'code' and 'message':
 	 *
-	 *  return ['code' => null, 'message' => null);
+	 *  ['code' => string|int, 'message' => string);
 	 *
-	 * @return array
+	 * @return array<string,string|int>
 	 */
 	public function error(): array
 	{

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -428,9 +428,9 @@ class Connection extends BaseConnection
 	 *
 	 * Must return an array with keys 'code' and 'message':
 	 *
-	 *  return ['code' => null, 'message' => null);
+	 *  ['code' => string|int, 'message' => string);
 	 *
-	 * @return array
+	 * @return array<string,string|int>
 	 */
 	public function error(): array
 	{

--- a/system/Model.php
+++ b/system/Model.php
@@ -463,13 +463,17 @@ class Model extends BaseModel
 
 	/**
 	 * Grabs the last error(s) that occurred from the Database connection.
+	 * The return array should be in the following format:
+	 *  ['source' => 'message']
 	 * This methods works only with dbCalls
 	 *
-	 * @return array|null
+	 * @return array<string,string>
 	 */
 	protected function doErrors()
 	{
-		return $this->db->error();
+		$error = $this->db->error();
+
+		return [get_class($this->db) => $error['message']];
 	}
 
 	/**

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -734,7 +734,7 @@ class Validation implements ValidationInterface
 	 *        'field2' => 'error message',
 	 *    ]
 	 *
-	 * @return array
+	 * @return array<string,string>
 	 *
 	 * Excluded from code coverage because that it always run as cli
 	 *

--- a/system/Validation/ValidationInterface.php
+++ b/system/Validation/ValidationInterface.php
@@ -105,7 +105,7 @@ interface ValidationInterface
 	 *        'field2' => 'error message',
 	 *    ]
 	 *
-	 * @return array
+	 * @return array<string,string>
 	 */
 	public function getErrors(): array;
 

--- a/user_guide_src/source/changelogs/v4.1.2.rst
+++ b/user_guide_src/source/changelogs/v4.1.2.rst
@@ -14,6 +14,7 @@ Changes:
 - ``Response::getCookie`` now returns a ``Cookie`` instance instead of an array of cookie attributes.
 - ``Response::getCookies`` now returns an array of ``Cookie`` instances instead of array of array of attributes.
 - To eliminate warnings from modern browsers' consoles, empty samesite values will be defaulted to ``Lax`` on cookie dispatch.
+- `Model::errors()` and `BaseModel::errors()` now always returns `array`; there was no definition change but the docblock has been updated.
 
 Deprecations:
 


### PR DESCRIPTION
**Description**
There is currently a bug where `BaseModel::errors()` returns a `string` error message despite specifying `array|null` as the return type. This is causing runtime errors in `Fabricator` when trying to `implode()` error values (see discussion at #4272).

This PR traces errors back through their two potential sources: `Validation::errors()` and `ConnectionInterface::error()`. These return very different formats (which I have tightened in their docblocks) which `Model` should be handling.

Due to this bug and the preexisting formats from `Validation` and `Connection` I am updating the docblock for `BaseModel::errors` and `Model::errors` no longer to allow `null` because a) null values are never inherited from their sources, they were only set in the model, and b) they introduce an unnecessary extra type check from any calling method. This is already consistent with the User Guide and the function definition but I noted the docblock update in the changelings.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
