### PR TITLE
Check intl extension loaded on check min PHP version

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -152,7 +152,11 @@ class CodeIgniter
 	{
 		if (version_compare(PHP_VERSION, self::MIN_PHP_VERSION, '<'))
 		{
-			exit(lang('Core.invalidPhpVersion', [self::MIN_PHP_VERSION, PHP_VERSION]));
+			$message = extension_loaded('intl')
+				? lang('Core.invalidPhpVersion', [self::MIN_PHP_VERSION, PHP_VERSION])
+				: sprintf('Your PHP version must be %s or higher to run CodeIgniter. Current version: %s', self::MIN_PHP_VERSION, PHP_VERSION);
+
+			exit($message);
 		}
 
 		$this->startTime = microtime(true);


### PR DESCRIPTION
Without intl extension check, it previously got the following output if no intl:

```bash
Your PHP version must be {0} or higher to run CodeIgniter. Current version: {1}%  
```

**Checklist:**
- [x] Securely signed commits
