### PR TITLE
feat(cache): add deleteMatching method to remove multiple cache items

### DIFF
--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -59,17 +59,6 @@ interface CacheInterface
 	//--------------------------------------------------------------------
 
 	/**
-	 * Deletes items from the cache store matching a given pattern.
-	 *
-	 * @param string $pattern Cache items glob-style pattern
-	 *
-	 * @return mixed
-	 */
-	public function deleteMatching(string $pattern);
-
-	//--------------------------------------------------------------------
-
-	/**
 	 * Performs atomic incrementation of a raw stored value.
 	 *
 	 * @param string  $key    Cache ID

--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -59,6 +59,17 @@ interface CacheInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Deletes items from the cache store matching a given pattern.
+	 *
+	 * @param string $pattern Cache items glob like pattern
+	 *
+	 * @return mixed
+	 */
+	public function deleteMatching(string $pattern);
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Performs atomic incrementation of a raw stored value.
 	 *
 	 * @param string  $key    Cache ID

--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -61,7 +61,7 @@ interface CacheInterface
 	/**
 	 * Deletes items from the cache store matching a given pattern.
 	 *
-	 * @param string $pattern Cache items glob like pattern
+	 * @param string $pattern Cache items glob-style pattern
 	 *
 	 * @return mixed
 	 */

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use Closure;
 use CodeIgniter\Cache\CacheInterface;
+use Exception;
 
 /**
  * Base class for cache handling
@@ -40,5 +41,19 @@ abstract class BaseHandler implements CacheInterface
 		$this->save($key, $value = $callback(), $ttl);
 
 		return $value;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Deletes items from the cache store matching a given pattern.
+	 *
+	 * @param string $pattern Cache items glob-style pattern
+	 *
+	 * @throws Exception
+	 */
+	public function deleteMatching(string $pattern)
+	{
+		throw new Exception('The deleteMatching method is not implemented.');
 	}
 }

--- a/system/Cache/Handlers/DummyHandler.php
+++ b/system/Cache/Handlers/DummyHandler.php
@@ -89,6 +89,20 @@ class DummyHandler extends BaseHandler
 	//--------------------------------------------------------------------
 
 	/**
+	 * Deletes items from the cache store matching a given pattern.
+	 *
+	 * @param string $pattern Cache items glob like pattern
+	 *
+	 * @return boolean
+	 */
+	public function deleteMatching(string $pattern)
+	{
+		return true;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Performs atomic incrementation of a raw stored value.
 	 *
 	 * @param string  $key    Cache ID

--- a/system/Cache/Handlers/DummyHandler.php
+++ b/system/Cache/Handlers/DummyHandler.php
@@ -91,7 +91,7 @@ class DummyHandler extends BaseHandler
 	/**
 	 * Deletes items from the cache store matching a given pattern.
 	 *
-	 * @param string $pattern Cache items glob like pattern
+	 * @param string $pattern Cache items glob-style pattern
 	 *
 	 * @return boolean
 	 */

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -173,7 +173,7 @@ class FileHandler extends BaseHandler
 
 		foreach (glob($this->path . $pattern) as $filename)
 		{
-			if (! is_file($filename) || ! unlink($filename))
+			if (! is_file($filename) || ! @unlink($filename))
 			{
 				$success = false;
 			}

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -163,7 +163,7 @@ class FileHandler extends BaseHandler
 	/**
 	 * Deletes items from the cache store matching a given pattern.
 	 *
-	 * @param string $pattern Cache items glob like pattern
+	 * @param string $pattern Cache items glob-style pattern
 	 *
 	 * @return boolean
 	 */

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -161,6 +161,30 @@ class FileHandler extends BaseHandler
 	//--------------------------------------------------------------------
 
 	/**
+	 * Deletes items from the cache store matching a given pattern.
+	 *
+	 * @param string $pattern Cache items glob like pattern
+	 *
+	 * @return boolean
+	 */
+	public function deleteMatching(string $pattern)
+	{
+		$success = true;
+
+		foreach (glob($this->path . $pattern) as $filename)
+		{
+			if (! is_file($filename) || ! unlink($filename))
+			{
+				$success = false;
+			}
+		}
+
+		return $success;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Performs atomic incrementation of a raw stored value.
 	 *
 	 * @param string  $key    Cache ID

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -252,13 +252,13 @@ class MemcachedHandler extends BaseHandler
 	/**
 	 * Deletes items from the cache store matching a given pattern.
 	 *
-	 * @param string $pattern Cache items glob like pattern
+	 * @param string $pattern Cache items glob-style pattern
 	 *
-	 * @return boolean
+	 * @throws Exception
 	 */
 	public function deleteMatching(string $pattern)
 	{
-		return false;
+		throw new Exception('The deleteMatching method is not implemented for Memcached. You must select File, Redis or Predis handlers to use it.');
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -250,6 +250,20 @@ class MemcachedHandler extends BaseHandler
 	//--------------------------------------------------------------------
 
 	/**
+	 * Deletes items from the cache store matching a given pattern.
+	 *
+	 * @param string $pattern Cache items glob like pattern
+	 *
+	 * @return boolean
+	 */
+	public function deleteMatching(string $pattern)
+	{
+		return false;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Performs atomic incrementation of a raw stored value.
 	 *
 	 * @param string  $key    Cache ID

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -15,6 +15,7 @@ use CodeIgniter\Exceptions\CriticalError;
 use Config\Cache;
 use Exception;
 use Predis\Client;
+use Predis\Collection\Iterator;
 
 /**
  * Predis cache handler
@@ -180,6 +181,30 @@ class PredisHandler extends BaseHandler
 	public function delete(string $key)
 	{
 		return ($this->redis->del($key) === 1);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Deletes items from the cache store matching a given pattern.
+	 *
+	 * @param string $pattern Cache items glob like pattern
+	 *
+	 * @return boolean
+	 */
+	public function deleteMatching(string $pattern)
+	{
+		$success = true;
+
+		foreach (new Iterator\Keyspace($this->redis, $pattern) as $key)
+		{
+			if ($this->redis->del($key) !== 1)
+			{
+				$success = false;
+			}
+		}
+
+		return $success;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -188,7 +188,7 @@ class PredisHandler extends BaseHandler
 	/**
 	 * Deletes items from the cache store matching a given pattern.
 	 *
-	 * @param string $pattern Cache items glob like pattern
+	 * @param string $pattern Cache items glob-style pattern
 	 *
 	 * @return boolean
 	 */

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -15,7 +15,7 @@ use CodeIgniter\Exceptions\CriticalError;
 use Config\Cache;
 use Exception;
 use Predis\Client;
-use Predis\Collection\Iterator;
+use Predis\Collection\Iterator\Keyspace;
 
 /**
  * Predis cache handler
@@ -196,7 +196,7 @@ class PredisHandler extends BaseHandler
 	{
 		$success = true;
 
-		foreach (new Iterator\Keyspace($this->redis, $pattern) as $key)
+		foreach (new Keyspace($this->redis, $pattern) as $key)
 		{
 			if ($this->redis->del($key) !== 1)
 			{

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -224,6 +224,34 @@ class RedisHandler extends BaseHandler
 	//--------------------------------------------------------------------
 
 	/**
+	 * Deletes items from the cache store matching a given pattern.
+	 *
+	 * @param string $pattern Cache items glob like pattern
+	 *
+	 * @return boolean
+	 */
+	public function deleteMatching(string $pattern)
+	{
+		$success  = true;
+		$iterator = null;
+
+		while ($keys = $this->redis->scan($iterator, $pattern))
+		{
+			foreach ($keys as $key)
+			{
+				if ($this->redis->del($key) !== 1)
+				{
+					$success = false;
+				}
+			}
+		}
+
+		return $success;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Performs atomic incrementation of a raw stored value.
 	 *
 	 * @param string  $key    Cache ID

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -226,7 +226,7 @@ class RedisHandler extends BaseHandler
 	/**
 	 * Deletes items from the cache store matching a given pattern.
 	 *
-	 * @param string $pattern Cache items glob like pattern
+	 * @param string $pattern Cache items glob-style pattern
 	 *
 	 * @return boolean
 	 */

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -114,6 +114,22 @@ class WincacheHandler extends BaseHandler
 	//--------------------------------------------------------------------
 
 	/**
+	 * Deletes items from the cache store matching a given pattern.
+	 *
+	 * @param string $pattern Cache items glob like pattern
+	 *
+	 * @return boolean
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function deleteMatching(string $pattern)
+	{
+		return false;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Performs atomic incrementation of a raw stored value.
 	 *
 	 * @param string  $key    Cache ID

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Cache\Handlers;
 
 use Config\Cache;
+use Exception;
 
 /**
  * Cache handler for WinCache from Microsoft & IIS.
@@ -116,15 +117,15 @@ class WincacheHandler extends BaseHandler
 	/**
 	 * Deletes items from the cache store matching a given pattern.
 	 *
-	 * @param string $pattern Cache items glob like pattern
+	 * @param string $pattern Cache items glob-style pattern
 	 *
-	 * @return boolean
+	 * @throws Exception
 	 *
 	 * @codeCoverageIgnore
 	 */
 	public function deleteMatching(string $pattern)
 	{
-		return false;
+		throw new Exception('The deleteMatching method is not implemented for Wincache. You must select File, Redis or Predis handlers to use it.');
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -132,7 +132,7 @@ class MockCache implements CacheInterface
 	 */
 	public function deleteMatching(string $pattern)
 	{
-		foreach ($this->cache as $key => $value)
+		foreach (array_keys($this->cache) as $key)
 		{
 			if (fnmatch($pattern, $key))
 			{

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -124,6 +124,28 @@ class MockCache implements CacheInterface
 	//--------------------------------------------------------------------
 
 	/**
+	 * Deletes items from the cache store matching a given pattern.
+	 *
+	 * @param string $pattern Cache items pattern
+	 *
+	 * @return boolean
+	 */
+	public function deleteMatching(string $pattern)
+	{
+		foreach ($this->cache as $key => $value)
+		{
+			if (fnmatch($pattern, $key))
+			{
+				unset($this->cache[$key]);
+			}
+		}
+
+		return true;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Performs atomic incrementation of a raw stored value.
 	 *
 	 * @param string  $key    Cache ID

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -126,7 +126,7 @@ class MockCache implements CacheInterface
 	/**
 	 * Deletes items from the cache store matching a given pattern.
 	 *
-	 * @param string $pattern Cache items pattern
+	 * @param string $pattern Cache items glob-style pattern
 	 *
 	 * @return boolean
 	 */

--- a/tests/system/Cache/Handlers/DummyHandlerTest.php
+++ b/tests/system/Cache/Handlers/DummyHandlerTest.php
@@ -41,6 +41,11 @@ class DummyHandlerTest extends CIUnitTestCase
 		$this->assertTrue($this->dummyHandler->delete('key'));
 	}
 
+	public function testDeleteMatching()
+	{
+		$this->assertTrue($this->dummyHandler->deleteMatching('key*'));
+	}
+
 	public function testIncrement()
 	{
 		$this->assertTrue($this->dummyHandler->increment('key'));

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -13,6 +13,7 @@ class FileHandlerTest extends CIUnitTestCase
 	private static $key1      = 'key1';
 	private static $key2      = 'key2';
 	private static $key3      = 'key3';
+	private static $key4      = 'another_key';
 
 	private static function getKeyArray()
 	{
@@ -20,6 +21,7 @@ class FileHandlerTest extends CIUnitTestCase
 			self::$key1,
 			self::$key2,
 			self::$key3,
+			self::$key4,
 		];
 	}
 
@@ -131,6 +133,26 @@ class FileHandlerTest extends CIUnitTestCase
 
 		$this->assertTrue($this->fileHandler->delete(self::$key1));
 		$this->assertFalse($this->fileHandler->delete(self::$dummy));
+	}
+
+	public function testDeleteMatching()
+	{
+		$this->fileHandler->save(self::$key1, 'value');
+		$this->fileHandler->save(self::$key2, 'value2');
+		$this->fileHandler->save(self::$key3, 'value3');
+		$this->fileHandler->save(self::$key4, 'value4');
+
+		$this->assertSame('value', $this->fileHandler->get(self::$key1));
+		$this->assertSame('value2', $this->fileHandler->get(self::$key2));
+		$this->assertSame('value3', $this->fileHandler->get(self::$key3));
+		$this->assertSame('value4', $this->fileHandler->get(self::$key4));
+
+		$this->assertTrue($this->fileHandler->deleteMatching('key*'));
+
+		$this->assertNull($this->fileHandler->get(self::$key1));
+		$this->assertNull($this->fileHandler->get(self::$key2));
+		$this->assertNull($this->fileHandler->get(self::$key3));
+		$this->assertSame('value4', $this->fileHandler->get(self::$key4));
 	}
 
 	public function testIncrement()

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -5,6 +5,7 @@ namespace CodeIgniter\Cache\Handlers;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Cache;
+use Exception;
 
 class MemcachedHandlerTest extends CIUnitTestCase
 {
@@ -91,8 +92,10 @@ class MemcachedHandlerTest extends CIUnitTestCase
 
 	public function testDeleteMatching()
 	{
-		// Not implemented for Memcached, should always return false
-		$this->assertFalse($this->memcachedHandler->deleteMatching('key*'));
+		// Not implemented for Memcached, should throw an exception
+		$this->expectException(Exception::class);
+
+		$this->memcachedHandler->deleteMatching('key*');
 	}
 
 	public function testIncrement()

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -89,6 +89,12 @@ class MemcachedHandlerTest extends CIUnitTestCase
 		$this->assertFalse($this->memcachedHandler->delete(self::$dummy));
 	}
 
+	public function testDeleteMatching()
+	{
+		// Not implemented for Memcached, should always return false
+		$this->assertFalse($this->memcachedHandler->deleteMatching('key*'));
+	}
+
 	public function testIncrement()
 	{
 		$this->memcachedHandler->save(self::$key1, 1);

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -12,12 +12,15 @@ class PredisHandlerTest extends CIUnitTestCase
 	private static $key1 = 'key1';
 	private static $key2 = 'key2';
 	private static $key3 = 'key3';
+	private static $key4 = 'another_key';
+
 	private static function getKeyArray()
 	{
 		return [
 			self::$key1,
 			self::$key2,
 			self::$key3,
+			self::$key4,
 		];
 	}
 
@@ -95,6 +98,26 @@ class PredisHandlerTest extends CIUnitTestCase
 
 		$this->assertTrue($this->PredisHandler->delete(self::$key1));
 		$this->assertFalse($this->PredisHandler->delete(self::$dummy));
+	}
+
+	public function testDeleteMatching()
+	{
+		$this->PredisHandler->save(self::$key1, 'value');
+		$this->PredisHandler->save(self::$key2, 'value2');
+		$this->PredisHandler->save(self::$key3, 'value3');
+		$this->PredisHandler->save(self::$key4, 'value4');
+
+		$this->assertSame('value', $this->PredisHandler->get(self::$key1));
+		$this->assertSame('value2', $this->PredisHandler->get(self::$key2));
+		$this->assertSame('value3', $this->PredisHandler->get(self::$key3));
+		$this->assertSame('value4', $this->PredisHandler->get(self::$key4));
+
+		$this->assertTrue($this->PredisHandler->deleteMatching('key*'));
+
+		$this->assertNull($this->PredisHandler->get(self::$key1));
+		$this->assertNull($this->PredisHandler->get(self::$key2));
+		$this->assertNull($this->PredisHandler->get(self::$key3));
+		$this->assertSame('value4', $this->PredisHandler->get(self::$key4));
 	}
 
 	public function testClean()

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -12,12 +12,15 @@ class RedisHandlerTest extends CIUnitTestCase
 	private static $key1 = 'key1';
 	private static $key2 = 'key2';
 	private static $key3 = 'key3';
+	private static $key4 = 'another_key';
+
 	private static function getKeyArray()
 	{
 		return [
 			self::$key1,
 			self::$key2,
 			self::$key3,
+			self::$key4,
 		];
 	}
 
@@ -95,6 +98,26 @@ class RedisHandlerTest extends CIUnitTestCase
 
 		$this->assertTrue($this->redisHandler->delete(self::$key1));
 		$this->assertFalse($this->redisHandler->delete(self::$dummy));
+	}
+
+	public function testDeleteMatching()
+	{
+		$this->redisHandler->save(self::$key1, 'value');
+		$this->redisHandler->save(self::$key2, 'value2');
+		$this->redisHandler->save(self::$key3, 'value3');
+		$this->redisHandler->save(self::$key4, 'value4');
+
+		$this->assertSame('value', $this->redisHandler->get(self::$key1));
+		$this->assertSame('value2', $this->redisHandler->get(self::$key2));
+		$this->assertSame('value3', $this->redisHandler->get(self::$key3));
+		$this->assertSame('value4', $this->redisHandler->get(self::$key4));
+
+		$this->assertTrue($this->redisHandler->deleteMatching('key*'));
+
+		$this->assertNull($this->redisHandler->get(self::$key1));
+		$this->assertNull($this->redisHandler->get(self::$key2));
+		$this->assertNull($this->redisHandler->get(self::$key3));
+		$this->assertSame('value4', $this->redisHandler->get(self::$key4));
 	}
 
 	//FIXME: I don't like all Hash logic very much. It's wasting memory.

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -136,6 +136,27 @@ Class Reference
 
         $cache->delete('cache_item_id');
 
+.. php:method:: deleteMatching($pattern): bool
+
+    :param string $pattern: glob-style pattern to match cached items keys
+    :returns: ``true`` on success, ``false`` if one of the deletes fails
+    :rtype: bool
+
+    This method will delete multiple items from the cache store at once by
+    matching their keys against a glob pattern.
+    If one of the cache item deletion fails, the method will return FALSE.
+
+    .. important:: This method is only implemented for File, Redis and Predis handlers.
+        Due to limitations, it couldn't be implemented for Memcached and Wincache handlers.
+
+    Example::
+
+        $cache->deleteMatching('prefix_*'); // deletes all keys starting with "prefix_"
+        $cache->deleteMatching('*_suffix'); // deletes all keys ending with "_suffix"
+
+    For more information on glob-style syntax, please see
+        `https://en.wikipedia.org/wiki/Glob_(programming) <https://en.wikipedia.org/wiki/Glob_(programming)#Syntax>`_.
+
 .. php:method:: increment($key[, $offset = 1]): mixed
 
     :param string $key: Cache ID


### PR DESCRIPTION
### Add deleteMatching() method to cache service

**Description**

Maintaining a big number of cache keys with dependencies to each other can be a hassle with the current existing methods in the cache service.
This feature allows for deleting multiple cache items at once using a [glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)):

```php
cache()->deleteMatching('some_prefix*');
cache()->deleteMatching('*some_suffix');
// etc.
```

To handle cache dependencies, CI4 users would be able to structure their cache items with the same key prefix and delete the whole "pack" in one go.

Initially discussed in this post: https://forum.codeigniter.com/thread-77789-post-380976.html and on [Slack](https://codeigniterchat.slack.com/archives/C47FK3GRY/p1617614168038800).

**Limitations**

The implementation is only effective for **file** and **redis/predis** handlers.

Because of certain limitations, memcached and wincache handlers do not implement the method.
Both would require to go through the whole cache store (if it ever could) and match each keys
against the glob pattern. That would inevitably result in performance issues.

Also, correct me if I'm wrong, I believe memcached and wincache are not used as much as file and redis handlers. That being said, knowing the limitations and documenting them well would allow users to have access to this feature. That could remove some of the heavy load of having to maintain cache items and dependencies between them.

Any feedback is welcome!

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
  
