### PR TITLE
[Rector] Apply Full PHP 7.3 Rector Set List

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -46,6 +46,7 @@ parameters:
 		- '#Return type \(bool\) of method CodeIgniter\\HTTP\\Files\\UploadedFile::move\(\) should be compatible with return type \(CodeIgniter\\Files\\File\) of method CodeIgniter\\Files\\File::move\(\)#'
 		- '#Return type \(bool\) of method CodeIgniter\\Test\\TestLogger::log\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::log\(\)#'
 		- '#Parameter \#2 \$assoc of function json_decode expects bool, null given#'
+	reportUnmatchedIgnoredErrors: false
 	parallel:
 		processTimeout: 300.0
 	scanDirectories:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -45,6 +45,7 @@ parameters:
 		- '#Return type \(bool\) of method CodeIgniter\\Log\\Logger::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::(emergency|alert|critical|error|warning|notice|info|debug|log)\(\)#'
 		- '#Return type \(bool\) of method CodeIgniter\\HTTP\\Files\\UploadedFile::move\(\) should be compatible with return type \(CodeIgniter\\Files\\File\) of method CodeIgniter\\Files\\File::move\(\)#'
 		- '#Return type \(bool\) of method CodeIgniter\\Test\\TestLogger::log\(\) should be compatible with return type \(null\) of method Psr\\Log\\LoggerInterface::log\(\)#'
+		- '#Parameter \#2 \$assoc of function json_decode expects bool, null given#'
 	parallel:
 		processTimeout: 300.0
 	scanDirectories:

--- a/rector.php
+++ b/rector.php
@@ -21,7 +21,7 @@ use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRect
 use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
 use Rector\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector;
-use Rector\Php73\Rector\FuncCall\ArrayKeyFirstLastRector;
+use Rector\Set\ValueObject\SetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Utils\Rector\PassStrictParameterToFunctionParameterRector;
 use Utils\Rector\UnderscoreToCamelCaseVariableNameRector;
@@ -35,6 +35,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 	// do you need to include constants, class aliases or custom autoloader? files listed will be executed
 	$parameters->set(Option::BOOTSTRAP_FILES, [
 		__DIR__ . '/system/Test/bootstrap.php',
+	]);
+
+	$parameters->set(Option::SETS, [
+		SetList::PHP_73,
 	]);
 
 	// is there a file you need to skip?
@@ -61,7 +65,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 	$services->set(ForToForeachRector::class);
 	$services->set(ChangeNestedForeachIfsToEarlyContinueRector::class);
 	$services->set(ChangeIfElseValueAssignToEarlyReturnRector::class);
-	$services->set(ArrayKeyFirstLastRector::class);
 	$services->set(SimplifyStrposLowerRector::class);
 	$services->set(CombineIfRector::class);
 	$services->set(SimplifyIfReturnBoolRector::class);

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -401,7 +401,7 @@ trait ResponseTrait
 		{
 			// Recursively convert objects into associative arrays
 			// Conversion not required for JSONFormatter
-			$data = json_decode(json_encode($data), true);
+			$data = json_decode(json_encode($data, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
 		}
 
 		return $this->formatter->format($data);

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -259,7 +259,7 @@ class Autoloader
 			{
 				$directory = rtrim($directory, '\\/');
 
-				if (strpos($class, $namespace) === 0)
+				if (strpos($class, (string) $namespace) === 0)
 				{
 					$filePath = $directory . str_replace('\\', DIRECTORY_SEPARATOR, substr($class, strlen($namespace))) . '.php';
 					$filename = $this->includeFile($filePath);

--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -231,7 +231,7 @@ trait GeneratorTrait
 			$class = $matches[1] . ucfirst($matches[2]);
 		}
 
-		if ($this->enabledSuffixing && $this->getOption('suffix') && ! strripos($class, $component))
+		if ($this->enabledSuffixing && $this->getOption('suffix') && ! strripos($class, (string) $component))
 		{
 			$class .= ucfirst($component);
 		}

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -56,7 +56,7 @@ class Config extends BaseConfig
 		if (is_array($group))
 		{
 			$config = $group;
-			$group  = 'custom-' . md5(json_encode($config));
+			$group  = 'custom-' . md5(json_encode($config, JSON_THROW_ON_ERROR));
 		}
 
 		$config = $config ?? config('Database');

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -165,7 +165,7 @@ class Toolbar
 			$response->CSP->addImageSrc('data:');
 		}
 
-		return json_encode($data);
+		return json_encode($data, JSON_THROW_ON_ERROR);
 	}
 
 	//--------------------------------------------------------------------
@@ -431,7 +431,7 @@ class Toolbar
 	 */
 	protected function format(string $data, string $format = 'html'): string
 	{
-		$data = json_decode($data, true);
+		$data = json_decode($data, true, 512, JSON_THROW_ON_ERROR);
 
 		if ($this->config->maxHistory !== 0)
 		{

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -940,7 +940,7 @@ class Email
 
 		foreach ($this->baseCharsets as $charset)
 		{
-			if (strpos($this->charset, $charset) === 0)
+			if (strpos($this->charset, (string) $charset) === 0)
 			{
 				$this->encoding = '7bit';
 

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -734,7 +734,7 @@ class CURLRequest extends Request
 		if (isset($config['json']))
 		{
 			// Will be set as the body in `applyBody()`
-			$json = json_encode($config['json']);
+			$json = json_encode($config['json'], JSON_THROW_ON_ERROR);
 			$this->setBody($json);
 			$this->setHeader('Content-Type', 'application/json');
 			$this->setHeader('Content-Length', (string) strlen($json));

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -362,7 +362,7 @@ class IncomingRequest extends Request
 
 		if (! $assoc)
 		{
-			return json_decode(json_encode($data));
+			return json_decode(json_encode($data, JSON_THROW_ON_ERROR), null, 512, JSON_THROW_ON_ERROR);
 		}
 
 		return $data;
@@ -727,14 +727,14 @@ class IncomingRequest extends Request
 		if (isset($_SERVER['SCRIPT_NAME'][0]) && pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_EXTENSION) === 'php')
 		{
 			// strip the script name from the beginning of the URI
-			if (strpos($uri, $_SERVER['SCRIPT_NAME']) === 0 && strpos($uri, '/index.php') === 0)
+			if (strpos($uri, (string) $_SERVER['SCRIPT_NAME']) === 0 && strpos($uri, '/index.php') === 0)
 			{
 				$uri = (string) substr($uri, strlen($_SERVER['SCRIPT_NAME']));
 			}
 			// if the script is nested, strip the parent folder & script from the URI
-			elseif (strpos($uri, $_SERVER['SCRIPT_NAME']) > 0)
+			elseif (strpos($uri, (string) $_SERVER['SCRIPT_NAME']) > 0)
 			{
-				$uri = (string) substr($uri, strpos($uri, $_SERVER['SCRIPT_NAME']) + strlen($_SERVER['SCRIPT_NAME']));
+				$uri = (string) substr($uri, strpos($uri, (string) $_SERVER['SCRIPT_NAME']) + strlen($_SERVER['SCRIPT_NAME']));
 			}
 			// or if index.php is implied
 			elseif (strpos($uri, dirname($_SERVER['SCRIPT_NAME'])) === 0)

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -115,7 +115,7 @@ trait RequestTrait
 					}
 
 					// If the proxy entry doesn't match the IP protocol - skip it
-					if (strpos($proxyIP, $separator) === false)
+					if (strpos($proxyIP, (string) $separator) === false)
 					{
 						continue;
 					}

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -177,7 +177,7 @@ class ChromeLoggerHandler extends BaseHandler
 			$response = Services::response(null, true);
 		}
 
-		$data = base64_encode(utf8_encode(json_encode($this->json)));
+		$data = base64_encode(utf8_encode(json_encode($this->json, JSON_THROW_ON_ERROR)));
 
 		$response->setHeader($this->header, $data);
 	}

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1342,7 +1342,7 @@ class RouteCollection implements RouteCollectionInterface
 
 			// Ensure that the param we're inserting matches
 			// the expected param type.
-			$pos  = strpos($from, $pattern);
+			$pos  = strpos($from, (string) $pattern);
 			$from = substr_replace($from, $params[$index], $pos, strlen($pattern));
 		}
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -254,7 +254,7 @@ class Security implements SecurityInterface
 		{
 			// We kill this since we're done and we don't want to pollute the JSON data.
 			unset($json->{$this->tokenName});
-			$request->setBody(json_encode($json));
+			$request->setBody(json_encode($json, JSON_THROW_ON_ERROR));
 		}
 
 		if ($this->regenerate)

--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -406,7 +406,7 @@ class TestResponse extends TestCase
 	 */
 	public function assertJSONFragment(array $fragment, bool $strict = false)
 	{
-		$json    = json_decode($this->getJSON(), true);
+		$json    = json_decode($this->getJSON(), true, 512, JSON_THROW_ON_ERROR);
 		$patched = array_replace_recursive($json, $fragment);
 
 		if ($strict)

--- a/tests/system/EntityTest.php
+++ b/tests/system/EntityTest.php
@@ -543,7 +543,7 @@ class EntityTest extends CIUnitTestCase
 
 		// Check if serialiazed
 		$check = $this->getPrivateProperty($entity, 'attributes')['eleventh'];
-		$this->assertEquals(json_encode([1, 2, 3]), $check);
+		$this->assertEquals(json_encode([1, 2, 3], JSON_THROW_ON_ERROR), $check);
 
 		// Check if unserialized
 		$this->assertEquals([1, 2, 3], $entity->eleventh);
@@ -563,7 +563,7 @@ class EntityTest extends CIUnitTestCase
 
 		// Check if serialiazed
 		$check = $this->getPrivateProperty($entity, 'attributes')['eleventh'];
-		$this->assertEquals(json_encode([1, 2, 3]), $check);
+		$this->assertEquals(json_encode([1, 2, 3], JSON_THROW_ON_ERROR), $check);
 
 		// Check if unserialized
 		$this->assertEquals([1, 2, 3], $entity->eleventh);
@@ -947,7 +947,7 @@ class EntityTest extends CIUnitTestCase
 	{
 		$entity = $this->getEntity();
 		$entity->setBar('foo');
-		$this->assertEquals(json_encode($entity->toArray()), json_encode($entity));
+		$this->assertEquals(json_encode($entity->toArray(), JSON_THROW_ON_ERROR), json_encode($entity, JSON_THROW_ON_ERROR));
 	}
 
 	protected function getEntity() : Entity

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -923,7 +923,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
 
 		$this->assertEquals('post', $this->request->getMethod());
 
-		$expected = json_encode($params);
+		$expected = json_encode($params, JSON_THROW_ON_ERROR);
 		$this->assertEquals($expected, $this->request->getBody());
 	}
 
@@ -940,7 +940,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
 		];
 		$this->request->setJSON($params)->post('/post');
 
-		$this->assertEquals(json_encode($params), $this->request->getBody());
+		$this->assertEquals(json_encode($params, JSON_THROW_ON_ERROR), $this->request->getBody());
 		$this->assertEquals('application/json', $this->request->getHeaderLine('Content-Type'));
 	}
 

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -308,7 +308,7 @@ class IncomingRequestTest extends CIUnitTestCase
 				'fizz' => 'buzz',
 			],
 		];
-		$json    = json_encode($jsonObj);
+		$json    = json_encode($jsonObj, JSON_THROW_ON_ERROR);
 
 		$config          = new App();
 		$config->baseURL = 'http://example.com/';
@@ -330,7 +330,7 @@ class IncomingRequestTest extends CIUnitTestCase
 				'foo'  => 'bar',
 			],
 		];
-		$json    = json_encode($jsonObj);
+		$json    = json_encode($jsonObj, JSON_THROW_ON_ERROR);
 
 		$config          = new App();
 		$config->baseURL = 'http://example.com/';
@@ -345,7 +345,7 @@ class IncomingRequestTest extends CIUnitTestCase
 
 	public function testGetJsonVarCanFilter()
 	{
-		$json = json_encode(['foo' => 'bar']);
+		$json = json_encode(['foo' => 'bar'], JSON_THROW_ON_ERROR);
 
 		$config          = new App();
 		$config->baseURL = 'http://example.com/';
@@ -361,7 +361,7 @@ class IncomingRequestTest extends CIUnitTestCase
 			'foo'  => 'bar',
 			'fizz' => 'buzz',
 		];
-		$json    = json_encode($jsonObj);
+		$json    = json_encode($jsonObj, JSON_THROW_ON_ERROR);
 
 		$config          = new App();
 		$config->baseURL = 'http://example.com/';

--- a/tests/system/Test/ControllerTestTraitTest.php
+++ b/tests/system/Test/ControllerTestTraitTest.php
@@ -205,7 +205,7 @@ class ControllerTestTraitTest extends CIUnitTestCase
 				->controller(Popcorn::class)
 				->execute('index3');
 
