### PR TITLE
[UG] Authentication provide clause

### DIFF
--- a/user_guide_src/source/extending/authentication.rst
+++ b/user_guide_src/source/extending/authentication.rst
@@ -11,3 +11,10 @@ Recommendations
 
 * Modules that handle login and logout operations should trigger the ``login`` and ``logout`` Events when successful
 * Modules that define a "current user" should define the function ``user_id()`` to return the user's unique identifier, or ``null`` for "no current user"
+
+Modules that meet these requirements may indicate compatibility with these framework expectations by adding
+the following provision to **composer.json**::
+
+    "provide": {
+        "codeigniter4/authentication-implementation": "1.0",
+    },


### PR DESCRIPTION
**Description**
Authentication interest waxes and wanes over time. It seems like we are on the rise at the moment, for whatever reason. We remain committed to keeping authentication out of the core, but do provide [some recommendations](https://codeigniter4.github.io/CodeIgniter4/extending/authentication.html) for parties that wish to publish authentication components.

This PR defines a new provision `codeigniter/authentication-implementation` so packages can acknowledge their adherence to the recommendations above. This is a weak implementation since we have no actual interfaces but it should a) encourage people to use the recommendations, and b) help firm up some standards.

I would be open to recommendations for a stronger implementation but this seems like the most consistent solution with what we already have published. 

*See also [Composer Schema on provide](https://getcomposer.org/doc/04-schema.md#provide)

**Checklist:**
- [X] Securely signed commits
- n/a Component(s) with PHPdocs
- n/a Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
