### PR TITLE
Default HTTPVerb

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -134,7 +134,7 @@ class RouteCollection implements RouteCollectionInterface
 	 *
 	 * @var string
 	 */
-	protected $HTTPVerb;
+	protected $HTTPVerb = '*';
 
 	/**
 	 * The default list of HTTP methods (and CLI for command line usage)


### PR DESCRIPTION
**Description**
Fixes #4435 by supplying an initial string placeholder so `$HTTPVerb` will never be `null`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
