### PR TITLE
Changed work with subqueries

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -263,7 +263,9 @@ class BaseBuilder
 			throw new DatabaseException('A table must be specified when creating a new Query Builder.');
 		}
 
-		/** @var BaseConnection $db */
+		/**
+ * @var BaseConnection $db
+*/
 		$this->db = $db;
 
 		$this->tableName = $tableName;
@@ -821,10 +823,9 @@ class BaseBuilder
 					$k .= " $op";
 				}
 
-				if ($v instanceof Closure)
+				if ($builder = $this->getInstanceForSubquery($v))
 				{
-					$builder = $this->cleanClone();
-					$v       = '(' . str_replace("\n", ' ', $v($builder)->getCompiledSelect()) . ')';
+					$v = '(' . str_replace("\n", ' ', $builder->getCompiledSelect()) . ')';
 				}
 				else
 				{
@@ -858,9 +859,9 @@ class BaseBuilder
 	 * Generates a WHERE field IN('item', 'item') SQL query,
 	 * joined with 'AND' if appropriate.
 	 *
-	 * @param string               $key    The field to search
-	 * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-	 * @param boolean              $escape
+	 * @param string                           $key    The field to search
+	 * @param array|string|Closure|BaseBuilder $values The values searched on, or anonymous function with subquery
+	 * @param boolean                          $escape
 	 *
 	 * @return $this
 	 */
@@ -877,9 +878,9 @@ class BaseBuilder
 	 * Generates a WHERE field IN('item', 'item') SQL query,
 	 * joined with 'OR' if appropriate.
 	 *
-	 * @param string               $key    The field to search
-	 * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-	 * @param boolean              $escape
+	 * @param string                           $key    The field to search
+	 * @param array|string|Closure|BaseBuilder $values The values searched on, or anonymous function with subquery
+	 * @param boolean                          $escape
 	 *
 	 * @return $this
 	 */
@@ -896,9 +897,9 @@ class BaseBuilder
 	 * Generates a WHERE field NOT IN('item', 'item') SQL query,
 	 * joined with 'AND' if appropriate.
 	 *
-	 * @param string               $key    The field to search
-	 * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-	 * @param boolean              $escape
+	 * @param string                           $key    The field to search
+	 * @param array|string|Closure|BaseBuilder $values The values searched on, or anonymous function with subquery
+	 * @param boolean                          $escape
 	 *
 	 * @return $this
 	 */
@@ -915,9 +916,9 @@ class BaseBuilder
 	 * Generates a WHERE field NOT IN('item', 'item') SQL query,
 	 * joined with 'OR' if appropriate.
 	 *
-	 * @param string               $key    The field to search
-	 * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-	 * @param boolean              $escape
+	 * @param string                           $key    The field to search
+	 * @param array|string|Closure|BaseBuilder $values The values searched on, or anonymous function with subquery
+	 * @param boolean                          $escape
 	 *
 	 * @return $this
 	 */
@@ -934,9 +935,9 @@ class BaseBuilder
 	 * Generates a HAVING field IN('item', 'item') SQL query,
 	 * joined with 'AND' if appropriate.
 	 *
-	 * @param string               $key    The field to search
-	 * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-	 * @param boolean              $escape
+	 * @param string                           $key    The field to search
+	 * @param array|string|Closure|BaseBuilder $values The values searched on, or anonymous function with subquery
+	 * @param boolean                          $escape
 	 *
 	 * @return $this
 	 */
@@ -953,9 +954,9 @@ class BaseBuilder
 	 * Generates a HAVING field IN('item', 'item') SQL query,
 	 * joined with 'OR' if appropriate.
 	 *
-	 * @param string               $key    The field to search
-	 * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-	 * @param boolean              $escape
+	 * @param string                           $key    The field to search
+	 * @param array|string|Closure|BaseBuilder $values The values searched on, or anonymous function with subquery
+	 * @param boolean                          $escape
 	 *
 	 * @return $this
 	 */
@@ -972,9 +973,9 @@ class BaseBuilder
 	 * Generates a HAVING field NOT IN('item', 'item') SQL query,
 	 * joined with 'AND' if appropriate.
 	 *
-	 * @param string               $key    The field to search
-	 * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-	 * @param boolean              $escape
+	 * @param string                           $key    The field to search
+	 * @param array|string|Closure|BaseBuilder $values The values searched on, or anonymous function with subquery
+	 * @param boolean                          $escape
 	 *
 	 * @return $this
 	 */
@@ -991,9 +992,9 @@ class BaseBuilder
 	 * Generates a HAVING field NOT IN('item', 'item') SQL query,
 	 * joined with 'OR' if appropriate.
 	 *
-	 * @param string               $key    The field to search
-	 * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-	 * @param boolean              $escape
+	 * @param string                           $key    The field to search
+	 * @param array|string|Closure|BaseBuilder $values The values searched on, or anonymous function with subquery
+	 * @param boolean                          $escape
 	 *
 	 * @return $this
 	 */
@@ -1012,12 +1013,12 @@ class BaseBuilder
 	 * @used-by whereNotIn()
 	 * @used-by orWhereNotIn()
 	 *
-	 * @param  string             $key    The field to search
-	 * @param  array|Closure|null $values The values searched on, or anonymous function with subquery
-	 * @param  boolean            $not    If the statement would be IN or NOT IN
-	 * @param  string             $type
-	 * @param  boolean            $escape
-	 * @param  string             $clause (Internal use only)
+	 * @param  string                         $key    The field to search
+	 * @param  array|Closure|null|BaseBuilder $values The values searched on, or anonymous function with subquery
+	 * @param  boolean                        $not    If the statement would be IN or NOT IN
+	 * @param  string                         $type
+	 * @param  boolean                        $escape
+	 * @param  string                         $clause (Internal use only)
 	 * @throws InvalidArgumentException
 	 *
 	 * @return $this
@@ -1035,7 +1036,7 @@ class BaseBuilder
 			// @codeCoverageIgnoreEnd
 		}
 
-		if ($values === null || (! is_array($values) && ! ($values instanceof Closure)))
+		if ($values === null || (! is_array($values) && $this->getInstanceForSubquery($values) === null))
 		{
 			if (CI_DEBUG)
 			{
@@ -1060,10 +1061,9 @@ class BaseBuilder
 
 		$not = ($not) ? ' NOT' : '';
 
-		if ($values instanceof Closure)
+		if ($builder = $this->getInstanceForSubquery($values))
 		{
-			$builder = $this->cleanClone();
-			$ok      = str_replace("\n", ' ', $values($builder)->getCompiledSelect());
+			$ok = str_replace("\n", ' ', $builder->getCompiledSelect());
 		}
 		else
 		{
@@ -1074,7 +1074,8 @@ class BaseBuilder
 		$prefix = empty($this->$clause) ? $this->groupGetType('') : $this->groupGetType($type);
 
 		$whereIn = [
-			'condition' => $prefix . $key . $not . ($values instanceof Closure ? " IN ($ok)" : " IN :{$ok}:"),
+			'condition' => $prefix . $key . $not
+							. ($this->getInstanceForSubquery($values) ? " IN ($ok)" : " IN :{$ok}:"),
 			'escape'    => false,
 		];
 
@@ -3516,12 +3517,64 @@ class BaseBuilder
 	/**
 	 * Returns a clone of a Base Builder with reset query builder values.
 	 *
-	 * @return $this
+	 * @return static
 	 */
-	protected function cleanClone()
+	protected function getBuilderClone(): self
 	{
 		return (clone $this)->from([], true)->resetQuery();
 	}
 
-	//--------------------------------------------------------------------
+	/**
+	 * Trying to get BaseBuilder instance of the class for subqueries
+	 *
+	 * @param mixed   $builder        Value for subquery recognition
+	 * @param boolean $throwException Throw an exception on error
+	 *
+	 * @return BaseBuilder|null
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	protected function getInstanceForSubquery($builder, bool $throwException = false)
+	{
+		$isClosure = false;
+
+		if ($builder instanceof Closure)
+		{
+			$isClosure = true;
+			$builder   = $builder($this->getBuilderClone());
+		}
+
+		if ($builder instanceof BaseBuilder)
+		{
+			if (spl_object_hash($builder) === spl_object_hash($this))
+			{
+				throw new InvalidArgumentException(
+					'A subquery builder instance cannot be equal to an instance of the parent builder class'
+				);
+			}
+
+			return $builder;
+		}
+
+		if ($isClosure)
+		{
+			throw new InvalidArgumentException('The closure must return an instance of the BaseBuilder class');
+		}
+
+		if ($throwException)
+		{
+			$data = debug_backtrace(0, 2)[1];
+
+			throw new InvalidArgumentException(
+				sprintf(
+					'The argument passed to the %s::%s() method must be
+					a Closure or an instance of the BaseBuilder class',
+					$data['class'],
+					$data['function']
+				)
+			);
+		}
+
+		return null;
+	}
 }

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -263,9 +263,7 @@ class BaseBuilder
 			throw new DatabaseException('A table must be specified when creating a new Query Builder.');
 		}
 
-		/**
- * @var BaseConnection $db
-*/
+		/** @var BaseConnection $db */
 		$this->db = $db;
 
 		$this->tableName = $tableName;
@@ -1074,8 +1072,7 @@ class BaseBuilder
 		$prefix = empty($this->$clause) ? $this->groupGetType('') : $this->groupGetType($type);
 
 		$whereIn = [
-			'condition' => $prefix . $key . $not
-							. ($this->getInstanceForSubquery($values) ? " IN ($ok)" : " IN :{$ok}:"),
+			'condition' => $prefix . $key . $not . ($this->getInstanceForSubquery($values) ? " IN ($ok)" : " IN :{$ok}:"),
 			'escape'    => false,
 		];
 
@@ -3518,6 +3515,18 @@ class BaseBuilder
 	 * Returns a clone of a Base Builder with reset query builder values.
 	 *
 	 * @return static
+	 *
+	 * @deprecated Use $this->getBuilderClone() instead
+	 */
+	protected function cleanClone()
+	{
+		return $this->getBuilderClone();
+	}
+
+	/**
+	 * Returns a clone of a Base Builder with reset query builder values.
+	 *
+	 * @return static
 	 */
 	protected function getBuilderClone(): self
 	{
@@ -3565,14 +3574,11 @@ class BaseBuilder
 		{
 			$data = debug_backtrace(0, 2)[1];
 
-			throw new InvalidArgumentException(
-				sprintf(
-					'The argument passed to the %s::%s() method must be
-					a Closure or an instance of the BaseBuilder class',
-					$data['class'],
-					$data['function']
-				)
-			);
+			throw new InvalidArgumentException(sprintf(
+				'The argument passed to the %s::%s() method must be a Closure or an instance of the BaseBuilder class.',
+				$data['class'],
+				$data['function']
+			));
 		}
 
 		return null;

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3530,7 +3530,9 @@ class BaseBuilder
 	 */
 	protected function getBuilderClone(): self
 	{
-		return (clone $this)->from([], true)->resetQuery();
+		$builder         = (clone $this)->resetQuery()->from([], true);
+		$builder->QBFrom = [];
+		return $builder;
 	}
 
 	/**

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -712,10 +712,9 @@ class Builder extends BaseBuilder
 					$k .= " $op";
 				}
 
-				if ($v instanceof Closure)
+				if ($builder = $this->getInstanceForSubquery($v))
 				{
-					$builder = $this->cleanClone();
-					$v       = '(' . str_replace("\n", ' ', $v($builder)->getCompiledSelect()) . ')';
+					$v = '(' . str_replace("\n", ' ', $builder->getCompiledSelect()) . ')';
 				}
 				else
 				{

--- a/tests/system/Database/Builder/GroupTest.php
+++ b/tests/system/Database/Builder/GroupTest.php
@@ -79,7 +79,7 @@ class GroupTest extends CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testHavingInClosure()
+	public function testHavingInSubquery()
 	{
 		$builder = new BaseBuilder('user', $this->db);
 
@@ -93,6 +93,12 @@ class GroupTest extends CIUnitTestCase
 		$expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)';
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+		$subquery = $this->db->table('users_jobs')->select('user_id')->where('group_id', 3);
+
+		$builder->select('name')->groupBy('name')->havingIn('id', $subquery);
+
+		$this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 	}
 
 	//--------------------------------------------------------------------
@@ -113,7 +119,7 @@ class GroupTest extends CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testOrHavingInClosure()
+	public function testOrHavingInSubquery()
 	{
 		$builder = new BaseBuilder('user', $this->db);
 
@@ -128,6 +134,16 @@ class GroupTest extends CIUnitTestCase
 		});
 
 		$expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3) OR "group_id" IN (SELECT "group_id" FROM "groups" WHERE "group_id" = 6)';
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+		$subquery1 = $this->db->table('users_jobs')->select('user_id')->where('group_id', 3);
+		$subquery2 = $this->db->table('groups')->select('group_id')->where('group_id', 6);
+
+		$builder->select('name')
+			->groupBy('name')
+			->havingIn('id', $subquery1)
+			->orHavingIn('group_id', $subquery2);
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 	}
@@ -149,7 +165,7 @@ class GroupTest extends CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testHavingNotInClosure()
+	public function testHavingNotInSubquery()
 	{
 		$builder = new BaseBuilder('user', $this->db);
 
@@ -161,6 +177,12 @@ class GroupTest extends CIUnitTestCase
 		});
 
 		$expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)';
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+		$subquery = $this->db->table('users_jobs')->select('user_id')->where('group_id', 3);
+
+		$builder->select('name')->groupBy('name')->havingNotIn('id', $subquery);
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 	}
@@ -183,7 +205,7 @@ class GroupTest extends CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
-	public function testOrHavingNotInClosure()
+	public function testOrHavingNotInSubquery()
 	{
 		$builder = new BaseBuilder('user', $this->db);
 
@@ -198,6 +220,16 @@ class GroupTest extends CIUnitTestCase
 		});
 
 		$expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3) OR "group_id" NOT IN (SELECT "group_id" FROM "groups" WHERE "group_id" = 6)';
+
+		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+		$subquery1 = $this->db->table('users_jobs')->select('user_id')->where('group_id', 3);
+		$subquery2 = $this->db->table('groups')->select('group_id')->where('group_id', 6);
+
+		$builder->select('name')
+			->groupBy('name')
+			->havingNotIn('id', $subquery1)
+			->orHavingNotIn('group_id', $subquery2);
 
 		$this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 	}

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -305,14 +305,25 @@ methods:
         $builder->where('MATCH (field) AGAINST ("value")', null, false);
 
 #. **Subqueries:**
-    You can use an anonymous function to create a subquery.
+    With anonymous function::
 
-    ::
+        //importing the class at the top of the file
+        use CodeIgniter\Database\BaseBuilder;
 
-        $builder->where('advance_amount <', function(BaseBuilder $builder) {
+        //...
+
+        $builder->where('advance_amount <', function (BaseBuilder $builder) {
             return $builder->select('MAX(advance_amount)', false)->from('orders')->where('id >', 2);
         });
         // Produces: WHERE "advance_amount" < (SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2)
+
+    With Builder::
+
+        $subquery = $this->db->table('orders')->select('MAX(advance_amount)', false)->where('id >', 2);
+
+        $builder->where('advance_amount <', $subquery);
+        // Produces: WHERE "advance_amount" < (SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2)
+
 
 **$builder->orWhere()**
 
@@ -338,12 +349,25 @@ appropriate
 
 You can use subqueries instead of an array of values.
 
-    ::
+    With anonymous function::
 
-        $builder->whereIn('id', function(BaseBuilder $builder) {
+        //importing the class at the top of the file
+        use CodeIgniter\Database\BaseBuilder;
+
+        //...
+
+        $builder->whereIn('id', function (BaseBuilder $builder) {
             return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
         });
         // Produces: WHERE "id" IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
+
+    With Builder::
+
+        $subquery = $this->db->table('users_jobs')->select('job_id')->where('user_id', 3)
+
+        $builder->whereIn('id', $subquery);
+        // Produces: WHERE "id" IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
+
 
 **$builder->orWhereIn()**
 
@@ -358,11 +382,24 @@ appropriate
 
 You can use subqueries instead of an array of values.
 
-    ::
+    With anonymous function::
 
-        $builder->orWhereIn('id', function(BaseBuilder $builder) {
+        //importing the class at the top of the file
+        use CodeIgniter\Database\BaseBuilder;
+
+        //...
+
+        $builder->orWhereIn('id', function (BaseBuilder $builder) {
             return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
         });
+
+        // Produces: OR "id" IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
+
+    With Builder::
+
+        $subquery = $this->db->table('users_jobs')->select('job_id')->where('user_id', 3)
+
+        $builder->orWhereIn('id', $subquery);
 
         // Produces: OR "id" IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
 
@@ -379,11 +416,25 @@ AND if appropriate
 
 You can use subqueries instead of an array of values.
 
-    ::
+    With anonymous function::
 
-        $builder->whereNotIn('id', function(BaseBuilder $builder) {
+        //importing the class at the top of the file
+        use CodeIgniter\Database\BaseBuilder;
+
+        //...
+
+        $builder->whereNotIn('id', function (BaseBuilder $builder) {
             return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
         });
+
+        // Produces: WHERE "id" NOT IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
+
+
+    With Builder::
+
+        $subquery = $this->db->table('users_jobs')->select('job_id')->where('user_id', 3);
+
+        $builder->whereNotIn('id', $subquery);
 
         // Produces: WHERE "id" NOT IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
 
@@ -401,11 +452,24 @@ if appropriate
 
 You can use subqueries instead of an array of values.
 
-    ::
+    With anonymous function::
 
-        $builder->orWhereNotIn('id', function(BaseBuilder $builder) {
+        //importing the class at the top of the file
+        use CodeIgniter\Database\BaseBuilder;
+
+        //...
+
+        $builder->orWhereNotIn('id', function (BaseBuilder $builder) {
             return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
         });
+
+        // Produces: OR "id" NOT IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
+
+    With Builder::
+
+        $subquery = $this->db->table('users_jobs')->select('job_id')->where('user_id', 3);
+
+        $builder->orWhereNotIn('id', $subquery);
 
         // Produces: OR "id" NOT IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
 
@@ -542,12 +606,25 @@ appropriate
 
 You can use subqueries instead of an array of values.
 
-::
+    With anonymous function::
 
-    $builder->havingIn('id', function(BaseBuilder $builder) {
-        return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
-    });
-    // Produces: HAVING "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
+        //importing the class at the top of the file
+        use CodeIgniter\Database\BaseBuilder;
+
+        //...
+
+        $builder->havingIn('id', function (BaseBuilder $builder) {
+            return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
+        });
+        // Produces: HAVING "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
+
+
+    With Builder::
+
+        $subquery = $this->db->table('users_jobs')->select('user_id')->where('group_id', 3);
+
+        $builder->havingIn('id', $subquery);
+        // Produces: HAVING "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
 
 **$builder->orHavingIn()**
 
@@ -562,13 +639,25 @@ appropriate
 
 You can use subqueries instead of an array of values.
 
-::
+    With anonymous function::
 
-    $builder->orHavingIn('id', function(BaseBuilder $builder) {
-        return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
-    });
+        //importing the class at the top of the file
+        use CodeIgniter\Database\BaseBuilder;
 
-    // Produces: OR "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
+        //...
+
+        $builder->orHavingIn('id', function (BaseBuilder $builder) {
+            return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
+        });
+        // Produces: OR "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
+
+
+    With Builder::
+
+        $subquery = $this->db->table('users_jobs')->select('user_id')->where('group_id', 3);
+
+        $builder->orHavingIn('id', $subquery);
+        // Produces: OR "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
 
 **$builder->havingNotIn()**
 
@@ -583,14 +672,24 @@ AND if appropriate
 
 You can use subqueries instead of an array of values.
 
-::
+    With anonymous function::
 
-    $builder->havingNotIn('id', function(BaseBuilder $builder) {
-        return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
-    });
+        //importing the class at the top of the file
+        use CodeIgniter\Database\BaseBuilder;
 
-    // Produces: HAVING "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
+        //...
 
+        $builder->havingNotIn('id', function (BaseBuilder $builder) {
+            return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
+        });
+        // Produces: HAVING "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
+
+    With Builder::
+
+        $subquery = $this->db->table('users_jobs')->select('user_id')->where('group_id', 3);
+
+        $builder->havingNotIn('id', $subquery);
+        // Produces: HAVING "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
 
 **$builder->orHavingNotIn()**
 
@@ -605,13 +704,25 @@ if appropriate
 
 You can use subqueries instead of an array of values.
 
-::
+    With anonymous function::
 
-    $builder->orHavingNotIn('id', function(BaseBuilder $builder) {
-        return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
-    });
+        //importing the class at the top of the file
+        use CodeIgniter\Database\BaseBuilder;
 
-    // Produces: OR "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
+        //...
+
+        $builder->orHavingNotIn('id', function (BaseBuilder $builder) {
+            return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
+        });
+        // Produces: OR "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
+
+
+    With Builder::
+
+        $subquery = $this->db->table('users_jobs')->select('user_id')->where('group_id', 3);
+
+        $builder->orHavingNotIn('id', $subquery);
+        // Produces: OR "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
 
 **$builder->havingLike()**
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -246,6 +246,8 @@ methods:
 .. note:: All values passed to this function are escaped automatically,
     producing safer queries.
 
+All ``where`` methods support :ref:`subqueries`
+
 #. **Simple key/value method:**
 
     ::
@@ -304,26 +306,6 @@ methods:
 
         $builder->where('MATCH (field) AGAINST ("value")', null, false);
 
-#. **Subqueries:**
-    With anonymous function::
-
-        //importing the class at the top of the file
-        use CodeIgniter\Database\BaseBuilder;
-
-        //...
-
-        $builder->where('advance_amount <', function (BaseBuilder $builder) {
-            return $builder->select('MAX(advance_amount)', false)->from('orders')->where('id >', 2);
-        });
-        // Produces: WHERE "advance_amount" < (SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2)
-
-    With Builder::
-
-        $subquery = $this->db->table('orders')->select('MAX(advance_amount)', false)->where('id >', 2);
-
-        $builder->where('advance_amount <', $subquery);
-        // Produces: WHERE "advance_amount" < (SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2)
-
 
 **$builder->orWhere()**
 
@@ -347,27 +329,6 @@ appropriate
         $builder->whereIn('username', $names);
         // Produces: WHERE username IN ('Frank', 'Todd', 'James')
 
-You can use subqueries instead of an array of values.
-
-    With anonymous function::
-
-        //importing the class at the top of the file
-        use CodeIgniter\Database\BaseBuilder;
-
-        //...
-
-        $builder->whereIn('id', function (BaseBuilder $builder) {
-            return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
-        });
-        // Produces: WHERE "id" IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
-
-    With Builder::
-
-        $subquery = $this->db->table('users_jobs')->select('job_id')->where('user_id', 3)
-
-        $builder->whereIn('id', $subquery);
-        // Produces: WHERE "id" IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
-
 
 **$builder->orWhereIn()**
 
@@ -380,28 +341,6 @@ appropriate
         $builder->orWhereIn('username', $names);
         // Produces: OR username IN ('Frank', 'Todd', 'James')
 
-You can use subqueries instead of an array of values.
-
-    With anonymous function::
-
-        //importing the class at the top of the file
-        use CodeIgniter\Database\BaseBuilder;
-
-        //...
-
-        $builder->orWhereIn('id', function (BaseBuilder $builder) {
-            return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
-        });
-
-        // Produces: OR "id" IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
-
-    With Builder::
-
-        $subquery = $this->db->table('users_jobs')->select('job_id')->where('user_id', 3)
-
-        $builder->orWhereIn('id', $subquery);
-
-        // Produces: OR "id" IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
 
 **$builder->whereNotIn()**
 
@@ -413,30 +352,6 @@ AND if appropriate
         $names = ['Frank', 'Todd', 'James'];
         $builder->whereNotIn('username', $names);
         // Produces: WHERE username NOT IN ('Frank', 'Todd', 'James')
-
-You can use subqueries instead of an array of values.
-
-    With anonymous function::
-
-        //importing the class at the top of the file
-        use CodeIgniter\Database\BaseBuilder;
-
-        //...
-
-        $builder->whereNotIn('id', function (BaseBuilder $builder) {
-            return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
-        });
-
-        // Produces: WHERE "id" NOT IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
-
-
-    With Builder::
-
-        $subquery = $this->db->table('users_jobs')->select('job_id')->where('user_id', 3);
-
-        $builder->whereNotIn('id', $subquery);
-
-        // Produces: WHERE "id" NOT IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
 
 
 **$builder->orWhereNotIn()**
@@ -450,28 +365,6 @@ if appropriate
         $builder->orWhereNotIn('username', $names);
         // Produces: OR username NOT IN ('Frank', 'Todd', 'James')
 
-You can use subqueries instead of an array of values.
-
-    With anonymous function::
-
-        //importing the class at the top of the file
-        use CodeIgniter\Database\BaseBuilder;
-
-        //...
-
-        $builder->orWhereNotIn('id', function (BaseBuilder $builder) {
-            return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
-        });
-
-        // Produces: OR "id" NOT IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
-
-    With Builder::
-
-        $subquery = $this->db->table('users_jobs')->select('job_id')->where('user_id', 3);
-
-        $builder->orWhereNotIn('id', $subquery);
-
-        // Produces: OR "id" NOT IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
 
 ************************
 Looking for Similar Data
@@ -604,28 +497,6 @@ appropriate
     $builder->havingIn('group_id', $groups);
     // Produces: HAVING group_id IN (1, 2, 3)
 
-You can use subqueries instead of an array of values.
-
-    With anonymous function::
-
-        //importing the class at the top of the file
-        use CodeIgniter\Database\BaseBuilder;
-
-        //...
-
-        $builder->havingIn('id', function (BaseBuilder $builder) {
-            return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
-        });
-        // Produces: HAVING "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
-
-
-    With Builder::
-
-        $subquery = $this->db->table('users_jobs')->select('user_id')->where('group_id', 3);
-
-        $builder->havingIn('id', $subquery);
-        // Produces: HAVING "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
-
 **$builder->orHavingIn()**
 
 Generates a ``HAVING field IN ('item', 'item')`` SQL query joined with OR if
@@ -637,27 +508,6 @@ appropriate
     $builder->orHavingIn('group_id', $groups);
     // Produces: OR group_id IN (1, 2, 3)
 
-You can use subqueries instead of an array of values.
-
-    With anonymous function::
-
-        //importing the class at the top of the file
-        use CodeIgniter\Database\BaseBuilder;
-
-        //...
-
-        $builder->orHavingIn('id', function (BaseBuilder $builder) {
-            return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
-        });
-        // Produces: OR "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
-
-
-    With Builder::
-
-        $subquery = $this->db->table('users_jobs')->select('user_id')->where('group_id', 3);
-
-        $builder->orHavingIn('id', $subquery);
-        // Produces: OR "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
 
 **$builder->havingNotIn()**
 
@@ -670,26 +520,6 @@ AND if appropriate
     $builder->havingNotIn('group_id', $groups);
     // Produces: HAVING group_id NOT IN (1, 2, 3)
 
-You can use subqueries instead of an array of values.
-
-    With anonymous function::
-
-        //importing the class at the top of the file
-        use CodeIgniter\Database\BaseBuilder;
-
-        //...
-
-        $builder->havingNotIn('id', function (BaseBuilder $builder) {
-            return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
-        });
-        // Produces: HAVING "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
-
-    With Builder::
-
-        $subquery = $this->db->table('users_jobs')->select('user_id')->where('group_id', 3);
-
-        $builder->havingNotIn('id', $subquery);
-        // Produces: HAVING "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
 
 **$builder->orHavingNotIn()**
 
@@ -699,30 +529,8 @@ if appropriate
 ::
 
     $groups = [1, 2, 3];
-    $builder->havingNotIn('group_id', $groups);
+    $builder->orHavingNotIn('group_id', $groups);
     // Produces: OR group_id NOT IN (1, 2, 3)
-
-You can use subqueries instead of an array of values.
-
-    With anonymous function::
-
-        //importing the class at the top of the file
-        use CodeIgniter\Database\BaseBuilder;
-
-        //...
-
-        $builder->orHavingNotIn('id', function (BaseBuilder $builder) {
-            return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
-        });
-        // Produces: OR "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
-
-
-    With Builder::
-
-        $subquery = $this->db->table('users_jobs')->select('user_id')->where('group_id', 3);
-
-        $builder->orHavingNotIn('id', $subquery);
-        // Produces: OR "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
 
 **$builder->havingLike()**
 
@@ -886,6 +694,39 @@ Example::
 As is in countAllResult method, this method resets any field values that you may have passed
 to ``select()`` as well. If you need to keep them, you can pass ``false`` as the
 first parameter.
+
+.. _subqueries:
+
+**********
+Subqueries
+**********
+
+Several query builder methods support the use of subqueries. Subqueries are passed as a closure or an instance of the
+BaseBuilder class as the second argument to the method.
+
+Subquery as closure::
+
+    //importing the class at the top of the file
+    use CodeIgniter\Database\BaseBuilder;
+
+    //...
+
+    $builder->where('advance_amount <', function (BaseBuilder $builder) {
+        return $builder->select('MAX(advance_amount)', false)->from('orders')->where('id >', 2);
+    });
+
+    // Produces: WHERE "advance_amount" < (SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2)
+
+Subquery as instance of the BaseBuilder class::
+
+    $subquery = $this->db->table('orders')->select('MAX(advance_amount)', false)->where('id >', 2);
+
+    $builder->where('advance_amount <', $subquery);
+
+    // Produces: WHERE "advance_amount" < (SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2)
+
+**List of methods that support subqueries**: where(), orWhere(), whereIn(), orWhereIn(), whereNotIn(), orWhereNotIn(),
+havingIn(), orHavingIn(), havingNotIn(), orHavingNotIn().
 
 **************
 Query grouping
@@ -1530,7 +1371,7 @@ Class Reference
     .. php:method:: orWhereIn([$key = null[, $values = null[, $escape = null]]])
 
         :param string $key: The field to search
-        :param array|Closure $values: Array of target values, or anonymous function for subquery
+        :param array|Closure|BaseBuilder $values: Array of target values, or anonymous function for subquery
         :param bool $escape: Whether to escape values and identifiers
         :returns: ``BaseBuilder`` instance (method chaining)
         :rtype:	``BaseBuilder``
@@ -1540,7 +1381,7 @@ Class Reference
     .. php:method:: orWhereNotIn([$key = null[, $values = null[, $escape = null]]])
 
         :param string $key: The field to search
-        :param array|Closure $values: Array of target values, or anonymous function for subquery
+        :param array|Closure|BaseBuilder $values: Array of target values, or anonymous function for subquery
         :param bool $escape: Whether to escape values and identifiers
         :returns: ``BaseBuilder`` instance (method chaining)
         :rtype:	``BaseBuilder``
@@ -1550,7 +1391,7 @@ Class Reference
     .. php:method:: whereIn([$key = null[, $values = null[, $escape = null]]])
 
         :param string $key: Name of field to examine
-        :param array|Closure $values: Array of target values, or anonymous function for subquery
+        :param array|Closure|BaseBuilder $values: Array of target values, or anonymous function for subquery
         :param bool $escape: Whether to escape values and identifiers
         :returns: ``BaseBuilder`` instance (method chaining)
         :rtype:	``BaseBuilder``
@@ -1560,7 +1401,7 @@ Class Reference
     .. php:method:: whereNotIn([$key = null[, $values = null[, $escape = null]]])
 
         :param string $key: Name of field to examine
-        :param array|Closure $values: Array of target values, or anonymous function for subquery
+        :param array|Closure|BaseBuilder $values: Array of target values, or anonymous function for subquery
         :param bool	$escape: Whether to escape values and identifiers
         :returns: ``BaseBuilder`` instance (method chaining)
         :rtype:	``BaseBuilder``
@@ -1653,7 +1494,7 @@ Class Reference
     .. php:method:: having($key[, $value = null[, $escape = null]])
 
         :param mixed $key: Identifier (string) or associative array of field/value pairs
-        :param string $value: Value sought if $key is an identifier
+        :param string|Closure|BaseBuilder $value: Value sought if $key is an identifier
         :param string $escape: Whether to escape values and identifiers
         :returns: ``BaseBuilder`` instance (method chaining)
         :rtype:	``BaseBuilder``
@@ -1663,7 +1504,7 @@ Class Reference
     .. php:method:: orHaving($key[, $value = null[, $escape = null]])
 
         :param mixed $key: Identifier (string) or associative array of field/value pairs
-        :param string $value: Value sought if $key is an identifier
+        :param string|Closure|BaseBuilder $value: Value sought if $key is an identifier
         :param string $escape: Whether to escape values and identifiers
         :returns: ``BaseBuilder`` instance (method chaining)
         :rtype:	``BaseBuilder``
@@ -1673,7 +1514,7 @@ Class Reference
     .. php:method:: orHavingIn([$key = null[, $values = null[, $escape = null]]])
 
         :param string $key: The field to search
-        :param array|Closure $values: Array of target values, or anonymous function for subquery
+        :param array|Closure|BaseBuilder $values: Array of target values, or anonymous function for subquery
         :param bool	$escape: Whether to escape values and identifiers
         :returns: ``BaseBuilder`` instance (method chaining)
         :rtype:	``BaseBuilder``
@@ -1683,7 +1524,7 @@ Class Reference
     .. php:method:: orHavingNotIn([$key = null[, $values = null[, $escape = null]]])
 
         :param string $key: The field to search
-        :param array|Closure $values: Array of target values, or anonymous function for subquery
+        :param array|Closure|BaseBuilder $values: Array of target values, or anonymous function for subquery
         :param bool	$escape: Whether to escape values and identifiers
         :returns: ``BaseBuilder`` instance (method chaining)
         :rtype:	``BaseBuilder``
@@ -1693,7 +1534,7 @@ Class Reference
     .. php:method:: havingIn([$key = null[, $values = null[, $escape = null]]])
 
         :param string $key: Name of field to examine
-        :param array|Closure $values: Array of target values, or anonymous function for subquery
+        :param array|Closure|BaseBuilder $values: Array of target values, or anonymous function for subquery
         :param bool $escape: Whether to escape values and identifiers
         :returns: ``BaseBuilder`` instance (method chaining)
         :rtype:	``BaseBuilder``
@@ -1703,7 +1544,7 @@ Class Reference
     .. php:method:: havingNotIn([$key = null[, $values = null[, $escape = null]]])
 
         :param string $key: Name of field to examine
-        :param array|Closure $values: Array of target values, or anonymous function for subquery
+        :param array|Closure|BaseBuilder $values: Array of target values, or anonymous function for subquery
         :param bool $escape: Whether to escape values and identifiers
         :param bool $insensitiveSearch: Whether to force a case-insensitive search
         :returns: ``BaseBuilder`` instance (method chaining)


### PR DESCRIPTION
**Description**
The approach to subqueries in the query builder has changed. Methods now accept both a closure and an instance of the BaseBuilder class.
The new method lays the foundation for further embedding subqueries in query builder methods. 

* BaseBuilder::cleanClone() method renamed to BaseBuilder::getBuilderClone(). 
* Added the BaseBuilder::getInstanceForSubquery() method.
* Added tests 
* Fixed UG. Added class import for closures in examples.


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide