### PR TITLE
Use/Fix `preg_quote()` delimiters

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 use Rector\CodeQuality\Rector\Expression\InlineIfToExplicitIfRector;
 use Rector\CodeQuality\Rector\For_\ForToForeachRector;
 use Rector\CodeQuality\Rector\Foreach_\UnusedForeachValueToArrayKeysRector;
+use Rector\CodeQuality\Rector\FuncCall\AddPregQuoteDelimiterRector;
 use Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector;
 use Rector\CodeQuality\Rector\FuncCall\SimplifyStrposLowerRector;
 use Rector\CodeQuality\Rector\If_\CombineIfRector;
@@ -94,4 +95,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(ListToArrayDestructRector::class);
     $services->set(MoveVariableDeclarationNearReferenceRector::class);
     $services->set(RemoveVarTagFromClassConstantRector::class);
+    $services->set(AddPregQuoteDelimiterRector::class);
 };

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -701,7 +701,7 @@ class BaseBuilder
                 $operator = $this->getOperator($condition);
 
                 $cond .= $joints[$i];
-                $cond .= preg_match("/(\(*)?([\[\]\w\.'-]+)" . preg_quote($operator) . '(.*)/i', $condition, $match) ? $match[1] . $this->db->protectIdentifiers($match[2]) . $operator . $this->db->protectIdentifiers($match[3]) : $condition;
+                $cond .= preg_match("/(\(*)?([\[\]\w\.'-]+)" . preg_quote($operator, '/') . '(.*)/i', $condition, $match) ? $match[1] . $this->db->protectIdentifiers($match[2]) . $operator . $this->db->protectIdentifiers($match[3]) : $condition;
             }
         }
 

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -173,7 +173,7 @@ class Builder extends BaseBuilder
                 $operator = $this->getOperator($condition);
 
                 $cond .= $joints[$i];
-                $cond .= preg_match("/(\(*)?([\[\]\w\.'-]+)" . preg_quote($operator) . '(.*)/i', $condition, $match) ? $match[1] . $this->db->protectIdentifiers($match[2]) . $operator . $this->db->protectIdentifiers($match[3]) : $condition;
+                $cond .= preg_match("/(\(*)?([\[\]\w\.'-]+)" . preg_quote($operator, '/') . '(.*)/i', $condition, $match) ? $match[1] . $this->db->protectIdentifiers($match[2]) . $operator . $this->db->protectIdentifiers($match[3]) : $condition;
             }
         }
 

--- a/system/HTTP/UserAgent.php
+++ b/system/HTTP/UserAgent.php
@@ -366,7 +366,7 @@ class UserAgent
         {
             foreach ($this->config->platforms as $key => $val)
             {
-                if (preg_match('|' . preg_quote($key) . '|i', $this->agent))
+                if (preg_match('|' . preg_quote($key, '|') . '|i', $this->agent))
                 {
                     $this->platform = $val;
 
@@ -421,7 +421,7 @@ class UserAgent
         {
             foreach ($this->config->robots as $key => $val)
             {
-                if (preg_match('|' . preg_quote($key) . '|i', $this->agent))
+                if (preg_match('|' . preg_quote($key, '|') . '|i', $this->agent))
                 {
                     $this->isRobot = true;
                     $this->robot   = $val;

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -347,7 +347,7 @@ class FileHandler extends BaseHandler
 
         $pattern = sprintf(
             '#\A%s' . $pattern . $this->sessionIDRegex . '\z#',
-            preg_quote($this->cookieName)
+            preg_quote($this->cookieName, '#')
         );
 
         while (($file = readdir($directory)) !== false)

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -299,7 +299,7 @@ class Parser extends View
      */
     protected function parseSingle(string $key, string $val): array
     {
-        $pattern = '#' . $this->leftDelimiter . '!?\s*' . preg_quote($key) . '(?(?=\s*\|\s*)(\s*\|*\s*([|\w<>=\(\),:.\-\s\+\\\\/]+)*\s*))(\s*)!?' . $this->rightDelimiter . '#ms';
+        $pattern = '#' . $this->leftDelimiter . '!?\s*' . preg_quote($key, '#') . '(?(?=\s*\|\s*)(\s*\|*\s*([|\w<>=\(\),:.\-\s\+\\\\/]+)*\s*))(\s*)!?' . $this->rightDelimiter . '#ms';
 
         return [$pattern => $val];
     }
@@ -325,8 +325,8 @@ class Parser extends View
         // Find all matches of space-flexible versions of {tag}{/tag} so we
         // have something to loop over.
         preg_match_all(
-            '#' . $this->leftDelimiter . '\s*' . preg_quote($variable) . '\s*' . $this->rightDelimiter . '(.+?)' .
-            $this->leftDelimiter . '\s*' . '/' . preg_quote($variable) . '\s*' . $this->rightDelimiter . '#s', $template, $matches, PREG_SET_ORDER
+            '#' . $this->leftDelimiter . '\s*' . preg_quote($variable, '#') . '\s*' . $this->rightDelimiter . '(.+?)' .
+            $this->leftDelimiter . '\s*' . '/' . preg_quote($variable, '#') . '\s*' . $this->rightDelimiter . '#s', $template, $matches, PREG_SET_ORDER
         );
 
         /*
@@ -383,7 +383,7 @@ class Parser extends View
                         $val = 'Resource';
                     }
 
-                    $temp['#' . $this->leftDelimiter . '!?\s*' . preg_quote($key) . '(?(?=\s*\|\s*)(\s*\|*\s*([|\w<>=\(\),:.\-\s\+\\\\/]+)*\s*))(\s*)!?' . $this->rightDelimiter . '#s'] = $val;
+                    $temp['#' . $this->leftDelimiter . '!?\s*' . preg_quote($key, '#') . '(?(?=\s*\|\s*)(\s*\|*\s*([|\w<>=\(\),:.\-\s\+\\\\/]+)*\s*))(\s*)!?' . $this->rightDelimiter . '#s'] = $val;
                 }
 
                 // Now replace our placeholders with the new content.


### PR DESCRIPTION
`preg_quote()` delimiters were missing in some places - some of them are potential bugs, for example, when `#` was used in the pattern, but `preg_quote()` was defaulting to `/`.

:octocat: