### PR TITLE
[Cache] Allow covariant returns and optimize code

### DIFF
--- a/system/Cache/Handlers/DummyHandler.php
+++ b/system/Cache/Handlers/DummyHandler.php
@@ -23,7 +23,6 @@ class DummyHandler extends BaseHandler
 	 */
 	public function initialize()
 	{
-		// Nothing to see here...
 	}
 
 	//--------------------------------------------------------------------
@@ -33,7 +32,7 @@ class DummyHandler extends BaseHandler
 	 *
 	 * @param string $key Cache item name
 	 *
-	 * @return mixed
+	 * @return null
 	 */
 	public function get(string $key)
 	{
@@ -49,7 +48,7 @@ class DummyHandler extends BaseHandler
 	 * @param integer $ttl      Time to live
 	 * @param Closure $callback Callback return value
 	 *
-	 * @return mixed
+	 * @return null
 	 */
 	public function remember(string $key, int $ttl, Closure $callback)
 	{
@@ -108,7 +107,7 @@ class DummyHandler extends BaseHandler
 	 * @param string  $key    Cache ID
 	 * @param integer $offset Step/value to increase by
 	 *
-	 * @return mixed
+	 * @return boolean
 	 */
 	public function increment(string $key, int $offset = 1)
 	{
@@ -123,7 +122,7 @@ class DummyHandler extends BaseHandler
 	 * @param string  $key    Cache ID
 	 * @param integer $offset Step/value to increase by
 	 *
-	 * @return mixed
+	 * @return boolean
 	 */
 	public function decrement(string $key, int $offset = 1)
 	{
@@ -150,7 +149,7 @@ class DummyHandler extends BaseHandler
 	 * The information returned and the structure of the data
 	 * varies depending on the handler.
 	 *
-	 * @return mixed
+	 * @return null
 	 */
 	public function getCacheInfo()
 	{
@@ -164,7 +163,7 @@ class DummyHandler extends BaseHandler
 	 *
 	 * @param string $key Cache item name.
 	 *
-	 * @return mixed
+	 * @return null
 	 */
 	public function getMetaData(string $key)
 	{
@@ -182,6 +181,4 @@ class DummyHandler extends BaseHandler
 	{
 		return true;
 	}
-
-	//--------------------------------------------------------------------
 }

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -71,7 +71,7 @@ class FileHandler extends BaseHandler
 		}
 
 		$this->mode   = $config->file['mode'] ?? 0640;
-		$this->prefix = (string) $config->prefix;
+		$this->prefix = $config->prefix;
 	}
 
 	//--------------------------------------------------------------------
@@ -81,7 +81,6 @@ class FileHandler extends BaseHandler
 	 */
 	public function initialize()
 	{
-		// Not to see here...
 	}
 
 	//--------------------------------------------------------------------
@@ -190,7 +189,7 @@ class FileHandler extends BaseHandler
 	 * @param string  $key    Cache ID
 	 * @param integer $offset Step/value to increase by
 	 *
-	 * @return mixed
+	 * @return boolean
 	 */
 	public function increment(string $key, int $offset = 1)
 	{
@@ -223,7 +222,7 @@ class FileHandler extends BaseHandler
 	 * @param string  $key    Cache ID
 	 * @param integer $offset Step/value to increase by
 	 *
-	 * @return mixed
+	 * @return bool
 	 */
 	public function decrement(string $key, int $offset = 1)
 	{
@@ -268,7 +267,7 @@ class FileHandler extends BaseHandler
 	 * The information returned and the structure of the data
 	 * varies depending on the handler.
 	 *
-	 * @return mixed
+	 * @return array|false
 	 */
 	public function getCacheInfo()
 	{
@@ -534,6 +533,8 @@ class FileHandler extends BaseHandler
 			$returnedValues = explode(',', $returnedValues);
 		}
 
+		$fileInfo = [];
+
 		foreach ($returnedValues as $key)
 		{
 			switch ($key)
@@ -565,8 +566,6 @@ class FileHandler extends BaseHandler
 			}
 		}
 
-		return $fileInfo; // @phpstan-ignore-line
+		return $fileInfo;
 	}
-
-	//--------------------------------------------------------------------
 }

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -57,7 +57,7 @@ class MemcachedHandler extends BaseHandler
 	 */
 	public function __construct(Cache $config)
 	{
-		$this->prefix = (string) $config->prefix;
+		$this->prefix = $config->prefix;
 
 		if (! empty($config))
 		{
@@ -269,7 +269,7 @@ class MemcachedHandler extends BaseHandler
 	 * @param string  $key    Cache ID
 	 * @param integer $offset Step/value to increase by
 	 *
-	 * @return mixed
+	 * @return integer|false
 	 */
 	public function increment(string $key, int $offset = 1)
 	{
@@ -292,7 +292,7 @@ class MemcachedHandler extends BaseHandler
 	 * @param string  $key    Cache ID
 	 * @param integer $offset Step/value to increase by
 	 *
-	 * @return mixed
+	 * @return integer|false
 	 */
 	public function decrement(string $key, int $offset = 1)
 	{
@@ -328,7 +328,7 @@ class MemcachedHandler extends BaseHandler
 	 * The information returned and the structure of the data
 	 * varies depending on the handler.
 	 *
-	 * @return mixed
+	 * @return array|false
 	 */
 	public function getCacheInfo()
 	{
@@ -380,6 +380,6 @@ class MemcachedHandler extends BaseHandler
 	 */
 	public function isSupported(): bool
 	{
-		return (extension_loaded('memcached') || extension_loaded('memcache'));
+		return extension_loaded('memcached') || extension_loaded('memcache');
 	}
 }

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -58,7 +58,7 @@ class PredisHandler extends BaseHandler
 	 */
 	public function __construct(Cache $config)
 	{
-		$this->prefix = (string) $config->prefix;
+		$this->prefix = $config->prefix;
 
 		if (isset($config->redis))
 		{
@@ -101,10 +101,9 @@ class PredisHandler extends BaseHandler
 	 */
 	public function get(string $key)
 	{
-		$data = array_combine([
-			'__ci_type',
-			'__ci_value',
-		], $this->redis->hmget($key, ['__ci_type', '__ci_value'])
+		$data = array_combine(
+			['__ci_type', '__ci_value'],
+			$this->redis->hmget($key, ['__ci_type', '__ci_value'])
 		);
 
 		if (! isset($data['__ci_type'], $data['__ci_value']) || $data['__ci_value'] === false)
@@ -180,7 +179,7 @@ class PredisHandler extends BaseHandler
 	 */
 	public function delete(string $key)
 	{
-		return ($this->redis->del($key) === 1);
+		return $this->redis->del($key) === 1;
 	}
 
 	//--------------------------------------------------------------------
@@ -194,7 +193,6 @@ class PredisHandler extends BaseHandler
 	 */
 	public function deleteMatching(string $pattern)
 	{
-		$deleted = 0;
 		$matchedKeys = [];
 
 		foreach (new Keyspace($this->redis, $pattern) as $key)
@@ -213,7 +211,7 @@ class PredisHandler extends BaseHandler
 	 * @param string  $key    Cache ID
 	 * @param integer $offset Step/value to increase by
 	 *
-	 * @return mixed
+	 * @return integer
 	 */
 	public function increment(string $key, int $offset = 1)
 	{
@@ -228,7 +226,7 @@ class PredisHandler extends BaseHandler
 	 * @param string  $key    Cache ID
 	 * @param integer $offset Step/value to increase by
 	 *
-	 * @return mixed
+	 * @return integer
 	 */
 	public function decrement(string $key, int $offset = 1)
 	{
@@ -255,7 +253,7 @@ class PredisHandler extends BaseHandler
 	 * The information returned and the structure of the data
 	 * varies depending on the handler.
 	 *
-	 * @return mixed
+	 * @return array
 	 */
 	public function getCacheInfo()
 	{

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -57,7 +57,7 @@ class RedisHandler extends BaseHandler
 	 */
 	public function __construct(Cache $config)
 	{
-		$this->prefix = (string) $config->prefix;
+		$this->prefix = $config->prefix;
 
 		if (! empty($config))
 		{
@@ -72,7 +72,7 @@ class RedisHandler extends BaseHandler
 	 */
 	public function __destruct()
 	{
-		if ($this->redis) // @phpstan-ignore-line
+		if (isset($this->redis))
 		{
 			$this->redis->close();
 		}
@@ -218,7 +218,7 @@ class RedisHandler extends BaseHandler
 	{
 		$key = $this->prefix . $key;
 
-		return ($this->redis->del($key) === 1);
+		return $this->redis->del($key) === 1;
 	}
 
 	//--------------------------------------------------------------------
@@ -262,7 +262,7 @@ class RedisHandler extends BaseHandler
 	 * @param string  $key    Cache ID
 	 * @param integer $offset Step/value to increase by
 	 *
-	 * @return mixed
+	 * @return integer
 	 */
 	public function increment(string $key, int $offset = 1)
 	{
@@ -279,7 +279,7 @@ class RedisHandler extends BaseHandler
 	 * @param string  $key    Cache ID
 	 * @param integer $offset Step/value to increase by
 	 *
-	 * @return mixed
+	 * @return integer
 	 */
 	public function decrement(string $key, int $offset = 1)
 	{
@@ -308,7 +308,7 @@ class RedisHandler extends BaseHandler
 	 * The information returned and the structure of the data
 	 * varies depending on the handler.
 	 *
-	 * @return mixed
+	 * @return array
 	 */
 	public function getCacheInfo()
 	{
@@ -358,6 +358,4 @@ class RedisHandler extends BaseHandler
 	{
 		return extension_loaded('redis');
 	}
-
-	//--------------------------------------------------------------------
 }

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -16,8 +16,8 @@ use Exception;
 
 /**
  * Cache handler for WinCache from Microsoft & IIS.
- * Windows-only, so not testable on travis-ci.
- * Unusable methods flagged for code coverage ignoring.
+ *
+ * @codeCoverageIgnore
  */
 class WincacheHandler extends BaseHandler
 {
@@ -37,19 +37,16 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function __construct(Cache $config)
 	{
-		$this->prefix = (string) $config->prefix;
+		$this->prefix = $config->prefix;
 	}
 
 	//--------------------------------------------------------------------
 
 	/**
 	 * Takes care of any handler-specific setup that must be done.
-	 *
-	 * @codeCoverageIgnore
 	 */
 	public function initialize()
 	{
-		// Nothing to see here...
 	}
 
 	//--------------------------------------------------------------------
@@ -60,15 +57,12 @@ class WincacheHandler extends BaseHandler
 	 * @param string $key Cache item name
 	 *
 	 * @return mixed
-	 *
-	 * @codeCoverageIgnore
 	 */
 	public function get(string $key)
 	{
-		$key = $this->prefix . $key;
-
 		$success = false;
-		$data    = wincache_ucache_get($key, $success);
+
+		$data = wincache_ucache_get($this->prefix . $key, $success);
 
 		// Success returned by reference from wincache_ucache_get()
 		return $success ? $data : null;
@@ -84,14 +78,10 @@ class WincacheHandler extends BaseHandler
 	 * @param integer $ttl   Time To Live, in seconds (default 60)
 	 *
 	 * @return boolean Success or failure
-	 *
-	 * @codeCoverageIgnore
 	 */
 	public function save(string $key, $value, int $ttl = 60)
 	{
-		$key = $this->prefix . $key;
-
-		return wincache_ucache_set($key, $value, $ttl);
+		return wincache_ucache_set($this->prefix . $key, $value, $ttl);
 	}
 
 	//--------------------------------------------------------------------
@@ -102,14 +92,10 @@ class WincacheHandler extends BaseHandler
 	 * @param string $key Cache item name
 	 *
 	 * @return boolean Success or failure
-	 *
-	 * @codeCoverageIgnore
 	 */
 	public function delete(string $key)
 	{
-		$key = $this->prefix . $key;
-
-		return wincache_ucache_delete($key);
+		return wincache_ucache_delete($this->prefix . $key);
 	}
 
 	//--------------------------------------------------------------------
@@ -120,8 +106,6 @@ class WincacheHandler extends BaseHandler
 	 * @param string $pattern Cache items glob-style pattern
 	 *
 	 * @throws Exception
-	 *
-	 * @codeCoverageIgnore
 	 */
 	public function deleteMatching(string $pattern)
 	{
@@ -136,18 +120,11 @@ class WincacheHandler extends BaseHandler
 	 * @param string  $key    Cache ID
 	 * @param integer $offset Step/value to increase by
 	 *
-	 * @return mixed
-	 *
-	 * @codeCoverageIgnore
+	 * @return integer|false
 	 */
 	public function increment(string $key, int $offset = 1)
 	{
-		$key = $this->prefix . $key;
-
-		$success = false;
-		$value   = wincache_ucache_inc($key, $offset, $success);
-
-		return $success ? $value : false; // @phpstan-ignore-line
+		return wincache_ucache_inc($this->prefix . $key, $offset);
 	}
 
 	//--------------------------------------------------------------------
@@ -158,18 +135,11 @@ class WincacheHandler extends BaseHandler
 	 * @param string  $key    Cache ID
 	 * @param integer $offset Step/value to increase by
 	 *
-	 * @return mixed
-	 *
-	 * @codeCoverageIgnore
+	 * @return integer|false
 	 */
 	public function decrement(string $key, int $offset = 1)
 	{
-		$key = $this->prefix . $key;
-
-		$success = false;
-		$value   = wincache_ucache_dec($key, $offset, $success);
-
-		return $success ? $value : false; // @phpstan-ignore-line
+		return wincache_ucache_dec($this->prefix . $key, $offset);
 	}
 
 	//--------------------------------------------------------------------
@@ -178,8 +148,6 @@ class WincacheHandler extends BaseHandler
 	 * Will delete all items in the entire cache.
 	 *
 	 * @return boolean Success or failure
-	 *
-	 * @codeCoverageIgnore
 	 */
 	public function clean()
 	{
@@ -194,9 +162,7 @@ class WincacheHandler extends BaseHandler
 	 * The information returned and the structure of the data
 	 * varies depending on the handler.
 	 *
-	 * @return mixed
-	 *
-	 * @codeCoverageIgnore
+	 * @return array|false
 	 */
 	public function getCacheInfo()
 	{
@@ -214,14 +180,10 @@ class WincacheHandler extends BaseHandler
 	 *   Returns null if the item does not exist, otherwise array<string, mixed>
 	 *   with at least the 'expires' key for absolute epoch expiry (or null).
 	 *   Some handlers may return false when an item does not exist, which is deprecated.
-	 *
-	 * @codeCoverageIgnore
 	 */
 	public function getMetaData(string $key)
 	{
-		$key = $this->prefix . $key;
-
-		if ($stored = wincache_ucache_info(false, $key))
+		if ($stored = wincache_ucache_info(false, $this->prefix . $key))
 		{
 			$age      = $stored['ucache_entries'][1]['age_seconds'];
 			$ttl      = $stored['ucache_entries'][1]['ttl_seconds'];
@@ -247,8 +209,6 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function isSupported(): bool
 	{
-		return (extension_loaded('wincache') && ini_get('wincache.ucenabled'));
+		return extension_loaded('wincache') && ini_get('wincache.ucenabled');
 	}
-
-	//--------------------------------------------------------------------
 }


### PR DESCRIPTION
**Description**
- Allow covariant return types in docblocks of Cache handlers
- Simplify other code

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Conforms to style guide
