### PR TITLE
Remove removed `safe_mode` ini Option

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -793,8 +793,8 @@ if (! function_exists('is_really_writable'))
      */
     function is_really_writable(string $file): bool
     {
-        // If we're on a Unix server with safe_mode off we call is_writable
-        if (DIRECTORY_SEPARATOR === '/' || ! ini_get('safe_mode'))
+        // If we're on a Unix server we call is_writable
+        if (DIRECTORY_SEPARATOR === '/')
         {
             return is_writable($file);
         }


### PR DESCRIPTION
`safe_mode` was removed in PHP 5.4 🙈 

:octocat:
