### PR TITLE
MockCache::getCacheInfo()

### DIFF
--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -235,7 +235,7 @@ class MockCache extends BaseHandler implements CacheInterface
 	 * The information returned and the structure of the data
 	 * varies depending on the handler.
 	 *
-	 * @return array Keys currently present in the store
+	 * @return string[] Keys currently present in the store
 	 */
 	public function getCacheInfo()
 	{

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -235,11 +235,11 @@ class MockCache extends BaseHandler implements CacheInterface
 	 * The information returned and the structure of the data
 	 * varies depending on the handler.
 	 *
-	 * @return mixed
+	 * @return array Keys currently present in the store
 	 */
 	public function getCacheInfo()
 	{
-		return [];
+		return array_keys($this->cache);
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
**Description**
When testing with `MockCache` using an unknown cache agent it is impossible to determine what happens in the cache without using private property inspectors. This PR expands `MockCache::cacehInfo()` to return the current keys so it is easy to make assertions like "did use cache".

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
