### PR TITLE
Internal URI handling

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -124,7 +124,7 @@ class IncomingRequest extends Request
 	/**
 	 * Constructor
 	 *
-	 * @param object      $config
+	 * @param App         $config
 	 * @param URI         $uri
 	 * @param string|null $body
 	 * @param UserAgent   $userAgent

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\HTTP;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\Files\FileCollection;
 use CodeIgniter\HTTP\Files\UploadedFile;
+use CodeIgniter\HTTP\URI;
 use Config\App;
 use Config\Services;
 use InvalidArgumentException;
@@ -149,7 +150,7 @@ class IncomingRequest extends Request
 
 		$this->populateHeaders();
 
-		// Get our current URI.
+		// Determine the current URI
 		// NOTE: This WILL NOT match the actual URL in the browser since for
 		// everything this cares about (and the router, etc) is the portion
 		// AFTER the script name. So, if hosted in a sub-folder this will
@@ -157,6 +158,12 @@ class IncomingRequest extends Request
 		$this->uri = $uri;
 
 		$this->detectURI($config->uriProtocol, $config->baseURL);
+
+		// Check if the baseURL scheme needs to be coerced into its secure version
+		if ($config->forceGlobalSecureRequests && $this->uri->getScheme() === 'http')
+		{
+			$this->uri->setScheme('https');
+		}
 
 		$this->validLocales = $config->supportedLocales;
 
@@ -610,11 +617,11 @@ class IncomingRequest extends Request
 
 		// It's possible the user forgot a trailing slash on their
 		// baseURL, so let's help them out.
-		$baseURL = ! empty($baseURL) ? rtrim($baseURL, '/ ') . '/' : $baseURL;
+		$baseURL = $baseURL === '' ? $baseURL : rtrim($baseURL, '/ ') . '/';
 
 		// Based on our baseURL provided by the developer
 		// set our current domain name, scheme
-		if (! empty($baseURL))
+		if ($baseURL !== '')
 		{
 			$this->uri->setScheme(parse_url($baseURL, PHP_URL_SCHEME));
 			$this->uri->setHost(parse_url($baseURL, PHP_URL_HOST));
@@ -758,12 +765,9 @@ class IncomingRequest extends Request
 
 		parse_str($_SERVER['QUERY_STRING'], $_GET);
 
-		if ($uri === '/' || $uri === '')
-		{
-			return '/';
-		}
+		$uri = URI::removeDotSegments($uri);
 
-		return $this->removeRelativeDirectory($uri);
+		return ($uri === '/' || $uri === '') ? '/' : ltrim($uri, '/');
 	}
 
 	//--------------------------------------------------------------------
@@ -793,7 +797,9 @@ class IncomingRequest extends Request
 
 		parse_str($_SERVER['QUERY_STRING'], $_GET);
 
-		return $this->removeRelativeDirectory($uri);
+		$uri = URI::removeDotSegments($uri);
+
+		return ($uri === '/' || $uri === '') ? '/' : ltrim($uri, '/');
 	}
 
 	//--------------------------------------------------------------------
@@ -806,22 +812,13 @@ class IncomingRequest extends Request
 	 * @param string $uri
 	 *
 	 * @return string
+	 *
+	 * @deprecated Use URI::removeDotSegments() directly
 	 */
 	protected function removeRelativeDirectory(string $uri): string
 	{
-		$uris = [];
-		$tok  = strtok($uri, '/');
-		while ($tok !== false)
-		{
-			if ((! empty($tok) || $tok === '0') && $tok !== '..')
-			{
-				$uris[] = $tok;
-			}
-			$tok = strtok('/');
-		}
+		$uri = URI::removeDotSegments($uri);
 
-		return implode('/', $uris);
+		return $uri === '/' ? $uri : ltrim($uri, '/');
 	}
-
-	// --------------------------------------------------------------------
 }

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -8,6 +8,7 @@ use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockIncomingRequest;
 use CodeIgniter\Test\Mock\MockResponse;
+use Config\App;
 use stdClass;
 
 class ResponseTraitTest extends CIUnitTestCase
