### PR TITLE
docs: add missing TOC

### DIFF
--- a/user_guide_src/source/database/call_function.rst
+++ b/user_guide_src/source/database/call_function.rst
@@ -2,6 +2,10 @@
 Custom Function Calls
 #####################
 
+.. contents::
+    :local:
+    :depth: 2
+
 $db->callFunction();
 ============================
 

--- a/user_guide_src/source/database/connecting.rst
+++ b/user_guide_src/source/database/connecting.rst
@@ -2,6 +2,10 @@
 Connecting to your Database
 ###########################
 
+.. contents::
+    :local:
+    :depth: 2
+
 You can connect to your database by adding this line of code in any
 function where it is needed, or in your class constructor to make the
 database available globally in that class.

--- a/user_guide_src/source/database/events.rst
+++ b/user_guide_src/source/database/events.rst
@@ -7,6 +7,10 @@ order to learn more about what is happening during the database execution. These
 be used to collect data for analysis and reporting. The :doc:`Debug Toolbar </testing/debugging>`
 uses this to collect the queries to display in the Toolbar.
 
+.. contents::
+    :local:
+    :depth: 2
+
 ==========
 The Events
 ==========

--- a/user_guide_src/source/database/examples.rst
+++ b/user_guide_src/source/database/examples.rst
@@ -6,6 +6,10 @@ The following page contains example code showing how the database class
 is used. For complete details please read the individual pages
 describing each function.
 
+.. contents::
+    :local:
+    :depth: 2
+
 Initializing the Database Class
 ===============================
 

--- a/user_guide_src/source/database/helpers.rst
+++ b/user_guide_src/source/database/helpers.rst
@@ -2,6 +2,10 @@
 Query Helper Methods
 ####################
 
+.. contents::
+    :local:
+    :depth: 2
+
 Information From Executing a Query
 ==================================
 

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -12,6 +12,10 @@ online resource to learn about them for your particular database. The
 information below assumes you have a basic understanding of
 transactions.
 
+.. contents::
+    :local:
+    :depth: 2
+
 CodeIgniter's Approach to Transactions
 ======================================
 

--- a/user_guide_src/source/testing/controllers.rst
+++ b/user_guide_src/source/testing/controllers.rst
@@ -10,6 +10,10 @@ case you need it.
 .. note:: Because the entire framework has not been bootstrapped, there will be times when you cannot test a controller
     this way.
 
+.. contents::
+    :local:
+    :depth: 2
+
 The Helper Trait
 ================
 

--- a/user_guide_src/source/testing/fabricator.rst
+++ b/user_guide_src/source/testing/fabricator.rst
@@ -6,6 +6,10 @@ Often you will need sample data for your application to run its tests. The ``Fab
 uses fzaninotto's `Faker <https://github.com/fzaninotto/Faker//>`_ to turn models into generators
 of random data. Use fabricators in your seeds or test cases to stage fake data for your unit tests.
 
+.. contents::
+    :local:
+    :depth: 2
+
 Supported Models
 ================
 


### PR DESCRIPTION
**Description**
Add missing TOC.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
