### PR TITLE
WIP: Entity - Properly handle only changed in recursive toArray()/toRawArray()

### DIFF
--- a/system/Entity.php
+++ b/system/Entity.php
@@ -151,9 +151,10 @@ class Entity implements JsonSerializable
 
 			if ($recursive)
 			{
+				//@todo: handle arrays of entities
 				if ($return[$key] instanceof Entity)
 				{
-					$return[$key] = $return[$key]->toArray($onlyChanged, $cast, $recursive);
+					$return[$key] = $return[$key]->toArray(false, $cast, $recursive);
 				}
 				elseif (is_callable([$return[$key], 'toArray']))
 				{
@@ -184,10 +185,11 @@ class Entity implements JsonSerializable
 		{
 			if ($recursive)
 			{
-				return array_map(function ($value) use ($onlyChanged, $recursive) {
+				return array_map(function ($value) use ($recursive) {
+					//@todo: handle arrays of entities
 					if ($value instanceof Entity)
 					{
-						$value = $value->toRawArray($onlyChanged, $recursive);
+						$value = $value->toRawArray(false, $recursive);
 					}
 					elseif (is_callable([$value, 'toRawArray']))
 					{
@@ -209,9 +211,10 @@ class Entity implements JsonSerializable
 
 			if ($recursive)
 			{
+				//@todo: handle arrays of entities
 				if ($value instanceof Entity)
 				{
-					$value = $value->toRawArray($onlyChanged, $recursive);
+					$value = $value->toRawArray(false, $recursive);
 				}
 				elseif (is_callable([$value, 'toRawArray']))
 				{
@@ -252,6 +255,15 @@ class Entity implements JsonSerializable
 		// If no parameter was given then check all attributes
 		if ($key === null)
 		{
+			//We need to check if any inner entities has changed
+			foreach ($this->attributes as $attribute)
+			{
+				//@todo: handle arrays of entities
+				if ($attribute instanceof Entity && $attribute->hasChanged())
+				{
+					return true;
+				}
+			}
 			return     $this->original !== $this->attributes;
 		}
 
@@ -267,6 +279,11 @@ class Entity implements JsonSerializable
 			return true;
 		}
 
+		// If attribute is inner entity we need if it has changed
+		if ($this->attributes[$key] instanceof Entity)
+		{
+			return $this->attributes[$key]->hasChanged();
+		}
 		return $this->original[$key] !== $this->attributes[$key];
 	}
 

--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -807,6 +807,43 @@ class EntityTest extends CIUnitTestCase
 		]);
 	}
 
+	public function testToRawArrayRecursiveOnlyChanged()
+	{
+		$entity         = $this->getEntity();
+		$entity->entity = $this->getEntity();
+
+		$result = $entity->toRawArray(true, true);
+
+		$this->assertEquals($result, [
+			'entity' => [
+				'foo'        => null,
+				'bar'        => null,
+				'default'    => 'sumfin',
+				'created_at' => null,
+			],
+		]);
+	}
+
+	public function testToRawArrayRecursiveOnlyChangedInner()
+	{
+		$entity         = $this->getEntity();
+		$entity->entity = $this->getEntity();
+		$entity->syncOriginal();
+
+		$entity->entity->foo = 'bar';
+
+		$result = $entity->toRawArray(true, true);
+
+		$this->assertEquals([
+			'entity' => [
+				'foo'        => 'bar',
+				'bar'        => null,
+				'default'    => 'sumfin',
+				'created_at' => null,
+			],
+		], $result);
+	}
+
 	//--------------------------------------------------------------------
 
 	public function testFilledConstruction()


### PR DESCRIPTION
**Description**
Related to #4360 pointed out by @iRedds 

When recursive parameter was introduced in those methods the intended purpose was to be able to generate json to be returned in for example Ajax responses.

It was not planned that at some point those will be used to write data in the db as it is impossible to write arrays directly in SQL. But now with the introduction on BaseModel we have means to write entities in NoSQL database as nested objects.

The issue with NoSQL and nested object is that methods for updating the nested objects are very different for each database so the only feasible solution is not to update the inner values but instead do complete replace of the nested object in the root document. 

So the use of recursive option in those methods should always return the complete data array even if only single attribute of the nested object is changed. 

Models which are going to implement methods for partially updating the nested objects should be developed using non recursive version of such methods and handling the inner object updates manually inside the model logic.

For the time being this ads support for properly handling nested Entity objects in hasChanges() methods and converts single objects to arrays in both toArray() and toRawArray() methods.

But in the meantime I noticed another issue with the recursive parameter. In the current state it's not possible to do a recursive conversion on attributes which are arrays of entity objects and such cases have to be handled properly. So the work on this continues. 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

  
