### PR TITLE
[WIP] Implement escape defaults in the Model

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -693,10 +693,11 @@ class Model extends BaseModel
 				$data = $this->transformDataToArray($data, 'insert');
 				$data = array_merge($this->tempData['data'], $data);
 			}
+
+			$this->escape   = $this->tempData['escape'] ?? [];
+			$this->tempData = [];
 		}
 
-		$this->escape   = $this->tempData['escape'] ?? [];
-		$this->tempData = [];
 
 		return parent::insert($data, $returnID);
 	}
@@ -725,10 +726,11 @@ class Model extends BaseModel
 				$data = $this->transformDataToArray($data, 'update');
 				$data = array_merge($this->tempData['data'], $data);
 			}
+
+			$this->escape   = $this->tempData['escape'] ?? [];
+			$this->tempData = [];
 		}
 
-		$this->escape   = $this->tempData['escape'] ?? [];
-		$this->tempData = [];
 
 		return parent::update($id, $data);
 	}


### PR DESCRIPTION
Currently, if you have in your model defined the $escape property, it will be ignored when doing a insert or update operation (see [this](https://github.com/codeigniter4/CodeIgniter4/issues/4339) issue).

I'm attempting to fix this by moving those statements inside the conditional above because they don't seem to make sense outsite thus ocasioning the issue.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs (do not apply)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide

