### PR TITLE
Helper form_multiselect $data param as array

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -313,14 +313,14 @@ if (! function_exists('form_multiselect'))
 	/**
 	 * Multi-select menu
 	 *
-	 * @param string $name
+	 * @param mixed  $name
 	 * @param array  $options
 	 * @param array  $selected
 	 * @param mixed  $extra
 	 *
 	 * @return string
 	 */
-	function form_multiselect(string $name = '', array $options = [], array $selected = [], $extra = ''): string
+	function form_multiselect($name = '', array $options = [], array $selected = [], $extra = ''): string
 	{
 		$extra = stringify_attributes($extra);
 

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -557,6 +557,33 @@ EOH;
 	}
 
 	// ------------------------------------------------------------------------
+	public function testFormMultiselectArrayData()
+	{
+		$expected = <<<EOH
+<select name="shirts[]"  multiple="multiple">
+<option value="small">Small Shirt</option>
+<option value="med" selected="selected">Medium Shirt</option>
+<option value="large" selected="selected">Large Shirt</option>
+<option value="xlarge">Extra Large Shirt</option>
+</select>\n
+EOH;
+		$options  = [
+			'small'  => 'Small Shirt',
+			'med'    => 'Medium Shirt',
+			'large'  => 'Large Shirt',
+			'xlarge' => 'Extra Large Shirt',
+		];
+
+		$data  = [
+			'name' 	 	=> 'shirts[]',
+			'options'	=> $options,
+			'selected'  => ['med', 'large'],
+		];
+
+		$this->assertEquals($expected, form_multiselect($data));
+	}
+
+	// ------------------------------------------------------------------------
 	public function testFormFieldset()
 	{
 		$expected = <<<EOH


### PR DESCRIPTION
**Description**
Helper function form_multiselect $data parameter type should be mixed as form_dropdown. 
So when passed array it should handle the array instead of error.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
