### PR TITLE
Test with MySQL 8

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -138,7 +138,7 @@ jobs:
           DB: ${{ matrix.db-platforms }}
           TERM: xterm-256color
 
-      - if: matrix.php-versions == '7.4'
+      - if: github.repository_owner == 'codeigniter4' && matrix.php-versions == '7.4'
         name: Run Coveralls
         run: |
           composer global require php-coveralls/php-coveralls:^2.4
@@ -149,6 +149,7 @@ jobs:
           COVERALLS_FLAG_NAME: PHP ${{ matrix.php-versions }} - ${{ matrix.db-platforms }}
 
   coveralls-finish:
+    if: github.repository_owner == 'codeigniter4'
     needs: [tests]
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -42,10 +42,15 @@ jobs:
       matrix:
         php-versions: ['7.3', '7.4', '8.0']
         db-platforms: ['MySQLi', 'Postgre', 'SQLite3', 'SQLSRV']
+        mysql-versions: ['5.7']
+        include:
+          - php-versions: 7.4
+            db-platforms: MySQLi
+            mysql-versions: 8.0
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:${{ matrix.mysql-versions }}
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: test

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -249,8 +249,16 @@ class ForgeTest extends CIUnitTestCase
 	public function testCreateTableWithNullableFieldsGivesNullDataType(): void
 	{
 		$this->forge->addField([
-			'id'   => ['type' => 'INT', 'constraint' => 11, 'auto_increment' => true],
-			'name' => ['type' => 'VARCHAR', 'constraint' => 255, 'null' => true],
+			'id'   => [
+				'type'           => 'INT',
+				'constraint'     => 11,
+				'auto_increment' => true,
+			],
+			'name' => [
+				'type'       => 'VARCHAR',
+				'constraint' => 255,
+				'null'       => true,
+			],
 		]);
 
 		$createTable = $this->getPrivateMethodInvoker($this->forge, '_createTable');
@@ -620,7 +628,13 @@ class ForgeTest extends CIUnitTestCase
 			$this->assertEquals($fieldsData[0]->type, 'int');
 			$this->assertEquals($fieldsData[1]->type, 'varchar');
 
-			$this->assertEquals($fieldsData[0]->max_length, 11);
+			if (version_compare($this->db->getVersion(), '8.0.17', '<'))
+			{
+				// As of MySQL 8.0.17, the display width attribute for integer data types
+				// is deprecated and is not reported back anymore.
+				// @see https://dev.mysql.com/doc/refman/8.0/en/numeric-type-attributes.html
+				$this->assertEquals($fieldsData[0]->max_length, 11);
+			}
 
 			$this->assertNull($fieldsData[0]->default);
 			$this->assertNull($fieldsData[1]->default);


### PR DESCRIPTION
Greetings 👋 ,

I'm running PHP 8 and MySQL 8 on my machine and noticed one failing test (`ForgeTest::testAddFields()`, it seems that the `max_length` cannot be retrieved for `BIGINT` fields).

https://github.com/codeigniter4/CodeIgniter4/blob/6da0e5bdc6213edc40ef040de5cbfdcc45a03ead/tests/system/Database/Live/ForgeTest.php#L617-L623

Here's the failing test on my fork: https://github.com/jeromegamez/CodeIgniter4/runs/2643301715?check_suite_focus=true

In order to be able to show the error, I started by adding it to the test matrix (but am not sure how to change the workflow name to reflect it, since all matrix combinations start all types of databases).

<s>The added `mysql8` branch in the triggers is only so that I could run the action, this would of course be removed before merging, if you wish to proceed, that is 😅 </s>

I don't know CodeIgniter at all and am only using this repo, so, if you have an idea why this test might fail, I'm all ears👂, otherwise, I will try to dive deeper into it in the hopes to find a good explanation or even a fix 😅

:octocat: 