### PR TITLE
Allow `Utils\\` namespace to be available in external CI4 libraries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,7 +21,6 @@ Vagrantfile.dist export-ignore
 
 # They don't want our test files
 tests/system/ export-ignore
-utils/ export-ignore
 rector.php export-ignore
 phpunit.xml.dist export-ignore
 phpstan.neon.dist export-ignore

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     },
     "autoload": {
         "psr-4": {
-            "CodeIgniter\\": "system/"
+            "CodeIgniter\\": "system/",
+            "Utils\\": "utils/"
         },
         "exclude-from-classmap": [
             "**/Database/Migrations/**"
@@ -49,8 +50,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "CodeIgniter\\": "tests/system/",
-            "Utils\\": "utils/"
+            "CodeIgniter\\": "tests/system/"
         }
     },
     "scripts": {


### PR DESCRIPTION
**Description**
Caution: Developers using the utilities should know that it is "use-at-your-own-risk" and is not covered by backward compatibility promise.

I'm targeting `develop` as most libs use `dev-develop` as their dependency branch so this can be tested easily.

**Checklist:**
- [x] Securely signed commits
