### PR TITLE
Make CLI detection as interface independent as possible

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -683,19 +683,11 @@ if (! function_exists('is_cli')) {
      *
      * @return bool
      *
-     * @codeCoverageIgnore Cannot be tested fully as PHPUnit always run in CLI
+     * @codeCoverageIgnore Cannot be tested fully as PHPUnit always run in php-cli
      */
     function is_cli(): bool
     {
-        if (PHP_SAPI === 'cli') {
-            return true;
-        }
-
         if (defined('STDIN')) {
-            return true;
-        }
-
-        if (stristr(PHP_SAPI, 'cgi') && getenv('TERM')) {
             return true;
         }
 


### PR DESCRIPTION
**Description**
CLI detection is a problematic case as it involves a lot of factors to consider, which may not work at all times at all platforms. This attempts to make detection independent of the interface (i.e. no longer depending on the value of `PHP_SAPI`) but instead rely on other variables.

Fixes #4843 
Fixes #4848 

**Checklist:**
- [x] Securely signed commits
