### PR TITLE
Add Services::codeigniter()

### DIFF
--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Config;
 
 use CodeIgniter\Autoloader\Autoloader;
 use CodeIgniter\Autoloader\FileLocator;
+use CodeIgniter\CodeIgniter;
 use Config\Autoload;
 use Config\Modules;
 use CodeIgniter\Cache\CacheInterface;
@@ -73,6 +74,7 @@ use CodeIgniter\View\View;
  *
  * @method static CacheInterface cache(\Config\Cache $config = null, $getShared = true)
  * @method static CLIRequest clirequest(\Config\App $config = null, $getShared = true)
+ * @method static CodeIgniter codeigniter(\Config\App $config = null, $getShared = true)
  * @method static Commands commands($getShared = true)
  * @method static CURLRequest curlrequest($options = [], \CodeIgniter\HTTP\ResponseInterface $response = null, \Config\App $config = null, $getShared = true)
  * @method static Email email($config = null, $getShared = true)

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -150,7 +150,7 @@ class BaseService
 	 * $key must be a name matching a service.
 	 *
 	 * @param string $key
-	 * @param array  ...$params
+	 * @param mixed  ...$params
 	 *
 	 * @return mixed
 	 */

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Config;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\CLI\Commands;
+use CodeIgniter\CodeIgniter;
 use CodeIgniter\Database\ConnectionInterface;
 use CodeIgniter\Database\MigrationRunner;
 use CodeIgniter\Debug\Exceptions;
@@ -132,6 +133,26 @@ class Services extends BaseService
 	}
 
 	//--------------------------------------------------------------------
+
+	/**
+	 * CodeIgniter, the core of the framework.
+	 *
+	 * @param App|null $config
+	 * @param boolean  $getShared
+	 *
+	 * @return CodeIgniter
+	 */
+	public static function codeigniter(App $config = null, bool $getShared = true)
+	{
+		if ($getShared)
+		{
+			return static::getSharedInstance('codeigniter', $config);
+		}
+
+		$config = $config ?? config('App');
+
+		return new CodeIgniter($config);
+	}
 
 	/**
 	 * The commands utility for running and working with CLI commands.

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -155,7 +155,7 @@ helper('url');
  * the pieces all working together.
  */
 
-$app = new CodeIgniter(new App());
+$app = Services::codeigniter(new App());
 $app->initialize();
 
 return $app;


### PR DESCRIPTION
**Description**
In the current implementation, there is no way to extend the class `CodeIgniter`.
This PR enables users to extend `CodeIgniter`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
