### PR TITLE
Check for configured instead of hard-coded database in DbUtilsTest

### DIFF
--- a/tests/system/Database/Live/DbUtilsTest.php
+++ b/tests/system/Database/Live/DbUtilsTest.php
@@ -79,7 +79,7 @@ class DbUtilsTest extends CIUnitTestCase
 		{
 			$databases = $util->listDatabases();
 
-			$this->assertTrue(in_array('test', $databases, true));
+			$this->assertTrue(in_array($this->db->getDatabase(), $databases, true));
 		}
 		elseif ($this->db->DBDriver === 'SQLite3')
 		{
@@ -98,7 +98,7 @@ class DbUtilsTest extends CIUnitTestCase
 
 		if (in_array($this->db->DBDriver, ['MySQLi', 'Postgre', 'SQLSRV'], true))
 		{
-			$exist = $util->databaseExists('test');
+			$exist = $util->databaseExists($this->db->getDatabase());
 
 			$this->assertTrue($exist);
 		}
@@ -107,7 +107,7 @@ class DbUtilsTest extends CIUnitTestCase
 			$this->expectException(DatabaseException::class);
 			$this->expectExceptionMessage('Unsupported feature of the database platform you are using.');
 
-			$util->databaseExists('test');
+			$util->databaseExists($this->db->getDatabase());
 		}
 	}
 


### PR DESCRIPTION
Greetings 👋,

I'm currently setting up this repo and its test suite on my local machine (PHP 8.0.5, MySQL 8.0.23) and am coming across some problems while I'm learning the ropes 😅.

With the help of @MGatner I was able to connect the test suite to my local database by adding this snippet to my `phpunit.xml`:

```xml
<phpunit>
    <php>
		<!-- Database configuration -->
		<env name="database.tests.strictOn" value="true"/>
		<env name="database.tests.hostname" value="localhost"/>
		<env name="database.tests.database" value="codeigniter"/>
		<env name="database.tests.username" value="root"/>
		<env name="database.tests.password" value=""/>
		<env name="database.tests.DBDriver" value="MySQLi"/>
		<env name="database.tests.DBPrefix" value="tests_"/>
    </php>
</phpunit>
```

Since I like to name my local databases after the project I'm working with, I used `codeigniter` as the database name (instead of `test`); but this caused some tests to fail because `test` was hardcoded in them 🙈, so I'd like to propose this change which made it work for me, and, I hope, for you as well 😅.

:octocat: