### PR TITLE
FilterTestTrait: Closure

### DIFF
--- a/system/Test/FilterTestTrait.php
+++ b/system/Test/FilterTestTrait.php
@@ -19,6 +19,7 @@ use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Router\RouteCollection;
 use Config\Filters as FiltersConfig;
 use Config\Services;
+use Closure;
 use InvalidArgumentException;
 use RuntimeException;
 
@@ -127,9 +128,9 @@ trait FilterTestTrait
 	 * @param FilterInterface|string $filter   The filter instance, class, or alias
 	 * @param string                 $position "before" or "after"
 	 *
-	 * @return callable
+	 * @return Closure
 	 */
-	protected function getFilterCaller($filter, string $position): callable
+	protected function getFilterCaller($filter, string $position): Closure
 	{
 		if (! in_array($position, ['before', 'after'], true))
 		{

--- a/system/Test/FilterTestTrait.php
+++ b/system/Test/FilterTestTrait.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Test;
 
+use Closure;
 use CodeIgniter\Filters\Exceptions\FilterException;
 use CodeIgniter\Filters\Filters;
 use CodeIgniter\Filters\FilterInterface;
@@ -19,7 +20,6 @@ use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Router\RouteCollection;
 use Config\Filters as FiltersConfig;
 use Config\Services;
-use Closure;
 use InvalidArgumentException;
 use RuntimeException;
 

--- a/tests/system/Test/FilterTestTraitTest.php
+++ b/tests/system/Test/FilterTestTraitTest.php
@@ -41,11 +41,12 @@ class FilterTestTraitTest extends CIUnitTestCase
 		$this->assertInstanceOf(RequestInterface::class, $this->request);
 	}
 
-	public function testGetCallerReturnsCallable()
+	public function testGetCallerReturnsClosure()
 	{
 		$caller = $this->getFilterCaller('test-customfilter', 'before');
 
 		$this->assertIsCallable($caller);
+		$this->assertInstanceOf('Closure', $caller);
 	}
 
 	public function testGetCallerInvalidPosition()

--- a/user_guide_src/source/testing/controllers.rst
+++ b/user_guide_src/source/testing/controllers.rst
@@ -362,7 +362,7 @@ method using these properties to test your Filter code safely and check the resu
     :param	FilterInterface|string	$filter: The filter instance, class, or alias
     :param	string	$position: The filter method to run, "before" or "after"
 	:returns:	A callable method to run the simulated Filter event
-	:rtype:	callable
+	:rtype:	Closure
 
     Usage example::
 
@@ -374,7 +374,7 @@ method using these properties to test your Filter code safely and check the resu
 			$this->assertInstanceOf('CodeIgniter\HTTP\RedirectResponse', $result);
 		}
 	
-	Notice how the ``callable`` can take input parameters which are passed to your filter method.
+	Notice how the ``Closure`` can take input parameters which are passed to your filter method.
 
 Assertions
 ----------


### PR DESCRIPTION
**Description**
One small tweak to the recent `FilterTestTrait` addition, to specify the actual return type since it is a `Closure`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
