### PR TITLE
[Scipts] Ensure admin/setup.sh exists before run bash admin/setup.sh

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
 	"scripts": {
 		"post-update-cmd": [
 			"CodeIgniter\\ComposerScripts::postUpdate",
-			"bash admin/setup.sh"
+			"if [ -f \"admin/setup.sh\" ]; then bash admin/setup.sh; fi"
 		],
 		"analyze": "phpstan analyze",
 		"test": "phpunit"


### PR DESCRIPTION
This ensure check `admin/setup.sh` exists before run it as `admin` directory is on `.gitattributes`.

https://github.com/codeigniter4/CodeIgniter4/blob/7546ee04a55071d4731c77346deb47843f397c87/.gitattributes#L12

To avoid usage of download and run composer update with got error: 

```bash
Script bash admin/setup.sh handling the post-update-cmd event returned with error code 127
```

**Checklist:**
- [x] Securely signed commits
