### PR TITLE
Fix validation of array data

### DIFF
--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -39,8 +39,10 @@ if (! function_exists('dot_array_search'))
 if (! function_exists('_array_search_dot'))
 {
 	/**
-	 * Used by dot_array_search to recursively search the
+	 * Used by `dot_array_search` to recursively search the
 	 * array with wildcards.
+	 *
+	 * @internal This should not be used on its own.
 	 *
 	 * @param array $indexes
 	 * @param array $array

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -22,7 +22,7 @@ if (! function_exists('dot_array_search'))
 	 * @param string $index
 	 * @param array  $array
 	 *
-	 * @return mixed|null
+	 * @return mixed
 	 */
 	function dot_array_search(string $index, array $array)
 	{
@@ -45,14 +45,12 @@ if (! function_exists('_array_search_dot'))
 	 * @param array $indexes
 	 * @param array $array
 	 *
-	 * @return mixed|null
+	 * @return mixed
 	 */
 	function _array_search_dot(array $indexes, array $array)
 	{
 		// Grab the current index
-		$currentIndex = $indexes
-			? array_shift($indexes)
-			: null;
+		$currentIndex = $indexes ? array_shift($indexes) : null;
 
 		if ((empty($currentIndex) && (int) $currentIndex !== 0) || (! isset($array[$currentIndex]) && $currentIndex !== '*'))
 		{
@@ -62,18 +60,28 @@ if (! function_exists('_array_search_dot'))
 		// Handle Wildcard (*)
 		if ($currentIndex === '*')
 		{
-			// If $array has more than 1 item, we have to loop over each.
+			$answer = [];
+
 			foreach ($array as $value)
 			{
-				$answer = _array_search_dot($indexes, $value);
-
-				if ($answer !== null)
-				{
-					return $answer;
-				}
+				$answer[] = _array_search_dot($indexes, $value);
 			}
 
-			// Still here after searching all child nodes?
+			$answer = array_filter($answer, static function ($value) {
+				return $value !== null;
+			});
+
+			if ($answer !== [])
+			{
+				if (count($answer) === 1)
+				{
+					// If array only has one element, we return that element for BC.
+					return current($answer);
+				}
+
+				return $answer;
+			}
+
 			return null;
 		}
 
@@ -85,7 +93,7 @@ if (! function_exists('_array_search_dot'))
 		}
 
 		// Do we need to recursively search this value?
-		if (is_array($array[$currentIndex]) && $array[$currentIndex])
+		if (is_array($array[$currentIndex]) && $array[$currentIndex] !== [])
 		{
 			return _array_search_dot($indexes, $array[$currentIndex]);
 		}

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -49,6 +49,20 @@ class ArrayHelperTest extends CIUnitTestCase
 		$this->assertEquals(42, dot_array_search('foo\.bar.baz', $data));
 	}
 
+	public function testArraySearchDotMultiLevels()
+	{
+		$data1 = ['bar' => [['foo' => 'baz']]];
+		$data2 = ['bar' => [
+			['foo' => 'bizz'],
+			['foo' => 'buzz'],
+		]];
+		$data3 = ['baz' => 'none'];
+
+		$this->assertSame('baz', dot_array_search('bar.*.foo', $data1));
+		$this->assertSame(['bizz', 'buzz'], dot_array_search('bar.*.foo', $data2));
+		$this->assertNull(dot_array_search('bar.*.foo', $data3));
+	}
+
 	public function testArrayDotReturnNullEmptyArray()
 	{
 		$data = [];

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -300,7 +300,8 @@ final class ValidationTest extends CIUnitTestCase
 
 	public function testSetRuleGroupWithCustomErrorMessage()
 	{
-		$this->validation->reset()->setRuleGroup('login');
+		$this->validation->reset();
+		$this->validation->setRuleGroup('login');
 		$this->validation->run([
 			'username' => 'codeigniter',
 		]);
@@ -1017,6 +1018,62 @@ final class ValidationTest extends CIUnitTestCase
 						'bub' => 5,
 					],
 				],
+			]],
+		];
+	}
+
+	/**
+	 * @dataProvider validationArrayDataCaseProvider
+	 *
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/4510
+	 *
+	 * @param boolean $expected
+	 * @param array $rules
+	 * @param array $data
+	 *
+	 * @return void
+	 */
+	public function testValidationOfArrayData(bool $expected, array $rules, array $data): void
+	{
+		$actual = $this->validation->setRules($rules)->run($data);
+		$this->assertSame($expected, $actual);
+	}
+
+	public function validationArrayDataCaseProvider(): iterable
+	{
+		yield 'fail-empty-string' => [
+			false,
+			['bar.*.foo' => 'required'],
+			['bar' => [
+				['foo' => 'baz'],
+				['foo' => ''],
+			]],
+		];
+
+		yield 'pass-nonempty-string' => [
+			true,
+			['bar.*.foo' => 'required'],
+			['bar' => [
+				['foo' => 'baz'],
+				['foo' => 'boz'],
+			]],
+		];
+
+		yield 'fail-empty-array' => [
+			false,
+			['bar.*.foo' => 'required'],
+			['bar' => [
+				['foo' => 'baz'],
+				['foo' => []],
+			]],
+		];
+
+		yield 'pass-nonempty-array' => [
+			true,
+			['bar.*.foo' => 'required'],
+			['bar' => [
+				['foo' => 'baz'],
+				['foo' => ['boz']],
 			]],
 		];
 	}

--- a/user_guide_src/source/changelogs/v4.1.2.rst
+++ b/user_guide_src/source/changelogs/v4.1.2.rst
@@ -24,6 +24,7 @@ Changes:
 - ``Entity::castAsJson`` uses external cast handler ``JsonCast::get``.
 - ``Entity::mutateDate`` uses external cast handler ``DatetimeCast::get``.
 - In order for ``Config\**`` classes to get their respective properties' values from the ``.env``, it is now necessary to namespace the property with the name of the class. Previously, the property names are enough but now disallowed because it can get system environment variables, like ``PATH``.
+- The array helper ``_array_search_dot`` is now marked for ``@internal`` use. As this is used by ``dot_array_search``, users should not use ``_array_search_dot`` directly in their code.
 
 Deprecations:
 


### PR DESCRIPTION
**Description**
Fixes #4510 

This changes the behavior of `_array_search_dot`. Currently, the function returns early when it matched a non-null element in its value traversal, leaving the remaining elements in the loop as untouched. This PR accumulates the finds in an array, filters out the nulls. If resulting array contains only one element, then we'll return that element instead of an array in order to preserve BC. Otherwise, an array containing matches will be returned.

@luispastendev, can you check this? This passes locally on your use case .

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
