### PR TITLE
Cache Key Validation

### DIFF
--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -14,12 +14,65 @@ namespace CodeIgniter\Cache\Handlers;
 use Closure;
 use CodeIgniter\Cache\CacheInterface;
 use Exception;
+use InvalidArgumentException;
 
 /**
  * Base class for cache handling
  */
 abstract class BaseHandler implements CacheInterface
 {
+	/**
+	 * Reserved characters that cannot be used in a key or tag.
+	 *
+	 * @see https://github.com/symfony/cache-contracts/blob/c0446463729b89dd4fa62e9aeecc80287323615d/ItemInterface.php#L43
+	 */
+	public const RESERVED_CHARACTERS = '{}()/\@:';
+
+	/**
+	 * Maximum key length.
+	 */
+	public const MAX_KEY_LENGTH = PHP_INT_MAX;
+
+	/**
+	 * Prefix to apply to cache keys.
+	 * May not be used by all handlers.
+	 *
+	 * @var string
+	 */
+	protected $prefix;
+
+	/**
+	 * Validates a cache key according to PSR-6.
+	 * Keys that exceed MAX_KEY_LENGTH are hashed.
+	 *
+	 * @param string $key    The key to validate
+	 * @param string $prefix Optional prefix to include in length calculations
+	 *
+	 * @throws InvalidArgumentException When $key is not valid
+	 *
+	 * @see https://github.com/symfony/cache/blob/7b024c6726af21fd4984ac8d1eae2b9f3d90de88/CacheItem.php#L158
+	 */
+	public static function validateKey($key, $prefix = ''): string
+	{
+		if (! is_string($key))
+		{
+			throw new InvalidArgumentException('Cache key must be a string');
+		}
+		if ($key === '')
+		{
+			throw new InvalidArgumentException('Cache key cannot be empty.');
+		}
+		if (strpbrk($key, self::RESERVED_CHARACTERS) !== false)
+		{
+			throw new InvalidArgumentException('Cache key contains reserved characters ' . self::RESERVED_CHARACTERS);
+		}
+
+		// If the key with prefix exceeds the length then return the hashed version
+		return strlen($prefix . $key) > static::MAX_KEY_LENGTH ? $prefix . md5($key) : $prefix . $key;
+	}
+
+	//--------------------------------------------------------------------
+
 	/**
 	 * Get an item from the cache, or execute the given Closure and store the result.
 	 *

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -23,8 +23,7 @@ abstract class BaseHandler implements CacheInterface
 {
 	/**
 	 * Reserved characters that cannot be used in a key or tag.
-	 *
-	 * @see https://github.com/symfony/cache-contracts/blob/c0446463729b89dd4fa62e9aeecc80287323615d/ItemInterface.php#L43
+	 * From https://github.com/symfony/cache-contracts/blob/c0446463729b89dd4fa62e9aeecc80287323615d/ItemInterface.php#L43
 	 */
 	public const RESERVED_CHARACTERS = '{}()/\@:';
 
@@ -44,13 +43,12 @@ abstract class BaseHandler implements CacheInterface
 	/**
 	 * Validates a cache key according to PSR-6.
 	 * Keys that exceed MAX_KEY_LENGTH are hashed.
+	 * From https://github.com/symfony/cache/blob/7b024c6726af21fd4984ac8d1eae2b9f3d90de88/CacheItem.php#L158
 	 *
 	 * @param string $key    The key to validate
 	 * @param string $prefix Optional prefix to include in length calculations
 	 *
 	 * @throws InvalidArgumentException When $key is not valid
-	 *
-	 * @see https://github.com/symfony/cache/blob/7b024c6726af21fd4984ac8d1eae2b9f3d90de88/CacheItem.php#L158
 	 */
 	public static function validateKey($key, $prefix = ''): string
 	{

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -21,11 +21,9 @@ use Throwable;
 class FileHandler extends BaseHandler
 {
 	/**
-	 * Prefixed to all cache names.
-	 *
-	 * @var string
+	 * Maximum key length.
 	 */
-	protected $prefix;
+	public const MAX_KEY_LENGTH = 255;
 
 	/**
 	 * Where to store cached files on the disk.
@@ -94,8 +92,7 @@ class FileHandler extends BaseHandler
 	 */
 	public function get(string $key)
 	{
-		$key = $this->prefix . $key;
-
+		$key  = static::validateKey($key, $this->prefix);
 		$data = $this->getItem($key);
 
 		return is_array($data) ? $data['data'] : null;
@@ -114,7 +111,7 @@ class FileHandler extends BaseHandler
 	 */
 	public function save(string $key, $value, int $ttl = 60)
 	{
-		$key = $this->prefix . $key;
+		$key = static::validateKey($key, $this->prefix);
 
 		$contents = [
 			'time' => time(),
@@ -152,7 +149,7 @@ class FileHandler extends BaseHandler
 	 */
 	public function delete(string $key)
 	{
-		$key = $this->prefix . $key;
+		$key = static::validateKey($key, $this->prefix);
 
 		return is_file($this->path . $key) && unlink($this->path . $key);
 	}
@@ -170,7 +167,7 @@ class FileHandler extends BaseHandler
 	{
 		$deleted = 0;
 
-		foreach (glob($this->path . $pattern,  GLOB_NOSORT) as $filename)
+		foreach (glob($this->path . $pattern, GLOB_NOSORT) as $filename)
 		{
 			if (is_file($filename) && @unlink($filename))
 			{
@@ -193,8 +190,7 @@ class FileHandler extends BaseHandler
 	 */
 	public function increment(string $key, int $offset = 1)
 	{
-		$key = $this->prefix . $key;
-
+		$key  = static::validateKey($key, $this->prefix);
 		$data = $this->getItem($key);
 
 		if ($data === false)
@@ -222,12 +218,11 @@ class FileHandler extends BaseHandler
 	 * @param string  $key    Cache ID
 	 * @param integer $offset Step/value to increase by
 	 *
-	 * @return bool
+	 * @return boolean
 	 */
 	public function decrement(string $key, int $offset = 1)
 	{
-		$key = $this->prefix . $key;
-
+		$key  = static::validateKey($key, $this->prefix);
 		$data = $this->getItem($key);
 
 		if ($data === false)
@@ -288,7 +283,7 @@ class FileHandler extends BaseHandler
 	 */
 	public function getMetaData(string $key)
 	{
-		$key = $this->prefix . $key;
+		$key = static::validateKey($key, $this->prefix);
 
 		if (! is_file($this->path . $key))
 		{
@@ -342,26 +337,26 @@ class FileHandler extends BaseHandler
 	 * Does the heavy lifting of actually retrieving the file and
 	 * verifying it's age.
 	 *
-	 * @param string $key
+	 * @param string $filename
 	 *
 	 * @return boolean|mixed
 	 */
-	protected function getItem(string $key)
+	protected function getItem(string $filename)
 	{
-		if (! is_file($this->path . $key))
+		if (! is_file($this->path . $filename))
 		{
 			return false;
 		}
 
-		$data = unserialize(file_get_contents($this->path . $key));
+		$data = unserialize(file_get_contents($this->path . $filename));
 
 		// @phpstan-ignore-next-line
 		if ($data['ttl'] > 0 && time() > $data['time'] + $data['ttl'])
 		{
 			// If the file is still there then remove it
-			if (is_file($this->path . $key))
+			if (is_file($this->path . $filename))
 			{
-				unlink($this->path . $key);
+				unlink($this->path . $filename);
 			}
 
 			return false;

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -23,7 +23,7 @@ class FileHandler extends BaseHandler
 	/**
 	 * Maximum key length.
 	 */
-	public const MAX_KEY_LENGTH = 255;
+	public const MAX_KEY_LENGTH = PHP_MAXPATHLEN;
 
 	/**
 	 * Where to store cached files on the disk.

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -23,13 +23,6 @@ use Memcached;
 class MemcachedHandler extends BaseHandler
 {
 	/**
-	 * Prefixed to all cache names.
-	 *
-	 * @var string
-	 */
-	protected $prefix;
-
-	/**
 	 * The memcached object
 	 *
 	 * @var Memcached|Memcache
@@ -166,7 +159,7 @@ class MemcachedHandler extends BaseHandler
 	 */
 	public function get(string $key)
 	{
-		$key = $this->prefix . $key;
+		$key = static::validateKey($key, $this->prefix);
 
 		if ($this->memcached instanceof Memcached)
 		{
@@ -206,7 +199,7 @@ class MemcachedHandler extends BaseHandler
 	 */
 	public function save(string $key, $value, int $ttl = 60)
 	{
-		$key = $this->prefix . $key;
+		$key = static::validateKey($key, $this->prefix);
 
 		if (! $this->config['raw'])
 		{
@@ -242,7 +235,7 @@ class MemcachedHandler extends BaseHandler
 	 */
 	public function delete(string $key)
 	{
-		$key = $this->prefix . $key;
+		$key = static::validateKey($key, $this->prefix);
 
 		return $this->memcached->delete($key);
 	}
@@ -278,7 +271,7 @@ class MemcachedHandler extends BaseHandler
 			return false;
 		}
 
-		$key = $this->prefix . $key;
+		$key = static::validateKey($key, $this->prefix);
 
 		// @phpstan-ignore-next-line
 		return $this->memcached->increment($key, $offset, $offset, 60);
@@ -301,7 +294,7 @@ class MemcachedHandler extends BaseHandler
 			return false;
 		}
 
-		$key = $this->prefix . $key;
+		$key = static::validateKey($key, $this->prefix);
 
 		//FIXME: third parameter isn't other handler actions.
 		// @phpstan-ignore-next-line
@@ -349,8 +342,7 @@ class MemcachedHandler extends BaseHandler
 	 */
 	public function getMetaData(string $key)
 	{
-		$key = $this->prefix . $key;
-
+		$key    = static::validateKey($key, $this->prefix);
 		$stored = $this->memcached->get($key);
 
 		// if not an array, don't try to count for PHP7.2

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -23,13 +23,6 @@ use Predis\Collection\Iterator\Keyspace;
 class PredisHandler extends BaseHandler
 {
 	/**
-	 * Prefixed to all cache names.
-	 *
-	 * @var string
-	 */
-	protected $prefix;
-
-	/**
 	 * Default config
 	 *
 	 * @var array
@@ -101,8 +94,12 @@ class PredisHandler extends BaseHandler
 	 */
 	public function get(string $key)
 	{
-		$data = array_combine(
-			['__ci_type', '__ci_value'],
+		$key = static::validateKey($key);
+
+		$data = array_combine([
+			'__ci_type',
+			'__ci_value',
+		],
 			$this->redis->hmget($key, ['__ci_type', '__ci_value'])
 		);
 
@@ -141,6 +138,8 @@ class PredisHandler extends BaseHandler
 	 */
 	public function save(string $key, $value, int $ttl = 60)
 	{
+		$key = static::validateKey($key);
+
 		switch ($dataType = gettype($value))
 		{
 			case 'array':
@@ -179,6 +178,8 @@ class PredisHandler extends BaseHandler
 	 */
 	public function delete(string $key)
 	{
+		$key = static::validateKey($key);
+
 		return $this->redis->del($key) === 1;
 	}
 
@@ -215,6 +216,8 @@ class PredisHandler extends BaseHandler
 	 */
 	public function increment(string $key, int $offset = 1)
 	{
+		$key = static::validateKey($key);
+
 		return $this->redis->hincrby($key, 'data', $offset);
 	}
 
@@ -230,6 +233,8 @@ class PredisHandler extends BaseHandler
 	 */
 	public function decrement(string $key, int $offset = 1)
 	{
+		$key = static::validateKey($key);
+
 		return $this->redis->hincrby($key, 'data', -$offset);
 	}
 
@@ -273,6 +278,8 @@ class PredisHandler extends BaseHandler
 	 */
 	public function getMetaData(string $key)
 	{
+		$key = static::validateKey($key);
+
 		$data = array_combine(['__ci_value'], $this->redis->hmget($key, ['__ci_value']));
 
 		if (isset($data['__ci_value']) && $data['__ci_value'] !== false)

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -22,13 +22,6 @@ use RedisException;
 class RedisHandler extends BaseHandler
 {
 	/**
-	 * Prefixed to all cache names.
-	 *
-	 * @var string
-	 */
-	protected $prefix;
-
-	/**
 	 * Default config
 	 *
 	 * @var array
@@ -134,8 +127,7 @@ class RedisHandler extends BaseHandler
 	 */
 	public function get(string $key)
 	{
-		$key = $this->prefix . $key;
-
+		$key  = static::validateKey($key, $this->prefix);
 		$data = $this->redis->hMGet($key, ['__ci_type', '__ci_value']);
 
 		if (! isset($data['__ci_type'], $data['__ci_value']) || $data['__ci_value'] === false)
@@ -173,7 +165,7 @@ class RedisHandler extends BaseHandler
 	 */
 	public function save(string $key, $value, int $ttl = 60)
 	{
-		$key = $this->prefix . $key;
+		$key = static::validateKey($key, $this->prefix);
 
 		switch ($dataType = gettype($value))
 		{
@@ -216,7 +208,7 @@ class RedisHandler extends BaseHandler
 	 */
 	public function delete(string $key)
 	{
-		$key = $this->prefix . $key;
+		$key = static::validateKey($key, $this->prefix);
 
 		return $this->redis->del($key) === 1;
 	}
@@ -233,7 +225,7 @@ class RedisHandler extends BaseHandler
 	public function deleteMatching(string $pattern)
 	{
 		$matchedKeys = [];
-		$iterator = null;
+		$iterator    = null;
 
 		do
 		{
@@ -266,7 +258,7 @@ class RedisHandler extends BaseHandler
 	 */
 	public function increment(string $key, int $offset = 1)
 	{
-		$key = $this->prefix . $key;
+		$key = static::validateKey($key, $this->prefix);
 
 		return $this->redis->hIncrBy($key, 'data', $offset);
 	}
@@ -283,7 +275,7 @@ class RedisHandler extends BaseHandler
 	 */
 	public function decrement(string $key, int $offset = 1)
 	{
-		$key = $this->prefix . $key;
+		$key = static::validateKey($key, $this->prefix);
 
 		return $this->redis->hIncrBy($key, 'data', -$offset);
 	}
@@ -328,8 +320,7 @@ class RedisHandler extends BaseHandler
 	 */
 	public function getMetaData(string $key)
 	{
-		$key = $this->prefix . $key;
-
+		$key   = static::validateKey($key, $this->prefix);
 		$value = $this->get($key);
 
 		if ($value !== null)

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -22,15 +22,6 @@ use Exception;
 class WincacheHandler extends BaseHandler
 {
 	/**
-	 * Prefixed to all cache names.
-	 *
-	 * @var string
-	 */
-	protected $prefix;
-
-	//--------------------------------------------------------------------
-
-	/**
 	 * Constructor.
 	 *
 	 * @param Cache $config
@@ -60,6 +51,7 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function get(string $key)
 	{
+		$key     = static::validateKey($key);
 		$success = false;
 
 		$data = wincache_ucache_get($this->prefix . $key, $success);
@@ -81,6 +73,8 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function save(string $key, $value, int $ttl = 60)
 	{
+		$key = static::validateKey($key);
+
 		return wincache_ucache_set($this->prefix . $key, $value, $ttl);
 	}
 
@@ -95,6 +89,8 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function delete(string $key)
 	{
+		$key = static::validateKey($key);
+
 		return wincache_ucache_delete($this->prefix . $key);
 	}
 
@@ -124,6 +120,8 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function increment(string $key, int $offset = 1)
 	{
+		$key = static::validateKey($key);
+
 		return wincache_ucache_inc($this->prefix . $key, $offset);
 	}
 
@@ -139,6 +137,8 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function decrement(string $key, int $offset = 1)
 	{
+		$key = static::validateKey($key);
+
 		return wincache_ucache_dec($this->prefix . $key, $offset);
 	}
 
@@ -183,6 +183,8 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function getMetaData(string $key)
 	{
+		$key = static::validateKey($key);
+
 		if ($stored = wincache_ucache_info(false, $this->prefix . $key))
 		{
 			$age      = $stored['ucache_entries'][1]['age_seconds'];

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -51,10 +51,10 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function get(string $key)
 	{
-		$key     = static::validateKey($key);
+		$key     = static::validateKey($key, $this->prefix);
 		$success = false;
 
-		$data = wincache_ucache_get($this->prefix . $key, $success);
+		$data = wincache_ucache_get($key, $success);
 
 		// Success returned by reference from wincache_ucache_get()
 		return $success ? $data : null;
@@ -73,9 +73,9 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function save(string $key, $value, int $ttl = 60)
 	{
-		$key = static::validateKey($key);
+		$key = static::validateKey($key, $this->prefix);
 
-		return wincache_ucache_set($this->prefix . $key, $value, $ttl);
+		return wincache_ucache_set($key, $value, $ttl);
 	}
 
 	//--------------------------------------------------------------------
@@ -89,9 +89,9 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function delete(string $key)
 	{
-		$key = static::validateKey($key);
+		$key = static::validateKey($key, $this->prefix);
 
-		return wincache_ucache_delete($this->prefix . $key);
+		return wincache_ucache_delete($key);
 	}
 
 	//--------------------------------------------------------------------
@@ -120,9 +120,9 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function increment(string $key, int $offset = 1)
 	{
-		$key = static::validateKey($key);
+		$key = static::validateKey($key, $this->prefix);
 
-		return wincache_ucache_inc($this->prefix . $key, $offset);
+		return wincache_ucache_inc($key, $offset);
 	}
 
 	//--------------------------------------------------------------------
@@ -137,9 +137,9 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function decrement(string $key, int $offset = 1)
 	{
-		$key = static::validateKey($key);
+		$key = static::validateKey($key, $this->prefix);
 
-		return wincache_ucache_dec($this->prefix . $key, $offset);
+		return wincache_ucache_dec($key, $offset);
 	}
 
 	//--------------------------------------------------------------------
@@ -183,9 +183,9 @@ class WincacheHandler extends BaseHandler
 	 */
 	public function getMetaData(string $key)
 	{
-		$key = static::validateKey($key);
+		$key = static::validateKey($key, $this->prefix);
 
-		if ($stored = wincache_ucache_info(false, $this->prefix . $key))
+		if ($stored = wincache_ucache_info(false, $key))
 		{
 			$age      = $stored['ucache_entries'][1]['age_seconds'];
 			$ttl      = $stored['ucache_entries'][1]['ttl_seconds'];

--- a/tests/_support/Cache/RestrictiveHandler.php
+++ b/tests/_support/Cache/RestrictiveHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Cache;
+
+use CodeIgniter\Cache\Handlers\DummyHandler;
+
+/**
+ * Handler with unnecessarily restrictive
+ * key limit for testing validateKey.
+ */
+class RestrictiveHandler extends DummyHandler
+{
+	/**
+	 * Maximum key length.
+	 */
+	public const MAX_KEY_LENGTH = 10;
+}

--- a/tests/system/Cache/Handlers/BaseHandlerTest.php
+++ b/tests/system/Cache/Handlers/BaseHandlerTest.php
@@ -1,0 +1,66 @@
+<?php namespace CodeIgniter\Cache\Handlers;
+
+use stdClass;
+use CodeIgniter\Test\CIUnitTestCase;
+use Tests\Support\Cache\RestrictiveHandler;
+
+class BaseHandlerTest extends CIUnitTestCase
+{
+	/**
+	 * @dataProvider invalidTypeProvider
+	 */
+	public function testValidateKeyInvalidType($input)
+	{
+		$this->expectException('InvalidArgumentException');
+		$this->expectExceptionMessage('Cache key must be a string');
+
+		BaseHandler::validateKey(false);
+	}
+
+	public function invalidTypeProvider(): array
+	{
+		return [
+			[true],
+			[false],
+			[null],
+			[42],
+			[new stdClass],
+		];
+	}
+
+	public function testValidateKeySuccess()
+	{
+		$string = 'banana';
+		$result = BaseHandler::validateKey($string);
+
+		$this->assertSame($string, $result);
+	}
+
+	public function testValidateKeySuccessWithPrefix()
+	{
+		$string = 'banana';
+		$result = BaseHandler::validateKey($string, 'prefix');
+
+		$this->assertSame('prefix' . $string, $result);
+	}
+
+	public function testValidateExcessiveLength()
+	{
+		$string   = 'MoreThanTenCharacters';
+		$expected = md5($string);
+
+		$result = RestrictiveHandler::validateKey($string);
+
+		$this->assertSame($expected, $result);
+	}
+
+	public function testValidateExcessiveLengthWithPrefix()
+	{
+		$string   = 'MoreThanTenCharacters';
+		$expected = 'prefix' . md5($string);
+
+		$result = RestrictiveHandler::validateKey($string, 'prefix');
+
+		$this->assertSame($expected, $result);
+	}
+}

--- a/tests/system/Cache/Handlers/BaseHandlerTest.php
+++ b/tests/system/Cache/Handlers/BaseHandlerTest.php
@@ -14,7 +14,7 @@ class BaseHandlerTest extends CIUnitTestCase
 		$this->expectException('InvalidArgumentException');
 		$this->expectExceptionMessage('Cache key must be a string');
 
-		BaseHandler::validateKey(false);
+		BaseHandler::validateKey($input);
 	}
 
 	public function invalidTypeProvider(): array

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -129,7 +129,7 @@ class FileHandlerTest extends CIUnitTestCase
 
 	public function testSaveExcessiveKeyLength()
 	{
-		$key  = str_repeat('a', 300);
+		$key  = str_repeat('a', PHP_MAXPATHLEN + 10);
 		$file = $this->config->file['storePath'] . DIRECTORY_SEPARATOR . md5($key);
 
 		$this->assertTrue($this->fileHandler->save($key, 'value'));

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -51,6 +51,8 @@ class FileHandlerTest extends CIUnitTestCase
 
 	public function tearDown(): void
 	{
+		parent::tearDown();
+
 		if (is_dir($this->config->file['storePath']))
 		{
 			chmod($this->config->file['storePath'], 0777);
@@ -123,6 +125,17 @@ class FileHandlerTest extends CIUnitTestCase
 
 		chmod($this->config->file['storePath'], 0444);
 		$this->assertFalse($this->fileHandler->save(self::$key2, 'value'));
+	}
+
+	public function testSaveExcessiveKeyLength()
+	{
+		$key  = str_repeat('a', 300);
+		$file = $this->config->file['storePath'] . DIRECTORY_SEPARATOR . md5($key);
+
+		$this->assertTrue($this->fileHandler->save($key, 'value'));
+		$this->assertFileExists($file);
+
+		unlink($file);
 	}
 
 	public function testDelete()

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -229,6 +229,21 @@ Class Reference
           on which adapter is being used. Some adapters (File, Memcached, Wincache)
           still return ``false`` for missing items.
 
+.. php:staticmethod:: validateKey(string $key, string $prefix)
+
+    :param string $key: Potential cache key
+    :param string $prefix: Optional prefix
+    :returns: The verified and prefixed key. If the key exceeds the driver's max key length it will be hashed.
+    :rtype: string
+
+    This method is used by handler methods to check that keys are valid. It will throw
+    an ``InvalidArgumentException`` for non-strings, invalid characters, and empty lengths.
+
+    Example::
+
+        $prefixedKey = BaseHandler::validateKey($key, $prefix);
+
+
 *******
 Drivers
 *******


### PR DESCRIPTION
**Description**
Cache keys are currently a free-for-all, though the specification is much tighter than that. Additionally, some handlers have limits on the length of key that can be used. So far the only one I know for sure is `FileHandler`, because using too long of a key fails to create the file since it is invalid in the filesystem.

This PR adds cache key validation and hashing to address the above issues. Note that I am *not* a cache expert, so if someone with more knowledge or experience wants to chime in I would be grateful. For example, the restricted characters were based on PSR-6 but some handlers may actually allow broader key usage than that.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [x] User guide updated
- [X] Conforms to style guide
