### PR TITLE
Define initial "m" rules

### DIFF
--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -15,7 +15,7 @@ namespace CodeIgniter\Test;
 
 class BootstrapFCPATHTest extends CIUnitTestCase
 {
-    private $currentDir = __dir__;
+    private $currentDir = __DIR__;
     private $dir1       = '/tmp/dir1';
     private $file1      = '/tmp/dir1/testFile.php';
 
@@ -44,7 +44,7 @@ class BootstrapFCPATHTest extends CIUnitTestCase
 
     private function correctFCPATH()
     {
-        return realpath(__dir__ . '/../../../public') . DIRECTORY_SEPARATOR;
+        return realpath(__DIR__ . '/../../../public') . DIRECTORY_SEPARATOR;
     }
 
     private function buildDirectories() : void

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -106,6 +106,7 @@ final class CodeIgniter4 extends AbstractRuleset
             'lowercase_static_reference'            => true,
             'magic_constant_casing'                 => true,
             'magic_method_casing'                   => true,
+            'mb_str_functions'                      => false,
             'modernize_types_casting'               => true,
             'no_alias_functions'                    => ['sets' => ['@all']],
             'no_short_bool_cast'                    => true,

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -104,6 +104,8 @@ final class CodeIgniter4 extends AbstractRuleset
             'lowercase_cast'                        => true,
             'lowercase_keywords'                    => true,
             'lowercase_static_reference'            => true,
+            'magic_constant_casing'                 => true,
+            'magic_method_casing'                   => true,
             'modernize_types_casting'               => true,
             'no_alias_functions'                    => ['sets' => ['@all']],
             'no_short_bool_cast'                    => true,


### PR DESCRIPTION
**Description**
- Ensures all PHP magic constants (`__FILE__`, `__DIR__`, etc.) and methods (`__sleep()`, `__get()`, etc.) are written in the correct case.
- Sets the `mb_str_functions` fixer as `false` (off) by default

**Checklist:**
- [x] Securely signed commits
