### PR TITLE
[Helper] Fixes base_url("0") and site_url("0") to correctly point to /0

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -47,7 +47,7 @@ if (! function_exists('site_url'))
 		{
 			$fullPath .= rtrim($config->indexPage, '/');
 		}
-		if (! empty($uri))
+		if ($uri !== '')
 		{
 			$fullPath .= '/' . $uri;
 		}

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -99,7 +99,7 @@ if (! function_exists('base_url'))
 		unset($config);
 
 		// Merge in the path set by the user, if any
-		if (! empty($uri))
+		if ($uri !== '')
 		{
 			$url = $url->resolveRelativeURI($uri);
 		}

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -145,6 +145,13 @@ class URLHelperTest extends CIUnitTestCase
 				'http://example.com/index.php/foo',
 			],
 			[
+				'http://example.com/',
+				'index.php',
+				'0',
+				null,
+				'http://example.com/index.php/0',
+			],
+			[
 				'http://example.com/public',
 				'index.php',
 				'foo',

--- a/tests/system/Helpers/URLHelperTest.php
+++ b/tests/system/Helpers/URLHelperTest.php
@@ -248,6 +248,11 @@ class URLHelperTest extends CIUnitTestCase
 		$this->assertEquals('https://example.com/foo', base_url('foo', 'https'));
 	}
 
+	public function testBaseURLPathZero()
+	{
+		$this->assertEquals('http://example.com/0', base_url('0'));
+	}
+
 	public function testBaseURLHeedsBaseURL()
 	{
 		// Since we're on a CLI, we must provide our own URI


### PR DESCRIPTION
Handle `base_url("0")` to ensure point to `/0` with compare to empty string instead of using `empty($uri)` check.

**Checklist:**
- [x] Securely signed commits
