### PR TITLE
Remove PHPStan ignoreErrors: Unsafe usage of new static()

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -47,7 +47,6 @@ parameters:
 		- '#Return type \(bool\) of method CodeIgniter\\Log\\Logger::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\)#'
 		- '#Return type \(bool\) of method CodeIgniter\\HTTP\\Files\\UploadedFile::move\(\) should be compatible with return type \(CodeIgniter\\Files\\File\) of method CodeIgniter\\Files\\File::move\(\)#'
 		- '#Return type \(bool\) of method CodeIgniter\\Test\\TestLogger::log\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::log\(\)#'
-		- '#Unsafe usage of new static\(\)*#'
 	parallel:
 		processTimeout: 300.0
 	scanDirectories:

--- a/system/Cache/Exceptions/CacheException.php
+++ b/system/Cache/Exceptions/CacheException.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Cache\Exceptions;
 
 use CodeIgniter\Exceptions\DebugTraceableTrait;
+use CodeIgniter\Exceptions\ExceptionInterface;
 use RuntimeException;
 
 /**

--- a/system/Cache/Exceptions/ExceptionInterface.php
+++ b/system/Cache/Exceptions/ExceptionInterface.php
@@ -16,6 +16,8 @@ namespace CodeIgniter\Cache\Exceptions;
  * of all framework-related exceptions.
  *
  * catch (\CodeIgniter\Cache\Exceptions\ExceptionInterface) { ... }
+ *
+ * @deprecated 4.1.2
  */
 interface ExceptionInterface
 {

--- a/system/Exceptions/DebugTraceableTrait.php
+++ b/system/Exceptions/DebugTraceableTrait.php
@@ -20,7 +20,7 @@ trait DebugTraceableTrait
 	 * @param integer        $code
 	 * @param Throwable|null $previous
 	 */
-	public function __construct(string $message = '', int $code = 0, Throwable $previous = null)
+	final public function __construct(string $message = '', int $code = 0, Throwable $previous = null)
 	{
 		parent::__construct($message, $code, $previous);
 

--- a/system/Exceptions/DebugTraceableTrait.php
+++ b/system/Exceptions/DebugTraceableTrait.php
@@ -28,7 +28,10 @@ trait DebugTraceableTrait
 
 		if (isset($trace['class']) && $trace['class'] === static::class)
 		{
-			['line' => $this->line, 'file' => $this->file] = $trace;
+			[
+				'line' => $this->line,
+				'file' => $this->file,
+			] = $trace;
 		}
 	}
 }

--- a/system/HTTP/Cookie/Cookie.php
+++ b/system/HTTP/Cookie/Cookie.php
@@ -252,7 +252,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
 	 *
 	 * @throws CookieException
 	 */
-	public function __construct(
+	final public function __construct(
 		string $name,
 		string $value = '',
 		$expires = 0,

--- a/system/HTTP/Cookie/CookieStore.php
+++ b/system/HTTP/Cookie/CookieStore.php
@@ -66,7 +66,7 @@ class CookieStore implements Countable, IteratorAggregate
 	 *
 	 * @throws CookieException
 	 */
-	public function __construct(array $cookies)
+	final public function __construct(array $cookies)
 	{
 		$this->validateCookies($cookies);
 


### PR DESCRIPTION
**Description**
Removes PHPStan ignoreErrors: `Unsafe usage of new static()`.

See <https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static>.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
