### PR TITLE
Enable `method_chaining_indentation` fixer

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -1167,8 +1167,7 @@ if (! function_exists('view')) {
             unset($options['saveData']);
         }
 
-        return $renderer->setData($data, 'raw')
-                        ->render($name, $options, $saveData);
+        return $renderer->setData($data, 'raw')->render($name, $options, $saveData);
     }
 }
 

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -796,9 +796,9 @@ class MigrationRunner
         $this->ensureTable();
 
         $query = $this->db->table($this->table)
-                          ->where('batch', $batch)
-                          ->orderBy('id', $order)
-                          ->get();
+            ->where('batch', $batch)
+            ->orderBy('id', $order)
+            ->get();
 
         return ! empty($query) ? $query->getResultObject() : [];
     }
@@ -815,11 +815,11 @@ class MigrationRunner
         $this->ensureTable();
 
         $batches = $this->db->table($this->table)
-                          ->select('batch')
-                          ->distinct()
-                          ->orderBy('batch', 'asc')
-                          ->get()
-                          ->getResultArray();
+            ->select('batch')
+            ->distinct()
+            ->orderBy('batch', 'asc')
+            ->get()
+            ->getResultArray();
 
         return array_map('intval', array_column($batches, 'batch'));
     }
@@ -836,9 +836,9 @@ class MigrationRunner
         $this->ensureTable();
 
         $batch = $this->db->table($this->table)
-                          ->selectMax('batch')
-                          ->get()
-                          ->getResultObject();
+            ->selectMax('batch')
+            ->get()
+            ->getResultObject();
 
         $batch = is_array($batch) && count($batch)
             ? end($batch)->batch
@@ -894,11 +894,11 @@ class MigrationRunner
         }
 
         $migration = $this->db->table($this->table)
-              ->where('batch', $batch)
-              ->orderBy('id', 'desc')
-              ->limit(1)
-              ->get()
-              ->getResultObject();
+            ->where('batch', $batch)
+            ->orderBy('id', 'desc')
+            ->limit(1)
+            ->get()
+            ->getResultObject();
 
         return count($migration) ? $migration[0]->version : 0;
     }

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -173,8 +173,7 @@ class Connection extends BaseConnection
             )) {
                 // Prior to version 5.7.3, MySQL silently downgrades to an unencrypted connection if SSL setup fails
                 if (($clientFlags & MYSQLI_CLIENT_SSL) && version_compare($this->mysqli->client_info, 'mysqlnd 5.7.3', '<=')
-                    && empty($this->mysqli->query("SHOW STATUS LIKE 'ssl_cipher'")
-                                          ->fetch_object()->Value)
+                    && empty($this->mysqli->query("SHOW STATUS LIKE 'ssl_cipher'")->fetch_object()->Value)
                 ) {
                     $this->mysqli->close();
                     $message = 'MySQLi was configured for an SSL connection, but got an unencrypted connection instead!';

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -136,11 +136,10 @@ class Forge extends BaseForge
                 return '';
 
             case 'CHANGE':
-                $sqlTable = new Table($this->db, $this);
-
-                $sqlTable->fromTable($table)
-                         ->modifyColumn($field)
-                         ->run();
+                (new Table($this->db, $this))
+                    ->fromTable($table)
+                    ->modifyColumn($field)
+                    ->run();
 
                 return null;
 

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -346,8 +346,8 @@ class Toolbar
             // for this response
             if ($request->isAJAX() || strpos($format, 'html') === false) {
                 $response->setHeader('Debugbar-Time', "$time")
-                        ->setHeader('Debugbar-Link', site_url("?debugbar_time={$time}"))
-                        ->getBody();
+                    ->setHeader('Debugbar-Link', site_url("?debugbar_time={$time}"))
+                    ->getBody();
 
                 return;
             }

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -1077,9 +1077,10 @@ class URI
 
         // 5.2.2 Transform References in a non-strict method (no scheme)
         if (! empty($relative->getAuthority())) {
-            $transformed->setAuthority($relative->getAuthority())
-                    ->setPath($relative->getPath())
-                    ->setQuery($relative->getQuery());
+            $transformed
+                ->setAuthority($relative->getAuthority())
+                ->setPath($relative->getPath())
+                ->setQuery($relative->getQuery());
         } else {
             if ($relative->getPath() === '') {
                 $transformed->setPath($this->getPath());

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -1097,8 +1097,8 @@ class Time extends DateTime
         $testTime = $this->getUTCObject($testTime, $timezone);
 
         $ourTime = $this->toDateTime()
-                ->setTimezone(new DateTimeZone('UTC'))
-                ->format('Y-m-d H:i:s');
+            ->setTimezone(new DateTimeZone('UTC'))
+            ->format('Y-m-d H:i:s');
 
         return $testTime->format('Y-m-d H:i:s') === $ourTime;
     }

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -548,19 +548,16 @@ abstract class BaseHandler implements ImageHandlerInterface
                 return $this->rotate(180);
 
             case 4:
-                return $this->rotate(180)
-                                ->flip('horizontal');
+                return $this->rotate(180)->flip('horizontal');
 
             case 5:
-                return $this->rotate(270)
-                                ->flip('horizontal');
+                return $this->rotate(270)->flip('horizontal');
 
             case 6:
                 return $this->rotate(270);
 
             case 7:
-                return $this->rotate(90)
-                                ->flip('horizontal');
+                return $this->rotate(90)->flip('horizontal');
 
             case 8:
                 return $this->rotate(90);
@@ -644,8 +641,7 @@ abstract class BaseHandler implements ImageHandlerInterface
 
         [$x, $y] = $this->calcCropCoords($cropWidth, $cropHeight, $origWidth, $origHeight, $position);
 
-        return $this->crop($cropWidth, $cropHeight, $x, $y)
-                        ->resize($width, $height);
+        return $this->crop($cropWidth, $cropHeight, $x, $y)->resize($width, $height);
     }
 
     //--------------------------------------------------------------------

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -506,19 +506,16 @@ class ImageMagickHandler extends BaseHandler
                 return $this->rotate(180);
 
             case 4:
-                return $this->rotate(180)
-                                ->flip('horizontal');
+                return $this->rotate(180)->flip('horizontal');
 
             case 5:
-                return $this->rotate(90)
-                                ->flip('horizontal');
+                return $this->rotate(90)->flip('horizontal');
 
             case 6:
                 return $this->rotate(90);
 
             case 7:
-                return $this->rotate(270)
-                                ->flip('horizontal');
+                return $this->rotate(270)->flip('horizontal');
 
             case 8:
                 return $this->rotate(270);

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -150,10 +150,10 @@ class Pager implements PagerInterface
         if (! array_key_exists($template, $this->config->templates)) {
             throw PagerException::forInvalidTemplate($template);
         }
+
         $pager = new PagerRenderer($this->getDetails($group));
 
-        return $this->view->setVar('pager', $pager)
-                        ->render($this->config->templates[$template]);
+        return $this->view->setVar('pager', $pager)->render($this->config->templates[$template]);
     }
 
     //--------------------------------------------------------------------

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -139,8 +139,8 @@ class DatabaseHandler extends BaseHandler
         }
 
         $builder = $this->db->table($this->table)
-                ->select($this->platform === 'postgre' ? "encode(data, 'base64') AS data" : 'data')
-                ->where('id', $sessionID);
+            ->select($this->platform === 'postgre' ? "encode(data, 'base64') AS data" : 'data')
+            ->where('id', $sessionID);
 
         if ($this->matchIP) {
             $builder = $builder->where('ip_address', $this->ipAddress);

--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -163,8 +163,8 @@ trait ControllerTester
         helper('url');
 
         $result = (new ControllerResponse())
-                ->setRequest($this->request)
-                ->setResponse($this->response);
+            ->setRequest($this->request)
+            ->setResponse($this->response);
 
         $response = null;
 

--- a/system/Test/DatabaseTestTrait.php
+++ b/system/Test/DatabaseTestTrait.php
@@ -232,8 +232,8 @@ trait DatabaseTestTrait
         if (! empty($this->insertCache)) {
             foreach ($this->insertCache as $row) {
                 $this->db->table($row[0])
-                        ->where($row[1])
-                        ->delete();
+                    ->where($row[1])
+                    ->delete();
             }
         }
     }
@@ -267,9 +267,9 @@ trait DatabaseTestTrait
     public function grabFromDatabase(string $table, string $column, array $where)
     {
         $query = $this->db->table($table)
-                          ->select($column)
-                          ->where($where)
-                          ->get();
+            ->select($column)
+            ->where($where)
+            ->get();
 
         $query = $query->getRow();
 
@@ -309,8 +309,8 @@ trait DatabaseTestTrait
     public function dontSeeInDatabase(string $table, array $where)
     {
         $count = $this->db->table($table)
-                          ->where($where)
-                          ->countAllResults();
+            ->where($where)
+            ->countAllResults();
 
         $this->assertTrue($count === 0, 'Row was found in database');
     }
@@ -331,8 +331,7 @@ trait DatabaseTestTrait
             $data,
         ];
 
-        return $this->db->table($table)
-                        ->insert($data);
+        return $this->db->table($table)->insert($data);
     }
 
     /**
@@ -350,8 +349,8 @@ trait DatabaseTestTrait
     public function seeNumRecords(int $expected, string $table, array $where)
     {
         $count = $this->db->table($table)
-                          ->where($where)
-                          ->countAllResults();
+            ->where($where)
+            ->countAllResults();
 
         $this->assertEquals($expected, $count, 'Wrong number of matching rows in database.');
     }

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -194,8 +194,8 @@ class FeatureTestCase extends CIUnitTestCase
         Services::injectMock('filters', Services::filters(null, false));
 
         $response = $this->app
-                ->setRequest($request)
-                ->run($routes, true);
+            ->setRequest($request)
+            ->run($routes, true);
 
         $output = \ob_get_contents();
         if (empty($response->getBody()) && ! empty($output)) {

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -188,8 +188,8 @@ trait FeatureTestTrait
         Services::injectMock('filters', Services::filters(null, false));
 
         $response = $this->app
-                ->setRequest($request)
-                ->run($routes, true);
+            ->setRequest($request)
+            ->run($routes, true);
 
         $output = \ob_get_contents();
         if (empty($response->getBody()) && ! empty($output)) {

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -136,9 +136,9 @@ class Rules
         $db = Database::connect($data['DBGroup'] ?? null);
 
         $row = $db->table($table)
-                  ->select('1')
-                  ->where($field, $str)
-                  ->limit(1);
+            ->select('1')
+            ->where($field, $str)
+            ->limit(1);
 
         if (! empty($whereField) && ! empty($whereValue) && ! preg_match('/^\{(\w+)\}$/', $whereValue)) {
             $row = $row->where($whereField, $whereValue);
@@ -192,9 +192,9 @@ class Rules
         $db = Database::connect($data['DBGroup'] ?? null);
 
         $row = $db->table($table)
-                  ->select('1')
-                  ->where($field, $str)
-                  ->limit(1);
+            ->select('1')
+            ->where($field, $str)
+            ->limit(1);
 
         if (! empty($ignoreField) && ! empty($ignoreValue) && ! preg_match('/^\{(\w+)\}$/', $ignoreValue)) {
             $row = $row->where("{$ignoreField} !=", $ignoreValue);

--- a/tests/system/CommonFunctionsSendTest.php
+++ b/tests/system/CommonFunctionsSendTest.php
@@ -30,8 +30,8 @@ class CommonFunctionsSendTest extends CIUnitTestCase
         $routes->add('user/login', 'Auth::verify', ['as' => 'login']);
 
         $response = redirect()->route('login')
-                ->setCookie('foo', 'onething', YEAR)
-                ->setCookie('login_time', $loginTime, YEAR);
+            ->setCookie('foo', 'onething', YEAR)
+            ->setCookie('login_time', $loginTime, YEAR);
         $response->pretend(false);
         $this->assertTrue($response->hasCookie('foo', 'onething'));
         $this->assertTrue($response->hasCookie('login_time'));

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -109,9 +109,7 @@ class CommonFunctionsTest extends CIUnitTestCase
         \CodeIgniter\Services::injectMock('routes', $routes);
 
         $routes->add('home/base', 'Controller::index', ['as' => 'base']);
-
-        $response->method('redirect')
-                ->will($this->returnArgument(0));
+        $response->method('redirect')->will($this->returnArgument(0));
 
         $this->assertInstanceOf(RedirectResponse::class, redirect('base'));
     }
@@ -391,8 +389,8 @@ class CommonFunctionsTest extends CIUnitTestCase
         $routes->add('user/login', 'Auth::verify', ['as' => 'login']);
 
         $answer1 = redirect()->route('login')
-                ->setCookie('foo', 'onething', YEAR)
-                ->setCookie('login_time', $loginTime, YEAR);
+            ->setCookie('foo', 'onething', YEAR)
+            ->setCookie('login_time', $loginTime, YEAR);
 
         $this->assertTrue($answer1->hasCookie('foo', 'onething'));
         $this->assertTrue($answer1->hasCookie('login_time'));

--- a/tests/system/Database/Builder/GroupTest.php
+++ b/tests/system/Database/Builder/GroupTest.php
@@ -25,8 +25,7 @@ class GroupTest extends CIUnitTestCase
     {
         $builder = new BaseBuilder('user', $this->db);
 
-        $builder->select('name')
-                ->groupBy('name');
+        $builder->select('name')->groupBy('name');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name"';
 
@@ -40,8 +39,8 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->having('SUM(id) > 2');
+            ->groupBy('name')
+            ->having('SUM(id) > 2');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) > 2';
 
@@ -55,9 +54,9 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->having('id >', 3)
-                ->orHaving('SUM(id) > 2');
+            ->groupBy('name')
+            ->having('id >', 3)
+            ->orHaving('SUM(id) > 2');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" > 3 OR SUM(id) > 2';
 
@@ -71,8 +70,8 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->havingIn('id', [1, 2]);
+            ->groupBy('name')
+            ->havingIn('id', [1, 2]);
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" IN (1,2)';
 
@@ -85,8 +84,7 @@ class GroupTest extends CIUnitTestCase
     {
         $builder = new BaseBuilder('user', $this->db);
 
-        $builder->select('name')
-                ->groupBy('name');
+        $builder->select('name')->groupBy('name');
 
         $builder->havingIn('id', static function (BaseBuilder $builder) {
             return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
@@ -104,9 +102,9 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->havingIn('id', [1, 2])
-                ->orHavingIn('group_id', [5, 6]);
+            ->groupBy('name')
+            ->havingIn('id', [1, 2])
+            ->orHavingIn('group_id', [5, 6]);
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" IN (1,2) OR "group_id" IN (5,6)';
 
@@ -119,8 +117,7 @@ class GroupTest extends CIUnitTestCase
     {
         $builder = new BaseBuilder('user', $this->db);
 
-        $builder->select('name')
-                ->groupBy('name');
+        $builder->select('name')->groupBy('name');
 
         $builder->havingIn('id', static function (BaseBuilder $builder) {
             return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
@@ -141,8 +138,8 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->havingNotIn('id', [1, 2]);
+            ->groupBy('name')
+            ->havingNotIn('id', [1, 2]);
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" NOT IN (1,2)';
 
@@ -155,8 +152,7 @@ class GroupTest extends CIUnitTestCase
     {
         $builder = new BaseBuilder('user', $this->db);
 
-        $builder->select('name')
-                ->groupBy('name');
+        $builder->select('name')->groupBy('name');
 
         $builder->havingNotIn('id', static function (BaseBuilder $builder) {
             return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
@@ -174,9 +170,9 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->havingNotIn('id', [1, 2])
-                ->orHavingNotIn('group_id', [5, 6]);
+            ->groupBy('name')
+            ->havingNotIn('id', [1, 2])
+            ->orHavingNotIn('group_id', [5, 6]);
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" NOT IN (1,2) OR "group_id" NOT IN (5,6)';
 
@@ -189,8 +185,7 @@ class GroupTest extends CIUnitTestCase
     {
         $builder = new BaseBuilder('user', $this->db);
 
-        $builder->select('name')
-                ->groupBy('name');
+        $builder->select('name')->groupBy('name');
 
         $builder->havingNotIn('id', static function (BaseBuilder $builder) {
             return $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
@@ -211,8 +206,8 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->havingLike('pet_name', 'a');
+            ->groupBy('name')
+            ->havingLike('pet_name', 'a');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a%\' ESCAPE \'!\'';
 
@@ -226,8 +221,8 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->havingLike('pet_name', 'a', 'before');
+            ->groupBy('name')
+            ->havingLike('pet_name', 'a', 'before');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a\' ESCAPE \'!\'';
 
@@ -241,8 +236,8 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->havingLike('pet_name', 'a', 'after');
+            ->groupBy('name')
+            ->havingLike('pet_name', 'a', 'after');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'a%\' ESCAPE \'!\'';
 
@@ -256,8 +251,8 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->notHavingLike('pet_name', 'a');
+            ->groupBy('name')
+            ->notHavingLike('pet_name', 'a');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" NOT LIKE \'%a%\' ESCAPE \'!\'';
 
@@ -271,8 +266,8 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->notHavingLike('pet_name', 'a', 'before');
+            ->groupBy('name')
+            ->notHavingLike('pet_name', 'a', 'before');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" NOT LIKE \'%a\' ESCAPE \'!\'';
 
@@ -286,8 +281,8 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->notHavingLike('pet_name', 'a', 'after');
+            ->groupBy('name')
+            ->notHavingLike('pet_name', 'a', 'after');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" NOT LIKE \'a%\' ESCAPE \'!\'';
 
@@ -301,9 +296,9 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->havingLike('pet_name', 'a')
-                ->orHavingLike('pet_color', 'b');
+            ->groupBy('name')
+            ->havingLike('pet_name', 'a')
+            ->orHavingLike('pet_color', 'b');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a%\' ESCAPE \'!\' OR  "pet_color" LIKE \'%b%\' ESCAPE \'!\'';
 
@@ -317,9 +312,9 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->havingLike('pet_name', 'a', 'before')
-                ->orHavingLike('pet_color', 'b', 'before');
+            ->groupBy('name')
+            ->havingLike('pet_name', 'a', 'before')
+            ->orHavingLike('pet_color', 'b', 'before');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a\' ESCAPE \'!\' OR  "pet_color" LIKE \'%b\' ESCAPE \'!\'';
 
@@ -333,9 +328,9 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->havingLike('pet_name', 'a', 'after')
-                ->orHavingLike('pet_color', 'b', 'after');
+            ->groupBy('name')
+            ->havingLike('pet_name', 'a', 'after')
+            ->orHavingLike('pet_color', 'b', 'after');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'a%\' ESCAPE \'!\' OR  "pet_color" LIKE \'b%\' ESCAPE \'!\'';
 
@@ -349,9 +344,9 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->havingLike('pet_name', 'a')
-                ->orNotHavingLike('pet_color', 'b');
+            ->groupBy('name')
+            ->havingLike('pet_name', 'a')
+            ->orNotHavingLike('pet_color', 'b');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a%\' ESCAPE \'!\' OR  "pet_color" NOT LIKE \'%b%\' ESCAPE \'!\'';
 
@@ -365,9 +360,9 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->havingLike('pet_name', 'a', 'before')
-                ->orNotHavingLike('pet_color', 'b', 'before');
+            ->groupBy('name')
+            ->havingLike('pet_name', 'a', 'before')
+            ->orNotHavingLike('pet_color', 'b', 'before');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a\' ESCAPE \'!\' OR  "pet_color" NOT LIKE \'%b\' ESCAPE \'!\'';
 
@@ -381,9 +376,9 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->havingLike('pet_name', 'a', 'after')
-                ->orNotHavingLike('pet_color', 'b', 'after');
+            ->groupBy('name')
+            ->havingLike('pet_name', 'a', 'after')
+            ->orNotHavingLike('pet_color', 'b', 'after');
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'a%\' ESCAPE \'!\' OR  "pet_color" NOT LIKE \'b%\' ESCAPE \'!\'';
 
@@ -397,12 +392,12 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->having('SUM(id) <', 3)
-                ->havingGroupStart()
-                    ->having('SUM(id)', 2)
-                    ->having('name', 'adam')
-                ->havingGroupEnd();
+            ->groupBy('name')
+            ->having('SUM(id) <', 3)
+            ->havingGroupStart()
+            ->having('SUM(id)', 2)
+            ->having('name', 'adam')
+            ->havingGroupEnd();
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) < 3 AND   ( SUM(id) = 2 AND "name" = \'adam\'  )';
 
@@ -416,12 +411,12 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->having('SUM(id) >', 3)
-                ->orHavingGroupStart()
-                    ->having('SUM(id)', 2)
-                    ->having('name', 'adam')
-                ->havingGroupEnd();
+            ->groupBy('name')
+            ->having('SUM(id) >', 3)
+            ->orHavingGroupStart()
+            ->having('SUM(id)', 2)
+            ->having('name', 'adam')
+            ->havingGroupEnd();
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) > 3 OR   ( SUM(id) = 2 AND "name" = \'adam\'  )';
 
@@ -435,12 +430,12 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->having('SUM(id) <', 3)
-                ->notHavingGroupStart()
-                    ->having('SUM(id)', 2)
-                    ->having('name', 'adam')
-                ->havingGroupEnd();
+            ->groupBy('name')
+            ->having('SUM(id) <', 3)
+            ->notHavingGroupStart()
+            ->having('SUM(id)', 2)
+            ->having('name', 'adam')
+            ->havingGroupEnd();
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) < 3 AND NOT   ( SUM(id) = 2 AND "name" = \'adam\'  )';
 
@@ -454,12 +449,12 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->select('name')
-                ->groupBy('name')
-                ->having('SUM(id) <', 3)
-                ->orNotHavingGroupStart()
-                    ->having('SUM(id)', 2)
-                    ->having('name', 'adam')
-                ->havingGroupEnd();
+            ->groupBy('name')
+            ->having('SUM(id) <', 3)
+            ->orNotHavingGroupStart()
+            ->having('SUM(id)', 2)
+            ->having('name', 'adam')
+            ->havingGroupEnd();
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) < 3 OR NOT   ( SUM(id) = 2 AND "name" = \'adam\'  )';
 
@@ -473,10 +468,10 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->groupStart()
-                    ->where('id >', 3)
-                    ->where('name !=', 'Luke')
-                ->groupEnd()
-                ->where('name', 'Darth');
+            ->where('id >', 3)
+            ->where('name !=', 'Luke')
+            ->groupEnd()
+            ->where('name', 'Darth');
 
         $expectedSQL = 'SELECT * FROM "user" WHERE   ( "id" > 3 AND "name" != \'Luke\'  ) AND "name" = \'Darth\'';
 
@@ -490,10 +485,10 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->where('name', 'Darth')
-                ->orGroupStart()
-                    ->where('id >', 3)
-                    ->where('name !=', 'Luke')
-                ->groupEnd();
+            ->orGroupStart()
+            ->where('id >', 3)
+            ->where('name !=', 'Luke')
+            ->groupEnd();
 
         $expectedSQL = 'SELECT * FROM "user" WHERE "name" = \'Darth\' OR   ( "id" > 3 AND "name" != \'Luke\'  )';
 
@@ -507,10 +502,10 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->where('name', 'Darth')
-                ->notGroupStart()
-                ->where('id >', 3)
-                ->where('name !=', 'Luke')
-                ->groupEnd();
+            ->notGroupStart()
+            ->where('id >', 3)
+            ->where('name !=', 'Luke')
+            ->groupEnd();
 
         $expectedSQL = 'SELECT * FROM "user" WHERE "name" = \'Darth\' AND NOT   ( "id" > 3 AND "name" != \'Luke\'  )';
 
@@ -524,15 +519,13 @@ class GroupTest extends CIUnitTestCase
         $builder = new BaseBuilder('user', $this->db);
 
         $builder->where('name', 'Darth')
-                ->orNotGroupStart()
-                ->where('id >', 3)
-                ->where('name !=', 'Luke')
-                ->groupEnd();
+            ->orNotGroupStart()
+            ->where('id >', 3)
+            ->where('name !=', 'Luke')
+            ->groupEnd();
 
         $expectedSQL = 'SELECT * FROM "user" WHERE "name" = \'Darth\' OR NOT   ( "id" > 3 AND "name" != \'Luke\'  )';
 
         $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
-
-    //--------------------------------------------------------------------
 }

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -151,8 +151,7 @@ class WhereTest extends CIUnitTestCase
     {
         $builder = $this->db->table('jobs');
 
-        $builder->where('name', 'Accountant')
-                ->orWhere('name', 'foobar');
+        $builder->where('name', 'Accountant')->orWhere('name', 'foobar');
 
         $expectedSQL   = 'SELECT * FROM "jobs" WHERE "name" = \'Accountant\' OR "name" = \'foobar\'';
         $expectedBinds = [

--- a/tests/system/Database/Live/DeleteTest.php
+++ b/tests/system/Database/Live/DeleteTest.php
@@ -58,8 +58,7 @@ class DeleteTest extends CIUnitTestCase
         $this->seeNumRecords(2, 'user', ['country' => 'US']);
 
         try {
-            $this->db->table('user')
-                     ->delete(['country' => 'US'], 1);
+            $this->db->table('user')->delete(['country' => 'US'], 1);
         } catch (DatabaseException $e) {
             if (strpos($e->getMessage(), 'does not allow LIMITs on DELETE queries.') !== false) {
                 return;

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -536,8 +536,8 @@ class ForgeTest extends CIUnitTestCase
         $this->forge->addColumn('forge_test_table', $newField);
 
         $fieldNames = $this->db->table('forge_test_table')
-                ->get()
-                ->getFieldNames();
+            ->get()
+            ->getFieldNames();
 
         $this->forge->dropTable('forge_test_table', true);
 

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -19,9 +19,7 @@ class GetTest extends CIUnitTestCase
 
     public function testGet()
     {
-        $jobs = $this->db->table('job')
-                         ->get()
-                         ->getResult();
+        $jobs = $this->db->table('job')->get()->getResult();
 
         $this->assertCount(4, $jobs);
         $this->assertEquals('Developer', $jobs[0]->name);
@@ -34,9 +32,7 @@ class GetTest extends CIUnitTestCase
 
     public function testGetWitLimit()
     {
-        $jobs = $this->db->table('job')
-                         ->get(2, 2)
-                         ->getResult();
+        $jobs = $this->db->table('job')->get(2, 2)->getResult();
 
         $this->assertCount(2, $jobs);
         $this->assertEquals('Accountant', $jobs[0]->name);
@@ -48,8 +44,8 @@ class GetTest extends CIUnitTestCase
     public function testGetWhereArray()
     {
         $jobs = $this->db->table('job')
-                         ->getWhere(['id' => 1])
-                         ->getResult();
+            ->getWhere(['id' => 1])
+            ->getResult();
 
         $this->assertCount(1, $jobs);
         $this->assertEquals('Developer', $jobs[0]->name);
@@ -60,8 +56,8 @@ class GetTest extends CIUnitTestCase
     public function testGetWhereWithLimits()
     {
         $jobs = $this->db->table('job')
-                         ->getWhere('id > 1', 1, 1)
-                         ->getResult();
+            ->getWhere('id > 1', 1, 1)
+            ->getResult();
 
         $this->assertCount(1, $jobs);
         $this->assertEquals('Accountant', $jobs[0]->name);
@@ -71,9 +67,7 @@ class GetTest extends CIUnitTestCase
 
     public function testGetFieldCount()
     {
-        $jobs = $this->db->table('job')
-                         ->get()
-                         ->getFieldCount();
+        $jobs = $this->db->table('job')->get()->getFieldCount();
 
         $this->assertEquals(6, $jobs);
     }
@@ -82,9 +76,7 @@ class GetTest extends CIUnitTestCase
 
     public function testGetFieldNames()
     {
-        $jobs = $this->db->table('job')
-                         ->get()
-                         ->getFieldNames();
+        $jobs = $this->db->table('job')->get()->getFieldNames();
 
         $this->assertTrue(in_array('name', $jobs, true));
         $this->assertTrue(in_array('description', $jobs, true));
@@ -94,16 +86,12 @@ class GetTest extends CIUnitTestCase
 
     public function testGetFieldData()
     {
-        $jobs = $this->db->table('job')
-                         ->get()
-                         ->getFieldData();
+        $jobs = $this->db->table('job')->get()->getFieldData();
 
         $this->assertEquals('id', $jobs[0]->name);
         $this->assertEquals('name', $jobs[1]->name);
 
-        $typeTest = $this->db->table('type_test')
-                              ->get()
-                              ->getFieldData();
+        $typeTest = $this->db->table('type_test')->get()->getFieldData();
 
         if ($this->db->DBDriver === 'SQLite3') {
             $this->assertEquals('integer', $typeTest[0]->type_name); //INTEGER AUTO INC
@@ -186,8 +174,7 @@ class GetTest extends CIUnitTestCase
 
     public function testGetDataSeek()
     {
-        $data = $this->db->table('job')
-                         ->get();
+        $data = $this->db->table('job')->get();
 
         if ($this->db->DBDriver === 'SQLite3') {
             $this->expectException(DatabaseException::class);
@@ -203,8 +190,7 @@ class GetTest extends CIUnitTestCase
     //--------------------------------------------------------------------
     public function testGetAnotherDataSeek()
     {
-        $data = $this->db->table('job')
-                         ->get();
+        $data = $this->db->table('job')->get();
 
         $data->dataSeek(0);
 
@@ -220,9 +206,7 @@ class GetTest extends CIUnitTestCase
 
     public function testFreeResult()
     {
-        $data = $this->db->table('job')
-                         ->where('id', 4)
-                         ->get();
+        $data = $this->db->table('job')->where('id', 4)->get();
 
         $details = $data->getResult();
 
@@ -237,9 +221,7 @@ class GetTest extends CIUnitTestCase
 
     public function testGetRowWithColumnName()
     {
-        $name = $this->db->table('user')
-                         ->get()
-                         ->getRow('name', 'array');
+        $name = $this->db->table('user')->get()->getRow('name', 'array');
 
         $this->assertEquals('Derek Jones', $name);
     }
@@ -248,9 +230,7 @@ class GetTest extends CIUnitTestCase
 
     public function testGetRowWithReturnType()
     {
-        $user = $this->db->table('user')
-                         ->get()
-                         ->getRow(0, 'array');
+        $user = $this->db->table('user')->get()->getRow(0, 'array');
 
         $this->assertEquals('Derek Jones', $user['name']);
     }
@@ -261,9 +241,7 @@ class GetTest extends CIUnitTestCase
     {
         $testClass = new class { };
 
-        $user = $this->db->table('user')
-                         ->get()
-                         ->getRow(0, get_class($testClass));
+        $user = $this->db->table('user')->get()->getRow(0, get_class($testClass));
 
         $this->assertEquals('Derek Jones', $user->name);
     }
@@ -272,9 +250,7 @@ class GetTest extends CIUnitTestCase
 
     public function testGetFirstRow()
     {
-        $user = $this->db->table('user')
-                         ->get()
-                         ->getFirstRow();
+        $user = $this->db->table('user')->get()->getFirstRow();
 
         $this->assertEquals('Derek Jones', $user->name);
     }
@@ -283,9 +259,7 @@ class GetTest extends CIUnitTestCase
 
     public function testGetLastRow()
     {
-        $user = $this->db->table('user')
-                         ->get()
-                         ->getLastRow();
+        $user = $this->db->table('user')->get()->getLastRow();
 
         $this->assertEquals('Chris Martin', $user->name);
     }
@@ -294,9 +268,7 @@ class GetTest extends CIUnitTestCase
 
     public function testGetNextRow()
     {
-        $user = $this->db->table('user')
-                         ->get()
-                         ->getNextRow();
+        $user = $this->db->table('user')->get()->getNextRow();
 
         $this->assertEquals('Ahmadinejad', $user->name);
     }
@@ -305,11 +277,11 @@ class GetTest extends CIUnitTestCase
 
     public function testGetPreviousRow()
     {
-        $user = $this->db->table('user')
-                         ->get();
+        $user = $this->db->table('user')->get();
 
         $user->currentRow = 3;
-        $user             = $user->getPreviousRow();
+
+        $user = $user->getPreviousRow();
 
         $this->assertEquals('Richard A Causey', $user->name);
     }

--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -19,10 +19,10 @@ class GroupTest extends CIUnitTestCase
     public function testGroupBy()
     {
         $result = $this->db->table('user')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->get()
-                        ->getResult();
+            ->select('name')
+            ->groupBy('name')
+            ->get()
+            ->getResult();
 
         $this->assertCount(4, $result);
     }
@@ -32,11 +32,11 @@ class GroupTest extends CIUnitTestCase
     public function testHavingBy()
     {
         $result = $this->db->table('job')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->having('SUM(id) > 2')
-                        ->get()
-                        ->getResultArray();
+            ->select('name')
+            ->groupBy('name')
+            ->having('SUM(id) > 2')
+            ->get()
+            ->getResultArray();
 
         $this->assertCount(2, $result);
     }
@@ -46,12 +46,12 @@ class GroupTest extends CIUnitTestCase
     public function testOrHavingBy()
     {
         $result = $this->db->table('user')
-                        ->select('id')
-                        ->groupBy('id')
-                        ->having('id >', 3)
-                        ->orHaving('SUM(id) > 2')
-                        ->get()
-                        ->getResult();
+            ->select('id')
+            ->groupBy('id')
+            ->having('id >', 3)
+            ->orHaving('SUM(id) > 2')
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $result);
     }
@@ -61,12 +61,12 @@ class GroupTest extends CIUnitTestCase
     public function testHavingIn()
     {
         $result = $this->db->table('job')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->orderBy('name', 'asc')
-                        ->havingIn('name', ['Developer', 'Politician'])
-                        ->get()
-                        ->getResult();
+            ->select('name')
+            ->groupBy('name')
+            ->orderBy('name', 'asc')
+            ->havingIn('name', ['Developer', 'Politician'])
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $result);
         $this->assertEquals('Developer', $result[0]->name);
@@ -78,13 +78,13 @@ class GroupTest extends CIUnitTestCase
     public function testorHavingIn()
     {
         $result = $this->db->table('job')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->orderBy('name', 'asc')
-                        ->havingIn('name', ['Developer'])
-                        ->orHavingIn('name', ['Politician'])
-                        ->get()
-                        ->getResult();
+            ->select('name')
+            ->groupBy('name')
+            ->orderBy('name', 'asc')
+            ->havingIn('name', ['Developer'])
+            ->orHavingIn('name', ['Politician'])
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $result);
         $this->assertEquals('Developer', $result[0]->name);
@@ -96,12 +96,12 @@ class GroupTest extends CIUnitTestCase
     public function testHavingNotIn()
     {
         $result = $this->db->table('job')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->orderBy('name', 'asc')
-                        ->havingNotIn('name', ['Developer', 'Politician'])
-                        ->get()
-                        ->getResult();
+            ->select('name')
+            ->groupBy('name')
+            ->orderBy('name', 'asc')
+            ->havingNotIn('name', ['Developer', 'Politician'])
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $result);
         $this->assertEquals('Accountant', $result[0]->name);
@@ -113,13 +113,13 @@ class GroupTest extends CIUnitTestCase
     public function testOrHavingNotIn()
     {
         $result = $this->db->table('job')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->orderBy('name', 'asc')
-                        ->having('SUM(id) > 2')
-                        ->orHavingNotIn('name', ['Developer', 'Politician'])
-                        ->get()
-                        ->getResult();
+            ->select('name')
+            ->groupBy('name')
+            ->orderBy('name', 'asc')
+            ->having('SUM(id) > 2')
+            ->orHavingNotIn('name', ['Developer', 'Politician'])
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $result);
         $this->assertEquals('Accountant', $result[0]->name);
@@ -131,11 +131,11 @@ class GroupTest extends CIUnitTestCase
     public function testHavingLike()
     {
         $result = $this->db->table('job')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->havingLike('name', 'elo')
-                        ->get()
-                        ->getResult();
+            ->select('name')
+            ->groupBy('name')
+            ->havingLike('name', 'elo')
+            ->get()
+            ->getResult();
 
         $this->assertCount(1, $result);
         $this->assertEquals('Developer', $result[0]->name);
@@ -146,12 +146,12 @@ class GroupTest extends CIUnitTestCase
     public function testNotHavingLike()
     {
         $result = $this->db->table('job')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->orderBy('name', 'asc')
-                        ->notHavingLike('name', 'ian')
-                        ->get()
-                        ->getResult();
+            ->select('name')
+            ->groupBy('name')
+            ->orderBy('name', 'asc')
+            ->notHavingLike('name', 'ian')
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $result);
         $this->assertEquals('Accountant', $result[0]->name);
@@ -163,13 +163,13 @@ class GroupTest extends CIUnitTestCase
     public function testOrHavingLike()
     {
         $result = $this->db->table('job')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->orderBy('name', 'asc')
-                        ->havingLike('name', 'elo')
-                        ->orHavingLike('name', 'cc')
-                        ->get()
-                        ->getResult();
+            ->select('name')
+            ->groupBy('name')
+            ->orderBy('name', 'asc')
+            ->havingLike('name', 'elo')
+            ->orHavingLike('name', 'cc')
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $result);
         $this->assertEquals('Accountant', $result[0]->name);
@@ -181,13 +181,13 @@ class GroupTest extends CIUnitTestCase
     public function testOrNotHavingLike()
     {
         $result = $this->db->table('job')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->orderBy('name', 'asc')
-                        ->having('SUM(id) > 2')
-                        ->orNotHavingLike('name', 'ian')
-                        ->get()
-                        ->getResult();
+            ->select('name')
+            ->groupBy('name')
+            ->orderBy('name', 'asc')
+            ->having('SUM(id) > 2')
+            ->orNotHavingLike('name', 'ian')
+            ->get()
+            ->getResult();
 
         $this->assertCount(3, $result);
         $this->assertEquals('Accountant', $result[0]->name);
@@ -200,16 +200,16 @@ class GroupTest extends CIUnitTestCase
     public function testAndHavingGroupStart()
     {
         $result = $this->db->table('job')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->orderBy('name', 'asc')
-                        ->having('SUM(id) > 2')
-                        ->havingGroupStart()
-                            ->having('SUM(id) <= 4')
-                            ->havingLike('name', 'ant', 'before')
-                        ->havingGroupEnd()
-                        ->get()
-                        ->getResult();
+            ->select('name')
+            ->groupBy('name')
+            ->orderBy('name', 'asc')
+            ->having('SUM(id) > 2')
+            ->havingGroupStart()
+            ->having('SUM(id) <= 4')
+            ->havingLike('name', 'ant', 'before')
+            ->havingGroupEnd()
+            ->get()
+            ->getResult();
 
         $this->assertCount(1, $result);
         $this->assertEquals('Accountant', $result[0]->name);
@@ -220,16 +220,16 @@ class GroupTest extends CIUnitTestCase
     public function testOrHavingGroupStart()
     {
         $result = $this->db->table('job')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->orderBy('name', 'asc')
-                        ->having('SUM(id) > 2')
-                        ->orHavingGroupStart()
-                            ->having('SUM(id) <= 4')
-                            ->havingLike('name', 'ant', 'before')
-                        ->havingGroupEnd()
-                        ->get()
-                        ->getResult();
+            ->select('name')
+            ->groupBy('name')
+            ->orderBy('name', 'asc')
+            ->having('SUM(id) > 2')
+            ->orHavingGroupStart()
+            ->having('SUM(id) <= 4')
+            ->havingLike('name', 'ant', 'before')
+            ->havingGroupEnd()
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $result);
         $this->assertEquals('Accountant', $result[0]->name);
@@ -241,16 +241,16 @@ class GroupTest extends CIUnitTestCase
     public function testNotHavingGroupStart()
     {
         $result = $this->db->table('job')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->orderBy('name', 'asc')
-                        ->having('SUM(id) > 2')
-                        ->notHavingGroupStart()
-                            ->having('SUM(id) <= 4')
-                            ->havingLike('name', 'ant', 'before')
-                        ->havingGroupEnd()
-                        ->get()
-                        ->getResult();
+            ->select('name')
+            ->groupBy('name')
+            ->orderBy('name', 'asc')
+            ->having('SUM(id) > 2')
+            ->notHavingGroupStart()
+            ->having('SUM(id) <= 4')
+            ->havingLike('name', 'ant', 'before')
+            ->havingGroupEnd()
+            ->get()
+            ->getResult();
 
         $this->assertCount(1, $result);
         $this->assertEquals('Musician', $result[0]->name);
@@ -261,16 +261,16 @@ class GroupTest extends CIUnitTestCase
     public function testOrNotHavingGroupStart()
     {
         $result = $this->db->table('job')
-                        ->select('name')
-                        ->groupBy('name')
-                        ->orderBy('name', 'asc')
-                        ->having('SUM(id) > 2')
-                        ->orNotHavingGroupStart()
-                            ->having('SUM(id) < 2')
-                            ->havingLike('name', 'o')
-                        ->havingGroupEnd()
-                        ->get()
-                        ->getResult();
+            ->select('name')
+            ->groupBy('name')
+            ->orderBy('name', 'asc')
+            ->having('SUM(id) > 2')
+            ->orNotHavingGroupStart()
+            ->having('SUM(id) < 2')
+            ->havingLike('name', 'o')
+            ->havingGroupEnd()
+            ->get()
+            ->getResult();
 
         $this->assertCount(3, $result);
         $this->assertEquals('Accountant', $result[0]->name);
@@ -283,13 +283,13 @@ class GroupTest extends CIUnitTestCase
     public function testAndGroups()
     {
         $result = $this->db->table('user')
-                ->groupStart()
-                ->where('id >=', 3)
-                ->where('name !=', 'Chris Martin')
-                ->groupEnd()
-                ->where('country', 'US')
-                ->get()
-                ->getResult();
+            ->groupStart()
+            ->where('id >=', 3)
+            ->where('name !=', 'Chris Martin')
+            ->groupEnd()
+            ->where('country', 'US')
+            ->get()
+            ->getResult();
 
         $this->assertCount(1, $result);
         $this->assertEquals('Richard A Causey', $result[0]->name);
@@ -300,13 +300,13 @@ class GroupTest extends CIUnitTestCase
     public function testOrGroups()
     {
         $result = $this->db->table('user')
-                ->where('country', 'Iran')
-                ->orGroupStart()
-                ->where('id >=', 3)
-                ->where('name !=', 'Richard A Causey')
-                ->groupEnd()
-                ->get()
-                ->getResult();
+            ->where('country', 'Iran')
+            ->orGroupStart()
+            ->where('id >=', 3)
+            ->where('name !=', 'Richard A Causey')
+            ->groupEnd()
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $result);
         $this->assertEquals('Ahmadinejad', $result[0]->name);
@@ -318,13 +318,13 @@ class GroupTest extends CIUnitTestCase
     public function testNotGroups()
     {
         $result = $this->db->table('user')
-                ->where('country', 'US')
-                ->notGroupStart()
-                ->where('id >=', 3)
-                ->where('name !=', 'Chris Martin')
-                ->groupEnd()
-                ->get()
-                ->getResult();
+            ->where('country', 'US')
+            ->notGroupStart()
+            ->where('id >=', 3)
+            ->where('name !=', 'Chris Martin')
+            ->groupEnd()
+            ->get()
+            ->getResult();
 
         $this->assertCount(1, $result);
         $this->assertEquals('Derek Jones', $result[0]->name);
@@ -335,13 +335,13 @@ class GroupTest extends CIUnitTestCase
     public function testOrNotGroups()
     {
         $result = $this->db->table('user')
-                ->where('country', 'US')
-                ->orNotGroupStart()
-                ->where('id >=', 2)
-                ->where('country', 'Iran')
-                ->groupEnd()
-                ->get()
-                ->getResult();
+            ->where('country', 'US')
+            ->orNotGroupStart()
+            ->where('id >=', 2)
+            ->where('country', 'Iran')
+            ->groupEnd()
+            ->get()
+            ->getResult();
 
         $this->assertCount(3, $result);
         $this->assertEquals('Derek Jones', $result[0]->name);
@@ -354,11 +354,11 @@ class GroupTest extends CIUnitTestCase
     public function testGroupByCount()
     {
         $result = $this->db->table('user')
-                ->selectCount('id', 'count')
-                ->groupBy('country')
-                ->orderBy('country', 'desc')
-                ->get()
-                ->getResult();
+            ->selectCount('id', 'count')
+            ->groupBy('country')
+            ->orderBy('country', 'desc')
+            ->get()
+            ->getResult();
 
         $this->assertEquals(2, $result[0]->count);
     }

--- a/tests/system/Database/Live/IncrementTest.php
+++ b/tests/system/Database/Live/IncrementTest.php
@@ -21,8 +21,8 @@ class IncrementTest extends CIUnitTestCase
         $this->hasInDatabase('job', ['name' => 'incremental', 'description' => '6']);
 
         $this->db->table('job')
-                ->where('name', 'incremental')
-                ->increment('description');
+            ->where('name', 'incremental')
+            ->increment('description');
 
         $this->seeInDatabase('job', ['name' => 'incremental', 'description' => '7']);
     }
@@ -34,8 +34,8 @@ class IncrementTest extends CIUnitTestCase
         $this->hasInDatabase('job', ['name' => 'incremental', 'description' => '6']);
 
         $this->db->table('job')
-                 ->where('name', 'incremental')
-                 ->increment('description', 2);
+            ->where('name', 'incremental')
+            ->increment('description', 2);
 
         $this->seeInDatabase('job', ['name' => 'incremental', 'description' => '8']);
     }
@@ -47,8 +47,8 @@ class IncrementTest extends CIUnitTestCase
         $this->hasInDatabase('job', ['name' => 'incremental', 'description' => '6']);
 
         $this->db->table('job')
-                 ->where('name', 'incremental')
-                 ->decrement('description');
+            ->where('name', 'incremental')
+            ->decrement('description');
 
         $this->seeInDatabase('job', ['name' => 'incremental', 'description' => '5']);
     }
@@ -60,8 +60,8 @@ class IncrementTest extends CIUnitTestCase
         $this->hasInDatabase('job', ['name' => 'incremental', 'description' => '6']);
 
         $this->db->table('job')
-                 ->where('name', 'incremental')
-                 ->decrement('description', 2);
+            ->where('name', 'incremental')
+            ->decrement('description', 2);
 
         $this->seeInDatabase('job', ['name' => 'incremental', 'description' => '4']);
     }

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -62,8 +62,8 @@ class InsertTest extends CIUnitTestCase
         $this->db->table('job')->replace($data);
 
         $row = $this->db->table('job')
-                        ->getwhere(['id' => 5])
-                        ->getRow();
+            ->getwhere(['id' => 5])
+            ->getRow();
 
         $this->assertEquals('Cab Driver', $row->name);
     }
@@ -81,8 +81,8 @@ class InsertTest extends CIUnitTestCase
         $this->db->table('job')->replace($data);
 
         $row = $this->db->table('job')
-                        ->getwhere(['id' => 1])
-                        ->getRow();
+            ->getwhere(['id' => 1])
+            ->getRow();
 
         $this->assertEquals('Cab Driver', $row->name);
     }

--- a/tests/system/Database/Live/JoinTest.php
+++ b/tests/system/Database/Live/JoinTest.php
@@ -19,10 +19,10 @@ class JoinTest extends CIUnitTestCase
     public function testSimpleJoin()
     {
         $row = $this->db->table('job')
-                        ->select('job.id as job_id, job.name as job_name, user.id as user_id, user.name as user_name')
-                        ->join('user', 'user.id = job.id')
-                        ->get()
-                        ->getRow();
+            ->select('job.id as job_id, job.name as job_name, user.id as user_id, user.name as user_name')
+            ->join('user', 'user.id = job.id')
+            ->get()
+            ->getRow();
 
         $this->assertEquals(1, $row->job_id);
         $this->assertEquals(1, $row->user_id);

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -74,9 +74,9 @@ class LikeTest extends CIUnitTestCase
     public function testOrLike()
     {
         $jobs = $this->db->table('job')->like('name', 'ian')
-                        ->orLike('name', 'veloper')
-                        ->get()
-                        ->getResult();
+            ->orLike('name', 'veloper')
+            ->get()
+            ->getResult();
 
         $this->assertCount(3, $jobs);
         $this->assertEquals('Developer', $jobs[0]->name);
@@ -89,9 +89,9 @@ class LikeTest extends CIUnitTestCase
     public function testNotLike()
     {
         $jobs = $this->db->table('job')
-                         ->notLike('name', 'veloper')
-                         ->get()
-                         ->getResult();
+            ->notLike('name', 'veloper')
+            ->get()
+            ->getResult();
 
         $this->assertCount(3, $jobs);
         $this->assertEquals('Politician', $jobs[0]->name);
@@ -104,10 +104,10 @@ class LikeTest extends CIUnitTestCase
     public function testOrNotLike()
     {
         $jobs = $this->db->table('job')
-                         ->like('name', 'ian')
-                         ->orNotLike('name', 'veloper')
-                         ->get()
-                         ->getResult();
+            ->like('name', 'ian')
+            ->orNotLike('name', 'veloper')
+            ->get()
+            ->getResult();
 
         $this->assertCount(3, $jobs);
         $this->assertEquals('Politician', $jobs[0]->name);

--- a/tests/system/Database/Live/LimitTest.php
+++ b/tests/system/Database/Live/LimitTest.php
@@ -18,9 +18,9 @@ class LimitTest extends CIUnitTestCase
     public function testLimit()
     {
         $jobs = $this->db->table('job')
-                        ->limit(2)
-                        ->get()
-                        ->getResult();
+            ->limit(2)
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $jobs);
         $this->assertEquals('Developer', $jobs[0]->name);
@@ -32,9 +32,9 @@ class LimitTest extends CIUnitTestCase
     public function testLimitAndOffset()
     {
         $jobs = $this->db->table('job')
-                        ->limit(2, 2)
-                        ->get()
-                        ->getResult();
+            ->limit(2, 2)
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $jobs);
         $this->assertEquals('Accountant', $jobs[0]->name);

--- a/tests/system/Database/Live/OrderTest.php
+++ b/tests/system/Database/Live/OrderTest.php
@@ -19,9 +19,9 @@ class OrderTest extends CIUnitTestCase
     public function testOrderAscending()
     {
         $jobs = $this->db->table('job')
-                        ->orderBy('name', 'asc')
-                        ->get()
-                        ->getResult();
+            ->orderBy('name', 'asc')
+            ->get()
+            ->getResult();
 
         $this->assertCount(4, $jobs);
         $this->assertEquals('Accountant', $jobs[0]->name);
@@ -35,9 +35,9 @@ class OrderTest extends CIUnitTestCase
     public function testOrderDescending()
     {
         $jobs = $this->db->table('job')
-                         ->orderBy('name', 'desc')
-                         ->get()
-                         ->getResult();
+            ->orderBy('name', 'desc')
+            ->get()
+            ->getResult();
 
         $this->assertCount(4, $jobs);
         $this->assertEquals('Accountant', $jobs[3]->name);
@@ -51,10 +51,10 @@ class OrderTest extends CIUnitTestCase
     public function testMultipleOrderValues()
     {
         $users = $this->db->table('user')
-                        ->orderBy('country', 'asc')
-                        ->orderBy('name', 'desc')
-                        ->get()
-                        ->getResult();
+            ->orderBy('country', 'asc')
+            ->orderBy('name', 'desc')
+            ->get()
+            ->getResult();
 
         $this->assertCount(4, $users);
         $this->assertEquals('Ahmadinejad', $users[0]->name);

--- a/tests/system/Database/Live/PretendTest.php
+++ b/tests/system/Database/Live/PretendTest.php
@@ -22,14 +22,14 @@ class PretendTest extends CIUnitTestCase
     public function testPretendReturnsQueryObject()
     {
         $result = $this->db->pretend(false)
-                           ->table('user')
-                           ->get();
+            ->table('user')
+            ->get();
 
         $this->assertFalse($result instanceof Query);
 
         $result = $this->db->pretend(true)
-                    ->table('user')
-                    ->get();
+            ->table('user')
+            ->get();
 
         $this->assertInstanceOf(Query::class, $result);
     }

--- a/tests/system/Database/Live/SelectTest.php
+++ b/tests/system/Database/Live/SelectTest.php
@@ -183,10 +183,10 @@ class SelectTest extends CIUnitTestCase
     public function testSelectWithMultipleWheresOnSameColumnAgain()
     {
         $users = $this->db->table('user')
-                          ->whereIn('id', [1, 2])
-                          ->orWhere('id', 3)
-                          ->get()
-                          ->getResultArray();
+            ->whereIn('id', [1, 2])
+            ->orWhere('id', 3)
+            ->get()
+            ->getResultArray();
 
         $this->assertCount(3, $users);
 

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -19,8 +19,7 @@ class UpdateTest extends CIUnitTestCase
 
     public function testUpdateSetsAllWithoutWhere()
     {
-        $this->db->table('user')
-                    ->update(['name' => 'Bobby']);
+        $this->db->table('user')->update(['name' => 'Bobby']);
 
         $result = $this->db->table('user')->get()->getResult();
 
@@ -35,13 +34,12 @@ class UpdateTest extends CIUnitTestCase
     public function testUpdateSetsAllWithoutWhereAndLimit()
     {
         try {
-            $this->db->table('user')
-                     ->update(['name' => 'Bobby'], null, 1);
+            $this->db->table('user')->update(['name' => 'Bobby'], null, 1);
 
             $result = $this->db->table('user')
-                               ->orderBy('id', 'asc')
-                               ->get()
-                               ->getResult();
+                ->orderBy('id', 'asc')
+                ->get()
+                ->getResult();
 
             $this->assertEquals('Bobby', $result[0]->name);
             $this->assertEquals('Ahmadinejad', $result[1]->name);
@@ -60,8 +58,7 @@ class UpdateTest extends CIUnitTestCase
 
     public function testUpdateWithWhere()
     {
-        $this->db->table('user')
-                 ->update(['name' => 'Bobby'], ['country' => 'US']);
+        $this->db->table('user')->update(['name' => 'Bobby'], ['country' => 'US']);
 
         $result = $this->db->table('user')->get()->getResultArray();
 
@@ -81,12 +78,9 @@ class UpdateTest extends CIUnitTestCase
     public function testUpdateWithWhereAndLimit()
     {
         try {
-            $this->db->table('user')
-                     ->update(['name' => 'Bobby'], ['country' => 'US'], 1);
+            $this->db->table('user')->update(['name' => 'Bobby'], ['country' => 'US'], 1);
 
-            $result = $this->db->table('user')
-                               ->get()
-                               ->getResult();
+            $result = $this->db->table('user')->get()->getResult();
 
             $this->assertEquals('Bobby', $result[0]->name);
             $this->assertEquals('Ahmadinejad', $result[1]->name);
@@ -116,8 +110,7 @@ class UpdateTest extends CIUnitTestCase
             ],
         ];
 
-        $this->db->table('user')
-                    ->updateBatch($data, 'name');
+        $this->db->table('user')->updateBatch($data, 'name');
 
         $this->seeInDatabase('user', [
             'name'    => 'Derek Jones',
@@ -133,8 +126,7 @@ class UpdateTest extends CIUnitTestCase
 
     public function testUpdateWithWhereSameColumn()
     {
-        $this->db->table('user')
-                 ->update(['country' => 'CA'], ['country' => 'US']);
+        $this->db->table('user')->update(['country' => 'CA'], ['country' => 'US']);
 
         $result = $this->db->table('user')->get()->getResultArray();
 
@@ -155,9 +147,9 @@ class UpdateTest extends CIUnitTestCase
     {
         // calling order: set() -> where()
         $this->db->table('user')
-                 ->set('country', 'CA')
-                 ->where('country', 'US')
-                 ->update();
+            ->set('country', 'CA')
+            ->where('country', 'US')
+            ->update();
 
         $result = $this->db->table('user')->get()->getResultArray();
 
@@ -178,8 +170,8 @@ class UpdateTest extends CIUnitTestCase
     {
         // calling order: where() -> set() in update()
         $this->db->table('user')
-                 ->where('country', 'US')
-                 ->update(['country' => 'CA']);
+            ->where('country', 'US')
+            ->update(['country' => 'CA']);
 
         $result = $this->db->table('user')->get()->getResultArray();
 
@@ -222,8 +214,8 @@ class UpdateTest extends CIUnitTestCase
     public function testSetWithoutEscape()
     {
         $this->db->table('job')
-                 ->set('description', 'name', false)
-                 ->update();
+            ->set('description', 'name', false)
+            ->update();
 
         $result = $this->db->table('user')->get()->getResultArray();
 

--- a/tests/system/Database/Live/WhereTest.php
+++ b/tests/system/Database/Live/WhereTest.php
@@ -53,8 +53,8 @@ class WhereTest extends CIUnitTestCase
     public function testWhereCustomString()
     {
         $jobs = $this->db->table('job')->where("id > 2 AND name != 'Accountant'")
-                            ->get()
-                            ->getResult();
+            ->get()
+            ->getResult();
 
         $this->assertCount(1, $jobs);
 
@@ -67,10 +67,10 @@ class WhereTest extends CIUnitTestCase
     public function testOrWhere()
     {
         $jobs = $this->db->table('job')
-                        ->where('name !=', 'Accountant')
-                        ->orWhere('id >', 3)
-                        ->get()
-                        ->getResult();
+            ->where('name !=', 'Accountant')
+            ->orWhere('id >', 3)
+            ->get()
+            ->getResult();
 
         $this->assertCount(3, $jobs);
         $this->assertEquals('Developer', $jobs[0]->name);
@@ -83,10 +83,10 @@ class WhereTest extends CIUnitTestCase
     public function testOrWhereSameColumn()
     {
         $jobs = $this->db->table('job')
-                        ->where('name', 'Developer')
-                        ->orWhere('name', 'Politician')
-                        ->get()
-                        ->getResult();
+            ->where('name', 'Developer')
+            ->orWhere('name', 'Politician')
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $jobs);
         $this->assertEquals('Developer', $jobs[0]->name);
@@ -98,9 +98,9 @@ class WhereTest extends CIUnitTestCase
     public function testWhereIn()
     {
         $jobs = $this->db->table('job')
-                        ->whereIn('name', ['Politician', 'Accountant'])
-                        ->get()
-                        ->getResult();
+            ->whereIn('name', ['Politician', 'Accountant'])
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $jobs);
         $this->assertEquals('Politician', $jobs[0]->name);
@@ -115,9 +115,9 @@ class WhereTest extends CIUnitTestCase
     public function testWhereNotIn()
     {
         $jobs = $this->db->table('job')
-                         ->whereNotIn('name', ['Politician', 'Accountant'])
-                         ->get()
-                         ->getResult();
+            ->whereNotIn('name', ['Politician', 'Accountant'])
+            ->get()
+            ->getResult();
 
         $this->assertCount(2, $jobs);
         $this->assertEquals('Developer', $jobs[0]->name);
@@ -129,14 +129,14 @@ class WhereTest extends CIUnitTestCase
     public function testSubQuery()
     {
         $subQuery = $this->db->table('job')
-                             ->select('id')
-                             ->where('name', 'Developer')
-                             ->getCompiledSelect();
+            ->select('id')
+            ->where('name', 'Developer')
+            ->getCompiledSelect();
 
         $jobs = $this->db->table('job')
-                         ->where('id not in (' . $subQuery . ')', null, false)
-                         ->get()
-                         ->getResult();
+            ->where('id not in (' . $subQuery . ')', null, false)
+            ->get()
+            ->getResult();
 
         $this->assertCount(3, $jobs);
         $this->assertEquals('Politician', $jobs[0]->name);
@@ -149,14 +149,14 @@ class WhereTest extends CIUnitTestCase
     public function testSubQueryAnotherType()
     {
         $subQuery = $this->db->table('job')
-                             ->select('id')
-                             ->where('name', 'Developer')
-                             ->getCompiledSelect();
+            ->select('id')
+            ->where('name', 'Developer')
+            ->getCompiledSelect();
 
         $jobs = $this->db->table('job')
-                         ->where('id = (' . $subQuery . ')', null, false)
-                         ->get()
-                         ->getResult();
+            ->where('id = (' . $subQuery . ')', null, false)
+            ->get()
+            ->getResult();
 
         $this->assertCount(1, $jobs);
         $this->assertEquals('Developer', $jobs[0]->name);
@@ -167,15 +167,15 @@ class WhereTest extends CIUnitTestCase
     public function testWhereNullParam()
     {
         $this->db->table('job')
-                 ->insert([
-                     'name'        => 'Brewmaster',
-                     'description' => null,
-                 ]);
+            ->insert([
+                'name'        => 'Brewmaster',
+                'description' => null,
+            ]);
 
         $jobs = $this->db->table('job')
-                         ->where('description', null)
-                         ->get()
-                         ->getResult();
+            ->where('description', null)
+            ->get()
+            ->getResult();
 
         $this->assertCount(1, $jobs);
         $this->assertEquals('Brewmaster', $jobs[0]->name);
@@ -186,15 +186,15 @@ class WhereTest extends CIUnitTestCase
     public function testWhereIsNull()
     {
         $this->db->table('job')
-                 ->insert([
-                     'name'        => 'Brewmaster',
-                     'description' => null,
-                 ]);
+            ->insert([
+                'name'        => 'Brewmaster',
+                'description' => null,
+            ]);
 
         $jobs = $this->db->table('job')
-                         ->where('description IS NULL')
-                         ->get()
-                         ->getResult();
+            ->where('description IS NULL')
+            ->get()
+            ->getResult();
 
         $this->assertCount(1, $jobs);
         $this->assertEquals('Brewmaster', $jobs[0]->name);
@@ -205,15 +205,15 @@ class WhereTest extends CIUnitTestCase
     public function testWhereIsNotNull()
     {
         $this->db->table('job')
-                 ->insert([
-                     'name'        => 'Brewmaster',
-                     'description' => null,
-                 ]);
+            ->insert([
+                'name'        => 'Brewmaster',
+                'description' => null,
+            ]);
 
         $jobs = $this->db->table('job')
-                         ->where('description IS NOT NULL')
-                         ->get()
-                         ->getResult();
+            ->where('description IS NOT NULL')
+            ->get()
+            ->getResult();
 
         $this->assertCount(4, $jobs);
     }

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -669,8 +669,10 @@ class FiltersTest extends CIUnitTestCase
 
         $filters = new Filters((object) $config, $this->request, $this->response);
 
-        $filters = $filters->addFilter('Some\OtherClass', 'another', 'before', 'globals')
-                ->initialize('admin/foo/bar');
+        $filters = $filters
+            ->addFilter('Some\OtherClass', 'another', 'before', 'globals')
+            ->initialize('admin/foo/bar');
+
         $list = $filters->getFilters();
 
         $this->assertTrue(in_array('another', $list['before'], true));
@@ -684,9 +686,11 @@ class FiltersTest extends CIUnitTestCase
 
         $filters = new Filters((object) $config, $this->request, $this->response);
 
-        $filters = $filters->addFilter('Some\OtherClass', 'another', 'before', 'globals')
-                ->initialize('admin/foo/bar')
-                ->initialize();
+        $filters = $filters
+            ->addFilter('Some\OtherClass', 'another', 'before', 'globals')
+            ->initialize('admin/foo/bar')
+            ->initialize();
+
         $list = $filters->getFilters();
 
         $this->assertTrue(in_array('another', $list['before'], true));

--- a/tests/system/HTTP/HeaderTest.php
+++ b/tests/system/HTTP/HeaderTest.php
@@ -174,8 +174,7 @@ class HeaderTest extends CIUnitTestCase
         $expected = '';
 
         $header = new Header($name);
-        $header->setValue('bar')
-               ->setValue(null);
+        $header->setValue('bar')->setValue(null);
 
         $this->assertEquals($name, $header->getName());
         $this->assertEquals($expected, $header->getValueLine());
@@ -189,8 +188,7 @@ class HeaderTest extends CIUnitTestCase
 
         $header = new Header($name);
 
-        $header->setValue('bar')
-               ->appendValue(['baz' => 'fuzz']);
+        $header->setValue('bar')->appendValue(['baz' => 'fuzz']);
 
         $this->assertEquals($name, $header->getName());
         $this->assertEquals($expected, $header->getValueLine());
@@ -206,8 +204,7 @@ class HeaderTest extends CIUnitTestCase
 
         $header = new Header($name);
 
-        $header->setValue('bar')
-               ->appendValue(['baz' => 'fuzz']);
+        $header->setValue('bar')->appendValue(['baz' => 'fuzz']);
 
         $this->assertEquals($expected, (string) $header);
     }

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -128,8 +128,7 @@ class RedirectResponseTest extends CIUnitTestCase
         $response = new RedirectResponse(new App());
 
         $validation = $this->createMock(Validation::class);
-        $validation->method('getErrors')
-                ->willReturn(['foo' => 'bar']);
+        $validation->method('getErrors')->willReturn(['foo' => 'bar']);
 
         Services::injectMock('validation', $validation);
 

--- a/tests/system/HTTP/ResponseSendTest.php
+++ b/tests/system/HTTP/ResponseSendTest.php
@@ -116,8 +116,8 @@ class ResponseSendTest extends CIUnitTestCase
         $routes->add('user/login', 'Auth::verify', ['as' => 'login']);
 
         $answer1 = $response->redirect('/login')
-                ->setCookie('foo', 'bar', YEAR)
-                ->setCookie('login_time', $loginTime, YEAR);
+            ->setCookie('foo', 'bar', YEAR)
+            ->setCookie('login_time', $loginTime, YEAR);
         $this->assertTrue($answer1->hasCookie('foo', 'bar'));
         $this->assertTrue($answer1->hasCookie('login_time'));
         $response->setBody('Hello');

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -522,8 +522,8 @@ class ResponseTest extends CIUnitTestCase
 
         $response = new Response(new App());
         $answer1  = $response->redirect('/login')
-                ->setCookie('foo', 'bar', YEAR)
-                ->setCookie('login_time', $loginTime, YEAR);
+            ->setCookie('foo', 'bar', YEAR)
+            ->setCookie('login_time', $loginTime, YEAR);
 
         $this->assertTrue($answer1->hasCookie('foo'));
         $this->assertTrue($answer1->hasCookie('login_time'));

--- a/tests/system/Models/DeleteModelTest.php
+++ b/tests/system/Models/DeleteModelTest.php
@@ -96,8 +96,8 @@ final class DeleteModelTest extends LiveModelTestCase
         $this->createModel(UserModel::class);
 
         $this->db->table('user')
-                 ->where('id', 1)
-                 ->update(['deleted_at' => date('Y-m-d H:i:s')]);
+            ->where('id', 1)
+            ->update(['deleted_at' => date('Y-m-d H:i:s')]);
 
         $this->model->purgeDeleted();
 
@@ -110,8 +110,8 @@ final class DeleteModelTest extends LiveModelTestCase
         $this->createModel(UserModel::class);
 
         $this->db->table('user')
-                 ->where('id', 1)
-                 ->update(['deleted_at' => date('Y-m-d H:i:s')]);
+            ->where('id', 1)
+            ->update(['deleted_at' => date('Y-m-d H:i:s')]);
 
         $users = $this->model->onlyDeleted()->findAll();
         $this->assertCount(1, $users);
@@ -190,8 +190,8 @@ final class DeleteModelTest extends LiveModelTestCase
     public function testPurgeDeletedWithSoftDeleteFalse(): void
     {
         $this->db->table('job')
-                 ->where('id', 1)
-                 ->update(['deleted_at' => time()]);
+            ->where('id', 1)
+            ->update(['deleted_at' => time()]);
 
         $this->createModel(JobModel::class);
         $this->model->purgeDeleted();

--- a/tests/system/Models/FindModelTest.php
+++ b/tests/system/Models/FindModelTest.php
@@ -72,8 +72,8 @@ final class FindModelTest extends LiveModelTestCase
     public function testFindRespectsSoftDeletes(): void
     {
         $this->db->table('user')
-                 ->where('id', 4)
-                 ->update(['deleted_at' => date('Y-m-d H:i:s')]);
+            ->where('id', 4)
+            ->update(['deleted_at' => date('Y-m-d H:i:s')]);
 
         $this->createModel(UserModel::class);
 
@@ -122,8 +122,8 @@ final class FindModelTest extends LiveModelTestCase
     public function testFindAllRespectsSoftDeletes(): void
     {
         $this->db->table('user')
-                 ->where('id', 4)
-                 ->update(['deleted_at' => date('Y-m-d H:i:s')]);
+            ->where('id', 4)
+            ->update(['deleted_at' => date('Y-m-d H:i:s')]);
 
         $this->createModel(UserModel::class);
 
@@ -171,8 +171,8 @@ final class FindModelTest extends LiveModelTestCase
     public function testFirstRespectsSoftDeletes($aggregate, $groupBy): void
     {
         $this->db->table('user')
-                 ->where('id', 1)
-                 ->update(['deleted_at' => date('Y-m-d H:i:s')]);
+            ->where('id', 1)
+            ->update(['deleted_at' => date('Y-m-d H:i:s')]);
 
         $this->createModel(UserModel::class);
 

--- a/tests/system/Test/ControllerTestTraitTest.php
+++ b/tests/system/Test/ControllerTestTraitTest.php
@@ -26,9 +26,9 @@ class ControllerTestTraitTest extends CIUnitTestCase
         $this->expectException(InvalidArgumentException::class);
         $logger = new Logger(new LoggerConfig());
         $result = $this->withURI('http://example.com')
-                ->withLogger($logger)
-                ->controller(NeverHeardOfIt::class)
-                ->execute('index');
+            ->withLogger($logger)
+            ->controller(NeverHeardOfIt::class)
+            ->execute('index');
     }
 
     public function testBadControllerMethod()
@@ -36,18 +36,18 @@ class ControllerTestTraitTest extends CIUnitTestCase
         $this->expectException(InvalidArgumentException::class);
         $logger = new Logger(new LoggerConfig());
         $result = $this->withURI('http://example.com')
-                ->withLogger($logger)
-                ->controller(Home::class)
-                ->execute('nothere');
+            ->withLogger($logger)
+            ->controller(Home::class)
+            ->execute('nothere');
     }
 
     public function testController()
     {
         $logger = new Logger(new LoggerConfig());
         $result = $this->withURI('http://example.com')
-                ->withLogger($logger)
-                ->controller(Home::class)
-                ->execute('index');
+            ->withLogger($logger)
+            ->controller(Home::class)
+            ->execute('index');
 
         $body = $result->response()->getBody();
         $this->assertTrue($result->isOK());
@@ -56,8 +56,8 @@ class ControllerTestTraitTest extends CIUnitTestCase
     public function testControllerWithoutLogger()
     {
         $result = $this->withURI('http://example.com')
-                ->controller(Home::class)
-                ->execute('index');
+            ->controller(Home::class)
+            ->execute('index');
 
         $body = $result->response()->getBody();
         $this->assertTrue($result->isOK());
@@ -67,9 +67,9 @@ class ControllerTestTraitTest extends CIUnitTestCase
     {
         $logger = new Logger(new LoggerConfig());
         $result = $this->withURI('http://example.com')
-                ->withLogger($logger)
-                ->controller(Popcorn::class)
-                ->execute('index');
+            ->withLogger($logger)
+            ->controller(Popcorn::class)
+            ->execute('index');
 
         $body = $result->response()->getBody();
         $this->assertTrue($result->isOK());
@@ -79,9 +79,9 @@ class ControllerTestTraitTest extends CIUnitTestCase
     {
         $logger = new Logger(new LoggerConfig());
         $result = $this->withURI('http://example.com')
-                ->withLogger($logger)
-                ->controller(Popcorn::class)
-                ->execute('index');
+            ->withLogger($logger)
+            ->controller(Popcorn::class)
+            ->execute('index');
 
         $body = $result->response()->getBody();
         $this->assertEquals('Hi there', $body);
@@ -91,9 +91,9 @@ class ControllerTestTraitTest extends CIUnitTestCase
     {
         $logger = new Logger(new LoggerConfig());
         $result = $this->withURI('http://example.com')
-                ->withLogger($logger)
-                ->controller(Popcorn::class)
-                ->execute('pop');
+            ->withLogger($logger)
+            ->controller(Popcorn::class)
+            ->execute('pop');
 
         $this->assertEquals(567, $result->response()->getStatusCode());
     }
@@ -102,9 +102,9 @@ class ControllerTestTraitTest extends CIUnitTestCase
     {
         $logger = new Logger(new LoggerConfig());
         $result = $this->withURI('http://example.com')
-                ->withLogger($logger)
-                ->controller(Popcorn::class)
-                ->execute('popper');
+            ->withLogger($logger)
+            ->controller(Popcorn::class)
+            ->execute('popper');
 
         $this->assertEquals(500, $result->response()->getStatusCode());
     }
@@ -116,13 +116,13 @@ class ControllerTestTraitTest extends CIUnitTestCase
         $body   = '';
 
         $result = $this->withURI('http://example.com')
-                ->withConfig($config)
-                ->withRequest(Services::request($config))
-                ->withResponse(Services::response($config))
-                ->withLogger($logger)
-                ->withBody($body)
-                ->controller(Popcorn::class)
-                ->execute('index');
+            ->withConfig($config)
+            ->withRequest(Services::request($config))
+            ->withResponse(Services::response($config))
+            ->withLogger($logger)
+            ->withBody($body)
+            ->controller(Popcorn::class)
+            ->execute('index');
 
         $body = $result->response()->getBody();
         $this->assertEquals('Hi there', $body);
@@ -132,9 +132,9 @@ class ControllerTestTraitTest extends CIUnitTestCase
     {
         $logger = new Logger(new LoggerConfig());
         $result = $this->withURI('http://example.com')
-                ->withLogger($logger)
-                ->controller(Popcorn::class)
-                ->execute('popper');
+            ->withLogger($logger)
+            ->controller(Popcorn::class)
+            ->execute('popper');
 
         $req = $result->request();
         $this->assertEquals('get', $req->getMethod());
@@ -144,9 +144,9 @@ class ControllerTestTraitTest extends CIUnitTestCase
     {
         $logger = new Logger(new LoggerConfig());
         $result = $this->withURI('http://example.com')
-                ->withLogger($logger)
-                ->controller(Popcorn::class)
-                ->execute('oops');
+            ->withLogger($logger)
+            ->controller(Popcorn::class)
+            ->execute('oops');
 
         $this->assertFalse($result->isOK());
         $this->assertEquals(401, $result->response()->getStatusCode());
@@ -156,9 +156,9 @@ class ControllerTestTraitTest extends CIUnitTestCase
     {
         $logger = new Logger(new LoggerConfig());
         $result = $this->withURI('http://example.com')
-                ->withLogger($logger)
-                ->controller(Popcorn::class)
-                ->execute('weasel');
+            ->withLogger($logger)
+            ->controller(Popcorn::class)
+            ->execute('weasel');
 
         $body = $result->response()->getBody(); // empty
         $this->assertEmpty($body);
@@ -169,9 +169,9 @@ class ControllerTestTraitTest extends CIUnitTestCase
     {
         $logger = new Logger(new LoggerConfig());
         $result = $this->withURI('http://example.com')
-                ->withLogger($logger)
-                ->controller(Popcorn::class)
-                ->execute('goaway');
+            ->withLogger($logger)
+            ->controller(Popcorn::class)
+            ->execute('goaway');
 
         $this->assertTrue($result->isRedirect());
     }
@@ -180,9 +180,9 @@ class ControllerTestTraitTest extends CIUnitTestCase
     {
         $logger = new Logger(new LoggerConfig());
         $result = $this->withURI('http://example.com')
-                ->withLogger($logger)
-                ->controller(Popcorn::class)
-                ->execute('index');
+            ->withLogger($logger)
+            ->controller(Popcorn::class)
+            ->execute('index');
 
         $this->assertTrue($result->see('Hi'));
     }
@@ -191,9 +191,9 @@ class ControllerTestTraitTest extends CIUnitTestCase
     {
         $logger = new Logger(new LoggerConfig());
         $result = $this->withURI('http://example.com')
-                ->withLogger($logger)
-                ->controller(Popcorn::class)
-                ->execute('index');
+            ->withLogger($logger)
+            ->controller(Popcorn::class)
+            ->execute('index');
 
         // won't fail, but doesn't do anything
         $this->assertNull($result->ohno('Hi'));
@@ -205,8 +205,8 @@ class ControllerTestTraitTest extends CIUnitTestCase
     public function testResponseOverriding()
     {
         $result = $this->withURI('http://example.com/rest/')
-                ->controller(Popcorn::class)
-                ->execute('index3');
+            ->controller(Popcorn::class)
+            ->execute('index3');
 
         $response = json_decode($result->response()->getBody());
         $this->assertEquals('en', $response->lang);
@@ -219,8 +219,8 @@ class ControllerTestTraitTest extends CIUnitTestCase
     {
         $logger = new Logger(new LoggerConfig());
         $result = $this->withLogger($logger)
-                       ->controller(Home::class)
-                       ->execute('index');
+            ->controller(Home::class)
+            ->execute('index');
 
         $body = $result->response()->getBody();
         $this->assertTrue($result->isOK());
@@ -229,7 +229,7 @@ class ControllerTestTraitTest extends CIUnitTestCase
     public function testRedirectRoute()
     {
         $result = $this->controller(Popcorn::class)
-                        ->execute('toindex');
+            ->execute('toindex');
         $this->assertTrue($result->isRedirect());
     }
 }

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -691,11 +691,11 @@ class RulesTest extends CIUnitTestCase
     {
         $db = Database::connect();
         $db->table('user')
-           ->insert([
-               'name'    => 'Derek Travis',
-               'email'   => 'derek@world.com',
-               'country' => 'Elbonia',
-           ]);
+            ->insert([
+                'name'    => 'Derek Travis',
+                'email'   => 'derek@world.com',
+                'country' => 'Elbonia',
+            ]);
 
         $data = [
             'email' => 'derek@world.com',
@@ -733,17 +733,17 @@ class RulesTest extends CIUnitTestCase
      */
     public function testIsUniqueIgnoresParams()
     {
-        $db   = Database::connect();
-        $user = $db->table('user')
-                   ->insert([
-                       'name'    => 'Developer A',
-                       'email'   => 'deva@example.com',
-                       'country' => 'Elbonia',
-                   ]);
+        $db = Database::connect();
+        $db->table('user')
+            ->insert([
+                'name'    => 'Developer A',
+                'email'   => 'deva@example.com',
+                'country' => 'Elbonia',
+            ]);
         $row = $db->table('user')
-                   ->limit(1)
-                   ->get()
-                   ->getRow();
+            ->limit(1)
+            ->get()
+            ->getRow();
 
         $data = [
             'email' => 'derek@world.co.uk',
@@ -771,9 +771,9 @@ class RulesTest extends CIUnitTestCase
 
         $db  = Database::connect();
         $row = $db->table('user')
-                  ->limit(1)
-                  ->get()
-                  ->getRow();
+            ->limit(1)
+            ->get()
+            ->getRow();
 
         $data = [
             'id'    => $row->id,
@@ -796,11 +796,11 @@ class RulesTest extends CIUnitTestCase
     {
         $db = Database::connect();
         $db->table('user')
-                   ->insert([
-                       'name'    => 'Developer A',
-                       'email'   => 'deva@example.com',
-                       'country' => 'Elbonia',
-                   ]);
+            ->insert([
+                'name'    => 'Developer A',
+                'email'   => 'deva@example.com',
+                'country' => 'Elbonia',
+            ]);
 
         $this->assertFalse((new Rules())->is_unique('deva@example.com', 'user.email,id,{id}', []));
     }
@@ -814,11 +814,11 @@ class RulesTest extends CIUnitTestCase
     {
         $db = Database::connect();
         $db->table('user')
-           ->insert([
-               'name'    => 'Derek Travis',
-               'email'   => 'derek@world.com',
-               'country' => 'Elbonia',
-           ]);
+            ->insert([
+                'name'    => 'Derek Travis',
+                'email'   => 'derek@world.com',
+                'country' => 'Elbonia',
+            ]);
 
         $data = [
             'email' => 'derek1@world.com',
@@ -840,11 +840,11 @@ class RulesTest extends CIUnitTestCase
     {
         $db = Database::connect();
         $db->table('user')
-           ->insert([
-               'name'    => 'Derek Travis',
-               'email'   => 'derek@world.com',
-               'country' => 'Elbonia',
-           ]);
+            ->insert([
+                'name'    => 'Derek Travis',
+                'email'   => 'derek@world.com',
+                'country' => 'Elbonia',
+            ]);
 
         $data = [
             'email' => 'derek@world.com',
@@ -864,17 +864,17 @@ class RulesTest extends CIUnitTestCase
      */
     public function testIsNotUniqueIgnoresParams()
     {
-        $db   = Database::connect();
-        $user = $db->table('user')
-                   ->insert([
-                       'name'    => 'Developer A',
-                       'email'   => 'deva@example.com',
-                       'country' => 'Elbonia',
-                   ]);
+        $db = Database::connect();
+        $db->table('user')
+            ->insert([
+                'name'    => 'Developer A',
+                'email'   => 'deva@example.com',
+                'country' => 'Elbonia',
+            ]);
         $row = $db->table('user')
-                   ->limit(1)
-                   ->get()
-                   ->getRow();
+            ->limit(1)
+            ->get()
+            ->getRow();
 
         $data = [
             'email' => 'derek@world.co.uk',
@@ -902,9 +902,9 @@ class RulesTest extends CIUnitTestCase
 
         $db  = Database::connect();
         $row = $db->table('user')
-                  ->limit(1)
-                  ->get()
-                  ->getRow();
+            ->limit(1)
+            ->get()
+            ->getRow();
 
         $data = [
             'id'    => $row->id,
@@ -927,11 +927,11 @@ class RulesTest extends CIUnitTestCase
     {
         $db = Database::connect();
         $db->table('user')
-                   ->insert([
-                       'name'    => 'Developer A',
-                       'email'   => 'deva@example.com',
-                       'country' => 'Elbonia',
-                   ]);
+            ->insert([
+                'name'    => 'Developer A',
+                'email'   => 'deva@example.com',
+                'country' => 'Elbonia',
+            ]);
 
         $this->assertTrue((new Rules())->is_not_unique('deva@example.com', 'user.email,id,{id}', []));
     }

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -113,6 +113,7 @@ final class CodeIgniter4 extends AbstractRuleset
                 'keep_multiple_spaces_after_comma' => false,
                 'on_multiline'                     => 'ensure_fully_multiline',
             ],
+            'method_chaining_indentation'            => true,
             'modernize_types_casting'                => true,
             'multiline_comment_opening_closing'      => true,
             'multiline_whitespace_before_semicolons' => ['strategy' => 'no_multi_line'],


### PR DESCRIPTION
**Description**
Method chaining MUST be properly indented. Method chaining with different levels of indentation is not supported.

**Checklist:**
- [x] Securely signed commits
