### PR TITLE
Remove erroneous mixin

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -22,8 +22,6 @@ use InvalidArgumentException;
  * Provides the core Query Builder methods.
  * Database-specific Builders might need to override
  * certain methods to make them work.
- *
- * @mixin \CodeIgniter\Model
  */
 class BaseBuilder
 {

--- a/system/Model.php
+++ b/system/Model.php
@@ -170,7 +170,7 @@ class Model extends BaseModel
 	 */
 	protected function doFindColumn(string $columnName)
 	{
-		return $this->select($columnName)->asArray()->find();
+		return $this->select($columnName)->asArray()->find(); // @phpstan-ignore-line
 	}
 
 	/**


### PR DESCRIPTION
**Description**
`Model` has been causing PHPStan segmentation faults for me for months (e.g. https://github.com/tattersoftware/codeigniter4-forms/pull/7/checks?check_run_id=2179115051). I've always found ways to change the code to work around it but I finally hit a wall. After hours of digging I determined the issue is the recursive `@mixin`s: `Model` mixes in `BaseBuilder` which mixes in `Model`. The `@mixin` on `BaseBuilder` is actually a mistake, and I think was done to solve the issue of Model line 173 where PHPStan detects the `select()` as coming from `BaseBuilder` (because of the `@mixin`) so baulks at `asArray()` which does not exist on `BaseBuilder`. I think simply ignoring the line is the best approach, but we could break the chain up and specify types if that feels better.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
