### PR TITLE
Heredocs-related rules

### DIFF
--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -103,10 +103,10 @@ class ResponseTraitTest extends CIUnitTestCase
         $this->assertEquals(201, $this->response->getStatusCode());
 
         $expected = <<<EOH
-{
-    "id": 3
-}
-EOH;
+            {
+                "id": 3
+            }
+            EOH;
         $this->assertEquals($expected, $this->response->getBody());
     }
 
@@ -125,10 +125,10 @@ EOH;
         $controller      = $this->makeController();
         $payload         = ['answer' => 42];
         $expected        = <<<EOH
-{
-    "answer": 42
-}
-EOH;
+            {
+                "answer": 42
+            }
+            EOH;
         $controller->respond($payload);
         $this->assertEquals($expected, $this->response->getBody());
     }
@@ -143,12 +143,12 @@ EOH;
             3,
         ];
         $expected = <<<EOH
-[
-    1,
-    2,
-    3
-]
-EOH;
+            [
+                1,
+                2,
+                3
+            ]
+            EOH;
         $controller->respond($payload);
         $this->assertEquals($expected, $this->response->getBody());
     }
@@ -161,11 +161,11 @@ EOH;
         $payload->name   = 'Tom';
         $payload->id     = 1;
         $expected        = <<<EOH
-{
-    "name": "Tom",
-    "id": 1
-}
-EOH;
+            {
+                "name": "Tom",
+                "id": 1
+            }
+            EOH;
         $controller->respond((array) $payload);
         $this->assertEquals($expected, $this->response->getBody());
     }
@@ -480,10 +480,10 @@ EOH;
 
         $controller->respondCreated(['id' => 3], 'A Custom Reason');
         $expected = <<<EOH
-<?xml version="1.0"?>
-<response><id>3</id></response>
+            <?xml version="1.0"?>
+            <response><id>3</id></response>
 
-EOH;
+            EOH;
         $this->assertEquals($expected, $this->response->getBody());
     }
 

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -102,7 +102,7 @@ class ResponseTraitTest extends CIUnitTestCase
         $this->assertEquals('A Custom Reason', $this->response->getReason());
         $this->assertEquals(201, $this->response->getStatusCode());
 
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             {
                 "id": 3
             }
@@ -124,7 +124,7 @@ class ResponseTraitTest extends CIUnitTestCase
         $this->formatter = null;
         $controller      = $this->makeController();
         $payload         = ['answer' => 42];
-        $expected        = <<<EOH
+        $expected        = <<<'EOH'
             {
                 "answer": 42
             }
@@ -142,7 +142,7 @@ class ResponseTraitTest extends CIUnitTestCase
             2,
             3,
         ];
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             [
                 1,
                 2,
@@ -160,7 +160,7 @@ class ResponseTraitTest extends CIUnitTestCase
         $payload         = new stdClass();
         $payload->name   = 'Tom';
         $payload->id     = 1;
-        $expected        = <<<EOH
+        $expected        = <<<'EOH'
             {
                 "name": "Tom",
                 "id": 1
@@ -479,7 +479,7 @@ class ResponseTraitTest extends CIUnitTestCase
         $this->assertEquals('CodeIgniter\Format\XMLFormatter', get_class($this->formatter));
 
         $controller->respondCreated(['id' => 3], 'A Custom Reason');
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <?xml version="1.0"?>
             <response><id>3</id></response>
 

--- a/tests/system/Database/Builder/DeleteTest.php
+++ b/tests/system/Database/Builder/DeleteTest.php
@@ -42,9 +42,9 @@ class DeleteTest extends CIUnitTestCase
         $sql = $builder->getCompiledDelete();
 
         $expectedSQL = <<<'EOL'
-		DELETE FROM "jobs"
-		WHERE "id" = 1
-		EOL;
+            DELETE FROM "jobs"
+            WHERE "id" = 1
+            EOL;
         $this->assertSame($expectedSQL, $sql);
     }
 
@@ -55,9 +55,9 @@ class DeleteTest extends CIUnitTestCase
         $sql = $builder->where('id', 1)->limit(10)->getCompiledDelete();
 
         $expectedSQL = <<<'EOL'
-		DELETE FROM "jobs"
-		WHERE "id" = 1 LIMIT 10
-		EOL;
+            DELETE FROM "jobs"
+            WHERE "id" = 1 LIMIT 10
+            EOL;
         $this->assertSame($expectedSQL, $sql);
     }
 }

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -120,28 +120,28 @@ class UpdateTest extends CIUnitTestCase
         $space = ' ';
 
         $expected = <<<EOF
-		UPDATE "jobs" SET "name" = CASE{$space}
-		WHEN "id" = :id: THEN :name:
-		WHEN "id" = :id.1: THEN :name.1:
-		ELSE "name" END, "description" = CASE{$space}
-		WHEN "id" = :id: THEN :description:
-		WHEN "id" = :id.1: THEN :description.1:
-		ELSE "description" END
-		WHERE "id" IN(:id:,:id.1:)
-		EOF;
+            UPDATE "jobs" SET "name" = CASE{$space}
+            WHEN "id" = :id: THEN :name:
+            WHEN "id" = :id.1: THEN :name.1:
+            ELSE "name" END, "description" = CASE{$space}
+            WHEN "id" = :id: THEN :description:
+            WHEN "id" = :id.1: THEN :description.1:
+            ELSE "description" END
+            WHERE "id" IN(:id:,:id.1:)
+            EOF;
 
         $this->assertSame($expected, $query->getOriginalQuery());
 
         $expected = <<<EOF
-		UPDATE "jobs" SET "name" = CASE{$space}
-		WHEN "id" = 2 THEN 'Comedian'
-		WHEN "id" = 3 THEN 'Cab Driver'
-		ELSE "name" END, "description" = CASE{$space}
-		WHEN "id" = 2 THEN 'There''s something in your teeth'
-		WHEN "id" = 3 THEN 'I am yellow'
-		ELSE "description" END
-		WHERE "id" IN(2,3)
-		EOF;
+            UPDATE "jobs" SET "name" = CASE{$space}
+            WHEN "id" = 2 THEN 'Comedian'
+            WHEN "id" = 3 THEN 'Cab Driver'
+            ELSE "name" END, "description" = CASE{$space}
+            WHEN "id" = 2 THEN 'There''s something in your teeth'
+            WHEN "id" = 3 THEN 'I am yellow'
+            ELSE "description" END
+            WHERE "id" IN(2,3)
+            EOF;
 
         $this->assertSame($expected, $query->getQuery() );
     }

--- a/tests/system/Format/XMLFormatterTest.php
+++ b/tests/system/Format/XMLFormatterTest.php
@@ -22,10 +22,10 @@ class XMLFormatterTest extends CIUnitTestCase
         ];
 
         $expected = <<<EOH
-<?xml version="1.0"?>
-<response><foo>bar</foo></response>
+            <?xml version="1.0"?>
+            <response><foo>bar</foo></response>
 
-EOH;
+            EOH;
 
         $this->assertEquals($expected, $this->xmlFormatter->format($data));
     }
@@ -37,10 +37,10 @@ EOH;
         ];
 
         $expected = <<<EOH
-<?xml version="1.0"?>
-<response><foo><item0>bar</item0></foo></response>
+            <?xml version="1.0"?>
+            <response><foo><item0>bar</item0></foo></response>
 
-EOH;
+            EOH;
 
         $this->assertEquals($expected, $this->xmlFormatter->format($data));
     }
@@ -52,10 +52,10 @@ EOH;
         ];
 
         $expected = <<<EOH
-<?xml version="1.0"?>
-<response><item0><item0>foo</item0></item0></response>
+            <?xml version="1.0"?>
+            <response><item0><item0>foo</item0></item0></response>
 
-EOH;
+            EOH;
 
         $this->assertEquals($expected, $this->xmlFormatter->format($data));
     }
