### PR TITLE
Language: getTranslationOutput: make method overridable by child classes

### DIFF
--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -146,7 +146,7 @@ class Language
 	/**
 	 * @return array|string|null
 	 */
-	private function getTranslationOutput(string $locale, string $file, string $parsedLine)
+	protected function getTranslationOutput(string $locale, string $file, string $parsedLine)
 	{
 		$output = $this->language[$locale][$file][$parsedLine] ?? null;
 		if ($output !== null)


### PR DESCRIPTION
Makes `getTranslationOutput` overridable by child classes.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
