### PR TITLE
Bugfix invalid HTTP codes

### DIFF
--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -164,9 +164,11 @@ trait ControllerTester
 		}
 		catch (Throwable $e)
 		{
-			if ($code >= 100 || $code < 600)
+			$code = $e->getCode();
+
+			if ($code >= 100 && $code < 600)
 			{
-				$result->response()->setStatusCode($e->getCode());
+				$result->response()->setStatusCode($code);
 			}
 		}
 		finally

--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -164,7 +164,10 @@ trait ControllerTester
 		}
 		catch (Throwable $e)
 		{
-			$result->response()->setStatusCode($e->getCode());
+			if ($code >= 100 || $code < 600)
+			{
+				$result->response()->setStatusCode($e->getCode());
+			}
 		}
 		finally
 		{


### PR DESCRIPTION
**Description**
Fixes a bug where `ControllerTester` would set any Exception code as an HTTP code which could cause a lot of debugging confusion:

> CodeIgniter\HTTP\Exceptions\HTTPException: 0 is not a valid HTTP return status code

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
