### PR TITLE
Address Chromium 'Unsafe header' error with 

### DIFF
--- a/system/Debug/Toolbar/Views/toolbarloader.js.php
+++ b/system/Debug/Toolbar/Views/toolbarloader.js.php
@@ -71,20 +71,19 @@ function newXHR() {
 	var realXHR = new oldXHR();
 	realXHR.addEventListener("readystatechange", function() {
 		// Only success responses and URLs that do not contains "debugbar_time" are tracked
-		if (realXHR.readyState === 4 && realXHR.status.toString()[0] === '2' && realXHR.responseURL.indexOf('debugbar_time') === -1 ) {
+		if (realXHR.readyState === 4 && realXHR.status.toString()[0] === '2' && realXHR.responseURL.indexOf('debugbar_time') === -1) {
 			if (realXHR.getAllResponseHeaders().indexOf("Debugbar-Time") >= 0) {
-
     				var debugbarTime = realXHR.getResponseHeader('Debugbar-Time');
 
 				if (debugbarTime) {
 					var h2 = document.querySelector('#ci-history > h2');
-					if(h2) {
+					if (h2) {
 						h2.innerHTML = 'History <small>You have new debug data.</small> <button onclick="loadDoc(' + debugbarTime + ')">Update</button>';
 						var badge = document.querySelector('a[data-tab="ci-history"] > span > .badge');
 						badge.className += ' active';
 					}
 				}
-  			}
+			}
 		}
 	}, false);
 	return realXHR;

--- a/system/Debug/Toolbar/Views/toolbarloader.js.php
+++ b/system/Debug/Toolbar/Views/toolbarloader.js.php
@@ -71,7 +71,7 @@ function newXHR() {
 	var realXHR = new oldXHR();
 	realXHR.addEventListener("readystatechange", function() {
 		// Only success responses and URLs that do not contains "debugbar_time" are tracked
-		if (realXHR.readyState === 4 && realXHR.status.toString()[0] === '2' && realXHR.responseURL.indexOf('debugbar_time') === -1 && ) {
+		if (realXHR.readyState === 4 && realXHR.status.toString()[0] === '2' && realXHR.responseURL.indexOf('debugbar_time') === -1 ) {
 			if (realXHR.getAllResponseHeaders().indexOf("Debugbar-Time") >= 0) {
 
     				var debugbarTime = realXHR.getResponseHeader('Debugbar-Time');

--- a/system/Debug/Toolbar/Views/toolbarloader.js.php
+++ b/system/Debug/Toolbar/Views/toolbarloader.js.php
@@ -71,16 +71,20 @@ function newXHR() {
 	var realXHR = new oldXHR();
 	realXHR.addEventListener("readystatechange", function() {
 		// Only success responses and URLs that do not contains "debugbar_time" are tracked
-		if (realXHR.readyState === 4 && realXHR.status.toString()[0] === '2' && realXHR.responseURL.indexOf('debugbar_time') === -1) {
-			var debugbarTime = realXHR.getResponseHeader('Debugbar-Time');
-			if (debugbarTime) {
-				var h2 = document.querySelector('#ci-history > h2');
-				if(h2) {
-					h2.innerHTML = 'History <small>You have new debug data.</small> <button onclick="loadDoc(' + debugbarTime + ')">Update</button>';
-					var badge = document.querySelector('a[data-tab="ci-history"] > span > .badge');
-					badge.className += ' active';
+		if (realXHR.readyState === 4 && realXHR.status.toString()[0] === '2' && realXHR.responseURL.indexOf('debugbar_time') === -1 && ) {
+			if (realXHR.getAllResponseHeaders().indexOf("Debugbar-Time") >= 0) {
+
+    				var debugbarTime = realXHR.getResponseHeader('Debugbar-Time');
+
+				if (debugbarTime) {
+					var h2 = document.querySelector('#ci-history > h2');
+					if(h2) {
+						h2.innerHTML = 'History <small>You have new debug data.</small> <button onclick="loadDoc(' + debugbarTime + ')">Update</button>';
+						var badge = document.querySelector('a[data-tab="ci-history"] > span > .badge');
+						badge.className += ' active';
+					}
 				}
-			}
+  			}
 		}
 	}, false);
 	return realXHR;


### PR DESCRIPTION
Chromium browsers raise a scary-looking but non-blocking error in the console if a referenced header is null. The issue is well-explained [here](https://trackjs.com/blog/refused-unsafe-header/).

The current check for the header only looks for a non-null value, which seems insufficient to prevent Chrome raising this error. 

I have added to the logic here to include a check for the header itself first to hopefully avoid the console error.
