### PR TITLE
Feature Response null

### DIFF
--- a/system/Test/FeatureResponse.php
+++ b/system/Test/FeatureResponse.php
@@ -42,11 +42,11 @@ class FeatureResponse extends TestCase
 	 *
 	 * @param ResponseInterface $response
 	 */
-	public function __construct(ResponseInterface $response = null)
+	public function __construct(ResponseInterface $response)
 	{
 		$this->response = $response;
 
-		$body = $response->getBody();
+		$body = $this->response->getBody();
 		if (! empty($body) && is_string($body))
 		{
 			$this->domParser = (new DOMParser())->withString($body);


### PR DESCRIPTION
**Description**
Our `FeatureResponse` constructor allows `null` input but very clearly relies on having a valid `ResponseInterface`. ~~For now this PR provides a fallback when `null` is provided to prevent breaking changes but IMO the parameter should be made mandatory at some point.~~ This PR removes the `null` option.

Along those lines, this is part of some bigger test response changes I have in the works but I didn't want to bundle this bugfix with that PR.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
