### PR TITLE
[Rector] Apply Rector: RemoveUnusedPrivateMethodRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
 		"phpunit/phpunit": "^9.1",
 		"predis/predis": "^1.1",
 		"rector/rector": "^0.9",
-		"squizlabs/php_codesniffer": "^3.3"
+		"squizlabs/php_codesniffer": "^3.3",
+		"symplify/rule-doc-generator": "9.2.11"
 	},
 	"suggest": {
 		"ext-fileinfo": "Improves mime type detection for files"

--- a/rector.php
+++ b/rector.php
@@ -12,6 +12,7 @@ use Rector\CodeQuality\Rector\Return_\SimplifyUselessVariableRector;
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\Foreach_\RemoveUnusedForeachKeyRector;
 use Rector\DeadCode\Rector\Switch_\RemoveDuplicatedCaseInSwitchRector;
 use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
@@ -38,6 +39,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 		__DIR__ . '/tests/system/Models',
 		__DIR__ . '/tests/_support',
 		PassStrictParameterToFunctionParameterRector::class => [__DIR__ . '/tests/system/Database/Live/SelectTest.php'],
+		RemoveUnusedPrivateMethodRector::class => [__DIR__ . '/tests/system/Test/ReflectionHelperTest.php'],
 	]);
 
 	// Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
@@ -72,4 +74,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 	$services->set(RemoveUnusedForeachKeyRector::class);
 	$services->set(SimplifyIfElseToTernaryRector::class);
 	$services->set(UnusedForeachValueToArrayKeysRector::class);
+	$services->set(RemoveUnusedPrivateMethodRector::class);
 };

--- a/system/Entity.php
+++ b/system/Entity.php
@@ -577,22 +577,6 @@ class Entity implements JsonSerializable
 		return $handlers[$type]::$method($value, $params);
 	}
 
-	//--------------------------------------------------------------------
-
-	/**
-	 * Cast as JSON
-	 *
-	 * @param mixed   $value
-	 * @param boolean $asArray
-	 *
-	 * @return mixed
-	 * @throws CastException
-	 */
-	private function castAsJson($value, bool $asArray = false)
-	{
-		return CastAsJson::get($value, $asArray ? ['array'] : []);
-	}
-
 	/**
 	 * Support for json_encode()
 	 *


### PR DESCRIPTION
Remove unused private method with `RemoveUnusedPrivateMethodRector` rector rule.

Also currently pin `symplify/rule-doc-generator` to v9.2.11 due removed `Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface` see https://github.com/rectorphp/rector/issues/5908

The interface moved to `symplify/rule-doc-generator-contracts` that will be included in next rector release, but for now, pin to `symplify/rule-doc-generator` to v9.2.11.

**Checklist:**
- [x] Securely signed commits