### PR TITLE
Set WarningsReturnAsErrors = 0 before connection

### DIFF
--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -130,7 +130,6 @@ class Connection extends BaseConnection
 		}
 
 		sqlsrv_configure('WarningsReturnAsErrors', 0);
-		
 		$this->connID = sqlsrv_connect($this->hostname, $connection);
 
 		if ($this->connID !== false)

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -129,12 +129,12 @@ class Connection extends BaseConnection
 			unset($connection['UID'], $connection['PWD']);
 		}
 
+		sqlsrv_configure('WarningsReturnAsErrors', 0);
+		
 		$this->connID = sqlsrv_connect($this->hostname, $connection);
 
 		if ($this->connID !== false)
 		{
-			sqlsrv_configure('WarningsReturnAsErrors', 0);
-
 			// Determine how identifiers are escaped
 			$query = $this->query('SELECT CASE WHEN (@@OPTIONS | 256) = @@OPTIONS THEN 1 ELSE 0 END AS qi');
 			$query = $query->getResultObject();


### PR DESCRIPTION
Description

We have moved `sqlsrv_configure('WarningsReturnAsErrors', 0);` prior to `sqlsrv_connect($this->hostname, $connection)` because if there is a warning or an information message establishing the connection, it will treat it as an error and Codeigniter will throw an exception. Driver's configuration should be set prior the connection.

Example:
Before change, exception shows up (image1): "Unable to connect to the database. Main connection [SQLSRV]: Driver's SQLSetConnectAttr failed", but it is thrown by information message (IM006), as we can see when executing `sqlsrv_errors()` (image2).
Image1:
![before](https://user-images.githubusercontent.com/50045374/120366679-3de14a80-c310-11eb-9155-bb924816e3c0.png)

Image2:
![information message](https://user-images.githubusercontent.com/50045374/120366671-3c178700-c310-11eb-8fad-a0c1320531b4.png)

After change: Connection is established without problems:
![after](https://user-images.githubusercontent.com/50045374/120366676-3d48b400-c310-11eb-9f19-b240e5e8c724.png)


**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
  