### PR TITLE
Use message directly if intl is not available

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -143,8 +143,6 @@ class CodeIgniter
 	 */
 	protected $useSafeOutput = false;
 
-	//--------------------------------------------------------------------
-
 	/**
 	 * Constructor.
 	 *
@@ -154,14 +152,12 @@ class CodeIgniter
 	{
 		if (version_compare(PHP_VERSION, self::MIN_PHP_VERSION, '<'))
 		{
-			die(lang('Core.invalidPhpVersion', [self::MIN_PHP_VERSION, PHP_VERSION]));
+			exit(lang('Core.invalidPhpVersion', [self::MIN_PHP_VERSION, PHP_VERSION]));
 		}
 
 		$this->startTime = microtime(true);
 		$this->config    = $config;
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Handles some basic app and environment setup.
@@ -178,9 +174,7 @@ class CodeIgniter
 		// Run this check for manual installations
 		if (! is_file(COMPOSER_PATH))
 		{
-			// @codeCoverageIgnoreStart
-			$this->resolvePlatformExtensions();
-			// @codeCoverageIgnoreEnd
+			$this->resolvePlatformExtensions(); // @codeCoverageIgnore
 		}
 
 		// Set default locale on the server
@@ -193,19 +187,16 @@ class CodeIgniter
 
 		if (! CI_DEBUG)
 		{
-			// @codeCoverageIgnoreStart
-			Kint::$enabled_mode = false;
-			// @codeCoverageIgnoreEnd
+			Kint::$enabled_mode = false; // @codeCoverageIgnore
 		}
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Checks system for missing required PHP extensions.
 	 *
-	 * @return void
 	 * @throws FrameworkException
+	 *
+	 * @return void
 	 *
 	 * @codeCoverageIgnore
 	 */
@@ -229,13 +220,11 @@ class CodeIgniter
 			}
 		}
 
-		if ($missingExtensions)
+		if ($missingExtensions !== [])
 		{
 			throw FrameworkException::forMissingExtension(implode(', ', $missingExtensions));
 		}
 	}
-
-	//--------------------------------------------------------------------
 
 	/**
 	 * Initializes Kint

--- a/system/Exceptions/FrameworkException.php
+++ b/system/Exceptions/FrameworkException.php
@@ -40,7 +40,21 @@ class FrameworkException extends RuntimeException implements ExceptionInterface
 
 	public static function forMissingExtension(string $extension)
 	{
-		return new static(lang('Core.missingExtension', [$extension]));
+		if (strpos($extension, 'intl') !== false)
+		{
+			// @codeCoverageIgnoreStart
+			$message = sprintf(
+				'The framework needs the following extension(s) installed and loaded: %s.',
+				$extension
+			);
+			// @codeCoverageIgnoreEnd
+		}
+		else
+		{
+			$message = lang('Core.missingExtension', [$extension]);
+		}
+
+		return new static($message);
 	}
 
 	public static function forNoHandlers(string $class)


### PR DESCRIPTION
**Description**
If `intl` is among the list of missing extensions, then it doesn't make sense to use `intl`'s message formatting features to format the missing extension exception. If so, we default to plain message.

**Checklist:**
- [x] Securely signed commits
