### PR TITLE
[Scripts] Make sure bash script still works in Windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
 	"scripts": {
 		"post-update-cmd": [
 			"CodeIgniter\\ComposerScripts::postUpdate",
-			"if [ -f \"admin/setup.sh\" ]; then bash admin/setup.sh; fi"
+			"bash -c \"if [ -f admin/setup.sh ]; then bash admin/setup.sh; fi\""
 		],
 		"analyze": "phpstan analyze",
 		"test": "phpunit"


### PR DESCRIPTION
#4650 does not work on Windows.

```console
> CodeIgniter\ComposerScripts::postUpdate
> if [ -f "admin/setup.sh" ]; then bash admin/setup.sh; fi
Script if [ -f "admin/setup.sh" ]; then bash admin/setup.sh; fi handling the post-update-cmd event returned with error code 1
```

Fixed:
```console
> CodeIgniter\ComposerScripts::postUpdate
> bash -c "if [ -f admin/setup.sh ]; then bash admin/setup.sh; fi"
```