### PR TITLE
Other PHPUnit-related fixers

### DIFF
--- a/admin/module/tests/_support/DatabaseTestCase.php
+++ b/admin/module/tests/_support/DatabaseTestCase.php
@@ -45,14 +45,14 @@ final class DatabaseTestCase extends CIUnitTestCase
      */
     protected $namespace = 'Tests\Support';
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
         // Extra code to run before each test
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/admin/module/tests/_support/SessionTestCase.php
+++ b/admin/module/tests/_support/SessionTestCase.php
@@ -17,7 +17,7 @@ final class SessionTestCase extends CIUnitTestCase
      */
     protected $session;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/admin/module/tests/database/ExampleDatabaseTest.php
+++ b/admin/module/tests/database/ExampleDatabaseTest.php
@@ -7,7 +7,7 @@ use Tests\Support\Models\ExampleModel;
  */
 final class ExampleDatabaseTest extends \Tests\Support\DatabaseTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/admin/module/tests/session/ExampleSessionTest.php
+++ b/admin/module/tests/session/ExampleSessionTest.php
@@ -5,7 +5,7 @@
  */
 final class ExampleSessionTest extends \Tests\Support\SessionTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/admin/module/tests/unit/ExampleTest.php
+++ b/admin/module/tests/unit/ExampleTest.php
@@ -5,7 +5,7 @@
  */
 final class ExampleTest extends \CodeIgniter\Test\CIUnitTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/admin/starter/tests/_support/DatabaseTestCase.php
+++ b/admin/starter/tests/_support/DatabaseTestCase.php
@@ -45,14 +45,14 @@ final class DatabaseTestCase extends CIUnitTestCase
      */
     protected $namespace = 'Tests\Support';
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
         // Extra code to run before each test
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/admin/starter/tests/_support/SessionTestCase.php
+++ b/admin/starter/tests/_support/SessionTestCase.php
@@ -17,7 +17,7 @@ final class SessionTestCase extends CIUnitTestCase
      */
     protected $session;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/admin/starter/tests/database/ExampleDatabaseTest.php
+++ b/admin/starter/tests/database/ExampleDatabaseTest.php
@@ -7,7 +7,7 @@ use Tests\Support\Models\ExampleModel;
  */
 final class ExampleDatabaseTest extends \Tests\Support\DatabaseTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/admin/starter/tests/session/ExampleSessionTest.php
+++ b/admin/starter/tests/session/ExampleSessionTest.php
@@ -5,7 +5,7 @@
  */
 final class ExampleSessionTest extends \Tests\Support\SessionTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/admin/starter/tests/unit/HealthTest.php
+++ b/admin/starter/tests/unit/HealthTest.php
@@ -7,7 +7,7 @@ use Config\Services;
  */
 final class HealthTest extends \CodeIgniter\Test\CIUnitTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -21,7 +21,7 @@ final class CLITest extends CIUnitTestCase
         $this->stream_filter        = stream_filter_append(STDOUT, 'CITestStreamFilter');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         stream_filter_remove($this->stream_filter);
     }

--- a/tests/system/CLI/CommandRunnerTest.php
+++ b/tests/system/CLI/CommandRunnerTest.php
@@ -45,7 +45,7 @@ final class CommandRunnerTest extends CIUnitTestCase
         $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         stream_filter_remove($this->streamFilter);
     }

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -42,7 +42,7 @@ final class ConsoleTest extends CIUnitTestCase
         $this->app = new MockCodeIgniter(new MockCLIConfig());
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         stream_filter_remove($this->stream_filter);
     }

--- a/tests/system/Cache/CacheFactoryTest.php
+++ b/tests/system/Cache/CacheFactoryTest.php
@@ -26,7 +26,7 @@ final class CacheFactoryTest extends CIUnitTestCase
         $this->config->storePath .= self::$directory;
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if (is_dir($this->config->storePath)) {
             chmod($this->config->storePath, 0777);

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -49,7 +49,7 @@ final class FileHandlerTest extends CIUnitTestCase
         $this->fileHandler->initialize();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -40,7 +40,7 @@ final class MemcachedHandlerTest extends CIUnitTestCase
         $this->memcachedHandler->initialize();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         foreach (self::getKeyArray() as $key) {
             $this->memcachedHandler->delete($key);

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -39,7 +39,7 @@ final class PredisHandlerTest extends CIUnitTestCase
         $this->PredisHandler->initialize();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         foreach (self::getKeyArray() as $key) {
             $this->PredisHandler->delete($key);

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -39,7 +39,7 @@ final class RedisHandlerTest extends CIUnitTestCase
         $this->redisHandler->initialize();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         foreach (self::getKeyArray() as $key) {
             $this->redisHandler->delete($key);

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -37,7 +37,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter = new MockCodeIgniter($config);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/system/Commands/ClearCacheTest.php
+++ b/tests/system/Commands/ClearCacheTest.php
@@ -26,7 +26,7 @@ final class ClearCacheTest extends CIUnitTestCase
         Services::injectMock('cache', CacheFactory::getHandler(config('Cache')));
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         stream_filter_remove($this->streamFilter);
     }

--- a/tests/system/Commands/InfoCacheTest.php
+++ b/tests/system/Commands/InfoCacheTest.php
@@ -26,7 +26,7 @@ final class InfoCacheTest extends CIUnitTestCase
         Services::injectMock('cache', CacheFactory::getHandler(config('Cache')));
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         stream_filter_remove($this->streamFilter);
 

--- a/tests/system/Commands/SessionsCommandsTest.php
+++ b/tests/system/Commands/SessionsCommandsTest.php
@@ -22,7 +22,7 @@ final class SessionsCommandsTest extends CIUnitTestCase
         $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         stream_filter_remove($this->streamFilter);
 

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -111,7 +111,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
         \CodeIgniter\Services::injectMock('routes', $routes);
 
         $routes->add('home/base', 'Controller::index', ['as' => 'base']);
-        $response->method('redirect')->will($this->returnArgument(0));
+        $response->method('redirect')->willReturnArgument(0);
 
         $this->assertInstanceOf(RedirectResponse::class, redirect('base'));
     }

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -52,7 +52,7 @@ final class ServicesTest extends CIUnitTestCase
         $this->config   = new App();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $_SERVER = $this->original;
         Services::reset();

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
@@ -45,7 +45,7 @@ final class DatabaseTestCaseMigrationOnce1Test extends CIUnitTestCase
         'Tests\Support\MigrationTestMigrations',
     ];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         Services::autoloader()->addNamespace('Tests\Support\MigrationTestMigrations', SUPPORTPATH . 'MigrationTestMigrations');
 

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
@@ -44,7 +44,7 @@ final class DatabaseTestCaseMigrationOnce2Test extends CIUnitTestCase
         'Tests\Support\MigrationTestMigrations',
     ];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         Services::autoloader()->addNamespace('Tests\Support\MigrationTestMigrations', SUPPORTPATH . 'MigrationTestMigrations');
 

