### PR TITLE
Implementing subqueries in FROM section

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -954,21 +954,28 @@ abstract class BaseConnection implements ConnectionInterface
 	/**
 	 * Returns an instance of the query builder for this connection.
 	 *
-	 * @param string|array $tableName
+	 * @param Closure|BaseBuilder|SqlExpression|array|string|null $tableName Table
 	 *
 	 * @return BaseBuilder
 	 * @throws DatabaseException
 	 */
 	public function table($tableName)
 	{
-		if (empty($tableName))
-		{
-			throw new DatabaseException('You must set the database table to be used with your query.');
-		}
-
 		$className = str_replace('Connection', 'Builder', get_class($this));
 
 		return new $className($tableName, $this);
+	}
+
+	/**
+	 * Returns a wrapper for a raw SQL subquery
+	 *
+	 * @param string $statement SQL statement
+	 *
+	 * @return SqlExpression
+	 */
+	public function raw(string $statement): SqlExpression
+	{
+		return new SqlExpression($statement);
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -11,7 +11,6 @@
 
 namespace CodeIgniter\Database\SQLSRV;
 
-use Closure;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
@@ -300,6 +299,12 @@ class Builder extends BaseBuilder
 	private function getFullName(string $table): string
 	{
 		$alias = '';
+
+		// subquery filter
+		if (strpos($table, '(') !== false)
+		{
+			return $table;
+		}
 
 		if (strpos($table, ' ') !== false)
 		{
@@ -712,10 +717,10 @@ class Builder extends BaseBuilder
 					$k .= " $op";
 				}
 
-				if ($v instanceof Closure)
+				if ($this->isSubquery($v))
 				{
-					$builder = $this->cleanClone();
-					$v       = '(' . str_replace("\n", ' ', $v($builder)->getCompiledSelect()) . ')';
+					$query = $this->subqueryProcessing($v);
+					$v     = $this->parenthesesWrapper(str_replace("\n", ' ', $query));
 				}
 				else
 				{

--- a/system/Database/SqlExpression.php
+++ b/system/Database/SqlExpression.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database;
+
+use CodeIgniter\Database\Exceptions\DatabaseException;
+
+/**
+ * Class SQLStatement
+ *
+ * Wrapper for a raw SQL subquery
+ */
+class SqlExpression
+{
+	/**
+	 * SQL Statement
+	 *
+	 * @var string
+	 */
+	protected $value;
+
+	/**
+	 * SQLStatement constructor.
+	 *
+	 * @param string $value SQL Statement
+	 */
+	public function __construct(string $value)
+	{
+		if (empty($value))
+		{
+			throw new DatabaseException('SQL expression cannot be empty.');
+		}
+
+		$this->value = $value;
+	}
+
+	/**
+	 * Return SQL Statement
+	 *
+	 * @return string
+	 */
+	public function getValue(): string
+	{
+		return $this->value;
+	}
+
+	/**
+	 * Return SQL Statement
+	 *
+	 * @return string
+	 */
+	public function __toString(): string
+	{
+		return $this->getValue();
+	}
+}


### PR DESCRIPTION
**Description**
I am waiting feedback of the community, so I see no reason to add tests and descriptions to UG right now.

**Added BaseConnection::raw() method.** 
It expects a raw SQL subquery as an argument and returns an instance of the SqlExpression class. 
This is to prevent processing subqueries as a simple string.

**BaseConnection::table() and BaseBuilder::from() methods**.
Now takes as an argument Closure, BaseBuilder, SqlExpression, array, string, null.

```php
//Closure 
$this->db->table(function(BaseBuilder $builder) { /* subquery */  });

// BaseBuilder 
$subquery = $this->db->table('user');
$this->db->table($subquery);

// SqlExpression
$this->db->table($this->db->raw('SELECT * FROM user'));

// new instance of BaseBuilder without dafeult table 
// Thanks to the designers. Because it is impossible to correctly create a clean instance of the class without BCs. 
$this->db->table(null);
```
This solution makes it possible to use a wrapper for the main query. 
```sql
SELECT * FROM (main query)
```
and will allow better implementation of support for UNION queries. 

Query builder methods that previously took Closure as an argument now take BaseBuilder and SqlExpression.
```php
$builder->where('id', $this->db->raw('SELECT id FROM user'));
```


**Help wanted**
I also want to ask about this "problem".
The problem starts with tests (SQLSRV). We get an instance of the query builder. 
```php
$this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
$builder = new SQLSRVBuilder('user', $this->db);
```
If ``$this->db->table(null)`` is called inside the query builder, then the ``MockBuilder`` instance will be retrieved, not the ``SQLSRVBuilder`` instance.
And the subquery will not be generated correctly.

There are several solutions. 
Use ``new static(null, $this->db)`` instead of ``$this->db->table(null)`` , but phpstan says: ``Unsafe usage of new static()``.
Or use the SQLSRV driver's Coonnection class instead of the MockConnection class for testing. 
```php
$this->db = new Connection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
```
But I'm not sure if replacing the connection class is correct. 

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide