### PR TITLE
SQLite3 "nullable"

### DIFF
--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -332,9 +332,9 @@ class Table
 		foreach ($fields as $field)
 		{
 			$return[$field->name] = [
-				'type'     => $field->type,
-				'default'  => $field->default,
-				'nullable' => $field->nullable,
+				'type'    => $field->type,
+				'default' => $field->default,
+				'null'    => $field->nullable,
 			];
 
 			if ($field->primary_key)

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -83,17 +83,17 @@ class AlterTableTest extends CIUnitTestCase
 		$this->assertCount(4, $fields);
 		$this->assertTrue(array_key_exists('id', $fields));
 		$this->assertNull($fields['id']['default']);
-		$this->assertTrue($fields['id']['nullable']);
+		$this->assertTrue($fields['id']['null']);
 		$this->assertEquals('integer', strtolower($fields['id']['type']));
 
 		$this->assertTrue(array_key_exists('name', $fields));
 		$this->assertNull($fields['name']['default']);
-		$this->assertFalse($fields['name']['nullable']);
+		$this->assertFalse($fields['name']['null']);
 		$this->assertEquals('varchar', strtolower($fields['name']['type']));
 
 		$this->assertTrue(array_key_exists('email', $fields));
 		$this->assertNull($fields['email']['default']);
-		$this->assertTrue($fields['email']['nullable']);
+		$this->assertTrue($fields['email']['null']);
 		$this->assertEquals('varchar', strtolower($fields['email']['type']));
 
 		$keys = $this->getPrivateProperty($this->table, 'keys');


### PR DESCRIPTION
**Description**
The correct Forge attribute for handling `null` columns is "null", not "nullable": https://github.com/codeigniter4/CodeIgniter4/blob/1b5f05e63a6489a90672b1d4a9f04d2c69730f56/system/Database/Forge.php#L995

Super scary to me that this has always been wrong and never been reported. 😳 Fixes #4746

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
