### PR TITLE
Prioritize database trait methods

### DIFF
--- a/system/Test/DatabaseTestTrait.php
+++ b/system/Test/DatabaseTestTrait.php
@@ -47,7 +47,7 @@ trait DatabaseTestTrait
 	/**
 	 * Runs the trait set up methods.
 	 */
-	protected function setUpDatabaseTestTrait()
+	protected function setUpDatabase()
 	{
 		$this->loadDependencies();
 		$this->setUpMigrate();
@@ -57,7 +57,7 @@ trait DatabaseTestTrait
 	/**
 	 * Runs the trait set up methods.
 	 */
-	protected function tearDownDatabaseTestTrait()
+	protected function tearDownDatabase()
 	{
 		$this->clearInsertCache();
 	}

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -154,7 +154,7 @@ Traits
 ------
 
 A common way to enhance your tests is by using traits to consolidate staging across different
-test cases. ``CIUintTestCase`` will detect any class traits and look for staging methods to
+test cases. ``CIUnitTestCase`` will detect any class traits and look for staging methods
 to run named for the trait itself. For example, if you needed to add authentication to some
 of your test cases you could create an authentication trait with a set up method to fake a
 logged in user::

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -155,11 +155,9 @@ Traits
 
 A common way to enhance your tests is by using traits to consolidate staging across different
 test cases. ``CIUintTestCase`` will detect any class traits and look for staging methods to
-to run named for the trait itself. The framework's own ``DatabaseTestTrait`` implements this
-with methods ``setUpDatabaseTestTrait()`` and ``tearDownDatabaseTestTrait()``.
-
-For example, if you needed to add authentication to some of your test cases you could create
-an authentication trait with a set up method to fake a logged in user::
+to run named for the trait itself. For example, if you needed to add authentication to some
+of your test cases you could create an authentication trait with a set up method to fake a
+logged in user::
 
 	trait AuthTrait
 	{


### PR DESCRIPTION
**Description**
An alternative to #4422 (see the description of the problem there). I think this simpler solution is the better choice. I do think `class_uses_recursive()` is probably costly so I took advantage still of storing the results for a little performance boost.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
