### PR TITLE
Database trait methods

### DIFF
--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -14,12 +14,9 @@ namespace CodeIgniter\Test;
 use CodeIgniter\CodeIgniter;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Database\BaseConnection;
-use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Database\MigrationRunner;
 use CodeIgniter\Database\Seeder;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Session\Handlers\ArrayHandler;
-use CodeIgniter\Test\Constraints\SeeInDatabase;
 use CodeIgniter\Test\Mock\MockCache;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
 use CodeIgniter\Test\Mock\MockEmail;
@@ -467,107 +464,6 @@ abstract class CIUnitTestCase extends TestCase
 		{
 			return false;
 		}
-	}
-
-	//--------------------------------------------------------------------
-	// Database
-	//--------------------------------------------------------------------
-
-	/**
-	 * Asserts that records that match the conditions in $where do
-	 * not exist in the database.
-	 *
-	 * @param string $table
-	 * @param array  $where
-	 *
-	 * @return void
-	 */
-	public function dontSeeInDatabase(string $table, array $where)
-	{
-		$count = $this->db->table($table)
-						  ->where($where)
-						  ->countAllResults();
-
-		$this->assertTrue($count === 0, 'Row was found in database');
-	}
-
-	/**
-	 * Asserts that records that match the conditions in $where DO
-	 * exist in the database.
-	 *
-	 * @param string $table
-	 * @param array  $where
-	 *
-	 * @return void
-	 * @throws DatabaseException
-	 */
-	public function seeInDatabase(string $table, array $where)
-	{
-		$constraint = new SeeInDatabase($this->db, $where);
-		static::assertThat($table, $constraint);
-	}
-
-	/**
-	 * Fetches a single column from a database row with criteria
-	 * matching $where.
-	 *
-	 * @param string $table
-	 * @param string $column
-	 * @param array  $where
-	 *
-	 * @return boolean
-	 * @throws DatabaseException
-	 */
-	public function grabFromDatabase(string $table, string $column, array $where)
-	{
-		$query = $this->db->table($table)
-						  ->select($column)
-						  ->where($where)
-						  ->get();
-
-		$query = $query->getRow();
-
-		return $query->$column ?? false;
-	}
-
-	/**
-	 * Inserts a row into to the database. This row will be removed
-	 * after the test has run.
-	 *
-	 * @param string $table
-	 * @param array  $data
-	 *
-	 * @return boolean
-	 */
-	public function hasInDatabase(string $table, array $data)
-	{
-		$this->insertCache[] = [
-			$table,
-			$data,
-		];
-
-		return $this->db->table($table)
-						->insert($data);
-	}
-
-	/**
-	 * Asserts that the number of rows in the database that match $where
-	 * is equal to $expected.
-	 *
-	 * @param integer $expected
-	 * @param string  $table
-	 * @param array   $where
-	 *
-	 * @return void
-	 * @throws DatabaseException
-	 */
-	public function seeNumRecords(int $expected, string $table, array $where)
-	{
-		$count = $this->db->table($table)
-						  ->where($where)
-						  ->countAllResults();
-
-		$this->assertEquals($expected, $count, 'Wrong number of matching rows in database.');
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
This PR moves the database test methods back to `DatabaseTestTrait` and reorganizes the class a little better. This brings it in line with the test support class organization that is firming up: methods on traits, properties on `CIUnitTestCase`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
