### PR TITLE
Expand Query named binds recognition

### DIFF
--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -315,13 +315,13 @@ class Query implements QueryInterface
 	 *
 	 * @return void
 	 *
-	 * @see https://regex101.com/r/EUEhay/1 Test
+	 * @see https://regex101.com/r/EUEhay/4
 	 */
 	protected function compileBinds()
 	{
 		$sql = $this->finalQueryString;
 
-		$hasNamedBinds = preg_match('/:[a-z\d.)_(]+:/i', $sql) === 1;
+		$hasNamedBinds = preg_match('/:((?!=).+):/', $sql) === 1;
 
 		if (empty($this->binds)
 			|| empty($this->bindMarker)


### PR DESCRIPTION
**Description**
Another pass to fixing named binds recognition by adding a negative lookahead for `:=` types.

Fixes #4760 .
Supersedes and closes #4764 

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide
