### PR TITLE
fix(cache): add check for redis empty results in deleteMatching

### DIFF
--- a/system/Cache/Handlers/DummyHandler.php
+++ b/system/Cache/Handlers/DummyHandler.php
@@ -93,7 +93,7 @@ class DummyHandler extends BaseHandler
 	 *
 	 * @param string $pattern Cache items glob-style pattern
 	 *
-	 * @return integer $deleted The number of deleted items
+	 * @return integer The number of deleted items
 	 */
 	public function deleteMatching(string $pattern)
 	{

--- a/system/Cache/Handlers/DummyHandler.php
+++ b/system/Cache/Handlers/DummyHandler.php
@@ -93,11 +93,11 @@ class DummyHandler extends BaseHandler
 	 *
 	 * @param string $pattern Cache items glob-style pattern
 	 *
-	 * @return boolean
+	 * @return integer $deleted The number of deleted items
 	 */
 	public function deleteMatching(string $pattern)
 	{
-		return true;
+		return 0;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -165,21 +165,21 @@ class FileHandler extends BaseHandler
 	 *
 	 * @param string $pattern Cache items glob-style pattern
 	 *
-	 * @return boolean
+	 * @return integer $deleted The number of deleted items
 	 */
 	public function deleteMatching(string $pattern)
 	{
-		$success = true;
+		$deleted = 0;
 
 		foreach (glob($this->path . $pattern) as $filename)
 		{
-			if (! is_file($filename) || ! @unlink($filename))
+			if (is_file($filename) && @unlink($filename))
 			{
-				$success = false;
+				$deleted++;
 			}
 		}
 
-		return $success;
+		return $deleted;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -165,13 +165,13 @@ class FileHandler extends BaseHandler
 	 *
 	 * @param string $pattern Cache items glob-style pattern
 	 *
-	 * @return integer $deleted The number of deleted items
+	 * @return integer The number of deleted items
 	 */
 	public function deleteMatching(string $pattern)
 	{
 		$deleted = 0;
 
-		foreach (glob($this->path . $pattern) as $filename)
+		foreach (glob($this->path . $pattern,  GLOB_NOSORT) as $filename)
 		{
 			if (is_file($filename) && @unlink($filename))
 			{

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -190,21 +190,19 @@ class PredisHandler extends BaseHandler
 	 *
 	 * @param string $pattern Cache items glob-style pattern
 	 *
-	 * @return integer $deleted The number of deleted items
+	 * @return integer The number of deleted items
 	 */
 	public function deleteMatching(string $pattern)
 	{
 		$deleted = 0;
+		$matchedKeys = [];
 
 		foreach (new Keyspace($this->redis, $pattern) as $key)
 		{
-			if ($this->redis->del($key) === 1)
-			{
-				$deleted++;
-			}
+			array_push($matchedKeys, $key);
 		}
 
-		return $deleted;
+		return $this->redis->del($matchedKeys);
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -199,7 +199,7 @@ class PredisHandler extends BaseHandler
 
 		foreach (new Keyspace($this->redis, $pattern) as $key)
 		{
-			array_push($matchedKeys, $key);
+			$matchedKeys[] = $key;
 		}
 
 		return $this->redis->del($matchedKeys);

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -190,21 +190,21 @@ class PredisHandler extends BaseHandler
 	 *
 	 * @param string $pattern Cache items glob-style pattern
 	 *
-	 * @return boolean
+	 * @return integer $deleted The number of deleted items
 	 */
 	public function deleteMatching(string $pattern)
 	{
-		$success = true;
+		$deleted = 0;
 
 		foreach (new Keyspace($this->redis, $pattern) as $key)
 		{
-			if ($this->redis->del($key) !== 1)
+			if ($this->redis->del($key) === 1)
 			{
-				$success = false;
+				$deleted++;
 			}
 		}
 
-		return $success;
+		return $deleted;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -228,11 +228,11 @@ class RedisHandler extends BaseHandler
 	 *
 	 * @param string $pattern Cache items glob-style pattern
 	 *
-	 * @return integer $deleted The number of deleted items
+	 * @return integer The number of deleted items
 	 */
 	public function deleteMatching(string $pattern)
 	{
-		$deleted  = 0;
+		$matchedKeys = [];
 		$iterator = null;
 
 		do
@@ -245,16 +245,13 @@ class RedisHandler extends BaseHandler
 			{
 				foreach ($keys as $key)
 				{
-					if ($this->redis->del($key) === 1)
-					{
-						$deleted++;
-					}
+					array_push($matchedKeys, $key);
 				}
 			}
 		}
 		while ($iterator > 0); // @phpstan-ignore-line
 
-		return $deleted;
+		return $this->redis->del($matchedKeys);
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -228,25 +228,33 @@ class RedisHandler extends BaseHandler
 	 *
 	 * @param string $pattern Cache items glob-style pattern
 	 *
-	 * @return boolean
+	 * @return integer $deleted The number of deleted items
 	 */
 	public function deleteMatching(string $pattern)
 	{
-		$success  = true;
+		$deleted  = 0;
 		$iterator = null;
 
-		while ($keys = $this->redis->scan($iterator, $pattern))
+		do
 		{
-			foreach ($keys as $key)
+			// Scan for some keys
+			$keys = $this->redis->scan($iterator, $pattern);
+
+			// Redis may return empty results, so protect against that
+			if ($keys !== false)
 			{
-				if ($this->redis->del($key) !== 1)
+				foreach ($keys as $key)
 				{
-					$success = false;
+					if ($this->redis->del($key) === 1)
+					{
+						$deleted++;
+					}
 				}
 			}
 		}
+		while ($iterator > 0); // @phpstan-ignore-line
 
-		return $success;
+		return $deleted;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -245,7 +245,7 @@ class RedisHandler extends BaseHandler
 			{
 				foreach ($keys as $key)
 				{
-					array_push($matchedKeys, $key);
+					$matchedKeys[] = $key;
 				}
 			}
 		}

--- a/tests/system/Cache/Handlers/DummyHandlerTest.php
+++ b/tests/system/Cache/Handlers/DummyHandlerTest.php
@@ -43,7 +43,7 @@ class DummyHandlerTest extends CIUnitTestCase
 
 	public function testDeleteMatching()
 	{
-		$this->assertTrue($this->dummyHandler->deleteMatching('key*'));
+		$this->assertSame(0, $this->dummyHandler->deleteMatching('key*'));
 	}
 
 	public function testIncrement()

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -13,7 +13,6 @@ class FileHandlerTest extends CIUnitTestCase
 	private static $key1      = 'key1';
 	private static $key2      = 'key2';
 	private static $key3      = 'key3';
-	private static $key4      = 'another_key';
 
 	private static function getKeyArray()
 	{
@@ -21,7 +20,6 @@ class FileHandlerTest extends CIUnitTestCase
 			self::$key1,
 			self::$key2,
 			self::$key3,
-			self::$key4,
 		];
 	}
 
@@ -135,24 +133,42 @@ class FileHandlerTest extends CIUnitTestCase
 		$this->assertFalse($this->fileHandler->delete(self::$dummy));
 	}
 
-	public function testDeleteMatching()
+	public function testDeleteMatchingPrefix()
 	{
-		$this->fileHandler->save(self::$key1, 'value');
-		$this->fileHandler->save(self::$key2, 'value2');
-		$this->fileHandler->save(self::$key3, 'value3');
-		$this->fileHandler->save(self::$key4, 'value4');
+		// Save 101 items to match on
+		for ($i = 1; $i <= 101; $i++)
+		{
+			$this->fileHandler->save('key_' . $i, 'value' . $i);
+		}
 
-		$this->assertSame('value', $this->fileHandler->get(self::$key1));
-		$this->assertSame('value2', $this->fileHandler->get(self::$key2));
-		$this->assertSame('value3', $this->fileHandler->get(self::$key3));
-		$this->assertSame('value4', $this->fileHandler->get(self::$key4));
+		// check that there are 101 items is cache store
+		$this->assertSame(101, count($this->fileHandler->getCacheInfo()));
 
-		$this->assertTrue($this->fileHandler->deleteMatching('key*'));
+		// Checking that given the prefix "key_1", deleteMatching deletes 13 keys:
+		// (key_1, key_10, key_11, key_12, key_13, key_14, key_15, key_16, key_17, key_18, key_19, key_100, key_101)
+		$this->assertSame(13, $this->fileHandler->deleteMatching('key_1*'));
 
-		$this->assertNull($this->fileHandler->get(self::$key1));
-		$this->assertNull($this->fileHandler->get(self::$key2));
-		$this->assertNull($this->fileHandler->get(self::$key3));
-		$this->assertSame('value4', $this->fileHandler->get(self::$key4));
+		// check that there remains (101 - 13) = 88 items is cache store
+		$this->assertSame(88, count($this->fileHandler->getCacheInfo()));
+	}
+
+	public function testDeleteMatchingSuffix()
+	{
+		// Save 101 items to match on
+		for ($i = 1; $i <= 101; $i++)
+		{
+			$this->fileHandler->save('key_' . $i, 'value' . $i);
+		}
+
+		// check that there are 101 items is cache store
+		$this->assertSame(101, count($this->fileHandler->getCacheInfo()));
+
+		// Checking that given the suffix "1", deleteMatching deletes 11 keys:
+		// (key_1, key_11, key_21, key_31, key_41, key_51, key_61, key_71, key_81, key_91, key_101)
+		$this->assertSame(11, $this->fileHandler->deleteMatching('*1'));
+
+		// check that there remains (101 - 13) = 88 items is cache store
+		$this->assertSame(90, count($this->fileHandler->getCacheInfo()));
 	}
 
 	public function testIncrement()

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -150,6 +150,9 @@ class FileHandlerTest extends CIUnitTestCase
 
 		// check that there remains (101 - 13) = 88 items is cache store
 		$this->assertSame(88, count($this->fileHandler->getCacheInfo()));
+
+		// Clear all files
+		$this->fileHandler->clean();
 	}
 
 	public function testDeleteMatchingSuffix()
@@ -169,6 +172,9 @@ class FileHandlerTest extends CIUnitTestCase
 
 		// check that there remains (101 - 13) = 88 items is cache store
 		$this->assertSame(90, count($this->fileHandler->getCacheInfo()));
+
+		// Clear all files
+		$this->fileHandler->clean();
 	}
 
 	public function testIncrement()

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -12,7 +12,6 @@ class PredisHandlerTest extends CIUnitTestCase
 	private static $key1 = 'key1';
 	private static $key2 = 'key2';
 	private static $key3 = 'key3';
-	private static $key4 = 'another_key';
 
 	private static function getKeyArray()
 	{
@@ -20,7 +19,6 @@ class PredisHandlerTest extends CIUnitTestCase
 			self::$key1,
 			self::$key2,
 			self::$key3,
-			self::$key4,
 		];
 	}
 
@@ -100,24 +98,42 @@ class PredisHandlerTest extends CIUnitTestCase
 		$this->assertFalse($this->PredisHandler->delete(self::$dummy));
 	}
 
-	public function testDeleteMatching()
+	public function testDeleteMatchingPrefix()
 	{
-		$this->PredisHandler->save(self::$key1, 'value');
-		$this->PredisHandler->save(self::$key2, 'value2');
-		$this->PredisHandler->save(self::$key3, 'value3');
-		$this->PredisHandler->save(self::$key4, 'value4');
+		// Save 101 items to match on
+		for ($i = 1; $i <= 101; $i++)
+		{
+			$this->PredisHandler->save('key_' . $i, 'value' . $i);
+		}
 
-		$this->assertSame('value', $this->PredisHandler->get(self::$key1));
-		$this->assertSame('value2', $this->PredisHandler->get(self::$key2));
-		$this->assertSame('value3', $this->PredisHandler->get(self::$key3));
-		$this->assertSame('value4', $this->PredisHandler->get(self::$key4));
+		// check that there are 101 items is cache store
+		$this->assertSame('101', $this->PredisHandler->getCacheInfo()['Keyspace']['db0']['keys']);
 
-		$this->assertTrue($this->PredisHandler->deleteMatching('key*'));
+		// Checking that given the prefix "key_1", deleteMatching deletes 13 keys:
+		// (key_1, key_10, key_11, key_12, key_13, key_14, key_15, key_16, key_17, key_18, key_19, key_100, key_101)
+		$this->assertSame(13, $this->PredisHandler->deleteMatching('key_1*'));
 
-		$this->assertNull($this->PredisHandler->get(self::$key1));
-		$this->assertNull($this->PredisHandler->get(self::$key2));
-		$this->assertNull($this->PredisHandler->get(self::$key3));
-		$this->assertSame('value4', $this->PredisHandler->get(self::$key4));
+		// check that there remains (101 - 13) = 88 items is cache store
+		$this->assertSame('88', $this->PredisHandler->getCacheInfo()['Keyspace']['db0']['keys']);
+	}
+
+	public function testDeleteMatchingSuffix()
+	{
+		// Save 101 items to match on
+		for ($i = 1; $i <= 101; $i++)
+		{
+			$this->PredisHandler->save('key_' . $i, 'value' . $i);
+		}
+
+		// check that there are 101 items is cache store
+		$this->assertSame('101', $this->PredisHandler->getCacheInfo()['Keyspace']['db0']['keys']);
+
+		// Checking that given the suffix "1", deleteMatching deletes 11 keys:
+		// (key_1, key_11, key_21, key_31, key_41, key_51, key_61, key_71, key_81, key_91, key_101)
+		$this->assertSame(11, $this->PredisHandler->deleteMatching('*1'));
+
+		// check that there remains (101 - 13) = 88 items is cache store
+		$this->assertSame('90', $this->PredisHandler->getCacheInfo()['Keyspace']['db0']['keys']);
 	}
 
 	public function testClean()

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -136,23 +136,22 @@ Class Reference
 
         $cache->delete('cache_item_id');
 
-.. php:method:: deleteMatching($pattern): bool
+.. php:method:: deleteMatching($pattern): integer
 
     :param string $pattern: glob-style pattern to match cached items keys
-    :returns: ``true`` on success, ``false`` if one of the deletes fails
-    :rtype: bool
+    :returns: number of deleted items
+    :rtype: integer
 
     This method will delete multiple items from the cache store at once by
-    matching their keys against a glob pattern.
-    If one of the cache item deletion fails, the method will return FALSE.
+    matching their keys against a glob-style pattern. It will return the total number of deleted items.
 
     .. important:: This method is only implemented for File, Redis and Predis handlers.
         Due to limitations, it couldn't be implemented for Memcached and Wincache handlers.
 
     Example::
 
-        $cache->deleteMatching('prefix_*'); // deletes all keys starting with "prefix_"
-        $cache->deleteMatching('*_suffix'); // deletes all keys ending with "_suffix"
+        $cache->deleteMatching('prefix_*'); // deletes all items of which keys start with "prefix_"
+        $cache->deleteMatching('*_suffix'); // deletes all items of which keys end with "_suffix"
 
     For more information on glob-style syntax, please see
         `https://en.wikipedia.org/wiki/Glob_(programming) <https://en.wikipedia.org/wiki/Glob_(programming)#Syntax>`_.


### PR DESCRIPTION
**Description**

The deleteMatching implementation for the RedisHandler is not deleting all matching cache items as intended.
This PR is meant to fix that bug and fix the tests that were supposed to fail.

Also, the deleteMatching method now returns the number of deleted items as it is offers better feedback than true/false (mainly for testing purposes).

Thanks to @benjaminbellamy for the heads up!

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide