### PR TITLE
Use speedtrap to document slow tests

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -123,7 +123,7 @@ jobs:
           COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
       - name: Test with PHPUnit
-        run: script -e -c "vendor/bin/phpunit -v"
+        run: script -e -c "vendor/bin/phpunit --color=always"
         env:
           DB: ${{ matrix.db-platforms }}
           TERM: xterm-256color
@@ -140,7 +140,7 @@ jobs:
 
   coveralls-finish:
     needs: [tests]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
 	"require-dev": {
 		"codeigniter4/codeigniter4-standard": "^1.0",
 		"fakerphp/faker": "^1.9",
+		"johnkary/phpunit-speedtrap": "^3.3",
 		"mikey179/vfsstream": "^1.6",
 		"phpstan/phpstan": "0.12.81",
 		"phpunit/phpunit": "^9.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		bootstrap="system/Test/bootstrap.php"
-		backupGlobals="false"
-		colors="true"
-		convertErrorsToExceptions="true"
-		convertNoticesToExceptions="true"
-		convertWarningsToExceptions="true"
-		stopOnError="false"
-		stopOnFailure="false"
-		stopOnIncomplete="false"
-		stopOnSkipped="false"
-		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+		 xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+		 bootstrap="system/Test/bootstrap.php"
+		 backupGlobals="false"
+		 beStrictAboutOutputDuringTests="true"
+		 beStrictAboutTodoAnnotatedTests="true"
+		 cacheResultFile="build/.phpunit.cache/test-results"
+		 colors="true"
+		 failOnRisky="true"
+		 failOnWarning="true"
+		 verbose="true">
+
 	<coverage processUncoveredFiles="true">
 		<include>
 			<directory suffix=".php">./system</directory>
 		</include>
+
 		<exclude>
 			<directory>./system/Commands/Generators/Views</directory>
 			<directory>./system/Debug/Toolbar/Views</directory>
@@ -26,10 +27,12 @@
 			<file>./system/Config/Routes.php</file>
 			<file>./system/Test/bootstrap.php</file>
 		</exclude>
+
 		<report>
 			<clover outputFile="build/logs/clover.xml"/>
 		</report>
 	</coverage>
+
 	<testsuites>
 		<testsuite name="System">
 			<directory>./tests/system</directory>
@@ -39,7 +42,28 @@
 			<directory>./tests/system/Database</directory>
 		</testsuite>
 	</testsuites>
-	<logging/>
+
+	<listeners>
+		<listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener">
+			<arguments>
+				<array>
+					<!-- Number of milliseconds when a test is considered "slow" (Default: 500ms) -->
+					<element key="slowThreshold">
+						<integer>500</integer>
+					</element>
+					<!-- Number of slow tests included in the report (Default: 10 tests) -->
+					<element key="reportLength">
+						<integer>30</integer>
+					</element>
+					<!-- Stop execution upon first slow test (Default: false) -->
+					<element key="stopOnSlow">
+						<boolean>false</boolean>
+					</element>
+				</array>
+			</arguments>
+		</listener>
+	</listeners>
+
 	<php>
 		<env name="XDEBUG_MODE" value="coverage"/>
 		<server name="app.baseURL" value="http://example.com/"/>


### PR DESCRIPTION
**Description**
Use `johnkary/phpunit-speedtrap` to document slow tests in the framework's test suites. This is the starting point to optimize the speed of our tests.

Ref: #4438 

**Checklist:**
- [x] Securely signed commits
