### PR TITLE
Bugfix empty Model errors

### DIFF
--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -90,10 +90,8 @@ interface ConnectionInterface
 
 	/**
 	 * Returns the last error encountered by this connection.
-	 *
-	 * Must return an array with keys 'code' and 'message':
-	 *
-	 *  ['code' => string|int, 'message' => string);
+	 * Must return this format: ['code' => string|int, 'message' => string]
+	 * intval(code) === 0 means "no error".
 	 *
 	 * @return array<string,string|int>
 	 */

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -645,10 +645,8 @@ class Connection extends BaseConnection
 
 	/**
 	 * Returns the last error code and message.
-	 *
-	 * Must return an array with keys 'code' and 'message':
-	 *
-	 *  ['code' => string|int, 'message' => string);
+	 * Must return this format: ['code' => string|int, 'message' => string]
+	 * intval(code) === 0 means "no error".
 	 *
 	 * @return array<string,string|int>
 	 */

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -436,10 +436,8 @@ class Connection extends BaseConnection
 
 	/**
 	 * Returns the last error code and message.
-	 *
-	 * Must return an array with keys 'code' and 'message':
-	 *
-	 *  ['code' => string|int, 'message' => string);
+	 * Must return this format: ['code' => string|int, 'message' => string]
+	 * intval(code) === 0 means "no error".
 	 *
 	 * @return array<string,string|int>
 	 */

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -398,10 +398,8 @@ class Connection extends BaseConnection
 
 	/**
 	 * Returns the last error code and message.
-	 *
-	 * Must return an array with keys 'code' and 'message':
-	 *
-	 *  ['code' => string|int, 'message' => string);
+	 * Must return this format: ['code' => string|int, 'message' => string]
+	 * intval(code) === 0 means "no error".
 	 *
 	 * @return array<string,string|int>
 	 */

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -425,10 +425,8 @@ class Connection extends BaseConnection
 
 	/**
 	 * Returns the last error code and message.
-	 *
-	 * Must return an array with keys 'code' and 'message':
-	 *
-	 *  ['code' => string|int, 'message' => string);
+	 * Must return this format: ['code' => string|int, 'message' => string]
+	 * intval(code) === 0 means "no error".
 	 *
 	 * @return array<string,string|int>
 	 */

--- a/system/Model.php
+++ b/system/Model.php
@@ -471,7 +471,13 @@ class Model extends BaseModel
 	 */
 	protected function doErrors()
 	{
+		// $error is always ['code' => string|int, 'message' => string]
 		$error = $this->db->error();
+
+		if (intval($error['code']) === 0)
+		{
+			return [];
+		}
 
 		return [get_class($this->db) => $error['message']];
 	}

--- a/system/Model.php
+++ b/system/Model.php
@@ -474,7 +474,7 @@ class Model extends BaseModel
 		// $error is always ['code' => string|int, 'message' => string]
 		$error = $this->db->error();
 
-		if (intval($error['code']) === 0)
+		if ((int) $error['code'] === 0)
 		{
 			return [];
 		}

--- a/tests/system/Models/ValidationModelTest.php
+++ b/tests/system/Models/ValidationModelTest.php
@@ -17,6 +17,19 @@ final class ValidationModelTest extends LiveModelTestCase
 		$this->createModel(ValidModel::class);
 	}
 
+	public function testValid(): void
+	{
+		$data = [
+			'name'        => 'some name',
+			'description' => 'some great marketing stuff',
+		];
+
+		$this->assertIsInt($this->model->insert($data));
+
+		$errors = $this->model->errors();
+		$this->assertEquals([], $errors);
+	}
+
 	public function testValidationBasics(): void
 	{
 		$data = [


### PR DESCRIPTION
**Description**
While standardizing error formats (#4312) test and I both failed to account for the fact that `ConnectionInterface::errors()` returns content even when there is no error. This extends the work from that PR to define a "no error" value. This is a little awkward because the "no error" value of `code` for each driver varies:
* MySQL: `0`
* SQLite3: `0`
* Postgres: `''`
* SQLSRV: `'00000'`

I settled on `interval(code) === 0` which is consistent with our current drivers and hopefully works with any third-party extensions.

FYI this was yet another bug in the code previous to #4312 because `BaseModel::errors()` would return `null` only when `message` was empty (`return $error['message'] ?? null;`) which was not always the case (e.g. SQLite3 returns `'not an error`').

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
