### PR TITLE
[Feature] Introduce the `Debug\Deprecation` utility component

### DIFF
--- a/system/Debug/Deprecation/DeprecatedClassMethodTrait.php
+++ b/system/Debug/Deprecation/DeprecatedClassMethodTrait.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Debug\Deprecation;
+
+use BadMethodCallException;
+use Error;
+use ReflectionMethod;
+
+/**
+ * This support trait can be used in two flavors.
+ * - Used to prevent child classes from using deprecated parent methods;
+ * - Used to prevent method calls outside the class.
+ *
+ * __(1) Used to prevent child classes from using deprecated parent methods__
+ *
+ * If intention is to encapsulate code within the parent class, this trait
+ * should be imported into the parent. The deprecated method should be set
+ * as `private` and the name and its replacement will be setup in a private
+ * `$deprecatedMethods` property array. The property is set private to prevent
+ * overrides by child classes. If the deprecated method is static, the setup
+ * will be made in a private static `$deprecatedStaticMethods` property array.
+ *
+ * __(2) Used to prevent method calls outside the class__
+ *
+ * To prevent out-of-class method calls of the deprecated methods, the method
+ * should be set as either `protected` or `private` (i.e., preventing access).
+ * After that, add the name of the method and its replacement into the respective
+ * array property, depending if the method is static or not.
+ *
+ * __NOTE:__
+ *
+ * This trait will give access to previously inaccessible methods of a class. If this
+ * behavior is not desired, the names of methods to be excluded and to remain as
+ * not accessible should be added to the private static `$methodAccessExclusions`
+ * property.
+ *
+ * @property-read array<string, string>  $deprecatedMethods
+ * @property-read array<string, string>  $deprecatedStaticMethods
+ * @property-read array<integer, string> $methodAccessExclusions
+ */
+trait DeprecatedClassMethodTrait
+{
+	/**
+	 * Intercept calls to inaccessible and/or deprecated non-static methods.
+	 *
+	 * @param string  $name      Name of the static method
+	 * @param mixed[] $arguments Arguments to be passed
+	 *
+	 * @throws Error                  When the method is not deprecated but is not allowed for access
+	 * @throws BadMethodCallException When the method is not defined
+	 * @throws DeprecationException   When the method is deprecated and handling mode is `Deprecation::THROW_EXCEPTION`
+	 *
+	 * @return mixed
+	 */
+	public function __call(string $name, array $arguments)
+	{
+		if (! method_exists($this, $name))
+		{
+			throw new BadMethodCallException(sprintf('Trying to access undefined method "%s::%s()".', static::class, $name));
+		}
+
+		if (array_key_exists($name, $this->deprecatedMethods))
+		{
+			// a deprecated method is always resolved to the class importing
+			// this trait, so this is always `self::class`
+			$classMethod = self::class . '::' . $name;
+
+			Deprecation::triggerForMethod($classMethod, $this->deprecatedMethods[$name]);
+		}
+
+		// did we accidentally grant access to methods we should not let everyone to use?
+		if (in_array($name, self::$methodAccessExclusions, true))
+		{
+			$visibility = self::determineMethodVisibility($name);
+			$backtrace  = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+
+			throw new Error(sprintf(
+				'Call to %s method "%s::%s()" from scope "%s".',
+				$visibility,
+				self::class,
+				$name,
+				$backtrace[1]['class'] ?? $backtrace[2]['class'] ?? 'unknown'
+			));
+		}
+
+		return $this->{$name}(...$arguments);
+	}
+
+	/**
+	 * Intercept calls to inaccessible and/or deprecated static methods.
+	 *
+	 * @param string  $name      Name of the static method
+	 * @param mixed[] $arguments Arguments to be passed
+	 *
+	 * @throws Error                  When the method is not deprecated but is not allowed for access
+	 * @throws BadMethodCallException When the method is not defined
+	 * @throws DeprecationException   When the method is deprecated and handling mode is `Deprecation::THROW_EXCEPTION`
+	 *
+	 * @return mixed
+	 */
+	public static function __callStatic(string $name, array $arguments)
+	{
+		if (! method_exists(self::class, $name))
+		{
+			throw new BadMethodCallException(sprintf('Trying to access undefined static method "%s::%s()".', self::class, $name));
+		}
+
+		if (array_key_exists($name, self::$deprecatedStaticMethods))
+		{
+			// a deprecated static method is always resolved to the class
+			// importing this trait, so this is always `self::class`
+			$classMethod = self::class . '::' . $name;
+
+			Deprecation::triggerForStaticMethod($classMethod, self::$deprecatedStaticMethods[$name]);
+		}
+
+		// did we accidentally grant access to methods we should not let everyone to use?
+		if (in_array($name, self::$methodAccessExclusions, true))
+		{
+			$visibility = self::determineMethodVisibility($name);
+			$backtrace  = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+
+			throw new Error(sprintf(
+				'Call to %s static method "%s::%s()" from scope "%s".',
+				$visibility,
+				self::class,
+				$name,
+				$backtrace[1]['class'] ?? $backtrace[2]['class'] ?? 'unknown'
+			));
+		}
+
+		return static::{$name}(...$arguments);
+	}
+
+	private static function determineMethodVisibility(string $method): string
+	{
+		$method = new ReflectionMethod(self::class, $method);
+
+		if ($method->isPrivate())
+		{
+			return 'private';
+		}
+
+		if ($method->isProtected())
+		{
+			return 'protected';
+		}
+
+		return 'public'; // @codeCoverageIgnore
+	}
+}

--- a/system/Debug/Deprecation/DeprecatedClassPropertyTrait.php
+++ b/system/Debug/Deprecation/DeprecatedClassPropertyTrait.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Debug\Deprecation;
+
+use Error;
+use LogicException;
+use ReflectionProperty;
+
+/**
+ * Support trait in order to properly intercept calls to deprecated class
+ * properties. This should be imported to classes where the properties are
+ * defined. The deprecated properties should no longer be accessible
+ * outside the class by setting its visibility either as `protected` or `private`.
+ * If used in the context of forbidding child classes to use the properties,
+ * the visibility should be set as `private` instead.
+ *
+ * Two special array properties are needed for this to work:
+ * - `$deprecatedProperties` - Array containing the name of the deprecated
+ * 		property as the key and the suggested replacement as value. This is
+ *      used when a value of a deprecated property is retrieved.
+ * - `$deprecatedSettableProperties` - Array containing the name of the
+ *      deprecated property which is forbidden to be given a value. This is
+ * 		a simple list consisting of the names as array values.
+ *
+ * __NOTE:__
+ *
+ * This trait will give access to previously inaccessible properties. If a global
+ * access is not intended and intercept should be done only on the deprecated
+ * properties, then the names to be excluded should be added in the private
+ * static `$propertyAccessExclusions` property.
+ *
+ * @property-read array<string, string>  $deprecatedProperties
+ * @property-read array<integer, string> $deprecatedSettableProperties
+ * @property-read array<integer, string> $propertyAccessExclusions
+ */
+trait DeprecatedClassPropertyTrait
+{
+	/**
+	 * Intercept property access to inaccessible and/or deprecated properties.
+	 *
+	 * @param string $property Name of property to inspect
+	 *
+	 * @throws Error                When the property is not deprecated but is not allowed for access
+	 * @throws LogicException       When property is not defined by the class
+	 * @throws DeprecationException When property is deprecated and handling mode is `Deprecation::THROW_EXCEPTION`
+	 *
+	 * @return mixed
+	 */
+	public function __get(string $property)
+	{
+		if (! property_exists($this, $property))
+		{
+			throw new LogicException(sprintf('Trying to access unknown property "%s::$%s".', static::class, $property));
+		}
+
+		if (array_key_exists($property, $this->deprecatedProperties))
+		{
+			Deprecation::triggerForPropertyAccess($property, static::class, $this->deprecatedProperties[$property]);
+		}
+
+		// did we accidentally grant access to inaccessible properties?
+		if (in_array($property, self::$propertyAccessExclusions, true))
+		{
+			$visibility = self::determinePropertyVisibility($property);
+			$backtrace  = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+
+			throw new Error(sprintf(
+				'Cannot access %s property "%s::$%s" from scope "%s".',
+				$visibility,
+				self::class,
+				$property,
+				$backtrace[1]['class'] ?? $backtrace[2]['class'] ?? 'unknown'
+			));
+		}
+
+		return $this->$property;
+	}
+
+	/**
+	 * Set a value to a property. If the property is deprecated and
+	 * setting values to it is disallowed, this will issue a deprecation
+	 * message.
+	 *
+	 * @param string $property Name of property to inspect
+	 * @param mixed  $value    Value to assign
+	 *
+	 * @throws Error                When the property is not deprecated but is not allowed for assignment
+	 * @throws LogicException       When the property is not defined in the class
+	 * @throws DeprecationException When the property is deprecated and handling mode is `Deprecation::THROW_EXCEPTION`
+	 *
+	 * @return void
+	 */
+	public function __set(string $property, $value): void
+	{
+		if (! property_exists($this, $property))
+		{
+			throw new LogicException(sprintf('Trying to set value on unknown property "%s::$%s"', static::class, $property));
+		}
+
+		if (in_array($property, $this->deprecatedSettableProperties, true))
+		{
+			Deprecation::triggerForPropertyAssignment($property, static::class);
+		}
+
+		// did we accidentally grant access to inaccessible properties?
+		if (in_array($property, self::$propertyAccessExclusions, true))
+		{
+			$visibility = self::determinePropertyVisibility($property);
+			$backtrace  = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
+
+			throw new Error(sprintf(
+				'Cannot assign value to %s property "%s::$%s" from scope "%s".',
+				$visibility,
+				self::class,
+				$property,
+				$backtrace[1]['class'] ?? $backtrace[2]['class'] ?? 'unknown'
+			));
+		}
+
+		$this->$property = $value;
+	}
+
+	private static function determinePropertyVisibility(string $property): string
+	{
+		$property = new ReflectionProperty(self::class, $property);
+
+		if ($property->isPrivate())
+		{
+			return 'private';
+		}
+
+		if ($property->isProtected())
+		{
+			return 'protected';
+		}
+
+		return 'public'; // @codeCoverageIgnore
+	}
+}

--- a/system/Debug/Deprecation/Deprecation.php
+++ b/system/Debug/Deprecation/Deprecation.php
@@ -272,8 +272,9 @@ final class Deprecation
 			return self::normalizeVariablesWithDollars($parameterName);
 		}, (array) $parameterNames);
 
-		$paramCount = count($parameterNames);
-		$parameters = implode('", "', $parameterNames);
+		$paramCount  = count($parameterNames);
+		$parameters  = implode('", "', $parameterNames);
+		$classMethod = self::normalizeMethodsWithParens($classMethod);
 
 		$message = $paramCount > 1
 			? lang('Deprecation.methodParametersDeprecated', [$parameters, $classMethod])

--- a/system/Debug/Deprecation/Deprecation.php
+++ b/system/Debug/Deprecation/Deprecation.php
@@ -1,0 +1,463 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Debug\Deprecation;
+
+use Psr\Log\LogLevel;
+use UnexpectedValueException;
+
+/**
+ * The Deprecation class manages usage of deprecated elements in the framework.
+ */
+final class Deprecation
+{
+	/**
+	 * Mode to log the deprecation messages instead of halting the application.
+	 *
+	 * @var string
+	 */
+	public const LOG_MESSAGE = 'log_message';
+
+	/**
+	 * Mode to throw a `DeprecationException` for all encountered uses
+	 * of deprecated elements.
+	 *
+	 * @var string
+	 */
+	public const THROW_EXCEPTION = 'throw_exception';
+
+	/**
+	 * List of supported deprecation handling modes.
+	 *
+	 * @var array<integer, string>
+	 */
+	public const SUPPORTED_MODES = [self::LOG_MESSAGE, self::THROW_EXCEPTION];
+
+	/**
+	 * Current deprecation handling mode.
+	 *
+	 * @var string
+	 */
+	private static $mode = self::LOG_MESSAGE;
+
+	/**
+	 * @codeCoverageIgnore
+	 */
+	private function __construct()
+	{
+	}
+
+	/**
+	 * Set the deprecation handling mode. Allowed values can be any
+	 * of `Deprecation::THROW_EXCEPTION` or `Deprecation::LOG_MESSAGE`.
+	 *
+	 * Default mode is `Deprecation::LOG_MESSAGE`.
+	 *
+	 * @param string $mode Any of `Deprecation::THROW_EXCEPTION` or `Deprecation::LOG_MESSAGE`
+	 *
+	 * @throws UnexpectedValueException When mode is not supported
+	 *
+	 * @return void
+	 */
+	public static function setMode(string $mode): void
+	{
+		if (! in_array($mode, self::SUPPORTED_MODES, true))
+		{
+			throw new UnexpectedValueException(sprintf(
+				'Mode "%s" is not supported. Allowed: "%s".',
+				$mode,
+				implode('", "', self::SUPPORTED_MODES)
+			));
+		}
+
+		self::$mode = $mode;
+	}
+
+	/**
+	 * Retrieve the current deprecation handling mode.
+	 *
+	 * @return string
+	 */
+	public static function mode(): string
+	{
+		return self::$mode;
+	}
+
+	/**
+	 * Generic trigger of deprecation message.
+	 *
+	 * @param string $message Deprecation message
+	 * @param string $level   Log level for logging the deprecation message, default is `error`
+	 *
+	 * @throws DeprecationException
+	 *
+	 * @return void
+	 */
+	public static function trigger(string $message, string $level = LogLevel::ERROR): void
+	{
+		self::triggerDeprecation($message, $level);
+	}
+
+	/**
+	 * Trigger a deprecation message when a deprecated class is used.
+	 *
+	 * @param string $deprecated  Fully qualified name of deprecated class
+	 * @param string $replacement Fully qualified name of replacement class
+	 * @param string $level       Log level for logging the deprecation message, default is `error`
+	 *
+	 * @throws DeprecationException
+	 * @throws UnexpectedValueException
+	 *
+	 * @return void
+	 */
+	public static function triggerForClass(string $deprecated, string $replacement, string $level = LogLevel::ERROR): void
+	{
+		self::determineIfValidObjectType('deprecated', $deprecated, true, false, false);
+		self::determineIfValidObjectType('replacement', $replacement, true, true, false);
+
+		$message = lang('Deprecation.classDeprecated', [$deprecated, $replacement]);
+
+		self::triggerDeprecation($message, $level);
+	}
+
+	/**
+	 * Trigger a deprecation message on use of deprecated interface.
+	 *
+	 * @param string $deprecated  Fully qualified name of deprecated interface
+	 * @param string $replacement Fully qualified name of replacement class or interface
+	 * @param string $level       Log level for logging the deprecation message, default is `error`
+	 *
+	 * @throws DeprecationException
+	 * @throws UnexpectedValueException
+	 *
+	 * @return void
+	 */
+	public static function triggerForInterface(string $deprecated, string $replacement, string $level = LogLevel::ERROR): void
+	{
+		self::determineIfValidObjectType('deprecated', $deprecated, false, false, true);
+		self::determineIfValidObjectType('replacement', $replacement, true, false, true);
+
+		$message = lang('Deprecation.interfaceDeprecated', [$deprecated, $replacement]);
+
+		self::triggerDeprecation($message, $level);
+	}
+
+	/**
+	 * Trigger a deprecation message when a deprecated trait is used.
+	 *
+	 * @param string $deprecated  Fully qualified name of deprecated trait
+	 * @param string $replacement Fully qualified name of replacement class or trait
+	 * @param string $level       Log level for logging the deprecation message, default is `error`
+	 *
+	 * @throws DeprecationException
+	 * @throws UnexpectedValueException
+	 *
+	 * @return void
+	 */
+	public static function triggerForTrait(string $deprecated, string $replacement, string $level = LogLevel::ERROR): void
+	{
+		self::determineIfValidObjectType('deprecated', $deprecated, false, true, false);
+		self::determineIfValidObjectType('replacement', $replacement, true, true, false);
+
+		$message = lang('Deprecation.traitDeprecated', [$deprecated, $replacement]);
+
+		self::triggerDeprecation($message, $level);
+	}
+
+	/**
+	 * Trigger a deprecation message for retrieving the value of a deprecated class property.
+	 *
+	 * @param string $property    Name of the property
+	 * @param string $class       Name of the class where the property belongs
+	 * @param string $replacement Name of replacing property
+	 * @param string $level       Log level for logging the deprecation message, default is `error`
+	 *
+	 * @throws DeprecationException
+	 *
+	 * @return void
+	 */
+	public static function triggerForPropertyAccess(string $property, string $class, string $replacement, string $level = LogLevel::ERROR): void
+	{
+		self::determineIfValidObjectType('class', $class, true, false, false);
+		$property = self::normalizeVariablesWithDollars($property);
+		$message  = lang('Deprecation.propertyAccessDeprecated', [$property, $class, $replacement]);
+
+		self::triggerDeprecation($message, $level);
+	}
+
+	/**
+	 * Trigger a deprecation message when trying to assign a value to a deprecated class property.
+	 *
+	 * @param string $property Name of the property
+	 * @param string $class    Name of the class where the property belongs
+	 * @param string $level    Log level for logging the deprecation message, default is `error`
+	 *
+	 * @throws DeprecationException
+	 *
+	 * @return void
+	 */
+	public static function triggerForPropertyAssignment(string $property, string $class, string $level = LogLevel::ERROR): void
+	{
+		self::determineIfValidObjectType('class', $class, true, false, false);
+		$property = self::normalizeVariablesWithDollars($property);
+		$message  = lang('Deprecation.propertyAssignmentDeprecated', [$property, $class]);
+
+		self::triggerDeprecation($message, $level);
+	}
+
+	/**
+	 * Trigger a deprecation for use of a non-static class method already marked as deprecated.
+	 *
+	 * @param string $method      Complete name of the deprecated method, usually given as `__METHOD__`
+	 * @param string $replacement Complete name of the replacement method
+	 * @param string $level       Log level for logging the deprecation message, default is `error`
+	 *
+	 * @throws DeprecationException
+	 *
+	 * @return void
+	 */
+	public static function triggerForMethod(string $method, string $replacement, string $level = LogLevel::ERROR): void
+	{
+		$classMethod = self::normalizeMethodsWithParens($method);
+		$replacement = self::normalizeMethodsWithParens($replacement);
+
+		$message = lang('Deprecation.methodAccessDeprecated', [$classMethod, $replacement]);
+
+		self::triggerDeprecation($message, $level);
+	}
+
+	/**
+	 * Trigger a deprecation for use of a static class method already marked as deprecated.
+	 *
+	 * @param string $staticMethod Complete name of the deprecated static method
+	 * @param string $replacement  Complete name of the replacement method
+	 * @param string $level        Log level for logging the deprecation message, default is `error`
+	 *
+	 * @throws DeprecationException
+	 *
+	 * @return void
+	 */
+	public static function triggerForStaticMethod(string $staticMethod, string $replacement, string $level = LogLevel::ERROR): void
+	{
+		$staticMethod = self::normalizeMethodsWithParens($staticMethod);
+		$replacement  = self::normalizeMethodsWithParens($replacement);
+
+		$message = lang('Deprecation.methodStaticAccessDeprecated', [$staticMethod, $replacement]);
+
+		self::triggerDeprecation($message, $level);
+	}
+
+	/**
+	 * Trigger deprecation message for a set of deprecated parameters of a class method.
+	 *
+	 * @param string|string[] $parameterNames Name(s) of the parameter(s)
+	 * @param string          $classMethod    Method where the parameter is used
+	 * @param string          $level          Log level for logging the deprecation message, default is `error`
+	 *
+	 * @throws DeprecationException
+	 *
+	 * @return void
+	 */
+	public static function triggerForMethodParameter($parameterNames, string $classMethod, string $level = LogLevel::ERROR): void
+	{
+		$parameterNames = array_map(static function (string $parameterName): string {
+			return self::normalizeVariablesWithDollars($parameterName);
+		}, (array) $parameterNames);
+
+		$paramCount = count($parameterNames);
+		$parameters = implode('", "', $parameterNames);
+
+		$message = $paramCount > 1
+			? lang('Deprecation.methodParametersDeprecated', [$parameters, $classMethod])
+			: lang('Deprecation.methodParameterDeprecated', [$parameters, $classMethod]);
+
+		self::triggerDeprecation($message, $level);
+	}
+
+	/**
+	 * Utility method to detect uses of deprecated interfaces.
+	 *
+	 * __NOTE:__
+	 * Deprecation warning cannot be setup after the interface definition because
+	 * PHP only resolves the interface once.
+	 *
+	 * @param string|object $objectOrClass A class instance or class name
+	 * @param string        $deprecated    Name of deprecated interface
+	 * @param string        $replacement   Name of replacement interface or class
+	 * @param string        $level         Log level for logging the deprecation message, default is `error`
+	 *
+	 * @throws DeprecationException
+	 * @throws UnexpectedValueException
+	 *
+	 * @return void
+	 */
+	public static function checkDeprecatedInterface($objectOrClass, string $deprecated, string $replacement, string $level = LogLevel::ERROR): void
+	{
+		if (in_array($deprecated, class_implements($objectOrClass), true))
+		{
+			self::triggerForInterface($deprecated, $replacement, $level);
+		}
+	}
+
+	/**
+	 * Utility method to detect uses of deprecated traits.
+	 *
+	 * __NOTE:__
+	 * Deprecation warning cannot be setup after the trait definition because
+	 * PHP will emit a fatal error during class fetch.
+	 *
+	 * @param string|object $objectOrClass A class instance or class name
+	 * @param string        $deprecated    Name of deprecated trait
+	 * @param string        $replacement   Name of replacement trait or class
+	 * @param string        $level         Log level for logging the deprecation message, default is `error`
+	 *
+	 * @throws DeprecationException
+	 * @throws UnexpectedValueException
+	 *
+	 * @return void
+	 */
+	public static function checkDeprecatedTrait($objectOrClass, string $deprecated, string $replacement, string $level = LogLevel::ERROR): void
+	{
+		if (in_array($deprecated, class_uses($objectOrClass), true))
+		{
+			self::triggerForTrait($deprecated, $replacement, $level);
+		}
+	}
+
+	/**
+	 * Internal method to trigger the deprecation message based on
+	 * the selected handling mode.
+	 *
+	 * @param string $message
+	 * @param string $level
+	 *
+	 * @throws DeprecationException
+	 *
+	 * @return void
+	 */
+	private static function triggerDeprecation(string $message, string $level): void
+	{
+		if (self::$mode === self::THROW_EXCEPTION)
+		{
+			throw new DeprecationException($message);
+		}
+
+		// Always make sure the message is prepended
+		if (substr($message, 0, 12) !== 'DEPRECATED: ')
+		{
+			$message = 'DEPRECATED: ' . $message;
+		}
+
+		log_message($level, $message);
+	}
+
+	/**
+	 * Internal method to normalize names of properties and parameters to always
+	 * start with a dollar sign (`$`).
+	 *
+	 * @param string $variable
+	 *
+	 * @return string
+	 */
+	private static function normalizeVariablesWithDollars(string $variable): string
+	{
+		if (substr($variable, 0, 1) !== '$')
+		{
+			$variable = '$' . $variable;
+		}
+
+		return $variable;
+	}
+
+	/**
+	 * Internal function to normalize names of methods with
+	 * a pair of parenthesis at their ends.
+	 *
+	 * @param string $method
+	 *
+	 * @return string
+	 */
+	private static function normalizeMethodsWithParens(string $method): string
+	{
+		if (substr($method, -1, 2) !== '()')
+		{
+			$method .= '()';
+		}
+
+		return $method;
+	}
+
+	/**
+	 * Internal method to determine if a valid object type is given,
+	 * and throw an `UnexpectedValueException` if not.
+	 *
+	 * @param string  $parameter
+	 * @param string  $argument
+	 * @param boolean $classType
+	 * @param boolean $traitType
+	 * @param boolean $interfaceType
+	 *
+	 * @throws UnexpectedValueException
+	 *
+	 * @return void
+	 */
+	private static function determineIfValidObjectType(string $parameter, string $argument, bool $classType, bool $traitType, bool $interfaceType): void
+	{
+		$allObjectTypes   = $classType && $traitType && $interfaceType;
+		$classOrTrait     = $classType && $traitType;
+		$classOrInterface = $classType && $interfaceType;
+		$traitOrInterface = $traitType && $interfaceType;
+
+		$parameter = self::normalizeVariablesWithDollars($parameter);
+
+		// this check is very highly unlikely to be imposed but added here for prudence
+		if ($allObjectTypes && ! (class_exists($argument) || trait_exists($argument) || interface_exists($argument)))
+		{
+			throw new UnexpectedValueException(sprintf('Argument "%s" passed to parameter "%s" is neither a valid class, trait nor interface.', $argument, $parameter));
+		}
+
+		// disjunctive type: class OR trait
+		if ($classOrTrait && ! (class_exists($argument) || trait_exists($argument)))
+		{
+			throw new UnexpectedValueException(sprintf('Argument "%s" passed to parameter "%s" is neither a valid class nor trait.', $argument, $parameter));
+		}
+
+		// disjunctive type: class OR interface
+		if ($classOrInterface && ! (class_exists($argument) || interface_exists($argument)))
+		{
+			throw new UnexpectedValueException(sprintf('Argument "%s" passed to parameter "%s" is neither a valid class nor interface.', $argument, $parameter));
+		}
+
+		// disjunctive type: trait OR interface
+		if ($traitOrInterface && ! (trait_exists($argument) || interface_exists($argument)))
+		{
+			throw new UnexpectedValueException(sprintf('Argument "%s" passed to parameter "%s" is neither a valid trait nor interface.', $argument, $parameter));
+		}
+
+		// not a disjunctive type, so check if class
+		if (! ($classOrTrait || $classOrInterface) && $classType && ! class_exists($argument))
+		{
+			throw new UnexpectedValueException(sprintf('Argument "%s" passed to parameter "%s" is not a valid class.', $argument, $parameter));
+		}
+
+		// not a disjunctive type, so check if trait
+		if (! ($classOrTrait || $traitOrInterface) && $traitType && ! trait_exists($argument))
+		{
+			throw new UnexpectedValueException(sprintf('Argument "%s" passed to parameter "%s" is not a valid trait.', $argument, $parameter));
+		}
+
+		// not a disjunctive type, so check if interface
+		if (! ($classOrInterface || $traitOrInterface) && $interfaceType && ! interface_exists($argument))
+		{
+			throw new UnexpectedValueException(sprintf('Argument "%s" passed to parameter "%s" is not a valid interface.', $argument, $parameter));
+		}
+	}
+}

