### PR TITLE
Tests deprecate

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,7 @@
 			<file>./system/ComposerScripts.php</file>
 			<file>./system/Config/Routes.php</file>
 			<file>./system/Test/bootstrap.php</file>
+			<file>./system/Test/ControllerTester.php</file>
 			<file>./system/Test/FeatureTestCase.php</file>
 		</exclude>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,7 @@
 			<file>./system/ComposerScripts.php</file>
 			<file>./system/Config/Routes.php</file>
 			<file>./system/Test/bootstrap.php</file>
+			<file>./system/Test/FeatureTestCase.php</file>
 		</exclude>
 
 		<report>

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1568,7 +1568,7 @@ class RouteCollection implements RouteCollectionInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * Reset the routes, so that a FeatureTestCase can provide the
+	 * Reset the routes, so that a test case can provide the
 	 * explicit ones needed for it.
 	 */
 	public function resetRoutes()

--- a/system/Test/ControllerResponse.php
+++ b/system/Test/ControllerResponse.php
@@ -16,6 +16,8 @@ use Config\Services;
 
 /**
  * Testable response from a controller
+ *
+ * @deprecated Use TestResponse directly
  */
 class ControllerResponse extends TestResponse
 {
@@ -38,7 +40,7 @@ class ControllerResponse extends TestResponse
 	protected $dom;
 
 	/**
-	 * Maintains the deprecated $domParser property.
+	 * Maintains the deprecated $dom property.
 	 */
 	public function __construct()
 	{

--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -21,7 +21,7 @@ use InvalidArgumentException;
 use Throwable;
 
 /**
- * ControllerTester Trait
+ * Controller Test Trait
  *
  * Provides features that make testing controllers simple and fluent.
  *
@@ -33,10 +33,8 @@ use Throwable;
  *       ->withBody($body)
  *       ->controller('App\Controllers\Home')
  *       ->execute('methodName');
- *
- * @deprecated Use ControllerTestTrait instead
  */
-trait ControllerTester
+trait ControllerTestTrait
 {
 	/**
 	 * Controller configuration.
@@ -153,7 +151,7 @@ trait ControllerTester
 	 *
 	 * @throws InvalidArgumentException
 	 *
-	 * @return ControllerResponse
+	 * @return TestResponse
 	 */
 	public function execute(string $method, ...$params)
 	{
@@ -166,7 +164,7 @@ trait ControllerTester
 		// so ensure it's available.
 		helper('url');
 
-		$result = (new ControllerResponse())
+		$result = (new TestResponse())
 				->setRequest($this->request)
 				->setResponse($this->response);
 

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -11,16 +11,427 @@
 
 namespace CodeIgniter\Test;
 
+use CodeIgniter\Events\Events;
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Request;
+use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\UserAgent;
+use CodeIgniter\Router\Exceptions\RedirectException;
+use CodeIgniter\Router\RouteCollection;
+use Config\App;
+use Config\Services;
+use Exception;
+use ReflectionException;
+
 /**
  * Class FeatureTestCase
  *
  * Provides a base class with the trait for doing full HTTP testing
  * against your application.
  *
- * @deprecated Include the traits directly in the test case
+ * @deprecated Use FeatureTestTrait instead
  */
 class FeatureTestCase extends CIUnitTestCase
 {
-	use FeatureTestTrait;
 	use DatabaseTestTrait;
+
+	/**
+	 * Sets a RouteCollection that will override
+	 * the application's route collection.
+	 *
+	 * Example routes:
+	 * [
+	 *    ['get', 'home', 'Home::index']
+	 * ]
+	 *
+	 * @param array $routes
+	 *
+	 * @return $this
+	 */
+	protected function withRoutes(array $routes = null)
+	{
+		$collection = Services::routes();
+
+		if ($routes)
+		{
+			$collection->resetRoutes();
+			foreach ($routes as $route)
+			{
+				$collection->{$route[0]}($route[1], $route[2]);
+			}
+		}
+
+		$this->routes = $collection;
+
+		return $this;
+	}
+
+	/**
+	 * Sets any values that should exist during this session.
+	 *
+	 * @param array|null $values Array of values, or null to use the current $_SESSION
+	 *
+	 * @return $this
+	 */
+	public function withSession(array $values = null)
+	{
+		$this->session = is_null($values) ? $_SESSION : $values;
+
+		return $this;
+	}
+
+	/**
+	 * Set request's headers
+	 *
+	 * Example of use
+	 * withHeaders([
+	 *  'Authorization' => 'Token'
+	 * ])
+	 *
+	 * @param array $headers Array of headers
+	 *
+	 * @return $this
+	 */
+	public function withHeaders(array $headers = [])
+	{
+		$this->headers = $headers;
+
+		return $this;
+	}
+
+	/**
+	 * Set the format the request's body should have.
+	 *
+	 * @param  string $format The desired format. Currently supported formats: xml, json
+	 * @return $this
+	 */
+	public function withBodyFormat(string $format)
+	{
+		$this->bodyFormat = $format;
+
+		return $this;
+	}
+
+	/**
+	 * Set the raw body for the request
+	 *
+	 * @param  mixed $body
+	 * @return $this
+	 */
+	public function withBody($body)
+	{
+		$this->requestBody = $body;
+
+		return $this;
+	}
+
+	/**
+	 * Don't run any events while running this test.
+	 *
+	 * @return $this
+	 */
+	public function skipEvents()
+	{
+		Events::simulate(true);
+
+		return $this;
+	}
+
+	/**
+	 * Calls a single URI, executes it, and returns a FeatureResponse
+	 * instance that can be used to run many assertions against.
+	 *
+	 * @param string     $method
+	 * @param string     $path
+	 * @param array|null $params
+	 *
+	 * @return FeatureResponse
+	 * @throws RedirectException
+	 * @throws Exception
+	 */
+	public function call(string $method, string $path, array $params = null)
+	{
+		$buffer = \ob_get_level();
+
+		// Clean up any open output buffers
+		// not relevant to unit testing
+		// @codeCoverageIgnoreStart
+		if (\ob_get_level() > 0 && (! isset($this->clean) || $this->clean === true))
+		{
+			\ob_end_clean();
+		}
+		// @codeCoverageIgnoreEnd
+
+		// Simulate having a blank session
+		$_SESSION                  = [];
+		$_SERVER['REQUEST_METHOD'] = $method;
+
+		$request = $this->setupRequest($method, $path);
+		$request = $this->setupHeaders($request);
+		$request = $this->populateGlobals($method, $request, $params);
+		$request = $this->setRequestBody($request);
+
+		// Initialize the RouteCollection
+		if (! $routes = $this->routes)
+		{
+			require APPPATH . 'Config/Routes.php';
+
+			/**
+			 * @var RouteCollection $routes
+			 */
+			$routes->getRoutes('*');
+		}
+
+		$routes->setHTTPVerb($method);
+
+		// Make sure any other classes that might call the request
+		// instance get the right one.
+		Services::injectMock('request', $request);
+
+		// Make sure filters are reset between tests
+		Services::injectMock('filters', Services::filters(null, false));
+
+		$response = $this->app
+				->setRequest($request)
+				->run($routes, true);
+
+		$output = \ob_get_contents();
+		if (empty($response->getBody()) && ! empty($output))
+		{
+			$response->setBody($output);
+		}
+
+		// Reset directory if it has been set
+		Services::router()->setDirectory(null);
+
+		// Ensure the output buffer is identical so no tests are risky
+		// @codeCoverageIgnoreStart
+		while (\ob_get_level() > $buffer)
+		{
+			\ob_end_clean();
+		}
+		while (\ob_get_level() < $buffer)
+		{
+			\ob_start();
+		}
+		// @codeCoverageIgnoreEnd
+
+		return new FeatureResponse($response);
+	}
+
+	/**
+	 * Performs a GET request.
+	 *
+	 * @param string     $path
+	 * @param array|null $params
+	 *
+	 * @return FeatureResponse
+	 * @throws RedirectException
+	 * @throws Exception
+	 */
+	public function get(string $path, array $params = null)
+	{
+		return $this->call('get', $path, $params);
+	}
+
+	/**
+	 * Performs a POST request.
+	 *
+	 * @param string     $path
+	 * @param array|null $params
+	 *
+	 * @return FeatureResponse
+	 * @throws RedirectException
+	 * @throws Exception
+	 */
+	public function post(string $path, array $params = null)
+	{
+		return $this->call('post', $path, $params);
+	}
+
+	/**
+	 * Performs a PUT request
+	 *
+	 * @param string     $path
+	 * @param array|null $params
+	 *
+	 * @return FeatureResponse
+	 * @throws RedirectException
+	 * @throws Exception
+	 */
+	public function put(string $path, array $params = null)
+	{
+		return $this->call('put', $path, $params);
+	}
+
+	/**
+	 * Performss a PATCH request
+	 *
+	 * @param string     $path
+	 * @param array|null $params
+	 *
+	 * @return FeatureResponse
+	 * @throws RedirectException
+	 * @throws Exception
+	 */
+	public function patch(string $path, array $params = null)
+	{
+		return $this->call('patch', $path, $params);
+	}
+
+	/**
+	 * Performs a DELETE request.
+	 *
+	 * @param string     $path
+	 * @param array|null $params
+	 *
+	 * @return FeatureResponse
+	 * @throws RedirectException
+	 * @throws Exception
+	 */
+	public function delete(string $path, array $params = null)
+	{
+		return $this->call('delete', $path, $params);
+	}
+
+	/**
+	 * Performs an OPTIONS request.
+	 *
+	 * @param string     $path
+	 * @param array|null $params
+	 *
+	 * @return FeatureResponse
+	 * @throws RedirectException
+	 * @throws Exception
+	 */
+	public function options(string $path, array $params = null)
+	{
+		return $this->call('options', $path, $params);
+	}
+
+	/**
+	 * Setup a Request object to use so that CodeIgniter
+	 * won't try to auto-populate some of the items.
+	 *
+	 * @param string      $method
+	 * @param string|null $path
+	 *
+	 * @return IncomingRequest
+	 */
+	protected function setupRequest(string $method, string $path = null): IncomingRequest
+	{
+		$config = config(App::class);
+		$uri    = new URI(rtrim($config->baseURL, '/') . '/' . trim($path, '/ '));
+
+		$request      = new IncomingRequest($config, clone($uri), null, new UserAgent());
+		$request->uri = $uri;
+
+		$request->setMethod($method);
+		$request->setProtocolVersion('1.1');
+
+		if ($config->forceGlobalSecureRequests)
+		{
+			$_SERVER['HTTPS'] = 'test';
+		}
+
+		return $request;
+	}
+
+	/**
+	 * Setup the custom request's headers
+	 *
+	 * @param IncomingRequest $request
+	 *
+	 * @return IncomingRequest
+	 */
+	protected function setupHeaders(IncomingRequest $request)
+	{
+		if (! empty($this->headers))
+		{
+			foreach ($this->headers as $name => $value)
+			{
+				$request->setHeader($name, $value);
+			}
+		}
+
+		return $request;
+	}
+
+	/**
+	 * Populates the data of our Request with "global" data
+	 * relevant to the request, like $_POST data.
+	 *
+	 * Always populate the GET vars based on the URI.
+	 *
+	 * @param string     $method
+	 * @param Request    $request
+	 * @param array|null $params
+	 *
+	 * @return Request
+	 * @throws ReflectionException
+	 */
+	protected function populateGlobals(string $method, Request $request, array $params = null)
+	{
+		// $params should set the query vars if present,
+		// otherwise set it from the URL.
+		$get = ! empty($params) && $method === 'get'
+			? $params
+			: $this->getPrivateProperty($request->uri, 'query'); // @phpstan-ignore-line
+
+		$request->setGlobal('get', $get);
+		if ($method !== 'get')
+		{
+			$request->setGlobal($method, $params);
+		}
+
+		$request->setGlobal('request', $params);
+
+		$_SESSION = $this->session ?? [];
+
+		return $request;
+	}
+
+	/**
+	 * Set the request's body formatted according to the value in $this->bodyFormat.
+	 * This allows the body to be formatted in a way that the controller is going to
+	 * expect as in the case of testing a JSON or XML API.
+	 *
+	 * @param  Request    $request
+	 * @param  null|array $params  The parameters to be formatted and put in the body. If this is empty, it will get the
+	 *                               what has been loaded into the request global of the request class.
+	 * @return Request
+	 */
+	protected function setRequestBody(Request $request, array $params = null): Request
+	{
+		if (isset($this->requestBody) && $this->requestBody !== '')
+		{
+			$request->setBody($this->requestBody);
+			return $request;
+		}
+
+		if (isset($this->bodyFormat) && $this->bodyFormat !== '')
+		{
+			if (empty($params))
+			{
+				$params = $request->fetchGlobal('request');
+			}
+			$formatMime = '';
+			if ($this->bodyFormat === 'json')
+			{
+				$formatMime = 'application/json';
+			}
+			elseif ($this->bodyFormat === 'xml')
+			{
+				$formatMime = 'application/xml';
+			}
+			if (! empty($formatMime) && ! empty($params))
+			{
+				$formatted = Services::format()->getFormatter($formatMime)->format($params);
+				$request->setBody($formatted);
+				$request->setHeader('Content-Type', $formatMime);
+			}
+		}
+
+		return $request;
+	}
 }

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -134,14 +134,14 @@ trait FeatureTestTrait
 	}
 
 	/**
-	 * Calls a single URI, executes it, and returns a FeatureResponse
+	 * Calls a single URI, executes it, and returns a TestResponse
 	 * instance that can be used to run many assertions against.
 	 *
 	 * @param string     $method
 	 * @param string     $path
 	 * @param array|null $params
 	 *
-	 * @return FeatureResponse
+	 * @return TestResponse
 	 * @throws RedirectException
 	 * @throws Exception
 	 */
@@ -212,7 +212,7 @@ trait FeatureTestTrait
 		}
 		// @codeCoverageIgnoreEnd
 
-		return new FeatureResponse($response);
+		return new TestResponse($response);
 	}
 
 	/**
@@ -221,7 +221,7 @@ trait FeatureTestTrait
 	 * @param string     $path
 	 * @param array|null $params
 	 *
-	 * @return FeatureResponse
+	 * @return TestResponse
 	 * @throws RedirectException
 	 * @throws Exception
 	 */
@@ -236,7 +236,7 @@ trait FeatureTestTrait
 	 * @param string     $path
 	 * @param array|null $params
 	 *
-	 * @return FeatureResponse
+	 * @return TestResponse
 	 * @throws RedirectException
 	 * @throws Exception
 	 */
@@ -251,7 +251,7 @@ trait FeatureTestTrait
 	 * @param string     $path
 	 * @param array|null $params
 	 *
-	 * @return FeatureResponse
+	 * @return TestResponse
 	 * @throws RedirectException
 	 * @throws Exception
 	 */
@@ -266,7 +266,7 @@ trait FeatureTestTrait
 	 * @param string     $path
 	 * @param array|null $params
 	 *
-	 * @return FeatureResponse
+	 * @return TestResponse
 	 * @throws RedirectException
 	 * @throws Exception
 	 */
@@ -281,7 +281,7 @@ trait FeatureTestTrait
 	 * @param string     $path
 	 * @param array|null $params
 	 *
-	 * @return FeatureResponse
+	 * @return TestResponse
 	 * @throws RedirectException
 	 * @throws Exception
 	 */
@@ -296,7 +296,7 @@ trait FeatureTestTrait
 	 * @param string     $path
 	 * @param array|null $params
 	 *
-	 * @return FeatureResponse
+	 * @return TestResponse
 	 * @throws RedirectException
 	 * @throws Exception
 	 */

--- a/tests/_support/Controllers/Popcorn.php
+++ b/tests/_support/Controllers/Popcorn.php
@@ -10,7 +10,6 @@ use CodeIgniter\Controller;
  */
 class Popcorn extends Controller
 {
-
 	use ResponseTrait;
 
 	public function index()

--- a/tests/system/HomeTest.php
+++ b/tests/system/HomeTest.php
@@ -20,7 +20,7 @@ class HomeTest extends CIUnitTestCase
 		]);
 
 		$response = $this->get('home');
-		$this->assertInstanceOf('CodeIgniter\Test\FeatureResponse', $response);
+		$this->assertInstanceOf('CodeIgniter\Test\TestResponse', $response);
 		$this->assertTrue($response->isOK());
 	}
 }

--- a/tests/system/Test/ControllerTestTraitTest.php
+++ b/tests/system/Test/ControllerTestTraitTest.php
@@ -15,9 +15,9 @@ use Tests\Support\Controllers\Popcorn;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState         disabled
  */
-class ControllerTesterTest extends CIUnitTestCase
+class ControllerTestTraitTest extends CIUnitTestCase
 {
-	use ControllerTester;
+	use ControllerTestTrait;
 
 	public function testBadController()
 	{

--- a/tests/system/Test/ControllerTestTraitTest.php
+++ b/tests/system/Test/ControllerTestTraitTest.php
@@ -47,7 +47,7 @@ class ControllerTestTraitTest extends CIUnitTestCase
 				->controller(Home::class)
 				->execute('index');
 
-		$body = $result->getBody();
+		$body = $result->response()->getBody();
 		$this->assertTrue($result->isOK());
 	}
 
@@ -57,7 +57,7 @@ class ControllerTestTraitTest extends CIUnitTestCase
 				->controller(Home::class)
 				->execute('index');
 
-		$body = $result->getBody();
+		$body = $result->response()->getBody();
 		$this->assertTrue($result->isOK());
 	}
 
