### PR TITLE
Fix nullable type not showing in SQL string

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -150,6 +150,8 @@ class Forge
 	 * NULL value representation in CREATE/ALTER TABLE statements
 	 *
 	 * @var string
+	 *
+	 * @internal Used for marking nullable fields. Not covered by BC promise.
 	 */
 	protected $null = '';
 

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -88,8 +88,10 @@ class Forge extends BaseForge
 	 * NULL value representation in CREATE/ALTER TABLE statements
 	 *
 	 * @var string
+	 *
+	 * @internal
 	 */
-	protected $_null = 'NULL';
+	protected $null = 'NULL';
 
 	//--------------------------------------------------------------------
 

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -53,8 +53,10 @@ class Forge extends BaseForge
 	 * NULL value representation in CREATE/ALTER TABLE statements
 	 *
 	 * @var string
+	 *
+	 * @internal
 	 */
-	protected $_null = 'NULL';
+	protected $null = 'NULL';
 
 	//--------------------------------------------------------------------
 

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -31,8 +31,10 @@ class Forge extends BaseForge
 	 * NULL value representation in CREATE/ALTER TABLE statements
 	 *
 	 * @var string
+	 *
+	 * @internal
 	 */
-	protected $_null = 'NULL';
+	protected $null = 'NULL';
 
 	//--------------------------------------------------------------------
 

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -243,6 +243,32 @@ class ForgeTest extends CIUnitTestCase
 		}
 	}
 
+	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/4693
+	 */
+	public function testCreateTableWithNullableFieldsGivesNullDataType(): void
+	{
+		$this->forge->addField([
+			'id'   => ['type' => 'INT', 'constraint' => 11, 'auto_increment' => true],
+			'name' => ['type' => 'VARCHAR', 'constraint' => 255, 'null' => true],
+		]);
+
+		$createTable = $this->getPrivateMethodInvoker($this->forge, '_createTable');
+
+		$sql = $createTable('forge_nullable_table', false, []);
+
+		if ($this->db->DBDriver !== 'SQLSRV')
+		{
+			// @see https://regex101.com/r/bIHVNw/1
+			$this->assertMatchesRegularExpression('/(?:`name`|"name") VARCHAR(.*) NULL/', $sql);
+		}
+		else
+		{
+			// sqlsrv table fields are default nullable
+			$this->assertMatchesRegularExpression('/"name" VARCHAR/', $sql);
+		}
+	}
+
 	public function testCreateTableWithStringField()
 	{
 		$this->forge->dropTable('forge_test_table', true);


### PR DESCRIPTION
**Description**
Fixes #4693 .

It appears the Base Forge provides use of `$null` property but all DB extensions uses the underscored version `$_null`. Then the Base Forge uses `$this->null` so I don't know which to follow. For now, I followed the extensions' work.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide
