### PR TITLE
Publisher Class

### DIFF
--- a/app/Config/Publisher.php
+++ b/app/Config/Publisher.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\Publisher as BasePublisher;
+
+/**
+ * Publisher Configuration
+ *
+ * Defines basic security restrictions for the Publisher class
+ * to prevent abuse by injecting malicious files into a project.
+ */
+class Publisher extends BasePublisher
+{
+	/**
+	 * A list of allowed destinations with a (pseudo-)regex
+	 * of allowed files for each destination.
+	 * Attempts to publish to directories not in this list will
+	 * result in a PublisherException. Files that do no fit the
+	 * pattern will cause copy/merge to fail.
+	 *
+	 * @var array<string,string>
+	 */
+	public $restrictions = [
+		ROOTPATH => '*',
+		FCPATH   => '#\.(?css|js|map|htm?|xml|json|webmanifest|tff|eot|woff?|gif|jpe?g|tiff?|png|webp|bmp|ico|svg)$#i',
+	];
+}

--- a/system/Commands/Utilities/Publish.php
+++ b/system/Commands/Utilities/Publish.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\Publisher\Publisher;
+
+/**
+ * Discovers all Publisher classes from the "Publishers/" directory
+ * across namespaces. Executes `publish()` from each instance, parsing
+ * each result.
+ */
+class Publish extends BaseCommand
+{
+	/**
+	 * The group the command is lumped under
+	 * when listing commands.
+	 *
+	 * @var string
+	 */
+	protected $group = 'CodeIgniter';
+
+	/**
+	 * The Command's name
+	 *
+	 * @var string
+	 */
+	protected $name = 'publish';
+
+	/**
+	 * The Command's short description
+	 *
+	 * @var string
+	 */
+	protected $description = 'Discovers and executes all predefined Publisher classes.';
+
+	/**
+	 * The Command's usage
+	 *
+	 * @var string
+	 */
+	protected $usage = 'publish [directory]';
+
+	/**
+	 * The Command's arguments
+	 *
+	 * @var array<string, string>
+	 */
+	protected $arguments = [
+		'directory' => '[Optional] The directory to scan within each namespace. Default: "Publishers".',
+	];
+
+	/**
+	 * the Command's Options
+	 *
+	 * @var array
+	 */
+	protected $options = [];
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Displays the help for the spark cli script itself.
+	 *
+	 * @param array $params
+	 */
+	public function run(array $params)
+	{
+		$directory = array_shift($params) ?? 'Publishers';
+
+		if ([] === $publishers = Publisher::discover($directory))
+		{
+			CLI::write(lang('Publisher.publishMissing', [$directory]));
+			return;
+		}
+
+		foreach ($publishers as $publisher)
+		{
+			if ($publisher->publish())
+			{
+				CLI::write(lang('Publisher.publishSuccess', [
+					get_class($publisher),
+					count($publisher->getPublished()),
+					$publisher->getDestination(),
+				]), 'green');
+			}
+			else
+			{
+				CLI::error(lang('Publisher.publishFailure', [
+					get_class($publisher),
+					$publisher->getDestination(),
+				]), 'light_gray', 'red');
+
+				foreach ($publisher->getErrors() as $file => $exception)
+				{
+					CLI::write($file);
+					CLI::newLine();
+
+					$this->showError($exception);
+				}
+			}
+		}
+	}
+}

--- a/system/Commands/Utilities/Publish.php
+++ b/system/Commands/Utilities/Publish.php
@@ -49,7 +49,7 @@ class Publish extends BaseCommand
 	 *
 	 * @var string
 	 */
-	protected $usage = 'publish [directory]';
+	protected $usage = 'publish [<directory>]';
 
 	/**
 	 * The Command's arguments
@@ -104,9 +104,8 @@ class Publish extends BaseCommand
 				foreach ($publisher->getErrors() as $file => $exception)
 				{
 					CLI::write($file);
+					CLI::error($exception->getMessage());
 					CLI::newLine();
-
-					$this->showError($exception);
 				}
 			}
 		}

--- a/system/Config/Publisher.php
+++ b/system/Config/Publisher.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Config;
+
+/**
+ * Publisher Configuration
+ *
+ * Defines basic security restrictions for the Publisher class
+ * to prevent abuse by injecting malicious files into a project.
+ */
+class Publisher extends BaseConfig
+{
+	/**
+	 * A list of allowed destinations with a (pseudo-)regex
+	 * of allowed files for each destination.
+	 * Attempts to publish to directories not in this list will
+	 * result in a PublisherException. Files that do no fit the
+	 * pattern will cause copy/merge to fail.
+	 *
+	 * @var array<string,string>
+	 */
+	public $restrictions = [
+		ROOTPATH => '*',
+		FCPATH   => '#\.(?css|js|map|htm?|xml|json|webmanifest|tff|eot|woff?|gif|jpe?g|tiff?|png|webp|bmp|ico|svg)$#i',
+	];
+
+	/**
+	 * Disables Registrars to prevent modules from altering the restrictions.
+	 */
+	final protected function registerProperties()
+	{
+	}
+}

--- a/system/Language/en/Publisher.php
+++ b/system/Language/en/Publisher.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// Publisher language settings
+return [
+	'expectedFile'      => 'Publisher::{0} expects a valid file.',
+	'expectedDirectory' => 'Publisher::{0} expects a valid directory.',
+	'collision'         => 'Publisher encountered an unexpected {0} while copying {1} to {2}.',
+];

--- a/system/Language/en/Publisher.php
+++ b/system/Language/en/Publisher.php
@@ -14,4 +14,9 @@ return [
 	'collision'         => 'Publisher encountered an unexpected {0} while copying {1} to {2}.',
 	'expectedDirectory' => 'Publisher::{0} expects a valid directory.',
 	'expectedFile'      => 'Publisher::{0} expects a valid file.',
+
+	// Publish Command
+	'publishMissing'    => 'No Publisher classes detected in {0} across all namespaces.',
+	'publishSuccess'    => '{0} published {1} file(s) to {2}.',
+	'publishFailure'    => '{0} failed to publish to {1}!',
 ];

--- a/system/Language/en/Publisher.php
+++ b/system/Language/en/Publisher.php
@@ -11,7 +11,7 @@
 
 // Publisher language settings
 return [
-	'expectedFile'      => 'Publisher::{0} expects a valid file.',
-	'expectedDirectory' => 'Publisher::{0} expects a valid directory.',
 	'collision'         => 'Publisher encountered an unexpected {0} while copying {1} to {2}.',
+	'expectedDirectory' => 'Publisher::{0} expects a valid directory.',
+	'expectedFile'      => 'Publisher::{0} expects a valid file.',
 ];

--- a/system/Language/en/Publisher.php
+++ b/system/Language/en/Publisher.php
@@ -11,9 +11,11 @@
 
 // Publisher language settings
 return [
-	'collision'         => 'Publisher encountered an unexpected {0} while copying {1} to {2}.',
-	'expectedDirectory' => 'Publisher::{0} expects a valid directory.',
-	'expectedFile'      => 'Publisher::{0} expects a valid file.',
+	'collision'             => 'Publisher encountered an unexpected {0} while copying {1} to {2}.',
+	'expectedDirectory'     => 'Publisher::{0} expects a valid directory.',
+	'expectedFile'          => 'Publisher::{0} expects a valid file.',
+	'destinationNotAllowed' => 'Destination is not on the allowed list of Publisher directories: {0}',
+	'fileNotAllowed'        => '{0} fails the following restriction for {1}: {2}',
 
 	// Publish Command
 	'publishMissing'    => 'No Publisher classes detected in {0} across all namespaces.',

--- a/system/Publisher/Exceptions/PublisherException.php
+++ b/system/Publisher/Exceptions/PublisherException.php
@@ -13,18 +13,39 @@ namespace CodeIgniter\Publisher\Exceptions;
 
 use CodeIgniter\Exceptions\FrameworkException;
 
+/**
+ * Publisher Exception Class
+ *
+ * Handles exceptions related to actions taken by a Publisher.
+ */
 class PublisherException extends FrameworkException
 {
+	/**
+	 * Throws when a file should be overwritten yet cannot.
+	 *
+	 * @param string $from The source file
+	 * @param string $to   The destination file
+	 */
 	public static function forCollision(string $from, string $to)
 	{
 		return new static(lang('Publisher.collision', [filetype($to), $from, $to]));
 	}
 
+	/**
+	 * Throws when an object is expected to be a directory but is not or is missing.
+	 *
+	 * @param string $caller The method causing the exception
+	 */
 	public static function forExpectedDirectory(string $caller)
 	{
 		return new static(lang('Publisher.expectedDirectory', [$caller]));
 	}
 
+	/**
+	 * Throws when an object is expected to be a file but is not or is missing.
+	 *
+	 * @param string $caller The method causing the exception
+	 */
 	public static function forExpectedFile(string $caller)
 	{
 		return new static(lang('Publisher.expectedFile', [$caller]));

--- a/system/Publisher/Exceptions/PublisherException.php
+++ b/system/Publisher/Exceptions/PublisherException.php
@@ -50,4 +50,26 @@ class PublisherException extends FrameworkException
 	{
 		return new static(lang('Publisher.expectedFile', [$caller]));
 	}
+
+	/**
+	 * Throws when given a destination that is not in the list of allowed directories.
+	 *
+	 * @param string $destination
+	 */
+	public static function forDestinationNotAllowed(string $destination)
+	{
+		return new static(lang('Publisher.destinationNotAllowed', [$destination]));
+	}
+
+	/**
+	 * Throws when a file fails to match the allowed pattern for its destination.
+	 *
+	 * @param string $file
+	 * @param string $directory
+	 * @param string $pattern
+	 */
+	public static function forFileNotAllowed(string $file, string $directory, string $pattern)
+	{
+		return new static(lang('Publisher.fileNotAllowed', [$file, $directory, $pattern]));
+	}
 }

--- a/system/Publisher/Exceptions/PublisherException.php
+++ b/system/Publisher/Exceptions/PublisherException.php
@@ -15,6 +15,11 @@ use CodeIgniter\Exceptions\FrameworkException;
 
 class PublisherException extends FrameworkException
 {
+	public static function forCollision(string $from, string $to)
+	{
+		return new static(lang('Publisher.collision', [filetype($to), $from, $to]));
+	}
+
 	public static function forExpectedDirectory(string $caller)
 	{
 		return new static(lang('Publisher.expectedDirectory', [$caller]));
@@ -23,10 +28,5 @@ class PublisherException extends FrameworkException
 	public static function forExpectedFile(string $caller)
 	{
 		return new static(lang('Publisher.expectedFile', [$caller]));
-	}
-
-	public static function forCollision(string $from, string $to)
-	{
-		return new static(lang('Publisher.collision', [filetype($to), $from, $to]));
 	}
 }

--- a/system/Publisher/Exceptions/PublisherException.php
+++ b/system/Publisher/Exceptions/PublisherException.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Publisher\Exceptions;
+
+use CodeIgniter\Exceptions\FrameworkException;
+
+class PublisherException extends FrameworkException
+{
+	public static function forExpectedDirectory(string $caller)
+	{
+		return new static(lang('Publisher.expectedDirectory', [$caller]));
+	}
+
+	public static function forExpectedFile(string $caller)
+	{
+		return new static(lang('Publisher.expectedFile', [$caller]));
+	}
+
+	public static function forCollision(string $from, string $to)
+	{
+		return new static(lang('Publisher.collision', [filetype($to), $from, $to]));
+	}
+}

--- a/system/Publisher/Publisher.php
+++ b/system/Publisher/Publisher.php
@@ -20,24 +20,18 @@ use Throwable;
 /**
  * Publisher Class
  *
- * Publishers read in file paths from a variety
- * of sources and copy the files out to different
- * destinations.
- * This class acts both as a base for individual
- * publication directives as well as the mode of
- * discovery for said instances.
- * In this class a "file" is a full path to a
- * verified file while a "path" is relative to
- * to its source or destination and may indicate
- * either a file or directory fo unconfirmed
- * existence.
- * Class failures throw a PublisherException,
- * but some underlying methods may percolate
- * different exceptions, like FileException,
- * FileNotFoundException, InvalidArgumentException.
- * Write operations will catch all errors in the
- * file-specific $errors property to minimize
- * impact of partial batch operations.
+ * Publishers read in file paths from a variety of sources and copy
+ * the files out to different destinations. This class acts both as
+ * a base for individual publication directives as well as the mode
+ * of discovery for said instances. In this class a "file" is a full
+ * path to a verified file while a "path" is relative to its source
+ * or destination and may indicate either a file or directory of
+ * unconfirmed existence.
+ * class failures throw the PublisherException, but some underlying
+ * methods may percolate different exceptions, like FileException,
+ * FileNotFoundException or InvalidArgumentException.
+ * Write operations will catch all errors in the file-specific
+ * $errors property to minimize impact of partial batch operations.
  */
 class Publisher
 {
@@ -90,14 +84,17 @@ class Publisher
 	 * Discovers and returns all Publishers
 	 * in the specified namespace directory.
 	 *
+	 * @param string $directory
+	 *
 	 * @return self[]
 	 */
-	public static function discover($directory = 'Publishers'): array
+	public static function discover(string $directory = 'Publishers'): array
 	{
 		if (isset(self::$discovered[$directory]))
 		{
 			return self::$discovered[$directory];
 		}
+	
 		self::$discovered[$directory] = [];
 
 		/** @var FileLocator $locator */
@@ -145,8 +142,7 @@ class Publisher
 	}
 
 	/**
-	 * Resolves a full path and verifies
-	 * it is an actual file.
+	 * Resolves a full path and verifies it is an actual file.
 	 *
 	 * @param string $file
 	 *
@@ -184,11 +180,10 @@ class Publisher
 	}
 
 	/**
-	 * Returns any files whose basename matches
-	 * the given pattern.
+	 * Returns any files whose `basename` matches the given pattern.
 	 *
-	 * @param string[] $files
-	 * @param string $pattern Regex or pseudo-regex string
+	 * @param array<string> $files
+	 * @param string        $pattern Regex or pseudo-regex string
 	 *
 	 * @return string[]
 	 */
@@ -239,13 +234,12 @@ class Publisher
 	}
 
 	/**
-	 * Copies a file with directory creation
-	 * and identical file awareness.
+	 * Copies a file with directory creation and identical file awareness.
 	 * Intentionally allows errors.
 	 *
-	 * @param string $from
-	 * @param string $to
-	 * @param bool $replace
+	 * @param string  $from
+	 * @param string  $to
+	 * @param boolean $replace
 	 *
 	 * @return void
 	 *
@@ -301,8 +295,7 @@ class Publisher
 	}
 
 	/**
-	 * Cleans up any temporary files
-	 * in the scratch space.
+	 * Cleans up any temporary files in the scratch space.
 	 */
 	public function __destruct()
 	{
@@ -315,14 +308,13 @@ class Publisher
 	}
 
 	/**
-	 * Reads in file sources and copies out
-	 * the files to their destinations.
-	 * This method should be reimplemented by
-	 * child classes intended for discovery.
+	 * Reads files in the sources and copies them out to their destinations.
+	 * This method should be reimplemented by child classes intended for
+	 * discovery.
 	 *
-	 * @return bool
+	 * @return boolean
 	 */
-	public function publish()
+	public function publish(): bool
 	{
 		return $this->addPath('/')->merge(true);
 	}
@@ -347,8 +339,7 @@ class Publisher
 	}
 
 	/**
-	 * Returns any errors from the last
-	 * write operation.
+	 * Returns errors from the last write operation if any.
 	 *
 	 * @return array<string,Throwable>
 	 */
@@ -358,8 +349,7 @@ class Publisher
 	}
 
 	/**
-	 * Optimizes and returns the
-	 * current file list.
+	 * Optimizes and returns the current file list.
 	 *
 	 * @return string[]
 	 */
@@ -372,11 +362,10 @@ class Publisher
 	}
 
 	/**
-	 * Sets the file list directly.
-	 * Files are still subject to verification.
+	 * Sets the file list directly, files are still subject to verification.
 	 * This works as a "reset" method with [].
 	 *
-	 * @param string[] $files  A new file list to use
+	 * @param string[] $files The new file list to use
 	 *
 	 * @return $this
 	 */