@@ -69,7 +69,7 @@ class ControllerTestTraitTest extends CIUnitTestCase
 				->controller(Popcorn::class)
 				->execute('index');
 
-		$body = $result->getBody();
+		$body = $result->response()->getBody();
 		$this->assertTrue($result->isOK());
 	}
 
@@ -81,7 +81,7 @@ class ControllerTestTraitTest extends CIUnitTestCase
 				->controller(Popcorn::class)
 				->execute('index');
 
-		$body = $result->getBody();
+		$body = $result->response()->getBody();
 		$this->assertEquals('Hi there', $body);
 	}
 
@@ -122,7 +122,7 @@ class ControllerTestTraitTest extends CIUnitTestCase
 				->controller(Popcorn::class)
 				->execute('index');
 
-		$body = $result->getBody();
+		$body = $result->response()->getBody();
 		$this->assertEquals('Hi there', $body);
 	}
 
@@ -158,7 +158,7 @@ class ControllerTestTraitTest extends CIUnitTestCase
 				->controller(Popcorn::class)
 				->execute('weasel');
 
-		$body = $result->getBody(); // empty
+		$body = $result->response()->getBody(); // empty
 		$this->assertEmpty($body);
 		$this->assertFalse($result->isOK());
 	}
@@ -204,7 +204,7 @@ class ControllerTestTraitTest extends CIUnitTestCase
 				->controller(Popcorn::class)
 				->execute('index3');
 
-		$response = json_decode($result->getBody());
+		$response = json_decode($result->response()->getBody());
 		$this->assertEquals('en', $response->lang);
 	}
 
@@ -216,7 +216,7 @@ class ControllerTestTraitTest extends CIUnitTestCase
 					   ->controller(Home::class)
 					   ->execute('index');
 
-		$body = $result->getBody();
+		$body = $result->response()->getBody();
 		$this->assertTrue($result->isOK());
 	}
 

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -4,9 +4,9 @@ namespace CodeIgniter\Test;
 
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Response;
-use CodeIgniter\Test\FeatureResponse;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\FeatureTestTrait;
+use CodeIgniter\Test\TestResponse;
 
 /**
  * @group                       DatabaseLive
@@ -54,7 +54,7 @@ class FeatureTestTraitTest extends CIUnitTestCase
 		]);
 		$response = $this->call('get', 'home');
 
-		$this->assertInstanceOf(FeatureResponse::class, $response);
+		$this->assertInstanceOf(TestResponse::class, $response);
 		$this->assertInstanceOf(Response::class, $response->response);
 		$this->assertTrue($response->isOK());
 		$this->assertEquals('Hello Earth', $response->response->getBody());
@@ -220,7 +220,7 @@ class FeatureTestTraitTest extends CIUnitTestCase
 			],
 		]);
 		$response = $this->get('home');
-		$response->assertEmpty($response->response->getBody());
+		$response->assertEmpty($response->response()->getBody());
 	}
 
 	public function testEchoesWithParams()

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -13,7 +13,7 @@ use CodeIgniter\Test\FeatureTestTrait;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState         disabled
  */
-class FeatureTestCaseTest extends CIUnitTestCase
+class FeatureTestTraitTest extends CIUnitTestCase
 {
 	use FeatureTestTrait;
 

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -55,10 +55,10 @@ class FeatureTestTraitTest extends CIUnitTestCase
 		$response = $this->call('get', 'home');
 
 		$this->assertInstanceOf(TestResponse::class, $response);
-		$this->assertInstanceOf(Response::class, $response->response);
+		$this->assertInstanceOf(Response::class, $response->response());
 		$this->assertTrue($response->isOK());
-		$this->assertEquals('Hello Earth', $response->response->getBody());
-		$this->assertEquals(200, $response->response->getStatusCode());
+		$this->assertEquals('Hello Earth', $response->response()->getBody());
+		$this->assertEquals(200, $response->response()->getStatusCode());
 	}
 
 	public function testCallPost()

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -5,15 +5,17 @@ namespace CodeIgniter\Test;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\FeatureResponse;
-use CodeIgniter\Test\FeatureTestCase;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\FeatureTestTrait;
 
 /**
  * @group                       DatabaseLive
  * @runTestsInSeparateProcesses
  * @preserveGlobalState         disabled
  */
-class FeatureTestCaseTest extends FeatureTestCase
+class FeatureTestCaseTest extends CIUnitTestCase
 {
+	use FeatureTestTrait;
 
 	protected function setUp(): void
 	{

--- a/user_guide_src/source/changelogs/v4.1.2.rst
+++ b/user_guide_src/source/changelogs/v4.1.2.rst
@@ -33,6 +33,8 @@ Deprecations:
 - Deprecated ``Security::isExpired()`` to use the ``Cookie``'s internal expires status.
 - Deprecated ``CIDatabaseTestCase`` to use the ``DatabaseTestTrait`` instead.
 - Deprecated ``FeatureTestCase`` to use the ``FeatureTestTrait`` instead.
+- Deprecated ``ControllerTester`` to use the ``ControllerTestTrait`` instead.
+- Consolidated and deprecated ``ControllerResponse`` and ``FeatureResponse`` in favor of ``TestResponse``.
 
 Bugs Fixed:
 

--- a/user_guide_src/source/installation/upgrade_412.rst
+++ b/user_guide_src/source/installation/upgrade_412.rst
@@ -4,7 +4,7 @@ Upgrading from 4.1.1 to 4.1.2
 
 **BaseConnection::query() return values**
 
-`BaseConnection::query()` method in prior versions was incorrectly returning BaseResult objects
+``BaseConnection::query()`` method in prior versions was incorrectly returning BaseResult objects
 even if the query failed. This method will now return ``false`` for failed queries (or throw an
 Exception if ``DBDebug==true``) and will return booleans for write-type queries. Review any use
 of ``query()`` method and be assess whether the value might be boolean instead of Result object.
@@ -16,3 +16,44 @@ and any DBMS-specific override ``isWriteType()`` in the relevant Connection clas
 If you have written any classes that implement ConnectionInterface, these must now implement the
 ``isWriteType()`` method, declared as ``public function isWriteType($sql): bool``. If your class extends BaseConnection, then that class will provide a basic ``isWriteType()``
 method which you might want to override.
+
+**Test Traits**
+
+The ``CodeIgniter\Test`` namespace has had significant improvements to help developers with their
+own test cases. Most notably test extensions have moved to Traits to make them easier to
+pick-and-choose across various test case needs. The ``DatabaseTestCase`` and ``FeatureTestCase``
+classes have been deprecated and their methods moved to ``DatabaseTestTrait`` and
+``FeatureTestTrait`` respectively. Update your test cases to extend the main test case
+and use any traits you need. For example::
+
+	use CodeIgniter\Test\DatabaseTestCase;
+
+	class MyDatabaseTest extends DatabaseTestCase
+	{
+		public function testBadRow()
+		{
+
+... becomes::
+
+	use CodeIgniter\Test\CIUnitTestCase;
+	use CodeIgniter\Test\DatabaseTestTrait;
+
+	class MyDatabaseTest extends CIUnitTestCase
+	{
+		use DatabaseTestTrait;
+
+		public function testBadRow()
+		{
+
+Finally, ``ControllerTester`` has been superseded by ``ControllerTestTrait`` to standardize
+approach and take advantage of the updated response testing (below).
+
+**Test Responses**
+
+The tools for testing responses have been consolidated and improved. A new
+``TestResponse`` replaces ``ControllerResponse`` and ``FeatureResponse`` with a complete
+set of methods and properties expected from both those classes. In most cases these changes
+will be "behind the scenes" by ``ControllerTestTrait`` and ``FeatureTestCase``, but two
+changes to be aware of:
+* ``TestResponse``'s ``$request`` and ``$response`` properties are protected and should only be access through their getter methods, ``request()`` and ``response()``
+* ``TestResponse`` does not have ``getBody()`` and ``setBody()`` methods, but rather uses the Response methods directly, e.g.: ``$body = $result->response()->getBody();``

--- a/user_guide_src/source/testing/controllers.rst
+++ b/user_guide_src/source/testing/controllers.rst
@@ -17,19 +17,19 @@ case you need it.
 The Helper Trait
 ================
 
-To enable Controller Testing you need to use the ``ControllerTester`` trait within your tests::
+To enable Controller Testing you need to use the ``ControllerTestTrait`` trait within your tests::
 
     <?php
 
     namespace CodeIgniter;
 
-    use CodeIgniter\Test\ControllerTester;
+    use CodeIgniter\Test\ControllerTestTrait;
     use CodeIgniter\Test\CIUnitTestCase;
     use CodeIgniter\Test\DatabaseTestTrait;
 
     class TestControllerA extends CIUnitTestCase
     {
-        use ControllerTester, DatabaseTestTrait;
+        use ControllerTestTrait, DatabaseTestTrait;
     }
 
 Once the trait has been included, you can start setting up the environment, including the request and response classes,
@@ -41,13 +41,13 @@ to run as the parameter::
 
     namespace CodeIgniter;
 
-    use CodeIgniter\Test\ControllerTester;
+    use CodeIgniter\Test\ControllerTestTrait;
     use CodeIgniter\Test\CIUnitTestCase;
     use CodeIgniter\Test\DatabaseTestTrait;
 
     class TestControllerA extends CIUnitTestCase
     {
-        use ControllerTester, DatabaseTestTrait;
+        use ControllerTestTrait, DatabaseTestTrait;
 
         public function testShowCategories()
         {
@@ -159,7 +159,7 @@ you need to set a JSON value as the body. The only parameter is a string that re
 Checking the Response
 =====================
 
-``ControllerTester::execute()`` returns an instance of a ``TestResponse``. See `Testing Responses <response.html>`_ on
+``ControllerTestTrait::execute()`` returns an instance of a ``TestResponse``. See `Testing Responses <response.html>`_ on
 how to use this class to perform additional assertions and verification in your test cases.
 
 Filter Testing
@@ -190,7 +190,7 @@ Configuration
 -------------
 
 Because of the logical overlap with Controller Testing ``FilterTestTrait`` is designed to
-work together with ``ControllerTester`` should you need both on the same class.
+work together with ``ControllerTestTrait`` should you need both on the same class.
 Once the trait has been included ``CIUnitTestCase`` will detect its ``setUp`` method and
 prepare all the components needed for your tests. Should you need a special configuration
 you can alter any of the properties before calling the support methods:


### PR DESCRIPTION
**Description**
In preparation for the next release, this PR reverts the changes to "Feature" and "Controller" testing to leave them deprecated in place. The unreleased `FeatureTestTrait` can now return a `TestResponse` directly, and this PR introduces an alternate trait for controller testing, `ControllerTestTrait` (more consistent with our new naming scheme too). With these changes we can separate the deprecated classes and remove them from coverage and start using their updated versions.

Also fixes a number of logic errors in `execute()` for controller testing:
* `getStatusCode()` can never be empty
* Controller buffered output should be prepended to response bodies, not discarded
* `null` bodies should be allowed

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
