### PR TITLE
Fix new service replacement service provider precedence on core factory implementations

### DIFF
--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -65,7 +65,7 @@ use Config\Images;
 use Config\Migrations;
 use Config\Modules;
 use Config\Pager as ConfigPager;
-use Config\Services;
+use Config\Services as AppServices;
 use Config\Toolbar as ConfigToolbar;
 use Config\Validation as ConfigValidation;
 use Config\View as ConfigView;
@@ -85,7 +85,7 @@ use Config\View as ConfigView;
  * whereas with DI Containers there usually isn't a way for them to do this.
  *
  * Warning: To allow overrides by service providers do not use static calls,
- * rather call out to \Config\Services instead.
+ * instead call out to \Config\Services (imported as AppServices).
  *
  * @see http://blog.ircmaxell.com/2015/11/simple-easy-risk-and-change.html
  * @see http://www.infoq.com/presentations/Simple-Made-Easy
@@ -189,7 +189,7 @@ class BaseService
 			// Make sure $getShared is false
 			$params[] = false;
 
-			static::$instances[$key] = Services::$key(...$params);
+			static::$instances[$key] = AppServices::$key(...$params);
 		}
 
 		return static::$instances[$key];

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -185,7 +185,7 @@ class BaseService
 			// Make sure $getShared is false
 			$params[] = false;
 
-			static::$instances[$key] = static::$key(...$params);
+			static::$instances[$key] = \Config\Services::$key(...$params);
 		}
 
 		return static::$instances[$key];

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -65,6 +65,7 @@ use Config\Images;
 use Config\Migrations;
 use Config\Modules;
 use Config\Pager as ConfigPager;
+use Config\Services;
 use Config\Toolbar as ConfigToolbar;
 use Config\Validation as ConfigValidation;
 use Config\View as ConfigView;
@@ -82,6 +83,9 @@ use Config\View as ConfigView;
  * of the applications built on top of CodeIgniter. A bonus side-effect
  * is that IDEs are able to determine what class you are calling
  * whereas with DI Containers there usually isn't a way for them to do this.
+ *
+ * Warning: To allow overrides by service providers do not use static calls,
+ * rather call out to \Config\Services instead.
  *
  * @see http://blog.ircmaxell.com/2015/11/simple-easy-risk-and-change.html
  * @see http://www.infoq.com/presentations/Simple-Made-Easy
@@ -185,7 +189,7 @@ class BaseService
 			// Make sure $getShared is false
 			$params[] = false;
 
-			static::$instances[$key] = \Config\Services::$key(...$params);
+			static::$instances[$key] = Services::$key(...$params);
 		}
 
 		return static::$instances[$key];

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -68,6 +68,7 @@ use Config\Pager as PagerConfig;
 use Config\Toolbar as ToolbarConfig;
 use Config\Validation as ValidationConfig;
 use Config\View as ViewConfig;
+use Config\Services as AppServices;
 
 /**
  * Services Configuration file.
@@ -275,8 +276,8 @@ class Services extends BaseService
 		}
 
 		$config   = $config ?? config('Exceptions');
-		$request  = $request ?? static::request();
-		$response = $response ?? static::response();
+		$request  = $request ?? AppServices::request();
+		$response = $response ?? AppServices::response();
 
 		return new Exceptions($config, $request, $response);
 	}
@@ -303,7 +304,7 @@ class Services extends BaseService
 
 		$config = $config ?? config('Filters');
 
-		return new Filters($config, static::request(), static::response());
+		return new Filters($config, AppServices::request(), AppServices::response());
 	}
 
 	//--------------------------------------------------------------------
@@ -416,7 +417,7 @@ class Services extends BaseService
 		}
 
 		// Use '?:' for empty string check
-		$locale = $locale ?: static::request()->getLocale();
+		$locale = $locale ?: AppServices::request()->getLocale();
 
 		return new Language($locale);
 	}
@@ -483,7 +484,7 @@ class Services extends BaseService
 			return static::getSharedInstance('negotiator', $request);
 		}
 
-		$request = $request ?? static::request();
+		$request = $request ?? AppServices::request();
 
 		return new Negotiate($request);
 	}
@@ -507,7 +508,7 @@ class Services extends BaseService
 		}
 
 		$config = $config ?? config('Pager');
-		$view   = $view ?? static::renderer();
+		$view   = $view ?? AppServices::renderer();
 
 		return new Pager($config, $view);
 	}
@@ -533,7 +534,7 @@ class Services extends BaseService
 		$viewPath = $viewPath ?: config('Paths')->viewDirectory;
 		$config   = $config ?? config('View');
 
-		return new Parser($config, $viewPath, static::locator(), CI_DEBUG, static::logger());
+		return new Parser($config, $viewPath, AppServices::locator(), CI_DEBUG, AppServices::logger());
 	}
 
 	//--------------------------------------------------------------------
@@ -559,7 +560,7 @@ class Services extends BaseService
 		$viewPath = $viewPath ?: config('Paths')->viewDirectory;
 		$config   = $config ?? config('View');
 
-		return new View($config, $viewPath, static::locator(), CI_DEBUG, static::logger());
+		return new View($config, $viewPath, AppServices::locator(), CI_DEBUG, AppServices::logger());
 	}
 
 	//--------------------------------------------------------------------
@@ -583,7 +584,7 @@ class Services extends BaseService
 
 		return new IncomingRequest(
 			$config,
-			static::uri(),
+			AppServices::uri(),
 			'php://input',
 			new UserAgent()
 		);
@@ -630,7 +631,7 @@ class Services extends BaseService
 
 		$config   = $config ?? config('App');
 		$response = new RedirectResponse($config);
-		$response->setProtocolVersion(static::request()->getProtocolVersion());
+		$response->setProtocolVersion(AppServices::request()->getProtocolVersion());
 
 		return $response;
 	}
@@ -652,7 +653,7 @@ class Services extends BaseService
 			return static::getSharedInstance('routes');
 		}
 
-		return new RouteCollection(static::locator(), config('Modules'));
+		return new RouteCollection(AppServices::locator(), config('Modules'));
 	}
 
 	//--------------------------------------------------------------------
@@ -674,8 +675,8 @@ class Services extends BaseService
 			return static::getSharedInstance('router', $routes, $request);
 		}
 
-		$routes  = $routes ?? static::routes();
-		$request = $request ?? static::request();
+		$routes  = $routes ?? AppServices::routes();
+		$request = $request ?? AppServices::request();
 
 		return new Router($routes, $request);
 	}
@@ -721,10 +722,10 @@ class Services extends BaseService
 		}
 
 		$config = $config ?? config('App');
-		$logger = static::logger();
+		$logger = AppServices::logger();
 
 		$driverName = $config->sessionDriver;
-		$driver     = new $driverName($config, static::request()->getIPAddress());
+		$driver     = new $driverName($config, AppServices::request()->getIPAddress());
 		$driver->setLogger($logger);
 
 		$session = new Session($driver, $config);
@@ -755,7 +756,7 @@ class Services extends BaseService
 			return static::getSharedInstance('throttler');
 		}
 
-		return new Throttler(static::cache());
+		return new Throttler(AppServices::cache());
 	}
 
 	//--------------------------------------------------------------------
@@ -839,7 +840,7 @@ class Services extends BaseService
 
 		$config = $config ?? config('Validation');
 
-		return new Validation($config, static::renderer());
+		return new Validation($config, AppServices::renderer());
 	}
 
 	//--------------------------------------------------------------------
@@ -859,7 +860,7 @@ class Services extends BaseService
 			return static::getSharedInstance('viewcell');
 		}
 
-		return new Cell(static::cache());
+		return new Cell(AppServices::cache());
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
This fixes #4483 
Replacing `static::foobar()` with `\Config\Services::foobar()` (https://regex101.com/r/QyahlU/1).

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide