### PR TITLE
Enforce instanceOf for factory shares

### DIFF
--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -102,18 +102,22 @@ class Factories
 		if (isset(self::$basenames[$options['component']][$basename]))
 		{
 			$class = self::$basenames[$options['component']][$basename];
-		}
-		else
-		{
-			// Try to locate the class
-			if (! $class = self::locateClass($options, $name))
-			{
-				return null;
-			}
 
-			self::$instances[$options['component']][$class]    = new $class(...$arguments);
-			self::$basenames[$options['component']][$basename] = $class;
+			// Need to verify if the shared instance matches the request
+			if (self::verifyInstanceOf($options, $class))
+			{
+				return self::$instances[$options['component']][$class];
+			}
 		}
+
+		// Try to locate the class
+		if (! $class = self::locateClass($options, $name))
+		{
+			return null;
+		}
+
+		self::$instances[$options['component']][$class]    = new $class(...$arguments);
+		self::$basenames[$options['component']][$basename] = $class;
 
 		return self::$instances[$options['component']][$class];
 	}

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -217,6 +217,14 @@ class FactoriesTest extends CIUnitTestCase
 		$this->assertNull($result);
 	}
 
+	public function testSharedRespectsInstanceOf()
+	{
+		Factories::injectMock('widgets', 'SomeWidget', new OtherWidget());
+
+		$result = Factories::widgets('SomeWidget', ['instanceOf' => stdClass::class]);
+		$this->assertInstanceOf(SomeWidget::class, $result);
+	}
+
 	public function testPrioritizesParameterOptions()
 	{
 		Factories::setOptions('widgets', ['instanceOf' => stdClass::class]);


### PR DESCRIPTION
**Description**
This one is a bit obscure but currently `Factories` is failing to check the `instanceOf` option for classes that match an existing shared instance. An example:
```
namespace Bar\Models
class UserModel
{
}

=======

namespace Foo\Models;
class UserModel
{
}

=======

$model = Factories::model('UserModel'); // Bar\Models\UserModel
$model = Factories::model('UserModel', ['instanceOf' => 'Foo\Models\UserModel']); // Bar\Models\UserModel
```

This PR adds a test to demonstrate the issue and fixes it by running shared instances through the `verifyInstanceOf()` method.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
