### PR TITLE
Fix html formatting for exceptions and errors

### DIFF
--- a/app/Views/errors/html/error_404.php
+++ b/app/Views/errors/html/error_404.php
@@ -74,7 +74,7 @@
 
 		<p>
 			<?php if (! empty($message) && $message !== '(null)') : ?>
-				<?= esc(nl2br($message)) ?>
+				<?= nl2br(esc($message)) ?>
 			<?php else : ?>
 				Sorry! Cannot seem to find the page you were looking for.
 			<?php endif ?>

--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -21,7 +21,7 @@
 		<div class="container">
 			<h1><?= esc($title), esc($exception->getCode() ? ' #' . $exception->getCode() : '') ?></h1>
 			<p>
-				<?= esc(nl2br($exception->getMessage())) ?>
+				<?= nl2br(esc($exception->getMessage())) ?>
 				<a href="https://www.duckduckgo.com/?q=<?= urlencode($title . ' ' . preg_replace('#\'.*\'|".*"#Us', '', $exception->getMessage())) ?>"
 				   rel="noreferrer" target="_blank">search &rarr;</a>
 			</p>


### PR DESCRIPTION
Fix #4533 

**Description**
Changed the order of `nl2br` and `esc`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide