### PR TITLE
Enable to use extened CodeIgniter class in testing

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -168,8 +168,7 @@ class CodeIgniter
 	 */
 	public function initialize()
 	{
-		// Define environment variables
-		$this->detectEnvironment();
+		// Load boot file
 		$this->bootstrapEnvironment();
 
 		// Setup Exception Handling
@@ -494,36 +493,6 @@ class CodeIgniter
 		Events::trigger('post_system');
 
 		return $this->response;
-	}
-
-	//--------------------------------------------------------------------
-
-	/**
-	 * You can load different configurations depending on your
-	 * current environment. Setting the environment also influences
-	 * things like logging and error reporting.
-	 *
-	 * This can be set to anything, but default usage is:
-	 *
-	 *     development
-	 *     testing
-	 *     production
-	 */
-	protected function detectEnvironment()
-	{
-		// Make sure ENVIRONMENT isn't already set by other means.
-		if (! defined('ENVIRONMENT'))
-		{
-			// running under Continuous Integration server?
-			if (getenv('CI') !== false)
-			{
-				define('ENVIRONMENT', 'testing');
-			}
-			else
-			{
-				define('ENVIRONMENT', $_SERVER['CI_ENVIRONMENT'] ?? 'production');
-			}
-		}
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -47,6 +47,7 @@ use CodeIgniter\Router\RouteCollectionInterface;
 use CodeIgniter\Router\Router;
 use CodeIgniter\Security\Security;
 use CodeIgniter\Session\Session;
+use CodeIgniter\Test\Mock\MockCodeIgniter;
 use CodeIgniter\Throttle\Throttler;
 use CodeIgniter\Typography\Typography;
 use CodeIgniter\Validation\Validation;
@@ -150,6 +151,11 @@ class Services extends BaseService
 		}
 
 		$config = $config ?? config('App');
+
+		if (ENVIRONMENT === 'testing')
+		{
+			return new MockCodeIgniter($config);
+		}
 
 		return new CodeIgniter($config);
 	}

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -152,11 +152,6 @@ class Services extends BaseService
 
 		$config = $config ?? config('App');
 
-		if (ENVIRONMENT === 'testing')
-		{
-			return new MockCodeIgniter($config);
-		}
-
 		return new CodeIgniter($config);
 	}
 

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -532,6 +532,9 @@ abstract class CIUnitTestCase extends TestCase
 		// Initialize the autoloader.
 		Services::autoloader()->initialize(new Autoload(), new Modules());
 
+		$app = new MockCodeIgniter(new App());
+		Services::injectMock('codeigniter', $app);
+
 		$app = Services::codeigniter(new App());
 		$app->initialize();
 

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -532,7 +532,7 @@ abstract class CIUnitTestCase extends TestCase
 		// Initialize the autoloader.
 		Services::autoloader()->initialize(new Autoload(), new Modules());
 
-		$app = new MockCodeIgniter(new App());
+		$app = Services::codeigniter(new App());
 		$app->initialize();
 
 		return $app;

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -145,6 +145,36 @@ helper('url');
 
 /*
  * ---------------------------------------------------------------
+ * DETECT ENVIRONMENT
+ * ---------------------------------------------------------------
+ *
+ * You can load different configurations depending on your
+ * current environment. Setting the environment also influences
+ * things like logging and error reporting.
+ *
+ * This can be set to anything, but default usage is:
+ *
+ *     development
+ *     testing
+ *     production
+ */
+
+// Make sure ENVIRONMENT isn't already set by other means.
+if (! defined('ENVIRONMENT'))
+{
+	// running under Continuous Integration server?
+	if (getenv('CI') !== false)
+	{
+		define('ENVIRONMENT', 'testing');
+	}
+	else
+	{
+		define('ENVIRONMENT', $_SERVER['CI_ENVIRONMENT'] ?? 'production');
+	}
+}
+
+/*
+ * ---------------------------------------------------------------
  * GRAB OUR CODEIGNITER INSTANCE
  * ---------------------------------------------------------------
  *


### PR DESCRIPTION
**Description**
#4376 makes the `CodeIgniter` class extensible.
But `CIUnitTestCase` has hard coded code `new MockCodeIgniter()`.

When we extend the `CodeIgniter` class, we need to use the extended `MockCodeIgniter`
in testing. 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
