### PR TITLE
Update BaseConfig.php

### DIFF
--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -145,7 +145,7 @@ class BaseConfig
 			case array_key_exists("{$prefix}.{$property}", $_SERVER):
 				return $_SERVER["{$prefix}.{$property}"];
 			default:
-				$value = getenv($property);
+				$value = strtolower($property) == 'path' ? false : getenv($property);
 				return $value === false ? null : $value;
 		}
 	}


### PR DESCRIPTION
Exclude when the configuration class attribute is $path, getenv will get the value of system path when env is not configured

**Description**
Under windows, if the env value is not configured, the value of (new \Config\Cookie())->path will be wrong
same question https://github.com/codeigniter4/CodeIgniter4/issues/853 
https://www.php.net/manual/zh/function.getenv.php#122599

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

---------Remove from here down in your description----------

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository
  
