### PR TITLE
Additional check for `$argv` variable when detecting CLI

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -763,7 +763,7 @@ if (! function_exists('is_cli'))
 			return true;
 		}
 
-		if (! isset($_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_USER_AGENT']))
+		if (! isset($_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_USER_AGENT']) && isset($_SERVER['argv']) && count($_SERVER['argv']) > 0)
 		{
 			return true;
 		}


### PR DESCRIPTION
**Description**
After checking existence of `REMOTE_ADDR` and `HTTP_USER_AGENT` keys in `$_SERVER`, additionally check if the `$argv` is set. Please note this will fail if the ini directive `register_argv_argc` is turned on for non-CLI requests.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
