### PR TITLE
Enable `class_definition` fixer

### DIFF
--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -69,6 +69,11 @@ final class CodeIgniter4 extends AbstractRuleset
                     'method' => 'one',
                 ],
             ],
+            'class_definition' => [
+                'multi_line_extends_each_single_line' => true,
+                'single_item_single_line'             => true,
+                'single_line'                         => true,
+            ],
             'function_to_constant'                  => true,
             'indentation_type'                      => true,
             'line_ending'                           => true,
@@ -77,6 +82,7 @@ final class CodeIgniter4 extends AbstractRuleset
             'no_trailing_comma_in_singleline_array' => true,
             'no_whitespace_before_comma_in_array'   => ['after_heredoc' => true],
             'normalize_index_brace'                 => true,
+            'ordered_imports'                       => ['sort_algorithm' => 'alpha'],
             'phpdoc_align'                          => true,
             'phpdoc_scalar'                         => [
                 'types' => [


### PR DESCRIPTION
**Description**
Whitespace around the keywords of a class, trait or interfaces definition should be one space.

**Checklist:**
- [x] Securely signed commits
