### PR TITLE
Authentication: Add Packagist link

### DIFF
--- a/user_guide_src/source/extending/authentication.rst
+++ b/user_guide_src/source/extending/authentication.rst
@@ -12,9 +12,10 @@ Recommendations
 * Modules that handle login and logout operations should trigger the ``login`` and ``logout`` Events when successful
 * Modules that define a "current user" should define the function ``user_id()`` to return the user's unique identifier, or ``null`` for "no current user"
 
-Modules that meet these requirements may indicate compatibility with these framework expectations by adding
-the following provision to **composer.json**::
+Modules that fulfill these recommendations may indicate compatibility by adding the following provision to **composer.json**::
 
     "provide": {
-        "codeigniter4/authentication-implementation": "1.0",
+        "codeigniter4/authentication-implementation": "1.0"
     },
+
+You may view a list of modules that provide this implementation on `Packagist <https://packagist.org/providers/codeigniter4/authentication-implementation>`_.


### PR DESCRIPTION
**Description**
A slight extension to the Composer provision as recommended by @agungsugiarto.

**Checklist:**
- [X] Securely signed commits
- n/a Component(s) with PHPdocs
- n/a Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
