### PR TITLE
Don't override `$value` parameter

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2188,9 +2188,9 @@ class BaseBuilder
 
             $clean = [];
 
-            foreach ($row as $k => $value)
+            foreach ($row as $k => $rowValue)
             {
-                $clean[] = ':' . $this->setBind($k, $value, $escape) . ':';
+                $clean[] = ':' . $this->setBind($k, $rowValue, $escape) . ':';
             }
 
             $row = $clean;


### PR DESCRIPTION
`$value` is given as a parameter and overridden when iterating over the `$keys`. While it doesn't make a difference when executing the method, it could introduce side effects in the future in case the method is changed and the override is overlooked 🤞

:octocat: