### PR TITLE
Allow chmod failures on cache write

### DIFF
--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Cache\Exceptions\CacheException;
 use Config\Cache;
+use Throwable;
 
 /**
  * File system cache handler
@@ -124,7 +125,16 @@ class FileHandler extends BaseHandler
 
 		if ($this->writeFile($this->path . $key, serialize($contents)))
 		{
-			chmod($this->path . $key, $this->mode);
+			try
+			{
+				chmod($this->path . $key, $this->mode);
+			}
+			// @codeCoverageIgnoreStart
+			catch (Throwable $e)
+			{
+				log_message('debug', 'Failed to set mode on cache file: ' . $e->getMessage());
+			}
+			// @codeCoverageIgnoreEnd
 
 			return true;
 		}


### PR DESCRIPTION
**Description**
Cache's `FileHandler` will attempt to se the file mode after writes using `chmod()`. This is already allowed to fail (i.e. return `false`) since files can be writable but not owned, however some circumstances can actually cause a fatal error:
```
chmod(): Operation not permitted
at SYSTEMPATH/Cache/Handlers/FileHandler.php:127

Backtrace:
  1    [internal function]
       CodeIgniter\Debug\Exceptions()->errorHandler()

  2    SYSTEMPATH/Cache/Handlers/FileHandler.php:127
       chmod()
```

This PR catches any throwable and log and ignores the exception.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
