### PR TITLE
Create .git/hooks directory if not already present

### DIFF
--- a/admin/setup.sh
+++ b/admin/setup.sh
@@ -2,5 +2,6 @@
 
 # Install a pre-commit hook that
 # automatically runs phpcs to fix styles
+mkdir -p .git/hooks
 cp admin/pre-commit .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit


### PR DESCRIPTION
Greetings 👋 ,

the Composer `post-update-cmd` failed on my machine because the `admin/setup.sh` script tried to copy the pre-commit hook into `.git/hooks`, which didn't exist yet.

:octocat:

