### PR TITLE
EntityCast - Boolean - Use Filter Var

### DIFF
--- a/system/EntityCast/CastAsBoolean.php
+++ b/system/EntityCast/CastAsBoolean.php
@@ -22,6 +22,6 @@ class CastAsBoolean extends AbstractCast
 	 */
 	public static function get($value, array $params = []): bool
 	{
-		return (bool) $value;
+		return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true;
 	}
 }


### PR DESCRIPTION
**Description**
We have bool cast just cast the type to (bool) this changes it to use filter_var instead so values like `true` , `false`, `yes`, `no` can be casted properly to boolean.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide