### PR TITLE
Added MySQLi resultMode and updated user guide

### DIFF
--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -65,6 +65,19 @@ class Connection extends BaseConnection
     //--------------------------------------------------------------------
 
     /**
+     * MySQLi constant
+     *
+     * For unbuffered queries use `MYSQLI_USE_RESULT`.
+     *
+     * Default mode for buffered queries uses `MYSQLI_STORE_RESULT`.
+     *
+     * @var int
+     */
+    public $resultMode = MYSQLI_STORE_RESULT;
+
+    //--------------------------------------------------------------------
+
+    /**
      * Connect to the database.
      *
      * @param bool $persistent
@@ -295,7 +308,7 @@ class Connection extends BaseConnection
         }
 
         try {
-            return $this->connID->query($this->prepQuery($sql));
+            return $this->connID->query($this->prepQuery($sql), $this->resultMode);
         } catch (mysqli_sql_exception $e) {
             log_message('error', $e->getMessage());
 

--- a/user_guide_src/source/database/results.rst
+++ b/user_guide_src/source/database/results.rst
@@ -166,6 +166,36 @@ it returns the current row and moves the internal data pointer ahead.
         echo $row->body;
     }
 
+For use with MySQLi you may set MySQLi's result mode to 
+``MYSQLI_USE_RESULT`` for maximum memory savings. Use of this is not 
+generally recommended but it can be beneficial in some circumstances 
+such as writing large queries to csv. If you change the result mode 
+be aware of the tradeoffs associated with it.
+
+::
+
+    $db->resultMode = MYSQLI_USE_RESULT; // for unbuffered results
+
+    $query = $db->query("YOUR QUERY");
+
+    $file = new \CodeIgniter\Files\File(WRITEPATH.'data.csv');
+
+    $csv = $file->openFile('w');
+
+    while ($row = $query->getUnbufferedRow('array'))
+    {	
+    	$csv->fputcsv($row);
+    }
+
+    $db->resultMode = MYSQLI_STORE_RESULT; // return to default mode
+
+.. note:: When using ``MYSQLI_USE_RESULT`` all subsequent calls on the same  
+    connection will result in error until all records have been fetched or 
+    a ``freeResult()`` call has been made. The ``getNumRows()`` method will only 
+    return the number of rows based on the current position of the data pointer. 
+    MyISAM tables will remain locked until all the records have been fetched 
+    or a ``freeResult()`` call has been made.
+
 You can optionally pass 'object' (default) or 'array' in order to specify
 the returned value's type::
 


### PR DESCRIPTION
Added public property $resultMode to MySQLi's Connection.php. Then added the property to MySQLi's query method. This allows for the use of MYSQLI_USE_RESULT for unbuffered queries. The unbuffered queries will save a lot of memory when running large queries. Also updated user guide to demonstrate use.

**Checklist:**
- [ ] Securely signed commits
- [x] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
