### PR TITLE
Expand Time for interface

### DIFF
--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -1253,19 +1253,18 @@ class Time extends DateTime
 	{
 		if ($time instanceof Time)
 		{
-			$time = $time->toDateTime()
-					->setTimezone(new DateTimeZone('UTC'));
-		}
-		elseif ($time instanceof DateTime || $time instanceof DateTimeImmutable)
-		{
-			$time = $time->setTimezone(new DateTimeZone('UTC'));
+			$time = $time->toDateTime();
 		}
 		elseif (is_string($time))
 		{
 			$timezone = $timezone ?: $this->timezone;
 			$timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone);
 			$time     = new DateTime($time, $timezone);
-			$time     = $time->setTimezone(new DateTimeZone('UTC'));
+		}
+
+		if ($time instanceof DateTime || $time instanceof DateTimeImmutable)
+		{
+			$time = $time->setTimezone(new DateTimeZone('UTC'));
 		}
 
 		return $time;

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -14,6 +14,8 @@ namespace CodeIgniter\I18n;
 use CodeIgniter\I18n\Exceptions\I18nException;
 use DateInterval;
 use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
 use DateTimeZone;
 use Exception;
 use IntlCalendar;
@@ -57,7 +59,7 @@ class Time extends DateTime
 	protected static $relativePattern = '/this|next|last|tomorrow|yesterday|midnight|today|[+-]|first|last|ago/i';
 
 	/**
-	 * @var \CodeIgniter\I18n\Time|DateTime|null
+	 * @var static|DateTimeInterface|null
 	 */
 	protected static $testNow;
 
@@ -301,6 +303,25 @@ class Time extends DateTime
 	//--------------------------------------------------------------------
 
 	/**
+	 * Takes an instance of DateTimeInterface and returns an instance of Time with it's same values.
+	 *
+	 * @param DateTimeInterface $dateTime
+	 * @param string|null       $locale
+	 *
+	 * @return Time
+	 * @throws Exception
+	 */
+	public static function createFromInstance(DateTimeInterface $dateTime, string $locale = null)
+	{
+		$date     = $dateTime->format('Y-m-d H:i:s');
+		$timezone = $dateTime->getTimezone();
+
+		return new Time($date, $timezone, $locale);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * Takes an instance of DateTime and returns an instance of Time with it's same values.
 	 *
 	 * @param DateTime    $dateTime
@@ -308,13 +329,13 @@ class Time extends DateTime
 	 *
 	 * @return Time
 	 * @throws Exception
+	 *
+	 * @deprecated         Use createFromInstance() instead
+	 * @codeCoverageIgnore
 	 */
 	public static function instance(DateTime $dateTime, string $locale = null)
 	{
-		$date     = $dateTime->format('Y-m-d H:i:s');
-		$timezone = $dateTime->getTimezone();
-
-		return new Time($date, $timezone, $locale);
+		return self::createFromInstance($dateTime, $locale);
 	}
 
 	//--------------------------------------------------------------------
@@ -341,9 +362,9 @@ class Time extends DateTime
 	 * Creates an instance of Time that will be returned during testing
 	 * when calling 'Time::now' instead of the current time.
 	 *
-	 * @param Time|DateTime|string|null $datetime
-	 * @param DateTimeZone|string|null  $timezone
-	 * @param string|null               $locale
+	 * @param Time|DateTimeInterface|string|null $datetime
+	 * @param DateTimeZone|string|null           $timezone
+	 * @param string|null                        $locale
 	 *
 	 * @throws Exception
 	 */
@@ -361,7 +382,7 @@ class Time extends DateTime
 		{
 			$datetime = new Time($datetime, $timezone, $locale);
 		}
-		elseif ($datetime instanceof DateTime && ! $datetime instanceof Time)
+		elseif ($datetime instanceof DateTimeInterface && ! $datetime instanceof Time)
 		{
 			$datetime = new Time($datetime->format('Y-m-d H:i:s'), $timezone);
 		}
@@ -1038,8 +1059,8 @@ class Time extends DateTime
 	 * and are not required to be in the same timezone, as both times are
 	 * converted to UTC and compared that way.
 	 *
-	 * @param Time|DateTime|string $testTime
-	 * @param string|null          $timezone
+	 * @param Time|DateTimeInterface|string $testTime
+	 * @param string|null                   $timezone
 	 *
 	 * @return boolean
 	 * @throws Exception
@@ -1060,15 +1081,15 @@ class Time extends DateTime
 	/**
 	 * Ensures that the times are identical, taking timezone into account.
 	 *
-	 * @param Time|DateTime|string $testTime
-	 * @param string|null          $timezone
+	 * @param Time|DateTimeInterface|string $testTime
+	 * @param string|null                   $timezone
 	 *
 	 * @return boolean
 	 * @throws Exception
 	 */
 	public function sameAs($testTime, string $timezone = null): bool
 	{
-		if ($testTime instanceof DateTime)
+		if ($testTime instanceof DateTimeInterface)
 		{
 			$testTime = $testTime->format('Y-m-d H:i:s');
 		}
@@ -1235,7 +1256,7 @@ class Time extends DateTime
 			$time = $time->toDateTime()
 					->setTimezone(new DateTimeZone('UTC'));
 		}
-		elseif ($time instanceof DateTime)
+		elseif ($time instanceof DateTime || $time instanceof DateTimeImmutable)
 		{
 			$time = $time->setTimezone(new DateTimeZone('UTC'));
 		}

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1004,12 +1004,11 @@ class TimeTest extends CIUnitTestCase
 	}
 
 	//--------------------------------------------------------------------
-	// Missing tests
 
-	public function testInstance()
+	public function testCreateFromInstance()
 	{
 		$datetime = new DateTime();
-		$time     = Time::instance($datetime);
+		$time     = Time::createFromInstance($datetime);
 		$this->assertTrue($time instanceof Time);
 		$this->assertTrue($time->sameAs($datetime));
 	}

--- a/user_guide_src/source/changelogs/v4.1.2.rst
+++ b/user_guide_src/source/changelogs/v4.1.2.rst
@@ -39,6 +39,7 @@ Deprecations:
 - Deprecated ``FeatureTestCase`` to use the ``FeatureTestTrait`` instead.
 - Deprecated ``ControllerTester`` to use the ``ControllerTestTrait`` instead.
 - Consolidated and deprecated ``ControllerResponse`` and ``FeatureResponse`` in favor of ``TestResponse``.
+- Deprecated ``Time::instance()``, use ``Time::createFromInstance()`` instead (now accepts ``DateTimeInterface``).
 
 Bugs Fixed:
 


### PR DESCRIPTION
**Description**
Many libraries use `DateTimeInterface` to allow `DateTime` or `DateTimeImmutable`. In a few cases in `Time` our functions are already compatible with either yet the docblocks limit it to `DateTime`. This PR expands the use for the interface, with one deprecation for an explicit method type.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