@@ -407,8 +396,7 @@ class Publisher
 	}
 
 	/**
-	 * Verifies and adds a single file
-	 * to the file list.
+	 * Verifies and adds a single file to the file list.
 	 *
 	 * @param string $file
 	 *
@@ -469,11 +457,10 @@ class Publisher
 	}
 
 	/**
-	 * Verifies and adds all files
-	 * from a directory.
+	 * Verifies and adds all files from a directory.
 	 *
-	 * @param string $directory
-	 * @param bool $recursive
+	 * @param string  $directory
+	 * @param boolean $recursive
 	 *
 	 * @return $this
 	 */
@@ -520,8 +507,8 @@ class Publisher
 	/**
 	 * Adds a single path to the file list.
 	 *
-	 * @param string $path
-	 * @param bool $recursive
+	 * @param string  $path
+	 * @param boolean $recursive
 	 *
 	 * @return $this
 	 */
@@ -563,8 +550,7 @@ class Publisher
 	}
 
 	/**
-	 * Downloads a file from the URI
-	 * and adds it to the file list.
+	 * Downloads a file from the URI, and adds it to the file list.
 	 *
 	 * @param string $uri Because HTTP\URI is stringable it will still be accepted
 	 *
@@ -576,8 +562,7 @@ class Publisher
 		$file = $this->getScratch() . basename((new URI($uri))->getPath());
 
 		// Get the content and write it to the scratch space
-		$response = service('curlrequest')->get($uri);
-		write_file($file, $response->getBody());
+		write_file($file, service('curlrequest')->get($uri)->getBody());
 
 		return $this->addFile($file);
 	}
@@ -585,11 +570,11 @@ class Publisher
 	//--------------------------------------------------------------------
 
 	/**
-	 * Removes any files from the list that match
-	 * the supplied pattern (within the optional scope).
+	 * Removes any files from the list that match the supplied pattern
+	 * (within the optional scope).
 	 *
-	 * @param string $pattern    Regex or pseudo-regex string
-	 * @param string|null $scope A directory to limit the scope
+	 * @param string      $pattern Regex or pseudo-regex string
+	 * @param string|null $scope The directory to limit the scope
 	 *
 	 * @return $this
 	 */
@@ -601,9 +586,7 @@ class Publisher
 		}
 
 		// Start with all files or those in scope
-		$files = is_null($scope)
-			? $this->files
-			: self::filterFiles($this->files, $scope);
+		$files = is_null($scope) ? $this->files : self::filterFiles($this->files, $scope);
 
 		// Remove any files that match the pattern
 		return $this->removeFiles(self::matchFiles($files, $pattern));
@@ -611,9 +594,9 @@ class Publisher
 
 	/**
 	 * Keeps only the files from the list that match
-	 * the supplied pattern (within the optional scope).
+	 * (within the optional scope).
 	 *
-	 * @param string $pattern    Regex or pseudo-regex string
+	 * @param string      $pattern Regex or pseudo-regex string
 	 * @param string|null $scope A directory to limit the scope
 	 *
 	 * @return $this
@@ -654,10 +637,9 @@ class Publisher
 	//--------------------------------------------------------------------
 
 	/**
-	 * Copies all files into the destination.
-	 * Does not create directory structure.
+	 * Copies all files into the destination, does not create directory structure.
 	 *
-	 * @param bool $replace Whether to overwrite existing files.
+	 * @param boolean $replace Whether to overwrite existing files.
 	 *
 	 * @return boolean Whether all files were copied successfully
 	 */
@@ -684,10 +666,9 @@ class Publisher
 
 	/**
 	 * Merges all files into the destination.
-	 * Creates a mirrored directory structure
-	 * only for files from source.
+	 * Creates a mirrored directory structure only for files from source.
 	 *
-	 * @param bool $replace Whether to overwrite existing files.
+	 * @param boolean $replace Whether to overwrite existing files.
 	 *
 	 * @return boolean Whether all files were copied successfully
 	 */

