### PR TITLE
Use constants instead of functions

### DIFF
--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -389,7 +389,7 @@
 
 			<p>
 				Displayed at <?= esc(date('H:i:sa')) ?> &mdash;
-				PHP: <?= esc(phpversion()) ?>  &mdash;
+				PHP: <?= esc(PHP_VERSION) ?>  &mdash;
 				CodeIgniter: <?= esc(\CodeIgniter\CodeIgniter::CI_VERSION) ?>
 			</p>
 

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1202,7 +1202,7 @@ abstract class BaseModel
 
         if (empty($this->allowedFields))
         {
-            throw DataException::forInvalidAllowedFields(get_class($this));
+            throw DataException::forInvalidAllowedFields(static::class);
         }
 
         foreach (array_keys($data) as $key)

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -448,7 +448,7 @@ class CLI
      */
     public static function isWindows(): bool
     {
-        return stripos(PHP_OS, 'WIN') === 0;
+        return PHP_OS_FAMILY === 'Windows';
     }
 
     //--------------------------------------------------------------------

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -707,7 +707,7 @@ abstract class BaseConnection implements ConnectionInterface
         }
 
         // query is not write-type, so it must be read-type query; return QueryResult
-        $resultClass = str_replace('Connection', 'Result', get_class($this));
+        $resultClass = str_replace('Connection', 'Result', static::class);
         return new $resultClass($this->connID, $this->resultID);
     }
 
@@ -965,7 +965,7 @@ abstract class BaseConnection implements ConnectionInterface
             throw new DatabaseException('You must set the database table to be used with your query.');
         }
 
-        $className = str_replace('Connection', 'Builder', get_class($this));
+        $className = str_replace('Connection', 'Builder', static::class);
 
         return new $className($tableName, $this);
     }
@@ -1009,7 +1009,7 @@ abstract class BaseConnection implements ConnectionInterface
             $sql = $sql->getOriginalQuery();
         }
 
-        $class = str_ireplace('Connection', 'PreparedQuery', get_class($this));
+        $class = str_ireplace('Connection', 'PreparedQuery', static::class);
         /**
          * @var BasePreparedQuery $class
          */

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -143,7 +143,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
         Events::trigger('DBQuery', $query);
 
         // Return a result object
-        $resultClass = str_replace('PreparedQuery', 'Result', get_class($this));
+        $resultClass = str_replace('PreparedQuery', 'Result', static::class);
 
         $resultID = $this->_getResult();
 

--- a/system/Debug/Toolbar/Collectors/Config.php
+++ b/system/Debug/Toolbar/Collectors/Config.php
@@ -31,8 +31,8 @@ class Config
 
         return [
             'ciVersion'   => CodeIgniter::CI_VERSION,
-            'phpVersion'  => phpversion(),
-            'phpSAPI'     => php_sapi_name(),
+            'phpVersion'  => PHP_VERSION,
+            'phpSAPI'     => PHP_SAPI,
             'environment' => ENVIRONMENT,
             'baseURL'     => $config->baseURL,
             'timezone'    => app_timezone(),

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -410,7 +410,7 @@ class Email
             $config = get_object_vars($config);
         }
 
-        foreach (array_keys(get_class_vars(get_class($this))) as $key)
+        foreach (array_keys(get_class_vars(static::class)) as $key)
         {
             if (property_exists($this, $key) && isset($config[$key]))
             {

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -485,7 +485,7 @@ trait ResponseTrait
 
         // Per spec, MUST be sent with each request, if possible.
         // http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
-        if (! isset($this->headers['Date']) && php_sapi_name() !== 'cli-server')
+        if (! isset($this->headers['Date']) && PHP_SAPI !== 'cli-server')
         {
             $this->setDate(DateTime::createFromFormat('U', (string) time()));
         }

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -73,7 +73,7 @@ class ImageMagickHandler extends BaseHandler
         $destination = $this->getResourcePath();
 
         $escape = '\\';
-        if (stripos(PHP_OS, 'WIN') === 0)
+        if (PHP_OS_FAMILY === 'Windows')
         {
             $escape = '';
         }

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -88,7 +88,7 @@ class MockConnection extends BaseConnection
         }
 
         // query is not write-type, so it must be read-type query; return QueryResult
-        $resultClass = str_replace('Connection', 'Result', get_class($this));
+        $resultClass = str_replace('Connection', 'Result', static::class);
         return new $resultClass($this->connID, $this->resultID);
     }
 

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -34,6 +34,7 @@ final class CodeIgniter4 extends AbstractRuleset
             ],
             'blank_line_after_namespace'   => true,
             'blank_line_after_opening_tag' => true,
+            'function_to_constant'         => true,
             'indentation_type'             => true,
             'line_ending'                  => true,
             'static_lambda'                => true,


### PR DESCRIPTION
Using constants instead of methods saves some OPCode steps 💪 

[`PHP_OS_FAMILY` has a smaller, predefined set of possible values](https://www.php.net/manual/en/reserved.constants.php#constant.php-os-family)

:octocat: 