### PR TITLE
[Commands] Remove unused $minPHPVersion property at Serve command

### DIFF
--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -24,13 +24,6 @@ use CodeIgniter\CLI\CLI;
 class Serve extends BaseCommand
 {
     /**
-     * Minimum PHP version
-     *
-     * @var string
-     */
-    protected $minPHPVersion = '7.3';
-
-    /**
      * Group
      *
      * @var string


### PR DESCRIPTION
The min php version check already moved to CodeIgniter class.

**Checklist:**
- [x] Securely signed commits