### PR TITLE
[ci skip] Remove ajax filter reference from docs. Fixes #2314

### DIFF
--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -167,11 +167,8 @@ specify the method name in lowercase. It's value would be an array of filters to
         'get'  => ['baz'],
     ]
 
-In addition to the standard HTTP methods, this also supports two special cases: 'cli', and 'ajax'. The names are
-self-explanatory here, but 'cli' would apply to all requests that were run from the command line, while 'ajax'
-would apply to every AJAX request.
-
-.. note:: The AJAX requests depends on the ``X-Requested-With`` header, which in some cases is not sent by default in XHR requests via JavaScript (i.e., fetch). See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
+In addition to the standard HTTP methods, this also supports one special case: 'cli'. The 'cli' method would apply to
+all requests that were run from the command line.
 
 $filters
 ========


### PR DESCRIPTION
Removes the reference to `ajax` filters as an available method since it is not implemented. 

Long time coming :)
  
