### PR TITLE
Namespace extracted by GeneratorTrait should always end in backslash

### DIFF
--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -229,14 +229,14 @@ trait GeneratorTrait
         // Trims input, normalize separators, and ensure that all paths are in Pascalcase.
         $class = ltrim(implode('\\', array_map('pascalize', explode('\\', str_replace('/', '\\', trim($class))))), '\\/');
 
-        // Gets the namespace from input.
-        $namespace = trim(str_replace('/', '\\', $this->getOption('namespace') ?? APP_NAMESPACE), '\\');
+        // Gets the namespace from input. Don't forget the ending backslash!
+        $namespace = trim(str_replace('/', '\\', $this->getOption('namespace') ?? APP_NAMESPACE), '\\') . '\\';
 
         if (strncmp($class, $namespace, strlen($namespace)) === 0) {
             return $class; // @codeCoverageIgnore
         }
 
-        return $namespace . '\\' . $this->directory . '\\' . str_replace('/', '\\', $class);
+        return $namespace . $this->directory . '\\' . str_replace('/', '\\', $class);
     }
 
     /**

--- a/tests/system/Commands/CommandGeneratorTest.php
+++ b/tests/system/Commands/CommandGeneratorTest.php
@@ -119,4 +119,24 @@ final class CommandGeneratorTest extends CIUnitTestCase
         $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
         $this->assertFileExists(APPPATH . 'Controllers/TestModuleController.php');
     }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/4857
+     */
+    public function testGeneratorIsNotConfusedWithNamespaceLikeClassNames(): void
+    {
+        $time = time();
+        $notExists = true;
+        command('make:migration App_Lesson');
+
+        // we got 5 chances to prove that the file created went to app/Database/Migrations
+        foreach (range(0, 4) as $increment) {
+            $expectedFile = sprintf('%sDatabase/Migrations/%s_AppLesson.php', APPPATH, gmdate('Y-m-d-His', $time + $increment));
+            clearstatcache(true, $expectedFile);
+
+            $notExists = $notExists && ! is_file($expectedFile);
+        }
+
+        $this->assertFalse($notExists, 'Creating migration file for class "AppLesson" did not go to "app/Database/Migrations"');
+    }
 }


### PR DESCRIPTION
**Description**
Fixes #4857 

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
