### PR TITLE
URL Class

### DIFF
--- a/system/HTTP/URL.php
+++ b/system/HTTP/URL.php
@@ -39,26 +39,34 @@ class URL
 	//--------------------------------------------------------------------
 
 	/**
-	 * Returns an instance representing the current URL.
+	 * Returns an instance representing the base URL.
+	 *
+	 * @param string $uri Additional URI string to include
 	 *
 	 * @return static
 	 */
-	final public static function base()
+	final public static function base(string $uri = '')
 	{
-		return new static('');
+		// Base URLs never include the index page
+		$config            = clone config('App');
+		$config->indexPage = '';
+
+		return new static($uri, $config);
 	}
 
 	/**
-	 * Returns an instance representing the current URL.
+	 * Returns an instance representing a routed URL.
 	 *
-	 * @param string $uri
+	 * @param string $uri Named route, reverse route, or URI string
 	 *
 	 * @return static
 	 */
 	final public static function to(string $uri)
 	{
+		$uri = rtrim($uri, '/ ');
+
 		// Check for a named or reverse-route
-		if ($route = Services::routes()->reverseRoute($uri))
+		if ($uri !== '' && $route = Services::routes()->reverseRoute($uri))
 		{
 			return new static($route);
 		}

--- a/system/HTTP/URL.php
+++ b/system/HTTP/URL.php
@@ -24,6 +24,13 @@ use InvalidArgumentException;
 final class URL
 {
 	/**
+	 * Explicit URL to use for current.
+	 *
+	 * @var static|null
+	 */
+	private static $current;
+
+	/**
 	 * Underlying URI instance
 	 *
 	 * @var URI
@@ -73,6 +80,11 @@ final class URL
 	 */
 	public static function current()
 	{
+		if (isset(self::$current))
+		{
+			return self::$current;
+		}
+
 		return static::fromRequest(Services::request());
 	}
 
@@ -122,6 +134,18 @@ final class URL
 		$query = isset($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '';
 
 		return new static($path . $query, $request->config);
+	}
+
+	/**
+	 * Injects a URL to use for the current.
+	 * Useful for testing components whose behavior
+	 * depends on the URL being visited.
+	 *
+	 * @param URL|null $url
+	 */
+	public static function setCurrent(?URL $url)
+	{
+		self::$current = $url;
 	}
 
 	//--------------------------------------------------------------------

--- a/system/HTTP/URL.php
+++ b/system/HTTP/URL.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP;
+
+use CodeIgniter\HTTP\IncomingRequest;
+use Config\App;
+use Config\Services;
+use InvalidArgumentException;
+
+/**
+ * URI wrapper to work with complete project URLs.
+ * This class creates immutable instances.
+ */
+class URL
+{
+	/**
+	 * Underlying URI instance
+	 *
+	 * @var URI
+	 */
+	private $uri;
+
+	/**
+	 * Path relative to baseURL
+	 *
+	 * @var string
+	 */
+	protected $relativePath;
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns an instance representing the current URL.
+	 *
+	 * @return static
+	 */
+	final public static function base()
+	{
+		return new static('');
+	}
+
+	/**
+	 * Returns an instance representing the current URL.
+	 *
+	 * @param string $uri
+	 *
+	 * @return static
+	 */
+	final public static function to(string $uri)
+	{
+		// Check for a named or reverse-route
+		if ($route = Services::routes()->reverseRoute($uri))
+		{
+			return new static($route);
+		}
+
+		return new static($uri);
+	}
+
+	/**
+	 * Returns an instance representing the current URL.
+	 *
+	 * @return static
+	 */
+	final public static function current()
+	{
+		return static::fromRequest(Services::request());
+	}
+
+	/**
+	 * Returns an instance representing the URL from
+	 * an Incoming Request (as defined by Config\App).
+	 *
+	 * @param IncomingRequest $request
+	 *
+	 * @return static
+	 */
+	final public static function fromRequest(IncomingRequest $request)
+	{
+		$path  = $request->detectPath($request->config->uriProtocol);
+		$query = isset($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '';
+
+		return new static($path . $query, $request->config);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Store the App configuration and create the URI
+	 * instance from the relative path.
+	 *
+	 * @param string   $relativePath
+	 * @param App|null $config
+	 */
+	final public function __construct(string $relativePath = '', App $config = null)
+	{
+		$config = $config ?? config('App');
+
+		if ($config->baseURL === '')
+		{
+			throw new InvalidArgumentException('URL class requires a valid baseURL.');
+		}
+		if (is_int(strpos($relativePath, '://')))
+		{
+			throw new InvalidArgumentException('URL class only accepts relative paths.');
+		}
+
+		$this->relativePath = ltrim(URI::removeDotSegments($relativePath), '/');
+
+		// Build the full URL based on $config and $relativePath
+		$url = rtrim($config->baseURL, '/ ') . '/';
+
+		// Check for an index page
+		if ($config->indexPage !== '')
+		{
+			$url .= $config->indexPage;
+
+			// If the relative path has anything other than ? (for query) we need a separator
+			if ($this->relativePath !== '' && strncmp($this->relativePath, '?', 1) !== 0)
+			{
+				$url .= '/';
+			}
+		}
+
+		$url .= $this->relativePath;
+
+		$this->uri = new URI($url);
+
+		// Check if the baseURL scheme needs to be coerced into its secure version
+		if ($config->forceGlobalSecureRequests && $this->uri->getScheme() === 'http')
+		{
+			$this->uri->setScheme('https');
+		}
+	}
+
+	/**
+	 * Returns the path relative to baseUrl, loosely
+	 * what was passed to the constructor.
+	 *
+	 * @return string
+	 */
+	public function getPath(): string
+	{
+		return $this->relativePath;
+	}
+
+	/**
+	 * Returns the underlying URI instance.
+	 * In order for this instance to remain
+	 * immutable a clone is returned.
+	 *
+	 * @return URI
+	 */
+	public function getUri(): URI
+	{
+		return clone $this->uri;
+	}
+
+	/**
+	 * Returns this URL as a string.
+	 *
+	 * @return string
+	 */
+	public function __toString(): string
+	{
+		return (string) $this->uri;
+	}
+}

--- a/tests/system/HTTP/URLTest.php
+++ b/tests/system/HTTP/URLTest.php
@@ -193,9 +193,9 @@ final class URLTest extends CIUnitTestCase
 		$this->assertSame($baseURL, (string) $url);
 	}
 
-	public function testBaseWithUri()
+	public function testPublic()
 	{
-		$url = URL::base('images/cat.gif');
+		$url = URL::public('images/cat.gif');
 
 		$this->assertSame('http://example.com/images/cat.gif', (string) $url);
 	}
@@ -207,20 +207,20 @@ final class URLTest extends CIUnitTestCase
 		$this->assertSame('http://example.com/index.php/fruit/basket', (string) $url);
 	}
 
-	public function testToNamedRoute()
+	public function testNamedRoute()
 	{
-		Services::routes()->add('apples', 'Home::index', ['as' => 'home']);
+		Services::routes()->add('apples', 'Home::index', ['as' => 'orchard']);
 
-		$url = URL::to('home');
+		$url = URL::route('orchard');
 
 		$this->assertSame('http://example.com/index.php/apples', (string) $url);
 	}
 
-	public function testToReverseRoute()
+	public function testReverseRoute()
 	{
 		Services::routes()->add('oranges', 'Basket::fruit');
 
-		$url = URL::to('App\Controllers\Basket::fruit');
+		$url = URL::route('App\Controllers\Basket::fruit');
 
 		$this->assertSame('http://example.com/index.php/oranges', (string) $url);
 	}
@@ -367,11 +367,11 @@ final class URLTest extends CIUnitTestCase
 			],
 			[
 				'?blahblah=true',
-				'http://example.com/index.php?blahblah=true',
+				'http://example.com/index.php',
 			],
 			[
 				'http://example.com/index.php?blahblah=true',
-				'http://example.com/index.php?blahblah=true',
+				'http://example.com/index.php',
 			],
 		];
 	}

--- a/tests/system/HTTP/URLTest.php
+++ b/tests/system/HTTP/URLTest.php
@@ -1,0 +1,364 @@
+<?php
+
+namespace CodeIgniter\HTTP;
+
+use CodeIgniter\Config\Factories;
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\App;
+use Config\Services;
+use InvalidArgumentException;
+
+final class URLTest extends CIUnitTestCase
+{
+	/**
+	 * @var App
+	 */
+	private $config;
+
+	/**
+	 * Sets a common base configuration.
+	 * Overriden by individual tests.
+	 */
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
+		$_SERVER['REQUEST_URI'] = '/';
+
+		$this->config                            = new App();
+		$this->config->baseURL                   = 'http://example.com/';
+		$this->config->indexPage                 = 'index.php';
+		$this->config->forceGlobalSecureRequests = false;
+
+		Factories::injectMock('config', 'App', $this->config);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Updates a single Config value.
+	 *
+	 * @param string $uri
+	 *
+	 * @return $this
+	 */
+	private function setConfig(string $key, string $value): self
+	{
+		$this->config->$key = $value;
+
+		return $this;
+	}
+
+	/**
+	 * Fakes the current URL and re-initializes the Request.
+	 *
+	 * @param string $uri
+	 *
+	 * @return $this
+	 */
+	private function setCurrent(string $uri): self
+	{
+		$parts = parse_url($uri);
+		if ($parts === false)
+		{
+			throw InvalidArgumentException('Could not parse URI: ' . $uri);
+		}
+
+		$_SERVER['REQUEST_URI'] = $parts['path'] ?? '';
+
+		if (! empty($parts['host']))
+		{
+			$_SERVER['HTTP_HOST'] = $parts['host'];
+		}
+		if (! empty($parts['query']))
+		{
+			$_SERVER['REQUEST_URI'] .= '?' . $parts['query'];
+		}
+		if (isset($parts['scheme']))
+		{
+			$_SERVER['HTTPS'] = strtolower(rtrim($parts['scheme'], ':/')) === 'https' ? 'on' : 'off';
+		}
+
+		// Recreate the Incoming Request to force detection
+		$request = Services::request($this->config, false);
+		Services::injectMock('request', $request);
+
+		return $this;
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testDefault()
+	{
+		$url = new URL();
+
+		$result = $this->getPrivateProperty($url, 'relativePath');
+		$this->assertSame('', $result);
+
+		$result = $this->getPrivateProperty($url, 'uri');
+		$this->assertInstanceOf(URI::class, $result);
+	}
+
+	public function testGetPath()
+	{
+		$result = (new URL('banana'))->getPath();
+
+		$this->assertSame('banana', $result);
+	}
+
+	public function testGetUri()
+	{
+		$url    = new URL('banana');
+		$result = $url->getUri();
+
+		$this->assertInstanceOf(URI::class, $result);
+		$this->assertSame((string) $url, (string) $result);
+	}
+
+	public function testFullUri()
+	{
+		$this->expectException('InvalidArgumentException');
+		$this->expectExceptionMessage('URL class only accepts relative paths.');
+
+		$url = new URL('http://example.com/bam');
+	}
+
+	public function testInvalidBaseURL()
+	{
+		$this->config->baseURL = '';
+
+		$this->expectException('InvalidArgumentException');
+		$this->expectExceptionMessage('URL class requires a valid baseURL.');
+
+		$url = new URL('banana', $this->config);
+	}
+
+	/**
+	 * This test mostly replicates URI::testRemoveDotSegments()
+	 * but it demonstrates how input is cleaned up.
+	 *
+	 * @dataProvider pathProvider
+	 */
+	public function testConstructorPath(string $path, string $expected)
+	{
+		$result = (new URL($path))->getPath();
+
+		$this->assertSame($expected, $result);
+	}
+
+	/**
+	 * @dataProvider configProvider
+	 */
+	public function testConstructorConfig(array $configs, string $baseURL)
+	{
+		foreach ($configs as $key => $value)
+		{
+			$this->setConfig($key, $value);
+		}
+
+		$url      = new URL('testaroo', $this->config);
+		$expected = rtrim($baseURL, '/') . '/testaroo';
+
+		$this->assertSame($expected, (string) $url);
+	}
+
+	/**
+	 * @dataProvider currentProvider
+	 */
+	public function testCurrent(string $uri, string $expected = null)
+	{
+		$this->setCurrent($uri);
+
+		$url = URL::current();
+
+		$this->assertInstanceOf(URL::class, $url);
+		$this->assertSame($expected ?? $uri, (string) $url);
+	}
+
+	/**
+	 * @dataProvider configProvider
+	 */
+	public function testBase(array $configs, string $expected)
+	{
+		foreach ($configs as $key => $value)
+		{
+			$this->setConfig($key, $value);
+		}
+
+		Factories::injectMock('config', 'App', $this->config);
+
+		$url = URL::base();
+
+		$this->assertSame($expected, (string) $url);
+	}
+
+	public function testTo()
+	{
+		$url = URL::to('fruit/basket');
+
+		$this->assertSame('http://example.com/index.php/fruit/basket', (string) $url);
+	}
+
+	public function testToNamedRoute()
+	{
+		Services::routes()->add('apples', 'Home::index', ['as' => 'home']);
+
+		$url = URL::to('home');
+
+		$this->assertSame('http://example.com/index.php/apples', (string) $url);
+	}
+
+	public function testToReverseRoute()
+	{
+		Services::routes()->add('oranges', 'Basket::fruit');
+
+		$url = URL::to('App\Controllers\Basket::fruit');
+
+		$this->assertSame('http://example.com/index.php/oranges', (string) $url);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function pathProvider(): array
+	{
+		return [
+			[
+				'',
+				'',
+			],
+			[
+				'/',
+				'',
+			],
+			[
+				'//',
+				'',
+			],
+			[
+				'/foo/..',
+				'',
+			],
+			[
+				'/foo',
+				'foo',
+			],
+			[
+				'foo',
+				'foo',
+			],
+			[
+				'foo/',
+				'foo/',
+			],
+			[
+				'?bar=bam',
+				'?bar=bam',
+			],
+			[
+				'foo?bar=bam',
+				'foo?bar=bam',
+			],
+		];
+	}
+
+	public function configProvider(): array
+	{
+		return [
+			[
+				[
+					'baseURL' => 'http://bananas.com',
+				],
+				'http://bananas.com/index.php',
+			],
+			[
+				[
+					'baseURL' => 'http://bananas.com/',
+				],
+				'http://bananas.com/index.php',
+			],
+			[
+				[
+					'baseURL' => 'http://bananas.com/subfolder/',
+				],
+				'http://bananas.com/subfolder/index.php',
+			],
+			[
+				[
+					'indexPage' => '',
+				],
+				'http://example.com/',
+			],
+			[
+				[
+					'baseURL'   => 'http://bananas.com/subfolder/',
+					'indexPage' => '',
+				],
+				'http://bananas.com/subfolder/',
+			],
+			[
+				[
+					'forceGlobalSecureRequests' => true,
+				],
+				'https://example.com/index.php',
+			],
+			[
+				[
+					'baseURL'                   => 'http://bananas.com/',
+					'forceGlobalSecureRequests' => true,
+				],
+				'https://bananas.com/index.php',
+			],
+			[
+				[
+					'baseURL'                   => 'https://bananas.com/subfolder/',
+					'forceGlobalSecureRequests' => true,
+				],
+				'https://bananas.com/subfolder/index.php',
+			],
+		];
+	}
+
+	public function currentProvider(): array
+	{
+		return [
+			[
+				'',
+				'http://example.com/index.php',
+			],
+			[
+				'/',
+				'http://example.com/index.php',
+			],
+			[
+				'http://example.com/index.php/sauce',
+				null,
+			],
+			[
+				'http://example.com/index.php/sauce/',
+				null,
+			],
+			[
+				'/sauce/',
+				'http://example.com/index.php/sauce/',
+			],
+			[
+				'http://bananas.com/index.php',
+				'http://example.com/index.php',
+			],
+			[
+				'https://example.com/index.php',
+				'http://example.com/index.php',
+			],
+			[
+				'?blahblah=true',
+				'http://example.com/index.php?blahblah=true',
+			],
+			[
+				'http://example.com/index.php?blahblah=true',
+				'http://example.com/index.php?blahblah=true',
+			],
+		];
+	}
+}

--- a/tests/system/HTTP/URLTest.php
+++ b/tests/system/HTTP/URLTest.php
@@ -151,17 +151,16 @@ final class URLTest extends CIUnitTestCase
 	/**
 	 * @dataProvider configProvider
 	 */
-	public function testConstructorConfig(array $configs, string $baseURL)
+	public function testConstructorConfig(array $configs, string $baseURL, string $siteURL)
 	{
 		foreach ($configs as $key => $value)
 		{
 			$this->setConfig($key, $value);
 		}
 
-		$url      = new URL('testaroo', $this->config);
-		$expected = rtrim($baseURL, '/') . '/testaroo';
+		$url = new URL('testaroo', $this->config);
 
-		$this->assertSame($expected, (string) $url);
+		$this->assertSame($siteURL, (string) $url);
 	}
 
 	/**
@@ -180,7 +179,7 @@ final class URLTest extends CIUnitTestCase
 	/**
 	 * @dataProvider configProvider
 	 */
-	public function testBase(array $configs, string $expected)
+	public function testBase(array $configs, string $baseURL, string $siteURL)
 	{
 		foreach ($configs as $key => $value)
 		{
@@ -191,7 +190,14 @@ final class URLTest extends CIUnitTestCase
 
 		$url = URL::base();
 
-		$this->assertSame($expected, (string) $url);
+		$this->assertSame($baseURL, (string) $url);
+	}
+
+	public function testBaseWithUri()
+	{
+		$url = URL::base('images/cat.gif');
+
+		$this->assertSame('http://example.com/images/cat.gif', (string) $url);
 	}
 
 	public function testTo()
@@ -270,25 +276,29 @@ final class URLTest extends CIUnitTestCase
 				[
 					'baseURL' => 'http://bananas.com',
 				],
-				'http://bananas.com/index.php',
+				'http://bananas.com/',
+				'http://bananas.com/index.php/testaroo',
 			],
 			[
 				[
 					'baseURL' => 'http://bananas.com/',
 				],
-				'http://bananas.com/index.php',
+				'http://bananas.com/',
+				'http://bananas.com/index.php/testaroo',
 			],
 			[
 				[
 					'baseURL' => 'http://bananas.com/subfolder/',
 				],
-				'http://bananas.com/subfolder/index.php',
+				'http://bananas.com/subfolder/',
+				'http://bananas.com/subfolder/index.php/testaroo',
 			],
 			[
 				[
 					'indexPage' => '',
 				],
 				'http://example.com/',
+				'http://example.com/testaroo',
 			],
 			[
 				[
@@ -296,26 +306,30 @@ final class URLTest extends CIUnitTestCase
 					'indexPage' => '',
 				],
 				'http://bananas.com/subfolder/',
+				'http://bananas.com/subfolder/testaroo',
 			],
 			[
 				[
 					'forceGlobalSecureRequests' => true,
 				],
-				'https://example.com/index.php',
+				'https://example.com/',
+				'https://example.com/index.php/testaroo',
 			],
 			[
 				[
 					'baseURL'                   => 'http://bananas.com/',
 					'forceGlobalSecureRequests' => true,
 				],
-				'https://bananas.com/index.php',
+				'https://bananas.com/',
+				'https://bananas.com/index.php/testaroo',
 			],
 			[
 				[
 					'baseURL'                   => 'https://bananas.com/subfolder/',
 					'forceGlobalSecureRequests' => true,
 				],
-				'https://bananas.com/subfolder/index.php',
+				'https://bananas.com/subfolder/',
+				'https://bananas.com/subfolder/index.php/testaroo',
 			],
 		];
 	}


### PR DESCRIPTION
**Description**
"Stage Three", this PR introduces a companion class to `URI`: `URL`. The `URL` class handles internal URIs (i.e. specific to the project) in the following manner:
* A `URL` is always constructed with a relative path
* A `URL` will always use the App config values from its construction (`baseURL`, `indexPage`, `forceGlobalSecureRequest`)
* A `URL` is immutable, not affected by changes to `$_SERVER` or services once it has been created

I would like `URL` to become the definitive source for internal URLs within the framework (e.g. replace the logic in `base_url()` and `current_url()`, be used by `RedirectResponse`, etc) but for now this PR is just introducing the concept and demonstrating the tests. Please be thorough with any reviews, since URLs have been a long pain point (particularly around subfolders).

Note: This PR relies on #4644 and #4646.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
