### PR TITLE
BaseModel - Add public getIdValue() method

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -463,8 +463,25 @@ abstract class BaseModel
 	 * @param array|object $data Data
 	 *
 	 * @return integer|array|string|null
+	 *
+	 * @deprecated Add an override on getIdValue() instead. Will be removed in version 5.0.
 	 */
 	abstract protected function idValue($data);
+
+	/**
+	 * Public getter to return the id value using the idValue() method
+	 * For example with SQL this will return $data->$this->primaryKey
+	 *
+	 * @param array|object $data
+	 *
+	 * @return array|integer|string|null
+	 *
+	 * @todo: Make abstract in version 5.0
+	 */
+	public function getIdValue($data)
+	{
+		return $this->idValue($data);
+	}
 
 	/**
 	 * Override countAllResults to account for soft deleted accounts.
@@ -663,7 +680,7 @@ abstract class BaseModel
 
 		if ($this->shouldUpdate($data))
 		{
-			$response = $this->update($this->idValue($data), $data);
+			$response = $this->update($this->getIdValue($data), $data);
 		}
 		else
 		{
@@ -687,7 +704,7 @@ abstract class BaseModel
 	 */
 	protected function shouldUpdate($data) : bool
 	{
-		return ! empty($this->idValue($data));
+		return ! empty($this->getIdValue($data));
 	}
 
 	/**

--- a/system/Model.php
+++ b/system/Model.php
@@ -459,8 +459,22 @@ class Model extends BaseModel
 	 * @param array|object $data Data
 	 *
 	 * @return integer|array|string|null
+	 *
+	 * @deprecated Use getIdValue() instead. Will be removed in version 5.0.
 	 */
 	protected function idValue($data)
+	{
+		return $this->getIdValue($data);
+	}
+
+	/**
+	 * Returns the id value for the data array or object
+	 *
+	 * @param array|object $data Data
+	 *
+	 * @return integer|array|string|null
+	 */
+	public function getIdValue($data)
 	{
 		if (is_object($data) && isset($data->{$this->primaryKey}))
 		{
@@ -636,7 +650,7 @@ class Model extends BaseModel
 		return parent::shouldUpdate($data) &&
 			($this->useAutoIncrement
 				? true
-				: $this->where($this->primaryKey, $this->idValue($data))->countAllResults() === 1
+				: $this->where($this->primaryKey, $this->getIdValue($data))->countAllResults() === 1
 			);
 	}
 

--- a/user_guide_src/source/changelogs/v4.1.2.rst
+++ b/user_guide_src/source/changelogs/v4.1.2.rst
@@ -52,6 +52,7 @@ Deprecations:
 - Deprecated ``Time::instance()``, use ``Time::createFromInstance()`` instead (now accepts ``DateTimeInterface``).
 - Deprecated ``IncomingRequest::removeRelativeDirectory()``, use ``URI::removeDotSegments()`` instead
 - Deprecated ``\API\ResponseTrait::failValidationError`` to use ``\API\ResponseTrait::failValidationErrors`` instead
+- Deprecated ``BaseModel::idValue()`` in favor of public ``BaseModel::getIdValue()``. ``BaseModel::getIdValue()`` will be defined as abstract in future any custom Model classes should be updated.
 
 Bugs Fixed:
 


### PR DESCRIPTION
**Description**
This makes it possible to use protected idValue() method from outside of the model to get the id value of the entity. 


**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
  
