### PR TITLE
UTC Time from timestamp

### DIFF
--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -297,7 +297,7 @@ class Time extends DateTime
 	 */
 	public static function createFromTimestamp(int $timestamp, $timezone = null, string $locale = null)
 	{
-		return new Time(date('Y-m-d H:i:s', $timestamp), $timezone, $locale);
+		return new Time(gmdate('Y-m-d H:i:s', $timestamp), $timezone ?? 'UTC', $locale);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -212,7 +212,15 @@ class TimeTest extends CIUnitTestCase
 
 	public function testCreateFromTimestamp()
 	{
-		$time = Time::createFromTimestamp(strtotime('2017-03-18 midnight'));
+		// Se the timezone temporarily to UTC to make sure the test timestamp is correct
+		$tz = date_default_timezone_get();
+		date_default_timezone_set('UTC');
+
+		$timestamp = strtotime('2017-03-18 midnight');
+
+		date_default_timezone_set($tz);
+
+		$time = Time::createFromTimestamp($timestamp);
 
 		$this->assertEquals(date('2017-03-18 00:00:00'), $time->toDateTimeString());
 	}


### PR DESCRIPTION
**Description**
Fixes #3951. The test case for this was actually incorrect, since `strtotime()` uses the current default timezone. I confirmed that fixing the test case broke the previous implementation, and the update implementation passes the fixed test.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
