### PR TITLE
Fix: filter_var usage

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -356,7 +356,7 @@ class IncomingRequest extends Request
 
 		if (! is_array($data))
 		{
-			$filter = is_numeric($filter) ? (int) $filter : FILTER_DEFAULT;
+			$filter = $filter ?? FILTER_DEFAULT;
 			$flags  = is_array($flags) ? $flags : (is_numeric($flags) ? (int) $flags : 0);
 
 			return filter_var($data, $filter, $flags);

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -342,13 +342,13 @@ class IncomingRequest extends Request
 	/**
 	 * Get a specific variable from a JSON input stream
 	 *
-	 * @param  string       $index  The variable that you want which can use dot syntax for getting specific values.
-	 * @param  boolean      $assoc  If true, return the result as an associative array.
-	 * @param  integer|null $filter Filter Constant
-	 * @param  mixed        $flags
+	 * @param  string             $index  The variable that you want which can use dot syntax for getting specific values.
+	 * @param  boolean            $assoc  If true, return the result as an associative array.
+	 * @param  integer|null       $filter Filter Constant
+	 * @param  array|integer|null $flags  Option
 	 * @return mixed
 	 */
-	public function getJsonVar(string $index, bool $assoc = false, $filter = null, $flags = null)
+	public function getJsonVar(string $index, bool $assoc = false, ?int $filter = null, $flags = null)
 	{
 		helper('array');
 
@@ -356,7 +356,9 @@ class IncomingRequest extends Request
 
 		if (! is_array($data))
 		{
-			$filter = $filter ?? FILTER_DEFAULT;
+			$filter = is_numeric($filter) ? (int) $filter : FILTER_DEFAULT;
+			$flags  = is_array($flags) ? $flags : (is_numeric($flags) ? (int) $flags : 0);
+
 			return filter_var($data, $filter, $flags);
 		}
 

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -257,7 +257,7 @@ trait RequestTrait
 		}
 
 		// Null filters cause null values to return.
-		$filter = is_numeric($filter) ? (int) $filter : FILTER_DEFAULT;
+		$filter = $filter ?? FILTER_DEFAULT;
 		$flags  = is_array($flags) ? $flags : (is_numeric($flags) ? (int) $flags : 0);
 
 		// Return all values when $index is null

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -240,14 +240,14 @@ trait RequestTrait
 	 *
 	 * http://php.net/manual/en/filter.filters.sanitize.php
 	 *
-	 * @param string            $method Input filter constant
-	 * @param string|array|null $index
-	 * @param integer|null      $filter Filter constant
-	 * @param mixed             $flags
+	 * @param string             $method Input filter constant
+	 * @param string|array|null  $index
+	 * @param integer|null       $filter Filter constant
+	 * @param array|integer|null $flags  Options
 	 *
 	 * @return mixed
 	 */
-	public function fetchGlobal($method, $index = null, $filter = null, $flags = null)
+	public function fetchGlobal(string $method, $index = null, ?int $filter = null, $flags = null)
 	{
 		$method = strtolower($method);
 
@@ -257,10 +257,8 @@ trait RequestTrait
 		}
 
 		// Null filters cause null values to return.
-		if (is_null($filter))
-		{
-			$filter = FILTER_DEFAULT;
-		}
+		$filter = is_numeric($filter) ? (int) $filter : FILTER_DEFAULT;
+		$flags  = is_array($flags) ? $flags : (is_numeric($flags) ? (int) $flags : 0);
 
 		// Return all values when $index is null
 		if (is_null($index))
@@ -319,7 +317,13 @@ trait RequestTrait
 		}
 
 		// @phpstan-ignore-next-line
-		if (is_array($value) && ($filter !== null || $flags !== null))
+		if (is_array($value)
+			&& ($filter !== FILTER_DEFAULT
+				|| ((is_numeric($flags) && $flags !== 0)
+					|| is_array($flags) && count($flags) > 0
+				)
+			)
+		)
 		{
 			// Iterate over array and append filter and flags
 			array_walk_recursive($value, function (&$val) use ($filter, $flags) {


### PR DESCRIPTION
**Description**
When using the flag parameter in the filter_var function, the default value was incorrectly passed. 
By default, null is passed, but an array or integer is expected.
Soft type casting may mask future problems. 

Changes:
* Updated variable types in docBlock 
* Added nullable type for filter parameter 
* Defined a default value for the filter and flag arguments if passed null.
* The filter and flag arguments are cast to the expected types. 
* Adjusted the data validation condition based on the changes above. 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide