### PR TITLE
Update will throw exception for null id

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2463,6 +2463,17 @@ class BaseBuilder
 			$this->where($where);
 		}
 
+		if (empty($this->QBWhere))
+		{
+			if (CI_DEBUG)
+			{
+				throw new DatabaseException('Updates are not allowed unless they contain a "where" or "like" clause.');
+			}
+			// @codeCoverageIgnoreStart
+			return false;
+			// @codeCoverageIgnoreEnd
+		}
+
 		if (! empty($limit))
 		{
 			if (! $this->canLimitWhereUpdates)

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -17,15 +17,11 @@ class UpdateTest extends CIUnitTestCase
 
 	public function testUpdateSetsAllWithoutWhere()
 	{
+		$this->expectException(DatabaseException::class);
+		$this->expectExceptionMessage('Updates are not allowed unless they contain a "where" or "like" clause.');
+
 		$this->db->table('user')
 					->update(['name' => 'Bobby']);
-
-		$result = $this->db->table('user')->get()->getResult();
-
-		$this->assertEquals('Bobby', $result[0]->name);
-		$this->assertEquals('Bobby', $result[1]->name);
-		$this->assertEquals('Bobby', $result[2]->name);
-		$this->assertEquals('Bobby', $result[3]->name);
 	}
 
 	//--------------------------------------------------------------------
@@ -226,18 +222,13 @@ class UpdateTest extends CIUnitTestCase
 	//--------------------------------------------------------------------
 
 	// @see https://codeigniter4.github.io/CodeIgniter4/database/query_builder.html#updating-data
-	public function testSetWithoutEscape()
+	public function testSetWithoutEscapeWillThrowException()
 	{
+		$this->expectException(DatabaseException::class);
+		$this->expectExceptionMessage('Updates are not allowed unless they contain a "where" or "like" clause.');
 		$this->db->table('job')
 				 ->set('description', 'name', false)
 				 ->update();
-
-		$result = $this->db->table('user')->get()->getResultArray();
-
-		$this->seeInDatabase('job', [
-			'name'        => 'Developer',
-			'description' => 'Developer',
-		]);
 	}
 
 }

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -2,6 +2,7 @@
 
 namespace CodeIgniter\Models;
 
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Entity\Entity;
 use stdClass;
@@ -80,6 +81,24 @@ final class UpdateModelTest extends LiveModelTestCase
 		$this->assertTrue($result);
 		$this->seeInDatabase('user', ['id' => 1, 'name' => 'Foo Bar']);
 		$this->seeInDatabase('user', ['id' => 2, 'name' => 'Foo Bar']);
+	}
+
+	public function testUpdateThrowDatabaseExceptionForNullId(): void
+	{
+		$data = [
+			'name'    => 'Foo',
+			'email'   => 'foo@example.com',
+			'country' => 'US',
+			'deleted' => 0,
+		];
+
+		$this->createModel(UserModel::class);
+		$this->model->insert($data);
+
+		$this->expectException(DatabaseException::class);
+		$this->expectExceptionMessage('Updates are not allowed unless they contain a "where" or "like" clause.');
+
+		$this->model->update(null, ['name' => 'Foo Bar']);
 	}
 
 	public function testUpdateResultFail(): void


### PR DESCRIPTION
#4617 
**Description**
Throwing an exception when null is provided instead of id to update. 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide