### PR TITLE
Format URI directly

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -347,7 +347,8 @@ class CURLRequest extends Request
 
 		$uri = $this->baseURI->resolveRelativeURI($url);
 
-		return (string) $uri;
+		// Create the string instead of casting to prevent baseURL muddling
+		return URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -34,6 +34,24 @@ class CURLRequestTest extends CIUnitTestCase
 	//--------------------------------------------------------------------
 
 	/**
+	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/4707
+	 */
+	public function testPrepareURLIgnoresAppConfig()
+	{
+		config('App')->baseURL = 'http://example.com/fruit/';
+
+		$request = $this->getRequest([
+			'base_uri' => 'http://example.com/v1/',
+		]);
+
+		$method = $this->getPrivateMethodInvoker($request, 'prepareURL');
+
+		$this->assertEquals('http://example.com/v1/bananas', $method('bananas'));
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
 	 * @see https://github.com/codeigniter4/CodeIgniter4/issues/1029
 	 */
 	public function testGetRemembersBaseURI()


### PR DESCRIPTION
**Description**
Fixes #4707, where `CURLRequest`'s `baseURI` could get muddled with `App::$baseUrl` during `URI::__toString()`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
