### PR TITLE
Fix Query named bind recognition

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1338,13 +1338,12 @@ abstract class BaseConnection implements ConnectionInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * DB Prefix
-	 *
 	 * Prepends a database prefix if one exists in configuration
 	 *
 	 * @param string $table the table
 	 *
 	 * @return string
+	 *
 	 * @throws DatabaseException
 	 */
 	public function prefixTable(string $table = ''): string

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -315,13 +315,13 @@ class Query implements QueryInterface
 	 *
 	 * @return void
 	 *
-	 * @see https://regex101.com/r/jgAWNQ/1
+	 * @see https://regex101.com/r/jgAWNQ/2
 	 */
 	protected function compileBinds()
 	{
 		$sql = $this->finalQueryString;
 
-		$hasNamedBinds = preg_match('/\:(?:[\w\.]+)\:/', $sql) === 1;
+		$hasNamedBinds = preg_match('/\:(?:[\w\.\(\)]+)\:/', $sql) === 1;
 
 		if (empty($this->binds)
 			|| empty($this->bindMarker)

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -348,4 +348,16 @@ class WhereTest extends CIUnitTestCase
 
 		$this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 	}
+
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/4443
+	 */
+	public function testWhereWithLower()
+	{
+		$builder = $this->db->table('jobs');
+		$builder->where('LOWER(jobs.name)', 'accountant');
+
+		$expectedSQL = 'SELECT * FROM "jobs" WHERE LOWER(jobs.name) = \'accountant\'';
+		$this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+	}
 }

--- a/tests/system/Database/Live/WhereTest.php
+++ b/tests/system/Database/Live/WhereTest.php
@@ -216,6 +216,21 @@ class WhereTest extends CIUnitTestCase
 		$this->assertCount(4, $jobs);
 	}
 
-	//--------------------------------------------------------------------
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/4443
+	 */
+	public function testWhereWithLower()
+	{
+		$builder = $this->db->table('job');
+		$builder->insert([
+			'name'        => 'Brewmaster',
+			'description' => null,
+		]);
 
+		$job = $builder
+			->where(sprintf('LOWER(%s.name)', $this->db->prefixTable('job')), 'brewmaster')
+			->get()
+			->getResult();
+		$this->assertCount(1, $job);
+	}
 }


### PR DESCRIPTION
**Description**
Fixes #4443 by changing the regex used by `Query` on how it recognizes a named bind by including parentheses.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
