### PR TITLE
Bugfix data cache

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -524,7 +524,7 @@ class Forge
 
 		if (($result = $this->db->query($sql)) !== false)
 		{
-			if (! isset($this->db->dataCache['table_names'][$table]))
+			if (isset($this->db->dataCache['table_names']) && ! in_array($table, $this->db->dataCache['table_names'], true))
 			{
 				$this->db->dataCache['table_names'][] = $table;
 			}


### PR DESCRIPTION
**Description**
`BaseConnection::$dataCache` is an array of cached data of varying formats. Unfortunately this is not enumerated anymore so it is easy to mistake the format. This PR fixes just such a bug, where `table_names` was assumed to have keys for each table when in fact it is just a list of strings.

This fixes a rare issue where calling `createTable()` immediately after `resetDataCache()` would incorrectly set the list of tables to just the single newly create table. Go ahead, ask me how long I spent tracking this one down 🙄

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
