### PR TITLE
Non-persistent fake

### DIFF
--- a/system/Helpers/test_helper.php
+++ b/system/Helpers/test_helper.php
@@ -26,7 +26,7 @@ if (! function_exists('fake'))
 	 *
 	 * @return object|array
 	 */
-	function fake($model, array $overrides = null)
+	function fake($model, array $overrides = null, $persist = true)
 	{
 		// Get a model-appropriate Fabricator instance
 		$fabricator = new Fabricator($model);
@@ -37,6 +37,11 @@ if (! function_exists('fake'))
 			$fabricator->setOverrides($overrides);
 		}
 
-		return $fabricator->create();
+		if ($persist)
+		{
+			return $fabricator->create();
+		}
+
+		return $fabricator->make();
 	}
 }

--- a/tests/system/Database/Live/FabricatorLiveTest.php
+++ b/tests/system/Database/Live/FabricatorLiveTest.php
@@ -79,4 +79,12 @@ class FabricatorLiveTest extends CIUnitTestCase
 
 		fake(ValidModel::class, ['name' => 'eh']);
 	}
+
+	public function testHelperDoesNotPersist()
+	{
+		helper('test');
+		$result = fake(UserModel::class, ['name' => 'Derek'], false);
+		$this->assertEquals('Derek', $result->name);
+		$this->dontSeeInDatabase('user', ['name' => 'Derek']);
+	}
 }

--- a/user_guide_src/source/testing/fabricator.rst
+++ b/user_guide_src/source/testing/fabricator.rst
@@ -217,7 +217,7 @@ Test Helper
 ===========
 
 Often all you will need is a one-and-done fake object for testing. The Test Helper provides
-the ``fake($model, $overrides)`` function to do just this::
+the ``fake($model, $overrides, $persist = true)`` function to do just this::
 
     helper('test');
     $user = fake('App\Models\UserModel', ['name' => 'Gerry']);
@@ -227,6 +227,8 @@ This is equivalent to::
     $fabricator = new Fabricator('App\Models\UserModel');
     $fabricator->setOverrides(['name' => 'Gerry']);
     $user = $fabricator->create();
+
+If you just need a fake object without saving it to the database you can pass false into the persist parameter.
 
 Table Counts
 ============


### PR DESCRIPTION

**Description**
Added a parameter to the fake() test helper so that you can use it without saving the object in the database.


**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
