### PR TITLE
Simplify Cookie Class

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -244,7 +244,7 @@ if (! function_exists('cookie'))
 	 */
 	function cookie(string $name, string $value = '', array $options = []): Cookie
 	{
-		return Cookie::create($name, $value, $options);
+		return new Cookie($name, $value, $options);
 	}
 }
 

--- a/system/Cookie/CloneableCookieInterface.php
+++ b/system/Cookie/CloneableCookieInterface.php
@@ -53,7 +53,7 @@ interface CloneableCookieInterface extends CookieInterface
 	 *
 	 * @return static
 	 */
-	public function withExpiresAt($expires = 0);
+	public function withExpires($expires);
 
 	/**
 	 * Creates a new Cookie that will expire the cookie from the browser.

--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -27,7 +27,7 @@ use LogicException;
  * reassign this new instance to a new variable to capture it.
  *
  * ```php
- * $cookie = Cookie::create('test_cookie', 'test_value');
+ * $cookie = new Cookie('test_cookie', 'test_value');
  * $cookie->getName(); // test_cookie
  *
  * $cookie->withName('prod_cookie');
@@ -149,8 +149,8 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
 			$newDefaults = $config;
 		}
 
-		// This array union ensures that even if passed `$config`
-		// is not `CookieConfig` or `array`, no empty defaults will occur.
+		// This array union ensures that even if passed `$config` is not
+		// `CookieConfig` or `array`, no empty defaults will occur.
 		self::$defaults = $newDefaults + $oldDefaults;
 
 		return $oldDefaults;
@@ -197,21 +197,19 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
 			$data[strtolower($attr)] = $val;
 		}
 
-		return static::create($name, $value, $data);
+		return new static($name, $value, $data);
 	}
 
 	/**
-	 * Create Cookie objects on the fly.
+	 * Construct a new Cookie instance.
 	 *
-	 * @param string               $name
-	 * @param string               $value
-	 * @param array<string, mixed> $options
+	 * @param string               $name    The cookie's name
+	 * @param string               $value   The cookie's value
+	 * @param array<string, mixed> $options The cookie's options
 	 *
 	 * @throws CookieException
-	 *
-	 * @return static
 	 */
-	public static function create(string $name, string $value = '', array $options = [])
+	final public function __construct(string $name, string $value = '', array $options = [])
 	{
 		$options += self::$defaults;
 
@@ -224,56 +222,14 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
 			unset($options['max-age']);
 		}
 
-		return new static(
-			$name,
-			$value,
-			$options['expires'],
-			$options['prefix'],
-			$options['path'],
-			$options['domain'],
-			$options['secure'],
-			$options['httponly'],
-			$options['raw'],
-			$options['samesite']
-		);
-	}
-
-	/**
-	 * Construct a new Cookie instance.
-	 *
-	 * @param string                           $name     The name of the cookie
-	 * @param string                           $value    The value of the cookie
-	 * @param DateTimeInterface|integer|string $expires  The time the cookie expires
-	 * @param string|null                      $prefix   The prefix of the cookie
-	 * @param string|null                      $path     The path on the server in which the cookie is available
-	 * @param string|null                      $domain   The domain in which the cookie is available
-	 * @param boolean                          $secure   Whether to send back the cookie over HTTPS
-	 * @param boolean                          $httponly Whether to forbid JavaScript access to cookies
-	 * @param boolean                          $raw      Whether the cookie should be sent with no URL encoding
-	 * @param string                           $samesite Whether the cookie will be available for cross-site requests
-	 *
-	 * @throws CookieException
-	 */
-	final public function __construct(
-		string $name,
-		string $value = '',
-		$expires = 0,
-		string $prefix = null,
-		string $path = null,
-		string $domain = null,
-		bool $secure = false,
-		bool $httponly = true,
-		bool $raw = false,
-		string $samesite = self::SAMESITE_LAX
-	)
-	{
 		// to retain BC
-		$prefix   = $prefix ?: self::$defaults['prefix'];
-		$path     = $path ?: self::$defaults['path'];
-		$domain   = $domain ?: self::$defaults['domain'];
-		$secure   = $secure ?: self::$defaults['secure'];
-		$httponly = $httponly ?: self::$defaults['httponly'];
-		$samesite = $samesite ?: self::$defaults['samesite'];
+		$prefix   = $options['prefix'] ?: self::$defaults['prefix'];
+		$path     = $options['path'] ?: self::$defaults['path'];
+		$domain   = $options['domain'] ?: self::$defaults['domain'];
+		$secure   = $options['secure'] ?: self::$defaults['secure'];
+		$httponly = $options['httponly'] ?: self::$defaults['httponly'];
+		$samesite = $options['samesite'] ?: self::$defaults['samesite'];
+		$raw      = $options['raw'] ?: self::$defaults['raw'];
 
 		$this->validateName($name, $raw);
 		$this->validatePrefix($prefix, $secure, $path, $domain);
@@ -282,7 +238,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
 		$this->prefix   = $prefix;
 		$this->name     = $name;
 		$this->value    = $value;
-		$this->expires  = static::convertExpiresTimestamp($expires);
+		$this->expires  = static::convertExpiresTimestamp($options['expires']);
 		$this->path     = $path;
 		$this->domain   = $domain;
 		$this->secure   = $secure;
@@ -438,7 +394,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
 	 */
 	public function getOptions(): array
 	{
-		// This is the order of options in `setcookie`. DO NOT change.
+		// This is the order of options in `setcookie`. DO NOT CHANGE.
 		return [
 			'expires'  => $this->expires,
 			'path'     => $this->path,
@@ -496,7 +452,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
 	/**
 	 * {@inheritDoc}
 	 */
-	public function withExpiresAt($expires = 0)
+	public function withExpires($expires)
 	{
 		$cookie = clone $this;
 

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -607,7 +607,7 @@ trait ResponseTrait
 			$expire = $expire > 0 ? time() + $expire : 0;
 		}
 
-		$options = [
+		$cookie = new Cookie($name, $value, [
 			'expires'  => $expire ?: 0,
 			'domain'   => $domain,
 			'path'     => $path,
@@ -615,9 +615,7 @@ trait ResponseTrait
 			'secure'   => $secure,
 			'httponly' => $httponly,
 			'samesite' => $samesite ?? '',
-		];
-
-		$cookie = Cookie::create($name, $value, $options);
+		]);
 
 		$this->cookieStore = $this->cookieStore->put($cookie);
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -149,7 +149,7 @@ class Security implements SecurityInterface
 		$expires = $security->expires ?? $config->CSRFExpire ?? 7200;
 
 		Cookie::setDefaults($cookie);
-		$this->cookie = Cookie::create($rawCookieName, $this->generateHash(), [
+		$this->cookie = new Cookie($rawCookieName, $this->generateHash(), [
 			'expires' => $expires === 0 ? 0 : time() + $expires,
 		]);
 	}

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -192,7 +192,7 @@ class Session implements SessionInterface
 		 */
 		$config = config('Cookie');
 
-		$this->cookie = Cookie::create($this->sessionCookieName, '', [
+		$this->cookie = new Cookie($this->sessionCookieName, '', [
 			'expires'  => $this->sessionExpiration === 0 ? 0 : time() + $this->sessionExpiration,
 			'path'     => $config->path,
 			'domain'   => $config->domain,
@@ -1009,7 +1009,7 @@ class Session implements SessionInterface
 	protected function setCookie()
 	{
 		$expiration   = $this->sessionExpiration === 0 ? 0 : time() + $this->sessionExpiration;
-		$this->cookie = $this->cookie->withValue(session_id())->withExpiresAt($expiration);
+		$this->cookie = $this->cookie->withValue(session_id())->withExpires($expiration);
 
 		cookies([$this->cookie], false)->dispatch();
 	}

--- a/system/Test/Mock/MockSession.php
+++ b/system/Test/Mock/MockSession.php
@@ -57,7 +57,7 @@ class MockSession extends Session
 	protected function setCookie()
 	{
 		$expiration   = $this->sessionExpiration === 0 ? 0 : time() + $this->sessionExpiration;
-		$this->cookie = $this->cookie->withValue(session_id())->withExpiresAt($expiration);
+		$this->cookie = $this->cookie->withValue(session_id())->withExpires($expiration);
 
 		$this->cookies[] = $this->cookie;
 	}

--- a/tests/system/Cookie/CookieStoreTest.php
+++ b/tests/system/Cookie/CookieStoreTest.php
@@ -32,8 +32,8 @@ final class CookieStoreTest extends CIUnitTestCase
 	public function testCookieStoreInitialization(): void
 	{
 		$cookies = [
-			Cookie::create('dev', 'cookie'),
-			Cookie::create('prod', 'cookie', ['raw' => true]),
+			new Cookie('dev', 'cookie'),
+			new Cookie('prod', 'cookie', ['raw' => true]),
 		];
 
 		$store = new CookieStore($cookies);
@@ -76,12 +76,12 @@ final class CookieStoreTest extends CIUnitTestCase
 	public function testPutRemoveCookiesInStore(): void
 	{
 		$cookies = [
-			Cookie::create('dev', 'cookie'),
-			Cookie::create('prod', 'cookie', ['raw' => true]),
+			new Cookie('dev', 'cookie'),
+			new Cookie('prod', 'cookie', ['raw' => true]),
 		];
 
 		$store  = new CookieStore($cookies);
-		$bottle = $store->put(Cookie::create('test', 'cookie'));
+		$bottle = $store->put(new Cookie('test', 'cookie'));
 		$jar    = $store->remove('dev');
 
 		$this->assertNotSame($store->display(), $bottle->display());
@@ -94,8 +94,8 @@ final class CookieStoreTest extends CIUnitTestCase
 	public function testCookieDispatching(): void
 	{
 		$cookies = [
-			'dev'  => Cookie::create('dev', 'cookie'),
-			'prod' => Cookie::create('prod', 'cookie', ['raw' => true]),
+			'dev'  => new Cookie('dev', 'cookie'),
+			'prod' => new Cookie('prod', 'cookie', ['raw' => true]),
 		];
 
 		$dev  = $cookies['dev']->getOptions();

--- a/user_guide_src/source/libraries/cookies.rst
+++ b/user_guide_src/source/libraries/cookies.rst
@@ -2,11 +2,11 @@
 Cookies
 #######
 
-An **HTTP cookie** (web cookie, browser cookie) is a small piece of data that a
-server sends to the user's web browser. The browser may store it and send it
-back with later requests to the same server. Typically, it's used to tell if
-two requests came from the same browser — keeping a user logged-in, for
-example. It remembers stateful information for the stateless HTTP protocol.
+An **HTTP cookie** (web cookie, browser cookie) is a small piece of data that a server
+sends to the user's web browser. The browser may store it and send it back with later
+requests to the same server. Typically, it's used to tell if two requests came from
+the same browser — keeping a user logged-in, for example.
+It remembers stateful information for the stateless HTTP protocol.
 
 Cookies are mainly used for three purposes:
 
@@ -26,29 +26,15 @@ cookie interaction.
 Creating Cookies
 ****************
 
-There are currently five (5) ways to create a new ``Cookie`` value object.
+There are currently four (4) ways to create a new ``Cookie`` value object.
 
 ::
 
     use CodeIgniter\Cookie\Cookie;
     use DateTime;
 
-    // Providing all arguments in the constructor
+    // Throw the constructor
     $cookie = new Cookie(
-        'remember_token', // name
-        'f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6', // value
-        new DateTime('+2 hours'), // expires
-        '__Secure-', // prefix
-        '/', // path
-        '', // domain
-        true, // secure
-        true, // httponly
-        false, // raw
-        Cookie::SAMESITE_LAX // samesite
-    );
-
-    // Using the static constructor
-    $cookie = Cookie::create(
         'remember_token',
         'f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6',
         [
@@ -77,24 +63,24 @@ There are currently five (5) ways to create a new ``Cookie`` value object.
         ->withPath('/')
         ->withDomain('')
         ->withSecure(true)
-        ->withHttpOnly(true)
+        ->withHTTPOnly(true)
         ->withSameSite(Cookie::SAMESITE_LAX);
 
-    // Using the global function `cookie` which implicitly calls `Cookie::create()`
+    // Using the global function `cookie` which implicitly calls `new Cookie()`
     $cookie = cookie('remember_token', 'f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6');
 
 When constructing the ``Cookie`` object, only the ``name`` attribute is required. All other else are optional.
 If the optional attributes are not modified, their values will be filled up by the default values saved in
-the ``Cookie`` class. To override the defaults currently stored in the class, you can pass a ``Config\App``
+the ``Cookie`` class. To override the defaults currently stored in the class, you can pass a ``Config\Cookie``
 instance or an array of defaults to the static ``Cookie::setDefaults()`` method.
 
 ::
 
     use CodeIgniter\Cookie\Cookie;
-    use Config\App;
+    use Config\Cookie as CookieConfig;
 
     // pass in an App instance before constructing a Cookie class
-    Cookie::setDefaults(new App());
+    Cookie::setDefaults(new CookieConfig());
     $cookie = new Cookie('login_token');
 
     // pass in an array of defaults
@@ -103,9 +89,9 @@ instance or an array of defaults to the static ``Cookie::setDefaults()`` method.
         'samesite' => Cookie::SAMESITE_STRICT,
     ];
     Cookie::setDefaults($myDefaults);
-    $cookie = Cookie::create('login_token');
+    $cookie = new Cookie('login_token');
 
-Passing the ``Config\App`` instance or an array to ``Cookie::setDefaults()`` will effectively
+Passing the ``Config\Cookie`` instance or an array to ``Cookie::setDefaults()`` will effectively
 overwrite your defaults and will persist until new defaults are passed. If you do not want this
 behavior but only want to change defaults for a limited time, you can take advantage of
 ``Cookie::setDefaults()`` return which returns the old defaults array.
@@ -113,10 +99,10 @@ behavior but only want to change defaults for a limited time, you can take advan
 ::
 
     use CodeIgniter\Cookie\Cookie;
-    use Config\App;
+    use Config\Cookie as CookieConfig;
 
-    $oldDefaults = Cookie::setDefaults(new App());
-    $cookie = Cookie::create('my_token', 'muffins');
+    $oldDefaults = Cookie::setDefaults(new CookieConfig());
+    $cookie = new Cookie('my_token', 'muffins');
 
     // return the old defaults
     Cookie::setDefaults($oldDefaults);
@@ -133,7 +119,7 @@ Once instantiated, you can easily access a ``Cookie``'s attribute by using one o
     use DateTime;
     use DateTimeZone;
 
-    $cookie = Cookie::create(
+    $cookie = new Cookie(
         'remember_token',
         'f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6',
         [
@@ -159,7 +145,7 @@ Once instantiated, you can easily access a ``Cookie``'s attribute by using one o
     $cookie->isSecure(); // true
     $cookie->getPath(); // '/'
     $cookie->getDomain(); // ''
-    $cookie->isHttpOnly(); // true
+    $cookie->isHTTPOnly(); // true
     $cookie->getSameSite(); // 'Lax'
 
     // additional getter
@@ -182,7 +168,7 @@ returns a new instance. You need to retain this new instance in order to use it.
 
     use CodeIgniter\Cookie\Cookie;
 
-    $cookie = Cookie::create('login_token', 'admin');
+    $cookie = new Cookie('login_token', 'admin');
     $cookie->getName(); // 'login_token'
 
     $cookie->withName('remember_token');
@@ -276,8 +262,8 @@ CodeIgniter provides three (3) other ways to create a new instance of the ``Cook
 
     // Passing an array of `Cookie` objects in the constructor
     $store = new CookieStore([
-        Cookie::create('login_token'),
-        Cookie::create('remember_token'),
+        new Cookie('login_token'),
+        new Cookie('remember_token'),
     ]);
 
     // Passing an array of `Set-Cookie` header strings
@@ -287,7 +273,7 @@ CodeIgniter provides three (3) other ways to create a new instance of the ``Cook
     ]);
 
     // using the global `cookies` function
-    $store = cookies([Cookie::create('login_token')], false);
+    $store = cookies([new Cookie('login_token')], false);
 
     // retrieving the `CookieStore` instance saved in our current `Response` object
     $store = cookies();
@@ -306,8 +292,8 @@ To check whether a ``Cookie`` object exists in the ``CookieStore`` instance, you
 
     // check if cookie is in the current cookie collection
     $store = new CookieStore([
-        Cookie::create('login_token'),
-        Cookie::create('remember_token'),
+        new Cookie('login_token'),
+        new Cookie('remember_token'),
     ]);
     $store->has('login_token');
 
@@ -331,8 +317,8 @@ Retrieving a ``Cookie`` instance in a cookie collection is very easy::
 
     // getting cookie in the current cookie collection
     $store = new CookieStore([
-        Cookie::create('login_token'),
-        Cookie::create('remember_token'),
+        new Cookie('login_token'),
+        new Cookie('remember_token'),
     ]);
     $store->get('login_token');
 
@@ -389,12 +375,12 @@ in order to work on it. The original instance is left unchanged.
     use Config\Services;
 
     $store = new CookieStore([
-        Cookie::create('login_token'),
-        Cookie::create('remember_token'),
+        new Cookie('login_token'),
+        new Cookie('remember_token'),
     ]);
 
     // adding a new Cookie instance
-    $new = $store->put(Cookie::create('admin_token', 'yes'));
+    $new = $store->put(new Cookie('admin_token', 'yes'));
 
     // removing a Cookie instance
     $new = $store->remove('login_token');
@@ -433,8 +419,8 @@ of ``headers_sent()``.
     use CodeIgniter\Cookie\CookieStore;
 
     $store = new CookieStore([
-        Cookie::create('login_token'),
-        Cookie::create('remember_token'),
+        new Cookie('login_token'),
+        new Cookie('remember_token'),
     ]);
 
     $store->dispatch(); // After dispatch, the collection is now empty.
@@ -445,19 +431,19 @@ Cookie Personalization
 
 Sane defaults are already in place inside the ``Cookie`` class to ensure the smooth creation of cookie
 objects. However, you may wish to define your own settings by changing the following settings in the
-``Config\App`` class in ``app/Config/App.php`` file.
+``Config\Cookie`` class in ``app/Config/Cookie.php`` file.
 
 ==================== ===================================== ========= =====================================================
 Setting              Options/ Types                        Default   Description
 ==================== ===================================== ========= =====================================================
-**$cookiePrefix**    ``string``                            ``''``    Prefix to prepend to the cookie name.
-**$cookieDomain**    ``string``                            ``''``    The domain property of the cookie.
-**$cookiePath**      ``string``                            ``/``     The path property of the cookie, with trailing slash.
-**$cookieSecure**    ``true/false``                        ``false`` If to be sent over secure HTTPS.
-**$cookieHTTPOnly**  ``true/false``                        ``true``  If not accessible to JavaScript.
-**$cookieSameSite**  ``Lax|None|Strict|lax|none|strict''`` ``Lax``   The SameSite attribute.
-**$cookieRaw**       ``true/false``                        ``false`` If to be dispatched using ``setrawcookie()``.
-**$cookieExpires**   ``DateTimeInterface|string|int``      ``0``     The expires timestamp.
+**$prefix**          ``string``                            ``''``    Prefix to prepend to the cookie name.
+**$expires**         ``DateTimeInterface|string|int``      ``0``     The expires timestamp.
+**$path**            ``string``                            ``/``     The path property of the cookie.
+**$domain**          ``string``                            ``''``    The domain property of the cookie.with trailing slash.
+**$secure**          ``true/false``                        ``false`` If to be sent over secure HTTPS.
+**$httponly**        ``true/false``                        ``true``  If not accessible to JavaScript.
+**$samesite**        ``Lax|None|Strict|lax|none|strict''`` ``Lax``   The SameSite attribute.
+**$raw**             ``true/false``                        ``false`` If to be dispatched using ``setrawcookie()``.
 ==================== ===================================== ========= =====================================================
 
 In runtime, you can manually supply a new default using the ``Cookie::setDefaults()`` method.
@@ -486,29 +472,11 @@ Class Reference
 
         Create a new Cookie instance from a ``Set-Cookie`` header.
 
-    .. php:staticmethod:: create(string $name[, string $value = ''[, array $options = []]])
+    .. php:method:: __construct(string $name[, string $value = ''[, array $options = []]])
 
         :param string $name: The cookie name
         :param string $value: The cookie value
-        :param aray $options: The cookie options
-        :rtype: ``Cookie``
-        :returns: ``Cookie`` instance
-        :throws: ``CookieException``
-
-        Create Cookie objects on the fly.
-
-    .. php:method:: __construct(string $name[, string $value = ''[, $expires = 0[, ?string $prefix = null[, ?string $path = null[, ?string $domain = null[, bool $secure = false[, bool $httpOnly = true[, bool $raw = false[, string $sameSite = self::SAMESITE_LAX]]]]]]]]])
-
-        :param string $name:
-        :param string $value:
-        :param DateTimeInterface|string|int $expires:
-        :param string|null $prefix:
-        :param string|null $path:
-        :param string|null $domain:
-        :param bool $secure:
-        :param bool $httpOnly:
-        :param bool $raw:
-        :param string $sameSite:
+        :param array $options: The cookie options
         :rtype: ``Cookie``
         :returns: ``Cookie`` instance
         :throws: ``CookieException``
@@ -520,7 +488,6 @@ Class Reference
         :rtype: string
         :returns: The ID used in indexing in the cookie collection.
 
-    .. php:method:: isRaw(): bool
     .. php:method:: getPrefix(): string
     .. php:method:: getName(): string
     .. php:method:: getPrefixedName(): string
@@ -532,8 +499,9 @@ Class Reference
     .. php:method:: getDomain(): string
     .. php:method:: getPath(): string
     .. php:method:: isSecure(): bool
-    .. php:method:: isHttpOnly(): bool
+    .. php:method:: isHTTPOnly(): bool
     .. php:method:: getSameSite(): string
+    .. php:method:: isRaw(): bool
     .. php:method:: getOptions(): array
 
     .. php:method:: withRaw([bool $raw = true])
@@ -568,7 +536,7 @@ Class Reference
 
         Creates a new Cookie with new value.
 
-    .. php:method:: withExpiresAt($expires)
+    .. php:method:: withExpires($expires)
 
         :param DateTimeInterface|string|int $expires:
         :rtype: ``Cookie``
@@ -615,17 +583,17 @@ Class Reference
 
         Creates a new Cookie with new "Secure" attribute.
 
-    .. php:method:: withHttpOnly([bool $httpOnly = true])
+    .. php:method:: withHTTPOnly([bool $httponly = true])
 
-        :param bool $httpOnly:
+        :param bool $httponly:
         :rtype: ``Cookie``
         :returns: new ``Cookie`` instance
 
         Creates a new Cookie with new "HttpOnly" attribute.
 
-    .. php:method:: withSameSite(string $sameSite)
+    .. php:method:: withSameSite(string $samesite)
 
-        :param string $sameSite:
+        :param string $samesite:
         :rtype: ``Cookie``
         :returns: new ``Cookie`` instance
 


### PR DESCRIPTION
Since we use php min version `7.3`, why not passing all cookie options to the constructor itself directly.
Removed `Cookie::create` while `new Cookie` do the same thing directly.
Renamed `Cookie::getExpiresTimestamp` to `Cookie::getExpires` to be short and refer to it's property,
Renamed `Cookie::withExpiresAt` to `Cookie::withExpires` to fit it's property and also it may return expired cookie.

I think this is last change to new Cookie class should be done before the upcoming release

@paulbalandan what do you think about this changes? is it keeps the interface "fluent"? Thanks in advance