### PR TITLE
[CS Migration]PSR12 rules starting with "b"

### DIFF
--- a/admin/module/tests/_support/Database/Migrations/2020-02-22-222222_example_migration.php
+++ b/admin/module/tests/_support/Database/Migrations/2020-02-22-222222_example_migration.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Database\Migrations;
+<?php
+
+namespace Tests\Support\Database\Migrations;
 
 use CodeIgniter\Database\Migration;
 

--- a/admin/module/tests/_support/Database/Seeds/ExampleSeeder.php
+++ b/admin/module/tests/_support/Database/Seeds/ExampleSeeder.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Database\Seeds;
+<?php
+
+namespace Tests\Support\Database\Seeds;
 
 use CodeIgniter\Database\Seeder;
 

--- a/admin/module/tests/_support/DatabaseTestCase.php
+++ b/admin/module/tests/_support/DatabaseTestCase.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support;
+<?php
+
+namespace Tests\Support;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/admin/module/tests/_support/DatabaseTestCase.php
+++ b/admin/module/tests/_support/DatabaseTestCase.php
@@ -1,4 +1,5 @@
 <?php namespace Tests\Support;
+
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 

--- a/admin/module/tests/_support/Models/ExampleModel.php
+++ b/admin/module/tests/_support/Models/ExampleModel.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Models;
+<?php
+
+namespace Tests\Support\Models;
 
 use CodeIgniter\Model;
 

--- a/admin/module/tests/_support/SessionTestCase.php
+++ b/admin/module/tests/_support/SessionTestCase.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support;
+<?php
+
+namespace Tests\Support;
 
 use CodeIgniter\Session\Handlers\ArrayHandler;
 use CodeIgniter\Session\SessionInterface;

--- a/admin/starter/tests/_support/Database/Migrations/2020-02-22-222222_example_migration.php
+++ b/admin/starter/tests/_support/Database/Migrations/2020-02-22-222222_example_migration.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Database\Migrations;
+<?php
+
+namespace Tests\Support\Database\Migrations;
 
 use CodeIgniter\Database\Migration;
 

--- a/admin/starter/tests/_support/Database/Seeds/ExampleSeeder.php
+++ b/admin/starter/tests/_support/Database/Seeds/ExampleSeeder.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Database\Seeds;
+<?php
+
+namespace Tests\Support\Database\Seeds;
 
 use CodeIgniter\Database\Seeder;
 

--- a/admin/starter/tests/_support/DatabaseTestCase.php
+++ b/admin/starter/tests/_support/DatabaseTestCase.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support;
+<?php
+
+namespace Tests\Support;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/admin/starter/tests/_support/Models/ExampleModel.php
+++ b/admin/starter/tests/_support/Models/ExampleModel.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Models;
+<?php
+
+namespace Tests\Support\Models;
 
 use CodeIgniter\Model;
 

--- a/admin/starter/tests/_support/SessionTestCase.php
+++ b/admin/starter/tests/_support/SessionTestCase.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support;
+<?php
+
+namespace Tests\Support;
 
 use CodeIgniter\Session\Handlers\ArrayHandler;
 use CodeIgniter\Session\SessionInterface;

--- a/tests/_support/Commands/AbstractInfo.php
+++ b/tests/_support/Commands/AbstractInfo.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tests\Support\Commands;
 
 use CodeIgniter\CLI\BaseCommand;

--- a/tests/_support/Commands/AppInfo.php
+++ b/tests/_support/Commands/AppInfo.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tests\Support\Commands;
 
 use CodeIgniter\CLI\BaseCommand;

--- a/tests/_support/Commands/InvalidCommand.php
+++ b/tests/_support/Commands/InvalidCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tests\Support\Commands;
 
 use CodeIgniter\CLI\BaseCommand;

