### PR TITLE
Feature: Escaping array dot notation

### DIFF
--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -28,7 +28,7 @@ if (! function_exists('dot_array_search'))
 	{
 		$segments = preg_split('/(?<!\\\)\./', rtrim($index, '* '), 0, PREG_SPLIT_NO_EMPTY);
 
-		$segments = array_map(function ($key) {
+		$segments = array_map(static function ($key) {
 			return str_replace('\.', '.', $key);
 		}, $segments);
 

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -26,7 +26,11 @@ if (! function_exists('dot_array_search'))
 	 */
 	function dot_array_search(string $index, array $array)
 	{
-		$segments = explode('.', rtrim(rtrim($index, '* '), '.'));
+		$segments = preg_split('/(?<!\\\)\./', rtrim($index, '* '), 0, PREG_SPLIT_NO_EMPTY);
+
+		$segments = array_map(function ($key) {
+			return str_replace('\.', '.', $key);
+		}, $segments);
 
 		return _array_search_dot($segments, $array);
 	}

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -34,6 +34,21 @@ class ArrayHelperTest extends CIUnitTestCase
 		$this->assertEquals(23, dot_array_search('foo.bar.baz', $data));
 	}
 
+	public function testArrayDotEscape()
+	{
+		$data = [
+			'foo'     => [
+				'bar.baz' => 23,
+			],
+			'foo.bar' => [
+				'baz' => 42,
+			],
+		];
+
+		$this->assertEquals(23, dot_array_search('foo.bar\.baz', $data));
+		$this->assertEquals(42, dot_array_search('foo\.bar.baz', $data));
+	}
+
 	public function testArrayDotReturnNullEmptyArray()
 	{
 		$data = [];

--- a/user_guide_src/source/helpers/array_helper.rst
+++ b/user_guide_src/source/helpers/array_helper.rst
@@ -58,6 +58,7 @@ The following functions are available:
         $baz = dot_array_search('foo.*.baz', $data);
 
     If the array key contains a dot, then the key can be escaped with a backslash::
+
         $data = [
             'foo' => [
                 'bar.baz' => 23
@@ -65,7 +66,6 @@ The following functions are available:
             'foo.bar' => [
                 'baz' => 43
             ],
-
         ];
 
         // Returns: 23

--- a/user_guide_src/source/helpers/array_helper.rst
+++ b/user_guide_src/source/helpers/array_helper.rst
@@ -57,6 +57,23 @@ The following functions are available:
         // Returns: 23
         $baz = dot_array_search('foo.*.baz', $data);
 
+    If the array key contains a dot, then the key can be escaped with a backslash::
+        $data = [
+            'foo' => [
+                'bar.baz' => 23
+            ],
+            'foo.bar' => [
+                'baz' => 43
+            ],
+
+        ];
+
+        // Returns: 23
+        $barBaz = dot_array_search('foo.bar\.baz', $data);
+        // Returns: 42
+        $fooBar = dot_array_search('foo\.bar.baz', $data);
+
+
 ..  php:function:: array_deep_search($key, array $array)
 
     :param  mixed  $key: The target key


### PR DESCRIPTION
**Description**
Sometimes an array key can contain a dot. In this case, you cannot access the value of this key using dot notation.
This PR makes available keys containing a dot, with dot notation.

```php
$data = [
    'foo' => [
        'bar.baz' => 23
    ],
];

// Returns: 23
$barBaz = dot_array_search('foo.bar\.baz', $data);
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide