### PR TITLE
Remove unused private rowOffset property in Database/SQLSRV/Result.php

### DIFF
--- a/system/Database/SQLSRV/Result.php
+++ b/system/Database/SQLSRV/Result.php
@@ -20,13 +20,6 @@ use stdClass;
  */
 class Result extends BaseResult
 {
-	/**
-	 * Row offset
-	 *
-	 * @var integer
-	 */
-	private $rowOffset = 0;
-
 	//--------------------------------------------------------------------
 
 	/**


### PR DESCRIPTION
Detected by latest rector dev-main that I run in my local dev.

**Checklist:**
- [x] Securely signed commits