### PR TITLE
Shortcircuit toolbar on CLI

### DIFF
--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -46,7 +46,7 @@ Events::on('pre_system', function () {
 	 * --------------------------------------------------------------------
 	 * If you delete, they will no longer be collected.
 	 */
-	if (CI_DEBUG)
+	if (CI_DEBUG && ! is_cli())
 	{
 		Events::on('DBQuery', 'CodeIgniter\Debug\Toolbar\Collectors\Database::collect');
 		Services::toolbar()->respond();


### PR DESCRIPTION
**Description**
`Toolbar` is already disabled under CLI, but the listener events still trigger. This PR excludes those Events from triggering as well, which could prevent some performance hits (especially if developers add their own collectors).

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
