### PR TITLE
Fixes IDE errors on Model/BaseModel

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -12,12 +12,14 @@
 namespace CodeIgniter;
 
 use Closure;
+use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\BaseResult;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Pager\Pager;
+use CodeIgniter\Validation\Validation;
 use CodeIgniter\Validation\ValidationInterface;
 use Config\Services;
 use InvalidArgumentException;
@@ -44,8 +46,6 @@ use stdClass;
  */
 abstract class BaseModel
 {
-	// region Properties
-
 	/**
 	 * Pager instance.
 	 * Populated after calling $this->paginate()
@@ -160,7 +160,7 @@ abstract class BaseModel
 	/**
 	 * Database Connection
 	 *
-	 * @var object
+	 * @var BaseConnection
 	 */
 	protected $db;
 
@@ -200,7 +200,7 @@ abstract class BaseModel
 	/**
 	 * Our validator instance.
 	 *
-	 * @var ValidationInterface
+	 * @var Validation
 	 */
 	protected $validation;
 
@@ -288,10 +288,6 @@ abstract class BaseModel
 	 */
 	protected $afterDelete = [];
 
-	// endregion
-
-	// region Constructor
-
 	/**
 	 * BaseModel constructor.
 	 *
@@ -302,12 +298,12 @@ abstract class BaseModel
 		$this->tempReturnType     = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
 		$this->tempAllowCallbacks = $this->allowCallbacks;
-		$this->validation         = $validation ?? Services::validation(null, false);
+
+		/** @var Validation $validation */
+		$validation = $validation ?? Services::validation(null, false);
+
+		$this->validation = $validation;
 	}
-
-	// endregion
-
-	// region Abstract Methods
 
 	/**
 	 * Fetches the row of database
@@ -482,10 +478,6 @@ abstract class BaseModel
 	 * @throws DataException
 	 */
 	abstract public function chunk(int $size, Closure $userFunc);
-
-	// endregion
-
-	// region CRUD & Finders
 
 	/**
 	 * Fetches the row of database
@@ -1105,10 +1097,6 @@ abstract class BaseModel
 		return $this->doErrors();
 	}
 
-	// endregion
-
-	// region Pager
-
 	/**
 	 * Works with Pager to get the size and offset parameters.
 	 * Expects a GET variable (?page=2) that specifies the page of results
@@ -1138,10 +1126,6 @@ abstract class BaseModel
 
 		return $this->findAll($perPage, $offset);
 	}
-
-	// endregion
-
-	// region Allowed Fields
 
 	/**
 	 * It could be used when you have to change default or override current allowed fields.
@@ -1207,10 +1191,6 @@ abstract class BaseModel
 
 		return $data;
 	}
-
-	// endregion
-
-	// region Timestamps
 
 	/**
 	 * Sets the date or current date if null value is passed
@@ -1285,10 +1265,6 @@ abstract class BaseModel
 				return (string) $value;
 		}
 	}
-
-	// endregion
-
-	// region Validation
 
 	/**
 	 * Set the value of the skipValidation flag.
@@ -1432,7 +1408,6 @@ abstract class BaseModel
 		// or an array of rules.
 		if (is_string($rules))
 		{
-			// @phpstan-ignore-next-line
 			$rules = $this->validation->loadRuleGroup($rules);
 		}
 
@@ -1486,10 +1461,6 @@ abstract class BaseModel
 
 		return $rules;
 	}
-
-	// endregion
-
-	// region Callbacks
 
 	/**
 	 * Sets $tempAllowCallbacks value so that we can temporarily override
@@ -1548,10 +1519,6 @@ abstract class BaseModel
 
 		return $eventData;
 	}
-
-	// endregion
-
-	// region Utility
 
 	/**
 	 * Sets the return type of the results to be as an associative array.
@@ -1702,10 +1669,6 @@ abstract class BaseModel
 		return $data;
 	}
 
-	// endregion
-
-	// region Magic
-
 	/**
 	 * Provides the db connection and model's properties.
 	 *
@@ -1761,10 +1724,6 @@ abstract class BaseModel
 
 		return null;
 	}
-
-	// endregion
-
-	// region Deprecated
 
 	/**
 	 * Replace any placeholders within the rules with the values that
@@ -1826,6 +1785,4 @@ abstract class BaseModel
 
 		return $rules;
 	}
-
-	// endregion
 }

--- a/system/Model.php
+++ b/system/Model.php
@@ -39,14 +39,10 @@ use ReflectionProperty;
  *      - allow intermingling calls to the builder
  *      - removes the need to use Result object directly in most cases
  *
- * @property ConnectionInterface $db
- *
  * @mixin BaseBuilder
  */
 class Model extends BaseModel
 {
-	// region Properties
-
 	/**
 	 * Name of database table
 	 *
@@ -92,10 +88,6 @@ class Model extends BaseModel
 	 */
 	protected $escape = [];
 
-	// endregion
-
-	// region Constructor
-
 	/**
 	 * Model constructor.
 	 *
@@ -106,19 +98,11 @@ class Model extends BaseModel
 	{
 		parent::__construct($validation);
 
-		if (is_null($db))
-		{
-			$this->db = Database::connect($this->DBGroup);
-		}
-		else
-		{
-			$this->db = &$db;
-		}
+		/** @var BaseConnection $db */
+		$db = $db ?? Database::connect($this->DBGroup);
+
+		$this->db = &$db;
 	}
-
-	// endregion
-
-	// region Setters
 
 	/**
 	 * Specify the table associated with a model
@@ -133,10 +117,6 @@ class Model extends BaseModel
 
 		return $this;
 	}
-
-	// endregion
-
-	// region Database Methods
 
 	/**
 	 * Fetches the row of database from $this->table with a primary key
@@ -283,7 +263,6 @@ class Model extends BaseModel
 			}
 			else
 			{
-				// @phpstan-ignore-next-line
 				$this->insertID = $this->db->insertID();
 			}
 		}
@@ -400,9 +379,7 @@ class Model extends BaseModel
 					);
 				}
 
-				// @codeCoverageIgnoreStart
-				return false;
-				// @codeCoverageIgnoreEnd
+				return false; // @codeCoverageIgnore
 			}
 
 			$set[$this->deletedField] = $this->setDate();
@@ -573,10 +550,6 @@ class Model extends BaseModel
 		return $this->builder()->testMode($test)->countAllResults($reset);
 	}
 
-	// endregion
-
-	// region Builder
-
 	/**
 	 * Provides a shared instance of the Query Builder.
 	 *
@@ -650,12 +623,6 @@ class Model extends BaseModel
 
 		return $this;
 	}
-
-	// endregion
-
-	// region Overrides
-
-	// region CRUD & Finders
 
 	/**
 	 * This method is called on save to determine if entry have to be updated
@@ -740,10 +707,6 @@ class Model extends BaseModel
 		return parent::update($id, $data);
 	}
 
-	// endregion
-
-	// region Utility
-
 	/**
 	 * Takes a class an returns an array of it's public and protected
 	 * properties as an array with raw values.
@@ -769,10 +732,6 @@ class Model extends BaseModel
 
 		return $properties;
 	}
-
-	// endregion
-
-	// region Magic
 
 	/**
 	 * Provides/instantiates the builder/db connection and model's table/primary key names and return type.
@@ -850,12 +809,6 @@ class Model extends BaseModel
 		return $result;
 	}
 
-	// endregion
-
-	// endregion
-
-	// region Deprecated
-
 	/**
 	 * Takes a class an returns an array of it's public and protected
 	 * properties as an array suitable for use in creates and updates.
@@ -931,7 +884,4 @@ class Model extends BaseModel
 
 		return $properties;
 	}
-
-	// endregion
-
 }


### PR DESCRIPTION
**Description**
Fixes the IDE errors reported by Intelephense on `Model` and `BaseModel`. This is on `$db` and `$validation`.

Fixes #4329 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Conforms to style guide
