### PR TITLE
Fix truncated SCRIPT_NAME

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -270,7 +270,7 @@ class IncomingRequest extends Request
 			foreach (explode('/', $_SERVER['SCRIPT_NAME']) as $i => $segment)
 			{
 				// If these segments are not the same then we're done
-				if ($segment !== $segments[$i])
+				if (! isset($segments[$i]) || $segment !== $segments[$i])
 				{
 					break;
 				}


### PR DESCRIPTION
**Description**
It appears that some PHP web servers do not guarantee the `SCRIPT_NAME` as a substring of `REQUEST_URI`. From consulting other frameworks, it is still safe to determine the relative path this way, but we need to ensure the segments before checking.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
