### PR TITLE
Repeat App Routes

### DIFF
--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -17,6 +17,7 @@ use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Router\Exceptions\RedirectException;
+use CodeIgniter\Router\RouteCollection;
 use Config\App;
 use Config\Services;
 use Exception;
@@ -166,8 +167,17 @@ trait FeatureTestTrait
 		$request = $this->populateGlobals($method, $request, $params);
 		$request = $this->setRequestBody($request);
 
-		// Make sure the RouteCollection knows what method we're using...
-		$routes = $this->routes ?? Services::routes();
+		// Initialize the RouteCollection
+		if (! $routes = $this->routes)
+		{
+			require APPPATH . 'Config/Routes.php';
+
+			/**
+			 * @var RouteCollection $routes
+			 */
+			$routes->getRoutes('*');
+		}
+
 		$routes->setHTTPVerb($method);
 
 		// Make sure any other classes that might call the request


### PR DESCRIPTION
**Description**
Presumably for performance reasons, `RouteCollection` skips re-loading routes from `App`. This works until feature tests reset services and reload routes. Then the collection fails to discover App routes during `discoverRoutes()`.

I think the root of this issue is because the original Routes service is initiated during bootstrap (see **system/Test/bootstrap.php** at the bottom) so there may be a better solution by moving that into the test classes somewhere, but I spent so long tracking this down I have to get it written all out or I will forget it.

EDIT: My thought was correct. I've replaced my original solution with this variant. Feature Tests will now use the App initialized version of `RouteCollection` instead of the raw service version.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
