### PR TITLE
Test Types

### DIFF
--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Test;
 
+use CodeIgniter\Controller;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\URI;
@@ -45,7 +46,7 @@ trait ControllerTester
 	/**
 	 * Request.
 	 *
-	 * @var Request
+	 * @var IncomingRequest
 	 */
 	protected $request;
 

--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -263,8 +263,8 @@ class TestResponse extends TestCase
 	/**
 	 * Asserts that an SESSION key has been set and, optionally, test it's value.
 	 *
-	 * @param string      $key
-	 * @param string|null $value
+	 * @param string $key
+	 * @param mixed  $value
 	 *
 	 * @throws Exception
 	 */


### PR DESCRIPTION
**Description**
Fixes a few incorrect types on test classes. Presumably the missing imports on the trait are because PHPStan expects traits to be mixed in.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