@@ -64,10 +64,10 @@ EOH;
     {
         $data     = ['Something'];
         $expected = <<<EOH
-<?xml version="1.0"?>
-<response><item0>Something</item0></response>
+            <?xml version="1.0"?>
+            <response><item0>Something</item0></response>
 
-EOH;
+            EOH;
 
         $this->assertEquals($expected, $this->xmlFormatter->format($data));
     }
@@ -79,10 +79,10 @@ EOH;
             '096630FR'    => 'bar',
         ];
         $expected = <<<EOH
-<?xml version="1.0"?>
-<response><BBB096630BD>foo</BBB096630BD><item096630FR>bar</item096630FR></response>
+            <?xml version="1.0"?>
+            <response><BBB096630BD>foo</BBB096630BD><item096630FR>bar</item096630FR></response>
 
-EOH;
+            EOH;
 
         $this->assertEquals($expected, $this->xmlFormatter->format($data));
     }
@@ -96,10 +96,10 @@ EOH;
     public function testValidatingInvalidTags(string $expected, array $input)
     {
         $expectedXML = <<<EOH
-<?xml version="1.0"?>
-<response><{$expected}>bar</{$expected}></response>
+            <?xml version="1.0"?>
+            <response><{$expected}>bar</{$expected}></response>
 
-EOH;
+            EOH;
 
         $this->assertEquals($expectedXML, $this->xmlFormatter->format($input));
     }
@@ -172,42 +172,42 @@ EOH;
 
         // do not change to tabs!!
         $expectedXML = <<<EOF
-<?xml version="1.0"?>
-<response>
-  <data>
-    <master>
-      <name>Foo</name>
-      <email>foo@bar.com</email>
-      <dependents/>
-    </master>
-    <vote>
-      <list/>
-    </vote>
-    <user>
-      <account>
-        <demo>
-          <info>
-            <is_banned>true</is_banned>
-            <last_login>2020-08-31</last_login>
-            <last_login_ip>127.0.0.1</last_login_ip>
-          </info>
-        </demo>
-      </account>
-    </user>
-    <itemxml>
-      <itemxml_version>1.0</itemxml_version>
-      <itemxml_encoding>utf-8</itemxml_encoding>
-    </itemxml>
-    <item0>
-      <misc>miscellaneous</misc>
-    </item0>
-    <item1>
-      <misc_data>miscellaneous data</misc_data>
-    </item1>
-  </data>
-</response>
+            <?xml version="1.0"?>
+            <response>
+              <data>
+                <master>
+                  <name>Foo</name>
+                  <email>foo@bar.com</email>
+                  <dependents/>
+                </master>
+                <vote>
+                  <list/>
+                </vote>
+                <user>
+                  <account>
+                    <demo>
+                      <info>
+                        <is_banned>true</is_banned>
+                        <last_login>2020-08-31</last_login>
+                        <last_login_ip>127.0.0.1</last_login_ip>
+                      </info>
+                    </demo>
+                  </account>
+                </user>
+                <itemxml>
+                  <itemxml_version>1.0</itemxml_version>
+                  <itemxml_encoding>utf-8</itemxml_encoding>
+                </itemxml>
+                <item0>
+                  <misc>miscellaneous</misc>
+                </item0>
+                <item1>
+                  <misc_data>miscellaneous data</misc_data>
+                </item1>
+              </data>
+            </response>
 
-EOF;
+            EOF;
 
         $dom                     = new DOMDocument('1.0');
         $dom->preserveWhiteSpace = false;

--- a/tests/system/Format/XMLFormatterTest.php
+++ b/tests/system/Format/XMLFormatterTest.php
@@ -21,7 +21,7 @@ class XMLFormatterTest extends CIUnitTestCase
             'foo' => 'bar',
         ];
 
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <?xml version="1.0"?>
             <response><foo>bar</foo></response>
 
@@ -36,7 +36,7 @@ class XMLFormatterTest extends CIUnitTestCase
             'foo' => ['bar'],
         ];
 
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <?xml version="1.0"?>
             <response><foo><item0>bar</item0></foo></response>
 
@@ -51,7 +51,7 @@ class XMLFormatterTest extends CIUnitTestCase
             ['foo'],
         ];
 
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <?xml version="1.0"?>
             <response><item0><item0>foo</item0></item0></response>
 
@@ -63,7 +63,7 @@ class XMLFormatterTest extends CIUnitTestCase
     public function testStringFormatting()
     {
         $data     = ['Something'];
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <?xml version="1.0"?>
             <response><item0>Something</item0></response>
 
@@ -78,7 +78,7 @@ class XMLFormatterTest extends CIUnitTestCase
             'BBB096630BD' => 'foo',
             '096630FR'    => 'bar',
         ];
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <?xml version="1.0"?>
             <response><BBB096630BD>foo</BBB096630BD><item096630FR>bar</item096630FR></response>
 
@@ -171,7 +171,7 @@ class XMLFormatterTest extends CIUnitTestCase
         ];
 
         // do not change to tabs!!
-        $expectedXML = <<<EOF
+        $expectedXML = <<<'EOF'
             <?xml version="1.0"?>
             <response>
               <data>

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -33,15 +33,15 @@ class FormHelperTest extends CIUnitTestCase
             $Value    = csrf_hash();
             $Name     = csrf_token();
             $expected = <<<EOH
-<form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
-<input type="hidden" name="$Name" value="$Value" style="display:none;" />
+                <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
+                <input type="hidden" name="$Name" value="$Value" style="display:none;" />
 
-EOH;
+                EOH;
         } else {
             $expected = <<<EOH
-<form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
+                <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
 
-EOH;
+                EOH;
         }
 
         $attributes = [
@@ -63,9 +63,9 @@ EOH;
 
         Services::injectMock('request', $request);
         $expected = <<<EOH
-<form action="http://example.com/index.php/en/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
+            <form action="http://example.com/index.php/en/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
 
-EOH;
+            EOH;
 
         $attributes = [
             'name'   => 'form',
@@ -91,15 +91,15 @@ EOH;
             $Value    = csrf_hash();
             $Name     = csrf_token();
             $expected = <<<EOH
-<form action="http://example.com/index.php" name="form" id="form" method="POST" accept-charset="utf-8">
-<input type="hidden" name="$Name" value="$Value" style="display:none;" />
+                <form action="http://example.com/index.php" name="form" id="form" method="POST" accept-charset="utf-8">
+                <input type="hidden" name="$Name" value="$Value" style="display:none;" />
 
-EOH;
+                EOH;
         } else {
             $expected = <<<EOH
-<form action="http://example.com/index.php" name="form" id="form" method="POST" accept-charset="utf-8">
+                <form action="http://example.com/index.php" name="form" id="form" method="POST" accept-charset="utf-8">
 
-EOH;
+                EOH;
         }
         $attributes = [
             'name'   => 'form',
@@ -125,15 +125,15 @@ EOH;
             $Value    = csrf_hash();
             $Name     = csrf_token();
             $expected = <<<EOH
-<form action="http://example.com/index.php/foo/bar" name="form" id="form" method="post" accept-charset="utf-8">
-<input type="hidden" name="$Name" value="$Value" style="display:none;" />
+                <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="post" accept-charset="utf-8">
+                <input type="hidden" name="$Name" value="$Value" style="display:none;" />
 
-EOH;
+                EOH;
         } else {
             $expected = <<<EOH
-<form action="http://example.com/index.php/foo/bar" name="form" id="form" method="post" accept-charset="utf-8">
+                <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="post" accept-charset="utf-8">
 
-EOH;
+                EOH;
         }
 
         $attributes = [
@@ -159,18 +159,18 @@ EOH;
             $Value    = csrf_hash();
             $Name     = csrf_token();
             $expected = <<<EOH
-<form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
-<input type="hidden" name="foo" value="bar" />
-<input type="hidden" name="$Name" value="$Value" />
+                <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
+                <input type="hidden" name="foo" value="bar" />
+                <input type="hidden" name="$Name" value="$Value" />
 
-EOH;
+                EOH;
         } else {
             $expected = <<<EOH
-<form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
+                <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
 
-<input type="hidden" name="foo" value="bar" />
+                <input type="hidden" name="foo" value="bar" />
 
-EOH;
+                EOH;
         }
 
         $attributes = [
@@ -200,15 +200,15 @@ EOH;
             $Value    = csrf_hash();
             $Name     = csrf_token();
             $expected = <<<EOH
-<form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" enctype="multipart/form-data" accept-charset="utf-8">
-<input type="hidden" name="$Name" value="$Value" style="display:none;" />
+                <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" enctype="multipart/form-data" accept-charset="utf-8">
+                <input type="hidden" name="$Name" value="$Value" style="display:none;" />
 
-EOH;
+                EOH;
         } else {
             $expected = <<<EOH
-<form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" enctype="multipart/form-data" accept-charset="utf-8">
+                <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" enctype="multipart/form-data" accept-charset="utf-8">
 
-EOH;
+                EOH;
         }
         $attributes = [
             'name'   => 'form',
@@ -227,8 +227,8 @@ EOH;
     {
         $expected = <<<EOH
 
-<input type="hidden" name="username" value="johndoe" />\n
-EOH;
+            <input type="hidden" name="username" value="johndoe" />\n
+            EOH;
         $this->assertEquals($expected, form_hidden('username', 'johndoe'));
     }
 
@@ -240,9 +240,9 @@ EOH;
         ];
         $expected = <<<EOH
 
-<input type="hidden" name="foo" value="bar" />
+            <input type="hidden" name="foo" value="bar" />
 
-EOH;
+            EOH;
         $this->assertEquals($expected, form_hidden($data, null));
     }
 
@@ -254,9 +254,9 @@ EOH;
         ];
         $expected = <<<EOH
 
-<input type="hidden" name="name[foo]" value="bar" />
+            <input type="hidden" name="name[foo]" value="bar" />
 
-EOH;
+            EOH;
         $this->assertEquals($expected, form_hidden('name', $data));
     }
 
@@ -264,8 +264,8 @@ EOH;
     public function testFormInput()
     {
         $expected = <<<EOH
-<input type="text" name="username" value="johndoe" id="username" maxlength="100" size="50" style="width:50%" />\n
-EOH;
+            <input type="text" name="username" value="johndoe" id="username" maxlength="100" size="50" style="width:50%" />\n
+            EOH;
         $data = [
             'name'      => 'username',
             'id'        => 'username',
@@ -280,8 +280,8 @@ EOH;
     public function testFormInputWithExtra()
     {
         $expected = <<<EOH
-<input type="email" name="identity" value="" id="identity" class="form-control form-control-lg" />\n
-EOH;
+            <input type="email" name="identity" value="" id="identity" class="form-control form-control-lg" />\n
+            EOH;
         $data = [
             'id'   => 'identity',
             'name' => 'identity',
@@ -297,8 +297,8 @@ EOH;
     public function testFormPassword()
     {
         $expected = <<<EOH
-<input type="password" name="password" value="" />\n
-EOH;
+            <input type="password" name="password" value="" />\n
+            EOH;
         $this->assertEquals($expected, form_password('password'));
     }
 
@@ -306,8 +306,8 @@ EOH;
     public function testFormUpload()
     {
         $expected = <<<EOH
-<input type="file" name="attachment" />\n
-EOH;
+            <input type="file" name="attachment" />\n
+            EOH;
         $this->assertEquals($expected, form_upload('attachment'));
     }
 
@@ -315,8 +315,8 @@ EOH;
     public function testFormTextarea()
     {
         $expected = <<<EOH
-<textarea name="notes" cols="40" rows="10">Notes</textarea>\n
-EOH;
+            <textarea name="notes" cols="40" rows="10">Notes</textarea>\n
+            EOH;
         $this->assertEquals($expected, form_textarea('notes', 'Notes'));
     }
 
@@ -328,9 +328,9 @@ EOH;
             'value' => 'bar',
         ];
         $expected = <<<EOH
-<textarea name="foo" cols="40" rows="10">bar</textarea>
+            <textarea name="foo" cols="40" rows="10">bar</textarea>
 
-EOH;
+            EOH;
         $this->assertEquals($expected, form_textarea($data));
     }
 
@@ -342,8 +342,8 @@ EOH;
             'rows' => '5',
         ];
         $expected = <<<EOH
-<textarea name="notes" cols="30" rows="5">Notes</textarea>\n
-EOH;
+            <textarea name="notes" cols="30" rows="5">Notes</textarea>\n
+            EOH;
         $this->assertEquals($expected, form_textarea('notes', 'Notes', $extra));
     }
 
@@ -352,8 +352,8 @@ EOH;
     {
         $extra    = 'cols="30" rows="5"';
         $expected = <<<EOH
-<textarea name="notes" cols="30" rows="5">Notes</textarea>\n
-EOH;
+            <textarea name="notes" cols="30" rows="5">Notes</textarea>\n
+            EOH;
         $this->assertEquals($expected, form_textarea('notes', 'Notes', $extra));
     }
 
@@ -361,13 +361,13 @@ EOH;
     public function testFormDropdown()
     {
         $expected = <<<EOH
-<select name="shirts">
-<option value="small">Small Shirt</option>
-<option value="med">Medium Shirt</option>
-<option value="large" selected="selected">Large Shirt</option>
-<option value="xlarge">Extra Large Shirt</option>
-</select>\n
-EOH;
+            <select name="shirts">
+            <option value="small">Small Shirt</option>
+            <option value="med">Medium Shirt</option>
+            <option value="large" selected="selected">Large Shirt</option>
+            <option value="xlarge">Extra Large Shirt</option>
+            </select>\n
+            EOH;
         $options = [
             'small'  => 'Small Shirt',
             'med'    => 'Medium Shirt',
@@ -376,13 +376,13 @@ EOH;
         ];
         $this->assertEquals($expected, form_dropdown('shirts', $options, 'large'));
         $expected = <<<EOH
-<select name="shirts" multiple="multiple">
-<option value="small" selected="selected">Small Shirt</option>
-<option value="med">Medium Shirt</option>
-<option value="large" selected="selected">Large Shirt</option>
-<option value="xlarge">Extra Large Shirt</option>
-</select>\n
-EOH;
+            <select name="shirts" multiple="multiple">
+            <option value="small" selected="selected">Small Shirt</option>
+            <option value="med">Medium Shirt</option>
+            <option value="large" selected="selected">Large Shirt</option>
+            <option value="xlarge">Extra Large Shirt</option>
+            </select>\n
+            EOH;
         $shirtsOnSale = [
             'small',
             'large',
@@ -399,17 +399,17 @@ EOH;
             ],
         ];
         $expected = <<<EOH
-<select name="cars" multiple="multiple">
-<optgroup label="Swedish Cars">
-<option value="volvo" selected="selected">Volvo</option>
-<option value="saab">Saab</option>
-</optgroup>
-<optgroup label="German Cars">
-<option value="mercedes">Mercedes</option>
-<option value="audi" selected="selected">Audi</option>
-</optgroup>
-</select>\n
-EOH;
+            <select name="cars" multiple="multiple">
+            <optgroup label="Swedish Cars">
+            <option value="volvo" selected="selected">Volvo</option>
+            <option value="saab">Saab</option>
+            </optgroup>
+            <optgroup label="German Cars">
+            <option value="mercedes">Mercedes</option>
+            <option value="audi" selected="selected">Audi</option>
+            </optgroup>
+            </select>\n
+            EOH;
         $this->assertEquals($expected, form_dropdown('cars', $options, ['volvo', 'audi']));
     }
 
@@ -426,17 +426,17 @@ EOH;
             ],
         ];
         $expected = <<<EOH
-<select name="cars">
-<optgroup label="Swedish Cars">
-<option value="volvo">Volvo</option>
-<option value="saab">Saab</option>
-</optgroup>
-<optgroup label="German Cars">
-<option value="mercedes">Mercedes</option>
-<option value="audi">Audi</option>
-</optgroup>
-</select>\n
-EOH;
+            <select name="cars">
+            <optgroup label="Swedish Cars">
+            <option value="volvo">Volvo</option>
+            <option value="saab">Saab</option>
+            </optgroup>
+            <optgroup label="German Cars">
+            <option value="mercedes">Mercedes</option>
+            <option value="audi">Audi</option>
+            </optgroup>
+            </select>\n
+            EOH;
         $this->assertEquals($expected, form_dropdown('cars', $options));
     }
 
@@ -453,17 +453,17 @@ EOH;
             ],
         ];
         $expected = <<<EOH
-<select name="cars">
-<optgroup label="Swedish Cars">
-<option value="volvo">Volvo</option>
-<option value="saab">Saab</option>
-</optgroup>
-<optgroup label="German Cars">
-<option value="mercedes">Mercedes</option>
-<option value="audi" selected="selected">Audi</option>
-</optgroup>
-</select>\n
-EOH;
+            <select name="cars">
+            <optgroup label="Swedish Cars">
+            <option value="volvo">Volvo</option>
+            <option value="saab">Saab</option>
+            </optgroup>
+            <optgroup label="German Cars">
+            <option value="mercedes">Mercedes</option>
+            <option value="audi" selected="selected">Audi</option>
+            </optgroup>
+            </select>\n
+            EOH;
         $_POST['cars'] = 'audi';
         $this->assertEquals($expected, form_dropdown('cars', $options));
         unset($_POST['cars']);
@@ -473,11 +473,11 @@ EOH;
     public function testFormDropdownWithSelectedAttribute()
     {
         $expected = <<<EOH
-<select name="foo">
-<option value="bar" selected="selected">Bar</option>
-</select>
+            <select name="foo">
+            <option value="bar" selected="selected">Bar</option>
+            </select>
 
-EOH;
+            EOH;
         $data = [
             'name'     => 'foo',
             'selected' => 'bar',
@@ -492,11 +492,11 @@ EOH;
     public function testFormDropdownWithOptionsAttribute()
     {
         $expected = <<<EOH
-<select name="foo">
-<option value="bar">Bar</option>
-</select>
+            <select name="foo">
+            <option value="bar">Bar</option>
+            </select>
 
-EOH;
+            EOH;
         $data = [
             'name'    => 'foo',
             'options' => [
@@ -510,10 +510,10 @@ EOH;
     public function testFormDropdownWithEmptyArrayOptionValue()
     {
         $expected = <<<EOH
-<select name="foo">
-</select>
+            <select name="foo">
+            </select>
 
-EOH;
+            EOH;
         $options = [
             'bar' => [],
         ];
@@ -524,13 +524,13 @@ EOH;
     public function testFormMultiselect()
     {
         $expected = <<<EOH
-<select name="shirts[]"  multiple="multiple">
-<option value="small">Small Shirt</option>
-<option value="med" selected="selected">Medium Shirt</option>
-<option value="large" selected="selected">Large Shirt</option>
-<option value="xlarge">Extra Large Shirt</option>
-</select>\n
-EOH;
+            <select name="shirts[]"  multiple="multiple">
+            <option value="small">Small Shirt</option>
+            <option value="med" selected="selected">Medium Shirt</option>
+            <option value="large" selected="selected">Large Shirt</option>
+            <option value="xlarge">Extra Large Shirt</option>
+            </select>\n
+            EOH;
         $options = [
             'small'  => 'Small Shirt',
             'med'    => 'Medium Shirt',
@@ -544,13 +544,13 @@ EOH;
     public function testFormMultiselectArrayData()
     {
         $expected = <<<EOH
-<select name="shirts[]"  multiple="multiple">
-<option value="small">Small Shirt</option>
-<option value="med" selected="selected">Medium Shirt</option>
-<option value="large" selected="selected">Large Shirt</option>
-<option value="xlarge">Extra Large Shirt</option>
-</select>\n
-EOH;
+            <select name="shirts[]"  multiple="multiple">
+            <option value="small">Small Shirt</option>
+            <option value="med" selected="selected">Medium Shirt</option>
+            <option value="large" selected="selected">Large Shirt</option>
+            <option value="xlarge">Extra Large Shirt</option>
+            </select>\n
+            EOH;
         $options = [
             'small'  => 'Small Shirt',
             'med'    => 'Medium Shirt',
@@ -574,9 +574,9 @@ EOH;
     public function testFormFieldset()
     {
         $expected = <<<EOH
-<fieldset>
-<legend>Address Information</legend>\n
-EOH;
+            <fieldset>
+            <legend>Address Information</legend>\n
+            EOH;
         $this->assertEquals($expected, form_fieldset('Address Information'));
     }
 
@@ -584,9 +584,9 @@ EOH;
     public function testFormFieldsetWithNoLegent()
     {
         $expected = <<<EOH
-<fieldset>
+            <fieldset>
 
-EOH;
+            EOH;
         $this->assertEquals($expected, form_fieldset());
     }
 
@@ -597,10 +597,10 @@ EOH;
             'name' => 'bar',
         ];
         $expected = <<<EOH
-<fieldset name="bar">
-<legend>Foo</legend>
+            <fieldset name="bar">
+            <legend>Foo</legend>
 
-EOH;
+            EOH;
         $this->assertEquals($expected, form_fieldset('Foo', $attributes));
     }
 
@@ -608,8 +608,8 @@ EOH;
     public function testFormFieldsetClose()
     {
         $expected = <<<EOH
-</fieldset></div></div>
-EOH;
+            </fieldset></div></div>
+            EOH;
         $this->assertEquals($expected, form_fieldset_close('</div></div>'));
     }
 
@@ -617,8 +617,8 @@ EOH;
     public function testFormCheckbox()
     {
         $expected = <<<EOH
-<input type="checkbox" name="newsletter" value="accept" checked="checked" />\n
-EOH;
+            <input type="checkbox" name="newsletter" value="accept" checked="checked" />\n
+            EOH;
         $this->assertEquals($expected, form_checkbox('newsletter', 'accept', true));
     }
 
@@ -631,9 +631,9 @@ EOH;
             'checked' => true,
         ];
         $expected = <<<EOH
-<input type="checkbox" name="foo" value="bar" checked="checked" />
+            <input type="checkbox" name="foo" value="bar" checked="checked" />
 
-EOH;
+            EOH;
         $this->assertEquals($expected, form_checkbox($data));
     }
 
@@ -646,9 +646,9 @@ EOH;
             'checked' => false,
         ];
         $expected = <<<EOH
-<input type="checkbox" name="foo" value="bar" />
+            <input type="checkbox" name="foo" value="bar" />
 
-EOH;
+            EOH;
         $this->assertEquals($expected, form_checkbox($data));
     }
 
@@ -656,8 +656,8 @@ EOH;
     public function testFormRadio()
     {
         $expected = <<<EOH
-<input type="radio" name="newsletter" value="accept" checked="checked" />\n
-EOH;
+            <input type="radio" name="newsletter" value="accept" checked="checked" />\n
+            EOH;
         $this->assertEquals($expected, form_radio('newsletter', 'accept', true));
     }
 
@@ -665,8 +665,8 @@ EOH;
     public function testFormSubmit()
     {
         $expected = <<<EOH
-<input type="submit" name="mysubmit" value="Submit Post!" />\n
-EOH;
+            <input type="submit" name="mysubmit" value="Submit Post!" />\n
+            EOH;
         $this->assertEquals($expected, form_submit('mysubmit', 'Submit Post!'));
     }
 
@@ -674,8 +674,8 @@ EOH;
     public function testFormLabel()
     {
         $expected = <<<EOH
-<label for="username">What is your Name</label>
-EOH;
+            <label for="username">What is your Name</label>
+            EOH;
         $this->assertEquals($expected, form_label('What is your Name', 'username'));
     }
 
@@ -686,8 +686,8 @@ EOH;
             'id' => 'label1',
         ];
         $expected = <<<EOH
-<label for="foo" id="label1">bar</label>
-EOH;
+            <label for="foo" id="label1">bar</label>
+            EOH;
         $this->assertEquals($expected, form_label('bar', 'foo', $attributes));
     }
 
@@ -695,8 +695,8 @@ EOH;
     public function testFormReset()
     {
         $expected = <<<EOH
-<input type="reset" name="myreset" value="Reset" />\n
-EOH;
+            <input type="reset" name="myreset" value="Reset" />\n
+            EOH;
         $this->assertEquals($expected, form_reset('myreset', 'Reset'));
     }
 
@@ -704,8 +704,8 @@ EOH;
     public function testFormButton()
     {
         $expected = <<<EOH
-<button name="name" type="button">content</button>\n
-EOH;
+            <button name="name" type="button">content</button>\n
+            EOH;
         $this->assertEquals($expected, form_button('name', 'content'));
     }
 
@@ -717,9 +717,9 @@ EOH;
             'content' => 'bar',
         ];
         $expected = <<<EOH
-<button name="foo" type="button">bar</button>
+            <button name="foo" type="button">bar</button>
 
-EOH;
+            EOH;
         $this->assertEquals($expected, form_button($data));
     }
 
@@ -727,8 +727,8 @@ EOH;
     public function testFormClose()
     {
         $expected = <<<EOH
-</form></div></div>
-EOH;
+            </form></div></div>
+            EOH;
         $this->assertEquals($expected, form_close('</div></div>'));
     }
 
@@ -740,13 +740,13 @@ EOH;
             'bar1',
         ];
         $expected = <<<EOH
-<input type="text" name="foo" value="bar" list="foo_list" />
+            <input type="text" name="foo" value="bar" list="foo_list" />
 
-<datalist id='foo_list'><option value='foo1'>
-<option value='bar1'>
-</datalist>
+            <datalist id='foo_list'><option value='foo1'>
+            <option value='bar1'>
+            </datalist>
 
-EOH;
+            EOH;
         $this->assertEquals($expected, form_datalist('foo', 'bar', $options));
     }
 

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -38,7 +38,7 @@ class FormHelperTest extends CIUnitTestCase
 
                 EOH;
         } else {
-            $expected = <<<EOH
+            $expected = <<<'EOH'
                 <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
 
                 EOH;
@@ -62,7 +62,7 @@ class FormHelperTest extends CIUnitTestCase
         $request->uri      = new URI('http://example.com/');
 
         Services::injectMock('request', $request);
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <form action="http://example.com/index.php/en/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
 
             EOH;
@@ -96,7 +96,7 @@ class FormHelperTest extends CIUnitTestCase
 
                 EOH;
         } else {
-            $expected = <<<EOH
+            $expected = <<<'EOH'
                 <form action="http://example.com/index.php" name="form" id="form" method="POST" accept-charset="utf-8">
 
                 EOH;
@@ -130,7 +130,7 @@ class FormHelperTest extends CIUnitTestCase
 
                 EOH;
         } else {
-            $expected = <<<EOH
+            $expected = <<<'EOH'
                 <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="post" accept-charset="utf-8">
 
                 EOH;
@@ -165,7 +165,7 @@ class FormHelperTest extends CIUnitTestCase
 
                 EOH;
         } else {
-            $expected = <<<EOH
+            $expected = <<<'EOH'
                 <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
 
                 <input type="hidden" name="foo" value="bar" />
@@ -205,7 +205,7 @@ class FormHelperTest extends CIUnitTestCase
 
                 EOH;
         } else {
-            $expected = <<<EOH
+            $expected = <<<'EOH'
                 <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" enctype="multipart/form-data" accept-charset="utf-8">
 
                 EOH;
@@ -238,7 +238,7 @@ class FormHelperTest extends CIUnitTestCase
         $data = [
             'foo' => 'bar',
         ];
-        $expected = <<<EOH
+        $expected = <<<'EOH'
 
             <input type="hidden" name="foo" value="bar" />
 
@@ -252,7 +252,7 @@ class FormHelperTest extends CIUnitTestCase
         $data = [
             'foo' => 'bar',
         ];
-        $expected = <<<EOH
+        $expected = <<<'EOH'
 
             <input type="hidden" name="name[foo]" value="bar" />
 
@@ -327,7 +327,7 @@ class FormHelperTest extends CIUnitTestCase
             'name'  => 'foo',
             'value' => 'bar',
         ];
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <textarea name="foo" cols="40" rows="10">bar</textarea>
 
             EOH;
@@ -472,7 +472,7 @@ class FormHelperTest extends CIUnitTestCase
     // ------------------------------------------------------------------------
     public function testFormDropdownWithSelectedAttribute()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <select name="foo">
             <option value="bar" selected="selected">Bar</option>
             </select>
@@ -491,7 +491,7 @@ class FormHelperTest extends CIUnitTestCase
     // ------------------------------------------------------------------------
     public function testFormDropdownWithOptionsAttribute()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <select name="foo">
             <option value="bar">Bar</option>
             </select>
@@ -509,7 +509,7 @@ class FormHelperTest extends CIUnitTestCase
     // ------------------------------------------------------------------------
     public function testFormDropdownWithEmptyArrayOptionValue()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <select name="foo">
             </select>
 
@@ -583,7 +583,7 @@ class FormHelperTest extends CIUnitTestCase
     // ------------------------------------------------------------------------
     public function testFormFieldsetWithNoLegent()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <fieldset>
 
             EOH;
@@ -596,7 +596,7 @@ class FormHelperTest extends CIUnitTestCase
         $attributes = [
             'name' => 'bar',
         ];
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <fieldset name="bar">
             <legend>Foo</legend>
 
@@ -607,7 +607,7 @@ class FormHelperTest extends CIUnitTestCase
     // ------------------------------------------------------------------------
     public function testFormFieldsetClose()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             </fieldset></div></div>
             EOH;
         $this->assertEquals($expected, form_fieldset_close('</div></div>'));
@@ -630,7 +630,7 @@ class FormHelperTest extends CIUnitTestCase
             'value'   => 'bar',
             'checked' => true,
         ];
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <input type="checkbox" name="foo" value="bar" checked="checked" />
 
             EOH;
@@ -645,7 +645,7 @@ class FormHelperTest extends CIUnitTestCase
             'value'   => 'bar',
             'checked' => false,
         ];
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <input type="checkbox" name="foo" value="bar" />
 
             EOH;
@@ -673,7 +673,7 @@ class FormHelperTest extends CIUnitTestCase
     // ------------------------------------------------------------------------
     public function testFormLabel()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <label for="username">What is your Name</label>
             EOH;
         $this->assertEquals($expected, form_label('What is your Name', 'username'));
@@ -685,7 +685,7 @@ class FormHelperTest extends CIUnitTestCase
         $attributes = [
             'id' => 'label1',
         ];
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <label for="foo" id="label1">bar</label>
             EOH;
         $this->assertEquals($expected, form_label('bar', 'foo', $attributes));
@@ -716,7 +716,7 @@ class FormHelperTest extends CIUnitTestCase
             'name'    => 'foo',
             'content' => 'bar',
         ];
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <button name="foo" type="button">bar</button>
 
             EOH;
@@ -726,7 +726,7 @@ class FormHelperTest extends CIUnitTestCase
     // ------------------------------------------------------------------------
     public function testFormClose()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             </form></div></div>
             EOH;
         $this->assertEquals($expected, form_close('</div></div>'));
