### PR TITLE
[Query] Do not recompile binds if already compiled

### DIFF
--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -472,7 +472,12 @@ class Query implements QueryInterface
 			')',
 		];
 
-		$sql = $this->getQuery();
+		if (empty($this->finalQueryString))
+		{
+			$this->compileBinds(); // @codeCoverageIgnore
+		}
+
+		$sql = $this->finalQueryString;
 
 		foreach ($highlight as $term)
 		{


### PR DESCRIPTION
**Description**
Fixes #4518 

The thing is the Database Collector call `Query::debugToolbarDisplay` to return a nicely formatted SQL string. However, that method will erroneously call `$this->compileBinds()` everytime. The problem with this approach is that the DB operation had run before the toolbar display collection so all queries have been compiled. Calling it again will give false positives for bind markers when special syntaxes uses the bind marker (such as Postgres' JSON operations).

What we really need is the compiled final query string. Since the compiling was done before collection, we can be sure that it is already set. However, for the sake of prudence, we'll put up a guard if the requested string is not yet initialized and then we'll call `compileBinds()` right away.

ping @byazrail kindly check this if it will work on your issue

**Checklist:**
- [x] Securely signed commits
