### PR TITLE
Reset Single Service

### DIFF
--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -307,8 +307,7 @@ class BaseService
 	 */
 	public static function resetSingle(string $name)
 	{
-		unset(static::$mocks[$name]);
-		unset(static::$instances[$name]);
+		unset(static::$mocks[$name], static::$instances[$name]);
 	}
 
 	/**

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -301,6 +301,17 @@ class BaseService
 	}
 
 	/**
+	 * Resets any mock and shared instances for a single service.
+	 *
+	 * @param string $name
+	 */
+	public static function resetSingle(string $name)
+	{
+		unset(static::$mocks[$name]);
+		unset(static::$instances[$name]);
+	}
+
+	/**
 	 * Inject mock object for testing.
 	 *
 	 * @param string $name

--- a/tests/system/CommonSingleServiceTest.php
+++ b/tests/system/CommonSingleServiceTest.php
@@ -77,6 +77,7 @@ final class CommonSingleServiceTest extends CIUnitTestCase
 				'__callStatic',
 				'serviceExists',
 				'reset',
+				'resetSingle',
 				'injectMock',
 				'encrypter', // Encrypter needs a starter key
 				'session', // Headers already sent

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -26,6 +26,7 @@ use CodeIgniter\Security\Security;
 use CodeIgniter\Session\Session;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockResponse;
+use CodeIgniter\Test\Mock\MockSecurity;
 use CodeIgniter\Throttle\Throttler;
 use CodeIgniter\Typography\Typography;
 use CodeIgniter\Validation\Validation;
@@ -310,6 +311,30 @@ class ServicesTest extends CIUnitTestCase
 		$this->assertInstanceOf(MockResponse::class, $response2);
 
 		$this->assertTrue($response !== $response2);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState  disabled
+	 */
+	public function testResetSingle()
+	{
+		Services::injectMock('response', new MockResponse(new App()));
+		Services::injectMock('security', new MockSecurity(new App()));
+		$response = service('response');
+		$security = service('security');
+		$this->assertInstanceOf(MockResponse::class, $response);
+		$this->assertInstanceOf(MockSecurity::class, $security);
+
+		Services::resetSingle('response');
+
+		$response2 = service('response');
+		$security2 = service('security');
+		$this->assertNotInstanceOf(MockResponse::class, $response2);
+		$this->assertInstanceOf(MockSecurity::class, $security2);
+
+		$this->assertNotSame($response, $response2);
+		$this->assertSame($security, $security2);
 	}
 
 	public function testFilters()

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -309,8 +309,8 @@ Mocking Services
 
 You will often find that you need to mock one of the services defined in **app/Config/Services.php** to limit
 your tests to only the code in question, while simulating various responses from the services. This is especially
-true when testing controllers and other integration testing. The **Services** class provides two methods to make this
-simple: ``injectMock()``, and ``reset()``.
+true when testing controllers and other integration testing. The **Services** class provides the following methods
+to simplify this.
 
 **injectMock()**
 
@@ -335,7 +335,11 @@ class exactly. The second parameter is the instance to replace it with.
 
 Removes all mocked classes from the Services class, bringing it back to its original state.
 
-.. note:: The ``Email`` and ``Session`` services are mocked by default to prevent intrusive testing behavior. To prevent these from mocking remove their method callback from the class property: ``$setUpMethods = ['mockEmail', 'mockSession'];``
+**resetSingle(string $name)**
+
+Removes any mock and shared instances for a single service, by its name.
+
+.. note:: The ``Cache``, ``Email`` and ``Session`` services are mocked by default to prevent intrusive testing behavior. To prevent these from mocking remove their method callback from the class property: ``$setUpMethods = ['mockEmail', 'mockSession'];``
 
 Mocking Factory Instances
 =========================


### PR DESCRIPTION
**Description**
Frequently I find myself doing acrobatics to accomplish this. It is past time this was added: the ability to reset a single Service by its name.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
