### PR TITLE
Add more info to `seeInDatabase` assertions

### DIFF
--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -19,6 +19,7 @@ use CodeIgniter\Database\MigrationRunner;
 use CodeIgniter\Database\Seeder;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Session\Handlers\ArrayHandler;
+use CodeIgniter\Test\Constraints\SeeInDatabase;
 use CodeIgniter\Test\Mock\MockCache;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
 use CodeIgniter\Test\Mock\MockEmail;
@@ -473,11 +474,8 @@ abstract class CIUnitTestCase extends TestCase
 	 */
 	public function seeInDatabase(string $table, array $where)
 	{
-		$count = $this->db->table($table)
-						  ->where($where)
-						  ->countAllResults();
-
-		$this->assertTrue($count > 0, 'Row not found in database: ' . $this->db->showLastQuery());
+		$constraint = new SeeInDatabase($this->db, $where);
+		static::assertThat($table, $constraint);
 	}
 
 	/**

--- a/system/Test/Constraints/SeeInDatabase.php
+++ b/system/Test/Constraints/SeeInDatabase.php
@@ -95,7 +95,7 @@ class SeeInDatabase extends Constraint
 				->get()
 				->getResultArray();
 
-			if (count($results) === 0)
+			if ($results !== [])
 			{
 				return 'The table is empty.';
 			}

--- a/system/Test/Constraints/SeeInDatabase.php
+++ b/system/Test/Constraints/SeeInDatabase.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace CodeIgniter\Test\Constraints;
+
+use CodeIgniter\Database\ConnectionInterface;
+use PHPUnit\Framework\Constraint\Constraint;
+
+class SeeInDatabase extends Constraint
+{
+	/**
+	 * The number of results that will show in the database
+	 * in case of failure.
+	 *
+	 * @var integer
+	 */
+	protected $show = 3;
+
+	/**
+	 * @var \CodeIgniter\Database\ConnectionInterface
+	 */
+	protected $db;
+
+	/**
+	 * Data used to compare results against.
+	 *
+	 * @var array
+	 */
+	protected $data;
+
+	/**
+	 * SeeInDatabase constructor.
+	 *
+	 * @param \CodeIgniter\Database\ConnectionInterface $db
+	 * @param array                                     $data
+	 */
+	public function __construct(ConnectionInterface $db, array $data)
+	{
+		$this->db   = $db;
+		$this->data = $data;
+	}
+
+	/**
+	 * Check if data is found in the table
+	 *
+	 * @param mixed $table
+	 *
+	 * @return boolean
+	 */
+	public function matches($table): bool
+	{
+		return $this->db->table($table)->where($this->data)->countAllResults() > 0;
+	}
+
+	/**
+	 * Get the description of the failure
+	 *
+	 * @param mixed $table
+	 *
+	 * @return string
+	 */
+	public function failureDescription($table): string
+	{
+		return sprintf(
+			"a row in the table [%s] matches the attributes \n%s\n\n%s",
+			$table, $this->toString(JSON_PRETTY_PRINT), $this->getAdditionalInfo($table)
+		);
+	}
+
+	/**
+	 * Gets additional records similar to $data.
+	 *
+	 * @param string $table
+	 *
+	 * @return string
+	 */
+	protected function getAdditionalInfo(string $table): string
+	{
+		$builder = $this->db->table($table);
+
+		$similar = $builder->where(
+				array_key_first($this->data),
+				$this->data[array_key_first($this->data)]
+			)->limit($this->show)
+			->get()->getResultArray();
+
+		if (count($similar))
+		{
+			$description = 'Found similar results: ' . json_encode($similar, JSON_PRETTY_PRINT);
+		}
+		else
+		{
+			// Does the table have any results at all?
+			$results = $this->db->table($table)
+				->limit($this->show)
+				->get()
+				->getResultArray();
+
+			if (count($results) === 0)
+			{
+				return 'The table is empty.';
+			}
+
+			$description = 'Found: ' . json_encode($results, JSON_PRETTY_PRINT);
+		}
+
+		$total = $this->db->table($table)->countAll();
+		if ($total > $this->show)
+		{
+			$description .= sprintf(' and %s others', $total - $this->show);
+		}
+
+		return $description;
+	}
+
+	/**
+	 * Gets a string representation of the constraint
+	 *
+	 * @param integer $options
+	 *
+	 * @return string
+	 */
+	public function toString($options = 0): string
+	{
+		return json_encode($this->data, $options);
+	}
+}

--- a/system/Test/Constraints/SeeInDatabase.php
+++ b/system/Test/Constraints/SeeInDatabase.php
@@ -83,7 +83,7 @@ class SeeInDatabase extends Constraint
 			)->limit($this->show)
 			->get()->getResultArray();
 
-		if (count($similar))
+		if ($similar !== [])
 		{
 			$description = 'Found similar results: ' . json_encode($similar, JSON_PRETTY_PRINT);
 		}

--- a/system/Test/Constraints/SeeInDatabase.php
+++ b/system/Test/Constraints/SeeInDatabase.php
@@ -16,7 +16,7 @@ class SeeInDatabase extends Constraint
 	protected $show = 3;
 
 	/**
-	 * @var \CodeIgniter\Database\ConnectionInterface
+	 * @var ConnectionInterface
 	 */
 	protected $db;
 
@@ -30,8 +30,8 @@ class SeeInDatabase extends Constraint
 	/**
 	 * SeeInDatabase constructor.
 	 *
-	 * @param \CodeIgniter\Database\ConnectionInterface $db
-	 * @param array                                     $data
+	 * @param ConnectionInterface $db
+	 * @param array               $data
 	 */
 	public function __construct(ConnectionInterface $db, array $data)
 	{

--- a/tests/system/Database/Live/DatabaseTestTraitCaseTest.php
+++ b/tests/system/Database/Live/DatabaseTestTraitCaseTest.php
@@ -21,21 +21,15 @@ class DatabaseTestTraitCaseTest extends CIUnitTestCase
 		$this->seeInDatabase('user', ['name' => 'Ricky', 'email' => 'sofine@example.com', 'country' => 'US']);
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testDontSeeInDatabase()
 	{
 		$this->dontSeeInDatabase('user', ['name' => 'Ricardo']);
 	}
 
-	//--------------------------------------------------------------------
-
 	public function testSeeNumRecords()
 	{
 		$this->seeNumRecords(2, 'user', ['country' => 'US']);
 	}
-
-	//--------------------------------------------------------------------
 
 	public function testGrabFromDatabase()
 	{
@@ -44,6 +38,14 @@ class DatabaseTestTraitCaseTest extends CIUnitTestCase
 		$this->assertEquals('derek@world.com', $email);
 	}
 
-	//--------------------------------------------------------------------
+	public function testSeeInDatabase()
+	{
+		$this->hasInDatabase('user', [
+			'name'    => 'Ricardo',
+			'email'   => 'ricardo@example.com',
+			'country' => 'The Moon',
+		]);
 
+		$this->seeInDatabase('user', ['name' => 'Ricardo']);
+	}
 }


### PR DESCRIPTION
Refactored the seeInDatabase assertion into a Constraint so we can provide context when it fails by showing potentially similar rows within the database.