### PR TITLE
Resolve DB test trait conflicts

### DIFF
--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -13,6 +13,10 @@ namespace CodeIgniter\Test;
 
 use CodeIgniter\CodeIgniter;
 use CodeIgniter\Config\Factories;
+use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\MigrationRunner;
+use CodeIgniter\Database\Seeder;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Session\Handlers\ArrayHandler;
 use CodeIgniter\Test\Mock\MockCache;
@@ -23,14 +27,14 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 
 /**
- * PHPunit test case.
+ * Framework test case for PHPUnit.
  */
 abstract class CIUnitTestCase extends TestCase
 {
 	use ReflectionHelper;
 
 	/**
-	 * @var \CodeIgniter\CodeIgniter
+	 * @var CodeIgniter
 	 */
 	protected $app;
 
@@ -52,6 +56,101 @@ abstract class CIUnitTestCase extends TestCase
 	 * @var array of methods
 	 */
 	protected $tearDownMethods = [];
+
+	//--------------------------------------------------------------------
+	// Database Properties
+	//--------------------------------------------------------------------
+
+	/**
+	 * Should run db migration?
+	 *
+	 * @var boolean
+	 */
+	protected $migrate = true;
+
+	/**
+	 * Should run db migration only once?
+	 *
+	 * @var boolean
+	 */
+	protected $migrateOnce = false;
+
+	/**
+	 * Should run seeding only once?
+	 *
+	 * @var boolean
+	 */
+	protected $seedOnce = false;
+
+	/**
+	 * Should the db be refreshed before test?
+	 *
+	 * @var boolean
+	 */
+	protected $refresh = true;
+
+	/**
+	 * The seed file(s) used for all tests within this test case.
+	 * Should be fully-namespaced or relative to $basePath
+	 *
+	 * @var string|array
+	 */
+	protected $seed = '';
+
+	/**
+	 * The path to the seeds directory.
+	 * Allows overriding the default application directories.
+	 *
+	 * @var string
+	 */
+	protected $basePath = SUPPORTPATH . 'Database';
+
+	/**
+	 * The namespace(s) to help us find the migration classes.
+	 * Empty is equivalent to running `spark migrate -all`.
+	 * Note that running "all" runs migrations in date order,
+	 * but specifying namespaces runs them in namespace order (then date)
+	 *
+	 * @var string|array|null
+	 */
+	protected $namespace = 'Tests\Support';
+
+	/**
+	 * The name of the database group to connect to.
+	 * If not present, will use the defaultGroup.
+	 *
+	 * @var string
+	 */
+	protected $DBGroup = 'tests';
+
+	/**
+	 * Our database connection.
+	 *
+	 * @var BaseConnection
+	 */
+	protected $db;
+
+	/**
+	 * Migration Runner instance.
+	 *
+	 * @var MigrationRunner|mixed
+	 */
+	protected $migrations;
+
+	/**
+	 * Seeder instance
+	 *
+	 * @var Seeder
+	 */
+	protected $seeder;
+
+	/**
+	 * Stores information needed to remove any
+	 * rows inserted via $this->hasInDatabase();
+	 *
+	 * @var array
+	 */
+	protected $insertCache = [];
 
 	//--------------------------------------------------------------------
 	// Staging
@@ -80,6 +179,15 @@ abstract class CIUnitTestCase extends TestCase
 		{
 			$this->$method();
 		}
+
+		// Check for methods added by DatabaseTestTrait
+		if (isset($this->setUpMethodsDatabase) && is_array($this->setUpMethodsDatabase))
+		{
+			foreach ($this->setUpMethodsDatabase as $method)
+			{
+				$this->$method();
+			}
+		}
 	}
 
 	protected function tearDown(): void
@@ -89,6 +197,15 @@ abstract class CIUnitTestCase extends TestCase
 		foreach ($this->tearDownMethods as $method)
 		{
 			$this->$method();
+		}
+
+		// Check for methods added by DatabaseTestTrait
+		if (isset($this->tearDownMethodsDatabase) && is_array($this->tearDownMethodsDatabase))
+		{
+			foreach ($this->tearDownMethodsDatabase as $method)
+			{
+				$this->$method();
+			}
 		}
 	}
 
@@ -312,6 +429,110 @@ abstract class CIUnitTestCase extends TestCase
 		{
 			return false;
 		}
+	}
+
+	//--------------------------------------------------------------------
+	// Database
+	//--------------------------------------------------------------------
+
+	/**
+	 * Asserts that records that match the conditions in $where do
+	 * not exist in the database.
+	 *
+	 * @param string $table
+	 * @param array  $where
+	 *
+	 * @return void
+	 */
+	public function dontSeeInDatabase(string $table, array $where)
+	{
+		$count = $this->db->table($table)
+						  ->where($where)
+						  ->countAllResults();
+
+		$this->assertTrue($count === 0, 'Row was found in database');
+	}
+
+	/**
+	 * Asserts that records that match the conditions in $where DO
+	 * exist in the database.
+	 *
+	 * @param string $table
+	 * @param array  $where
+	 *
+	 * @return void
+	 * @throws DatabaseException
+	 */
+	public function seeInDatabase(string $table, array $where)
+	{
+		$count = $this->db->table($table)
+						  ->where($where)
+						  ->countAllResults();
+
+		$this->assertTrue($count > 0, 'Row not found in database: ' . $this->db->showLastQuery());
+	}
+
+	/**
+	 * Fetches a single column from a database row with criteria
+	 * matching $where.
+	 *
+	 * @param string $table
+	 * @param string $column
+	 * @param array  $where
+	 *
+	 * @return boolean
+	 * @throws DatabaseException
+	 */
+	public function grabFromDatabase(string $table, string $column, array $where)
+	{
+		$query = $this->db->table($table)
+						  ->select($column)
+						  ->where($where)
+						  ->get();
+
+		$query = $query->getRow();
+
+		return $query->$column ?? false;
+	}
+
+	/**
+	 * Inserts a row into to the database. This row will be removed
+	 * after the test has run.
+	 *
+	 * @param string $table
+	 * @param array  $data
+	 *
+	 * @return boolean
+	 */
+	public function hasInDatabase(string $table, array $data)
+	{
+		$this->insertCache[] = [
+			$table,
+			$data,
+		];
+
+		return $this->db->table($table)
+						->insert($data);
+	}
+
+	/**
+	 * Asserts that the number of rows in the database that match $where
+	 * is equal to $expected.
+	 *
+	 * @param integer $expected
+	 * @param string  $table
+	 * @param array   $where
+	 *
+	 * @return void
+	 * @throws DatabaseException
+	 */
+	public function seeNumRecords(int $expected, string $table, array $where)
+	{
+		$count = $this->db->table($table)
+						  ->where($where)
+						  ->countAllResults();
+
+		$this->assertEquals($expected, $count, 'Wrong number of matching rows in database.');
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Database/Live/DatabaseTestTraitCaseTest.php
+++ b/tests/system/Database/Live/DatabaseTestTraitCaseTest.php
@@ -1,12 +1,15 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class CIDbTestCaseTest extends CIDatabaseTestCase
+class DatabaseTestTraitCaseTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';


### PR DESCRIPTION
**Description**
This splits the properties out of DatabaseTestTrait to resolve trait conflicts introduced during #4335. I also took the liberty of moving the test methods back to `CIUnitTestCase` since that seemed to be the original intent.

This PR leverages two new internal properties to work around the property conflict: `setUpMethodsDatabase` and `tearDownMethodsDatabase`. I've marked them as internal because I would like these to go away when we get around to refactoring the entire test suite.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
