### PR TITLE
Don't include `utils/` in the `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,7 +21,6 @@ Vagrantfile.dist export-ignore
 
 # They don't want our test files
 tests/system/ export-ignore
-utils/ export-ignore
 rector.php export-ignore
 phpunit.xml.dist export-ignore
 phpstan.neon.dist export-ignore


### PR DESCRIPTION
**Description**
This allows modules/libraries depending on `codeigniter4/codeigniter4` to use its "utilities" for their own use.

**Checklist:**
- [x] Securely signed commits
