### PR TITLE
Use descriptive failure message for `assertLogged`

### DIFF
--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -362,7 +362,12 @@ abstract class CIUnitTestCase extends TestCase
 	{
 		$result = TestLogger::didLog($level, $expectedMessage);
 
-		$this->assertTrue($result);
+		$this->assertTrue($result, sprintf(
+			'Failed asserting that expected message "%s" with level "%s" was logged.',
+			$expectedMessage ?? '',
+			$level
+		));
+
 		return $result;
 	}
 


### PR DESCRIPTION
**Description**
Instead of the generic `Failed asserting that false is true.`, display the message that was failed to be logged.

**Checklist:**
- [x] Securely signed commits
