### PR TITLE
Replace URI string casts

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -474,7 +474,7 @@ class CodeIgniter
 
 		// Save our current URI as the previous URI in the session
 		// for safer, more accurate use with `previous_url()` helper function.
-		$this->storePreviousURL((string) current_url(true));
+		$this->storePreviousURL(current_url(true));
 
 		unset($uri);
 
@@ -1080,7 +1080,7 @@ class CodeIgniter
 
 		if (isset($_SESSION))
 		{
-			$_SESSION['_ci_previous_url'] = (string) $uri;
+			$_SESSION['_ci_previous_url'] = URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
 		}
 	}
 

--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -36,7 +36,7 @@ class RedirectResponse extends Response
 		// for better security.
 		if (strpos($uri, 'http') !== 0)
 		{
-			$uri = (string) current_url(true)->resolveRelativeURI($uri);
+			$uri = site_url($uri);
 		}
 
 		return $this->redirect($uri, $method, $code);

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -205,20 +205,9 @@ if (! function_exists('uri_string'))
 	 */
 	function uri_string(bool $relative = false): string
 	{
-		$request = Services::request();
-		$uri     = $request->uri;
-
-		// An absolute path is equivalent to getPath()
-		if (! $relative)
-		{
-			return $uri->getPath();
-		}
-
-		// Remove the baseURL from the entire URL
-		$url     = (string) $uri->__toString();
-		$baseURL = rtrim($request->config->baseURL, '/ ') . '/';
-
-		return substr($url, strlen($baseURL));
+		return $relative
+			? ltrim(Services::request()->getPath(), '/')
+			: Services::request()->getUri()->getPath();
 	}
 }
 

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -87,9 +87,7 @@ class ChromeLoggerHandler extends BaseHandler
 	{
 		parent::__construct($config);
 
-		$request = Services::request(null, true);
-
-		$this->json['request_uri'] = (string) $request->uri;
+		$this->json['request_uri'] = current_url();
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -377,7 +377,7 @@ class Pager implements PagerInterface
 			$uri->setQueryArray($query);
 		}
 
-		return $returnObject === true ? $uri : (string) $uri;
+		return $returnObject === true ? $uri : URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -156,7 +156,7 @@ class PagerRenderer
 			$uri->setSegment($this->segment, $this->first - 1);
 		}
 
-		return (string) $uri;
+		return URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
 	}
 
 	//--------------------------------------------------------------------
@@ -200,7 +200,7 @@ class PagerRenderer
 			$uri->setSegment($this->segment, $this->last + 1);
 		}
 
-		return (string) $uri;
+		return URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
 	}
 
 	//--------------------------------------------------------------------
@@ -223,7 +223,7 @@ class PagerRenderer
 			$uri->setSegment($this->segment, 1);
 		}
 
-		return (string) $uri;
+		return URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
 	}
 
 	//--------------------------------------------------------------------
@@ -246,7 +246,7 @@ class PagerRenderer
 			$uri->setSegment($this->segment, $this->pageCount);
 		}
 
-		return (string) $uri;
+		return URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
 	}
 
 	//--------------------------------------------------------------------
@@ -269,7 +269,7 @@ class PagerRenderer
 			$uri->setSegment($this->segment, $this->current);
 		}
 
-		return (string) $uri;
+		return URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
 	}
 
 	//--------------------------------------------------------------------
@@ -290,8 +290,9 @@ class PagerRenderer
 
 		for ($i = $this->first; $i <= $this->last; $i ++)
 		{
+			$uri     = $this->segment === 0 ? $uri->addQuery($this->pageSelector, $i) : $uri->setSegment($this->segment, $i);
 			$links[] = [
-				'uri'    => (string) ($this->segment === 0 ? $uri->addQuery($this->pageSelector, $i) : $uri->setSegment($this->segment, $i)),
+				'uri'    => URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment()),
 				'title'  => (int) $i,
 				'active' => ($i === $this->current),
 			];
@@ -359,7 +360,7 @@ class PagerRenderer
 			$uri->setSegment($this->segment, $this->current - 1);
 		}
 
-		return (string) $uri;
+		return URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
 	}
 
 	//--------------------------------------------------------------------
@@ -401,7 +402,7 @@ class PagerRenderer
 			$uri->setSegment($this->segment, $this->current + 1);
 		}
 
-		return (string) $uri;
+		return URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
 	}
 
 	/**

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -90,7 +90,7 @@ class RedirectResponseTest extends CIUnitTestCase
 		$response = $response->to('/foo');
 
 		$this->assertTrue($response->hasHeader('Location'));
-		$this->assertEquals('http://example.com/foo', $response->getHeaderLine('Location'));
+		$this->assertEquals('http://example.com/index.php/foo', $response->getHeaderLine('Location'));
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -153,7 +153,6 @@ final class CurrentUrlTest extends CIUnitTestCase
 
 		Services::injectMock('request', $request);
 
-		$url = current_url();
 		$this->assertEquals('/assets/image.jpg', uri_string());
 	}
 
@@ -167,7 +166,6 @@ final class CurrentUrlTest extends CIUnitTestCase
 
 		Services::injectMock('request', $request);
 
-		$url = current_url();
 		$this->assertEquals('assets/image.jpg', uri_string(true));
 	}
 
@@ -182,7 +180,6 @@ final class CurrentUrlTest extends CIUnitTestCase
 
 		Services::injectMock('request', $request);
 
-		$url = current_url();
 		$this->assertEquals('/assets/image.jpg', uri_string());
 	}
 
@@ -197,7 +194,6 @@ final class CurrentUrlTest extends CIUnitTestCase
 
 		Services::injectMock('request', $request);
 
-		$url = current_url();
 		$this->assertEquals('assets/image.jpg', uri_string(true));
 	}
 
@@ -208,7 +204,6 @@ final class CurrentUrlTest extends CIUnitTestCase
 
 		Services::injectMock('request', $request);
 
-		$url = current_url();
 		$this->assertEquals('/', uri_string());
 	}
 
@@ -219,7 +214,6 @@ final class CurrentUrlTest extends CIUnitTestCase
 
 		Services::injectMock('request', $request);
 
-		$url = current_url();
 		$this->assertEquals('', uri_string(true));
 	}
 
@@ -234,15 +228,14 @@ final class CurrentUrlTest extends CIUnitTestCase
 
 		Services::injectMock('request', $request);
 
-		$url = current_url();
 		$this->assertEquals('/subfolder/assets/image.jpg', uri_string());
 	}
 
 	public function testUriStringSubfolderRelative()
 	{
 		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/assets/image.jpg';
 		$_SERVER['REQUEST_URI'] = '/subfolder/assets/image.jpg';
+		$_SERVER['SCRIPT_NAME'] = '/subfolder/index.php';
 
 		$this->config->baseURL = 'http://example.com/subfolder/';
 		$request               = Services::request($this->config);
@@ -250,7 +243,6 @@ final class CurrentUrlTest extends CIUnitTestCase
 
 		Services::injectMock('request', $request);
 
-		$url = current_url();
 		$this->assertEquals('assets/image.jpg', uri_string(true));
 	}
 
@@ -304,7 +296,8 @@ final class CurrentUrlTest extends CIUnitTestCase
 	 */
 	public function testUrlIs(string $currentPath, string $testPath, bool $expected)
 	{
-		$_SERVER['HTTP_HOST'] = 'example.com';
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/' . $currentPath;
 
 		$request      = Services::request();
 		$request->uri = new URI('http://example.com/' . $currentPath);
@@ -319,6 +312,7 @@ final class CurrentUrlTest extends CIUnitTestCase
 	public function testUrlIsNoIndex(string $currentPath, string $testPath, bool $expected)
 	{
 		$_SERVER['HTTP_HOST']    = 'example.com';
+		$_SERVER['REQUEST_URI']  = '/' . $currentPath;
 		$this->config->indexPage = '';
 
 		$request      = Services::request($this->config);
@@ -333,8 +327,10 @@ final class CurrentUrlTest extends CIUnitTestCase
 	 */
 	public function testUrlIsWithSubfolder(string $currentPath, string $testPath, bool $expected)
 	{
-		$_SERVER['HTTP_HOST']  = 'example.com';
-		$this->config->baseURL = 'http://example.com/subfolder/';
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/' . $currentPath;
+		$_SERVER['SCRIPT_NAME'] = '/subfolder/index.php';
+		$this->config->baseURL  = 'http://example.com/subfolder/';
 
 		$request      = Services::request($this->config);
 		$request->uri = new URI('http://example.com/subfolder/' . $currentPath);

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -61,6 +61,11 @@ using the URI class' static ``createURIString()`` method::
 	// Creates: http://exmample.com/some/path?foo=bar#first-heading
 	echo URI::createURIString('http', 'example.com', 'some/path', 'foo=bar', 'first-heading');
 
+.. important:: When ``URI`` is cast to a string, it will attempt to adjust project URLs to the
+	settings defined in ``Config\App``. If you need the exact, unaltered string representation
+	then use ``URI::createURIString()`` instead.
+
+
 =============
 The URI Parts
 =============


### PR DESCRIPTION
**Description**
Due to the following: https://github.com/codeigniter4/CodeIgniter4/blob/7eef1f708750fe11089e5eb056e7c817a691d0fa/system/HTTP/URI.php#L681-L702
... `URI::__toString()` is only suitable for project URLs, because any partial match of `baseURL` will be a false positive. Following on #4715, this PR removes the remaining string casts of `URI` when they are not explicitly a project URI.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
