### PR TITLE
Ensure single space between cast and variable

### DIFF
--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -295,9 +295,10 @@ class DatabaseHandler extends BaseHandler
      */
     public function gc($maxlifetime): bool
     {
-        $interval = implode(" '"[(int)($this->platform === 'postgre')], ['', "{$maxlifetime} second", '']);
+        $separator = $this->platform === 'postgre' ? '\'' : ' ';
+        $interval  = implode($separator, ['', "{$maxlifetime} second", '']);
 
-        return ($this->db->table($this->table)->delete("timestamp < now() - INTERVAL {$interval}")) ? true : $this->fail();
+        return $this->db->table($this->table)->delete("timestamp < now() - INTERVAL {$interval}") ? true : $this->fail();
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -166,7 +166,7 @@ EOH;
     "id": 1
 }
 EOH;
-        $controller->respond((array)$payload);
+        $controller->respond((array) $payload);
         $this->assertEquals($expected, $this->response->getBody());
     }
 

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -197,7 +197,7 @@ class MigrationRunnerTest extends CIUnitTestCase
 
         $runner = $runner->setNamespace('Tests\Support\MigrationTestMigrations');
 
-        $mig1      = (object)[
+        $mig1      = (object) [
             'name'      => 'Some_migration',
             'path'      => TESTPATH . '_support/MigrationTestMigrations/Database/Migrations/2018-01-24-102301_Some_migration.php',
             'version'   => '2018-01-24-102301',
@@ -206,7 +206,7 @@ class MigrationRunnerTest extends CIUnitTestCase
         ];
         $mig1->uid = $runner->getObjectUid($mig1);
 
-        $mig2      = (object)[
+        $mig2      = (object) [
             'name'      => 'Another_migration',
             'path'      => TESTPATH . '_support/MigrationTestMigrations/Database/Migrations/2018-01-24-102302_Another_migration.php',
             'version'   => '2018-01-24-102302',

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -727,8 +727,7 @@ class FiltersTest extends CIUnitTestCase
             ],
         ];
 
-        $filters = new Filters((object)$config, $this->request, $this->response);
-
+        $filters = new Filters((object) $config, $this->request, $this->response);
         $filters = $filters->initialize('admin/foo/bar');
 
         $filters->enableFilter('role:admin , super', 'before');
@@ -759,7 +758,7 @@ class FiltersTest extends CIUnitTestCase
             ],
         ];
 
-        $filters = new Filters((object)$config, $this->request, $this->response);
+        $filters = new Filters((object) $config, $this->request, $this->response);
 
         $filters = $filters->initialize('admin/foo/bar');
 

--- a/tests/system/HTTP/HeaderTest.php
+++ b/tests/system/HTTP/HeaderTest.php
@@ -209,6 +209,6 @@ class HeaderTest extends CIUnitTestCase
         $header->setValue('bar')
                ->appendValue(['baz' => 'fuzz']);
 
-        $this->assertEquals($expected, (string)$header);
+        $this->assertEquals($expected, (string) $header);
     }
 }

--- a/tests/system/Models/ValidationModelTest.php
+++ b/tests/system/Models/ValidationModelTest.php
@@ -290,7 +290,7 @@ final class ValidationModelTest extends LiveModelTestCase
         $this->createModel(ValidErrorsModel::class);
 
         $id = $this->model->insert($data);
-        $this->assertFalse((bool)$id);
+        $this->assertFalse((bool) $id);
         $this->assertSame('Minimum Length Error', $this->model->errors()['name']);
     }
 

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -229,9 +229,9 @@ class PagerTest extends CIUnitTestCase
         $this->pager->store('foo', 2, 12, 70);
 
         $expected = current_url(true);
-        $expected = (string)$expected->setQuery('page_foo=3');
+        $expected = (string) $expected->setQuery('page_foo=3');
 
-        $this->assertEquals((string)$expected, $this->pager->getNextPageURI('foo'));
+        $this->assertEquals((string) $expected, $this->pager->getNextPageURI('foo'));
     }
 
     public function testGetNextURIReturnsNullOnLastPage()
@@ -246,7 +246,7 @@ class PagerTest extends CIUnitTestCase
         $this->pager->store('foo', 1, 12, 70);
 
         $expected = current_url(true);
-        $expected = (string)$expected->setQuery('page_foo=2');
+        $expected = (string) $expected->setQuery('page_foo=2');
 
         $this->assertEquals($expected, $this->pager->getNextPageURI('foo'));
     }
@@ -258,9 +258,9 @@ class PagerTest extends CIUnitTestCase
         $this->pager->store('foo', 2, 12, 70);
 
         $expected = current_url(true);
-        $expected = (string)$expected->setQuery('page_foo=1');
+        $expected = (string) $expected->setQuery('page_foo=1');
 
-        $this->assertEquals((string)$expected, $this->pager->getPreviousPageURI('foo'));
+        $this->assertEquals((string) $expected, $this->pager->getPreviousPageURI('foo'));
     }
 
     public function testGetNextURIReturnsNullOnFirstPage()
@@ -278,11 +278,11 @@ class PagerTest extends CIUnitTestCase
         ];
 
         $expected = current_url(true);
-        $expected = (string)$expected->setQueryArray($_GET);
+        $expected = (string) $expected->setQueryArray($_GET);
 
         $this->pager->store('foo', $_GET['page_foo'] - 1, 12, 70);
 
-        $this->assertEquals((string)$expected, $this->pager->getNextPageURI('foo'));
+        $this->assertEquals((string) $expected, $this->pager->getNextPageURI('foo'));
     }
 
     public function testGetPreviousURIWithQueryStringUsesCurrentURI()
@@ -292,11 +292,11 @@ class PagerTest extends CIUnitTestCase
             'status'   => 1,
         ];
         $expected = current_url(true);
-        $expected = (string)$expected->setQueryArray($_GET);
+        $expected = (string) $expected->setQueryArray($_GET);
 
         $this->pager->store('foo', $_GET['page_foo'] + 1, 12, 70);
 
-        $this->assertEquals((string)$expected, $this->pager->getPreviousPageURI('foo'));
+        $this->assertEquals((string) $expected, $this->pager->getPreviousPageURI('foo'));
     }
 
     public function testGetOnlyQueries()
@@ -319,15 +319,15 @@ class PagerTest extends CIUnitTestCase
 
         $this->assertEquals(
             $this->pager->only($onlyQueries)
-                        ->getPreviousPageURI(), (string)$uri->setQuery('search=foo&order=asc&page=1')
+                        ->getPreviousPageURI(), (string) $uri->setQuery('search=foo&order=asc&page=1')
         );
         $this->assertEquals(
             $this->pager->only($onlyQueries)
-                        ->getNextPageURI(), (string)$uri->setQuery('search=foo&order=asc&page=3')
+                        ->getNextPageURI(), (string) $uri->setQuery('search=foo&order=asc&page=3')
         );
         $this->assertEquals(
             $this->pager->only($onlyQueries)
-                        ->getPageURI(4), (string)$uri->setQuery('search=foo&order=asc&page=4')
+                        ->getPageURI(4), (string) $uri->setQuery('search=foo&order=asc&page=4')
         );
     }
 
@@ -430,9 +430,9 @@ class PagerTest extends CIUnitTestCase
         $this->pager->store('foo', 2, 12, 70);
 
         $expected = current_url(true);
-        $expected = (string)$expected->setQuery('page_foo=1');
+        $expected = (string) $expected->setQuery('page_foo=1');
 
-        $this->assertEquals((string)$expected, $this->pager->getPreviousPageURI('foo'));
+        $this->assertEquals((string) $expected, $this->pager->getPreviousPageURI('foo'));
     }
 
     public function testAccessPageMoreThanPageCountGetLastPage()

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -43,7 +43,7 @@ class RulesTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->validation = new Validation((object)$this->config, Services::renderer());
+        $this->validation = new Validation((object) $this->config, Services::renderer());
         $this->validation->reset();
 
         $_FILES = [];

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -61,6 +61,7 @@ final class CodeIgniter4 extends AbstractRuleset
                 'position_after_control_structures'                 => 'same',
                 'position_after_functions_and_oop_constructs'       => 'next',
             ],
+            'cast_spaces'                  => ['space' => 'single'],
             'function_to_constant'         => true,
             'indentation_type'             => true,
             'line_ending'                  => true,


### PR DESCRIPTION
**Description**
This enables the `cast_spaces` fixer and set to ensure there's a single space between the cast and the casted variable.

**Checklist:**
- [x] Securely signed commits