--- a/system/Debug/Deprecation/DeprecationException.php
+++ b/system/Debug/Deprecation/DeprecationException.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Debug\Deprecation;
+
+use ErrorException;
+
+/**
+ * ErrorException for the deprecation messages.
+ *
+ * @internal
+ */
+final class DeprecationException extends ErrorException
+{
+	/**
+	 * Constructor.
+	 *
+	 * @param string $message
+	 */
+	public function __construct(string $message)
+	{
+		// Always make sure the message is prepended
+		if (substr($message, 0, 12) !== 'DEPRECATED: ')
+		{
+			$message = 'DEPRECATED: ' . $message;
+		}
+
+		parent::__construct($message, 0, E_USER_DEPRECATED);
+	}
+}

--- a/system/Language/en/Deprecation.php
+++ b/system/Language/en/Deprecation.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// Deprecation language settings
+return [
+	'classDeprecated'              => 'Class "{0}" is deprecated. You should avoid using it. Use "{1}" instead.',
+	'interfaceDeprecated'          => 'Interface "{0}" is deprecated. You should avoid using it. Use "{1}" instead.',
+	'methodAccessDeprecated'       => 'Class method "{0}" is deprecated. You should avoid using it. Use "{1}" instead.',
+	'methodStaticAccessDeprecated' => 'Static class method "{0}" is deprecated. You should avoid using it. Use "{1}" instead.',
+	'methodParameterDeprecated'    => 'Parameter "{0}" of method "{1}" is deprecated. You should avoid using it.',
+	'methodParametersDeprecated'   => 'Parameters "{0}" of method "{1}" are deprecated. You should avoid using them.',
+	'propertyAccessDeprecated'     => 'Property "{0}" of class "{1}" is deprecated. You should avoid using it. Use "{2}" instead.',
+	'propertyAssignmentDeprecated' => 'Assignment of value to deprecated property "{0}" of class "{1}" is no longer supported.',
+	'traitDeprecated'              => 'Trait "{0}" is deprecated. You should avoid using it. Use "{1}" instead.',
+];

--- a/tests/_support/Debug/Deprecation/DeprecationChecker.php
+++ b/tests/_support/Debug/Deprecation/DeprecationChecker.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Support\Debug\Deprecation;
+
+use CodeIgniter\Debug\Deprecation\Deprecation;
+
+abstract class DeprecationChecker
+{
+	public function __construct()
+	{
+		Deprecation::checkDeprecatedInterface($this, MyDeprecatedInterface::class, MyReplacementInterface::class);
+		Deprecation::checkDeprecatedTrait($this, MyDeprecatedTrait::class, MyReplacementTrait::class);
+	}
+}

--- a/tests/_support/Debug/Deprecation/MyClassWithDeprecatedMethods.php
+++ b/tests/_support/Debug/Deprecation/MyClassWithDeprecatedMethods.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Support\Debug\Deprecation;
+
+use CodeIgniter\Debug\Deprecation\DeprecatedClassMethodTrait;
+use CodeIgniter\Debug\Deprecation\Deprecation;
+
+class MyClassWithDeprecatedMethods
+{
+	use DeprecatedClassMethodTrait;
+
+	private $deprecatedMethods = [
+		'implicitlyDeprecatedProtected' => self::class . '::replacement',
+		'implicitlyDeprecatedPrivate'   => self::class . '::replacement',
+	];
+
+	private static $deprecatedStaticMethods = [
+		'staticDeprecatedProtected' => self::class . '::staticReplacement',
+		'staticDeprecatedPrivate'   => self::class . '::staticReplacement',
+	];
+
+	private static $methodAccessExclusions = [
+		'barred',
+		'staticBarred',
+	];
+
+	public function withDeprecatedParams($deprecated1 = 1, $deprecated2 = 2)
+	{
+		if (func_num_args() > 0)
+		{
+			Deprecation::triggerForMethodParameter(['deprecated1', 'deprecated2'], __METHOD__);
+		}
+
+		return 3;
+	}
+
+	public function withDeprecatedParam($notDeprecated, $deprecated = true)
+	{
+		if (func_num_args() > 1)
+		{
+			Deprecation::triggerForMethodParameter('deprecated', __METHOD__);
+		}
+
+		return $notDeprecated;
+	}
+
+	public function explicitlyDeprecated()
+	{
+		Deprecation::triggerForMethod(__METHOD__, self::class . '::replacement');
+		$this->replacement();
+	}
+
+	public function replacement()
+	{
+	}
+
+	private function barred()
+	{
+	}
+
+	private function notBarred()
+	{
+	}
+
+	public static function staticReplacement()
+	{
+	}
+
+	protected function implicitlyDeprecatedProtected()
+	{
+	}
+
+	private function implicitlyDeprecatedPrivate()
+	{
+	}
+
+	protected static function staticDeprecatedProtected()
+	{
+	}
+
+	private static function staticDeprecatedPrivate()
+	{
+	}
+
+	protected static function staticBarred()
+	{
+	}
+
+	private static function staticNotBarred()
+	{
+	}
+}

--- a/tests/_support/Debug/Deprecation/MyClassWithDeprecatedProps.php
+++ b/tests/_support/Debug/Deprecation/MyClassWithDeprecatedProps.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Support\Debug\Deprecation;
+
+use CodeIgniter\Debug\Deprecation\DeprecatedClassPropertyTrait;
+
+class MyClassWithDeprecatedProps
+{
+	use DeprecatedClassPropertyTrait;
+
+	public $replacement = 1;
+
+	protected $deprecatedProtected = 2;
+
+	protected $barredToo = 6;
+
+	private $deprecatedPrivate = 3;
+
+	private $barred = 4;
+
+	private $notBarred = 0;
+
+	private $deprecatedProperties = [
+		'deprecatedProtected' => '$replacement',
+		'deprecatedPrivate'   => '$replacement',
+	];
+
+	private $deprecatedSettableProperties = [
+		'deprecatedProtected',
+		'deprecatedPrivate',
+	];
+
+	private static $propertyAccessExclusions = [
+		'barred',
+		'barredToo',
+	];
+}

--- a/tests/_support/Debug/Deprecation/MyDeprecatedClass.php
+++ b/tests/_support/Debug/Deprecation/MyDeprecatedClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Support\Debug\Deprecation;
+
+use CodeIgniter\Debug\Deprecation\Deprecation;
+
+class MyDeprecatedClass
+{
+	public function __construct()
+	{
+		Deprecation::triggerForClass(self::class, MyReplacementClass::class);
+	}
+}

--- a/tests/_support/Debug/Deprecation/MyDeprecatedInterface.php
+++ b/tests/_support/Debug/Deprecation/MyDeprecatedInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Support\Debug\Deprecation;
+
+interface MyDeprecatedInterface
+{
+	public function foo();
+}

--- a/tests/_support/Debug/Deprecation/MyDeprecatedTrait.php
+++ b/tests/_support/Debug/Deprecation/MyDeprecatedTrait.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Support\Debug\Deprecation;
+
+trait MyDeprecatedTrait
+{
+	public function bar() {}
+}

--- a/tests/_support/Debug/Deprecation/MyReplacementClass.php
+++ b/tests/_support/Debug/Deprecation/MyReplacementClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Tests\Support\Debug\Deprecation;
+
+class MyReplacementClass
+{
+}

--- a/tests/_support/Debug/Deprecation/MyReplacementInterface.php
+++ b/tests/_support/Debug/Deprecation/MyReplacementInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Support\Debug\Deprecation;
+
+interface MyReplacementInterface
+{
+	public function foo();
+}

--- a/tests/_support/Debug/Deprecation/MyReplacementTrait.php
+++ b/tests/_support/Debug/Deprecation/MyReplacementTrait.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Support\Debug\Deprecation;
+
+trait MyReplacementTrait
+{
+	public function bar() {}
+}

--- a/tests/system/Debug/Deprecation/DeprecationExceptionTest.php
+++ b/tests/system/Debug/Deprecation/DeprecationExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CodeIgniter\Debug\Deprecation;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use ErrorException;
+
+/**
+ * @internal
+ */
+final class DeprecationExceptionTest extends CIUnitTestCase
+{
+	public function testInstance(): void
+	{
+		$error = new DeprecationException('The deprecation message.');
+
+		$this->assertInstanceOf(DeprecationException::class, $error);
+		$this->assertInstanceOf(ErrorException::class, $error);
+		$this->assertSame('DEPRECATED: The deprecation message.', $error->getMessage());
+		$this->assertSame(0, $error->getCode());
+		$this->assertSame(E_USER_DEPRECATED, $error->getSeverity());
+	}
+
+	public function testExceptionNormalizesMessage(): void
+	{
+		$error1 = new DeprecationException('Yes.');
+		$error2 = new DeprecationException('DEPRECATED: Yes.');
+
+		$this->assertSame('DEPRECATED: Yes.', $error1->getMessage());
+		$this->assertSame('DEPRECATED: Yes.', $error2->getMessage());
+		$this->assertSame($error1->getMessage(), $error2->getMessage());
+	}
+}

--- a/tests/system/Debug/Deprecation/DeprecationTest.php
+++ b/tests/system/Debug/Deprecation/DeprecationTest.php
@@ -1,0 +1,360 @@
+<?php
+
+namespace CodeIgniter\Debug\Deprecation;
+
+use BadMethodCallException;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\ReflectionHelper;
+use Error;
+use LogicException;
+use Psr\Log\LogLevel;
+use Tests\Support\Debug\Deprecation\DeprecationChecker;
+use Tests\Support\Debug\Deprecation\MyClassWithDeprecatedMethods;
+use Tests\Support\Debug\Deprecation\MyClassWithDeprecatedProps;
+use Tests\Support\Debug\Deprecation\MyDeprecatedClass;
+use Tests\Support\Debug\Deprecation\MyDeprecatedInterface;
+use Tests\Support\Debug\Deprecation\MyDeprecatedTrait;
+use Tests\Support\Debug\Deprecation\MyReplacementClass;
+use Throwable;
+use UnexpectedValueException;
+
+/**
+ * @internal
+ */
+final class DeprecationTest extends CIUnitTestCase
+{
+	use ReflectionHelper;
+
+	private $mode = '';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->mode = Deprecation::mode();
+		Deprecation::setMode(Deprecation::THROW_EXCEPTION);
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+
+		Deprecation::setMode($this->mode);
+	}
+
+	public function testModeIsDefined(): void
+	{
+		$this->assertContains(Deprecation::mode(), Deprecation::SUPPORTED_MODES);
+	}
+
+	public function testSettingUnknownModeFails(): void
+	{
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessage('Mode "foo" is not supported. Allowed: "log_message", "throw_exception".');
+		Deprecation::setMode('foo');
+	}
+
+	public function testSettingModeChangesCurrentMode(): void
+	{
+		$oldMode = Deprecation::mode();
+		Deprecation::setMode(Deprecation::LOG_MESSAGE);
+
+		$this->assertSame(Deprecation::THROW_EXCEPTION, $oldMode);
+		$this->assertSame(Deprecation::LOG_MESSAGE, Deprecation::mode());
+
+		Deprecation::setMode($oldMode);
+	}
+
+	public function testGenericTrigger(): void
+	{
+		Deprecation::setMode(Deprecation::LOG_MESSAGE);
+		Deprecation::trigger('A deprecation is raised.');
+		$this->assertLogged(LogLevel::ERROR, 'DEPRECATED: A deprecation is raised.');
+
+		Deprecation::setMode(Deprecation::THROW_EXCEPTION);
+		$this->expectException(DeprecationException::class);
+		$this->expectExceptionMessage('DEPRECATED: A deprecation is raised.');
+		Deprecation::trigger('A deprecation is raised.');
+	}
+
+	public function testTriggerForClass(): void
+	{
+		$this->expectException(DeprecationException::class);
+		new MyDeprecatedClass();
+	}
+
+	public function testTriggerForClassOnExtends(): void
+	{
+		try
+		{
+			new class extends MyDeprecatedClass {};
+		}
+		catch (Throwable $e)
+		{
+			$this->assertInstanceOf(DeprecationException::class, $e);
+			Deprecation::setMode(Deprecation::LOG_MESSAGE);
+			new class extends MyDeprecatedClass {};
+			$this->assertLogged(LogLevel::ERROR, $e->getMessage());
+		}
+	}
+
+	public function testTriggerForClassWithInvalidReplacement(): void
+	{
+		$this->expectException(UnexpectedValueException::class);
+		new class {
+			public function __construct()
+			{
+				Deprecation::triggerForClass(self::class, 'Foo');
+			}
+		};
+	}
+
+	public function testTriggerForClassWithInvalidName(): void
+	{
+		$this->expectException(UnexpectedValueException::class);
+		new class {
+			public function __construct()
+			{
+				Deprecation::triggerForClass('Foo', MyReplacementClass::class);
+			}
+		};
+	}
+
+	public function testTriggerForInterface(): void
+	{
+		try
+		{
+			new class extends DeprecationChecker implements MyDeprecatedInterface {
+				public function foo() {}
+			};
+		}
+		catch (Throwable $e)
+		{
+			$this->assertInstanceOf(DeprecationException::class, $e);
+			Deprecation::setMode(Deprecation::LOG_MESSAGE);
+			new class extends DeprecationChecker implements MyDeprecatedInterface {
+				public function foo() {}
+			};
+			$this->assertLogged(LogLevel::ERROR, $e->getMessage());
+		}
+	}
+
+	public function testTriggerForTrait(): void
+	{
+		try
+		{
+			new class extends DeprecationChecker { use MyDeprecatedTrait; };
+		}
+		catch (Throwable $e)
+		{
+			$this->assertInstanceOf(DeprecationException::class, $e);
+			Deprecation::setMode(Deprecation::LOG_MESSAGE);
+			new class extends DeprecationChecker { use MyDeprecatedTrait; };
+			$this->assertLogged(LogLevel::ERROR, $e->getMessage());
+		}
+	}
+
+	public function testTriggerForPropertyAccess(): void
+	{
+		$this->expectException(DeprecationException::class);
+		$class = new MyClassWithDeprecatedProps();
+		$class->notBarred;
+		$class->deprecatedProtected;
+	}
+
+	public function testTriggerForPropertyAccessByChild(): void
+	{
+		$this->expectException(DeprecationException::class);
+		$class = new class extends MyClassWithDeprecatedProps {};
+		$class->deprecatedPrivate;
+	}
+
+	public function testPropertyAccessFailingForInexistentProps(): void
+	{
+		$this->expectException(LogicException::class);
+		$class = new MyClassWithDeprecatedProps();
+		$class->unknown;
+	}
+
+	public function testPropertyAccessForDisallowedProperties(): void
+	{
+		$this->expectException(Error::class);
+		$class = new MyClassWithDeprecatedProps();
+		$class->barred;
+	}
+
+	public function testTriggerForPropertyAssignment(): void
+	{
+		$this->expectException(DeprecationException::class);
+		$class = new MyClassWithDeprecatedProps();
+		$class->deprecatedProtected = 5;
+	}
+
+	public function testTriggerForPropertyAssignmentByChild(): void
+	{
+		$this->expectException(DeprecationException::class);
+		$class = new class extends MyClassWithDeprecatedProps {
+			public function foo()
+			{
+				$this->deprecatedPrivate = 5;
+			}
+		};
+		$class->notBarred = 5;
+		$class->foo();
+	}
+
+	public function testPropertyAssignmentFailingForUnknownProps(): void
+	{
+		$this->expectException(LogicException::class);
+		$class = new MyClassWithDeprecatedProps();
+		$class->unknown = 5;
+	}
+
+	public function testPropertyAssignmentFailingForDisallowedProps(): void
+	{
+		$this->expectException(Error::class);
+		$class = new MyClassWithDeprecatedProps();
+		$class->barredToo = 5;
+	}
+
+	public function testTriggerForPropertySilent(): void
+	{
+		Deprecation::setMode(Deprecation::LOG_MESSAGE);
+		$class = new MyClassWithDeprecatedProps();
+
+		$class->deprecatedProtected;
+		$this->assertLogged(LogLevel::ERROR, 'DEPRECATED: ' . lang('Deprecation.propertyAccessDeprecated', ['$deprecatedProtected', MyClassWithDeprecatedProps::class, '$replacement']));
+
+		$class->deprecatedPrivate = 5;
+		$this->assertLogged(LogLevel::ERROR, 'DEPRECATED: ' . lang('Deprecation.propertyAssignmentDeprecated', ['$deprecatedPrivate', MyClassWithDeprecatedProps::class]));
+	}
+
+	public function testMethodAccessFailForUnknownMethod(): void
+	{
+		$this->expectException(BadMethodCallException::class);
+		$class = new MyClassWithDeprecatedMethods();
+		$class->unknown();
+	}
+
+	public function testMethodAccessFailForUnknownStaticMethod(): void
+	{
+		$this->expectException(BadMethodCallException::class);
+		MyClassWithDeprecatedMethods::staticUnknown();
+	}
+
+	public function testTriggerForMethod(): void
+	{
+		try
+		{
+			$class = new MyClassWithDeprecatedMethods();
+			$class->explicitlyDeprecated();
+		}
+		catch (Throwable $e)
+		{
+			$this->assertInstanceOf(DeprecationException::class, $e);
+			Deprecation::setMode(Deprecation::LOG_MESSAGE);
+			$class->explicitlyDeprecated();
+			$this->assertLogged(LogLevel::ERROR, $e->getMessage());
+		}
+	}
+
+	public function testMethodAccessOutsideClass(): void
+	{
+		$this->expectException(DeprecationException::class);
+		$class = new MyClassWithDeprecatedMethods();
+		$class->implicitlyDeprecatedProtected();
+	}
+
+	public function testMethodAccessByChild(): void
+	{
+		$this->expectException(DeprecationException::class);
+		$class = new class extends MyClassWithDeprecatedMethods {};
+		$class->implicitlyDeprecatedPrivate();
+	}
+
+	public function testMethodAccessBarred(): void
+	{
+		$this->expectException(Error::class);
+		$class = new MyClassWithDeprecatedMethods();
+		$class->notBarred();
+		$class->barred();
+	}
+
+	public function testStaticMethodAccess(): void
+	{
+		try
+		{
+			MyClassWithDeprecatedMethods::staticDeprecatedProtected();
+		}
+		catch (Throwable $e)
+		{
+			$this->assertInstanceOf(DeprecationException::class, $e);
+			Deprecation::setMode(Deprecation::LOG_MESSAGE);
+			MyClassWithDeprecatedMethods::staticDeprecatedProtected();
+			$this->assertLogged(LogLevel::ERROR, $e->getMessage());
+		}
+	}
+
+	public function testStaticMethodAccessBarred(): void
+	{
+		$this->expectException(Error::class);
+		MyClassWithDeprecatedMethods::staticNotBarred();
+		MyClassWithDeprecatedMethods::staticBarred();
+	}
+
+	public function testMethodParameterAccess(): void
+	{
+		try
+		{
+			$class = new MyClassWithDeprecatedMethods();
+			$class->withDeprecatedParams(1, 2);
+		}
+		catch (Throwable $e)
+		{
+			$this->assertInstanceOf(DeprecationException::class, $e);
+			Deprecation::setMode(Deprecation::LOG_MESSAGE);
+			$class->withDeprecatedParams(1);
+			$this->assertLogged(LogLevel::ERROR, $e->getMessage());
+		}
+	}
+
+	public function testMethodParameterAccessOne(): void
+	{
+		$this->expectException(DeprecationException::class);
+		$class = new MyClassWithDeprecatedMethods();
+		$class->withDeprecatedParam(3, true);
+	}
+
+	/**
+	 * @dataProvider validObjectTypesProvider
+	 *
+	 * @param boolean $classType
+	 * @param boolean $traitType
+	 * @param boolean $interfaceType
+	 *
+	 * @return void
+	 */
+	public function testValidObjectTypesDeterminationFailing(bool $classType, bool $traitType, bool $interfaceType): void
+	{
+		$this->expectException(UnexpectedValueException::class);
+		$determinator = $this->getPrivateMethodInvoker(Deprecation::class, 'determineIfValidObjectType');
+		$determinator('deprecated', 'Foo', $classType, $traitType, $interfaceType);
+	}
+
+	public function validObjectTypesProvider(): iterable
+	{
+		yield 'all-types' => [true, true, true];
+
+		yield 'class-or-trait' => [true, true, false];
+
+		yield 'class-or-interface' => [true, false, true];
+
+		yield 'trait-or-interface' => [false, true, true];
+
+		yield 'class-only' => [true, false, false];
+
+		yield 'trait-only' => [false, true, false];
+
+		yield 'interface-only' => [false, false, true];
+	}
+}


### PR DESCRIPTION
**Description**
This PR introduces the `CodeIgniter\Debug\Deprecation` namespace containing a set of classes and traits to be used in deprecating certain elements in the framework. This can be used in the future for debugging deprecated elements that needs eventual removal.

**1. CodeIgniter\Debug\Deprecation\Deprecation**
This final static class is the "trigger" for the deprecation proper. It hosts a variety of methods to call in a deprecation message for a particular element (e.g., a class, method, property, or method parameter).

This has two modes on how to handle a deprecation. If mode is `Deprecation::LOG_MESSAGE`, which is the default mode, the deprecation call will just log the message to our registered loggers with a default log level of `error` (to conform with the default logging threshold and increase the chance the message is logged and read by the user). If mode is set to `Deprecation::THROW_EXCEPTION`, a `DeprecationException` will be thrown containing the deprecation message thus halting the script execution. Mode can be set by `Deprecation::setMode()` and retrieved by `Deprecation::mode()`.

**2. CodeIgniter\Debug\Deprecation\DeprecationException**
This exception class is a child of `ErrorException` class. The original approach was to use the regular mechanic of `trigger_error($message, E_USER_DEPRECATED)` but I found out that our error handler catches this error and throws an `ErrorException` instead. So, to make a short cut, this class is thrown instead directly. This class adds a minor tweak to the error message and ensures `$severity` level is `E_USER_DEPRECATED`.

**3. CodeIgniter\Debug\Deprecation\DeprecatedClassMethodTrait**
This support trait is intended to be imported by classes with deprecated methods and doesn't want those to be used outside the class. This trait can also be used by parent classes to prevent child classes to use their deprecated methods. The trait intercepts calls to methods via the magic `__call` and `__callStatic` methods. *(More info on the class definition)*

**4. CodeIgniter\Debug\Deprecation\DeprecatedClassPropertyTrait**
This is similar to the `DeprecatedClassMethodTrait` except that this trait intercept calls to properties instead using the magic `__get` and `__set` methods. This trait is available only for properties in object context because PHP do not currently have `__getStatic` and `__setStatic` methods. *(More info on the class definition)*

Localized deprecation messages are stored in `system/Language/en/Deprecation.php`.

When using the traits, please be aware of the notion of [overloading in PHP](https://www.php.net/manual/en/language.oop5.overloading.php). If the inaccessible property/method is declared in the current scope, the traits' specially tweaked magic methods won't be invoked. That is, accessing a deprecated private property within the class will not emit a deprecation message since this is accessible.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Conforms to style guide

**Pending:**
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Integration into the framework internals