-		$response = json_decode($result->response()->getBody());
+		$response = json_decode($result->response()->getBody(), null, 512, JSON_THROW_ON_ERROR);
 		$this->assertEquals('en', $response->lang);
 	}
 

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -353,7 +353,7 @@ class FeatureTestTraitTest extends CIUnitTestCase
 
 		$request = $this->withBodyFormat('json')->setRequestBody($request, ['foo1' => 'bar1']);
 
-		$this->assertJsonStringEqualsJsonString(json_encode(['foo1' => 'bar1']), $request->getBody());
+		$this->assertJsonStringEqualsJsonString(json_encode(['foo1' => 'bar1'], JSON_THROW_ON_ERROR), $request->getBody());
 		$this->assertTrue('application/json' === $request->header('Content-Type')->getValue());
 	}
 

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -467,7 +467,7 @@ final class ValidationTest extends CIUnitTestCase
 			'role'     => 'administrator',
 			'usepass'  => 0,
 		];
-		$json = json_encode($data);
+		$json = json_encode($data, JSON_THROW_ON_ERROR);
 
 		$_SERVER['CONTENT_TYPE'] = 'application/json';
 
@@ -955,8 +955,8 @@ final class ValidationTest extends CIUnitTestCase
 	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/4521
 	 *
 	 * @param boolean $expected
-	 * @param array $rules
-	 * @param array $data
+	 * @param array   $rules
+	 * @param array   $data
 	 *
 	 * @return void
 	 */
@@ -969,55 +969,63 @@ final class ValidationTest extends CIUnitTestCase
 	public function dotNotationForIfExistProvider()
 	{
 		yield 'dot-on-end-fail' => [
-			false,
-			['status.*' => 'if_exist|in_list[status_1,status_2]'],
-			['status'   => ['bad-status']],
-		];
+				  false,
+				  ['status.*' => 'if_exist|in_list[status_1,status_2]'],
+				  ['status' => ['bad-status']],
+			  ];
 
 		yield 'dot-on-end-pass' => [
-			true,
-			['status.*' => 'if_exist|in_list[status_1,status_2]'],
-			['status'   => ['status_1']],
-		];
+				  true,
+				  ['status.*' => 'if_exist|in_list[status_1,status_2]'],
+				  ['status' => ['status_1']],
+			  ];
 
 		yield 'dot-on-middle-fail' => [
-			false,
-			['fizz.*.baz' => 'if_exist|numeric'],
-			['fizz'       => [
-				'bar' => ['baz' => 'yes'],
-			]],
-		];
+				  false,
+				  ['fizz.*.baz' => 'if_exist|numeric'],
+				  [
+					   'fizz' => [
+						   'bar' => ['baz' => 'yes'],
+					   ],
+				   ],
+			  ];
 
 		yield 'dot-on-middle-pass' => [
-			true,
-			['fizz.*.baz' => 'if_exist|numeric'],
-			['fizz'       => [
-				'bar' => ['baz' => 30],
-			]],
-		];
+				  true,
+				  ['fizz.*.baz' => 'if_exist|numeric'],
+				  [
+					   'fizz' => [
+						   'bar' => ['baz' => 30],
+					   ],
+				   ],
+			  ];
 
 		yield 'dot-multiple-fail' => [
-			false,
-			['fizz.*.bar.*' => 'if_exist|numeric'],
-			['fizz' => [
-				'bos' => [
-					'bar' => [
-						'bub' => 'noo',
-					],
-				],
-			]],
-		];
+				  false,
+				  ['fizz.*.bar.*' => 'if_exist|numeric'],
+				  [
+					   'fizz' => [
+						   'bos' => [
+							   'bar' => [
+								   'bub' => 'noo',
+							   ],
+						   ],
+					   ],
+				   ],
+			  ];
 
 		yield 'dot-multiple-pass' => [
-			true,
-			['fizz.*.bar.*' => 'if_exist|numeric'],
-			['fizz' => [
-				'bos' => [
-					'bar' => [
-						'bub' => 5,
-					],
-				],
-			]],
-		];
+				  true,
+				  ['fizz.*.bar.*' => 'if_exist|numeric'],
+				  [
+					   'fizz' => [
+						   'bos' => [
+							   'bar' => [
+								   'bub' => 5,
+							   ],
+						   ],
+					   ],
+				   ],
+			  ];
 	}
 }


### PR DESCRIPTION
Using : 

```php
	$parameters->set(Option::SETS, [
		SetList::PHP_73,
	]);
```

to apply full php 7.3 rector set list.

**Checklist:**
- [x] Securely signed commits