### PR TITLE
Revert Model coalesce

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -707,7 +707,17 @@ class Model extends BaseModel
      */
     public function __get(string $name)
     {
-        return parent::__get($name) ?? $this->builder()->$name ?? null;
+         if (parent::__isset($name))
+         {
+             return parent::__get($name);
+         }
+
+         if (isset($this->builder()->$name))
+         {
+             return $this->builder()->$name;
+         }
+
+         return null;
     }
 
     /**


### PR DESCRIPTION
**Description**
The following change was made to `Model::__get()` to simplify code with null coalescence: https://github.com/codeigniter4/CodeIgniter4/commit/ace9df0da6e3a09937e7d38c40016e31cae22d9f#diff-1a690370bdbdc5997068f9ff210bacef314eeb65d1df73af206783ce055d8d1d

However, because of the magic accessors on `BaseModel` and `Connection` this did not end up being logically equivalent. Reverting that part of the PR.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
