### PR TITLE
[Rector] Using Option::BOOTSTRAP_FILES

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -24,13 +24,16 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Utils\Rector\PassStrictParameterToFunctionParameterRector;
 use Utils\Rector\UnderscoreToCamelCaseVariableNameRector;
 
-require_once __DIR__ . '/system/Test/bootstrap.php';
-
 return static function (ContainerConfigurator $containerConfigurator): void {
 	$parameters = $containerConfigurator->parameters();
 
 	// paths to refactor; solid alternative to CLI arguments
 	$parameters->set(Option::PATHS, [__DIR__ . '/app', __DIR__ . '/system', __DIR__ . '/tests']);
+
+	// do you need to include constants, class aliases or custom autoloader? files listed will be executed
+	$parameters->set(Option::BOOTSTRAP_FILES, [
+		__DIR__ . '/system/Test/bootstrap.php',
+	]);
 
 	// is there a file you need to skip?
 	$parameters->set(Option::SKIP, [


### PR DESCRIPTION
in Rector 0.10, the option to include files in config was removed, as included files are now processed by static reflection.

There is addition of  `BOOTSTRAP_FILES` in `0.10.2` to make include constants, class aliases or custom autoloader working again. ref https://github.com/rectorphp/rector/pull/5964

**Checklist:**
- [x] Securely signed commits