@@ -739,7 +739,7 @@ class FormHelperTest extends CIUnitTestCase
             'foo1',
             'bar1',
         ];
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <input type="text" name="foo" value="bar" list="foo_list" />
 
             <datalist id='foo_list'><option value='foo1'>

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -37,7 +37,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testBasicUL()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <ul>
               <li>foo</li>
               <li>bar</li>
@@ -56,7 +56,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testULWithClass()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <ul class="test">
               <li>foo</li>
               <li>bar</li>
@@ -75,7 +75,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testMultiLevelUL()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <ul>
               <li>foo</li>
               <li>bar</li>
@@ -106,7 +106,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testBasicOL()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <ol>
               <li>foo</li>
               <li>bar</li>
@@ -125,7 +125,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testOLWithClass()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <ol class="test">
               <li>foo</li>
               <li>bar</li>
@@ -144,7 +144,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testMultiLevelOL()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <ol>
               <li>foo</li>
               <li>bar</li>
@@ -299,7 +299,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testVideo()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <video src="http://www.codeigniter.com/test.mp4" controls>
               Your browser does not support the video tag.
             </video>
@@ -314,7 +314,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testVideoWithTracks()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <video src="http://example.com/test.mp4" controls>
               <track src="subtitles_no.vtt" kind="subtitles" srclang="no" label="Norwegian No" />
               <track src="subtitles_yes.vtt" kind="subtitles" srclang="yes" label="Norwegian Yes" />
@@ -331,7 +331,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testVideoWithTracksAndIndex()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <video src="http://example.com/index.php/test.mp4" controls>
               <track src="subtitles_no.vtt" kind="subtitles" srclang="no" label="Norwegian No" />
               <track src="subtitles_yes.vtt" kind="subtitles" srclang="yes" label="Norwegian Yes" />
@@ -348,7 +348,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testVideoMultipleSources()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <video class="test" controls>
               <source src="http://example.com/movie.mp4" type="video/mp4" class="test" />
               <source src="http://example.com/movie.ogg" type="video/ogg" />
@@ -377,7 +377,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testAudio()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <audio id="test" controls>
               <source src="http://example.com/sound.ogg" type="audio/ogg" />
               <source src="http://example.com/sound.mpeg" type="audio/mpeg" />
@@ -400,7 +400,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testAudioSimple()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <audio src="http://example.com/sound.mpeg" type="audio/mpeg" id="test" controls>
               Your browser does not support the audio tag.
             </audio>
@@ -416,7 +416,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testAudioWithSource()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <audio src="http://codeigniter.com/sound.mpeg" type="audio/mpeg" id="test" controls>
               Your browser does not support the audio tag.
             </audio>
@@ -432,7 +432,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testAudioWithIndex()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <audio src="http://example.com/index.php/sound.mpeg" type="audio/mpeg" id="test" controls>
               Your browser does not support the audio tag.
             </audio>
@@ -448,7 +448,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testAudioWithTracks()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <audio src="http://example.com/sound.mpeg" type="audio/mpeg" id="test" controls>
               <track src="subtitles_no.vtt" kind="subtitles" srclang="no" label="Norwegian No" />
               <track src="subtitles_yes.vtt" kind="subtitles" srclang="yes" label="Norwegian Yes" />
@@ -468,7 +468,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testMediaNameOnly()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <av>
             </av>
 
@@ -478,7 +478,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testMediaWithSources()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <av>
               <source src="http://example.com/sound.ogg" type="audio/ogg" />
               <source src="http://example.com/sound.mpeg" type="audio/mpeg" />
@@ -502,7 +502,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testEmbed()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <embed src="http://example.com/movie.mov" type="video/quicktime" class="test" />
 
             EOH;
@@ -514,7 +514,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testEmbedIndexed()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <embed src="http://example.com/index.php/movie.mov" type="video/quicktime" class="test" />
 
             EOH;
@@ -526,7 +526,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testObject()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <object data="http://example.com/movie.swf" class="test"></object>
 
             EOH;
@@ -539,7 +539,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testObjectWithParams()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <object data="http://example.com/movie.swf" class="test">
               <param name="foo" type="ref" value="bar" class="test" />
               <param name="hello" type="ref" value="world" class="test" />
@@ -558,7 +558,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testObjectIndexed()
     {
-        $expected = <<<EOH
+        $expected = <<<'EOH'
             <object data="http://example.com/index.php/movie.swf" class="test"></object>
 
             EOH;

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -38,12 +38,12 @@ final class HTMLHelperTest extends CIUnitTestCase
     public function testBasicUL()
     {
         $expected = <<<EOH
-<ul>
-  <li>foo</li>
-  <li>bar</li>
-</ul>
+            <ul>
+              <li>foo</li>
+              <li>bar</li>
+            </ul>
 
-EOH;
+            EOH;
 
         $expected = ltrim($expected);
         $list     = [
@@ -57,12 +57,12 @@ EOH;
     public function testULWithClass()
     {
         $expected = <<<EOH
-<ul class="test">
-  <li>foo</li>
-  <li>bar</li>
-</ul>
+            <ul class="test">
+              <li>foo</li>
+              <li>bar</li>
+            </ul>
 
-EOH;
+            EOH;
 
         $expected = ltrim($expected);
         $list     = [
@@ -76,18 +76,18 @@ EOH;
     public function testMultiLevelUL()
     {
         $expected = <<<EOH
-<ul>
-  <li>foo</li>
-  <li>bar</li>
-  <li>2
-    <ul>
-      <li>foo</li>
-      <li>bar</li>
-    </ul>
-  </li>
-</ul>
+            <ul>
+              <li>foo</li>
+              <li>bar</li>
+              <li>2
+                <ul>
+                  <li>foo</li>
+                  <li>bar</li>
+                </ul>
+              </li>
+            </ul>
 
-EOH;
+            EOH;
 
         $expected = ltrim($expected);
         $list     = [
@@ -107,12 +107,12 @@ EOH;
     public function testBasicOL()
     {
         $expected = <<<EOH
-<ol>
-  <li>foo</li>
-  <li>bar</li>
-</ol>
+            <ol>
+              <li>foo</li>
+              <li>bar</li>
+            </ol>
 
-EOH;
+            EOH;
 
         $expected = ltrim($expected);
         $list     = [
@@ -126,12 +126,12 @@ EOH;
     public function testOLWithClass()
     {
         $expected = <<<EOH
-<ol class="test">
-  <li>foo</li>
-  <li>bar</li>
-</ol>
+            <ol class="test">
+              <li>foo</li>
+              <li>bar</li>
+            </ol>
 
-EOH;
+            EOH;
 
         $expected = ltrim($expected);
         $list     = [
@@ -145,18 +145,18 @@ EOH;
     public function testMultiLevelOL()
     {
         $expected = <<<EOH
-<ol>
-  <li>foo</li>
-  <li>bar</li>
-  <li>2
-    <ol>
-      <li>foo</li>
-      <li>bar</li>
-    </ol>
-  </li>
-</ol>
+            <ol>
+              <li>foo</li>
+              <li>bar</li>
+              <li>2
+                <ol>
+                  <li>foo</li>
+                  <li>bar</li>
+                </ol>
+              </li>
+            </ol>
 
-EOH;
+            EOH;
 
         $expected = ltrim($expected);
         $list     = [
@@ -300,11 +300,11 @@ EOH;
     public function testVideo()
     {
         $expected = <<<EOH
-<video src="http://www.codeigniter.com/test.mp4" controls>
-  Your browser does not support the video tag.
-</video>
+            <video src="http://www.codeigniter.com/test.mp4" controls>
+              Your browser does not support the video tag.
+            </video>
 
-EOH;
+            EOH;
 
         $target  = 'http://www.codeigniter.com/test.mp4';
         $message = 'Your browser does not support the video tag.';
@@ -315,13 +315,13 @@ EOH;
     public function testVideoWithTracks()
     {
         $expected = <<<EOH
-<video src="http://example.com/test.mp4" controls>
-  <track src="subtitles_no.vtt" kind="subtitles" srclang="no" label="Norwegian No" />
-  <track src="subtitles_yes.vtt" kind="subtitles" srclang="yes" label="Norwegian Yes" />
-  Your browser does not support the video tag.
-</video>
+            <video src="http://example.com/test.mp4" controls>
+              <track src="subtitles_no.vtt" kind="subtitles" srclang="no" label="Norwegian No" />
+              <track src="subtitles_yes.vtt" kind="subtitles" srclang="yes" label="Norwegian Yes" />
+              Your browser does not support the video tag.
+            </video>
 
-EOH;
+            EOH;
 
         $target  = 'test.mp4';
         $message = 'Your browser does not support the video tag.';
@@ -332,13 +332,13 @@ EOH;
     public function testVideoWithTracksAndIndex()
     {
         $expected = <<<EOH
-<video src="http://example.com/index.php/test.mp4" controls>
-  <track src="subtitles_no.vtt" kind="subtitles" srclang="no" label="Norwegian No" />
-  <track src="subtitles_yes.vtt" kind="subtitles" srclang="yes" label="Norwegian Yes" />
-  Your browser does not support the video tag.
-</video>
+            <video src="http://example.com/index.php/test.mp4" controls>
+              <track src="subtitles_no.vtt" kind="subtitles" srclang="no" label="Norwegian No" />
+              <track src="subtitles_yes.vtt" kind="subtitles" srclang="yes" label="Norwegian Yes" />
+              Your browser does not support the video tag.
+            </video>
 
-EOH;
+            EOH;
 
         $target  = 'test.mp4';
         $message = 'Your browser does not support the video tag.';
@@ -349,17 +349,17 @@ EOH;
     public function testVideoMultipleSources()
     {
         $expected = <<<EOH
-<video class="test" controls>
-  <source src="http://example.com/movie.mp4" type="video/mp4" class="test" />
-  <source src="http://example.com/movie.ogg" type="video/ogg" />
-  <source src="http://example.com/movie.mov" type="video/quicktime" />
-  <source src="http://example.com/movie.ogv" type="video/ogv; codecs=dirac, speex" />
-  <track src="subtitles_no.vtt" kind="subtitles" srclang="no" label="Norwegian No" />
-  <track src="subtitles_yes.vtt" kind="subtitles" srclang="yes" label="Norwegian Yes" />
-  Your browser does not support the video tag.
-</video>
+            <video class="test" controls>
+              <source src="http://example.com/movie.mp4" type="video/mp4" class="test" />
+              <source src="http://example.com/movie.ogg" type="video/ogg" />
+              <source src="http://example.com/movie.mov" type="video/quicktime" />
+              <source src="http://example.com/movie.ogv" type="video/ogv; codecs=dirac, speex" />
+              <track src="subtitles_no.vtt" kind="subtitles" srclang="no" label="Norwegian No" />
+              <track src="subtitles_yes.vtt" kind="subtitles" srclang="yes" label="Norwegian Yes" />
+              Your browser does not support the video tag.
+            </video>
 
-EOH;
+            EOH;
 
         $sources = [
             source('movie.mp4', 'video/mp4', 'class="test"'),
@@ -378,15 +378,15 @@ EOH;
     public function testAudio()
     {
         $expected = <<<EOH
-<audio id="test" controls>
-  <source src="http://example.com/sound.ogg" type="audio/ogg" />
-  <source src="http://example.com/sound.mpeg" type="audio/mpeg" />
-  <track src="subtitles_no.vtt" kind="subtitles" srclang="no" label="Norwegian No" />
-  <track src="subtitles_yes.vtt" kind="subtitles" srclang="yes" label="Norwegian Yes" />
-  Your browser does not support the audio tag.
-</audio>
+            <audio id="test" controls>
+              <source src="http://example.com/sound.ogg" type="audio/ogg" />
+              <source src="http://example.com/sound.mpeg" type="audio/mpeg" />
+              <track src="subtitles_no.vtt" kind="subtitles" srclang="no" label="Norwegian No" />
+              <track src="subtitles_yes.vtt" kind="subtitles" srclang="yes" label="Norwegian Yes" />
+              Your browser does not support the audio tag.
+            </audio>
 
-EOH;
+            EOH;
 
         $sources = [
             source('sound.ogg', 'audio/ogg'),
@@ -401,11 +401,11 @@ EOH;
     public function testAudioSimple()
     {
         $expected = <<<EOH
-<audio src="http://example.com/sound.mpeg" type="audio/mpeg" id="test" controls>
-  Your browser does not support the audio tag.
-</audio>
+            <audio src="http://example.com/sound.mpeg" type="audio/mpeg" id="test" controls>
+              Your browser does not support the audio tag.
+            </audio>
 
-EOH;
+            EOH;
 
         $source  = 'sound.mpeg';
         $message = 'Your browser does not support the audio tag.';
@@ -417,11 +417,11 @@ EOH;
     public function testAudioWithSource()
     {
         $expected = <<<EOH
-<audio src="http://codeigniter.com/sound.mpeg" type="audio/mpeg" id="test" controls>
-  Your browser does not support the audio tag.
-</audio>
+            <audio src="http://codeigniter.com/sound.mpeg" type="audio/mpeg" id="test" controls>
+              Your browser does not support the audio tag.
+            </audio>
 
-EOH;
+            EOH;
 
         $source  = 'http://codeigniter.com/sound.mpeg';
         $message = 'Your browser does not support the audio tag.';
@@ -433,11 +433,11 @@ EOH;
     public function testAudioWithIndex()
     {
         $expected = <<<EOH
-<audio src="http://example.com/index.php/sound.mpeg" type="audio/mpeg" id="test" controls>
-  Your browser does not support the audio tag.
-</audio>
+            <audio src="http://example.com/index.php/sound.mpeg" type="audio/mpeg" id="test" controls>
+              Your browser does not support the audio tag.
+            </audio>
 
-EOH;
+            EOH;
 
         $source  = 'sound.mpeg';
         $message = 'Your browser does not support the audio tag.';
@@ -449,13 +449,13 @@ EOH;
     public function testAudioWithTracks()
     {
         $expected = <<<EOH
-<audio src="http://example.com/sound.mpeg" type="audio/mpeg" id="test" controls>
-  <track src="subtitles_no.vtt" kind="subtitles" srclang="no" label="Norwegian No" />
-  <track src="subtitles_yes.vtt" kind="subtitles" srclang="yes" label="Norwegian Yes" />
-  Your browser does not support the audio tag.
-</audio>
+            <audio src="http://example.com/sound.mpeg" type="audio/mpeg" id="test" controls>
+              <track src="subtitles_no.vtt" kind="subtitles" srclang="no" label="Norwegian No" />
+              <track src="subtitles_yes.vtt" kind="subtitles" srclang="yes" label="Norwegian Yes" />
+              Your browser does not support the audio tag.
+            </audio>
 
-EOH;
+            EOH;
 
         $source  = 'sound.mpeg';
         $message = 'Your browser does not support the audio tag.';
@@ -469,22 +469,22 @@ EOH;
     public function testMediaNameOnly()
     {
         $expected = <<<EOH
-<av>
-</av>
+            <av>
+            </av>
 
-EOH;
+            EOH;
         $this->assertEquals($expected, _media('av'));
     }
 
     public function testMediaWithSources()
     {
         $expected = <<<EOH
-<av>
-  <source src="http://example.com/sound.ogg" type="audio/ogg" />
-  <source src="http://example.com/sound.mpeg" type="audio/mpeg" />
-</av>
+            <av>
+              <source src="http://example.com/sound.ogg" type="audio/ogg" />
+              <source src="http://example.com/sound.mpeg" type="audio/mpeg" />
+            </av>
 
-EOH;
+            EOH;
         $sources = [
             source('sound.ogg', 'audio/ogg'),
             source('sound.mpeg', 'audio/mpeg'),
@@ -503,9 +503,9 @@ EOH;
     public function testEmbed()
     {
         $expected = <<<EOH
-<embed src="http://example.com/movie.mov" type="video/quicktime" class="test" />
+            <embed src="http://example.com/movie.mov" type="video/quicktime" class="test" />
 
-EOH;
+            EOH;
 
         $type  = 'video/quicktime';
         $embed = embed('movie.mov', $type, 'class="test"');
@@ -515,9 +515,9 @@ EOH;
     public function testEmbedIndexed()
     {
         $expected = <<<EOH
-<embed src="http://example.com/index.php/movie.mov" type="video/quicktime" class="test" />
+            <embed src="http://example.com/index.php/movie.mov" type="video/quicktime" class="test" />
 
-EOH;
+            EOH;
 
         $type  = 'video/quicktime';
         $embed = embed('movie.mov', $type, 'class="test"', true);
@@ -527,9 +527,9 @@ EOH;
     public function testObject()
     {
         $expected = <<<EOH
-<object data="http://example.com/movie.swf" class="test"></object>
+            <object data="http://example.com/movie.swf" class="test"></object>
 
-EOH;
+            EOH;
 
         $type   = 'application/x-shockwave-flash';
         $object = object('movie.swf', $type, 'class="test"');
@@ -540,12 +540,12 @@ EOH;
     public function testObjectWithParams()
     {
         $expected = <<<EOH
-<object data="http://example.com/movie.swf" class="test">
-  <param name="foo" type="ref" value="bar" class="test" />
-  <param name="hello" type="ref" value="world" class="test" />
-</object>
+            <object data="http://example.com/movie.swf" class="test">
+              <param name="foo" type="ref" value="bar" class="test" />
+              <param name="hello" type="ref" value="world" class="test" />
+            </object>
 
-EOH;
+            EOH;
 
         $type  = 'application/x-shockwave-flash';
         $parms = [
@@ -559,9 +559,9 @@ EOH;
     public function testObjectIndexed()
     {
         $expected = <<<EOH
-<object data="http://example.com/index.php/movie.swf" class="test"></object>
+            <object data="http://example.com/index.php/movie.swf" class="test"></object>
 
-EOH;
+            EOH;
 
         $type   = 'application/x-shockwave-flash';
         $object = object('movie.swf', $type, 'class="test"', [], true);

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -180,7 +180,7 @@ class ParserFilterTest extends CIUnitTestCase
         $parser->setData($data);
 
         $template = '{ value1|highlight_code }';
-        $expected = <<<EOF
+        $expected = <<<'EOF'
             <code><span style="color: #000000">
             <span style="color: #0000BB">Sincerely&nbsp;</span>
             </span>

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -181,11 +181,11 @@ class ParserFilterTest extends CIUnitTestCase
 
         $template = '{ value1|highlight_code }';
         $expected = <<<EOF
-<code><span style="color: #000000">
-<span style="color: #0000BB">Sincerely&nbsp;</span>
-</span>
-</code>
-EOF;
+            <code><span style="color: #000000">
+            <span style="color: #0000BB">Sincerely&nbsp;</span>
+            </span>
+            </code>
+            EOF;
         $this->assertEquals($expected, $parser->renderString($template));
     }
 

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -929,20 +929,20 @@ class ParserTest extends CIUnitTestCase
         ];
 
         $template = <<<'EOF'
-		<h3>#{heading}</h3>
-		{entries}
-			<h5>#{title}</h5>
-			<p>{body}</p>
-		{/entries}
-		EOF;
+            <h3>#{heading}</h3>
+            {entries}
+            	<h5>#{title}</h5>
+            	<p>{body}</p>
+            {/entries}
+            EOF;
 
         $expected = <<<'EOF'
-		<h3>#My Title</h3>
+            <h3>#My Title</h3>
 
-			<h5>#Subtitle</h5>
-			<p>Lorem ipsum</p>
+            	<h5>#Subtitle</h5>
+            	<p>Lorem ipsum</p>
 
-		EOF;
+            EOF;
 
         $this->parser->setData($data);
         $this->assertSame($expected, $this->parser->renderString($template));

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -75,6 +75,7 @@ final class CodeIgniter4 extends AbstractRuleset
                 'single_line'                         => true,
             ],
             'function_to_constant'                  => true,
+            'heredoc_indentation'                   => ['indentation' => 'start_plus_one'],
             'indentation_type'                      => true,
             'line_ending'                           => true,
             'list_syntax'                           => ['syntax' => 'short'],

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -76,6 +76,7 @@ final class CodeIgniter4 extends AbstractRuleset
             ],
             'function_to_constant'                  => true,
             'heredoc_indentation'                   => ['indentation' => 'start_plus_one'],
+            'heredoc_to_nowdoc'                     => true,
             'indentation_type'                      => true,
             'line_ending'                           => true,
             'list_syntax'                           => ['syntax' => 'short'],

--- a/utils/Rector/RemoveErrorSuppressInTryCatchStmtsRector.php
+++ b/utils/Rector/RemoveErrorSuppressInTryCatchStmtsRector.php
@@ -18,15 +18,15 @@ final class RemoveErrorSuppressInTryCatchStmtsRector extends AbstractRector
         return new RuleDefinition('Remove error suppression operator `@` inside try...catch blocks', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
-					try {
-						@rmdir($dirname);
-					} catch (Exception $e) {}
-				CODE_SAMPLE,
+                    	try {
+                    		@rmdir($dirname);
+                    	} catch (Exception $e) {}
+                    CODE_SAMPLE,
                 <<<'CODE_SAMPLE'
-				try {
-					rmdir($dirname);
-				} catch (Exception $e) {}
-				CODE_SAMPLE
+                    try {
+                    	rmdir($dirname);
+                    } catch (Exception $e) {}
+                    CODE_SAMPLE
             ),
         ]);
     }

--- a/utils/Rector/RemoveVarTagFromClassConstantRector.php
+++ b/utils/Rector/RemoveVarTagFromClassConstantRector.php
@@ -18,18 +18,18 @@ final class RemoveVarTagFromClassConstantRector extends AbstractRector
         return new RuleDefinition('Remove @var tag from class constant', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
-				class Foo
-				{
-					/** @var string */
-					const X = 'test';
-				}
-				CODE_SAMPLE,
+                    class Foo
+                    {
+                    	/** @var string */
+                    	const X = 'test';
+                    }
+                    CODE_SAMPLE,
                 <<<'CODE_SAMPLE'
-				class Foo
-				{
-					const X = 'test';
-				}
-				CODE_SAMPLE
+                    class Foo
+                    {
+                    	const X = 'test';
+                    }
+                    CODE_SAMPLE
             ),
         ]);
     }

--- a/utils/Rector/UnderscoreToCamelCaseVariableNameRector.php
+++ b/utils/Rector/UnderscoreToCamelCaseVariableNameRector.php
@@ -51,24 +51,24 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
         return new RuleDefinition('Change under_score names to camelCase', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
-final class SomeClass
-{
-    public function run($a_b)
-    {
-        $some_value = $a_b;
-    }
-}
-CODE_SAMPLE
+                    final class SomeClass
+                    {
+                        public function run($a_b)
+                        {
+                            $some_value = $a_b;
+                        }
+                    }
+                    CODE_SAMPLE
 ,
                 <<<'CODE_SAMPLE'
-final class SomeClass
-{
-    public function run($aB)
-    {
-        $someValue = $aB;
-    }
-}
-CODE_SAMPLE
+                    final class SomeClass
+                    {
+                        public function run($aB)
+                        {
+                            $someValue = $aB;
+                        }
+                    }
+                    CODE_SAMPLE
             ),
         ]);
     }


### PR DESCRIPTION
**Description**
This enables:
- Heredoc indentations (available as of PHP 7.3)
- Converts heredoc syntaxes to nowdoc if not involving variables

**Checklist:**
- [x] Securely signed commits
