### PR TITLE
Add stricter validation for URLs

### DIFF
--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -328,7 +328,9 @@ class FormatRules
 	}
 
 	/**
-	 * Checks a URL to ensure it's formed correctly.
+	 * Checks a string to ensure it is (loosely) a URL.
+	 * Warning: this rule will pass basic strings like
+	 * "banana"; use valid_url_strict for a stricter rule.
 	 *
 	 * @param string $str
 	 *
@@ -354,6 +356,35 @@ class FormatRules
 		$str = 'http://' . $str;
 
 		return (filter_var($str, FILTER_VALIDATE_URL) !== false);
+	}
+
+	/**
+	 * Checks a URL to ensure it's formed correctly.
+	 *
+	 * @param string $str
+	 *
+	 * @return boolean
+	 */
+	public function valid_url_strict(string $str = null): bool
+	{
+		if (empty($str))
+		{
+			return false;
+		}
+
+		/**
+		 * Pattern borrowed from Laravel.
+		 *
+		 * @see https://github.com/laravel/framework/blob/277c2fbd0cebd2cb194807654d870f4040e288c0/src/Illuminate/Routing/UrlGenerator.php#L583
+		 */
+		$pattern = '~^(#|//|https?://|(mailto|tel|sms):)~';
+
+		if (filter_var($str, FILTER_VALIDATE_URL) !== false)
+		{
+			return (bool) preg_match($pattern, $str);
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -76,7 +76,7 @@ class FormatRulesTest extends CIUnitTestCase
 	/**
 	 * @dataProvider urlProvider
 	 */
-	public function testValidURL(?string $url, bool $expected)
+	public function testValidURL(?string $url, bool $isLoose, bool $isStrict)
 	{
 		$data = [
 			'foo' => $url,
@@ -86,7 +86,23 @@ class FormatRulesTest extends CIUnitTestCase
 			'foo' => 'valid_url',
 		]);
 
-		$this->assertEquals($expected, $this->validation->run($data));
+		$this->assertEquals($isLoose, $this->validation->run($data));
+	}
+
+	/**
+	 * @dataProvider urlProvider
+	 */
+	public function testStrictURL(?string $url, bool $isLoose, bool $isStrict)
+	{
+		$data = [
+			'foo' => $url,
+		];
+
+		$this->validation->setRules([
+			'foo' => 'valid_url_strict',
+		]);
+
+		$this->assertEquals($isStrict, $this->validation->run($data));
 	}
 
 	public function urlProvider()
@@ -95,59 +111,83 @@ class FormatRulesTest extends CIUnitTestCase
 			[
 				'www.codeigniter.com',
 				true,
+				false,
 			],
 			[
 				'http://codeigniter.com',
 				true,
+				true,
 			],
-			//https://bugs.php.net/bug.php?id=51192
+			// https://bugs.php.net/bug.php?id=51192
 			[
 				'http://accept-dashes.tld',
 				true,
+				true,
 			],
 			[
-				'http://reject_underscores',
+				'http://test_underscores',
+				false,
 				false,
 			],
 			// https://github.com/codeigniter4/CodeIgniter/issues/4415
 			[
 				'http://[::1]/ipv6',
 				true,
+				true,
 			],
 			[
 				'htt://www.codeigniter.com',
+				false,
 				false,
 			],
 			[
 				'',
 				false,
+				false,
+			],
+			[
+				'codeigniter',
+				true,
+				false,
 			],
 			[
 				'code igniter',
+				false,
 				false,
 			],
 			[
 				null,
 				false,
+				false,
 			],
 			[
 				'http://',
 				true,
-			], // this is apparently valid!
+				false,
+			],
 			[
 				'http:///oops.com',
+				false,
 				false,
 			],
 			[
 				'123.com',
 				true,
+				false,
 			],
 			[
 				'abc.123',
 				true,
+				false,
 			],
 			[
 				'http:8080//abc.com',
+				true,
+				false,
+			],
+			[
+				'mailto:support@codeigniter.com',
+				true,
 				true,
 			],
 		];

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -849,7 +849,12 @@ valid_emails            No         Fails if any value provided in a comma
 valid_ip                No         Fails if the supplied IP is not valid.        valid_ip[ipv6]
                                    Accepts an optional parameter of ‘ipv4’ or
                                    ‘ipv6’ to specify an IP format.
-valid_url               No         Fails if field does not contain a valid URL.
+valid_url               No         Fails if field does not contain (loosely) a
+                                   URL. Includes simple strings that could be
+                                   domains, like "codeigniter".
+valid_url_strict        No         Fails if field does not contain a valid URL.
+                                   Roughly equivalent to a "fail anything that
+                                   would not be a clickable link."
 valid_date              No         Fails if field does not contain a valid date. valid_date[d/m/Y]
                                    Accepts an optional parameter to matches
                                    a date format.


### PR DESCRIPTION
**Description**
Fixes #3156.

This one was a bit of a contentious conversation. I ended up going with a separate rule that borrows the validation regex from Laravel and still using `filter_var()`. I don't know that there is an ideal way to do this but this seems to me a solid middle ground between expectations and implementation.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
