### PR TITLE
[Rector] Fix rector notice Interface Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
 		"phpunit/phpunit": "^9.1",
 		"predis/predis": "^1.1",
 		"rector/rector": "^0.9",
-		"squizlabs/php_codesniffer": "^3.3"
+		"squizlabs/php_codesniffer": "^3.3",
+		"symplify/rule-doc-generator-contracts": "^9.2"
 	},
 	"suggest": {
 		"ext-fileinfo": "Improves mime type detection for files"


### PR DESCRIPTION
The interface is moved to `symplify/rule-doc-generator-contracts` package. While wait for next rector release, we need to require-dev it.

**Checklist:**
- [x] Securely signed commits
