### PR TITLE
Add is_null judgment to body, fix issue#4381

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -293,7 +293,7 @@ class IncomingRequest extends Request
 	 */
 	public function getVar($index = null, $filter = null, $flags = null)
 	{
-		if (strpos($this->getHeaderLine('Content-Type'), 'application/json') !== false)
+		if (strpos($this->getHeaderLine('Content-Type'), 'application/json') !== false && !is_null($this->body))
 		{
 			if (is_null($index))
 			{
@@ -312,8 +312,8 @@ class IncomingRequest extends Request
 
 			return $this->getJsonVar($index, false, $filter, $flags);
 		}
-
-		return $this->fetchGlobal('request', $index, $filter, $flags);
+		$output = $this->fetchGlobal('request', $index, $filter, $flags);
+		return is_null($index) ? (object)$output : $output;
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -383,6 +383,33 @@ class IncomingRequestTest extends CIUnitTestCase
 		$this->assertEquals('buzz', $all->fizz);
 	}
 
+	public function testGetVarWorksWithJsonAndGetParams()
+	{
+		$config = new App();
+		$config->baseURL = 'http://example.com/';
+		// get method
+		$uri = new URI('http://example.com/path?foo=bar&fizz=buzz');
+		$_REQUEST['foo'] = 'bar';
+		$_REQUEST['fizz'] = 'buzz';
+		$request = new IncomingRequest($config, $uri, 'php://input', new UserAgent());
+		$request = $request->withMethod('GET');
+		// json type
+		$request->setHeader('Content-Type', 'application/json');
+
+		$this->assertEquals('bar', $request->getVar('foo'));
+		$this->assertEquals('buzz', $request->getVar('fizz'));
+
+		$multiple = $request->getVar(['foo', 'fizz']);
+		$this->assertIsArray($multiple);
+		$this->assertEquals('bar', $multiple['foo']);
+		$this->assertEquals('buzz', $multiple['fizz']);
+
+		$all = $request->getVar();
+		$this->assertIsObject($all);
+		$this->assertEquals('bar', $all->foo);
+		$this->assertEquals('buzz', $all->fizz);
+	}
+
 	public function testCanGrabGetRawInput()
 	{
 		$rawstring = 'username=admin001&role=administrator&usepass=0';


### PR DESCRIPTION
add is_null judgmennt. Compatible with the getVar method of version 4.0.4, but the return is still an object when the index is null. #4381 