### PR TITLE
Traitify Feature Tests

### DIFF
--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -18,6 +18,7 @@ use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\MigrationRunner;
 use CodeIgniter\Database\Seeder;
 use CodeIgniter\Events\Events;
+use CodeIgniter\Router\RouteCollection;
 use CodeIgniter\Session\Handlers\ArrayHandler;
 use CodeIgniter\Test\Constraints\SeeInDatabase;
 use CodeIgniter\Test\Mock\MockCache;
@@ -61,6 +62,13 @@ abstract class CIUnitTestCase extends TestCase
 	 * @var array of methods
 	 */
 	protected $tearDownMethods = [];
+
+	/**
+	 * Store of identified traits.
+	 *
+	 * @var string[]|null
+	 */
+	private $traits;
 
 	//--------------------------------------------------------------------
 	// Database Properties
@@ -158,15 +166,58 @@ abstract class CIUnitTestCase extends TestCase
 	protected $insertCache = [];
 
 	//--------------------------------------------------------------------
-	// Staging
+	// Feature Properties
 	//--------------------------------------------------------------------
 
 	/**
-	 * Store of identified traits.
+	 * If present, will override application
+	 * routes when using call().
 	 *
-	 * @var string[]|null
+	 * @var RouteCollection|null
 	 */
-	private $traits;
+	protected $routes;
+
+	/**
+	 * Values to be set in the SESSION global
+	 * before running the test.
+	 *
+	 * @var array
+	 */
+	protected $session = [];
+
+	/**
+	 * Enabled auto clean op buffer after request call
+	 *
+	 * @var boolean
+	 */
+	protected $clean = true;
+
+	/**
+	 * Custom request's headers
+	 *
+	 * @var array
+	 */
+	protected $headers = [];
+
+	/**
+	 * Allows for formatting the request body to what
+	 * the controller is going to expect
+	 *
+	 * @var string
+	 */
+	protected $bodyFormat = '';
+
+	/**
+	 * Allows for directly setting the body to what
+	 * it needs to be.
+	 *
+	 * @var mixed
+	 */
+	protected $requestBody = '';
+
+	//--------------------------------------------------------------------
+	// Staging
+	//--------------------------------------------------------------------
 
 	/**
 	 * Load the helpers.

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -11,8 +11,6 @@
 
 namespace CodeIgniter\Test;
 
-use CodeIgniter\Router\RouteCollection;
-
 /**
  * Class FeatureTestCase
  *
@@ -23,50 +21,4 @@ class FeatureTestCase extends CIUnitTestCase
 {
 	use FeatureTestTrait;
 	use DatabaseTestTrait;
-
-	/**
-	 * If present, will override application
-	 * routes when using call().
-	 *
-	 * @var RouteCollection
-	 */
-	protected $routes;
-
-	/**
-	 * Values to be set in the SESSION global
-	 * before running the test.
-	 *
-	 * @var array
-	 */
-	protected $session = [];
-
-	/**
-	 * Enabled auto clean op buffer after request call
-	 *
-	 * @var boolean
-	 */
-	protected $clean = true;
-
-	/**
-	 * Custom request's headers
-	 *
-	 * @var array
-	 */
-	protected $headers = [];
-
-	/**
-	 * Allows for formatting the request body to what
-	 * the controller is going to expect
-	 *
-	 * @var string
-	 */
-	protected $bodyFormat = '';
-
-	/**
-	 * Allows for directly setting the body to what
-	 * it needs to be.
-	 *
-	 * @var mixed
-	 */
-	protected $requestBody = '';
 }

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -16,6 +16,8 @@ namespace CodeIgniter\Test;
  *
  * Provides a base class with the trait for doing full HTTP testing
  * against your application.
+ *
+ * @deprecated Include the traits directly in the test case
  */
 class FeatureTestCase extends CIUnitTestCase
 {

--- a/user_guide_src/source/changelogs/v4.1.2.rst
+++ b/user_guide_src/source/changelogs/v4.1.2.rst
@@ -30,6 +30,7 @@ Deprecations:
 - Deprecated cookie-related properties of ``Session`` in order to use the ``Cookie`` class.
 - Deprecated ``Security::isExpired()`` to use the ``Cookie``'s internal expires status.
 - Deprecated ``CIDatabaseTestCase`` to use the ``DatabaseTestTrait`` instead.
+- Deprecated ``FeatureTestCase`` to use the ``FeatureTestTrait`` instead.
 
 Bugs Fixed:
 

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -14,35 +14,42 @@ and more.
 The Test Class
 ==============
 
-Feature testing requires that all of your test classes extend the ``CodeIgniter\Test\FeatureTestCase``
-class or use the ``CodeIgniter\Test\FeatureTestTrait``. Since these testing tools extend
-`CIDatabaseTestCase <database.html>`_ you must always ensure that ``parent::setUp()`` and ``parent::tearDown()``
-are called before you take your actions.
+Feature testing requires that all of your test classes use the ``CodeIgniter\Test\DatabaseTestCase``
+and ``CodeIgniter\Test\FeatureTestTrait`` traits. Since these testing tools rely on proper database
+staging you must always ensure that ``parent::setUp()`` and ``parent::tearDown()``
+are called if you implement your own methods.
 ::
 
     <?php
 
     namespace App;
 
-    use CodeIgniter\Test\FeatureTestCase;
+    use CodeIgniter\Test\DatabaseTestTrait;
+    use CodeIgniter\Test\FeatureTestTrait;
 
     class TestFoo extends FeatureTestCase
     {
-        public function setUp(): void
+    	use DatabaseTestTrait, FeatureTestTrait;
+
+        protected function setUp(): void
         {
             parent::setUp();
+
+			$this->myClassMethod();
         }
 
-        public function tearDown(): void
+        protected function tearDown(): void
         {
             parent::tearDown();
+
+			$this->anotherClassMethod();
         }
     }
 
 Requesting A Page
 =================
 
-Essentially, the FeatureTestCase simply allows you to call an endpoint on your application and get the results back.
+Essentially, feature tests simply allows you to call an endpoint on your application and get the results back.
 to do this, you use the ``call()`` method. The first parameter is the HTTP method to use (most frequently either GET or POST).
 The second parameter is the path on your site to test. The third parameter accepts an array that is used to populate the
 superglobal variables for the HTTP verb you are using. So, a method of **GET** would have the **$_GET** variable


### PR DESCRIPTION
**Description**
Continuing the trend of a core test class with supplemental traits, this PR moves `FeatureTestCase` properties (already made optional when we split out `FeatureTestTrait`) into `CIUnitTestCase` and deprecated the class in favor of using the trait directly on an extension of `CIUnitTestCase`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
