### PR TITLE
[Rector] Update Rector 0.10.6, re-enable auto imports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"phpstan/phpstan": "0.12.83",
 		"phpunit/phpunit": "^9.1",
 		"predis/predis": "^1.1",
-		"rector/rector": "0.10.4",
+		"rector/rector": "0.10.6",
 		"squizlabs/php_codesniffer": "^3.3"
 	},
 	"suggest": {

--- a/rector.php
+++ b/rector.php
@@ -49,8 +49,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 	]);
 
 	// auto import fully qualified class names
-	// temporary disable auto import as cause spaces on @param/@throws trimmed
-	// $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+	$parameters->set(Option::AUTO_IMPORT_NAMES, true);
 	$parameters->set(Option::ENABLE_CACHE, true);
 	$parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_73);
 


### PR DESCRIPTION
In rector 0.10.4, previously, auto imports options is disabled due change spacing in `@param`, `@throws`. It fixed in latest rector.

**Checklist:**
- [x] Securely signed commits
