### PR TITLE
Deduplicate code

### DIFF
--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -127,25 +127,16 @@ class Seeder
 	 */
 	public function call(string $class)
 	{
-		if (empty($class))
+		$class = trim($class);
+
+		if ($class === '')
 		{
 			throw new InvalidArgumentException('No seeder was specified.');
 		}
 
-		$path = str_replace('.php', '', $class) . '.php';
-
-		// If we have namespaced class, simply try to load it.
-		if (strpos($class, '\\') !== false)
+		if (strpos($class, '\\') === false)
 		{
-			/**
-			 * @var Seeder
-			 */
-			$seeder = new $class($this->config);
-		}
-		// Otherwise, try to load the class manually.
-		else
-		{
-			$path = $this->seedPath . $path;
+			$path = $this->seedPath . str_replace('.php', '', $class) . '.php';
 
 			if (! is_file($path))
 			{
@@ -160,14 +151,13 @@ class Seeder
 			{
 				require_once $path;
 			}
-
-			/**
-			 * @var Seeder
-			 */
-			$seeder = new $class($this->config);
 			// @codeCoverageIgnoreEnd
 		}
 
+		/**
+		 * @var Seeder
+		 */
+		$seeder = new $class($this->config);
 		$seeder->setSilent($this->silent)->run();
 
 		unset($seeder);

--- a/system/Format/XMLFormatter.php
+++ b/system/Format/XMLFormatter.php
@@ -63,15 +63,15 @@ class XMLFormatter implements FormatterInterface
 	{
 		foreach ($data as $key => $value)
 		{
+			$key = $this->normalizeXMLTag($key);
+
 			if (is_array($value))
 			{
-				$key     = $this->normalizeXMLTag($key);
 				$subnode = $output->addChild("$key");
 				$this->arrayToXML($value, $subnode);
 			}
 			else
 			{
-				$key = $this->normalizeXMLTag($key);
 				$output->addChild("$key", htmlspecialchars("$value"));
 			}
 		}


### PR DESCRIPTION
I noticed that `$seeder = new $class($this->config);` was called twice and that this could be an opportunity to shorten the `Seeder::call()` method a bit - similarly in the XMLFormatter 💪 

:octocat: 