### PR TITLE
Cache getMetadata() Format

### DIFF
--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -108,7 +108,10 @@ interface CacheInterface
 	 *
 	 * @param string $key Cache item name.
 	 *
-	 * @return mixed
+	 * @return array|false|null
+	 *   Returns null if the item does not exist, otherwise array<string, mixed>
+	 *   with at least the 'expires' key for absolute epoch expiry.
+	 *   Some handlers may return false when an item does not exist, which is deprecated.
 	 */
 	public function getMetaData(string $key);
 

--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -110,7 +110,7 @@ interface CacheInterface
 	 *
 	 * @return array|false|null
 	 *   Returns null if the item does not exist, otherwise array<string, mixed>
-	 *   with at least the 'expires' key for absolute epoch expiry.
+	 *   with at least the 'expires' key for absolute epoch expiry (or null).
 	 *   Some handlers may return false when an item does not exist, which is deprecated.
 	 */
 	public function getMetaData(string $key);

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -282,7 +282,10 @@ class FileHandler extends BaseHandler
 	 *
 	 * @param string $key Cache item name.
 	 *
-	 * @return mixed
+	 * @return array|false|null
+	 *   Returns null if the item does not exist, otherwise array<string, mixed>
+	 *   with at least the 'expires' key for absolute epoch expiry.
+	 *   Some handlers may return false when an item does not exist, which is deprecated.
 	 */
 	public function getMetaData(string $key)
 	{
@@ -290,7 +293,7 @@ class FileHandler extends BaseHandler
 
 		if (! is_file($this->path . $key))
 		{
-			return false;
+			return false; // This will return null in a future release
 		}
 
 		$data = @unserialize(file_get_contents($this->path . $key));
@@ -301,17 +304,17 @@ class FileHandler extends BaseHandler
 
 			if (! isset($data['ttl']))
 			{
-				return false;
+				return false; // This will return null in a future release
 			}
 
 			return [
-				'expire' => $mtime + $data['ttl'],
+				'expire' => $data['time'] + $data['ttl'],
 				'mtime'  => $mtime,
 				'data'   => $data['data'],
 			];
 		}
 
-		return false;
+		return false; // This will return null in a future release
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -344,7 +344,7 @@ class MemcachedHandler extends BaseHandler
 	 *
 	 * @return array|false|null
 	 *   Returns null if the item does not exist, otherwise array<string, mixed>
-	 *   with at least the 'expires' key for absolute epoch expiry.
+	 *   with at least the 'expires' key for absolute epoch expiry (or null).
 	 *   Some handlers may return false when an item does not exist, which is deprecated.
 	 */
 	public function getMetaData(string $key)
@@ -359,10 +359,13 @@ class MemcachedHandler extends BaseHandler
 			return false; // This will return null in a future release
 		}
 
-		list($data, $time, $ttl) = $stored;
+		list($data, $time, $limit) = $stored;
+
+		// Calculate the remaining time to live from the original limit
+		$ttl = time() - $time - $limit;
 
 		return [
-			'expire' => $time + $ttl,
+			'expire' => $limit > 0 ? $time + $limit : null,
 			'mtime'  => $time,
 			'data'   => $data,
 		];

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -342,7 +342,10 @@ class MemcachedHandler extends BaseHandler
 	 *
 	 * @param string $key Cache item name.
 	 *
-	 * @return mixed
+	 * @return array|false|null
+	 *   Returns null if the item does not exist, otherwise array<string, mixed>
+	 *   with at least the 'expires' key for absolute epoch expiry.
+	 *   Some handlers may return false when an item does not exist, which is deprecated.
 	 */
 	public function getMetaData(string $key)
 	{
@@ -353,7 +356,7 @@ class MemcachedHandler extends BaseHandler
 		// if not an array, don't try to count for PHP7.2
 		if (! is_array($stored) || count($stored) !== 3)
 		{
-			return false;
+			return false; // This will return null in a future release
 		}
 
 		list($data, $time, $ttl) = $stored;

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -271,7 +271,9 @@ class PredisHandler extends BaseHandler
 	 *
 	 * @param string $key Cache item name.
 	 *
-	 * @return mixed
+	 * @return array|false|null
+	 *   Returns null if the item does not exist, otherwise array<string, mixed>
+	 *   with at least the 'expires' key for absolute epoch expiry.
 	 */
 	public function getMetaData(string $key)
 	{

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -273,7 +273,7 @@ class PredisHandler extends BaseHandler
 	 *
 	 * @return array|false|null
 	 *   Returns null if the item does not exist, otherwise array<string, mixed>
-	 *   with at least the 'expires' key for absolute epoch expiry.
+	 *   with at least the 'expires' key for absolute epoch expiry (or null).
 	 */
 	public function getMetaData(string $key)
 	{
@@ -282,8 +282,10 @@ class PredisHandler extends BaseHandler
 		if (isset($data['__ci_value']) && $data['__ci_value'] !== false)
 		{
 			$time = time();
+			$ttl  = $this->redis->ttl($key);
+
 			return [
-				'expire' => $time + $this->redis->ttl($key),
+				'expire' => $ttl > 0 ? time() + $ttl : null,
 				'mtime'  => $time,
 				'data'   => $data['__ci_value'],
 			];

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -317,7 +317,9 @@ class RedisHandler extends BaseHandler
 	 *
 	 * @param string $key Cache item name.
 	 *
-	 * @return mixed
+	 * @return array|null
+	 *   Returns null if the item does not exist, otherwise array<string, mixed>
+	 *   with at least the 'expires' key for absolute epoch expiry.
 	 */
 	public function getMetaData(string $key)
 	{

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -319,7 +319,7 @@ class RedisHandler extends BaseHandler
 	 *
 	 * @return array|null
 	 *   Returns null if the item does not exist, otherwise array<string, mixed>
-	 *   with at least the 'expires' key for absolute epoch expiry.
+	 *   with at least the 'expires' key for absolute epoch expiry (or null).
 	 */
 	public function getMetaData(string $key)
 	{
@@ -330,8 +330,10 @@ class RedisHandler extends BaseHandler
 		if ($value !== null)
 		{
 			$time = time();
+			$ttl  = $this->redis->ttl($key);
+
 			return [
-				'expire' => $time + $this->redis->ttl($key),
+				'expire' => $ttl > 0 ? time() + $ttl : null,
 				'mtime'  => $time,
 				'data'   => $value,
 			];

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -71,7 +71,7 @@ class WincacheHandler extends BaseHandler
 		$data    = wincache_ucache_get($key, $success);
 
 		// Success returned by reference from wincache_ucache_get()
-		return ($success) ? $data : null;
+		return $success ? $data : null;
 	}
 
 	//--------------------------------------------------------------------
@@ -147,7 +147,7 @@ class WincacheHandler extends BaseHandler
 		$success = false;
 		$value   = wincache_ucache_inc($key, $offset, $success);
 
-		return ($success === true) ? $value : false; // @phpstan-ignore-line
+		return $success ? $value : false; // @phpstan-ignore-line
 	}
 
 	//--------------------------------------------------------------------
@@ -169,7 +169,7 @@ class WincacheHandler extends BaseHandler
 		$success = false;
 		$value   = wincache_ucache_dec($key, $offset, $success);
 
-		return ($success === true) ? $value : false; // @phpstan-ignore-line
+		return $success ? $value : false; // @phpstan-ignore-line
 	}
 
 	//--------------------------------------------------------------------
@@ -210,7 +210,10 @@ class WincacheHandler extends BaseHandler
 	 *
 	 * @param string $key Cache item name.
 	 *
-	 * @return mixed
+	 * @return array|false|null
+	 *   Returns null if the item does not exist, otherwise array<string, mixed>
+	 *   with at least the 'expires' key for absolute epoch expiry.
+	 *   Some handlers may return false when an item does not exist, which is deprecated.
 	 *
 	 * @codeCoverageIgnore
 	 */
@@ -225,14 +228,14 @@ class WincacheHandler extends BaseHandler
 			$hitcount = $stored['ucache_entries'][1]['hitcount'];
 
 			return [
-				'expire'   => $ttl - $age,
+				'expire'   => time() + $ttl,
 				'hitcount' => $hitcount,
 				'age'      => $age,
 				'ttl'      => $ttl,
 			];
 		}
 
-		return false;
+		return false; // This will return null in a future release
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -212,7 +212,7 @@ class WincacheHandler extends BaseHandler
 	 *
 	 * @return array|false|null
 	 *   Returns null if the item does not exist, otherwise array<string, mixed>
-	 *   with at least the 'expires' key for absolute epoch expiry.
+	 *   with at least the 'expires' key for absolute epoch expiry (or null).
 	 *   Some handlers may return false when an item does not exist, which is deprecated.
 	 *
 	 * @codeCoverageIgnore
@@ -228,7 +228,7 @@ class WincacheHandler extends BaseHandler
 			$hitcount = $stored['ucache_entries'][1]['hitcount'];
 
 			return [
-				'expire'   => time() + $ttl,
+				'expire'   => $ttl > 0 ? time() + $ttl : null,
 				'hitcount' => $hitcount,
 				'age'      => $age,
 				'ttl'      => $ttl,

--- a/user_guide_src/source/changelogs/v4.1.2.rst
+++ b/user_guide_src/source/changelogs/v4.1.2.rst
@@ -26,6 +26,7 @@ Changes:
 - ``Entity::mutateDate`` uses external cast handler ``DatetimeCast::get``.
 - In order for ``Config\**`` classes to get their respective properties' values from the ``.env``, it is now necessary to namespace the property with the name of the class. Previously, the property names are enough but now disallowed because it can get system environment variables, like ``PATH``.
 - The array helper ``_array_search_dot`` is now marked for ``@internal`` use. As this is used by ``dot_array_search``, users should not use ``_array_search_dot`` directly in their code.
+- ``CacheInterface::getMetaData()`` returns have been specified to be null or and array with at least the "expires" key (absolute epoch expiration); on misses the File, Memcached, and Wincache Handlers still return ``false`` which will become ``null` in a future release.
 
 Deprecations:
 

--- a/user_guide_src/source/changelogs/v4.1.2.rst
+++ b/user_guide_src/source/changelogs/v4.1.2.rst
@@ -26,7 +26,7 @@ Changes:
 - ``Entity::mutateDate`` uses external cast handler ``DatetimeCast::get``.
 - In order for ``Config\**`` classes to get their respective properties' values from the ``.env``, it is now necessary to namespace the property with the name of the class. Previously, the property names are enough but now disallowed because it can get system environment variables, like ``PATH``.
 - The array helper ``_array_search_dot`` is now marked for ``@internal`` use. As this is used by ``dot_array_search``, users should not use ``_array_search_dot`` directly in their code.
-- ``CacheInterface::getMetaData()`` returns have been specified to be null or and array with at least the "expires" key (absolute epoch expiration); on misses the File, Memcached, and Wincache Handlers still return ``false`` which will become ``null` in a future release.
+- ``CacheInterface::getMetaData()`` returns ``null`` for misses, or an array with at least the "expires" key set to the absolute epoch expiration, or ``null`` for "never expires". The File, Memcached, and Wincache Handlers still return ``false`` which will become ``null`` in a future release.
 
 Deprecations:
 

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -216,8 +216,8 @@ Class Reference
 .. php:method:: getMetadata(string $key)
 
     :param string $key: Cache item name
-    :returns: Metadata for the cached item
-    :rtype: mixed
+    :returns: Metadata for the cached item with at least the "expires" key for absolute epoch expiry, ``null`` for missing items.
+    :rtype: array|null
 
     This method will return detailed information on a specific item in the
     cache.
@@ -227,7 +227,8 @@ Class Reference
         var_dump($cache->getMetadata('my_cached_item'));
 
 .. note:: The information returned and the structure of the data is dependent
-          on which adapter is being used.
+          on which adapter is being used. Some adapters (File, Memcached, Wincache)
+          still return ``false`` for missing items.
 
 *******
 Drivers

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -216,7 +216,7 @@ Class Reference
 .. php:method:: getMetadata(string $key)
 
     :param string $key: Cache item name
-    :returns: Metadata for the cached item with at least the "expires" key for absolute epoch expiry, ``null`` for missing items.
+    :returns: Metadata for the cached item. ``null`` for missing items, or an array with at least the "expire" key for absolute epoch expiry (``null`` for never expires).
     :rtype: array|null
 
     This method will return detailed information on a specific item in the


### PR DESCRIPTION
**Description**
`CacheInterface::getMetadata()` thus far returns a generic array of info "dependent on each adapter", as well as `false` or `null` for missing items (also dependent on each adapter). This PR attempts to standardize the expected return values while still leaving the `false` in place for now. Additionally:
* Fixes a bug where "expire" was not always an absolute time value
* Fixes a discrepancy between relative and absolute TTL values
* Adds support for `null` values to "expire" when a TTL was specified as "never expire"

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
