### PR TITLE
[Rector] Update rector 0.11.2 and phpstan 0.12.86

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,12 @@
 		"fakerphp/faker": "^1.9",
 		"mikey179/vfsstream": "^1.6",
 		"nexusphp/tachycardia": "^1.0",
-		"nikic/php-parser": "4.10.4",
-		"phpstan/phpstan": "0.12.85",
+		"phpstan/phpstan": "0.12.86",
 		"phpunit/phpunit": "^9.1",
 		"predis/predis": "^1.1",
-		"rector/rector": "0.10.22",
-		"squizlabs/php_codesniffer": "^3.3"
+		"rector/rector": "0.11.2",
+		"squizlabs/php_codesniffer": "^3.3",
+		"symplify/package-builder": "^9.3"
 	},
 	"suggest": {
 		"ext-fileinfo": "Improves mime type detection for files"

--- a/rector.php
+++ b/rector.php
@@ -60,6 +60,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 	$parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_73);
 
 	$services = $containerConfigurator->services();
+	$services->load('Symplify\\PackageBuilder\\', __DIR__ . '/vendor/symplify/package-builder/src');
+
 	$services->set(UnderscoreToCamelCaseVariableNameRector::class);
 	$services->set(SimplifyUselessVariableRector::class);
 	$services->set(RemoveAlwaysElseRector::class);

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -241,7 +241,7 @@ class RedisHandler extends BaseHandler
 				}
 			}
 		}
-		while ($iterator > 0); // @phpstan-ignore-line
+		while ($iterator > 0);
 
 		return $this->redis->del($matchedKeys);
 	}


### PR DESCRIPTION
Update to rector 0.11.2. Rector now prefixed by default, so need `symplify/package-builder` for string format converter usage in 

https://github.com/codeigniter4/CodeIgniter4/blob/43e0e9611b7e527a4b927127fc6f26a1c6d123a5/utils/Rector/UnderscoreToCamelCaseVariableNameRector.php#L16

Also update phpstan to 0.12.86

**Checklist:**
- [x] Securely signed commits