--- a/tests/_support/Config/BadRegistrar.php
+++ b/tests/_support/Config/BadRegistrar.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Config;
+<?php
+
+namespace Tests\Support\Config;
 
 /**
  * Class BadRegistrar

--- a/tests/_support/Config/Filters.php
+++ b/tests/_support/Config/Filters.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tests\Support\Config\Filters;
 
 $filters->aliases['test-customfilter'] = \Tests\Support\Filters\Customfilter::class;

--- a/tests/_support/Config/Routes.php
+++ b/tests/_support/Config/Routes.php
@@ -1,4 +1,5 @@
 <?php namespace Tests\Support\Config;
+
 /**
  * This is a simple file to include for testing the RouteCollection class.
  */

--- a/tests/_support/Config/Routes.php
+++ b/tests/_support/Config/Routes.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Config;
+<?php
+
+namespace Tests\Support\Config;
 
 /**
  * This is a simple file to include for testing the RouteCollection class.

--- a/tests/_support/Config/TestRegistrar.php
+++ b/tests/_support/Config/TestRegistrar.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Config;
+<?php
+
+namespace Tests\Support\Config;
 
 /**
  * Class Registrar

--- a/tests/_support/Controllers/Hello.php
+++ b/tests/_support/Controllers/Hello.php
@@ -1,4 +1,6 @@
-<?php namespace App\Controllers;
+<?php
+
+namespace App\Controllers;
 
 use CodeIgniter\Controller;
 

--- a/tests/_support/Controllers/Popcorn.php
+++ b/tests/_support/Controllers/Popcorn.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tests\Support\Controllers;
 
 use CodeIgniter\API\ResponseTrait;

--- a/tests/_support/Filters/Customfilter.php
+++ b/tests/_support/Filters/Customfilter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tests\Support\Filters;
 
 use CodeIgniter\HTTP\RequestInterface;

--- a/tests/_support/Helpers/baguette_helper.php
+++ b/tests/_support/Helpers/baguette_helper.php
@@ -1,2 +1,3 @@
 <?php
+
 // You did it!

--- a/tests/_support/Language/SecondMockLanguage.php
+++ b/tests/_support/Language/SecondMockLanguage.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Language;
+<?php
+
+namespace Tests\Support\Language;
 
 use CodeIgniter\Language\Language;
 

--- a/tests/_support/Language/ab-CD/Allin.php
+++ b/tests/_support/Language/ab-CD/Allin.php
@@ -1,4 +1,5 @@
 <?php
+
 // seven wonders of the ancient world
 return [
     'one' => 'Pyramid of Giza',

--- a/tests/_support/Language/ab/Allin.php
+++ b/tests/_support/Language/ab/Allin.php
@@ -1,4 +1,5 @@
 <?php
+
 // seven deadly sins
 return [
     'two' => 'gluttony',

--- a/tests/_support/Language/en-ZZ/More.php
+++ b/tests/_support/Language/en-ZZ/More.php
@@ -1,4 +1,5 @@
 <?php
+
 return [
     'strongForce' => 'These are not the droids you are looking for',
     'notaMoon'    => "It's made of cheese",

--- a/tests/_support/Language/en/Allin.php
+++ b/tests/_support/Language/en/Allin.php
@@ -1,4 +1,5 @@
 <?php
+
 // 12 days of Christmas
 return [
     'for' => 'four calling birds',

--- a/tests/_support/Log/Handlers/TestHandler.php
+++ b/tests/_support/Log/Handlers/TestHandler.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Log\Handlers;
+<?php
+
+namespace Tests\Support\Log\Handlers;
 
 /**
  * Class TestHandler

--- a/tests/_support/MigrationTestMigrations/Database/Migrations/2018-01-24-102301_Some_migration.php
+++ b/tests/_support/MigrationTestMigrations/Database/Migrations/2018-01-24-102301_Some_migration.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\MigrationTestMigrations\Database\Migrations;
+<?php
+
+namespace Tests\Support\MigrationTestMigrations\Database\Migrations;
 
 class Migration_some_migration extends \CodeIgniter\Database\Migration
 {

--- a/tests/_support/MigrationTestMigrations/Database/Migrations/2018-01-24-102302_Another_migration.php
+++ b/tests/_support/MigrationTestMigrations/Database/Migrations/2018-01-24-102302_Another_migration.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\MigrationTestMigrations\Database\Migrations;
+<?php
+
+namespace Tests\Support\MigrationTestMigrations\Database\Migrations;
 
 class Migration_another_migration extends \CodeIgniter\Database\Migration
 {

--- a/tests/_support/Models/EntityModel.php
+++ b/tests/_support/Models/EntityModel.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Models;
+<?php
+
+namespace Tests\Support\Models;
 
 use CodeIgniter\Model;
 

--- a/tests/_support/Models/EventModel.php
+++ b/tests/_support/Models/EventModel.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Models;
+<?php
+
+namespace Tests\Support\Models;
 
 use CodeIgniter\Model;
 

--- a/tests/_support/Models/FabricatorModel.php
+++ b/tests/_support/Models/FabricatorModel.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Models;
+<?php
+
+namespace Tests\Support\Models;
 
 use CodeIgniter\Model;
 use Faker\Generator;

--- a/tests/_support/Models/JobModel.php
+++ b/tests/_support/Models/JobModel.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Models;
+<?php
+
+namespace Tests\Support\Models;
 
 use CodeIgniter\Model;
 

--- a/tests/_support/Models/SecondaryModel.php
+++ b/tests/_support/Models/SecondaryModel.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Models;
+<?php
+
+namespace Tests\Support\Models;
 
 use CodeIgniter\Model;
 

--- a/tests/_support/Models/StringifyPkeyModel.php
+++ b/tests/_support/Models/StringifyPkeyModel.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Models;
+<?php
+
+namespace Tests\Support\Models;
 
 use CodeIgniter\Model;
 

--- a/tests/_support/Models/UserModel.php
+++ b/tests/_support/Models/UserModel.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Models;
+<?php
+
+namespace Tests\Support\Models;
 
 use CodeIgniter\Model;
 

--- a/tests/_support/Models/ValidErrorsModel.php
+++ b/tests/_support/Models/ValidErrorsModel.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Models;
+<?php
+
+namespace Tests\Support\Models;
 
 use CodeIgniter\Model;
 

--- a/tests/_support/Models/ValidModel.php
+++ b/tests/_support/Models/ValidModel.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Models;
+<?php
+
+namespace Tests\Support\Models;
 
 use CodeIgniter\Model;
 

--- a/tests/_support/RESTful/Worker.php
+++ b/tests/_support/RESTful/Worker.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tests\Support\RESTful;
 
 use CodeIgniter\RESTful\ResourceController;

--- a/tests/_support/RESTful/Worker2.php
+++ b/tests/_support/RESTful/Worker2.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tests\Support\RESTful;
 
 use CodeIgniter\RESTful\ResourcePresenter;

--- a/tests/_support/Services.php
+++ b/tests/_support/Services.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter;
+<?php
+
+namespace CodeIgniter;
 
 use CIUnitTestCase;
 use Config\Services as ConfigServices;

--- a/tests/_support/Validation/TestRules.php
+++ b/tests/_support/Validation/TestRules.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\Validation;
+<?php
+
+namespace Tests\Support\Validation;
 
 class TestRules {
 

--- a/tests/_support/View/SampleClass.php
+++ b/tests/_support/View/SampleClass.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\View;
+<?php
+
+namespace Tests\Support\View;
 
 /**
  * Class SampleClass

--- a/tests/_support/View/SampleClassWithInitController.php
+++ b/tests/_support/View/SampleClassWithInitController.php
@@ -1,4 +1,6 @@
-<?php namespace Tests\Support\View;
+<?php
+
+namespace Tests\Support\View;
 
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\API;
 
 use CodeIgniter\Format\JSONFormatter;

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Autoloader;
+<?php
+
+namespace CodeIgniter\Autoloader;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Autoload;

--- a/tests/system/Cache/CacheFactoryTest.php
+++ b/tests/system/Cache/CacheFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Cache;
 
 use CodeIgniter\Cache\Handlers\DummyHandler;

--- a/tests/system/Cache/Handlers/BaseHandlerTest.php
+++ b/tests/system/Cache/Handlers/BaseHandlerTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Cache\Handlers;
+<?php
+
+namespace CodeIgniter\Cache\Handlers;
 
 use stdClass;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Cache/Handlers/DummyHandlerTest.php
+++ b/tests/system/Cache/Handlers/DummyHandlerTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Cache\Handlers;
+<?php
+
+namespace CodeIgniter\Cache\Handlers;
 
 use CodeIgniter\Test\CIUnitTestCase;
 

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter;
+<?php
+
+namespace CodeIgniter;
 
 use \CodeIgniter\Config\Services;
 use CodeIgniter\Router\RouteCollection;

--- a/tests/system/Commands/BaseCommandTest.php
+++ b/tests/system/Commands/BaseCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\CLI\CommandRunner;

--- a/tests/system/Commands/ClearCacheTest.php
+++ b/tests/system/Commands/ClearCacheTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Commands;
+<?php
+
+namespace CodeIgniter\Commands;
 
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Config/ConfigTest.php
+++ b/tests/system/Config/ConfigTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Config;
 
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter;
+<?php
+
+namespace CodeIgniter;
 
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Request;

--- a/tests/system/Database/Builder/AliasTest.php
+++ b/tests/system/Database/Builder/AliasTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;

--- a/tests/system/Database/Builder/BaseTest.php
+++ b/tests/system/Database/Builder/BaseTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\Query;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Builder/CountTest.php
+++ b/tests/system/Database/Builder/CountTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Builder/DistinctTest.php
+++ b/tests/system/Database/Builder/DistinctTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Builder/EmptyTest.php
+++ b/tests/system/Database/Builder/EmptyTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\SQLSRV\Builder as SQLSRVBuilder;

--- a/tests/system/Database/Builder/GetTest.php
+++ b/tests/system/Database/Builder/GetTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;

--- a/tests/system/Database/Builder/GroupTest.php
+++ b/tests/system/Database/Builder/GroupTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\Query;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Builder/JoinTest.php
+++ b/tests/system/Database/Builder/JoinTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Postgre\Builder as PostgreBuilder;

--- a/tests/system/Database/Builder/LikeTest.php
+++ b/tests/system/Database/Builder/LikeTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Builder/LimitTest.php
+++ b/tests/system/Database/Builder/LimitTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Builder/OrderTest.php
+++ b/tests/system/Database/Builder/OrderTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Builder/PrefixTest.php
+++ b/tests/system/Database/Builder/PrefixTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;

--- a/tests/system/Database/Builder/ReplaceTest.php
+++ b/tests/system/Database/Builder/ReplaceTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DataException;

--- a/tests/system/Database/Builder/TruncateTest.php
+++ b/tests/system/Database/Builder/TruncateTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Builder;
+<?php
+
+namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Database;
 
 use CodeIgniter\Database\BaseConnection;

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\DatabaseTestCase;
+<?php
+
+namespace CodeIgniter\Database\DatabaseTestCase;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\DatabaseTestCase;
+<?php
+
+namespace CodeIgniter\Database\DatabaseTestCase;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database;
+<?php
+
+namespace CodeIgniter\Database;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/AliasTest.php
+++ b/tests/system/Database/Live/AliasTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/BadQueryTest.php
+++ b/tests/system/Database/Live/BadQueryTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\SQLite3\Connection;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Live/CountTest.php
+++ b/tests/system/Database/Live/CountTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/DEBugTest.php
+++ b/tests/system/Database/Live/DEBugTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/DatabaseTestTraitCaseTest.php
+++ b/tests/system/Database/Live/DatabaseTestTraitCaseTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/DeleteTest.php
+++ b/tests/system/Database/Live/DeleteTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Live/EmptyTest.php
+++ b/tests/system/Database/Live/EmptyTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/EscapeTest.php
+++ b/tests/system/Database/Live/EscapeTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/FabricatorLiveTest.php
+++ b/tests/system/Database/Live/FabricatorLiveTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Live/FromTest.php
+++ b/tests/system/Database/Live/FromTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/GetNumRowsTest.php
+++ b/tests/system/Database/Live/GetNumRowsTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/IncrementTest.php
+++ b/tests/system/Database/Live/IncrementTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/JoinTest.php
+++ b/tests/system/Database/Live/JoinTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/LimitTest.php
+++ b/tests/system/Database/Live/LimitTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/PretendTest.php
+++ b/tests/system/Database/Live/PretendTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\Query;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live\SQLite;
+<?php
+
+namespace CodeIgniter\Database\Live\SQLite;
 
 use CodeIgniter\Database\SQLite3\Connection;
 use CodeIgniter\Database\SQLite3\Forge;

--- a/tests/system/Database/Live/SelectTest.php
+++ b/tests/system/Database/Live/SelectTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/Live/WhereTest.php
+++ b/tests/system/Database/Live/WhereTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Database/Live/WriteTypeQueryTest.php
+++ b/tests/system/Database/Live/WriteTypeQueryTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database\Live;
+<?php
+
+namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Database/ModelFactoryTest.php
+++ b/tests/system/Database/ModelFactoryTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Database;
+<?php
+
+namespace CodeIgniter\Database;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Debug;
+<?php
+
+namespace CodeIgniter\Debug;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Email;
+<?php
+
+namespace CodeIgniter\Email;
 
 use CodeIgniter\Events\Events;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Files;
+<?php
+
+namespace CodeIgniter\Files;
 
 use CodeIgniter\Test\CIUnitTestCase;
 

--- a/tests/system/Files/FileWithVfsTest.php
+++ b/tests/system/Files/FileWithVfsTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Files;
+<?php
+
+namespace CodeIgniter\Files;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use org\bovigo\vfs\vfsStream;

--- a/tests/system/Filters/CSRFTest.php
+++ b/tests/system/Filters/CSRFTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Filters;
 
 use CodeIgniter\Config\Services;

--- a/tests/system/Filters/DebugToolbarTest.php
+++ b/tests/system/Filters/DebugToolbarTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Filters;
 
 use CodeIgniter\Config\Services;

--- a/tests/system/Filters/HoneypotTest.php
+++ b/tests/system/Filters/HoneypotTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Filters;
 
 use CodeIgniter\Config\Services;

--- a/tests/system/Filters/fixtures/GoogleCurious.php
+++ b/tests/system/Filters/fixtures/GoogleCurious.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Filters\fixtures;
+<?php
+
+namespace CodeIgniter\Filters\fixtures;
 
 use CodeIgniter\Filters\FilterInterface;
 use CodeIgniter\HTTP\RequestInterface;

--- a/tests/system/Filters/fixtures/GoogleEmpty.php
+++ b/tests/system/Filters/fixtures/GoogleEmpty.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Filters\fixtures;
+<?php
+
+namespace CodeIgniter\Filters\fixtures;
 
 use CodeIgniter\Filters\FilterInterface;
 use CodeIgniter\HTTP\RequestInterface;

--- a/tests/system/Filters/fixtures/GoogleMe.php
+++ b/tests/system/Filters/fixtures/GoogleMe.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Filters\fixtures;
+<?php
+
+namespace CodeIgniter\Filters\fixtures;
 
 use CodeIgniter\Filters\FilterInterface;
 use CodeIgniter\HTTP\RequestInterface;

--- a/tests/system/Filters/fixtures/GoogleYou.php
+++ b/tests/system/Filters/fixtures/GoogleYou.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Filters\fixtures;
+<?php
+
+namespace CodeIgniter\Filters\fixtures;
 
 use CodeIgniter\Config\Services;
 use CodeIgniter\Filters\FilterInterface;

--- a/tests/system/Filters/fixtures/InvalidClass.php
+++ b/tests/system/Filters/fixtures/InvalidClass.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Filters\fixtures;
+<?php
+
+namespace CodeIgniter\Filters\fixtures;
 
 class InvalidClass
 {

--- a/tests/system/Filters/fixtures/Multiple1.php
+++ b/tests/system/Filters/fixtures/Multiple1.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Filters\fixtures;
+<?php
+
+namespace CodeIgniter\Filters\fixtures;
 
 use CodeIgniter\Filters\FilterInterface;
 use CodeIgniter\HTTP\RequestInterface;

--- a/tests/system/Filters/fixtures/Multiple2.php
+++ b/tests/system/Filters/fixtures/Multiple2.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Filters\fixtures;
+<?php
+
+namespace CodeIgniter\Filters\fixtures;
 
 use CodeIgniter\Filters\FilterInterface;
 use CodeIgniter\HTTP\RequestInterface;

--- a/tests/system/Format/JSONFormatterTest.php
+++ b/tests/system/Format/JSONFormatterTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Format;
+<?php
+
+namespace CodeIgniter\Format;
 
 use CodeIgniter\Test\CIUnitTestCase;
 

--- a/tests/system/Format/XMLFormatterTest.php
+++ b/tests/system/Format/XMLFormatterTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Format;
+<?php
+
+namespace CodeIgniter\Format;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use DOMDocument;

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Exceptions\DownloadException;

--- a/tests/system/HTTP/Files/FileCollectionTest.php
+++ b/tests/system/HTTP/Files/FileCollectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\HTTP\Files;
 
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\HTTP\Files;
 
 use CodeIgniter\HTTP\Exceptions\HTTPException;

--- a/tests/system/HTTP/HeaderTest.php
+++ b/tests/system/HTTP/HeaderTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\HTTP;
+<?php
+
+namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use stdClass;

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\HTTP\Exceptions\HTTPException;

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/HTTP/ResponseCookieTest.php
+++ b/tests/system/HTTP/ResponseCookieTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Cookie\Cookie;

--- a/tests/system/HTTP/ResponseSendTest.php
+++ b/tests/system/HTTP/ResponseSendTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/HTTP/UserAgentTest.php
+++ b/tests/system/HTTP/UserAgentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\HTTP\UserAgent;

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Helpers;
 
 use CodeIgniter\Cookie\Exceptions\CookieException;

--- a/tests/system/Helpers/DateHelperTest.php
+++ b/tests/system/Helpers/DateHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Helpers;
 
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Helpers;
 
 use CodeIgniter\Files\Exceptions\FileNotFoundException;

--- a/tests/system/Helpers/InflectorHelperTest.php
+++ b/tests/system/Helpers/InflectorHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Helpers;
 
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Helpers/NumberHelperTest.php
+++ b/tests/system/Helpers/NumberHelperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Helpers;
 
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Helpers/SecurityHelperTest.php
+++ b/tests/system/Helpers/SecurityHelperTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Helpers;
+<?php
+
+namespace CodeIgniter\Helpers;
 
 use CodeIgniter\Test\CIUnitTestCase;
 

--- a/tests/system/I18n/TimeDifferenceTest.php
+++ b/tests/system/I18n/TimeDifferenceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\I18n;
 
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\I18n;
 
 use CodeIgniter\I18n\Exceptions\I18nException;

--- a/tests/system/Images/BaseHandlerTest.php
+++ b/tests/system/Images/BaseHandlerTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Images;
+<?php
+
+namespace CodeIgniter\Images;
 
 use CodeIgniter\Config\Services;
 use CodeIgniter\Files\Exceptions\FileNotFoundException;

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Images;
+<?php
+
+namespace CodeIgniter\Images;
 
 use CodeIgniter\Config\Services;
 use CodeIgniter\Images\Exceptions\ImageException;

--- a/tests/system/Images/ImageMagickHandlerTest.php
+++ b/tests/system/Images/ImageMagickHandlerTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Images;
+<?php
+
+namespace CodeIgniter\Images;
 
 use Imagick;
 use CodeIgniter\Config\Services;

--- a/tests/system/Images/ImageTest.php
+++ b/tests/system/Images/ImageTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Images;
+<?php
+
+namespace CodeIgniter\Images;
 
 use CodeIgniter\Images\Exceptions\ImageException;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
+++ b/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Log\Handlers;
+<?php
+
+namespace CodeIgniter\Log\Handlers;
 
 use CodeIgniter\Services;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Log/Handlers/FileHandlerTest.php
+++ b/tests/system/Log/Handlers/FileHandlerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Log\Handlers;
 
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Log;
+<?php
+
+namespace CodeIgniter\Log;
 
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\Log\Exceptions\LogException;

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Pager;
+<?php
+
+namespace CodeIgniter\Pager;
 
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Pager\Exceptions\PagerException;

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\RESTful;
 
 use CodeIgniter\CodeIgniter;

--- a/tests/system/RESTful/ResourcePresenterTest.php
+++ b/tests/system/RESTful/ResourcePresenterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\RESTful;
 
 use CodeIgniter\CodeIgniter;

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Router;
 
 use CodeIgniter\Config\Services;

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Router;
 
 use CodeIgniter\Config\Services;

--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Test;
+<?php
+
+namespace CodeIgniter\Test;
 
 /**
  * Class BootstrapFCPATHTest

--- a/tests/system/Test/ControllerTestTraitTest.php
+++ b/tests/system/Test/ControllerTestTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Test;
 
 use App\Controllers\NeverHeardOfIt;

--- a/tests/system/Test/DOMParserTest.php
+++ b/tests/system/Test/DOMParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Test;
 
 use InvalidArgumentException;

--- a/tests/system/Test/FabricatorTest.php
+++ b/tests/system/Test/FabricatorTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Test;
+<?php
+
+namespace CodeIgniter\Test;
 
 use CodeIgniter\Database\ModelFactory;
 use CodeIgniter\Test\CIUnitTestCase;

--- a/tests/system/Test/ReflectionHelperTest.php
+++ b/tests/system/Test/ReflectionHelperTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Test;
+<?php
+
+namespace CodeIgniter\Test;
 
 class ReflectionHelperTest extends CIUnitTestCase
 {

--- a/tests/system/Test/TestCaseEmissionsTest.php
+++ b/tests/system/Test/TestCaseEmissionsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Test;
 
 use CodeIgniter\HTTP\Response;

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\Test;
 
 use CodeIgniter\CLI\CLI;

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Throttle;
+<?php
+
+namespace CodeIgniter\Throttle;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockCache;

--- a/tests/system/Typography/TypographyTest.php
+++ b/tests/system/Typography/TypographyTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Typography;
+<?php
+
+namespace CodeIgniter\Typography;
 
 use CodeIgniter\Test\CIUnitTestCase;
 

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Validation;
+<?php
+
+namespace CodeIgniter\Validation;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -1,4 +1,6 @@
-<?php namespace CodeIgniter\Validation;
+<?php
+
+namespace CodeIgniter\Validation;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;

--- a/tests/system/View/TableTest.php
+++ b/tests/system/View/TableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\View;
 
 use CodeIgniter\Database\MySQLi\Result;

--- a/tests/system/View/ViewTest.php
+++ b/tests/system/View/ViewTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CodeIgniter\View;
 
 use CodeIgniter\Config\Services;

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -32,10 +32,11 @@ final class CodeIgniter4 extends AbstractRuleset
                     '.=' => 'align_single_space',
                 ],
             ],
-            'blank_line_after_namespace' => true,
-            'indentation_type'           => true,
-            'line_ending'                => true,
-            'static_lambda'              => true,
+            'blank_line_after_namespace'   => true,
+            'blank_line_after_opening_tag' => true,
+            'indentation_type'             => true,
+            'line_ending'                  => true,
+            'static_lambda'                => true,
         ];
 
         $this->requiredPHPVersion = 70300;

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -32,9 +32,10 @@ final class CodeIgniter4 extends AbstractRuleset
                     '.=' => 'align_single_space',
                 ],
             ],
-            'indentation_type' => true,
-            'line_ending'      => true,
-            'static_lambda'    => true,
+            'blank_line_after_namespace' => true,
+            'indentation_type'           => true,
+            'line_ending'                => true,
+            'static_lambda'              => true,
         ];
 
         $this->requiredPHPVersion = 70300;


### PR DESCRIPTION
**Description**
Depends on #4779 

Enables the following rules starting with "b" and are part of the PSR 12 preset.
- blank_line_after_namespace
- blank_line_after_opening_tag

The last 2 "b" rules will be dealt with separately as those need discussion and diffs would be large.

**Checklist:**
- [x] Securely signed commits
