### PR TITLE
Entity getCastHandlers

### DIFF
--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -34,6 +34,35 @@ use JsonSerializable;
 class Entity implements JsonSerializable
 {
 	/**
+	 * Default cast handlers
+	 *
+	 * @var array<string, string>
+	 */
+	private static $defaultCastHandlers = [
+		'array'     => ArrayCast::class,
+		'bool'      => BooleanCast::class,
+		'boolean'   => BooleanCast::class,
+		'csv'       => CSVCast::class,
+		'datetime'  => DatetimeCast::class,
+		'double'    => FloatCast::class,
+		'float'     => FloatCast::class,
+		'int'       => IntegerCast::class,
+		'integer'   => IntegerCast::class,
+		'json'      => JsonCast::class,
+		'object'    => ObjectCast::class,
+		'string'    => StringCast::class,
+		'timestamp' => TimestampCast::class,
+		'uri'       => URICast::class,
+	];
+
+	/**
+	 * Custom cast handlers
+	 *
+	 * @var array<string, string>
+	 */
+	protected static $customCastHandlers = [];
+
+	/**
 	 * Maps names used in sets and gets against unique
 	 * names within the class, allowing independence from
 	 * database column names.
@@ -61,30 +90,10 @@ class Entity implements JsonSerializable
 	 * Custom convert handlers
 	 *
 	 * @var array<string, string>
+	 *
+	 * @deprecated Use static::$customCastHandlers instead
 	 */
 	protected $castHandlers = [];
-
-	/**
-	 * Default convert handlers
-	 *
-	 * @var array<string, string>
-	 */
-	private $defaultCastHandlers = [
-		'array'     => ArrayCast::class,
-		'bool'      => BooleanCast::class,
-		'boolean'   => BooleanCast::class,
-		'csv'       => CSVCast::class,
-		'datetime'  => DatetimeCast::class,
-		'double'    => FloatCast::class,
-		'float'     => FloatCast::class,
-		'int'       => IntegerCast::class,
-		'integer'   => IntegerCast::class,
-		'json'      => JsonCast::class,
-		'object'    => ObjectCast::class,
-		'string'    => StringCast::class,
-		'timestamp' => TimestampCast::class,
-		'uri'       => URICast::class,
-	];
 
 	/**
 	 * Holds the current values of all class vars.
@@ -108,6 +117,21 @@ class Entity implements JsonSerializable
 	 * @var boolean
 	 **/
 	private $_cast = true;
+
+	/**
+	 * Returns this Entity's supported
+	 * cast types and their handlers.
+	 *
+	 * Note: This method does not support
+	 * handlers defined in the deprecated,
+	 * non-static $castHandlers property.
+	 *
+	 * @return array<string,string>
+	 */
+	final public static function getCastHandlers(): array
+	{
+		return array_merge(self::$defaultCastHandlers, static::$customCastHandlers);
+	}
 
 	/**
 	 * Allows filling in Entity parameters during construction.
@@ -393,7 +417,7 @@ class Entity implements JsonSerializable
 			$type = substr($type, 1);
 		}
 
-		//In order not to create a separate handler for the
+		// In order not to create a separate handler for the
 		// json-array type, we transform the required one.
 		$type = $type === 'json-array' ? 'json[array]' : $type;
 
@@ -419,7 +443,7 @@ class Entity implements JsonSerializable
 
 		$type = trim($type, '[]');
 
-		$handlers = array_merge($this->defaultCastHandlers, $this->castHandlers);
+		$handlers = array_merge(self::getCastHandlers(), $this->castHandlers);
 
 		if (empty($handlers[$type]))
 		{

--- a/user_guide_src/source/changelogs/v4.1.3.rst
+++ b/user_guide_src/source/changelogs/v4.1.3.rst
@@ -4,3 +4,11 @@ Version 4.1.3
 Release Date: Not released
 
 **4.1.3 release of CodeIgniter4**
+
+Enhancements:
+
+- ``Entity`` classes can now report on the casts they support (default and custom) with the static ``getCastHandlers()``.
+
+Deprecations:
+
+- Deprecated ``Codeigniter\Entity\Entity::$castHandlers`` property - use the static ``$customCastHandlers`` instead.

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -329,7 +329,7 @@ Property Casting
 You can specify that properties in your Entity should be converted to common data types with the **casts** property.
 This option should be an array where the key is the name of the class property, and the value is the data type it
 should be cast to. Casting only affects when values are read. No conversions happen that affect the permanent value in
-either the entity or the database. Properties can be cast to any of the following data types:
+either the entity or the database. Properties can be cast to any of the following data types by default:
 **integer**, **float**, **double**, **string**, **boolean**, **object**, **array**, **datetime**, **timestamp**, and **uri**.
 Add a question mark at the beginning of type to mark property as nullable, i.e., **?string**, **?integer**.
 
@@ -432,7 +432,7 @@ Let's say the class will be located in the 'app/Entity/Cast' directory::
     
     use CodeIgniter\Entity\Cast\BaseCast;
 
-    //The class must inherit the CodeIgniter\Entity\Cast\BaseCast class
+    // The class must inherit the CodeIgniter\Entity\Cast\BaseCast class
     class CastBase64 extends BaseCast
     {
         public static function get($value, array $params = [])
@@ -456,14 +456,14 @@ Now you need to register it::
 
     class MyEntity extends Entity
     {
-        // Specifying the type for the field
-        protected $casts = [
-            'key' => 'base64',
+        // Bind the type to the handler
+        protected static $customCastHandlers = [
+            'base64' => 'App\Entity\Cast\CastBase64',
         ];
 
-        //Bind the type to the handler
-        protected $castHandlers = [
-            'base64' => 'App\Entity\Cast\CastBase64',
+        // ... and specify the type for the field
+        protected $casts = [
+            'key' => 'base64',
         ];
     }
 
@@ -485,6 +485,7 @@ If you don't need to change values when getting or setting a value. Then just do
         }
     }
 
+Use the static method ``getCastHandlers()`` to determine which casts and handlers are available for any Entity child.
 
 **Parameters**
 


### PR DESCRIPTION
**Description**
I think it is important for classes that interact with `Entity` (mostly models) to know what data types any given Entity can handle. It's unfortunate these properties were not static to begin with, but this PR provides a deprecation and static getter to access it in a backwards-compatible approach.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