--- a/system/Publisher/Publisher.php
+++ b/system/Publisher/Publisher.php
@@ -317,6 +317,7 @@ class Publisher
 	 */
 	public function publish(): bool
 	{
+		// Safeguard against accidental misuse
 		if ($this->source === ROOTPATH && $this->destination === FCPATH)
 		{
 			throw new RuntimeException('Child classes of Publisher should provide their own source and destination or publish method.');

--- a/system/Publisher/Publisher.php
+++ b/system/Publisher/Publisher.php
@@ -1,0 +1,713 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Publisher;
+
+use CodeIgniter\Autoloader\FileLocator;
+use CodeIgniter\Files\File;
+use CodeIgniter\HTTP\URI;
+use CodeIgniter\Publisher\Exceptions\PublisherException;
+use Throwable;
+
+/**
+ * Publisher Class
+ *
+ * Publishers read in file paths from a variety
+ * of sources and copy the files out to different
+ * destinations.
+ * This class acts both as a base for individual
+ * publication directives as well as the mode of
+ * discovery for said instances.
+ * In this class a "file" is a full path to a
+ * verified file while a "path" is relative to
+ * to its source or destination and may indicate
+ * either a file or directory fo unconfirmed
+ * existence.
+ * Class failures throw a PublisherException,
+ * but some underlying methods may percolate
+ * different exceptions, like FileException,
+ * FileNotFoundException, InvalidArgumentException.
+ * Write operations will catch all errors in the
+ * file-specific $errors property to minimize
+ * impact of partial batch operations.
+ */
+class Publisher
+{
+	/**
+	 * Array of discovered Publishers.
+	 *
+	 * @var array<string,self[]|null>
+	 */
+	private static $discovered = [];
+
+	/**
+	 * Directory to use for methods
+	 * that need temporary storage.
+	 * Created on-the-fly as needed.
+	 *
+	 * @var string|null
+	 */
+	private $scratch;
+
+	/**
+	 * The current list of files.
+	 *
+	 * @var string[]
+	 */
+	private $files = [];
+
+	/**
+	 * Exceptions for specific files
+	 * from the last write operation.
+	 *
+	 * @var array<string,Throwable>
+	 */
+	private $errors = [];
+
+	/**
+	 * Base path to use for the source.
+	 *
+	 * @var string
+	 */
+	protected $source = ROOTPATH;
+
+	/**
+	 * Base path to use for the destination.
+	 *
+	 * @var string
+	 */
+	protected $destination = FCPATH;
+
+	/**
+	 * Discovers and returns all Publishers
+	 * in the specified namespace directory.
+	 *
+	 * @return self[]
+	 */
+	public static function discover($directory = 'Publishers'): array
+	{
+		if (isset(self::$discovered[$directory]))
+		{
+			return self::$discovered[$directory];
+		}
+		self::$discovered[$directory] = [];
+
+		/** @var FileLocator $locator */
+		$locator = service('locator');
+
+		if ([] === $files = $locator->listFiles($directory))
+		{
+			return [];
+		}
+
+		// Loop over each file checking to see if it is a Primer
+		foreach ($files as $file)
+		{
+			$className = $locator->findQualifiedNameFromPath($file);
+
+			if (is_string($className) && class_exists($className) && is_a($className, self::class, true))
+			{
+				self::$discovered[$directory][] = new $className();
+			}
+		}
+		sort(self::$discovered[$directory]);
+
+		return self::$discovered[$directory];
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Resolves a full path and verifies
+	 * it is an actual directory.
+	 *
+	 * @param string $directory
+	 *
+	 * @return string
+	 */
+	private static function resolveDirectory(string $directory): string
+	{
+		if (! is_dir($directory = set_realpath($directory)))
+		{
+			$caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1];
+			throw PublisherException::forExpectedDirectory($caller['function']);
+		}
+
+		return $directory;
+	}
+
+	/**
+	 * Resolves a full path and verifies
+	 * it is an actual file.
+	 *
+	 * @param string $file
+	 *
+	 * @return string
+	 */
+	private static function resolveFile(string $file): string
+	{
+		if (! is_file($file = set_realpath($file)))
+		{
+			$caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1];
+			throw PublisherException::forExpectedFile($caller['function']);
+		}
+
+		return $file;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Filters an array of files, removing files not
+	 * part of the given directory (recursive).
+	 *
+	 * @param string[] $files
+	 * @param string $directory
+	 *
+	 * @return string[]
+	 */
+	private static function filterFiles(array $files, string $directory): array
+	{
+		$directory = self::resolveDirectory($directory);
+
+		return array_filter($files, function ($value) use ($directory) {
+			return strpos($value, $directory) === 0;
+		});
+	}
+
+	/**
+	 * Returns any files whose basename matches
+	 * the given pattern.
+	 *
+	 * @param string[] $files
+	 * @param string $pattern Regex or pseudo-regex string
+	 *
+	 * @return string[]
+	 */
+	private static function matchFiles(array $files, string $pattern)
+	{
+		// Convert pseudo-regex into their true form
+		if (@preg_match($pattern, null) === false) // @phpstan-ignore-line
+		{
+			$pattern = str_replace(
+				['#', '.', '*', '?'],
+				['\#', '\.', '.*', '.'],
+				$pattern
+			);
+			$pattern = "#{$pattern}#";
+		}
+
+		return array_filter($files, function ($value) use ($pattern) {
+			return (bool) preg_match($pattern, basename($value));
+		});
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Removes a directory and all its files
+	 * and subdirectories.
+	 *
+	 * @param string $directory
+	 *
+	 * @return void
+	 */
+	private static function wipeDirectory(string $directory)
+	{
+		if (is_dir($directory))
+		{
+			// Try a few times in case of lingering locks
+			$attempts = 10;
+			while ((bool) $attempts && ! delete_files($directory, true, false, true))
+			{
+				$attempts--;
+				usleep(100000); // .1s
+			}
+
+			@rmdir($directory);
+		}
+	}
+
+	/**
+	 * Copies a file with directory creation
+	 * and identical file awareness.
+	 * Intentionally allows errors.
+	 *
+	 * @param string $from
+	 * @param string $to
+	 * @param bool $replace
+	 *
+	 * @return void
+	 *
+	 * @throws PublisherException For unresolvable collisions
+	 */
+	private static function safeCopyFile(string $from, string $to, bool $replace): void
+	{
+		// Check for an existing file
+		if (file_exists($to))
+		{
+			// If not replacing or if files are identical then consider successful
+			if (! $replace || same_file($from, $to))
+			{
+				return;
+			}
+
+			// If it is a directory then do not try to remove it
+			if (is_dir($to))
+			{
+				throw PublisherException::forCollision($from, $to);
+			}
+
+			// Try to remove anything else
+			unlink($to);
+		}
+
+		// Allow copy() to throw errors
+		copy($from, $to);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Loads the helper and verifies the
+	 * source and destination directories.
+	 *
+	 * @param string|null $source
+	 * @param string|null $destination
+	 */
+	public function __construct(string $source = null, string $destination = null)
+	{
+		helper(['filesystem']);
+
+		$this->source      = self::resolveDirectory($source ?? $this->source);
+		$this->destination = self::resolveDirectory($destination ?? $this->destination);
+	}
+
+	/**
+	 * Cleans up any temporary files
+	 * in the scratch space.
+	 */
+	public function __destruct()
+	{
+		if (isset($this->scratch))
+		{
+			self::wipeDirectory($this->scratch);
+
+			$this->scratch = null;
+		}
+	}
+
+	/**
+	 * Reads in file sources and copies out
+	 * the files to their destinations.
+	 * This method should be reimplemented by
+	 * child classes intended for discovery.
+	 *
+	 * @return void
+	 */
+	public function publish()
+	{
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Returns the temporary workspace,
+	 * creating it if necessary.
+	 *
+	 * @return string
+	 */
+	protected function getScratch(): string
+	{
+		if (is_null($this->scratch))
+		{
+			$this->scratch = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . bin2hex(random_bytes(6)) . DIRECTORY_SEPARATOR;
+			mkdir($this->scratch, 0700);
+		}
+
+		return $this->scratch;
+	}
+
+	/**
+	 * Returns any errors from the last
+	 * write operation.
+	 *
+	 * @return array<string,Throwable>
+	 */
+	public function getErrors(): array
+	{
+		return $this->errors;
+	}
+
+	/**
+	 * Optimizes and returns the
+	 * current file list.
+	 *
+	 * @return string[]
+	 */
+	public function getFiles(): array
+	{
+		$this->files = array_unique($this->files, SORT_STRING);
+		sort($this->files, SORT_STRING);
+
+		return $this->files;
+	}
+
+	/**
+	 * Sets the file list directly.
+	 * Files are still subject to verification.
+	 * This works as a "reset" method with [].
+	 *
+	 * @param string[] $files  A new file list to use
+	 *
+	 * @return $this
+	 */
+	public function setFiles(array $files)
+	{
+		$this->files = [];
+
+		return $this->addFiles($files);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Verifies and adds files to the list.
+	 *
+	 * @param string[] $files
+	 *
+	 * @return $this
+	 */
+	public function addFiles(array $files)
+	{
+		foreach ($files as $file)
+		{
+			$this->addFile($file);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Verifies and adds a single file
+	 * to the file list.
+	 *
+	 * @param string $file
+	 *
+	 * @return $this
+	 */
+	public function addFile(string $file)
+	{
+		$this->files[] = self::resolveFile($file);
+
+		return $this;
+	}
+
+	/**
+	 * Removes files from the list.
+	 *
+	 * @param string[] $files
+	 *
+	 * @return $this
+	 */
+	public function removeFiles(array $files)
+	{
+		$this->files = array_diff($this->files, $files);
+
+		return $this;
+	}
+
+	/**
+	 * Removes a single file from the list.
+	 *
+	 * @param string $file
+	 *
+	 * @return $this
+	 */
+	public function removeFile(string $file)
+	{
+		return $this->removeFiles([$file]);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Verifies and adds files from each
+	 * directory to the list.
+	 *
+	 * @param string[] $directories
+	 * @param bool $recursive
+	 *
+	 * @return $this
+	 */
+	public function addDirectories(array $directories, bool $recursive = false)
+	{
+		foreach ($directories as $directory)
+		{
+			$this->addDirectory($directory, $recursive);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Verifies and adds all files
+	 * from a directory.
+	 *
+	 * @param string $directory
+	 * @param bool $recursive
+	 *
+	 * @return $this
+	 */
+	public function addDirectory(string $directory, bool $recursive = false)
+	{
+		$directory = self::resolveDirectory($directory);
+
+		// Map the directory to depth 2 to so directories become arrays
+		foreach (directory_map($directory, 2, true) as $key => $path)
+		{
+			if (is_string($path))
+			{
+				$this->addFile($directory . $path);
+			}
+			elseif ($recursive && is_array($path))
+			{
+				$this->addDirectory($directory . $key, true);
+			}
+		}
+
+		return $this;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Verifies and adds paths to the list.
+	 *
+	 * @param string[] $paths
+	 * @param bool $recursive
+	 *
+	 * @return $this
+	 */
+	public function addPaths(array $paths, bool $recursive = true)
+	{
+		foreach ($paths as $path)
+		{
+			$this->addPath($path, $recursive);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Adds a single path to the file list.
+	 *
+	 * @param string $path
+	 * @param bool $recursive
+	 *
+	 * @return $this
+	 */
+	public function addPath(string $path, bool $recursive = true)
+	{
+		$full = $this->source . $path;
+
+		// Test for a directory
+		try
+		{
+			$directory = self::resolveDirectory($full);
+		}
+		catch (PublisherException $e)
+		{
+			return $this->addFile($full);
+		}
+
+		return $this->addDirectory($full, $recursive);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Downloads and stages files from
+	 * an array of URIs.
+	 *
+	 * @param string[] $uris
+	 *
+	 * @return $this
+	 */
+	public function addUris(array $uris)
+	{
+		foreach ($uris as $uri)
+		{
+			$this->addUri($uri);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Downloads a file from the URI
+	 * and adds it to the file list.
+	 *
+	 * @param string $uri Because HTTP\URI is stringable it will still be accepted
+	 *
+	 * @return $this
+	 */
+	public function addUri(string $uri)
+	{
+		// Figure out a good filename (using URI strips queries and fragments)
+		$file = $this->getScratch() . basename((new URI($uri))->getPath());
+
+		// Get the content and write it to the scratch space
+		$response = service('curlrequest')->get($uri);
+		write_file($file, $response->getBody());
+
+		return $this->addFile($file);
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Removes any files from the list that match
+	 * the supplied pattern (within the optional scope).
+	 *
+	 * @param string $pattern    Regex or pseudo-regex string
+	 * @param string|null $scope A directory to limit the scope
+	 *
+	 * @return $this
+	 */
+	public function removePattern(string $pattern, string $scope = null)
+	{
+		if ($pattern === '')
+		{
+			return $this;
+		}
+
+		// Start with all files or those in scope
+		$files = is_null($scope)
+			? $this->files
+			: self::filterFiles($this->files, $scope);
+
+		// Remove any files that match the pattern
+		return $this->removeFiles(self::matchFiles($files, $pattern));
+	}
+
+	/**
+	 * Keeps only the files from the list that match
+	 * the supplied pattern (within the optional scope).
+	 *
+	 * @param string $pattern    Regex or pseudo-regex string
+	 * @param string|null $scope A directory to limit the scope
+	 *
+	 * @return $this
+	 */
+	public function retainPattern(string $pattern, string $scope = null)
+	{
+		if ($pattern === '')
+		{
+			return $this;
+		}
+
+		// Start with all files or those in scope
+		$files = is_null($scope)
+			? $this->files
+			: self::filterFiles($this->files, $scope);
+
+		// Match the pattern within the scoped files
+		$matched = self::matchFiles($files, $pattern);
+
+		// ... and remove their inverse
+		return $this->removeFiles(array_diff($files, $matched));
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Removes the destination and all its files and folders.
+	 *
+	 * @return $this
+	 */
+	public function wipe()
+	{
+		self::wipeDirectory($this->destination);
+
+		return $this;
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * Copies all files into the destination.
+	 * Does not create directory structure.
+	 *
+	 * @param bool $replace Whether to overwrite existing files.
+	 *
+	 * @return boolean Whether all files were copied successfully
+	 */
+	public function copy(bool $replace = true): bool
+	{
+		$this->errors = [];
+
+		foreach ($this->getFiles() as $file)
+		{
+			$to = $this->destination . basename($file);
+
+			try
+			{
+				self::safeCopyFile($file, $to, $replace);
+			}
+			catch (Throwable $e)
+			{
+				$this->errors[$file] = $e;
+			}
+		}
+
+		return $this->errors === [];
+	}
+
+	/**
+	 * Merges all files into the destination.
+	 * Creates a mirrored directory structure
+	 * only for files from source.
+	 *
+	 * @param bool $replace Whether to overwrite existing files.
+	 *
+	 * @return boolean Whether all files were copied successfully
+	 */
+	public function merge(bool $replace = true): bool
+	{
+		$this->errors = [];
+
+		// Get the file from source for special handling
+		$sourced = self::matchFiles($this->getFiles(), $this->source);
+
+		// Handle everything else with a flat copy
+		$this->files = array_diff($this->files, $sourced);
+		$this->copy($replace);
+
+		// Copy each sourced file to its relative destination
+		foreach ($sourced as $file)
+		{
+			// Resolve the destination path
+			$to = $this->destination . substr($file, strlen($this->source));
+
+			try
+			{
+				self::safeCopyFile($file, $to, $replace);
+			}
+			catch (Throwable $e)
+			{
+				$this->errors[$file] = $e;
+			}
+		}
+
+		return $this->errors === [];
+	}
+}

--- a/system/Publisher/Publisher.php
+++ b/system/Publisher/Publisher.php
@@ -43,8 +43,7 @@ class Publisher
 	private static $discovered = [];
 
 	/**
-	 * Directory to use for methods
-	 * that need temporary storage.
+	 * Directory to use for methods that need temporary storage.
 	 * Created on-the-fly as needed.
 	 *
 	 * @var string|null
@@ -59,8 +58,7 @@ class Publisher
 	private $files = [];
 
 	/**
-	 * Exceptions for specific files
-	 * from the last write operation.
+	 * Exceptions for specific files from the last write operation.
 	 *
 	 * @var array<string,Throwable>
 	 */
@@ -81,8 +79,7 @@ class Publisher
 	protected $destination = FCPATH;
 
 	/**
-	 * Discovers and returns all Publishers
-	 * in the specified namespace directory.
+	 * Discovers and returns all Publishers in the specified namespace directory.
 	 *
 	 * @param string $directory
 	 *
@@ -115,6 +112,7 @@ class Publisher
 				self::$discovered[$directory][] = new $className();
 			}
 		}
+
 		sort(self::$discovered[$directory]);
 
 		return self::$discovered[$directory];
@@ -123,8 +121,7 @@ class Publisher
 	//--------------------------------------------------------------------
 
 	/**
-	 * Resolves a full path and verifies
-	 * it is an actual directory.
+	 * Resolves a full path and verifies it is an actual directory.
 	 *
 	 * @param string $directory
 	 *
@@ -162,11 +159,10 @@ class Publisher
 	//--------------------------------------------------------------------
 
 	/**
-	 * Filters an array of files, removing files not
-	 * part of the given directory (recursive).
+	 * Removes files that are not part of the given directory (recursive).
 	 *
 	 * @param string[] $files
-	 * @param string $directory
+	 * @param string   $directory
 	 *
 	 * @return string[]
 	 */
@@ -207,15 +203,14 @@ class Publisher
 
 	//--------------------------------------------------------------------
 
-	/**
-	 * Removes a directory and all its files
-	 * and subdirectories.
+	/*
+	 * Removes a directory and all its files and subdirectories.
 	 *
 	 * @param string $directory
 	 *
 	 * @return void
 	 */
-	private static function wipeDirectory(string $directory)
+	private static function wipeDirectory(string $directory): void
 	{
 		if (is_dir($directory))
 		{
@@ -267,8 +262,7 @@ class Publisher
 		}
 
 		// Make sure the directory exists
-		$directory = pathinfo($to, PATHINFO_DIRNAME);
-		if (! is_dir($directory))
+		if (! is_dir($directory = pathinfo($to, PATHINFO_DIRNAME)))
 		{
 			mkdir($directory, 0775, true);
 		}
@@ -280,8 +274,7 @@ class Publisher
 	//--------------------------------------------------------------------
 
 	/**
-	 * Loads the helper and verifies the
-	 * source and destination directories.
+	 * Loads the helper and verifies the source and destination directories.
 	 *
 	 * @param string|null $source
 	 * @param string|null $destination
@@ -322,8 +315,7 @@ class Publisher
 	//--------------------------------------------------------------------
 
 	/**
-	 * Returns the temporary workspace,
-	 * creating it if necessary.
+	 * Returns the temporary workspace, creating it if necessary.
 	 *
 	 * @return string
 	 */
@@ -532,8 +524,7 @@ class Publisher
 	//--------------------------------------------------------------------
 
 	/**
-	 * Downloads and stages files from
-	 * an array of URIs.
+	 * Downloads and stages files from an array of URIs.
 	 *
 	 * @param string[] $uris
 	 *
@@ -609,15 +600,10 @@ class Publisher
 		}
 
 		// Start with all files or those in scope
-		$files = is_null($scope)
-			? $this->files
-			: self::filterFiles($this->files, $scope);
+		$files = is_null($scope) ? $this->files : self::filterFiles($this->files, $scope);
 
-		// Match the pattern within the scoped files
-		$matched = self::matchFiles($files, $pattern);
-
-		// ... and remove their inverse
-		return $this->removeFiles(array_diff($files, $matched));
+		// Matches the pattern within the scoped files and remove their inverse.
+		return $this->removeFiles(array_diff($files, self::matchFiles($files, $pattern)));
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/_support/Config/Registrar.php
+++ b/tests/_support/Config/Registrar.php
@@ -113,4 +113,18 @@ class Registrar
 
         return $config;
     }
+
+    /**
+     * Demonstrates Publisher security.
+     *
+     * @see PublisherRestrictionsTest::testRegistrarsNotAllowed()
+     *
+     * @return array
+     */
+    public static function Publisher()
+    {
+        return [
+            'restrictions' => [SUPPORTPATH => '*'],
+        ];
+    }
 }

--- a/tests/_support/Publishers/TestPublisher.php
+++ b/tests/_support/Publishers/TestPublisher.php
@@ -4,13 +4,62 @@ namespace Tests\Support\Publishers;
 
 use CodeIgniter\Publisher\Publisher;
 
-class TestPublisher extends Publisher
+final class TestPublisher extends Publisher
 {
 	/**
-	 * Runs the defined Operations.
+	 * Fakes an error on the given file.
+	 *
+	 * @return $this
+	 */
+	public static function setError(string $file)
+	{
+		self::$error = $file;
+	}
+
+	/**
+	 * A file to cause an error
+	 *
+	 * @var string
+	 */
+	private static $error = '';
+
+	/**
+	 * Base path to use for the source.
+	 *
+	 * @var string
+	 */
+	protected $source = SUPPORTPATH . 'Files';
+
+	/**
+	 * Base path to use for the destination.
+	 *
+	 * @var string
+	 */
+	protected $destination = WRITEPATH;
+
+	/**
+	 * Fakes a publish event so no files are actually copied.
 	 */
 	public function publish(): bool
 	{
-		$this->downloadFromUrls($urls)->mergeToDirectory(FCPATH . 'assets');
+		$this->errors = $this->published = [];
+
+		$this->addPath('');
+
+		// Copy each sourced file to its relative destination
+		foreach ($this->getFiles() as $file)
+		{
+			if ($file === self::$error)
+			{
+				$this->errors[$file] = new RuntimeException('Have an error, dear.');
+			}
+			else
+			{
+				// Resolve the destination path
+				$this->published[] = $this->destination . substr($file, strlen($this->source));
+			}
+		}
+
+		return $this->errors === [];
 	}
 }

--- a/tests/_support/Publishers/TestPublisher.php
+++ b/tests/_support/Publishers/TestPublisher.php
@@ -3,6 +3,7 @@
 namespace Tests\Support\Publishers;
 
 use CodeIgniter\Publisher\Publisher;
+use RuntimeException;
 
 final class TestPublisher extends Publisher
 {
@@ -11,17 +12,17 @@ final class TestPublisher extends Publisher
 	 *
 	 * @return $this
 	 */
-	public static function setError(string $file)
+	public static function setResult(bool $result)
 	{
-		self::$error = $file;
+		self::$result = $result;
 	}
 
 	/**
-	 * A file to cause an error
+	 * Return value for publish()
 	 *
-	 * @var string
+	 * @var boolean
 	 */
-	private static $error = '';
+	private static $result = true;
 
 	/**
 	 * Base path to use for the source.
@@ -42,24 +43,8 @@ final class TestPublisher extends Publisher
 	 */
 	public function publish(): bool
 	{
-		$this->errors = $this->published = [];
-
 		$this->addPath('');
 
-		// Copy each sourced file to its relative destination
-		foreach ($this->getFiles() as $file)
-		{
-			if ($file === self::$error)
-			{
-				$this->errors[$file] = new RuntimeException('Have an error, dear.');
-			}
-			else
-			{
-				// Resolve the destination path
-				$this->published[] = $this->destination . substr($file, strlen($this->source));
-			}
-		}
-
-		return $this->errors === [];
+		return self::$result;
 	}
 }

--- a/tests/_support/Publishers/TestPublisher.php
+++ b/tests/_support/Publishers/TestPublisher.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Support\Publishers;
+
+use CodeIgniter\Publisher\Publisher;
+
+class TestPublisher extends Publisher
+{
+	/**
+	 * Runs the defined Operations.
+	 */
+	public function publish()
+	{
+		$this->downloadFromUrls($urls)->mergeToDirectory(FCPATH . 'assets');
+	}
+}

--- a/tests/_support/Publishers/TestPublisher.php
+++ b/tests/_support/Publishers/TestPublisher.php
@@ -9,8 +9,6 @@ final class TestPublisher extends Publisher
 {
 	/**
 	 * Fakes an error on the given file.
-	 *
-	 * @return $this
 	 */
 	public static function setResult(bool $result)
 	{

--- a/tests/_support/Publishers/TestPublisher.php
+++ b/tests/_support/Publishers/TestPublisher.php
@@ -9,7 +9,7 @@ class TestPublisher extends Publisher
 	/**
 	 * Runs the defined Operations.
 	 */
-	public function publish()
+	public function publish(): bool
 	{
 		$this->downloadFromUrls($urls)->mergeToDirectory(FCPATH . 'assets');
 	}

--- a/tests/system/Commands/PublishCommandTest.php
+++ b/tests/system/Commands/PublishCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Tests\Support\Publishers\TestPublisher;
+
+final class PublishCommandTest extends CIUnitTestCase
+{
+	private $streamFilter;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		CITestStreamFilter::$buffer = '';
+
+		$this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
+		$this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+
+		stream_filter_remove($this->streamFilter);
+		TestPublisher::setResult(true);
+	}
+
+	public function testDefault()
+	{
+		command('publish');
+
+		$this->assertStringContainsString(lang('Publisher.publishSuccess', [
+			TestPublisher::class,
+			0,
+			WRITEPATH,
+		]), CITestStreamFilter::$buffer);
+	}
+
+	public function testFailure()
+	{
+		TestPublisher::setResult(false);
+
+		command('publish');
+
+		$this->assertStringContainsString(lang('Publisher.publishFailure', [
+			TestPublisher::class,
+			WRITEPATH,
+		]), CITestStreamFilter::$buffer);
+	}
+}

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -6,9 +6,6 @@ use CodeIgniter\Test\CIUnitTestCase;
 use InvalidArgumentException;
 use org\bovigo\vfs\vfsStream;
 
-use org\bovigo\vfs\vfsStreamDirectory;
-use org\bovigo\vfs\visitor\vfsStreamStructureVisitor;
-
 class FilesystemHelperTest extends CIUnitTestCase
 {
     protected function setUp(): void

--- a/tests/system/Publisher/PublisherInputTest.php
+++ b/tests/system/Publisher/PublisherInputTest.php
@@ -1,4 +1,4 @@
-<?php namespace CodeIgniter\Pager;
+<?php
 
 use CodeIgniter\Publisher\Exceptions\PublisherException;
 use CodeIgniter\Publisher\Publisher;

--- a/tests/system/Publisher/PublisherInputTest.php
+++ b/tests/system/Publisher/PublisherInputTest.php
@@ -1,0 +1,472 @@
+<?php namespace CodeIgniter\Pager;
+
+use CodeIgniter\Publisher\Exceptions\PublisherException;
+use CodeIgniter\Publisher\Publisher;
+use CodeIgniter\Test\CIUnitTestCase;
+use Tests\Support\Publishers\TestPublisher;
+
+class PublisherInputTest extends CIUnitTestCase
+{
+	/**
+	 * A known, valid file
+	 *
+	 * @var string
+	 */
+	private $file = SUPPORTPATH . 'Files/baker/banana.php';
+
+	/**
+	 * A known, valid directory
+	 *
+	 * @var string
+	 */
+	private $directory = SUPPORTPATH . 'Files/able/';
+
+	/**
+	 * Initialize the helper, since some
+	 * tests call static methods before
+	 * the constructor would load it.
+	 */
+	public static function setUpBeforeClass(): void
+	{
+		parent::setUpBeforeClass();
+
+		helper(['filesystem']);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testAddFile()
+	{
+		$publisher = new Publisher();
+		$this->assertSame([], $this->getPrivateProperty($publisher, 'files'));
+
+		$publisher->addFile($this->file);
+		$this->assertSame([$this->file], $this->getPrivateProperty($publisher, 'files'));
+	}
+
+	public function testAddFileMissing()
+	{
+		$publisher = new Publisher();
+
+		$this->expectException(PublisherException::class);
+		$this->expectExceptionMessage(lang('Publisher.expectedFile', ['addFile']));
+
+		$publisher->addFile('TheHillsAreAlive.bmp');
+	}
+
+	public function testAddFileDirectory()
+	{
+		$publisher = new Publisher();
+
+		$this->expectException(PublisherException::class);
+		$this->expectExceptionMessage(lang('Publisher.expectedFile', ['addFile']));
+
+		$publisher->addFile($this->directory);
+	}
+
+	public function testAddFiles()
+	{
+		$publisher = new Publisher();
+		$files     = [
+			$this->file,
+			$this->file,
+		];
+
+		$publisher->addFiles($files);
+		$this->assertSame($files, $this->getPrivateProperty($publisher, 'files'));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testGetFiles()
+	{
+		$publisher = new Publisher();
+		$publisher->addFile($this->file);
+
+		$this->assertSame([$this->file], $publisher->getFiles());
+	}
+
+	public function testGetFilesSorts()
+	{
+		$publisher = new Publisher();
+		$files     = [
+			$this->file,
+			$this->directory . 'apple.php',
+		];
+
+		$publisher->addFiles($files);
+
+		$this->assertSame(array_reverse($files), $publisher->getFiles());
+	}
+
+	public function testGetFilesUniques()
+	{
+		$publisher = new Publisher();
+		$files     = [
+			$this->file,
+			$this->file,
+		];
+
+		$publisher->addFiles($files);
+		$this->assertSame([$this->file], $publisher->getFiles());
+	}
+
+	public function testSetFiles()
+	{
+		$publisher = new Publisher();
+
+		$publisher->setFiles([$this->file]);
+		$this->assertSame([$this->file], $publisher->getFiles());
+	}
+
+	public function testSetFilesInvalid()
+	{
+		$publisher = new Publisher();
+
+		$this->expectException(PublisherException::class);
+		$this->expectExceptionMessage(lang('Publisher.expectedFile', ['addFile']));
+
+		$publisher->setFiles(['flerb']);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testRemoveFile()
+	{
+		$publisher = new Publisher();
+		$files     = [
+			$this->file,
+			$this->directory . 'apple.php',
+		];
+
+		$publisher->addFiles($files);
+
+		$publisher->removeFile($this->file);
+
+		$this->assertSame([$this->directory . 'apple.php'], $publisher->getFiles());
+	}
+
+	public function testRemoveFiles()
+	{
+		$publisher = new Publisher();
+		$files     = [
+			$this->file,
+			$this->directory . 'apple.php',
+		];
+
+		$publisher->addFiles($files);
+
+		$publisher->removeFiles($files);
+
+		$this->assertSame([], $publisher->getFiles());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testAddDirectoryInvalid()
+	{
+		$publisher = new Publisher();
+
+		$this->expectException(PublisherException::class);
+		$this->expectExceptionMessage(lang('Publisher.expectedDirectory', ['addDirectory']));
+
+		$publisher->addDirectory($this->file);
+	}
+
+	public function testAddDirectory()
+	{
+		$publisher = new Publisher();
+		$expected  = [
+			$this->directory . 'apple.php',
+			$this->directory . 'fig_3.php',
+			$this->directory . 'prune_ripe.php',
+		];
+
+		$publisher->addDirectory($this->directory);
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+
+	public function testAddDirectoryRecursive()
+	{
+		$publisher = new Publisher();
+		$expected  = [
+			$this->directory . 'apple.php',
+			$this->directory . 'fig_3.php',
+			$this->directory . 'prune_ripe.php',
+			SUPPORTPATH . 'Files/baker/banana.php',
+		];
+
+		$publisher->addDirectory(SUPPORTPATH . 'Files', true);
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+
+	public function testAddDirectories()
+	{
+		$publisher = new Publisher();
+		$expected  = [
+			$this->directory . 'apple.php',
+			$this->directory . 'fig_3.php',
+			$this->directory . 'prune_ripe.php',
+			SUPPORTPATH . 'Files/baker/banana.php',
+		];
+
+		$publisher->addDirectories([
+			$this->directory,
+			SUPPORTPATH . 'Files/baker',
+		]);
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+
+	public function testAddDirectoriesRecursive()
+	{
+		$publisher = new Publisher();
+		$expected  = [
+			$this->directory . 'apple.php',
+			$this->directory . 'fig_3.php',
+			$this->directory . 'prune_ripe.php',
+			SUPPORTPATH . 'Files/baker/banana.php',
+			SUPPORTPATH . 'Log/Handlers/TestHandler.php',
+		];
+
+		$publisher->addDirectories([
+			SUPPORTPATH . 'Files',
+			SUPPORTPATH . 'Log',
+		], true);
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testAddPathFile()
+	{
+		$publisher = new Publisher(SUPPORTPATH . 'Files');
+
+		$publisher->addPath('baker/banana.php');
+
+		$this->assertSame([$this->file], $publisher->getFiles());
+	}
+
+	public function testAddPathFileRecursiveDoesNothing()
+	{
+		$publisher = new Publisher(SUPPORTPATH . 'Files');
+
+		$publisher->addPath('baker/banana.php', true);
+
+		$this->assertSame([$this->file], $publisher->getFiles());
+	}
+
+	public function testAddPathDirectory()
+	{
+		$publisher = new Publisher(SUPPORTPATH . 'Files');
+
+		$expected = [
+			$this->directory . 'apple.php',
+			$this->directory . 'fig_3.php',
+			$this->directory . 'prune_ripe.php',
+		];
+
+		$publisher->addPath('able');
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+
+	public function testAddPathDirectoryRecursive()
+	{
+		$publisher = new Publisher(SUPPORTPATH);
+
+		$expected = [
+			$this->directory . 'apple.php',
+			$this->directory . 'fig_3.php',
+			$this->directory . 'prune_ripe.php',
+			SUPPORTPATH . 'Files/baker/banana.php',
+		];
+
+		$publisher->addPath('Files');
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+
+	public function testAddPaths()
+	{
+		$publisher = new Publisher(SUPPORTPATH . 'Files');
+
+		$expected = [
+			$this->directory . 'apple.php',
+			$this->directory . 'fig_3.php',
+			$this->directory . 'prune_ripe.php',
+			SUPPORTPATH . 'Files/baker/banana.php',
+		];
+
+		$publisher->addPaths([
+			'able',
+			'baker/banana.php',
+		]);
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+
+	public function testAddPathsRecursive()
+	{
+		$publisher = new Publisher(SUPPORTPATH);
+
+		$expected = [
+			$this->directory . 'apple.php',
+			$this->directory . 'fig_3.php',
+			$this->directory . 'prune_ripe.php',
+			SUPPORTPATH . 'Files/baker/banana.php',
+			SUPPORTPATH . 'Log/Handlers/TestHandler.php',
+		];
+
+		$publisher->addPaths([
+			'Files',
+			'Log',
+		], true);
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testAddUri()
+	{
+		$publisher = new Publisher();
+		$publisher->addUri('https://raw.githubusercontent.com/codeigniter4/CodeIgniter4/develop/composer.json');
+
+		$scratch = $this->getPrivateProperty($publisher, 'scratch');
+
+		$this->assertSame([$scratch . 'composer.json'], $publisher->getFiles());
+	}
+
+	public function testAddUris()
+	{
+		$publisher = new Publisher();
+		$publisher->addUris([
+			'https://raw.githubusercontent.com/codeigniter4/CodeIgniter4/develop/LICENSE',
+			'https://raw.githubusercontent.com/codeigniter4/CodeIgniter4/develop/composer.json',
+		]);
+
+		$scratch = $this->getPrivateProperty($publisher, 'scratch');
+
+		$this->assertSame([$scratch . 'LICENSE', $scratch . 'composer.json'], $publisher->getFiles());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testRemovePatternEmpty()
+	{
+		$publisher = new Publisher();
+		$publisher->addDirectory(SUPPORTPATH . 'Files', true);
+
+		$files = $publisher->getFiles();
+
+		$publisher->removePattern('');
+
+		$this->assertSame($files, $publisher->getFiles());
+	}
+
+	public function testRemovePatternRegex()
+	{
+		$publisher = new Publisher();
+		$publisher->addDirectory(SUPPORTPATH . 'Files', true);
+
+		$expected = [
+			$this->directory . 'apple.php',
+			SUPPORTPATH . 'Files/baker/banana.php',
+		];
+
+		$publisher->removePattern('#[a-z]+_.*#');
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+
+	public function testRemovePatternPseudo()
+	{
+		$publisher = new Publisher();
+		$publisher->addDirectory(SUPPORTPATH . 'Files', true);
+
+		$expected = [
+			$this->directory . 'apple.php',
+			SUPPORTPATH . 'Files/baker/banana.php',
+		];
+
+		$publisher->removePattern('*_*.php');
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+
+	public function testRemovePatternScope()
+	{
+		$publisher = new Publisher();
+		$publisher->addDirectory(SUPPORTPATH . 'Files', true);
+
+		$expected = [
+			SUPPORTPATH . 'Files/baker/banana.php',
+		];
+
+		$publisher->removePattern('*.php', $this->directory);
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testRetainPatternEmpty()
+	{
+		$publisher = new Publisher();
+		$publisher->addDirectory(SUPPORTPATH . 'Files', true);
+
+		$files = $publisher->getFiles();
+
+		$publisher->retainPattern('');
+
+		$this->assertSame($files, $publisher->getFiles());
+	}
+
+	public function testRetainPatternRegex()
+	{
+		$publisher = new Publisher();
+		$publisher->addDirectory(SUPPORTPATH . 'Files', true);
+
+		$expected = [
+			$this->directory . 'fig_3.php',
+			$this->directory . 'prune_ripe.php',
+		];
+
+		$publisher->retainPattern('#[a-z]+_.*#');
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+
+	public function testRetainPatternPseudo()
+	{
+		$publisher = new Publisher();
+		$publisher->addDirectory(SUPPORTPATH . 'Files', true);
+
+		$expected = [
+			$this->directory . 'fig_3.php',
+		];
+
+		$publisher->retainPattern('*_?.php');
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+
+	public function testRetainPatternScope()
+	{
+		$publisher = new Publisher();
+		$publisher->addDirectory(SUPPORTPATH . 'Files', true);
+
+		$expected = [
+			$this->directory . 'fig_3.php',
+			SUPPORTPATH . 'Files/baker/banana.php',
+		];
+
+		$publisher->retainPattern('*_?.php', $this->directory);
+
+		$this->assertSame($expected, $publisher->getFiles());
+	}
+}

--- a/tests/system/Publisher/PublisherOutputTest.php
+++ b/tests/system/Publisher/PublisherOutputTest.php
@@ -1,4 +1,4 @@
-<?php namespace CodeIgniter\Pager;
+<?php
 
 use CodeIgniter\Publisher\Exceptions\PublisherException;
 use CodeIgniter\Publisher\Publisher;
@@ -68,6 +68,9 @@ class PublisherOutputTest extends CIUnitTestCase
 		];
 
 		$this->root = vfsStream::setup('root', null, $this->structure);
+
+		// Add root to the list of allowed destinations
+		config('Publisher')->restrictions[$this->root->url()] = '*';
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/system/Publisher/PublisherOutputTest.php
+++ b/tests/system/Publisher/PublisherOutputTest.php
@@ -112,6 +112,7 @@ class PublisherOutputTest extends CIUnitTestCase
 
 		$result = $publisher->copy(true);
 		$this->assertTrue($result);
+		$this->assertSame([$this->root->url() . '/banana.php'], $publisher->getPublished());
 	}
 
 	public function testCopyIgnoresCollision()
@@ -121,10 +122,10 @@ class PublisherOutputTest extends CIUnitTestCase
 		mkdir($this->root->url() . '/banana.php');
 
 		$result = $publisher->addFile($this->file)->copy(false);
-		$errors = $publisher->getErrors();
 
 		$this->assertTrue($result);
-		$this->assertSame([], $errors);
+		$this->assertSame([], $publisher->getErrors());
+		$this->assertSame([$this->root->url() . '/banana.php'], $publisher->getPublished());
 	}
 
 	public function testCopyCollides()
@@ -140,6 +141,7 @@ class PublisherOutputTest extends CIUnitTestCase
 		$this->assertFalse($result);
 		$this->assertCount(1, $errors);
 		$this->assertSame([$this->file], array_keys($errors));
+		$this->assertSame([], $publisher->getPublished());
 		$this->assertSame($expected, $errors[$this->file]->getMessage());
 	}
 
@@ -148,6 +150,12 @@ class PublisherOutputTest extends CIUnitTestCase
 	public function testMerge()
 	{
 		$publisher = new Publisher(SUPPORTPATH . 'Files', $this->root->url());
+		$expected  = [
+			$this->root->url() . '/able/apple.php',
+			$this->root->url() . '/able/fig_3.php',
+			$this->root->url() . '/able/prune_ripe.php',
+			$this->root->url() . '/baker/banana.php',
+		];
 
 		$this->assertFileDoesNotExist($this->root->url() . '/able/fig_3.php');
 		$this->assertDirectoryDoesNotExist($this->root->url() . '/baker');
@@ -157,23 +165,36 @@ class PublisherOutputTest extends CIUnitTestCase
 		$this->assertTrue($result);
 		$this->assertFileExists($this->root->url() . '/able/fig_3.php');
 		$this->assertDirectoryExists($this->root->url() . '/baker');
+		$this->assertSame($expected, $publisher->getPublished());
 	}
 
 	public function testMergeReplace()
 	{
 		$this->assertFalse(same_file($this->directory . 'apple.php', $this->root->url() . '/able/apple.php'));
 		$publisher = new Publisher(SUPPORTPATH . 'Files', $this->root->url());
+		$expected  = [
+			$this->root->url() . '/able/apple.php',
+			$this->root->url() . '/able/fig_3.php',
+			$this->root->url() . '/able/prune_ripe.php',
+			$this->root->url() . '/baker/banana.php',
+		];
 
 		$result = $publisher->addPath('/')->merge(true);
 
 		$this->assertTrue($result);
 		$this->assertTrue(same_file($this->directory . 'apple.php', $this->root->url() . '/able/apple.php'));
+		$this->assertSame($expected, $publisher->getPublished());
 	}
 
 	public function testMergeCollides()
 	{
 		$publisher = new Publisher(SUPPORTPATH . 'Files', $this->root->url());
 		$expected  = lang('Publisher.collision', ['dir', $this->directory . 'fig_3.php', $this->root->url() . '/able/fig_3.php']);
+		$published = [
+			$this->root->url() . '/able/apple.php',
+			$this->root->url() . '/able/prune_ripe.php',
+			$this->root->url() . '/baker/banana.php',
+		];
 
 		mkdir($this->root->url() . '/able/fig_3.php');
 
@@ -183,6 +204,7 @@ class PublisherOutputTest extends CIUnitTestCase
 		$this->assertFalse($result);
 		$this->assertCount(1, $errors);
 		$this->assertSame([$this->directory . 'fig_3.php'], array_keys($errors));
+		$this->assertSame($published, $publisher->getPublished());
 		$this->assertSame($expected, $errors[$this->directory . 'fig_3.php']->getMessage());
 	}
 

--- a/tests/system/Publisher/PublisherOutputTest.php
+++ b/tests/system/Publisher/PublisherOutputTest.php
@@ -1,0 +1,202 @@
+<?php namespace CodeIgniter\Pager;
+
+use CodeIgniter\Publisher\Exceptions\PublisherException;
+use CodeIgniter\Publisher\Publisher;
+use CodeIgniter\Test\CIUnitTestCase;
+use Tests\Support\Publishers\TestPublisher;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+
+class PublisherOutputTest extends CIUnitTestCase
+{
+	/**
+	 * Files to seed to VFS
+	 *
+	 * @var array
+	 */
+	private $structure;
+
+	/**
+	 * Virtual destination
+	 *
+	 * @var vfsStreamDirectory
+	 */
+	private $root;
+
+	/**
+	 * A known, valid file
+	 *
+	 * @var string
+	 */
+	private $file = SUPPORTPATH . 'Files/baker/banana.php';
+
+	/**
+	 * A known, valid directory
+	 *
+	 * @var string
+	 */
+	private $directory = SUPPORTPATH . 'Files/able/';
+
+	/**
+	 * Initialize the helper, since some
+	 * tests call static methods before
+	 * the constructor would load it.
+	 */
+	public static function setUpBeforeClass(): void
+	{
+		parent::setUpBeforeClass();
+
+		helper(['filesystem']);
+	}
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->structure = [
+			'able'          => [
+				'apple.php' => 'Once upon a midnight dreary',
+				'bazam'     => 'While I pondered weak and weary',
+			],
+			'boo'           => [
+				'far' => 'Upon a tome of long-forgotten lore',
+				'faz' => 'There came a tapping up on the door',
+			],
+			'AnEmptyFolder' => [],
+			'simpleFile'    => 'A tap-tap-tapping upon my door',
+			'.hidden'       => 'There is no spoon',
+		];
+
+		$this->root = vfsStream::setup('root', null, $this->structure);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testCopy()
+	{
+		$publisher = new Publisher($this->directory, $this->root->url());
+		$publisher->addFile($this->file);
+
+		$this->assertFileDoesNotExist($this->root->url() . '/banana.php');
+
+		$result = $publisher->copy(false);
+
+		$this->assertTrue($result);
+		$this->assertFileExists($this->root->url() . '/banana.php');
+	}
+
+	public function testCopyReplace()
+	{
+		$file      = $this->directory . 'apple.php';
+		$publisher = new Publisher($this->directory, $this->root->url() . '/able');
+		$publisher->addFile($file);
+
+		$this->assertFileExists($this->root->url() . '/able/apple.php');
+		$this->assertFalse(same_file($file, $this->root->url() . '/able/apple.php'));
+
+		$result = $publisher->copy(true);
+
+		$this->assertTrue($result);
+		$this->assertTrue(same_file($file, $this->root->url() . '/able/apple.php'));
+	}
+
+	public function testCopyIgnoresSame()
+	{
+		$publisher = new Publisher($this->directory, $this->root->url());
+		$publisher->addFile($this->file);
+
+		copy($this->file, $this->root->url() . '/banana.php');
+
+		$result = $publisher->copy(false);
+		$this->assertTrue($result);
+
+		$result = $publisher->copy(true);
+		$this->assertTrue($result);
+	}
+
+	public function testCopyIgnoresCollision()
+	{
+		$publisher = new Publisher($this->directory, $this->root->url());
+
+		mkdir($this->root->url() . '/banana.php');
+
+		$result = $publisher->addFile($this->file)->copy(false);
+		$errors = $publisher->getErrors();
+
+		$this->assertTrue($result);
+		$this->assertSame([], $errors);
+	}
+
+	public function testCopyCollides()
+	{
+		$publisher = new Publisher($this->directory, $this->root->url());
+		$expected  = lang('Publisher.collision', ['dir', $this->file, $this->root->url() . '/banana.php']);
+
+		mkdir($this->root->url() . '/banana.php');
+
+		$result = $publisher->addFile($this->file)->copy(true);
+		$errors = $publisher->getErrors();
+
+		$this->assertFalse($result);
+		$this->assertCount(1, $errors);
+		$this->assertSame([$this->file], array_keys($errors));
+		$this->assertSame($expected, $errors[$this->file]->getMessage());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testMerge()
+	{
+		$publisher = new Publisher(SUPPORTPATH . 'Files', $this->root->url());
+
+		$this->assertFileDoesNotExist($this->root->url() . '/able/fig_3.php');
+		$this->assertDirectoryDoesNotExist($this->root->url() . '/baker');
+
+		$result = $publisher->addPath('/')->merge(false);
+
+		$this->assertTrue($result);
+		$this->assertFileExists($this->root->url() . '/able/fig_3.php');
+		$this->assertDirectoryExists($this->root->url() . '/baker');
+	}
+
+	public function testMergeReplace()
+	{
+		$this->assertFalse(same_file($this->directory . 'apple.php', $this->root->url() . '/able/apple.php'));
+		$publisher = new Publisher(SUPPORTPATH . 'Files', $this->root->url());
+
+		$result = $publisher->addPath('/')->merge(true);
+
+		$this->assertTrue($result);
+		$this->assertTrue(same_file($this->directory . 'apple.php', $this->root->url() . '/able/apple.php'));
+	}
+
+	public function testMergeCollides()
+	{
+		$publisher = new Publisher(SUPPORTPATH . 'Files', $this->root->url());
+		$expected  = lang('Publisher.collision', ['dir', $this->directory . 'fig_3.php', $this->root->url() . '/able/fig_3.php']);
+
+		mkdir($this->root->url() . '/able/fig_3.php');
+
+		$result = $publisher->addPath('/')->merge(true);
+		$errors = $publisher->getErrors();
+
+		$this->assertFalse($result);
+		$this->assertCount(1, $errors);
+		$this->assertSame([$this->directory . 'fig_3.php'], array_keys($errors));
+		$this->assertSame($expected, $errors[$this->directory . 'fig_3.php']->getMessage());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testPublish()
+	{
+		$publisher = new Publisher(SUPPORTPATH . 'Files', $this->root->url());
+
+		$result = $publisher->publish();
+
+		$this->assertTrue($result);
+		$this->assertFileExists($this->root->url() . '/able/fig_3.php');
+		$this->assertDirectoryExists($this->root->url() . '/baker');
+		$this->assertTrue(same_file($this->directory . 'apple.php', $this->root->url() . '/able/apple.php'));
+	}
+}

--- a/tests/system/Publisher/PublisherRestrictionsTest.php
+++ b/tests/system/Publisher/PublisherRestrictionsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use CodeIgniter\Publisher\Exceptions\PublisherException;
+use CodeIgniter\Publisher\Publisher;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * Publisher Restrictions Test
+ *
+ * Tests that the restrictions defined in the configuration
+ * file properly prevent disallowed actions.
+ */
+class PublisherRestrictionsTest extends CIUnitTestCase
+{
+	/**
+	 * @see Tests\Support\Config\Registrars::Publisher()
+	 */
+	public function testRegistrarsNotAllowed()
+	{
+		$this->assertArrayNotHasKey(SUPPORTPATH, config('Publisher')->restrictions);
+	}
+
+	public function testImmutableRestrictions()
+	{
+		$publisher = new Publisher();
+
+		// Try to "hack" the Publisher by adding our desired destination to the config
+		config('Publisher')->restrictions[SUPPORTPATH] = '*';
+
+		$restrictions = $this->getPrivateProperty($publisher, 'restrictions');
+
+		$this->assertArrayNotHasKey(SUPPORTPATH, $restrictions);
+	}
+
+	/**
+	 * @dataProvider fileProvider
+	 */
+	public function testDefaultPublicRestrictions(string $path)
+	{
+		$publisher = new Publisher(ROOTPATH, FCPATH);
+		$pattern   = config('Publisher')->restrictions[FCPATH];
+
+		// Use the scratch space to create a file
+		$file = $publisher->getScratch() . $path;
+		file_put_contents($file, 'To infinity and beyond!');
+
+		$result = $publisher->addFile($file)->merge();
+		$this->assertFalse($result);
+
+		$errors = $publisher->getErrors();
+		$this->assertCount(1, $errors);
+		$this->assertSame([$file], array_keys($errors));
+
+		$expected = lang('Publisher.fileNotAllowed', [$file, FCPATH, $pattern]);
+		$this->assertSame($expected, $errors[$file]->getMessage());
+	}
+
+	public function fileProvider()
+	{
+		yield 'php'  => ['index.php'];
+		yield 'exe'  => ['cat.exe'];
+		yield 'flat' => ['banana'];
+	}
+
+	/**
+	 * @dataProvider destinationProvider
+	 */
+	public function testDestinations(string $destination, bool $allowed)
+	{
+		config('Publisher')->restrictions = [
+			APPPATH                   => '',
+			FCPATH                    => '',
+			SUPPORTPATH . 'Files'     => '',
+			SUPPORTPATH . 'Files/../' => '',
+		];
+
+		if (! $allowed)
+		{
+			$this->expectException(PublisherException::class);
+			$this->expectExceptionMessage(lang('Publisher.destinationNotAllowed', [$destination]));
+		}
+
+		$publisher = new Publisher(null, $destination);
+		$this->assertInstanceOf(Publisher::class, $publisher);
+	}
+
+	public function destinationProvider()
+	{
+		return [
+			'explicit' => [
+				APPPATH,
+				true,
+			],
+			'subdirectory' => [
+				APPPATH . 'Config',
+				true,
+			],
+			'relative' => [
+				SUPPORTPATH . 'Files/able/../',
+				true,
+			],
+			'parent' => [
+				SUPPORTPATH,
+				false,
+			],
+		];
+	}
+}

--- a/tests/system/Publisher/PublisherSupportTest.php
+++ b/tests/system/Publisher/PublisherSupportTest.php
@@ -1,4 +1,4 @@
-<?php namespace CodeIgniter\Pager;
+<?php
 
 use CodeIgniter\Publisher\Exceptions\PublisherException;
 use CodeIgniter\Publisher\Publisher;
@@ -203,6 +203,7 @@ class PublisherSupportTest extends CIUnitTestCase
 		$directory = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . bin2hex(random_bytes(6));
 		mkdir($directory, 0700);
 		$this->assertDirectoryExists($directory);
+		config('Publisher')->restrictions[$directory] = ''; // Allow the directory
 
 		$publisher = new Publisher($this->directory, $directory);
 		$publisher->wipe();

--- a/tests/system/Publisher/PublisherSupportTest.php
+++ b/tests/system/Publisher/PublisherSupportTest.php
@@ -126,13 +126,26 @@ class PublisherSupportTest extends CIUnitTestCase
 
 	//--------------------------------------------------------------------
 
+	public function testGetSource()
+	{
+		$publisher = new Publisher(ROOTPATH);
+
+		$this->assertSame(ROOTPATH, $publisher->getSource());
+	}
+
+	public function testGetDestination()
+	{
+		$publisher = new Publisher(ROOTPATH, SUPPORTPATH);
+
+		$this->assertSame(SUPPORTPATH, $publisher->getDestination());
+	}
+
 	public function testGetScratch()
 	{
 		$publisher = new Publisher();
 		$this->assertNull($this->getPrivateProperty($publisher, 'scratch'));
 
-		$method  = $this->getPrivateMethodInvoker($publisher, 'getScratch');
-		$scratch = $method();
+		$scratch = $publisher->getScratch();
 
 		$this->assertIsString($scratch);
 		$this->assertDirectoryExists($scratch);

--- a/tests/system/Publisher/PublisherSupportTest.php
+++ b/tests/system/Publisher/PublisherSupportTest.php
@@ -1,0 +1,199 @@
+<?php namespace CodeIgniter\Pager;
+
+use CodeIgniter\Publisher\Exceptions\PublisherException;
+use CodeIgniter\Publisher\Publisher;
+use CodeIgniter\Test\CIUnitTestCase;
+use Tests\Support\Publishers\TestPublisher;
+
+class PublisherSupportTest extends CIUnitTestCase
+{
+	/**
+	 * A known, valid file
+	 *
+	 * @var string
+	 */
+	private $file = SUPPORTPATH . 'Files/baker/banana.php';
+
+	/**
+	 * A known, valid directory
+	 *
+	 * @var string
+	 */
+	private $directory = SUPPORTPATH . 'Files/able/';
+
+	/**
+	 * Initialize the helper, since some
+	 * tests call static methods before
+	 * the constructor would load it.
+	 */
+	public static function setUpBeforeClass(): void
+	{
+		parent::setUpBeforeClass();
+
+		helper(['filesystem']);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testDiscoverDefault()
+	{
+		$result = Publisher::discover();
+
+		$this->assertCount(1, $result);
+		$this->assertInstanceOf(TestPublisher::class, $result[0]);
+	}
+
+	public function testDiscoverNothing()
+	{
+		$result = Publisher::discover('Nothing');
+
+		$this->assertSame([], $result);
+	}
+
+	public function testDiscoverStores()
+	{
+		$publisher = Publisher::discover()[0];
+		$publisher->addFile($this->file);
+
+		$result = Publisher::discover();
+		$this->assertSame($publisher, $result[0]);
+		$this->assertSame([$this->file], $result[0]->getFiles());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testResolveDirectoryDirectory()
+	{
+		$method = $this->getPrivateMethodInvoker(Publisher::class, 'resolveDirectory');
+
+		$this->assertSame($this->directory, $method($this->directory));
+	}
+
+	public function testResolveDirectoryFile()
+	{
+		$method = $this->getPrivateMethodInvoker(Publisher::class, 'resolveDirectory');
+
+		$this->expectException(PublisherException::class);
+		$this->expectExceptionMessage(lang('Publisher.expectedDirectory', ['invokeArgs']));
+
+		$method($this->file);
+	}
+
+	public function testResolveDirectorySymlink()
+	{
+		// Create a symlink to test
+		$link = sys_get_temp_dir() . DIRECTORY_SEPARATOR . bin2hex(random_bytes(4));
+		symlink($this->directory, $link);
+
+		$method = $this->getPrivateMethodInvoker(Publisher::class, 'resolveDirectory');
+
+		$this->assertSame($this->directory, $method($link));
+
+		unlink($link);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testResolveFileFile()
+	{
+		$method = $this->getPrivateMethodInvoker(Publisher::class, 'resolveFile');
+
+		$this->assertSame($this->file, $method($this->file));
+	}
+
+	public function testResolveFileSymlink()
+	{
+		// Create a symlink to test
+		$link = sys_get_temp_dir() . DIRECTORY_SEPARATOR . bin2hex(random_bytes(4));
+		symlink($this->file, $link);
+
+		$method = $this->getPrivateMethodInvoker(Publisher::class, 'resolveFile');
+
+		$this->assertSame($this->file, $method($link));
+
+		unlink($link);
+	}
+
+	public function testResolveFileDirectory()
+	{
+		$method = $this->getPrivateMethodInvoker(Publisher::class, 'resolveFile');
+
+		$this->expectException(PublisherException::class);
+		$this->expectExceptionMessage(lang('Publisher.expectedFile', ['invokeArgs']));
+
+		$method($this->directory);
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testGetScratch()
+	{
+		$publisher = new Publisher();
+		$this->assertNull($this->getPrivateProperty($publisher, 'scratch'));
+
+		$method  = $this->getPrivateMethodInvoker($publisher, 'getScratch');
+		$scratch = $method();
+
+		$this->assertIsString($scratch);
+		$this->assertDirectoryExists($scratch);
+		$this->assertDirectoryIsWritable($scratch);
+		$this->assertNotNull($this->getPrivateProperty($publisher, 'scratch'));
+
+		// Directory and contents should be removed on __destruct()
+		$file = $scratch . 'obvious_statement.txt';
+		file_put_contents($file, 'Bananas are a most peculiar fruit');
+
+		$publisher->__destruct();
+
+		$this->assertFileDoesNotExist($file);
+		$this->assertDirectoryDoesNotExist($scratch);
+	}
+
+	public function testGetErrors()
+	{
+		$publisher = new Publisher();
+		$this->assertSame([], $publisher->getErrors());
+
+		$expected = [
+			$this->file => PublisherException::forCollision($this->file, $this->file),
+		];
+
+		$this->setPrivateProperty($publisher, 'errors', $expected);
+
+		$this->assertSame($expected, $publisher->getErrors());
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testWipeDirectory()
+	{
+		$directory = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . bin2hex(random_bytes(6));
+		mkdir($directory, 0700);
+		$this->assertDirectoryExists($directory);
+
+		$method = $this->getPrivateMethodInvoker(Publisher::class, 'wipeDirectory');
+		$method($directory);
+
+		$this->assertDirectoryDoesNotExist($directory);
+	}
+
+	public function testWipeIgnoresFiles()
+	{
+		$method = $this->getPrivateMethodInvoker(Publisher::class, 'wipeDirectory');
+		$method($this->file);
+
+		$this->assertFileExists($this->file);
+	}
+
+	public function testWipe()
+	{
+		$directory = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . bin2hex(random_bytes(6));
+		mkdir($directory, 0700);
+		$this->assertDirectoryExists($directory);
+
+		$publisher = new Publisher($this->directory, $directory);
+		$publisher->wipe();
+
+		$this->assertDirectoryDoesNotExist($directory);
+	}
+}

--- a/tests/system/Publisher/PublisherSupportTest.php
+++ b/tests/system/Publisher/PublisherSupportTest.php
@@ -53,7 +53,7 @@ class PublisherSupportTest extends CIUnitTestCase
 	public function testDiscoverStores()
 	{
 		$publisher = Publisher::discover()[0];
-		$publisher->addFile($this->file);
+		$publisher->setFiles([])->addFile($this->file);
 
 		$result = Publisher::discover();
 		$this->assertSame($publisher, $result[0]);

--- a/user_guide_src/source/libraries/index.rst
+++ b/user_guide_src/source/libraries/index.rst
@@ -14,6 +14,7 @@ Library Reference
     honeypot
     images
     pagination
+    publisher
     security
     sessions
     throttler

--- a/user_guide_src/source/libraries/publisher.rst
+++ b/user_guide_src/source/libraries/publisher.rst
@@ -246,7 +246,7 @@ into an application for use::
 	use CodeIgniter\Publisher\Publisher;
 	use Throwable;
 
-	class Publish extends BaseCommand
+	class AuthPublish extends BaseCommand
 	{
 		protected $group       = 'Auth';
 		protected $name        = 'auth:publish';
@@ -275,11 +275,8 @@ into an application for use::
 			}
 
 			// If publication succeeded then update namespaces
-			foreach ($publisher->getFiles as $original)
+			foreach ($publisher->getPublished() as $file)
 			{
-				// Get the location of the new file
-				$file = str_replace($source, APPPATH, $original);
-
 				// Replace the namespace
 				$contents = file_get_contents($file);
 				$contents = str_replace('namespace Math\\Auth', 'namespace ' . APP_NAMESPACE, );

--- a/user_guide_src/source/libraries/publisher.rst
+++ b/user_guide_src/source/libraries/publisher.rst
@@ -44,11 +44,12 @@ By default the source and destination will be set to ``ROOTPATH`` and ``FCPATH``
 easy access to take any file from your project and make it web-accessible. Alternatively you may pass a new source
 or source and destination into the constructor::
 
+	use CodeIgniter\Publisher\Publisher;
+	
 	$vendorPublisher = new Publisher(ROOTPATH . 'vendor');
 	$filterPublisher = new Publisher('/path/to/module/Filters', APPPATH . 'Filters');
 
-Once the source and destination are set you may start adding relative input files::
-
+	// Once the source and destination are set you may start adding relative input files
 	$frameworkPublisher = new Publisher(ROOTPATH . 'vendor/codeigniter4/codeigniter4');
 
 	// All "path" commands are relative to $source
@@ -73,7 +74,7 @@ to their destination(s)::
 	// Place files into their relative $destination directories, overwriting and saving the boolean result
 	$result = $frameworkPublisher->merge(true);
 
-See the Library Reference for a full description of available methods.
+See the :ref:`reference` for a full description of available methods.
 
 Automation and Discovery
 ========================
@@ -90,7 +91,7 @@ the powerful ``Autoloader`` to locate any child classes primed for publication::
 
 		if ($result === false)
 		{
-			CLI::write(get_class($publisher) . ' failed to publish!', 'red');
+			CLI::error(get_class($publisher) . ' failed to publish!', 'red');
 		}
 	}
 
@@ -139,7 +140,7 @@ You can set up :doc:`Custom Command </cli/cli_commands>` to run daily that will 
 
 			try
 			{
-				$publisher->addPath('daily_photo.jpg')->copy($replace = true);
+				$publisher->addPath('daily_photo.jpg')->copy(true); // `true` to enable overwrites
 			}
 			catch (Throwable $e)
 			{
@@ -152,7 +153,7 @@ Now running ``spark publish:daily`` will keep your homepage's image up-to-date. 
 coming from an external API? You can use ``addUri()`` in place of ``addPath()`` to download the remote
 resource and publish it out instead::
 
-	$publisher->addUri('https://example.com/feeds/daily_photo.jpg')->copy($replace = true);
+	$publisher->addUri('https://example.com/feeds/daily_photo.jpg')->copy(true);
 
 Asset Dependencies Example
 ==========================
@@ -160,8 +161,6 @@ Asset Dependencies Example
 You want to integrate the frontend library "Bootstrap" into your project, but the frequent updates makes it a hassle
 to keep up with. You can create a publication definition in your project to sync frontend assets by adding extending
 ``Publisher`` in your project. So **app/Publishers/BootstrapPublisher.php** might look like this::
-
-	<?php
 
 	namespace App\Publishers;
 
@@ -205,6 +204,7 @@ to keep up with. You can create a publication definition in your project to sync
 				// Merge-and-replace to retain the original directory structure
 				->merge(true);
 		}
+	}
 
 Now add the dependency via Composer and call ``spark publish`` to run the publication::
 
@@ -297,6 +297,8 @@ Now when your module users run ``php spark auth:publish`` they will have the fol
 	app/Database/Migrations/2017-11-20-223112_create_auth_tables.php.php
 	app/Models/LoginModel.php
 	app/Models/UserModel.php
+
+.. _reference:
 
 *****************
 Library Reference

--- a/user_guide_src/source/libraries/publisher.rst
+++ b/user_guide_src/source/libraries/publisher.rst
@@ -119,6 +119,8 @@ You want to display a "photo of the day" image on your homepage. You have a feed
 need to get the actual file into a browsable location in your project at **public/images/daily_photo.jpg**.
 You can set up :doc:`Custom Command </cli/cli_commands>` to run daily that will handle this for you::
 
+	<?php
+
 	namespace App\Commands;
 
 	use CodeIgniter\CLI\BaseCommand;
@@ -158,6 +160,8 @@ Asset Dependencies Example
 You want to integrate the frontend library "Bootstrap" into your project, but the frequent updates makes it a hassle
 to keep up with. You can create a publication definition in your project to sync frontend assets by adding extending
 ``Publisher`` in your project. So **app/Publishers/BootstrapPublisher.php** might look like this::
+
+	<?php
 
 	namespace App\Publishers;
 
@@ -207,7 +211,7 @@ Now add the dependency via Composer and call ``spark publish`` to run the public
 	> composer require twbs/bootstrap
 	> php spark publish
 
-... and you'll end up with something like this:
+... and you'll end up with something like this::
 
 	public/.htaccess
 	public/favicon.ico
@@ -239,6 +243,8 @@ Module Deployment Example
 You want to allow developers using your popular authentication module the ability to expand on the default behavior
 of your Migration, Controller, and Model. You can create your own module "publish" command to inject these components
 into an application for use::
+
+	<?php
 
 	namespace Math\Auth\Commands;
 

--- a/user_guide_src/source/libraries/publisher.rst
+++ b/user_guide_src/source/libraries/publisher.rst
@@ -162,6 +162,8 @@ You want to integrate the frontend library "Bootstrap" into your project, but th
 to keep up with. You can create a publication definition in your project to sync frontend assets by adding extending
 ``Publisher`` in your project. So **app/Publishers/BootstrapPublisher.php** might look like this::
 
+	<?php
+	
 	namespace App\Publishers;
 
 	use CodeIgniter\Publisher\Publisher;
@@ -195,11 +197,11 @@ to keep up with. You can create a publication definition in your project to sync
 		public function publish(): bool
 		{
 			return $this
-				// Add all the files relative to $source			
+				// Add all the files relative to $source
 				->addPath('dist')
 
 				// Indicate we only want the minimized versions
-				->retainPattern('*.min.*)
+				->retainPattern('*.min.*')
 
 				// Merge-and-replace to retain the original directory structure
 				->merge(true);

--- a/user_guide_src/source/libraries/publisher.rst
+++ b/user_guide_src/source/libraries/publisher.rst
@@ -107,6 +107,20 @@ Most of the time you will not need to handle your own discovery, just use the pr
 By default on your class extension ``publish()`` will add all files from your ``$source`` and merge them
 out to your destination, overwriting on collision.
 
+Security
+========
+
+In order to prevent modules from injecting malicious code into your projects, ``Publisher`` contains a config file
+that defines which directories and file patterns are allowed as destinations. By default, files may only be published
+to your project (to prevent access to the rest of the filesystem), and the **public/** folder (``FCPATH``) will only
+receive files with the following extensions:
+* Web assets: css, scss, js, map
+* Non-executable web files: htm, html, xml, json, webmanifest
+* Fonts: tff, eot, woff
+* Images: gif, jpg, jpeg, tiff, png, webp, bmp, ico, svg
+
+If you need to add or adjust the security for your project then alter the ``$restrictions`` property of ``Config\Publisher``.
+
 ********
 Examples
 ********
@@ -159,7 +173,7 @@ Asset Dependencies Example
 ==========================
 
 You want to integrate the frontend library "Bootstrap" into your project, but the frequent updates makes it a hassle
-to keep up with. You can create a publication definition in your project to sync frontend assets by adding extending
+to keep up with. You can create a publication definition in your project to sync frontend assets by extending
 ``Publisher`` in your project. So **app/Publishers/BootstrapPublisher.php** might look like this::
 
 	<?php


### PR DESCRIPTION
**Description**
This PR introduces a new component: the Publisher Class. This combines a handful of different solutions I've been using in my modules to solve a variety of problems:
1. How do I maintain project assets with version dependencies?
2. How do I manage uploads and other "dynamic" files that need to be web accessible?
3. How can I update my project when the framework or modules change?
4. How can the framework/modules publish their modified content to a project?

`Publisher` has two functional modes: it can be instantiated and used dynamically with runtime input, or can use predefined workflows staged for automatic discovery. With either approach developers use fluent-style methods to build a payload manifest and then one of the "write" commands to deliver the files. For example, to inject the latest Bootstrap minimized JS & CSS files:
```
$publisher = new Publisher();
$publisher
	->addPath('vendor/twbs/bootstrap/dist')
	->retainPattern('*.min.*)
	->merge();
```

By default `Publisher` assumes the source is `ROOTPATH` and the destination is `FCPATH` but this can be changed with the constructor:
```
$publisher = new Publisher('vendor', FCPATH . 'assets/vendor/');
```
... or set directly on extensions:
```
class BootstrapPublisher extends Publisher
{
	protected $source = ROOTPATH . 'vendor/twbs/bootstrap';
	protected $destination = FCPATH . 'bootstrap/';
}
```

I will have lots more explanations and examples in the User Guide but I wanted to get this PR up for reviews since it has been a while since we added an entirely new component.

*Note: This will need to be re-styled after the coding standards release.*

*A few motivations for this library:*
* https://github.com/tattersoftware/codeigniter4-assets#publishing
* https://github.com/tattersoftware/codeigniter4-patches#description
* https://github.com/lonnieezell/myth-auth/blob/develop/docs/commands.md#publish
* https://github.com/paulbalandan/liaison-revision
* https://github.com/codeigniter4/CodeIgniter4/pull/4634

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
