### PR TITLE
[Rector] Remove @var from class constant

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -12,7 +12,6 @@ use Rector\CodeQuality\Rector\If_\SimplifyIfReturnBoolRector;
 use Rector\CodeQuality\Rector\Return_\SimplifyUselessVariableRector;
 use Rector\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector;
 use Rector\CodeQualityStrict\Rector\Variable\MoveVariableDeclarationNearReferenceRector;
-use Rector\CodingStyle\Rector\ClassConst\VarConstantCommentRector;
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
@@ -32,6 +31,7 @@ use Rector\Set\ValueObject\SetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Utils\Rector\PassStrictParameterToFunctionParameterRector;
 use Utils\Rector\RemoveErrorSuppressInTryCatchStmtsRector;
+use Utils\Rector\RemoveVarTagFromClassConstantRector;
 use Utils\Rector\UnderscoreToCamelCaseVariableNameRector;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -93,5 +93,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 	$services->set(TernaryToNullCoalescingRector::class);
 	$services->set(ListToArrayDestructRector::class);
 	$services->set(MoveVariableDeclarationNearReferenceRector::class);
-	$services->set(VarConstantCommentRector::class);
+	$services->set(RemoveVarTagFromClassConstantRector::class);
 };

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -24,15 +24,11 @@ abstract class BaseHandler implements CacheInterface
 	/**
 	 * Reserved characters that cannot be used in a key or tag.
 	 * From https://github.com/symfony/cache-contracts/blob/c0446463729b89dd4fa62e9aeecc80287323615d/ItemInterface.php#L43
-	 *
-	 * @var string
 	 */
 	public const RESERVED_CHARACTERS = '{}()/\@:';
 
 	/**
 	 * Maximum key length.
-	 *
-	 * @var int
 	 */
 	public const MAX_KEY_LENGTH = PHP_INT_MAX;
 

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -22,8 +22,6 @@ class FileHandler extends BaseHandler
 {
 	/**
 	 * Maximum key length.
-	 *
-	 * @var int
 	 */
 	public const MAX_KEY_LENGTH = 255;
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -43,14 +43,9 @@ class CodeIgniter
 {
 	/**
 	 * The current version of CodeIgniter Framework
-	 *
-	 * @var string
 	 */
 	const CI_VERSION = '4.1.2';
 
-	/**
-	 * @var string
-	 */
 	private const MIN_PHP_VERSION = '7.3';
 
 	/**

--- a/system/Cookie/CookieInterface.php
+++ b/system/Cookie/CookieInterface.php
@@ -22,8 +22,6 @@ interface CookieInterface
 	 * Cookies will be sent in all contexts, i.e in responses to both
 	 * first-party and cross-origin requests. If `SameSite=None` is set,
 	 * the cookie `Secure` attribute must also be set (or the cookie will be blocked).
-	 *
-	 * @var string
 	 */
 	public const SAMESITE_NONE = 'none';
 
@@ -31,23 +29,17 @@ interface CookieInterface
 	 * Cookies are not sent on normal cross-site subrequests (for example to
 	 * load images or frames into a third party site), but are sent when a
 	 * user is navigating to the origin site (i.e. when following a link).
-	 *
-	 * @var string
 	 */
 	public const SAMESITE_LAX = 'lax';
 
 	/**
 	 * Cookies will only be sent in a first-party context and not be sent
 	 * along with requests initiated by third party websites.
-	 *
-	 * @var string
 	 */
 	public const SAMESITE_STRICT = 'strict';
 
 	/**
 	 * RFC 6265 allowed values for the "SameSite" attribute.
-	 *
-	 * @var string[]
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
 	 */
@@ -59,8 +51,6 @@ interface CookieInterface
 
 	/**
 	 * Expires date format.
-	 *
-	 * @var string
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
 	 * @see https://tools.ietf.org/html/rfc7231#section-7.1.1.2

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -36,271 +36,73 @@ interface ResponseInterface
 	/**
 	 * Constants for status codes.
 	 * From  https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
-	 *
-	 * @var int
 	 */
 	// Informational
-	const HTTP_CONTINUE = 100;
-	/**
-	 * @var int
-	 */
-	const HTTP_SWITCHING_PROTOCOLS = 101;
-	/**
-	 * @var int
-	 */
-	const HTTP_PROCESSING = 102;
-	/**
-	 * @var int
-	 */
-	const HTTP_EARLY_HINTS = 103;
-	// Success
-	/**
-	 * @var int
-	 */
-	const HTTP_OK = 200;
-	/**
-	 * @var int
-	 */
-	const HTTP_CREATED = 201;
-	/**
-	 * @var int
-	 */
-	const HTTP_ACCEPTED = 202;
-	/**
-	 * @var int
-	 */
-	const HTTP_NONAUTHORITATIVE_INFORMATION = 203;
-	/**
-	 * @var int
-	 */
-	const HTTP_NO_CONTENT = 204;
-	/**
-	 * @var int
-	 */
-	const HTTP_RESET_CONTENT = 205;
-	/**
-	 * @var int
-	 */
-	const HTTP_PARTIAL_CONTENT = 206;
-	/**
-	 * @var int
-	 */
-	const HTTP_MULTI_STATUS = 207;
-	/**
-	 * @var int
-	 */
-	const HTTP_ALREADY_REPORTED = 208;
-	/**
-	 * @var int
-	 */
-	const HTTP_IM_USED = 226;
-	// Redirection
-	/**
-	 * @var int
-	 */
-	const HTTP_MULTIPLE_CHOICES = 300;
-	/**
-	 * @var int
-	 */
-	const HTTP_MOVED_PERMANENTLY = 301;
-	/**
-	 * @var int
-	 */
-	const HTTP_FOUND = 302;
-	/**
-	 * @var int
-	 */
-	const HTTP_SEE_OTHER = 303;
-	/**
-	 * @var int
-	 */
-	const HTTP_NOT_MODIFIED = 304;
-	/**
-	 * @var int
-	 */
-	const HTTP_USE_PROXY = 305;
-	/**
-	 * @var int
-	 */
-	const HTTP_SWITCH_PROXY = 306;
-	/**
-	 * @var int
-	 */
-	const HTTP_TEMPORARY_REDIRECT = 307;
-	/**
-	 * @var int
-	 */
-	const HTTP_PERMANENT_REDIRECT = 308;
-	// Client Error
-	/**
-	 * @var int
-	 */
-	const HTTP_BAD_REQUEST = 400;
-	/**
-	 * @var int
-	 */
-	const HTTP_UNAUTHORIZED = 401;
-	/**
-	 * @var int
-	 */
-	const HTTP_PAYMENT_REQUIRED = 402;
-	/**
-	 * @var int
-	 */
-	const HTTP_FORBIDDEN = 403;
-	/**
-	 * @var int
-	 */
-	const HTTP_NOT_FOUND = 404;
-	/**
-	 * @var int
-	 */
-	const HTTP_METHOD_NOT_ALLOWED = 405;
-	/**
-	 * @var int
-	 */
-	const HTTP_NOT_ACCEPTABLE = 406;
-	/**
-	 * @var int
-	 */
-	const HTTP_PROXY_AUTHENTICATION_REQUIRED = 407;
-	/**
-	 * @var int
-	 */
-	const HTTP_REQUEST_TIMEOUT = 408;
-	/**
-	 * @var int
-	 */
-	const HTTP_CONFLICT = 409;
-	/**
-	 * @var int
-	 */
-	const HTTP_GONE = 410;
-	/**
-	 * @var int
-	 */
-	const HTTP_LENGTH_REQUIRED = 411;
-	/**
-	 * @var int
-	 */
-	const HTTP_PRECONDITION_FAILED = 412;
-	/**
-	 * @var int
-	 */
-	const HTTP_PAYLOAD_TOO_LARGE = 413;
-	/**
-	 * @var int
-	 */
-	const HTTP_URI_TOO_LONG = 414;
-	/**
-	 * @var int
-	 */
-	const HTTP_UNSUPPORTED_MEDIA_TYPE = 415;
-	/**
-	 * @var int
-	 */
-	const HTTP_RANGE_NOT_SATISFIABLE = 416;
-	/**
-	 * @var int
-	 */
-	const HTTP_EXPECTATION_FAILED = 417;
-	/**
-	 * @var int
-	 */
-	const HTTP_IM_A_TEAPOT = 418;
-	/**
-	 * @var int
-	 */
-	const HTTP_MISDIRECTED_REQUEST = 421;
-	/**
-	 * @var int
-	 */
-	const HTTP_UNPROCESSABLE_ENTITY = 422;
-	/**
-	 * @var int
-	 */
-	const HTTP_LOCKED = 423;
-	/**
-	 * @var int
-	 */
-	const HTTP_FAILED_DEPENDENCY = 424;
-	/**
-	 * @var int
-	 */
-	const HTTP_TOO_EARLY = 425;
-	/**
-	 * @var int
-	 */
-	const HTTP_UPGRADE_REQUIRED = 426;
-	/**
-	 * @var int
-	 */
-	const HTTP_PRECONDITION_REQUIRED = 428;
-	/**
-	 * @var int
-	 */
-	const HTTP_TOO_MANY_REQUESTS = 429;
-	/**
-	 * @var int
-	 */
+	const HTTP_CONTINUE                        = 100;
+	const HTTP_SWITCHING_PROTOCOLS             = 101;
+	const HTTP_PROCESSING                      = 102;
+	const HTTP_EARLY_HINTS                     = 103;
+	const HTTP_OK                              = 200;
+	const HTTP_CREATED                         = 201;
+	const HTTP_ACCEPTED                        = 202;
+	const HTTP_NONAUTHORITATIVE_INFORMATION    = 203;
+	const HTTP_NO_CONTENT                      = 204;
+	const HTTP_RESET_CONTENT                   = 205;
+	const HTTP_PARTIAL_CONTENT                 = 206;
+	const HTTP_MULTI_STATUS                    = 207;
+	const HTTP_ALREADY_REPORTED                = 208;
+	const HTTP_IM_USED                         = 226;
+	const HTTP_MULTIPLE_CHOICES                = 300;
+	const HTTP_MOVED_PERMANENTLY               = 301;
+	const HTTP_FOUND                           = 302;
+	const HTTP_SEE_OTHER                       = 303;
+	const HTTP_NOT_MODIFIED                    = 304;
+	const HTTP_USE_PROXY                       = 305;
+	const HTTP_SWITCH_PROXY                    = 306;
+	const HTTP_TEMPORARY_REDIRECT              = 307;
+	const HTTP_PERMANENT_REDIRECT              = 308;
+	const HTTP_BAD_REQUEST                     = 400;
+	const HTTP_UNAUTHORIZED                    = 401;
+	const HTTP_PAYMENT_REQUIRED                = 402;
+	const HTTP_FORBIDDEN                       = 403;
+	const HTTP_NOT_FOUND                       = 404;
+	const HTTP_METHOD_NOT_ALLOWED              = 405;
+	const HTTP_NOT_ACCEPTABLE                  = 406;
+	const HTTP_PROXY_AUTHENTICATION_REQUIRED   = 407;
+	const HTTP_REQUEST_TIMEOUT                 = 408;
+	const HTTP_CONFLICT                        = 409;
+	const HTTP_GONE                            = 410;
+	const HTTP_LENGTH_REQUIRED                 = 411;
+	const HTTP_PRECONDITION_FAILED             = 412;
+	const HTTP_PAYLOAD_TOO_LARGE               = 413;
+	const HTTP_URI_TOO_LONG                    = 414;
+	const HTTP_UNSUPPORTED_MEDIA_TYPE          = 415;
+	const HTTP_RANGE_NOT_SATISFIABLE           = 416;
+	const HTTP_EXPECTATION_FAILED              = 417;
+	const HTTP_IM_A_TEAPOT                     = 418;
+	const HTTP_MISDIRECTED_REQUEST             = 421;
+	const HTTP_UNPROCESSABLE_ENTITY            = 422;
+	const HTTP_LOCKED                          = 423;
+	const HTTP_FAILED_DEPENDENCY               = 424;
+	const HTTP_TOO_EARLY                       = 425;
+	const HTTP_UPGRADE_REQUIRED                = 426;
+	const HTTP_PRECONDITION_REQUIRED           = 428;
+	const HTTP_TOO_MANY_REQUESTS               = 429;
 	const HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
-	/**
-	 * @var int
-	 */
-	const HTTP_UNAVAILABLE_FOR_LEGAL_REASONS = 451;
-	/**
-	 * @var int
-	 */
-	const HTTP_CLIENT_CLOSED_REQUEST = 499;
-	// Server Error
-	/**
-	 * @var int
-	 */
-	const HTTP_INTERNAL_SERVER_ERROR = 500;
-	/**
-	 * @var int
-	 */
-	const HTTP_NOT_IMPLEMENTED = 501;
-	/**
-	 * @var int
-	 */
-	const HTTP_BAD_GATEWAY = 502;
-	/**
-	 * @var int
-	 */
-	const HTTP_SERVICE_UNAVAILABLE = 503;
-	/**
-	 * @var int
-	 */
-	const HTTP_GATEWAY_TIMEOUT = 504;
-	/**
-	 * @var int
-	 */
-	const HTTP_HTTP_VERSION_NOT_SUPPORTED = 505;
-	/**
-	 * @var int
-	 */
-	const HTTP_VARIANT_ALSO_NEGOTIATES = 506;
-	/**
-	 * @var int
-	 */
-	const HTTP_INSUFFICIENT_STORAGE = 507;
-	/**
-	 * @var int
-	 */
-	const HTTP_LOOP_DETECTED = 508;
-	/**
-	 * @var int
-	 */
-	const HTTP_NOT_EXTENDED = 510;
-	/**
-	 * @var int
-	 */
+	const HTTP_UNAVAILABLE_FOR_LEGAL_REASONS   = 451;
+	const HTTP_CLIENT_CLOSED_REQUEST           = 499;
+	const HTTP_INTERNAL_SERVER_ERROR           = 500;
+	const HTTP_NOT_IMPLEMENTED                 = 501;
+	const HTTP_BAD_GATEWAY                     = 502;
+	const HTTP_SERVICE_UNAVAILABLE             = 503;
+	const HTTP_GATEWAY_TIMEOUT                 = 504;
+	const HTTP_HTTP_VERSION_NOT_SUPPORTED      = 505;
+	const HTTP_VARIANT_ALSO_NEGOTIATES         = 506;
+	const HTTP_INSUFFICIENT_STORAGE            = 507;
+	const HTTP_LOOP_DETECTED                   = 508;
+	const HTTP_NOT_EXTENDED                    = 510;
 	const HTTP_NETWORK_AUTHENTICATION_REQUIRED = 511;
-	/**
-	 * @var int
-	 */
-	const HTTP_NETWORK_CONNECT_TIMEOUT_ERROR = 599;
+	const HTTP_NETWORK_CONNECT_TIMEOUT_ERROR   = 599;
 
 	/**
 	 * Gets the response status code.

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -21,15 +21,11 @@ class URI
 {
 	/**
 	 * Sub-delimiters used in query strings and fragments.
-	 *
-	 * @var string
 	 */
 	const CHAR_SUB_DELIMS = '!\$&\'\(\)\*\+,;=';
 
 	/**
 	 * Unreserved characters used in paths, query strings, and fragments.
-	 *
-	 * @var string
 	 */
 	const CHAR_UNRESERVED = 'a-zA-Z0-9_\-\.~';
 

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -26,8 +26,6 @@ class ChromeLoggerHandler extends BaseHandler
 {
 	/**
 	 * Version of this library - for ChromeLogger use.
-	 *
-	 * @var float
 	 */
 	const VERSION = 1.0;
 

--- a/system/Log/Handlers/ErrorlogHandler.php
+++ b/system/Log/Handlers/ErrorlogHandler.php
@@ -22,15 +22,11 @@ class ErrorlogHandler extends BaseHandler
 	 * Message is sent to PHP's system logger, using the Operating System's
 	 * system logging mechanism or a file, depending on what the error_log
 	 * configuration directive is set to.
-	 *
-	 * @var int
 	 */
 	public const TYPE_OS = 0;
 
 	/**
 	 * Message is sent directly to the SAPI logging handler.
-	 *
-	 * @var int
 	 */
 	public const TYPE_SAPI = 4;
 

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -9,13 +9,7 @@ use Tests\Support\Validation\TestRules;
 class FormatRulesTest extends CIUnitTestCase
 {
 
-	/**
-	 * @var string
-	 */
-	const ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ';
-	/**
-	 * @var string
-	 */
+	const ALPHABET     = 'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ';
 	const ALPHANUMERIC = 'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ0123456789';
 
 	/**

--- a/utils/Rector/PassStrictParameterToFunctionParameterRector.php
+++ b/utils/Rector/PassStrictParameterToFunctionParameterRector.php
@@ -18,9 +18,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class PassStrictParameterToFunctionParameterRector extends AbstractRector
 {
-	/**
-	 * @var array<string, int>
-	 */
 	private const FUNCTION_WITH_ARG_POSITION = [
 		// position start from 0
 		'array_search'  => 2,

--- a/utils/Rector/RemoveVarTagFromClassConstantRector.php
+++ b/utils/Rector/RemoveVarTagFromClassConstantRector.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassConst;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+
+final class RemoveVarTagFromClassConstantRector extends AbstractRector
+{
+	public function getRuleDefinition(): RuleDefinition
+	{
+		return new RuleDefinition('Remove @var tag from class constant', [
+			new CodeSample(
+				<<<'CODE_SAMPLE'
+				class Foo
+				{
+					/** @var string */
+					const X = 'test';
+				}
+				CODE_SAMPLE,
+				<<<'CODE_SAMPLE'
+				class Foo
+				{
+					const X = 'test';
+				}
+				CODE_SAMPLE
+			),
+		]);
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getNodeTypes(): array
+	{
+		return [ClassConst::class];
+	}
+
+	/**
+	 * @param ClassConst $node
+	 */
+	public function refactor(Node $node): ?Node
+	{
+		$phpDocInfo      = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+		$varTagValueNode = $phpDocInfo->getVarTagValueNode();
+		if (! $varTagValueNode instanceof VarTagValueNode)
+		{
+			return null;
+		}
+
+		$phpDocInfo->removeByType(VarTagValueNode::class);
+		return $node;
+	}
+}

--- a/utils/Rector/UnderscoreToCamelCaseVariableNameRector.php
+++ b/utils/Rector/UnderscoreToCamelCaseVariableNameRector.php
@@ -24,7 +24,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
 {
 	/**
-	 * @var string
 	 * @see https://regex101.com/r/OtFn8I/1
 	 */
 	private const PARAM_NAME_REGEX = '#(?<paramPrefix>@param\s.*\s+\$)(?<paramName>%s)#ms';


### PR DESCRIPTION
I created new custom rector rule `RemoveVarTagFromClassConstantRector` to remove `@var` from class const per this discussion https://github.com/codeigniter4/CodeIgniter4/pull/4759#issuecomment-852125720

**Checklist:**
- [x] Securely signed commits