--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -49,7 +49,7 @@ final class DatabaseTestCaseTest extends CIUnitTestCase
         'Tests\Support\MigrationTestMigrations',
     ];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (! self::$loaded) {
             Services::autoloader()->addNamespace('Tests\Support\MigrationTestMigrations', SUPPORTPATH . 'MigrationTestMigrations');

--- a/tests/system/Database/Live/DEBugTest.php
+++ b/tests/system/Database/Live/DEBugTest.php
@@ -30,7 +30,7 @@ final class DEBugTest extends CIUnitTestCase
         $this->assertFalse($result);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->setPrivateProperty($this->db, 'DBDebug', true);
         parent::tearDown();

--- a/tests/system/Database/Live/GetNumRowsTest.php
+++ b/tests/system/Database/Live/GetNumRowsTest.php
@@ -22,7 +22,7 @@ final class GetNumRowsTest extends CIUnitTestCase
      *
      * @see \CodeIgniter\Test\CIDatabaseTestCase::setUp()
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }
@@ -33,7 +33,7 @@ final class GetNumRowsTest extends CIUnitTestCase
      *
      * @see \CodeIgniter\Test\CIDatabaseTestCase::tearDown()
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/system/Database/Live/PretendTest.php
+++ b/tests/system/Database/Live/PretendTest.php
@@ -15,7 +15,7 @@ final class PretendTest extends CIUnitTestCase
 {
     use DatabaseTestTrait;
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         // We share `$this->db` in testing, so we need to restore the state.
         $this->db->pretend(false);

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -40,7 +40,7 @@ final class AlterTableTest extends CIUnitTestCase
      */
     protected $forge;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -29,7 +29,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
     protected $start;
     protected $config;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/system/Database/Migrations/MigrationTest.php
+++ b/tests/system/Database/Migrations/MigrationTest.php
@@ -13,7 +13,7 @@ final class MigrationTest extends CIUnitTestCase
 {
     use DatabaseTestTrait;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/system/Files/FileWithVfsTest.php
+++ b/tests/system/Files/FileWithVfsTest.php
@@ -32,7 +32,7 @@ final class FileWithVfsTest extends CIUnitTestCase
         $this->file  = new File($this->start . 'able/apple.php');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -13,7 +13,7 @@ use DateTimeZone;
  */
 final class DownloadResponseTest extends CIUnitTestCase
 {
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         if (isset($_SERVER['HTTP_USER_AGENT'])) {
             unset($_SERVER['HTTP_USER_AGENT']);

--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -28,7 +28,7 @@ final class FileMovingTest extends CIUnitTestCase
         $_FILES = [];
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->root = null;

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -25,7 +25,7 @@ final class MessageTest extends CIUnitTestCase
 
     //--------------------------------------------------------------------
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->message = null;
         unset($this->message);

--- a/tests/system/HTTP/NegotiateTest.php
+++ b/tests/system/HTTP/NegotiateTest.php
@@ -33,7 +33,7 @@ final class NegotiateTest extends CIUnitTestCase
 
     //--------------------------------------------------------------------
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->request = $this->negotiate = null;
         unset($this->request, $this->negotiate);

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -25,7 +25,7 @@ final class ResponseTest extends CIUnitTestCase
         $this->server = $_SERVER;
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $_SERVER = $this->server;
         Factories::reset('config');

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -22,7 +22,7 @@ final class URITest extends CIUnitTestCase
 
     //--------------------------------------------------------------------
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Factories::reset('config');
     }

--- a/tests/system/Helpers/SecurityHelperTest.php
+++ b/tests/system/Helpers/SecurityHelperTest.php
@@ -34,7 +34,7 @@ final class SecurityHelperTest extends CIUnitTestCase
         $this->assertEquals('http://example.com/spacer.gif', strip_image_tags('<img src="http://example.com/spacer.gif" alt="Who needs CSS when you have a spacer.gif?" />'));
     }
 
-    public function test_encode_php_tags()
+    public function testEncodePhpTags()
     {
         $this->assertEquals('&lt;? echo $foo; ?&gt;', encode_php_tags('<? echo $foo; ?>'));
     }

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -49,7 +49,7 @@ final class CurrentUrlTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME'] = '/index.php';
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -41,7 +41,7 @@ final class MiscUrlTest extends CIUnitTestCase
         Factories::injectMock('config', 'App', $this->config);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -42,7 +42,7 @@ final class SiteUrlTest extends CIUnitTestCase
         Factories::injectMock('config', 'App', $this->config);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -60,7 +60,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $this->codeigniter = new MockCodeIgniter($config);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/system/RESTful/ResourcePresenterTest.php
+++ b/tests/system/RESTful/ResourcePresenterTest.php
@@ -54,7 +54,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $this->codeigniter = new MockCodeIgniter($config);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -14,7 +14,7 @@ use Config\Modules;
  */
 final class RouteCollectionTest extends CIUnitTestCase
 {
-    public function tearDown(): void
+    protected function tearDown(): void
     {
     }
 

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -64,7 +64,7 @@ final class RouterTest extends CIUnitTestCase
 
     //--------------------------------------------------------------------
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
     }
 

--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -41,7 +41,7 @@ final class BootstrapFCPATHTest extends CIUnitTestCase
     {
         $result1     = $this->readOutput($this->file1);
         $correctPath = $this->correctFCPATH();
-        self::assertEquals($correctPath, $result1);
+        $this->assertEquals($correctPath, $result1);
     }
 
     private function correctFCPATH()

--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -30,7 +30,7 @@ final class BootstrapFCPATHTest extends CIUnitTestCase
         $this->writeFiles();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->deleteFiles();

--- a/tests/system/View/TableTest.php
+++ b/tests/system/View/TableTest.php
@@ -12,7 +12,7 @@ use stdClass;
  */
 final class TableTest extends CIUnitTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->table = new MockTable();
     }

--- a/tests/system/View/TableTest.php
+++ b/tests/system/View/TableTest.php
@@ -43,7 +43,7 @@ final class TableTest extends CIUnitTestCase
     }
 
     /**
-     * @depends	testPrepArgs
+     * @depends testPrepArgs
      */
     public function testSetHeading()
     {
@@ -83,7 +83,7 @@ final class TableTest extends CIUnitTestCase
     }
 
     /**
-     * @depends	testPrepArgs
+     * @depends testPrepArgs
      */
     public function testAddRow()
     {

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -147,6 +147,7 @@ final class CodeIgniter4 extends AbstractRuleset
             'php_unit_dedicate_assert'               => ['target' => 'newest'],
             'php_unit_dedicate_assert_internal_type' => ['target' => 'newest'],
             'php_unit_expectation'                   => ['target' => 'newest'],
+            'php_unit_fqcn_annotation'               => true,
             'php_unit_internal_class'                => ['types' => ['normal', 'final']],
             'php_unit_no_expectation_annotation'     => [
                 'target'          => 'newest',

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -157,11 +157,15 @@ final class CodeIgniter4 extends AbstractRuleset
                 'target'          => 'newest',
                 'use_class_const' => true,
             ],
-            'php_unit_set_up_tear_down_visibility' => true,
-            'php_unit_test_annotation'             => ['style' => 'prefix'],
-            'phpdoc_align'                         => true,
-            'phpdoc_indent'                        => true,
-            'phpdoc_inline_tag_normalizer'         => [
+            'php_unit_set_up_tear_down_visibility'   => true,
+            'php_unit_test_annotation'               => ['style' => 'prefix'],
+            'php_unit_test_case_static_method_calls' => [
+                'call_type' => 'this',
+                'methods'   => [],
+            ],
+            'phpdoc_align'                 => true,
+            'phpdoc_indent'                => true,
+            'phpdoc_inline_tag_normalizer' => [
                 'tags' => [
                     'example',
                     'id',

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -150,6 +150,8 @@ final class CodeIgniter4 extends AbstractRuleset
             'php_unit_fqcn_annotation'               => true,
             'php_unit_internal_class'                => ['types' => ['normal', 'final']],
             'php_unit_method_casing'                 => ['case' => 'camel_case'],
+            'php_unit_mock'                          => ['target' => 'newest'],
+            'php_unit_mock_short_will_return'        => true,
             'php_unit_no_expectation_annotation'     => [
                 'target'          => 'newest',
                 'use_class_const' => true,

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -157,9 +157,10 @@ final class CodeIgniter4 extends AbstractRuleset
                 'target'          => 'newest',
                 'use_class_const' => true,
             ],
-            'phpdoc_align'                 => true,
-            'phpdoc_indent'                => true,
-            'phpdoc_inline_tag_normalizer' => [
+            'php_unit_set_up_tear_down_visibility' => true,
+            'phpdoc_align'                         => true,
+            'phpdoc_indent'                        => true,
+            'phpdoc_inline_tag_normalizer'         => [
                 'tags' => [
                     'example',
                     'id',

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -152,6 +152,7 @@ final class CodeIgniter4 extends AbstractRuleset
             'php_unit_method_casing'                 => ['case' => 'camel_case'],
             'php_unit_mock'                          => ['target' => 'newest'],
             'php_unit_mock_short_will_return'        => true,
+            'php_unit_namespaced'                    => true,
             'php_unit_no_expectation_annotation'     => [
                 'target'          => 'newest',
                 'use_class_const' => true,

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -158,14 +158,16 @@ final class CodeIgniter4 extends AbstractRuleset
                 'use_class_const' => true,
             ],
             'php_unit_set_up_tear_down_visibility'   => true,
+            'php_unit_size_class'                    => false,
             'php_unit_test_annotation'               => ['style' => 'prefix'],
             'php_unit_test_case_static_method_calls' => [
                 'call_type' => 'this',
                 'methods'   => [],
             ],
-            'phpdoc_align'                 => true,
-            'phpdoc_indent'                => true,
-            'phpdoc_inline_tag_normalizer' => [
+            'php_unit_test_class_requires_covers' => false,
+            'phpdoc_align'                        => true,
+            'phpdoc_indent'                       => true,
+            'phpdoc_inline_tag_normalizer'        => [
                 'tags' => [
                     'example',
                     'id',

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -149,6 +149,7 @@ final class CodeIgniter4 extends AbstractRuleset
             'php_unit_expectation'                   => ['target' => 'newest'],
             'php_unit_fqcn_annotation'               => true,
             'php_unit_internal_class'                => ['types' => ['normal', 'final']],
+            'php_unit_method_casing'                 => ['case' => 'camel_case'],
             'php_unit_no_expectation_annotation'     => [
                 'target'          => 'newest',
                 'use_class_const' => true,

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -158,6 +158,7 @@ final class CodeIgniter4 extends AbstractRuleset
                 'use_class_const' => true,
             ],
             'php_unit_set_up_tear_down_visibility' => true,
+            'php_unit_test_annotation'             => ['style' => 'prefix'],
             'phpdoc_align'                         => true,
             'phpdoc_indent'                        => true,
             'phpdoc_inline_tag_normalizer'         => [


### PR DESCRIPTION
**Description**
Configures other PHPUnit-related fixers.

The last one, `php_unit_strict`, will be done separately as it requires others to be merged and it would require a lot of fixing test failures.

**Checklist:**
- [x] Securely signed commits
