### PR TITLE
Replace `isset()` with the `??` null coalesce operator

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -22,6 +22,7 @@ use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRect
 use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
 use Rector\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector;
+use Rector\Php70\Rector\Ternary\TernaryToNullCoalescingRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
 use Rector\Set\ValueObject\SetList;
@@ -86,4 +87,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 	$services->set(UnnecessaryTernaryExpressionRector::class);
 	$services->set(RemoveUnusedPrivatePropertyRector::class);
 	$services->set(RemoveErrorSuppressInTryCatchStmtsRector::class);
+	$services->set(TernaryToNullCoalescingRector::class);
 };

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -983,7 +983,7 @@ class CLI
 
 		// If the option didn't have a value, simply return TRUE
 		// so they know it was set, otherwise return the actual value.
-		$val = static::$options[$name] === null ? true : static::$options[$name];
+		$val = static::$options[$name] ?? true;
 
 		return $val;
 	}

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -964,8 +964,8 @@ class Forge
 
 			$field = [
 				'name'           => $key,
-				'new_name'       => isset($attributes['NAME']) ? $attributes['NAME'] : null,
-				'type'           => isset($attributes['TYPE']) ? $attributes['TYPE'] : null,
+				'new_name'       => $attributes['NAME'] ?? null,
+				'type'           => $attributes['TYPE'] ?? null,
 				'length'         => '',
 				'unsigned'       => '',
 				'null'           => '',

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -98,7 +98,7 @@ class Result extends BaseResult
 			$retVal[$i]              = new stdClass();
 			$retVal[$i]->name        = $data->name;
 			$retVal[$i]->type        = $data->type;
-			$retVal[$i]->type_name   = in_array($data->type, [1, 247], true) ? 'char' : (isset($dataTypes[$data->type]) ? $dataTypes[$data->type] : null);
+			$retVal[$i]->type_name   = in_array($data->type, [1, 247], true) ? 'char' : ($dataTypes[$data->type] ?? null);
 			$retVal[$i]->max_length  = $data->max_length;
 			$retVal[$i]->primary_key = (int) ($data->flags & 2);
 			$retVal[$i]->length      = $data->length;

--- a/system/Database/SQLSRV/Result.php
+++ b/system/Database/SQLSRV/Result.php
@@ -99,7 +99,7 @@ class Result extends BaseResult
 			$retVal[$i]             = new stdClass();
 			$retVal[$i]->name       = $field['Name'];
 			$retVal[$i]->type       = $field['Type'];
-			$retVal[$i]->type_name  = isset($dataTypes[$field['Type']]) ? $dataTypes[$field['Type']] : null;
+			$retVal[$i]->type_name  = $dataTypes[$field['Type']] ?? null;
 			$retVal[$i]->max_length = $field['Size'];
 		}
 

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -76,7 +76,7 @@ class Result extends BaseResult
 			$retVal[$i]->name       = $this->resultID->columnName($i); // @phpstan-ignore-line
 			$type                   = $this->resultID->columnType($i); // @phpstan-ignore-line
 			$retVal[$i]->type       = $type;
-			$retVal[$i]->type_name  = isset($dataTypes[$type]) ? $dataTypes[$type] : null;
+			$retVal[$i]->type_name  = $dataTypes[$type] ?? null;
 			$retVal[$i]->max_length = null;
 			$retVal[$i]->length     = null;
 		}

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -301,12 +301,8 @@ class Table
 
 		foreach ($this->fields as $name => $details)
 		{
-			$newFields[] = isset($details['new_name'])
-				// Are we modifying the column?
-				? $details['new_name']
-				: $name;
-
-			$exFields[] = $name;
+			$newFields[] = $details['new_name'] ?? $name;
+			$exFields[]  = $name;
 		}
 
 		$exFields  = implode(', ', $exFields);

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -1432,7 +1432,7 @@ class Email
 			{
 				continue;
 			}
-			$name  = isset($attachment['name'][1]) ? $attachment['name'][1] : basename($attachment['name'][0]);
+			$name  = $attachment['name'][1] ?? basename($attachment['name'][0]);
 			$body .= '--' . $boundary . $this->newline
 				. 'Content-Type: ' . $attachment['type'] . '; name="' . $name . '"' . $this->newline
 				. 'Content-Disposition: ' . $attachment['disposition'] . ';' . $this->newline

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -60,7 +60,7 @@ trait RequestTrait
 		/**
 		 * @deprecated $this->proxyIPs property will be removed in the future
 		 */
-		$proxyIPs = isset($this->proxyIPs) ? $this->proxyIPs : config('App')->proxyIPs;
+		$proxyIPs = $this->proxyIPs ?? config('App')->proxyIPs;
 		if (! empty($proxyIPs) && ! is_array($proxyIPs))
 		{
 			$proxyIPs = explode(',', str_replace(' ', '', $proxyIPs));

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -187,7 +187,9 @@ class Session implements SessionInterface
 		$this->cookieSecure   = $config->cookieSecure ?? $this->cookieSecure;
 		$this->cookieSameSite = $config->cookieSameSite ?? $this->cookieSameSite;
 
-		/** @var CookieConfig */
+		/**
+		 * @var CookieConfig
+		 */
 		$cookie = config('Cookie');
 
 		$this->cookie = new Cookie($this->sessionCookieName, '', [
@@ -512,7 +514,7 @@ class Session implements SessionInterface
 	 */
 	public function get(string $key = null)
 	{
-		if (! empty($key) && (! is_null($value = isset($_SESSION[$key]) ? $_SESSION[$key] : null) || ! is_null($value = dot_array_search($key, $_SESSION ?? []))))
+		if (! empty($key) && (! is_null($value = $_SESSION[$key] ?? null) || ! is_null($value = dot_array_search($key, $_SESSION ?? []))))
 		{
 			return $value;
 		}

--- a/system/View/Table.php
+++ b/system/View/Table.php
@@ -320,7 +320,7 @@ class Table
 					}
 				}
 
-				$out .= $temp . (isset($heading['data']) ? $heading['data'] : '') . $this->template['heading_cell_end'];
+				$out .= $temp . ($heading['data'] ?? '') . $this->template['heading_cell_end'];
 			}
 
 			$out .= $this->template['heading_row_end'] . $this->newline . $this->template['thead_close'] . $this->newline;
@@ -352,7 +352,7 @@ class Table
 						}
 					}
 
-					$cell = isset($cell['data']) ? $cell['data'] : '';
+					$cell = $cell['data'] ?? '';
 					$out .= $temp;
 
 					if ($cell === '' || $cell === null)
@@ -394,7 +394,7 @@ class Table
 					}
 				}
 
-				$out .= $temp . (isset($footing['data']) ? $footing['data'] : '') . $this->template['footing_cell_end'];
+				$out .= $temp . ($footing['data'] ?? '') . $this->template['footing_cell_end'];
 			}
 
 			$out .= $this->template['footing_row_end'] . $this->newline . $this->template['tfoot_close'] . $this->newline;


### PR DESCRIPTION
Since the minimum PHP version is PHP 7.3, we can make use of the language features it provides 🥳, in this case:

```php
$x = $y ?? null
```
instead of
```php
$x = isset($y) ? $y : null
``` 

:octocat: 