@@ -30,7 +31,8 @@ class ResponseTraitTest extends CIUnitTestCase
 
 	protected function makeController(array $userConfig = [], string $uri = 'http://example.com', array $userHeaders = [])
 	{
-		$config = [
+		$config = new App();
+		foreach ([
 			'baseURL'          => 'http://example.com/',
 			'uriProtocol'      => 'REQUEST_URI',
 			'defaultLocale'    => 'en',
@@ -44,9 +46,10 @@ class ResponseTraitTest extends CIUnitTestCase
 			'cookieHTTPOnly'   => false,
 			'proxyIPs'         => [],
 			'cookieSameSite'   => 'Lax',
-		];
-
-		$config = array_merge($config, $userConfig);
+		] as $key => $value)
+		{
+			$config->$key = $value;
+		}
 
 		if (is_null($this->request))
 		{
@@ -472,7 +475,8 @@ EOH;
 
 	public function testFormatByRequestNegotiateIfFormatIsNotJsonOrXML()
 	{
-		$config = [
+		$config = new App();
+		foreach ([
 			'baseURL'          => 'http://example.com/',
 			'uriProtocol'      => 'REQUEST_URI',
 			'defaultLocale'    => 'en',
@@ -486,10 +490,13 @@ EOH;
 			'cookieHTTPOnly'   => false,
 			'proxyIPs'         => [],
 			'cookieSameSite'   => 'Lax',
-		];
+		] as $key => $value)
+		{
+			$config->$key = $value;
+		}
 
-		$request  = new MockIncomingRequest((object) $config, new URI($config['baseURL']), null, new UserAgent());
-		$response = new MockResponse((object) $config);
+		$request  = new MockIncomingRequest($config, new URI($config->baseURL), null, new UserAgent());
+		$response = new MockResponse($config);
 
 		$controller = new class($request, $response)
 		{

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -1007,19 +1007,19 @@ class URITest extends CIUnitTestCase
 
 		Factories::injectMock('config', 'App', $config);
 
-		$request      = Services::request($config);
-		$request->uri = new URI('http://example.com/ci/v4/controller/method');
+		$uri     = new URI('http://example.com/ci/v4/controller/method');
+		$request = new IncomingRequest($config, $uri, 'php://input', new UserAgent());
 
 		Services::injectMock('request', $request);
 
-		// going through request
+		// Detected by request
 		$this->assertEquals('https://example.com/ci/v4/controller/method', (string) $request->uri);
 
-		// standalone
+		// Standalone
 		$uri = new URI('http://example.com/ci/v4/controller/method');
 		$this->assertEquals('https://example.com/ci/v4/controller/method', (string) $uri);
 
-		$this->assertEquals($uri->getPath(), $request->uri->getPath());
+		$this->assertEquals(trim($uri->getPath(), '/'), trim($request->uri->getPath(), '/'));
 	}
 
 	public function testZeroAsURIPath()

--- a/user_guide_src/source/changelogs/v4.1.2.rst
+++ b/user_guide_src/source/changelogs/v4.1.2.rst
@@ -41,6 +41,7 @@ Deprecations:
 - Deprecated ``ControllerTester`` to use the ``ControllerTestTrait`` instead.
 - Consolidated and deprecated ``ControllerResponse`` and ``FeatureResponse`` in favor of ``TestResponse``.
 - Deprecated ``Time::instance()``, use ``Time::createFromInstance()`` instead (now accepts ``DateTimeInterface``).
+- Deprecated ``IncomingRequest::removeRelativeDirectory()``, use ``URI::removeDotSegments()`` instead
 
 Bugs Fixed:
 


### PR DESCRIPTION
**Description**
"Stage two" of URI changes, this PR backs off some of the heavy-handed coercing that `URI::__toString()` does to create "project URLs". IMO `URI` should not be in the business of dealing with `baseURL` at all, but since this is currently the case we can't remove it entirely. Also improves `IncomingRequest`'s interactions with `URI` to detect the "current" URL, and fixes a bug where scheme inconsistencies could create looping redirects.

Note: This PR relies on #4644

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
