### PR TITLE
Create Config::Cookie Class

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -3,7 +3,6 @@
 namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
-use DateTimeInterface;
 
 class App extends BaseConfig
 {
@@ -242,6 +241,8 @@ class App extends BaseConfig
 	 * Set a cookie name prefix if you need to avoid collisions.
 	 *
 	 * @var string
+	 * 
+	 * @deprecated use Config\Cookie::$prefix property instead.
 	 */
 	public $cookiePrefix = '';
 
@@ -253,6 +254,8 @@ class App extends BaseConfig
 	 * Set to `.your-domain.com` for site-wide cookies.
 	 *
 	 * @var string
+	 * 
+	 * @deprecated use Config\Cookie::$domain property instead.
 	 */
 	public $cookieDomain = '';
 
@@ -264,6 +267,8 @@ class App extends BaseConfig
 	 * Typically will be a forward slash.
 	 *
 	 * @var string
+	 * 
+	 * @deprecated use Config\Cookie::$path property instead.
 	 */
 	public $cookiePath = '/';
 
@@ -275,6 +280,8 @@ class App extends BaseConfig
 	 * Cookie will only be set if a secure HTTPS connection exists.
 	 *
 	 * @var boolean
+	 * 
+	 * @deprecated use Config\Cookie::$secure property instead.
 	 */
 	public $cookieSecure = false;
 
@@ -286,6 +293,8 @@ class App extends BaseConfig
 	 * Cookie will only be accessible via HTTP(S) (no JavaScript).
 	 *
 	 * @var boolean
+	 * 
+	 * @deprecated use Config\Cookie::$httponly property instead.
 	 */
 	public $cookieHTTPOnly = true;
 
@@ -310,39 +319,10 @@ class App extends BaseConfig
 	 * will be set on cookies. If set to `None`, `$cookieSecure` must also be set.
 	 *
 	 * @var string
+	 * 
+	 * @deprecated use Config\Cookie::$samesite property instead.
 	 */
 	public $cookieSameSite = 'Lax';
-
-	/**
-	 * --------------------------------------------------------------------------
-	 * Cookie Raw
-	 * --------------------------------------------------------------------------
-	 *
-	 * This flag allows setting a "raw" cookie, i.e., its name and value are
-	 * not URL encoded using `rawurlencode()`.
-	 *
-	 * If this is set to `true`, cookie names should be compliant of RFC 2616's
-	 * list of allowed characters.
-	 *
-	 * @var boolean
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes
-	 * @see https://tools.ietf.org/html/rfc2616#section-2.2
-	 */
-	public $cookieRaw = false;
-
-	/**
-	 * --------------------------------------------------------------------------
-	 * Cookie Expires Timestamp
-	 * --------------------------------------------------------------------------
-	 *
-	 * Default expires timestamp for cookies. Setting this to `0` will mean the
-	 * cookie will not have the `Expires` attribute and will behave as a session
-	 * cookie.
-	 *
-	 * @var DateTimeInterface|integer|string
-	 */
-	public $cookieExpires = 0;
 
 	/**
 	 * --------------------------------------------------------------------------

--- a/app/Config/Cookie.php
+++ b/app/Config/Cookie.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+use DateTimeInterface;
+
+class Cookie extends BaseConfig
+{
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie Prefix
+	 * --------------------------------------------------------------------------
+	 *
+	 * Set a cookie name prefix if you need to avoid collisions.
+	 *
+	 * @var string
+	 */
+	public $prefix = '';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie Expires Timestamp
+	 * --------------------------------------------------------------------------
+	 *
+	 * Default expires timestamp for cookies. Setting this to `0` will mean the
+	 * cookie will not have the `Expires` attribute and will behave as a session
+	 * cookie.
+	 *
+	 * @var DateTimeInterface|integer|string
+	 */
+	public $expires = 0;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie Path
+	 * --------------------------------------------------------------------------
+	 *
+	 * Typically will be a forward slash.
+	 *
+	 * @var string
+	 */
+	public $path = '/';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie Domain
+	 * --------------------------------------------------------------------------
+	 *
+	 * Set to `.your-domain.com` for site-wide cookies.
+	 *
+	 * @var string
+	 */
+	public $domain = '';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie Secure
+	 * --------------------------------------------------------------------------
+	 *
+	 * Cookie will only be set if a secure HTTPS connection exists.
+	 *
+	 * @var boolean
+	 */
+	public $secure = false;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie HTTPOnly
+	 * --------------------------------------------------------------------------
+	 *
+	 * Cookie will only be accessible via HTTP(S) (no JavaScript).
+	 *
+	 * @var boolean
+	 */
+	public $httponly = true;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie SameSite
+	 * --------------------------------------------------------------------------
+	 *
+	 * Configure cookie SameSite setting. Allowed values are:
+	 * - None
+	 * - Lax
+	 * - Strict
+	 * - ''
+	 *
+	 * Alternatively, you can use the constant names:
+	 * - `Cookie::SAMESITE_NONE`
+	 * - `Cookie::SAMESITE_LAX`
+	 * - `Cookie::SAMESITE_STRICT`
+	 *
+	 * Defaults to `Lax` for compatibility with modern browsers. Setting `''`
+	 * (empty string) means default SameSite attribute set by browsers (`Lax`)
+	 * will be set on cookies. If set to `None`, `$secure` must also be set.
+	 *
+	 * @var string
+	 */
+	public $samesite = 'Lax';
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Cookie Raw
+	 * --------------------------------------------------------------------------
+	 *
+	 * This flag allows setting a "raw" cookie, i.e., its name and value are
+	 * not URL encoded using `rawurlencode()`.
+	 *
+	 * If this is set to `true`, cookie names should be compliant of RFC 2616's
+	 * list of allowed characters.
+	 *
+	 * @var boolean
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes
+	 * @see https://tools.ietf.org/html/rfc2616#section-2.2
+	 */
+	public $raw = false;
+}

--- a/env
+++ b/env
@@ -89,6 +89,19 @@
 # contentsecuritypolicy.upgradeInsecureRequests = false
 
 #--------------------------------------------------------------------
+# COOKIE
+#--------------------------------------------------------------------
+
+# cookie.prefix   = ''
+# cookie.expires  = 0
+# cookie.path     = '/'
+# cookie.domain   = ''
+# cookie.secure   = false
+# cookie.httponly = false
+# cookie.samesite = 'Lax'
+# cookie.raw      = false
+
+#--------------------------------------------------------------------
 # ENCRYPTION
 #--------------------------------------------------------------------
 

--- a/system/Cookie/CloneableCookieInterface.php
+++ b/system/Cookie/CloneableCookieInterface.php
@@ -20,15 +20,6 @@ use DateTimeInterface;
 interface CloneableCookieInterface extends CookieInterface
 {
 	/**
-	 * Creates a new Cookie with URL encoding option updated.
-	 *
-	 * @param boolean $raw
-	 *
-	 * @return static
-	 */
-	public function withRaw(bool $raw = true);
-
-	/**
 	 * Creates a new Cookie with a new cookie prefix.
 	 *
 	 * @param string $prefix
@@ -79,15 +70,6 @@ interface CloneableCookieInterface extends CookieInterface
 	public function withNeverExpiring();
 
 	/**
-	 * Creates a new Cookie with a new domain the cookie is available.
-	 *
-	 * @param string|null $domain
-	 *
-	 * @return static
-	 */
-	public function withDomain(?string $domain);
-
-	/**
 	 * Creates a new Cookie with a new path on the server the cookie is available.
 	 *
 	 * @param string|null $path
@@ -95,6 +77,15 @@ interface CloneableCookieInterface extends CookieInterface
 	 * @return static
 	 */
 	public function withPath(?string $path);
+
+	/**
+	 * Creates a new Cookie with a new domain the cookie is available.
+	 *
+	 * @param string|null $domain
+	 *
+	 * @return static
+	 */
+	public function withDomain(?string $domain);
 
 	/**
 	 * Creates a new Cookie with a new "Secure" attribute.
@@ -108,18 +99,27 @@ interface CloneableCookieInterface extends CookieInterface
 	/**
 	 * Creates a new Cookie with a new "HttpOnly" attribute
 	 *
-	 * @param boolean $httpOnly
+	 * @param boolean $httponly
 	 *
 	 * @return static
 	 */
-	public function withHttpOnly(bool $httpOnly = true);
+	public function withHTTPOnly(bool $httponly = true);
 
 	/**
 	 * Creates a new Cookie with a new "SameSite" attribute.
 	 *
-	 * @param string $sameSite
+	 * @param string $samesite
 	 *
 	 * @return static
 	 */
-	public function withSameSite(string $sameSite);
+	public function withSameSite(string $samesite);
+
+	/**
+	 * Creates a new Cookie with URL encoding option updated.
+	 *
+	 * @param boolean $raw
+	 *
+	 * @return static
+	 */
+	public function withRaw(bool $raw = true);
 }

