### PR TITLE
Use static lambda if a binding to `$this` is not required.

### DIFF
--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -22,7 +22,7 @@ use CodeIgniter\Exceptions\FrameworkException;
  *      Events::on('create', [$myInstance, 'myMethod']);
  */
 
-Events::on('pre_system', function () {
+Events::on('pre_system', static function () {
     if (ENVIRONMENT !== 'testing')
     {
         if (ini_get('zlib.output_compression'))
@@ -35,7 +35,7 @@ Events::on('pre_system', function () {
             ob_end_flush();
         }
 
-        ob_start(function ($buffer) {
+        ob_start(static function ($buffer) {
             return $buffer;
         });
     }

--- a/app/Views/errors/cli/error_exception.php
+++ b/app/Views/errors/cli/error_exception.php
@@ -50,7 +50,7 @@ if (defined('SHOW_DEBUG_BACKTRACE') && SHOW_DEBUG_BACKTRACE)
             $function .= $padClass . $error['function'];
         }
 
-        $args = implode(', ', array_map(function ($value) {
+        $args = implode(', ', array_map(static function ($value) {
             switch (true)
             {
                 case is_object($value):

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -845,7 +845,7 @@ class CLI
 
             $first = true;
 
-            array_walk($lines, function (&$line) use ($padLeft, &$first) {
+            array_walk($lines, static function (&$line) use ($padLeft, &$first) {
                 if (! $first)
                 {
                     $line = str_repeat(' ', $padLeft) . $line;

--- a/system/Config/Routes.php
+++ b/system/Config/Routes.php
@@ -22,12 +22,12 @@ use CodeIgniter\Exceptions\PageNotFoundException;
  */
 
 // Prevent access to BaseController
-$routes->add('BaseController(:any)', function () {
+$routes->add('BaseController(:any)', static function () {
     throw PageNotFoundException::forPageNotFound();
 });
 
 // Prevent access to initController method
-$routes->add('(:any)/initController', function () {
+$routes->add('(:any)/initController', static function () {
     throw PageNotFoundException::forPageNotFound();
 });
 

--- a/system/Cookie/CookieStore.php
+++ b/system/Cookie/CookieStore.php
@@ -46,7 +46,7 @@ class CookieStore implements Countable, IteratorAggregate
         /**
          * @var Cookie[] $cookies
          */
-        $cookies = array_filter(array_map(function (string $header) use ($raw) {
+        $cookies = array_filter(array_map(static function (string $header) use ($raw) {
             try
             {
                 return Cookie::fromHeaderString($header, $raw);

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -345,7 +345,7 @@ class Connection extends BaseConnection
             $obj         = new stdClass();
             $obj->name   = $row->indexname;
             $_fields     = explode(',', preg_replace('/^.*\((.+?)\)$/', '$1', trim($row->indexdef)));
-            $obj->fields = array_map(function ($v) {
+            $obj->fields = array_map(static function ($v) {
                 return trim($v);
             }, $_fields);
 

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -112,7 +112,7 @@ class PreparedQuery extends BasePreparedQuery
         // Track our current value
         $count = 0;
 
-        return preg_replace_callback('/\?/', function () use (&$count) {
+        return preg_replace_callback('/\?/', static function () use (&$count) {
             $count ++;
             return "\${$count}";
         }, $sql);

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -116,7 +116,7 @@ class Query implements QueryInterface
 
             if ($setEscape)
             {
-                array_walk($binds, function (&$item) {
+                array_walk($binds, static function (&$item) {
                     $item = [
                         $item,
                         true,
@@ -141,7 +141,7 @@ class Query implements QueryInterface
     {
         if ($setEscape)
         {
-            array_walk($binds, function (&$item) {
+            array_walk($binds, static function (&$item) {
                 $item = [
                     $item,
                     true,

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -441,7 +441,7 @@ class Builder extends BaseBuilder
 
         // Get the binds
         $binds = $this->binds;
-        array_walk($binds, function (&$item) {
+        array_walk($binds, static function (&$item) {
             $item = $item[0];
         });
 

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -259,7 +259,7 @@ class Connection extends BaseConnection
             $obj->name = $row->index_name;
 
             $_fields     = explode(',', trim($row->index_keys));
-            $obj->fields = array_map(function ($v) {
+            $obj->fields = array_map(static function ($v) {
                 return trim($v);
             }, $_fields);
 

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -149,7 +149,7 @@ class Forge extends BaseForge
 
             $sql = 'ALTER TABLE [' . $table . '] DROP ';
 
-            $fields = array_map(function ($item) {
+            $fields = array_map(static function ($item) {
                 return 'COLUMN [' . trim($item) . ']';
             }, (array) $field);
 

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -138,7 +138,7 @@ class Database extends BaseCollector
      */
     public function display(): array
     {
-        $data['queries'] = array_map(function (Query $query) {
+        $data['queries'] = array_map(static function (Query $query) {
             return [
                 'duration' => ((float) $query->getDuration(5) * 1000) . ' ms',
                 'sql'      => $query->debugToolbarDisplay(),

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -160,7 +160,7 @@ class Entity implements JsonSerializable
     {
         $this->_cast = $cast;
 
-        $keys = array_filter(array_keys($this->attributes), function ($key) {
+        $keys = array_filter(array_keys($this->attributes), static function ($key) {
             return strpos($key, '_') !== 0;
         });
 
@@ -217,7 +217,7 @@ class Entity implements JsonSerializable
         {
             if ($recursive)
             {
-                return array_map(function ($value) use ($onlyChanged, $recursive) {
+                return array_map(static function ($value) use ($onlyChanged, $recursive) {
                     if ($value instanceof Entity)
                     {
                         $value = $value->toRawArray($onlyChanged, $recursive);

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -361,7 +361,7 @@ class Filters
             [$name, $params] = explode(':', $name);
 
             $params = explode(',', $params);
-            array_walk($params, function (&$item) {
+            array_walk($params, static function (&$item) {
                 $item = trim($item);
             });
 

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -265,7 +265,7 @@ class Negotiate
         }
 
         // Sort to get the highest results first
-        usort($results, function ($a, $b) {
+        usort($results, static function ($a, $b) {
             if ($a['q'] === $b['q'])
             {
                 $aAst = substr_count($a['value'], '*');

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -326,7 +326,7 @@ trait RequestTrait
         )
         {
             // Iterate over array and append filter and flags
-            array_walk_recursive($value, function (&$val) use ($filter, $flags) {
+            array_walk_recursive($value, static function (&$val) use ($filter, $flags) {
                 $val = filter_var($val, $filter, $flags);
             });
 

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -1031,7 +1031,7 @@ class URI
 
         // Encode characters
         $path = preg_replace_callback(
-                '/(?:[^' . static::CHAR_UNRESERVED . ':@&=\+\$,\/;%]+|%(?![A-Fa-f0-9]{2}))/', function (array $matches) {
+                '/(?:[^' . static::CHAR_UNRESERVED . ':@&=\+\$,\/;%]+|%(?![A-Fa-f0-9]{2}))/', static function (array $matches) {
                     return rawurlencode($matches[0]);
                 }, $path
         );
@@ -1223,8 +1223,8 @@ class URI
         $return = [];
         $query  = explode('&', $query);
 
-        $params = array_map(function (string $chunk) {
-            return preg_replace_callback('/^(?<key>[^&=]+?)(?:\[[^&=]*\])?=(?<value>[^&=]+)/', function (array $match) {
+        $params = array_map(static function (string $chunk) {
+            return preg_replace_callback('/^(?<key>[^&=]+?)(?:\[[^&=]*\])?=(?<value>[^&=]+)/', static function (array $match) {
                 return str_replace($match['key'], bin2hex($match['key']), $match[0]);
             }, urldecode($chunk));
         }, $query);

--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -251,7 +251,7 @@ if (! function_exists('number_to_roman'))
             return null;
         }
 
-        $_number_to_roman = function ($num, $th) use (&$_number_to_roman) {
+        $_number_to_roman = static function ($num, $th) use (&$_number_to_roman) {
             $return = '';
             $key1   = null;
             $key2   = null;

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1423,7 +1423,7 @@ class RouteCollection implements RouteCollectionInterface
             for ($i = (int) $options['offset'] + 1; $i < (int) $options['offset'] + 7; $i ++)
             {
                 $to = preg_replace_callback(
-                        '/\$X/', function ($m) use ($i) {
+                        '/\$X/', static function ($m) use ($i) {
                             return '$' . $i;
                         }, $to, 1
                 );

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -603,7 +603,7 @@ class Router implements RouterInterface
      */
     protected function scanControllers(array $segments): array
     {
-        $segments = array_filter($segments, function ($segment) {
+        $segments = array_filter($segments, static function ($segment) {
             return $segment !== '';
         });
         // numerically reindex the array, removing gaps

--- a/system/Test/FilterTestTrait.php
+++ b/system/Test/FilterTestTrait.php
@@ -163,14 +163,14 @@ trait FilterTestTrait
 
         if ($position === 'before')
         {
-            return function (array $params = null) use ($filter, $request) {
+            return static function (array $params = null) use ($filter, $request) {
                 return $filter->before($request, $params);
             };
         }
 
         $response = clone $this->response;
 
-        return function (array $params = null) use ($filter, $request, $response) {
+        return static function (array $params = null) use ($filter, $request, $response) {
             return $filter->after($request, $response, $params);
         };
     }

--- a/system/Test/ReflectionHelper.php
+++ b/system/Test/ReflectionHelper.php
@@ -38,7 +38,7 @@ trait ReflectionHelper
         $refMethod->setAccessible(true);
         $obj = (gettype($obj) === 'object') ? $obj : null;
 
-        return function () use ($obj, $refMethod) {
+        return static function () use ($obj, $refMethod) {
             $args = func_get_args();
             return $refMethod->invokeArgs($obj, $args);
         };

--- a/tests/system/Cache/Handlers/DummyHandlerTest.php
+++ b/tests/system/Cache/Handlers/DummyHandlerTest.php
@@ -24,7 +24,7 @@ class DummyHandlerTest extends CIUnitTestCase
 
     public function testRemember()
     {
-        $dummyHandler = $this->dummyHandler->remember('key', 2, function () {
+        $dummyHandler = $this->dummyHandler->remember('key', 2, static function () {
             return 'value';
         });
 

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -119,7 +119,7 @@ final class FileHandlerTest extends CIUnitTestCase
      */
     public function testRemember()
     {
-        $this->fileHandler->remember(self::$key1, 2, function () {
+        $this->fileHandler->remember(self::$key1, 2, static function () {
             return 'value';
         });
 

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -74,7 +74,7 @@ final class MemcachedHandlerTest extends CIUnitTestCase
      */
     public function testRemember()
     {
-        $this->memcachedHandler->remember(self::$key1, 2, function () {
+        $this->memcachedHandler->remember(self::$key1, 2, static function () {
             return 'value';
         });
 

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -82,7 +82,7 @@ final class PredisHandlerTest extends CIUnitTestCase
      */
     public function testRemember()
     {
-        $this->PredisHandler->remember(self::$key1, 2, function () {
+        $this->PredisHandler->remember(self::$key1, 2, static function () {
             return 'value';
         });
 

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -82,7 +82,7 @@ final class RedisHandlerTest extends CIUnitTestCase
      */
     public function testRemember()
     {
-        $this->redisHandler->remember(self::$key1, 2, function () {
+        $this->redisHandler->remember(self::$key1, 2, static function () {
             return 'value';
         });
 

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -72,7 +72,7 @@ class CodeIgniterTest extends CIUnitTestCase
 
         // Inject mock router.
         $routes = Services::routes();
-        $routes->add('pages/(:segment)', function ($segment) {
+        $routes->add('pages/(:segment)', static function ($segment) {
             echo 'You want to see "' . esc($segment) . '" page.';
         });
         $router = Services::router($routes, Services::request());
@@ -122,7 +122,7 @@ class CodeIgniterTest extends CIUnitTestCase
         // Inject mock router.
         $routes = new RouteCollection(Services::locator(), new Modules());
         $routes->setAutoRoute(false);
-        $routes->set404Override(function () {
+        $routes->set404Override(static function () {
             echo '404 Override by Closure.';
         });
         $router = Services::router($routes, Services::request());
@@ -148,7 +148,7 @@ class CodeIgniterTest extends CIUnitTestCase
 
         // Inject mock router.
         $routes = Services::routes();
-        $routes->add('pages/(:segment)', function ($segment) {
+        $routes->add('pages/(:segment)', static function ($segment) {
             return 'You want to see "' . esc($segment) . '" page.';
         });
         $router = Services::router($routes, Services::request());
@@ -174,7 +174,7 @@ class CodeIgniterTest extends CIUnitTestCase
 
         // Inject mock router.
         $routes = Services::routes();
-        $routes->add('pages/(:segment)', function ($segment) {
+        $routes->add('pages/(:segment)', static function ($segment) {
             $response = Services::response();
             $string   = "You want to see 'about' page.";
             return $response->setBody($string);
@@ -297,7 +297,7 @@ class CodeIgniterTest extends CIUnitTestCase
 
         // Inject mock router.
         $routes = Services::routes();
-        $routes->add('pages/named', function () {
+        $routes->add('pages/named', static function () {
         }, ['as' => 'name']);
         $routes->addRedirect('example', 'name');
 
@@ -322,7 +322,7 @@ class CodeIgniterTest extends CIUnitTestCase
 
         // Inject mock router.
         $routes = Services::routes();
-        $routes->add('pages/uri', function () {
+        $routes->add('pages/uri', static function () {
         });
         $routes->addRedirect('example', 'pages/uri');
 

--- a/tests/system/Database/Builder/GroupTest.php
+++ b/tests/system/Database/Builder/GroupTest.php
@@ -86,7 +86,7 @@ class GroupTest extends CIUnitTestCase
         $builder->select('name')
                 ->groupBy('name');
 
-        $builder->havingIn('id', function (BaseBuilder $builder) {
+        $builder->havingIn('id', static function (BaseBuilder $builder) {
             return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
         });
 
@@ -120,10 +120,10 @@ class GroupTest extends CIUnitTestCase
         $builder->select('name')
                 ->groupBy('name');
 
-        $builder->havingIn('id', function (BaseBuilder $builder) {
+        $builder->havingIn('id', static function (BaseBuilder $builder) {
             return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
         });
-        $builder->orHavingIn('group_id', function (BaseBuilder $builder) {
+        $builder->orHavingIn('group_id', static function (BaseBuilder $builder) {
             return $builder->select('group_id')->from('groups')->where('group_id', 6);
         });
 
@@ -156,7 +156,7 @@ class GroupTest extends CIUnitTestCase
         $builder->select('name')
                 ->groupBy('name');
 
-        $builder->havingNotIn('id', function (BaseBuilder $builder) {
+        $builder->havingNotIn('id', static function (BaseBuilder $builder) {
             return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
         });
 
@@ -190,10 +190,10 @@ class GroupTest extends CIUnitTestCase
         $builder->select('name')
                 ->groupBy('name');
 
-        $builder->havingNotIn('id', function (BaseBuilder $builder) {
+        $builder->havingNotIn('id', static function (BaseBuilder $builder) {
             return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
         });
-        $builder->orHavingNotIn('group_id', function (BaseBuilder $builder) {
+        $builder->orHavingNotIn('group_id', static function (BaseBuilder $builder) {
             return $builder->select('group_id')->from('groups')->where('group_id', 6);
         });
 

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -113,7 +113,7 @@ class WhereTest extends CIUnitTestCase
     {
         $builder = $this->db->table('neworder');
 
-        $builder->where('advance_amount <', function (BaseBuilder $builder) {
+        $builder->where('advance_amount <', static function (BaseBuilder $builder) {
             return $builder->select('MAX(advance_amount)', false)->from('orders')->where('id >', 2);
         });
         $expectedSQL = 'SELECT * FROM "neworder" WHERE "advance_amount" < (SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2)';
@@ -191,7 +191,7 @@ class WhereTest extends CIUnitTestCase
     {
         $builder = $this->db->table('jobs');
 
-        $builder->whereIn('id', function (BaseBuilder $builder) {
+        $builder->whereIn('id', static function (BaseBuilder $builder) {
             return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
         });
 
@@ -264,7 +264,7 @@ class WhereTest extends CIUnitTestCase
     {
         $builder = $this->db->table('jobs');
 
-        $builder->whereNotIn('id', function (BaseBuilder $builder) {
+        $builder->whereNotIn('id', static function (BaseBuilder $builder) {
             return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
         });
 
@@ -302,7 +302,7 @@ class WhereTest extends CIUnitTestCase
     {
         $builder = $this->db->table('jobs');
 
-        $builder->where('deleted_at', null)->orWhereIn('id', function (BaseBuilder $builder) {
+        $builder->where('deleted_at', null)->orWhereIn('id', static function (BaseBuilder $builder) {
             return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
         });
 
@@ -340,7 +340,7 @@ class WhereTest extends CIUnitTestCase
     {
         $builder = $this->db->table('jobs');
 
-        $builder->where('deleted_at', null)->orWhereNotIn('id', function (BaseBuilder $builder) {
+        $builder->where('deleted_at', null)->orWhereNotIn('id', static function (BaseBuilder $builder) {
             return $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
         });
 

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -21,7 +21,7 @@ class PreparedQueryTest extends CIUnitTestCase
 
     public function testPrepareReturnsPreparedQuery()
     {
-        $query = $this->db->prepare(function ($db) {
+        $query = $this->db->prepare(static function ($db) {
             return $db->table('user')->insert([
                 'name'  => 'a',
                 'email' => 'b@example.com',
@@ -56,7 +56,7 @@ class PreparedQueryTest extends CIUnitTestCase
 
     public function testPrepareReturnsManualPreparedQuery()
     {
-        $query = $this->db->prepare(function ($db) {
+        $query = $this->db->prepare(static function ($db) {
             $sql = "INSERT INTO {$db->DBPrefix}user (name, email, country) VALUES (?, ?, ?)";
 
             return (new Query($db))->setQuery($sql);
@@ -83,7 +83,7 @@ class PreparedQueryTest extends CIUnitTestCase
 
     public function testExecuteRunsQueryAndReturnsResultObject()
     {
-        $query = $this->db->prepare(function ($db) {
+        $query = $this->db->prepare(static function ($db) {
             return $db->table('user')->insert([
                 'name'    => 'a',
                 'email'   => 'b@example.com',
@@ -102,7 +102,7 @@ class PreparedQueryTest extends CIUnitTestCase
 
     public function testExecuteRunsQueryAndReturnsManualResultObject()
     {
-        $query = $this->db->prepare(function ($db) {
+        $query = $this->db->prepare(static function ($db) {
             $sql = "INSERT INTO {$db->DBPrefix}user (name, email, country) VALUES (?, ?, ?)";
 
             return (new Query($db))->setQuery($sql);

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -319,7 +319,7 @@ class MigrationRunnerTest extends CIUnitTestCase
             ->clearHistory();
 
         $result = null;
-        Events::on('migrate', function ($arg) use (&$result) {
+        Events::on('migrate', static function ($arg) use (&$result) {
             $result = $arg;
         });
 
@@ -337,7 +337,7 @@ class MigrationRunnerTest extends CIUnitTestCase
             ->clearHistory();
 
         $result = null;
-        Events::on('migrate', function ($arg) use (&$result) {
+        Events::on('migrate', static function ($arg) use (&$result) {
             $result = $arg;
         });
 

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -96,7 +96,7 @@ class EmailTest extends CIUnitTestCase
 
         $result = null;
 
-        Events::on('email', function ($arg) use (&$result) {
+        Events::on('email', static function ($arg) use (&$result) {
             $result = $arg;
         });
 
@@ -116,7 +116,7 @@ class EmailTest extends CIUnitTestCase
 
         $result = null;
 
-        Events::on('email', function ($arg) use (&$result) {
+        Events::on('email', static function ($arg) use (&$result) {
             $result = $arg;
         });
 

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -63,7 +63,7 @@ class EventsTest extends CIUnitTestCase
     public function testPerformance()
     {
         $result = null;
-        Events::on('foo', function ($arg) use (&$result) {
+        Events::on('foo', static function ($arg) use (&$result) {
             $result = $arg;
         });
         Events::trigger('foo', 'bar');
@@ -75,9 +75,9 @@ class EventsTest extends CIUnitTestCase
 
     public function testListeners()
     {
-        $callback1 = function () {
+        $callback1 = static function () {
         };
-        $callback2 = function () {
+        $callback2 = static function () {
         };
 
         Events::on('foo', $callback1, EVENT_PRIORITY_HIGH);
@@ -90,7 +90,7 @@ class EventsTest extends CIUnitTestCase
     {
         $result = null;
 
-        Events::on('foo', function ($arg) use (&$result) {
+        Events::on('foo', static function ($arg) use (&$result) {
             $result = $arg;
         });
 
@@ -105,11 +105,11 @@ class EventsTest extends CIUnitTestCase
 
         // This should cancel the flow of events, and leave
         // $result = 1.
-        Events::on('foo', function ($arg) use (&$result) {
+        Events::on('foo', static function ($arg) use (&$result) {
             $result = 1;
             return false;
         });
-        Events::on('foo', function ($arg) use (&$result) {
+        Events::on('foo', static function ($arg) use (&$result) {
             $result = 2;
         });
 
@@ -121,13 +121,13 @@ class EventsTest extends CIUnitTestCase
     {
         $result = 0;
 
-        Events::on('foo', function () use (&$result) {
+        Events::on('foo', static function () use (&$result) {
             $result = 1;
             return false;
         }, EVENT_PRIORITY_NORMAL);
         // Since this has a higher priority, it will
         // run first.
-        Events::on('foo', function () use (&$result) {
+        Events::on('foo', static function () use (&$result) {
             $result = 2;
             return false;
         }, EVENT_PRIORITY_HIGH);
@@ -140,19 +140,19 @@ class EventsTest extends CIUnitTestCase
     {
         $result = [];
 
-        Events::on('foo', function () use (&$result) {
+        Events::on('foo', static function () use (&$result) {
             $result[] = 'a';
         }, EVENT_PRIORITY_NORMAL);
 
-        Events::on('foo', function () use (&$result) {
+        Events::on('foo', static function () use (&$result) {
             $result[] = 'b';
         }, EVENT_PRIORITY_LOW);
 
-        Events::on('foo', function () use (&$result) {
+        Events::on('foo', static function () use (&$result) {
             $result[] = 'c';
         }, EVENT_PRIORITY_HIGH);
 
-        Events::on('foo', function () use (&$result) {
+        Events::on('foo', static function () use (&$result) {
             $result[] = 'd';
         }, 75);
 
@@ -164,7 +164,7 @@ class EventsTest extends CIUnitTestCase
     {
         $result = false;
 
-        $callback = function () use (&$result) {
+        $callback = static function () use (&$result) {
             $result = true;
         };
 
@@ -184,7 +184,7 @@ class EventsTest extends CIUnitTestCase
     {
         $result = false;
 
-        $callback = function () use (&$result) {
+        $callback = static function () use (&$result) {
             $result = true;
         };
 
@@ -205,7 +205,7 @@ class EventsTest extends CIUnitTestCase
     {
         $result = false;
 
-        $callback = function () use (&$result) {
+        $callback = static function () use (&$result) {
             $result = true;
         };
 
@@ -225,7 +225,7 @@ class EventsTest extends CIUnitTestCase
     {
         $result = false;
 
-        $callback = function () use (&$result) {
+        $callback = static function () use (&$result) {
             $result = true;
         };
 
@@ -242,7 +242,7 @@ class EventsTest extends CIUnitTestCase
     {
         $result = false;
 
-        $callback = function () use (&$result) {
+        $callback = static function () use (&$result) {
             $result = true;
         };
 
@@ -285,7 +285,7 @@ class EventsTest extends CIUnitTestCase
     {
         $result = 0;
 
-        $callback = function () use (&$result) {
+        $callback = static function () use (&$result) {
             $result += 2;
         };
 

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -258,7 +258,7 @@ class RouteCollectionTest extends CIUnitTestCase
         $routes = $this->getCollector();
 
         $routes->group(
-                'admin', function ($routes) {
+                'admin', static function ($routes) {
                     $routes->add('users/list', '\Users::list');
                 }
         );
@@ -277,7 +277,7 @@ class RouteCollectionTest extends CIUnitTestCase
         $routes = $this->getCollector();
 
         $routes->group(
-                '<script>admin', function ($routes) {
+                '<script>admin', static function ($routes) {
                     $routes->add('users/list', '\Users::list');
                 }
         );
@@ -296,7 +296,7 @@ class RouteCollectionTest extends CIUnitTestCase
         $routes = $this->getCollector();
 
         $routes->group(
-                'admin', ['namespace' => 'Admin'], function ($routes) {
+                'admin', ['namespace' => 'Admin'], static function ($routes) {
                     $routes->add('users/list', 'Users::list');
                 }
         );
@@ -315,7 +315,7 @@ class RouteCollectionTest extends CIUnitTestCase
         $routes = $this->getCollector();
 
         $routes->group(
-                '', function ($routes) {
+                '', static function ($routes) {
                     $routes->add('users/list', '\Users::list');
                 }
         );
@@ -335,12 +335,12 @@ class RouteCollectionTest extends CIUnitTestCase
 
         $routes->add('verify/begin', '\VerifyController::begin');
 
-        $routes->group('admin', function ($routes) {
+        $routes->group('admin', static function ($routes) {
             $routes->group(
-                '', function ($routes) {
+                '', static function ($routes) {
                     $routes->add('users/list', '\Users::list');
 
-                    $routes->group('delegate', function ($routes) {
+                    $routes->group('delegate', static function ($routes) {
                         $routes->add('foo', '\Users::foo');
                     });
                 });
@@ -795,13 +795,13 @@ class RouteCollectionTest extends CIUnitTestCase
         $expected = ['here' => '\there'];
 
         $routes->environment(
-                'testing', function ($routes) {
+                'testing', static function ($routes) {
                     $routes->get('here', 'there');
                 }
         );
 
         $routes->environment(
-                'badenvironment', function ($routes) {
+                'badenvironment', static function ($routes) {
                     $routes->get('from', 'to');
                 }
         );
@@ -938,11 +938,11 @@ class RouteCollectionTest extends CIUnitTestCase
 
         $routes->get('user/insert', 'myController::goto/$1/$2', ['as' => 'namedRoute1']);
         $routes->post(
-                'user/insert', function () {
+                'user/insert', static function () {
                 }, ['as' => 'namedRoute2']
         );
         $routes->put(
-                'user/insert', function () {
+                'user/insert', static function () {
                 }, ['as' => 'namedRoute3']
         );
 
@@ -967,13 +967,13 @@ class RouteCollectionTest extends CIUnitTestCase
         $routes->get('{locale}/user/insert', 'myController::goto/$1/$2', ['as' => 'namedRoute1']);
         $routes->post(
             '{locale}/user/insert',
-            function () {
+            static function () {
             },
             ['as' => 'namedRoute2']
         );
         $routes->put(
             '{locale}/user/insert',
-            function () {
+            static function () {
             },
             ['as' => 'namedRoute3']
         );
@@ -1216,7 +1216,7 @@ class RouteCollectionTest extends CIUnitTestCase
     {
         $routes = $this->getCollector();
 
-        $routes->add('login', function () {
+        $routes->add('login', static function () {
         });
 
         $match = $routes->reverseRoute('login');
@@ -1228,7 +1228,7 @@ class RouteCollectionTest extends CIUnitTestCase
     {
         $routes = $this->getCollector();
 
-        $routes->add('login', function () {
+        $routes->add('login', static function () {
         });
 
         $this->assertFalse($routes->reverseRoute('foobar'));
@@ -1286,7 +1286,7 @@ class RouteCollectionTest extends CIUnitTestCase
             'foo' => 'baz',
         ];
         $routes->add(
-                'administrator', function () {
+                'administrator', static function () {
                 }, $options
         );
 
@@ -1312,15 +1312,15 @@ class RouteCollectionTest extends CIUnitTestCase
             'bar' => 'baz',
         ];
         $routes->get(
-                'administrator', function () {
+                'administrator', static function () {
                 }, $options1
         );
         $routes->post(
-                'administrator', function () {
+                'administrator', static function () {
                 }, $options2
         );
         $routes->add(
-                'administrator', function () {
+                'administrator', static function () {
                 }, $options3
         );
 
@@ -1343,7 +1343,7 @@ class RouteCollectionTest extends CIUnitTestCase
         $routes = $this->getCollector();
 
         $routes->group(
-                'admin', ['filter' => 'role'], function ($routes) {
+                'admin', ['filter' => 'role'], static function ($routes) {
                     $routes->add('users', '\Users::list');
                 }
         );
@@ -1360,7 +1360,7 @@ class RouteCollectionTest extends CIUnitTestCase
         $routes = $this->getCollector();
 
         $routes->group(
-                'admin', ['filter' => 'role:admin,manager'], function ($routes) {
+                'admin', ['filter' => 'role:admin,manager'], static function ($routes) {
                     $routes->add('users', '\Users::list');
                 }
         );
@@ -1394,7 +1394,7 @@ class RouteCollectionTest extends CIUnitTestCase
         Services::request()->setMethod('get');
         $routes = $this->getCollector();
 
-        $routes->set404Override(function () {
+        $routes->set404Override(static function () {
             echo 'Explode now';
         }
         );

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -44,7 +44,7 @@ class RouterTest extends CIUnitTestCase
             'posts/(:num)'                                    => 'Blog::show/$1',
             'posts/(:num)/edit'                               => 'Blog::edit/$1',
             'books/(:num)/(:alpha)/(:num)'                    => 'Blog::show/$3/$1',
-            'closure/(:num)/(:alpha)'                         => function ($num, $str) {
+            'closure/(:num)/(:alpha)'                         => static function ($num, $str) {
                 return $num . '-' . $str;
             },
             '{locale}/pages'                                  => 'App\Pages::list_all',
@@ -421,13 +421,13 @@ class RouterTest extends CIUnitTestCase
             'as'  => 'login',
             'foo' => 'baz',
         ];
-        $this->collection->add('foo', function () {
+        $this->collection->add('foo', static function () {
         }, $optionsFoo);
         $optionsBaz = [
             'as'  => 'admin',
             'foo' => 'bar',
         ];
-        $this->collection->add('baz', function () {
+        $this->collection->add('baz', static function () {
         }, $optionsBaz);
 
         $router = new Router($this->collection, $this->request);
@@ -441,7 +441,7 @@ class RouterTest extends CIUnitTestCase
     {
         $collection = $this->collection;
 
-        $collection->group('foo', ['filter' => 'test'], function ($routes) {
+        $collection->group('foo', ['filter' => 'test'], static function ($routes) {
             $routes->add('bar', 'TestController::foobar');
         });
 
@@ -467,7 +467,7 @@ class RouterTest extends CIUnitTestCase
                 'namespace' => 'App\Controllers\Api',
                 'filter'    => 'api-auth',
             ],
-            function (RouteCollection $routes) {
+            static function (RouteCollection $routes) {
                 $routes->resource('posts', [
                     'controller' => 'PostController',
                 ]);

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -30,7 +30,7 @@ class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'get',
                 'home',
-                function () {
+                static function () {
                     return 'Hello World';
                 },
             ],
@@ -47,7 +47,7 @@ class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'add',
                 'home',
-                function () {
+                static function () {
                     return 'Hello Earth';
                 },
             ],
@@ -67,7 +67,7 @@ class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'post',
                 'home',
-                function () {
+                static function () {
                     return 'Hello Mars';
                 },
             ],
@@ -83,7 +83,7 @@ class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'post',
                 'home',
-                function () {
+                static function () {
                     return 'Hello ' . service('request')->getPost('foo') . '!';
                 },
             ],
@@ -99,7 +99,7 @@ class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'put',
                 'home',
-                function () {
+                static function () {
                     return 'Hello Pluto';
                 },
             ],
@@ -115,7 +115,7 @@ class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'patch',
                 'home',
-                function () {
+                static function () {
                     return 'Hello Jupiter';
                 },
             ],
@@ -131,7 +131,7 @@ class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'options',
                 'home',
-                function () {
+                static function () {
                     return 'Hello George';
                 },
             ],
@@ -147,7 +147,7 @@ class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'delete',
                 'home',
-                function () {
+                static function () {
                     return 'Hello Wonka';
                 },
             ],
@@ -163,7 +163,7 @@ class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'get',
                 'home',
-                function () {
+                static function () {
                     return 'Home';
                 },
             ],
@@ -187,7 +187,7 @@ class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'get',
                 'home',
-                function () {
+                static function () {
                     return 'Home';
                 },
             ],

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -38,7 +38,7 @@ class TestCaseTest extends CIUnitTestCase
 
     public function testEventTriggering()
     {
-        Events::on('foo', function ($arg) use (&$result) {
+        Events::on('foo', static function ($arg) use (&$result) {
             $result = $arg;
         });
 

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -711,7 +711,7 @@ class ParserTest extends CIUnitTestCase
      */
     public function testCanAddAndRemovePlugins()
     {
-        $this->parser->addPlugin('first', function ($str) {
+        $this->parser->addPlugin('first', static function ($str) {
             return $str;
         });
 
@@ -745,7 +745,7 @@ class ParserTest extends CIUnitTestCase
      */
     public function testParserPluginNoParams()
     {
-        $this->parser->addPlugin('hit:it', function ($str) {
+        $this->parser->addPlugin('hit:it', static function ($str) {
             return str_replace('here', 'Hip to the Hop', $str);
         }, true);
 
@@ -762,7 +762,7 @@ class ParserTest extends CIUnitTestCase
     public function testParserPluginClosure()
     {
         $config                   = $this->config;
-        $config->plugins['hello'] = function (array $params = []) {
+        $config->plugins['hello'] = static function (array $params = []) {
             return 'Hello, ' . trim($params[0]);
         };
 
@@ -780,7 +780,7 @@ class ParserTest extends CIUnitTestCase
      */
     public function testParserPluginParams()
     {
-        $this->parser->addPlugin('growth', function ($str, array $params) {
+        $this->parser->addPlugin('growth', static function ($str, array $params) {
             $step  = $params['step'] ?? 1;
             $count = $params['count'] ?? 2;
 
@@ -806,7 +806,7 @@ class ParserTest extends CIUnitTestCase
      */
     public function testParserSingleTag()
     {
-        $this->parser->addPlugin('hit:it', function () {
+        $this->parser->addPlugin('hit:it', static function () {
             return 'Hip to the Hop';
         }, false);
 
@@ -820,7 +820,7 @@ class ParserTest extends CIUnitTestCase
      */
     public function testParserSingleTagWithParams()
     {
-        $this->parser->addPlugin('hit:it', function (array $params = []) {
+        $this->parser->addPlugin('hit:it', static function (array $params = []) {
             return "{$params['first']} to the {$params['last']}";
         }, false);
 
@@ -834,7 +834,7 @@ class ParserTest extends CIUnitTestCase
      */
     public function testParserSingleTagWithSingleParams()
     {
-        $this->parser->addPlugin('hit:it', function (array $params = []) {
+        $this->parser->addPlugin('hit:it', static function (array $params = []) {
             return "{$params[0]} to the {$params[1]}";
         }, false);
 
@@ -848,7 +848,7 @@ class ParserTest extends CIUnitTestCase
      */
     public function testParserSingleTagWithQuotedParams()
     {
-        $this->parser->addPlugin('count', function (array $params = []) {
+        $this->parser->addPlugin('count', static function (array $params = []) {
             $out = '';
 
             foreach ($params as $index => $param)
@@ -869,7 +869,7 @@ class ParserTest extends CIUnitTestCase
      */
     public function testParserSingleTagWithNamedParams()
     {
-        $this->parser->addPlugin('read_params', function (array $params = []) {
+        $this->parser->addPlugin('read_params', static function (array $params = []) {
             $out = '';
 
             foreach ($params as $index => $param)

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -34,6 +34,7 @@ final class CodeIgniter4 extends AbstractRuleset
             ],
             'indentation_type' => true,
             'line_ending'      => true,
+            'static_lambda'    => true,
         ];
 
         $this->requiredPHPVersion = 70300;


### PR DESCRIPTION
When not declared `static`, anonymous functions are bound to/hold a reference to `$this`, which can prevent garbage collection. It can also bring additional performance improvements, e.g. as [here](https://github.com/Ocramius/GeneratedHydrator/releases/tag/3.0.0)

> Also, by using `static function () {}` closures, we squeezed out another 15% of hydration performance when dealing with private properties.

:octocat: 