### PR TITLE
Fix incorrect html output caused by escaping

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -1173,7 +1173,7 @@ if (! function_exists('stringify_attributes'))
 
 		foreach ($attributes as $key => $val)
 		{
-			$atts .= ($js) ? $key . '=' . esc($val, 'js') . ',' : ' ' . $key . '="' . esc($val, 'attr') . '"';
+			$atts .= ($js) ? $key . '=' . esc($val, 'js') . ',' : ' ' . $key . '="' . esc($val) . '"';
 		}
 
 		return rtrim($atts, ',');

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -944,7 +944,7 @@ if (! function_exists('parse_form_attributes'))
 				{
 					continue;
 				}
-				$att .= $key . '="' . $val . '"' . ($val === end($default) ? '' : ' ');
+				$att .= $key . '="' . $val . '"' . ($key === array_key_last($default) ? '' : ' ');
 			}
 			else
 			{

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -110,7 +110,7 @@ if (! function_exists('form_open_multipart'))
 	{
 		if (is_string($attributes))
 		{
-			$attributes .= ' enctype="' . esc('multipart/form-data', 'attr') . '"';
+			$attributes .= ' enctype="' . esc('multipart/form-data') . '"';
 		}
 		else
 		{

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -213,7 +213,7 @@ EOH;
 			$Value    = csrf_hash();
 			$Name     = csrf_token();
 			$expected = <<<EOH
-<form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" enctype="multipart&#x2F;form-data" accept-charset="utf-8">
+<form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" enctype="multipart/form-data" accept-charset="utf-8">
 <input type="hidden" name="$Name" value="$Value" style="display:none;" />
 
 EOH;
@@ -221,7 +221,7 @@ EOH;
 		else
 		{
 			$expected = <<<EOH
-<form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" enctype="multipart&#x2F;form-data" accept-charset="utf-8">
+<form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" enctype="multipart/form-data" accept-charset="utf-8">
 
 EOH;
 		}
@@ -290,6 +290,22 @@ EOH;
 			'style'     => 'width:50%',
 		];
 		$this->assertEquals($expected, form_input($data));
+	}
+
+	public function testFormInputWithExtra()
+	{
+		$expected = <<<EOH
+<input type="email" name="identity" value="" id="identity" class="form-control form-control-lg" />\n
+EOH;
+		$data = [
+			'id'   => 'identity',
+			'name' => 'identity',
+			'type' => 'email',
+		];
+		$extra = [
+			'class' => 'form-control form-control-lg',
+		];
+		$this->assertEquals($expected, form_input($data, '', $extra));
 	}
 
 	// ------------------------------------------------------------------------

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -722,6 +722,12 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 				'<a href="http://example.com">http://example.com</a>',
 				'/',
 			],
+			'noindex08' => [
+				'<a href="http://example.com" class="btn btn-primary">http://example.com</a>',
+				'',
+				'',
+				['class' => 'btn btn-primary'],
+			],
 		];
 	}
 
@@ -800,7 +806,7 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 				'title="News title"',
 			],
 			'egpage02' => [
-				'<a href="http://example.com/index.php/news/local/123" title="The&#x20;best&#x20;news&#x21;">My News</a>',
+				'<a href="http://example.com/index.php/news/local/123" title="The best news!">My News</a>',
 				'news/local/123',
 				'My News',
 				['title' => 'The best news!'],
@@ -897,7 +903,7 @@ class URLHelperTest extends \CodeIgniter\Test\CIUnitTestCase
 				'Click Here to Contact Me',
 			],
 			'page02' => [
-				'<a href="mailto:me@my-site.com" title="Mail&#x20;me">Contact Me</a>',
+				'<a href="mailto:me@my-site.com" title="Mail me">Contact Me</a>',
 				'me@my-site.com',
 				'Contact Me',
 				['title' => 'Mail me'],


### PR DESCRIPTION
**Description**
Supersedes and closes #4298
fixes #4235 


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
