### PR TITLE
The getVar method is compatible with version 4.0.4 

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -281,7 +281,7 @@ class IncomingRequest extends Request
 	//--------------------------------------------------------------------
 
 	/**
-	 * Fetch an item from the $_REQUEST object or a JSON input stream. This is the simplest way
+	 * Fetch an item from JSON input stream with fallback to $_REQUEST object. This is the simplest way
 	 * to grab data from the request object and can be used in lieu of the
 	 * other get* methods in most cases.
 	 *
@@ -312,8 +312,7 @@ class IncomingRequest extends Request
 
 			return $this->getJsonVar($index, false, $filter, $flags);
 		}
-		$output = $this->fetchGlobal('request', $index, $filter, $flags);
-		return is_null($index) ? (object)$output : $output;
+		return $this->fetchGlobal('request', $index, $filter, $flags);
 	}
 
 	//--------------------------------------------------------------------

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -293,7 +293,7 @@ class IncomingRequest extends Request
 	 */
 	public function getVar($index = null, $filter = null, $flags = null)
 	{
-		if (strpos($this->getHeaderLine('Content-Type'), 'application/json') !== false)
+		if (strpos($this->getHeaderLine('Content-Type'), 'application/json') !== false && !is_null($this->body))
 		{
 			if (is_null($index))
 			{
@@ -312,8 +312,8 @@ class IncomingRequest extends Request
 
 			return $this->getJsonVar($index, false, $filter, $flags);
 		}
-
-		return $this->fetchGlobal('request', $index, $filter, $flags);
+		$output = $this->fetchGlobal('request', $index, $filter, $flags);
+		return is_null($index) ? (object)$output : $output;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -293,7 +293,7 @@ class IncomingRequest extends Request
 	 */
 	public function getVar($index = null, $filter = null, $flags = null)
 	{
-		if (strpos($this->getHeaderLine('Content-Type'), 'application/json') !== false && !is_null($this->body))
+		if (strpos($this->getHeaderLine('Content-Type'), 'application/json') !== false && ! is_null($this->body))
 		{
 			if (is_null($index))
 			{

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -385,15 +385,17 @@ class IncomingRequestTest extends CIUnitTestCase
 
 	public function testGetVarWorksWithJsonAndGetParams()
 	{
-		$config = new App();
+		$config          = new App();
 		$config->baseURL = 'http://example.com/';
-		// get method
-		$uri = new URI('http://example.com/path?foo=bar&fizz=buzz');
-		$_REQUEST['foo'] = 'bar';
+
+		// GET method
+		$_REQUEST['foo']  = 'bar';
 		$_REQUEST['fizz'] = 'buzz';
-		$request = new IncomingRequest($config, $uri, 'php://input', new UserAgent());
+
+		$request = new IncomingRequest($config, new URI('http://example.com/path?foo=bar&fizz=buzz'), 'php://input', new UserAgent());
 		$request = $request->withMethod('GET');
-		// json type
+
+		// JSON type
 		$request->setHeader('Content-Type', 'application/json');
 
 		$this->assertEquals('bar', $request->getVar('foo'));

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -383,6 +383,33 @@ class IncomingRequestTest extends CIUnitTestCase
 		$this->assertEquals('buzz', $all->fizz);
 	}
 
+	public function testGetVarWorksWithJsonAndGetParams()
+	{
+		$config = new App();
+		$config->baseURL = 'http://example.com/';
+		// get method
+		$uri = new URI('http://example.com/path?foo=bar&fizz=buzz');
+		$_REQUEST['foo'] = 'bar';
+		$_REQUEST['fizz'] = 'buzz';
+		$request = new IncomingRequest($config, $uri, 'php://input', new UserAgent());
+		$request = $request->withMethod('GET');
+		// json type
+		$request->setHeader('Content-Type', 'application/json');
+
+		$this->assertEquals('bar', $request->getVar('foo'));
+		$this->assertEquals('buzz', $request->getVar('fizz'));
+
+		$multiple = $request->getVar(['foo', 'fizz']);
+		$this->assertIsArray($multiple);
+		$this->assertEquals('bar', $multiple['foo']);
+		$this->assertEquals('buzz', $multiple['fizz']);
+
+		$all = $request->getVar();
+		$this->assertIsObject($all);
+		$this->assertEquals('bar', $all->foo);
+		$this->assertEquals('buzz', $all->fizz);
+	}
+
 	public function testCanGrabGetRawInput()
 	{
 		$rawstring = 'username=admin001&role=administrator&usepass=0';

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -405,9 +405,9 @@ class IncomingRequestTest extends CIUnitTestCase
 		$this->assertEquals('buzz', $multiple['fizz']);
 
 		$all = $request->getVar();
-		$this->assertIsObject($all);
-		$this->assertEquals('bar', $all->foo);
-		$this->assertEquals('buzz', $all->fizz);
+		$this->assertIsArray($all);
+		$this->assertEquals('bar', $all['foo']);
+		$this->assertEquals('buzz', $all['fizz']);
 	}
 
 	public function testCanGrabGetRawInput()


### PR DESCRIPTION
The getVar method is compatible with version 4.0.4 #4381 

**Description**
In the current version, when the request is the get method and the content-type is json, the $_REQUEST parameter cannot be obtained 

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

---------Remove from here down in your description----------

**Notes**
- Increase the length of the judgment body 
- Add unit tests under json and get methods 
  
