### PR TITLE
Unify migration message format for `migrate` and `migrate:rollback`

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -771,7 +771,7 @@ class MigrationRunner
 		if (is_cli())
 		{
 			$this->cliMessages[] = "\t" . CLI::color(lang('Migrations.removed'),
-					'yellow') . "($history->namespace) " . $history->version . '_' . $this->getMigrationName($history->class);
+					'yellow') . "($history->namespace) " . $history->version . '_' . $history->class;
 		}
 	}
 

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -738,20 +738,24 @@ class MigrationRunner
 	 */
 	protected function addHistory($migration, int $batch)
 	{
-		$this->db->table($this->table)
-				 ->insert([
-					 'version'   => $migration->version,
-					 'class'     => $migration->class,
-					 'group'     => $this->group,
-					 'namespace' => $migration->namespace,
-					 'time'      => time(),
-					 'batch'     => $batch,
-				 ]);
+		$this->db->table($this->table)->insert([
+			'version'   => $migration->version,
+			'class'     => $migration->class,
+			'group'     => $this->group,
+			'namespace' => $migration->namespace,
+			'time'      => time(),
+			'batch'     => $batch,
+		]);
 
 		if (is_cli())
 		{
-			$this->cliMessages[] = "\t" . CLI::color(lang('Migrations.added'),
-					'yellow') . "($migration->namespace) " . $migration->version . '_' . $migration->class;
+			$this->cliMessages[] = sprintf(
+				"\t%s(%s) %s_%s",
+				CLI::color(lang('Migrations.added'), 'yellow'),
+				$migration->namespace,
+				$migration->version,
+				$migration->class
+			);
 		}
 	}
 
@@ -770,8 +774,13 @@ class MigrationRunner
 
 		if (is_cli())
 		{
-			$this->cliMessages[] = "\t" . CLI::color(lang('Migrations.removed'),
-					'yellow') . "($history->namespace) " . $history->version . '_' . $history->class;
+			$this->cliMessages[] = sprintf(
+				"\t%s(%s) %s_%s",
+				CLI::color(lang('Migrations.removed'), 'yellow'),
+				$history->namespace,
+				$history->version,
+				$history->class
+			);
 		}
 	}
 

--- a/tests/system/Commands/MigrationIntegrationTest.php
+++ b/tests/system/Commands/MigrationIntegrationTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+/**
+ * @internal
+ */
+final class MigrationIntegrationTest extends CIUnitTestCase
+{
+	private $streamFilter;
+
+	private $migrationFileFrom = SUPPORTPATH . 'Database/Migrations/20160428212500_Create_test_tables.php';
+
+	private $migrationFileTo = APPPATH . 'Database/Migrations/20160428212500_Create_test_tables.php';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		if (! is_file($this->migrationFileFrom))
+		{
+			$this->fail(clean_path($this->migrationFileFrom) . ' is not found.');
+		}
+
+		if (is_file($this->migrationFileTo))
+		{
+			@unlink($this->migrationFileTo);
+		}
+
+		copy($this->migrationFileFrom, $this->migrationFileTo);
+
+		$contents = file_get_contents($this->migrationFileTo);
+		$contents = str_replace('namespace Tests\Support\Database\Migrations;', 'namespace App\Database\Migrations;', $contents);
+		file_put_contents($this->migrationFileTo, $contents);
+
+		CITestStreamFilter::$buffer = '';
+
+		$this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
+		$this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+
+		if (is_file($this->migrationFileTo))
+		{
+			@unlink($this->migrationFileTo);
+		}
+
+		stream_filter_remove($this->streamFilter);
+	}
+
+	/**
+	 * @runTestsInSeparateProcesses
+	 */
+	public function testMigrationWithRollbackHasSameNameFormat(): void
+	{
+		command('migrate -n App');
+		$this->assertStringContainsString(
+			'(App) 20160428212500_App\Database\Migrations\Migration_Create_test_tables',
+			CITestStreamFilter::$buffer
+		);
+
+		CITestStreamFilter::$buffer = '';
+
+		command('migrate:rollback -n App');
+		$this->assertStringContainsString(
+			'(App) 20160428212500_App\Database\Migrations\Migration_Create_test_tables',
+			CITestStreamFilter::$buffer
+		);
+	}
+}


### PR DESCRIPTION
**Description**
Fixes #4579 
Replaces and closes #4584 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
