### PR TITLE
[Autoloader] include_once is not needed on Autoloader::loadClass() with no namespace

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -22,17 +22,17 @@ use InvalidArgumentException;
  * An autoloader that uses both PSR4 autoloading, and traditional classmaps.
  *
  * Given a foo-bar package of classes in the file system at the following paths:
- *```
+ * ```
  *      /path/to/packages/foo-bar/
  *          /src
  *              Baz.php         # Foo\Bar\Baz
  *              Qux/
  *                  Quux.php    # Foo\Bar\Qux\Quux
- *```
+ * ```
  * you can add the path to the configuration array that is passed in the constructor.
  * The Config array consists of 2 primary keys, both of which are associative arrays:
  * 'psr4', and 'classmap'.
- *```
+ * ```
  *      $Config = [
  *          'psr4' => [
  *              'Foo\Bar'   => '/path/to/packages/foo-bar'
@@ -41,9 +41,9 @@ use InvalidArgumentException;
  *              'MyClass'   => '/path/to/class/file.php'
  *          ]
  *      ];
- *```
+ * ```
  * Example:
- *```
+ * ```
  *      <?php
  *      // our configuration array
  *      $Config = [ ... ];
@@ -51,7 +51,7 @@ use InvalidArgumentException;
  *
  *      // register the autoloader
  *      $loader->register();
- *```
+ * ```
  */
 class Autoloader
 {
@@ -260,9 +260,9 @@ class Autoloader
 		{
 			$class    = 'Config\\' . $class;
 			$filePath = APPPATH . str_replace('\\', DIRECTORY_SEPARATOR, $class) . '.php';
-			$filename = $this->includeFile($filePath);
+			$filename = $this->sanitizeFilename($filePath);
 
-			if ($filename)
+			if (is_file($filename))
 			{
 				return $filename;
 			}
@@ -353,7 +353,9 @@ class Autoloader
 			return;
 		}
 
-		/** @var ClassLoader $composer */
+		/**
+		 * @var ClassLoader $composer
+		 */
 		$composer = include COMPOSER_PATH;
 		$paths    = $composer->getPrefixesPsr4();
 		$classes  = $composer->getClassMap();

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -258,15 +258,6 @@ class Autoloader
 	{
 		if (strpos($class, '\\') === false)
 		{
-			$class    = 'Config\\' . $class;
-			$filePath = APPPATH . str_replace('\\', DIRECTORY_SEPARATOR, $class) . '.php';
-			$filename = $this->sanitizeFilename($filePath);
-
-			if (is_file($filename))
-			{
-				return $filename;
-			}
-
 			return false;
 		}
 

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -172,19 +172,9 @@ class AutoloaderTest extends CIUnitTestCase
 		$this->assertFalse((bool) $this->loader->loadClass('My\App\AutoloaderTest'));
 	}
 
-	public function testloadClassConfigFound()
+	public function testloadClassNonNamespaced()
 	{
-		$this->loader->addNamespace('Config', APPPATH . 'Config');
-		$this->assertSame(
-			APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'Modules.php',
-			$this->loader->loadClass('Modules')
-		);
-	}
-
-	public function testloadClassConfigNotFound()
-	{
-		$this->loader->addNamespace('Config', APPPATH . 'Config');
-		$this->assertFalse($this->loader->loadClass('NotFound'));
+		$this->assertFalse($this->loader->loadClass('Modules'));
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
include_once is not needed on get class with no namespace for `Autoloader::loadClass()` call as it try to get `app\Config` that autoloaded.

**Checklist:**
- [x] Securely signed commits