### PR TITLE
[Feat][Autoloader] Allow autoloading non-class files

### DIFF
--- a/app/Config/Autoload.php
+++ b/app/Config/Autoload.php
@@ -6,7 +6,7 @@ use CodeIgniter\Config\AutoloadConfig;
 
 /**
  * -------------------------------------------------------------------
- * AUTO-LOADER
+ * AUTOLOADER CONFIGURATION
  * -------------------------------------------------------------------
  *
  * This file defines the namespaces and class maps so the Autoloader
@@ -31,12 +31,12 @@ class Autoload extends AutoloadConfig
 	 * else you will need to modify all of those classes for this to work.
 	 *
 	 * Prototype:
-	 *
+	 *```
 	 *   $psr4 = [
 	 *       'CodeIgniter' => SYSTEMPATH,
 	 *       'App'	       => APPPATH
 	 *   ];
-	 *
+	 *```
 	 * @var array<string, string>
 	 */
 	public $psr4 = [
@@ -55,12 +55,30 @@ class Autoload extends AutoloadConfig
 	 * were being autoloaded through a namespace.
 	 *
 	 * Prototype:
-	 *
+	 *```
 	 *   $classmap = [
 	 *       'MyClass'   => '/path/to/class/file.php'
 	 *   ];
-	 *
+	 *```
 	 * @var array<string, string>
 	 */
 	public $classmap = [];
+
+	/**
+	 * -------------------------------------------------------------------
+	 * Files
+	 * -------------------------------------------------------------------
+	 * The files array provides a list of paths to __non-class__ files
+	 * that will be autoloaded. This can be useful for bootstrap operations
+	 * or for loading functions.
+	 *
+	 * Prototype:
+	 * ```
+	 *	  $files = [
+	 *	 	   '/path/to/my/file.php',
+	 *    ];
+	 * ```
+	 * @var array<int, string>
+	 */
+	public $files = [];
 }

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -70,6 +70,13 @@ class Autoloader
 	protected $classmap = [];
 
 	/**
+	 * Stores files as a list.
+	 *
+	 * @var array<int, string>
+	 */
+	protected $files = [];
+
+	/**
 	 * Reads in the configuration array (described above) and stores
 	 * the valid parts that we'll need.
 	 *
@@ -97,6 +104,11 @@ class Autoloader
 			$this->classmap = $config->classmap;
 		}
 
+		if (isset($config->files))
+		{
+			$this->files = $config->files;
+		}
+
 		// Should we load through Composer's namespaces, also?
 		if ($modules->discoverInComposer)
 		{
@@ -116,6 +128,12 @@ class Autoloader
 
 		// Now prepend another loader for the files in our class map.
 		spl_autoload_register([$this, 'loadClassmap'], true, true); // @phpstan-ignore-line
+
+		// Load our non-class files
+		foreach ($this->files as $file)
+		{
+			$this->includeFile($file);
+		}
 	}
 
 	/**

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -132,7 +132,10 @@ class Autoloader
 		// Load our non-class files
 		foreach ($this->files as $file)
 		{
-			$this->includeFile($file);
+			if (is_string($file))
+			{
+				$this->includeFile($file);
+			}
 		}
 	}
 

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -12,7 +12,7 @@
 namespace CodeIgniter\Config;
 
 /**
- * AUTOLOADER
+ * AUTOLOADER CONFIGURATION
  *
  * This file defines the namespaces and class maps so the Autoloader
  * can find the files as needed.
@@ -32,7 +32,7 @@ class AutoloadConfig
 	 * but this should be done prior to creating any namespaced classes,
 	 * else you will need to modify all of those classes for this to work.
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	public $psr4 = [];
 
@@ -46,9 +46,21 @@ class AutoloadConfig
 	 * searched for within one or more directories as they would if they
 	 * were being autoloaded through a namespace.
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	public $classmap = [];
+
+	/**
+	 * -------------------------------------------------------------------
+	 * Files
+	 * -------------------------------------------------------------------
+	 * The files array provides a list of paths to __non-class__ files
+	 * that will be autoloaded. This can be useful for bootstrap operations
+	 * or for loading functions.
+	 *
+	 * @var array<int, string>
+	 */
+	public $files = [];
 
 	/**
 	 * -------------------------------------------------------------------
@@ -61,7 +73,7 @@ class AutoloadConfig
 	 * Do not change the name of the CodeIgniter namespace or your application
 	 * will break.
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	protected $corePsr4 = [
 		'CodeIgniter' => SYSTEMPATH,
@@ -78,7 +90,7 @@ class AutoloadConfig
 	 * searched for within one or more directories as they would if they
 	 * were being autoloaded through a namespace.
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	protected $coreClassmap = [
 		'Psr\Log\AbstractLogger'           => SYSTEMPATH . 'ThirdParty/PSR/Log/AbstractLogger.php',
@@ -92,7 +104,15 @@ class AutoloadConfig
 		'Laminas\Escaper\Escaper'          => SYSTEMPATH . 'ThirdParty/Escaper/Escaper.php',
 	];
 
-	//--------------------------------------------------------------------
+	/**
+	 * -------------------------------------------------------------------
+	 * Core Files
+	 * -------------------------------------------------------------------
+	 * List of files from the framework to be autoloaded early.
+	 *
+	 * @var array<int, string>
+	 */
+	protected $coreFiles = [];
 
 	/**
 	 * Constructor.
@@ -111,5 +131,6 @@ class AutoloadConfig
 
 		$this->psr4     = array_merge($this->corePsr4, $this->psr4);
 		$this->classmap = array_merge($this->coreClassmap, $this->classmap);
+		$this->files    = array_merge($this->coreFiles, $this->files);
 	}
 }

--- a/tests/_support/Autoloader/functions.php
+++ b/tests/_support/Autoloader/functions.php
@@ -1,0 +1,14 @@
+<?php
+
+if (! function_exists('autoload_foo'))
+{
+	function autoload_foo(): string
+	{
+		return 'I am autoloaded by Autoloader through $files!';
+	}
+}
+
+if (! defined('AUTOLOAD_CONSTANT'))
+{
+	define('AUTOLOAD_CONSTANT', 'foo');
+}

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -242,4 +242,20 @@ class AutoloaderTest extends CIUnitTestCase
 		$namespaces = $this->loader->getNamespace();
 		$this->assertArrayNotHasKey('Laminas\\Escaper', $namespaces);
 	}
+
+	public function testAutoloaderLoadsNonClassFiles(): void
+	{
+		$config = new Autoload();
+
+		$config->files[] = SUPPORTPATH . 'Autoloader/functions.php';
+
+		$this->loader = new Autoloader();
+		$this->loader->initialize($config, new Modules());
+		$this->loader->register();
+
+		$this->assertTrue(function_exists('autoload_foo'));
+		$this->assertSame('I am autoloaded by Autoloader through $files!', autoload_foo());
+		$this->assertTrue(defined('AUTOLOAD_CONSTANT'));
+		$this->assertSame('foo', AUTOLOAD_CONSTANT);
+	}
 }

--- a/user_guide_src/source/changelogs/v4.1.2.rst
+++ b/user_guide_src/source/changelogs/v4.1.2.rst
@@ -8,10 +8,11 @@ Release Date: Not released
 Enhancements:
 
 - New HTTP classes, ``Cookie`` and ``CookieStore``, for abstracting web cookies.
-- New `assertRedirectTo()` assertion available for HTTP tests.
+- New ``assertRedirectTo()`` assertion available for HTTP tests.
 - New logger handler, ``ErrorlogHandler``, that writes to ``error_log()``.
 - Entity. Added custom type casting functionality.
 - New option in routing. The ``priority`` option lower the priority of specific route processing.
+- The ``Autoloader`` class can now load files which do not contain PHP classes. The list of `non-class` files will be listed in the ``$files`` property of ``Config\Autoload`` class.
 
 Changes:
 

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -32,11 +32,10 @@ directory in the main project root::
 
 Open **app/Config/Autoload.php** and add the **Acme** namespace to the ``psr4`` array property::
 
-    $psr4 = [
-        'Config'        => APPPATH . 'Config',
-        APP_NAMESPACE   => APPPATH,                // For custom namespace
-        'App'           => APPPATH,                // To ensure filters, etc still found,
-        'Acme'          => ROOTPATH.'acme'
+    public $psr4 = [
+        APP_NAMESPACE => APPPATH, // For custom namespace
+        'Config'      => APPPATH . 'Config',
+        'Acme'        => ROOTPATH . 'acme',
     ];
 
 Now that this is set up, we can access any file within the **acme** folder through the ``Acme`` namespace. This alone
@@ -62,6 +61,27 @@ A common directory structure within a module will mimic the main application fol
 Of course, there is nothing forcing you to use this exact structure, and you should organize it in the manner that
 best suits your module, leaving out directories you don't need, creating new directories for Entities, Interfaces,
 or Repositories, etc.
+
+===========================
+Autoloading Non-class Files
+===========================
+
+More often than not that your module will not contain only PHP classes but also others like procedural
+functions, bootstrapping files, module constants files, etc. which are not normally loaded the way classes
+are loaded. One approach for this is using ``require``-ing the file(s) at the start of the file where it
+would be used.
+
+Another approach provided by CodeIgniter is to autoload these *non-class* files like how you would autoload
+your classes. All we need to do is provide the list of paths to those files and include them in the
+``$files`` property of your ``app/Config/Autoload.php`` file.
+
+::
+
+    public $files = [
+        'path/to/my/functions.php',
+        'path/to/my/constants.php',
+        'path/to/my/bootstrap.php',
+    ];
 
 ==============
 Auto-Discovery


### PR DESCRIPTION
**Description**
This PR now allows `Autoloader` to load **non-class files** beside classes. This is similar to Composer's `files` array in composer.json. A user will now need to put the list of paths to the files in `Config\Autoload::$files`` and CI4 will autoload these on autoload registration.

Fixes #4447 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