--- a/system/Cookie/CookieInterface.php
+++ b/system/Cookie/CookieInterface.php
@@ -67,18 +67,11 @@ interface CookieInterface
 
 	/**
 	 * Returns a unique identifier for the cookie consisting
-	 * of its name, prefix, domain, and path.
+	 * of its prefixed name, path, and domain.
 	 *
 	 * @return string
 	 */
 	public function getId(): string;
-
-	/**
-	 * Checks if the cookie should be sent with no URL encoding.
-	 *
-	 * @return boolean
-	 */
-	public function isRaw(): bool;
 
 	/**
 	 * Gets the cookie prefix.
@@ -137,18 +130,18 @@ interface CookieInterface
 	public function getMaxAge(): int;
 
 	/**
-	 * Gets the "Domain" cookie attribute.
-	 *
-	 * @return string
-	 */
-	public function getDomain(): string;
-
-	/**
 	 * Gets the "Path" cookie attribute.
 	 *
 	 * @return string
 	 */
 	public function getPath(): string;
+
+	/**
+	 * Gets the "Domain" cookie attribute.
+	 *
+	 * @return string
+	 */
+	public function getDomain(): string;
 
 	/**
 	 * Gets the "Secure" cookie attribute.
@@ -168,7 +161,7 @@ interface CookieInterface
 	 *
 	 * @return boolean
 	 */
-	public function isHttpOnly(): bool;
+	public function isHTTPOnly(): bool;
 
 	/**
 	 * Gets the "SameSite" cookie attribute.
@@ -176,6 +169,13 @@ interface CookieInterface
 	 * @return string
 	 */
 	public function getSameSite(): string;
+
+	/**
+	 * Checks if the cookie should be sent with no URL encoding.
+	 *
+	 * @return boolean
+	 */
+	public function isRaw(): bool;
 
 	/**
 	 * Gets the options that are passable to the `setcookie` variant

--- a/system/Cookie/CookieStore.php
+++ b/system/Cookie/CookieStore.php
@@ -167,11 +167,8 @@ class CookieStore implements Countable, IteratorAggregate
 	public function remove(string $name, string $prefix = '')
 	{
 		$default = Cookie::setDefaults();
-		$name    = $prefix . $name;
-		$domain  = $default['domain'];
-		$path    = $default['path'];
 
-		$id = implode(';', [$name, $domain, $path]);
+		$id = implode(';', [$prefix . $name, $default['path'], $default['domain']]);
 
 		$store = clone $this;
 
@@ -191,7 +188,7 @@ class CookieStore implements Countable, IteratorAggregate
 	 *
 	 * @return void
 	 */
-	public function dispatch()
+	public function dispatch(): void
 	{
 		foreach ($this->cookies as $cookie)
 		{
@@ -217,7 +214,7 @@ class CookieStore implements Countable, IteratorAggregate
 	 *
 	 * @return array<string, Cookie>
 	 */
-	public function display()
+	public function display(): array
 	{
 		return $this->cookies;
 	}
@@ -237,7 +234,7 @@ class CookieStore implements Countable, IteratorAggregate
 	 *
 	 * @return integer
 	 */
-	public function count()
+	public function count(): int
 	{
 		return count($this->cookies);
 	}
@@ -285,7 +282,7 @@ class CookieStore implements Countable, IteratorAggregate
 	 *
 	 * @return void
 	 */
-	protected function setRawCookie(string $name, string $value, array $options)
+	protected function setRawCookie(string $name, string $value, array $options): void
 	{
 		setrawcookie($name, $value, $options);
 	}
@@ -301,7 +298,7 @@ class CookieStore implements Countable, IteratorAggregate
 	 *
 	 * @return void
 	 */
-	protected function setCookie(string $name, string $value, array $options)
+	protected function setCookie(string $name, string $value, array $options): void
 	{
 		setcookie($name, $value, $options);
 	}

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -16,6 +16,7 @@ use CodeIgniter\Cookie\CookieStore;
 use CodeIgniter\HTTP\Exceptions\CookieException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use Config\App;
+use Config\ContentSecurityPolicy as CSPConfig;
 
 /**
  * Representation of an outgoing, getServer-side response.
@@ -151,7 +152,7 @@ class Response extends Message implements MessageInterface, ResponseInterface
 		$this->noCache();
 
 		// We need CSP object even if not enabled to avoid calls to non existing methods
-		$this->CSP = new ContentSecurityPolicy(new \Config\ContentSecurityPolicy());
+		$this->CSP = new ContentSecurityPolicy(new CSPConfig());
 
 		$this->CSPEnabled = $config->CSPEnabled;
 
@@ -173,7 +174,7 @@ class Response extends Message implements MessageInterface, ResponseInterface
 		}
 
 		$this->cookieStore = new CookieStore([]);
-		Cookie::setDefaults($config);
+		Cookie::setDefaults(config('Cookie'));
 
 		// Default to an HTML Content-Type. Devs can override if needed.
 		$this->setContentType('text/html');

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -15,6 +15,7 @@ use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use Config\App;
+use Config\Cookie as CookieConfig;
 use Config\Security as SecurityConfig;
 
 /**
@@ -136,11 +137,18 @@ class Security implements SecurityInterface
 		$this->headerName = $security->headerName ?? $config->CSRFHeaderName ?? $this->headerName;
 		$this->regenerate = $security->regenerate ?? $config->CSRFRegenerate ?? $this->regenerate;
 		$rawCookieName    = $security->cookieName ?? $config->CSRFCookieName ?? $this->cookieName;
-		$this->cookieName = $config->cookiePrefix . $rawCookieName;
+
+		/**
+		 * @var CookieConfig
+		 */
+		$cookie = config('Cookie');
+
+		$cookiePrefix     = $cookie->prefix ?? $config->cookiePrefix;
+		$this->cookieName = $cookiePrefix . $rawCookieName;
 
 		$expires = $security->expires ?? $config->CSRFExpire ?? 7200;
 
-		Cookie::setDefaults($config);
+		Cookie::setDefaults($cookie);
 		$this->cookie = Cookie::create($rawCookieName, $this->generateHash(), [
 			'expires' => $expires === 0 ? 0 : time() + $expires,
 		]);

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Session;
 
 use CodeIgniter\Cookie\Cookie;
 use Config\App;
+use Config\Cookie as CookieConfig;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use SessionHandlerInterface;
@@ -181,19 +182,24 @@ class Session implements SessionInterface
 		//---------------------------------------------------------------------
 		// DEPRECATED COOKIE MANAGEMENT
 		//---------------------------------------------------------------------
-		$this->cookieDomain   = $config->cookieDomain ?? $this->cookieDomain;
 		$this->cookiePath     = $config->cookiePath ?? $this->cookiePath;
+		$this->cookieDomain   = $config->cookieDomain ?? $this->cookieDomain;
 		$this->cookieSecure   = $config->cookieSecure ?? $this->cookieSecure;
 		$this->cookieSameSite = $config->cookieSameSite ?? $this->cookieSameSite;
 
+		/**
+		 * @var CookieConfig
+		 */
+		$config = config('Cookie');
+
 		$this->cookie = Cookie::create($this->sessionCookieName, '', [
 			'expires'  => $this->sessionExpiration === 0 ? 0 : time() + $this->sessionExpiration,
-			'raw'      => $config->cookieRaw ?? false,
-			'domain'   => $config->cookieDomain ?? '',
-			'path'     => $config->cookiePath ?? '/',
-			'secure'   => $config->cookieSecure ?? false,
+			'path'     => $config->path,
+			'domain'   => $config->domain,
+			'secure'   => $config->secure,
 			'httponly' => true, // for security
-			'samesite' => $config->cookieSameSite ?? Cookie::SAMESITE_LAX,
+			'samesite' => $config->samesite,
+			'raw'      => $config->raw,
 		]);
 
 		helper('array');

--- a/tests/system/Cookie/CookieTest.php
+++ b/tests/system/Cookie/CookieTest.php
@@ -5,7 +5,7 @@ namespace CodeIgniter\Cookie;
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\HTTP\Exceptions\CookieException;
 use CodeIgniter\Test\CIUnitTestCase;
-use Config\App;
+use Config\Cookie as CookieConfig;
 use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
@@ -41,35 +41,36 @@ final class CookieTest extends CIUnitTestCase
 		$this->assertSame('test', $cookie->getName());
 		$this->assertSame('value', $cookie->getValue());
 		$this->assertSame($options['prefix'], $cookie->getPrefix());
-		$this->assertSame($options['raw'], $cookie->isRaw());
 		$this->assertSame($options['expires'], $cookie->getExpiresTimestamp());
-		$this->assertSame($options['domain'], $cookie->getDomain());
 		$this->assertSame($options['path'], $cookie->getPath());
+		$this->assertSame($options['domain'], $cookie->getDomain());
 		$this->assertSame($options['secure'], $cookie->isSecure());
-		$this->assertSame($options['httponly'], $cookie->isHttpOnly());
+		$this->assertSame($options['httponly'], $cookie->isHTTPOnly());
 		$this->assertSame($options['samesite'], $cookie->getSameSite());
+		$this->assertSame($options['raw'], $cookie->isRaw());
 	}
 
 	public function testConfigInjectionForDefaults(): void
 	{
 		/**
-		 * @var App $app
+		 * @var CookieConfig $config
 		 */
-		$app = config('App', false);
-		$old = Cookie::setDefaults($app);
+		$config = new CookieConfig();
+
+		$old = Cookie::setDefaults($config);
 
 		$cookie = Cookie::create('test', 'value');
-		$this->assertSame($app->cookiePrefix . 'test', $cookie->getPrefixedName());
+		$this->assertSame($config->prefix . 'test', $cookie->getPrefixedName());
 		$this->assertSame('test', $cookie->getName());
 		$this->assertSame('value', $cookie->getValue());
-		$this->assertSame($app->cookiePrefix, $cookie->getPrefix());
-		$this->assertSame($app->cookieRaw, $cookie->isRaw());
-		$this->assertSame($app->cookieExpires, $cookie->getExpiresTimestamp());
-		$this->assertSame($app->cookieDomain, $cookie->getDomain());
-		$this->assertSame($app->cookiePath, $cookie->getPath());
-		$this->assertSame($app->cookieSecure, $cookie->isSecure());
-		$this->assertSame($app->cookieHTTPOnly, $cookie->isHttpOnly());
-		$this->assertSame($app->cookieSameSite, $cookie->getSameSite());
+		$this->assertSame($config->prefix, $cookie->getPrefix());
+		$this->assertSame($config->expires, $cookie->getExpiresTimestamp());
+		$this->assertSame($config->path, $cookie->getPath());
+		$this->assertSame($config->domain, $cookie->getDomain());
+		$this->assertSame($config->secure, $cookie->isSecure());
+		$this->assertSame($config->httponly, $cookie->isHTTPOnly());
+		$this->assertSame($config->samesite, $cookie->getSameSite());
+		$this->assertSame($config->raw, $cookie->isRaw());
 
 		Cookie::setDefaults($old);
 	}
@@ -213,7 +214,7 @@ final class CookieTest extends CIUnitTestCase
 		$i = $a->withDomain('localhost');
 		$j = $a->withPath('/web');
 		$k = $a->withSecure();
-		$l = $a->withHttpOnly();
+		$l = $a->withHTTPOnly();
 		$m = $a->withSameSite(Cookie::SAMESITE_STRICT);
 
 		$this->assertNotSame($a, $b);
@@ -236,7 +237,7 @@ final class CookieTest extends CIUnitTestCase
 
 		$a = Cookie::create('cookie', 'lover');
 		$b = $a->withValue('monster')->withPath('/web')->withDomain('localhost')->withExpiresAt($date);
-		$c = $a->withSecure()->withHttpOnly(false)->withSameSite(Cookie::SAMESITE_STRICT);
+		$c = $a->withSecure()->withHTTPOnly(false)->withSameSite(Cookie::SAMESITE_STRICT);
 
 		$max = (string) $b->getMaxAge();
 		$old = Cookie::setDefaults(['samesite' => '']);
@@ -270,7 +271,7 @@ final class CookieTest extends CIUnitTestCase
 		$this->assertTrue(isset($cookie['expire']));
 		$this->assertSame($cookie['expire'], $cookie->getExpiresTimestamp());
 		$this->assertTrue(isset($cookie['httponly']));
-		$this->assertSame($cookie['httponly'], $cookie->isHttpOnly());
+		$this->assertSame($cookie['httponly'], $cookie->isHTTPOnly());
 		$this->assertTrue(isset($cookie['samesite']));
 		$this->assertSame($cookie['samesite'], $cookie->getSameSite());
 		$this->assertTrue(isset($cookie['path']));

--- a/tests/system/HTTP/ResponseCookieTest.php
+++ b/tests/system/HTTP/ResponseCookieTest.php
@@ -6,6 +6,7 @@ use CodeIgniter\Cookie\CookieStore;
 use CodeIgniter\HTTP\Exceptions\CookieException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use Config\Cookie as CookieConfig;
 
 /**
  * @internal
@@ -30,9 +31,9 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 	public function testCookiePrefixed()
 	{
-		$config               = new App();
-		$config->cookiePrefix = 'mine';
-		$response             = new Response($config);
+		$config         = config('Cookie');
+		$config->prefix = 'mine';
+		$response       = new Response(new App());
 		$response->setCookie('foo', 'bar');
 
 		$this->assertInstanceOf(Cookie::class, $response->getCookie('foo'));
@@ -45,8 +46,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 	public function testCookiesAll()
 	{
-		$config   = new App();
-		$response = new Response($config);
+		$response = new Response(new App());
 		$response->setCookie('foo', 'bar');
 		$response->setCookie('bee', 'bop');
 
@@ -57,8 +57,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 	public function testCookieGet()
 	{
-		$config   = new App();
-		$response = new Response($config);
+		$response = new Response(new App());
 		$response->setCookie('foo', 'bar');
 		$response->setCookie('bee', 'bop');
 
@@ -68,8 +67,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 	public function testCookieDomain()
 	{
-		$config   = new App();
-		$response = new Response($config);
+		$response = new Response(new App());
 
 		$response->setCookie('foo', 'bar');
 		$cookie = $response->getCookie('foo');
@@ -79,8 +77,9 @@ final class ResponseCookieTest extends CIUnitTestCase
 		$cookie = $response->getCookie('bee');
 		$this->assertSame('somewhere.com', $cookie->getDomain());
 
-		$config->cookieDomain = 'mine.com';
-		$response             = new Response($config);
+		$config         = config('Cookie');
+		$config->domain = 'mine.com';
+		$response       = new Response(new App());
 		$response->setCookie('alu', 'la');
 		$cookie = $response->getCookie('alu');
 		$this->assertSame('mine.com', $cookie->getDomain());
@@ -88,8 +87,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 	public function testCookiePath()
 	{
-		$config   = new App();
-		$response = new Response($config);
+		$response = new Response(new App());
 
 		$response->setCookie('foo', 'bar');
 		$cookie = $response->getCookie('foo');
@@ -102,8 +100,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 	public function testCookieSecure()
 	{
-		$config   = new App();
-		$response = new Response($config);
+		$response = new Response(new App());
 
 		$response->setCookie('foo', 'bar');
 		$cookie = $response->getCookie('foo');
@@ -116,33 +113,31 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 	public function testCookieHTTPOnly()
 	{
-		$config   = new App();
-		$response = new Response($config);
+		$response = new Response(new App());
 
 		$response->setCookie('foo', 'bar');
 		$cookie = $response->getCookie('foo');
-		$this->assertTrue($cookie->isHttpOnly());
+		$this->assertTrue($cookie->isHTTPOnly());
 
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'httponly' => false]);
 		$cookie = $response->getCookie('bee');
-		$this->assertTrue($cookie->isHttpOnly());
+		$this->assertTrue($cookie->isHTTPOnly());
 	}
 
 	public function testCookieExpiry()
 	{
-		$config   = new App();
-		$response = new Response($config);
+		$response = new Response(new App());
 
 		$response->setCookie('foo', 'bar');
 		$cookie = $response->getCookie('foo');
 		$this->assertTrue($cookie->isExpired());
 
-		$response = new Response($config);
+		$response = new Response(new App());
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
 		$cookie = $response->getCookie('bee');
 		$this->assertFalse($cookie->isExpired());
 
-		$response = new Response($config);
+		$response = new Response(new App());
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => -1000]);
 		$cookie = $response->getCookie('bee');
 		$this->assertSame(0, $cookie->getExpiresTimestamp());
@@ -150,8 +145,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 	public function testCookieDelete()
 	{
-		$config   = new App();
-		$response = new Response($config);
+		$response = new Response(new App());
 
 		// foo is already expired, bee will stick around
 		$response->setCookie('foo', 'bar');
@@ -160,36 +154,37 @@ final class ResponseCookieTest extends CIUnitTestCase
 		$this->assertFalse($cookie->isExpired());
 
 		// delete cookie manually
-		$response = new Response($config);
+		$response = new Response(new App());
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => '']);
 		$cookie = $response->getCookie('bee');
 		$this->assertTrue($cookie->isExpired(), $cookie->getExpiresTimestamp() . ' should be less than ' . time());
 
 		// delete with no effect
-		$response = new Response($config);
+		$response = new Response(new App());
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
 		$response->deleteCookie();
 		$cookie = $response->getCookie('bee');
 		$this->assertFalse($cookie->isExpired());
 
 		// delete cookie for real
-		$response = new Response($config);
+		$response = new Response(new App());
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
 		$response->deleteCookie('bee');
 		$cookie = $response->getCookie('bee');
 		$this->assertTrue($cookie->isExpired(), $cookie->getExpiresTimestamp() . ' should be less than ' . time());
 
+		$config = config('Cookie');
 		// delete cookie for real, with prefix
-		$config->cookiePrefix = 'mine';
-		$response             = new Response($config);
+		$config->prefix = 'mine';
+		$response       = new Response(new App());
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
 		$response->deleteCookie('bee');
 		$cookie = $response->getCookie('bee');
 		$this->assertSame($cookie->getExpiresTimestamp(), 0);
 
 		// delete cookie with wrong prefix?
-		$config->cookiePrefix = 'mine';
-		$response             = new Response($config);
+		$config->prefix = 'mine';
+		$response       = new Response(new App());
 		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'expire' => 1000]);
 		$response->deleteCookie('bee', '', '', 'wrong');
 		$cookie = $response->getCookie('bee');
@@ -199,8 +194,8 @@ final class ResponseCookieTest extends CIUnitTestCase
 		$this->assertSame($cookie->getExpiresTimestamp(), 0);
 
 		// delete cookie with wrong domain?
-		$config->cookieDomain = '.mine.com';
-		$response             = new Response($config);
+		$config->domain = '.mine.com';
+		$response       = new Response(new App());
 		$response->setCookie(['name' => 'bees', 'value' => 'bop', 'expire' => 1000]);
 		$response->deleteCookie('bees', 'wrong', '', '');
 		$cookie = $response->getCookie('bees');
@@ -212,8 +207,7 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 	public function testCookieDefaultSetSameSite()
 	{
-		$config   = new App();
-		$response = new Response($config);
+		$response = new Response(new App());
 		$response->setCookie([
 			'name'  => 'bar',
 			'value' => 'foo',
@@ -221,15 +215,15 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 		$allCookies = $response->getCookies();
 		$this->assertCount(1, $allCookies);
-		$this->assertInstanceOf(Cookie::class, $allCookies['bar;;/']);
-		$this->assertSame('Lax', $allCookies['bar;;/']->getSameSite());
+		$this->assertInstanceOf(Cookie::class, $allCookies['bar;/;']);
+		$this->assertSame('Lax', $allCookies['bar;/;']->getSameSite());
 	}
 
 	public function testCookieStrictSetSameSite()
 	{
-		$config                 = new App();
-		$config->cookieSameSite = 'Strict';
-		$response               = new Response($config);
+		$config           = config('Cookie');
+		$config->samesite = 'Strict';
+		$response         = new Response(new App());
 		$response->setCookie([
 			'name'  => 'bar',
 			'value' => 'foo',
@@ -237,15 +231,15 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 		$allCookies = $response->getCookies();
 		$this->assertCount(1, $allCookies);
-		$this->assertInstanceOf(Cookie::class, $allCookies['bar;;/']);
-		$this->assertSame('Strict', $allCookies['bar;;/']->getSameSite());
+		$this->assertInstanceOf(Cookie::class, $allCookies['bar;/;']);
+		$this->assertSame('Strict', $allCookies['bar;/;']->getSameSite());
 	}
 
 	public function testCookieBlankSetSameSite()
 	{
-		$config                 = new App();
-		$config->cookieSameSite = '';
-		$response               = new Response($config);
+		$config           = config('Cookie');
+		$config->samesite = '';
+		$response         = new Response(new App());
 		$response->setCookie([
 			'name'  => 'bar',
 			'value' => 'foo',
@@ -253,15 +247,15 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 		$allCookies = $response->getCookies();
 		$this->assertCount(1, $allCookies);
-		$this->assertInstanceOf(Cookie::class, $allCookies['bar;;/']);
-		$this->assertSame('', $allCookies['bar;;/']->getSameSite());
+		$this->assertInstanceOf(Cookie::class, $allCookies['bar;/;']);
+		$this->assertSame('', $allCookies['bar;/;']->getSameSite());
 	}
 
 	public function testCookieWithoutSameSite()
 	{
-		$config = new App();
-		unset($config->cookieSameSite);
-		$response = new Response($config);
+		$config = new CookieConfig();
+		unset($config->samesite);
+		$response = new Response(new App());
 		$response->setCookie([
 			'name'  => 'bar',
 			'value' => 'foo',
@@ -269,14 +263,13 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 		$allCookies = $response->getCookies();
 		$this->assertCount(1, $allCookies);
-		$this->assertInstanceOf(Cookie::class, $allCookies['bar;;/']);
-		$this->assertSame('Lax', $allCookies['bar;;/']->getSameSite());
+		$this->assertInstanceOf(Cookie::class, $allCookies['bar;/;']);
+		$this->assertSame('Lax', $allCookies['bar;/;']->getSameSite());
 	}
 
 	public function testCookieStrictSameSite()
 	{
-		$config   = new App();
-		$response = new Response($config);
+		$response = new Response(new App());
 		$response->setCookie([
 			'name'     => 'bar',
 			'value'    => 'foo',
@@ -285,14 +278,13 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 		$allCookies = $response->getCookies();
 		$this->assertCount(1, $allCookies);
-		$this->assertInstanceOf(Cookie::class, $allCookies['bar;;/']);
-		$this->assertSame('Strict', $allCookies['bar;;/']->getSameSite());
+		$this->assertInstanceOf(Cookie::class, $allCookies['bar;/;']);
+		$this->assertSame('Strict', $allCookies['bar;/;']->getSameSite());
 	}
 
 	public function testCookieInvalidSameSite()
 	{
-		$config   = new App();
-		$response = new Response($config);
+		$response = new Response(new App());
 
 		$this->expectException(CookieException::class);
 		$this->expectExceptionMessage(lang('Cookie.invalidSameSite', ['Invalid']));

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -11,6 +11,7 @@ use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockAppConfig;
 use CodeIgniter\Test\Mock\MockSecurity;
+use Config\Cookie as CookieConfig;
 use Config\Security as SecurityConfig;
 
 /**
@@ -21,7 +22,10 @@ class SecurityTest extends CIUnitTestCase
 	protected function setUp(): void
 	{
 		parent::setUp();
+
 		$_COOKIE = [];
+
+		Factories::reset();
 	}
 
 	public function testBasicConfigIsSaved()
@@ -209,12 +213,13 @@ class SecurityTest extends CIUnitTestCase
 		$request = $this->createMock(IncomingRequest::class);
 		$request->method('isSecure')->willReturn(false);
 
-		$config = new MockAppConfig();
+		$config = new CookieConfig();
 
-		$config->cookieSecure = true;
+		$config->secure = true;
+		Factories::injectMock('config', CookieConfig::class, $config);
 
 		$security = $this->getMockBuilder(Security::class)
-			->setConstructorArgs([$config])
+			->setConstructorArgs([new MockAppConfig()])
 			->onlyMethods(['doSendCookie'])
 			->getMock();
 

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -2,13 +2,15 @@
 
 namespace CodeIgniter\Session;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\Exceptions\CookieException;
 use CodeIgniter\Session\Handlers\FileHandler;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockSession;
 use CodeIgniter\Test\TestLogger;
 use Config\App as AppConfig;
-use Config\Logger;
+use Config\Cookie as CookieConfig;
+use Config\Logger as LoggerConfig;
 
 /**
  * @runTestsInSeparateProcesses
@@ -50,7 +52,7 @@ class SessionTest extends CIUnitTestCase
 		}
 
 		$session = new MockSession(new FileHandler($appConfig, '127.0.0.1'), $appConfig);
-		$session->setLogger(new TestLogger(new Logger()));
+		$session->setLogger(new TestLogger(new LoggerConfig()));
 
 		return $session;
 	}
@@ -552,7 +554,11 @@ class SessionTest extends CIUnitTestCase
 
 	public function testLaxSameSite()
 	{
-		$session = $this->getInstance(['cookieSameSite' => 'Lax']);
+		$config           = new CookieConfig();
+		$config->samesite = 'Lax';
+		Factories::injectMock('config', CookieConfig::class, $config);
+
+		$session = $this->getInstance();
 		$session->start();
 		$cookies = $session->cookies;
 		$this->assertCount(1, $cookies);
@@ -561,7 +567,13 @@ class SessionTest extends CIUnitTestCase
 
 	public function testNoneSameSite()
 	{
-		$session = $this->getInstance(['cookieSameSite' => 'None', 'cookieSecure' => true]);
+		$config           = new CookieConfig();
+		$config->secure   = true;
+		$config->samesite = 'None';
+
+		Factories::injectMock('config', CookieConfig::class, $config);
+
+		$session = $this->getInstance();
 		$session->start();
 
 		$cookies = $session->cookies;
@@ -571,7 +583,12 @@ class SessionTest extends CIUnitTestCase
 
 	public function testNoSameSiteReturnsDefault()
 	{
-		$session = $this->getInstance(['cookieSameSite' => '']);
+		$config           = new CookieConfig();
+		$config->samesite = '';
+
+		Factories::injectMock('config', CookieConfig::class, $config);
+
+		$session = $this->getInstance();
 		$session->start();
 
 		$cookies = $session->cookies;
@@ -584,7 +601,12 @@ class SessionTest extends CIUnitTestCase
 		$this->expectException(CookieException::class);
 		$this->expectExceptionMessage(lang('Cookie.invalidSameSite', ['Invalid']));
 
-		$session = $this->getInstance(['cookieSameSite' => 'Invalid']);
+		$config           = new CookieConfig();
+		$config->samesite = 'Invalid';
+
+		Factories::injectMock('config', CookieConfig::class, $config);
+
+		$session = $this->getInstance();
 		$session->start();
 	}
 


### PR DESCRIPTION
While we are taking a step forward to make config folder separated as much as possible, Cookie class should have it's own config file