### PR TITLE
fix setPrefix() sample

### DIFF
--- a/user_guide_src/source/database/queries.rst
+++ b/user_guide_src/source/database/queries.rst
@@ -69,7 +69,7 @@ the following::
 If for any reason you would like to change the prefix programmatically
 without needing to create a new connection you can use this method::
 
-    $db->setPrefix('newprefix');
+    $db->setPrefix('newprefix_');
     $db->prefixTable('tablename'); // outputs newprefix_tablename
 
 You can get the current prefix any time with this method::


### PR DESCRIPTION
**Description**
The expected is `newprefix_tablename` but the steps produce `newprefixtablename`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
