### PR TITLE
[Rector] Apply Rector: MoveVariableDeclarationNearReferenceRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
 		"fakerphp/faker": "^1.9",
 		"mikey179/vfsstream": "^1.6",
 		"nexusphp/tachycardia": "^1.0",
-		"phpstan/phpstan": "0.12.86",
+		"phpstan/phpstan": "0.12.88",
 		"phpunit/phpunit": "^9.1",
 		"predis/predis": "^1.1",
-		"rector/rector": "0.11.2",
+		"rector/rector": "0.11.7",
 		"squizlabs/php_codesniffer": "^3.3",
 		"symplify/package-builder": "^9.3"
 	},

--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,7 @@ use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
 use Rector\CodeQuality\Rector\If_\SimplifyIfReturnBoolRector;
 use Rector\CodeQuality\Rector\Return_\SimplifyUselessVariableRector;
 use Rector\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector;
+use Rector\CodeQualityStrict\Rector\Variable\MoveVariableDeclarationNearReferenceRector;
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
@@ -90,4 +91,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 	$services->set(RemoveErrorSuppressInTryCatchStmtsRector::class);
 	$services->set(TernaryToNullCoalescingRector::class);
 	$services->set(ListToArrayDestructRector::class);
+	$services->set(MoveVariableDeclarationNearReferenceRector::class);
 };

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -147,12 +147,11 @@ class Pager implements PagerInterface
 	 */
 	protected function displayLinks(string $group, string $template): string
 	{
-		$pager = new PagerRenderer($this->getDetails($group));
-
 		if (! array_key_exists($template, $this->config->templates))
 		{
 			throw PagerException::forInvalidTemplate($template);
 		}
+		$pager = new PagerRenderer($this->getDetails($group));
 
 		return $this->view->setVar('pager', $pager)
 						->render($this->config->templates[$template]);


### PR DESCRIPTION
Move variable declaration near its reference with `MoveVariableDeclarationNearReferenceRector` rector rule. It needs latest rector `0.11.7`. I updated phpstan/phpstan to `0.12.88` as well.

**Checklist:**
- [x] Securely signed commits