### PR TITLE
Expand Query named binds recognition

### DIFF
--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -315,13 +315,13 @@ class Query implements QueryInterface
 	 *
 	 * @return void
 	 *
-	 * @see https://regex101.com/r/EUEhay/1 Test
+	 * @see https://regex101.com/r/EUEhay/2
 	 */
 	protected function compileBinds()
 	{
 		$sql = $this->finalQueryString;
 
-		$hasNamedBinds = preg_match('/:[a-z\d.)_(]+:/i', $sql) === 1;
+		$hasNamedBinds = preg_match('/:(.+):/', $sql) === 1;
 
 		if (empty($this->binds)
 			|| empty($this->bindMarker)


### PR DESCRIPTION
**Description**
Fixes #4760 
Replaces and closes #4764 

This expands Query's named binds regular expression to include the widest possible pattern. Besides, named binds in CI4 are constructed by enclosing the key in `:` so this should work in most cases.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
