### PR TITLE
[Rector] Pin "nikic/php-parser": "4.10.4"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 		"fakerphp/faker": "^1.9",
 		"mikey179/vfsstream": "^1.6",
 		"nexusphp/tachycardia": "^1.0",
+		"nikic/php-parser": "4.10.4",
 		"phpstan/phpstan": "0.12.85",
 		"phpunit/phpunit": "^9.1",
 		"predis/predis": "^1.1",


### PR DESCRIPTION
Latest "nikic/php-parser": "4.10.5" seems temporary cause error notice in rector repo, ref https://github.com/rectorphp/rector/runs/2495148646#step:6:6 . 

This patch pin to 4.10.4 which is working. We can use dependabot to ensure `php-parser`, `phpstan`, and `rector` version run ok on every new release.

**Checklist:**
- [x] Securely signed commits
