### PR TITLE
use DatabaseTestTrait CIUnitTestCase instead CIDatabaseTestCase

### DIFF
--- a/admin/module/tests/README.md
+++ b/admin/module/tests/README.md
@@ -75,7 +75,7 @@ HTML code coverage reports.
 Every test needs a *test case*, or class that your tests extend. CodeIgniter 4
 provides a few that you may use directly:
 * `CodeIgniter\Test\CIUnitTestCase` - for basic tests with no other service needs
-* `CodeIgniter\Test\CIDatabaseTestCase` - for tests that need database access
+* `CodeIgniter\Test\DatabaseTestTrait` - for tests that need database access
 
 Most of the time you will want to write your own test cases to hold functions and services
 common to your test suites.

--- a/admin/module/tests/_support/DatabaseTestCase.php
+++ b/admin/module/tests/_support/DatabaseTestCase.php
@@ -1,7 +1,11 @@
 <?php namespace Tests\Support;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
-class DatabaseTestCase extends \CodeIgniter\Test\CIDatabaseTestCase
+class DatabaseTestCase extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	/**
 	 * Should the database be refreshed before each test?
 	 *

--- a/admin/starter/tests/README.md
+++ b/admin/starter/tests/README.md
@@ -80,7 +80,7 @@ HTML code coverage reports.
 Every test needs a *test case*, or class that your tests extend. CodeIgniter 4
 provides a few that you may use directly:
 * `CodeIgniter\Test\CIUnitTestCase` - for basic tests with no other service needs
-* `CodeIgniter\Test\CIDatabaseTestCase` - for tests that need database access
+* `CodeIgniter\Test\DatabaseTestTrait` - for tests that need database access
 
 Most of the time you will want to write your own test cases to hold functions and services
 common to your test suites.

--- a/admin/starter/tests/_support/DatabaseTestCase.php
+++ b/admin/starter/tests/_support/DatabaseTestCase.php
@@ -1,7 +1,12 @@
 <?php namespace Tests\Support;
 
-class DatabaseTestCase extends \CodeIgniter\Test\CIDatabaseTestCase
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+
+class DatabaseTestCase extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	/**
 	 * Should the database be refreshed before each test?
 	 *

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
@@ -1,6 +1,7 @@
 <?php namespace CodeIgniter\Database\DatabaseTestCase;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
 use Config\Services;
 
@@ -10,8 +11,10 @@ use Config\Services;
  *
  * @group DatabaseLive
  */
-class DatabaseTestCaseMigrationOnce1Test extends CIDatabaseTestCase
+class DatabaseTestCaseMigrationOnce1Test extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	/**
 	 * Should run db migration only once?
 	 *

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
@@ -1,6 +1,7 @@
 <?php namespace CodeIgniter\Database\DatabaseTestCase;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Services;
 
 /**
@@ -9,8 +10,10 @@ use Config\Services;
  *
  * @group DatabaseLive
  */
-class DatabaseTestCaseMigrationOnce2Test extends CIDatabaseTestCase
+class DatabaseTestCaseMigrationOnce2Test extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	/**
 	 * Should run db migration only once?
 	 *

--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -1,13 +1,16 @@
 <?php namespace CodeIgniter\Database;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Services;
 
 /**
  * @group DatabaseLive
  */
-class DatabaseTestCaseTest extends CIDatabaseTestCase
+class DatabaseTestCaseTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected static $loaded = false;
 
 	/**

--- a/tests/system/Database/Live/AliasTest.php
+++ b/tests/system/Database/Live/AliasTest.php
@@ -1,12 +1,15 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class AliasTest extends CIDatabaseTestCase
+class AliasTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/BadQueryTest.php
+++ b/tests/system/Database/Live/BadQueryTest.php
@@ -1,13 +1,16 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use Exception;
 
 /**
  * @group DatabaseLive
  */
-class BadQueryTest extends CIDatabaseTestCase
+class BadQueryTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -1,9 +1,9 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Config\Config;
 use CodeIgniter\Database\SQLite3\Connection;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Config\Factories;
 use Config\Database;
 
 /**
@@ -74,7 +74,7 @@ class ConnectTest extends CIUnitTestCase
 
 		$config                      = config('Database');
 		$config->default['DBDriver'] = 'MySQLi';
-		Config::injectMock('Database', $config);
+		Factories::injectMock('config','Database', $config);
 
 		$db1 = Database::connect('default');
 		$this->assertNotInstanceOf(Connection::class, $db1);

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -2,14 +2,17 @@
 
 use CodeIgniter\Config\Config;
 use CodeIgniter\Database\SQLite3\Connection;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
 
 /**
  * @group DatabaseLive
  */
-class ConnectTest extends CIDatabaseTestCase
+class ConnectTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $group1;
 
 	protected $group2;

--- a/tests/system/Database/Live/CountTest.php
+++ b/tests/system/Database/Live/CountTest.php
@@ -1,12 +1,15 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class CountTest extends CIDatabaseTestCase
+class CountTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/DEBugTest.php
+++ b/tests/system/Database/Live/DEBugTest.php
@@ -1,12 +1,14 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class DEBugTest extends CIDatabaseTestCase
+class DEBugTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
 
 	protected $refresh = true;
 

--- a/tests/system/Database/Live/DbUtilsTest.php
+++ b/tests/system/Database/Live/DbUtilsTest.php
@@ -4,13 +4,15 @@ namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\Database;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class DbUtilsTest extends CIDatabaseTestCase
+class DbUtilsTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
 
 	protected $refresh = true;
 	protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/DeleteTest.php
+++ b/tests/system/Database/Live/DeleteTest.php
@@ -1,13 +1,16 @@
 <?php namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class DeleteTest extends CIDatabaseTestCase
+class DeleteTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/EmptyTest.php
+++ b/tests/system/Database/Live/EmptyTest.php
@@ -1,12 +1,15 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class EmptyTest extends CIDatabaseTestCase
+class EmptyTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/EscapeTest.php
+++ b/tests/system/Database/Live/EscapeTest.php
@@ -1,12 +1,15 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class EscapeTest extends CIDatabaseTestCase
+class EscapeTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = false;
 
 	protected $char;

--- a/tests/system/Database/Live/FabricatorLiveTest.php
+++ b/tests/system/Database/Live/FabricatorLiveTest.php
@@ -1,7 +1,8 @@
 <?php namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Exceptions\FrameworkException;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\Fabricator;
 use Tests\Support\Models\UserModel;
 use Tests\Support\Models\ValidModel;
@@ -9,8 +10,10 @@ use Tests\Support\Models\ValidModel;
 /**
  * @group DatabaseLive
  */
-class FabricatorLiveTest extends CIDatabaseTestCase
+class FabricatorLiveTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	public function testCreateAddsToDatabase()

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -4,7 +4,8 @@ namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Forge;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
 use InvalidArgumentException;
 use RuntimeException;
@@ -12,8 +13,9 @@ use RuntimeException;
 /**
  * @group DatabaseLive
  */
-class ForgeTest extends CIDatabaseTestCase
+class ForgeTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
 
 	protected $refresh = true;
 	protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/FromTest.php
+++ b/tests/system/Database/Live/FromTest.php
@@ -1,12 +1,15 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class FromTest extends CIDatabaseTestCase
+class FromTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/GetNumRowsTest.php
+++ b/tests/system/Database/Live/GetNumRowsTest.php
@@ -1,9 +1,12 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
-class GetNumRowsTest extends CIDatabaseTestCase
+class GetNumRowsTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -3,13 +3,16 @@
 namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class GetTest extends CIDatabaseTestCase
+class GetTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -1,12 +1,15 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class GroupTest extends CIDatabaseTestCase
+class GroupTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/IncrementTest.php
+++ b/tests/system/Database/Live/IncrementTest.php
@@ -1,12 +1,15 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class IncrementTest extends CIDatabaseTestCase
+class IncrementTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -1,12 +1,15 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class InsertTest extends CIDatabaseTestCase
+class InsertTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/JoinTest.php
+++ b/tests/system/Database/Live/JoinTest.php
@@ -1,12 +1,15 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class JoinTest extends CIDatabaseTestCase
+class JoinTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -1,12 +1,15 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class LikeTest extends CIDatabaseTestCase
+class LikeTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/LimitTest.php
+++ b/tests/system/Database/Live/LimitTest.php
@@ -1,12 +1,14 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class LimitTest extends CIDatabaseTestCase
+class LimitTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -2,14 +2,16 @@
 
 namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
 
 /**
  * @group DatabaseLive
  */
-class MetadataTest extends CIDatabaseTestCase
+class MetadataTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
 
 	protected $refresh = true;
 	protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/OrderTest.php
+++ b/tests/system/Database/Live/OrderTest.php
@@ -2,13 +2,16 @@
 
 namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class OrderTest extends CIDatabaseTestCase
+class OrderTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -4,13 +4,15 @@ namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\BasePreparedQuery;
 use CodeIgniter\Database\Query;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class PreparedQueryTest extends CIDatabaseTestCase
+class PreparedQueryTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
 
 	protected $refresh = true;
 	protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/PretendTest.php
+++ b/tests/system/Database/Live/PretendTest.php
@@ -1,13 +1,16 @@
 <?php namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\Query;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class PretendTest extends CIDatabaseTestCase
