### PR TITLE
Use case-sensitive matching for special cookie prefixes

### DIFF
--- a/system/HTTP/Cookie/Cookie.php
+++ b/system/HTTP/Cookie/Cookie.php
@@ -861,12 +861,12 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
 	 */
 	protected function validatePrefix(string $prefix, bool $secure, string $domain, string $path): void
 	{
-		if (stripos($prefix, '__Secure-') === 0 && ! $secure)
+		if (strpos($prefix, '__Secure-') === 0 && ! $secure)
 		{
 			throw CookieException::forInvalidSecurePrefix();
 		}
 
-		if (stripos($prefix, '__Host-') === 0 && (! $secure || $domain !== '' || $path !== '/'))
+		if (strpos($prefix, '__Host-') === 0 && (! $secure || $domain !== '' || $path !== '/'))
 		{
 			throw CookieException::forInvalidHostPrefix();
 		}


### PR DESCRIPTION
**Description**
Per Sections 15 and 16 of RFC 6265, handling of special cookie prefixes, `__Secure-` and `__Host-` is done case-sensitively.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
