### PR TITLE
Cease catching non-HTTP errors

### DIFF
--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -179,10 +179,13 @@ trait ControllerTester
 		{
 			$code = $e->getCode();
 
-			if ($code >= 100 && $code < 600)
+			// If code is not a valid HTTP status then assume there is an error
+			if ($code < 100 || $code >= 600)
 			{
-				$result->response()->setStatusCode($code);
+				throw $e;
 			}
+
+			$result->response()->setStatusCode($code);
 		}
 		finally
 		{


### PR DESCRIPTION
**Description**
`ControllerTester` catches any exceptions and wraps them into a `TestResponse`. If the error is a valid HTTP status code then it will set it on the response, otherwise it ignores them. This ignoring means that any regular exception (i.e. developer mistake) will return a `TestResponse` with `200` status and a `null` body - very misleading.

This PR re-throws exceptions that are non-HTTP statuses to prevent masking underlying issues.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