+class PretendTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	public function tearDown(): void
 	{
 		// We share `$this->db` in testing, so we need to restore the state.

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -3,14 +3,17 @@
 use CodeIgniter\Database\SQLite3\Connection;
 use CodeIgniter\Database\SQLite3\Forge;
 use CodeIgniter\Database\SQLite3\Table;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
 
 /**
  * @group DatabaseLive
  */
-class AlterTableTest extends CIDatabaseTestCase
+class AlterTableTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	/**
 	 * In setUp() db connection is changed. So migration doesn't work
 	 *

--- a/tests/system/Database/Live/SelectTest.php
+++ b/tests/system/Database/Live/SelectTest.php
@@ -1,12 +1,15 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class SelectTest extends CIDatabaseTestCase
+class SelectTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -1,13 +1,16 @@
 <?php namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class UpdateTest extends CIDatabaseTestCase
+class UpdateTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/WhereTest.php
+++ b/tests/system/Database/Live/WhereTest.php
@@ -1,12 +1,15 @@
 <?php namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class WhereTest extends CIDatabaseTestCase
+class WhereTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Live/WriteTypeQueryTest.php
+++ b/tests/system/Database/Live/WriteTypeQueryTest.php
@@ -1,13 +1,16 @@
 <?php namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\BaseBuilder;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
 /**
  * @group DatabaseLive
  */
-class WriteTypeQueryTest extends CIDatabaseTestCase
+class WriteTypeQueryTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -7,7 +7,8 @@ use CodeIgniter\Database\Config;
 use CodeIgniter\Database\MigrationRunner;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\ConfigException;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
 use Config\Migrations;
 use Config\Services;
@@ -16,8 +17,10 @@ use org\bovigo\vfs\vfsStream;
 /**
  * @group DatabaseLive
  */
-class MigrationRunnerTest extends CIDatabaseTestCase
+class MigrationRunnerTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	protected $root;

--- a/tests/system/Database/Migrations/MigrationTest.php
+++ b/tests/system/Database/Migrations/MigrationTest.php
@@ -3,10 +3,13 @@
 namespace CodeIgniter\Database\Migrations;
 
 use CodeIgniter\Database\Migration;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 
-class MigrationTest extends CIDatabaseTestCase
+class MigrationTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	public function setUp(): void
 	{
 		parent::setUp();

--- a/tests/system/Database/ModelFactoryTest.php
+++ b/tests/system/Database/ModelFactoryTest.php
@@ -1,11 +1,14 @@
 <?php namespace CodeIgniter\Database;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use Tests\Support\Models\JobModel;
 use Tests\Support\Models\UserModel;
 
-class ModelFactoryTest extends CIDatabaseTestCase
+class ModelFactoryTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected function setUp(): void
 	{
 		parent::setUp();

--- a/tests/system/Models/LiveModelTestCase.php
+++ b/tests/system/Models/LiveModelTestCase.php
@@ -4,15 +4,17 @@ namespace CodeIgniter\Models;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Model;
-use CodeIgniter\Test\CIDatabaseTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\ReflectionHelper;
 
 /**
  * LiveModelTestCase should be in testing Model's features that
  * requires a database connection.
  */
-abstract class LiveModelTestCase extends CIDatabaseTestCase
+abstract class LiveModelTestCase extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
 	use ReflectionHelper;
 
 	/**

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -2,15 +2,17 @@
 
 namespace CodeIgniter\Validation;
 
-use CodeIgniter\Test\CIDatabaseTestCase;
-use CodeIgniter\Validation\Rules;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
 use Config\Services;
 use stdClass;
 use Tests\Support\Validation\TestRules;
 
-class RulesTest extends CIDatabaseTestCase
+class RulesTest extends CIUnitTestCase
 {
+	use DatabaseTestTrait;
+
 	protected $refresh = true;
 
 	/**

--- a/user_guide_src/source/testing/controllers.rst
+++ b/user_guide_src/source/testing/controllers.rst
@@ -21,9 +21,12 @@ within your tests::
     namespace CodeIgniter;
 
     use CodeIgniter\Test\ControllerTester;
+    use CodeIgniter\Test\CIUnitTestCase;
+    use CodeIgniter\Test\DatabaseTestTrait;
 
-    class TestControllerA extends \CIDatabaseTestCase
+    class TestControllerA extends CIUnitTestCase
     {
+        use DatabaseTestTrait;
         use ControllerTester;
     }
 
@@ -37,9 +40,12 @@ to run as the parameter::
     namespace CodeIgniter;
 
     use CodeIgniter\Test\ControllerTester;
+    use CodeIgniter\Test\CIUnitTestCase;
+    use CodeIgniter\Test\DatabaseTestTrait;
 
-    class TestControllerA extends \CIDatabaseTestCase
+    class TestControllerA extends CIUnitTestCase
     {
+        use DatabaseTestTrait;
         use ControllerTester;
 
         public function testShowCategories()

--- a/user_guide_src/source/testing/database.rst
+++ b/user_guide_src/source/testing/database.rst
@@ -141,7 +141,7 @@ To run migrations from all available namespaces set this property to ``null``.
 Helper Methods
 ==============
 
-The **CIDatabaseTestCase** class provides several helper methods to aid in testing your database.
+The **DatabaseTestTrait** class provides several helper methods to aid in testing your database.
 
 **regressDatabase()**
 

--- a/user_guide_src/source/testing/fabricator.rst
+++ b/user_guide_src/source/testing/fabricator.rst
@@ -276,4 +276,4 @@ you deleted a fake item but wanted to track the change.
 **resetCounts()**
 
 Resets all counts. Good idea to call this between test cases (though using
-``CIDatabaseTestCase::$refresh = true`` does it automatically).
+``CIUnitTestCase::$refresh = true`` does it automatically).


### PR DESCRIPTION
Fixes #4351

- use ``DatabaseTestTrait`` ``CIUnitTestCase`` instead ``CIDatabaseTestCase``
- use ``Factories`` instead ``CodeIgniter/Config/Config`` in ``Database/Live/ConnectTest.php ``

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

