### PR TITLE
Tweaks to TestResponse

### DIFF
--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -142,18 +142,6 @@ class TestResponse extends TestCase
 	}
 
 	/**
-	 * Returns whether or not the Response was a redirect or RedirectResponse
-	 *
-	 * @return boolean
-	 */
-	public function isRedirect(): bool
-	{
-		return $this->response instanceof RedirectResponse
-			|| $this->response->hasHeader('Location')
-			|| $this->response->hasHeader('Refresh');
-	}
-
-	/**
 	 * Asserts that the status is a specific value.
 	 *
 	 * @param integer $code
@@ -188,6 +176,18 @@ class TestResponse extends TestCase
 	//--------------------------------------------------------------------
 	// Redirection
 	//--------------------------------------------------------------------
+
+	/**
+	 * Returns whether or not the Response was a redirect or RedirectResponse
+	 *
+	 * @return boolean
+	 */
+	public function isRedirect(): bool
+	{
+		return $this->response instanceof RedirectResponse
+			|| $this->response->hasHeader('Location')
+			|| $this->response->hasHeader('Refresh');
+	}
 
 	/**
 	 * Assert that the given response was a redirect.
@@ -272,9 +272,18 @@ class TestResponse extends TestCase
 	{
 		$this->assertTrue(array_key_exists($key, $_SESSION), "'{$key}' is not in the current \$_SESSION");
 
-		if ($value !== null)
+		if (is_null($value))
+		{
+			return;
+		}
+
+		if (is_string($value))
 		{
 			$this->assertEquals($value, $_SESSION[$key], "The value of '{$key}' ({$value}) does not match expected value.");
+		}
+		else
+		{
+			$this->assertEquals($value, $_SESSION[$key], "The value of '{$key}' does not match expected value.");
 		}
 	}
 

--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -277,7 +277,7 @@ class TestResponse extends TestCase
 			return;
 		}
 
-		if (is_string($value))
+		if (is_scalar($value))
 		{
 			$this->assertEquals($value, $_SESSION[$key], "The value of '{$key}' ({$value}) does not match expected value.");
 		}

--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -431,6 +431,11 @@ class TestResponse extends TestCase
 	{
 		$json = $this->getJSON();
 
+		if (is_object($test))
+		{
+			$test = method_exists($test, 'toArray') ? $test->toArray() : (array) $test;
+		}
+
 		if (is_array($test))
 		{
 			$test = Services::format()->getFormatter('application/json')->format($test);

--- a/tests/system/Test/FeatureTestCaseTest.php
+++ b/tests/system/Test/FeatureTestCaseTest.php
@@ -331,6 +331,20 @@ class FeatureTestCaseTest extends FeatureTestCase
 		$response->assertJSONExact(['foo' => 'bar']);
 	}
 
+	public function testCallWithJsonRequestObject()
+	{
+		$this->withRoutes([
+			[
+				'post',
+				'home',
+				'\Tests\Support\Controllers\Popcorn::echoJson',
+			],
+		]);
+		$response = $this->withBodyFormat('json')->call('post', 'home', ['foo' => 'bar']);
+		$response->assertOK();
+		$response->assertJSONExact((object) ['foo' => 'bar']);
+	}
+
 	public function testSetupRequestBodyWithParams()
 	{
 		$request = $this->setupRequest('post', 'home');


### PR DESCRIPTION
**Description**
This is a slight "addendum" to the `TestResponse` PR. Fixes a few things:
1. `assertSessionHas()` uses a nice display for failed assertions, however `$value` is not always a string which can lead to errors like "array to string conversion". This PR limits the value display to when it is actually a string. You still get the PHPUnit comparison, e.g.:
```
The value of 'session-var' does not match expected value.
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     0 => Array (
-        'class' => 'foobar'
+        'class' => 'success'
         'text' => 'New factory created successfully.'
     )
 )
```
2. `assertJSONExact()` accepts an `array` which it will automatically convert to JSON which is very handy for testing RESTful responses. This PR expands that to accept objects (which will be converted to arrays) for endpoints that may return a singleton. Previously this would cause an error:
> TypeError: Argument 1 passed to PHPUnit\Framework\Assert::assertJsonStringEqualsJsonString() must be of the type string, object given, called in /opt/CodeIgniter4/system/Test/TestResponse.php on line 439
3. `isRedirect()` was incorrectly grouped with the statuses - this PR moves it to the Redirects section.

**Checklist:**
- [X] Securely signed commits
- [x] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
