### PR TITLE
Add default TTL

### DIFF
--- a/app/Config/Cache.php
+++ b/app/Config/Cache.php
@@ -84,6 +84,21 @@ class Cache extends BaseConfig
 
 	/**
 	 * --------------------------------------------------------------------------
+	 * Default TTL
+	 * --------------------------------------------------------------------------
+	 *
+	 * The default number of seconds to save items when none is specified.
+	 *
+	 * WARNING: This is not used by framework handlers where 60 seconds is
+	 * hard-coded, but may be useful to projects and modules. This will replace
+	 * the hard-coded value in a future release.
+	 *
+	 * @var integer
+	 */
+	public $ttl = 60;
+
+	/**
+	 * --------------------------------------------------------------------------
 	 * File settings
 	 * --------------------------------------------------------------------------
 	 * Your file storage preferences can be specified below, if you are using

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -59,6 +59,12 @@ more complex, multi-server setups.
 If you have more than one application using the same cache storage, you can add a custom prefix
 string here that is prepended to all key names.
 
+**$ttl**
+
+The default number of seconds to save items when none is specified.
+WARNING: This is not used by framework handlers where 60 seconds is hard-coded, but may be useful
+to projects and modules. This will replace the hard-coded value in a future release.
+
 **$file**
 
 This is an array of settings specific to the  ``File`` handler to determine how it should save the cache files.


### PR DESCRIPTION
**Description**
I am constantly adding a default Cache Time To Live value to modules and projects that interact with the cache. It's quite frustrating that the framework interface and handlers have this value hard-coded, so we cannot change that in version 4, but supplying this in the config file gives an opportunity for developers to implement it themselves (and to replace the hard-coded interface in version 5).

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- n/a Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
