### PR TITLE
Routes. Option to lower route priority

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -197,6 +197,13 @@ class RouteCollection implements RouteCollectionInterface
 	 */
 	protected $moduleConfig;
 
+	/**
+	 * Flag for sorting routes by priority.
+	 *
+	 * @var boolean
+	 */
+	protected $enablePrioritySorting = false;
+
 	//--------------------------------------------------------------------
 
 	/**
@@ -1592,4 +1599,27 @@ class RouteCollection implements RouteCollectionInterface
 
 		return $options;
 	}
+
+	/**
+	 * Enables sorting routes by priority
+	 *
+	 * @return $this
+	 */
+	public function enablePrioritySorting(): RouteCollectionInterface
+	{
+		$this->enablePrioritySorting = true;
+
+		return $this;
+	}
+
+	/**
+	 * Returns the sorting status of routes by priority. Enabled or not.
+	 *
+	 * @return boolean
+	 */
+	public function isPrioritySortingEnabled(): bool
+	{
+		return  $this->enablePrioritySorting;
+	}
+
 }

--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -244,4 +244,18 @@ interface RouteCollectionInterface
 	public function getRedirectCode(string $from): int;
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * Enables sorting routes by priority
+	 *
+	 * @return $this
+	 */
+	public function enablePrioritySorting() : self;
+
+	/**
+	 * Returns the sorting status of routes by priority. Enabled or not.
+	 *
+	 * @return boolean
+	 */
+	public function isPrioritySortingEnabled() : bool;
 }

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -382,6 +382,21 @@ class Router implements RouterInterface
 			? $uri
 			: ltrim($uri, '/ ');
 
+		// sorting routes by priority
+		if ($this->collection->isPrioritySortingEnabled())
+		{
+			$order = [];
+
+			foreach ($routes as $key => $value)
+			{
+				$key                    = $key === '/' ? $key : ltrim($key, '/ ');
+				$priority               = $this->collection->getRoutesOptions($key)['order'] ?? 0;
+				$order[$priority][$key] = $value;
+			}
+			ksort($order);
+			$routes = array_merge(...$order);
+		}
+
 		// Loop through the route array looking for wildcards
 		foreach ($routes as $key => $val)
 		{

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -452,6 +452,27 @@ class RouterTest extends \CodeIgniter\Test\CIUnitTestCase
 		$this->assertEquals('auth_post', $router->methodName());
 	}
 
+	public function testRoutePriorityOrder()
+	{
+		$this->collection->add('main', 'Main::index');
+		$this->collection->add('(.*)', 'Main::wildcard', ['order' => 1]);
+		$this->collection->add('module', 'Module::index');
+
+		$router = new Router($this->collection, $this->request);
+
+		$this->collection->setHTTPVerb('get');
+
+		$router->handle('module');
+		$this->assertEquals('\Main', $router->controllerName());
+		$this->assertEquals('wildcard', $router->methodName());
+
+		$this->collection->enablePrioritySorting();
+
+		$router->handle('module');
+		$this->assertEquals('\Module', $router->controllerName());
+		$this->assertEquals('index', $router->methodName());
+	}
+
 	/**
 	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/1564
 	 */

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -427,6 +427,26 @@ be used when the first parameter is a language string::
     // Creates:
     $routes['users/(:num)'] = 'users/show/$2';
 
+.. _priority:
+
+Routes priority
+---------------
+
+When working with modules, it can be a problem if the routes in the application contain windcards.
+Then the module routes will not be processed correctly.
+You can solve this problem by lowering the priority of the route using the `` order`` option::
+
+    // First you need to enable sorting.
+    $routes->enablePrioritySorting();
+
+    // App\Config\Routes
+    $routes->add('(.*)', 'Posts::index', ['order' => 1]);
+
+    // Modules\Acme\Config\Routes
+    $routes->add('admin', 'Admin::index');
+
+    // The "admin" route will now be processed before the wildcard router.
+
 Routes Configuration Options
 ============================
 
@@ -518,3 +538,15 @@ a valid class/method pair, just like you would show in any route, or a Closure::
     {
         echo view('my_errors/not_found.html');
     });
+
+
+Enabled router priority
+-----------------------
+
+Enabling the priority of applying routes. For more information see :ref:`priority`
+
+::
+
+    $routes->enablePrioritySorting();
+
+

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -447,6 +447,11 @@ You can solve this problem by lowering the priority of the route using the `` or
 
     // The "admin" route will now be processed before the wildcard router.
 
+
+.. note:: By default, all routes have a priority of 0.
+The higher the number specified in "order", the lower the priority of the route.
+
+
 Routes Configuration Options
 ============================
 


### PR DESCRIPTION
**Description**
Work with modules was added in CI4, but the following issue is not resolved.
A situation may arise when an application route containing a wildcard will process routes specified in the module. 

Example 
```php
// App\Config\Routes.php
$routes->add('(.*)', 'MainController::wildcard');

// Modules\Acme\Config\Routes.php
$routes->add('admin', 'AdminController::index');
```
In this case, the URL __/admin__ will be handled by the route __$routes->add('(. *)', 'MainController :: wildcard');__

This PR adds an option that can lower the priority of the route. 

```php
// App\Config\Routes.php
$routes->add('(.*)', 'MainController::wildcard', ['order' => 1]);

// Modules\Acme\Config\Routes.php
$routes->add('admin', 'AdminController::index');
```
Now the URL __/admin__ will be handled by the route __$routes->add('admin', 'AdminController::index');__

Changes:
* Added "order" option to lower route priority.
* Sorting by priority is disabled by default.
* Added methods to RouteCollectionInterface: RouteCollectionInterface::enablePrioritySorting() and RouteCollectionInterface::isPrioritySortingEnabled().

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
