### PR TITLE
Add missing imports

### DIFF
--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -23,7 +23,7 @@ use Config\Services;
  * instantiation checks.
  *
  * @method static Model models(...$arguments)
- * @method static \Config\BaseConfig config(...$arguments)
+ * @method static BaseConfig config(...$arguments)
  */
 class Factories
 {

--- a/system/Helpers/test_helper.php
+++ b/system/Helpers/test_helper.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+use CodeIgniter\Model;
 use CodeIgniter\Test\Fabricator;
 
 /**

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Test;
 use CodeIgniter\CodeIgniter;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Database\MigrationRunner;
 use CodeIgniter\Database\Seeder;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Router\RouteCollection;

--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -19,6 +19,7 @@ use CodeIgniter\HTTP\URI;
 use Config\App;
 use Config\Services;
 use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 /**

--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -18,6 +18,7 @@ use CodeIgniter\HTTP\URI;
 use Config\App;
 use Config\Services;
 use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 /**

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Test;
 
 use CodeIgniter\Exceptions\FrameworkException;
+use CodeIgniter\Model;
 use Faker\Factory;
 use Faker\Generator;
 use InvalidArgumentException;
@@ -42,7 +43,7 @@ class Fabricator
 	/**
 	 * Model instance (can be non-framework if it follows framework design)
 	 *
-	 * @var CodeIgniter\Model|object
+	 * @var Model|object
 	 */
 	protected $model;
 


### PR DESCRIPTION
Some class imports were missing - they were only used in PHPDocs, but it helps IDEs with not complaining about it and autocompletion 😅 

:octocat: 