### PR TITLE
Don't load PHP input body, if the request is too big

### DIFF
--- a/app/Config/Exceptions.php
+++ b/app/Config/Exceptions.php
@@ -57,4 +57,16 @@ class Exceptions extends BaseConfig
 	 * @var array
 	 */
 	public $sensitiveDataInTrace = [];
+        
+        
+        /**
+         * --------------------------------------------------------------------------
+         * Throw error on big request
+         * --------------------------------------------------------------------------
+         * If will be send big request on CI, throw an exception.
+         * 
+         * @var bool
+         */
+        
+        public $throwExceptionOnBigRequest = false;
 }

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -162,7 +162,7 @@ class IncomingRequest extends Request
                     // If the send content is too big, it wouldn't be load to the memory
                     if(((int) $this->fetchGlobal("server", "CONTENT_LENGTH") ?? 0) > $freeMemory)
                     {
-                        log_message(7, "The 'php://input' is too big for loading it to the \$body");
+                        log_message("debug", "The 'php://input' is too big for loading it into \$body");
                     } 
                     else 
                     {

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -154,7 +154,7 @@ class IncomingRequest extends Request
 		// Get Maximum avaible memory
 		$memory_limit = preg_split('/\d+\K/', ini_get('memory_limit'));
 		// Translate memory limit from human readible to bytes and substract already used memory
-		$free_memory = $memory_limit[0] * pow(1024, (array_search(strtolower($memory_limit[1]), ["k", "m", "g", "t", "p"]) ?: -1) + 1) - memory_get_peak_usage();
+		$free_memory = ((int) $memory_limit[0]) * pow(1024, (array_search(strtolower($memory_limit[1]), ["k", "m", "g", "t", "p"]) ?: -1) + 1) - memory_get_peak_usage();
 		// Get our body from php://input - if the send content is too big, it wouldn't be load to the memory
 		if ($body === 'php://input' && ((int) $_SERVER['CONTENT_LENGTH'] ?: 0) < $free_memory)
 		{

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -158,7 +158,8 @@ class IncomingRequest extends Request
                     // Get unit
                     $unit = strtolower($memoryLimit[1] ?? "");
                     // Get the exponent
-                    $exponent = ((int) array_search($unit, ["k", "m", "g", "t"]) ?: - 1) + 1;
+                    $possibleExponents = ["", "k", "m", "g", "t"];
+                    $exponent = (int) array_search($unit, $possibleExponents) ?? 0;
                     // Translate memory limit from human readible to bytes
                     $memoryLimitBytes = ((int) $memoryLimit[0] ?? 0 ) * pow(1024, $exponent);
                     // Get free space in memory by substracting already used memory

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -165,7 +165,7 @@ class IncomingRequest extends Request
                     // Get free space in memory by substracting already used memory
                     $freeMemory = $memoryLimitBytes - memory_get_peak_usage();
                     // If the send content is too big, it wouldn't be load to the memory
-                    if(((int) $this->fetchGlobal("server", "CONTENT_LENGTH") ?? 0) > $freeMemory)
+                    if(((int) $this->fetchGlobal("server", "CONTENT_LENGTH") ?? 0) > ($freeMemory  < 0 ? INF : $freeMemory))
                     {
                         log_message("debug", "The 'php://input' is too big for loading it into \$body");
                     } 

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -155,8 +155,12 @@ class IncomingRequest extends Request
 		{
                     // Get Maximum avaible memory
                     $memoryLimit = preg_split('/\d+\K/', ini_get('memory_limit'));
+                    // Get unit
+                    $unit = strtolower($memoryLimit[1] ?? "");
+                    // Get the exponent
+                    $exponent = ((int) array_search($unit, ["k", "m", "g", "t"]) ?: - 1) + 1;
                     // Translate memory limit from human readible to bytes
-                    $memoryLimitBytes = ((int) $memoryLimit[0] ?? 0 ) * pow(1024, ((int) array_search(strtolower($memoryLimit[1] ?? ""), ["k", "m", "g", "t"]) ?: -1) + 1);
+                    $memoryLimitBytes = ((int) $memoryLimit[0] ?? 0 ) * pow(1024, $exponent);
                     // Get free space in memory by substracting already used memory
                     $freeMemory = $memoryLimitBytes - memory_get_peak_usage();
                     // If the send content is too big, it wouldn't be load to the memory

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -151,8 +151,12 @@ class IncomingRequest extends Request
 			throw new InvalidArgumentException('You must supply the parameters: uri, userAgent.');
 		}
 
-		// Get our body from php://input
-		if ($body === 'php://input')
+		// Get Maximum avaible memory
+		$memory_limit = preg_split('/\d+\K/', ini_get('memory_limit'));
+		// Translate memory limit from human readible to bytes and substract already used memory
+		$free_memory = $memory_limit[0] * pow(1024, (array_search(strtolower($memory_limit[1]), ["k", "m", "g", "t", "p"]) ?: -1) + 1) - memory_get_peak_usage();
+		// Get our body from php://input - if the send content is too big, it wouldn't be load to the memory
+		if ($body === 'php://input' && ((int) $_SERVER['CONTENT_LENGTH'] ?: 0) < $free_memory)
 		{
 			$body = file_get_contents('php://input');
 		}

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -16,6 +16,7 @@ use CodeIgniter\HTTP\Files\FileCollection;
 use CodeIgniter\HTTP\Files\UploadedFile;
 use Config\App;
 use Config\Services;
+use Config\Exceptions;
 use InvalidArgumentException;
 use LengthException;
 use Locale;
@@ -164,7 +165,7 @@ class IncomingRequest extends Request
                     // Translate memory limit from human readible to bytes
                     $memoryLimitBytes = ((int) $memoryLimit[0] ?? 0 ) * pow(1024, $exponent);
                     // Load Exception config
-                    $configException = new \Config\Exceptions();
+                    $configException = new Exceptions();
                     // Get the request length of body
                     $contentLength = (int) $this->fetchGlobal("server", "CONTENT_LENGTH") ?? 0;
                     // If the send content is too big, it wouldn't be load to the memory
@@ -173,7 +174,7 @@ class IncomingRequest extends Request
                         $body = file_get_contents('php://input');
                     }
                     // The content is bigger then the memory_limit - throw an exceptin if is set in config
-                    else if(isset($configException->throwExceptionOnBigRequest) ? $configException->throwExceptionOnBigRequest : false )
+                    else if($configException->throwExceptionOnBigRequest ?? false )
                     {
                         throw new LengthException("The 'php://input' is too big for loading it into \$body");
                     }

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -152,11 +152,11 @@ class IncomingRequest extends Request
 		}
 
 		// Get Maximum avaible memory
-		$memory_limit = preg_split('/\d+\K/', ini_get('memory_limit'));
+		$memoryLimit = preg_split('/\d+\K/', ini_get('memory_limit'));
 		// Translate memory limit from human readible to bytes and substract already used memory
-		$free_memory = ((int) $memory_limit[0]) * pow(1024, (array_search(strtolower($memory_limit[1]), ["k", "m", "g", "t", "p"]) ?: -1) + 1) - memory_get_peak_usage();
+		$freeMemory = ((int) $memoryLimit[0] ?? 0 ) * pow(1024, (array_search(strtolower($memoryLimit[1] ?? ""), ["k", "m", "g", "t"]) ?: -1) + 1) - memory_get_peak_usage();
 		// Get our body from php://input - if the send content is too big, it wouldn't be load to the memory
-		if ($body === 'php://input' && ((int) $_SERVER['CONTENT_LENGTH'] ?: 0) < $free_memory)
+		if ($body === 'php://input' && ((int) $_SERVER['CONTENT_LENGTH'] ?: 0) < $freeMemory)
 		{
 			$body = file_get_contents('php://input');
 		}

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -168,12 +168,15 @@ class IncomingRequest extends Request
                     $configException = new Exceptions();
                     // Get the request length of body
                     $contentLength = (int) $this->fetchGlobal("server", "CONTENT_LENGTH") ?? 0;
-                    // If the send content is too big, it wouldn't be load to the memory
+                    /* 
+		     * If the send content it's not too big, it wwill be load to the $body
+		     * If the content is bigger then the memory_limit - throw an exceptin if is set in config
+		     * otherwise send info to log
+		     */
                     if($contentLength < $memoryLimitBytes)
                     {
                         $body = file_get_contents('php://input');
                     }
-                    // The content is bigger then the memory_limit - throw an exceptin if is set in config
                     else if($configException->throwExceptionOnBigRequest ?? false )
                     {
                         throw new LengthException("The 'php://input' is too big for loading it into \$body");


### PR DESCRIPTION
When I the client sending big http request (upload big file/s), there is potential risk, that the php haven't enough free memory:

`Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 98566176 bytes) in /var/www/ci4/system/HTTP/IncomingRequest.php on line 158`

Maybe there is somewhere config for disable this functionality, but I was unable to find it in the documentation.

This will prevent load the content to the memory, if the content is too big

Each pull request should address a single issue and have a meaningful title.

**Description**
Explain what you have changed, and why.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

---------Remove from here down in your description----------

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository
  
