### PR TITLE
[Debug] [4.2] Sort timeline elements by start and duration.

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -245,6 +245,12 @@ class Toolbar
         }
 
         // Sort it
+        $sortArray = [
+          array_column($data, 'start'), SORT_NUMERIC, SORT_ASC,
+          array_column($data, 'duration'), SORT_NUMERIC, SORT_DESC,
+          &$data
+        ];
+        array_multisort(...$sortArray);
 
         return $data;
     }


### PR DESCRIPTION
Closes and supersedes #4863 to target the 4.2 branch.