### PR TITLE
Fix setting of value in Cookie's flag attributes

### DIFF
--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -220,15 +220,19 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
 			unset($options['max-age']);
 		}
 
-		// to retain backward compatibility with previous versions' fallback
-		$prefix   = $options['prefix'] ?: self::$defaults['prefix'];
-		$path     = $options['path'] ?: self::$defaults['path'];
-		$domain   = $options['domain'] ?: self::$defaults['domain'];
-		$secure   = $options['secure'] ?: self::$defaults['secure'];
-		$httponly = $options['httponly'] ?: self::$defaults['httponly'];
+		// to preserve backward compatibility with array-based cookies in previous CI versions
+		$prefix = $options['prefix'] ?: self::$defaults['prefix'];
+		$path   = $options['path'] ?: self::$defaults['path'];
+		$domain = $options['domain'] ?: self::$defaults['domain'];
+
+		// empty string SameSite should use the default for browsers
 		$samesite = $options['samesite'] ?: self::$defaults['samesite'];
 
-		$this->validateName($name, $options['raw']);
+		$raw      = $options['raw'];
+		$secure   = $options['secure'];
+		$httponly = $options['httponly'];
+
+		$this->validateName($name, $raw);
 		$this->validatePrefix($prefix, $secure, $path, $domain);
 		$this->validateSameSite($samesite, $secure);
 
@@ -241,7 +245,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
 		$this->secure   = $secure;
 		$this->httponly = $httponly;
 		$this->samesite = ucfirst(strtolower($samesite));
-		$this->raw      = $options['raw'];
+		$this->raw      = $raw;
 	}
 
 	//=========================================================================

--- a/tests/system/HTTP/ResponseCookieTest.php
+++ b/tests/system/HTTP/ResponseCookieTest.php
@@ -117,9 +117,9 @@ final class ResponseCookieTest extends CIUnitTestCase
 
 		$response->setCookie('foo', 'bar');
 		$cookie = $response->getCookie('foo');
-		$this->assertTrue($cookie->isHTTPOnly());
+		$this->assertFalse($cookie->isHTTPOnly());
 
-		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'httponly' => false]);
+		$response->setCookie(['name' => 'bee', 'value' => 'bop', 'httponly' => true]);
 		$cookie = $response->getCookie('bee');
 		$this->assertTrue($cookie->isHTTPOnly());
 	}

--- a/user_guide_src/source/libraries/cookies.rst
+++ b/user_guide_src/source/libraries/cookies.rst
@@ -33,7 +33,7 @@ There are currently four (4) ways to create a new ``Cookie`` value object.
     use CodeIgniter\Cookie\Cookie;
     use DateTime;
 
-    // Throw the constructor
+    // Using the constructor
     $cookie = new Cookie(
         'remember_token',
         'f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6',
@@ -79,7 +79,7 @@ instance or an array of defaults to the static ``Cookie::setDefaults()`` method.
     use CodeIgniter\Cookie\Cookie;
     use Config\Cookie as CookieConfig;
 
-    // pass in an App instance before constructing a Cookie class
+    // pass in an Config\Cookie instance before constructing a Cookie class
     Cookie::setDefaults(new CookieConfig());
     $cookie = new Cookie('login_token');
 
@@ -456,11 +456,11 @@ Class Reference
 
     .. php:staticmethod:: setDefaults([$config = []])
 
-        :param App|array $config: The configuration array or instance
+        :param \Config\Cookie|array $config: The configuration array or instance
         :rtype: array<string, mixed>
         :returns: The old defaults
 
-        Set the default attributes to a Cookie instance by injecting the values from the ``App`` config or an array.
+        Set the default attributes to a Cookie instance by injecting the values from the ``\Config\Cookie`` config or an array.
 
     .. php:staticmethod:: fromHeaderString(string $header[, bool $raw = false])
 


### PR DESCRIPTION
**Description**
- Fixes a bug in Cookie constructor where you cannot set a falsy value for `HttpOnly` and `Secure` attributes. Also removed extra code for `$defaults` merging.
- Fixes some errors in the docs

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
