### PR TITLE
[WIP] Include "LIMIT 0" in compiled SELECT statements

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2042,7 +2042,7 @@ class BaseBuilder
 			$this->where($where);
 		}
 
-		if (! empty($limit))
+		if (! is_null($limit))
 		{
 			$this->limit($limit, $offset);
 		}
@@ -2466,7 +2466,7 @@ class BaseBuilder
 			$this->where($where);
 		}
 
-		if (! empty($limit))
+		if (! is_null($limit))
 		{
 			if (! $this->canLimitWhereUpdates)
 			{
@@ -2522,7 +2522,7 @@ class BaseBuilder
 		return 'UPDATE ' . $this->compileIgnore('update') . $table . ' SET ' . implode(', ', $valStr)
 				. $this->compileWhereHaving('QBWhere')
 				. $this->compileOrderBy()
-				. ($this->QBLimit ? $this->_limit(' ', true) : '');
+				. ($this->QBLimit !== false ? $this->_limit(' ', true) : '');
 	}
 
 	//--------------------------------------------------------------------
@@ -2861,12 +2861,12 @@ class BaseBuilder
 
 		$sql = $this->_delete($table);
 
-		if (! empty($limit))
+		if (! is_null($limit))
 		{
 			$this->QBLimit = $limit;
 		}
 
-		if (! empty($this->QBLimit))
+		if ($this->QBLimit !== false)
 		{
 			if (! $this->canLimitDeletes)
 			{

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3040,7 +3040,7 @@ class BaseBuilder
 				. $this->compileWhereHaving('QBHaving')
 				. $this->compileOrderBy(); // ORDER BY
 		// LIMIT
-		if ($this->QBLimit)
+		if ($this->QBLimit !== false)
 		{
 			return $this->_limit($sql . "\n");
 		}

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -245,7 +245,7 @@ class Builder extends BaseBuilder
 	 */
 	public function delete($where = '', int $limit = null, bool $resetData = true)
 	{
-		if (! empty($limit) || ! empty($this->QBLimit))
+		if (! is_null($limit) || $this->QBLimit !== false)
 		{
 			throw new DatabaseException('PostgreSQL does not allow LIMITs on DELETE queries.');
 		}
@@ -286,7 +286,7 @@ class Builder extends BaseBuilder
 	 */
 	protected function _update(string $table, array $values): string
 	{
-		if (! empty($this->QBLimit))
+		if ($this->QBLimit !== false)
 		{
 			throw new DatabaseException('Postgres does not support LIMITs with UPDATE queries.');
 		}

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -234,7 +234,7 @@ class Builder extends BaseBuilder
 
 		$fullTableName = $this->getFullName($table);
 
-		$statement = 'UPDATE ' . (empty($this->QBLimit) ? '' : 'TOP(' . $this->QBLimit . ') ') . $fullTableName . ' SET '
+		$statement = 'UPDATE ' . ($this->QBLimit !== false ? 'TOP(' . $this->QBLimit . ') ' : '') . $fullTableName . ' SET '
 				. implode(', ', $valstr) . $this->compileWhereHaving('QBWhere') . $this->compileOrderBy();
 
 		return $this->keyPermission ? $this->addIdentity($fullTableName, $statement) : $statement;
@@ -533,7 +533,7 @@ class Builder extends BaseBuilder
 	 */
 	protected function _delete(string $table): string
 	{
-		return 'DELETE' . (empty($this->QBLimit) ? '' : ' TOP (' . $this->QBLimit . ') ') . ' FROM ' . $this->getFullName($table) . $this->compileWhereHaving('QBWhere');
+		return 'DELETE' . ($this->QBLimit !== false ? ' TOP (' . $this->QBLimit . ') ' : '') . ' FROM ' . $this->getFullName($table) . $this->compileWhereHaving('QBWhere');
 	}
 
 	/**
@@ -567,7 +567,7 @@ class Builder extends BaseBuilder
 			return false; // @codeCoverageIgnore
 		}
 
-		if (! empty($limit))
+		if (! is_null($limit))
 		{
 			$this->QBLimit = $limit;
 		}
@@ -647,7 +647,7 @@ class Builder extends BaseBuilder
 				. $this->compileWhereHaving('QBHaving')
 				. $this->compileOrderBy(); // ORDER BY
 		// LIMIT
-		if ($this->QBLimit)
+		if ($this->QBLimit !== false)
 		{
 			return $sql = $this->_limit($sql . "\n");
 		}

--- a/system/Model.php
+++ b/system/Model.php
@@ -192,7 +192,7 @@ class Model extends BaseModel
 			$builder->where($this->table . '.' . $this->deletedField, null);
 		}
 
-		return $builder->limit($limit, $offset)
+		return $builder->limit($limit ?: null, $offset)
 			->get()
 			->getResult($this->tempReturnType);
 	}


### PR DESCRIPTION
**Description**
The following function of the BaseBuilder class permits setting LIMIT to zero.

```
limit(?int $value = null, ?int $offset = 0)
```

I think this is by design, as the default value here is `null`, in contrast to `$offset`. But setting it to zero has no effect on the resulting SQL statement (to my awareness). 

This is caused by the `compileSelect` method. Adding "LIMIT 0" is skipped there because zero is interpreted as `false` - the empty default value. So, instead of an empty result, all table lines (fitting the other conditions) are returned.

So I propose changing the IF statement in `compileSelect` to differentiate between `0` and `false` when checking `$this->QBLimit`.

**Checklist:**
Sorry, I don't know how to fulfill the points on the checklist. But I searched all open and closed issues / PRs and haven't noticed this topic anywhere. So, I hope this small change is helpful nevertheless :)

**EDIT**: Oh, sorry, I see the tests failing one after the other. So that's not the solution.