### PR TITLE
Fix #4579 Missing classname information on output during migrate:rollback

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -771,7 +771,7 @@ class MigrationRunner
 		if (is_cli())
 		{
 			$this->cliMessages[] = "\t" . CLI::color(lang('Migrations.removed'),
-					'yellow') . "($history->namespace) " . $history->version . '_' . $this->getMigrationName($history->class);
+					'yellow') . "($history->namespace) " . $history->version . '_' . $history->class;
 		}
 	}
 


### PR DESCRIPTION
Fix codeigniter4#4579 Class information on output is missing during migrate:rollback command

**Description**

At system\Database\MigrationRunner.php

Changed removeHistory at line 774 using the same logic of addHistory to access the $history->class information, so I've been revoved getMigrationName method.

As far as I could see, getMigrationName method was just erasing the information with array_shift function (there was no "_" to work on) 

After changing, all rollback passed to show all information correctly.

Now all classes are printed on command results

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide

