### PR TITLE
Add Model::initialize()

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -295,6 +295,11 @@ abstract class BaseModel
 	 */
 	public function __construct(ValidationInterface $validation = null)
 	{
+		if (method_exists($this, 'initModel'))
+		{
+			$this->initModel();
+		}
+
 		$this->tempReturnType     = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
 		$this->tempAllowCallbacks = $this->allowCallbacks;

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -295,10 +295,7 @@ abstract class BaseModel
 	 */
 	public function __construct(ValidationInterface $validation = null)
 	{
-		if (method_exists($this, 'initModel'))
-		{
-			$this->initModel();
-		}
+		$this->initModel();
 
 		$this->tempReturnType     = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
@@ -310,6 +307,14 @@ abstract class BaseModel
 		$validation = $validation ?? Services::validation(null, false);
 
 		$this->validation = $validation;
+	}
+
+	/**
+	 * Initializes the instance with any additional steps.
+	 * Optionally provided by child classes.
+	 */
+	protected function initModel()
+	{
 	}
 
 	/**

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -295,8 +295,6 @@ abstract class BaseModel
 	 */
 	public function __construct(ValidationInterface $validation = null)
 	{
-		$this->initModel();
-
 		$this->tempReturnType     = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;
 		$this->tempAllowCallbacks = $this->allowCallbacks;
@@ -304,16 +302,17 @@ abstract class BaseModel
 		/**
 		 * @var Validation $validation
 		 */
-		$validation = $validation ?? Services::validation(null, false);
-
+		$validation       = $validation ?? Services::validation(null, false);
 		$this->validation = $validation;
+
+		$this->initialize();
 	}
 
 	/**
 	 * Initializes the instance with any additional steps.
-	 * Optionally provided by child classes.
+	 * Optionally implemented by child classes.
 	 */
-	protected function initModel()
+	protected function initialize()
 	{
 	}
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -97,14 +97,14 @@ class Model extends BaseModel
 	 */
 	public function __construct(ConnectionInterface &$db = null, ValidationInterface $validation = null)
 	{
-		parent::__construct($validation);
-
 		/**
 		 * @var BaseConnection $db
 		 */
 		$db = $db ?? Database::connect($this->DBGroup);
 
 		$this->db = &$db;
+
+		parent::__construct($validation);
 	}
 
 	/**

--- a/tests/system/Models/GeneralModelTest.php
+++ b/tests/system/Models/GeneralModelTest.php
@@ -139,4 +139,27 @@ final class GeneralModelTest extends CIUnitTestCase
 		$this->assertSame('jobs', $builder2->getTable());
 		$this->assertSame('user', $builder3->getTable());
 	}
+
+	public function testInitModel(): void
+	{
+		$model = new class extends Model {
+
+			/**
+			 * @var boolean
+			 */
+			public $didInit = false;
+
+			/**
+			 * Marks the model as initialized.
+			 *
+			 * @return void
+			 */
+			protected function initModel(): void
+			{
+				$this->didInit = true;
+			}
+		};
+
+		$this->assertTrue($model->didInit);
+	}
 }

--- a/tests/system/Models/GeneralModelTest.php
+++ b/tests/system/Models/GeneralModelTest.php
@@ -140,26 +140,26 @@ final class GeneralModelTest extends CIUnitTestCase
 		$this->assertSame('user', $builder3->getTable());
 	}
 
-	public function testInitModel(): void
+	public function testInitialize(): void
 	{
 		$model = new class extends Model {
 
 			/**
 			 * @var boolean
 			 */
-			public $didInit = false;
+			public $initialized = false;
 
 			/**
 			 * Marks the model as initialized.
 			 *
 			 * @return void
 			 */
-			protected function initModel(): void
+			protected function initialize(): void
 			{
-				$this->didInit = true;
+				$this->initialized = true;
 			}
 		};
 
-		$this->assertTrue($model->didInit);
+		$this->assertTrue($model->initialized);
 	}
 }

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -73,6 +73,28 @@ that extends ``CodeIgniter\Model``::
 This empty class provides convenient access to the database connection, the Query Builder,
 and a number of additional convenience methods.
 
+Should you need additional setup in your model you may define an ``initModel()`` function
+which will be run at the very beginning of the Model's constructor. This allows you to perform
+extra steps without repeating the constructor parameters, for example extending other models::
+
+    <?php
+
+    namespace App\Models;
+
+    use Modules\Authentication\Models\UserAuthModel;
+
+    class UserModel extends UserAuthModel
+    {
+    	/**
+    	 * Called during initialization. Appends
+    	 * our custom field to the module's model.
+    	 */
+        protected function initModel()
+        {
+        	$this->allowedFields[] = 'middlename';
+        }
+    }
+
 Connecting to the Database
 --------------------------
 

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -89,7 +89,7 @@ extra steps without repeating the constructor parameters, for example extending 
     	 * Called during initialization. Appends
     	 * our custom field to the module's model.
     	 */
-        protected function inititialize()
+        protected function initialize()
         {
         	$this->allowedFields[] = 'middlename';
         }

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -73,8 +73,8 @@ that extends ``CodeIgniter\Model``::
 This empty class provides convenient access to the database connection, the Query Builder,
 and a number of additional convenience methods.
 
-Should you need additional setup in your model you may define an ``initModel()`` function
-which will be run at the very beginning of the Model's constructor. This allows you to perform
+Should you need additional setup in your model you may extend the ``inititialize()`` function
+which will be run immediately after the Model's constructor. This allows you to perform
 extra steps without repeating the constructor parameters, for example extending other models::
 
     <?php
@@ -89,7 +89,7 @@ extra steps without repeating the constructor parameters, for example extending 
     	 * Called during initialization. Appends
     	 * our custom field to the module's model.
     	 */
-        protected function initModel()
+        protected function inititialize()
         {
         	$this->allowedFields[] = 'middlename';
         }

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -73,7 +73,7 @@ that extends ``CodeIgniter\Model``::
 This empty class provides convenient access to the database connection, the Query Builder,
 and a number of additional convenience methods.
 
-Should you need additional setup in your model you may extend the ``inititialize()`` function
+Should you need additional setup in your model you may extend the ``initialize()`` function
 which will be run immediately after the Model's constructor. This allows you to perform
 extra steps without repeating the constructor parameters, for example extending other models::
 


### PR DESCRIPTION
**Description**
I frequently find myself extending the constructor on module models to do some additional configuration. That makes for some awkward repeating of parameters, like:
```
	/**
	 * @param ConnectionInterface $db
	 * @param ValidationInterface $validation
	 */
	public function __construct(ConnectionInterface &$db = null, ValidationInterface $validation = null)
	{
		// Call the module constructor
		parent::__construct($db, $validation);
		
		// Do whatever I needed to do
	}
```

With the split into `BaseModel` and `Model` this gets even more uncomfortable, as additional extensions of `BaseModel` likely won't have the same constructor parameters.

This PR defines a new "event" during `BaseModel::__construct()` that checks for an `initModel()` method which will allow developers to handle model extensions without messing with the constructor itself. The inspiration came from `Controller` (though it's actually the opposite there since the contrsuctor is left for the developer).

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
