### PR TITLE
CURL (CURLRequest) do not send int/float headers

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -309,6 +309,8 @@ class CURLRequest extends Request
 
         if (array_key_exists('headers', $options) && is_array($options['headers'])) {
             foreach ($options['headers'] as $name => $value) {
+            	if(is_int($value) || is_float($value) || is_bool($value))
+            		$value = (string)$value;
                 $this->setHeader($name, $value);
             }
 

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -309,8 +309,9 @@ class CURLRequest extends Request
 
         if (array_key_exists('headers', $options) && is_array($options['headers'])) {
             foreach ($options['headers'] as $name => $value) {
-            	if(is_int($value) || is_float($value) || is_bool($value))
-            		$value = (string)$value;
+                if(is_scalar($value)) {
+                    $value = (string)$value;
+                }
                 $this->setHeader($name, $value);
             }
 

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -309,7 +309,7 @@ class CURLRequest extends Request
 
         if (array_key_exists('headers', $options) && is_array($options['headers'])) {
             foreach ($options['headers'] as $name => $value) {
-                if(is_scalar($value)) {
+                if (is_scalar($value)) {
                     $value = (string)$value;
                 }
                 $this->setHeader($name, $value);


### PR DESCRIPTION
All the headers that were ints/floats in config['headers'] were lost after passing to setHeader.
$config['headers'] = ['X' => 1323, 'Y' => '3566']; 

Of course there is no reason to support complex types, but it would be good to cast ints/floats/booleans to string.
Tested/working.
