### PR TITLE
Replace alias functions with origins

### DIFF
--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -68,7 +68,7 @@ class PreparedQuery extends BasePreparedQuery
         // Determine the type string
         foreach ($data as $item)
         {
-            if (is_integer($item))
+            if (is_int($item))
             {
                 $bindTypes .= 'i';
             }

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -70,7 +70,7 @@ class PreparedQuery extends BasePreparedQuery
         foreach ($data as $key => $item)
         {
             // Determine the type string
-            if (is_integer($item))
+            if (is_int($item))
             {
                 $bindType = SQLITE3_INTEGER;
             }

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -1956,8 +1956,8 @@ class Email
             return false;
         }
 
-        fputs($fp, $this->headerStr);
-        fputs($fp, $this->finalBody);
+        fwrite($fp, $this->headerStr);
+        fwrite($fp, $this->finalBody);
         $status = pclose($fp);
 
         if ($status !== 0)

--- a/tests/system/Filters/fixtures/Role.php
+++ b/tests/system/Filters/fixtures/Role.php
@@ -13,7 +13,7 @@ class Role implements FilterInterface
     {
         if (is_array($arguments))
         {
-            $response->setBody(join(';', $arguments));
+            $response->setBody(implode(';', $arguments));
         }
         elseif (is_null($arguments))
         {
@@ -30,7 +30,7 @@ class Role implements FilterInterface
     {
         if (is_array($arguments))
         {
-            return join(';', $arguments);
+            return implode(';', $arguments);
         }
         if (is_null($arguments))
         {

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -36,6 +36,9 @@ final class CodeIgniter4 extends AbstractRuleset
             'blank_line_after_opening_tag' => true,
             'indentation_type'             => true,
             'line_ending'                  => true,
+            'no_alias_functions'           => [
+                'sets' => ['@all'],
+            ],
             'static_lambda'                => true,
         ];
 


### PR DESCRIPTION
In order to avoid surprises (e.g. `mysqli_*` aliases were dropped in PHP 5.4 or `magic_quotes_runtime` was dropped in PHP 7.0), we should not rely on alias functions at all.

:octocat: 