### PR TITLE
Phpdoc param return types

### DIFF
--- a/admin/module/tests/_support/DatabaseTestCase.php
+++ b/admin/module/tests/_support/DatabaseTestCase.php
@@ -12,7 +12,7 @@ class DatabaseTestCase extends CIUnitTestCase
     /**
      * Should the database be refreshed before each test?
      *
-     * @var boolean
+     * @var bool
      */
     protected $refresh = true;
 

--- a/admin/module/tests/_support/Libraries/ConfigReader.php
+++ b/admin/module/tests/_support/Libraries/ConfigReader.php
@@ -30,9 +30,11 @@
  * THE SOFTWARE.
  *
  * @package    CodeIgniter
+ *
  * @author     CodeIgniter Dev Team
  * @copyright  2019-2021 CodeIgniter Foundation
  * @license    https://opensource.org/licenses/MIT	MIT License
+ *
  * @link       https://codeigniter.com
  * @since      Version 4.0.0
  * @filesource

--- a/admin/starter/tests/_support/DatabaseTestCase.php
+++ b/admin/starter/tests/_support/DatabaseTestCase.php
@@ -12,7 +12,7 @@ class DatabaseTestCase extends CIUnitTestCase
     /**
      * Should the database be refreshed before each test?
      *
-     * @var boolean
+     * @var bool
      */
     protected $refresh = true;
 

--- a/admin/starter/tests/_support/Libraries/ConfigReader.php
+++ b/admin/starter/tests/_support/Libraries/ConfigReader.php
@@ -30,9 +30,11 @@
  * THE SOFTWARE.
  *
  * @package    CodeIgniter
+ *
  * @author     CodeIgniter Dev Team
  * @copyright  2019-2021 CodeIgniter Foundation
  * @license    https://opensource.org/licenses/MIT	MIT License
+ *
  * @link       https://codeigniter.com
  * @since      Version 4.0.0
  * @filesource

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -81,7 +81,7 @@ class App extends BaseConfig
      *
      * If false, no automatic detection will be performed.
      *
-     * @var boolean
+     * @var bool
      */
     public $negotiateLocale = false;
 
@@ -134,7 +134,7 @@ class App extends BaseConfig
      * secure, the user will be redirected to a secure version of the page
      * and the HTTP Strict Transport Security header will be set.
      *
-     * @var boolean
+     * @var bool
      */
     public $forceGlobalSecureRequests = false;
 
@@ -172,7 +172,7 @@ class App extends BaseConfig
      * The number of SECONDS you want the session to last.
      * Setting to 0 (zero) means expire when the browser is closed.
      *
-     * @var integer
+     * @var int
      */
     public $sessionExpiration = 7200;
 
@@ -205,7 +205,7 @@ class App extends BaseConfig
      * WARNING: If you're using the database driver, don't forget to update
      *          your session table's PRIMARY KEY when changing this setting.
      *
-     * @var boolean
+     * @var bool
      */
     public $sessionMatchIP = false;
 
@@ -216,7 +216,7 @@ class App extends BaseConfig
      *
      * How many seconds between CI regenerating the session ID.
      *
-     * @var integer
+     * @var int
      */
     public $sessionTimeToUpdate = 300;
 
@@ -229,7 +229,7 @@ class App extends BaseConfig
      * when auto-regenerating the session ID. When set to FALSE, the data
      * will be later deleted by the garbage collector.
      *
-     * @var boolean
+     * @var bool
      */
     public $sessionRegenerateDestroy = false;
 
@@ -279,7 +279,7 @@ class App extends BaseConfig
      *
      * Cookie will only be set if a secure HTTPS connection exists.
      *
-     * @var boolean
+     * @var bool
      *
      * @deprecated use Config\Cookie::$secure property instead.
      */
@@ -292,7 +292,7 @@ class App extends BaseConfig
      *
      * Cookie will only be accessible via HTTP(S) (no JavaScript).
      *
-     * @var boolean
+     * @var bool
      *
      * @deprecated use Config\Cookie::$httponly property instead.
      */
@@ -392,7 +392,7 @@ class App extends BaseConfig
      *
      * @deprecated Use `Config\Security` $expire property instead of using this property.
      *
-     * @var integer
+     * @var int
      */
     public $CSRFExpire = 7200;
 
@@ -405,7 +405,7 @@ class App extends BaseConfig
      *
      * @deprecated Use `Config\Security` $regenerate property instead of using this property.
      *
-     * @var boolean
+     * @var bool
      */
     public $CSRFRegenerate = true;
 
@@ -418,7 +418,7 @@ class App extends BaseConfig
      *
      * @deprecated Use `Config\Security` $redirect property instead of using this property.
      *
-     * @var boolean
+     * @var bool
      */
     public $CSRFRedirect = true;
 
@@ -459,7 +459,7 @@ class App extends BaseConfig
      * @see http://www.html5rocks.com/en/tutorials/security/content-security-policy/
      * @see http://www.w3.org/TR/CSP/
      *
-     * @var boolean
+     * @var bool
      */
     public $CSPEnabled = false;
 }

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -436,7 +436,6 @@ class App extends BaseConfig
      * Defaults to `Lax` as recommended in this link:
      *
      * @see https://portswigger.net/web-security/csrf/samesite-cookies
-     *
      * @deprecated Use `Config\Security` $samesite property instead of using this property.
      *
      * @var string

--- a/app/Config/Autoload.php
+++ b/app/Config/Autoload.php
@@ -37,6 +37,7 @@ class Autoload extends AutoloadConfig
      *       'App'	       => APPPATH
      *   ];
      *```
+     *
      * @var array<string, string>
      */
     public $psr4 = [
@@ -60,6 +61,7 @@ class Autoload extends AutoloadConfig
      *       'MyClass'   => '/path/to/class/file.php'
      *   ];
      *```
+     *
      * @var array<string, string>
      */
     public $classmap = [];
@@ -78,6 +80,7 @@ class Autoload extends AutoloadConfig
      *	 	   '/path/to/my/file.php',
      *    ];
      * ```
+     *
      * @var array<int, string>
      */
     public $files = [];

--- a/app/Config/Cache.php
+++ b/app/Config/Cache.php
@@ -66,7 +66,7 @@ class Cache extends BaseConfig
      *    array('q') = Enabled, but only take into account the specified list
      *                 of query parameters.
      *
-     * @var boolean|string[]
+     * @var bool|string[]
      */
     public $cacheQueryString = false;
 
@@ -93,7 +93,7 @@ class Cache extends BaseConfig
      * hard-coded, but may be useful to projects and modules. This will replace
      * the hard-coded value in a future release.
      *
-     * @var integer
+     * @var int
      */
     public $ttl = 60;
 

--- a/app/Config/ContentSecurityPolicy.php
+++ b/app/Config/ContentSecurityPolicy.php
@@ -22,7 +22,7 @@ class ContentSecurityPolicy extends BaseConfig
     /**
      * Default CSP report context
      *
-     * @var boolean
+     * @var bool
      */
     public $reportOnly = false;
 
@@ -39,7 +39,7 @@ class ContentSecurityPolicy extends BaseConfig
      * HTTP to HTTPS. This directive is for websites with
      * large numbers of old URLs that need to be rewritten.
      *
-     * @var boolean
+     * @var bool
      */
     public $upgradeInsecureRequests = false;
 

--- a/app/Config/Cookie.php
+++ b/app/Config/Cookie.php
@@ -27,7 +27,7 @@ class Cookie extends BaseConfig
      * cookie will not have the `Expires` attribute and will behave as a session
      * cookie.
      *
-     * @var DateTimeInterface|integer|string
+     * @var DateTimeInterface|int|string
      */
     public $expires = 0;
 
@@ -60,7 +60,7 @@ class Cookie extends BaseConfig
      *
      * Cookie will only be set if a secure HTTPS connection exists.
      *
-     * @var boolean
+     * @var bool
      */
     public $secure = false;
 
@@ -71,7 +71,7 @@ class Cookie extends BaseConfig
      *
      * Cookie will only be accessible via HTTP(S) (no JavaScript).
      *
-     * @var boolean
+     * @var bool
      */
     public $httponly = true;
 
@@ -110,7 +110,7 @@ class Cookie extends BaseConfig
      * If this is set to `true`, cookie names should be compliant of RFC 2616's
      * list of allowed characters.
      *
-     * @var boolean
+     * @var bool
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes
      * @see https://tools.ietf.org/html/rfc2616#section-2.2

--- a/app/Config/Email.php
+++ b/app/Config/Email.php
@@ -66,21 +66,21 @@ class Email extends BaseConfig
     /**
      * SMTP Port
      *
-     * @var integer
+     * @var int
      */
     public $SMTPPort = 25;
 
     /**
      * SMTP Timeout (in seconds)
      *
-     * @var integer
+     * @var int
      */
     public $SMTPTimeout = 5;
 
     /**
      * Enable persistent SMTP connections
      *
-     * @var boolean
+     * @var bool
      */
     public $SMTPKeepAlive = false;
 
@@ -94,14 +94,14 @@ class Email extends BaseConfig
     /**
      * Enable word-wrap
      *
-     * @var boolean
+     * @var bool
      */
     public $wordWrap = true;
 
     /**
      * Character count to wrap at
      *
-     * @var integer
+     * @var int
      */
     public $wrapChars = 76;
 
@@ -122,14 +122,14 @@ class Email extends BaseConfig
     /**
      * Whether to validate the email address
      *
-     * @var boolean
+     * @var bool
      */
     public $validate = false;
 
     /**
      * Email Priority. 1 = highest. 5 = lowest. 3 = normal
      *
-     * @var integer
+     * @var int
      */
     public $priority = 3;
 
@@ -150,21 +150,21 @@ class Email extends BaseConfig
     /**
      * Enable BCC Batch Mode.
      *
-     * @var boolean
+     * @var bool
      */
     public $BCCBatchMode = false;
 
     /**
      * Number of emails in each BCC batch
      *
-     * @var integer
+     * @var int
      */
     public $BCCBatchSize = 200;
 
     /**
      * Enable notify message from server
      *
-     * @var boolean
+     * @var bool
      */
     public $DSN = false;
 }

--- a/app/Config/Encryption.php
+++ b/app/Config/Encryption.php
@@ -50,7 +50,7 @@ class Encryption extends BaseConfig
      *
      * See the user guide for more information on padding.
      *
-     * @var integer
+     * @var int
      */
     public $blockSize = 16;
 

--- a/app/Config/Exceptions.php
+++ b/app/Config/Exceptions.php
@@ -18,7 +18,7 @@ class Exceptions extends BaseConfig
      *
      * Default: true
      *
-     * @var boolean
+     * @var bool
      */
     public $log = true;
 

--- a/app/Config/Honeypot.php
+++ b/app/Config/Honeypot.php
@@ -9,7 +9,7 @@ class Honeypot extends BaseConfig
     /**
      * Makes Honeypot visible or not to human
      *
-     * @var boolean
+     * @var bool
      */
     public $hidden = true;
 

--- a/app/Config/Logger.php
+++ b/app/Config/Logger.php
@@ -35,7 +35,7 @@ class Logger extends BaseConfig
      * For a live site you'll usually enable Critical or higher (3) to be logged otherwise
      * your log files will fill up very fast.
      *
-     * @var integer|array
+     * @var int|array
      */
     public $threshold = 4;
 

--- a/app/Config/Migrations.php
+++ b/app/Config/Migrations.php
@@ -16,7 +16,7 @@ class Migrations extends BaseConfig
      * You should enable migrations whenever you intend to do a schema migration
      * and disable it back when you're done.
      *
-     * @var boolean
+     * @var bool
      */
     public $enabled = true;
 

--- a/app/Config/Modules.php
+++ b/app/Config/Modules.php
@@ -15,7 +15,7 @@ class Modules extends BaseModules
      * $aliases below. If false, no auto-discovery will happen at all,
      * giving a slight performance boost.
      *
-     * @var boolean
+     * @var bool
      */
     public $enabled = true;
 
@@ -27,7 +27,7 @@ class Modules extends BaseModules
      * If true, then auto-discovery will happen across all namespaces loaded
      * by Composer, as well as the namespaces configured locally.
      *
-     * @var boolean
+     * @var bool
      */
     public $discoverInComposer = true;
 

--- a/app/Config/Pager.php
+++ b/app/Config/Pager.php
@@ -33,7 +33,7 @@ class Pager extends BaseConfig
      *
      * The default number of results shown in a single page.
      *
-     * @var integer
+     * @var int
      */
     public $perPage = 20;
 }

--- a/app/Config/Security.php
+++ b/app/Config/Security.php
@@ -48,7 +48,7 @@ class Security extends BaseConfig
      *
      * Defaults to two hours (in seconds).
      *
-     * @var integer
+     * @var int
      */
     public $expires = 7200;
 
@@ -59,7 +59,7 @@ class Security extends BaseConfig
      *
      * Regenerate CSRF Token on every request.
      *
-     * @var boolean
+     * @var bool
      */
     public $regenerate = true;
 
@@ -70,7 +70,7 @@ class Security extends BaseConfig
      *
      * Redirect to previous page with error on failure.
      *
-     * @var boolean
+     * @var bool
      */
     public $redirect = true;
 

--- a/app/Config/Toolbar.php
+++ b/app/Config/Toolbar.php
@@ -53,7 +53,7 @@ class Toolbar extends BaseConfig
      * helping to conserve file space used to store them. You can set it to
      * 0 (zero) to not have any history stored, or -1 for unlimited history.
      *
-     * @var integer
+     * @var int
      */
     public $maxHistory = 20;
 
@@ -81,7 +81,7 @@ class Toolbar extends BaseConfig
      *
      * `$maxQueries` defines the maximum amount of queries that will be stored.
      *
-     * @var integer
+     * @var int
      */
     public $maxQueries = 100;
 }

--- a/app/Config/View.php
+++ b/app/Config/View.php
@@ -14,7 +14,7 @@ class View extends BaseView
      * calls so that it is available to all views. If that is the case,
      * set $saveData to true.
      *
-     * @var boolean
+     * @var bool
      */
     public $saveData = true;
 

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -88,7 +88,7 @@ trait ResponseTrait
      * to match the requested format, with proper content-type and status code.
      *
      * @param array|string|null $data
-     * @param int           $status
+     * @param int               $status
      * @param string            $message
      *
      * @return mixed
@@ -129,7 +129,7 @@ trait ResponseTrait
      * Used for generic failures that no custom methods exist for.
      *
      * @param string|array $messages
-     * @param int      $status        HTTP status code
+     * @param int          $status        HTTP status code
      * @param string|null  $code          Custom, API-specific, error code
      * @param string       $customMessage
      *
@@ -284,8 +284,8 @@ trait ResponseTrait
      * Used when the data provided by the client cannot be validated on one or more fields.
      *
      * @param string|string[] $errors
-     * @param string|null 	  $code
-     * @param string		  $message
+     * @param string|null     $code
+     * @param string          $message
      *
      * @return mixed
      */

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -88,7 +88,7 @@ trait ResponseTrait
      * to match the requested format, with proper content-type and status code.
      *
      * @param array|string|null $data
-     * @param integer           $status
+     * @param int           $status
      * @param string            $message
      *
      * @return mixed
@@ -129,7 +129,7 @@ trait ResponseTrait
      * Used for generic failures that no custom methods exist for.
      *
      * @param string|array $messages
-     * @param integer      $status        HTTP status code
+     * @param int      $status        HTTP status code
      * @param string|null  $code          Custom, API-specific, error code
      * @param string       $customMessage
      *

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -221,7 +221,7 @@ class Autoloader
      * @param string $class The fully qualified class name.
      *
      * @return string|false The mapped file on success, or boolean false
-     *                          on failure.
+     *                      on failure.
      */
     public function loadClass(string $class)
     {

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -176,9 +176,9 @@ class FileLocator
      *      'app/Modules/bar/Config/Routes.php',
      *  ]
      *
-     * @param string  $path
-     * @param string  $ext
-     * @param bool $prioritizeApp
+     * @param string $path
+     * @param string $ext
+     * @param bool   $prioritizeApp
      *
      * @return array
      */

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -178,7 +178,7 @@ class FileLocator
      *
      * @param string  $path
      * @param string  $ext
-     * @param boolean $prioritizeApp
+     * @param bool $prioritizeApp
      *
      * @return array
      */

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -320,7 +320,7 @@ abstract class BaseModel
      * Fetches the row of database
      * This methods works only with dbCalls
      *
-     * @param bool                   $singleton Single or multiple results
+     * @param bool                  $singleton Single or multiple results
      * @param array|int|string|null $id        One primary key or an array of primary keys
      *
      * @return array|object|null The resulting row of data, or null.
@@ -372,10 +372,10 @@ abstract class BaseModel
      * Compiles batch insert and runs the queries, validating each row prior.
      * This methods works only with dbCalls
      *
-     * @param array|null   $set       An associative array of insert values
-     * @param bool|null $escape    Whether to escape values and identifiers
-     * @param int      $batchSize The size of the batch to run
-     * @param bool      $testing   True means only number of records is returned, false will execute the query
+     * @param array|null $set       An associative array of insert values
+     * @param bool|null  $escape    Whether to escape values and identifiers
+     * @param int        $batchSize The size of the batch to run
+     * @param bool       $testing   True means only number of records is returned, false will execute the query
      *
      * @return int|bool Number of rows inserted or FALSE on failure
      */
@@ -386,7 +386,7 @@ abstract class BaseModel
      * This methods works only with dbCalls
      *
      * @param int|array|string|null $id   ID
-     * @param array|null                $data Data
+     * @param array|null            $data Data
      *
      * @return bool
      */
@@ -398,10 +398,10 @@ abstract class BaseModel
      *
      * @param array|null  $set       An associative array of update values
      * @param string|null $index     The where key
-     * @param int     $batchSize The size of the batch to run
-     * @param bool     $returnSQL True means SQL is returned, false will execute the query
+     * @param int         $batchSize The size of the batch to run
+     * @param bool        $returnSQL True means SQL is returned, false will execute the query
      *
-     * @return mixed    Number of rows affected or FALSE on failure
+     * @return mixed Number of rows affected or FALSE on failure
      *
      * @throws DatabaseException
      */
@@ -412,7 +412,7 @@ abstract class BaseModel
      * This methods works only with dbCalls
      *
      * @param int|string|array|null $id    The rows primary key(s)
-     * @param bool                   $purge Allows overriding the soft deletes setting.
+     * @param bool                  $purge Allows overriding the soft deletes setting.
      *
      * @return string|bool
      *
@@ -443,7 +443,7 @@ abstract class BaseModel
      * This methods works only with dbCalls
      *
      * @param array|null $data      Data
-     * @param bool    $returnSQL Set to true to return Query String
+     * @param bool       $returnSQL Set to true to return Query String
      *
      * @return mixed
      */
@@ -498,7 +498,7 @@ abstract class BaseModel
      * Loops over records in batches, allowing you to operate on them.
      * This methods works only with dbCalls
      *
-     * @param int $size     Size
+     * @param int     $size     Size
      * @param Closure $userFunc Callback Function
      *
      * @return void
@@ -708,7 +708,7 @@ abstract class BaseModel
      * it will attempt to convert it to an array.
      *
      * @param array|object|null $data     Data
-     * @param bool           $returnID Whether insert ID should be returned or not.
+     * @param bool              $returnID Whether insert ID should be returned or not.
      *
      * @return int|string|bool
      *
@@ -779,10 +779,10 @@ abstract class BaseModel
     /**
      * Compiles batch insert runs the queries, validating each row prior.
      *
-     * @param array|null   $set       an associative array of insert values
-     * @param bool|null $escape    Whether to escape values and identifiers
-     * @param int      $batchSize The size of the batch to run
-     * @param bool      $testing   True means only number of records is returned, false will execute the query
+     * @param array|null $set       an associative array of insert values
+     * @param bool|null  $escape    Whether to escape values and identifiers
+     * @param int        $batchSize The size of the batch to run
+     * @param bool       $testing   True means only number of records is returned, false will execute the query
      *
      * @return int|bool Number of rows inserted or FALSE on failure
      *
@@ -836,7 +836,7 @@ abstract class BaseModel
      * it will attempt to convert it into an array.
      *
      * @param int|array|string|null $id   ID
-     * @param array|object|null         $data Data
+     * @param array|object|null     $data Data
      *
      * @return bool
      *
@@ -898,10 +898,10 @@ abstract class BaseModel
      *
      * @param array|null  $set       An associative array of update values
      * @param string|null $index     The where key
-     * @param int     $batchSize The size of the batch to run
-     * @param bool     $returnSQL True means SQL is returned, false will execute the query
+     * @param int         $batchSize The size of the batch to run
+     * @param bool        $returnSQL True means SQL is returned, false will execute the query
      *
-     * @return mixed    Number of rows affected or FALSE on failure
+     * @return mixed Number of rows affected or FALSE on failure
      *
      * @throws DatabaseException
      * @throws ReflectionException
@@ -954,7 +954,7 @@ abstract class BaseModel
      * Deletes a single record from the database where $id matches
      *
      * @param int|string|array|null $id    The rows primary key(s)
-     * @param bool                   $purge Allows overriding the soft deletes setting.
+     * @param bool                  $purge Allows overriding the soft deletes setting.
      *
      * @return BaseResult|bool
      *
@@ -1039,7 +1039,7 @@ abstract class BaseModel
      * Compiles a replace and runs the query
      *
      * @param array|null $data      Data
-     * @param bool    $returnSQL Set to true to return Query String
+     * @param bool       $returnSQL Set to true to return Query String
      *
      * @return mixed
      */
@@ -1080,7 +1080,7 @@ abstract class BaseModel
      * to display.
      *
      * @param int|null $perPage Items per page
-     * @param string       $group   Will be used by the pagination library to identify a unique pagination set.
+     * @param string   $group   Will be used by the pagination library to identify a unique pagination set.
      * @param int|null $page    Optional page number (useful when the page number is provided in different way)
      * @param int      $segment Optional URI segment number (if page number is provided by URI segment)
      *
@@ -1520,8 +1520,8 @@ abstract class BaseModel
      * to string on all Time instances
      *
      * @param string|object $data        Data
-     * @param bool       $onlyChanged Only Changed Property
-     * @param bool       $recursive   If true, inner entities will be casted as array as well
+     * @param bool          $onlyChanged Only Changed Property
+     * @param bool          $recursive   If true, inner entities will be casted as array as well
      *
      * @return array Array
      *
@@ -1550,8 +1550,8 @@ abstract class BaseModel
      * properties as an array with raw values.
      *
      * @param string|object $data        Data
-     * @param bool       $onlyChanged Only Changed Property
-     * @param bool       $recursive   If true, inner entities will be casted as array as well
+     * @param bool          $onlyChanged Only Changed Property
+     * @param bool          $recursive   If true, inner entities will be casted as array as well
      *
      * @return array|null Array
      *

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -57,7 +57,7 @@ abstract class BaseModel
     /**
      * Last insert ID
      *
-     * @var integer|string
+     * @var int|string
      */
     protected $insertID = 0;
 
@@ -82,7 +82,7 @@ abstract class BaseModel
      * simply set a date when rows are deleted, or
      * do hard deletes.
      *
-     * @var boolean
+     * @var bool
      */
     protected $useSoftDeletes = false;
 
@@ -98,7 +98,7 @@ abstract class BaseModel
      * If true, will set created_at, and updated_at
      * values during insert and update routines.
      *
-     * @var boolean
+     * @var bool
      */
     protected $useTimestamps = false;
 
@@ -130,7 +130,7 @@ abstract class BaseModel
      * Used by withDeleted to override the
      * model's softDelete setting.
      *
-     * @var boolean
+     * @var bool
      */
     protected $tempUseSoftDeletes;
 
@@ -153,7 +153,7 @@ abstract class BaseModel
      * Whether we should limit fields in inserts
      * and updates to those available in $allowedFields or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $protectFields = true;
 
@@ -185,7 +185,7 @@ abstract class BaseModel
      * Skip the model's validation. Used in conjunction with skipValidation()
      * to skip data validation for any future calls.
      *
-     * @var boolean
+     * @var bool
      */
     protected $skipValidation = false;
 
@@ -193,7 +193,7 @@ abstract class BaseModel
      * Whether rules should be removed that do not exist
      * in the passed in data. Used between inserts/updates.
      *
-     * @var boolean
+     * @var bool
      */
     protected $cleanValidationRules = true;
 
@@ -220,7 +220,7 @@ abstract class BaseModel
     /**
      * Whether to trigger the defined callbacks
      *
-     * @var boolean
+     * @var bool
      */
     protected $allowCallbacks = true;
 
@@ -228,7 +228,7 @@ abstract class BaseModel
      * Used by allowCallbacks() to override the
      * model's allowCallbacks setting.
      *
-     * @var boolean
+     * @var bool
      */
     protected $tempAllowCallbacks;
 
@@ -320,8 +320,8 @@ abstract class BaseModel
      * Fetches the row of database
      * This methods works only with dbCalls
      *
-     * @param boolean                   $singleton Single or multiple results
-     * @param array|integer|string|null $id        One primary key or an array of primary keys
+     * @param bool                   $singleton Single or multiple results
+     * @param array|int|string|null $id        One primary key or an array of primary keys
      *
      * @return array|object|null The resulting row of data, or null.
      */
@@ -343,8 +343,8 @@ abstract class BaseModel
      * Fetches all results, while optionally limiting them.
      * This methods works only with dbCalls
      *
-     * @param integer $limit  Limit
-     * @param integer $offset Offset
+     * @param int $limit  Limit
+     * @param int $offset Offset
      *
      * @return array
      */
@@ -364,7 +364,7 @@ abstract class BaseModel
      *
      * @param array $data Data
      *
-     * @return integer|string|boolean
+     * @return int|string|bool
      */
     abstract protected function doInsert(array $data);
 
@@ -373,11 +373,11 @@ abstract class BaseModel
      * This methods works only with dbCalls
      *
      * @param array|null   $set       An associative array of insert values
-     * @param boolean|null $escape    Whether to escape values and identifiers
-     * @param integer      $batchSize The size of the batch to run
-     * @param boolean      $testing   True means only number of records is returned, false will execute the query
+     * @param bool|null $escape    Whether to escape values and identifiers
+     * @param int      $batchSize The size of the batch to run
+     * @param bool      $testing   True means only number of records is returned, false will execute the query
      *
-     * @return integer|boolean Number of rows inserted or FALSE on failure
+     * @return int|bool Number of rows inserted or FALSE on failure
      */
     abstract protected function doInsertBatch(?array $set = null, ?bool $escape = null, int $batchSize = 100, bool $testing = false);
 
@@ -385,10 +385,10 @@ abstract class BaseModel
      * Updates a single record in the database.
      * This methods works only with dbCalls
      *
-     * @param integer|array|string|null $id   ID
+     * @param int|array|string|null $id   ID
      * @param array|null                $data Data
      *
-     * @return boolean
+     * @return bool
      */
     abstract protected function doUpdate($id = null, $data = null): bool;
 
@@ -398,8 +398,8 @@ abstract class BaseModel
      *
      * @param array|null  $set       An associative array of update values
      * @param string|null $index     The where key
-     * @param integer     $batchSize The size of the batch to run
-     * @param boolean     $returnSQL True means SQL is returned, false will execute the query
+     * @param int     $batchSize The size of the batch to run
+     * @param bool     $returnSQL True means SQL is returned, false will execute the query
      *
      * @return mixed    Number of rows affected or FALSE on failure
      *
@@ -411,10 +411,10 @@ abstract class BaseModel
      * Deletes a single record from the database where $id matches
      * This methods works only with dbCalls
      *
-     * @param integer|string|array|null $id    The rows primary key(s)
-     * @param boolean                   $purge Allows overriding the soft deletes setting.
+     * @param int|string|array|null $id    The rows primary key(s)
+     * @param bool                   $purge Allows overriding the soft deletes setting.
      *
-     * @return string|boolean
+     * @return string|bool
      *
      * @throws DatabaseException
      */
@@ -425,7 +425,7 @@ abstract class BaseModel
      * through soft deletes (deleted = 1)
      * This methods works only with dbCalls
      *
-     * @return boolean|mixed
+     * @return bool|mixed
      */
     abstract protected function doPurgeDeleted();
 
@@ -443,7 +443,7 @@ abstract class BaseModel
      * This methods works only with dbCalls
      *
      * @param array|null $data      Data
-     * @param boolean    $returnSQL Set to true to return Query String
+     * @param bool    $returnSQL Set to true to return Query String
      *
      * @return mixed
      */
@@ -462,7 +462,7 @@ abstract class BaseModel
      *
      * @param array|object $data Data
      *
-     * @return integer|array|string|null
+     * @return int|array|string|null
      *
      * @deprecated Add an override on getIdValue() instead. Will be removed in version 5.0.
      */
@@ -474,7 +474,7 @@ abstract class BaseModel
      *
      * @param array|object $data
      *
-     * @return array|integer|string|null
+     * @return array|int|string|null
      *
      * @todo: Make abstract in version 5.0
      */
@@ -487,8 +487,8 @@ abstract class BaseModel
      * Override countAllResults to account for soft deleted accounts.
      * This methods works only with dbCalls
      *
-     * @param boolean $reset Reset
-     * @param boolean $test  Test
+     * @param bool $reset Reset
+     * @param bool $test  Test
      *
      * @return mixed
      */
@@ -498,7 +498,7 @@ abstract class BaseModel
      * Loops over records in batches, allowing you to operate on them.
      * This methods works only with dbCalls
      *
-     * @param integer $size     Size
+     * @param int $size     Size
      * @param Closure $userFunc Callback Function
      *
      * @return void
@@ -510,7 +510,7 @@ abstract class BaseModel
     /**
      * Fetches the row of database
      *
-     * @param array|integer|string|null $id One primary key or an array of primary keys
+     * @param array|int|string|null $id One primary key or an array of primary keys
      *
      * @return array|object|null The resulting row of data, or null.
      */
@@ -572,8 +572,8 @@ abstract class BaseModel
     /**
      * Fetches all results, while optionally limiting them.
      *
-     * @param integer $limit  Limit
-     * @param integer $offset Offset
+     * @param int $limit  Limit
+     * @param int $offset Offset
      *
      * @return array
      */
@@ -657,7 +657,7 @@ abstract class BaseModel
      *
      * @param array|object $data Data
      *
-     * @return boolean
+     * @return bool
      *
      * @throws ReflectionException
      */
@@ -686,7 +686,7 @@ abstract class BaseModel
      *
      * @param array|object $data Data
      *
-     * @return boolean
+     * @return bool
      */
     protected function shouldUpdate($data) : bool
     {
@@ -696,7 +696,7 @@ abstract class BaseModel
     /**
      * Returns last insert ID or 0.
      *
-     * @return integer|string
+     * @return int|string
      */
     public function getInsertID()
     {
@@ -708,9 +708,9 @@ abstract class BaseModel
      * it will attempt to convert it to an array.
      *
      * @param array|object|null $data     Data
-     * @param boolean           $returnID Whether insert ID should be returned or not.
+     * @param bool           $returnID Whether insert ID should be returned or not.
      *
-     * @return integer|string|boolean
+     * @return int|string|bool
      *
      * @throws ReflectionException
      */
@@ -780,11 +780,11 @@ abstract class BaseModel
      * Compiles batch insert runs the queries, validating each row prior.
      *
      * @param array|null   $set       an associative array of insert values
-     * @param boolean|null $escape    Whether to escape values and identifiers
-     * @param integer      $batchSize The size of the batch to run
-     * @param boolean      $testing   True means only number of records is returned, false will execute the query
+     * @param bool|null $escape    Whether to escape values and identifiers
+     * @param int      $batchSize The size of the batch to run
+     * @param bool      $testing   True means only number of records is returned, false will execute the query
      *
-     * @return integer|boolean Number of rows inserted or FALSE on failure
+     * @return int|bool Number of rows inserted or FALSE on failure
      *
      * @throws ReflectionException
      */
@@ -835,10 +835,10 @@ abstract class BaseModel
      * Updates a single record in the database. If an object is provided,
      * it will attempt to convert it into an array.
      *
-     * @param integer|array|string|null $id   ID
+     * @param int|array|string|null $id   ID
      * @param array|object|null         $data Data
      *
-     * @return boolean
+     * @return bool
      *
      * @throws ReflectionException
      */
@@ -898,8 +898,8 @@ abstract class BaseModel
      *
      * @param array|null  $set       An associative array of update values
      * @param string|null $index     The where key
-     * @param integer     $batchSize The size of the batch to run
-     * @param boolean     $returnSQL True means SQL is returned, false will execute the query
+     * @param int     $batchSize The size of the batch to run
+     * @param bool     $returnSQL True means SQL is returned, false will execute the query
      *
      * @return mixed    Number of rows affected or FALSE on failure
      *
@@ -953,10 +953,10 @@ abstract class BaseModel
     /**
      * Deletes a single record from the database where $id matches
      *
-     * @param integer|string|array|null $id    The rows primary key(s)
-     * @param boolean                   $purge Allows overriding the soft deletes setting.
+     * @param int|string|array|null $id    The rows primary key(s)
+     * @param bool                   $purge Allows overriding the soft deletes setting.
      *
-     * @return BaseResult|boolean
+     * @return BaseResult|bool
      *
      * @throws DatabaseException
      */
@@ -995,7 +995,7 @@ abstract class BaseModel
      * Permanently deletes all rows that have been marked as deleted
      * through soft deletes (deleted = 1)
      *
-     * @return boolean|mixed
+     * @return bool|mixed
      */
     public function purgeDeleted()
     {
@@ -1010,7 +1010,7 @@ abstract class BaseModel
      * Sets $useSoftDeletes value so that we can temporarily override
      * the soft deletes settings. Can be used for all find* methods.
      *
-     * @param boolean $val Value
+     * @param bool $val Value
      *
      * @return $this
      */
@@ -1039,7 +1039,7 @@ abstract class BaseModel
      * Compiles a replace and runs the query
      *
      * @param array|null $data      Data
-     * @param boolean    $returnSQL Set to true to return Query String
+     * @param bool    $returnSQL Set to true to return Query String
      *
      * @return mixed
      */
@@ -1060,7 +1060,7 @@ abstract class BaseModel
      * The return array should be in the following format:
      *  ['source' => 'message']
      *
-     * @param boolean $forceDB Always grab the db error, not validation
+     * @param bool $forceDB Always grab the db error, not validation
      *
      * @return array<string,string>
      */
@@ -1079,10 +1079,10 @@ abstract class BaseModel
      * Expects a GET variable (?page=2) that specifies the page of results
      * to display.
      *
-     * @param integer|null $perPage Items per page
+     * @param int|null $perPage Items per page
      * @param string       $group   Will be used by the pagination library to identify a unique pagination set.
-     * @param integer|null $page    Optional page number (useful when the page number is provided in different way)
-     * @param integer      $segment Optional URI segment number (if page number is provided by URI segment)
+     * @param int|null $page    Optional page number (useful when the page number is provided in different way)
+     * @param int      $segment Optional URI segment number (if page number is provided by URI segment)
      *
      * @return array|null
      */
@@ -1121,7 +1121,7 @@ abstract class BaseModel
      * Sets whether or not we should whitelist data set during
      * updates or inserts against $this->availableFields.
      *
-     * @param boolean $protect Value
+     * @param bool $protect Value
      *
      * @return $this
      */
@@ -1167,7 +1167,7 @@ abstract class BaseModel
     /**
      * Sets the date or current date if null value is passed
      *
-     * @param integer|null $userData An optional PHP timestamp to be converted.
+     * @param int|null $userData An optional PHP timestamp to be converted.
      *
      * @return mixed
      *
@@ -1191,9 +1191,9 @@ abstract class BaseModel
      *  - 'datetime' - Stores the data in the SQL datetime format
      *  - 'date'     - Stores the date (only) in the SQL date format.
      *
-     * @param integer $value value
+     * @param int $value value
      *
-     * @return integer|string
+     * @return int|string
      *
      * @throws ModelException
      */
@@ -1224,7 +1224,7 @@ abstract class BaseModel
      *
      * @param Time $value value
      *
-     * @return string|integer
+     * @return string|int
      */
     protected function timeToDate(Time $value)
     {
@@ -1246,7 +1246,7 @@ abstract class BaseModel
     /**
      * Set the value of the skipValidation flag.
      *
-     * @param boolean $skip Value
+     * @param bool $skip Value
      *
      * @return $this
      */
@@ -1323,7 +1323,7 @@ abstract class BaseModel
      * Should validation rules be removed before saving?
      * Most handy when doing updates.
      *
-     * @param boolean $choice Value
+     * @param bool $choice Value
      *
      * @return $this
      */
@@ -1340,7 +1340,7 @@ abstract class BaseModel
      *
      * @param array|object $data Data
      *
-     * @return boolean
+     * @return bool
      */
     public function validate($data): bool
     {
@@ -1433,7 +1433,7 @@ abstract class BaseModel
      * Sets $tempAllowCallbacks value so that we can temporarily override
      * the setting. Resets after the next method that uses triggers.
      *
-     * @param boolean $val value
+     * @param bool $val value
      *
      * @return $this
      */
@@ -1520,8 +1520,8 @@ abstract class BaseModel
      * to string on all Time instances
      *
      * @param string|object $data        Data
-     * @param boolean       $onlyChanged Only Changed Property
-     * @param boolean       $recursive   If true, inner entities will be casted as array as well
+     * @param bool       $onlyChanged Only Changed Property
+     * @param bool       $recursive   If true, inner entities will be casted as array as well
      *
      * @return array Array
      *
@@ -1550,8 +1550,8 @@ abstract class BaseModel
      * properties as an array with raw values.
      *
      * @param string|object $data        Data
-     * @param boolean       $onlyChanged Only Changed Property
-     * @param boolean       $recursive   If true, inner entities will be casted as array as well
+     * @param bool       $onlyChanged Only Changed Property
+     * @param bool       $recursive   If true, inner entities will be casted as array as well
      *
      * @return array|null Array
      *
@@ -1644,7 +1644,7 @@ abstract class BaseModel
      *
      * @param string $name Name
      *
-     * @return boolean
+     * @return bool
      */
     public function __isset(string $name): bool
     {

--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -184,9 +184,9 @@ abstract class BaseCommand
      * Pads our string out so that all titles are the same length to nicely line up descriptions.
      *
      * @param string  $item
-     * @param integer $max
-     * @param integer $extra  How many extra spaces to add at the end
-     * @param integer $indent
+     * @param int $max
+     * @param int $extra  How many extra spaces to add at the end
+     * @param int $indent
      *
      * @return string
      */
@@ -201,9 +201,9 @@ abstract class BaseCommand
      * Get pad for $key => $value array output
      *
      * @param array   $array
-     * @param integer $pad
+     * @param int $pad
      *
-     * @return integer
+     * @return int
      *
      * @deprecated Use setPad() instead.
      *
@@ -237,7 +237,7 @@ abstract class BaseCommand
      *
      * @param string $key
      *
-     * @return boolean
+     * @return bool
      */
     public function __isset(string $key): bool
     {

--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -183,10 +183,10 @@ abstract class BaseCommand
     /**
      * Pads our string out so that all titles are the same length to nicely line up descriptions.
      *
-     * @param string  $item
-     * @param int $max
-     * @param int $extra  How many extra spaces to add at the end
-     * @param int $indent
+     * @param string $item
+     * @param int    $max
+     * @param int    $extra  How many extra spaces to add at the end
+     * @param int    $indent
      *
      * @return string
      */
@@ -200,8 +200,8 @@ abstract class BaseCommand
     /**
      * Get pad for $key => $value array output
      *
-     * @param array   $array
-     * @param int $pad
+     * @param array $array
+     * @param int   $pad
      *
      * @return int
      *

--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -114,6 +114,7 @@ abstract class BaseCommand
      * @param array  $params
      *
      * @return mixed
+     *
      * @throws ReflectionException
      */
     protected function call(string $command, array $params = [])

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -180,7 +180,8 @@ class CLI
      * Named options must be in the following formats:
      * php index.php user -v --v -name=John --name=John
      *
-     * @param  string $prefix
+     * @param string $prefix
+     *
      * @return string
      *
      * @codeCoverageIgnore

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -391,7 +391,7 @@ class CLI
      * Waits a certain number of seconds, optionally showing a wait message and
      * waiting for a key press.
      *
-     * @param int $seconds   Number of seconds
+     * @param int  $seconds   Number of seconds
      * @param bool $countdown Show a countdown or not
      */
     public static function wait(int $seconds, bool $countdown = false)
@@ -475,7 +475,7 @@ class CLI
      * @param string $background The background color
      * @param string $format     Other formatting to apply. Currently only 'underline' is understood
      *
-     * @return string    The color coded string
+     * @return string The color coded string
      */
     public static function color(string $text, string $foreground, string $background = null, string $format = null): string
     {
@@ -714,7 +714,7 @@ class CLI
      * to update it. Set $thisStep = false to erase the progress bar.
      *
      * @param int|bool $thisStep
-     * @param int         $totalSteps
+     * @param int      $totalSteps
      */
     public static function showProgress($thisStep = 1, int $totalSteps = 10)
     {
@@ -754,9 +754,9 @@ class CLI
      * will padded with that many spaces to the left. Useful when printing
      * short descriptions that need to start on an existing line.
      *
-     * @param string  $string
-     * @param int $max
-     * @param int $padLeft
+     * @param string $string
+     * @param int    $max
+     * @param int    $padLeft
      *
      * @return string
      */

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -39,7 +39,7 @@ class CLI
     /**
      * Is the readline library on the system?
      *
-     * @var boolean
+     * @var bool
      */
     public static $readline_support = false;
 
@@ -53,7 +53,7 @@ class CLI
     /**
      * Has the class already been initialized?
      *
-     * @var boolean
+     * @var bool
      */
     protected static $initialized = false;
 
@@ -122,21 +122,21 @@ class CLI
     /**
      * Height of the CLI window
      *
-     * @var integer|null
+     * @var int|null
      */
     protected static $height;
 
     /**
      * Width of the CLI window
      *
-     * @var integer|null
+     * @var int|null
      */
     protected static $width;
 
     /**
      * Whether the current stream supports colored output.
      *
-     * @var boolean
+     * @var bool
      */
     protected static $isColored = false;
 
@@ -280,7 +280,7 @@ class CLI
      * @param string       $value Input value
      * @param string|array $rules Validation rules
      *
-     * @return boolean
+     * @return bool
      *
      * @codeCoverageIgnore
      */
@@ -378,7 +378,7 @@ class CLI
     /**
      * Beeps a certain number of times.
      *
-     * @param integer $num The number of times to beep
+     * @param int $num The number of times to beep
      */
     public static function beep(int $num = 1)
     {
@@ -391,8 +391,8 @@ class CLI
      * Waits a certain number of seconds, optionally showing a wait message and
      * waiting for a key press.
      *
-     * @param integer $seconds   Number of seconds
-     * @param boolean $countdown Show a countdown or not
+     * @param int $seconds   Number of seconds
+     * @param bool $countdown Show a countdown or not
      */
     public static function wait(int $seconds, bool $countdown = false)
     {
@@ -422,7 +422,7 @@ class CLI
     /**
      * if operating system === windows
      *
-     * @return boolean
+     * @return bool
      */
     public static function isWindows(): bool
     {
@@ -434,7 +434,7 @@ class CLI
     /**
      * Enter a number of empty lines
      *
-     * @param integer $num Number of lines to output
+     * @param int $num Number of lines to output
      *
      * @return void
      */
@@ -536,7 +536,7 @@ class CLI
      *
      * @param string $string
      *
-     * @return integer
+     * @return int
      */
     public static function strlen(?string $string): int
     {
@@ -566,7 +566,7 @@ class CLI
      * @param string   $function
      * @param resource $resource
      *
-     * @return boolean
+     * @return bool
      */
     public static function streamSupports(string $function, $resource): bool
     {
@@ -594,7 +594,7 @@ class CLI
      *
      * @param resource $resource
      *
-     * @return boolean
+     * @return bool
      */
     public static function hasColorSupport($resource): bool
     {
@@ -625,9 +625,9 @@ class CLI
     /**
      * Attempts to determine the width of the viewable CLI window.
      *
-     * @param integer $default
+     * @param int $default
      *
-     * @return integer
+     * @return int
      */
     public static function getWidth(int $default = 80): int
     {
@@ -643,9 +643,9 @@ class CLI
     /**
      * Attempts to determine the height of the viewable CLI window.
      *
-     * @param integer $default
+     * @param int $default
      *
-     * @return integer
+     * @return int
      */
     public static function getHeight(int $default = 32): int
     {
@@ -713,8 +713,8 @@ class CLI
      * Displays a progress bar on the CLI. You must call it repeatedly
      * to update it. Set $thisStep = false to erase the progress bar.
      *
-     * @param integer|boolean $thisStep
-     * @param integer         $totalSteps
+     * @param int|bool $thisStep
+     * @param int         $totalSteps
      */
     public static function showProgress($thisStep = 1, int $totalSteps = 10)
     {
@@ -755,8 +755,8 @@ class CLI
      * short descriptions that need to start on an existing line.
      *
      * @param string  $string
-     * @param integer $max
-     * @param integer $padLeft
+     * @param int $max
+     * @param int $padLeft
      *
      * @return string
      */
@@ -867,7 +867,7 @@ class CLI
      *
      * **IMPORTANT:** The index here is one-based instead of zero-based.
      *
-     * @param integer $index
+     * @param int $index
      *
      * @return mixed|null
      */
@@ -896,7 +896,7 @@ class CLI
      *
      * @param string $name
      *
-     * @return boolean|mixed|null
+     * @return bool|mixed|null
      */
     public static function getOption(string $name)
     {
@@ -929,8 +929,8 @@ class CLI
      * Returns the options as a string, suitable for passing along on
      * the CLI to other commands.
      *
-     * @param boolean $useLongOpts Use '--' for long options?
-     * @param boolean $trim        Trim final string output?
+     * @param bool $useLongOpts Use '--' for long options?
+     * @param bool $trim        Trim final string output?
      *
      * @return string
      */

--- a/system/CLI/CommandRunner.php
+++ b/system/CLI/CommandRunner.php
@@ -43,6 +43,7 @@ class CommandRunner extends Controller
      * @param array  ...$params
      *
      * @return mixed
+     *
      * @throws ReflectionException
      */
     public function _remap($method, ...$params)
@@ -61,6 +62,7 @@ class CommandRunner extends Controller
      * @param array $params
      *
      * @return mixed
+     *
      * @throws ReflectionException
      */
     public function index(array $params)

--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -142,7 +142,7 @@ class Commands
      * @param string $command
      * @param array  $commands
      *
-     * @return boolean
+     * @return bool
      */
     public function verifyCommand(string $command, array $commands): bool
     {

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -46,7 +46,7 @@ class Console
     /**
      * Runs the current command discovered on the CLI.
      *
-     * @param boolean $useSafeOutput
+     * @param bool $useSafeOutput
      *
      * @return RequestInterface|Response|ResponseInterface|mixed
      * @throws Exception
@@ -66,7 +66,7 @@ class Console
     /**
      * Displays basic information about the Console.
      *
-     * @param boolean $suppress
+     * @param bool $suppress
      */
     public function showHeader(bool $suppress = false)
     {

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -49,6 +49,7 @@ class Console
      * @param bool $useSafeOutput
      *
      * @return RequestInterface|Response|ResponseInterface|mixed
+     *
      * @throws Exception
      */
     public function run(bool $useSafeOutput = false)

--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -53,7 +53,7 @@ trait GeneratorTrait
      *
      * @internal
      *
-     * @var boolean
+     * @var bool
      */
     private $hasClassName = true;
 
@@ -62,7 +62,7 @@ trait GeneratorTrait
      *
      * @internal
      *
-     * @var boolean
+     * @var bool
      */
     private $sortImports = true;
 
@@ -71,7 +71,7 @@ trait GeneratorTrait
      *
      * @internal
      *
-     * @var boolean
+     * @var bool
      */
     private $enabledSuffixing = true;
 
@@ -335,7 +335,7 @@ trait GeneratorTrait
     /**
      * Allows child generators to modify the internal `$hasClassName` flag.
      *
-     * @param boolean $hasClassName
+     * @param bool $hasClassName
      *
      * @return $this
      */
@@ -349,7 +349,7 @@ trait GeneratorTrait
     /**
      * Allows child generators to modify the internal `$sortImports` flag.
      *
-     * @param boolean $sortImports
+     * @param bool $sortImports
      *
      * @return $this
      */
@@ -363,7 +363,7 @@ trait GeneratorTrait
     /**
      * Allows child generators to modify the internal `$enabledSuffixing` flag.
      *
-     * @param boolean $enabledSuffixing
+     * @param bool $enabledSuffixing
      *
      * @return $this
      */

--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -37,9 +37,9 @@ interface CacheInterface
     /**
      * Saves an item to the cache store.
      *
-     * @param string  $key   Cache item name
-     * @param mixed   $value The data to save
-     * @param int $ttl   Time To Live, in seconds (default 60)
+     * @param string $key   Cache item name
+     * @param mixed  $value The data to save
+     * @param int    $ttl   Time To Live, in seconds (default 60)
      *
      * @return bool Success or failure
      */
@@ -61,8 +61,8 @@ interface CacheInterface
     /**
      * Performs atomic incrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return mixed
      */
@@ -73,8 +73,8 @@ interface CacheInterface
     /**
      * Performs atomic decrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return mixed
      */
@@ -109,9 +109,9 @@ interface CacheInterface
      * @param string $key Cache item name.
      *
      * @return array|false|null
-     *   Returns null if the item does not exist, otherwise array<string, mixed>
-     *   with at least the 'expire' key for absolute epoch expiry (or null).
-     *   Some handlers may return false when an item does not exist, which is deprecated.
+     *                          Returns null if the item does not exist, otherwise array<string, mixed>
+     *                          with at least the 'expire' key for absolute epoch expiry (or null).
+     *                          Some handlers may return false when an item does not exist, which is deprecated.
      */
     public function getMetaData(string $key);
 

--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -39,9 +39,9 @@ interface CacheInterface
      *
      * @param string  $key   Cache item name
      * @param mixed   $value The data to save
-     * @param integer $ttl   Time To Live, in seconds (default 60)
+     * @param int $ttl   Time To Live, in seconds (default 60)
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function save(string $key, $value, int $ttl = 60);
 
@@ -52,7 +52,7 @@ interface CacheInterface
      *
      * @param string $key Cache item name
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function delete(string $key);
 
@@ -62,7 +62,7 @@ interface CacheInterface
      * Performs atomic incrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
      * @return mixed
      */
@@ -74,7 +74,7 @@ interface CacheInterface
      * Performs atomic decrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
      * @return mixed
      */
@@ -85,7 +85,7 @@ interface CacheInterface
     /**
      * Will delete all items in the entire cache.
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function clean();
 
@@ -120,7 +120,7 @@ interface CacheInterface
     /**
      * Determines if the driver is supported on this system.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSupported(): bool;
 

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -72,7 +72,7 @@ abstract class BaseHandler implements CacheInterface
      * Get an item from the cache, or execute the given Closure and store the result.
      *
      * @param string  $key      Cache item name
-     * @param int $ttl      Time to live
+     * @param int     $ttl      Time to live
      * @param Closure $callback Callback return value
      *
      * @return mixed

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -72,7 +72,7 @@ abstract class BaseHandler implements CacheInterface
      * Get an item from the cache, or execute the given Closure and store the result.
      *
      * @param string  $key      Cache item name
-     * @param integer $ttl      Time to live
+     * @param int $ttl      Time to live
      * @param Closure $callback Callback return value
      *
      * @return mixed

--- a/system/Cache/Handlers/DummyHandler.php
+++ b/system/Cache/Handlers/DummyHandler.php
@@ -45,7 +45,7 @@ class DummyHandler extends BaseHandler
      * Get an item from the cache, or execute the given Closure and store the result.
      *
      * @param string  $key      Cache item name
-     * @param int $ttl      Time to live
+     * @param int     $ttl      Time to live
      * @param Closure $callback Callback return value
      *
      * @return null
@@ -60,9 +60,9 @@ class DummyHandler extends BaseHandler
     /**
      * Saves an item to the cache store.
      *
-     * @param string  $key   Cache item name
-     * @param mixed   $value The data to save
-     * @param int $ttl   Time To Live, in seconds (default 60)
+     * @param string $key   Cache item name
+     * @param mixed  $value The data to save
+     * @param int    $ttl   Time To Live, in seconds (default 60)
      *
      * @return bool Success or failure
      */
@@ -104,8 +104,8 @@ class DummyHandler extends BaseHandler
     /**
      * Performs atomic incrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return bool
      */
@@ -119,8 +119,8 @@ class DummyHandler extends BaseHandler
     /**
      * Performs atomic decrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return bool
      */

--- a/system/Cache/Handlers/DummyHandler.php
+++ b/system/Cache/Handlers/DummyHandler.php
@@ -45,7 +45,7 @@ class DummyHandler extends BaseHandler
      * Get an item from the cache, or execute the given Closure and store the result.
      *
      * @param string  $key      Cache item name
-     * @param integer $ttl      Time to live
+     * @param int $ttl      Time to live
      * @param Closure $callback Callback return value
      *
      * @return null
@@ -62,9 +62,9 @@ class DummyHandler extends BaseHandler
      *
      * @param string  $key   Cache item name
      * @param mixed   $value The data to save
-     * @param integer $ttl   Time To Live, in seconds (default 60)
+     * @param int $ttl   Time To Live, in seconds (default 60)
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function save(string $key, $value, int $ttl = 60)
     {
@@ -78,7 +78,7 @@ class DummyHandler extends BaseHandler
      *
      * @param string $key Cache item name
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function delete(string $key)
     {
@@ -92,7 +92,7 @@ class DummyHandler extends BaseHandler
      *
      * @param string $pattern Cache items glob-style pattern
      *
-     * @return integer The number of deleted items
+     * @return int The number of deleted items
      */
     public function deleteMatching(string $pattern)
     {
@@ -105,9 +105,9 @@ class DummyHandler extends BaseHandler
      * Performs atomic incrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return boolean
+     * @return bool
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -120,9 +120,9 @@ class DummyHandler extends BaseHandler
      * Performs atomic decrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return boolean
+     * @return bool
      */
     public function decrement(string $key, int $offset = 1)
     {
@@ -134,7 +134,7 @@ class DummyHandler extends BaseHandler
     /**
      * Will delete all items in the entire cache.
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function clean()
     {
@@ -175,7 +175,7 @@ class DummyHandler extends BaseHandler
     /**
      * Determines if the driver is supported on this system.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSupported(): bool
     {

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -36,7 +36,7 @@ class FileHandler extends BaseHandler
      * Mode for the stored files.
      * Must be chmod-safe (octal).
      *
-     * @var integer
+     * @var int
      *
      * @see https://www.php.net/manual/en/function.chmod.php
      */
@@ -103,9 +103,9 @@ class FileHandler extends BaseHandler
      *
      * @param string  $key   Cache item name
      * @param mixed   $value The data to save
-     * @param integer $ttl   Time To Live, in seconds (default 60)
+     * @param int $ttl   Time To Live, in seconds (default 60)
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function save(string $key, $value, int $ttl = 60)
     {
@@ -140,7 +140,7 @@ class FileHandler extends BaseHandler
      *
      * @param string $key Cache item name
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function delete(string $key)
     {
@@ -156,7 +156,7 @@ class FileHandler extends BaseHandler
      *
      * @param string $pattern Cache items glob-style pattern
      *
-     * @return integer The number of deleted items
+     * @return int The number of deleted items
      */
     public function deleteMatching(string $pattern)
     {
@@ -177,9 +177,9 @@ class FileHandler extends BaseHandler
      * Performs atomic incrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return boolean
+     * @return bool
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -206,9 +206,9 @@ class FileHandler extends BaseHandler
      * Performs atomic decrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return boolean
+     * @return bool
      */
     public function decrement(string $key, int $offset = 1)
     {
@@ -234,7 +234,7 @@ class FileHandler extends BaseHandler
     /**
      * Will delete all items in the entire cache.
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function clean()
     {
@@ -288,7 +288,7 @@ class FileHandler extends BaseHandler
     /**
      * Determines if the driver is supported on this system.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSupported(): bool
     {
@@ -303,7 +303,7 @@ class FileHandler extends BaseHandler
      *
      * @param string $filename
      *
-     * @return boolean|mixed
+     * @return bool|mixed
      */
     protected function getItem(string $filename)
     {
@@ -341,7 +341,7 @@ class FileHandler extends BaseHandler
      * @param string $data
      * @param string $mode
      *
-     * @return boolean
+     * @return bool
      */
     protected function writeFile($path, $data, $mode = 'wb')
     {
@@ -374,11 +374,11 @@ class FileHandler extends BaseHandler
      * within the supplied base directory will be nuked as well.
      *
      * @param string  $path   File path
-     * @param boolean $delDir Whether to delete any directories found in the path
-     * @param boolean $htdocs Whether to skip deleting .htaccess and index page files
-     * @param integer $_level Current directory depth level (default: 0; internal use only)
+     * @param bool $delDir Whether to delete any directories found in the path
+     * @param bool $htdocs Whether to skip deleting .htaccess and index page files
+     * @param int $_level Current directory depth level (default: 0; internal use only)
      *
-     * @return boolean
+     * @return bool
      */
     protected function deleteFiles(string $path, bool $delDir = false, bool $htdocs = false, int $_level = 0): bool
     {
@@ -415,8 +415,8 @@ class FileHandler extends BaseHandler
      * Any sub-folders contained within the specified path are read as well.
      *
      * @param string  $sourceDir    Path to source
-     * @param boolean $topLevelOnly Look only at the top level directory specified?
-     * @param boolean $_recursion   Internal variable to determine recursion status - do not use in calls
+     * @param bool $topLevelOnly Look only at the top level directory specified?
+     * @param bool $_recursion   Internal variable to determine recursion status - do not use in calls
      *
      * @return array|false
      */

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -47,7 +47,8 @@ class FileHandler extends BaseHandler
     /**
      * Constructor.
      *
-     * @param  Cache $config
+     * @param Cache $config
+     *
      * @throws CacheException
      */
     public function __construct(Cache $config)
@@ -101,9 +102,9 @@ class FileHandler extends BaseHandler
     /**
      * Saves an item to the cache store.
      *
-     * @param string  $key   Cache item name
-     * @param mixed   $value The data to save
-     * @param int $ttl   Time To Live, in seconds (default 60)
+     * @param string $key   Cache item name
+     * @param mixed  $value The data to save
+     * @param int    $ttl   Time To Live, in seconds (default 60)
      *
      * @return bool Success or failure
      */
@@ -176,8 +177,8 @@ class FileHandler extends BaseHandler
     /**
      * Performs atomic incrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return bool
      */
@@ -205,8 +206,8 @@ class FileHandler extends BaseHandler
     /**
      * Performs atomic decrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return bool
      */
@@ -264,9 +265,9 @@ class FileHandler extends BaseHandler
      * @param string $key Cache item name.
      *
      * @return array|false|null
-     *   Returns null if the item does not exist, otherwise array<string, mixed>
-     *   with at least the 'expire' key for absolute epoch expiry (or null).
-     *   Some handlers may return false when an item does not exist, which is deprecated.
+     *                          Returns null if the item does not exist, otherwise array<string, mixed>
+     *                          with at least the 'expire' key for absolute epoch expiry (or null).
+     *                          Some handlers may return false when an item does not exist, which is deprecated.
      */
     public function getMetaData(string $key)
     {
@@ -373,10 +374,10 @@ class FileHandler extends BaseHandler
      * If the second parameter is set to TRUE, any directories contained
      * within the supplied base directory will be nuked as well.
      *
-     * @param string  $path   File path
-     * @param bool $delDir Whether to delete any directories found in the path
-     * @param bool $htdocs Whether to skip deleting .htaccess and index page files
-     * @param int $_level Current directory depth level (default: 0; internal use only)
+     * @param string $path   File path
+     * @param bool   $delDir Whether to delete any directories found in the path
+     * @param bool   $htdocs Whether to skip deleting .htaccess and index page files
+     * @param int    $_level Current directory depth level (default: 0; internal use only)
      *
      * @return bool
      */
@@ -414,9 +415,9 @@ class FileHandler extends BaseHandler
      *
      * Any sub-folders contained within the specified path are read as well.
      *
-     * @param string  $sourceDir    Path to source
-     * @param bool $topLevelOnly Look only at the top level directory specified?
-     * @param bool $_recursion   Internal variable to determine recursion status - do not use in calls
+     * @param string $sourceDir    Path to source
+     * @param bool   $topLevelOnly Look only at the top level directory specified?
+     * @param bool   $_recursion   Internal variable to determine recursion status - do not use in calls
      *
      * @return array|false
      */

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -169,9 +169,9 @@ class MemcachedHandler extends BaseHandler
     /**
      * Saves an item to the cache store.
      *
-     * @param string  $key   Cache item name
-     * @param mixed   $value The data to save
-     * @param int $ttl   Time To Live, in seconds (default 60)
+     * @param string $key   Cache item name
+     * @param mixed  $value The data to save
+     * @param int    $ttl   Time To Live, in seconds (default 60)
      *
      * @return bool Success or failure
      */
@@ -234,8 +234,8 @@ class MemcachedHandler extends BaseHandler
     /**
      * Performs atomic incrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return int|false
      */
@@ -256,8 +256,8 @@ class MemcachedHandler extends BaseHandler
     /**
      * Performs atomic decrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return int|false
      */
@@ -309,9 +309,9 @@ class MemcachedHandler extends BaseHandler
      * @param string $key Cache item name.
      *
      * @return array|false|null
-     *   Returns null if the item does not exist, otherwise array<string, mixed>
-     *   with at least the 'expire' key for absolute epoch expiry (or null).
-     *   Some handlers may return false when an item does not exist, which is deprecated.
+     *                          Returns null if the item does not exist, otherwise array<string, mixed>
+     *                          with at least the 'expire' key for absolute epoch expiry (or null).
+     *                          Some handlers may return false when an item does not exist, which is deprecated.
      */
     public function getMetaData(string $key)
     {

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -171,9 +171,9 @@ class MemcachedHandler extends BaseHandler
      *
      * @param string  $key   Cache item name
      * @param mixed   $value The data to save
-     * @param integer $ttl   Time To Live, in seconds (default 60)
+     * @param int $ttl   Time To Live, in seconds (default 60)
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function save(string $key, $value, int $ttl = 60)
     {
@@ -206,7 +206,7 @@ class MemcachedHandler extends BaseHandler
      *
      * @param string $key Cache item name
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function delete(string $key)
     {
@@ -235,9 +235,9 @@ class MemcachedHandler extends BaseHandler
      * Performs atomic incrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return integer|false
+     * @return int|false
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -257,9 +257,9 @@ class MemcachedHandler extends BaseHandler
      * Performs atomic decrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return integer|false
+     * @return int|false
      */
     public function decrement(string $key, int $offset = 1)
     {
@@ -279,7 +279,7 @@ class MemcachedHandler extends BaseHandler
     /**
      * Will delete all items in the entire cache.
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function clean()
     {
@@ -337,7 +337,7 @@ class MemcachedHandler extends BaseHandler
     /**
      * Determines if the driver is supported on this system.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSupported(): bool
     {

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -128,9 +128,9 @@ class PredisHandler extends BaseHandler
      *
      * @param string  $key   Cache item name
      * @param mixed   $value The data to save
-     * @param integer $ttl   Time To Live, in seconds (default 60)
+     * @param int $ttl   Time To Live, in seconds (default 60)
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function save(string $key, $value, int $ttl = 60)
     {
@@ -170,7 +170,7 @@ class PredisHandler extends BaseHandler
      *
      * @param string $key Cache item name
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function delete(string $key)
     {
@@ -186,7 +186,7 @@ class PredisHandler extends BaseHandler
      *
      * @param string $pattern Cache items glob-style pattern
      *
-     * @return integer The number of deleted items
+     * @return int The number of deleted items
      */
     public function deleteMatching(string $pattern)
     {
@@ -205,9 +205,9 @@ class PredisHandler extends BaseHandler
      * Performs atomic incrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return integer
+     * @return int
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -222,9 +222,9 @@ class PredisHandler extends BaseHandler
      * Performs atomic decrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return integer
+     * @return int
      */
     public function decrement(string $key, int $offset = 1)
     {
@@ -238,7 +238,7 @@ class PredisHandler extends BaseHandler
     /**
      * Will delete all items in the entire cache.
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function clean()
     {
@@ -296,7 +296,7 @@ class PredisHandler extends BaseHandler
     /**
      * Determines if the driver is supported on this system.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSupported(): bool
     {

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -126,9 +126,9 @@ class PredisHandler extends BaseHandler
     /**
      * Saves an item to the cache store.
      *
-     * @param string  $key   Cache item name
-     * @param mixed   $value The data to save
-     * @param int $ttl   Time To Live, in seconds (default 60)
+     * @param string $key   Cache item name
+     * @param mixed  $value The data to save
+     * @param int    $ttl   Time To Live, in seconds (default 60)
      *
      * @return bool Success or failure
      */
@@ -204,8 +204,8 @@ class PredisHandler extends BaseHandler
     /**
      * Performs atomic incrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return int
      */
@@ -221,8 +221,8 @@ class PredisHandler extends BaseHandler
     /**
      * Performs atomic decrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return int
      */
@@ -268,8 +268,8 @@ class PredisHandler extends BaseHandler
      * @param string $key Cache item name.
      *
      * @return array|false|null
-     *   Returns null if the item does not exist, otherwise array<string, mixed>
-     *   with at least the 'expire' key for absolute epoch expiry (or null).
+     *                          Returns null if the item does not exist, otherwise array<string, mixed>
+     *                          with at least the 'expire' key for absolute epoch expiry (or null).
      */
     public function getMetaData(string $key)
     {

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -152,9 +152,9 @@ class RedisHandler extends BaseHandler
     /**
      * Saves an item to the cache store.
      *
-     * @param string  $key   Cache item name
-     * @param mixed   $value The data to save
-     * @param int $ttl   Time To Live, in seconds (default 60)
+     * @param string $key   Cache item name
+     * @param mixed  $value The data to save
+     * @param int    $ttl   Time To Live, in seconds (default 60)
      *
      * @return bool Success or failure
      */
@@ -241,8 +241,8 @@ class RedisHandler extends BaseHandler
     /**
      * Performs atomic incrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return int
      */
@@ -258,8 +258,8 @@ class RedisHandler extends BaseHandler
     /**
      * Performs atomic decrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return int
      */
@@ -305,8 +305,8 @@ class RedisHandler extends BaseHandler
      * @param string $key Cache item name.
      *
      * @return array|null
-     *   Returns null if the item does not exist, otherwise array<string, mixed>
-     *   with at least the 'expire' key for absolute epoch expiry (or null).
+     *                    Returns null if the item does not exist, otherwise array<string, mixed>
+     *                    with at least the 'expire' key for absolute epoch expiry (or null).
      */
     public function getMetaData(string $key)
     {

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -154,9 +154,9 @@ class RedisHandler extends BaseHandler
      *
      * @param string  $key   Cache item name
      * @param mixed   $value The data to save
-     * @param integer $ttl   Time To Live, in seconds (default 60)
+     * @param int $ttl   Time To Live, in seconds (default 60)
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function save(string $key, $value, int $ttl = 60)
     {
@@ -198,7 +198,7 @@ class RedisHandler extends BaseHandler
      *
      * @param string $key Cache item name
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function delete(string $key)
     {
@@ -214,7 +214,7 @@ class RedisHandler extends BaseHandler
      *
      * @param string $pattern Cache items glob-style pattern
      *
-     * @return integer The number of deleted items
+     * @return int The number of deleted items
      */
     public function deleteMatching(string $pattern)
     {
@@ -242,9 +242,9 @@ class RedisHandler extends BaseHandler
      * Performs atomic incrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return integer
+     * @return int
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -259,9 +259,9 @@ class RedisHandler extends BaseHandler
      * Performs atomic decrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return integer
+     * @return int
      */
     public function decrement(string $key, int $offset = 1)
     {
@@ -275,7 +275,7 @@ class RedisHandler extends BaseHandler
     /**
      * Will delete all items in the entire cache.
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function clean()
     {
@@ -332,7 +332,7 @@ class RedisHandler extends BaseHandler
     /**
      * Determines if the driver is supported on this system.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSupported(): bool
     {

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -65,9 +65,9 @@ class WincacheHandler extends BaseHandler
     /**
      * Saves an item to the cache store.
      *
-     * @param string  $key   Cache item name
-     * @param mixed   $value The data to save
-     * @param int $ttl   Time To Live, in seconds (default 60)
+     * @param string $key   Cache item name
+     * @param mixed  $value The data to save
+     * @param int    $ttl   Time To Live, in seconds (default 60)
      *
      * @return bool Success or failure
      */
@@ -113,8 +113,8 @@ class WincacheHandler extends BaseHandler
     /**
      * Performs atomic incrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return int|false
      */
@@ -130,8 +130,8 @@ class WincacheHandler extends BaseHandler
     /**
      * Performs atomic decrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return int|false
      */
@@ -177,9 +177,9 @@ class WincacheHandler extends BaseHandler
      * @param string $key Cache item name.
      *
      * @return array|false|null
-     *   Returns null if the item does not exist, otherwise array<string, mixed>
-     *   with at least the 'expire' key for absolute epoch expiry (or null).
-     *   Some handlers may return false when an item does not exist, which is deprecated.
+     *                          Returns null if the item does not exist, otherwise array<string, mixed>
+     *                          with at least the 'expire' key for absolute epoch expiry (or null).
+     *                          Some handlers may return false when an item does not exist, which is deprecated.
      */
     public function getMetaData(string $key)
     {

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -67,9 +67,9 @@ class WincacheHandler extends BaseHandler
      *
      * @param string  $key   Cache item name
      * @param mixed   $value The data to save
-     * @param integer $ttl   Time To Live, in seconds (default 60)
+     * @param int $ttl   Time To Live, in seconds (default 60)
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function save(string $key, $value, int $ttl = 60)
     {
@@ -85,7 +85,7 @@ class WincacheHandler extends BaseHandler
      *
      * @param string $key Cache item name
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function delete(string $key)
     {
@@ -114,9 +114,9 @@ class WincacheHandler extends BaseHandler
      * Performs atomic incrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return integer|false
+     * @return int|false
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -131,9 +131,9 @@ class WincacheHandler extends BaseHandler
      * Performs atomic decrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return integer|false
+     * @return int|false
      */
     public function decrement(string $key, int $offset = 1)
     {
@@ -147,7 +147,7 @@ class WincacheHandler extends BaseHandler
     /**
      * Will delete all items in the entire cache.
      *
-     * @return boolean Success or failure
+     * @return bool Success or failure
      */
     public function clean()
     {
@@ -206,7 +206,7 @@ class WincacheHandler extends BaseHandler
     /**
      * Determines if the driver is supported on this system.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSupported(): bool
     {

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -121,7 +121,7 @@ class CodeIgniter
     /**
      * Cache expiration time
      *
-     * @var integer
+     * @var int
      */
     protected static $cacheTTL = 0;
 
@@ -136,7 +136,7 @@ class CodeIgniter
      * Should the Response instance "pretend"
      * to keep from setting headers/cookies/etc
      *
-     * @var boolean
+     * @var bool
      */
     protected $useSafeOutput = false;
 
@@ -285,9 +285,9 @@ class CodeIgniter
      * makes all of the pieces work together.
      *
      * @param RouteCollectionInterface|null $routes
-     * @param boolean                       $returnResponse
+     * @param bool                       $returnResponse
      *
-     * @return boolean|RequestInterface|ResponseInterface|mixed
+     * @return bool|RequestInterface|ResponseInterface|mixed
      * @throws RedirectException
      * @throws Exception
      */
@@ -345,7 +345,7 @@ class CodeIgniter
      * cookies and headers are not actually sent, allowing PHP 7.2+ to
      * not complain when ini_set() function is used.
      *
-     * @param boolean $safe
+     * @param bool $safe
      *
      * @return $this
      */
@@ -363,7 +363,7 @@ class CodeIgniter
      *
      * @param RouteCollectionInterface|null $routes
      * @param Cache                         $cacheConfig
-     * @param boolean                       $returnResponse
+     * @param bool                       $returnResponse
      *
      * @return RequestInterface|ResponseInterface|mixed
      * @throws RedirectException
@@ -585,7 +585,7 @@ class CodeIgniter
      * as set the HTTP Strict Transport Security header for those browsers
      * that support it.
      *
-     * @param integer $duration How long the Strict Transport Security
+     * @param int $duration How long the Strict Transport Security
      *                          should be enforced for this URL.
      */
     protected function forceSecureAccess($duration = 31536000)
@@ -606,7 +606,7 @@ class CodeIgniter
      *
      * @throws Exception
      *
-     * @return boolean|ResponseInterface
+     * @return bool|ResponseInterface
      */
     public function displayCache(Cache $config)
     {
@@ -643,7 +643,7 @@ class CodeIgniter
     /**
      * Tells the app that the final output should be cached.
      *
-     * @param integer $time
+     * @param int $time
      *
      * @return void
      */
@@ -1052,7 +1052,7 @@ class CodeIgniter
      * Made into a separate method so that it can be mocked during testing
      * without actually stopping script execution.
      *
-     * @param integer $code
+     * @param int $code
      */
     protected function callExit($code)
     {

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -288,6 +288,7 @@ class CodeIgniter
      * @param bool                          $returnResponse
      *
      * @return bool|RequestInterface|ResponseInterface|mixed
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -366,6 +367,7 @@ class CodeIgniter
      * @param bool                          $returnResponse
      *
      * @return RequestInterface|ResponseInterface|mixed
+     *
      * @throws RedirectException
      */
     protected function handleRequest(?RouteCollectionInterface $routes, Cache $cacheConfig, bool $returnResponse = false)
@@ -741,6 +743,7 @@ class CodeIgniter
      *                                              of the config file.
      *
      * @return string|null
+     *
      * @throws RedirectException
      */
     protected function tryToRouteIt(RouteCollectionInterface $routes = null)

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -285,7 +285,7 @@ class CodeIgniter
      * makes all of the pieces work together.
      *
      * @param RouteCollectionInterface|null $routes
-     * @param bool                       $returnResponse
+     * @param bool                          $returnResponse
      *
      * @return bool|RequestInterface|ResponseInterface|mixed
      * @throws RedirectException
@@ -363,7 +363,7 @@ class CodeIgniter
      *
      * @param RouteCollectionInterface|null $routes
      * @param Cache                         $cacheConfig
-     * @param bool                       $returnResponse
+     * @param bool                          $returnResponse
      *
      * @return RequestInterface|ResponseInterface|mixed
      * @throws RedirectException
@@ -586,7 +586,7 @@ class CodeIgniter
      * that support it.
      *
      * @param int $duration How long the Strict Transport Security
-     *                          should be enforced for this URL.
+     *                      should be enforced for this URL.
      */
     protected function forceSecureAccess($duration = 31536000)
     {
@@ -738,7 +738,7 @@ class CodeIgniter
      * "redirect route", will also handle the redirect.
      *
      * @param RouteCollectionInterface|null $routes An collection interface to use in place
-     *                                         of the config file.
+     *                                              of the config file.
      *
      * @return string|null
      * @throws RedirectException

--- a/system/Commands/Encryption/GenerateKey.php
+++ b/system/Commands/Encryption/GenerateKey.php
@@ -114,7 +114,7 @@ class GenerateKey extends BaseCommand
      * Generates a key and encodes it.
      *
      * @param string  $prefix
-     * @param integer $length
+     * @param int $length
      *
      * @return string
      */
@@ -135,7 +135,7 @@ class GenerateKey extends BaseCommand
      * @param string $key
      * @param array  $params
      *
-     * @return boolean
+     * @return bool
      */
     protected function setNewEncryptionKey(string $key, array $params): bool
     {
@@ -156,7 +156,7 @@ class GenerateKey extends BaseCommand
      *
      * @param array $params
      *
-     * @return boolean
+     * @return bool
      */
     protected function confirmOverwrite(array $params): bool
     {
@@ -169,7 +169,7 @@ class GenerateKey extends BaseCommand
      * @param string $oldKey
      * @param string $newKey
      *
-     * @return boolean
+     * @return bool
      */
     protected function writeNewEncryptionKeyToFile(string $oldKey, string $newKey): bool
     {

--- a/system/Commands/Encryption/GenerateKey.php
+++ b/system/Commands/Encryption/GenerateKey.php
@@ -113,8 +113,8 @@ class GenerateKey extends BaseCommand
     /**
      * Generates a key and encodes it.
      *
-     * @param string  $prefix
-     * @param int $length
+     * @param string $prefix
+     * @param int    $length
      *
      * @return string
      */

--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -68,14 +68,14 @@ class Serve extends BaseCommand
     /**
      * The current port offset.
      *
-     * @var integer
+     * @var int
      */
     protected $portOffset = 0;
 
     /**
      * The max number of ports to attempt to serve from
      *
-     * @var integer
+     * @var int
      */
     protected $tries = 10;
 

--- a/system/Commands/Utilities/Environment.php
+++ b/system/Commands/Utilities/Environment.php
@@ -124,7 +124,7 @@ final class Environment extends BaseCommand
      *
      * @param string $newEnv
      *
-     * @return boolean
+     * @return bool
      */
     private function writeNewEnvironmentToEnvFile(string $newEnv): bool
     {

--- a/system/Common.php
+++ b/system/Common.php
@@ -203,7 +203,7 @@ if (! function_exists('config')) {
      * More simple way of getting config instances from Factories
      *
      * @param string  $name
-     * @param boolean $getShared
+     * @param bool $getShared
      *
      * @return mixed
      */
@@ -236,7 +236,7 @@ if (! function_exists('cookies')) {
      * Fetches the global `CookieStore` instance held by `Response`.
      *
      * @param Cookie[] $cookies   If `getGlobal` is false, this is passed to CookieStore's constructor
-     * @param boolean  $getGlobal If false, creates a new instance of CookieStore
+     * @param bool  $getGlobal If false, creates a new instance of CookieStore
      *
      * @return CookieStore
      */
@@ -336,7 +336,7 @@ if (! function_exists('db_connect')) {
      * otherwise it will all calls will return the same instance.
      *
      * @param ConnectionInterface|array|string|null $db
-     * @param boolean                               $getShared
+     * @param bool                               $getShared
      *
      * @return BaseConnection
      */
@@ -472,7 +472,7 @@ if (! function_exists('force_https')) {
      *
      * @see https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
      *
-     * @param integer           $duration How long should the SSL header be set for? (in seconds)
+     * @param int           $duration How long should the SSL header be set for? (in seconds)
      *                                    Defaults to 1 year.
      * @param RequestInterface  $request
      * @param ResponseInterface $response
@@ -550,7 +550,7 @@ if (! function_exists('function_usable')) {
      *
      * @link   http://www.hardened-php.net/suhosin/
      * @param  string $functionName Function to check for
-     * @return boolean    TRUE if the function exists and is safe to call,
+     * @return bool    TRUE if the function exists and is safe to call,
      *             FALSE otherwise.
      *
      * @codeCoverageIgnore This is too exotic
@@ -677,7 +677,7 @@ if (! function_exists('is_cli')) {
     /**
      * Check if PHP was invoked from the command line.
      *
-     * @return boolean
+     * @return bool
      *
      * @codeCoverageIgnore Cannot be tested fully as PHPUnit always run in CLI
      */
@@ -716,7 +716,7 @@ if (! function_exists('is_really_writable')) {
      *
      * @param string $file
      *
-     * @return boolean
+     * @return bool
      *
      * @throws             Exception
      * @codeCoverageIgnore Not practical to test, as travis runs on linux
@@ -816,7 +816,7 @@ if (! function_exists('model')) {
      * More simple way of getting model instances from Factories
      *
      * @param string                   $name
-     * @param boolean                  $getShared
+     * @param bool                  $getShared
      * @param ConnectionInterface|null $conn
      *
      * @return mixed
@@ -834,7 +834,7 @@ if (! function_exists('old')) {
      *
      * @param string         $key
      * @param null           $default
-     * @param string|boolean $escape
+     * @param string|bool $escape
      *
      * @return mixed|null
      */
@@ -900,7 +900,7 @@ if (! function_exists('remove_invisible_characters')) {
      * between ascii characters, like Java\0script.
      *
      * @param string  $str
-     * @param boolean $urlEncoded
+     * @param bool $urlEncoded
      *
      * @return string
      */
@@ -1066,7 +1066,7 @@ if (! function_exists('stringify_attributes')) {
      * of attributes to a string.
      *
      * @param mixed   $attributes string, array, object
-     * @param boolean $js
+     * @param bool $js
      *
      * @return string
      */
@@ -1171,7 +1171,7 @@ if (! function_exists('view_cell')) {
      *
      * @param string      $library
      * @param null        $params
-     * @param integer     $ttl
+     * @param int     $ttl
      * @param string|null $cacheName
      *
      * @return string

--- a/system/Common.php
+++ b/system/Common.php
@@ -202,8 +202,8 @@ if (! function_exists('config')) {
     /**
      * More simple way of getting config instances from Factories
      *
-     * @param string  $name
-     * @param bool $getShared
+     * @param string $name
+     * @param bool   $getShared
      *
      * @return mixed
      */
@@ -236,7 +236,7 @@ if (! function_exists('cookies')) {
      * Fetches the global `CookieStore` instance held by `Response`.
      *
      * @param Cookie[] $cookies   If `getGlobal` is false, this is passed to CookieStore's constructor
-     * @param bool  $getGlobal If false, creates a new instance of CookieStore
+     * @param bool     $getGlobal If false, creates a new instance of CookieStore
      *
      * @return CookieStore
      */
@@ -336,7 +336,7 @@ if (! function_exists('db_connect')) {
      * otherwise it will all calls will return the same instance.
      *
      * @param ConnectionInterface|array|string|null $db
-     * @param bool                               $getShared
+     * @param bool                                  $getShared
      *
      * @return BaseConnection
      */
@@ -472,7 +472,7 @@ if (! function_exists('force_https')) {
      *
      * @see https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
      *
-     * @param int           $duration How long should the SSL header be set for? (in seconds)
+     * @param int               $duration How long should the SSL header be set for? (in seconds)
      *                                    Defaults to 1 year.
      * @param RequestInterface  $request
      * @param ResponseInterface $response
@@ -550,8 +550,8 @@ if (! function_exists('function_usable')) {
      *
      * @link   http://www.hardened-php.net/suhosin/
      * @param  string $functionName Function to check for
-     * @return bool    TRUE if the function exists and is safe to call,
-     *             FALSE otherwise.
+     * @return bool   TRUE if the function exists and is safe to call,
+     *                             FALSE otherwise.
      *
      * @codeCoverageIgnore This is too exotic
      */
@@ -581,7 +581,7 @@ if (! function_exists('helper')) {
      *   2. {namespace}/Helpers
      *   3. system/Helpers
      *
-     * @param  string|array $filenames
+     * @param  string|array          $filenames
      * @throws FileNotFoundException
      */
     function helper($filenames)
@@ -718,7 +718,7 @@ if (! function_exists('is_really_writable')) {
      *
      * @return bool
      *
-     * @throws             Exception
+     * @throws Exception
      * @codeCoverageIgnore Not practical to test, as travis runs on linux
      */
     function is_really_writable(string $file): bool
@@ -816,7 +816,7 @@ if (! function_exists('model')) {
      * More simple way of getting model instances from Factories
      *
      * @param string                   $name
-     * @param bool                  $getShared
+     * @param bool                     $getShared
      * @param ConnectionInterface|null $conn
      *
      * @return mixed
@@ -832,8 +832,8 @@ if (! function_exists('old')) {
      * Provides access to "old input" that was set in the session
      * during a redirect()->withInput().
      *
-     * @param string         $key
-     * @param null           $default
+     * @param string      $key
+     * @param null        $default
      * @param string|bool $escape
      *
      * @return mixed|null
@@ -899,8 +899,8 @@ if (! function_exists('remove_invisible_characters')) {
      * This prevents sandwiching null characters
      * between ascii characters, like Java\0script.
      *
-     * @param string  $str
-     * @param bool $urlEncoded
+     * @param string $str
+     * @param bool   $urlEncoded
      *
      * @return string
      */
@@ -1043,7 +1043,7 @@ if (! function_exists('slash_item')) {
      * @param string $item Config item name
      *
      * @return string|null The configuration item or NULL if
-     * the item doesn't exist
+     *                     the item doesn't exist
      */
     function slash_item(string $item): ?string
     {
@@ -1065,8 +1065,8 @@ if (! function_exists('stringify_attributes')) {
      * Helper function used to convert a string, array, or object
      * of attributes to a string.
      *
-     * @param mixed   $attributes string, array, object
-     * @param bool $js
+     * @param mixed $attributes string, array, object
+     * @param bool  $js
      *
      * @return string
      */
@@ -1171,7 +1171,7 @@ if (! function_exists('view_cell')) {
      *
      * @param string      $library
      * @param null        $params
-     * @param int     $ttl
+     * @param int         $ttl
      * @param string|null $cacheName
      *
      * @return string

--- a/system/Common.php
+++ b/system/Common.php
@@ -421,6 +421,7 @@ if (! function_exists('esc')) {
      * @param string       $encoding
      *
      * @return string|array
+     *
      * @throws InvalidArgumentException
      */
     function esc($data, string $context = 'html', string $encoding = null)
@@ -549,9 +550,11 @@ if (! function_exists('function_usable')) {
      * be just temporary, but would probably be kept for a few years.
      *
      * @link   http://www.hardened-php.net/suhosin/
-     * @param  string $functionName Function to check for
-     * @return bool   TRUE if the function exists and is safe to call,
-     *                             FALSE otherwise.
+     *
+     * @param string $functionName Function to check for
+     *
+     * @return bool TRUE if the function exists and is safe to call,
+     *              FALSE otherwise.
      *
      * @codeCoverageIgnore This is too exotic
      */
@@ -581,7 +584,8 @@ if (! function_exists('helper')) {
      *   2. {namespace}/Helpers
      *   3. system/Helpers
      *
-     * @param  string|array          $filenames
+     * @param string|array $filenames
+     *
      * @throws FileNotFoundException
      */
     function helper($filenames)
@@ -1175,6 +1179,7 @@ if (! function_exists('view_cell')) {
      * @param string|null $cacheName
      *
      * @return string
+     *
      * @throws ReflectionException
      */
     function view_cell(string $library, $params = null, int $ttl = 0, string $cacheName = null): string

--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -40,7 +40,7 @@ class BaseConfig
     /**
      * Has module discovery happened yet?
      *
-     * @var boolean
+     * @var bool
      */
     protected static $didDiscovery = false;
 

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -146,7 +146,7 @@ class BaseService
     /**
      * Have we already discovered other Services?
      *
-     * @var boolean
+     * @var bool
      */
     protected static $discovered = false;
 
@@ -197,7 +197,7 @@ class BaseService
      * The Autoloader class is the central class that handles our
      * spl_autoload_register method, and helper methods.
      *
-     * @param boolean $getShared
+     * @param bool $getShared
      *
      * @return Autoloader
      */
@@ -219,7 +219,7 @@ class BaseService
      * within namespaced folders, as well as convenience methods for
      * loading 'helpers', and 'libraries'.
      *
-     * @param boolean $getShared
+     * @param bool $getShared
      *
      * @return FileLocator
      */
@@ -282,7 +282,7 @@ class BaseService
     /**
      * Reset shared instances and mocks for testing.
      *
-     * @param boolean $initAutoloader Initializes autoloader instance
+     * @param bool $initAutoloader Initializes autoloader instance
      */
     public static function reset(bool $initAutoloader = false)
     {

--- a/system/Config/Config.php
+++ b/system/Config/Config.php
@@ -23,7 +23,7 @@ class Config
      * a shared instance
      *
      * @param string  $name      Configuration name
-     * @param boolean $getShared Use shared instance
+     * @param bool $getShared Use shared instance
      *
      * @return mixed|null
      */

--- a/system/Config/Config.php
+++ b/system/Config/Config.php
@@ -22,8 +22,8 @@ class Config
      * Create new configuration instances or return
      * a shared instance
      *
-     * @param string  $name      Configuration name
-     * @param bool $getShared Use shared instance
+     * @param string $name      Configuration name
+     * @param bool   $getShared Use shared instance
      *
      * @return mixed|null
      */

--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -45,7 +45,7 @@ class DotEnv
      * so that we end up with all settings in the PHP environment vars
      * (i.e. getenv(), $_ENV, and $_SERVER)
      *
-     * @return boolean
+     * @return bool
      */
     public function load(): bool
     {

--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -161,6 +161,7 @@ class DotEnv
      * @param string $value
      *
      * @return string
+     *
      * @throws InvalidArgumentException
      */
     protected function sanitizeValue(string $value): string

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -185,7 +185,7 @@ class Factories
      * @param array  $options The array of component-specific directives
      * @param string $name    Class name, namespace optional
      *
-     * @return boolean
+     * @return bool
      */
     protected static function verifyPreferApp(array $options, string $name): bool
     {
@@ -208,7 +208,7 @@ class Factories
      * @param array  $options The array of component-specific directives
      * @param string $name    Class name, namespace optional
      *
-     * @return boolean
+     * @return bool
      */
     protected static function verifyInstanceOf(array $options, string $name): bool
     {

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -94,7 +94,7 @@ class Services extends BaseService
      * complex data for later.
      *
      * @param Cache|null $config
-     * @param boolean    $getShared
+     * @param bool    $getShared
      *
      * @return CacheInterface
      */
@@ -116,7 +116,7 @@ class Services extends BaseService
      * a command line request.
      *
      * @param App|null $config
-     * @param boolean  $getShared
+     * @param bool  $getShared
      *
      * @return CLIRequest
      */
@@ -137,7 +137,7 @@ class Services extends BaseService
      * CodeIgniter, the core of the framework.
      *
      * @param App|null $config
-     * @param boolean  $getShared
+     * @param bool  $getShared
      *
      * @return CodeIgniter
      */
@@ -155,7 +155,7 @@ class Services extends BaseService
     /**
      * The commands utility for running and working with CLI commands.
      *
-     * @param boolean $getShared
+     * @param bool $getShared
      *
      * @return Commands
      */
@@ -175,7 +175,7 @@ class Services extends BaseService
      * @param array                  $options
      * @param ResponseInterface|null $response
      * @param App|null               $config
-     * @param boolean                $getShared
+     * @param bool                $getShared
      *
      * @return CURLRequest
      */
@@ -202,7 +202,7 @@ class Services extends BaseService
      * The Email class allows you to send email via mail, sendmail, SMTP.
      *
      * @param EmailConfig|array|null $config
-     * @param boolean                $getShared
+     * @param bool                $getShared
      *
      * @return Email
      */
@@ -223,7 +223,7 @@ class Services extends BaseService
      * The Encryption class provides two-way encryption.
      *
      * @param EncryptionConfig|null $config
-     * @param boolean               $getShared
+     * @param bool               $getShared
      *
      * @return EncrypterInterface Encryption handler
      */
@@ -251,7 +251,7 @@ class Services extends BaseService
      * @param ExceptionsConfig|null $config
      * @param IncomingRequest|null  $request
      * @param Response|null         $response
-     * @param boolean               $getShared
+     * @param bool               $getShared
      *
      * @return Exceptions
      */
@@ -281,7 +281,7 @@ class Services extends BaseService
      * act on or modify the response itself before it is sent to the client.
      *
      * @param FiltersConfig|null $config
-     * @param boolean            $getShared
+     * @param bool            $getShared
      *
      * @return Filters
      */
@@ -302,7 +302,7 @@ class Services extends BaseService
      * The Format class is a convenient place to create Formatters.
      *
      * @param FormatConfig|null $config
-     * @param boolean           $getShared
+     * @param bool           $getShared
      *
      * @return Format
      */
@@ -324,7 +324,7 @@ class Services extends BaseService
      * fill in, providing an additional safeguard when accepting user input.
      *
      * @param HoneypotConfig|null $config
-     * @param boolean             $getShared
+     * @param bool             $getShared
      *
      * @return Honeypot
      */
@@ -347,7 +347,7 @@ class Services extends BaseService
      *
      * @param string|null $handler
      * @param Images|null $config
-     * @param boolean     $getShared
+     * @param bool     $getShared
      *
      * @return BaseHandler
      */
@@ -371,7 +371,7 @@ class Services extends BaseService
      * and timing the results and memory usage. Used when debugging and
      * optimizing applications.
      *
-     * @param boolean $getShared
+     * @param bool $getShared
      *
      * @return Iterator
      */
@@ -390,7 +390,7 @@ class Services extends BaseService
      * Responsible for loading the language string translations.
      *
      * @param string|null $locale
-     * @param boolean     $getShared
+     * @param bool     $getShared
      *
      * @return Language
      */
@@ -412,7 +412,7 @@ class Services extends BaseService
      * The Logger class is a PSR-3 compatible Logging class that supports
      * multiple handlers that process the actual logging.
      *
-     * @param boolean $getShared
+     * @param bool $getShared
      *
      * @return Logger
      */
@@ -432,7 +432,7 @@ class Services extends BaseService
      *
      * @param Migrations|null          $config
      * @param ConnectionInterface|null $db
-     * @param boolean                  $getShared
+     * @param bool                  $getShared
      *
      * @return MigrationRunner
      */
@@ -455,7 +455,7 @@ class Services extends BaseService
      * and more.
      *
      * @param RequestInterface|null $request
-     * @param boolean               $getShared
+     * @param bool               $getShared
      *
      * @return Negotiate
      */
@@ -477,7 +477,7 @@ class Services extends BaseService
      *
      * @param PagerConfig|null       $config
      * @param RendererInterface|null $view
-     * @param boolean                $getShared
+     * @param bool                $getShared
      *
      * @return Pager
      */
@@ -500,7 +500,7 @@ class Services extends BaseService
      *
      * @param string|null     $viewPath
      * @param ViewConfig|null $config
-     * @param boolean         $getShared
+     * @param bool         $getShared
      *
      * @return Parser
      */
@@ -525,7 +525,7 @@ class Services extends BaseService
      *
      * @param string|null     $viewPath
      * @param ViewConfig|null $config
-     * @param boolean         $getShared
+     * @param bool         $getShared
      *
      * @return View
      */
@@ -547,7 +547,7 @@ class Services extends BaseService
      * The Request class models an HTTP request.
      *
      * @param App|null $config
-     * @param boolean  $getShared
+     * @param bool  $getShared
      *
      * @return IncomingRequest
      */
@@ -573,7 +573,7 @@ class Services extends BaseService
      * The Response class models an HTTP response.
      *
      * @param App|null $config
-     * @param boolean  $getShared
+     * @param bool  $getShared
      *
      * @return Response
      */
@@ -594,7 +594,7 @@ class Services extends BaseService
      * The Redirect class provides nice way of working with redirects.
      *
      * @param App|null $config
-     * @param boolean  $getShared
+     * @param bool  $getShared
      *
      * @return RedirectResponse
      */
@@ -617,7 +617,7 @@ class Services extends BaseService
      * The Routes service is a class that allows for easily building
      * a collection of routes.
      *
-     * @param boolean $getShared
+     * @param bool $getShared
      *
      * @return RouteCollection
      */
@@ -638,7 +638,7 @@ class Services extends BaseService
      *
      * @param RouteCollectionInterface|null $routes
      * @param Request|null                  $request
-     * @param boolean                       $getShared
+     * @param bool                       $getShared
      *
      * @return Router
      */
@@ -661,7 +661,7 @@ class Services extends BaseService
      * secure, most notably the CSRF protection tools.
      *
      * @param App|null $config
-     * @param boolean  $getShared
+     * @param bool  $getShared
      *
      * @return Security
      */
@@ -682,7 +682,7 @@ class Services extends BaseService
      * Return the session manager.
      *
      * @param App|null $config
-     * @param boolean  $getShared
+     * @param bool  $getShared
      *
      * @return Session
      */
@@ -715,7 +715,7 @@ class Services extends BaseService
      * The Throttler class provides a simple method for implementing
      * rate limiting in your applications.
      *
-     * @param boolean $getShared
+     * @param bool $getShared
      *
      * @return Throttler
      */
@@ -734,7 +734,7 @@ class Services extends BaseService
      * The Timer class provides a simple way to Benchmark portions of your
      * application.
      *
-     * @param boolean $getShared
+     * @param bool $getShared
      *
      * @return Timer
      */
@@ -753,7 +753,7 @@ class Services extends BaseService
      * Return the debug toolbar.
      *
      * @param ToolbarConfig|null $config
-     * @param boolean            $getShared
+     * @param bool            $getShared
      *
      * @return Toolbar
      */
@@ -774,7 +774,7 @@ class Services extends BaseService
      * The URI class provides a way to model and manipulate URIs.
      *
      * @param string  $uri
-     * @param boolean $getShared
+     * @param bool $getShared
      *
      * @return URI
      */
@@ -793,7 +793,7 @@ class Services extends BaseService
      * The Validation class provides tools for validating input data.
      *
      * @param ValidationConfig|null $config
-     * @param boolean               $getShared
+     * @param bool               $getShared
      *
      * @return Validation
      */
@@ -814,7 +814,7 @@ class Services extends BaseService
      * View cells are intended to let you insert HTML into view
      * that has been generated by any callable in the system.
      *
-     * @param boolean $getShared
+     * @param bool $getShared
      *
      * @return Cell
      */
@@ -832,7 +832,7 @@ class Services extends BaseService
     /**
      * The Typography class provides a way to format text in semantically relevant ways.
      *
-     * @param boolean $getShared
+     * @param bool $getShared
      *
      * @return Typography
      */

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -94,7 +94,7 @@ class Services extends BaseService
      * complex data for later.
      *
      * @param Cache|null $config
-     * @param bool    $getShared
+     * @param bool       $getShared
      *
      * @return CacheInterface
      */
@@ -116,7 +116,7 @@ class Services extends BaseService
      * a command line request.
      *
      * @param App|null $config
-     * @param bool  $getShared
+     * @param bool     $getShared
      *
      * @return CLIRequest
      */
@@ -137,7 +137,7 @@ class Services extends BaseService
      * CodeIgniter, the core of the framework.
      *
      * @param App|null $config
-     * @param bool  $getShared
+     * @param bool     $getShared
      *
      * @return CodeIgniter
      */
@@ -175,7 +175,7 @@ class Services extends BaseService
      * @param array                  $options
      * @param ResponseInterface|null $response
      * @param App|null               $config
-     * @param bool                $getShared
+     * @param bool                   $getShared
      *
      * @return CURLRequest
      */
@@ -202,7 +202,7 @@ class Services extends BaseService
      * The Email class allows you to send email via mail, sendmail, SMTP.
      *
      * @param EmailConfig|array|null $config
-     * @param bool                $getShared
+     * @param bool                   $getShared
      *
      * @return Email
      */
@@ -223,7 +223,7 @@ class Services extends BaseService
      * The Encryption class provides two-way encryption.
      *
      * @param EncryptionConfig|null $config
-     * @param bool               $getShared
+     * @param bool                  $getShared
      *
      * @return EncrypterInterface Encryption handler
      */
@@ -251,7 +251,7 @@ class Services extends BaseService
      * @param ExceptionsConfig|null $config
      * @param IncomingRequest|null  $request
      * @param Response|null         $response
-     * @param bool               $getShared
+     * @param bool                  $getShared
      *
      * @return Exceptions
      */
@@ -281,7 +281,7 @@ class Services extends BaseService
      * act on or modify the response itself before it is sent to the client.
      *
      * @param FiltersConfig|null $config
-     * @param bool            $getShared
+     * @param bool               $getShared
      *
      * @return Filters
      */
@@ -302,7 +302,7 @@ class Services extends BaseService
      * The Format class is a convenient place to create Formatters.
      *
      * @param FormatConfig|null $config
-     * @param bool           $getShared
+     * @param bool              $getShared
      *
      * @return Format
      */
@@ -324,7 +324,7 @@ class Services extends BaseService
      * fill in, providing an additional safeguard when accepting user input.
      *
      * @param HoneypotConfig|null $config
-     * @param bool             $getShared
+     * @param bool                $getShared
      *
      * @return Honeypot
      */
@@ -347,7 +347,7 @@ class Services extends BaseService
      *
      * @param string|null $handler
      * @param Images|null $config
-     * @param bool     $getShared
+     * @param bool        $getShared
      *
      * @return BaseHandler
      */
@@ -390,7 +390,7 @@ class Services extends BaseService
      * Responsible for loading the language string translations.
      *
      * @param string|null $locale
-     * @param bool     $getShared
+     * @param bool        $getShared
      *
      * @return Language
      */
@@ -432,7 +432,7 @@ class Services extends BaseService
      *
      * @param Migrations|null          $config
      * @param ConnectionInterface|null $db
-     * @param bool                  $getShared
+     * @param bool                     $getShared
      *
      * @return MigrationRunner
      */
@@ -455,7 +455,7 @@ class Services extends BaseService
      * and more.
      *
      * @param RequestInterface|null $request
-     * @param bool               $getShared
+     * @param bool                  $getShared
      *
      * @return Negotiate
      */
@@ -477,7 +477,7 @@ class Services extends BaseService
      *
      * @param PagerConfig|null       $config
      * @param RendererInterface|null $view
-     * @param bool                $getShared
+     * @param bool                   $getShared
      *
      * @return Pager
      */
@@ -500,7 +500,7 @@ class Services extends BaseService
      *
      * @param string|null     $viewPath
      * @param ViewConfig|null $config
-     * @param bool         $getShared
+     * @param bool            $getShared
      *
      * @return Parser
      */
@@ -525,7 +525,7 @@ class Services extends BaseService
      *
      * @param string|null     $viewPath
      * @param ViewConfig|null $config
-     * @param bool         $getShared
+     * @param bool            $getShared
      *
      * @return View
      */
@@ -547,7 +547,7 @@ class Services extends BaseService
      * The Request class models an HTTP request.
      *
      * @param App|null $config
-     * @param bool  $getShared
+     * @param bool     $getShared
      *
      * @return IncomingRequest
      */
@@ -573,7 +573,7 @@ class Services extends BaseService
      * The Response class models an HTTP response.
      *
      * @param App|null $config
-     * @param bool  $getShared
+     * @param bool     $getShared
      *
      * @return Response
      */
@@ -594,7 +594,7 @@ class Services extends BaseService
      * The Redirect class provides nice way of working with redirects.
      *
      * @param App|null $config
-     * @param bool  $getShared
+     * @param bool     $getShared
      *
      * @return RedirectResponse
      */
@@ -638,7 +638,7 @@ class Services extends BaseService
      *
      * @param RouteCollectionInterface|null $routes
      * @param Request|null                  $request
-     * @param bool                       $getShared
+     * @param bool                          $getShared
      *
      * @return Router
      */
@@ -661,7 +661,7 @@ class Services extends BaseService
      * secure, most notably the CSRF protection tools.
      *
      * @param App|null $config
-     * @param bool  $getShared
+     * @param bool     $getShared
      *
      * @return Security
      */
@@ -682,7 +682,7 @@ class Services extends BaseService
      * Return the session manager.
      *
      * @param App|null $config
-     * @param bool  $getShared
+     * @param bool     $getShared
      *
      * @return Session
      */
@@ -753,7 +753,7 @@ class Services extends BaseService
      * Return the debug toolbar.
      *
      * @param ToolbarConfig|null $config
-     * @param bool            $getShared
+     * @param bool               $getShared
      *
      * @return Toolbar
      */
@@ -773,8 +773,8 @@ class Services extends BaseService
     /**
      * The URI class provides a way to model and manipulate URIs.
      *
-     * @param string  $uri
-     * @param bool $getShared
+     * @param string $uri
+     * @param bool   $getShared
      *
      * @return URI
      */
@@ -793,7 +793,7 @@ class Services extends BaseService
      * The Validation class provides tools for validating input data.
      *
      * @param ValidationConfig|null $config
-     * @param bool               $getShared
+     * @param bool                  $getShared
      *
      * @return Validation
      */

--- a/system/Config/View.php
+++ b/system/Config/View.php
@@ -20,7 +20,7 @@ class View extends BaseConfig
      * When false, the view method will clear the data between each
      * call.
      *
-     * @var boolean
+     * @var bool
      */
     public $saveData = true;
 

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -55,7 +55,7 @@ class Controller
     /**
      * Should enforce HTTPS access for all methods in this controller.
      *
-     * @var integer Number of seconds to set HSTS header
+     * @var int Number of seconds to set HSTS header
      */
     protected $forceHTTPS = 0;
 
@@ -99,7 +99,7 @@ class Controller
      * will happen back to this method and HSTS header will be sent
      * to have modern browsers transform requests automatically.
      *
-     * @param integer $duration The number of seconds this link should be
+     * @param int $duration The number of seconds this link should be
      *                          considered secure for. Only with HSTS header.
      *                          Default value is 1 year.
      *
@@ -116,7 +116,7 @@ class Controller
      * Provides a simple way to tie into the main CodeIgniter class and
      * tell it how long to cache the current page for.
      *
-     * @param integer $time
+     * @param int $time
      */
     protected function cachePage(int $time)
     {
@@ -150,7 +150,7 @@ class Controller
      * @param array|string $rules
      * @param array        $messages An array of custom error messages
      *
-     * @return boolean
+     * @return bool
      */
     protected function validate($rules, array $messages = []): bool
     {

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -100,8 +100,8 @@ class Controller
      * to have modern browsers transform requests automatically.
      *
      * @param int $duration The number of seconds this link should be
-     *                          considered secure for. Only with HSTS header.
-     *                          Default value is 1 year.
+     *                      considered secure for. Only with HSTS header.
+     *                      Default value is 1 year.
      *
      * @throws HTTPException
      */

--- a/system/Cookie/CloneableCookieInterface.php
+++ b/system/Cookie/CloneableCookieInterface.php
@@ -49,7 +49,7 @@ interface CloneableCookieInterface extends CookieInterface
     /**
      * Creates a new Cookie with a new cookie expires time.
      *
-     * @param DateTimeInterface|integer|string $expires
+     * @param DateTimeInterface|int|string $expires
      *
      * @return static
      */
@@ -90,7 +90,7 @@ interface CloneableCookieInterface extends CookieInterface
     /**
      * Creates a new Cookie with a new "Secure" attribute.
      *
-     * @param boolean $secure
+     * @param bool $secure
      *
      * @return static
      */
@@ -99,7 +99,7 @@ interface CloneableCookieInterface extends CookieInterface
     /**
      * Creates a new Cookie with a new "HttpOnly" attribute
      *
-     * @param boolean $httponly
+     * @param bool $httponly
      *
      * @return static
      */
@@ -117,7 +117,7 @@ interface CloneableCookieInterface extends CookieInterface
     /**
      * Creates a new Cookie with URL encoding option updated.
      *
-     * @param boolean $raw
+     * @param bool $raw
      *
      * @return static
      */

--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -54,7 +54,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
     protected $value;
 
     /**
-     * @var integer
+     * @var int
      */
     protected $expires;
 
@@ -69,12 +69,12 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
     protected $domain = '';
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $secure = false;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $httponly = true;
 
@@ -84,7 +84,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
     protected $samesite = self::SAMESITE_LAX;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $raw = false;
 
@@ -159,7 +159,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
      * Create a new Cookie instance from a `Set-Cookie` header.
      *
      * @param string  $cookie
-     * @param boolean $raw
+     * @param bool $raw
      *
      * @throws CookieException
      *
@@ -567,7 +567,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
      *
      * @param string $offset
      *
-     * @return boolean
+     * @return bool
      */
     public function offsetExists($offset)
     {
@@ -700,9 +700,9 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
     /**
      * Converts expires time to Unix format.
      *
-     * @param DateTimeInterface|integer|string $expires
+     * @param DateTimeInterface|int|string $expires
      *
-     * @return integer
+     * @return int
      */
     protected static function convertExpiresTimestamp($expires = 0): int
     {
@@ -736,7 +736,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
      * as `setrawcookie()` will reject this.
      *
      * @param string  $name
-     * @param boolean $raw
+     * @param bool $raw
      *
      * @throws CookieException
      *
@@ -757,7 +757,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
      * Validates the special prefixes if some attribute requirements are met.
      *
      * @param string  $prefix
-     * @param boolean $secure
+     * @param bool $secure
      * @param string  $path
      * @param string  $domain
      *
@@ -780,7 +780,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
      * Validates the `SameSite` to be within the allowed types.
      *
      * @param string  $samesite
-     * @param boolean $secure
+     * @param bool $secure
      *
      * @throws CookieException
      *

--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -158,8 +158,8 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
     /**
      * Create a new Cookie instance from a `Set-Cookie` header.
      *
-     * @param string  $cookie
-     * @param bool $raw
+     * @param string $cookie
+     * @param bool   $raw
      *
      * @throws CookieException
      *
@@ -735,8 +735,8 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
      * If `$raw` is true, names should not contain invalid characters
      * as `setrawcookie()` will reject this.
      *
-     * @param string  $name
-     * @param bool $raw
+     * @param string $name
+     * @param bool   $raw
      *
      * @throws CookieException
      *
@@ -756,10 +756,10 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
     /**
      * Validates the special prefixes if some attribute requirements are met.
      *
-     * @param string  $prefix
-     * @param bool $secure
-     * @param string  $path
-     * @param string  $domain
+     * @param string $prefix
+     * @param bool   $secure
+     * @param string $path
+     * @param string $domain
      *
      * @throws CookieException
      *
@@ -779,8 +779,8 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
     /**
      * Validates the `SameSite` to be within the allowed types.
      *
-     * @param string  $samesite
-     * @param bool $secure
+     * @param string $samesite
+     * @param bool   $secure
      *
      * @throws CookieException
      *

--- a/system/Cookie/CookieInterface.php
+++ b/system/Cookie/CookieInterface.php
@@ -96,7 +96,7 @@ interface CookieInterface
     /**
      * Gets the time in Unix timestamp the cookie expires.
      *
-     * @return integer
+     * @return int
      */
     public function getExpiresTimestamp(): int;
 
@@ -110,14 +110,14 @@ interface CookieInterface
     /**
      * Checks if the cookie is expired.
      *
-     * @return boolean
+     * @return bool
      */
     public function isExpired(): bool;
 
     /**
      * Gets the "Max-Age" cookie attribute.
      *
-     * @return integer
+     * @return int
      */
     public function getMaxAge(): int;
 
@@ -142,7 +142,7 @@ interface CookieInterface
      * with the `https:` scheme (except on `localhost`), and therefore is more
      * resistent to man-in-the-middle attacks.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSecure(): bool;
 
@@ -151,7 +151,7 @@ interface CookieInterface
      *
      * Checks if JavaScript is forbidden from accessing the cookie.
      *
-     * @return boolean
+     * @return bool
      */
     public function isHTTPOnly(): bool;
 
@@ -165,7 +165,7 @@ interface CookieInterface
     /**
      * Checks if the cookie should be sent with no URL encoding.
      *
-     * @return boolean
+     * @return bool
      */
     public function isRaw(): bool;
 

--- a/system/Cookie/CookieStore.php
+++ b/system/Cookie/CookieStore.php
@@ -35,7 +35,7 @@ class CookieStore implements Countable, IteratorAggregate
      * Creates a CookieStore from an array of `Set-Cookie` headers.
      *
      * @param string[] $headers
-     * @param bool  $raw
+     * @param bool     $raw
      *
      * @throws CookieException
      *

--- a/system/Cookie/CookieStore.php
+++ b/system/Cookie/CookieStore.php
@@ -35,7 +35,7 @@ class CookieStore implements Countable, IteratorAggregate
      * Creates a CookieStore from an array of `Set-Cookie` headers.
      *
      * @param string[] $headers
-     * @param boolean  $raw
+     * @param bool  $raw
      *
      * @throws CookieException
      *
@@ -81,7 +81,7 @@ class CookieStore implements Countable, IteratorAggregate
      * @param string      $prefix
      * @param string|null $value
      *
-     * @return boolean
+     * @return bool
      */
     public function has(string $name, string $prefix = '', string $value = null): bool
     {
@@ -218,7 +218,7 @@ class CookieStore implements Countable, IteratorAggregate
     /**
      * Gets the Cookie count in this collection.
      *
-     * @return integer
+     * @return int
      */
     public function count(): int
     {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -248,9 +248,10 @@ class BaseBuilder
     /**
      * Constructor
      *
-     * @param  string|array        $tableName
-     * @param  ConnectionInterface $db
-     * @param  array               $options
+     * @param string|array        $tableName
+     * @param ConnectionInterface $db
+     * @param array               $options
+     *
      * @throws DatabaseException
      */
     public function __construct($tableName, ConnectionInterface &$db, array $options = null)
@@ -494,6 +495,7 @@ class BaseBuilder
      * @param string $type
      *
      * @return $this
+     *
      * @throws DataException
      * @throws DatabaseException
      */
@@ -959,12 +961,13 @@ class BaseBuilder
      * @used-by whereNotIn()
      * @used-by orWhereNotIn()
      *
-     * @param  string                   $key    The field to search
-     * @param  array|Closure|null       $values The values searched on, or anonymous function with subquery
-     * @param  bool                     $not    If the statement would be IN or NOT IN
-     * @param  string                   $type
-     * @param  bool                     $escape
-     * @param  string                   $clause (Internal use only)
+     * @param string             $key    The field to search
+     * @param array|Closure|null $values The values searched on, or anonymous function with subquery
+     * @param bool               $not    If the statement would be IN or NOT IN
+     * @param string             $type
+     * @param bool               $escape
+     * @param string             $clause (Internal use only)
+     *
      * @throws InvalidArgumentException
      *
      * @return $this
@@ -1957,7 +1960,8 @@ class BaseBuilder
      * @param bool  $escape    Whether to escape values and identifiers
      * @param int   $batchSize Batch size
      *
-     * @return int|false         Number of rows inserted or FALSE on failure
+     * @return int|false Number of rows inserted or FALSE on failure
+     *
      * @throws DatabaseException
      */
     public function insertBatch(array $set = null, bool $escape = null, int $batchSize = 100)
@@ -2161,6 +2165,7 @@ class BaseBuilder
      * has been chosen to be inserted into.
      *
      * @return bool
+     *
      * @throws DatabaseException
      */
     protected function validateInsert(): bool
@@ -2203,6 +2208,7 @@ class BaseBuilder
      * @param array $set An associative array of insert values
      *
      * @return BaseResult|Query|string|false
+     *
      * @throws DatabaseException
      */
     public function replace(array $set = null)
@@ -2383,6 +2389,7 @@ class BaseBuilder
      * chosen to be update.
      *
      * @return bool
+     *
      * @throws DatabaseException
      */
     protected function validateUpdate(): bool
@@ -2410,7 +2417,8 @@ class BaseBuilder
      * @param string $index     The where key
      * @param int    $batchSize The size of the batch to run
      *
-     * @return mixed             Number of rows affected, SQL string, or FALSE on failure
+     * @return mixed Number of rows affected, SQL string, or FALSE on failure
+     *
      * @throws DatabaseException
      */
     public function updateBatch(array $set = null, string $index = null, int $batchSize = 100)
@@ -2523,6 +2531,7 @@ class BaseBuilder
      * @param bool         $escape
      *
      * @return $this|null
+     *
      * @throws DatabaseException
      */
     public function setUpdateBatch($key, string $index = '', bool $escape = null)
@@ -2661,6 +2670,7 @@ class BaseBuilder
      * @param bool  $resetData
      *
      * @return string|bool
+     *
      * @throws DatabaseException
      */
     public function delete($where = '', int $limit = null, bool $resetData = true)

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -28,7 +28,7 @@ class BaseBuilder
     /**
      * Reset DELETE data flag
      *
-     * @var boolean
+     * @var bool
      */
     protected $resetDeleteData = false;
 
@@ -42,7 +42,7 @@ class BaseBuilder
     /**
      * QB DISTINCT flag
      *
-     * @var boolean
+     * @var bool
      */
     protected $QBDistinct = false;
 
@@ -91,14 +91,14 @@ class BaseBuilder
     /**
      * QB LIMIT data
      *
-     * @var integer|boolean
+     * @var int|bool
      */
     protected $QBLimit = false;
 
     /**
      * QB OFFSET data
      *
-     * @var integer|boolean
+     * @var int|bool
      */
     protected $QBOffset = false;
 
@@ -126,14 +126,14 @@ class BaseBuilder
     /**
      * QB WHERE group started flag
      *
-     * @var boolean
+     * @var bool
      */
     protected $QBWhereGroupStarted = false;
 
     /**
      * QB WHERE group count
      *
-     * @var integer
+     * @var int
      */
     protected $QBWhereGroupCount = 0;
 
@@ -142,7 +142,7 @@ class BaseBuilder
      * exceptions, for example in case of
      * duplicate keys.
      *
-     * @var boolean
+     * @var bool
      */
     protected $QBIgnore = false;
 
@@ -203,7 +203,7 @@ class BaseBuilder
      * Some databases, like SQLite, do not by default
      * allow limiting of delete clauses.
      *
-     * @var boolean
+     * @var bool
      */
     protected $canLimitDeletes = true;
 
@@ -211,7 +211,7 @@ class BaseBuilder
      * Some databases do not by default
      * allow limit update queries with WHERE.
      *
-     * @var boolean
+     * @var bool
      */
     protected $canLimitWhereUpdates = true;
 
@@ -226,7 +226,7 @@ class BaseBuilder
     /**
      * Builder testing mode status.
      *
-     * @var boolean
+     * @var bool
      */
     protected $testMode = false;
 
@@ -292,7 +292,7 @@ class BaseBuilder
     /**
      * Sets a test mode status.
      *
-     * @param boolean $mode Mode to set
+     * @param bool $mode Mode to set
      *
      * @return $this
      */
@@ -336,7 +336,7 @@ class BaseBuilder
      * Set ignore Flag for next insert,
      * update or delete query.
      *
-     * @param boolean $ignore
+     * @param bool $ignore
      *
      * @return $this
      */
@@ -355,7 +355,7 @@ class BaseBuilder
      * Generates the SELECT portion of the query
      *
      * @param string|array $select
-     * @param boolean      $escape
+     * @param bool      $escape
      *
      * @return $this
      */
@@ -552,7 +552,7 @@ class BaseBuilder
      *
      * Sets a flag which tells the query string compiler to add DISTINCT
      *
-     * @param boolean $val
+     * @param bool $val
      *
      * @return $this
      */
@@ -571,7 +571,7 @@ class BaseBuilder
      * Generates the FROM portion of the query
      *
      * @param mixed   $from      can be a string or array
-     * @param boolean $overwrite Should we remove the first table existing?
+     * @param bool $overwrite Should we remove the first table existing?
      *
      * @return $this
      */
@@ -614,7 +614,7 @@ class BaseBuilder
      * @param string  $table
      * @param string  $cond   The join condition
      * @param string  $type   The type of join
-     * @param boolean $escape Whether not to try to escape identifiers
+     * @param bool $escape Whether not to try to escape identifiers
      *
      * @return $this
      */
@@ -692,7 +692,7 @@ class BaseBuilder
      *
      * @param mixed   $key
      * @param mixed   $value
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return $this
      */
@@ -711,7 +711,7 @@ class BaseBuilder
      *
      * @param mixed   $key
      * @param mixed   $value
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return $this
      */
@@ -734,7 +734,7 @@ class BaseBuilder
      * @param mixed   $key
      * @param mixed   $value
      * @param string  $type
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return $this
      */
@@ -807,7 +807,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param boolean              $escape
+     * @param bool              $escape
      *
      * @return $this
      */
@@ -826,7 +826,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param boolean              $escape
+     * @param bool              $escape
      *
      * @return $this
      */
@@ -845,7 +845,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param boolean              $escape
+     * @param bool              $escape
      *
      * @return $this
      */
@@ -864,7 +864,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param boolean              $escape
+     * @param bool              $escape
      *
      * @return $this
      */
@@ -883,7 +883,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param boolean              $escape
+     * @param bool              $escape
      *
      * @return $this
      */
@@ -902,7 +902,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param boolean              $escape
+     * @param bool              $escape
      *
      * @return $this
      */
@@ -921,7 +921,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param boolean              $escape
+     * @param bool              $escape
      *
      * @return $this
      */
@@ -940,7 +940,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param boolean              $escape
+     * @param bool              $escape
      *
      * @return $this
      */
@@ -961,9 +961,9 @@ class BaseBuilder
      *
      * @param  string             $key    The field to search
      * @param  array|Closure|null $values The values searched on, or anonymous function with subquery
-     * @param  boolean            $not    If the statement would be IN or NOT IN
+     * @param  bool            $not    If the statement would be IN or NOT IN
      * @param  string             $type
-     * @param  boolean            $escape
+     * @param  bool            $escape
      * @param  string             $clause (Internal use only)
      * @throws InvalidArgumentException
      *
@@ -1032,8 +1032,8 @@ class BaseBuilder
      * @param mixed   $field
      * @param string  $match
      * @param string  $side
-     * @param boolean $escape
-     * @param boolean $insensitiveSearch IF true, will force a case-insensitive search
+     * @param bool $escape
+     * @param bool $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -1053,8 +1053,8 @@ class BaseBuilder
      * @param mixed   $field
      * @param string  $match
      * @param string  $side
-     * @param boolean $escape
-     * @param boolean $insensitiveSearch IF true, will force a case-insensitive search
+     * @param bool $escape
+     * @param bool $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -1074,8 +1074,8 @@ class BaseBuilder
      * @param mixed   $field
      * @param string  $match
      * @param string  $side
-     * @param boolean $escape
-     * @param boolean $insensitiveSearch IF true, will force a case-insensitive search
+     * @param bool $escape
+     * @param bool $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -1095,8 +1095,8 @@ class BaseBuilder
      * @param mixed   $field
      * @param string  $match
      * @param string  $side
-     * @param boolean $escape
-     * @param boolean $insensitiveSearch IF true, will force a case-insensitive search
+     * @param bool $escape
+     * @param bool $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -1116,7 +1116,7 @@ class BaseBuilder
      * @param mixed   $field
      * @param string  $match
      * @param string  $side
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return $this
      */
@@ -1136,7 +1136,7 @@ class BaseBuilder
      * @param mixed   $field
      * @param string  $match
      * @param string  $side
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return $this
      */
@@ -1156,7 +1156,7 @@ class BaseBuilder
      * @param mixed   $field
      * @param string  $match
      * @param string  $side
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return $this
      */
@@ -1176,7 +1176,7 @@ class BaseBuilder
      * @param mixed   $field
      * @param string  $match
      * @param string  $side
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return $this
      */
@@ -1204,8 +1204,8 @@ class BaseBuilder
      * @param string  $type
      * @param string  $side
      * @param string  $not
-     * @param boolean $escape
-     * @param boolean $insensitiveSearch IF true, will force a case-insensitive search
+     * @param bool $escape
+     * @param bool $insensitiveSearch IF true, will force a case-insensitive search
      * @param string  $clause            (Internal use only)
      *
      * @return $this
@@ -1263,7 +1263,7 @@ class BaseBuilder
      * @param string      $column
      * @param string|null $not
      * @param string      $bind
-     * @param boolean     $insensitiveSearch
+     * @param bool     $insensitiveSearch
      *
      * @return string     $like_statement
      */
@@ -1476,7 +1476,7 @@ class BaseBuilder
      * GROUP BY
      *
      * @param string|array $by
-     * @param boolean      $escape
+     * @param bool      $escape
      *
      * @return $this
      */
@@ -1515,7 +1515,7 @@ class BaseBuilder
      *
      * @param string|array $key
      * @param mixed        $value
-     * @param boolean      $escape
+     * @param bool      $escape
      *
      * @return $this
      */
@@ -1533,7 +1533,7 @@ class BaseBuilder
      *
      * @param string|array $key
      * @param mixed        $value
-     * @param boolean      $escape
+     * @param bool      $escape
      *
      * @return $this
      */
@@ -1549,7 +1549,7 @@ class BaseBuilder
      *
      * @param string  $orderBy
      * @param string  $direction ASC, DESC or RANDOM
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return $this
      */
@@ -1608,8 +1608,8 @@ class BaseBuilder
     /**
      * LIMIT
      *
-     * @param integer|null $value  LIMIT value
-     * @param integer|null $offset OFFSET value
+     * @param int|null $value  LIMIT value
+     * @param int|null $offset OFFSET value
      *
      * @return $this
      */
@@ -1631,7 +1631,7 @@ class BaseBuilder
     /**
      * Sets the OFFSET value
      *
-     * @param integer $offset OFFSET value
+     * @param int $offset OFFSET value
      *
      * @return $this
      */
@@ -1669,7 +1669,7 @@ class BaseBuilder
      *
      * @param string|array|object $key    Field name, or an array of field/value pairs
      * @param string              $value  Field value, if $key is a single field
-     * @param boolean             $escape Whether to escape values and identifiers
+     * @param bool             $escape Whether to escape values and identifiers
      *
      * @return $this
      */
@@ -1701,7 +1701,7 @@ class BaseBuilder
      * Returns the previously set() data, alternatively resetting it
      * if needed.
      *
-     * @param boolean $clean
+     * @param bool $clean
      *
      * @return array
      */
@@ -1723,7 +1723,7 @@ class BaseBuilder
      *
      * Compiles a SELECT query string and returns the sql.
      *
-     * @param boolean $reset TRUE: resets QB values; FALSE: leave QB values alone
+     * @param bool $reset TRUE: resets QB values; FALSE: leave QB values alone
      *
      * @return string
      */
@@ -1766,9 +1766,9 @@ class BaseBuilder
      * Compiles the select statement based on the other functions called
      * and runs the query
      *
-     * @param integer $limit  The limit clause
-     * @param integer $offset The offset clause
-     * @param boolean $reset  Are we want to clear query builder values?
+     * @param int $limit  The limit clause
+     * @param int $offset The offset clause
+     * @param bool $reset  Are we want to clear query builder values?
      *
      * @return ResultInterface|false
      */
@@ -1800,9 +1800,9 @@ class BaseBuilder
      * Generates a platform-specific query string that counts all records in
      * the particular table
      *
-     * @param boolean $reset Are we want to clear query builder values?
+     * @param bool $reset Are we want to clear query builder values?
      *
-     * @return integer|string when $test = true
+     * @return int|string when $test = true
      */
     public function countAll(bool $reset = true)
     {
@@ -1837,9 +1837,9 @@ class BaseBuilder
      * Generates a platform-specific query string that counts all records
      * returned by an Query Builder query.
      *
-     * @param boolean $reset
+     * @param bool $reset
      *
-     * @return integer|string when $test = true
+     * @return int|string when $test = true
      */
     public function countAllResults(bool $reset = true)
     {
@@ -1916,9 +1916,9 @@ class BaseBuilder
      * Allows the where clause, limit and offset to be added directly
      *
      * @param string|array $where  Where condition
-     * @param integer      $limit  Limit value
-     * @param integer      $offset Offset value
-     * @param boolean      $reset  Are we want to clear query builder values?
+     * @param int      $limit  Limit value
+     * @param int      $offset Offset value
+     * @param bool      $reset  Are we want to clear query builder values?
      *
      * @return ResultInterface
      */
@@ -1954,10 +1954,10 @@ class BaseBuilder
      * Compiles batch insert strings and runs the queries
      *
      * @param array   $set       An associative array of insert values
-     * @param boolean $escape    Whether to escape values and identifiers
-     * @param integer $batchSize Batch size
+     * @param bool $escape    Whether to escape values and identifiers
+     * @param int $batchSize Batch size
      *
-     * @return integer|false Number of rows inserted or FALSE on failure
+     * @return int|false Number of rows inserted or FALSE on failure
      * @throws DatabaseException
      */
     public function insertBatch(array $set = null, bool $escape = null, int $batchSize = 100)
@@ -2031,7 +2031,7 @@ class BaseBuilder
      *
      * @param mixed   $key
      * @param string  $value
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return $this|null
      */
@@ -2084,11 +2084,11 @@ class BaseBuilder
      *
      * Compiles an insert query and returns the sql
      *
-     * @param boolean $reset TRUE: reset QB values; FALSE: leave QB values alone
+     * @param bool $reset TRUE: reset QB values; FALSE: leave QB values alone
      *
      * @throws DatabaseException
      *
-     * @return string|boolean
+     * @return string|bool
      */
     public function getCompiledInsert(bool $reset = true)
     {
@@ -2115,11 +2115,11 @@ class BaseBuilder
      * Compiles an insert string and runs the query
      *
      * @param array   $set    An associative array of insert values
-     * @param boolean $escape Whether to escape values and identifiers
+     * @param bool $escape Whether to escape values and identifiers
      *
      * @throws DatabaseException
      *
-     * @return Query|boolean
+     * @return Query|bool
      */
     public function insert(array $set = null, bool $escape = null)
     {
@@ -2160,7 +2160,7 @@ class BaseBuilder
      * validate that the there data is actually being set and that table
      * has been chosen to be inserted into.
      *
-     * @return boolean
+     * @return bool
      * @throws DatabaseException
      */
     protected function validateInsert(): bool
@@ -2271,9 +2271,9 @@ class BaseBuilder
      *
      * Compiles an update query and returns the sql
      *
-     * @param boolean $reset TRUE: reset QB values; FALSE: leave QB values alone
+     * @param bool $reset TRUE: reset QB values; FALSE: leave QB values alone
      *
-     * @return string|boolean
+     * @return string|bool
      */
     public function getCompiledUpdate(bool $reset = true)
     {
@@ -2299,11 +2299,11 @@ class BaseBuilder
      *
      * @param array   $set   An associative array of update values
      * @param mixed   $where
-     * @param integer $limit
+     * @param int $limit
      *
      * @throws DatabaseException
      *
-     * @return boolean    TRUE on success, FALSE on failure
+     * @return bool    TRUE on success, FALSE on failure
      */
     public function update(array $set = null, $where = null, int $limit = null): bool
     {
@@ -2382,7 +2382,7 @@ class BaseBuilder
      * validate that data is actually being set and that a table has been
      * chosen to be update.
      *
-     * @return boolean
+     * @return bool
      * @throws DatabaseException
      */
     protected function validateUpdate(): bool
@@ -2408,7 +2408,7 @@ class BaseBuilder
      *
      * @param array   $set       An associative array of update values
      * @param string  $index     The where key
-     * @param integer $batchSize The size of the batch to run
+     * @param int $batchSize The size of the batch to run
      *
      * @return mixed    Number of rows affected, SQL string, or FALSE on failure
      * @throws DatabaseException
@@ -2520,7 +2520,7 @@ class BaseBuilder
      *
      * @param array|object $key
      * @param string       $index
-     * @param boolean      $escape
+     * @param bool      $escape
      *
      * @return $this|null
      * @throws DatabaseException
@@ -2568,7 +2568,7 @@ class BaseBuilder
      *
      * Compiles a delete string and runs "DELETE FROM table"
      *
-     * @return boolean|string    TRUE on success, FALSE on failure, string on testMode
+     * @return bool|string    TRUE on success, FALSE on failure, string on testMode
      */
     public function emptyTable()
     {
@@ -2594,7 +2594,7 @@ class BaseBuilder
      * If the database does not support the truncate() command
      * This function maps to "DELETE FROM table"
      *
-     * @return boolean|string    TRUE on success, FALSE on failure, string on testMode
+     * @return bool|string    TRUE on success, FALSE on failure, string on testMode
      */
     public function truncate()
     {
@@ -2637,7 +2637,7 @@ class BaseBuilder
      *
      * Compiles a delete query string and returns the sql
      *
-     * @param boolean $reset TRUE: reset QB values; FALSE: leave QB values alone
+     * @param bool $reset TRUE: reset QB values; FALSE: leave QB values alone
      *
      * @return string
      */
@@ -2657,10 +2657,10 @@ class BaseBuilder
      * Compiles a delete string and runs the query
      *
      * @param mixed   $where     The where clause
-     * @param integer $limit     The limit clause
-     * @param boolean $resetData
+     * @param int $limit     The limit clause
+     * @param bool $resetData
      *
-     * @return string|boolean
+     * @return string|bool
      * @throws DatabaseException
      */
     public function delete($where = '', int $limit = null, bool $resetData = true)
@@ -2707,9 +2707,9 @@ class BaseBuilder
      * Increments a numeric column by the specified value.
      *
      * @param string  $column
-     * @param integer $value
+     * @param int $value
      *
-     * @return boolean
+     * @return bool
      */
     public function increment(string $column, int $value = 1)
     {
@@ -2726,9 +2726,9 @@ class BaseBuilder
      * Decrements a numeric column by the specified value.
      *
      * @param string  $column
-     * @param integer $value
+     * @param int $value
      *
-     * @return boolean
+     * @return bool
      */
     public function decrement(string $column, int $value = 1)
     {
@@ -3092,7 +3092,7 @@ class BaseBuilder
      *
      * @param string $str
      *
-     * @return boolean
+     * @return bool
      */
     protected function isLiteral(string $str): bool
     {
@@ -3205,7 +3205,7 @@ class BaseBuilder
      *
      * @param string $str
      *
-     * @return boolean
+     * @return bool
      */
     protected function hasOperator(string $str): bool
     {
@@ -3218,7 +3218,7 @@ class BaseBuilder
      * Returns the SQL string operator
      *
      * @param string  $str
-     * @param boolean $list
+     * @param bool $list
      *
      * @return mixed
      */
@@ -3257,7 +3257,7 @@ class BaseBuilder
      *
      * @param string  $key
      * @param mixed   $value
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return string
      */

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -355,7 +355,7 @@ class BaseBuilder
      * Generates the SELECT portion of the query
      *
      * @param string|array $select
-     * @param bool      $escape
+     * @param bool         $escape
      *
      * @return $this
      */
@@ -570,8 +570,8 @@ class BaseBuilder
      *
      * Generates the FROM portion of the query
      *
-     * @param mixed   $from      can be a string or array
-     * @param bool $overwrite Should we remove the first table existing?
+     * @param mixed $from      can be a string or array
+     * @param bool  $overwrite Should we remove the first table existing?
      *
      * @return $this
      */
@@ -611,10 +611,10 @@ class BaseBuilder
      *
      * Generates the JOIN portion of the query
      *
-     * @param string  $table
-     * @param string  $cond   The join condition
-     * @param string  $type   The type of join
-     * @param bool $escape Whether not to try to escape identifiers
+     * @param string $table
+     * @param string $cond   The join condition
+     * @param string $type   The type of join
+     * @param bool   $escape Whether not to try to escape identifiers
      *
      * @return $this
      */
@@ -690,9 +690,9 @@ class BaseBuilder
      * Generates the WHERE portion of the query.
      * Separates multiple calls with 'AND'.
      *
-     * @param mixed   $key
-     * @param mixed   $value
-     * @param bool $escape
+     * @param mixed $key
+     * @param mixed $value
+     * @param bool  $escape
      *
      * @return $this
      */
@@ -709,9 +709,9 @@ class BaseBuilder
      * Generates the WHERE portion of the query.
      * Separates multiple calls with 'OR'.
      *
-     * @param mixed   $key
-     * @param mixed   $value
-     * @param bool $escape
+     * @param mixed $key
+     * @param mixed $value
+     * @param bool  $escape
      *
      * @return $this
      */
@@ -730,11 +730,11 @@ class BaseBuilder
      * @used-by having()
      * @used-by orHaving()
      *
-     * @param string  $qbKey  'QBWhere' or 'QBHaving'
-     * @param mixed   $key
-     * @param mixed   $value
-     * @param string  $type
-     * @param bool $escape
+     * @param string $qbKey  'QBWhere' or 'QBHaving'
+     * @param mixed  $key
+     * @param mixed  $value
+     * @param string $type
+     * @param bool   $escape
      *
      * @return $this
      */
@@ -807,7 +807,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param bool              $escape
+     * @param bool                 $escape
      *
      * @return $this
      */
@@ -826,7 +826,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param bool              $escape
+     * @param bool                 $escape
      *
      * @return $this
      */
@@ -845,7 +845,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param bool              $escape
+     * @param bool                 $escape
      *
      * @return $this
      */
@@ -864,7 +864,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param bool              $escape
+     * @param bool                 $escape
      *
      * @return $this
      */
@@ -883,7 +883,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param bool              $escape
+     * @param bool                 $escape
      *
      * @return $this
      */
@@ -902,7 +902,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param bool              $escape
+     * @param bool                 $escape
      *
      * @return $this
      */
@@ -921,7 +921,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param bool              $escape
+     * @param bool                 $escape
      *
      * @return $this
      */
@@ -940,7 +940,7 @@ class BaseBuilder
      *
      * @param string               $key    The field to search
      * @param array|string|Closure $values The values searched on, or anonymous function with subquery
-     * @param bool              $escape
+     * @param bool                 $escape
      *
      * @return $this
      */
@@ -959,12 +959,12 @@ class BaseBuilder
      * @used-by whereNotIn()
      * @used-by orWhereNotIn()
      *
-     * @param  string             $key    The field to search
-     * @param  array|Closure|null $values The values searched on, or anonymous function with subquery
-     * @param  bool            $not    If the statement would be IN or NOT IN
-     * @param  string             $type
-     * @param  bool            $escape
-     * @param  string             $clause (Internal use only)
+     * @param  string                   $key    The field to search
+     * @param  array|Closure|null       $values The values searched on, or anonymous function with subquery
+     * @param  bool                     $not    If the statement would be IN or NOT IN
+     * @param  string                   $type
+     * @param  bool                     $escape
+     * @param  string                   $clause (Internal use only)
      * @throws InvalidArgumentException
      *
      * @return $this
@@ -1029,11 +1029,11 @@ class BaseBuilder
      * Generates a %LIKE% portion of the query.
      * Separates multiple calls with 'AND'.
      *
-     * @param mixed   $field
-     * @param string  $match
-     * @param string  $side
-     * @param bool $escape
-     * @param bool $insensitiveSearch IF true, will force a case-insensitive search
+     * @param mixed  $field
+     * @param string $match
+     * @param string $side
+     * @param bool   $escape
+     * @param bool   $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -1050,11 +1050,11 @@ class BaseBuilder
      * Generates a NOT LIKE portion of the query.
      * Separates multiple calls with 'AND'.
      *
-     * @param mixed   $field
-     * @param string  $match
-     * @param string  $side
-     * @param bool $escape
-     * @param bool $insensitiveSearch IF true, will force a case-insensitive search
+     * @param mixed  $field
+     * @param string $match
+     * @param string $side
+     * @param bool   $escape
+     * @param bool   $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -1071,11 +1071,11 @@ class BaseBuilder
      * Generates a %LIKE% portion of the query.
      * Separates multiple calls with 'OR'.
      *
-     * @param mixed   $field
-     * @param string  $match
-     * @param string  $side
-     * @param bool $escape
-     * @param bool $insensitiveSearch IF true, will force a case-insensitive search
+     * @param mixed  $field
+     * @param string $match
+     * @param string $side
+     * @param bool   $escape
+     * @param bool   $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -1092,11 +1092,11 @@ class BaseBuilder
      * Generates a NOT LIKE portion of the query.
      * Separates multiple calls with 'OR'.
      *
-     * @param mixed   $field
-     * @param string  $match
-     * @param string  $side
-     * @param bool $escape
-     * @param bool $insensitiveSearch IF true, will force a case-insensitive search
+     * @param mixed  $field
+     * @param string $match
+     * @param string $side
+     * @param bool   $escape
+     * @param bool   $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -1113,10 +1113,10 @@ class BaseBuilder
      * Generates a %LIKE% portion of the query.
      * Separates multiple calls with 'AND'.
      *
-     * @param mixed   $field
-     * @param string  $match
-     * @param string  $side
-     * @param bool $escape
+     * @param mixed  $field
+     * @param string $match
+     * @param string $side
+     * @param bool   $escape
      *
      * @return $this
      */
@@ -1133,10 +1133,10 @@ class BaseBuilder
      * Generates a NOT LIKE portion of the query.
      * Separates multiple calls with 'AND'.
      *
-     * @param mixed   $field
-     * @param string  $match
-     * @param string  $side
-     * @param bool $escape
+     * @param mixed  $field
+     * @param string $match
+     * @param string $side
+     * @param bool   $escape
      *
      * @return $this
      */
@@ -1153,10 +1153,10 @@ class BaseBuilder
      * Generates a %LIKE% portion of the query.
      * Separates multiple calls with 'OR'.
      *
-     * @param mixed   $field
-     * @param string  $match
-     * @param string  $side
-     * @param bool $escape
+     * @param mixed  $field
+     * @param string $match
+     * @param string $side
+     * @param bool   $escape
      *
      * @return $this
      */
@@ -1173,10 +1173,10 @@ class BaseBuilder
      * Generates a NOT LIKE portion of the query.
      * Separates multiple calls with 'OR'.
      *
-     * @param mixed   $field
-     * @param string  $match
-     * @param string  $side
-     * @param bool $escape
+     * @param mixed  $field
+     * @param string $match
+     * @param string $side
+     * @param bool   $escape
      *
      * @return $this
      */
@@ -1199,14 +1199,14 @@ class BaseBuilder
      * @used-by notHavingLike()
      * @used-by orNotHavingLike()
      *
-     * @param mixed   $field
-     * @param string  $match
-     * @param string  $type
-     * @param string  $side
-     * @param string  $not
-     * @param bool $escape
-     * @param bool $insensitiveSearch IF true, will force a case-insensitive search
-     * @param string  $clause            (Internal use only)
+     * @param mixed  $field
+     * @param string $match
+     * @param string $type
+     * @param string $side
+     * @param string $not
+     * @param bool   $escape
+     * @param bool   $insensitiveSearch IF true, will force a case-insensitive search
+     * @param string $clause            (Internal use only)
      *
      * @return $this
      */
@@ -1263,9 +1263,9 @@ class BaseBuilder
      * @param string      $column
      * @param string|null $not
      * @param string      $bind
-     * @param bool     $insensitiveSearch
+     * @param bool        $insensitiveSearch
      *
-     * @return string     $like_statement
+     * @return string $like_statement
      */
     protected function _like_statement(?string $prefix, string $column, ?string $not, string $bind, bool $insensitiveSearch = false): string
     {
@@ -1476,7 +1476,7 @@ class BaseBuilder
      * GROUP BY
      *
      * @param string|array $by
-     * @param bool      $escape
+     * @param bool         $escape
      *
      * @return $this
      */
@@ -1515,7 +1515,7 @@ class BaseBuilder
      *
      * @param string|array $key
      * @param mixed        $value
-     * @param bool      $escape
+     * @param bool         $escape
      *
      * @return $this
      */
@@ -1533,7 +1533,7 @@ class BaseBuilder
      *
      * @param string|array $key
      * @param mixed        $value
-     * @param bool      $escape
+     * @param bool         $escape
      *
      * @return $this
      */
@@ -1547,9 +1547,9 @@ class BaseBuilder
     /**
      * ORDER BY
      *
-     * @param string  $orderBy
-     * @param string  $direction ASC, DESC or RANDOM
-     * @param bool $escape
+     * @param string $orderBy
+     * @param string $direction ASC, DESC or RANDOM
+     * @param bool   $escape
      *
      * @return $this
      */
@@ -1669,7 +1669,7 @@ class BaseBuilder
      *
      * @param string|array|object $key    Field name, or an array of field/value pairs
      * @param string              $value  Field value, if $key is a single field
-     * @param bool             $escape Whether to escape values and identifiers
+     * @param bool                $escape Whether to escape values and identifiers
      *
      * @return $this
      */
@@ -1766,8 +1766,8 @@ class BaseBuilder
      * Compiles the select statement based on the other functions called
      * and runs the query
      *
-     * @param int $limit  The limit clause
-     * @param int $offset The offset clause
+     * @param int  $limit  The limit clause
+     * @param int  $offset The offset clause
      * @param bool $reset  Are we want to clear query builder values?
      *
      * @return ResultInterface|false
@@ -1916,9 +1916,9 @@ class BaseBuilder
      * Allows the where clause, limit and offset to be added directly
      *
      * @param string|array $where  Where condition
-     * @param int      $limit  Limit value
-     * @param int      $offset Offset value
-     * @param bool      $reset  Are we want to clear query builder values?
+     * @param int          $limit  Limit value
+     * @param int          $offset Offset value
+     * @param bool         $reset  Are we want to clear query builder values?
      *
      * @return ResultInterface
      */
@@ -1953,11 +1953,11 @@ class BaseBuilder
      *
      * Compiles batch insert strings and runs the queries
      *
-     * @param array   $set       An associative array of insert values
-     * @param bool $escape    Whether to escape values and identifiers
-     * @param int $batchSize Batch size
+     * @param array $set       An associative array of insert values
+     * @param bool  $escape    Whether to escape values and identifiers
+     * @param int   $batchSize Batch size
      *
-     * @return int|false Number of rows inserted or FALSE on failure
+     * @return int|false         Number of rows inserted or FALSE on failure
      * @throws DatabaseException
      */
     public function insertBatch(array $set = null, bool $escape = null, int $batchSize = 100)
@@ -2029,9 +2029,9 @@ class BaseBuilder
     /**
      * The "setInsertBatch" function.  Allows key/value pairs to be set for batch inserts
      *
-     * @param mixed   $key
-     * @param string  $value
-     * @param bool $escape
+     * @param mixed  $key
+     * @param string $value
+     * @param bool   $escape
      *
      * @return $this|null
      */
@@ -2114,8 +2114,8 @@ class BaseBuilder
      *
      * Compiles an insert string and runs the query
      *
-     * @param array   $set    An associative array of insert values
-     * @param bool $escape Whether to escape values and identifiers
+     * @param array $set    An associative array of insert values
+     * @param bool  $escape Whether to escape values and identifiers
      *
      * @throws DatabaseException
      *
@@ -2297,13 +2297,13 @@ class BaseBuilder
      *
      * Compiles an update string and runs the query.
      *
-     * @param array   $set   An associative array of update values
-     * @param mixed   $where
-     * @param int $limit
+     * @param array $set   An associative array of update values
+     * @param mixed $where
+     * @param int   $limit
      *
      * @throws DatabaseException
      *
-     * @return bool    TRUE on success, FALSE on failure
+     * @return bool TRUE on success, FALSE on failure
      */
     public function update(array $set = null, $where = null, int $limit = null): bool
     {
@@ -2406,11 +2406,11 @@ class BaseBuilder
      *
      * Compiles an update string and runs the query
      *
-     * @param array   $set       An associative array of update values
-     * @param string  $index     The where key
-     * @param int $batchSize The size of the batch to run
+     * @param array  $set       An associative array of update values
+     * @param string $index     The where key
+     * @param int    $batchSize The size of the batch to run
      *
-     * @return mixed    Number of rows affected, SQL string, or FALSE on failure
+     * @return mixed             Number of rows affected, SQL string, or FALSE on failure
      * @throws DatabaseException
      */
     public function updateBatch(array $set = null, string $index = null, int $batchSize = 100)
@@ -2520,7 +2520,7 @@ class BaseBuilder
      *
      * @param array|object $key
      * @param string       $index
-     * @param bool      $escape
+     * @param bool         $escape
      *
      * @return $this|null
      * @throws DatabaseException
@@ -2568,7 +2568,7 @@ class BaseBuilder
      *
      * Compiles a delete string and runs "DELETE FROM table"
      *
-     * @return bool|string    TRUE on success, FALSE on failure, string on testMode
+     * @return bool|string TRUE on success, FALSE on failure, string on testMode
      */
     public function emptyTable()
     {
@@ -2594,7 +2594,7 @@ class BaseBuilder
      * If the database does not support the truncate() command
      * This function maps to "DELETE FROM table"
      *
-     * @return bool|string    TRUE on success, FALSE on failure, string on testMode
+     * @return bool|string TRUE on success, FALSE on failure, string on testMode
      */
     public function truncate()
     {
@@ -2656,9 +2656,9 @@ class BaseBuilder
      *
      * Compiles a delete string and runs the query
      *
-     * @param mixed   $where     The where clause
-     * @param int $limit     The limit clause
-     * @param bool $resetData
+     * @param mixed $where     The where clause
+     * @param int   $limit     The limit clause
+     * @param bool  $resetData
      *
      * @return string|bool
      * @throws DatabaseException
@@ -2706,8 +2706,8 @@ class BaseBuilder
     /**
      * Increments a numeric column by the specified value.
      *
-     * @param string  $column
-     * @param int $value
+     * @param string $column
+     * @param int    $value
      *
      * @return bool
      */
@@ -2725,8 +2725,8 @@ class BaseBuilder
     /**
      * Decrements a numeric column by the specified value.
      *
-     * @param string  $column
-     * @param int $value
+     * @param string $column
+     * @param int    $value
      *
      * @return bool
      */
@@ -2888,7 +2888,7 @@ class BaseBuilder
      *
      * @param string $qbKey 'QBWhere' or 'QBHaving'
      *
-     * @return string    SQL statement
+     * @return string SQL statement
      */
     protected function compileWhereHaving(string $qbKey): string
     {
@@ -2963,7 +2963,7 @@ class BaseBuilder
      * groupBy() is called prior to from(), join() and prefixTable is added
      * only if needed.
      *
-     * @return string    SQL statement
+     * @return string SQL statement
      */
     protected function compileGroupBy(): string
     {
@@ -2996,7 +2996,7 @@ class BaseBuilder
      * orderBy() is called prior to from(), join() and prefixTable is added
      * only if needed.
      *
-     * @return string    SQL statement
+     * @return string SQL statement
      */
     protected function compileOrderBy(): string
     {
@@ -3217,8 +3217,8 @@ class BaseBuilder
     /**
      * Returns the SQL string operator
      *
-     * @param string  $str
-     * @param bool $list
+     * @param string $str
+     * @param bool   $list
      *
      * @return mixed
      */
@@ -3255,9 +3255,9 @@ class BaseBuilder
      * with PHP 7+ we get a huge memory/performance gain with indexed
      * arrays instead, so lets take advantage of that here.
      *
-     * @param string  $key
-     * @param mixed   $value
-     * @param bool $escape
+     * @param string $key
+     * @param mixed  $value
+     * @param bool   $escape
      *
      * @return string
      */

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -31,7 +31,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Database port
      *
-     * @var integer|string
+     * @var int|string
      */
     protected $port = '';
 
@@ -88,7 +88,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Persistent connection flag
      *
-     * @var boolean
+     * @var bool
      */
     protected $pConnect = false;
 
@@ -97,7 +97,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * Whether to display error messages.
      *
-     * @var boolean
+     * @var bool
      */
     protected $DBDebug = false;
 
@@ -132,7 +132,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Compression flag
      *
-     * @var boolean
+     * @var bool
      */
     protected $compress = false;
 
@@ -141,7 +141,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * Whether we're running in strict SQL mode.
      *
-     * @var boolean
+     * @var bool
      */
     protected $strictOn;
 
@@ -165,21 +165,21 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Connection ID
      *
-     * @var object|resource|boolean
+     * @var object|resource|bool
      */
     public $connID = false;
 
     /**
      * Result ID
      *
-     * @var object|resource|boolean
+     * @var object|resource|bool
      */
     public $resultID = false;
 
     /**
      * Protect identifiers flag
      *
-     * @var boolean
+     * @var bool
      */
     public $protectIdentifiers = true;
 
@@ -239,28 +239,28 @@ abstract class BaseConnection implements ConnectionInterface
      * If true, no queries will actually be
      * ran against the database.
      *
-     * @var boolean
+     * @var bool
      */
     protected $pretend = false;
 
     /**
      * Transaction enabled flag
      *
-     * @var boolean
+     * @var bool
      */
     public $transEnabled = true;
 
     /**
      * Strict transaction mode flag
      *
-     * @var boolean
+     * @var bool
      */
     public $transStrict = true;
 
     /**
      * Transaction depth level
      *
-     * @var integer
+     * @var int
      */
     protected $transDepth = 0;
 
@@ -269,7 +269,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * Used with transactions to determine if a rollback should occur.
      *
-     * @var boolean
+     * @var bool
      */
     protected $transStatus = true;
 
@@ -278,7 +278,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * Used with transactions to determine if a transaction has failed.
      *
-     * @var boolean
+     * @var bool
      */
     protected $transFailure = false;
 
@@ -395,7 +395,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Connect to the database.
      *
-     * @param  boolean $persistent
+     * @param  bool $persistent
      * @return mixed
      */
     abstract public function connect(bool $persistent = false);
@@ -591,10 +591,10 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * @param string  $sql
      * @param mixed   ...$binds
-     * @param boolean $setEscapeFlags
+     * @param bool $setEscapeFlags
      * @param string  $queryClass
      *
-     * @return BaseResult|Query|boolean
+     * @return BaseResult|Query|bool
      *
      * @todo BC set $queryClass default as null in 4.1
      */
@@ -729,7 +729,7 @@ abstract class BaseConnection implements ConnectionInterface
      * If strict mode is disabled, each group is treated autonomously,
      * meaning a failure of one group will not affect any others
      *
-     * @param boolean $mode = true
+     * @param bool $mode = true
      *
      * @return $this
      */
@@ -745,8 +745,8 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Start Transaction
      *
-     * @param  boolean $testMode = FALSE
-     * @return boolean
+     * @param  bool $testMode = FALSE
+     * @return bool
      */
     public function transStart(bool $testMode = false): bool
     {
@@ -762,7 +762,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Complete Transaction
      *
-     * @return boolean
+     * @return bool
      */
     public function transComplete(): bool
     {
@@ -793,7 +793,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Lets you retrieve the transaction flag to determine if it has failed
      *
-     * @return boolean
+     * @return bool
      */
     public function transStatus(): bool
     {
@@ -805,8 +805,8 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Begin Transaction
      *
-     * @param  boolean $testMode
-     * @return boolean
+     * @param  bool $testMode
+     * @return bool
      */
     public function transBegin(bool $testMode = false): bool
     {
@@ -844,7 +844,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Commit Transaction
      *
-     * @return boolean
+     * @return bool
      */
     public function transCommit(): bool
     {
@@ -867,7 +867,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Rollback Transaction
      *
-     * @return boolean
+     * @return bool
      */
     public function transRollback(): bool
     {
@@ -890,7 +890,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Begin Transaction
      *
-     * @return boolean
+     * @return bool
      */
     abstract protected function _transBegin(): bool;
 
@@ -899,7 +899,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Commit Transaction
      *
-     * @return boolean
+     * @return bool
      */
     abstract protected function _transCommit(): bool;
 
@@ -908,7 +908,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Rollback Transaction
      *
-     * @return boolean
+     * @return bool
      */
     abstract protected function _transRollback(): bool;
 
@@ -1025,7 +1025,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * Used by the Debug Toolbar's timeline.
      *
-     * @param integer $decimals
+     * @param int $decimals
      *
      * @return string
      */
@@ -1057,9 +1057,9 @@ abstract class BaseConnection implements ConnectionInterface
      * the correct identifiers.
      *
      * @param string|array $item
-     * @param boolean      $prefixSingle
-     * @param boolean      $protectIdentifiers
-     * @param boolean      $fieldExists
+     * @param bool      $prefixSingle
+     * @param bool      $protectIdentifiers
+     * @param bool      $fieldExists
      *
      * @return string|array
      */
@@ -1283,7 +1283,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns the total number of rows affected by this query.
      *
-     * @return integer
+     * @return int
      */
     abstract public function affectedRows(): int;
 
@@ -1326,7 +1326,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Escape String
      *
      * @param  string|string[] $str  Input string
-     * @param  boolean         $like Whether or not the string will be used in a LIKE condition
+     * @param  bool         $like Whether or not the string will be used in a LIKE condition
      * @return string|string[]
      */
     public function escapeString($str, bool $like = false)
@@ -1399,7 +1399,7 @@ abstract class BaseConnection implements ConnectionInterface
      * @param string $functionName
      * @param array  ...$params
      *
-     * @return boolean
+     * @return bool
      * @throws DatabaseException
      */
     public function callFunction(string $functionName, ...$params): bool
@@ -1430,8 +1430,8 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns an array of table names
      *
-     * @param  boolean $constrainByPrefix = FALSE
-     * @return boolean|array
+     * @param  bool $constrainByPrefix = FALSE
+     * @return bool|array
      * @throws DatabaseException
      */
     public function listTables(bool $constrainByPrefix = false)
@@ -1484,7 +1484,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Determine if a particular table exists
      *
      * @param  string $tableName
-     * @return boolean
+     * @return bool
      */
     public function tableExists(string $tableName): bool
     {
@@ -1549,7 +1549,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * @param  string $fieldName
      * @param  string $tableName
-     * @return boolean
+     * @return bool
      */
     public function fieldExists(string $fieldName, string $tableName): bool
     {
@@ -1627,7 +1627,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * This is primarily used by the prepared query functionality.
      *
-     * @param boolean $pretend
+     * @param bool $pretend
      *
      * @return $this
      */
@@ -1658,7 +1658,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Determines if the statement is a write-type query or not.
      *
      * @param  string $sql
-     * @return boolean
+     * @return bool
      */
     public function isWriteType($sql): bool
     {
@@ -1683,7 +1683,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Insert ID
      *
-     * @return integer|string
+     * @return int|string
      */
     abstract public function insertID();
 
@@ -1692,7 +1692,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param boolean $constrainByPrefix
+     * @param bool $constrainByPrefix
      *
      * @return string|false
      */
@@ -1767,7 +1767,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * @param string $key
      *
-     * @return boolean
+     * @return bool
      */
     public function __isset(string $key): bool
     {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -74,6 +74,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Sub-driver
      *
      * @used-by CI_DB_pdo_driver
+     *
      * @var string
      */
     protected $subdriver;
@@ -322,6 +323,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Initializes the database connection/settings.
      *
      * @return mixed|void
+     *
      * @throws DatabaseException
      */
     public function initialize()
@@ -395,7 +397,8 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Connect to the database.
      *
-     * @param  bool  $persistent
+     * @param bool $persistent
+     *
      * @return mixed
      */
     abstract public function connect(bool $persistent = false);
@@ -745,7 +748,8 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Start Transaction
      *
-     * @param  bool $testMode = FALSE
+     * @param bool $testMode
+     *
      * @return bool
      */
     public function transStart(bool $testMode = false): bool
@@ -805,7 +809,8 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Begin Transaction
      *
-     * @param  bool $testMode
+     * @param bool $testMode
+     *
      * @return bool
      */
     public function transBegin(bool $testMode = false): bool
@@ -919,6 +924,7 @@ abstract class BaseConnection implements ConnectionInterface
      * @param string|array $tableName
      *
      * @return BaseBuilder
+     *
      * @throws DatabaseException
      */
     public function table($tableName)
@@ -1325,8 +1331,9 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Escape String
      *
-     * @param  string|string[] $str  Input string
-     * @param  bool            $like Whether or not the string will be used in a LIKE condition
+     * @param string|string[] $str  Input string
+     * @param bool            $like Whether or not the string will be used in a LIKE condition
+     *
      * @return string|string[]
      */
     public function escapeString($str, bool $like = false)
@@ -1366,7 +1373,8 @@ abstract class BaseConnection implements ConnectionInterface
      * Calls the individual driver for platform
      * specific escaping for LIKE conditions
      *
-     * @param  string|string[] $str
+     * @param string|string[] $str
+     *
      * @return string|string[]
      */
     public function escapeLikeString($str)
@@ -1400,6 +1408,7 @@ abstract class BaseConnection implements ConnectionInterface
      * @param array  ...$params
      *
      * @return bool
+     *
      * @throws DatabaseException
      */
     public function callFunction(string $functionName, ...$params): bool
@@ -1430,8 +1439,10 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns an array of table names
      *
-     * @param  bool              $constrainByPrefix = FALSE
+     * @param bool $constrainByPrefix = FALSE
+     *
      * @return bool|array
+     *
      * @throws DatabaseException
      */
     public function listTables(bool $constrainByPrefix = false)
@@ -1483,7 +1494,8 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Determine if a particular table exists
      *
-     * @param  string $tableName
+     * @param string $tableName
+     *
      * @return bool
      */
     public function tableExists(string $tableName): bool
@@ -1499,6 +1511,7 @@ abstract class BaseConnection implements ConnectionInterface
      * @param string $table Table name
      *
      * @return array|false
+     *
      * @throws DatabaseException
      */
     public function getFieldNames(string $table)
@@ -1547,8 +1560,9 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Determine if a particular field exists
      *
-     * @param  string $fieldName
-     * @param  string $tableName
+     * @param string $fieldName
+     * @param string $tableName
+     *
      * @return bool
      */
     public function fieldExists(string $fieldName, string $tableName): bool
@@ -1561,7 +1575,8 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns an object with field data
      *
-     * @param  string $table the table name
+     * @param string $table the table name
+     *
      * @return array
      */
     public function getFieldData(string $table)
@@ -1574,7 +1589,8 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns an object with key data
      *
-     * @param  string $table the table name
+     * @param string $table the table name
+     *
      * @return array
      */
     public function getIndexData(string $table)
@@ -1587,7 +1603,8 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns an object with foreign key data
      *
-     * @param  string $table the table name
+     * @param string $table the table name
+     *
      * @return array
      */
     public function getForeignKeyData(string $table)
@@ -1657,7 +1674,8 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Determines if the statement is a write-type query or not.
      *
-     * @param  string $sql
+     * @param string $sql
+     *
      * @return bool
      */
     public function isWriteType($sql): bool
@@ -1715,7 +1733,9 @@ abstract class BaseConnection implements ConnectionInterface
      * Platform-specific field data information.
      *
      * @param string $table
+     *
      * @see    getFieldData()
+     *
      * @return array
      */
     abstract protected function _fieldData(string $table): array;
@@ -1726,7 +1746,9 @@ abstract class BaseConnection implements ConnectionInterface
      * Platform-specific index data.
      *
      * @param string $table
+     *
      * @see    getIndexData()
+     *
      * @return array
      */
     abstract protected function _indexData(string $table): array;
@@ -1737,7 +1759,9 @@ abstract class BaseConnection implements ConnectionInterface
      * Platform-specific foreign keys data.
      *
      * @param string $table
+     *
      * @see    getForeignKeyData()
+     *
      * @return array
      */
     abstract protected function _foreignKeyData(string $table): array;

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -74,7 +74,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Sub-driver
      *
      * @used-by CI_DB_pdo_driver
-     * @var     string
+     * @var string
      */
     protected $subdriver;
 
@@ -395,7 +395,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Connect to the database.
      *
-     * @param  bool $persistent
+     * @param  bool  $persistent
      * @return mixed
      */
     abstract public function connect(bool $persistent = false);
@@ -589,10 +589,10 @@ abstract class BaseConnection implements ConnectionInterface
      * Should automatically handle different connections for read/write
      * queries if needed.
      *
-     * @param string  $sql
-     * @param mixed   ...$binds
-     * @param bool $setEscapeFlags
-     * @param string  $queryClass
+     * @param string $sql
+     * @param mixed  ...$binds
+     * @param bool   $setEscapeFlags
+     * @param string $queryClass
      *
      * @return BaseResult|Query|bool
      *
@@ -1057,9 +1057,9 @@ abstract class BaseConnection implements ConnectionInterface
      * the correct identifiers.
      *
      * @param string|array $item
-     * @param bool      $prefixSingle
-     * @param bool      $protectIdentifiers
-     * @param bool      $fieldExists
+     * @param bool         $prefixSingle
+     * @param bool         $protectIdentifiers
+     * @param bool         $fieldExists
      *
      * @return string|array
      */
@@ -1326,7 +1326,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Escape String
      *
      * @param  string|string[] $str  Input string
-     * @param  bool         $like Whether or not the string will be used in a LIKE condition
+     * @param  bool            $like Whether or not the string will be used in a LIKE condition
      * @return string|string[]
      */
     public function escapeString($str, bool $like = false)
@@ -1430,7 +1430,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns an array of table names
      *
-     * @param  bool $constrainByPrefix = FALSE
+     * @param  bool              $constrainByPrefix = FALSE
      * @return bool|array
      * @throws DatabaseException
      */
@@ -1714,7 +1714,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Platform-specific field data information.
      *
-     * @param  string $table
+     * @param string $table
      * @see    getFieldData()
      * @return array
      */
@@ -1725,7 +1725,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Platform-specific index data.
      *
-     * @param  string $table
+     * @param string $table
      * @see    getIndexData()
      * @return array
      */
@@ -1736,7 +1736,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Platform-specific foreign keys data.
      *
-     * @param  string $table
+     * @param string $table
      * @see    getForeignKeyData()
      * @return array
      */

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -29,7 +29,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
     /**
      * The error code, if any.
      *
-     * @var integer
+     * @var int
      */
     protected $errorCode;
 
@@ -156,7 +156,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
      *
      * @param array $data
      *
-     * @return boolean
+     * @return bool
      */
     abstract public function _execute(array $data): bool;
 
@@ -206,7 +206,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
     /**
      * A helper to determine if any error exists.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasError(): bool
     {
@@ -218,7 +218,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
     /**
      * Returns the error code created while executing this statement.
      *
-     * @return integer
+     * @return int
      */
     public function getErrorCode(): int
     {

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -28,7 +28,7 @@ abstract class BaseResult implements ResultInterface
     /**
      * Result ID
      *
-     * @var resource|object|boolean
+     * @var resource|object|bool
      */
     public $resultID;
 
@@ -56,14 +56,14 @@ abstract class BaseResult implements ResultInterface
     /**
      * Current Row index
      *
-     * @var integer
+     * @var int
      */
     public $currentRow = 0;
 
     /**
      * The number of records in the query result
      *
-     * @var integer|null
+     * @var int|null
      */
     protected $numRows = null;
 
@@ -296,7 +296,7 @@ abstract class BaseResult implements ResultInterface
      *
      * If row doesn't exists, returns null.
      *
-     * @param integer $n
+     * @param int $n
      * @param string  $className
      *
      * @return mixed
@@ -323,7 +323,7 @@ abstract class BaseResult implements ResultInterface
      *
      * If row doesn't exist, returns null.
      *
-     * @param integer $n
+     * @param int $n
      *
      * @return mixed
      */
@@ -348,7 +348,7 @@ abstract class BaseResult implements ResultInterface
      *
      * If row doesn't exist, returns null.
      *
-     * @param integer $n
+     * @param int $n
      *
      * @return mixed
      */
@@ -499,7 +499,7 @@ abstract class BaseResult implements ResultInterface
      * back on counting resultArray or resultObject, finally fetching resultArray
      * if nothing was previously fetched
      *
-     * @return integer
+     * @return int
      */
     public function getNumRows(): int
     {
@@ -519,7 +519,7 @@ abstract class BaseResult implements ResultInterface
     /**
      * Gets the number of fields in the result set.
      *
-     * @return integer
+     * @return int
      */
     abstract public function getFieldCount(): int;
 
@@ -557,7 +557,7 @@ abstract class BaseResult implements ResultInterface
      * internally before fetching results to make sure the result set
      * starts at zero.
      *
-     * @param integer $n
+     * @param int $n
      *
      * @return mixed
      */

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -296,8 +296,8 @@ abstract class BaseResult implements ResultInterface
      *
      * If row doesn't exists, returns null.
      *
-     * @param int $n
-     * @param string  $className
+     * @param int    $n
+     * @param string $className
      *
      * @return mixed
      */

--- a/system/Database/BaseUtils.php
+++ b/system/Database/BaseUtils.php
@@ -65,6 +65,7 @@ abstract class BaseUtils
      * List databases
      *
      * @return array|bool
+     *
      * @throws DatabaseException
      */
     public function listDatabases()
@@ -101,7 +102,8 @@ abstract class BaseUtils
     /**
      * Determine if a particular database exists
      *
-     * @param  string $databaseName
+     * @param string $databaseName
+     *
      * @return bool
      */
     public function databaseExists(string $databaseName): bool
@@ -141,6 +143,7 @@ abstract class BaseUtils
      * Optimize Database
      *
      * @return mixed
+     *
      * @throws DatabaseException
      */
     public function optimizeDatabase()

--- a/system/Database/BaseUtils.php
+++ b/system/Database/BaseUtils.php
@@ -30,21 +30,21 @@ abstract class BaseUtils
     /**
      * List databases statement
      *
-     * @var string|boolean
+     * @var string|bool
      */
     protected $listDatabases = false;
 
     /**
      * OPTIMIZE TABLE statement
      *
-     * @var string|boolean
+     * @var string|bool
      */
     protected $optimizeTable = false;
 
     /**
      * REPAIR TABLE statement
      *
-     * @var string|boolean
+     * @var string|bool
      */
     protected $repairTable = false;
 
@@ -64,7 +64,7 @@ abstract class BaseUtils
     /**
      * List databases
      *
-     * @return array|boolean
+     * @return array|bool
      * @throws DatabaseException
      */
     public function listDatabases()
@@ -102,7 +102,7 @@ abstract class BaseUtils
      * Determine if a particular database exists
      *
      * @param  string $databaseName
-     * @return boolean
+     * @return bool
      */
     public function databaseExists(string $databaseName): bool
     {
@@ -115,7 +115,7 @@ abstract class BaseUtils
      * Optimize Table
      *
      * @param  string $tableName
-     * @return boolean
+     * @return bool
      * @throws DatabaseException
      */
     public function optimizeTable(string $tableName)

--- a/system/Database/BaseUtils.php
+++ b/system/Database/BaseUtils.php
@@ -114,8 +114,10 @@ abstract class BaseUtils
     /**
      * Optimize Table
      *
-     * @param  string $tableName
+     * @param string $tableName
+     *
      * @return bool
+     *
      * @throws DatabaseException
      */
     public function optimizeTable(string $tableName)
@@ -184,8 +186,10 @@ abstract class BaseUtils
     /**
      * Repair Table
      *
-     * @param  string $tableName
+     * @param string $tableName
+     *
      * @return mixed
+     *
      * @throws DatabaseException
      */
     public function repairTable(string $tableName)
@@ -292,8 +296,10 @@ abstract class BaseUtils
     /**
      * Database Backup
      *
-     * @param  array|string $params
+     * @param array|string $params
+     *
      * @return mixed
+     *
      * @throws DatabaseException
      */
     public function backup($params = [])

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -41,7 +41,7 @@ class Config extends BaseConfig
      *
      * @param string|array $group     The name of the connection group to use,
      *                                or an array of configuration settings.
-     * @param bool      $getShared Whether to return a shared instance of the connection.
+     * @param bool         $getShared Whether to return a shared instance of the connection.
      *
      * @return BaseConnection
      */

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -41,7 +41,7 @@ class Config extends BaseConfig
      *
      * @param string|array $group     The name of the connection group to use,
      *                                or an array of configuration settings.
-     * @param boolean      $getShared Whether to return a shared instance of the connection.
+     * @param bool      $getShared Whether to return a shared instance of the connection.
      *
      * @return BaseConnection
      */

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -28,7 +28,8 @@ interface ConnectionInterface
     /**
      * Connect to the database.
      *
-     * @param  bool $persistent
+     * @param bool $persistent
+     *
      * @return mixed
      */
     public function connect(bool $persistent = false);

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -196,7 +196,8 @@ interface ConnectionInterface
     /**
      * Determines if the statement is a write-type query or not.
      *
-     * @param  string $sql
+     * @param string $sql
+     *
      * @return bool
      */
     public function isWriteType($sql): bool;

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -28,7 +28,7 @@ interface ConnectionInterface
     /**
      * Connect to the database.
      *
-     * @param  boolean $persistent
+     * @param  bool $persistent
      * @return mixed
      */
     public function connect(bool $persistent = false);
@@ -127,7 +127,7 @@ interface ConnectionInterface
      * @param string $sql
      * @param mixed  ...$binds
      *
-     * @return BaseResult|Query|boolean
+     * @return BaseResult|Query|bool
      */
     public function query(string $sql, $binds = null);
 
@@ -196,7 +196,7 @@ interface ConnectionInterface
      * Determines if the statement is a write-type query or not.
      *
      * @param  string $sql
-     * @return boolean
+     * @return bool
      */
     public function isWriteType($sql): bool;
 }

--- a/system/Database/Exceptions/DatabaseException.php
+++ b/system/Database/Exceptions/DatabaseException.php
@@ -18,7 +18,7 @@ class DatabaseException extends Error implements ExceptionInterface
     /**
      * Exit status code
      *
-     * @var integer
+     * @var int
      */
     protected $code = 8;
 }

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -189,8 +189,8 @@ class Forge
     /**
      * Create database
      *
-     * @param string  $dbName
-     * @param bool $ifNotExists Whether to add IF NOT EXISTS condition
+     * @param string $dbName
+     * @param bool   $ifNotExists Whether to add IF NOT EXISTS condition
      *
      * @return bool
      * @throws DatabaseException
@@ -306,8 +306,8 @@ class Forge
      * Add Key
      *
      * @param string|array $key
-     * @param bool      $primary
-     * @param bool      $unique
+     * @param bool         $primary
+     * @param bool         $unique
      *
      * @return Forge
      */
@@ -453,9 +453,9 @@ class Forge
     /**
      * Create Table
      *
-     * @param string  $table       Table name
-     * @param bool $ifNotExists Whether to add IF NOT EXISTS condition
-     * @param array   $attributes  Associative array of table attributes
+     * @param string $table       Table name
+     * @param bool   $ifNotExists Whether to add IF NOT EXISTS condition
+     * @param array  $attributes  Associative array of table attributes
      *
      * @return mixed
      * @throws DatabaseException
@@ -508,9 +508,9 @@ class Forge
     /**
      * Create Table
      *
-     * @param string  $table       Table name
-     * @param bool $ifNotExists Whether to add 'IF NOT EXISTS' condition
-     * @param array   $attributes  Associative array of table attributes
+     * @param string $table       Table name
+     * @param bool   $ifNotExists Whether to add 'IF NOT EXISTS' condition
+     * @param array  $attributes  Associative array of table attributes
      *
      * @return mixed
      */
@@ -582,9 +582,9 @@ class Forge
     /**
      * Drop Table
      *
-     * @param string  $tableName Table name
-     * @param bool $ifExists  Whether to add an IF EXISTS condition
-     * @param bool $cascade   Whether to add an CASCADE condition
+     * @param string $tableName Table name
+     * @param bool   $ifExists  Whether to add an IF EXISTS condition
+     * @param bool   $cascade   Whether to add an CASCADE condition
      *
      * @return mixed
      * @throws DatabaseException
@@ -633,9 +633,9 @@ class Forge
      *
      * Generates a platform-specific DROP TABLE string
      *
-     * @param string  $table    Table name
-     * @param bool $ifExists Whether to add an IF EXISTS condition
-     * @param bool $cascade  Whether to add an CASCADE condition
+     * @param string $table    Table name
+     * @param bool   $ifExists Whether to add an IF EXISTS condition
+     * @param bool   $cascade  Whether to add an CASCADE condition
      *
      * @return string|bool
      */

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -193,6 +193,7 @@ class Forge
      * @param bool   $ifNotExists Whether to add IF NOT EXISTS condition
      *
      * @return bool
+     *
      * @throws DatabaseException
      */
     public function createDatabase(string $dbName, bool $ifNotExists = false): bool
@@ -247,6 +248,7 @@ class Forge
      * @param string $dbName
      *
      * @return bool
+     *
      * @throws DatabaseException
      */
     private function databaseExists(string $dbName): bool
@@ -270,6 +272,7 @@ class Forge
      * @param string $dbName
      *
      * @return bool
+     *
      * @throws DatabaseException
      */
     public function dropDatabase(string $dbName): bool
@@ -405,6 +408,7 @@ class Forge
      * @param string $onDelete
      *
      * @return Forge
+     *
      * @throws DatabaseException
      */
     public function addForeignKey(string $fieldName = '', string $tableName = '', string $tableField = '', string $onUpdate = '', string $onDelete = '')
@@ -430,6 +434,7 @@ class Forge
      * @param string $foreignName Foreign name
      *
      * @return bool|BaseResult|Query|false|mixed
+     *
      * @throws DatabaseException
      */
     public function dropForeignKey(string $table, string $foreignName)
@@ -458,6 +463,7 @@ class Forge
      * @param array  $attributes  Associative array of table attributes
      *
      * @return mixed
+     *
      * @throws DatabaseException
      */
     public function createTable(string $table, bool $ifNotExists = false, array $attributes = [])
@@ -587,6 +593,7 @@ class Forge
      * @param bool   $cascade   Whether to add an CASCADE condition
      *
      * @return mixed
+     *
      * @throws DatabaseException
      */
     public function dropTable(string $tableName, bool $ifExists = false, bool $cascade = false)
@@ -665,6 +672,7 @@ class Forge
      * @param string $newTableName New table name
      *
      * @return mixed
+     *
      * @throws DatabaseException
      */
     public function renameTable(string $tableName, string $newTableName)
@@ -706,6 +714,7 @@ class Forge
      * @param string|array $field Column definition
      *
      * @return bool
+     *
      * @throws DatabaseException
      */
     public function addColumn(string $table, $field): bool
@@ -747,6 +756,7 @@ class Forge
      * @param string|array $columnName Column name Array or comma separated
      *
      * @return mixed
+     *
      * @throws DatabaseException
      */
     public function dropColumn(string $table, $columnName)
@@ -772,6 +782,7 @@ class Forge
      * @param string|array $field Column definition
      *
      * @return bool
+     *
      * @throws DatabaseException
      */
     public function modifyColumn(string $table, $field): bool

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -111,7 +111,7 @@ class Forge
     /**
      * CREATE TABLE IF statement
      *
-     * @var string|boolean
+     * @var string|bool
      */
     protected $createTableIfStr = 'CREATE TABLE IF NOT EXISTS';
 
@@ -121,14 +121,14 @@ class Forge
      * Whether table keys are created from within the
      * CREATE TABLE statement.
      *
-     * @var boolean
+     * @var bool
      */
     protected $createTableKeys = false;
 
     /**
      * DROP TABLE IF EXISTS statement
      *
-     * @var string|boolean
+     * @var string|bool
      */
     protected $dropTableIfStr = 'DROP TABLE IF EXISTS';
 
@@ -142,7 +142,7 @@ class Forge
     /**
      * UNSIGNED support
      *
-     * @var boolean|array
+     * @var bool|array
      */
     protected $unsigned = true;
 
@@ -190,9 +190,9 @@ class Forge
      * Create database
      *
      * @param string  $dbName
-     * @param boolean $ifNotExists Whether to add IF NOT EXISTS condition
+     * @param bool $ifNotExists Whether to add IF NOT EXISTS condition
      *
-     * @return boolean
+     * @return bool
      * @throws DatabaseException
      */
     public function createDatabase(string $dbName, bool $ifNotExists = false): bool
@@ -246,7 +246,7 @@ class Forge
      *
      * @param string $dbName
      *
-     * @return boolean
+     * @return bool
      * @throws DatabaseException
      */
     private function databaseExists(string $dbName): bool
@@ -269,7 +269,7 @@ class Forge
      *
      * @param string $dbName
      *
-     * @return boolean
+     * @return bool
      * @throws DatabaseException
      */
     public function dropDatabase(string $dbName): bool
@@ -306,8 +306,8 @@ class Forge
      * Add Key
      *
      * @param string|array $key
-     * @param boolean      $primary
-     * @param boolean      $unique
+     * @param bool      $primary
+     * @param bool      $unique
      *
      * @return Forge
      */
@@ -429,7 +429,7 @@ class Forge
      * @param string $table       Table name
      * @param string $foreignName Foreign name
      *
-     * @return boolean|BaseResult|Query|false|mixed
+     * @return bool|BaseResult|Query|false|mixed
      * @throws DatabaseException
      */
     public function dropForeignKey(string $table, string $foreignName)
@@ -454,7 +454,7 @@ class Forge
      * Create Table
      *
      * @param string  $table       Table name
-     * @param boolean $ifNotExists Whether to add IF NOT EXISTS condition
+     * @param bool $ifNotExists Whether to add IF NOT EXISTS condition
      * @param array   $attributes  Associative array of table attributes
      *
      * @return mixed
@@ -509,7 +509,7 @@ class Forge
      * Create Table
      *
      * @param string  $table       Table name
-     * @param boolean $ifNotExists Whether to add 'IF NOT EXISTS' condition
+     * @param bool $ifNotExists Whether to add 'IF NOT EXISTS' condition
      * @param array   $attributes  Associative array of table attributes
      *
      * @return mixed
@@ -583,8 +583,8 @@ class Forge
      * Drop Table
      *
      * @param string  $tableName Table name
-     * @param boolean $ifExists  Whether to add an IF EXISTS condition
-     * @param boolean $cascade   Whether to add an CASCADE condition
+     * @param bool $ifExists  Whether to add an IF EXISTS condition
+     * @param bool $cascade   Whether to add an CASCADE condition
      *
      * @return mixed
      * @throws DatabaseException
@@ -634,10 +634,10 @@ class Forge
      * Generates a platform-specific DROP TABLE string
      *
      * @param string  $table    Table name
-     * @param boolean $ifExists Whether to add an IF EXISTS condition
-     * @param boolean $cascade  Whether to add an CASCADE condition
+     * @param bool $ifExists Whether to add an IF EXISTS condition
+     * @param bool $cascade  Whether to add an CASCADE condition
      *
-     * @return string|boolean
+     * @return string|bool
      */
     protected function _dropTable(string $table, bool $ifExists, bool $cascade)
     {
@@ -705,7 +705,7 @@ class Forge
      * @param string       $table Table name
      * @param string|array $field Column definition
      *
-     * @return boolean
+     * @return bool
      * @throws DatabaseException
      */
     public function addColumn(string $table, $field): bool
@@ -771,7 +771,7 @@ class Forge
      * @param string       $table Table name
      * @param string|array $field Column definition
      *
-     * @return boolean
+     * @return bool
      * @throws DatabaseException
      */
     public function modifyColumn(string $table, $field): bool
@@ -856,7 +856,7 @@ class Forge
     /**
      * Process fields
      *
-     * @param boolean $createTable
+     * @param bool $createTable
      *
      * @return array
      */

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -233,7 +233,7 @@ class MigrationRunner
      *
      * Calls each migration step required to get to the provided batch
      *
-     * @param int     $targetBatch Target batch number, or negative for a relative batch, 0 for all
+     * @param int         $targetBatch Target batch number, or negative for a relative batch, 0 for all
      * @param string|null $group
      *
      * @throws ConfigException
@@ -439,7 +439,7 @@ class MigrationRunner
     /**
      * Retrieves list of available migration scripts
      *
-     * @return array    List of all located migrations by their UID
+     * @return array List of all located migrations by their UID
      */
     public function findMigrations(): array
     {
@@ -468,7 +468,7 @@ class MigrationRunner
      *
      * @param string $namespace The namespace to search for migrations
      *
-     * @return array    List of unsorted migrations from the namespace
+     * @return array List of unsorted migrations from the namespace
      */
     public function findNamespaceMigrations(string $namespace): array
     {
@@ -509,7 +509,7 @@ class MigrationRunner
      * @param string $path The path to the file
      * @param string $path The namespace of the target migration
      *
-     * @return object|false    Returns the migration object, or false on failure
+     * @return object|false Returns the migration object, or false on failure
      */
     protected function migrationFromFile(string $path, string $namespace)
     {
@@ -615,7 +615,7 @@ class MigrationRunner
      *
      * @param string $migration
      *
-     * @return string    Numeric portion of a migration filename
+     * @return string Numeric portion of a migration filename
      */
     protected function getMigrationNumber(string $migration): string
     {
@@ -631,7 +631,7 @@ class MigrationRunner
      *
      * @param string $migration
      *
-     * @return string    text portion of a migration filename
+     * @return string text portion of a migration filename
      */
     protected function getMigrationName(string $migration): string
     {
@@ -661,7 +661,7 @@ class MigrationRunner
     /**
      * Retrieves messages formatted for CLI output
      *
-     * @return array    Current migration version
+     * @return array Current migration version
      */
     public function getCliMessages(): array
     {
@@ -701,8 +701,8 @@ class MigrationRunner
     /**
      * Add a history to the table.
      *
-     * @param object  $migration
-     * @param int $batch
+     * @param object $migration
+     * @param int    $batch
      *
      * @return void
      */

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -28,7 +28,7 @@ class MigrationRunner
     /**
      * Whether or not migrations are allowed to run.
      *
-     * @var boolean
+     * @var bool
      */
     protected $enabled = false;
 
@@ -79,7 +79,7 @@ class MigrationRunner
      * If true, will continue instead of throwing
      * exceptions.
      *
-     * @var boolean
+     * @var bool
      */
     protected $silent = false;
 
@@ -94,7 +94,7 @@ class MigrationRunner
      * Tracks whether we have already ensured
      * the table exists or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $tableChecked = false;
 
@@ -115,7 +115,7 @@ class MigrationRunner
     /**
      * Used to skip current migration.
      *
-     * @var boolean
+     * @var bool
      */
     protected $groupSkip = false;
 
@@ -160,7 +160,7 @@ class MigrationRunner
      * @throws ConfigException
      * @throws RuntimeException
      *
-     * @return boolean
+     * @return bool
      */
     public function latest(string $group = null)
     {
@@ -233,7 +233,7 @@ class MigrationRunner
      *
      * Calls each migration step required to get to the provided batch
      *
-     * @param integer     $targetBatch Target batch number, or negative for a relative batch, 0 for all
+     * @param int     $targetBatch Target batch number, or negative for a relative batch, 0 for all
      * @param string|null $group
      *
      * @throws ConfigException
@@ -597,7 +597,7 @@ class MigrationRunner
      * If $silent == true, then will not throw exceptions and will
      * attempt to continue gracefully.
      *
-     * @param boolean $silent
+     * @param bool $silent
      *
      * @return MigrationRunner
      */
@@ -702,7 +702,7 @@ class MigrationRunner
      * Add a history to the table.
      *
      * @param object  $migration
-     * @param integer $batch
+     * @param int $batch
      *
      * @return void
      */
@@ -787,7 +787,7 @@ class MigrationRunner
     /**
      * Returns the migration history for a single batch.
      *
-     * @param integer $batch
+     * @param int $batch
      *
      * @return array
      */
@@ -829,7 +829,7 @@ class MigrationRunner
     /**
      * Returns the value of the last batch in the database.
      *
-     * @return integer
+     * @return int
      */
     public function getLastBatch(): int
     {
@@ -853,7 +853,7 @@ class MigrationRunner
      * Returns the version number of the first migration for a batch.
      * Mostly just for tests.
      *
-     * @param integer $batch
+     * @param int $batch
      *
      * @return string
      */
@@ -881,7 +881,7 @@ class MigrationRunner
      * Returns the version number of the last migration for a batch.
      * Mostly just for tests.
      *
-     * @param integer $batch
+     * @param int $batch
      *
      * @return string
      */
@@ -969,7 +969,7 @@ class MigrationRunner
      * @param string $direction "up" or "down"
      * @param object $migration The migration to run
      *
-     * @return boolean
+     * @return bool
      */
     protected function migrate($direction, $migration): bool
     {

--- a/system/Database/ModelFactory.php
+++ b/system/Database/ModelFactory.php
@@ -26,7 +26,7 @@ class ModelFactory
      * Creates new Model instances or returns a shared instance
      *
      * @param string              $name       Model name, namespace optional
-     * @param boolean             $getShared  Use shared instance
+     * @param bool             $getShared  Use shared instance
      * @param ConnectionInterface $connection
      *
      * @return mixed|null

--- a/system/Database/ModelFactory.php
+++ b/system/Database/ModelFactory.php
@@ -26,7 +26,7 @@ class ModelFactory
      * Creates new Model instances or returns a shared instance
      *
      * @param string              $name       Model name, namespace optional
-     * @param bool             $getShared  Use shared instance
+     * @param bool                $getShared  Use shared instance
      * @param ConnectionInterface $connection
      *
      * @return mixed|null

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -433,8 +433,10 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with field data
      *
-     * @param  string $table
+     * @param string $table
+     *
      * @return stdClass[]
+     *
      * @throws DatabaseException
      */
     public function _fieldData(string $table): array
@@ -467,8 +469,10 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with index data
      *
-     * @param  string $table
+     * @param string $table
+     *
      * @return stdClass[]
+     *
      * @throws DatabaseException
      * @throws LogicException
      */
@@ -515,8 +519,10 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with Foreign key data
      *
-     * @param  string $table
+     * @param string $table
+     *
      * @return stdClass[]
+     *
      * @throws DatabaseException
      */
     public function _foreignKeyData(string $table): array

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -70,6 +70,7 @@ class Connection extends BaseConnection
      * @param bool $persistent
      *
      * @return mixed
+     *
      * @throws DatabaseException
      */
     public function connect(bool $persistent = false)
@@ -345,7 +346,8 @@ class Connection extends BaseConnection
     /**
      * Platform-dependant string escape
      *
-     * @param  string $str
+     * @param string $str
+     *
      * @return string
      */
     protected function _escapeString(string $str): string
@@ -365,7 +367,8 @@ class Connection extends BaseConnection
      * additional "ESCAPE x" parameter for specifying the escape character
      * in "LIKE" strings, and this handles those directly with a backslash.
      *
-     * @param  string|string[] $str Input string
+     * @param string|string[] $str Input string
+     *
      * @return string|string[]
      */
     public function escapeLikeStringDirect($str)

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -38,7 +38,7 @@ class Connection extends BaseConnection
      * of affected rows to be shown. Uses a preg_replace when enabled,
      * adding a bit more processing to all queries.
      *
-     * @var boolean
+     * @var bool
      */
     public $deleteHack = true;
 
@@ -67,7 +67,7 @@ class Connection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @param boolean $persistent
+     * @param bool $persistent
      *
      * @return mixed
      * @throws DatabaseException
@@ -234,7 +234,7 @@ class Connection extends BaseConnection
      *
      * @param string $databaseName
      *
-     * @return boolean
+     * @return bool
      */
     public function setDatabase(string $databaseName): bool
     {
@@ -333,7 +333,7 @@ class Connection extends BaseConnection
     /**
      * Returns the total number of rows affected by this query.
      *
-     * @return integer
+     * @return int
      */
     public function affectedRows(): int
     {
@@ -399,7 +399,7 @@ class Connection extends BaseConnection
      * Generates the SQL for listing tables in a platform-dependent manner.
      * Uses escapeLikeStringDirect().
      *
-     * @param boolean $prefixLimit
+     * @param bool $prefixLimit
      *
      * @return string
      */
@@ -612,7 +612,7 @@ class Connection extends BaseConnection
     /**
      * Insert ID
      *
-     * @return integer
+     * @return int
      */
     public function insertID(): int
     {
@@ -624,7 +624,7 @@ class Connection extends BaseConnection
     /**
      * Begin Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transBegin(): bool
     {
@@ -638,7 +638,7 @@ class Connection extends BaseConnection
     /**
      * Commit Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transCommit(): bool
     {
@@ -656,7 +656,7 @@ class Connection extends BaseConnection
     /**
      * Rollback Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transRollback(): bool
     {

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -199,7 +199,8 @@ class Forge extends BaseForge
     /**
      * Process indexes
      *
-     * @param  string $table (ignored)
+     * @param string $table (ignored)
+     *
      * @return string
      */
     protected function _processIndexes(string $table): string

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -98,7 +98,8 @@ class Forge extends BaseForge
     /**
      * CREATE TABLE attributes
      *
-     * @param  array $attributes Associative array of table attributes
+     * @param array $attributes Associative array of table attributes
+     *
      * @return string
      */
     protected function _createTableAttributes(array $attributes): string
@@ -133,9 +134,10 @@ class Forge extends BaseForge
     /**
      * ALTER TABLE
      *
-     * @param  string $alterType ALTER type
-     * @param  string $table     Table name
-     * @param  mixed  $field     Column definition
+     * @param string $alterType ALTER type
+     * @param string $table     Table name
+     * @param mixed  $field     Column definition
+     *
      * @return string|string[]
      */
     protected function _alterTable(string $alterType, string $table, $field)
@@ -168,7 +170,8 @@ class Forge extends BaseForge
     /**
      * Process column
      *
-     * @param  array $field
+     * @param array $field
+     *
      * @return string
      */
     protected function _processColumn(array $field): string

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -45,7 +45,7 @@ class Forge extends BaseForge
      * Whether table keys are created from within the
      * CREATE TABLE statement.
      *
-     * @var boolean
+     * @var bool
      */
     protected $createTableKeys = true;
 

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -52,7 +52,7 @@ class PreparedQuery extends BasePreparedQuery
      *
      * @param array $data
      *
-     * @return boolean
+     * @return bool
      */
     public function _execute(array $data): bool
     {

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -23,7 +23,7 @@ class Result extends BaseResult
     /**
      * Gets the number of fields in the result set.
      *
-     * @return integer
+     * @return int
      */
     public function getFieldCount(): int
     {
@@ -129,7 +129,7 @@ class Result extends BaseResult
      * internally before fetching results to make sure the result set
      * starts at zero.
      *
-     * @param integer $n
+     * @param int $n
      *
      * @return mixed
      */
@@ -161,7 +161,7 @@ class Result extends BaseResult
      *
      * @param string $className
      *
-     * @return object|boolean|Entity
+     * @return object|bool|Entity
      */
     protected function fetchObject(string $className = 'stdClass')
     {
@@ -177,7 +177,7 @@ class Result extends BaseResult
     /**
      * Returns the number of rows in the resultID (i.e., mysqli_result object)
      *
-     * @return integer number of rows in a query result
+     * @return int number of rows in a query result
      */
     public function getNumRows(): int
     {

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -147,7 +147,9 @@ class Builder extends BaseBuilder
      * @param array $set An associative array of insert values
      *
      * @return mixed
+     *
      * @throws DatabaseException
+     *
      * @internal param true $bool returns the generated SQL, false executes the query.
      */
     public function replace(array $set = null)
@@ -228,7 +230,9 @@ class Builder extends BaseBuilder
      * @param bool  $resetData
      *
      * @return mixed
+     *
      * @throws DatabaseException
+     *
      * @internal param the $mixed where clause
      * @internal param the $mixed limit clause
      * @internal param $bool
@@ -269,7 +273,9 @@ class Builder extends BaseBuilder
      * @param array  $values
      *
      * @return string
+     *
      * @throws DatabaseException
+     *
      * @internal param the $string table name
      * @internal param the $array update data
      */

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -68,7 +68,7 @@ class Builder extends BaseBuilder
      *
      * @param string  $orderBy
      * @param string  $direction ASC, DESC or RANDOM
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return BaseBuilder
      */
@@ -98,7 +98,7 @@ class Builder extends BaseBuilder
      * Increments a numeric column by the specified value.
      *
      * @param string  $column
-     * @param integer $value
+     * @param int $value
      *
      * @throws DatabaseException
      *
@@ -119,7 +119,7 @@ class Builder extends BaseBuilder
      * Decrements a numeric column by the specified value.
      *
      * @param string  $column
-     * @param integer $value
+     * @param int $value
      *
      * @throws DatabaseException
      *
@@ -224,8 +224,8 @@ class Builder extends BaseBuilder
      * Compiles a delete string and runs the query
      *
      * @param mixed   $where
-     * @param integer $limit
-     * @param boolean $resetData
+     * @param int $limit
+     * @param bool $resetData
      *
      * @return   mixed
      * @throws   DatabaseException
@@ -378,7 +378,7 @@ class Builder extends BaseBuilder
      * @param string      $column
      * @param string|null $not
      * @param string      $bind
-     * @param boolean     $insensitiveSearch
+     * @param bool     $insensitiveSearch
      *
      * @return string     $like_statement
      */
@@ -399,7 +399,7 @@ class Builder extends BaseBuilder
      * @param string  $table
      * @param string  $cond   The join condition
      * @param string  $type   The type of join
-     * @param boolean $escape Whether not to try to escape identifiers
+     * @param bool $escape Whether not to try to escape identifiers
      *
      * @return BaseBuilder
      */

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -66,9 +66,9 @@ class Builder extends BaseBuilder
     /**
      * ORDER BY
      *
-     * @param string  $orderBy
-     * @param string  $direction ASC, DESC or RANDOM
-     * @param bool $escape
+     * @param string $orderBy
+     * @param string $direction ASC, DESC or RANDOM
+     * @param bool   $escape
      *
      * @return BaseBuilder
      */
@@ -97,8 +97,8 @@ class Builder extends BaseBuilder
     /**
      * Increments a numeric column by the specified value.
      *
-     * @param string  $column
-     * @param int $value
+     * @param string $column
+     * @param int    $value
      *
      * @throws DatabaseException
      *
@@ -118,8 +118,8 @@ class Builder extends BaseBuilder
     /**
      * Decrements a numeric column by the specified value.
      *
-     * @param string  $column
-     * @param int $value
+     * @param string $column
+     * @param int    $value
      *
      * @throws DatabaseException
      *
@@ -146,8 +146,8 @@ class Builder extends BaseBuilder
      *
      * @param array $set An associative array of insert values
      *
-     * @return   mixed
-     * @throws   DatabaseException
+     * @return mixed
+     * @throws DatabaseException
      * @internal param true $bool returns the generated SQL, false executes the query.
      */
     public function replace(array $set = null)
@@ -223,12 +223,12 @@ class Builder extends BaseBuilder
      *
      * Compiles a delete string and runs the query
      *
-     * @param mixed   $where
-     * @param int $limit
-     * @param bool $resetData
+     * @param mixed $where
+     * @param int   $limit
+     * @param bool  $resetData
      *
-     * @return   mixed
-     * @throws   DatabaseException
+     * @return mixed
+     * @throws DatabaseException
      * @internal param the $mixed where clause
      * @internal param the $mixed limit clause
      * @internal param $bool
@@ -268,8 +268,8 @@ class Builder extends BaseBuilder
      * @param string $table
      * @param array  $values
      *
-     * @return   string
-     * @throws   DatabaseException
+     * @return string
+     * @throws DatabaseException
      * @internal param the $string table name
      * @internal param the $array update data
      */
@@ -378,9 +378,9 @@ class Builder extends BaseBuilder
      * @param string      $column
      * @param string|null $not
      * @param string      $bind
-     * @param bool     $insensitiveSearch
+     * @param bool        $insensitiveSearch
      *
-     * @return string     $like_statement
+     * @return string $like_statement
      */
     public function _like_statement(?string $prefix, string $column, ?string $not, string $bind, bool $insensitiveSearch = false): string
     {
@@ -396,10 +396,10 @@ class Builder extends BaseBuilder
      *
      * Generates the JOIN portion of the query
      *
-     * @param string  $table
-     * @param string  $cond   The join condition
-     * @param string  $type   The type of join
-     * @param bool $escape Whether not to try to escape identifiers
+     * @param string $table
+     * @param string $cond   The join condition
+     * @param string $type   The type of join
+     * @param bool   $escape Whether not to try to escape identifiers
      *
      * @return BaseBuilder
      */

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -49,7 +49,8 @@ class Connection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @param  bool $persistent
+     * @param bool $persistent
+     *
      * @return mixed
      */
     public function connect(bool $persistent = false)
@@ -270,8 +271,10 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with field data
      *
-     * @param  string $table
+     * @param string $table
+     *
      * @return stdClass[]
+     *
      * @throws DatabaseException
      */
     public function _fieldData(string $table): array
@@ -306,8 +309,10 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with index data
      *
-     * @param  string $table
+     * @param string $table
+     *
      * @return stdClass[]
+     *
      * @throws DatabaseException
      */
     public function _indexData(string $table): array
@@ -349,8 +354,10 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with Foreign key data
      *
-     * @param  string $table
+     * @param string $table
+     *
      * @return stdClass[]
+     *
      * @throws DatabaseException
      */
     public function _foreignKeyData(string $table): array

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -49,7 +49,7 @@ class Connection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @param  boolean $persistent
+     * @param  bool $persistent
      * @return mixed
      */
     public function connect(bool $persistent = false)
@@ -118,7 +118,7 @@ class Connection extends BaseConnection
      *
      * @param string $databaseName
      *
-     * @return boolean
+     * @return bool
      */
     public function setDatabase(string $databaseName): bool
     {
@@ -174,7 +174,7 @@ class Connection extends BaseConnection
     /**
      * Returns the total number of rows affected by this query.
      *
-     * @return integer
+     * @return int
      */
     public function affectedRows(): int
     {
@@ -230,7 +230,7 @@ class Connection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param boolean $prefixLimit
+     * @param bool $prefixLimit
      *
      * @return string
      */
@@ -435,7 +435,7 @@ class Connection extends BaseConnection
     /**
      * Insert ID
      *
-     * @return integer|string
+     * @return int|string
      */
     public function insertID()
     {
@@ -530,7 +530,7 @@ class Connection extends BaseConnection
      * Set client encoding
      *
      * @param  string $charset The client encoding to which the data will be converted.
-     * @return boolean
+     * @return bool
      */
     protected function setClientEncoding(string $charset): bool
     {
@@ -542,7 +542,7 @@ class Connection extends BaseConnection
     /**
      * Begin Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transBegin(): bool
     {
@@ -554,7 +554,7 @@ class Connection extends BaseConnection
     /**
      * Commit Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transCommit(): bool
     {
@@ -566,7 +566,7 @@ class Connection extends BaseConnection
     /**
      * Rollback Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transRollback(): bool
     {
@@ -581,7 +581,7 @@ class Connection extends BaseConnection
      * Overrides BaseConnection::isWriteType, adding additional read query types.
      *
      * @param  string $sql An SQL query string
-     * @return boolean
+     * @return bool
      */
     public function isWriteType($sql): bool
     {

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -189,7 +189,8 @@ class Connection extends BaseConnection
      *
      * Escapes data based on type
      *
-     * @param  mixed $str
+     * @param mixed $str
+     *
      * @return mixed
      */
     public function escape($str)
@@ -214,7 +215,8 @@ class Connection extends BaseConnection
     /**
      * Platform-dependant string escape
      *
-     * @param  string $str
+     * @param string $str
+     *
      * @return string
      */
     protected function _escapeString(string $str): string
@@ -536,7 +538,8 @@ class Connection extends BaseConnection
     /**
      * Set client encoding
      *
-     * @param  string $charset The client encoding to which the data will be converted.
+     * @param string $charset The client encoding to which the data will be converted.
+     *
      * @return bool
      */
     protected function setClientEncoding(string $charset): bool
@@ -587,7 +590,8 @@ class Connection extends BaseConnection
      *
      * Overrides BaseConnection::isWriteType, adding additional read query types.
      *
-     * @param  string $sql An SQL query string
+     * @param string $sql An SQL query string
+     *
      * @return bool
      */
     public function isWriteType($sql): bool

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -80,7 +80,7 @@ class Forge extends BaseForge
      * @param string $table     Table name
      * @param mixed  $field     Column definition
      *
-     * @return string|array|boolean
+     * @return string|array|bool
      */
     protected function _alterTable(string $alterType, string $table, $field)
     {
@@ -207,8 +207,8 @@ class Forge extends BaseForge
      * Generates a platform-specific DROP TABLE string
      *
      * @param string  $table    Table name
-     * @param boolean $ifExists Whether to add an IF EXISTS condition
-     * @param boolean $cascade
+     * @param bool $ifExists Whether to add an IF EXISTS condition
+     * @param bool $cascade
      *
      * @return string
      */

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -63,7 +63,8 @@ class Forge extends BaseForge
     /**
      * CREATE TABLE attributes
      *
-     * @param  array $attributes Associative array of table attributes
+     * @param array $attributes Associative array of table attributes
+     *
      * @return string
      */
     protected function _createTableAttributes(array $attributes): string
@@ -131,7 +132,8 @@ class Forge extends BaseForge
     /**
      * Process column
      *
-     * @param  array $field
+     * @param array $field
+     *
      * @return string
      */
     protected function _processColumn(array $field): string
@@ -206,9 +208,9 @@ class Forge extends BaseForge
      *
      * Generates a platform-specific DROP TABLE string
      *
-     * @param string  $table    Table name
-     * @param bool $ifExists Whether to add an IF EXISTS condition
-     * @param bool $cascade
+     * @param string $table    Table name
+     * @param bool   $ifExists Whether to add an IF EXISTS condition
+     * @param bool   $cascade
      *
      * @return string
      */

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -32,7 +32,7 @@ class PreparedQuery extends BasePreparedQuery
      * The result resource from a successful
      * pg_exec. Or false.
      *
-     * @var Result|boolean
+     * @var Result|bool
      */
     protected $result;
 
@@ -74,7 +74,7 @@ class PreparedQuery extends BasePreparedQuery
      *
      * @param array $data
      *
-     * @return boolean
+     * @return bool
      */
     public function _execute(array $data): bool
     {

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -48,6 +48,7 @@ class PreparedQuery extends BasePreparedQuery
      *                        Unused in the MySQLi driver.
      *
      * @return mixed
+     *
      * @throws Exception
      */
     public function _prepare(string $sql, array $options = [])

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -23,7 +23,7 @@ class Result extends BaseResult
     /**
      * Gets the number of fields in the result set.
      *
-     * @return integer
+     * @return int
      */
     public function getFieldCount(): int
     {
@@ -95,7 +95,7 @@ class Result extends BaseResult
      * internally before fetching results to make sure the result set
      * starts at zero.
      *
-     * @param integer $n
+     * @param int $n
      *
      * @return mixed
      */
@@ -127,7 +127,7 @@ class Result extends BaseResult
      *
      * @param string $className
      *
-     * @return object|boolean|Entity
+     * @return object|bool|Entity
      */
     protected function fetchObject(string $className = 'stdClass')
     {
@@ -142,7 +142,7 @@ class Result extends BaseResult
     /**
      * Returns the number of rows in the resultID (i.e., PostgreSQL query result resource)
      *
-     * @return integer The number of rows in the query result
+     * @return int The number of rows in the query result
      */
     public function getNumRows(): int
     {

--- a/system/Database/PreparedQueryInterface.php
+++ b/system/Database/PreparedQueryInterface.php
@@ -60,7 +60,7 @@ interface PreparedQueryInterface
     /**
      * Returns the error code created while executing this statement.
      *
-     * @return integer
+     * @return int
      */
     public function getErrorCode(): int;
 

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -348,8 +348,9 @@ class Query implements QueryInterface
     /**
      * Match bindings
      *
-     * @param  string $sql
-     * @param  array  $binds
+     * @param string $sql
+     * @param array  $binds
+     *
      * @return string
      */
     protected function matchNamedBinds(string $sql, array $binds): string
@@ -376,10 +377,11 @@ class Query implements QueryInterface
     /**
      * Match bindings
      *
-     * @param  string $sql
-     * @param  array  $binds
-     * @param  int    $bindCount
-     * @param  int    $ml
+     * @param string $sql
+     * @param array  $binds
+     * @param int    $bindCount
+     * @param int    $ml
+     *
      * @return string
      */
     protected function matchSimpleBinds(string $sql, array $binds, int $bindCount, int $ml): string

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -65,7 +65,7 @@ class Query implements QueryInterface
     /**
      * The error code, if any.
      *
-     * @var integer
+     * @var int
      */
     protected $errorCode;
 
@@ -99,7 +99,7 @@ class Query implements QueryInterface
      *
      * @param string  $sql
      * @param mixed   $binds
-     * @param boolean $setEscape
+     * @param bool $setEscape
      *
      * @return $this
      */
@@ -130,7 +130,7 @@ class Query implements QueryInterface
      * Will store the variables to bind into the query later.
      *
      * @param array   $binds
-     * @param boolean $setEscape
+     * @param bool $setEscape
      *
      * @return $this
      */
@@ -193,8 +193,8 @@ class Query implements QueryInterface
     /**
      * Returns the start time in seconds with microseconds.
      *
-     * @param boolean $returnRaw
-     * @param integer $decimals
+     * @param bool $returnRaw
+     * @param int $decimals
      *
      * @return string|float
      */
@@ -211,7 +211,7 @@ class Query implements QueryInterface
      * Returns the duration of this query during execution, or null if
      * the query has not been executed yet.
      *
-     * @param integer $decimals The accuracy of the returned time.
+     * @param int $decimals The accuracy of the returned time.
      *
      * @return string
      */
@@ -223,7 +223,7 @@ class Query implements QueryInterface
     /**
      * Stores the error description that happened for this query.
      *
-     * @param integer $code
+     * @param int $code
      * @param string  $error
      *
      * @return $this
@@ -239,7 +239,7 @@ class Query implements QueryInterface
     /**
      * Reports whether this statement created an error not.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasError(): bool
     {
@@ -249,7 +249,7 @@ class Query implements QueryInterface
     /**
      * Returns the error code created while executing this statement.
      *
-     * @return integer
+     * @return int
      */
     public function getErrorCode(): int
     {
@@ -269,7 +269,7 @@ class Query implements QueryInterface
     /**
      * Determines if the statement is a write-type query or not.
      *
-     * @return boolean
+     * @return bool
      */
     public function isWriteType(): bool
     {
@@ -378,8 +378,8 @@ class Query implements QueryInterface
      *
      * @param  string  $sql
      * @param  array   $binds
-     * @param  integer $bindCount
-     * @param  integer $ml
+     * @param  int $bindCount
+     * @param  int $ml
      * @return string
      */
     protected function matchSimpleBinds(string $sql, array $binds, int $bindCount, int $ml): string

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -97,9 +97,9 @@ class Query implements QueryInterface
     /**
      * Sets the raw query string to use for this statement.
      *
-     * @param string  $sql
-     * @param mixed   $binds
-     * @param bool $setEscape
+     * @param string $sql
+     * @param mixed  $binds
+     * @param bool   $setEscape
      *
      * @return $this
      */
@@ -129,8 +129,8 @@ class Query implements QueryInterface
     /**
      * Will store the variables to bind into the query later.
      *
-     * @param array   $binds
-     * @param bool $setEscape
+     * @param array $binds
+     * @param bool  $setEscape
      *
      * @return $this
      */
@@ -194,7 +194,7 @@ class Query implements QueryInterface
      * Returns the start time in seconds with microseconds.
      *
      * @param bool $returnRaw
-     * @param int $decimals
+     * @param int  $decimals
      *
      * @return string|float
      */
@@ -223,8 +223,8 @@ class Query implements QueryInterface
     /**
      * Stores the error description that happened for this query.
      *
-     * @param int $code
-     * @param string  $error
+     * @param int    $code
+     * @param string $error
      *
      * @return $this
      */
@@ -376,10 +376,10 @@ class Query implements QueryInterface
     /**
      * Match bindings
      *
-     * @param  string  $sql
-     * @param  array   $binds
-     * @param  int $bindCount
-     * @param  int $ml
+     * @param  string $sql
+     * @param  array  $binds
+     * @param  int    $bindCount
+     * @param  int    $ml
      * @return string
      */
     protected function matchSimpleBinds(string $sql, array $binds, int $bindCount, int $ml): string

--- a/system/Database/QueryInterface.php
+++ b/system/Database/QueryInterface.php
@@ -22,9 +22,9 @@ interface QueryInterface
     /**
      * Sets the raw query string to use for this statement.
      *
-     * @param string  $sql
-     * @param mixed   $binds
-     * @param bool $setEscape
+     * @param string $sql
+     * @param mixed  $binds
+     * @param bool   $setEscape
      *
      * @return mixed
      */
@@ -71,8 +71,8 @@ interface QueryInterface
     /**
      * Stores the error description that happened for this query.
      *
-     * @param int $code
-     * @param string  $error
+     * @param int    $code
+     * @param string $error
      */
     public function setError(int $code, string $error);
 

--- a/system/Database/QueryInterface.php
+++ b/system/Database/QueryInterface.php
@@ -24,7 +24,7 @@ interface QueryInterface
      *
      * @param string  $sql
      * @param mixed   $binds
-     * @param boolean $setEscape
+     * @param bool $setEscape
      *
      * @return mixed
      */
@@ -60,7 +60,7 @@ interface QueryInterface
      * Returns the duration of this query during execution, or null if
      * the query has not been executed yet.
      *
-     * @param integer $decimals The accuracy of the returned time.
+     * @param int $decimals The accuracy of the returned time.
      *
      * @return string
      */
@@ -71,7 +71,7 @@ interface QueryInterface
     /**
      * Stores the error description that happened for this query.
      *
-     * @param integer $code
+     * @param int $code
      * @param string  $error
      */
     public function setError(int $code, string $error);
@@ -81,7 +81,7 @@ interface QueryInterface
     /**
      * Reports whether this statement created an error not.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasError(): bool;
 
@@ -90,7 +90,7 @@ interface QueryInterface
     /**
      * Returns the error code created while executing this statement.
      *
-     * @return integer
+     * @return int
      */
     public function getErrorCode(): int;
 
@@ -108,7 +108,7 @@ interface QueryInterface
     /**
      * Determines if the statement is a write-type query or not.
      *
-     * @return boolean
+     * @return bool
      */
     public function isWriteType(): bool;
 

--- a/system/Database/ResultInterface.php
+++ b/system/Database/ResultInterface.php
@@ -82,8 +82,8 @@ interface ResultInterface
      *
      * If row doesn't exists, returns null.
      *
-     * @param int $n
-     * @param string  $className
+     * @param int    $n
+     * @param string $className
      *
      * @return mixed
      */

--- a/system/Database/ResultInterface.php
+++ b/system/Database/ResultInterface.php
@@ -82,7 +82,7 @@ interface ResultInterface
      *
      * If row doesn't exists, returns null.
      *
-     * @param integer $n
+     * @param int $n
      * @param string  $className
      *
      * @return mixed
@@ -96,7 +96,7 @@ interface ResultInterface
      *
      * If row doesn't exist, returns null.
      *
-     * @param integer $n
+     * @param int $n
      *
      * @return mixed
      */
@@ -109,7 +109,7 @@ interface ResultInterface
      *
      * If row doesn't exist, returns null.
      *
-     * @param integer $n
+     * @param int $n
      *
      * @return mixed
      */
@@ -187,7 +187,7 @@ interface ResultInterface
     /**
      * Gets the number of fields in the result set.
      *
-     * @return integer
+     * @return int
      */
     public function getFieldCount(): int;
 
@@ -225,7 +225,7 @@ interface ResultInterface
      * internally before fetching results to make sure the result set
      * starts at zero.
      *
-     * @param integer $n
+     * @param int $n
      *
      * @return mixed
      */

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -42,21 +42,21 @@ class Builder extends BaseBuilder
      * Whether to use SQL-92 standard quoted identifier
      * (double quotes) or brackets for identifier escaping.
      *
-     * @var boolean
+     * @var bool
      */
     protected $_quoted_identifier = true;
 
     /**
      * Handle increment/decrement on text
      *
-     * @var boolean
+     * @var bool
      */
     public $castTextToInt = true;
 
     /**
      * Handle IDENTITY_INSERT property/
      *
-     * @var boolean
+     * @var bool
      */
     public $keyPermission = false;
 
@@ -106,7 +106,7 @@ class Builder extends BaseBuilder
      * @param string  $table
      * @param string  $cond   The join condition
      * @param string  $type   The type of join
-     * @param boolean $escape Whether not to try to escape identifiers
+     * @param bool $escape Whether not to try to escape identifiers
      *
      * @return $this
      */
@@ -228,9 +228,9 @@ class Builder extends BaseBuilder
      * Increments a numeric column by the specified value.
      *
      * @param string  $column
-     * @param integer $value
+     * @param int $value
      *
-     * @return boolean
+     * @return bool
      */
     public function increment(string $column, int $value = 1)
     {
@@ -250,9 +250,9 @@ class Builder extends BaseBuilder
      * Decrements a numeric column by the specified value.
      *
      * @param string  $column
-     * @param integer $value
+     * @param int $value
      *
-     * @return boolean
+     * @return bool
      */
     public function decrement(string $column, int $value = 1)
     {
@@ -309,7 +309,7 @@ class Builder extends BaseBuilder
      * Local implementation of limit
      *
      * @param string  $sql
-     * @param boolean $offsetIgnore
+     * @param bool $offsetIgnore
      *
      * @return string
      */
@@ -499,8 +499,8 @@ class Builder extends BaseBuilder
      * Compiles a delete string and runs the query
      *
      * @param mixed   $where     The where clause
-     * @param integer $limit     The limit clause
-     * @param boolean $resetData
+     * @param int $limit     The limit clause
+     * @param bool $resetData
      *
      * @return mixed
      * @throws DatabaseException
@@ -602,7 +602,7 @@ class Builder extends BaseBuilder
      * @param mixed   $key
      * @param mixed   $value
      * @param string  $type
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return $this
      */
@@ -671,9 +671,9 @@ class Builder extends BaseBuilder
      * Compiles the select statement based on the other functions called
      * and runs the query
      *
-     * @param integer $limit  The limit clause
-     * @param integer $offset The offset clause
-     * @param boolean $reset  Are we want to clear query builder values?
+     * @param int $limit  The limit clause
+     * @param int $offset The offset clause
+     * @param bool $reset  Are we want to clear query builder values?
      *
      * @return ResultInterface
      */

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -336,6 +336,7 @@ class Builder extends BaseBuilder
      * @param array|null $set An associative array of insert values
      *
      * @return mixed
+     *
      * @throws DatabaseException
      */
     public function replace(array $set = null)
@@ -503,6 +504,7 @@ class Builder extends BaseBuilder
      * @param bool  $resetData
      *
      * @return mixed
+     *
      * @throws DatabaseException
      */
     public function delete($where = '', int $limit = null, bool $resetData = true)

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -103,10 +103,10 @@ class Builder extends BaseBuilder
      *
      * Generates the JOIN portion of the query
      *
-     * @param string  $table
-     * @param string  $cond   The join condition
-     * @param string  $type   The type of join
-     * @param bool $escape Whether not to try to escape identifiers
+     * @param string $table
+     * @param string $cond   The join condition
+     * @param string $type   The type of join
+     * @param bool   $escape Whether not to try to escape identifiers
      *
      * @return $this
      */
@@ -227,8 +227,8 @@ class Builder extends BaseBuilder
     /**
      * Increments a numeric column by the specified value.
      *
-     * @param string  $column
-     * @param int $value
+     * @param string $column
+     * @param int    $value
      *
      * @return bool
      */
@@ -249,8 +249,8 @@ class Builder extends BaseBuilder
     /**
      * Decrements a numeric column by the specified value.
      *
-     * @param string  $column
-     * @param int $value
+     * @param string $column
+     * @param int    $value
      *
      * @return bool
      */
@@ -308,8 +308,8 @@ class Builder extends BaseBuilder
     /**
      * Local implementation of limit
      *
-     * @param string  $sql
-     * @param bool $offsetIgnore
+     * @param string $sql
+     * @param bool   $offsetIgnore
      *
      * @return string
      */
@@ -498,9 +498,9 @@ class Builder extends BaseBuilder
      *
      * Compiles a delete string and runs the query
      *
-     * @param mixed   $where     The where clause
-     * @param int $limit     The limit clause
-     * @param bool $resetData
+     * @param mixed $where     The where clause
+     * @param int   $limit     The limit clause
+     * @param bool  $resetData
      *
      * @return mixed
      * @throws DatabaseException
@@ -598,11 +598,11 @@ class Builder extends BaseBuilder
     /**
      * WHERE, HAVING
      *
-     * @param string  $qbKey  'QBWhere' or 'QBHaving'
-     * @param mixed   $key
-     * @param mixed   $value
-     * @param string  $type
-     * @param bool $escape
+     * @param string $qbKey  'QBWhere' or 'QBHaving'
+     * @param mixed  $key
+     * @param mixed  $value
+     * @param string $type
+     * @param bool   $escape
      *
      * @return $this
      */
@@ -671,8 +671,8 @@ class Builder extends BaseBuilder
      * Compiles the select statement based on the other functions called
      * and runs the query
      *
-     * @param int $limit  The limit clause
-     * @param int $offset The offset clause
+     * @param int  $limit  The limit clause
+     * @param int  $offset The offset clause
      * @param bool $reset  Are we want to clear query builder values?
      *
      * @return ResultInterface

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -233,8 +233,10 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with index data
      *
-     * @param  string $table
+     * @param string $table
+     *
      * @return stdClass[]
+     *
      * @throws DatabaseException
      */
     public function _indexData(string $table): array
@@ -273,8 +275,10 @@ class Connection extends BaseConnection
      * Returns an array of objects with Foreign key data
      * referenced_object_id  parent_object_id
      *
-     * @param  string $table
+     * @param string $table
+     *
      * @return stdClass[]
+     *
      * @throws DatabaseException
      */
     public function _foreignKeyData(string $table): array
@@ -341,8 +345,10 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with field data
      *
-     * @param  string $table
+     * @param string $table
+     *
      * @return stdClass[]
+     *
      * @throws DatabaseException
      */
     public function _fieldData(string $table): array

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -85,7 +85,8 @@ class Connection extends BaseConnection
     /**
      * Class constructor
      *
-     * @param  array $params
+     * @param array $params
+     *
      * @return void
      */
     public function __construct($params)
@@ -175,7 +176,8 @@ class Connection extends BaseConnection
     /**
      * Platform-dependant string escape
      *
-     * @param  string $str
+     * @param string $str
+     *
      * @return string
      */
     protected function _escapeString(string $str): string
@@ -572,7 +574,8 @@ class Connection extends BaseConnection
      *
      * Overrides BaseConnection::isWriteType, adding additional read query types.
      *
-     * @param  string $sql An SQL query string
+     * @param string $sql An SQL query string
+     *
      * @return bool
      */
     public function isWriteType($sql): bool

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -67,7 +67,7 @@ class Connection extends BaseConnection
      * Whether to use SQL-92 standard quoted identifier
      * (double quotes) or brackets for identifier escaping.
      *
-     * @var boolean
+     * @var bool
      */
     protected $_quoted_identifier = true;
 
@@ -101,7 +101,7 @@ class Connection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @param boolean $persistent
+     * @param bool $persistent
      *
      * @throws DatabaseException
      *
@@ -186,7 +186,7 @@ class Connection extends BaseConnection
     /**
      * Insert ID
      *
-     * @return integer
+     * @return int
      */
     public function insertID(): int
     {
@@ -196,7 +196,7 @@ class Connection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param boolean $prefixLimit
+     * @param bool $prefixLimit
      *
      * @return string
      */
@@ -376,7 +376,7 @@ class Connection extends BaseConnection
     /**
      * Begin Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transBegin(): bool
     {
@@ -386,7 +386,7 @@ class Connection extends BaseConnection
     /**
      * Commit Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transCommit(): bool
     {
@@ -396,7 +396,7 @@ class Connection extends BaseConnection
     /**
      * Rollback Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transRollback(): bool
     {
@@ -440,7 +440,7 @@ class Connection extends BaseConnection
     /**
      * Returns the total number of rows affected by this query.
      *
-     * @return integer
+     * @return int
      */
     public function affectedRows(): int
     {
@@ -567,7 +567,7 @@ class Connection extends BaseConnection
      * Overrides BaseConnection::isWriteType, adding additional read query types.
      *
      * @param  string $sql An SQL query string
-     * @return boolean
+     * @return bool
      */
     public function isWriteType($sql): bool
     {

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -361,8 +361,8 @@ class Forge extends BaseForge
      * @todo Support for cascade
      *
      * @param string  $table    Table name
-     * @param boolean $ifExists Whether to add an IF EXISTS condition
-     * @param boolean $cascade
+     * @param bool $ifExists Whether to add an IF EXISTS condition
+     * @param bool $cascade
      *
      * @return string
      */

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -101,7 +101,8 @@ class Forge extends BaseForge
     /**
      * CREATE TABLE attributes
      *
-     * @param  array $attributes Associative array of table attributes
+     * @param array $attributes Associative array of table attributes
+     *
      * @return string
      */
     protected function _createTableAttributes(array $attributes): string
@@ -216,7 +217,8 @@ class Forge extends BaseForge
     /**
      * Process column
      *
-     * @param  array $field
+     * @param array $field
+     *
      * @return string
      */
     protected function _processColumn(array $field): string
@@ -360,9 +362,9 @@ class Forge extends BaseForge
      *
      * @todo Support for cascade
      *
-     * @param string  $table    Table name
-     * @param bool $ifExists Whether to add an IF EXISTS condition
-     * @param bool $cascade
+     * @param string $table    Table name
+     * @param bool   $ifExists Whether to add an IF EXISTS condition
+     * @param bool   $cascade
      *
      * @return string
      */

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -45,6 +45,7 @@ class PreparedQuery extends BasePreparedQuery
      * @param array  $options Options takes an associative array;
      *
      * @return mixed
+     *
      * @throws Exception
      */
     public function _prepare(string $sql, array $options = [])

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -30,7 +30,7 @@ class PreparedQuery extends BasePreparedQuery
     /**
      * The result boolean from a sqlsrv_execute.
      *
-     * @var boolean
+     * @var bool
      */
     protected $result;
 
@@ -72,7 +72,7 @@ class PreparedQuery extends BasePreparedQuery
      *
      * @param array $data
      *
-     * @return boolean
+     * @return bool
      */
     public function _execute(array $data): bool
     {

--- a/system/Database/SQLSRV/Result.php
+++ b/system/Database/SQLSRV/Result.php
@@ -25,7 +25,7 @@ class Result extends BaseResult
     /**
      * Gets the number of fields in the result set.
      *
-     * @return integer
+     * @return int
      */
     public function getFieldCount(): int
     {
@@ -125,7 +125,7 @@ class Result extends BaseResult
      * internally before fetching results to make sure the result set
      * starts at zero.
      *
-     * @param integer $n
+     * @param int $n
      *
      * @return mixed
      */
@@ -161,7 +161,7 @@ class Result extends BaseResult
      *
      * @param string $className
      *
-     * @return object|boolean|Entity
+     * @return object|bool|Entity
      */
     protected function fetchObject(string $className = 'stdClass')
     {
@@ -176,7 +176,7 @@ class Result extends BaseResult
     /**
      * Returns the number of rows in the resultID (i.e., SQLSRV query result resource)
      *
-     * @return integer Returns the number of rows retrieved on success
+     * @return int Returns the number of rows retrieved on success
      */
     public function getNumRows(): int
     {

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -78,7 +78,8 @@ class Builder extends BaseBuilder
      * If the database does not support the TRUNCATE statement,
      * then this method maps to 'DELETE FROM table'
      *
-     * @param  string $table
+     * @param string $table
+     *
      * @return string
      */
     protected function _truncate(string $table): string

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -22,7 +22,7 @@ class Builder extends BaseBuilder
      * Default installs of SQLite typically do not
      * support limiting delete clauses.
      *
-     * @var boolean
+     * @var bool
      */
     protected $canLimitDeletes = false;
 
@@ -30,7 +30,7 @@ class Builder extends BaseBuilder
      * Default installs of SQLite do no support
      * limiting update queries in combo with WHERE.
      *
-     * @var boolean
+     * @var bool
      */
     protected $canLimitWhereUpdates = false;
 

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -131,7 +131,7 @@ class Connection extends BaseConnection
      *
      * @param string $sql
      *
-     * @return mixed    \SQLite3Result object or bool
+     * @return mixed \SQLite3Result object or bool
      */
     public function execute(string $sql)
     {
@@ -258,8 +258,10 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with field data
      *
-     * @param  string $table
+     * @param string $table
+     *
      * @return stdClass[]
+     *
      * @throws DatabaseException
      */
     public function _fieldData(string $table): array
@@ -295,8 +297,10 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with index data
      *
-     * @param  string $table
+     * @param string $table
+     *
      * @return stdClass[]
+     *
      * @throws DatabaseException
      */
     public function _indexData(string $table): array
@@ -340,7 +344,8 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with Foreign key data
      *
-     * @param  string $table
+     * @param string $table
+     *
      * @return stdClass[]
      */
     public function _foreignKeyData(string $table): array

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -42,7 +42,7 @@ class Connection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @param boolean $persistent
+     * @param bool $persistent
      *
      * @return mixed
      * @throws DatabaseException
@@ -99,7 +99,7 @@ class Connection extends BaseConnection
      *
      * @param string $databaseName
      *
-     * @return boolean
+     * @return bool
      */
     public function setDatabase(string $databaseName): bool
     {
@@ -154,7 +154,7 @@ class Connection extends BaseConnection
     /**
      * Returns the total number of rows affected by this query.
      *
-     * @return integer
+     * @return int
      */
     public function affectedRows(): int
     {
@@ -180,7 +180,7 @@ class Connection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param boolean $prefixLimit
+     * @param bool $prefixLimit
      *
      * @return string
      */
@@ -420,7 +420,7 @@ class Connection extends BaseConnection
     /**
      * Insert ID
      *
-     * @return integer
+     * @return int
      */
     public function insertID(): int
     {
@@ -432,7 +432,7 @@ class Connection extends BaseConnection
     /**
      * Begin Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transBegin(): bool
     {
@@ -444,7 +444,7 @@ class Connection extends BaseConnection
     /**
      * Commit Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transCommit(): bool
     {
@@ -456,7 +456,7 @@ class Connection extends BaseConnection
     /**
      * Rollback Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transRollback(): bool
     {
@@ -469,7 +469,7 @@ class Connection extends BaseConnection
      * Checks to see if the current install supports Foreign Keys
      * and has them enabled.
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsForeignKeys(): bool
     {

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -45,6 +45,7 @@ class Connection extends BaseConnection
      * @param bool $persistent
      *
      * @return mixed
+     *
      * @throws DatabaseException
      */
     public function connect(bool $persistent = false)
@@ -214,6 +215,7 @@ class Connection extends BaseConnection
      * @param string $table Table name
      *
      * @return array|false
+     *
      * @throws DatabaseException
      */
     public function getFieldNames(string $table)

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -23,7 +23,7 @@ class Forge extends BaseForge
     /**
      * UNSIGNED support
      *
-     * @var boolean|array
+     * @var bool|array
      */
     protected $_unsigned = false;
 
@@ -59,9 +59,9 @@ class Forge extends BaseForge
      * Create database
      *
      * @param string  $dbName
-     * @param boolean $ifNotExists Whether to add IF NOT EXISTS condition
+     * @param bool $ifNotExists Whether to add IF NOT EXISTS condition
      *
-     * @return boolean
+     * @return bool
      */
     public function createDatabase(string $dbName, bool $ifNotExists = false): bool
     {
@@ -77,7 +77,7 @@ class Forge extends BaseForge
      *
      * @param string $dbName
      *
-     * @return boolean
+     * @return bool
      * @throws DatabaseException
      */
     public function dropDatabase(string $dbName): bool
@@ -269,7 +269,7 @@ class Forge extends BaseForge
      * @param string $table       Table name
      * @param string $foreignName Foreign name
      *
-     * @return boolean
+     * @return bool
      * @throws DatabaseException
      */
     public function dropForeignKey(string $table, string $foreignName): bool

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -78,6 +78,7 @@ class Forge extends BaseForge
      * @param string $dbName
      *
      * @return bool
+     *
      * @throws DatabaseException
      */
     public function dropDatabase(string $dbName): bool
@@ -270,6 +271,7 @@ class Forge extends BaseForge
      * @param string $foreignName Foreign name
      *
      * @return bool
+     *
      * @throws DatabaseException
      */
     public function dropForeignKey(string $table, string $foreignName): bool

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -58,8 +58,8 @@ class Forge extends BaseForge
     /**
      * Create database
      *
-     * @param string  $dbName
-     * @param bool $ifNotExists Whether to add IF NOT EXISTS condition
+     * @param string $dbName
+     * @param bool   $ifNotExists Whether to add IF NOT EXISTS condition
      *
      * @return bool
      */

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -22,7 +22,7 @@ class PreparedQuery extends BasePreparedQuery
     /**
      * The SQLite3Result resource, or false.
      *
-     * @var Result|boolean
+     * @var Result|bool
      */
     protected $result;
 
@@ -57,7 +57,7 @@ class PreparedQuery extends BasePreparedQuery
      *
      * @param array $data
      *
-     * @return boolean
+     * @return bool
      */
     public function _execute(array $data): bool
     {

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -25,7 +25,7 @@ class Result extends BaseResult
     /**
      * Gets the number of fields in the result set.
      *
-     * @return integer
+     * @return int
      */
     public function getFieldCount(): int
     {
@@ -106,7 +106,7 @@ class Result extends BaseResult
      * internally before fetching results to make sure the result set
      * starts at zero.
      *
-     * @param integer $n
+     * @param int $n
      *
      * @return mixed
      * @throws DatabaseException
@@ -143,7 +143,7 @@ class Result extends BaseResult
      *
      * @param string $className
      *
-     * @return object|boolean
+     * @return object|bool
      */
     protected function fetchObject(string $className = 'stdClass')
     {

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -109,6 +109,7 @@ class Result extends BaseResult
      * @param int $n
      *
      * @return mixed
+     *
      * @throws DatabaseException
      */
     public function dataSeek(int $n = 0)

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -126,7 +126,7 @@ class Table
      * table with modifications, and copies the data over to the new table.
      * Resets the connection dataCache to be sure changes are collected.
      *
-     * @return boolean
+     * @return bool
      */
     public function run(): bool
     {
@@ -305,7 +305,7 @@ class Table
      * Converts fields retrieved from the database to
      * the format needed for creating fields with Forge.
      *
-     * @param array|boolean $fields
+     * @param array|bool $fields
      *
      * @return mixed
      */

--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -60,7 +60,7 @@ class Seeder
     /**
      * If true, will not display CLI messages.
      *
-     * @var boolean
+     * @var bool
      */
     protected $silent = false;
 
@@ -177,7 +177,7 @@ class Seeder
     /**
      * Sets the silent treatment.
      *
-     * @param boolean $silent
+     * @param bool $silent
      *
      * @return $this
      */

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -31,7 +31,7 @@ class Exceptions
     /**
      * Nesting level of the output buffering mechanism
      *
-     * @var integer
+     * @var int
      */
     public $ob_level;
 
@@ -155,10 +155,10 @@ class Exceptions
      *
      * This seems to be primarily when a user triggers it with trigger_error().
      *
-     * @param integer      $severity
+     * @param int      $severity
      * @param string       $message
      * @param string|null  $file
-     * @param integer|null $line
+     * @param int|null $line
      *
      * @throws ErrorException
      */
@@ -231,7 +231,7 @@ class Exceptions
      * Given an exception and status code will display the error to the client.
      *
      * @param Throwable $exception
-     * @param integer   $statusCode
+     * @param int   $statusCode
      */
     protected function render(Throwable $exception, int $statusCode)
     {
@@ -275,7 +275,7 @@ class Exceptions
      * Gathers the variables that will be made available to the view.
      *
      * @param Throwable $exception
-     * @param integer   $statusCode
+     * @param int   $statusCode
      *
      * @return array
      */
@@ -400,7 +400,7 @@ class Exceptions
      * Describes memory usage in real-world units. Intended for use
      * with memory_get_usage, etc.
      *
-     * @param integer $bytes
+     * @param int $bytes
      *
      * @return string
      */
@@ -422,10 +422,10 @@ class Exceptions
      * Creates a syntax-highlighted version of a PHP file.
      *
      * @param string  $file
-     * @param integer $lineNumber
-     * @param integer $lines
+     * @param int $lineNumber
+     * @param int $lines
      *
-     * @return boolean|string
+     * @return bool|string
      */
     public static function highlightFile(string $file, int $lineNumber, int $lines = 15)
     {

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -155,10 +155,10 @@ class Exceptions
      *
      * This seems to be primarily when a user triggers it with trigger_error().
      *
-     * @param int      $severity
-     * @param string       $message
-     * @param string|null  $file
-     * @param int|null $line
+     * @param int         $severity
+     * @param string      $message
+     * @param string|null $file
+     * @param int|null    $line
      *
      * @throws ErrorException
      */
@@ -200,7 +200,7 @@ class Exceptions
      * @param Throwable $exception
      * @param string    $templatePath
      *
-     * @return string       The path and filename of the view file to use
+     * @return string The path and filename of the view file to use
      */
     protected function determineView(Throwable $exception, string $templatePath): string
     {
@@ -231,7 +231,7 @@ class Exceptions
      * Given an exception and status code will display the error to the client.
      *
      * @param Throwable $exception
-     * @param int   $statusCode
+     * @param int       $statusCode
      */
     protected function render(Throwable $exception, int $statusCode)
     {
@@ -275,7 +275,7 @@ class Exceptions
      * Gathers the variables that will be made available to the view.
      *
      * @param Throwable $exception
-     * @param int   $statusCode
+     * @param int       $statusCode
      *
      * @return array
      */
@@ -421,9 +421,9 @@ class Exceptions
     /**
      * Creates a syntax-highlighted version of a PHP file.
      *
-     * @param string  $file
-     * @param int $lineNumber
-     * @param int $lines
+     * @param string $file
+     * @param int    $lineNumber
+     * @param int    $lines
      *
      * @return bool|string
      */

--- a/system/Debug/Iterator.php
+++ b/system/Debug/Iterator.php
@@ -61,7 +61,7 @@ class Iterator
      * time to execute the desired number of iterations, and the approximate
      * memory usage used during those iterations.
      *
-     * @param int $iterations
+     * @param int  $iterations
      * @param bool $output
      *
      * @return string|null

--- a/system/Debug/Iterator.php
+++ b/system/Debug/Iterator.php
@@ -61,8 +61,8 @@ class Iterator
      * time to execute the desired number of iterations, and the approximate
      * memory usage used during those iterations.
      *
-     * @param integer $iterations
-     * @param boolean $output
+     * @param int $iterations
+     * @param bool $output
      *
      * @return string|null
      */

--- a/system/Debug/Timer.php
+++ b/system/Debug/Timer.php
@@ -82,7 +82,7 @@ class Timer
      * Returns the duration of a recorded timer.
      *
      * @param string  $name     The name of the timer.
-     * @param integer $decimals Number of decimal places.
+     * @param int $decimals Number of decimal places.
      *
      * @return null|float       Returns null if timer exists by that name.
      *                          Returns a float representing the number of
@@ -110,7 +110,7 @@ class Timer
     /**
      * Returns the array of timers, with the duration pre-calculated for you.
      *
-     * @param integer $decimals Number of decimal places
+     * @param int $decimals Number of decimal places
      *
      * @return array
      */
@@ -136,7 +136,7 @@ class Timer
      *
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function has(string $name): bool
     {

--- a/system/Debug/Timer.php
+++ b/system/Debug/Timer.php
@@ -81,12 +81,12 @@ class Timer
     /**
      * Returns the duration of a recorded timer.
      *
-     * @param string  $name     The name of the timer.
-     * @param int $decimals Number of decimal places.
+     * @param string $name     The name of the timer.
+     * @param int    $decimals Number of decimal places.
      *
-     * @return null|float       Returns null if timer exists by that name.
-     *                          Returns a float representing the number of
-     *                          seconds elapsed while that timer was running.
+     * @return null|float Returns null if timer exists by that name.
+     *                    Returns a float representing the number of
+     *                    seconds elapsed while that timer was running.
      */
     public function getElapsedTime(string $name, int $decimals = 4)
     {

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -88,7 +88,7 @@ class Toolbar
     {
         /**
          * @var IncomingRequest $request
-         * @var Response $response
+         * @var Response        $response
          */
 
         // Data items used within the view.
@@ -185,11 +185,11 @@ class Toolbar
     /**
      * Called within the view to display the timeline itself.
      *
-     * @param array   $collectors
-     * @param float   $startTime
-     * @param int $segmentCount
-     * @param int $segmentDuration
-     * @param array   $styles
+     * @param array $collectors
+     * @param float $startTime
+     * @param int   $segmentCount
+     * @param int   $segmentDuration
+     * @param array $styles
      *
      * @return string
      */
@@ -277,8 +277,8 @@ class Toolbar
     /**
      * Rounds a number to the nearest incremental value.
      *
-     * @param float   $number
-     * @param int $increments
+     * @param float $number
+     * @param int   $increments
      *
      * @return float
      */
@@ -294,8 +294,8 @@ class Toolbar
     /**
      * Prepare for debugging..
      *
-     * @param  RequestInterface  $request
-     * @param  ResponseInterface $response
+     * @param RequestInterface  $request
+     * @param ResponseInterface $response
      * @global \CodeIgniter\CodeIgniter $app
      * @return void
      */
@@ -303,7 +303,7 @@ class Toolbar
     {
         /**
          * @var IncomingRequest $request
-         * @var Response $response
+         * @var Response        $response
          */
 
         if (CI_DEBUG && ! is_cli()) {

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -296,7 +296,9 @@ class Toolbar
      *
      * @param RequestInterface  $request
      * @param ResponseInterface $response
+     *
      * @global \CodeIgniter\CodeIgniter $app
+     *
      * @return void
      */
     public function prepare(RequestInterface $request = null, ResponseInterface $response = null)

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -187,8 +187,8 @@ class Toolbar
      *
      * @param array   $collectors
      * @param float   $startTime
-     * @param integer $segmentCount
-     * @param integer $segmentDuration
+     * @param int $segmentCount
+     * @param int $segmentDuration
      * @param array   $styles
      *
      * @return string
@@ -278,7 +278,7 @@ class Toolbar
      * Rounds a number to the nearest incremental value.
      *
      * @param float   $number
-     * @param integer $increments
+     * @param int $increments
      *
      * @return float
      */

--- a/system/Debug/Toolbar/Collectors/BaseCollector.php
+++ b/system/Debug/Toolbar/Collectors/BaseCollector.php
@@ -22,7 +22,7 @@ class BaseCollector
      * Whether this collector has data that can
      * be displayed in the Timeline.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTimeline = false;
 
@@ -30,7 +30,7 @@ class BaseCollector
      * Whether this collector needs to display
      * content in a tab or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTabContent = false;
 
@@ -38,7 +38,7 @@ class BaseCollector
      * Whether this collector needs to display
      * a label or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasLabel = false;
 
@@ -46,7 +46,7 @@ class BaseCollector
      * Whether this collector has data that
      * should be shown in the Vars tab.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasVarData = false;
 
@@ -63,7 +63,7 @@ class BaseCollector
     /**
      * Gets the Collector's title.
      *
-     * @param  boolean $safe
+     * @param  bool $safe
      * @return string
      */
     public function getTitle(bool $safe = false): string
@@ -92,7 +92,7 @@ class BaseCollector
     /**
      * Does this collector need it's own tab?
      *
-     * @return boolean
+     * @return bool
      */
     public function hasTabContent(): bool
     {
@@ -104,7 +104,7 @@ class BaseCollector
     /**
      * Does this collector have a label?
      *
-     * @return boolean
+     * @return bool
      */
     public function hasLabel(): bool
     {
@@ -116,7 +116,7 @@ class BaseCollector
     /**
      * Does this collector have information for the timeline?
      *
-     * @return boolean
+     * @return bool
      */
     public function hasTimelineData(): bool
     {
@@ -146,7 +146,7 @@ class BaseCollector
      * Does this Collector have data that should be shown in the
      * 'Vars' tab?
      *
-     * @return boolean
+     * @return bool
      */
     public function hasVarData(): bool
     {
@@ -239,7 +239,7 @@ class BaseCollector
      *
      * If not, then the toolbar button won't get shown.
      *
-     * @return boolean
+     * @return bool
      */
     public function isEmpty(): bool
     {

--- a/system/Debug/Toolbar/Collectors/BaseCollector.php
+++ b/system/Debug/Toolbar/Collectors/BaseCollector.php
@@ -63,7 +63,8 @@ class BaseCollector
     /**
      * Gets the Collector's title.
      *
-     * @param  bool $safe
+     * @param bool $safe
+     *
      * @return string
      */
     public function getTitle(bool $safe = false): string

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -21,21 +21,21 @@ class Database extends BaseCollector
     /**
      * Whether this collector has timeline data.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTimeline = true;
 
     /**
      * Whether this collector should display its own tab.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTabContent = true;
 
     /**
      * Whether this collector has data for the Vars tab.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasVarData = false;
 
@@ -150,7 +150,7 @@ class Database extends BaseCollector
     /**
      * Gets the "badge" value for the button.
      *
-     * @return integer
+     * @return int
      */
     public function getBadgeValue(): int
     {
@@ -175,7 +175,7 @@ class Database extends BaseCollector
     /**
      * Does this collector have any data collected?
      *
-     * @return boolean
+     * @return bool
      */
     public function isEmpty(): bool
     {

--- a/system/Debug/Toolbar/Collectors/Events.php
+++ b/system/Debug/Toolbar/Collectors/Events.php
@@ -23,7 +23,7 @@ class Events extends BaseCollector
      * Whether this collector has data that can
      * be displayed in the Timeline.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTimeline = false;
 
@@ -31,7 +31,7 @@ class Events extends BaseCollector
      * Whether this collector needs to display
      * content in a tab or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTabContent = true;
 
@@ -39,7 +39,7 @@ class Events extends BaseCollector
      * Whether this collector has data that
      * should be shown in the Vars tab.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasVarData = false;
 
@@ -136,7 +136,7 @@ class Events extends BaseCollector
     /**
      * Gets the "badge" value for the button.
      *
-     * @return integer
+     * @return int
      */
     public function getBadgeValue(): int
     {

--- a/system/Debug/Toolbar/Collectors/Files.php
+++ b/system/Debug/Toolbar/Collectors/Files.php
@@ -20,7 +20,7 @@ class Files extends BaseCollector
      * Whether this collector has data that can
      * be displayed in the Timeline.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTimeline = false;
 
@@ -28,7 +28,7 @@ class Files extends BaseCollector
      * Whether this collector needs to display
      * content in a tab or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTabContent = true;
 
@@ -95,7 +95,7 @@ class Files extends BaseCollector
     /**
      * Displays the number of included files as a badge in the tab button.
      *
-     * @return integer
+     * @return int
      */
     public function getBadgeValue(): int
     {

--- a/system/Debug/Toolbar/Collectors/History.php
+++ b/system/Debug/Toolbar/Collectors/History.php
@@ -20,7 +20,7 @@ class History extends BaseCollector
      * Whether this collector has data that can
      * be displayed in the Timeline.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTimeline = false;
 
@@ -28,7 +28,7 @@ class History extends BaseCollector
      * Whether this collector needs to display
      * content in a tab or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTabContent = true;
 
@@ -36,7 +36,7 @@ class History extends BaseCollector
      * Whether this collector needs to display
      * a label or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasLabel = true;
 
@@ -58,8 +58,8 @@ class History extends BaseCollector
     /**
      * Specify time limit & file count for debug history.
      *
-     * @param integer $current Current history time
-     * @param integer $limit   Max history files
+     * @param int $current Current history time
+     * @param int $limit   Max history files
      */
     public function setFiles(int $current, int $limit = 20)
     {
@@ -120,7 +120,7 @@ class History extends BaseCollector
     /**
      * Displays the number of included files as a badge in the tab button.
      *
-     * @return integer
+     * @return int
      */
     public function getBadgeValue(): int
     {
@@ -130,7 +130,7 @@ class History extends BaseCollector
     /**
      * Return true if there are no history files.
      *
-     * @return boolean
+     * @return bool
      */
     public function isEmpty(): bool
     {

--- a/system/Debug/Toolbar/Collectors/Logs.php
+++ b/system/Debug/Toolbar/Collectors/Logs.php
@@ -22,7 +22,7 @@ class Logs extends BaseCollector
      * Whether this collector has data that can
      * be displayed in the Timeline.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTimeline = false;
 
@@ -30,7 +30,7 @@ class Logs extends BaseCollector
      * Whether this collector needs to display
      * content in a tab or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTabContent = true;
 
@@ -68,7 +68,7 @@ class Logs extends BaseCollector
     /**
      * Does this collector actually have any data to display?
      *
-     * @return boolean
+     * @return bool
      */
     public function isEmpty(): bool
     {

--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -51,6 +51,7 @@ class Routes extends BaseCollector
      * Returns the data of this collector to be formatted in the toolbar
      *
      * @return array
+     *
      * @throws ReflectionException
      */
     public function display(): array

--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -25,7 +25,7 @@ class Routes extends BaseCollector
      * Whether this collector has data that can
      * be displayed in the Timeline.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTimeline = false;
 
@@ -33,7 +33,7 @@ class Routes extends BaseCollector
      * Whether this collector needs to display
      * content in a tab or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTabContent = true;
 
@@ -143,7 +143,7 @@ class Routes extends BaseCollector
     /**
      * Returns a count of all the routes in the system.
      *
-     * @return integer
+     * @return int
      */
     public function getBadgeValue(): int
     {

--- a/system/Debug/Toolbar/Collectors/Timers.php
+++ b/system/Debug/Toolbar/Collectors/Timers.php
@@ -22,7 +22,7 @@ class Timers extends BaseCollector
      * Whether this collector has data that can
      * be displayed in the Timeline.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTimeline = true;
 
@@ -30,7 +30,7 @@ class Timers extends BaseCollector
      * Whether this collector needs to display
      * content in a tab or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTabContent = false;
 

--- a/system/Debug/Toolbar/Collectors/Views.php
+++ b/system/Debug/Toolbar/Collectors/Views.php
@@ -23,7 +23,7 @@ class Views extends BaseCollector
      * Whether this collector has data that can
      * be displayed in the Timeline.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTimeline = true;
 
@@ -31,7 +31,7 @@ class Views extends BaseCollector
      * Whether this collector needs to display
      * content in a tab or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasTabContent = false;
 
@@ -39,7 +39,7 @@ class Views extends BaseCollector
      * Whether this collector needs to display
      * a label or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasLabel = true;
 
@@ -47,7 +47,7 @@ class Views extends BaseCollector
      * Whether this collector has data that
      * should be shown in the Vars tab.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasVarData = true;
 
@@ -142,7 +142,7 @@ class Views extends BaseCollector
     /**
      * Returns a count of all views.
      *
-     * @return integer
+     * @return int
      */
     public function getBadgeValue(): int
     {

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -91,21 +91,21 @@ class Email
     /**
      * SMTP Server port
      *
-     * @var integer
+     * @var int
      */
     public $SMTPPort = 25;
 
     /**
      * SMTP connection timeout in seconds
      *
-     * @var integer
+     * @var int
      */
     public $SMTPTimeout = 5;
 
     /**
      * SMTP persistent connection
      *
-     * @var boolean
+     * @var bool
      */
     public $SMTPKeepAlive = false;
 
@@ -119,7 +119,7 @@ class Email
     /**
      * Whether to apply word-wrapping to the message body.
      *
-     * @var boolean
+     * @var bool
      */
     public $wordWrap = true;
 
@@ -127,7 +127,7 @@ class Email
      * Number of characters to wrap at.
      *
      * @see Email::$wordWrap
-     * @var integer
+     * @var int
      */
     public $wrapChars = 76;
 
@@ -155,14 +155,14 @@ class Email
     /**
      * Whether to validate e-mail addresses.
      *
-     * @var boolean
+     * @var bool
      */
     public $validate = true;
 
     /**
      * X-Priority header value.
      *
-     * @var integer 1-5
+     * @var int 1-5
      */
     public $priority = 3;
 
@@ -192,7 +192,7 @@ class Email
     /**
      * Whether to use Delivery Status Notification.
      *
-     * @var boolean
+     * @var bool
      */
     public $DSN = false;
 
@@ -200,14 +200,14 @@ class Email
      * Whether to send multipart alternatives.
      * Yahoo! doesn't seem to like these.
      *
-     * @var boolean
+     * @var bool
      */
     public $sendMultipart = true;
 
     /**
      * Whether to send messages to BCC recipients in batches.
      *
-     * @var boolean
+     * @var bool
      */
     public $BCCBatchMode = false;
 
@@ -215,7 +215,7 @@ class Email
      * BCC Batch max number size.
      *
      * @see Email::$BCCBatchMode
-     * @var integer|string
+     * @var int|string
      */
     public $BCCBatchSize = 200;
 
@@ -264,14 +264,14 @@ class Email
     /**
      * Whether to perform SMTP authentication
      *
-     * @var boolean
+     * @var bool
      */
     protected $SMTPAuth = false;
 
     /**
      * Whether to send a Reply-To header
      *
-     * @var boolean
+     * @var bool
      */
     protected $replyToFlag = false;
 
@@ -374,7 +374,7 @@ class Email
     /**
      * mbstring.func_overload flag
      *
-     * @var boolean
+     * @var bool
      */
     protected static $func_overload;
 
@@ -429,7 +429,7 @@ class Email
     /**
      * Initialize the Email Data
      *
-     * @param boolean $clearAttachments
+     * @param bool $clearAttachments
      *
      * @return Email
      */
@@ -661,7 +661,7 @@ class Email
      * @param string|null $newname
      * @param string      $mime
      *
-     * @return Email|boolean
+     * @return Email|bool
      */
     public function attach($file, $disposition = '', $newname = null, $mime = '')
     {
@@ -712,7 +712,7 @@ class Email
      *
      * @param string $filename
      *
-     * @return string|boolean
+     * @return string|bool
      */
     public function setAttachmentCID($filename)
     {
@@ -791,7 +791,7 @@ class Email
     /**
      * Set Wordwrap
      *
-     * @param boolean $wordWrap
+     * @param bool $wordWrap
      *
      * @return Email
      */
@@ -819,7 +819,7 @@ class Email
     /**
      * Set Priority
      *
-     * @param integer $n
+     * @param int $n
      *
      * @return Email
      */
@@ -956,7 +956,7 @@ class Email
      *
      * @param string|array $email
      *
-     * @return boolean
+     * @return bool
      */
     public function validateEmail($email)
     {
@@ -982,7 +982,7 @@ class Email
      *
      * @param string $email
      *
-     * @return boolean
+     * @return bool
      */
     public function isValidEmail($email)
     {
@@ -1049,7 +1049,7 @@ class Email
      * Word Wrap
      *
      * @param string       $str
-     * @param integer|null $charlim Line-length limit
+     * @param int|null $charlim Line-length limit
      *
      * @return string
      */
@@ -1310,7 +1310,7 @@ class Email
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     protected function attachmentsHaveMultipart($type)
     {
@@ -1592,9 +1592,9 @@ class Email
     /**
      * Send Email
      *
-     * @param boolean $autoClear
+     * @param bool $autoClear
      *
-     * @return boolean
+     * @return bool
      */
     public function send($autoClear = true)
     {
@@ -1724,7 +1724,7 @@ class Email
     /**
      * Spool mail to the mail server
      *
-     * @return boolean
+     * @return bool
      */
     protected function spoolEmail()
     {
@@ -1764,7 +1764,7 @@ class Email
      *
      * @param string $email
      *
-     * @return boolean
+     * @return bool
      */
     protected function validateEmailForShell(&$email)
     {
@@ -1779,7 +1779,7 @@ class Email
     /**
      * Send using mail()
      *
-     * @return boolean
+     * @return bool
      */
     protected function sendWithMail()
     {
@@ -1801,7 +1801,7 @@ class Email
     /**
      * Send using Sendmail
      *
-     * @return boolean
+     * @return bool
      */
     protected function sendWithSendmail()
     {
@@ -1834,7 +1834,7 @@ class Email
     /**
      * Send using SMTP
      *
-     * @return boolean
+     * @return bool
      */
     protected function sendWithSmtp()
     {
@@ -1913,7 +1913,7 @@ class Email
     /**
      * SMTP Connect
      *
-     * @return string|boolean
+     * @return string|bool
      */
     protected function SMTPConnect()
     {
@@ -1971,7 +1971,7 @@ class Email
      * @param string $cmd
      * @param string $data
      *
-     * @return boolean
+     * @return bool
      */
     protected function sendCommand($cmd, $data = '')
     {
@@ -2044,7 +2044,7 @@ class Email
     /**
      * SMTP Authenticate
      *
-     * @return boolean
+     * @return bool
      */
     protected function SMTPAuthenticate()
     {
@@ -2101,7 +2101,7 @@ class Email
      *
      * @param string $data
      *
-     * @return boolean
+     * @return bool
      */
     protected function sendData($data)
     {
@@ -2255,7 +2255,7 @@ class Email
      *
      * @param string $str
      *
-     * @return integer
+     * @return int
      */
     protected static function strlen($str)
     {
@@ -2266,8 +2266,8 @@ class Email
      * Byte-safe substr()
      *
      * @param string       $str
-     * @param integer      $start
-     * @param integer|null $length
+     * @param int      $start
+     * @param int|null $length
      *
      * @return string
      */

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -127,6 +127,7 @@ class Email
      * Number of characters to wrap at.
      *
      * @see Email::$wordWrap
+     *
      * @var int
      */
     public $wrapChars = 76;
@@ -171,6 +172,7 @@ class Email
      * Use "\r\n" to comply with RFC 822.
      *
      * @link http://www.ietf.org/rfc/rfc822.txt
+     *
      * @var string "\r\n" or "\n"
      */
     public $newline = "\n";
@@ -185,6 +187,7 @@ class Email
      * that seems to work for all environments.
      *
      * @link http://www.ietf.org/rfc/rfc822.txt
+     *
      * @var string
      */
     public $CRLF = "\n";
@@ -215,6 +218,7 @@ class Email
      * BCC Batch max number size.
      *
      * @see Email::$BCCBatchMode
+     *
      * @var int|string
      */
     public $BCCBatchSize = 200;
@@ -279,6 +283,7 @@ class Email
      * Debug messages
      *
      * @see Email::printDebugger()
+     *
      * @var array
      */
     protected $debugMessage = [];
@@ -322,6 +327,7 @@ class Email
      * Valid $protocol values
      *
      * @see Email::$protocol
+     *
      * @var array
      */
     protected $protocols = [
@@ -349,6 +355,7 @@ class Email
      * Valid mail encodings
      *
      * @see Email::$encoding
+     *
      * @var array
      */
     protected $bitDepths = [
@@ -1758,6 +1765,7 @@ class Email
      *
      * @see     https://github.com/codeigniter4/CodeIgniter/issues/4963
      * @see     https://gist.github.com/Zenexer/40d02da5e07f151adeaeeaa11af9ab36
+     *
      * @license https://creativecommons.org/publicdomain/zero/1.0/    CC0 1.0, Public Domain
      *
      * Credits for the base concept go to Paul Buonopane <paul@namepros.com>

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -171,7 +171,7 @@ class Email
      * Use "\r\n" to comply with RFC 822.
      *
      * @link http://www.ietf.org/rfc/rfc822.txt
-     * @var  string "\r\n" or "\n"
+     * @var string "\r\n" or "\n"
      */
     public $newline = "\n";
 
@@ -185,7 +185,7 @@ class Email
      * that seems to work for all environments.
      *
      * @link http://www.ietf.org/rfc/rfc822.txt
-     * @var  string
+     * @var string
      */
     public $CRLF = "\n";
 
@@ -1048,7 +1048,7 @@ class Email
     /**
      * Word Wrap
      *
-     * @param string       $str
+     * @param string   $str
      * @param int|null $charlim Line-length limit
      *
      * @return string
@@ -2265,7 +2265,7 @@ class Email
     /**
      * Byte-safe substr()
      *
-     * @param string       $str
+     * @param string   $str
      * @param int      $start
      * @param int|null $length
      *

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -150,7 +150,7 @@ class Encryption
     /**
      * Create a random key
      *
-     * @param integer $length Output length
+     * @param int $length Output length
      *
      * @return string
      */
@@ -179,7 +179,7 @@ class Encryption
      * __isset() magic, providing checking for some of our protected properties
      *
      * @param  string $key Property name
-     * @return boolean
+     * @return bool
      */
     public function __isset($key): bool
     {

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -178,7 +178,8 @@ class Encryption
     /**
      * __isset() magic, providing checking for some of our protected properties
      *
-     * @param  string $key Property name
+     * @param string $key Property name
+     *
      * @return bool
      */
     public function __isset($key): bool

--- a/system/Encryption/Handlers/BaseHandler.php
+++ b/system/Encryption/Handlers/BaseHandler.php
@@ -48,8 +48,8 @@ abstract class BaseHandler implements EncrypterInterface
      * Byte-safe substr()
      *
      * @param string  $str
-     * @param integer $start
-     * @param integer $length
+     * @param int $start
+     * @param int $length
      *
      * @return string
      */
@@ -77,7 +77,7 @@ abstract class BaseHandler implements EncrypterInterface
      * __isset() magic, providing checking for some of our properties
      *
      * @param  string $key Property name
-     * @return boolean
+     * @return bool
      */
     public function __isset($key): bool
     {

--- a/system/Encryption/Handlers/BaseHandler.php
+++ b/system/Encryption/Handlers/BaseHandler.php
@@ -61,7 +61,8 @@ abstract class BaseHandler implements EncrypterInterface
     /**
      * __get() magic, providing readonly access to some of our properties
      *
-     * @param  string $key Property name
+     * @param string $key Property name
+     *
      * @return mixed
      */
     public function __get($key)
@@ -76,7 +77,8 @@ abstract class BaseHandler implements EncrypterInterface
     /**
      * __isset() magic, providing checking for some of our properties
      *
-     * @param  string $key Property name
+     * @param string $key Property name
+     *
      * @return bool
      */
     public function __isset($key): bool

--- a/system/Encryption/Handlers/BaseHandler.php
+++ b/system/Encryption/Handlers/BaseHandler.php
@@ -47,9 +47,9 @@ abstract class BaseHandler implements EncrypterInterface
     /**
      * Byte-safe substr()
      *
-     * @param string  $str
-     * @param int $start
-     * @param int $length
+     * @param string $str
+     * @param int    $start
+     * @param int    $length
      *
      * @return string
      */

--- a/system/Encryption/Handlers/SodiumHandler.php
+++ b/system/Encryption/Handlers/SodiumHandler.php
@@ -30,7 +30,7 @@ class SodiumHandler extends BaseHandler
     /**
      * Block size for padding message.
      *
-     * @var integer
+     * @var int
      */
     protected $blockSize = 16;
 

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -105,7 +105,7 @@ class Entity implements JsonSerializable
     /**
      * Holds info whenever properties have to be casted
      *
-     * @var boolean
+     * @var bool
      **/
     private $_cast = true;
 
@@ -148,9 +148,9 @@ class Entity implements JsonSerializable
      * of this entity as an array. All values are accessed through the
      * __get() magic method so will have any casts, etc applied to them.
      *
-     * @param boolean $onlyChanged If true, only return values that have changed since object creation
-     * @param boolean $cast        If true, properties will be casted.
-     * @param boolean $recursive   If true, inner entities will be casted as array as well.
+     * @param bool $onlyChanged If true, only return values that have changed since object creation
+     * @param bool $cast        If true, properties will be casted.
+     * @param bool $recursive   If true, inner entities will be casted as array as well.
      *
      * @return array
      */
@@ -195,8 +195,8 @@ class Entity implements JsonSerializable
     /**
      * Returns the raw values of the current attributes.
      *
-     * @param boolean $onlyChanged If true, only return values that have changed since object creation
-     * @param boolean $recursive   If true, inner entities will be casted as array as well.
+     * @param bool $onlyChanged If true, only return values that have changed since object creation
+     * @param bool $recursive   If true, inner entities will be casted as array as well.
      *
      * @return array
      */
@@ -258,7 +258,7 @@ class Entity implements JsonSerializable
      *
      * @param string $key
      *
-     * @return boolean
+     * @return bool
      */
     public function hasChanged(string $key = null): bool
     {
@@ -405,7 +405,7 @@ class Entity implements JsonSerializable
      * Cast as JSON
      *
      * @param mixed   $value
-     * @param boolean $asArray
+     * @param bool $asArray
      *
      * @throws CastException
      *
@@ -429,9 +429,9 @@ class Entity implements JsonSerializable
     /**
      * Change the value of the private $_cast property
      *
-     * @param boolean|null $cast
+     * @param bool|null $cast
      *
-     * @return boolean|Entity
+     * @return bool|Entity
      */
     public function cast(bool $cast = null)
     {
@@ -544,7 +544,7 @@ class Entity implements JsonSerializable
      *
      * @param string $key
      *
-     * @return boolean
+     * @return bool
      */
     public function __isset(string $key): bool
     {

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -404,8 +404,8 @@ class Entity implements JsonSerializable
     /**
      * Cast as JSON
      *
-     * @param mixed   $value
-     * @param bool $asArray
+     * @param mixed $value
+     * @param bool  $asArray
      *
      * @throws CastException
      *

--- a/system/Entity/Exceptions/CastException.php
+++ b/system/Entity/Exceptions/CastException.php
@@ -33,7 +33,7 @@ class CastException extends FrameworkException
     /**
      * Thrown when the Json format is invalid.
      *
-     * @param integer $error
+     * @param int $error
      *
      * @return static
      */

--- a/system/Events/Events.php
+++ b/system/Events/Events.php
@@ -34,7 +34,7 @@ class Events
      * Flag to let us know if we've read from the Config file(s)
      * and have all of the defined events.
      *
-     * @var boolean
+     * @var bool
      */
     protected static $initialized = false;
 
@@ -42,7 +42,7 @@ class Events
      * If true, events will not actually be fired.
      * Useful during testing.
      *
-     * @var boolean
+     * @var bool
      */
     protected static $simulate = false;
 
@@ -112,7 +112,7 @@ class Events
      *
      * @param string   $eventName
      * @param callable $callback
-     * @param integer  $priority
+     * @param int  $priority
      *
      * @return void
      */
@@ -140,7 +140,7 @@ class Events
      * @param string $eventName
      * @param mixed  $arguments
      *
-     * @return boolean
+     * @return bool
      */
     public static function trigger($eventName, ...$arguments): bool
     {
@@ -207,7 +207,7 @@ class Events
      * @param string   $eventName
      * @param callable $listener
      *
-     * @return boolean
+     * @return bool
      */
     public static function removeListener($eventName, callable $listener): bool
     {
@@ -273,7 +273,7 @@ class Events
      * simply logged. Useful during testing when you don't actually want
      * the tests to run.
      *
-     * @param boolean $choice
+     * @param bool $choice
      *
      * @return void
      */

--- a/system/Events/Events.php
+++ b/system/Events/Events.php
@@ -112,7 +112,7 @@ class Events
      *
      * @param string   $eventName
      * @param callable $callback
-     * @param int  $priority
+     * @param int      $priority
      *
      * @return void
      */

--- a/system/Exceptions/CastException.php
+++ b/system/Exceptions/CastException.php
@@ -25,7 +25,7 @@ class CastException extends CriticalError
     /**
      * Error code
      *
-     * @var integer
+     * @var int
      */
     protected $code = 3;
 

--- a/system/Exceptions/ConfigException.php
+++ b/system/Exceptions/ConfigException.php
@@ -21,7 +21,7 @@ class ConfigException extends CriticalError
     /**
      * Error code
      *
-     * @var integer
+     * @var int
      */
     protected $code = 3;
 

--- a/system/Exceptions/DebugTraceableTrait.php
+++ b/system/Exceptions/DebugTraceableTrait.php
@@ -17,7 +17,7 @@ trait DebugTraceableTrait
      * it is actually raised rather than were it is instantiated.
      *
      * @param string         $message
-     * @param int        $code
+     * @param int            $code
      * @param Throwable|null $previous
      */
     final public function __construct(string $message = '', int $code = 0, Throwable $previous = null)

--- a/system/Exceptions/DebugTraceableTrait.php
+++ b/system/Exceptions/DebugTraceableTrait.php
@@ -17,7 +17,7 @@ trait DebugTraceableTrait
      * it is actually raised rather than were it is instantiated.
      *
      * @param string         $message
-     * @param integer        $code
+     * @param int        $code
      * @param Throwable|null $previous
      */
     final public function __construct(string $message = '', int $code = 0, Throwable $previous = null)

--- a/system/Exceptions/PageNotFoundException.php
+++ b/system/Exceptions/PageNotFoundException.php
@@ -20,7 +20,7 @@ class PageNotFoundException extends OutOfBoundsException implements ExceptionInt
     /**
      * Error code
      *
-     * @var integer
+     * @var int
      */
     protected $code = 404;
 

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -24,7 +24,7 @@ class File extends SplFileInfo
     /**
      * The files size in bytes
      *
-     * @var integer
+     * @var int
      */
     protected $size;
 
@@ -42,7 +42,7 @@ class File extends SplFileInfo
      * that the path is really a file.
      *
      * @param string  $path
-     * @param boolean $checkFile
+     * @param bool $checkFile
      */
     public function __construct(string $path, bool $checkFile = false)
     {
@@ -62,7 +62,7 @@ class File extends SplFileInfo
      * the file in the $_FILES array if available, as PHP calculates this based
      * on the actual size transmitted.
      *
-     * @return integer The file size in bytes
+     * @return int The file size in bytes
      */
     public function getSize()
     {
@@ -74,7 +74,7 @@ class File extends SplFileInfo
      *
      * @param string $unit
      *
-     * @return integer|string
+     * @return int|string
      */
     public function getSizeByUnit(string $unit = 'b')
     {
@@ -150,7 +150,7 @@ class File extends SplFileInfo
      *
      * @param string      $targetPath
      * @param string|null $name
-     * @param boolean     $overwrite
+     * @param bool     $overwrite
      *
      * @return File
      */
@@ -184,7 +184,7 @@ class File extends SplFileInfo
      *
      * @param string  $destination
      * @param string  $delimiter
-     * @param integer $i
+     * @param int $i
      *
      * @return string
      */

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -41,8 +41,8 @@ class File extends SplFileInfo
      * Run our SplFileInfo constructor with an optional verification
      * that the path is really a file.
      *
-     * @param string  $path
-     * @param bool $checkFile
+     * @param string $path
+     * @param bool   $checkFile
      */
     public function __construct(string $path, bool $checkFile = false)
     {
@@ -150,7 +150,7 @@ class File extends SplFileInfo
      *
      * @param string      $targetPath
      * @param string|null $name
-     * @param bool     $overwrite
+     * @param bool        $overwrite
      *
      * @return File
      */
@@ -182,9 +182,9 @@ class File extends SplFileInfo
      * last element is an integer as there may be cases that the delimiter may be present in the filename.
      * For the all other cases, it appends an integer starting from zero before the file's extension.
      *
-     * @param string  $destination
-     * @param string  $delimiter
-     * @param int $i
+     * @param string $destination
+     * @param string $delimiter
+     * @param int    $i
      *
      * @return string
      */

--- a/system/Filters/CSRF.php
+++ b/system/Filters/CSRF.php
@@ -66,9 +66,9 @@ class CSRF implements FilterInterface
     /**
      * We don't have anything to do here.
      *
-     * @param RequestInterface|IncomingRequest             $request
-     * @param ResponseInterface|Response $response
-     * @param array|null                                   $arguments
+     * @param RequestInterface|IncomingRequest $request
+     * @param ResponseInterface|Response       $response
+     * @param array|null                       $arguments
      *
      * @return mixed
      */

--- a/system/Filters/CSRF.php
+++ b/system/Filters/CSRF.php
@@ -41,6 +41,7 @@ class CSRF implements FilterInterface
      * @param array|null                       $arguments
      *
      * @return mixed
+     *
      * @throws SecurityException
      */
     public function before(RequestInterface $request, $arguments = null)

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -159,6 +159,7 @@ class Filters
      * @param string $position
      *
      * @return RequestInterface|ResponseInterface|mixed
+     *
      * @throws FilterException
      */
     public function run(string $uri, string $position = 'before')

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -55,7 +55,7 @@ class Filters
      * Whether we've done initial processing
      * on the filter lists.
      *
-     * @var boolean
+     * @var bool
      */
     protected $initialized = false;
 
@@ -527,7 +527,7 @@ class Filters
      * @param string $uri   URI to test against
      * @param mixed  $paths The path patterns to test
      *
-     * @return boolean True if any of the paths apply to the URI
+     * @return bool True if any of the paths apply to the URI
      */
     private function pathApplies(string $uri, $paths)
     {

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -492,7 +492,8 @@ class Filters
     /**
      * Maps filter aliases to the equivalent filter classes
      *
-     * @param  string $position
+     * @param string $position
+     *
      * @throws FilterException
      *
      * @return void

--- a/system/Format/JSONFormatter.php
+++ b/system/Format/JSONFormatter.php
@@ -24,7 +24,7 @@ class JSONFormatter implements FormatterInterface
      *
      * @param mixed $data
      *
-     * @return string|boolean (JSON string | false)
+     * @return string|bool (JSON string | false)
      */
     public function format($data)
     {

--- a/system/Format/XMLFormatter.php
+++ b/system/Format/XMLFormatter.php
@@ -25,7 +25,7 @@ class XMLFormatter implements FormatterInterface
      *
      * @param mixed $data
      *
-     * @return string|boolean (XML string | false)
+     * @return string|bool (XML string | false)
      */
     public function format($data)
     {
@@ -76,7 +76,7 @@ class XMLFormatter implements FormatterInterface
      * Normalizes tags into the allowed by W3C.
      * Regex adopted from this StackOverflow answer.
      *
-     * @param string|integer $key
+     * @param string|int $key
      *
      * @return string
      *

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -136,7 +136,7 @@ class CLIRequest extends Request
      *
      *      getOptionString() = '-foo bar -baz "queue some stuff"'
      *
-     * @param boolean $useLongOpts
+     * @param bool $useLongOpts
      *
      * @return string
      */
@@ -211,7 +211,7 @@ class CLIRequest extends Request
     /**
      * Determines if this request was made from the command line (CLI).
      *
-     * @return boolean
+     * @return bool
      */
     public function isCLI(): bool
     {

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -251,8 +251,8 @@ class CURLRequest extends Request
     /**
      * Set form data to be sent.
      *
-     * @param array   $params
-     * @param bool $multipart Set TRUE if you are sending CURLFiles
+     * @param array $params
+     * @param bool  $multipart Set TRUE if you are sending CURLFiles
      *
      * @return $this
      */
@@ -552,8 +552,8 @@ class CURLRequest extends Request
     /**
      * Set CURL options
      *
-     * @param  array $curlOptions
-     * @param  array $config
+     * @param  array                    $curlOptions
+     * @param  array                    $config
      * @return array
      * @throws InvalidArgumentException
      */

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -552,9 +552,11 @@ class CURLRequest extends Request
     /**
      * Set CURL options
      *
-     * @param  array                    $curlOptions
-     * @param  array                    $config
+     * @param array $curlOptions
+     * @param array $config
+     *
      * @return array
+     *
      * @throws InvalidArgumentException
      */
     protected function setCURLOptions(array $curlOptions = [], array $config = [])

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -252,7 +252,7 @@ class CURLRequest extends Request
      * Set form data to be sent.
      *
      * @param array   $params
-     * @param boolean $multipart Set TRUE if you are sending CURLFiles
+     * @param bool $multipart Set TRUE if you are sending CURLFiles
      *
      * @return $this
      */
@@ -347,7 +347,7 @@ class CURLRequest extends Request
      * Get the request method. Overrides the Request class' method
      * since users expect a different answer here.
      *
-     * @param boolean|false $upper Whether to return in upper or lower case.
+     * @param bool|false $upper Whether to return in upper or lower case.
      *
      * @return string
      */

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -146,14 +146,14 @@ class ContentSecurityPolicy
     /**
      * Used for security enforcement
      *
-     * @var boolean
+     * @var bool
      */
     protected $upgradeInsecureRequests = false;
 
     /**
      * Used for security enforcement
      *
-     * @var boolean
+     * @var bool
      */
     protected $reportOnly = false;
 
@@ -230,7 +230,7 @@ class ContentSecurityPolicy
      * determine what errors need to be addressed before you turn on
      * all filtering.
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return $this
      */
@@ -249,7 +249,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-base-uri
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -271,7 +271,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-child-src
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -292,7 +292,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-connect-src
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -313,7 +313,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-default-src
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -333,7 +333,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-font-src
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -351,7 +351,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-form-action
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -369,7 +369,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-frame-ancestors
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -387,7 +387,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-frame-src
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -407,7 +407,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-img-src
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -425,7 +425,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-media-src
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -443,7 +443,7 @@ class ContentSecurityPolicy
      * @see https://www.w3.org/TR/CSP/#directive-manifest-src
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -461,7 +461,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-object-src
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -479,7 +479,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-plugin-types
      *
      * @param string|array $mime              One or more plugin mime types, separate by spaces
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -514,7 +514,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-sandbox
      *
      * @param string|array $flags             An array of sandbox flags that can be added to the directive.
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -532,7 +532,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-connect-src
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -550,7 +550,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-connect-src
      *
      * @param string|array $uri
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return $this
      */
@@ -565,7 +565,7 @@ class ContentSecurityPolicy
      * Sets whether the user agents should rewrite URL schemes, changing
      * HTTP to HTTPS.
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return $this
      */
@@ -585,7 +585,7 @@ class ContentSecurityPolicy
      *
      * @param string|array $options
      * @param string       $target
-     * @param boolean|null $explicitReporting
+     * @param bool|null $explicitReporting
      *
      * @return void
      */

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -249,7 +249,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-base-uri
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -271,7 +271,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-child-src
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -292,7 +292,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-connect-src
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -313,7 +313,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-default-src
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -333,7 +333,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-font-src
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -351,7 +351,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-form-action
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -369,7 +369,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-frame-ancestors
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -387,7 +387,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-frame-src
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -407,7 +407,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-img-src
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -425,7 +425,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-media-src
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -443,7 +443,7 @@ class ContentSecurityPolicy
      * @see https://www.w3.org/TR/CSP/#directive-manifest-src
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -461,7 +461,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-object-src
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -479,7 +479,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-plugin-types
      *
      * @param string|array $mime              One or more plugin mime types, separate by spaces
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -514,7 +514,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-sandbox
      *
      * @param string|array $flags             An array of sandbox flags that can be added to the directive.
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -532,7 +532,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-connect-src
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -550,7 +550,7 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-connect-src
      *
      * @param string|array $uri
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -585,7 +585,7 @@ class ContentSecurityPolicy
      *
      * @param string|array $options
      * @param string       $target
-     * @param bool|null $explicitReporting
+     * @param bool|null    $explicitReporting
      *
      * @return void
      */

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -37,7 +37,7 @@ class DownloadResponse extends Response
     /**
      * mime set flag
      *
-     * @var boolean
+     * @var bool
      */
     private $setMime;
 
@@ -65,7 +65,7 @@ class DownloadResponse extends Response
     /**
      * The current status code for this response.
      *
-     * @var integer
+     * @var int
      */
     protected $statusCode = 200;
 
@@ -73,7 +73,7 @@ class DownloadResponse extends Response
      * Constructor.
      *
      * @param string  $filename
-     * @param boolean $setMime
+     * @param bool $setMime
      */
     public function __construct(string $filename, bool $setMime)
     {
@@ -131,7 +131,7 @@ class DownloadResponse extends Response
     /**
      * get content length.
      *
-     * @return integer
+     * @return int
      */
     public function getContentLength() : int
     {
@@ -224,7 +224,7 @@ class DownloadResponse extends Response
     /**
      * Disallows status changing.
      *
-     * @param integer $code
+     * @param int $code
      * @param string  $reason
      *
      * @throws DownloadException

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -72,8 +72,8 @@ class DownloadResponse extends Response
     /**
      * Constructor.
      *
-     * @param string  $filename
-     * @param bool $setMime
+     * @param string $filename
+     * @param bool   $setMime
      */
     public function __construct(string $filename, bool $setMime)
     {
@@ -224,8 +224,8 @@ class DownloadResponse extends Response
     /**
      * Disallows status changing.
      *
-     * @param int $code
-     * @param string  $reason
+     * @param int    $code
+     * @param string $reason
      *
      * @throws DownloadException
      */

--- a/system/HTTP/Exceptions/HTTPException.php
+++ b/system/HTTP/Exceptions/HTTPException.php
@@ -128,7 +128,7 @@ class HTTPException extends FrameworkException
     /**
      * For Response
      *
-     * @param integer $code
+     * @param int $code
      *
      * @return HTTPException
      */
@@ -140,7 +140,7 @@ class HTTPException extends FrameworkException
     /**
      * For Response
      *
-     * @param integer $code
+     * @param int $code
      *
      * @return HTTPException
      */
@@ -164,7 +164,7 @@ class HTTPException extends FrameworkException
     /**
      * For URI
      *
-     * @param integer $segment
+     * @param int $segment
      *
      * @return HTTPException
      */
@@ -176,7 +176,7 @@ class HTTPException extends FrameworkException
     /**
      * For URI
      *
-     * @param integer $port
+     * @param int $port
      *
      * @return HTTPException
      */

--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -119,7 +119,7 @@ class FileCollection
      *
      * @param string $fileID The name of the uploaded file (from the input)
      *
-     * @return boolean
+     * @return bool
      */
     public function hasFile(string $fileID): bool
     {

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -75,11 +75,11 @@ class UploadedFile extends File implements UploadedFileInterface
     /**
      * Accepts the file information as would be filled in from the $_FILES array.
      *
-     * @param string  $path         The temporary location of the uploaded file.
-     * @param string  $originalName The client-provided filename.
-     * @param string  $mimeType     The type of file as provided by PHP
-     * @param int $size         The size of the file, in bytes
-     * @param int $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
+     * @param string $path         The temporary location of the uploaded file.
+     * @param string $originalName The client-provided filename.
+     * @param string $mimeType     The type of file as provided by PHP
+     * @param int    $size         The size of the file, in bytes
+     * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
      */
     public function __construct(string $path, string $originalName, string $mimeType = null, int $size = null, int $error = null)
     {
@@ -117,16 +117,16 @@ class UploadedFile extends File implements UploadedFileInterface
      * @see http://php.net/is_uploaded_file
      * @see http://php.net/move_uploaded_file
      *
-     * @param string  $targetPath Path to which to move the uploaded file.
-     * @param string  $name       the name to rename the file to.
-     * @param bool $overwrite  State for indicating whether to overwrite the previously generated file with the same
-     *                            name or not.
+     * @param string $targetPath Path to which to move the uploaded file.
+     * @param string $name       the name to rename the file to.
+     * @param bool   $overwrite  State for indicating whether to overwrite the previously generated file with the same
+     *                           name or not.
      *
      * @return bool
      *
      * @throws InvalidArgumentException if the $path specified is invalid.
-     * @throws RuntimeException on any error during the move operation.
-     * @throws RuntimeException on the second or subsequent call to the method.
+     * @throws RuntimeException         on any error during the move operation.
+     * @throws RuntimeException         on the second or subsequent call to the method.
      */
     public function move(string $targetPath, string $name = null, bool $overwrite = false)
     {

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -59,14 +59,14 @@ class UploadedFile extends File implements UploadedFileInterface
      * The error constant of the upload
      * (one of PHP's UPLOADERRXXX constants)
      *
-     * @var integer
+     * @var int
      */
     protected $error;
 
     /**
      * Whether the file has been moved already or not.
      *
-     * @var boolean
+     * @var bool
      */
     protected $hasMoved = false;
 
@@ -78,8 +78,8 @@ class UploadedFile extends File implements UploadedFileInterface
      * @param string  $path         The temporary location of the uploaded file.
      * @param string  $originalName The client-provided filename.
      * @param string  $mimeType     The type of file as provided by PHP
-     * @param integer $size         The size of the file, in bytes
-     * @param integer $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
+     * @param int $size         The size of the file, in bytes
+     * @param int $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
      */
     public function __construct(string $path, string $originalName, string $mimeType = null, int $size = null, int $error = null)
     {
@@ -119,10 +119,10 @@ class UploadedFile extends File implements UploadedFileInterface
      *
      * @param string  $targetPath Path to which to move the uploaded file.
      * @param string  $name       the name to rename the file to.
-     * @param boolean $overwrite  State for indicating whether to overwrite the previously generated file with the same
+     * @param bool $overwrite  State for indicating whether to overwrite the previously generated file with the same
      *                            name or not.
      *
-     * @return boolean
+     * @return bool
      *
      * @throws InvalidArgumentException if the $path specified is invalid.
      * @throws RuntimeException on any error during the move operation.
@@ -192,7 +192,7 @@ class UploadedFile extends File implements UploadedFileInterface
      * the move() method will not work and certain properties, like
      * the tempName, will no longer be available.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasMoved(): bool
     {
@@ -213,7 +213,7 @@ class UploadedFile extends File implements UploadedFileInterface
      * the file in the $_FILES array.
      *
      * @see    http://php.net/manual/en/features.file-upload.errors.php
-     * @return integer One of PHP's UPLOAD_ERR_XXX constants.
+     * @return int One of PHP's UPLOAD_ERR_XXX constants.
      */
     public function getError(): int
     {
@@ -348,7 +348,7 @@ class UploadedFile extends File implements UploadedFileInterface
      * Returns whether the file was uploaded successfully, based on whether
      * it was uploaded via HTTP and has no errors.
      *
-     * @return boolean
+     * @return bool
      */
     public function isValid(): bool
     {

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -213,6 +213,7 @@ class UploadedFile extends File implements UploadedFileInterface
      * the file in the $_FILES array.
      *
      * @see    http://php.net/manual/en/features.file-upload.errors.php
+     *
      * @return int One of PHP's UPLOAD_ERR_XXX constants.
      */
     public function getError(): int
@@ -361,8 +362,9 @@ class UploadedFile extends File implements UploadedFileInterface
      * By default, upload files are saved in writable/uploads directory. The YYYYMMDD folder
      * and random file name will be created.
      *
-     * @param  string $folderName the folder name to writable/uploads directory.
-     * @param  string $fileName   the name to rename the file to.
+     * @param string $folderName the folder name to writable/uploads directory.
+     * @param string $fileName   the name to rename the file to.
+     *
      * @return string file full path
      */
     public function store(string $folderName = null, string $fileName = null): string

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -26,11 +26,11 @@ interface UploadedFileInterface
     /**
      * Accepts the file information as would be filled in from the $_FILES array.
      *
-     * @param string  $path         The temporary location of the uploaded file.
-     * @param string  $originalName The client-provided filename.
-     * @param string  $mimeType     The type of file as provided by PHP
-     * @param int $size         The size of the file, in bytes
-     * @param int $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
+     * @param string $path         The temporary location of the uploaded file.
+     * @param string $originalName The client-provided filename.
+     * @param string $mimeType     The type of file as provided by PHP
+     * @param int    $size         The size of the file, in bytes
+     * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
      */
     public function __construct(string $path, string $originalName, string $mimeType = null, int $size = null, int $error = null);
 
@@ -62,8 +62,8 @@ interface UploadedFileInterface
      * @param string $name       the name to rename the file to.
      *
      * @throws InvalidArgumentException if the $path specified is invalid.
-     * @throws RuntimeException on any error during the move operation.
-     * @throws RuntimeException on the second or subsequent call to the method.
+     * @throws RuntimeException         on any error during the move operation.
+     * @throws RuntimeException         on the second or subsequent call to the method.
      */
     public function move(string $targetPath, string $name = null);
 
@@ -109,7 +109,7 @@ interface UploadedFileInterface
      * the file in the $_FILES array.
      *
      * @return string The filename sent by the client or null if none
-     *     was provided.
+     *                was provided.
      */
     public function getName(): string;
 
@@ -163,9 +163,9 @@ interface UploadedFileInterface
      * last element is an integer as there may be cases that the delimiter may be present in the filename.
      * For the all other cases, it appends an integer starting from zero before the file's extension.
      *
-     * @param string  $destination
-     * @param string  $delimiter
-     * @param int $i
+     * @param string $destination
+     * @param string $delimiter
+     * @param int    $i
      *
      * @return string
      */

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -92,6 +92,7 @@ interface UploadedFileInterface
      * the file in the $_FILES array.
      *
      * @see    http://php.net/manual/en/features.file-upload.errors.php
+     *
      * @return int One of PHP's UPLOAD_ERR_XXX constants.
      */
     public function getError(): int;

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -29,8 +29,8 @@ interface UploadedFileInterface
      * @param string  $path         The temporary location of the uploaded file.
      * @param string  $originalName The client-provided filename.
      * @param string  $mimeType     The type of file as provided by PHP
-     * @param integer $size         The size of the file, in bytes
-     * @param integer $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
+     * @param int $size         The size of the file, in bytes
+     * @param int $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
      */
     public function __construct(string $path, string $originalName, string $mimeType = null, int $size = null, int $error = null);
 
@@ -74,7 +74,7 @@ interface UploadedFileInterface
      * the move() method will not work and certain properties, like
      * the tempName, will no longer be available.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasMoved(): bool;
 
@@ -92,7 +92,7 @@ interface UploadedFileInterface
      * the file in the $_FILES array.
      *
      * @see    http://php.net/manual/en/features.file-upload.errors.php
-     * @return integer One of PHP's UPLOAD_ERR_XXX constants.
+     * @return int One of PHP's UPLOAD_ERR_XXX constants.
      */
     public function getError(): int;
 
@@ -150,7 +150,7 @@ interface UploadedFileInterface
      * Returns whether the file was uploaded successfully, based on whether
      * it was uploaded via HTTP and has no errors.
      *
-     * @return boolean
+     * @return bool
      */
     public function isValid(): bool;
 
@@ -165,7 +165,7 @@ interface UploadedFileInterface
      *
      * @param string  $destination
      * @param string  $delimiter
-     * @param integer $i
+     * @param int $i
      *
      * @return string
      */

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -569,10 +569,11 @@ class IncomingRequest extends Request
     /**
      * Get a specific variable from a JSON input stream
      *
-     * @param  string         $index  The variable that you want which can use dot syntax for getting specific values.
-     * @param  bool           $assoc  If true, return the result as an associative array.
-     * @param  int|null       $filter Filter Constant
-     * @param  array|int|null $flags  Option
+     * @param string         $index  The variable that you want which can use dot syntax for getting specific values.
+     * @param bool           $assoc  If true, return the result as an associative array.
+     * @param int|null       $filter Filter Constant
+     * @param array|int|null $flags  Option
+     *
      * @return mixed
      */
     public function getJsonVar(string $index, bool $assoc = false, ?int $filter = null, $flags = null)

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -50,7 +50,7 @@ class IncomingRequest extends Request
      * Enables a CSRF cookie token to be set.
      * Set automatically based on Config setting.
      *
-     * @var boolean
+     * @var bool
      */
     protected $enableCSRF = false;
 
@@ -333,7 +333,7 @@ class IncomingRequest extends Request
      *
      * @param string  $type
      * @param array   $supported
-     * @param boolean $strictMatch
+     * @param bool $strictMatch
      *
      * @return string
      */
@@ -365,7 +365,7 @@ class IncomingRequest extends Request
     /**
      * Determines if this request was made from the command line (CLI).
      *
-     * @return boolean
+     * @return bool
      */
     public function isCLI(): bool
     {
@@ -375,7 +375,7 @@ class IncomingRequest extends Request
     /**
      * Test to see if a request contains the HTTP_X_REQUESTED_WITH header.
      *
-     * @return boolean
+     * @return bool
      */
     public function isAJAX(): bool
     {
@@ -386,7 +386,7 @@ class IncomingRequest extends Request
      * Attempts to detect if the current connection is secure through
      * a few different methods.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSecure(): bool
     {
@@ -516,7 +516,7 @@ class IncomingRequest extends Request
      * other get* methods in most cases.
      *
      * @param string|array|null $index
-     * @param integer|null      $filter Filter constant
+     * @param int|null      $filter Filter constant
      * @param mixed             $flags
      *
      * @return mixed
@@ -553,9 +553,9 @@ class IncomingRequest extends Request
      * If $assoc == true, then all objects in the response will be converted
      * to associative arrays.
      *
-     * @param boolean $assoc   Whether to return objects as associative arrays
-     * @param integer $depth   How many levels deep to decode
-     * @param integer $options Bitmask of options
+     * @param bool $assoc   Whether to return objects as associative arrays
+     * @param int $depth   How many levels deep to decode
+     * @param int $options Bitmask of options
      *
      * @see http://php.net/manual/en/function.json-decode.php
      *
@@ -570,9 +570,9 @@ class IncomingRequest extends Request
      * Get a specific variable from a JSON input stream
      *
      * @param  string             $index  The variable that you want which can use dot syntax for getting specific values.
-     * @param  boolean            $assoc  If true, return the result as an associative array.
-     * @param  integer|null       $filter Filter Constant
-     * @param  array|integer|null $flags  Option
+     * @param  bool            $assoc  If true, return the result as an associative array.
+     * @param  int|null       $filter Filter Constant
+     * @param  array|int|null $flags  Option
      * @return mixed
      */
     public function getJsonVar(string $index, bool $assoc = false, ?int $filter = null, $flags = null)
@@ -616,7 +616,7 @@ class IncomingRequest extends Request
      * Fetch an item from GET data.
      *
      * @param string|array|null $index  Index for item to fetch from $_GET.
-     * @param integer|null      $filter A filter name to apply.
+     * @param int|null      $filter A filter name to apply.
      * @param mixed|null        $flags
      *
      * @return mixed
@@ -632,7 +632,7 @@ class IncomingRequest extends Request
      * Fetch an item from POST.
      *
      * @param string|array|null $index  Index for item to fetch from $_POST.
-     * @param integer|null      $filter A filter name to apply
+     * @param int|null      $filter A filter name to apply
      * @param mixed             $flags
      *
      * @return mixed
@@ -648,7 +648,7 @@ class IncomingRequest extends Request
      * Fetch an item from POST data with fallback to GET.
      *
      * @param string|array|null $index  Index for item to fetch from $_POST or $_GET
-     * @param integer|null      $filter A filter name to apply
+     * @param int|null      $filter A filter name to apply
      * @param mixed             $flags
      *
      * @return mixed
@@ -667,7 +667,7 @@ class IncomingRequest extends Request
      * Fetch an item from GET data with fallback to POST.
      *
      * @param string|array|null $index  Index for item to be fetched from $_GET or $_POST
-     * @param integer|null      $filter A filter name to apply
+     * @param int|null      $filter A filter name to apply
      * @param mixed             $flags
      *
      * @return mixed
@@ -686,7 +686,7 @@ class IncomingRequest extends Request
      * Fetch an item from the COOKIE array.
      *
      * @param string|array|null $index  Index for item to be fetched from $_COOKIE
-     * @param integer|null      $filter A filter name to be applied
+     * @param int|null      $filter A filter name to be applied
      * @param mixed             $flags
      *
      * @return mixed

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -331,9 +331,9 @@ class IncomingRequest extends Request
      * Provides a convenient way to work with the Negotiate class
      * for content negotiation.
      *
-     * @param string  $type
-     * @param array   $supported
-     * @param bool $strictMatch
+     * @param string $type
+     * @param array  $supported
+     * @param bool   $strictMatch
      *
      * @return string
      */
@@ -516,7 +516,7 @@ class IncomingRequest extends Request
      * other get* methods in most cases.
      *
      * @param string|array|null $index
-     * @param int|null      $filter Filter constant
+     * @param int|null          $filter Filter constant
      * @param mixed             $flags
      *
      * @return mixed
@@ -554,8 +554,8 @@ class IncomingRequest extends Request
      * to associative arrays.
      *
      * @param bool $assoc   Whether to return objects as associative arrays
-     * @param int $depth   How many levels deep to decode
-     * @param int $options Bitmask of options
+     * @param int  $depth   How many levels deep to decode
+     * @param int  $options Bitmask of options
      *
      * @see http://php.net/manual/en/function.json-decode.php
      *
@@ -569,8 +569,8 @@ class IncomingRequest extends Request
     /**
      * Get a specific variable from a JSON input stream
      *
-     * @param  string             $index  The variable that you want which can use dot syntax for getting specific values.
-     * @param  bool            $assoc  If true, return the result as an associative array.
+     * @param  string         $index  The variable that you want which can use dot syntax for getting specific values.
+     * @param  bool           $assoc  If true, return the result as an associative array.
      * @param  int|null       $filter Filter Constant
      * @param  array|int|null $flags  Option
      * @return mixed
@@ -616,7 +616,7 @@ class IncomingRequest extends Request
      * Fetch an item from GET data.
      *
      * @param string|array|null $index  Index for item to fetch from $_GET.
-     * @param int|null      $filter A filter name to apply.
+     * @param int|null          $filter A filter name to apply.
      * @param mixed|null        $flags
      *
      * @return mixed
@@ -632,7 +632,7 @@ class IncomingRequest extends Request
      * Fetch an item from POST.
      *
      * @param string|array|null $index  Index for item to fetch from $_POST.
-     * @param int|null      $filter A filter name to apply
+     * @param int|null          $filter A filter name to apply
      * @param mixed             $flags
      *
      * @return mixed
@@ -648,7 +648,7 @@ class IncomingRequest extends Request
      * Fetch an item from POST data with fallback to GET.
      *
      * @param string|array|null $index  Index for item to fetch from $_POST or $_GET
-     * @param int|null      $filter A filter name to apply
+     * @param int|null          $filter A filter name to apply
      * @param mixed             $flags
      *
      * @return mixed
@@ -667,7 +667,7 @@ class IncomingRequest extends Request
      * Fetch an item from GET data with fallback to POST.
      *
      * @param string|array|null $index  Index for item to be fetched from $_GET or $_POST
-     * @param int|null      $filter A filter name to apply
+     * @param int|null          $filter A filter name to apply
      * @param mixed             $flags
      *
      * @return mixed
@@ -686,7 +686,7 @@ class IncomingRequest extends Request
      * Fetch an item from the COOKIE array.
      *
      * @param string|array|null $index  Index for item to be fetched from $_COOKIE
-     * @param int|null      $filter A filter name to be applied
+     * @param int|null          $filter A filter name to be applied
      * @param mixed             $flags
      *
      * @return mixed

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -91,7 +91,7 @@ class Message implements MessageInterface
      *
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function hasHeader(string $name): bool
     {

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -69,9 +69,9 @@ class Negotiate
      * If no match is found, the first, highest-ranking client requested
      * type is returned.
      *
-     * @param array   $supported
-     * @param bool $strictMatch If TRUE, will return an empty string when no match found.
-     *                             If FALSE, will return the first supported element.
+     * @param array $supported
+     * @param bool  $strictMatch If TRUE, will return an empty string when no match found.
+     *                           If FALSE, will return the first supported element.
      *
      * @return string
      */
@@ -158,12 +158,12 @@ class Negotiate
      *
      * Portions of this code base on Aura.Accept library.
      *
-     * @param array   $supported    App-supported values
-     * @param string  $header       header string
-     * @param bool $enforceTypes If TRUE, will compare media types and sub-types.
-     * @param bool $strictMatch  If TRUE, will return empty string on no match.
-     *                              If FALSE, will return the first supported element.
-     * @param bool $matchLocales If TRUE, will match locale sub-types to a broad type (fr-FR = fr)
+     * @param array  $supported    App-supported values
+     * @param string $header       header string
+     * @param bool   $enforceTypes If TRUE, will compare media types and sub-types.
+     * @param bool   $strictMatch  If TRUE, will return empty string on no match.
+     *                             If FALSE, will return the first supported element.
+     * @param bool   $matchLocales If TRUE, will match locale sub-types to a broad type (fr-FR = fr)
      *
      * @return string Best match
      */
@@ -292,10 +292,10 @@ class Negotiate
     /**
      * Match-maker
      *
-     * @param array   $acceptable
-     * @param string  $supported
-     * @param bool $enforceTypes
-     * @param bool $matchLocales
+     * @param array  $acceptable
+     * @param string $supported
+     * @param bool   $enforceTypes
+     * @param bool   $matchLocales
      *
      * @return bool
      */

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -70,7 +70,7 @@ class Negotiate
      * type is returned.
      *
      * @param array   $supported
-     * @param boolean $strictMatch If TRUE, will return an empty string when no match found.
+     * @param bool $strictMatch If TRUE, will return an empty string when no match found.
      *                             If FALSE, will return the first supported element.
      *
      * @return string
@@ -160,10 +160,10 @@ class Negotiate
      *
      * @param array   $supported    App-supported values
      * @param string  $header       header string
-     * @param boolean $enforceTypes If TRUE, will compare media types and sub-types.
-     * @param boolean $strictMatch  If TRUE, will return empty string on no match.
+     * @param bool $enforceTypes If TRUE, will compare media types and sub-types.
+     * @param bool $strictMatch  If TRUE, will return empty string on no match.
      *                              If FALSE, will return the first supported element.
-     * @param boolean $matchLocales If TRUE, will match locale sub-types to a broad type (fr-FR = fr)
+     * @param bool $matchLocales If TRUE, will match locale sub-types to a broad type (fr-FR = fr)
      *
      * @return string Best match
      */
@@ -294,10 +294,10 @@ class Negotiate
      *
      * @param array   $acceptable
      * @param string  $supported
-     * @param boolean $enforceTypes
-     * @param boolean $matchLocales
+     * @param bool $enforceTypes
+     * @param bool $matchLocales
      *
-     * @return boolean
+     * @return bool
      */
     protected function match(array $acceptable, string $supported, bool $enforceTypes = false, $matchLocales = false): bool
     {
@@ -334,7 +334,7 @@ class Negotiate
      * @param array $acceptable
      * @param array $supported
      *
-     * @return boolean
+     * @return bool
      */
     protected function matchParameters(array $acceptable, array $supported): bool
     {
@@ -362,7 +362,7 @@ class Negotiate
      * @param array $acceptable
      * @param array $supported
      *
-     * @return boolean
+     * @return bool
      */
     public function matchTypes(array $acceptable, array $supported): bool
     {
@@ -394,7 +394,7 @@ class Negotiate
      * @param array $acceptable
      * @param array $supported
      *
-     * @return boolean
+     * @return bool
      */
     public function matchLocales(array $acceptable, array $supported): bool
     {

--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -25,7 +25,7 @@ class RedirectResponse extends Response
      * If no code is provided it will be automatically determined.
      *
      * @param string       $uri    The URI to redirect to
-     * @param integer|null $code   HTTP status code
+     * @param int|null $code   HTTP status code
      * @param string       $method
      *
      * @return $this
@@ -47,7 +47,7 @@ class RedirectResponse extends Response
      *
      * @param string  $route
      * @param array   $params
-     * @param integer $code
+     * @param int $code
      * @param string  $method
      *
      * @throws HTTPException
@@ -71,7 +71,7 @@ class RedirectResponse extends Response
      * Example:
      *  return redirect()->back();
      *
-     * @param integer|null $code
+     * @param int|null $code
      * @param string       $method
      *
      * @return $this

--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -24,9 +24,9 @@ class RedirectResponse extends Response
      * Sets the URI to redirect to and, optionally, the HTTP status code to use.
      * If no code is provided it will be automatically determined.
      *
-     * @param string       $uri    The URI to redirect to
+     * @param string   $uri    The URI to redirect to
      * @param int|null $code   HTTP status code
-     * @param string       $method
+     * @param string   $method
      *
      * @return $this
      */
@@ -45,10 +45,10 @@ class RedirectResponse extends Response
      * Sets the URI to redirect to but as a reverse-routed or named route
      * instead of a raw URI.
      *
-     * @param string  $route
-     * @param array   $params
-     * @param int $code
-     * @param string  $method
+     * @param string $route
+     * @param array  $params
+     * @param int    $code
+     * @param string $method
      *
      * @throws HTTPException
      *
@@ -72,7 +72,7 @@ class RedirectResponse extends Response
      *  return redirect()->back();
      *
      * @param int|null $code
-     * @param string       $method
+     * @param string   $method
      *
      * @return $this
      */

--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -72,7 +72,7 @@ class Request extends Message implements MessageInterface, RequestInterface
      * @param string $ip    IP Address
      * @param string $which IP protocol: 'ipv4' or 'ipv6'
      *
-     * @return boolean
+     * @return bool
      *
      * @deprecated Use Validation instead
      *
@@ -86,7 +86,7 @@ class Request extends Message implements MessageInterface, RequestInterface
     /**
      * Get the request method.
      *
-     * @param boolean $upper Whether to return in upper or lower case.
+     * @param bool $upper Whether to return in upper or lower case.
      *
      * @return string
      *

--- a/system/HTTP/RequestInterface.php
+++ b/system/HTTP/RequestInterface.php
@@ -36,7 +36,7 @@ interface RequestInterface
      * @param string $ip    IP Address
      * @param string $which IP protocol: 'ipv4' or 'ipv6'
      *
-     * @return boolean
+     * @return bool
      *
      * @deprecated Use Validation instead
      */
@@ -48,7 +48,7 @@ interface RequestInterface
      * Get the request method.
      * An extension of PSR-7's getMethod to allow casing.
      *
-     * @param boolean $upper Whether to return in upper or lower case.
+     * @param bool $upper Whether to return in upper or lower case.
      *
      * @return string
      *

--- a/system/HTTP/RequestInterface.php
+++ b/system/HTTP/RequestInterface.php
@@ -62,8 +62,9 @@ interface RequestInterface
      * Fetch an item from the $_SERVER array.
      * Supplied by RequestTrait.
      *
-     * @param  string $index  Index for item to be fetched from $_SERVER
-     * @param  null   $filter A filter name to be applied
+     * @param string $index  Index for item to be fetched from $_SERVER
+     * @param null   $filter A filter name to be applied
+     *
      * @return mixed
      */
     public function getServer($index = null, $filter = null);

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -161,7 +161,7 @@ trait RequestTrait
      * Fetch an item from the $_SERVER array.
      *
      * @param string|array|null $index  Index for item to be fetched from $_SERVER
-     * @param integer|null      $filter A filter name to be applied
+     * @param int|null      $filter A filter name to be applied
      * @param null              $flags
      *
      * @return mixed
@@ -218,8 +218,8 @@ trait RequestTrait
      *
      * @param string             $method Input filter constant
      * @param string|array|null  $index
-     * @param integer|null       $filter Filter constant
-     * @param array|integer|null $flags  Options
+     * @param int|null       $filter Filter constant
+     * @param array|int|null $flags  Options
      *
      * @return mixed
      */

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -161,7 +161,7 @@ trait RequestTrait
      * Fetch an item from the $_SERVER array.
      *
      * @param string|array|null $index  Index for item to be fetched from $_SERVER
-     * @param int|null      $filter A filter name to be applied
+     * @param int|null          $filter A filter name to be applied
      * @param null              $flags
      *
      * @return mixed
@@ -216,10 +216,10 @@ trait RequestTrait
      *
      * http://php.net/manual/en/filter.filters.sanitize.php
      *
-     * @param string             $method Input filter constant
-     * @param string|array|null  $index
-     * @param int|null       $filter Filter constant
-     * @param array|int|null $flags  Options
+     * @param string            $method Input filter constant
+     * @param string|array|null $index
+     * @param int|null          $filter Filter constant
+     * @param array|int|null    $flags  Options
      *
      * @return mixed
      */

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -125,14 +125,14 @@ class Response extends Message implements MessageInterface, ResponseInterface
      * The status code is a 3-digit integer result code of the server's attempt
      * to understand and satisfy the request.
      *
-     * @var integer
+     * @var int
      */
     protected $statusCode = 200;
 
     /**
      * If true, will not write output. Useful during testing.
      *
-     * @var boolean
+     * @var bool
      *
      * @internal Used for framework testing, should not be relied on otherwise
      */
@@ -192,7 +192,7 @@ class Response extends Message implements MessageInterface, ResponseInterface
      * Note that this is not a part of the interface so
      * should not be relied on outside of internal testing.
      *
-     * @param boolean $pretend
+     * @param bool $pretend
      *
      * @return $this
      */
@@ -209,7 +209,7 @@ class Response extends Message implements MessageInterface, ResponseInterface
      * The status code is a 3-digit integer result code of the getServer's attempt
      * to understand and satisfy the request.
      *
-     * @return integer Status code.
+     * @return int Status code.
      */
     public function getStatusCode(): int
     {

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -133,6 +133,7 @@ interface ResponseInterface
      *                       default to the IANA name.
      *
      * @return self
+     *
      * @throws InvalidArgumentException For invalid status code arguments.
      */
     public function setStatusCode(int $code, string $reason = '');
@@ -234,6 +235,7 @@ interface ResponseInterface
      * Retrieves the current body into XML and returns it.
      *
      * @return mixed|string
+     *
      * @throws InvalidArgumentException If the body property is not array.
      */
     public function getXML();
@@ -391,6 +393,7 @@ interface ResponseInterface
      * @param int    $code   The type of redirection, defaults to 302
      *
      * @return $this
+     *
      * @throws HTTPException For invalid status code.
      */
     public function redirect(string $uri, string $method = 'auto', int $code = null);

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -110,7 +110,7 @@ interface ResponseInterface
      * The status code is a 3-digit integer result code of the getServer's attempt
      * to understand and satisfy the request.
      *
-     * @return integer Status code.
+     * @return int Status code.
      *
      * @deprecated To be replaced by the PSR-7 version (compatible)
      */
@@ -127,7 +127,7 @@ interface ResponseInterface
      * @see http://tools.ietf.org/html/rfc7231#section-6
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      *
-     * @param integer $code   The 3-digit integer result code to set.
+     * @param int $code   The 3-digit integer result code to set.
      * @param string  $reason The reason phrase to use with the
      *                        provided status code; if none is provided, will
      *                        default to the IANA name.
@@ -206,7 +206,7 @@ interface ResponseInterface
      * Converts the $body into JSON and sets the Content Type header.
      *
      * @param array|string $body
-     * @param boolean      $unencoded
+     * @param bool      $unencoded
      *
      * @return $this
      */
@@ -321,8 +321,8 @@ interface ResponseInterface
      * @param string       $domain   Cookie domain (e.g.: '.yourdomain.com')
      * @param string       $path     Cookie path (default: '/')
      * @param string       $prefix   Cookie name prefix
-     * @param boolean      $secure   Whether to only transfer cookies via SSL
-     * @param boolean      $httponly Whether only make the cookie accessible via HTTP (no javascript)
+     * @param bool      $secure   Whether to only transfer cookies via SSL
+     * @param bool      $httponly Whether only make the cookie accessible via HTTP (no javascript)
      * @param string|null  $samesite
      *
      * @return $this
@@ -346,7 +346,7 @@ interface ResponseInterface
      * @param string|null $value
      * @param string      $prefix
      *
-     * @return boolean
+     * @return bool
      */
     public function hasCookie(string $name, string $value = null, string $prefix = ''): bool;
 
@@ -388,7 +388,7 @@ interface ResponseInterface
      *
      * @param string  $uri    The URI to redirect to
      * @param string  $method
-     * @param integer $code   The type of redirection, defaults to 302
+     * @param int $code   The type of redirection, defaults to 302
      *
      * @return $this
      * @throws HTTPException For invalid status code.
@@ -403,7 +403,7 @@ interface ResponseInterface
      *
      * @param string      $filename The path to the file to send
      * @param string|null $data     The data to be downloaded
-     * @param boolean     $setMime  Whether to try and send the actual MIME type
+     * @param bool     $setMime  Whether to try and send the actual MIME type
      *
      * @return DownloadResponse|null
      */

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -127,10 +127,10 @@ interface ResponseInterface
      * @see http://tools.ietf.org/html/rfc7231#section-6
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      *
-     * @param int $code   The 3-digit integer result code to set.
-     * @param string  $reason The reason phrase to use with the
-     *                        provided status code; if none is provided, will
-     *                        default to the IANA name.
+     * @param int    $code   The 3-digit integer result code to set.
+     * @param string $reason The reason phrase to use with the
+     *                       provided status code; if none is provided, will
+     *                       default to the IANA name.
      *
      * @return self
      * @throws InvalidArgumentException For invalid status code arguments.
@@ -206,7 +206,7 @@ interface ResponseInterface
      * Converts the $body into JSON and sets the Content Type header.
      *
      * @param array|string $body
-     * @param bool      $unencoded
+     * @param bool         $unencoded
      *
      * @return $this
      */
@@ -321,8 +321,8 @@ interface ResponseInterface
      * @param string       $domain   Cookie domain (e.g.: '.yourdomain.com')
      * @param string       $path     Cookie path (default: '/')
      * @param string       $prefix   Cookie name prefix
-     * @param bool      $secure   Whether to only transfer cookies via SSL
-     * @param bool      $httponly Whether only make the cookie accessible via HTTP (no javascript)
+     * @param bool         $secure   Whether to only transfer cookies via SSL
+     * @param bool         $httponly Whether only make the cookie accessible via HTTP (no javascript)
      * @param string|null  $samesite
      *
      * @return $this
@@ -386,9 +386,9 @@ interface ResponseInterface
     /**
      * Perform a redirect to a new URL, in two flavors: header or location.
      *
-     * @param string  $uri    The URI to redirect to
-     * @param string  $method
-     * @param int $code   The type of redirection, defaults to 302
+     * @param string $uri    The URI to redirect to
+     * @param string $method
+     * @param int    $code   The type of redirection, defaults to 302
      *
      * @return $this
      * @throws HTTPException For invalid status code.
@@ -403,7 +403,7 @@ interface ResponseInterface
      *
      * @param string      $filename The path to the file to send
      * @param string|null $data     The data to be downloaded
-     * @param bool     $setMime  Whether to try and send the actual MIME type
+     * @param bool        $setMime  Whether to try and send the actual MIME type
      *
      * @return DownloadResponse|null
      */

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -36,7 +36,7 @@ trait ResponseTrait
     /**
      * Whether Content Security Policy is being enforced.
      *
-     * @var boolean
+     * @var bool
      */
     protected $CSPEnabled = false;
 
@@ -84,7 +84,7 @@ trait ResponseTrait
     /**
      * Cookie will only be set if a secure HTTPS connection exists.
      *
-     * @var boolean
+     * @var bool
      *
      * @deprecated Use the dedicated Cookie class instead.
      */
@@ -93,7 +93,7 @@ trait ResponseTrait
     /**
      * Cookie will only be accessible via HTTP(S) (no javascript)
      *
-     * @var boolean
+     * @var bool
      *
      * @deprecated Use the dedicated Cookie class instead.
      */
@@ -134,7 +134,7 @@ trait ResponseTrait
      * @see http://tools.ietf.org/html/rfc7231#section-6
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      *
-     * @param integer $code   The 3-digit integer result code to set.
+     * @param int $code   The 3-digit integer result code to set.
      * @param string  $reason The reason phrase to use with the
      *                        provided status code; if none is provided, will
      *                        default to the IANA name.
@@ -241,7 +241,7 @@ trait ResponseTrait
      * Converts the $body into JSON and sets the Content Type header.
      *
      * @param array|string $body
-     * @param boolean      $unencoded
+     * @param bool      $unencoded
      *
      * @return $this
      */
@@ -498,7 +498,7 @@ trait ResponseTrait
      *
      * @param string  $uri    The URI to redirect to
      * @param string  $method
-     * @param integer $code   The type of redirection, defaults to 302
+     * @param int $code   The type of redirection, defaults to 302
      *
      * @return $this
      * @throws HTTPException For invalid status code.
@@ -548,8 +548,8 @@ trait ResponseTrait
      * @param string       $domain   Cookie domain (e.g.: '.yourdomain.com')
      * @param string       $path     Cookie path (default: '/')
      * @param string       $prefix   Cookie name prefix
-     * @param boolean      $secure   Whether to only transfer cookies via SSL
-     * @param boolean      $httponly Whether only make the cookie accessible via HTTP (no javascript)
+     * @param bool      $secure   Whether to only transfer cookies via SSL
+     * @param bool      $httponly Whether only make the cookie accessible via HTTP (no javascript)
      * @param string|null  $samesite
      *
      * @return $this
@@ -610,7 +610,7 @@ trait ResponseTrait
      * @param string|null $value
      * @param string      $prefix
      *
-     * @return boolean
+     * @return bool
      */
     public function hasCookie(string $name, string $value = null, string $prefix = ''): bool
     {
@@ -721,7 +721,7 @@ trait ResponseTrait
      *
      * @param string      $filename The path to the file to send
      * @param string|null $data     The data to be downloaded
-     * @param boolean     $setMime  Whether to try and send the actual MIME type
+     * @param bool     $setMime  Whether to try and send the actual MIME type
      *
      * @return DownloadResponse|null
      */

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -140,6 +140,7 @@ trait ResponseTrait
      *                       default to the IANA name.
      *
      * @return $this
+     *
      * @throws HTTPException For invalid status code arguments.
      */
     public function setStatusCode(int $code, string $reason = '')
@@ -288,6 +289,7 @@ trait ResponseTrait
      * Retrieves the current body into XML and returns it.
      *
      * @return mixed|string
+     *
      * @throws InvalidArgumentException If the body property is not array.
      */
     public function getXML()
@@ -309,6 +311,7 @@ trait ResponseTrait
      * @param string       $format Valid: json, xml
      *
      * @return mixed
+     *
      * @throws InvalidArgumentException If the body property is not string or array.
      */
     protected function formatBody($body, string $format)
@@ -501,6 +504,7 @@ trait ResponseTrait
      * @param int    $code   The type of redirection, defaults to 302
      *
      * @return $this
+     *
      * @throws HTTPException For invalid status code.
      */
     public function redirect(string $uri, string $method = 'auto', int $code = null)

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -134,10 +134,10 @@ trait ResponseTrait
      * @see http://tools.ietf.org/html/rfc7231#section-6
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      *
-     * @param int $code   The 3-digit integer result code to set.
-     * @param string  $reason The reason phrase to use with the
-     *                        provided status code; if none is provided, will
-     *                        default to the IANA name.
+     * @param int    $code   The 3-digit integer result code to set.
+     * @param string $reason The reason phrase to use with the
+     *                       provided status code; if none is provided, will
+     *                       default to the IANA name.
      *
      * @return $this
      * @throws HTTPException For invalid status code arguments.
@@ -241,7 +241,7 @@ trait ResponseTrait
      * Converts the $body into JSON and sets the Content Type header.
      *
      * @param array|string $body
-     * @param bool      $unencoded
+     * @param bool         $unencoded
      *
      * @return $this
      */
@@ -496,9 +496,9 @@ trait ResponseTrait
     /**
      * Perform a redirect to a new URL, in two flavors: header or location.
      *
-     * @param string  $uri    The URI to redirect to
-     * @param string  $method
-     * @param int $code   The type of redirection, defaults to 302
+     * @param string $uri    The URI to redirect to
+     * @param string $method
+     * @param int    $code   The type of redirection, defaults to 302
      *
      * @return $this
      * @throws HTTPException For invalid status code.
@@ -548,8 +548,8 @@ trait ResponseTrait
      * @param string       $domain   Cookie domain (e.g.: '.yourdomain.com')
      * @param string       $path     Cookie path (default: '/')
      * @param string       $prefix   Cookie name prefix
-     * @param bool      $secure   Whether to only transfer cookies via SSL
-     * @param bool      $httponly Whether only make the cookie accessible via HTTP (no javascript)
+     * @param bool         $secure   Whether to only transfer cookies via SSL
+     * @param bool         $httponly Whether only make the cookie accessible via HTTP (no javascript)
      * @param string|null  $samesite
      *
      * @return $this
@@ -721,7 +721,7 @@ trait ResponseTrait
      *
      * @param string      $filename The path to the file to send
      * @param string|null $data     The data to be downloaded
-     * @param bool     $setMime  Whether to try and send the actual MIME type
+     * @param bool        $setMime  Whether to try and send the actual MIME type
      *
      * @return DownloadResponse|null
      */

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -76,7 +76,7 @@ class URI
     /**
      * URI Port
      *
-     * @var integer
+     * @var int
      */
     protected $port;
 
@@ -117,21 +117,21 @@ class URI
      * Whether passwords should be shown in userInfo/authority calls.
      * Default to false because URIs often show up in logs
      *
-     * @var boolean
+     * @var bool
      */
     protected $showPassword = false;
 
     /**
      * If true, will continue instead of throwing exceptions.
      *
-     * @var boolean
+     * @var bool
      */
     protected $silent = false;
 
     /**
      * If true, will use raw query string.
      *
-     * @var boolean
+     * @var bool
      */
     protected $rawQueryString = false;
 
@@ -251,7 +251,7 @@ class URI
      * If $silent == true, then will not throw exceptions and will
      * attempt to continue gracefully.
      *
-     * @param boolean $silent
+     * @param bool $silent
      *
      * @return URI
      */
@@ -268,7 +268,7 @@ class URI
      * If $raw == true, then will use parseStr() method
      * instead of native parse_str() function.
      *
-     * @param boolean $raw
+     * @param bool $raw
      *
      * @return URI
      */
@@ -347,7 +347,7 @@ class URI
      *
      * @see https://tools.ietf.org/html/rfc3986#section-3.2
      *
-     * @param boolean $ignorePort
+     * @param bool $ignorePort
      *
      * @return string The URI authority, in "[user-info@]host[:port]" format.
      */
@@ -413,7 +413,7 @@ class URI
      * Temporarily sets the URI to show a password in userInfo. Will
      * reset itself after the first call to authority().
      *
-     * @param boolean $val
+     * @param bool $val
      *
      * @return URI
      */
@@ -457,7 +457,7 @@ class URI
      * If no port is present, but a scheme is present, this method MAY return
      * the standard port for that scheme, but SHOULD return null.
      *
-     * @return null|integer The URI port.
+     * @return null|int The URI port.
      */
     public function getPort()
     {
@@ -565,7 +565,7 @@ class URI
     /**
      * Returns the value of a specific segment of the URI path.
      *
-     * @param integer $number  Segment number
+     * @param int $number  Segment number
      * @param string  $default Default value
      *
      * @return string     The value of the segment. If no segment is found,
@@ -588,7 +588,7 @@ class URI
      * Set the value of a specific segment of the URI path.
      * Allows to set only existing segments or add new one.
      *
-     * @param integer $number
+     * @param int $number
      * @param mixed   $value  (string or int)
      *
      * @return $this
@@ -618,7 +618,7 @@ class URI
     /**
      * Returns the total number of segments.
      *
-     * @return integer
+     * @return int
      */
     public function getTotalSegments(): int
     {
@@ -758,7 +758,7 @@ class URI
     /**
      * Sets the port portion of the URI.
      *
-     * @param integer $port
+     * @param int $port
      *
      * @return $this
      */

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -184,6 +184,7 @@ class URI
      * @param string $path
      *
      * @return string
+     *
      * @internal
      */
     public static function removeDotSegments(string $path): string
@@ -321,6 +322,7 @@ class URI
      * added.
      *
      * @see    https://tools.ietf.org/html/rfc3986#section-3.1
+     *
      * @return string The URI scheme.
      */
     public function getScheme(): string
@@ -435,6 +437,7 @@ class URI
      * Section 3.2.2.
      *
      * @see    http://tools.ietf.org/html/rfc3986#section-3.2.2
+     *
      * @return string The URI host.
      */
     public function getHost(): string
@@ -489,6 +492,7 @@ class URI
      *
      * @see    https://tools.ietf.org/html/rfc3986#section-2
      * @see    https://tools.ietf.org/html/rfc3986#section-3.3
+     *
      * @return string The URI path.
      */
     public function getPath(): string

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -183,7 +183,7 @@ class URI
      *
      * @param string $path
      *
-     * @return   string
+     * @return string
      * @internal
      */
     public static function removeDotSegments(string $path): string
@@ -565,11 +565,11 @@ class URI
     /**
      * Returns the value of a specific segment of the URI path.
      *
-     * @param int $number  Segment number
-     * @param string  $default Default value
+     * @param int    $number  Segment number
+     * @param string $default Default value
      *
-     * @return string     The value of the segment. If no segment is found,
-     *                    throws InvalidArgumentError
+     * @return string The value of the segment. If no segment is found,
+     *                throws InvalidArgumentError
      */
     public function getSegment(int $number, string $default = ''): string
     {
@@ -588,8 +588,8 @@ class URI
      * Set the value of a specific segment of the URI path.
      * Allows to set only existing segments or add new one.
      *
-     * @param int $number
-     * @param mixed   $value  (string or int)
+     * @param int   $number
+     * @param mixed $value  (string or int)
      *
      * @return $this
      */

--- a/system/HTTP/UserAgent.php
+++ b/system/HTTP/UserAgent.php
@@ -28,21 +28,21 @@ class UserAgent
     /**
      * Flag for if the user-agent belongs to a browser
      *
-     * @var boolean
+     * @var bool
      */
     protected $isBrowser = false;
 
     /**
      * Flag for if the user-agent is a robot
      *
-     * @var boolean
+     * @var bool
      */
     protected $isRobot = false;
 
     /**
      * Flag for if the user-agent is a mobile browser
      *
-     * @var boolean
+     * @var bool
      */
     protected $isMobile = false;
 
@@ -121,7 +121,7 @@ class UserAgent
      *
      * @param string $key
      *
-     * @return boolean
+     * @return bool
      */
     public function isBrowser(string $key = null): bool
     {
@@ -145,7 +145,7 @@ class UserAgent
      *
      * @param string $key
      *
-     * @return boolean
+     * @return bool
      */
     public function isRobot(string $key = null): bool
     {
@@ -169,7 +169,7 @@ class UserAgent
      *
      * @param string $key
      *
-     * @return boolean
+     * @return bool
      */
     public function isMobile(string $key = null): bool
     {
@@ -191,7 +191,7 @@ class UserAgent
     /**
      * Is this a referral from another site?
      *
-     * @return boolean
+     * @return bool
      */
     public function isReferral(): bool
     {
@@ -344,7 +344,7 @@ class UserAgent
     /**
      * Set the Platform
      *
-     * @return boolean
+     * @return bool
      */
     protected function setPlatform(): bool
     {
@@ -368,7 +368,7 @@ class UserAgent
     /**
      * Set the Browser
      *
-     * @return boolean
+     * @return bool
      */
     protected function setBrowser(): bool
     {
@@ -393,7 +393,7 @@ class UserAgent
     /**
      * Set the Robot
      *
-     * @return boolean
+     * @return bool
      */
     protected function setRobot(): bool
     {
@@ -417,7 +417,7 @@ class UserAgent
     /**
      * Set the Mobile Device
      *
-     * @return boolean
+     * @return bool
      */
     protected function setMobile(): bool
     {

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -147,7 +147,7 @@ if (! function_exists('array_sort_by_multiple_keys')) {
      * @param array $sortColumns an associative array of columns to sort
      *                           after and their sorting flags
      *
-     * @return boolean
+     * @return bool
      */
     function array_sort_by_multiple_keys(array &$array, array $sortColumns): bool
     {

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -29,8 +29,8 @@ if (! function_exists('set_cookie')) {
      * @param string       $domain   For site-wide cookie. Usually: .yourdomain.com
      * @param string       $path     The cookie path
      * @param string       $prefix   The cookie prefix
-     * @param bool      $secure   True makes the cookie secure
-     * @param bool      $httpOnly True makes the cookie accessible via http(s) only (no javascript)
+     * @param bool         $secure   True makes the cookie secure
+     * @param bool         $httpOnly True makes the cookie accessible via http(s) only (no javascript)
      * @param string|null  $sameSite The cookie SameSite value
      *
      * @see \CodeIgniter\HTTP\Response::setCookie()
@@ -55,8 +55,8 @@ if (! function_exists('get_cookie')) {
     /**
      * Fetch an item from the $_COOKIE array
      *
-     * @param string  $index
-     * @param bool $xssClean
+     * @param string $index
+     * @param bool   $xssClean
      *
      * @return mixed
      *

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -29,8 +29,8 @@ if (! function_exists('set_cookie')) {
      * @param string       $domain   For site-wide cookie. Usually: .yourdomain.com
      * @param string       $path     The cookie path
      * @param string       $prefix   The cookie prefix
-     * @param boolean      $secure   True makes the cookie secure
-     * @param boolean      $httpOnly True makes the cookie accessible via http(s) only (no javascript)
+     * @param bool      $secure   True makes the cookie secure
+     * @param bool      $httpOnly True makes the cookie accessible via http(s) only (no javascript)
      * @param string|null  $sameSite The cookie SameSite value
      *
      * @see \CodeIgniter\HTTP\Response::setCookie()
@@ -56,7 +56,7 @@ if (! function_exists('get_cookie')) {
      * Fetch an item from the $_COOKIE array
      *
      * @param string  $index
-     * @param boolean $xssClean
+     * @param bool $xssClean
      *
      * @return mixed
      *
@@ -99,7 +99,7 @@ if (! function_exists('has_cookie')) {
      * @param string|null $value
      * @param string      $prefix
      *
-     * @return boolean
+     * @return bool
      */
     function has_cookie(string $name, string $value = null, string $prefix = ''): bool
     {

--- a/system/Helpers/date_helper.php
+++ b/system/Helpers/date_helper.php
@@ -46,10 +46,10 @@ if (! function_exists('timezone_select')) {
      *
      * Returns a string with the formatted HTML
      *
-     * @param string  $class   Optional class to apply to the select field
-     * @param string  $default Default value for initial selection
-     * @param int $what    One of the DateTimeZone class constants (for listIdentifiers)
-     * @param string  $country A two-letter ISO 3166-1 compatible country code (for listIdentifiers)
+     * @param string $class   Optional class to apply to the select field
+     * @param string $default Default value for initial selection
+     * @param int    $what    One of the DateTimeZone class constants (for listIdentifiers)
+     * @param string $country A two-letter ISO 3166-1 compatible country code (for listIdentifiers)
      *
      * @return string
      * @throws Exception

--- a/system/Helpers/date_helper.php
+++ b/system/Helpers/date_helper.php
@@ -23,6 +23,7 @@ if (! function_exists('now')) {
      * @param string $timezone
      *
      * @return int
+     *
      * @throws Exception
      */
     function now(string $timezone = null): int
@@ -52,6 +53,7 @@ if (! function_exists('timezone_select')) {
      * @param string $country A two-letter ISO 3166-1 compatible country code (for listIdentifiers)
      *
      * @return string
+     *
      * @throws Exception
      */
     function timezone_select(string $class = '', string $default = '', int $what = DateTimeZone::ALL, string $country = null): string

--- a/system/Helpers/date_helper.php
+++ b/system/Helpers/date_helper.php
@@ -22,7 +22,7 @@ if (! function_exists('now')) {
      *
      * @param string $timezone
      *
-     * @return integer
+     * @return int
      * @throws Exception
      */
     function now(string $timezone = null): int
@@ -48,7 +48,7 @@ if (! function_exists('timezone_select')) {
      *
      * @param string  $class   Optional class to apply to the select field
      * @param string  $default Default value for initial selection
-     * @param integer $what    One of the DateTimeZone class constants (for listIdentifiers)
+     * @param int $what    One of the DateTimeZone class constants (for listIdentifiers)
      * @param string  $country A two-letter ISO 3166-1 compatible country code (for listIdentifiers)
      *
      * @return string

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -379,7 +379,8 @@ if (! function_exists('symbolic_permissions')) {
      * Takes a numeric value representing a file's permissions and returns
      * standard symbolic notation representing that value
      *
-     * @param  int    $perms Permissions
+     * @param int $perms Permissions
+     *
      * @return string
      */
     function symbolic_permissions(int $perms): string
@@ -430,7 +431,8 @@ if (! function_exists('octal_permissions')) {
      * Takes a numeric value representing a file's permissions and returns
      * a three character string representing the file's octal permissions
      *
-     * @param  int    $perms Permissions
+     * @param int $perms Permissions
+     *
      * @return string
      */
     function octal_permissions(int $perms): string

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -22,10 +22,10 @@ if (! function_exists('directory_map')) {
      * representation of it. Sub-folders contained with the
      * directory will be mapped as well.
      *
-     * @param string  $sourceDir      Path to source
-     * @param int $directoryDepth Depth of directories to traverse
-     *                                 (0 = fully recursive, 1 = current dir, etc)
-     * @param bool $hidden         Whether to show hidden files
+     * @param string $sourceDir      Path to source
+     * @param int    $directoryDepth Depth of directories to traverse
+     *                               (0 = fully recursive, 1 = current dir, etc)
+     * @param bool   $hidden         Whether to show hidden files
      *
      * @return array
      */
@@ -71,9 +71,9 @@ if (! function_exists('directory_mirror')) {
      * Recursively copies the files and directories of the origin directory
      * into the target directory, i.e. "mirror" its contents.
      *
-     * @param string  $originDir
-     * @param string  $targetDir
-     * @param bool $overwrite Whether individual files overwrite on collision
+     * @param string $originDir
+     * @param string $targetDir
+     * @param bool   $overwrite Whether individual files overwrite on collision
      *
      * @return void
      *
@@ -159,10 +159,10 @@ if (! function_exists('delete_files')) {
      * If the second parameter is set to true, any directories contained
      * within the supplied base directory will be nuked as well.
      *
-     * @param string  $path   File path
-     * @param bool $delDir Whether to delete any directories found in the path
-     * @param bool $htdocs Whether to skip deleting .htaccess and index page files
-     * @param bool $hidden Whether to include hidden files (files beginning with a period)
+     * @param string $path   File path
+     * @param bool   $delDir Whether to delete any directories found in the path
+     * @param bool   $htdocs Whether to skip deleting .htaccess and index page files
+     * @param bool   $hidden Whether to include hidden files (files beginning with a period)
      *
      * @return bool
      */
@@ -210,7 +210,7 @@ if (! function_exists('get_filenames')) {
      * Reads the specified directory and builds an array containing the filenames.
      * Any sub-folders contained within the specified path are read as well.
      *
-     * @param string       $sourceDir   Path to source
+     * @param string    $sourceDir   Path to source
      * @param bool|null $includePath Whether to include the path as part of the filename; false for no path, null for a relative path, true for full path
      * @param bool      $hidden      Whether to include hidden files (files beginning with a period)
      *
@@ -262,9 +262,9 @@ if (! function_exists('get_dir_file_info')) {
      *
      * Any sub-folders contained within the specified path are read as well.
      *
-     * @param string  $sourceDir    Path to source
-     * @param bool $topLevelOnly Look only at the top level directory specified?
-     * @param bool $recursion    Internal variable to determine recursion status - do not use in calls
+     * @param string $sourceDir    Path to source
+     * @param bool   $topLevelOnly Look only at the top level directory specified?
+     * @param bool   $recursion    Internal variable to determine recursion status - do not use in calls
      *
      * @return array
      */
@@ -379,7 +379,7 @@ if (! function_exists('symbolic_permissions')) {
      * Takes a numeric value representing a file's permissions and returns
      * standard symbolic notation representing that value
      *
-     * @param  int $perms Permissions
+     * @param  int    $perms Permissions
      * @return string
      */
     function symbolic_permissions(int $perms): string
@@ -430,7 +430,7 @@ if (! function_exists('octal_permissions')) {
      * Takes a numeric value representing a file's permissions and returns
      * a three character string representing the file's octal permissions
      *
-     * @param  int $perms Permissions
+     * @param  int    $perms Permissions
      * @return string
      */
     function octal_permissions(int $perms): string
@@ -448,7 +448,7 @@ if (! function_exists('same_file')) {
      * @param string $file1
      * @param string $file2
      *
-     * @return bool  Same or not
+     * @return bool Same or not
      */
     function same_file(string $file1, string $file2): bool
     {
@@ -462,8 +462,8 @@ if (! function_exists('set_realpath')) {
     /**
      * Set Realpath
      *
-     * @param string  $path
-     * @param bool $checkExistence Checks to see if the path exists
+     * @param string $path
+     * @param bool   $checkExistence Checks to see if the path exists
      *
      * @return string
      */

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -23,9 +23,9 @@ if (! function_exists('directory_map')) {
      * directory will be mapped as well.
      *
      * @param string  $sourceDir      Path to source
-     * @param integer $directoryDepth Depth of directories to traverse
+     * @param int $directoryDepth Depth of directories to traverse
      *                                 (0 = fully recursive, 1 = current dir, etc)
-     * @param boolean $hidden         Whether to show hidden files
+     * @param bool $hidden         Whether to show hidden files
      *
      * @return array
      */
@@ -73,7 +73,7 @@ if (! function_exists('directory_mirror')) {
      *
      * @param string  $originDir
      * @param string  $targetDir
-     * @param boolean $overwrite Whether individual files overwrite on collision
+     * @param bool $overwrite Whether individual files overwrite on collision
      *
      * @return void
      *
@@ -123,7 +123,7 @@ if (! function_exists('write_file')) {
      * @param string $data Data to write
      * @param string $mode fopen() mode (default: 'wb')
      *
-     * @return boolean
+     * @return bool
      */
     function write_file(string $path, string $data, string $mode = 'wb'): bool
     {
@@ -160,11 +160,11 @@ if (! function_exists('delete_files')) {
      * within the supplied base directory will be nuked as well.
      *
      * @param string  $path   File path
-     * @param boolean $delDir Whether to delete any directories found in the path
-     * @param boolean $htdocs Whether to skip deleting .htaccess and index page files
-     * @param boolean $hidden Whether to include hidden files (files beginning with a period)
+     * @param bool $delDir Whether to delete any directories found in the path
+     * @param bool $htdocs Whether to skip deleting .htaccess and index page files
+     * @param bool $hidden Whether to include hidden files (files beginning with a period)
      *
-     * @return boolean
+     * @return bool
      */
     function delete_files(string $path, bool $delDir = false, bool $htdocs = false, bool $hidden = false): bool
     {
@@ -211,8 +211,8 @@ if (! function_exists('get_filenames')) {
      * Any sub-folders contained within the specified path are read as well.
      *
      * @param string       $sourceDir   Path to source
-     * @param boolean|null $includePath Whether to include the path as part of the filename; false for no path, null for a relative path, true for full path
-     * @param boolean      $hidden      Whether to include hidden files (files beginning with a period)
+     * @param bool|null $includePath Whether to include the path as part of the filename; false for no path, null for a relative path, true for full path
+     * @param bool      $hidden      Whether to include hidden files (files beginning with a period)
      *
      * @return array
      */
@@ -263,8 +263,8 @@ if (! function_exists('get_dir_file_info')) {
      * Any sub-folders contained within the specified path are read as well.
      *
      * @param string  $sourceDir    Path to source
-     * @param boolean $topLevelOnly Look only at the top level directory specified?
-     * @param boolean $recursion    Internal variable to determine recursion status - do not use in calls
+     * @param bool $topLevelOnly Look only at the top level directory specified?
+     * @param bool $recursion    Internal variable to determine recursion status - do not use in calls
      *
      * @return array
      */
@@ -379,7 +379,7 @@ if (! function_exists('symbolic_permissions')) {
      * Takes a numeric value representing a file's permissions and returns
      * standard symbolic notation representing that value
      *
-     * @param  integer $perms Permissions
+     * @param  int $perms Permissions
      * @return string
      */
     function symbolic_permissions(int $perms): string
@@ -430,7 +430,7 @@ if (! function_exists('octal_permissions')) {
      * Takes a numeric value representing a file's permissions and returns
      * a three character string representing the file's octal permissions
      *
-     * @param  integer $perms Permissions
+     * @param  int $perms Permissions
      * @return string
      */
     function octal_permissions(int $perms): string
@@ -448,7 +448,7 @@ if (! function_exists('same_file')) {
      * @param string $file1
      * @param string $file2
      *
-     * @return boolean  Same or not
+     * @return bool  Same or not
      */
     function same_file(string $file1, string $file2): bool
     {
@@ -463,7 +463,7 @@ if (! function_exists('set_realpath')) {
      * Set Realpath
      *
      * @param string  $path
-     * @param boolean $checkExistence Checks to see if the path exists
+     * @param bool $checkExistence Checks to see if the path exists
      *
      * @return string
      */

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -117,7 +117,7 @@ if (! function_exists('form_hidden')) {
      *
      * @param string|array $name      Field name or associative array to create multiple fields
      * @param string|array $value     Field value
-     * @param boolean      $recursing
+     * @param bool      $recursing
      *
      * @return string
      */
@@ -389,7 +389,7 @@ if (! function_exists('form_checkbox')) {
      *
      * @param mixed   $data
      * @param string  $value
-     * @param boolean $checked
+     * @param bool $checked
      * @param mixed   $extra
      *
      * @return string
@@ -429,7 +429,7 @@ if (! function_exists('form_radio')) {
      *
      * @param mixed   $data
      * @param string  $value
-     * @param boolean $checked
+     * @param bool $checked
      * @param mixed   $extra
      *
      * @return string
@@ -647,7 +647,7 @@ if (! function_exists('set_value')) {
      *
      * @param string          $field      Field name
      * @param string|string[] $default    Default value
-     * @param boolean         $htmlEscape Whether to escape HTML special characters or not
+     * @param bool         $htmlEscape Whether to escape HTML special characters or not
      *
      * @return string|string[]
      */
@@ -677,7 +677,7 @@ if (! function_exists('set_select')) {
      *
      * @param string  $field
      * @param string  $value
-     * @param boolean $default
+     * @param bool $default
      *
      * @return string
      */
@@ -722,7 +722,7 @@ if (! function_exists('set_checkbox')) {
      *
      * @param string  $field
      * @param string  $value
-     * @param boolean $default
+     * @param bool $default
      *
      * @return string
      */
@@ -768,7 +768,7 @@ if (! function_exists('set_radio')) {
      *
      * @param string  $field
      * @param string  $value
-     * @param boolean $default
+     * @param bool $default
      *
      * @return string
      */

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -117,7 +117,7 @@ if (! function_exists('form_hidden')) {
      *
      * @param string|array $name      Field name or associative array to create multiple fields
      * @param string|array $value     Field value
-     * @param bool      $recursing
+     * @param bool         $recursing
      *
      * @return string
      */
@@ -387,10 +387,10 @@ if (! function_exists('form_checkbox')) {
     /**
      * Checkbox Field
      *
-     * @param mixed   $data
-     * @param string  $value
-     * @param bool $checked
-     * @param mixed   $extra
+     * @param mixed  $data
+     * @param string $value
+     * @param bool   $checked
+     * @param mixed  $extra
      *
      * @return string
      */
@@ -427,10 +427,10 @@ if (! function_exists('form_radio')) {
     /**
      * Radio Button
      *
-     * @param mixed   $data
-     * @param string  $value
-     * @param bool $checked
-     * @param mixed   $extra
+     * @param mixed  $data
+     * @param string $value
+     * @param bool   $checked
+     * @param mixed  $extra
      *
      * @return string
      */
@@ -647,7 +647,7 @@ if (! function_exists('set_value')) {
      *
      * @param string          $field      Field name
      * @param string|string[] $default    Default value
-     * @param bool         $htmlEscape Whether to escape HTML special characters or not
+     * @param bool            $htmlEscape Whether to escape HTML special characters or not
      *
      * @return string|string[]
      */
@@ -675,9 +675,9 @@ if (! function_exists('set_select')) {
      * Let's you set the selected value of a <select> menu via data in the POST array.
      * If Form Validation is active it retrieves the info from the validation class
      *
-     * @param string  $field
-     * @param string  $value
-     * @param bool $default
+     * @param string $field
+     * @param string $value
+     * @param bool   $default
      *
      * @return string
      */
@@ -720,9 +720,9 @@ if (! function_exists('set_checkbox')) {
      * Let's you set the selected value of a checkbox via the value in the POST array.
      * If Form Validation is active it retrieves the info from the validation class
      *
-     * @param string  $field
-     * @param string  $value
-     * @param bool $default
+     * @param string $field
+     * @param string $value
+     * @param bool   $default
      *
      * @return string
      */
@@ -766,9 +766,9 @@ if (! function_exists('set_radio')) {
      * Let's you set the selected value of a radio field via info in the POST array.
      * If Form Validation is active it retrieves the info from the validation class
      *
-     * @param string  $field
-     * @param string  $value
-     * @param bool $default
+     * @param string $field
+     * @param string $value
+     * @param bool   $default
      *
      * @return string
      */

--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -63,10 +63,10 @@ if (! function_exists('_list')) {
      *
      * Generates an HTML ordered list from an single or multi-dimensional array.
      *
-     * @param string  $type
-     * @param mixed   $list
-     * @param mixed   $attributes string, array, object
-     * @param int $depth
+     * @param string $type
+     * @param mixed  $list
+     * @param mixed  $attributes string, array, object
+     * @param int    $depth
      *
      * @return string
      */
@@ -109,7 +109,7 @@ if (! function_exists('img')) {
      * Generates an image element
      *
      * @param string|array        $src        Image source URI, or array of attributes and values
-     * @param bool             $indexPage  Whether to treat $src as a routed URI string
+     * @param bool                $indexPage  Whether to treat $src as a routed URI string
      * @param string|array|object $attributes Additional HTML attributes
      *
      * @return string
@@ -218,8 +218,8 @@ if (! function_exists('script_tag')) {
      *
      * Generates link to a JS file
      *
-     * @param mixed   $src       Script source or an array
-     * @param bool $indexPage Should indexPage be added to the JS path
+     * @param mixed $src       Script source or an array
+     * @param bool  $indexPage Should indexPage be added to the JS path
      *
      * @return string
      */
@@ -254,13 +254,13 @@ if (! function_exists('link_tag')) {
      *
      * Generates link to a CSS file
      *
-     * @param mixed   $href      Stylesheet href or an array
-     * @param string  $rel
-     * @param string  $type
-     * @param string  $title
-     * @param string  $media
-     * @param bool $indexPage should indexPage be added to the CSS path.
-     * @param string  $hreflang
+     * @param mixed  $href      Stylesheet href or an array
+     * @param string $rel
+     * @param string $type
+     * @param string $title
+     * @param string $media
+     * @param bool   $indexPage should indexPage be added to the CSS path.
+     * @param string $hreflang
      *
      * @return string
      */
@@ -320,11 +320,11 @@ if (! function_exists('video')) {
      * Generates a video element to embed videos. The video element can
      * contain one or more video sources
      *
-     * @param mixed   $src                Either a source string or an array of sources
-     * @param string  $unsupportedMessage The message to display if the media tag is not supported by the browser
-     * @param string  $attributes         HTML attributes
-     * @param array   $tracks
-     * @param bool $indexPage
+     * @param mixed  $src                Either a source string or an array of sources
+     * @param string $unsupportedMessage The message to display if the media tag is not supported by the browser
+     * @param string $attributes         HTML attributes
+     * @param array  $tracks
+     * @param bool   $indexPage
      *
      * @return string
      */
@@ -374,11 +374,11 @@ if (! function_exists('audio')) {
      *
      * Generates an audio element to embed sounds
      *
-     * @param mixed   $src                Either a source string or an array of sources
-     * @param string  $unsupportedMessage The message to display if the media tag is not supported by the browser.
-     * @param string  $attributes         HTML attributes
-     * @param array   $tracks
-     * @param bool $indexPage
+     * @param mixed  $src                Either a source string or an array of sources
+     * @param string $unsupportedMessage The message to display if the media tag is not supported by the browser.
+     * @param string $attributes         HTML attributes
+     * @param array  $tracks
+     * @param bool   $indexPage
      *
      * @return string
      */
@@ -471,10 +471,10 @@ if (! function_exists('source')) {
      * Generates a source element that specifies multiple media resources
      * for either audio or video element
      *
-     * @param string  $src        The path of the media resource
-     * @param string  $type       The MIME-type of the resource with optional codecs parameters
-     * @param string  $attributes HTML attributes
-     * @param bool $indexPage
+     * @param string $src        The path of the media resource
+     * @param string $type       The MIME-type of the resource with optional codecs parameters
+     * @param string $attributes HTML attributes
+     * @param bool   $indexPage
      *
      * @return string
      */
@@ -531,11 +531,11 @@ if (! function_exists('object')) {
      * as either image or a resource plugin such as audio, video,
      * Java applets, ActiveX, PDF and Flash
      *
-     * @param string  $data       A resource URL
-     * @param string  $type       Content-type of the resource
-     * @param string  $attributes HTML attributes
-     * @param array   $params
-     * @param bool $indexPage
+     * @param string $data       A resource URL
+     * @param string $type       Content-type of the resource
+     * @param string $attributes HTML attributes
+     * @param array  $params
+     * @param bool   $indexPage
      *
      * @return string
      */
@@ -593,10 +593,10 @@ if (! function_exists('embed')) {
      *
      * Generates an embed element
      *
-     * @param string  $src        The path of the resource to embed
-     * @param string  $type       MIME-type
-     * @param string  $attributes HTML attributes
-     * @param bool $indexPage
+     * @param string $src        The path of the resource to embed
+     * @param string $type       MIME-type
+     * @param string $attributes HTML attributes
+     * @param bool   $indexPage
      *
      * @return string
      */

--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -66,7 +66,7 @@ if (! function_exists('_list')) {
      * @param string  $type
      * @param mixed   $list
      * @param mixed   $attributes string, array, object
-     * @param integer $depth
+     * @param int $depth
      *
      * @return string
      */
@@ -109,7 +109,7 @@ if (! function_exists('img')) {
      * Generates an image element
      *
      * @param string|array        $src        Image source URI, or array of attributes and values
-     * @param boolean             $indexPage  Whether to treat $src as a routed URI string
+     * @param bool             $indexPage  Whether to treat $src as a routed URI string
      * @param string|array|object $attributes Additional HTML attributes
      *
      * @return string
@@ -219,7 +219,7 @@ if (! function_exists('script_tag')) {
      * Generates link to a JS file
      *
      * @param mixed   $src       Script source or an array
-     * @param boolean $indexPage Should indexPage be added to the JS path
+     * @param bool $indexPage Should indexPage be added to the JS path
      *
      * @return string
      */
@@ -259,7 +259,7 @@ if (! function_exists('link_tag')) {
      * @param string  $type
      * @param string  $title
      * @param string  $media
-     * @param boolean $indexPage should indexPage be added to the CSS path.
+     * @param bool $indexPage should indexPage be added to the CSS path.
      * @param string  $hreflang
      *
      * @return string
@@ -324,7 +324,7 @@ if (! function_exists('video')) {
      * @param string  $unsupportedMessage The message to display if the media tag is not supported by the browser
      * @param string  $attributes         HTML attributes
      * @param array   $tracks
-     * @param boolean $indexPage
+     * @param bool $indexPage
      *
      * @return string
      */
@@ -378,7 +378,7 @@ if (! function_exists('audio')) {
      * @param string  $unsupportedMessage The message to display if the media tag is not supported by the browser.
      * @param string  $attributes         HTML attributes
      * @param array   $tracks
-     * @param boolean $indexPage
+     * @param bool $indexPage
      *
      * @return string
      */
@@ -474,7 +474,7 @@ if (! function_exists('source')) {
      * @param string  $src        The path of the media resource
      * @param string  $type       The MIME-type of the resource with optional codecs parameters
      * @param string  $attributes HTML attributes
-     * @param boolean $indexPage
+     * @param bool $indexPage
      *
      * @return string
      */
@@ -535,7 +535,7 @@ if (! function_exists('object')) {
      * @param string  $type       Content-type of the resource
      * @param string  $attributes HTML attributes
      * @param array   $params
-     * @param boolean $indexPage
+     * @param bool $indexPage
      *
      * @return string
      */
@@ -596,7 +596,7 @@ if (! function_exists('embed')) {
      * @param string  $src        The path of the resource to embed
      * @param string  $type       MIME-type
      * @param string  $attributes HTML attributes
-     * @param boolean $indexPage
+     * @param bool $indexPage
      *
      * @return string
      */
@@ -620,7 +620,7 @@ if (! function_exists('_has_protocol')) {
      *
      * @param string $url
      *
-     * @return false|integer
+     * @return false|int
      */
     function _has_protocol(string $url)
     {
@@ -634,7 +634,7 @@ if (! function_exists('_space_indent')) {
     /**
      * Provide space indenting.
      *
-     * @param integer $depth
+     * @param int $depth
      *
      * @return string
      */

--- a/system/Helpers/inflector_helper.php
+++ b/system/Helpers/inflector_helper.php
@@ -160,7 +160,8 @@ if (! function_exists('camelize')) {
      * Takes multiple words separated by spaces or
      * underscores and converts them to camel case.
      *
-     * @param  string $string Input string
+     * @param string $string Input string
+     *
      * @return string
      */
     function camelize(string $string): string

--- a/system/Helpers/inflector_helper.php
+++ b/system/Helpers/inflector_helper.php
@@ -138,8 +138,8 @@ if (! function_exists('counted')) {
      * Takes a number and a word to return the plural or not
      * E.g. 0 cats, 1 cat, 2 cats, ...
      *
-     * @param int $count  Number of items
-     * @param string  $string Input string
+     * @param int    $count  Number of items
+     * @param string $string Input string
      *
      * @return string
      */

--- a/system/Helpers/inflector_helper.php
+++ b/system/Helpers/inflector_helper.php
@@ -138,7 +138,7 @@ if (! function_exists('counted')) {
      * Takes a number and a word to return the plural or not
      * E.g. 0 cats, 1 cat, 2 cats, ...
      *
-     * @param integer $count  Number of items
+     * @param int $count  Number of items
      * @param string  $string Input string
      *
      * @return string
@@ -242,7 +242,7 @@ if (! function_exists('is_pluralizable')) {
      *
      * @param string $word Word to check
      *
-     * @return boolean
+     * @return bool
      */
     function is_pluralizable(string $word): bool
     {
@@ -325,7 +325,7 @@ if (! function_exists('ordinal')) {
      * number to denote the position in an ordered
      * sequence such as 1st, 2nd, 3rd, 4th.
      *
-     * @param integer $integer The integer to determine the suffix
+     * @param int $integer The integer to determine the suffix
      *
      * @return string
      */
@@ -356,7 +356,7 @@ if (! function_exists('ordinalize')) {
      * to denote the position in an ordered sequence
      * such as 1st, 2nd, 3rd, 4th.
      *
-     * @param integer $integer The integer to ordinalize
+     * @param int $integer The integer to ordinalize
      *
      * @return string
      */

--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -20,10 +20,10 @@ if (! function_exists('number_to_size')) {
      * Formats a numbers as bytes, based on size, and adds the appropriate suffix
      *
      * @param mixed   $num       Will be cast as int
-     * @param integer $precision
+     * @param int $precision
      * @param string  $locale
      *
-     * @return boolean|string
+     * @return bool|string
      */
     function number_to_size($num, int $precision = 1, string $locale = null)
     {
@@ -75,10 +75,10 @@ if (! function_exists('number_to_amount')) {
      * @see https://simple.wikipedia.org/wiki/Names_for_large_numbers
      *
      * @param string      $num
-     * @param integer     $precision
+     * @param int     $precision
      * @param string|null $locale
      *
-     * @return boolean|string
+     * @return bool|string
      */
     function number_to_amount($num, int $precision = 0, string $locale = null)
     {
@@ -125,7 +125,7 @@ if (! function_exists('number_to_currency')) {
      * @param float   $num
      * @param string  $currency
      * @param string  $locale
-     * @param integer $fraction
+     * @param int $fraction
      *
      * @return string
      */
@@ -147,7 +147,7 @@ if (! function_exists('format_number')) {
      * Used by all of the functions of the number_helper.
      *
      * @param float       $num
-     * @param integer     $precision
+     * @param int     $precision
      * @param string|null $locale
      * @param array       $options
      *

--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -19,9 +19,9 @@ if (! function_exists('number_to_size')) {
     /**
      * Formats a numbers as bytes, based on size, and adds the appropriate suffix
      *
-     * @param mixed   $num       Will be cast as int
-     * @param int $precision
-     * @param string  $locale
+     * @param mixed  $num       Will be cast as int
+     * @param int    $precision
+     * @param string $locale
      *
      * @return bool|string
      */
@@ -75,7 +75,7 @@ if (! function_exists('number_to_amount')) {
      * @see https://simple.wikipedia.org/wiki/Names_for_large_numbers
      *
      * @param string      $num
-     * @param int     $precision
+     * @param int         $precision
      * @param string|null $locale
      *
      * @return bool|string
@@ -122,10 +122,10 @@ if (! function_exists('number_to_amount')) {
 
 if (! function_exists('number_to_currency')) {
     /**
-     * @param float   $num
-     * @param string  $currency
-     * @param string  $locale
-     * @param int $fraction
+     * @param float  $num
+     * @param string $currency
+     * @param string $locale
+     * @param int    $fraction
      *
      * @return string
      */
@@ -147,7 +147,7 @@ if (! function_exists('format_number')) {
      * Used by all of the functions of the number_helper.
      *
      * @param float       $num
-     * @param int     $precision
+     * @param int         $precision
      * @param string|null $locale
      * @param array       $options
      *

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -23,7 +23,7 @@ if (! function_exists('word_limiter')) {
      * Limits a string to X number of words.
      *
      * @param string  $str
-     * @param integer $limit
+     * @param int $limit
      * @param string  $endChar the end character. Usually an ellipsis
      *
      * @return string
@@ -54,7 +54,7 @@ if (! function_exists('character_limiter')) {
      * so the character count may not be exactly as specified.
      *
      * @param string  $str
-     * @param integer $n
+     * @param int $n
      * @param string  $endChar the end character. Usually an ellipsis
      *
      * @return string
@@ -149,7 +149,7 @@ if (! function_exists('entities_to_ascii')) {
      * Converts character entities back to ASCII
      *
      * @param string  $str
-     * @param boolean $all
+     * @param bool $all
      *
      * @return string
      */
@@ -391,7 +391,7 @@ if (! function_exists('word_wrap')) {
      * will URLs.
      *
      * @param string  $str     the text string
-     * @param integer $charlim = 76    the number of characters to wrap at
+     * @param int $charlim = 76    the number of characters to wrap at
      *
      * @return string
      */
@@ -477,7 +477,7 @@ if (! function_exists('ellipsize')) {
      * This function will strip tags from a string, split it at its max_length and ellipsize
      *
      * @param string  $str       String to ellipsize
-     * @param integer $maxLength Max length of string
+     * @param int $maxLength Max length of string
      * @param mixed   $position  int (1|0) or float, .5, .2, etc for position to split
      * @param string  $ellipsis  ellipsis ; Default '...'
      *
@@ -609,7 +609,7 @@ if (! function_exists('reduce_multiples')) {
      *
      * @param string  $str
      * @param string  $character the character you wish to reduce
-     * @param boolean $trim      TRUE/FALSE - whether to trim the character from the beginning/end
+     * @param bool $trim      TRUE/FALSE - whether to trim the character from the beginning/end
      *
      * @return string
      */
@@ -630,7 +630,7 @@ if (! function_exists('random_string')) {
      * Useful for generating passwords or hashes.
      *
      * @param string  $type Type of random string.  basic, alpha, alnum, numeric, nozero, md5, sha1, and crypto
-     * @param integer $len  Number of characters
+     * @param int $len  Number of characters
      *
      * @return string
      */
@@ -684,7 +684,7 @@ if (! function_exists('increment_string')) {
      *
      * @param string  $str       Required
      * @param string  $separator What should the duplicate number be appended with
-     * @param integer $first     Which number should be used for the first dupe increment
+     * @param int $first     Which number should be used for the first dupe increment
      *
      * @return string
      */
@@ -735,7 +735,7 @@ if (! function_exists('excerpt')) {
      *
      * @param string  $text     String to search the phrase
      * @param string  $phrase   Phrase that will be searched for.
-     * @param integer $radius   The amount of characters returned around the phrase.
+     * @param int $radius   The amount of characters returned around the phrase.
      * @param string  $ellipsis Ending that will be appended
      *
      * @return string

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -22,9 +22,9 @@ if (! function_exists('word_limiter')) {
      *
      * Limits a string to X number of words.
      *
-     * @param string  $str
-     * @param int $limit
-     * @param string  $endChar the end character. Usually an ellipsis
+     * @param string $str
+     * @param int    $limit
+     * @param string $endChar the end character. Usually an ellipsis
      *
      * @return string
      */
@@ -53,9 +53,9 @@ if (! function_exists('character_limiter')) {
      * Limits the string based on the character count.  Preserves complete words
      * so the character count may not be exactly as specified.
      *
-     * @param string  $str
-     * @param int $n
-     * @param string  $endChar the end character. Usually an ellipsis
+     * @param string $str
+     * @param int    $n
+     * @param string $endChar the end character. Usually an ellipsis
      *
      * @return string
      */
@@ -148,8 +148,8 @@ if (! function_exists('entities_to_ascii')) {
      *
      * Converts character entities back to ASCII
      *
-     * @param string  $str
-     * @param bool $all
+     * @param string $str
+     * @param bool   $all
      *
      * @return string
      */
@@ -390,8 +390,8 @@ if (! function_exists('word_wrap')) {
      * Anything placed between {unwrap}{/unwrap} will not be word wrapped, nor
      * will URLs.
      *
-     * @param string  $str     the text string
-     * @param int $charlim = 76    the number of characters to wrap at
+     * @param string $str     the text string
+     * @param int    $charlim = 76    the number of characters to wrap at
      *
      * @return string
      */
@@ -476,12 +476,12 @@ if (! function_exists('ellipsize')) {
      *
      * This function will strip tags from a string, split it at its max_length and ellipsize
      *
-     * @param string  $str       String to ellipsize
-     * @param int $maxLength Max length of string
-     * @param mixed   $position  int (1|0) or float, .5, .2, etc for position to split
-     * @param string  $ellipsis  ellipsis ; Default '...'
+     * @param string $str       String to ellipsize
+     * @param int    $maxLength Max length of string
+     * @param mixed  $position  int (1|0) or float, .5, .2, etc for position to split
+     * @param string $ellipsis  ellipsis ; Default '...'
      *
-     * @return string    Ellipsized string
+     * @return string Ellipsized string
      */
     function ellipsize(string $str, int $maxLength, $position = 1, string $ellipsis = '&hellip;'): string
     {
@@ -516,7 +516,7 @@ if (! function_exists('strip_slashes')) {
      *
      * @param mixed $str string or array
      *
-     * @return mixed  string or array
+     * @return mixed string or array
      */
     function strip_slashes($str)
     {
@@ -607,9 +607,9 @@ if (! function_exists('reduce_multiples')) {
      *
      * Fred, Bill, Joe, Jimmy
      *
-     * @param string  $str
-     * @param string  $character the character you wish to reduce
-     * @param bool $trim      TRUE/FALSE - whether to trim the character from the beginning/end
+     * @param string $str
+     * @param string $character the character you wish to reduce
+     * @param bool   $trim      TRUE/FALSE - whether to trim the character from the beginning/end
      *
      * @return string
      */
@@ -629,8 +629,8 @@ if (! function_exists('random_string')) {
      *
      * Useful for generating passwords or hashes.
      *
-     * @param string  $type Type of random string.  basic, alpha, alnum, numeric, nozero, md5, sha1, and crypto
-     * @param int $len  Number of characters
+     * @param string $type Type of random string.  basic, alpha, alnum, numeric, nozero, md5, sha1, and crypto
+     * @param int    $len  Number of characters
      *
      * @return string
      */
@@ -682,9 +682,9 @@ if (! function_exists('increment_string')) {
     /**
      * Add's _1 to a string or increment the ending number to allow _2, _3, etc
      *
-     * @param string  $str       Required
-     * @param string  $separator What should the duplicate number be appended with
-     * @param int $first     Which number should be used for the first dupe increment
+     * @param string $str       Required
+     * @param string $separator What should the duplicate number be appended with
+     * @param int    $first     Which number should be used for the first dupe increment
      *
      * @return string
      */
@@ -733,10 +733,10 @@ if (! function_exists('excerpt')) {
      *
      * Allows to extract a piece of text surrounding a word or phrase.
      *
-     * @param string  $text     String to search the phrase
-     * @param string  $phrase   Phrase that will be searched for.
-     * @param int $radius   The amount of characters returned around the phrase.
-     * @param string  $ellipsis Ending that will be appended
+     * @param string $text     String to search the phrase
+     * @param string $phrase   Phrase that will be searched for.
+     * @param int    $radius   The amount of characters returned around the phrase.
+     * @param string $ellipsis Ending that will be appended
      *
      * @return string
      *

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -705,7 +705,8 @@ if (! function_exists('alternator')) {
      * Allows strings to be alternated. See docs...
      *
      * @phpstan-ignore-next-line
-     * @param                    string (as many parameters as needed)
+     *
+     * @param string (as many parameters as needed)
      *
      * @return string
      */

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -127,7 +127,7 @@ if (! function_exists('current_url')) {
      * Returns the current full URL based on the IncomingRequest.
      * String returns ignore query and fragment parts.
      *
-     * @param bool              $returnObject True to return an object instead of a string
+     * @param bool                 $returnObject True to return an object instead of a string
      * @param IncomingRequest|null $request      A request to use when retrieving the path
      *
      * @return string|URI
@@ -437,9 +437,9 @@ if (! function_exists('auto_link')) {
      * URLs or emails that end in a period. We'll strip these
      * off and add them after the link.
      *
-     * @param string  $str   the string
-     * @param string  $type  the type: email, url, or both
-     * @param bool $popup whether to create pop-up links
+     * @param string $str   the string
+     * @param string $type  the type: email, url, or both
+     * @param bool   $popup whether to create pop-up links
      *
      * @return string
      */
@@ -486,8 +486,8 @@ if (! function_exists('prep_url')) {
      * Formerly used URI, but that does not play nicely with URIs missing
      * the scheme.
      *
-     * @param  string  $str    the URL
-     * @param  bool $secure set true if you want to force https://
+     * @param  string $str    the URL
+     * @param  bool   $secure set true if you want to force https://
      * @return string
      */
     function prep_url(string $str = '', bool $secure = false): string
@@ -519,9 +519,9 @@ if (! function_exists('url_title')) {
      * human-friendly URL string with a "separator" string
      * as the word separator.
      *
-     * @param  string  $str       Input string
-     * @param  string  $separator Word separator (usually '-' or '_')
-     * @param  bool $lowercase Whether to transform the output string to lowercase
+     * @param  string $str       Input string
+     * @param  string $separator Word separator (usually '-' or '_')
+     * @param  bool   $lowercase Whether to transform the output string to lowercase
      * @return string
      */
     function url_title(string $str, string $separator = '-', bool $lowercase = false): string
@@ -559,9 +559,9 @@ if (! function_exists('mb_url_title')) {
      * human-friendly URL string with a "separator" string
      * as the word separator.
      *
-     * @param  string  $str       Input string
-     * @param  string  $separator Word separator (usually '-' or '_')
-     * @param  bool $lowercase Whether to transform the output string to lowercase
+     * @param  string $str       Input string
+     * @param  string $separator Word separator (usually '-' or '_')
+     * @param  bool   $lowercase Whether to transform the output string to lowercase
      * @return string
      */
     function mb_url_title(string $str, string $separator = '-', bool $lowercase = false): string

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -127,7 +127,7 @@ if (! function_exists('current_url')) {
      * Returns the current full URL based on the IncomingRequest.
      * String returns ignore query and fragment parts.
      *
-     * @param boolean              $returnObject True to return an object instead of a string
+     * @param bool              $returnObject True to return an object instead of a string
      * @param IncomingRequest|null $request      A request to use when retrieving the path
      *
      * @return string|URI
@@ -160,7 +160,7 @@ if (! function_exists('previous_url')) {
      * If that's not available, however, we'll use a sanitized url from $_SERVER['HTTP_REFERER']
      * which can be set by the user so is untrusted and not set by certain browsers/servers.
      *
-     * @param boolean $returnObject
+     * @param bool $returnObject
      *
      * @return URI|mixed|string
      */
@@ -185,7 +185,7 @@ if (! function_exists('uri_string')) {
      *
      * Returns the path part of the current URL
      *
-     * @param boolean $relative Whether the resulting path should be relative to baseURL
+     * @param bool $relative Whether the resulting path should be relative to baseURL
      *
      * @return string
      */
@@ -439,7 +439,7 @@ if (! function_exists('auto_link')) {
      *
      * @param string  $str   the string
      * @param string  $type  the type: email, url, or both
-     * @param boolean $popup whether to create pop-up links
+     * @param bool $popup whether to create pop-up links
      *
      * @return string
      */
@@ -487,7 +487,7 @@ if (! function_exists('prep_url')) {
      * the scheme.
      *
      * @param  string  $str    the URL
-     * @param  boolean $secure set true if you want to force https://
+     * @param  bool $secure set true if you want to force https://
      * @return string
      */
     function prep_url(string $str = '', bool $secure = false): string
@@ -521,7 +521,7 @@ if (! function_exists('url_title')) {
      *
      * @param  string  $str       Input string
      * @param  string  $separator Word separator (usually '-' or '_')
-     * @param  boolean $lowercase Whether to transform the output string to lowercase
+     * @param  bool $lowercase Whether to transform the output string to lowercase
      * @return string
      */
     function url_title(string $str, string $separator = '-', bool $lowercase = false): string
@@ -561,7 +561,7 @@ if (! function_exists('mb_url_title')) {
      *
      * @param  string  $str       Input string
      * @param  string  $separator Word separator (usually '-' or '_')
-     * @param  boolean $lowercase Whether to transform the output string to lowercase
+     * @param  bool $lowercase Whether to transform the output string to lowercase
      * @return string
      */
     function mb_url_title(string $str, string $separator = '-', bool $lowercase = false): string
@@ -613,7 +613,7 @@ if (! function_exists('url_is')) {
      *
      * @param string $path
      *
-     * @return boolean
+     * @return bool
      */
     function url_is(string $path): bool
     {

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -107,8 +107,9 @@ if (! function_exists('base_url')) {
      * Returns the base URL as defined by the App config.
      * Base URLs are trimmed site URLs without the index page.
      *
-     * @param  mixed  $relativePath URI string or array of URI segments
-     * @param  string $scheme
+     * @param mixed  $relativePath URI string or array of URI segments
+     * @param string $scheme
+     *
      * @return string
      */
     function base_url($relativePath = '', string $scheme = null): string
@@ -205,7 +206,8 @@ if (! function_exists('index_page')) {
      *
      * Returns the "index_page" from your config file
      *
-     * @param  App|null $altConfig Alternate configuration to use
+     * @param App|null $altConfig Alternate configuration to use
+     *
      * @return string
      */
     function index_page(App $altConfig = null): string
@@ -486,8 +488,9 @@ if (! function_exists('prep_url')) {
      * Formerly used URI, but that does not play nicely with URIs missing
      * the scheme.
      *
-     * @param  string $str    the URL
-     * @param  bool   $secure set true if you want to force https://
+     * @param string $str    the URL
+     * @param bool   $secure set true if you want to force https://
+     *
      * @return string
      */
     function prep_url(string $str = '', bool $secure = false): string
@@ -519,9 +522,10 @@ if (! function_exists('url_title')) {
      * human-friendly URL string with a "separator" string
      * as the word separator.
      *
-     * @param  string $str       Input string
-     * @param  string $separator Word separator (usually '-' or '_')
-     * @param  bool   $lowercase Whether to transform the output string to lowercase
+     * @param string $str       Input string
+     * @param string $separator Word separator (usually '-' or '_')
+     * @param bool   $lowercase Whether to transform the output string to lowercase
+     *
      * @return string
      */
     function url_title(string $str, string $separator = '-', bool $lowercase = false): string
@@ -559,9 +563,10 @@ if (! function_exists('mb_url_title')) {
      * human-friendly URL string with a "separator" string
      * as the word separator.
      *
-     * @param  string $str       Input string
-     * @param  string $separator Word separator (usually '-' or '_')
-     * @param  bool   $lowercase Whether to transform the output string to lowercase
+     * @param string $str       Input string
+     * @param string $separator Word separator (usually '-' or '_')
+     * @param bool   $lowercase Whether to transform the output string to lowercase
+     *
      * @return string
      */
     function mb_url_title(string $str, string $separator = '-', bool $lowercase = false): string

--- a/system/Helpers/xml_helper.php
+++ b/system/Helpers/xml_helper.php
@@ -17,8 +17,8 @@ if (! function_exists('xml_convert')) {
     /**
      * Convert Reserved XML characters to Entities
      *
-     * @param  string  $str
-     * @param  bool $protectAll
+     * @param  string $str
+     * @param  bool   $protectAll
      * @return string
      */
     function xml_convert(string $str, bool $protectAll = false): string

--- a/system/Helpers/xml_helper.php
+++ b/system/Helpers/xml_helper.php
@@ -17,8 +17,9 @@ if (! function_exists('xml_convert')) {
     /**
      * Convert Reserved XML characters to Entities
      *
-     * @param  string $str
-     * @param  bool   $protectAll
+     * @param string $str
+     * @param bool   $protectAll
+     *
      * @return string
      */
     function xml_convert(string $str, bool $protectAll = false): string

--- a/system/Helpers/xml_helper.php
+++ b/system/Helpers/xml_helper.php
@@ -18,7 +18,7 @@ if (! function_exists('xml_convert')) {
      * Convert Reserved XML characters to Entities
      *
      * @param  string  $str
-     * @param  boolean $protectAll
+     * @param  bool $protectAll
      * @return string
      */
     function xml_convert(string $str, bool $protectAll = false): string

--- a/system/Honeypot/Honeypot.php
+++ b/system/Honeypot/Honeypot.php
@@ -33,7 +33,8 @@ class Honeypot
     /**
      * Constructor.
      *
-     * @param  HoneypotConfig $config
+     * @param HoneypotConfig $config
+     *
      * @throws HoneypotException
      */
     public function __construct(HoneypotConfig $config)

--- a/system/Honeypot/Honeypot.php
+++ b/system/Honeypot/Honeypot.php
@@ -88,7 +88,8 @@ class Honeypot
      * Prepares the template by adding label
      * content and field name.
      *
-     * @param  string $template
+     * @param string $template
+     *
      * @return string
      */
     protected function prepareTemplate(string $template): string

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -195,9 +195,9 @@ class Time extends DateTime
      * Returns a new instance based on the year, month and day. If any of those three
      * are left empty, will default to the current value.
      *
-     * @param int|null             $year
-     * @param int|null             $month
-     * @param int|null             $day
+     * @param int|null                 $year
+     * @param int|null                 $month
+     * @param int|null                 $day
      * @param DateTimeZone|string|null $timezone
      * @param string|null              $locale
      *
@@ -214,9 +214,9 @@ class Time extends DateTime
     /**
      * Returns a new instance with the date set to today, and the time set to the values passed in.
      *
-     * @param int|null             $hour
-     * @param int|null             $minutes
-     * @param int|null             $seconds
+     * @param int|null                 $hour
+     * @param int|null                 $minutes
+     * @param int|null                 $seconds
      * @param DateTimeZone|string|null $timezone
      * @param string|null              $locale
      *
@@ -233,12 +233,12 @@ class Time extends DateTime
     /**
      * Returns a new instance with the date time values individually set.
      *
-     * @param int|null             $year
-     * @param int|null             $month
-     * @param int|null             $day
-     * @param int|null             $hour
-     * @param int|null             $minutes
-     * @param int|null             $seconds
+     * @param int|null                 $year
+     * @param int|null                 $month
+     * @param int|null                 $day
+     * @param int|null                 $hour
+     * @param int|null                 $minutes
+     * @param int|null                 $seconds
      * @param DateTimeZone|string|null $timezone
      * @param string|null              $locale
      *
@@ -284,7 +284,7 @@ class Time extends DateTime
     /**
      * Returns a new instance with the datetime set based on the provided UNIX timestamp.
      *
-     * @param int                  $timestamp
+     * @param int                      $timestamp
      * @param DateTimeZone|string|null $timezone
      * @param string|null              $locale
      *
@@ -736,8 +736,8 @@ class Time extends DateTime
     /**
      * Helper method to do the heavy lifting of the 'setX' methods.
      *
-     * @param string  $name
-     * @param int $value
+     * @param string $name
+     * @param int    $value
      *
      * @return Time
      * @throws Exception

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -114,6 +114,7 @@ class Time extends DateTime
      * @param string|null              $locale
      *
      * @return Time
+     *
      * @throws Exception
      */
     public static function now($timezone = null, string $locale = null)
@@ -134,6 +135,7 @@ class Time extends DateTime
      * @param string|null              $locale
      *
      * @return Time
+     *
      * @throws Exception
      */
     public static function parse(string $datetime, $timezone = null, string $locale = null)
@@ -150,6 +152,7 @@ class Time extends DateTime
      * @param string|null              $locale
      *
      * @return Time
+     *
      * @throws Exception
      */
     public static function today($timezone = null, string $locale = null)
@@ -166,6 +169,7 @@ class Time extends DateTime
      * @param string|null              $locale
      *
      * @return Time
+     *
      * @throws Exception
      */
     public static function yesterday($timezone = null, string $locale = null)
@@ -182,6 +186,7 @@ class Time extends DateTime
      * @param string|null              $locale
      *
      * @return Time
+     *
      * @throws Exception
      */
     public static function tomorrow($timezone = null, string $locale = null)
@@ -202,6 +207,7 @@ class Time extends DateTime
      * @param string|null              $locale
      *
      * @return Time
+     *
      * @throws Exception
      */
     public static function createFromDate(int $year = null, int $month = null, int $day = null, $timezone = null, string $locale = null)
@@ -221,6 +227,7 @@ class Time extends DateTime
      * @param string|null              $locale
      *
      * @return Time
+     *
      * @throws Exception
      */
     public static function createFromTime(int $hour = null, int $minutes = null, int $seconds = null, $timezone = null, string $locale = null)
@@ -243,6 +250,7 @@ class Time extends DateTime
      * @param string|null              $locale
      *
      * @return Time
+     *
      * @throws Exception
      */
     public static function create(int $year = null, int $month = null, int $day = null, int $hour = null, int $minutes = null, int $seconds = null, $timezone = null, string $locale = null)
@@ -268,6 +276,7 @@ class Time extends DateTime
      * @param DateTimeZone|string|null $timeZone
      *
      * @return Time
+     *
      * @throws Exception
      */
     public static function createFromFormat($format, $datetime, $timeZone = null)
@@ -289,6 +298,7 @@ class Time extends DateTime
      * @param string|null              $locale
      *
      * @return Time
+     *
      * @throws Exception
      */
     public static function createFromTimestamp(int $timestamp, $timezone = null, string $locale = null)
@@ -305,6 +315,7 @@ class Time extends DateTime
      * @param string|null       $locale
      *
      * @return Time
+     *
      * @throws Exception
      */
     public static function createFromInstance(DateTimeInterface $dateTime, string $locale = null)
@@ -324,6 +335,7 @@ class Time extends DateTime
      * @param string|null $locale
      *
      * @return Time
+     *
      * @throws Exception
      *
      * @deprecated         Use createFromInstance() instead
@@ -340,6 +352,7 @@ class Time extends DateTime
      * Converts the current instance to a mutable DateTime object.
      *
      * @return DateTime
+     *
      * @throws Exception
      */
     public function toDateTime()
@@ -404,6 +417,7 @@ class Time extends DateTime
      * Returns the localized Year
      *
      * @return string
+     *
      * @throws Exception
      */
     public function getYear(): string
@@ -417,6 +431,7 @@ class Time extends DateTime
      * Returns the localized Month
      *
      * @return string
+     *
      * @throws Exception
      */
     public function getMonth(): string
@@ -430,6 +445,7 @@ class Time extends DateTime
      * Return the localized day of the month.
      *
      * @return string
+     *
      * @throws Exception
      */
     public function getDay(): string
@@ -443,6 +459,7 @@ class Time extends DateTime
      * Return the localized hour (in 24-hour format).
      *
      * @return string
+     *
      * @throws Exception
      */
     public function getHour(): string
@@ -456,6 +473,7 @@ class Time extends DateTime
      * Return the localized minutes in the hour.
      *
      * @return string
+     *
      * @throws Exception
      */
     public function getMinute(): string
@@ -469,6 +487,7 @@ class Time extends DateTime
      * Return the localized seconds
      *
      * @return string
+     *
      * @throws Exception
      */
     public function getSecond(): string
@@ -482,6 +501,7 @@ class Time extends DateTime
      * Return the index of the day of the week
      *
      * @return string
+     *
      * @throws Exception
      */
     public function getDayOfWeek(): string
@@ -495,6 +515,7 @@ class Time extends DateTime
      * Return the index of the day of the year
      *
      * @return string
+     *
      * @throws Exception
      */
     public function getDayOfYear(): string
@@ -508,6 +529,7 @@ class Time extends DateTime
      * Return the index of the week in the month
      *
      * @return string
+     *
      * @throws Exception
      */
     public function getWeekOfMonth(): string
@@ -521,6 +543,7 @@ class Time extends DateTime
      * Return the index of the week in the year
      *
      * @return string
+     *
      * @throws Exception
      */
     public function getWeekOfYear(): string
@@ -534,6 +557,7 @@ class Time extends DateTime
      * Returns the age in years from the "current" date and 'now'
      *
      * @return int
+     *
      * @throws Exception
      */
     public function getAge()
@@ -551,6 +575,7 @@ class Time extends DateTime
      * Returns the number of the current quarter for the year.
      *
      * @return string
+     *
      * @throws Exception
      */
     public function getQuarter(): string
@@ -631,6 +656,7 @@ class Time extends DateTime
      * @param int|string $value
      *
      * @return Time
+     *
      * @throws Exception
      */
     public function setYear($value)
@@ -644,6 +670,7 @@ class Time extends DateTime
      * @param int|string $value
      *
      * @return Time
+     *
      * @throws Exception
      */
     public function setMonth($value)
@@ -665,6 +692,7 @@ class Time extends DateTime
      * @param int|string $value
      *
      * @return Time
+     *
      * @throws Exception
      */
     public function setDay($value)
@@ -688,6 +716,7 @@ class Time extends DateTime
      * @param int|string $value
      *
      * @return Time
+     *
      * @throws Exception
      */
     public function setHour($value)
@@ -705,6 +734,7 @@ class Time extends DateTime
      * @param int|string $value
      *
      * @return Time
+     *
      * @throws Exception
      */
     public function setMinute($value)
@@ -722,6 +752,7 @@ class Time extends DateTime
      * @param int|string $value
      *
      * @return Time
+     *
      * @throws Exception
      */
     public function setSecond($value)
@@ -740,6 +771,7 @@ class Time extends DateTime
      * @param int    $value
      *
      * @return Time
+     *
      * @throws Exception
      */
     protected function setValue(string $name, $value)
@@ -766,6 +798,7 @@ class Time extends DateTime
      * @param string|DateTimeZone $timezone
      *
      * @return Time
+     *
      * @throws Exception
      */
     public function setTimezone($timezone)
@@ -781,6 +814,7 @@ class Time extends DateTime
      * @param int $timestamp
      *
      * @return Time
+     *
      * @throws Exception
      */
     public function setTimestamp($timestamp)
@@ -982,6 +1016,7 @@ class Time extends DateTime
      * Returns a localized version of the date in Y-m-d format.
      *
      * @return string
+     *
      * @throws Exception
      */
     public function toDateString()
@@ -997,6 +1032,7 @@ class Time extends DateTime
      *  i.e. Apr 1, 2017
      *
      * @return string
+     *
      * @throws Exception
      */
     public function toFormattedDateString()
@@ -1012,6 +1048,7 @@ class Time extends DateTime
      *  i.e. 13:20:33
      *
      * @return string
+     *
      * @throws Exception
      */
     public function toTimeString()
@@ -1027,6 +1064,7 @@ class Time extends DateTime
      * @param string|null $format
      *
      * @return string|bool
+     *
      * @throws Exception
      */
     public function toLocalizedString(string $format = null)
@@ -1051,6 +1089,7 @@ class Time extends DateTime
      * @param string|null                   $timezone
      *
      * @return bool
+     *
      * @throws Exception
      */
     public function equals($testTime, string $timezone = null): bool
@@ -1073,6 +1112,7 @@ class Time extends DateTime
      * @param string|null                   $timezone
      *
      * @return bool
+     *
      * @throws Exception
      */
     public function sameAs($testTime, string $timezone = null): bool
@@ -1101,6 +1141,7 @@ class Time extends DateTime
      * @param string|null $timezone
      *
      * @return bool
+     *
      * @throws Exception
      */
     public function isBefore($testTime, string $timezone = null): bool
@@ -1121,6 +1162,7 @@ class Time extends DateTime
      * @param string|null $timezone
      *
      * @return bool
+     *
      * @throws Exception
      */
     public function isAfter($testTime, string $timezone = null): bool
@@ -1145,6 +1187,7 @@ class Time extends DateTime
      *  - 6 hours ago
      *
      * @return mixed
+     *
      * @throws Exception
      */
     public function humanize()
@@ -1197,6 +1240,7 @@ class Time extends DateTime
      * @param string|null $timezone
      *
      * @return TimeDifference
+     *
      * @throws Exception
      */
     public function difference($testTime, string $timezone = null)
@@ -1218,6 +1262,7 @@ class Time extends DateTime
      * @param string|null $timezone
      *
      * @return DateTime|static
+     *
      * @throws Exception
      */
     public function getUTCObject($time, string $timezone = null)
@@ -1247,6 +1292,7 @@ class Time extends DateTime
      * but available for public consumption if they need it.
      *
      * @return IntlCalendar
+     *
      * @throws Exception
      */
     public function getCalendar()
@@ -1279,6 +1325,7 @@ class Time extends DateTime
      * Outputs a short format version of the datetime.
      *
      * @return string
+     *
      * @throws Exception
      */
     public function __toString(): string

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -195,9 +195,9 @@ class Time extends DateTime
      * Returns a new instance based on the year, month and day. If any of those three
      * are left empty, will default to the current value.
      *
-     * @param integer|null             $year
-     * @param integer|null             $month
-     * @param integer|null             $day
+     * @param int|null             $year
+     * @param int|null             $month
+     * @param int|null             $day
      * @param DateTimeZone|string|null $timezone
      * @param string|null              $locale
      *
@@ -214,9 +214,9 @@ class Time extends DateTime
     /**
      * Returns a new instance with the date set to today, and the time set to the values passed in.
      *
-     * @param integer|null             $hour
-     * @param integer|null             $minutes
-     * @param integer|null             $seconds
+     * @param int|null             $hour
+     * @param int|null             $minutes
+     * @param int|null             $seconds
      * @param DateTimeZone|string|null $timezone
      * @param string|null              $locale
      *
@@ -233,12 +233,12 @@ class Time extends DateTime
     /**
      * Returns a new instance with the date time values individually set.
      *
-     * @param integer|null             $year
-     * @param integer|null             $month
-     * @param integer|null             $day
-     * @param integer|null             $hour
-     * @param integer|null             $minutes
-     * @param integer|null             $seconds
+     * @param int|null             $year
+     * @param int|null             $month
+     * @param int|null             $day
+     * @param int|null             $hour
+     * @param int|null             $minutes
+     * @param int|null             $seconds
      * @param DateTimeZone|string|null $timezone
      * @param string|null              $locale
      *
@@ -284,7 +284,7 @@ class Time extends DateTime
     /**
      * Returns a new instance with the datetime set based on the provided UNIX timestamp.
      *
-     * @param integer                  $timestamp
+     * @param int                  $timestamp
      * @param DateTimeZone|string|null $timezone
      * @param string|null              $locale
      *
@@ -388,7 +388,7 @@ class Time extends DateTime
     /**
      * Returns whether we have a testNow instance saved.
      *
-     * @return boolean
+     * @return bool
      */
     public static function hasTestNow(): bool
     {
@@ -533,7 +533,7 @@ class Time extends DateTime
     /**
      * Returns the age in years from the "current" date and 'now'
      *
-     * @return integer
+     * @return int
      * @throws Exception
      */
     public function getAge()
@@ -563,7 +563,7 @@ class Time extends DateTime
     /**
      * Are we in daylight savings time currently?
      *
-     * @return boolean
+     * @return bool
      */
     public function getDst(): bool
     {
@@ -590,7 +590,7 @@ class Time extends DateTime
      * Returns boolean whether the passed timezone is the same as
      * the local timezone.
      *
-     * @return boolean
+     * @return bool
      */
     public function getLocal(): bool
     {
@@ -604,7 +604,7 @@ class Time extends DateTime
     /**
      * Returns boolean whether object is in UTC.
      *
-     * @return boolean
+     * @return bool
      */
     public function getUtc(): bool
     {
@@ -628,7 +628,7 @@ class Time extends DateTime
     /**
      * Sets the current year for this instance.
      *
-     * @param integer|string $value
+     * @param int|string $value
      *
      * @return Time
      * @throws Exception
@@ -641,7 +641,7 @@ class Time extends DateTime
     /**
      * Sets the month of the year.
      *
-     * @param integer|string $value
+     * @param int|string $value
      *
      * @return Time
      * @throws Exception
@@ -662,7 +662,7 @@ class Time extends DateTime
     /**
      * Sets the day of the month.
      *
-     * @param integer|string $value
+     * @param int|string $value
      *
      * @return Time
      * @throws Exception
@@ -685,7 +685,7 @@ class Time extends DateTime
     /**
      * Sets the hour of the day (24 hour cycle)
      *
-     * @param integer|string $value
+     * @param int|string $value
      *
      * @return Time
      * @throws Exception
@@ -702,7 +702,7 @@ class Time extends DateTime
     /**
      * Sets the minute of the hour
      *
-     * @param integer|string $value
+     * @param int|string $value
      *
      * @return Time
      * @throws Exception
@@ -719,7 +719,7 @@ class Time extends DateTime
     /**
      * Sets the second of the minute.
      *
-     * @param integer|string $value
+     * @param int|string $value
      *
      * @return Time
      * @throws Exception
@@ -737,7 +737,7 @@ class Time extends DateTime
      * Helper method to do the heavy lifting of the 'setX' methods.
      *
      * @param string  $name
-     * @param integer $value
+     * @param int $value
      *
      * @return Time
      * @throws Exception
@@ -778,7 +778,7 @@ class Time extends DateTime
     /**
      * Returns a new instance with the date set to the new timestamp.
      *
-     * @param integer $timestamp
+     * @param int $timestamp
      *
      * @return Time
      * @throws Exception
@@ -797,7 +797,7 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $seconds added to the time.
      *
-     * @param integer $seconds
+     * @param int $seconds
      *
      * @return static
      */
@@ -811,7 +811,7 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $minutes added to the time.
      *
-     * @param integer $minutes
+     * @param int $minutes
      *
      * @return static
      */
@@ -825,7 +825,7 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $hours added to the time.
      *
-     * @param integer $hours
+     * @param int $hours
      *
      * @return static
      */
@@ -839,7 +839,7 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $days added to the time.
      *
-     * @param integer $days
+     * @param int $days
      *
      * @return static
      */
@@ -853,7 +853,7 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $months added to the time.
      *
-     * @param integer $months
+     * @param int $months
      *
      * @return static
      */
@@ -867,7 +867,7 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $years added to the time.
      *
-     * @param integer $years
+     * @param int $years
      *
      * @return static
      */
@@ -881,7 +881,7 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $seconds subtracted from the time.
      *
-     * @param integer $seconds
+     * @param int $seconds
      *
      * @return static
      */
@@ -895,7 +895,7 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $minutes subtracted from the time.
      *
-     * @param integer $minutes
+     * @param int $minutes
      *
      * @return static
      */
@@ -909,7 +909,7 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $hours subtracted from the time.
      *
-     * @param integer $hours
+     * @param int $hours
      *
      * @return static
      */
@@ -923,7 +923,7 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $days subtracted from the time.
      *
-     * @param integer $days
+     * @param int $days
      *
      * @return static
      */
@@ -937,7 +937,7 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $months subtracted from the time.
      *
-     * @param integer $months
+     * @param int $months
      *
      * @return static
      */
@@ -951,7 +951,7 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $hours subtracted from the time.
      *
-     * @param integer $years
+     * @param int $years
      *
      * @return static
      */
@@ -1026,7 +1026,7 @@ class Time extends DateTime
      *
      * @param string|null $format
      *
-     * @return string|boolean
+     * @return string|bool
      * @throws Exception
      */
     public function toLocalizedString(string $format = null)
@@ -1050,7 +1050,7 @@ class Time extends DateTime
      * @param Time|DateTimeInterface|string $testTime
      * @param string|null                   $timezone
      *
-     * @return boolean
+     * @return bool
      * @throws Exception
      */
     public function equals($testTime, string $timezone = null): bool
@@ -1072,7 +1072,7 @@ class Time extends DateTime
      * @param Time|DateTimeInterface|string $testTime
      * @param string|null                   $timezone
      *
-     * @return boolean
+     * @return bool
      * @throws Exception
      */
     public function sameAs($testTime, string $timezone = null): bool
@@ -1100,7 +1100,7 @@ class Time extends DateTime
      * @param mixed       $testTime
      * @param string|null $timezone
      *
-     * @return boolean
+     * @return bool
      * @throws Exception
      */
     public function isBefore($testTime, string $timezone = null): bool
@@ -1120,7 +1120,7 @@ class Time extends DateTime
      * @param mixed       $testTime
      * @param string|null $timezone
      *
-     * @return boolean
+     * @return bool
      * @throws Exception
      */
     public function isAfter($testTime, string $timezone = null): bool
@@ -1261,7 +1261,7 @@ class Time extends DateTime
      *
      * @param string $time
      *
-     * @return boolean
+     * @return bool
      */
     protected static function hasRelativeKeywords(string $time): bool
     {
@@ -1318,7 +1318,7 @@ class Time extends DateTime
      *
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function __isset($name): bool
     {

--- a/system/I18n/TimeDifference.php
+++ b/system/I18n/TimeDifference.php
@@ -57,42 +57,42 @@ class TimeDifference
     /**
      * Weeks.
      *
-     * @var integer
+     * @var int
      */
     protected $weeks = 0;
 
     /**
      * Days.
      *
-     * @var integer
+     * @var int
      */
     protected $days = 0;
 
     /**
      * Hours.
      *
-     * @var integer
+     * @var int
      */
     protected $hours = 0;
 
     /**
      * Minutes.
      *
-     * @var integer
+     * @var int
      */
     protected $minutes = 0;
 
     /**
      * Seconds.
      *
-     * @var integer
+     * @var int
      */
     protected $seconds = 0;
 
     /**
      * Difference in seconds.
      *
-     * @var integer
+     * @var int
      */
     protected $difference;
 
@@ -119,9 +119,9 @@ class TimeDifference
     /**
      * Returns the number of years of difference between the two.
      *
-     * @param boolean $raw
+     * @param bool $raw
      *
-     * @return float|integer
+     * @return float|int
      */
     public function getYears(bool $raw = false)
     {
@@ -137,9 +137,9 @@ class TimeDifference
     /**
      * Returns the number of months difference between the two dates.
      *
-     * @param boolean $raw
+     * @param bool $raw
      *
-     * @return float|integer
+     * @return float|int
      */
     public function getMonths(bool $raw = false)
     {
@@ -155,9 +155,9 @@ class TimeDifference
     /**
      * Returns the number of weeks difference between the two dates.
      *
-     * @param boolean $raw
+     * @param bool $raw
      *
-     * @return float|integer
+     * @return float|int
      */
     public function getWeeks(bool $raw = false)
     {
@@ -173,9 +173,9 @@ class TimeDifference
     /**
      * Returns the number of days difference between the two dates.
      *
-     * @param boolean $raw
+     * @param bool $raw
      *
-     * @return float|integer
+     * @return float|int
      */
     public function getDays(bool $raw = false)
     {
@@ -191,9 +191,9 @@ class TimeDifference
     /**
      * Returns the number of hours difference between the two dates.
      *
-     * @param boolean $raw
+     * @param bool $raw
      *
-     * @return float|integer
+     * @return float|int
      */
     public function getHours(bool $raw = false)
     {
@@ -209,9 +209,9 @@ class TimeDifference
     /**
      * Returns the number of minutes difference between the two dates.
      *
-     * @param boolean $raw
+     * @param bool $raw
      *
-     * @return float|integer
+     * @return float|int
      */
     public function getMinutes(bool $raw = false)
     {
@@ -227,9 +227,9 @@ class TimeDifference
     /**
      * Returns the number of seconds difference between the two dates.
      *
-     * @param boolean $raw
+     * @param bool $raw
      *
-     * @return integer
+     * @return int
      */
     public function getSeconds(bool $raw = false)
     {
@@ -313,7 +313,7 @@ class TimeDifference
      *
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function __isset($name)
     {

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -395,6 +395,7 @@ abstract class BaseHandler implements ImageHandlerInterface
      * @param int $blue
      *
      * @return $this
+     *
      * @internal
      */
     protected abstract function _flatten(int $red = 255, int $green = 255, int $blue = 255);

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -182,7 +182,8 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Verifies that a file has been supplied and it is an image.
      *
-     * @return Image  The image instance
+     * @return Image The image instance
+     *
      * @throws ImageException
      */
     protected function image(): Image
@@ -249,10 +250,10 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Resize the image
      *
-     * @param int $width
-     * @param int $height
-     * @param bool $maintainRatio If true, will get the closest match possible while keeping aspect ratio true.
-     * @param string  $masterDim
+     * @param int    $width
+     * @param int    $height
+     * @param bool   $maintainRatio If true, will get the closest match possible while keeping aspect ratio true.
+     * @param string $masterDim
      *
      * @return BaseHandler
      */
@@ -285,8 +286,8 @@ abstract class BaseHandler implements ImageHandlerInterface
      * @param int|null $height
      * @param int|null $x             X-axis coord to start cropping from the left of image
      * @param int|null $y             Y-axis coord to start cropping from the top of image
-     * @param bool      $maintainRatio
-     * @param string       $masterDim
+     * @param bool     $maintainRatio
+     * @param string   $masterDim
      *
      * @return $this
      */
@@ -393,7 +394,7 @@ abstract class BaseHandler implements ImageHandlerInterface
      * @param int $green
      * @param int $blue
      *
-     * @return   $this
+     * @return $this
      * @internal
      */
     protected abstract function _flatten(int $red = 255, int $green = 255, int $blue = 255);
@@ -577,7 +578,7 @@ abstract class BaseHandler implements ImageHandlerInterface
      * EXIF data is only supported fr JPEG & TIFF formats.
      *
      * @param string|null $key    If specified, will only return this piece of EXIF data.
-     * @param bool     $silent If true, will not throw our own exceptions.
+     * @param bool        $silent If true, will not throw our own exceptions.
      *
      * @throws ImageException
      *
@@ -623,9 +624,9 @@ abstract class BaseHandler implements ImageHandlerInterface
      *  - bottom
      *  - bottom-right
      *
-     * @param int $width
-     * @param int $height
-     * @param string  $position
+     * @param int    $width
+     * @param int    $height
+     * @param string $position
      *
      * @return BaseHandler
      */
@@ -701,7 +702,7 @@ abstract class BaseHandler implements ImageHandlerInterface
      * @param int|float $height
      * @param int|float $origWidth
      * @param int|float $origHeight
-     * @param string        $position
+     * @param string    $position
      *
      * @return array
      */
@@ -783,7 +784,7 @@ abstract class BaseHandler implements ImageHandlerInterface
      *          ->save($target);
      *
      * @param string|null $target
-     * @param int     $quality
+     * @param int         $quality
      *
      * @return bool
      */

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -39,42 +39,42 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Whether the image file has been confirmed.
      *
-     * @var boolean
+     * @var bool
      */
     protected $verified = false;
 
     /**
      * Image width.
      *
-     * @var integer
+     * @var int
      */
     protected $width = 0;
 
     /**
      * Image height.
      *
-     * @var integer
+     * @var int
      */
     protected $height = 0;
 
     /**
      * File permission mask.
      *
-     * @var integer
+     * @var int
      */
     protected $filePermissions = 0644;
 
     /**
      * X-axis.
      *
-     * @var integer|null
+     * @var int|null
      */
     protected $xAxis = 0;
 
     /**
      * Y-axis.
      *
-     * @var integer|null
+     * @var int|null
      */
     protected $yAxis = 0;
 
@@ -249,9 +249,9 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Resize the image
      *
-     * @param integer $width
-     * @param integer $height
-     * @param boolean $maintainRatio If true, will get the closest match possible while keeping aspect ratio true.
+     * @param int $width
+     * @param int $height
+     * @param bool $maintainRatio If true, will get the closest match possible while keeping aspect ratio true.
      * @param string  $masterDim
      *
      * @return BaseHandler
@@ -281,11 +281,11 @@ abstract class BaseHandler implements ImageHandlerInterface
      * is not provided, that value will be set the appropriate value based on offsets and
      * image dimensions.
      *
-     * @param integer|null $width
-     * @param integer|null $height
-     * @param integer|null $x             X-axis coord to start cropping from the left of image
-     * @param integer|null $y             Y-axis coord to start cropping from the top of image
-     * @param boolean      $maintainRatio
+     * @param int|null $width
+     * @param int|null $height
+     * @param int|null $x             X-axis coord to start cropping from the left of image
+     * @param int|null $y             Y-axis coord to start cropping from the top of image
+     * @param bool      $maintainRatio
      * @param string       $masterDim
      *
      * @return $this
@@ -316,7 +316,7 @@ abstract class BaseHandler implements ImageHandlerInterface
      * Changes the stored image type to indicate the new file format to use when saving.
      * Does not touch the actual resource.
      *
-     * @param integer $imageType A PHP imageType constant, e.g. https://www.php.net/manual/en/function.image-type-to-mime-type.php
+     * @param int $imageType A PHP imageType constant, e.g. https://www.php.net/manual/en/function.image-type-to-mime-type.php
      *
      * @return $this
      */
@@ -370,9 +370,9 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Flattens transparencies, default white background
      *
-     * @param integer $red
-     * @param integer $green
-     * @param integer $blue
+     * @param int $red
+     * @param int $green
+     * @param int $blue
      *
      * @return $this
      */
@@ -389,9 +389,9 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Handler-specific method to flattening an image's transparencies.
      *
-     * @param integer $red
-     * @param integer $green
-     * @param integer $blue
+     * @param int $red
+     * @param int $green
+     * @param int $blue
      *
      * @return   $this
      * @internal
@@ -403,7 +403,7 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Handler-specific method to handle rotating an image in 90 degree increments.
      *
-     * @param integer $angle
+     * @param int $angle
      *
      * @return mixed
      */
@@ -489,7 +489,7 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Handles the actual resizing of the image.
      *
-     * @param boolean $maintainRatio
+     * @param bool $maintainRatio
      *
      * @return $this
      */
@@ -509,7 +509,7 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Return image width.
      *
-     * @return integer
+     * @return int
      */
     public abstract function _getWidth();
 
@@ -518,7 +518,7 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Return the height of an image.
      *
-     * @return integer
+     * @return int
      */
     public abstract function _getHeight();
 
@@ -530,7 +530,7 @@ abstract class BaseHandler implements ImageHandlerInterface
      * with images taken by smartphones who always store the image up-right,
      * but set the orientation flag to display it correctly.
      *
-     * @param boolean $silent If true, will ignore exceptions when PHP doesn't support EXIF.
+     * @param bool $silent If true, will ignore exceptions when PHP doesn't support EXIF.
      *
      * @return $this
      */
@@ -577,7 +577,7 @@ abstract class BaseHandler implements ImageHandlerInterface
      * EXIF data is only supported fr JPEG & TIFF formats.
      *
      * @param string|null $key    If specified, will only return this piece of EXIF data.
-     * @param boolean     $silent If true, will not throw our own exceptions.
+     * @param bool     $silent If true, will not throw our own exceptions.
      *
      * @throws ImageException
      *
@@ -623,8 +623,8 @@ abstract class BaseHandler implements ImageHandlerInterface
      *  - bottom
      *  - bottom-right
      *
-     * @param integer $width
-     * @param integer $height
+     * @param int $width
+     * @param int $height
      * @param string  $position
      *
      * @return BaseHandler
@@ -651,10 +651,10 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Calculate image aspect ratio.
      *
-     * @param integer|float      $width
-     * @param integer|float|null $height
-     * @param integer|float      $origWidth
-     * @param integer|float      $origHeight
+     * @param int|float      $width
+     * @param int|float|null $height
+     * @param int|float      $origWidth
+     * @param int|float      $origHeight
      *
      * @return array
      */
@@ -697,10 +697,10 @@ abstract class BaseHandler implements ImageHandlerInterface
      * Based on the position, will determine the correct x/y coords to
      * crop the desired portion from the image.
      *
-     * @param integer|float $width
-     * @param integer|float $height
-     * @param integer|float $origWidth
-     * @param integer|float $origHeight
+     * @param int|float $width
+     * @param int|float $height
+     * @param int|float $origWidth
+     * @param int|float $origHeight
      * @param string        $position
      *
      * @return array
@@ -783,9 +783,9 @@ abstract class BaseHandler implements ImageHandlerInterface
      *          ->save($target);
      *
      * @param string|null $target
-     * @param integer     $quality
+     * @param int     $quality
      *
-     * @return boolean
+     * @return bool
      */
     public abstract function save(string $target = null, int $quality = 90);
 
@@ -868,7 +868,7 @@ abstract class BaseHandler implements ImageHandlerInterface
      *
      * accessor for testing; not part of interface
      *
-     * @return integer
+     * @return int
      */
     public function getWidth()
     {
@@ -880,7 +880,7 @@ abstract class BaseHandler implements ImageHandlerInterface
      *
      * accessor for testing; not part of interface
      *
-     * @return integer
+     * @return int
      */
     public function getHeight()
     {

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -43,9 +43,9 @@ class GDHandler extends BaseHandler
      * Handles the rotation of an image resource.
      * Doesn't save the image, but replaces the current resource.
      *
-     * @param integer $angle
+     * @param int $angle
      *
-     * @return boolean
+     * @return bool
      */
     protected function _rotate(int $angle): bool
     {
@@ -75,9 +75,9 @@ class GDHandler extends BaseHandler
     /**
      * Flattens transparencies
      *
-     * @param integer $red
-     * @param integer $green
-     * @param integer $blue
+     * @param int $red
+     * @param int $green
+     * @param int $blue
      *
      * @return $this
      */
@@ -236,9 +236,9 @@ class GDHandler extends BaseHandler
      *          ->save();
      *
      * @param string|null $target
-     * @param integer     $quality
+     * @param int     $quality
      *
-     * @return boolean
+     * @return bool
      */
     public function save(string $target = null, int $quality = 90): bool
     {
@@ -323,7 +323,7 @@ class GDHandler extends BaseHandler
      * @param string $path
      * @param string $imageType
      *
-     * @return resource|boolean
+     * @return resource|bool
      */
     protected function createImage(string $path = '', string $imageType = '')
     {
@@ -363,9 +363,9 @@ class GDHandler extends BaseHandler
      * Check if image type is supported and return image resource
      *
      * @param string  $path      Image path
-     * @param integer $imageType Image type
+     * @param int $imageType Image type
      *
-     * @return resource|boolean
+     * @return resource|bool
      * @throws ImageException
      */
     protected function getImageResource(string $path, int $imageType)
@@ -493,7 +493,7 @@ class GDHandler extends BaseHandler
      *
      * @param string  $text
      * @param array   $options
-     * @param boolean $isShadow Whether we are drawing the dropshadow or actual text
+     * @param bool $isShadow Whether we are drawing the dropshadow or actual text
      *
      * @return void
      */
@@ -540,7 +540,7 @@ class GDHandler extends BaseHandler
     /**
      * Return image width.
      *
-     * @return integer
+     * @return int
      */
     public function _getWidth()
     {
@@ -550,7 +550,7 @@ class GDHandler extends BaseHandler
     /**
      * Return image height.
      *
-     * @return integer
+     * @return int
      */
     public function _getHeight()
     {

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -22,7 +22,8 @@ class GDHandler extends BaseHandler
     /**
      * Constructor.
      *
-     * @param  Images|null $config
+     * @param Images|null $config
+     *
      * @throws ImageException
      */
     public function __construct($config = null)
@@ -236,7 +237,7 @@ class GDHandler extends BaseHandler
      *          ->save();
      *
      * @param string|null $target
-     * @param int     $quality
+     * @param int         $quality
      *
      * @return bool
      */
@@ -362,8 +363,8 @@ class GDHandler extends BaseHandler
     /**
      * Check if image type is supported and return image resource
      *
-     * @param string  $path      Image path
-     * @param int $imageType Image type
+     * @param string $path      Image path
+     * @param int    $imageType Image type
      *
      * @return resource|bool
      * @throws ImageException
@@ -491,9 +492,9 @@ class GDHandler extends BaseHandler
     /**
      * Handler-specific method for overlaying text on an image.
      *
-     * @param string  $text
-     * @param array   $options
-     * @param bool $isShadow Whether we are drawing the dropshadow or actual text
+     * @param string $text
+     * @param array  $options
+     * @param bool   $isShadow Whether we are drawing the dropshadow or actual text
      *
      * @return void
      */

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -367,6 +367,7 @@ class GDHandler extends BaseHandler
      * @param int    $imageType Image type
      *
      * @return resource|bool
+     *
      * @throws ImageException
      */
     protected function getImageResource(string $path, int $imageType)

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -41,7 +41,8 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Constructor.
      *
-     * @param  Images $config
+     * @param Images $config
+     *
      * @throws ImageException
      */
     public function __construct($config = null)
@@ -208,10 +209,10 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Handles all of the grunt work of resizing, etc.
      *
-     * @param string  $action
-     * @param int $quality
+     * @param string $action
+     * @param int    $quality
      *
-     * @return array  Lines of output from shell command
+     * @return array     Lines of output from shell command
      * @throws Exception
      */
     protected function process(string $action, int $quality = 100): array
@@ -259,7 +260,7 @@ class ImageMagickHandler extends BaseHandler
      *          ->save();
      *
      * @param string|null $target
-     * @param int     $quality
+     * @param int         $quality
      *
      * @return bool
      */

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -65,6 +65,7 @@ class ImageMagickHandler extends BaseHandler
      * @param bool $maintainRatio
      *
      * @return ImageMagickHandler
+     *
      * @throws Exception
      */
     public function _resize(bool $maintainRatio = false)
@@ -93,6 +94,7 @@ class ImageMagickHandler extends BaseHandler
      * Crops the image.
      *
      * @return bool|\CodeIgniter\Images\Handlers\ImageMagickHandler
+     *
      * @throws Exception
      */
     public function _crop()
@@ -121,6 +123,7 @@ class ImageMagickHandler extends BaseHandler
      * @param int $angle
      *
      * @return $this
+     *
      * @throws Exception
      */
     protected function _rotate(int $angle)
@@ -147,6 +150,7 @@ class ImageMagickHandler extends BaseHandler
      * @param int $blue
      *
      * @return $this
+     *
      * @throws Exception
      */
     public function _flatten(int $red = 255, int $green = 255, int $blue = 255)
@@ -171,6 +175,7 @@ class ImageMagickHandler extends BaseHandler
      * @param string $direction
      *
      * @return $this
+     *
      * @throws Exception
      */
     public function _flip(string $direction)
@@ -212,7 +217,8 @@ class ImageMagickHandler extends BaseHandler
      * @param string $action
      * @param int    $quality
      *
-     * @return array     Lines of output from shell command
+     * @return array Lines of output from shell command
+     *
      * @throws Exception
      */
     protected function process(string $action, int $quality = 100): array
@@ -310,6 +316,7 @@ class ImageMagickHandler extends BaseHandler
      * during the process, we'll use a PNG as the temp file type.
      *
      * @return string
+     *
      * @throws Exception
      */
     protected function getResourcePath()

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -61,7 +61,7 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Handles the actual resizing of the image.
      *
-     * @param boolean $maintainRatio
+     * @param bool $maintainRatio
      *
      * @return ImageMagickHandler
      * @throws Exception
@@ -91,7 +91,7 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Crops the image.
      *
-     * @return boolean|\CodeIgniter\Images\Handlers\ImageMagickHandler
+     * @return bool|\CodeIgniter\Images\Handlers\ImageMagickHandler
      * @throws Exception
      */
     public function _crop()
@@ -117,7 +117,7 @@ class ImageMagickHandler extends BaseHandler
      * Handles the rotation of an image resource.
      * Doesn't save the image, but replaces the current resource.
      *
-     * @param integer $angle
+     * @param int $angle
      *
      * @return $this
      * @throws Exception
@@ -141,9 +141,9 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Flattens transparencies, default white background
      *
-     * @param integer $red
-     * @param integer $green
-     * @param integer $blue
+     * @param int $red
+     * @param int $green
+     * @param int $blue
      *
      * @return $this
      * @throws Exception
@@ -209,7 +209,7 @@ class ImageMagickHandler extends BaseHandler
      * Handles all of the grunt work of resizing, etc.
      *
      * @param string  $action
-     * @param integer $quality
+     * @param int $quality
      *
      * @return array  Lines of output from shell command
      * @throws Exception
@@ -259,9 +259,9 @@ class ImageMagickHandler extends BaseHandler
      *          ->save();
      *
      * @param string|null $target
-     * @param integer     $quality
+     * @param int     $quality
      *
-     * @return boolean
+     * @return bool
      */
     public function save(string $target = null, int $quality = 90): bool
     {
@@ -457,7 +457,7 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Return the width of an image.
      *
-     * @return integer
+     * @return int
      */
     public function _getWidth()
     {
@@ -467,7 +467,7 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Return the height of an image.
      *
-     * @return integer
+     * @return int
      */
     public function _getHeight()
     {
@@ -482,7 +482,7 @@ class ImageMagickHandler extends BaseHandler
      * with images taken by smartphones who always store the image up-right,
      * but set the orientation flag to display it correctly.
      *
-     * @param boolean $silent If true, will ignore exceptions when PHP doesn't support EXIF.
+     * @param bool $silent If true, will ignore exceptions when PHP doesn't support EXIF.
      *
      * @return $this
      */

--- a/system/Images/Image.php
+++ b/system/Images/Image.php
@@ -22,14 +22,14 @@ class Image extends File
     /**
      * The original image width in pixels.
      *
-     * @var integer|float
+     * @var int|float
      */
     public $origWidth;
 
     /**
      * The original image height in pixels.
      *
-     * @var integer|float
+     * @var int|float
      */
     public $origHeight;
 
@@ -38,7 +38,7 @@ class Image extends File
      *
      * @see http://php.net/manual/en/image.constants.php
      *
-     * @var integer
+     * @var int
      */
     public $imageType;
 
@@ -63,9 +63,9 @@ class Image extends File
      *
      * @param string      $targetPath The directory to store the file in
      * @param string|null $targetName The new name of the copied file.
-     * @param integer     $perms      File permissions to be applied after copy.
+     * @param int     $perms      File permissions to be applied after copy.
      *
-     * @return boolean
+     * @return bool
      */
     public function copy(string $targetPath, string $targetName = null, int $perms = 0644): bool
     {
@@ -97,9 +97,9 @@ class Image extends File
      *
      * A helper function that gets info about the file
      *
-     * @param boolean $return
+     * @param bool $return
      *
-     * @return array|boolean
+     * @return array|bool
      */
     public function getProperties(bool $return = false)
     {

--- a/system/Images/Image.php
+++ b/system/Images/Image.php
@@ -63,7 +63,7 @@ class Image extends File
      *
      * @param string      $targetPath The directory to store the file in
      * @param string|null $targetName The new name of the copied file.
-     * @param int     $perms      File permissions to be applied after copy.
+     * @param int         $perms      File permissions to be applied after copy.
      *
      * @return bool
      */

--- a/system/Images/ImageHandlerInterface.php
+++ b/system/Images/ImageHandlerInterface.php
@@ -19,9 +19,9 @@ interface ImageHandlerInterface
     /**
      * Resize the image
      *
-     * @param integer $width
-     * @param integer $height
-     * @param boolean $maintainRatio If true, will get the closest match possible while keeping aspect ratio true.
+     * @param int $width
+     * @param int $height
+     * @param bool $maintainRatio If true, will get the closest match possible while keeping aspect ratio true.
      * @param string  $masterDim
      *
      * @return $this
@@ -35,11 +35,11 @@ interface ImageHandlerInterface
      * is not provided, that value will be set the appropriate value based on offsets and
      * image dimensions.
      *
-     * @param integer|null $width
-     * @param integer|null $height
-     * @param integer|null $x             X-axis coord to start cropping from the left of image
-     * @param integer|null $y             Y-axis coord to start cropping from the top of image
-     * @param boolean      $maintainRatio
+     * @param int|null $width
+     * @param int|null $height
+     * @param int|null $x             X-axis coord to start cropping from the left of image
+     * @param int|null $y             Y-axis coord to start cropping from the top of image
+     * @param bool      $maintainRatio
      * @param string       $masterDim
      *
      * @return $this
@@ -52,7 +52,7 @@ interface ImageHandlerInterface
      * Changes the stored image type to indicate the new file format to use when saving.
      * Does not touch the actual resource.
      *
-     * @param integer $imageType A PHP imagetype constant, e.g. https://www.php.net/manual/en/function.image-type-to-mime-type.php
+     * @param int $imageType A PHP imagetype constant, e.g. https://www.php.net/manual/en/function.image-type-to-mime-type.php
      *
      * @return $this
      */
@@ -74,9 +74,9 @@ interface ImageHandlerInterface
     /**
      * Flattens transparencies, default white background
      *
-     * @param integer $red
-     * @param integer $green
-     * @param integer $blue
+     * @param int $red
+     * @param int $green
+     * @param int $blue
      *
      * @return $this
      */
@@ -131,8 +131,8 @@ interface ImageHandlerInterface
      *  - bottom
      *  - bottom-right
      *
-     * @param integer $width
-     * @param integer $height
+     * @param int $width
+     * @param int $height
      * @param string  $position
      *
      * @return $this
@@ -173,9 +173,9 @@ interface ImageHandlerInterface
      *          ->save($target);
      *
      * @param string  $target
-     * @param integer $quality
+     * @param int $quality
      *
-     * @return boolean
+     * @return bool
      */
     public function save(string $target = null, int $quality = 90);
 }

--- a/system/Images/ImageHandlerInterface.php
+++ b/system/Images/ImageHandlerInterface.php
@@ -19,10 +19,10 @@ interface ImageHandlerInterface
     /**
      * Resize the image
      *
-     * @param int $width
-     * @param int $height
-     * @param bool $maintainRatio If true, will get the closest match possible while keeping aspect ratio true.
-     * @param string  $masterDim
+     * @param int    $width
+     * @param int    $height
+     * @param bool   $maintainRatio If true, will get the closest match possible while keeping aspect ratio true.
+     * @param string $masterDim
      *
      * @return $this
      */
@@ -39,8 +39,8 @@ interface ImageHandlerInterface
      * @param int|null $height
      * @param int|null $x             X-axis coord to start cropping from the left of image
      * @param int|null $y             Y-axis coord to start cropping from the top of image
-     * @param bool      $maintainRatio
-     * @param string       $masterDim
+     * @param bool     $maintainRatio
+     * @param string   $masterDim
      *
      * @return $this
      */
@@ -131,9 +131,9 @@ interface ImageHandlerInterface
      *  - bottom
      *  - bottom-right
      *
-     * @param int $width
-     * @param int $height
-     * @param string  $position
+     * @param int    $width
+     * @param int    $height
+     * @param string $position
      *
      * @return $this
      */
@@ -172,8 +172,8 @@ interface ImageHandlerInterface
      *    $image->resize(100, 200, true)
      *          ->save($target);
      *
-     * @param string  $target
-     * @param int $quality
+     * @param string $target
+     * @param int    $quality
      *
      * @return bool
      */

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -199,7 +199,7 @@ class Language
      * Advanced message formatting.
      *
      * @param string|array $message Message.
-     * @param array	       $args    Arguments.
+     * @param array        $args    Arguments.
      *
      * @return string|array Returns formatted message.
      */
@@ -227,9 +227,9 @@ class Language
      * will return the file's contents, otherwise will merge with
      * the existing language lines.
      *
-     * @param string  $file
-     * @param string  $locale
-     * @param bool $return
+     * @param string $file
+     * @param string $locale
+     * @param bool   $return
      *
      * @return void|array
      */

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -41,7 +41,7 @@ class Language
      * Boolean value whether the intl
      * libraries exist on the system.
      *
-     * @var boolean
+     * @var bool
      */
     protected $intlSupport = false;
 
@@ -229,7 +229,7 @@ class Language
      *
      * @param string  $file
      * @param string  $locale
-     * @param boolean $return
+     * @param bool $return
      *
      * @return void|array
      */

--- a/system/Log/Handlers/BaseHandler.php
+++ b/system/Log/Handlers/BaseHandler.php
@@ -50,7 +50,7 @@ abstract class BaseHandler implements HandlerInterface
      *
      * @param string $level
      *
-     * @return boolean
+     * @return bool
      */
     public function canHandle(string $level): bool
     {
@@ -68,7 +68,7 @@ abstract class BaseHandler implements HandlerInterface
      * @param string $level
      * @param string $message
      *
-     * @return boolean
+     * @return bool
      */
     abstract public function handle($level, $message): bool;
 

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -32,7 +32,7 @@ class ChromeLoggerHandler extends BaseHandler
     /**
      * The number of track frames returned from the backtrace.
      *
-     * @var integer
+     * @var int
      */
     protected $backtraceLevel = 0;
 
@@ -99,7 +99,7 @@ class ChromeLoggerHandler extends BaseHandler
      * @param string $level
      * @param string $message
      *
-     * @return boolean
+     * @return bool
      */
     public function handle($level, $message): bool
     {

--- a/system/Log/Handlers/ErrorlogHandler.php
+++ b/system/Log/Handlers/ErrorlogHandler.php
@@ -77,8 +77,8 @@ class ErrorlogHandler extends BaseHandler
     /**
      * Extracted call to `error_log()` in order to be tested.
      *
-     * @param string  $message
-     * @param int $messageType
+     * @param string $message
+     * @param int    $messageType
      *
      * @return bool
      *

--- a/system/Log/Handlers/ErrorlogHandler.php
+++ b/system/Log/Handlers/ErrorlogHandler.php
@@ -34,7 +34,7 @@ class ErrorlogHandler extends BaseHandler
      * Says where the error should go. Currently supported are
      * 0 (`TYPE_OS`) and 4 (`TYPE_SAPI`).
      *
-     * @var integer
+     * @var int
      */
     protected $messageType = 0;
 
@@ -65,7 +65,7 @@ class ErrorlogHandler extends BaseHandler
      * @param string $level
      * @param string $message
      *
-     * @return boolean
+     * @return bool
      */
     public function handle($level, $message): bool
     {
@@ -78,9 +78,9 @@ class ErrorlogHandler extends BaseHandler
      * Extracted call to `error_log()` in order to be tested.
      *
      * @param string  $message
-     * @param integer $messageType
+     * @param int $messageType
      *
-     * @return boolean
+     * @return bool
      *
      * @codeCoverageIgnore
      */

--- a/system/Log/Handlers/FileHandler.php
+++ b/system/Log/Handlers/FileHandler.php
@@ -36,7 +36,7 @@ class FileHandler extends BaseHandler
     /**
      * Permissions for new log files
      *
-     * @var integer
+     * @var int
      */
     protected $filePermissions;
 
@@ -70,7 +70,7 @@ class FileHandler extends BaseHandler
      * @param string $level
      * @param string $message
      *
-     * @return boolean
+     * @return bool
      * @throws Exception
      */
     public function handle($level, $message): bool

--- a/system/Log/Handlers/FileHandler.php
+++ b/system/Log/Handlers/FileHandler.php
@@ -71,6 +71,7 @@ class FileHandler extends BaseHandler
      * @param string $message
      *
      * @return bool
+     *
      * @throws Exception
      */
     public function handle($level, $message): bool

--- a/system/Log/Handlers/HandlerInterface.php
+++ b/system/Log/Handlers/HandlerInterface.php
@@ -25,7 +25,7 @@ interface HandlerInterface
      * @param string $level
      * @param string $message
      *
-     * @return boolean
+     * @return bool
      */
     public function handle($level, $message): bool;
 
@@ -37,7 +37,7 @@ interface HandlerInterface
      *
      * @param string $level
      *
-     * @return boolean
+     * @return bool
      */
     public function canHandle(string $level): bool;
 

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -114,8 +114,9 @@ class Logger implements LoggerInterface
     /**
      * Constructor.
      *
-     * @param  \Config\Logger   $config
-     * @param  bool             $debug
+     * @param \Config\Logger $config
+     * @param bool           $debug
+     *
      * @throws RuntimeException
      */
     public function __construct($config, bool $debug = CI_DEBUG)

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -60,7 +60,7 @@ class Logger implements LoggerInterface
     /**
      * File permissions
      *
-     * @var integer
+     * @var int
      */
     protected $filePermissions = 0644;
 
@@ -105,7 +105,7 @@ class Logger implements LoggerInterface
     /**
      * Should we cache our logged items?
      *
-     * @var boolean
+     * @var bool
      */
     protected $cacheLogs = false;
 
@@ -115,7 +115,7 @@ class Logger implements LoggerInterface
      * Constructor.
      *
      * @param  \Config\Logger $config
-     * @param  boolean        $debug
+     * @param  bool        $debug
      * @throws RuntimeException
      */
     public function __construct($config, bool $debug = CI_DEBUG)
@@ -159,7 +159,7 @@ class Logger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return boolean
+     * @return bool
      */
     public function emergency($message, array $context = []): bool
     {
@@ -177,7 +177,7 @@ class Logger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return boolean
+     * @return bool
      */
     public function alert($message, array $context = []): bool
     {
@@ -194,7 +194,7 @@ class Logger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return boolean
+     * @return bool
      */
     public function critical($message, array $context = []): bool
     {
@@ -210,7 +210,7 @@ class Logger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return boolean
+     * @return bool
      */
     public function error($message, array $context = []): bool
     {
@@ -228,7 +228,7 @@ class Logger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return boolean
+     * @return bool
      */
     public function warning($message, array $context = []): bool
     {
@@ -243,7 +243,7 @@ class Logger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return boolean
+     * @return bool
      */
     public function notice($message, array $context = []): bool
     {
@@ -260,7 +260,7 @@ class Logger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return boolean
+     * @return bool
      */
     public function info($message, array $context = []): bool
     {
@@ -275,7 +275,7 @@ class Logger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return boolean
+     * @return bool
      */
     public function debug($message, array $context = []): bool
     {
@@ -291,7 +291,7 @@ class Logger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return boolean
+     * @return bool
      */
     public function log($level, $message, array $context = []): bool
     {

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -114,8 +114,8 @@ class Logger implements LoggerInterface
     /**
      * Constructor.
      *
-     * @param  \Config\Logger $config
-     * @param  bool        $debug
+     * @param  \Config\Logger   $config
+     * @param  bool             $debug
      * @throws RuntimeException
      */
     public function __construct($config, bool $debug = CI_DEBUG)

--- a/system/Model.php
+++ b/system/Model.php
@@ -62,7 +62,7 @@ class Model extends BaseModel
     /**
      * Whether primary key uses auto increment.
      *
-     * @var boolean
+     * @var bool
      */
     protected $useAutoIncrement = true;
 
@@ -127,8 +127,8 @@ class Model extends BaseModel
      * matching $id. This methods works only with dbCalls
      * This methods works only with dbCalls
      *
-     * @param boolean                   $singleton Single or multiple results
-     * @param array|integer|string|null $id        One primary key or an array of primary keys
+     * @param bool                   $singleton Single or multiple results
+     * @param array|int|string|null $id        One primary key or an array of primary keys
      *
      * @return array|object|null    The resulting row of data, or null.
      */
@@ -173,8 +173,8 @@ class Model extends BaseModel
      * all results, while optionally limiting them.
      * This methods works only with dbCalls
      *
-     * @param integer $limit  Limit
-     * @param integer $offset Offset
+     * @param int $limit  Limit
+     * @param int $offset Offset
      *
      * @return array
      */
@@ -223,7 +223,7 @@ class Model extends BaseModel
      *
      * @param array $data Data
      *
-     * @return Query|boolean
+     * @return Query|bool
      */
     protected function doInsert(array $data)
     {
@@ -258,11 +258,11 @@ class Model extends BaseModel
      * This methods works only with dbCalls
      *
      * @param array|null   $set       An associative array of insert values
-     * @param boolean|null $escape    Whether to escape values and identifiers
-     * @param integer      $batchSize The size of the batch to run
-     * @param boolean      $testing   True means only number of records is returned, false will execute the query
+     * @param bool|null $escape    Whether to escape values and identifiers
+     * @param int      $batchSize The size of the batch to run
+     * @param bool      $testing   True means only number of records is returned, false will execute the query
      *
-     * @return integer|boolean Number of rows inserted or FALSE on failure
+     * @return int|bool Number of rows inserted or FALSE on failure
      */
     protected function doInsertBatch(?array $set = null, ?bool $escape = null, int $batchSize = 100, bool $testing = false)
     {
@@ -283,10 +283,10 @@ class Model extends BaseModel
      * Updates a single record in $this->table.
      * This methods works only with dbCalls
      *
-     * @param integer|array|string|null $id   ID
+     * @param int|array|string|null $id   ID
      * @param array|null                $data Data
      *
-     * @return boolean
+     * @return bool
      */
     protected function doUpdate($id = null, $data = null): bool
     {
@@ -313,8 +313,8 @@ class Model extends BaseModel
      *
      * @param array|null  $set       An associative array of update values
      * @param string|null $index     The where key
-     * @param integer     $batchSize The size of the batch to run
-     * @param boolean     $returnSQL True means SQL is returned, false will execute the query
+     * @param int     $batchSize The size of the batch to run
+     * @param bool     $returnSQL True means SQL is returned, false will execute the query
      *
      * @return mixed    Number of rows affected or FALSE on failure
      *
@@ -330,10 +330,10 @@ class Model extends BaseModel
      * the table's primaryKey
      * This methods works only with dbCalls
      *
-     * @param integer|string|array|null $id    The rows primary key(s)
-     * @param boolean                   $purge Allows overriding the soft deletes setting.
+     * @param int|string|array|null $id    The rows primary key(s)
+     * @param bool                   $purge Allows overriding the soft deletes setting.
      *
-     * @return string|boolean
+     * @return string|bool
      *
      * @throws DatabaseException
      */
@@ -373,7 +373,7 @@ class Model extends BaseModel
      * through soft deletes (deleted = 1)
      * This methods works only with dbCalls
      *
-     * @return boolean|mixed
+     * @return bool|mixed
      */
     protected function doPurgeDeleted()
     {
@@ -399,7 +399,7 @@ class Model extends BaseModel
      * This methods works only with dbCalls
      *
      * @param array|null $data      Data
-     * @param boolean    $returnSQL Set to true to return Query String
+     * @param bool    $returnSQL Set to true to return Query String
      *
      * @return mixed
      */
@@ -433,7 +433,7 @@ class Model extends BaseModel
      *
      * @param array|object $data Data
      *
-     * @return integer|array|string|null
+     * @return int|array|string|null
      *
      * @deprecated Use getIdValue() instead. Will be removed in version 5.0.
      */
@@ -447,7 +447,7 @@ class Model extends BaseModel
      *
      * @param array|object $data Data
      *
-     * @return integer|array|string|null
+     * @return int|array|string|null
      */
     public function getIdValue($data)
     {
@@ -468,7 +468,7 @@ class Model extends BaseModel
      * determine the rows to operate on.
      * This methods works only with dbCalls
      *
-     * @param integer $size     Size
+     * @param int $size     Size
      * @param Closure $userFunc Callback Function
      *
      * @return void
@@ -507,8 +507,8 @@ class Model extends BaseModel
     /**
      * Override countAllResults to account for soft deleted accounts.
      *
-     * @param boolean $reset Reset
-     * @param boolean $test  Test
+     * @param bool $reset Reset
+     * @param bool $test  Test
      *
      * @return mixed
      */
@@ -579,7 +579,7 @@ class Model extends BaseModel
      *
      * @param mixed        $key    Field name, or an array of field/value pairs
      * @param string|null  $value  Field value, if $key is a single field
-     * @param boolean|null $escape Whether to escape values and identifiers
+     * @param bool|null $escape Whether to escape values and identifiers
      *
      * @return $this
      */
@@ -602,7 +602,7 @@ class Model extends BaseModel
      *
      * @param array|object $data Data
      *
-     * @return boolean
+     * @return bool
      */
     protected function shouldUpdate($data) : bool
     {
@@ -620,9 +620,9 @@ class Model extends BaseModel
      * it will attempt to convert it to an array.
      *
      * @param array|object|null $data     Data
-     * @param boolean           $returnID Whether insert ID should be returned or not.
+     * @param bool           $returnID Whether insert ID should be returned or not.
      *
-     * @return BaseResult|object|integer|string|false
+     * @return BaseResult|object|int|string|false
      *
      * @throws ReflectionException
      */
@@ -647,10 +647,10 @@ class Model extends BaseModel
      * Updates a single record in the database. If an object is provided,
      * it will attempt to convert it into an array.
      *
-     * @param integer|array|string|null $id   ID
+     * @param int|array|string|null $id   ID
      * @param array|object|null         $data Data
      *
-     * @return boolean
+     * @return bool
      *
      * @throws ReflectionException
      */
@@ -676,8 +676,8 @@ class Model extends BaseModel
      * properties as an array with raw values.
      *
      * @param string|object $data        Data
-     * @param boolean       $onlyChanged Only Changed Property
-     * @param boolean       $recursive   If true, inner entities will be casted as array as well
+     * @param bool       $onlyChanged Only Changed Property
+     * @param bool       $recursive   If true, inner entities will be casted as array as well
      *
      * @return array|null Array
      *
@@ -713,7 +713,7 @@ class Model extends BaseModel
      *
      * @param string $name Name
      *
-     * @return boolean
+     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -765,7 +765,7 @@ class Model extends BaseModel
      * @param string|object $data        Data
      * @param string|null   $primaryKey  Primary Key
      * @param string        $dateFormat  Date Format
-     * @param boolean       $onlyChanged Only Changed
+     * @param bool       $onlyChanged Only Changed
      *
      * @return array
      *

--- a/system/Model.php
+++ b/system/Model.php
@@ -127,10 +127,10 @@ class Model extends BaseModel
      * matching $id. This methods works only with dbCalls
      * This methods works only with dbCalls
      *
-     * @param bool                   $singleton Single or multiple results
+     * @param bool                  $singleton Single or multiple results
      * @param array|int|string|null $id        One primary key or an array of primary keys
      *
-     * @return array|object|null    The resulting row of data, or null.
+     * @return array|object|null The resulting row of data, or null.
      */
     protected function doFind(bool $singleton, $id = null)
     {
@@ -257,10 +257,10 @@ class Model extends BaseModel
      * Compiles batch insert strings and runs the queries, validating each row prior.
      * This methods works only with dbCalls
      *
-     * @param array|null   $set       An associative array of insert values
-     * @param bool|null $escape    Whether to escape values and identifiers
-     * @param int      $batchSize The size of the batch to run
-     * @param bool      $testing   True means only number of records is returned, false will execute the query
+     * @param array|null $set       An associative array of insert values
+     * @param bool|null  $escape    Whether to escape values and identifiers
+     * @param int        $batchSize The size of the batch to run
+     * @param bool       $testing   True means only number of records is returned, false will execute the query
      *
      * @return int|bool Number of rows inserted or FALSE on failure
      */
@@ -284,7 +284,7 @@ class Model extends BaseModel
      * This methods works only with dbCalls
      *
      * @param int|array|string|null $id   ID
-     * @param array|null                $data Data
+     * @param array|null            $data Data
      *
      * @return bool
      */
@@ -313,10 +313,10 @@ class Model extends BaseModel
      *
      * @param array|null  $set       An associative array of update values
      * @param string|null $index     The where key
-     * @param int     $batchSize The size of the batch to run
-     * @param bool     $returnSQL True means SQL is returned, false will execute the query
+     * @param int         $batchSize The size of the batch to run
+     * @param bool        $returnSQL True means SQL is returned, false will execute the query
      *
-     * @return mixed    Number of rows affected or FALSE on failure
+     * @return mixed Number of rows affected or FALSE on failure
      *
      * @throws DatabaseException
      */
@@ -331,7 +331,7 @@ class Model extends BaseModel
      * This methods works only with dbCalls
      *
      * @param int|string|array|null $id    The rows primary key(s)
-     * @param bool                   $purge Allows overriding the soft deletes setting.
+     * @param bool                  $purge Allows overriding the soft deletes setting.
      *
      * @return string|bool
      *
@@ -399,7 +399,7 @@ class Model extends BaseModel
      * This methods works only with dbCalls
      *
      * @param array|null $data      Data
-     * @param bool    $returnSQL Set to true to return Query String
+     * @param bool       $returnSQL Set to true to return Query String
      *
      * @return mixed
      */
@@ -468,7 +468,7 @@ class Model extends BaseModel
      * determine the rows to operate on.
      * This methods works only with dbCalls
      *
-     * @param int $size     Size
+     * @param int     $size     Size
      * @param Closure $userFunc Callback Function
      *
      * @return void
@@ -577,9 +577,9 @@ class Model extends BaseModel
      * data here. This allows it to be used with any of the other
      * builder methods and still get validated data, like replace.
      *
-     * @param mixed        $key    Field name, or an array of field/value pairs
-     * @param string|null  $value  Field value, if $key is a single field
-     * @param bool|null $escape Whether to escape values and identifiers
+     * @param mixed       $key    Field name, or an array of field/value pairs
+     * @param string|null $value  Field value, if $key is a single field
+     * @param bool|null   $escape Whether to escape values and identifiers
      *
      * @return $this
      */
@@ -620,7 +620,7 @@ class Model extends BaseModel
      * it will attempt to convert it to an array.
      *
      * @param array|object|null $data     Data
-     * @param bool           $returnID Whether insert ID should be returned or not.
+     * @param bool              $returnID Whether insert ID should be returned or not.
      *
      * @return BaseResult|object|int|string|false
      *
@@ -648,7 +648,7 @@ class Model extends BaseModel
      * it will attempt to convert it into an array.
      *
      * @param int|array|string|null $id   ID
-     * @param array|object|null         $data Data
+     * @param array|object|null     $data Data
      *
      * @return bool
      *
@@ -676,8 +676,8 @@ class Model extends BaseModel
      * properties as an array with raw values.
      *
      * @param string|object $data        Data
-     * @param bool       $onlyChanged Only Changed Property
-     * @param bool       $recursive   If true, inner entities will be casted as array as well
+     * @param bool          $onlyChanged Only Changed Property
+     * @param bool          $recursive   If true, inner entities will be casted as array as well
      *
      * @return array|null Array
      *
@@ -765,7 +765,7 @@ class Model extends BaseModel
      * @param string|object $data        Data
      * @param string|null   $primaryKey  Primary Key
      * @param string        $dateFormat  Date Format
-     * @param bool       $onlyChanged Only Changed
+     * @param bool          $onlyChanged Only Changed
      *
      * @return array
      *

--- a/system/Model.php
+++ b/system/Model.php
@@ -41,6 +41,7 @@ use ReflectionProperty;
  *      - removes the need to use Result object directly in most cases
  *
  * @mixin    BaseBuilder
+ *
  * @property BaseConnection $db
  */
 class Model extends BaseModel
@@ -534,6 +535,7 @@ class Model extends BaseModel
      * @param string|null $table Table name
      *
      * @return BaseBuilder
+     *
      * @throws ModelException
      */
     public function builder(?string $table = null)

--- a/system/Modules/Modules.php
+++ b/system/Modules/Modules.php
@@ -21,14 +21,14 @@ class Modules
     /**
      * Auto-Discover
      *
-     * @var boolean
+     * @var bool
      */
     public $enabled = true;
 
     /**
      * Auto-Discovery Within Composer Packages
      *
-     * @var boolean
+     * @var bool
      */
     public $discoverInComposer = true;
 
@@ -44,7 +44,7 @@ class Modules
      *
      * @param string $alias
      *
-     * @return boolean
+     * @return bool
      */
     public function shouldDiscover(string $alias): bool
     {

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -116,12 +116,12 @@ class Pager implements PagerInterface
      * Allows for a simple, manual, form of pagination where all of the data
      * is provided by the user. The URL is the current URI.
      *
-     * @param int      $page
-     * @param int|null $perPage
-     * @param int      $total
-     * @param string       $template The output template alias to render.
-     * @param int      $segment  (whether page number is provided by URI segment)
-     * @param string|null  $group    optional group (i.e. if we'd like to define custom path)
+     * @param int         $page
+     * @param int|null    $perPage
+     * @param int         $total
+     * @param string      $template The output template alias to render.
+     * @param int         $segment  (whether page number is provided by URI segment)
+     * @param string|null $group    optional group (i.e. if we'd like to define custom path)
      *
      * @return string
      */
@@ -162,7 +162,7 @@ class Pager implements PagerInterface
      * Stores a set of pagination data for later display. Most commonly used
      * by the model to automate the process.
      *
-     * @param string       $group
+     * @param string   $group
      * @param int      $page
      * @param int|null $perPage
      * @param int      $total
@@ -198,8 +198,8 @@ class Pager implements PagerInterface
     /**
      * Sets segment for a group.
      *
-     * @param int $number
-     * @param string  $group
+     * @param int    $number
+     * @param string $group
      *
      * @return mixed
      */
@@ -335,8 +335,8 @@ class Pager implements PagerInterface
      * Returns the URI for a specific page for the specified group.
      *
      * @param int|null $page
-     * @param string       $group
-     * @param bool      $returnObject
+     * @param string   $group
+     * @param bool     $returnObject
      *
      * @return string|URI
      */
@@ -375,8 +375,8 @@ class Pager implements PagerInterface
     /**
      * Returns the full URI to the next page of results, or null.
      *
-     * @param string  $group
-     * @param bool $returnObject
+     * @param string $group
+     * @param bool   $returnObject
      *
      * @return string|null
      */
@@ -404,8 +404,8 @@ class Pager implements PagerInterface
     /**
      * Returns the full URL to the previous page of results, or null.
      *
-     * @param string  $group
-     * @param bool $returnObject
+     * @param string $group
+     * @param bool   $returnObject
      *
      * @return string|null
      */
@@ -492,8 +492,8 @@ class Pager implements PagerInterface
     /**
      * Ensures that an array exists for the group specified.
      *
-     * @param string  $group
-     * @param int $perPage
+     * @param string $group
+     * @param int    $perPage
      */
     protected function ensureGroup(string $group, int $perPage = null)
     {

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -116,11 +116,11 @@ class Pager implements PagerInterface
      * Allows for a simple, manual, form of pagination where all of the data
      * is provided by the user. The URL is the current URI.
      *
-     * @param integer      $page
-     * @param integer|null $perPage
-     * @param integer      $total
+     * @param int      $page
+     * @param int|null $perPage
+     * @param int      $total
      * @param string       $template The output template alias to render.
-     * @param integer      $segment  (whether page number is provided by URI segment)
+     * @param int      $segment  (whether page number is provided by URI segment)
      * @param string|null  $group    optional group (i.e. if we'd like to define custom path)
      *
      * @return string
@@ -163,10 +163,10 @@ class Pager implements PagerInterface
      * by the model to automate the process.
      *
      * @param string       $group
-     * @param integer      $page
-     * @param integer|null $perPage
-     * @param integer      $total
-     * @param integer      $segment
+     * @param int      $page
+     * @param int|null $perPage
+     * @param int      $total
+     * @param int      $segment
      *
      * @return $this
      */
@@ -198,7 +198,7 @@ class Pager implements PagerInterface
     /**
      * Sets segment for a group.
      *
-     * @param integer $number
+     * @param int $number
      * @param string  $group
      *
      * @return mixed
@@ -236,7 +236,7 @@ class Pager implements PagerInterface
      *
      * @param string $group
      *
-     * @return integer
+     * @return int
      */
     public function getTotal(string $group = 'default'): int
     {
@@ -252,7 +252,7 @@ class Pager implements PagerInterface
      *
      * @param string $group
      *
-     * @return integer
+     * @return int
      */
     public function getPageCount(string $group = 'default'): int
     {
@@ -268,7 +268,7 @@ class Pager implements PagerInterface
      *
      * @param string $group
      *
-     * @return integer
+     * @return int
      */
     public function getCurrentPage(string $group = 'default'): int
     {
@@ -284,7 +284,7 @@ class Pager implements PagerInterface
      *
      * @param string $group
      *
-     * @return boolean
+     * @return bool
      */
     public function hasMore(string $group = 'default'): bool
     {
@@ -300,7 +300,7 @@ class Pager implements PagerInterface
      *
      * @param string $group
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getLastPage(string $group = 'default')
     {
@@ -320,7 +320,7 @@ class Pager implements PagerInterface
      *
      * @param string $group
      *
-     * @return integer
+     * @return int
      */
     public function getFirstPage(string $group = 'default'): int
     {
@@ -334,9 +334,9 @@ class Pager implements PagerInterface
     /**
      * Returns the URI for a specific page for the specified group.
      *
-     * @param integer|null $page
+     * @param int|null $page
      * @param string       $group
-     * @param boolean      $returnObject
+     * @param bool      $returnObject
      *
      * @return string|URI
      */
@@ -376,7 +376,7 @@ class Pager implements PagerInterface
      * Returns the full URI to the next page of results, or null.
      *
      * @param string  $group
-     * @param boolean $returnObject
+     * @param bool $returnObject
      *
      * @return string|null
      */
@@ -405,7 +405,7 @@ class Pager implements PagerInterface
      * Returns the full URL to the previous page of results, or null.
      *
      * @param string  $group
-     * @param boolean $returnObject
+     * @param bool $returnObject
      *
      * @return string|null
      */
@@ -435,7 +435,7 @@ class Pager implements PagerInterface
      *
      * @param string $group
      *
-     * @return integer
+     * @return int
      */
     public function getPerPage(string $group = 'default'): int
     {
@@ -493,7 +493,7 @@ class Pager implements PagerInterface
      * Ensures that an array exists for the group specified.
      *
      * @param string  $group
-     * @param integer $perPage
+     * @param int $perPage
      */
     protected function ensureGroup(string $group, int $perPage = null)
     {

--- a/system/Pager/PagerInterface.php
+++ b/system/Pager/PagerInterface.php
@@ -46,9 +46,9 @@ interface PagerInterface
      * Allows for a simple, manual, form of pagination where all of the data
      * is provided by the user. The URL is the current URI.
      *
-     * @param integer $page
-     * @param integer $perPage
-     * @param integer $total
+     * @param int $page
+     * @param int $perPage
+     * @param int $total
      * @param string  $template The output template alias to render.
      *
      * @return string
@@ -62,9 +62,9 @@ interface PagerInterface
      * by the model to automate the process.
      *
      * @param string  $group
-     * @param integer $page
-     * @param integer $perPage
-     * @param integer $total
+     * @param int $page
+     * @param int $perPage
+     * @param int $total
      *
      * @return mixed
      */
@@ -89,7 +89,7 @@ interface PagerInterface
      *
      * @param string $group
      *
-     * @return integer
+     * @return int
      */
     public function getPageCount(string $group = 'default'): int;
 
@@ -100,7 +100,7 @@ interface PagerInterface
      *
      * @param string $group
      *
-     * @return integer
+     * @return int
      */
     public function getCurrentPage(string $group = 'default'): int;
 
@@ -108,9 +108,9 @@ interface PagerInterface
     /**
      * Returns the URI for a specific page for the specified group.
      *
-     * @param integer|null $page
+     * @param int|null $page
      * @param string       $group
-     * @param boolean      $returnObject
+     * @param bool      $returnObject
      *
      * @return string|URI
      */
@@ -123,7 +123,7 @@ interface PagerInterface
      *
      * @param string $group
      *
-     * @return boolean
+     * @return bool
      */
     public function hasMore(string $group = 'default'): bool;
 
@@ -134,7 +134,7 @@ interface PagerInterface
      *
      * @param string $group
      *
-     * @return integer
+     * @return int
      */
     public function getFirstPage(string $group = 'default');
 
@@ -145,7 +145,7 @@ interface PagerInterface
      *
      * @param string $group
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getLastPage(string $group = 'default');
 
@@ -178,7 +178,7 @@ interface PagerInterface
      *
      * @param string $group
      *
-     * @return integer
+     * @return int
      */
     public function getPerPage(string $group = 'default'): int;
 

--- a/system/Pager/PagerInterface.php
+++ b/system/Pager/PagerInterface.php
@@ -46,10 +46,10 @@ interface PagerInterface
      * Allows for a simple, manual, form of pagination where all of the data
      * is provided by the user. The URL is the current URI.
      *
-     * @param int $page
-     * @param int $perPage
-     * @param int $total
-     * @param string  $template The output template alias to render.
+     * @param int    $page
+     * @param int    $perPage
+     * @param int    $total
+     * @param string $template The output template alias to render.
      *
      * @return string
      */
@@ -61,10 +61,10 @@ interface PagerInterface
      * Stores a set of pagination data for later display. Most commonly used
      * by the model to automate the process.
      *
-     * @param string  $group
-     * @param int $page
-     * @param int $perPage
-     * @param int $total
+     * @param string $group
+     * @param int    $page
+     * @param int    $perPage
+     * @param int    $total
      *
      * @return mixed
      */
@@ -109,8 +109,8 @@ interface PagerInterface
      * Returns the URI for a specific page for the specified group.
      *
      * @param int|null $page
-     * @param string       $group
-     * @param bool      $returnObject
+     * @param string   $group
+     * @param bool     $returnObject
      *
      * @return string|URI
      */

--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -25,35 +25,35 @@ class PagerRenderer
     /**
      * First page number.
      *
-     * @var integer
+     * @var int
      */
     protected $first;
 
     /**
      * Last page number.
      *
-     * @var integer
+     * @var int
      */
     protected $last;
 
     /**
      * Current page number.
      *
-     * @var integer
+     * @var int
      */
     protected $current;
 
     /**
      * Total number of items.
      *
-     * @var integer
+     * @var int
      */
     protected $total;
 
     /**
      * Total number of pages.
      *
-     * @var integer
+     * @var int
      */
     protected $pageCount;
 
@@ -67,7 +67,7 @@ class PagerRenderer
     /**
      * Segment number used for pagination.
      *
-     * @var integer
+     * @var int
      */
     protected $segment;
 
@@ -104,7 +104,7 @@ class PagerRenderer
      * side of the current page. Adjusts the first and last counts
      * to reflect it.
      *
-     * @param integer|null $count
+     * @param int|null $count
      *
      * @return PagerRenderer
      */
@@ -120,7 +120,7 @@ class PagerRenderer
     /**
      * Checks to see if there is a "previous" page before our "first" page.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasPrevious(): bool
     {
@@ -160,7 +160,7 @@ class PagerRenderer
     /**
      * Checks to see if there is a "next" page after our "last" page.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasNext(): bool
     {
@@ -290,7 +290,7 @@ class PagerRenderer
      * which is the number of links surrounding the active page
      * to show.
      *
-     * @param integer|null $count The new "surroundCount"
+     * @param int|null $count The new "surroundCount"
      */
     protected function updatePages(int $count = null)
     {
@@ -307,7 +307,7 @@ class PagerRenderer
     /**
      * Checks to see if there is a "previous" page before our "first" page.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasPreviousPage(): bool
     {
@@ -345,7 +345,7 @@ class PagerRenderer
     /**
      * Checks to see if there is a "next" page after our "last" page.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasNextPage(): bool
     {
@@ -381,7 +381,7 @@ class PagerRenderer
     /**
      * Returns the page number of the first page.
      *
-     * @return integer
+     * @return int
      */
     public function getFirstPageNumber(): int
     {
@@ -391,7 +391,7 @@ class PagerRenderer
     /**
      * Returns the page number of the current page.
      *
-     * @return integer
+     * @return int
      */
     public function getCurrentPageNumber(): int
     {
@@ -401,7 +401,7 @@ class PagerRenderer
     /**
      * Returns the page number of the last page.
      *
-     * @return integer
+     * @return int
      */
     public function getLastPageNumber(): int
     {
@@ -411,7 +411,7 @@ class PagerRenderer
     /**
      * Returns total number of pages.
      *
-     * @return integer
+     * @return int
      */
     public function getPageCount(): int
     {
@@ -421,7 +421,7 @@ class PagerRenderer
     /**
      * Returns the previous page number.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getPreviousPageNumber(): ?int
     {
@@ -431,7 +431,7 @@ class PagerRenderer
     /**
      * Returns the next page number.
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getNextPageNumber(): ?int
     {

--- a/system/Router/Exceptions/RedirectException.php
+++ b/system/Router/Exceptions/RedirectException.php
@@ -21,7 +21,7 @@ class RedirectException extends Exception
     /**
      * Status code for redirects
      *
-     * @var integer
+     * @var int
      */
     protected $code = 302;
 }

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1253,6 +1253,7 @@ class RouteCollection implements RouteCollectionInterface
      * @param array|null $params
      *
      * @return string
+     *
      * @throws RouterException
      */
     protected function fillRouteParams(string $from, array $params = null): string

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -66,7 +66,7 @@ class RouteCollection implements RouteCollectionInterface
      *
      * Not used here. Pass-thru value for Router class.
      *
-     * @var boolean
+     * @var bool
      */
     protected $translateURIDashes = false;
 
@@ -76,7 +76,7 @@ class RouteCollection implements RouteCollectionInterface
      *
      * Not used here. Pass-thru value for Router class.
      *
-     * @var boolean
+     * @var bool
      */
     protected $autoRoute = true;
 
@@ -178,7 +178,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * A little performance booster.
      *
-     * @var boolean
+     * @var bool
      */
     protected $didDiscover = false;
 
@@ -199,14 +199,14 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Flag for sorting routes by priority.
      *
-     * @var boolean
+     * @var bool
      */
     protected $prioritize = false;
 
     /**
      * Route priority detection flag.
      *
-     * @var boolean
+     * @var bool
      */
     protected $prioritizeDetected = false;
 
@@ -306,7 +306,7 @@ class RouteCollection implements RouteCollectionInterface
      * find words and meaning in the URI for better SEO. But it
      * doesn't work well with PHP method names....
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return RouteCollectionInterface
      */
@@ -326,7 +326,7 @@ class RouteCollection implements RouteCollectionInterface
      *
      * If FALSE, will stop searching and do NO automatic routing.
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return RouteCollectionInterface
      */
@@ -460,7 +460,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Returns the current value of the translateURIDashes setting.
      *
-     * @return boolean
+     * @return bool
      */
     public function shouldTranslateURIDashes(): bool
     {
@@ -472,7 +472,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Returns the flag that tells whether to autoRoute URI against Controllers.
      *
-     * @return boolean
+     * @return bool
      */
     public function shouldAutoRoute(): bool
     {
@@ -627,7 +627,7 @@ class RouteCollection implements RouteCollectionInterface
      *
      * @param string  $from   The pattern to match against
      * @param string  $to     Either a route name or a URI to redirect to
-     * @param integer $status The HTTP status code that should be returned with this redirect
+     * @param int $status The HTTP status code that should be returned with this redirect
      *
      * @return RouteCollection
      */
@@ -652,7 +652,7 @@ class RouteCollection implements RouteCollectionInterface
      *
      * @param string $from
      *
-     * @return boolean
+     * @return bool
      */
     public function isRedirect(string $from): bool
     {
@@ -673,7 +673,7 @@ class RouteCollection implements RouteCollectionInterface
      *
      * @param string $from
      *
-     * @return integer
+     * @return int
      */
     public function getRedirectCode(string $from): int
     {
@@ -1211,7 +1211,7 @@ class RouteCollection implements RouteCollectionInterface
      * @param string      $search
      * @param string|null $verb
      *
-     * @return boolean
+     * @return bool
      */
     public function isFiltered(string $search, string $verb = null): bool
     {
@@ -1402,7 +1402,7 @@ class RouteCollection implements RouteCollectionInterface
      *
      * @param mixed $subdomains
      *
-     * @return boolean
+     * @return bool
      */
     private function checkSubdomains($subdomains): bool
     {
@@ -1523,7 +1523,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Enable or Disable sorting routes by priority
      *
-     * @param boolean $enabled The value status
+     * @param bool $enabled The value status
      *
      * @return $this
      */

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -625,9 +625,9 @@ class RouteCollection implements RouteCollectionInterface
      * redirecting traffic from old, non-existing routes to the new
      * moved routes.
      *
-     * @param string  $from   The pattern to match against
-     * @param string  $to     Either a route name or a URI to redirect to
-     * @param int $status The HTTP status code that should be returned with this redirect
+     * @param string $from   The pattern to match against
+     * @param string $to     Either a route name or a URI to redirect to
+     * @param int    $status The HTTP status code that should be returned with this redirect
      *
      * @return RouteCollection
      */

--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -98,7 +98,7 @@ interface RouteCollectionInterface
      * find words and meaning in the URI for better SEO. But it
      * doesn't work well with PHP method names....
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return mixed
      */
@@ -114,7 +114,7 @@ interface RouteCollectionInterface
      *
      * If FALSE, will stop searching and do NO automatic routing.
      *
-     * @param boolean $value
+     * @param bool $value
      *
      * @return RouteCollectionInterface
      */
@@ -177,7 +177,7 @@ interface RouteCollectionInterface
     /**
      * Returns the flag that tells whether to autoRoute URI against Controllers.
      *
-     * @return boolean
+     * @return bool
      */
     public function shouldAutoRoute();
 
@@ -228,7 +228,7 @@ interface RouteCollectionInterface
      *
      * @param string $from
      *
-     * @return boolean
+     * @return bool
      */
     public function isRedirect(string $from): bool;
 
@@ -239,7 +239,7 @@ interface RouteCollectionInterface
      *
      * @param string $from
      *
-     * @return integer
+     * @return int
      */
     public function getRedirectCode(string $from): int;
 

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -69,7 +69,7 @@ class Router implements RouterInterface
      * Whether dashes in URI's should be converted
      * to underscores when determining method names.
      *
-     * @var boolean
+     * @var bool
      */
     protected $translateURIDashes = false;
 
@@ -313,7 +313,7 @@ class Router implements RouterInterface
      * Tells the system whether we should translate URI dashes or not
      * in the URI from a dash to an underscore.
      *
-     * @param boolean|false $val
+     * @param bool|false $val
      *
      * @return $this
      */
@@ -330,7 +330,7 @@ class Router implements RouterInterface
      * Returns true/false based on whether the current route contained
      * a {locale} placeholder.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasLocale()
     {
@@ -358,7 +358,7 @@ class Router implements RouterInterface
      *
      * @param string $uri The URI path to compare against the routes
      *
-     * @return boolean Whether the route was matched or not.
+     * @return bool Whether the route was matched or not.
      * @throws RedirectException
      */
     protected function checkRoutes(string $uri): bool
@@ -618,8 +618,8 @@ class Router implements RouterInterface
      * Sets the sub-directory that the controller is in.
      *
      * @param string|null $dir
-     * @param boolean     $append
-     * @param boolean     $validate if true, checks to make sure $dir consists of only PSR4 compliant segments
+     * @param bool     $append
+     * @param bool     $validate if true, checks to make sure $dir consists of only PSR4 compliant segments
      */
     public function setDirectory(string $dir = null, bool $append = false, bool $validate = true)
     {
@@ -652,7 +652,7 @@ class Router implements RouterInterface
      * regex comes from https://www.php.net/manual/en/language.variables.basics.php
      *
      * @param  string $segment
-     * @return boolean
+     * @return bool
      */
     private function isValidSegment(string $segment): bool
     {

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -126,6 +126,7 @@ class Router implements RouterInterface
      * @param string|null $uri
      *
      * @return mixed|string
+     *
      * @throws RedirectException
      * @throws PageNotFoundException
      */
@@ -652,7 +653,8 @@ class Router implements RouterInterface
      *
      * regex comes from https://www.php.net/manual/en/language.variables.basics.php
      *
-     * @param  string $segment
+     * @param string $segment
+     *
      * @return bool
      */
     private function isValidSegment(string $segment): bool

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -359,6 +359,7 @@ class Router implements RouterInterface
      * @param string $uri The URI path to compare against the routes
      *
      * @return bool Whether the route was matched or not.
+     *
      * @throws RedirectException
      */
     protected function checkRoutes(string $uri): bool
@@ -618,8 +619,8 @@ class Router implements RouterInterface
      * Sets the sub-directory that the controller is in.
      *
      * @param string|null $dir
-     * @param bool     $append
-     * @param bool     $validate if true, checks to make sure $dir consists of only PSR4 compliant segments
+     * @param bool        $append
+     * @param bool        $validate if true, checks to make sure $dir consists of only PSR4 compliant segments
      */
     public function setDirectory(string $dir = null, bool $append = false, bool $validate = true)
     {

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -76,7 +76,7 @@ class Security implements SecurityInterface
      *
      * Defaults to two hours (in seconds).
      *
-     * @var integer
+     * @var int
      *
      * @deprecated
      */
@@ -87,7 +87,7 @@ class Security implements SecurityInterface
      *
      * Regenerate CSRF Token on every request.
      *
-     * @var boolean
+     * @var bool
      */
     protected $regenerate = true;
 
@@ -96,7 +96,7 @@ class Security implements SecurityInterface
      *
      * Redirect to previous page with error on failure.
      *
-     * @var boolean
+     * @var bool
      */
     protected $redirect = true;
 
@@ -298,7 +298,7 @@ class Security implements SecurityInterface
     /**
      * Check if CSRF cookie is expired.
      *
-     * @return boolean
+     * @return bool
      *
      * @deprecated
      *
@@ -311,7 +311,7 @@ class Security implements SecurityInterface
     /**
      * Check if request should be redirect on failure.
      *
-     * @return boolean
+     * @return bool
      */
     public function shouldRedirect(): bool
     {
@@ -330,7 +330,7 @@ class Security implements SecurityInterface
      * parameter, $relative_path to TRUE.
      *
      * @param string  $str          Input file name
-     * @param boolean $relativePath Whether to preserve paths
+     * @param bool $relativePath Whether to preserve paths
      *
      * @return string
      */

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -329,8 +329,8 @@ class Security implements SecurityInterface
      * e.g. file/in/some/approved/folder.txt, you can set the second optional
      * parameter, $relative_path to TRUE.
      *
-     * @param string  $str          Input file name
-     * @param bool $relativePath Whether to preserve paths
+     * @param string $str          Input file name
+     * @param bool   $relativePath Whether to preserve paths
      *
      * @return string
      */

--- a/system/Security/SecurityInterface.php
+++ b/system/Security/SecurityInterface.php
@@ -85,8 +85,8 @@ interface SecurityInterface
      * e.g. file/in/some/approved/folder.txt, you can set the second optional
      * parameter, $relative_path to TRUE.
      *
-     * @param string  $str          Input file name
-     * @param bool $relativePath Whether to preserve paths
+     * @param string $str          Input file name
+     * @param bool   $relativePath Whether to preserve paths
      *
      * @return string
      */

--- a/system/Security/SecurityInterface.php
+++ b/system/Security/SecurityInterface.php
@@ -61,7 +61,7 @@ interface SecurityInterface
     /**
      * Check if CSRF cookie is expired.
      *
-     * @return boolean
+     * @return bool
      *
      * @deprecated
      */
@@ -70,7 +70,7 @@ interface SecurityInterface
     /**
      * Check if request should be redirect on failure.
      *
-     * @return boolean
+     * @return bool
      */
     public function shouldRedirect(): bool;
 
@@ -86,7 +86,7 @@ interface SecurityInterface
      * parameter, $relative_path to TRUE.
      *
      * @param string  $str          Input file name
-     * @param boolean $relativePath Whether to preserve paths
+     * @param bool $relativePath Whether to preserve paths
      *
      * @return string
      */

--- a/system/Session/Handlers/ArrayHandler.php
+++ b/system/Session/Handlers/ArrayHandler.php
@@ -32,6 +32,7 @@ class ArrayHandler extends BaseHandler
      * @param string $name     Session cookie name
      *
      * @return bool
+     *
      * @throws Exception
      */
     public function open($savePath, $name): bool

--- a/system/Session/Handlers/ArrayHandler.php
+++ b/system/Session/Handlers/ArrayHandler.php
@@ -48,7 +48,7 @@ class ArrayHandler extends BaseHandler
      *
      * @param string $sessionID Session ID
      *
-     * @return string    Serialized session data
+     * @return string Serialized session data
      */
     public function read($sessionID): string
     {

--- a/system/Session/Handlers/ArrayHandler.php
+++ b/system/Session/Handlers/ArrayHandler.php
@@ -31,7 +31,7 @@ class ArrayHandler extends BaseHandler
      * @param string $savePath Path to session files' directory
      * @param string $name     Session cookie name
      *
-     * @return boolean
+     * @return bool
      * @throws Exception
      */
     public function open($savePath, $name): bool
@@ -65,7 +65,7 @@ class ArrayHandler extends BaseHandler
      * @param string $sessionID   Session ID
      * @param string $sessionData Serialized session data
      *
-     * @return boolean
+     * @return bool
      */
     public function write($sessionID, $sessionData): bool
     {
@@ -79,7 +79,7 @@ class ArrayHandler extends BaseHandler
      *
      * Releases locks and closes file descriptor.
      *
-     * @return boolean
+     * @return bool
      */
     public function close(): bool
     {
@@ -95,7 +95,7 @@ class ArrayHandler extends BaseHandler
      *
      * @param string $sessionID
      *
-     * @return boolean
+     * @return bool
      */
     public function destroy($sessionID): bool
     {
@@ -109,9 +109,9 @@ class ArrayHandler extends BaseHandler
      *
      * Deletes expired sessions
      *
-     * @param integer $maxlifetime Maximum lifetime of sessions
+     * @param int $maxlifetime Maximum lifetime of sessions
      *
-     * @return boolean
+     * @return bool
      */
     public function gc($maxlifetime): bool
     {

--- a/system/Session/Handlers/BaseHandler.php
+++ b/system/Session/Handlers/BaseHandler.php
@@ -60,7 +60,7 @@ abstract class BaseHandler implements SessionHandlerInterface
     /**
      * Cookie secure?
      *
-     * @var boolean
+     * @var bool
      */
     protected $cookieSecure = false;
 
@@ -74,7 +74,7 @@ abstract class BaseHandler implements SessionHandlerInterface
     /**
      * Match IP addresses for cookies?
      *
-     * @var boolean
+     * @var bool
      */
     protected $matchIP = false;
 
@@ -126,7 +126,7 @@ abstract class BaseHandler implements SessionHandlerInterface
      * Internal method to force removal of a cookie by the client
      * when session_destroy() is called.
      *
-     * @return boolean
+     * @return bool
      */
     protected function destroyCookie(): bool
     {
@@ -144,7 +144,7 @@ abstract class BaseHandler implements SessionHandlerInterface
      *
      * @param string $sessionID
      *
-     * @return boolean
+     * @return bool
      */
     protected function lockSession(string $sessionID): bool
     {
@@ -158,7 +158,7 @@ abstract class BaseHandler implements SessionHandlerInterface
     /**
      * Releases the lock, if any.
      *
-     * @return boolean
+     * @return bool
      */
     protected function releaseLock(): bool
     {
@@ -180,7 +180,7 @@ abstract class BaseHandler implements SessionHandlerInterface
      * so that the INI is set just in time for the error message to
      * be properly generated.
      *
-     * @return boolean
+     * @return bool
      */
     protected function fail(): bool
     {

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -53,7 +53,7 @@ class DatabaseHandler extends BaseHandler
     /**
      * Row exists flag
      *
-     * @var boolean
+     * @var bool
      */
     protected $rowExists = false;
 
@@ -101,7 +101,7 @@ class DatabaseHandler extends BaseHandler
      * @param string $savePath Path to session files' directory
      * @param string $name     Session cookie name
      *
-     * @return boolean
+     * @return bool
      * @throws Exception
      */
     public function open($savePath, $name): bool
@@ -179,7 +179,7 @@ class DatabaseHandler extends BaseHandler
      * @param string $sessionID   Session ID
      * @param string $sessionData Serialized session data
      *
-     * @return boolean
+     * @return bool
      */
     public function write($sessionID, $sessionData): bool
     {
@@ -241,7 +241,7 @@ class DatabaseHandler extends BaseHandler
      *
      * Releases locks and closes file descriptor.
      *
-     * @return boolean
+     * @return bool
      */
     public function close(): bool
     {
@@ -257,7 +257,7 @@ class DatabaseHandler extends BaseHandler
      *
      * @param string $sessionID
      *
-     * @return boolean
+     * @return bool
      */
     public function destroy($sessionID): bool
     {
@@ -289,9 +289,9 @@ class DatabaseHandler extends BaseHandler
      *
      * Deletes expired sessions
      *
-     * @param integer $maxlifetime Maximum lifetime of sessions
+     * @param int $maxlifetime Maximum lifetime of sessions
      *
-     * @return boolean
+     * @return bool
      */
     public function gc($maxlifetime): bool
     {
@@ -307,7 +307,7 @@ class DatabaseHandler extends BaseHandler
      * Lock the session.
      *
      * @param  string $sessionID
-     * @return boolean
+     * @return bool
      */
     protected function lockSession(string $sessionID): bool
     {
@@ -342,7 +342,7 @@ class DatabaseHandler extends BaseHandler
     /**
      * Releases the lock, if any.
      *
-     * @return boolean
+     * @return bool
      */
     protected function releaseLock(): bool
     {

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -102,6 +102,7 @@ class DatabaseHandler extends BaseHandler
      * @param string $name     Session cookie name
      *
      * @return bool
+     *
      * @throws Exception
      */
     public function open($savePath, $name): bool
@@ -306,7 +307,8 @@ class DatabaseHandler extends BaseHandler
     /**
      * Lock the session.
      *
-     * @param  string $sessionID
+     * @param string $sessionID
+     *
      * @return bool
      */
     protected function lockSession(string $sessionID): bool

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -122,7 +122,7 @@ class DatabaseHandler extends BaseHandler
      *
      * @param string $sessionID Session ID
      *
-     * @return string    Serialized session data
+     * @return string Serialized session data
      */
     public function read($sessionID): string
     {

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -44,14 +44,14 @@ class FileHandler extends BaseHandler
     /**
      * Whether this is a new file.
      *
-     * @var boolean
+     * @var bool
      */
     protected $fileNew;
 
     /**
      * Whether IP addresses should be matched.
      *
-     * @var boolean
+     * @var bool
      */
     protected $matchIP = false;
 
@@ -102,7 +102,7 @@ class FileHandler extends BaseHandler
      * @param string $savePath Path to session files' directory
      * @param string $name     Session cookie name
      *
-     * @return boolean
+     * @return bool
      * @throws Exception
      */
     public function open($savePath, $name): bool
@@ -132,7 +132,7 @@ class FileHandler extends BaseHandler
      *
      * @param string $sessionID Session ID
      *
-     * @return string|boolean    Serialized session data
+     * @return string|bool    Serialized session data
      */
     public function read($sessionID)
     {
@@ -196,7 +196,7 @@ class FileHandler extends BaseHandler
      * @param string $sessionID   Session ID
      * @param string $sessionData Serialized session data
      *
-     * @return boolean
+     * @return bool
      */
     public function write($sessionID, $sessionData): bool
     {
@@ -247,7 +247,7 @@ class FileHandler extends BaseHandler
      *
      * Releases locks and closes file descriptor.
      *
-     * @return boolean
+     * @return bool
      */
     public function close(): bool
     {
@@ -273,7 +273,7 @@ class FileHandler extends BaseHandler
      *
      * @param string $sessionId Session ID
      *
-     * @return boolean
+     * @return bool
      */
     public function destroy($sessionId): bool
     {
@@ -299,9 +299,9 @@ class FileHandler extends BaseHandler
      *
      * Deletes expired sessions
      *
-     * @param integer $maxlifetime Maximum lifetime of sessions
+     * @param int $maxlifetime Maximum lifetime of sessions
      *
-     * @return boolean
+     * @return bool
      */
     public function gc($maxlifetime): bool
     {

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -132,7 +132,7 @@ class FileHandler extends BaseHandler
      *
      * @param string $sessionID Session ID
      *
-     * @return string|bool    Serialized session data
+     * @return string|bool Serialized session data
      */
     public function read($sessionID)
     {

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -103,6 +103,7 @@ class FileHandler extends BaseHandler
      * @param string $name     Session cookie name
      *
      * @return bool
+     *
      * @throws Exception
      */
     public function open($savePath, $name): bool

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -44,7 +44,7 @@ class MemcachedHandler extends BaseHandler
     /**
      * Number of seconds until the session ends.
      *
-     * @var integer
+     * @var int
      */
     protected $sessionExpiration = 7200;
 
@@ -86,7 +86,7 @@ class MemcachedHandler extends BaseHandler
      * @param string $savePath Server path(s)
      * @param string $name     Session cookie name, unused
      *
-     * @return boolean
+     * @return bool
      */
     public function open($savePath, $name): bool
     {
@@ -169,7 +169,7 @@ class MemcachedHandler extends BaseHandler
      * @param string $sessionID   Session ID
      * @param string $sessionData Serialized session data
      *
-     * @return boolean
+     * @return bool
      */
     public function write($sessionID, $sessionData): bool
     {
@@ -213,7 +213,7 @@ class MemcachedHandler extends BaseHandler
      *
      * Releases locks and closes connection.
      *
-     * @return boolean
+     * @return bool
      */
     public function close(): bool
     {
@@ -241,7 +241,7 @@ class MemcachedHandler extends BaseHandler
      *
      * @param string $sessionId Session ID
      *
-     * @return boolean
+     * @return bool
      */
     public function destroy($sessionId): bool
     {
@@ -261,9 +261,9 @@ class MemcachedHandler extends BaseHandler
      *
      * Deletes expired sessions
      *
-     * @param integer $maxlifetime Maximum lifetime of sessions
+     * @param int $maxlifetime Maximum lifetime of sessions
      *
-     * @return boolean
+     * @return bool
      */
     public function gc($maxlifetime): bool
     {
@@ -280,7 +280,7 @@ class MemcachedHandler extends BaseHandler
      *
      * @param string $sessionID Session ID
      *
-     * @return boolean
+     * @return bool
      */
     protected function lockSession(string $sessionID): bool
     {
@@ -327,7 +327,7 @@ class MemcachedHandler extends BaseHandler
      *
      * Releases a previously acquired lock
      *
-     * @return boolean
+     * @return bool
      */
     protected function releaseLock(): bool
     {

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -53,8 +53,9 @@ class MemcachedHandler extends BaseHandler
     /**
      * Constructor
      *
-     * @param  AppConfig $config
-     * @param  string    $ipAddress
+     * @param AppConfig $config
+     * @param string    $ipAddress
+     *
      * @throws SessionException
      */
     public function __construct(AppConfig $config, string $ipAddress)
@@ -140,7 +141,7 @@ class MemcachedHandler extends BaseHandler
      *
      * @param string $sessionID Session ID
      *
-     * @return string    Serialized session data
+     * @return string Serialized session data
      */
     public function read($sessionID): string
     {

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -109,8 +109,9 @@ class RedisHandler extends BaseHandler
      *
      * Sanitizes save_path and initializes connection.
      *
-     * @param  string $savePath Server path
-     * @param  string $name     Session cookie name, unused
+     * @param string $savePath Server path
+     * @param string $name     Session cookie name, unused
+     *
      * @return bool
      */
     public function open($savePath, $name): bool
@@ -279,7 +280,8 @@ class RedisHandler extends BaseHandler
      *
      * Deletes expired sessions
      *
-     * @param  int  $maxlifetime Maximum lifetime of sessions
+     * @param int $maxlifetime Maximum lifetime of sessions
+     *
      * @return bool
      */
     public function gc($maxlifetime): bool

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -46,14 +46,14 @@ class RedisHandler extends BaseHandler
     /**
      * Key exists flag
      *
-     * @var boolean
+     * @var bool
      */
     protected $keyExists = false;
 
     /**
      * Number of seconds until the session ends.
      *
-     * @var integer
+     * @var int
      */
     protected $sessionExpiration = 7200;
 
@@ -111,7 +111,7 @@ class RedisHandler extends BaseHandler
      *
      * @param  string $savePath Server path
      * @param  string $name     Session cookie name, unused
-     * @return boolean
+     * @return bool
      */
     public function open($savePath, $name): bool
     {
@@ -176,7 +176,7 @@ class RedisHandler extends BaseHandler
      * @param string $sessionID   Session ID
      * @param string $sessionData Serialized session data
      *
-     * @return boolean
+     * @return bool
      */
     public function write($sessionID, $sessionData): bool
     {
@@ -221,7 +221,7 @@ class RedisHandler extends BaseHandler
      *
      * Releases locks and closes connection.
      *
-     * @return boolean
+     * @return bool
      */
     public function close(): bool
     {
@@ -257,7 +257,7 @@ class RedisHandler extends BaseHandler
      *
      * @param string $sessionID
      *
-     * @return boolean
+     * @return bool
      */
     public function destroy($sessionID): bool
     {
@@ -279,8 +279,8 @@ class RedisHandler extends BaseHandler
      *
      * Deletes expired sessions
      *
-     * @param  integer $maxlifetime Maximum lifetime of sessions
-     * @return boolean
+     * @param  int $maxlifetime Maximum lifetime of sessions
+     * @return bool
      */
     public function gc($maxlifetime): bool
     {
@@ -297,7 +297,7 @@ class RedisHandler extends BaseHandler
      *
      * @param string $sessionID Session ID
      *
-     * @return boolean
+     * @return bool
      */
     protected function lockSession(string $sessionID): bool
     {
@@ -351,7 +351,7 @@ class RedisHandler extends BaseHandler
      *
      * Releases a previously acquired lock
      *
-     * @return boolean
+     * @return bool
      */
     protected function releaseLock(): bool
     {

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -145,7 +145,7 @@ class RedisHandler extends BaseHandler
      *
      * @param string $sessionID Session ID
      *
-     * @return string	Serialized session data
+     * @return string Serialized session data
      */
     public function read($sessionID): string
     {
@@ -279,7 +279,7 @@ class RedisHandler extends BaseHandler
      *
      * Deletes expired sessions
      *
-     * @param  int $maxlifetime Maximum lifetime of sessions
+     * @param  int  $maxlifetime Maximum lifetime of sessions
      * @return bool
      */
     public function gc($maxlifetime): bool

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -775,8 +775,9 @@ class Session implements SessionInterface
      * Returns either a single piece of tempdata, or all temp data currently
      * in the session.
      *
-     * @param  string $key Session data key
-     * @return mixed  Session data value or null if not found.
+     * @param string $key Session data key
+     *
+     * @return mixed Session data value or null if not found.
      */
     public function getTempdata(string $key = null)
     {

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -482,8 +482,9 @@ class Session implements SessionInterface
      *
      * Replaces the legacy method $session->userdata();
      *
-     * @param  string|null $key Identifier of the session property to retrieve
-     * @return mixed	The property value(s)
+     * @param string|null $key Identifier of the session property to retrieve
+     *
+     * @return mixed The property value(s)
      */
     public function get(string $key = null)
     {
@@ -762,7 +763,7 @@ class Session implements SessionInterface
      *
      * @param string|array $data  Session data key or associative array of items
      * @param null         $value Value to store
-     * @param int      $ttl   Time-to-live in seconds
+     * @param int          $ttl   Time-to-live in seconds
      */
     public function setTempdata($data, $value = null, int $ttl = 300)
     {
@@ -813,7 +814,7 @@ class Session implements SessionInterface
      * it has a set lifespan within the session.
      *
      * @param string|array $key Property identifier or array of them
-     * @param int      $ttl Time to live, in seconds
+     * @param int          $ttl Time to live, in seconds
      *
      * @return bool False if any of the properties were not set
      */
@@ -860,7 +861,7 @@ class Session implements SessionInterface
      * Unmarks temporary data in the session, effectively removing its
      * lifespan and allowing it to live as long as the session does.
      *
-     * @param string|array $key	Property identifier or array of them
+     * @param string|array $key Property identifier or array of them
      */
     public function unmarkTempdata($key)
     {

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -53,7 +53,7 @@ class Session implements SessionInterface
      * The number of SECONDS you want the session to last.
      * Setting it to 0 (zero) means expire when the browser is closed.
      *
-     * @var integer
+     * @var int
      */
     protected $sessionExpiration = 7200;
 
@@ -79,14 +79,14 @@ class Session implements SessionInterface
      * WARNING: If you're using the database driver, don't forget to update
      * your session table's PRIMARY KEY when changing this setting.
      *
-     * @var boolean
+     * @var bool
      */
     protected $sessionMatchIP = false;
 
     /**
      * How many seconds between CI regenerating the session ID.
      *
-     * @var integer
+     * @var int
      */
     protected $sessionTimeToUpdate = 300;
 
@@ -95,7 +95,7 @@ class Session implements SessionInterface
      * when auto-regenerating the session ID. When set to FALSE, the data
      * will be later deleted by the garbage collector.
      *
-     * @var boolean
+     * @var bool
      */
     protected $sessionRegenerateDestroy = false;
 
@@ -129,7 +129,7 @@ class Session implements SessionInterface
     /**
      * Cookie will only be set if a secure HTTPS connection exists.
      *
-     * @var boolean
+     * @var bool
      *
      * @deprecated
      */
@@ -420,7 +420,7 @@ class Session implements SessionInterface
     /**
      * Regenerates the session ID.
      *
-     * @param boolean $destroy Should old session data be destroyed?
+     * @param bool $destroy Should old session data be destroyed?
      */
     public function regenerate(bool $destroy = false)
     {
@@ -518,7 +518,7 @@ class Session implements SessionInterface
      *
      * @param string $key Identifier of the session property we are interested in.
      *
-     * @return boolean
+     * @return bool
      */
     public function has(string $key): bool
     {
@@ -604,7 +604,7 @@ class Session implements SessionInterface
      *
      * @param string $key Identifier of the session property to remove.
      *
-     * @return boolean
+     * @return bool
      */
     public function __isset(string $key): bool
     {
@@ -677,7 +677,7 @@ class Session implements SessionInterface
      *
      * @param array|string $key Property identifier or array of them
      *
-     * @return boolean False if any of the properties are not already set
+     * @return bool False if any of the properties are not already set
      */
     public function markAsFlashdata($key): bool
     {
@@ -762,7 +762,7 @@ class Session implements SessionInterface
      *
      * @param string|array $data  Session data key or associative array of items
      * @param null         $value Value to store
-     * @param integer      $ttl   Time-to-live in seconds
+     * @param int      $ttl   Time-to-live in seconds
      */
     public function setTempdata($data, $value = null, int $ttl = 300)
     {
@@ -813,9 +813,9 @@ class Session implements SessionInterface
      * it has a set lifespan within the session.
      *
      * @param string|array $key Property identifier or array of them
-     * @param integer      $ttl Time to live, in seconds
+     * @param int      $ttl Time to live, in seconds
      *
-     * @return boolean False if any of the properties were not set
+     * @return bool False if any of the properties were not set
      */
     public function markAsTempdata($key, int $ttl = 300): bool
     {

--- a/system/Session/SessionInterface.php
+++ b/system/Session/SessionInterface.php
@@ -110,9 +110,10 @@ interface SessionInterface
      *
      * If the item key is null, return all flashdata.
      *
-     * @param  string $key Property identifier
-     * @return array|null	The requested property value, or an associative
-     *     array  of them
+     * @param string $key Property identifier
+     *
+     * @return array|null The requested property value, or an associative
+     *                    array  of them
      */
     public function getFlashdata(string $key = null);
 
@@ -141,7 +142,7 @@ interface SessionInterface
     /**
      * Unmark data in the session as flashdata.
      *
-     * @param string|array $key	Property identifier or array of them
+     * @param string|array $key Property identifier or array of them
      */
     public function unmarkFlashdata($key);
 
@@ -150,7 +151,7 @@ interface SessionInterface
     /**
      * Retrieve all of the keys for session data marked as flashdata.
      *
-     * @return array	The property names of all flashdata
+     * @return array The property names of all flashdata
      */
     public function getFlashKeys(): array;
 
@@ -162,7 +163,7 @@ interface SessionInterface
      *
      * @param string|array $data  Session data key or associative array of items
      * @param mixed        $value Value to store
-     * @param int      $ttl   Time-to-live in seconds
+     * @param int          $ttl   Time-to-live in seconds
      */
     public function setTempdata($data, $value = null, int $ttl = 300);
 
@@ -173,7 +174,7 @@ interface SessionInterface
      * in the session.
      *
      * @param  string $key Session data key
-     * @return mixed        Session data value or null if not found.
+     * @return mixed  Session data value or null if not found.
      */
     public function getTempdata(string $key = null);
 
@@ -193,9 +194,9 @@ interface SessionInterface
      * it has a set lifespan within the session.
      *
      * @param string|array $key Property identifier or array of them
-     * @param int      $ttl Time to live, in seconds
+     * @param int          $ttl Time to live, in seconds
      *
-     * @return bool    False if any of the properties were not set
+     * @return bool False if any of the properties were not set
      */
     public function markAsTempdata($key, int $ttl = 300);
 
@@ -205,7 +206,7 @@ interface SessionInterface
      * Unmarks temporary data in the session, effectively removing its
      * lifespan and allowing it to live as long as the session does.
      *
-     * @param string|array $key	Property identifier or array of them
+     * @param string|array $key Property identifier or array of them
      */
     public function unmarkTempdata($key);
 

--- a/system/Session/SessionInterface.php
+++ b/system/Session/SessionInterface.php
@@ -173,8 +173,9 @@ interface SessionInterface
      * Returns either a single piece of tempdata, or all temp data currently
      * in the session.
      *
-     * @param  string $key Session data key
-     * @return mixed  Session data value or null if not found.
+     * @param string $key Session data key
+     *
+     * @return mixed Session data value or null if not found.
      */
     public function getTempdata(string $key = null);
 

--- a/system/Session/SessionInterface.php
+++ b/system/Session/SessionInterface.php
@@ -19,7 +19,7 @@ interface SessionInterface
     /**
      * Regenerates the session ID.
      *
-     * @param boolean $destroy Should old session data be destroyed?
+     * @param bool $destroy Should old session data be destroyed?
      */
     public function regenerate(bool $destroy = false);
 
@@ -70,7 +70,7 @@ interface SessionInterface
      *
      * @param string $key Identifier of the session property we are interested in.
      *
-     * @return boolean
+     * @return bool
      */
     public function has(string $key): bool;
 
@@ -162,7 +162,7 @@ interface SessionInterface
      *
      * @param string|array $data  Session data key or associative array of items
      * @param mixed        $value Value to store
-     * @param integer      $ttl   Time-to-live in seconds
+     * @param int      $ttl   Time-to-live in seconds
      */
     public function setTempdata($data, $value = null, int $ttl = 300);
 
@@ -193,9 +193,9 @@ interface SessionInterface
      * it has a set lifespan within the session.
      *
      * @param string|array $key Property identifier or array of them
-     * @param integer      $ttl Time to live, in seconds
+     * @param int      $ttl Time to live, in seconds
      *
-     * @return boolean    False if any of the properties were not set
+     * @return bool    False if any of the properties were not set
      */
     public function markAsTempdata($key, int $ttl = 300);
 

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -349,6 +349,7 @@ abstract class CIUnitTestCase extends TestCase
      * @param string|null $expectedMessage
      *
      * @return bool
+     *
      * @throws Exception
      */
     public function assertLogged(string $level, $expectedMessage = null)
@@ -371,6 +372,7 @@ abstract class CIUnitTestCase extends TestCase
      * @param string $eventName
      *
      * @return bool
+     *
      * @throws Exception
      */
     public function assertEventTriggered(string $eventName): bool
@@ -483,6 +485,7 @@ abstract class CIUnitTestCase extends TestCase
      * @param int    $tolerance
      *
      * @return void|bool
+     *
      * @throws Exception
      */
     public function assertCloseEnoughString($expected, $actual, string $message = '', int $tolerance = 1)

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -75,28 +75,28 @@ abstract class CIUnitTestCase extends TestCase
     /**
      * Should run db migration?
      *
-     * @var boolean
+     * @var bool
      */
     protected $migrate = true;
 
     /**
      * Should run db migration only once?
      *
-     * @var boolean
+     * @var bool
      */
     protected $migrateOnce = false;
 
     /**
      * Should run seeding only once?
      *
-     * @var boolean
+     * @var bool
      */
     protected $seedOnce = false;
 
     /**
      * Should the db be refreshed before test?
      *
-     * @var boolean
+     * @var bool
      */
     protected $refresh = true;
 
@@ -186,7 +186,7 @@ abstract class CIUnitTestCase extends TestCase
     /**
      * Enabled auto clean op buffer after request call
      *
-     * @var boolean
+     * @var bool
      */
     protected $clean = true;
 
@@ -348,7 +348,7 @@ abstract class CIUnitTestCase extends TestCase
      * @param string      $level
      * @param string|null $expectedMessage
      *
-     * @return boolean
+     * @return bool
      * @throws Exception
      */
     public function assertLogged(string $level, $expectedMessage = null)
@@ -370,7 +370,7 @@ abstract class CIUnitTestCase extends TestCase
      *
      * @param string $eventName
      *
-     * @return boolean
+     * @return bool
      * @throws Exception
      */
     public function assertEventTriggered(string $eventName): bool
@@ -397,7 +397,7 @@ abstract class CIUnitTestCase extends TestCase
      * emitted
      *
      * @param string  $header     The leading portion of the header we are looking for
-     * @param boolean $ignoreCase
+     * @param bool $ignoreCase
      *
      * @throws Exception
      */
@@ -426,7 +426,7 @@ abstract class CIUnitTestCase extends TestCase
      * emitted
      *
      * @param string  $header     The leading portion of the header we don't want to find
-     * @param boolean $ignoreCase
+     * @param bool $ignoreCase
      *
      * @throws Exception
      */
@@ -457,10 +457,10 @@ abstract class CIUnitTestCase extends TestCase
      * where the result is close but not exactly equal to the
      * expected time, for reasons beyond our control.
      *
-     * @param integer $expected
+     * @param int $expected
      * @param mixed   $actual
      * @param string  $message
-     * @param integer $tolerance
+     * @param int $tolerance
      *
      * @throws Exception
      */
@@ -480,9 +480,9 @@ abstract class CIUnitTestCase extends TestCase
      * @param mixed   $expected
      * @param mixed   $actual
      * @param string  $message
-     * @param integer $tolerance
+     * @param int $tolerance
      *
-     * @return void|boolean
+     * @return void|bool
      * @throws Exception
      */
     public function assertCloseEnoughString($expected, $actual, string $message = '', int $tolerance = 1)
@@ -529,7 +529,7 @@ abstract class CIUnitTestCase extends TestCase
      * Return first matching emitted header.
      *
      * @param string  $header     Identifier of the header of interest
-     * @param boolean $ignoreCase
+     * @param bool $ignoreCase
      *
      * @return string|null The value of the header found, null if not found
      */

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -396,8 +396,8 @@ abstract class CIUnitTestCase extends TestCase
      * Hooks into xdebug's headers capture, looking for a specific header
      * emitted
      *
-     * @param string  $header     The leading portion of the header we are looking for
-     * @param bool $ignoreCase
+     * @param string $header     The leading portion of the header we are looking for
+     * @param bool   $ignoreCase
      *
      * @throws Exception
      */
@@ -425,8 +425,8 @@ abstract class CIUnitTestCase extends TestCase
      * Hooks into xdebug's headers capture, looking for a specific header
      * emitted
      *
-     * @param string  $header     The leading portion of the header we don't want to find
-     * @param bool $ignoreCase
+     * @param string $header     The leading portion of the header we don't want to find
+     * @param bool   $ignoreCase
      *
      * @throws Exception
      */
@@ -457,10 +457,10 @@ abstract class CIUnitTestCase extends TestCase
      * where the result is close but not exactly equal to the
      * expected time, for reasons beyond our control.
      *
-     * @param int $expected
-     * @param mixed   $actual
-     * @param string  $message
-     * @param int $tolerance
+     * @param int    $expected
+     * @param mixed  $actual
+     * @param string $message
+     * @param int    $tolerance
      *
      * @throws Exception
      */
@@ -477,10 +477,10 @@ abstract class CIUnitTestCase extends TestCase
      * where the result is close but not exactly equal to the
      * expected time, for reasons beyond our control.
      *
-     * @param mixed   $expected
-     * @param mixed   $actual
-     * @param string  $message
-     * @param int $tolerance
+     * @param mixed  $expected
+     * @param mixed  $actual
+     * @param string $message
+     * @param int    $tolerance
      *
      * @return void|bool
      * @throws Exception
@@ -528,8 +528,8 @@ abstract class CIUnitTestCase extends TestCase
     /**
      * Return first matching emitted header.
      *
-     * @param string  $header     Identifier of the header of interest
-     * @param bool $ignoreCase
+     * @param string $header     Identifier of the header of interest
+     * @param bool   $ignoreCase
      *
      * @return string|null The value of the header found, null if not found
      */

--- a/system/Test/Constraints/SeeInDatabase.php
+++ b/system/Test/Constraints/SeeInDatabase.php
@@ -11,7 +11,7 @@ class SeeInDatabase extends Constraint
      * The number of results that will show in the database
      * in case of failure.
      *
-     * @var integer
+     * @var int
      */
     protected $show = 3;
 
@@ -44,7 +44,7 @@ class SeeInDatabase extends Constraint
      *
      * @param mixed $table
      *
-     * @return boolean
+     * @return bool
      */
     public function matches($table): bool
     {
@@ -110,7 +110,7 @@ class SeeInDatabase extends Constraint
     /**
      * Gets a string representation of the constraint
      *
-     * @param integer $options
+     * @param int $options
      *
      * @return string
      */

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -216,9 +216,9 @@ class DOMParser
     /**
      * Search the DOM using an XPath expression.
      *
-     * @param  string|null $search
-     * @param  string      $element
-     * @param  array       $paths
+     * @param string|null $search
+     * @param string      $element
+     * @param array       $paths
      *
      * @return DOMNodeList
      */

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -273,7 +273,8 @@ class DOMParser
     /**
      * Look for the a selector  in the passed text.
      *
-     * @param  string $selector
+     * @param string $selector
+     *
      * @return array
      */
     public function parseSelector(string $selector)

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -111,7 +111,7 @@ class DOMParser
      * @param string $search
      * @param string $element
      *
-     * @return boolean
+     * @return bool
      */
     public function see(string $search = null, string $element = null): bool
     {
@@ -133,7 +133,7 @@ class DOMParser
      * @param string      $search
      * @param string|null $element
      *
-     * @return boolean
+     * @return bool
      */
     public function dontSee(string $search = null, string $element = null): bool
     {
@@ -146,7 +146,7 @@ class DOMParser
      *
      * @param string $element
      *
-     * @return boolean
+     * @return bool
      */
     public function seeElement(string $element): bool
     {
@@ -158,7 +158,7 @@ class DOMParser
      *
      * @param string $element
      *
-     * @return boolean
+     * @return bool
      */
     public function dontSeeElement(string $element): bool
     {
@@ -172,7 +172,7 @@ class DOMParser
      * @param string      $text
      * @param string|null $details
      *
-     * @return boolean
+     * @return bool
      */
     public function seeLink(string $text, string $details = null): bool
     {
@@ -185,7 +185,7 @@ class DOMParser
      * @param string $field
      * @param string $value
      *
-     * @return boolean
+     * @return bool
      */
     public function seeInField(string $field, string $value): bool
     {
@@ -199,7 +199,7 @@ class DOMParser
      *
      * @param string $element
      *
-     * @return boolean
+     * @return bool
      */
     public function seeCheckboxIsChecked(string $element): bool
     {

--- a/system/Test/DatabaseTestTrait.php
+++ b/system/Test/DatabaseTestTrait.php
@@ -337,9 +337,9 @@ trait DatabaseTestTrait
      * Asserts that the number of rows in the database that match $where
      * is equal to $expected.
      *
-     * @param int $expected
-     * @param string  $table
-     * @param array   $where
+     * @param int    $expected
+     * @param string $table
+     * @param array  $where
      *
      * @return void
      * @throws DatabaseException

--- a/system/Test/DatabaseTestTrait.php
+++ b/system/Test/DatabaseTestTrait.php
@@ -261,6 +261,7 @@ trait DatabaseTestTrait
      * @param array  $where
      *
      * @return bool
+     *
      * @throws DatabaseException
      */
     public function grabFromDatabase(string $table, string $column, array $where)
@@ -287,6 +288,7 @@ trait DatabaseTestTrait
      * @param array  $where
      *
      * @return void
+     *
      * @throws DatabaseException
      */
     public function seeInDatabase(string $table, array $where)
@@ -342,6 +344,7 @@ trait DatabaseTestTrait
      * @param array  $where
      *
      * @return void
+     *
      * @throws DatabaseException
      */
     public function seeNumRecords(int $expected, string $table, array $where)

--- a/system/Test/DatabaseTestTrait.php
+++ b/system/Test/DatabaseTestTrait.php
@@ -31,14 +31,14 @@ trait DatabaseTestTrait
     /**
      * Is db migration done once or more than once?
      *
-     * @var boolean
+     * @var bool
      */
     private static $doneMigration = false;
 
     /**
      * Is seeding done once or more than once?
      *
-     * @var boolean
+     * @var bool
      */
     private static $doneSeed = false;
 
@@ -260,7 +260,7 @@ trait DatabaseTestTrait
      * @param string $column
      * @param array  $where
      *
-     * @return boolean
+     * @return bool
      * @throws DatabaseException
      */
     public function grabFromDatabase(string $table, string $column, array $where)
@@ -320,7 +320,7 @@ trait DatabaseTestTrait
      * @param string $table
      * @param array  $data
      *
-     * @return boolean
+     * @return bool
      */
     public function hasInDatabase(string $table, array $data)
     {
@@ -337,7 +337,7 @@ trait DatabaseTestTrait
      * Asserts that the number of rows in the database that match $where
      * is equal to $expected.
      *
-     * @param integer $expected
+     * @param int $expected
      * @param string  $table
      * @param array   $where
      *

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -160,10 +160,10 @@ class Fabricator
     /**
      * Set the count for a specific table
      *
-     * @param string  $table Name of the target table
-     * @param int $count Count value
+     * @param string $table Name of the target table
+     * @param int    $count Count value
      *
-     * @return int  The new count value
+     * @return int The new count value
      */
     public static function setCount(string $table, int $count): int
     {
@@ -177,7 +177,7 @@ class Fabricator
      *
      * @param string $table Name of the target table
      *
-     * @return int  The new count value
+     * @return int The new count value
      */
     public static function upCount(string $table): int
     {
@@ -189,7 +189,7 @@ class Fabricator
      *
      * @param string $table Name of the target table
      *
-     * @return int  The new count value
+     * @return int The new count value
      */
     public static function downCount(string $table): int
     {
@@ -201,7 +201,7 @@ class Fabricator
     /**
      * Returns the model instance
      *
-     * @return object  Framework or compatible model
+     * @return object Framework or compatible model
      */
     public function getModel()
     {
@@ -247,8 +247,8 @@ class Fabricator
     /**
      * Set the overrides, once or persistent
      *
-     * @param array   $overrides Array of [field => value]
-     * @param bool $persist   Whether these overrides should persist through the next operation
+     * @param array $overrides Array of [field => value]
+     * @param bool  $persist   Whether these overrides should persist through the next operation
      *
      * @return $this
      */
@@ -318,7 +318,7 @@ class Fabricator
      *
      * @param string $field Name of the field
      *
-     * @return string  Name of the formatter
+     * @return string Name of the formatter
      */
     protected function guessFormatter($field): string
     {
@@ -367,7 +367,7 @@ class Fabricator
      *
      * @param int|null $count Optional number to create a collection
      *
-     * @return array|object  An array or object (based on returnType), or an array of returnTypes
+     * @return array|object An array or object (based on returnType), or an array of returnTypes
      */
     public function make(int $count = null)
     {
@@ -392,7 +392,7 @@ class Fabricator
     /**
      * Generate an array of faked data
      *
-     * @return array  An array of faked data
+     * @return array An array of faked data
      *
      * @throws RuntimeException
      */
@@ -429,7 +429,7 @@ class Fabricator
      *
      * @param string|null $className Class name of the object to create; null to use model default
      *
-     * @return object  An instance of the class with faked data
+     * @return object An instance of the class with faked data
      *
      * @throws RuntimeException
      */
@@ -479,9 +479,9 @@ class Fabricator
      * Generate new entities from the database
      *
      * @param int|null $count Optional number to create a collection
-     * @param bool      $mock  Whether to execute or mock the insertion
+     * @param bool     $mock  Whether to execute or mock the insertion
      *
-     * @return array|object  An array or object (based on returnType), or an array of returnTypes
+     * @return array|object An array or object (based on returnType), or an array of returnTypes
      *
      * @throws FrameworkException
      */
@@ -519,7 +519,7 @@ class Fabricator
      *
      * @param int|null $count Optional number to create a collection
      *
-     * @return array|object  An array or object (based on returnType), or an array of returnTypes
+     * @return array|object An array or object (based on returnType), or an array of returnTypes
      */
     protected function createMock(int $count = null)
     {

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -150,7 +150,7 @@ class Fabricator
      *
      * @param string $table Name of the target table
      *
-     * @return integer
+     * @return int
      */
     public static function getCount(string $table): int
     {
@@ -161,9 +161,9 @@ class Fabricator
      * Set the count for a specific table
      *
      * @param string  $table Name of the target table
-     * @param integer $count Count value
+     * @param int $count Count value
      *
-     * @return integer  The new count value
+     * @return int  The new count value
      */
     public static function setCount(string $table, int $count): int
     {
@@ -177,7 +177,7 @@ class Fabricator
      *
      * @param string $table Name of the target table
      *
-     * @return integer  The new count value
+     * @return int  The new count value
      */
     public static function upCount(string $table): int
     {
@@ -189,7 +189,7 @@ class Fabricator
      *
      * @param string $table Name of the target table
      *
-     * @return integer  The new count value
+     * @return int  The new count value
      */
     public static function downCount(string $table): int
     {
@@ -248,7 +248,7 @@ class Fabricator
      * Set the overrides, once or persistent
      *
      * @param array   $overrides Array of [field => value]
-     * @param boolean $persist   Whether these overrides should persist through the next operation
+     * @param bool $persist   Whether these overrides should persist through the next operation
      *
      * @return $this
      */
@@ -365,7 +365,7 @@ class Fabricator
     /**
      * Generate new entities with faked data
      *
-     * @param integer|null $count Optional number to create a collection
+     * @param int|null $count Optional number to create a collection
      *
      * @return array|object  An array or object (based on returnType), or an array of returnTypes
      */
@@ -478,8 +478,8 @@ class Fabricator
     /**
      * Generate new entities from the database
      *
-     * @param integer|null $count Optional number to create a collection
-     * @param boolean      $mock  Whether to execute or mock the insertion
+     * @param int|null $count Optional number to create a collection
+     * @param bool      $mock  Whether to execute or mock the insertion
      *
      * @return array|object  An array or object (based on returnType), or an array of returnTypes
      *
@@ -517,7 +517,7 @@ class Fabricator
     /**
      * Generate new database entities without actually inserting them
      *
-     * @param integer|null $count Optional number to create a collection
+     * @param int|null $count Optional number to create a collection
      *
      * @return array|object  An array or object (based on returnType), or an array of returnTypes
      */

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -389,9 +389,10 @@ class FeatureTestCase extends CIUnitTestCase
      * This allows the body to be formatted in a way that the controller is going to
      * expect as in the case of testing a JSON or XML API.
      *
-     * @param  Request    $request
-     * @param  null|array $params  The parameters to be formatted and put in the body. If this is empty, it will get the
-     *                               what has been loaded into the request global of the request class.
+     * @param Request    $request
+     * @param null|array $params  The parameters to be formatted and put in the body. If this is empty, it will get the
+     *                            what has been loaded into the request global of the request class.
+     *
      * @return Request
      */
     protected function setRequestBody(Request $request, array $params = null): Request

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -103,7 +103,8 @@ class FeatureTestCase extends CIUnitTestCase
     /**
      * Set the format the request's body should have.
      *
-     * @param  string $format The desired format. Currently supported formats: xml, json
+     * @param string $format The desired format. Currently supported formats: xml, json
+     *
      * @return $this
      */
     public function withBodyFormat(string $format)
@@ -116,7 +117,8 @@ class FeatureTestCase extends CIUnitTestCase
     /**
      * Set the raw body for the request
      *
-     * @param  mixed $body
+     * @param mixed $body
+     *
      * @return $this
      */
     public function withBody($body)
@@ -147,6 +149,7 @@ class FeatureTestCase extends CIUnitTestCase
      * @param array|null $params
      *
      * @return FeatureResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -223,6 +226,7 @@ class FeatureTestCase extends CIUnitTestCase
      * @param array|null $params
      *
      * @return FeatureResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -238,6 +242,7 @@ class FeatureTestCase extends CIUnitTestCase
      * @param array|null $params
      *
      * @return FeatureResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -253,6 +258,7 @@ class FeatureTestCase extends CIUnitTestCase
      * @param array|null $params
      *
      * @return FeatureResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -268,6 +274,7 @@ class FeatureTestCase extends CIUnitTestCase
      * @param array|null $params
      *
      * @return FeatureResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -283,6 +290,7 @@ class FeatureTestCase extends CIUnitTestCase
      * @param array|null $params
      *
      * @return FeatureResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -298,6 +306,7 @@ class FeatureTestCase extends CIUnitTestCase
      * @param array|null $params
      *
      * @return FeatureResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -362,6 +371,7 @@ class FeatureTestCase extends CIUnitTestCase
      * @param array|null $params
      *
      * @return Request
+     *
      * @throws ReflectionException
      */
     protected function populateGlobals(string $method, Request $request, array $params = null)

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -386,9 +386,10 @@ trait FeatureTestTrait
      * This allows the body to be formatted in a way that the controller is going to
      * expect as in the case of testing a JSON or XML API.
      *
-     * @param  Request    $request
-     * @param  null|array $params  The parameters to be formatted and put in the body. If this is empty, it will get the
-     *                               what has been loaded into the request global of the request class.
+     * @param Request    $request
+     * @param null|array $params  The parameters to be formatted and put in the body. If this is empty, it will get the
+     *                            what has been loaded into the request global of the request class.
+     *
      * @return Request
      */
     protected function setRequestBody(Request $request, array $params = null): Request

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -97,7 +97,8 @@ trait FeatureTestTrait
     /**
      * Set the format the request's body should have.
      *
-     * @param  string $format The desired format. Currently supported formats: xml, json
+     * @param string $format The desired format. Currently supported formats: xml, json
+     *
      * @return $this
      */
     public function withBodyFormat(string $format)
@@ -110,7 +111,8 @@ trait FeatureTestTrait
     /**
      * Set the raw body for the request
      *
-     * @param  mixed $body
+     * @param mixed $body
+     *
      * @return $this
      */
     public function withBody($body)
@@ -141,6 +143,7 @@ trait FeatureTestTrait
      * @param array|null $params
      *
      * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -217,6 +220,7 @@ trait FeatureTestTrait
      * @param array|null $params
      *
      * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -232,6 +236,7 @@ trait FeatureTestTrait
      * @param array|null $params
      *
      * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -247,6 +252,7 @@ trait FeatureTestTrait
      * @param array|null $params
      *
      * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -262,6 +268,7 @@ trait FeatureTestTrait
      * @param array|null $params
      *
      * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -277,6 +284,7 @@ trait FeatureTestTrait
      * @param array|null $params
      *
      * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -292,6 +300,7 @@ trait FeatureTestTrait
      * @param array|null $params
      *
      * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
      */
@@ -359,6 +368,7 @@ trait FeatureTestTrait
      * @param array|null $params
      *
      * @return Request
+     *
      * @throws ReflectionException
      */
     protected function populateGlobals(string $method, Request $request, array $params = null)

--- a/system/Test/FilterTestTrait.php
+++ b/system/Test/FilterTestTrait.php
@@ -36,7 +36,7 @@ trait FilterTestTrait
     /**
      * Have the one-time classes been instantiated?
      *
-     * @var boolean
+     * @var bool
      */
     private $doneFilterSetUp = false;
 

--- a/system/Test/Filters/CITestStreamFilter.php
+++ b/system/Test/Filters/CITestStreamFilter.php
@@ -32,10 +32,10 @@ class CITestStreamFilter extends php_user_filter
      *
      * @param resource $in
      * @param resource $out
-     * @param integer  $consumed
-     * @param boolean  $closing
+     * @param int  $consumed
+     * @param bool  $closing
      *
-     * @return integer
+     * @return int
      */
     public function filter($in, $out, &$consumed, $closing)
     {

--- a/system/Test/Filters/CITestStreamFilter.php
+++ b/system/Test/Filters/CITestStreamFilter.php
@@ -32,8 +32,8 @@ class CITestStreamFilter extends php_user_filter
      *
      * @param resource $in
      * @param resource $out
-     * @param int  $consumed
-     * @param bool  $closing
+     * @param int      $consumed
+     * @param bool     $closing
      *
      * @return int
      */

--- a/system/Test/Interfaces/FabricatorModel.php
+++ b/system/Test/Interfaces/FabricatorModel.php
@@ -34,7 +34,7 @@ interface FabricatorModel
      *
      * @param mixed|array|null $id One primary key or an array of primary keys
      *
-     * @return array|object|null    The resulting row of data, or null.
+     * @return array|object|null The resulting row of data, or null.
      */
     public function find($id = null);
 
@@ -43,7 +43,7 @@ interface FabricatorModel
      * it will attempt to convert it to an array.
      *
      * @param array|object $data
-     * @param bool      $returnID Whether insert ID should be returned or not.
+     * @param bool         $returnID Whether insert ID should be returned or not.
      *
      * @return int|string|bool
      * @throws ReflectionException

--- a/system/Test/Interfaces/FabricatorModel.php
+++ b/system/Test/Interfaces/FabricatorModel.php
@@ -46,6 +46,7 @@ interface FabricatorModel
      * @param bool         $returnID Whether insert ID should be returned or not.
      *
      * @return int|string|bool
+     *
      * @throws ReflectionException
      */
     public function insert($data = null, bool $returnID = true);

--- a/system/Test/Interfaces/FabricatorModel.php
+++ b/system/Test/Interfaces/FabricatorModel.php
@@ -43,9 +43,9 @@ interface FabricatorModel
      * it will attempt to convert it to an array.
      *
      * @param array|object $data
-     * @param boolean      $returnID Whether insert ID should be returned or not.
+     * @param bool      $returnID Whether insert ID should be returned or not.
      *
-     * @return integer|string|boolean
+     * @return int|string|bool
      * @throws ReflectionException
      */
     public function insert($data = null, bool $returnID = true);

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -62,7 +62,7 @@ class MockCache extends BaseHandler implements CacheInterface
      * Get an item from the cache, or execute the given Closure and store the result.
      *
      * @param string  $key      Cache item name
-     * @param int $ttl      Time to live
+     * @param int     $ttl      Time to live
      * @param Closure $callback Callback return value
      *
      * @return mixed
@@ -88,10 +88,10 @@ class MockCache extends BaseHandler implements CacheInterface
      * The $raw parameter is only utilized by Mamcache in order to
      * allow usage of increment() and decrement().
      *
-     * @param string  $key   Cache item name
-     * @param mixed   $value the data to save
-     * @param int $ttl   Time To Live, in seconds (default 60)
-     * @param bool $raw   Whether to store the raw value.
+     * @param string $key   Cache item name
+     * @param mixed  $value the data to save
+     * @param int    $ttl   Time To Live, in seconds (default 60)
+     * @param bool   $raw   Whether to store the raw value.
      *
      * @return bool
      */
@@ -157,8 +157,8 @@ class MockCache extends BaseHandler implements CacheInterface
     /**
      * Performs atomic incrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return bool
      */
@@ -181,8 +181,8 @@ class MockCache extends BaseHandler implements CacheInterface
     /**
      * Performs atomic decrementation of a raw stored value.
      *
-     * @param string  $key    Cache ID
-     * @param int $offset Step/value to increase by
+     * @param string $key    Cache ID
+     * @param int    $offset Step/value to increase by
      *
      * @return bool
      */
@@ -239,8 +239,8 @@ class MockCache extends BaseHandler implements CacheInterface
      * @param string $key Cache item name.
      *
      * @return array|null
-     *   Returns null if the item does not exist, otherwise array<string, mixed>
-     *   with at least the 'expire' key for absolute epoch expiry (or null).
+     *                    Returns null if the item does not exist, otherwise array<string, mixed>
+     *                    with at least the 'expire' key for absolute epoch expiry (or null).
      */
     public function getMetaData(string $key)
     {

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -62,7 +62,7 @@ class MockCache extends BaseHandler implements CacheInterface
      * Get an item from the cache, or execute the given Closure and store the result.
      *
      * @param string  $key      Cache item name
-     * @param integer $ttl      Time to live
+     * @param int $ttl      Time to live
      * @param Closure $callback Callback return value
      *
      * @return mixed
@@ -90,10 +90,10 @@ class MockCache extends BaseHandler implements CacheInterface
      *
      * @param string  $key   Cache item name
      * @param mixed   $value the data to save
-     * @param integer $ttl   Time To Live, in seconds (default 60)
-     * @param boolean $raw   Whether to store the raw value.
+     * @param int $ttl   Time To Live, in seconds (default 60)
+     * @param bool $raw   Whether to store the raw value.
      *
-     * @return boolean
+     * @return bool
      */
     public function save(string $key, $value, int $ttl = 60, bool $raw = false)
     {
@@ -112,7 +112,7 @@ class MockCache extends BaseHandler implements CacheInterface
      *
      * @param string $key Cache item name
      *
-     * @return boolean
+     * @return bool
      */
     public function delete(string $key)
     {
@@ -135,7 +135,7 @@ class MockCache extends BaseHandler implements CacheInterface
      *
      * @param string $pattern Cache items glob-style pattern
      *
-     * @return integer
+     * @return int
      */
     public function deleteMatching(string $pattern)
     {
@@ -158,9 +158,9 @@ class MockCache extends BaseHandler implements CacheInterface
      * Performs atomic incrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return boolean
+     * @return bool
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -182,9 +182,9 @@ class MockCache extends BaseHandler implements CacheInterface
      * Performs atomic decrementation of a raw stored value.
      *
      * @param string  $key    Cache ID
-     * @param integer $offset Step/value to increase by
+     * @param int $offset Step/value to increase by
      *
-     * @return boolean
+     * @return bool
      */
     public function decrement(string $key, int $offset = 1)
     {
@@ -206,7 +206,7 @@ class MockCache extends BaseHandler implements CacheInterface
     /**
      * Will delete all items in the entire cache.
      *
-     * @return boolean
+     * @return bool
      */
     public function clean()
     {
@@ -264,7 +264,7 @@ class MockCache extends BaseHandler implements CacheInterface
     /**
      * Determines if the driver is supported on this system.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSupported(): bool
     {

--- a/system/Test/Mock/MockCommon.php
+++ b/system/Test/Mock/MockCommon.php
@@ -16,8 +16,8 @@ if (! function_exists('is_cli')) {
      * Test to see if a request was made from the command line.
      * You can set the return value for testing.
      *
-     * @param  boolean $newReturn return value to set
-     * @return boolean
+     * @param  bool $newReturn return value to set
+     * @return bool
      */
     function is_cli(bool $newReturn = null): bool
     {

--- a/system/Test/Mock/MockCommon.php
+++ b/system/Test/Mock/MockCommon.php
@@ -16,7 +16,8 @@ if (! function_exists('is_cli')) {
      * Test to see if a request was made from the command line.
      * You can set the return value for testing.
      *
-     * @param  bool $newReturn return value to set
+     * @param bool $newReturn return value to set
+     *
      * @return bool
      */
     function is_cli(bool $newReturn = null): bool

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -43,10 +43,10 @@ class MockConnection extends BaseConnection
      * Should automatically handle different connections for read/write
      * queries if needed.
      *
-     * @param string  $sql
-     * @param mixed   ...$binds
-     * @param bool $setEscapeFlags
-     * @param string  $queryClass
+     * @param string $sql
+     * @param mixed  ...$binds
+     * @param bool   $setEscapeFlags
+     * @param string $queryClass
      *
      * @return BaseResult|Query|bool
      *

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -45,10 +45,10 @@ class MockConnection extends BaseConnection
      *
      * @param string  $sql
      * @param mixed   ...$binds
-     * @param boolean $setEscapeFlags
+     * @param bool $setEscapeFlags
      * @param string  $queryClass
      *
-     * @return BaseResult|Query|boolean
+     * @return BaseResult|Query|bool
      *
      * @todo BC set $queryClass default as null in 4.1
      */
@@ -95,7 +95,7 @@ class MockConnection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @param boolean $persistent
+     * @param bool $persistent
      *
      * @return mixed
      */
@@ -118,7 +118,7 @@ class MockConnection extends BaseConnection
      * Keep or establish the connection if no queries have been sent for
      * a length of time exceeding the server's idle timeout.
      *
-     * @return boolean
+     * @return bool
      */
     public function reconnect(): bool
     {
@@ -172,7 +172,7 @@ class MockConnection extends BaseConnection
     /**
      * Returns the total number of rows affected by this query.
      *
-     * @return integer
+     * @return int
      */
     public function affectedRows(): int
     {
@@ -203,7 +203,7 @@ class MockConnection extends BaseConnection
     /**
      * Insert ID
      *
-     * @return integer
+     * @return int
      */
     public function insertID(): int
     {
@@ -215,7 +215,7 @@ class MockConnection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param boolean $constrainByPrefix
+     * @param bool $constrainByPrefix
      *
      * @return string
      */
@@ -279,7 +279,7 @@ class MockConnection extends BaseConnection
     /**
      * Begin Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transBegin(): bool
     {
@@ -291,7 +291,7 @@ class MockConnection extends BaseConnection
     /**
      * Commit Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transCommit(): bool
     {
@@ -303,7 +303,7 @@ class MockConnection extends BaseConnection
     /**
      * Rollback Transaction
      *
-     * @return boolean
+     * @return bool
      */
     protected function _transRollback(): bool
     {

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -239,7 +239,8 @@ class MockConnection extends BaseConnection
     }
 
     /**
-     * @param  string $table
+     * @param string $table
+     *
      * @return array
      */
     protected function _fieldData(string $table): array
@@ -248,7 +249,8 @@ class MockConnection extends BaseConnection
     }
 
     /**
-     * @param  string $table
+     * @param string $table
+     *
      * @return array
      */
     protected function _indexData(string $table): array
@@ -257,7 +259,8 @@ class MockConnection extends BaseConnection
     }
 
     /**
-     * @param  string $table
+     * @param string $table
+     *
      * @return array
      */
     protected function _foreignKeyData(string $table): array

--- a/system/Test/Mock/MockEmail.php
+++ b/system/Test/Mock/MockEmail.php
@@ -19,7 +19,7 @@ class MockEmail extends Email
     /**
      * Value to return from mocked send().
      *
-     * @var boolean
+     * @var bool
      */
     public $returnValue = true;
 

--- a/system/Test/Mock/MockResponse.php
+++ b/system/Test/Mock/MockResponse.php
@@ -21,7 +21,7 @@ class MockResponse extends Response
     /**
      * If true, will not write output. Useful during testing.
      *
-     * @var boolean
+     * @var bool
      */
     protected $pretend = true;
 

--- a/system/Test/Mock/MockResult.php
+++ b/system/Test/Mock/MockResult.php
@@ -18,7 +18,7 @@ class MockResult extends BaseResult
     /**
      * Gets the number of fields in the result set.
      *
-     * @return integer
+     * @return int
      */
     public function getFieldCount(): int
     {
@@ -67,7 +67,7 @@ class MockResult extends BaseResult
      * internally before fetching results to make sure the result set
      * starts at zero.
      *
-     * @param integer $n
+     * @param int $n
      *
      * @return mixed
      */
@@ -109,7 +109,7 @@ class MockResult extends BaseResult
     /**
      * Gets the number of fields in the result set.
      *
-     * @return integer
+     * @return int
      */
     public function getNumRows(): int
     {

--- a/system/Test/ReflectionHelper.php
+++ b/system/Test/ReflectionHelper.php
@@ -30,6 +30,7 @@ trait ReflectionHelper
      * @param string        $method method name
      *
      * @return Closure
+     *
      * @throws ReflectionException
      */
     public static function getPrivateMethodInvoker($obj, $method)
@@ -52,6 +53,7 @@ trait ReflectionHelper
      * @param string        $property
      *
      * @return ReflectionProperty
+     *
      * @throws ReflectionException
      */
     private static function getAccessibleRefProperty($obj, $property)

--- a/system/Test/ReflectionHelper.php
+++ b/system/Test/ReflectionHelper.php
@@ -86,6 +86,7 @@ trait ReflectionHelper
      * @param string        $property property name
      *
      * @return mixed value
+     *
      * @throws ReflectionException
      */
     public static function getPrivateProperty($obj, $property)

--- a/system/Test/TestLogger.php
+++ b/system/Test/TestLogger.php
@@ -27,7 +27,7 @@ class TestLogger extends Logger
      * @param string $message
      * @param array  $context
      *
-     * @return boolean
+     * @return bool
      */
     public function log($level, $message, array $context = []): bool
     {
@@ -65,7 +65,7 @@ class TestLogger extends Logger
      * @param string $level
      * @param string $message
      *
-     * @return boolean
+     * @return bool
      */
     public static function didLog(string $level, $message)
     {

--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -123,7 +123,7 @@ class TestResponse extends TestCase
      * Boils down the possible responses into a boolean valid/not-valid
      * response type.
      *
-     * @return boolean
+     * @return bool
      */
     public function isOK(): bool
     {
@@ -141,7 +141,7 @@ class TestResponse extends TestCase
     /**
      * Asserts that the status is a specific value.
      *
-     * @param integer $code
+     * @param int $code
      *
      * @throws Exception
      */
@@ -177,7 +177,7 @@ class TestResponse extends TestCase
     /**
      * Returns whether or not the Response was a redirect or RedirectResponse
      *
-     * @return boolean
+     * @return bool
      */
     public function isRedirect(): bool
     {
@@ -388,7 +388,7 @@ class TestResponse extends TestCase
      * Test that the response contains a matching JSON fragment.
      *
      * @param array   $fragment
-     * @param boolean $strict
+     * @param bool $strict
      *
      * @throws Exception
      */

--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -525,8 +525,9 @@ class TestResponse extends TestCase
     /**
      * Forward any unrecognized method calls to our DOMParser instance.
      *
-     * @param  string $function Method name
-     * @param  mixed  $params   Any method parameters
+     * @param string $function Method name
+     * @param mixed  $params   Any method parameters
+     *
      * @return mixed
      */
     public function __call($function, $params)

--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -387,8 +387,8 @@ class TestResponse extends TestCase
     /**
      * Test that the response contains a matching JSON fragment.
      *
-     * @param array   $fragment
-     * @param bool $strict
+     * @param array $fragment
+     * @param bool  $strict
      *
      * @throws Exception
      */

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -100,6 +100,7 @@ class Throttler implements ThrottlerInterface
      * @param int    $cost     The number of tokens this action uses.
      *
      * @return bool
+     *
      * @internal param int $maxRequests
      */
     public function check(string $key, int $capacity, int $seconds, int $cost = 1): bool

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -94,12 +94,12 @@ class Throttler implements ThrottlerInterface
      *      die('You submitted over 60 requests within a minute.');
      * }
      *
-     * @param string  $key      The name to use as the "bucket" name.
-     * @param int $capacity The number of requests the "bucket" can hold
-     * @param int $seconds  The time it takes the "bucket" to completely refill
-     * @param int $cost     The number of tokens this action uses.
+     * @param string $key      The name to use as the "bucket" name.
+     * @param int    $capacity The number of requests the "bucket" can hold
+     * @param int    $seconds  The time it takes the "bucket" to completely refill
+     * @param int    $cost     The number of tokens this action uses.
      *
-     * @return   bool
+     * @return bool
      * @internal param int $maxRequests
      */
     public function check(string $key, int $capacity, int $seconds, int $cost = 1): bool

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -37,7 +37,7 @@ class Throttler implements ThrottlerInterface
     /**
      * The number of seconds until the next token is available.
      *
-     * @var integer
+     * @var int
      */
     protected $tokenTime = 0;
 
@@ -52,7 +52,7 @@ class Throttler implements ThrottlerInterface
     /**
      * Timestamp to use (during testing)
      *
-     * @var integer
+     * @var int
      */
     protected $testTime;
 
@@ -74,7 +74,7 @@ class Throttler implements ThrottlerInterface
      * Returns the number of seconds until the next available token will
      * be released for usage.
      *
-     * @return integer
+     * @return int
      */
     public function getTokenTime(): int
     {
@@ -95,11 +95,11 @@ class Throttler implements ThrottlerInterface
      * }
      *
      * @param string  $key      The name to use as the "bucket" name.
-     * @param integer $capacity The number of requests the "bucket" can hold
-     * @param integer $seconds  The time it takes the "bucket" to completely refill
-     * @param integer $cost     The number of tokens this action uses.
+     * @param int $capacity The number of requests the "bucket" can hold
+     * @param int $seconds  The time it takes the "bucket" to completely refill
+     * @param int $cost     The number of tokens this action uses.
      *
-     * @return   boolean
+     * @return   bool
      * @internal param int $maxRequests
      */
     public function check(string $key, int $capacity, int $seconds, int $cost = 1): bool
@@ -168,7 +168,7 @@ class Throttler implements ThrottlerInterface
     /**
      * Used during testing to set the current timestamp to use.
      *
-     * @param integer $time
+     * @param int $time
      *
      * @return $this
      */
@@ -184,7 +184,7 @@ class Throttler implements ThrottlerInterface
     /**
      * Return the test time, defaulting to current.
      *
-     * @return integer
+     * @return int
      */
     public function time(): int
     {

--- a/system/Throttle/ThrottlerInterface.php
+++ b/system/Throttle/ThrottlerInterface.php
@@ -28,11 +28,11 @@ interface ThrottlerInterface
      * }
      *
      * @param string  $key      The name to use as the "bucket" name.
-     * @param integer $capacity The number of requests the "bucket" can hold
-     * @param integer $seconds  The time it takes the "bucket" to completely refill
-     * @param integer $cost     The number of tokens this action uses.
+     * @param int $capacity The number of requests the "bucket" can hold
+     * @param int $seconds  The time it takes the "bucket" to completely refill
+     * @param int $cost     The number of tokens this action uses.
      *
-     * @return boolean
+     * @return bool
      */
     public function check(string $key, int $capacity, int $seconds, int $cost);
 
@@ -42,7 +42,7 @@ interface ThrottlerInterface
      * Returns the number of seconds until the next available token will
      * be released for usage.
      *
-     * @return integer
+     * @return int
      */
     public function getTokenTime(): int;
 }

--- a/system/Throttle/ThrottlerInterface.php
+++ b/system/Throttle/ThrottlerInterface.php
@@ -27,10 +27,10 @@ interface ThrottlerInterface
      *      die('You submitted over 60 requests within a minute.');
      * }
      *
-     * @param string  $key      The name to use as the "bucket" name.
-     * @param int $capacity The number of requests the "bucket" can hold
-     * @param int $seconds  The time it takes the "bucket" to completely refill
-     * @param int $cost     The number of tokens this action uses.
+     * @param string $key      The name to use as the "bucket" name.
+     * @param int    $capacity The number of requests the "bucket" can hold
+     * @param int    $seconds  The time it takes the "bucket" to completely refill
+     * @param int    $cost     The number of tokens this action uses.
      *
      * @return bool
      */

--- a/system/Typography/Typography.php
+++ b/system/Typography/Typography.php
@@ -54,7 +54,7 @@ class Typography
     /**
      * whether or not to protect quotes within { curly braces }
      *
-     * @var boolean
+     * @var bool
      */
     public $protectBracedQuotes = false;
 
@@ -70,7 +70,7 @@ class Typography
      *  - Converts two spaces into entities
      *
      * @param string  $str
-     * @param boolean $reduceLinebreaks whether to reduce more then two consecutive newlines to two
+     * @param bool $reduceLinebreaks whether to reduce more then two consecutive newlines to two
      *
      * @return string
      */

--- a/system/Typography/Typography.php
+++ b/system/Typography/Typography.php
@@ -231,7 +231,8 @@ class Typography
      * to curly entities, but it also converts em-dashes,
      * double spaces, and ampersands
      *
-     * @param  string $str
+     * @param string $str
+     *
      * @return string
      */
     public function formatCharacters(string $str): string
@@ -287,7 +288,8 @@ class Typography
      *
      * Converts newline characters into either <p> tags or <br />
      *
-     * @param  string $str
+     * @param string $str
+     *
      * @return string
      */
     protected function formatNewLines(string $str): string
@@ -325,7 +327,8 @@ class Typography
      * and we don't want double dashes converted to emdash entities, so they are marked with {@DD}
      * likewise double spaces are converted to {@NBS} to prevent entity conversion
      *
-     * @param  array  $match
+     * @param array $match
+     *
      * @return string
      */
     protected function protectCharacters(array $match): string
@@ -338,7 +341,8 @@ class Typography
     /**
      * Convert newlines to HTML line breaks except within PRE tags
      *
-     * @param  string $str
+     * @param string $str
+     *
      * @return string
      */
     public function nl2brExceptPre(string $str): string

--- a/system/Typography/Typography.php
+++ b/system/Typography/Typography.php
@@ -69,8 +69,8 @@ class Typography
      *     - Converts double dashes into em-dashes.
      *  - Converts two spaces into entities
      *
-     * @param string  $str
-     * @param bool $reduceLinebreaks whether to reduce more then two consecutive newlines to two
+     * @param string $str
+     * @param bool   $reduceLinebreaks whether to reduce more then two consecutive newlines to two
      *
      * @return string
      */
@@ -325,7 +325,7 @@ class Typography
      * and we don't want double dashes converted to emdash entities, so they are marked with {@DD}
      * likewise double spaces are converted to {@NBS} to prevent entity conversion
      *
-     * @param  array $match
+     * @param  array  $match
      * @return string
      */
     protected function protectCharacters(array $match): string

--- a/system/Validation/CreditCardRules.php
+++ b/system/Validation/CreditCardRules.php
@@ -175,7 +175,7 @@ class CreditCardRules
      * @param string|null $ccNumber
      * @param string      $type
      *
-     * @return boolean
+     * @return bool
      */
     public function valid_cc_number(?string $ccNumber, string $type): bool
     {
@@ -248,7 +248,7 @@ class CreditCardRules
      *
      * @param string $number
      *
-     * @return boolean
+     * @return bool
      */
     protected function isValidLuhn(string $number = null): bool
     {

--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -51,7 +51,7 @@ class FileRules
      * @param string|null $blank
      * @param string      $name
      *
-     * @return boolean
+     * @return bool
      */
     public function uploaded(?string $blank, string $name): bool
     {
@@ -89,7 +89,7 @@ class FileRules
      * @param string|null $blank
      * @param string      $params
      *
-     * @return boolean
+     * @return bool
      */
     public function max_size(?string $blank, string $params): bool
     {
@@ -132,7 +132,7 @@ class FileRules
      * @param string|null $blank
      * @param string      $params
      *
-     * @return boolean
+     * @return bool
      */
     public function is_image(?string $blank, string $params): bool
     {
@@ -174,7 +174,7 @@ class FileRules
      * @param string|null $blank
      * @param string      $params
      *
-     * @return boolean
+     * @return bool
      */
     public function mime_in(?string $blank, string $params): bool
     {
@@ -212,7 +212,7 @@ class FileRules
      * @param string|null $blank
      * @param string      $params
      *
-     * @return boolean
+     * @return bool
      */
     public function ext_in(?string $blank, string $params): bool
     {
@@ -251,7 +251,7 @@ class FileRules
      * @param string|null $blank
      * @param string      $params
      *
-     * @return boolean
+     * @return bool
      */
     public function max_dims(?string $blank, string $params): bool
     {

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -157,7 +157,8 @@ class FormatRules
     /**
      * Is a Natural number  (0,1,2,3, etc.)
      *
-     * @param  string|null $str
+     * @param string|null $str
+     *
      * @return bool
      */
     public function is_natural(?string $str = null): bool
@@ -168,7 +169,8 @@ class FormatRules
     /**
      * Is a Natural number, but not a zero  (1,2,3, etc.)
      *
-     * @param  string|null $str
+     * @param string|null $str
+     *
      * @return bool
      */
     public function is_natural_no_zero(?string $str = null): bool
@@ -227,7 +229,8 @@ class FormatRules
      * Tests a string for characters outside of the Base64 alphabet
      * as defined by RFC 2045 http://www.faqs.org/rfcs/rfc2045
      *
-     * @param  string $str
+     * @param string $str
+     *
      * @return bool
      */
     public function valid_base64(string $str = null): bool

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -23,7 +23,7 @@ class FormatRules
      *
      * @param string|null $str
      *
-     * @return boolean
+     * @return bool
      */
     public function alpha(?string $str = null): bool
     {
@@ -35,7 +35,7 @@ class FormatRules
      *
      * @param string|null $value Value.
      *
-     * @return boolean True if alpha with spaces, else false.
+     * @return bool True if alpha with spaces, else false.
      */
     public function alpha_space(?string $value = null): bool
     {
@@ -52,7 +52,7 @@ class FormatRules
      *
      * @param string|null $str
      *
-     * @return boolean
+     * @return bool
      */
     public function alpha_dash(?string $str = null): bool
     {
@@ -69,7 +69,7 @@ class FormatRules
      *
      * @param string $str
      *
-     * @return boolean
+     * @return bool
      */
     public function alpha_numeric_punct($str)
     {
@@ -82,7 +82,7 @@ class FormatRules
      *
      * @param string|null $str
      *
-     * @return boolean
+     * @return bool
      */
     public function alpha_numeric(?string $str = null): bool
     {
@@ -94,7 +94,7 @@ class FormatRules
      *
      * @param string|null $str
      *
-     * @return boolean
+     * @return bool
      */
     public function alpha_numeric_space(?string $str = null): bool
     {
@@ -110,7 +110,7 @@ class FormatRules
      *
      * @param string|null $str
      *
-     * @return boolean
+     * @return bool
      */
     public function string($str = null): bool
     {
@@ -122,7 +122,7 @@ class FormatRules
      *
      * @param string|null $str
      *
-     * @return boolean
+     * @return bool
      */
     public function decimal(?string $str = null): bool
     {
@@ -135,7 +135,7 @@ class FormatRules
      *
      * @param string|null $str
      *
-     * @return boolean
+     * @return bool
      */
     public function hex(?string $str = null): bool
     {
@@ -147,7 +147,7 @@ class FormatRules
      *
      * @param string|null $str
      *
-     * @return boolean
+     * @return bool
      */
     public function integer(?string $str = null): bool
     {
@@ -158,7 +158,7 @@ class FormatRules
      * Is a Natural number  (0,1,2,3, etc.)
      *
      * @param  string|null $str
-     * @return boolean
+     * @return bool
      */
     public function is_natural(?string $str = null): bool
     {
@@ -169,7 +169,7 @@ class FormatRules
      * Is a Natural number, but not a zero  (1,2,3, etc.)
      *
      * @param  string|null $str
-     * @return boolean
+     * @return bool
      */
     public function is_natural_no_zero(?string $str = null): bool
     {
@@ -181,7 +181,7 @@ class FormatRules
      *
      * @param string|null $str
      *
-     * @return boolean
+     * @return bool
      */
     public function numeric(?string $str = null): bool
     {
@@ -195,7 +195,7 @@ class FormatRules
      * @param string|null $str
      * @param string      $pattern
      *
-     * @return boolean
+     * @return bool
      */
     public function regex_match(?string $str, string $pattern): bool
     {
@@ -214,7 +214,7 @@ class FormatRules
      *
      * @param string $str
      *
-     * @return boolean
+     * @return bool
      */
     public function timezone(string $str = null): bool
     {
@@ -228,7 +228,7 @@ class FormatRules
      * as defined by RFC 2045 http://www.faqs.org/rfcs/rfc2045
      *
      * @param  string $str
-     * @return boolean
+     * @return bool
      */
     public function valid_base64(string $str = null): bool
     {
@@ -240,7 +240,7 @@ class FormatRules
      *
      * @param string $str
      *
-     * @return boolean
+     * @return bool
      */
     public function valid_json(string $str = null): bool
     {
@@ -254,7 +254,7 @@ class FormatRules
      *
      * @param string $str
      *
-     * @return boolean
+     * @return bool
      */
     public function valid_email(string $str = null): bool
     {
@@ -274,7 +274,7 @@ class FormatRules
      *
      * @param string $str
      *
-     * @return boolean
+     * @return bool
      */
     public function valid_emails(string $str = null): bool
     {
@@ -298,7 +298,7 @@ class FormatRules
      * @param string $ip    IP Address
      * @param string $which IP protocol: 'ipv4' or 'ipv6'
      *
-     * @return boolean
+     * @return bool
      */
     public function valid_ip(string $ip = null, string $which = null): bool
     {
@@ -328,7 +328,7 @@ class FormatRules
      *
      * @param string $str
      *
-     * @return boolean
+     * @return bool
      */
     public function valid_url(string $str = null): bool
     {
@@ -355,7 +355,7 @@ class FormatRules
      * @param string $str
      * @param string $format
      *
-     * @return boolean
+     * @return bool
      */
     public function valid_date(string $str = null, string $format = null): bool
     {

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -320,7 +320,7 @@ class Rules
      *
      * @param mixed $str Value
      *
-     * @return bool          True if valid, false if not
+     * @return bool True if valid, false if not
      */
     public function required($str = null): bool
     {

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -28,7 +28,7 @@ class Rules
      * @param string $field
      * @param array  $data  Other field/value pairs
      *
-     * @return boolean
+     * @return bool
      */
     public function differs(string $str = null, string $field, array $data): bool
     {
@@ -47,7 +47,7 @@ class Rules
      * @param string $str
      * @param string $val
      *
-     * @return boolean
+     * @return bool
      */
     public function equals(string $str = null, string $val): bool
     {
@@ -63,7 +63,7 @@ class Rules
      * @param string $str
      * @param string $val
      *
-     * @return boolean
+     * @return bool
      */
     public function exact_length(string $str = null, string $val): bool
     {
@@ -86,7 +86,7 @@ class Rules
      * @param string $str
      * @param string $min
      *
-     * @return boolean
+     * @return bool
      */
     public function greater_than(string $str = null, string $min): bool
     {
@@ -101,7 +101,7 @@ class Rules
      * @param string $str
      * @param string $min
      *
-     * @return boolean
+     * @return bool
      */
     public function greater_than_equal_to(string $str = null, string $min): bool
     {
@@ -123,7 +123,7 @@ class Rules
      * @param string $field
      * @param array  $data
      *
-     * @return boolean
+     * @return bool
      */
     public function is_not_unique(string $str = null, string $field, array $data): bool
     {
@@ -155,7 +155,7 @@ class Rules
      * @param string $value
      * @param string $list
      *
-     * @return boolean
+     * @return bool
      */
     public function in_list(string $value = null, string $list): bool
     {
@@ -179,7 +179,7 @@ class Rules
      * @param string $field
      * @param array  $data
      *
-     * @return boolean
+     * @return bool
      */
     public function is_unique(string $str = null, string $field, array $data): bool
     {
@@ -211,7 +211,7 @@ class Rules
      * @param string $str
      * @param string $max
      *
-     * @return boolean
+     * @return bool
      */
     public function less_than(string $str = null, string $max): bool
     {
@@ -226,7 +226,7 @@ class Rules
      * @param string $str
      * @param string $max
      *
-     * @return boolean
+     * @return bool
      */
     public function less_than_equal_to(string $str = null, string $max): bool
     {
@@ -242,7 +242,7 @@ class Rules
      * @param string $field
      * @param array  $data  Other field/value pairs
      *
-     * @return boolean
+     * @return bool
      */
     public function matches(string $str = null, string $field, array $data): bool
     {
@@ -261,7 +261,7 @@ class Rules
      * @param string $str
      * @param string $val
      *
-     * @return boolean
+     * @return bool
      */
     public function max_length(string $str = null, string $val): bool
     {
@@ -276,7 +276,7 @@ class Rules
      * @param string $str
      * @param string $val
      *
-     * @return boolean
+     * @return bool
      */
     public function min_length(string $str = null, string $val): bool
     {
@@ -291,7 +291,7 @@ class Rules
      * @param string $str
      * @param string $val
      *
-     * @return boolean
+     * @return bool
      */
     public function not_equals(string $str = null, string $val): bool
     {
@@ -306,7 +306,7 @@ class Rules
      * @param string $value
      * @param string $list
      *
-     * @return boolean
+     * @return bool
      */
     public function not_in_list(string $value = null, string $list): bool
     {
@@ -320,7 +320,7 @@ class Rules
      *
      * @param mixed $str Value
      *
-     * @return boolean          True if valid, false if not
+     * @return bool          True if valid, false if not
      */
     public function required($str = null): bool
     {
@@ -345,7 +345,7 @@ class Rules
      * @param string|null $fields List of fields that we should check if present
      * @param array       $data   Complete list of fields from the form
      *
-     * @return boolean
+     * @return bool
      */
     public function required_with($str = null, string $fields = null, array $data = []): bool
     {
@@ -393,7 +393,7 @@ class Rules
      * @param string|null $fields
      * @param array       $data
      *
-     * @return boolean
+     * @return bool
      */
     public function required_without($str = null, string $fields = null, array $data = []): bool
     {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -106,7 +106,7 @@ class Validation implements ValidationInterface
      * @param string|null $group   The predefined group of rules to apply.
      * @param string|null $dbGroup The database group to use.
      *
-     * @return boolean
+     * @return bool
      */
     public function run(array $data = null, string $group = null, string $dbGroup = null): bool
     {
@@ -166,7 +166,7 @@ class Validation implements ValidationInterface
      * @param string   $rule
      * @param string[] $errors
      *
-     * @return boolean
+     * @return bool
      */
     public function check($value, string $rule, array $errors = []): bool
     {
@@ -187,7 +187,7 @@ class Validation implements ValidationInterface
      * @param array|null   $rules
      * @param array        $data
      *
-     * @return boolean
+     * @return bool
      */
     protected function processRules(string $field, string $label = null, $value, $rules = null, array $data = null): bool
     {
@@ -432,7 +432,7 @@ class Validation implements ValidationInterface
      *
      * @param string $field
      *
-     * @return boolean
+     * @return bool
      */
     public function hasRule(string $field): bool
     {
@@ -630,7 +630,7 @@ class Validation implements ValidationInterface
      *
      * @param string $field
      *
-     * @return boolean
+     * @return bool
      */
     public function hasError(string $field): bool
     {

--- a/system/Validation/ValidationInterface.php
+++ b/system/Validation/ValidationInterface.php
@@ -25,7 +25,7 @@ interface ValidationInterface
      * @param array  $data  The array of data to validate.
      * @param string $group The pre-defined group of rules to apply.
      *
-     * @return boolean
+     * @return bool
      */
     public function run(array $data = null, string $group = null): bool;
 
@@ -39,7 +39,7 @@ interface ValidationInterface
      * @param string   $rule   Rule.
      * @param string[] $errors Errors.
      *
-     * @return boolean True if valid, else false.
+     * @return bool True if valid, else false.
      */
     public function check($value, string $rule, array $errors = []): bool;
 
@@ -76,7 +76,7 @@ interface ValidationInterface
      *
      * @param string $field
      *
-     * @return boolean
+     * @return bool
      */
     public function hasRule(string $field): bool;
 

--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -70,7 +70,7 @@ class Cell
      *
      * @param string      $library
      * @param null        $params
-     * @param integer     $ttl
+     * @param int     $ttl
      * @param string|null $cacheName
      *
      * @return string

--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -70,7 +70,7 @@ class Cell
      *
      * @param string      $library
      * @param null        $params
-     * @param int     $ttl
+     * @param int         $ttl
      * @param string|null $cacheName
      *
      * @return string

--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -74,6 +74,7 @@ class Cell
      * @param string|null $cacheName
      *
      * @return string
+     *
      * @throws ReflectionException
      */
     public function render(string $library, $params = null, int $ttl = 0, string $cacheName = null): string

--- a/system/View/Filters.php
+++ b/system/View/Filters.php
@@ -62,7 +62,7 @@ class Filters
      * @param string $value
      * @param string $adjustment
      *
-     * @return   int|false
+     * @return int|false
      */
     public static function date_modify($value, string $adjustment)
     {
@@ -108,9 +108,9 @@ class Filters
     /**
      * Returns an excerpt of the given string.
      *
-     * @param string  $value
-     * @param string  $phrase
-     * @param int $radius
+     * @param string $value
+     * @param string $phrase
+     * @param int    $radius
      *
      * @return string
      */
@@ -160,8 +160,8 @@ class Filters
      * Limits the number of characters to $limit, and trails of with an ellipsis.
      * Will break at word break so may be more or less than $limit.
      *
-     * @param string  $value
-     * @param int $limit
+     * @param string $value
+     * @param int    $limit
      *
      * @return string
      */
@@ -177,8 +177,8 @@ class Filters
     /**
      * Limits the number of words to $limit, and trails of with an ellipsis.
      *
-     * @param string  $value
-     * @param int $limit
+     * @param string $value
+     * @param int    $limit
      *
      * @return string
      */
@@ -194,10 +194,10 @@ class Filters
     /**
      * Returns the $value displayed in a localized manner.
      *
-     * @param int|float $value
-     * @param int       $precision
-     * @param string        $type
-     * @param string|null   $locale
+     * @param int|float   $value
+     * @param int         $precision
+     * @param string      $type
+     * @param string|null $locale
      *
      * @return string
      */
@@ -223,10 +223,10 @@ class Filters
     /**
      * Returns the $value displayed as a currency string.
      *
-     * @param int|float $value
-     * @param string        $currency
-     * @param string|null   $locale
-     * @param int       $fraction
+     * @param int|float   $value
+     * @param string      $currency
+     * @param string|null $locale
+     * @param int         $fraction
      *
      * @return string
      */

--- a/system/View/Filters.php
+++ b/system/View/Filters.php
@@ -62,8 +62,7 @@ class Filters
      * @param string $value
      * @param string $adjustment
      *
-     * @return   integer|false
-     * @internal param string $format
+     * @return   int|false
      */
     public static function date_modify($value, string $adjustment)
     {
@@ -111,7 +110,7 @@ class Filters
      *
      * @param string  $value
      * @param string  $phrase
-     * @param integer $radius
+     * @param int $radius
      *
      * @return string
      */
@@ -162,7 +161,7 @@ class Filters
      * Will break at word break so may be more or less than $limit.
      *
      * @param string  $value
-     * @param integer $limit
+     * @param int $limit
      *
      * @return string
      */
@@ -179,7 +178,7 @@ class Filters
      * Limits the number of words to $limit, and trails of with an ellipsis.
      *
      * @param string  $value
-     * @param integer $limit
+     * @param int $limit
      *
      * @return string
      */
@@ -195,8 +194,8 @@ class Filters
     /**
      * Returns the $value displayed in a localized manner.
      *
-     * @param integer|float $value
-     * @param integer       $precision
+     * @param int|float $value
+     * @param int       $precision
      * @param string        $type
      * @param string|null   $locale
      *
@@ -224,10 +223,10 @@ class Filters
     /**
      * Returns the $value displayed as a currency string.
      *
-     * @param integer|float $value
+     * @param int|float $value
      * @param string        $currency
      * @param string|null   $locale
-     * @param integer       $fraction
+     * @param int       $fraction
      *
      * @return string
      */

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -65,7 +65,7 @@ class Parser extends View
      * @param ViewConfig      $config
      * @param string          $viewPath
      * @param mixed           $loader
-     * @param boolean         $debug
+     * @param bool         $debug
      * @param LoggerInterface $logger
      */
     public function __construct(ViewConfig $config, string $viewPath = null, $loader = null, bool $debug = null, LoggerInterface $logger = null)
@@ -86,7 +86,7 @@ class Parser extends View
      *
      * @param string  $view
      * @param array   $options
-     * @param boolean $saveData
+     * @param bool $saveData
      *
      * @return string
      */
@@ -151,7 +151,7 @@ class Parser extends View
      *
      * @param string  $template
      * @param array   $options
-     * @param boolean $saveData
+     * @param bool $saveData
      *
      * @return string
      */
@@ -524,7 +524,7 @@ class Parser extends View
      * @param mixed   $pattern
      * @param string  $content
      * @param string  $template
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return string
      */
@@ -558,7 +558,7 @@ class Parser extends View
      *
      * @param array   $matches
      * @param string  $replace
-     * @param boolean $escape
+     * @param bool $escape
      *
      * @return string
      */
@@ -728,7 +728,7 @@ class Parser extends View
      * @param string   $alias
      * @param callable $callback
      *
-     * @param boolean  $isPair
+     * @param bool  $isPair
      *
      * @return $this
      */

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -65,7 +65,7 @@ class Parser extends View
      * @param ViewConfig      $config
      * @param string          $viewPath
      * @param mixed           $loader
-     * @param bool         $debug
+     * @param bool            $debug
      * @param LoggerInterface $logger
      */
     public function __construct(ViewConfig $config, string $viewPath = null, $loader = null, bool $debug = null, LoggerInterface $logger = null)
@@ -84,9 +84,9 @@ class Parser extends View
      * Parses pseudo-variables contained in the specified template view,
      * replacing them with any data that has already been set.
      *
-     * @param string  $view
-     * @param array   $options
-     * @param bool $saveData
+     * @param string $view
+     * @param array  $options
+     * @param bool   $saveData
      *
      * @return string
      */
@@ -149,9 +149,9 @@ class Parser extends View
      * Parses pseudo-variables contained in the specified string,
      * replacing them with any data that has already been set.
      *
-     * @param string  $template
-     * @param array   $options
-     * @param bool $saveData
+     * @param string $template
+     * @param array  $options
+     * @param bool   $saveData
      *
      * @return string
      */
@@ -503,8 +503,8 @@ class Parser extends View
     /**
      * Over-ride the substitution field delimiters.
      *
-     * @param  string $leftDelimiter
-     * @param  string $rightDelimiter
+     * @param  string            $leftDelimiter
+     * @param  string            $rightDelimiter
      * @return RendererInterface
      */
     public function setDelimiters($leftDelimiter = '{', $rightDelimiter = '}'): RendererInterface
@@ -521,10 +521,10 @@ class Parser extends View
      * Handles replacing a pseudo-variable with the actual content. Will double-check
      * for escaping brackets.
      *
-     * @param mixed   $pattern
-     * @param string  $content
-     * @param string  $template
-     * @param bool $escape
+     * @param mixed  $pattern
+     * @param string $content
+     * @param string $template
+     * @param bool   $escape
      *
      * @return string
      */
@@ -556,9 +556,9 @@ class Parser extends View
     /**
      * Callback used during parse() to apply any filters to the value.
      *
-     * @param array   $matches
-     * @param string  $replace
-     * @param bool $escape
+     * @param array  $matches
+     * @param string $replace
+     * @param bool   $escape
      *
      * @return string
      */
@@ -728,7 +728,7 @@ class Parser extends View
      * @param string   $alias
      * @param callable $callback
      *
-     * @param bool  $isPair
+     * @param bool $isPair
      *
      * @return $this
      */

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -273,8 +273,9 @@ class Parser extends View
     /**
      * Parse a single key/value, extracting it
      *
-     * @param  string $key
-     * @param  string $val
+     * @param string $key
+     * @param string $val
+     *
      * @return array
      */
     protected function parseSingle(string $key, string $val): array
@@ -291,9 +292,10 @@ class Parser extends View
      *
      * Parses tag pairs: {some_tag} string... {/some_tag}
      *
-     * @param  string $variable
-     * @param  array  $data
-     * @param  string $template
+     * @param string $variable
+     * @param array  $data
+     * @param string $template
+     *
      * @return array
      */
     protected function parsePair(string $variable, array $data, string $template): array
@@ -503,8 +505,9 @@ class Parser extends View
     /**
      * Over-ride the substitution field delimiters.
      *
-     * @param  string            $leftDelimiter
-     * @param  string            $rightDelimiter
+     * @param string $leftDelimiter
+     * @param string $rightDelimiter
+     *
      * @return RendererInterface
      */
     public function setDelimiters($leftDelimiter = '{', $rightDelimiter = '}'): RendererInterface
@@ -727,8 +730,7 @@ class Parser extends View
      *
      * @param string   $alias
      * @param callable $callback
-     *
-     * @param bool $isPair
+     * @param bool     $isPair
      *
      * @return $this
      */

--- a/system/View/RendererInterface.php
+++ b/system/View/RendererInterface.php
@@ -26,7 +26,7 @@ interface RendererInterface
      * @param array   $options  Reserved for 3rd-party uses since
      *                          it might be needed to pass additional info
      *                          to other template engines.
-     * @param boolean $saveData Whether to save data for subsequent calls
+     * @param bool $saveData Whether to save data for subsequent calls
      *
      * @return string
      */
@@ -42,7 +42,7 @@ interface RendererInterface
      * @param array   $options  Reserved for 3rd-party uses since
      *                          it might be needed to pass additional info
      *                          to other template engines.
-     * @param boolean $saveData Whether to save data for subsequent calls
+     * @param bool $saveData Whether to save data for subsequent calls
      *
      * @return string
      */

--- a/system/View/RendererInterface.php
+++ b/system/View/RendererInterface.php
@@ -22,11 +22,11 @@ interface RendererInterface
      * Builds the output based upon a file name and any
      * data that has already been set.
      *
-     * @param string  $view
-     * @param array   $options  Reserved for 3rd-party uses since
-     *                          it might be needed to pass additional info
-     *                          to other template engines.
-     * @param bool $saveData Whether to save data for subsequent calls
+     * @param string $view
+     * @param array  $options  Reserved for 3rd-party uses since
+     *                         it might be needed to pass additional info
+     *                         to other template engines.
+     * @param bool   $saveData Whether to save data for subsequent calls
      *
      * @return string
      */
@@ -38,11 +38,11 @@ interface RendererInterface
      * Builds the output based upon a string and any
      * data that has already been set.
      *
-     * @param string  $view     The view contents
-     * @param array   $options  Reserved for 3rd-party uses since
-     *                          it might be needed to pass additional info
-     *                          to other template engines.
-     * @param bool $saveData Whether to save data for subsequent calls
+     * @param string $view     The view contents
+     * @param array  $options  Reserved for 3rd-party uses since
+     *                         it might be needed to pass additional info
+     *                         to other template engines.
+     * @param bool   $saveData Whether to save data for subsequent calls
      *
      * @return string
      */

--- a/system/View/Table.php
+++ b/system/View/Table.php
@@ -44,7 +44,7 @@ class Table
     /**
      * Whether or not to automatically create the table header
      *
-     * @var boolean
+     * @var bool
      */
     public $autoHeading = true;
 
@@ -101,7 +101,7 @@ class Table
      * Set the template
      *
      * @param  array $template
-     * @return boolean
+     * @return bool
      */
     public function setTemplate($template)
     {
@@ -149,7 +149,7 @@ class Table
      * displayed in a table that has a fixed column count.
      *
      * @param  array   $array
-     * @param  integer $columnLimit
+     * @param  int $columnLimit
      * @return array|false
      */
     public function makeColumns($array = [], $columnLimit = 0)

--- a/system/View/Table.php
+++ b/system/View/Table.php
@@ -86,7 +86,8 @@ class Table
     /**
      * Set the template from the table config file if it exists
      *
-     * @param  array $config (default: array())
+     * @param array $config (default: array())
+     *
      * @return void
      */
     public function __construct($config = [])
@@ -100,7 +101,8 @@ class Table
     /**
      * Set the template
      *
-     * @param  array $template
+     * @param array $template
+     *
      * @return bool
      */
     public function setTemplate($template)
@@ -190,7 +192,8 @@ class Table
      *
      * Can be passed as an array or discreet params
      *
-     * @param  mixed $value
+     * @param mixed $value
+     *
      * @return Table
      */
     public function setEmpty($value)
@@ -219,7 +222,8 @@ class Table
      *
      * Ensures a standard associative array format for all cell data
      *
-     * @param  array $args
+     * @param array $args
+     *
      * @return array
      */
     protected function _prepArgs(array $args)
@@ -243,7 +247,8 @@ class Table
     /**
      * Add a table caption
      *
-     * @param  string $caption
+     * @param string $caption
+     *
      * @return Table
      */
     public function setCaption($caption)
@@ -400,7 +405,8 @@ class Table
     /**
      * Set table data from a database result object
      *
-     * @param  BaseResult $object Database result object
+     * @param BaseResult $object Database result object
+     *
      * @return void
      */
     protected function _setFromDBResult($object)

--- a/system/View/Table.php
+++ b/system/View/Table.php
@@ -148,8 +148,9 @@ class Table
      * columns. This allows a single array with many elements to be
      * displayed in a table that has a fixed column count.
      *
-     * @param  array   $array
-     * @param  int $columnLimit
+     * @param array $array
+     * @param int   $columnLimit
+     *
      * @return array|false
      */
     public function makeColumns($array = [], $columnLimit = 0)

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -140,7 +140,7 @@ class View implements RendererInterface
      * @param ViewConfig       $config
      * @param string|null      $viewPath
      * @param FileLocator|null $loader
-     * @param bool|null     $debug
+     * @param bool|null        $debug
      * @param LoggerInterface  $logger
      */
     public function __construct(ViewConfig $config, string $viewPath = null, FileLocator $loader = null, bool $debug = null, LoggerInterface $logger = null)
@@ -161,13 +161,13 @@ class View implements RendererInterface
      *  - cache      Number of seconds to cache for
      *  - cache_name Name to use for cache
      *
-     * @param string       $view     File name of the view source
-     * @param array|null   $options  Reserved for 3rd-party uses since
-     *                               it might be needed to pass additional info
-     *                               to other template engines.
-     * @param bool|null $saveData If true, saves data for subsequent calls,
-     *                               if false, cleans the data after displaying,
-     *                               if null, uses the config setting.
+     * @param string     $view     File name of the view source
+     * @param array|null $options  Reserved for 3rd-party uses since
+     *                             it might be needed to pass additional info
+     *                             to other template engines.
+     * @param bool|null  $saveData If true, saves data for subsequent calls,
+     *                             if false, cleans the data after displaying,
+     *                             if null, uses the config setting.
      *
      * @return string
      */
@@ -276,13 +276,13 @@ class View implements RendererInterface
      * data that has already been set.
      * Cache does not apply, because there is no "key".
      *
-     * @param string       $view     The view contents
-     * @param array|null   $options  Reserved for 3rd-party uses since
-     *                               it might be needed to pass additional info
-     *                               to other template engines.
-     * @param bool|null $saveData If true, saves data for subsequent calls,
-     *                               if false, cleans the data after displaying,
-     *                               if null, uses the config setting.
+     * @param string     $view     The view contents
+     * @param array|null $options  Reserved for 3rd-party uses since
+     *                             it might be needed to pass additional info
+     *                             to other template engines.
+     * @param bool|null  $saveData If true, saves data for subsequent calls,
+     *                             if false, cleans the data after displaying,
+     *                             if null, uses the config setting.
      *
      * @return string
      */
@@ -313,8 +313,9 @@ class View implements RendererInterface
     /**
      * Extract first bit of a long string and add ellipsis
      *
-     * @param  string  $string
-     * @param  int $length
+     * @param string $string
+     * @param int    $length
+     *
      * @return string
      */
     public function excerpt(string $string, int $length = 20): string
@@ -464,7 +465,7 @@ class View implements RendererInterface
      *
      * @param string     $view
      * @param array|null $options
-     * @param bool    $saveData
+     * @param bool       $saveData
      *
      * @return string
      */

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -70,7 +70,7 @@ class View implements RendererInterface
     /**
      * Should we store performance info?
      *
-     * @var boolean
+     * @var bool
      */
     protected $debug = false;
 
@@ -90,14 +90,14 @@ class View implements RendererInterface
     /**
      * Whether data should be saved between renders.
      *
-     * @var boolean
+     * @var bool
      */
     protected $saveData;
 
     /**
      * Number of loaded views
      *
-     * @var integer
+     * @var int
      */
     protected $viewsCount = 0;
 
@@ -140,7 +140,7 @@ class View implements RendererInterface
      * @param ViewConfig       $config
      * @param string|null      $viewPath
      * @param FileLocator|null $loader
-     * @param boolean|null     $debug
+     * @param bool|null     $debug
      * @param LoggerInterface  $logger
      */
     public function __construct(ViewConfig $config, string $viewPath = null, FileLocator $loader = null, bool $debug = null, LoggerInterface $logger = null)
@@ -165,7 +165,7 @@ class View implements RendererInterface
      * @param array|null   $options  Reserved for 3rd-party uses since
      *                               it might be needed to pass additional info
      *                               to other template engines.
-     * @param boolean|null $saveData If true, saves data for subsequent calls,
+     * @param bool|null $saveData If true, saves data for subsequent calls,
      *                               if false, cleans the data after displaying,
      *                               if null, uses the config setting.
      *
@@ -280,7 +280,7 @@ class View implements RendererInterface
      * @param array|null   $options  Reserved for 3rd-party uses since
      *                               it might be needed to pass additional info
      *                               to other template engines.
-     * @param boolean|null $saveData If true, saves data for subsequent calls,
+     * @param bool|null $saveData If true, saves data for subsequent calls,
      *                               if false, cleans the data after displaying,
      *                               if null, uses the config setting.
      *
@@ -314,7 +314,7 @@ class View implements RendererInterface
      * Extract first bit of a long string and add ellipsis
      *
      * @param  string  $string
-     * @param  integer $length
+     * @param  int $length
      * @return string
      */
     public function excerpt(string $string, int $length = 20): string
@@ -464,7 +464,7 @@ class View implements RendererInterface
      *
      * @param string     $view
      * @param array|null $options
-     * @param boolean    $saveData
+     * @param bool    $saveData
      *
      * @return string
      */

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -122,6 +122,7 @@ class View implements RendererInterface
      * if any.
      *
      * @var string|null
+     *
      * @deprecated
      */
     protected $currentSection;
@@ -421,6 +422,7 @@ class View implements RendererInterface
      * Captures the last section
      *
      * @return void
+     *
      * @throws RuntimeException
      */
     public function endSection()

--- a/tests/_support/Autoloader/FatalLocator.php
+++ b/tests/_support/Autoloader/FatalLocator.php
@@ -46,9 +46,9 @@ class FatalLocator extends FileLocator
      *      'app/Modules/bar/Config/Routes.php',
      *  ]
      *
-     * @param string  $path
-     * @param string  $ext
-     * @param bool $prioritizeApp
+     * @param string $path
+     * @param string $ext
+     * @param bool   $prioritizeApp
      *
      * @return array
      */

--- a/tests/_support/Autoloader/FatalLocator.php
+++ b/tests/_support/Autoloader/FatalLocator.php
@@ -48,7 +48,7 @@ class FatalLocator extends FileLocator
      *
      * @param string  $path
      * @param string  $ext
-     * @param boolean $prioritizeApp
+     * @param bool $prioritizeApp
      *
      * @return array
      */

--- a/tests/_support/Config/Services.php
+++ b/tests/_support/Config/Services.php
@@ -17,8 +17,8 @@ class Services extends BaseServices
     /**
      * The URI class provides a way to model and manipulate URIs.
      *
-     * @param string  $uri
-     * @param bool $getShared
+     * @param string $uri
+     * @param bool   $getShared
      *
      * @return URI
      */

--- a/tests/_support/Config/Services.php
+++ b/tests/_support/Config/Services.php
@@ -18,7 +18,7 @@ class Services extends BaseServices
      * The URI class provides a way to model and manipulate URIs.
      *
      * @param string  $uri
-     * @param boolean $getShared
+     * @param bool $getShared
      *
      * @return URI
      */

--- a/tests/_support/Language/en/Core.php
+++ b/tests/_support/Language/en/Core.php
@@ -3,9 +3,11 @@
  * Core language strings.
  *
  * @package    CodeIgniter
+ *
  * @author     CodeIgniter Dev Team
  * @copyright  2014-2018 British Columbia Institute of Technology (https://bcit.ca/)
  * @license    https://opensource.org/licenses/MIT	MIT License
+ *
  * @link       https://codeigniter.com
  * @since      Version 4.0.0
  * @filesource

--- a/tests/_support/Log/Handlers/TestHandler.php
+++ b/tests/_support/Log/Handlers/TestHandler.php
@@ -44,7 +44,7 @@ class TestHandler extends \CodeIgniter\Log\Handlers\FileHandler
      * @param $level
      * @param $message
      *
-     * @return boolean
+     * @return bool
      */
     public function handle($level, $message): bool
     {

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
@@ -20,14 +20,14 @@ class DatabaseTestCaseMigrationOnce1Test extends CIUnitTestCase
     /**
      * Should run db migration only once?
      *
-     * @var boolean
+     * @var bool
      */
     protected $migrateOnce = true;
 
     /**
      * Should the db be refreshed before test?
      *
-     * @var boolean
+     * @var bool
      */
     protected $refresh = true;
 

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
@@ -19,14 +19,14 @@ class DatabaseTestCaseMigrationOnce2Test extends CIUnitTestCase
     /**
      * Should run db migration only once?
      *
-     * @var boolean
+     * @var bool
      */
     protected $migrateOnce = true;
 
     /**
      * Should the db be refreshed before test?
      *
-     * @var boolean
+     * @var bool
      */
     protected $refresh = true;
 

--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -19,7 +19,7 @@ class DatabaseTestCaseTest extends CIUnitTestCase
      * Should the db be refreshed before
      * each test?
      *
-     * @var boolean
+     * @var bool
      */
     protected $refresh = true;
 

--- a/tests/system/Database/Live/DeleteTest.php
+++ b/tests/system/Database/Live/DeleteTest.php
@@ -49,6 +49,7 @@ class DeleteTest extends CIUnitTestCase
     //--------------------------------------------------------------------
     /**
      * @group  single
+     *
      * @throws DatabaseException
      */
     public function testDeleteWithLimit()

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -19,7 +19,7 @@ class AlterTableTest extends CIUnitTestCase
     /**
      * In setUp() db connection is changed. So migration doesn't work
      *
-     * @var boolean
+     * @var bool
      */
     protected $migrate = false;
 

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -198,6 +198,7 @@ class UpdateTest extends CIUnitTestCase
 
     /**
      * @group single
+     *
      * @see   https://github.com/codeigniter4/CodeIgniter4/issues/324
      */
     public function testUpdatePeriods()

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -56,7 +56,7 @@ final class SiteUrlTest extends CIUnitTestCase
      * @param string      $baseURL
      * @param string      $indexPage
      * @param string|null $scheme
-     * @param boolean     $secure
+     * @param bool     $secure
      * @param string      $path
      * @param string      $expectedSiteUrl
      *

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -56,7 +56,7 @@ final class SiteUrlTest extends CIUnitTestCase
      * @param string      $baseURL
      * @param string      $indexPage
      * @param string|null $scheme
-     * @param bool     $secure
+     * @param bool        $secure
      * @param string      $path
      * @param string      $expectedSiteUrl
      *

--- a/tests/system/Models/GeneralModelTest.php
+++ b/tests/system/Models/GeneralModelTest.php
@@ -144,7 +144,7 @@ final class GeneralModelTest extends CIUnitTestCase
         $model = new class extends Model {
 
             /**
-             * @var boolean
+             * @var bool
              */
             public $initialized = false;
 

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -49,9 +49,9 @@ class CreditCardRulesTest extends CIUnitTestCase
     /**
      * @dataProvider creditCardProvider
      *
-     * @param $type
-     * @param $number
-     * @param boolean $expected
+     * @param string $type
+     * @param string|null $number
+     * @param bool $expected
      */
     public function testValidCCNumber($type, $number, $expected = false)
     {
@@ -1217,8 +1217,8 @@ class CreditCardRulesTest extends CIUnitTestCase
      * Used to generate fake credit card numbers that will still pass the Luhn
      * check used to validate the card so we can be sure the cards are recognized correctly.
      *
-     * @param integer $prefix
-     * @param integer $length
+     * @param int $prefix
+     * @param int $length
      *
      * @return string
      */

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -49,9 +49,9 @@ class CreditCardRulesTest extends CIUnitTestCase
     /**
      * @dataProvider creditCardProvider
      *
-     * @param string $type
+     * @param string      $type
      * @param string|null $number
-     * @param bool $expected
+     * @param bool        $expected
      */
     public function testValidCCNumber($type, $number, $expected = false)
     {

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -395,7 +395,7 @@ class FormatRulesTest extends CIUnitTestCase
      * Test alpha with spaces.
      *
      * @param mixed   $value    Value.
-     * @param boolean $expected Expected.
+     * @param bool $expected Expected.
      *
      * @dataProvider alphaSpaceProvider
      */

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -394,8 +394,8 @@ class FormatRulesTest extends CIUnitTestCase
     /**
      * Test alpha with spaces.
      *
-     * @param mixed   $value    Value.
-     * @param bool $expected Expected.
+     * @param mixed $value    Value.
+     * @param bool  $expected Expected.
      *
      * @dataProvider alphaSpaceProvider
      */

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -1407,9 +1407,9 @@ class RulesTest extends CIUnitTestCase
     /**
      * @dataProvider inListProvider
      *
-     * @param string  $first
-     * @param string  $second
-     * @param bool $expected
+     * @param string $first
+     * @param string $second
+     * @param bool   $expected
      */
     public function testInList($first, $second, $expected)
     {
@@ -1429,9 +1429,9 @@ class RulesTest extends CIUnitTestCase
     /**
      * @dataProvider inListProvider
      *
-     * @param string  $first
-     * @param string  $second
-     * @param bool $expected
+     * @param string $first
+     * @param string $second
+     * @param bool   $expected
      */
     public function testNotInList($first, $second, $expected)
     {

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -1409,7 +1409,7 @@ class RulesTest extends CIUnitTestCase
      *
      * @param string  $first
      * @param string  $second
-     * @param boolean $expected
+     * @param bool $expected
      */
     public function testInList($first, $second, $expected)
     {
@@ -1431,7 +1431,7 @@ class RulesTest extends CIUnitTestCase
      *
      * @param string  $first
      * @param string  $second
-     * @param boolean $expected
+     * @param bool $expected
      */
     public function testNotInList($first, $second, $expected)
     {

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -953,7 +953,7 @@ final class ValidationTest extends CIUnitTestCase
      *
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4521
      *
-     * @param bool $expected
+     * @param bool  $expected
      * @param array $rules
      * @param array $data
      *
@@ -1025,7 +1025,7 @@ final class ValidationTest extends CIUnitTestCase
      *
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4510
      *
-     * @param bool $expected
+     * @param bool  $expected
      * @param array $rules
      * @param array $data
      *

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -953,7 +953,7 @@ final class ValidationTest extends CIUnitTestCase
      *
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4521
      *
-     * @param boolean $expected
+     * @param bool $expected
      * @param array $rules
      * @param array $data
      *
@@ -1025,7 +1025,7 @@ final class ValidationTest extends CIUnitTestCase
      *
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4510
      *
-     * @param boolean $expected
+     * @param bool $expected
      * @param array $rules
      * @param array $data
      *

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -68,6 +68,16 @@ final class CodeIgniter4 extends AbstractRuleset
             'no_alias_functions'           => [
                 'sets' => ['@all'],
             ],
+            'phpdoc_scalar' => [
+                'types' => [
+                    'boolean',
+                    'callback',
+                    'double',
+                    'integer',
+                    'real',
+                    'str',
+                ],
+            ],
             'static_lambda'                => true,
             'ternary_to_null_coalescing'   => true,
             'yoda_style'                   => [

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -79,6 +79,7 @@ final class CodeIgniter4 extends AbstractRuleset
                     'str',
                 ],
             ],
+            'phpdoc_separation'            => true,
             'static_lambda'                => true,
             'ternary_to_null_coalescing'   => true,
             'yoda_style'                   => [

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -68,6 +68,7 @@ final class CodeIgniter4 extends AbstractRuleset
             'no_alias_functions'           => [
                 'sets' => ['@all'],
             ],
+            'phpdoc_align'  => true,
             'phpdoc_scalar' => [
                 'types' => [
                     'boolean',


### PR DESCRIPTION
**Description**
Changes to PHPDocs:
- use short forms (`bool` instead of `boolean`, etc.)
- Align phpdocs
- Separate and group similar phpdocs (removes Laravel-like docblocks)

**Checklist:**
- [x] Securely signed commits
