### PR TITLE
Limit cache filenames

### DIFF
--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -23,7 +23,7 @@ class FileHandler extends BaseHandler
 	/**
 	 * Maximum key length.
 	 */
-	public const MAX_KEY_LENGTH = PHP_MAXPATHLEN;
+	public const MAX_KEY_LENGTH = 255;
 
 	/**
 	 * Where to store cached files on the disk.

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -129,7 +129,7 @@ class FileHandlerTest extends CIUnitTestCase
 
 	public function testSaveExcessiveKeyLength()
 	{
-		$key  = str_repeat('a', PHP_MAXPATHLEN + 10);
+		$key  = str_repeat('a', 260);
 		$file = $this->config->file['storePath'] . DIRECTORY_SEPARATOR . md5($key);
 
 		$this->assertTrue($this->fileHandler->save($key, 'value'));


### PR DESCRIPTION
**Description**
It turns out that `PHP_MAXPATHLEN` refers to internal PHP handling, not applicable to the local filesystem. From my research most filesystems cap at 255 so I'm reverting to that value.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
