### PR TITLE
Some fixes to the Pager Class

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -508,7 +508,6 @@ class Services extends BaseService
 		}
 
 		$config = $config ?? config('Pager');
-		$view   = $view ?? AppServices::renderer();
 
 		return new Pager($config, $view);
 	}

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -67,10 +67,10 @@ class Pager implements PagerInterface
 	/**
 	 * Constructor.
 	 *
-	 * @param PagerConfig       $config
-	 * @param RendererInterface $view
+	 * @param PagerConfig            $config
+	 * @param RendererInterface|null $view
 	 */
-	public function __construct(PagerConfig $config, RendererInterface $view)
+	public function __construct(PagerConfig $config, ?RendererInterface $view = null)
 	{
 		$this->config = $config;
 		$this->view   = $view;
@@ -152,6 +152,12 @@ class Pager implements PagerInterface
 		if (! array_key_exists($template, $this->config->templates))
 		{
 			throw PagerException::forInvalidTemplate($template);
+		}
+
+		if (isset($this->view))
+		{
+			return $this->view->setVar('pager', $pager)
+				->render($this->config->templates[$template]);
 		}
 
 		return view($this->config->templates[$template], ['pager' => $pager]);


### PR DESCRIPTION
**Description**
- Use view() method for rendering which can easily be overridden - I have an override in common.php to load the appropriate site template which is configurable by the user. The issue with pager is that is uses rendered directly instead of just loading the view and it makes it very hard to do the override

- Added setter for total pages to be used with NoSQL databases like ElasticSearch can return total count in the same query which is used for getting the data from the DB avoiding the need for another query to get count. This method makes it possible to set the total counts after initialing the pager and obtaining data results.

- Added public getter for RawCurrentPage. I have a need to show 404 error if greater page than total pages is requested. With current methods the pager will always return the last available page instead of actually requested page. This methods makes it possible to obtain the raw page value from the URL segment/ query string parameter 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
