### PR TITLE
Strive for stricter assertions

### DIFF
--- a/admin/module/tests/session/ExampleSessionTest.php
+++ b/admin/module/tests/session/ExampleSessionTest.php
@@ -16,6 +16,6 @@ final class ExampleSessionTest extends \Tests\Support\SessionTestCase
 
         $value = $this->session->get('logged_in');
 
-        $this->assertEquals(123, $value);
+        $this->assertSame(123, $value);
     }
 }

--- a/admin/starter/tests/session/ExampleSessionTest.php
+++ b/admin/starter/tests/session/ExampleSessionTest.php
@@ -16,6 +16,6 @@ final class ExampleSessionTest extends \Tests\Support\SessionTestCase
 
         $value = $this->session->get('logged_in');
 
-        $this->assertEquals(123, $value);
+        $this->assertSame(123, $value);
     }
 }

--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -16,6 +16,7 @@ use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Services;
 use Exception;
+use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -151,7 +152,7 @@ class TestResponse extends TestCase
      */
     public function assertStatus(int $code)
     {
-        $this->assertEquals($code, $this->response->getStatusCode());
+        $this->assertSame($code, $this->response->getStatusCode());
     }
 
     /**
@@ -275,9 +276,9 @@ class TestResponse extends TestCase
         }
 
         if (is_scalar($value)) {
-            $this->assertEquals($value, $_SESSION[$key], "The value of '{$key}' ({$value}) does not match expected value.");
+            $this->assertSame($value, $_SESSION[$key], "The value of '{$key}' ({$value}) does not match expected value.");
         } else {
-            $this->assertEquals($value, $_SESSION[$key], "The value of '{$key}' does not match expected value.");
+            $this->assertSame($value, $_SESSION[$key], "The value of '{$key}' does not match expected value.");
         }
     }
 
@@ -310,7 +311,7 @@ class TestResponse extends TestCase
         $this->assertTrue($this->response->hasHeader($key), "'{$key}' is not a valid Response header.");
 
         if ($value !== null) {
-            $this->assertEquals($value, $this->response->getHeaderLine($key), "The value of '{$key}' header ({$this->response->getHeaderLine($key)}) does not match expected value.");
+            $this->assertSame($value, $this->response->getHeaderLine($key), "The value of '{$key}' header ({$this->response->getHeaderLine($key)}) does not match expected value.");
         }
     }
 
@@ -405,7 +406,7 @@ class TestResponse extends TestCase
         if ($strict) {
             $this->assertSame($json, $patched, 'Response does not contain a matching JSON fragment.');
         } else {
-            $this->assertEquals($json, $patched, 'Response does not contain a matching JSON fragment.');
+            $this->assertThat($patched, new IsEqual($json), 'Response does not contain a matching JSON fragment.');
         }
     }
 

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -102,15 +102,15 @@ final class ResponseTraitTest extends CIUnitTestCase
         $controller      = $this->makeController([], 'http://codeigniter.com', ['Accept' => 'application/json']);
         $controller->respondCreated(['id' => 3], 'A Custom Reason');
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(201, $this->response->getStatusCode());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
+        $this->assertSame(201, $this->response->getStatusCode());
 
         $expected = <<<'EOH'
             {
                 "id": 3
             }
             EOH;
-        $this->assertEquals($expected, $this->response->getBody());
+        $this->assertSame($expected, $this->response->getBody());
     }
 
     public function testNoFormatter()
@@ -119,7 +119,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $controller      = $this->makeController([], 'http://codeigniter.com', ['Accept' => 'application/json']);
         $controller->respondCreated('A Custom Reason');
 
-        $this->assertEquals('A Custom Reason', $this->response->getBody());
+        $this->assertSame('A Custom Reason', $this->response->getBody());
     }
 
     public function testAssociativeArrayPayload()
@@ -133,7 +133,7 @@ final class ResponseTraitTest extends CIUnitTestCase
             }
             EOH;
         $controller->respond($payload);
-        $this->assertEquals($expected, $this->response->getBody());
+        $this->assertSame($expected, $this->response->getBody());
     }
 
     public function testArrayPayload()
@@ -153,7 +153,7 @@ final class ResponseTraitTest extends CIUnitTestCase
             ]
             EOH;
         $controller->respond($payload);
-        $this->assertEquals($expected, $this->response->getBody());
+        $this->assertSame($expected, $this->response->getBody());
     }
 
     public function testPHPtoArrayPayload()
@@ -170,7 +170,7 @@ final class ResponseTraitTest extends CIUnitTestCase
             }
             EOH;
         $controller->respond((array) $payload);
-        $this->assertEquals($expected, $this->response->getBody());
+        $this->assertSame($expected, $this->response->getBody());
     }
 
     public function testRespondSets404WithNoData()
@@ -178,7 +178,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $controller = $this->makeController();
         $controller->respond(null, null);
 
-        $this->assertEquals(404, $this->response->getStatusCode());
+        $this->assertSame(404, $this->response->getStatusCode());
         $this->assertNull($this->response->getBody());
     }
 
@@ -187,7 +187,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $controller = $this->makeController();
         $controller->respond(null, 201);
 
-        $this->assertEquals(201, $this->response->getStatusCode());
+        $this->assertSame(201, $this->response->getStatusCode());
         $this->assertNull($this->response->getBody());
     }
 
@@ -196,10 +196,10 @@ final class ResponseTraitTest extends CIUnitTestCase
         $controller = $this->makeController();
         $controller->respond('something', 201);
 
-        $this->assertEquals(201, $this->response->getStatusCode());
-        $this->assertEquals('something', $this->response->getBody());
+        $this->assertSame(201, $this->response->getStatusCode());
+        $this->assertSame('something', $this->response->getBody());
         $this->assertStringStartsWith('text/html', $this->response->getHeaderLine('Content-Type'));
-        $this->assertEquals('Created', $this->response->getReason());
+        $this->assertSame('Created', $this->response->getReason());
     }
 
     public function testRespondWithCustomReason()
@@ -207,8 +207,8 @@ final class ResponseTraitTest extends CIUnitTestCase
         $controller = $this->makeController();
         $controller->respond('something', 201, 'A Custom Reason');
 
-        $this->assertEquals(201, $this->response->getStatusCode());
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
+        $this->assertSame(201, $this->response->getStatusCode());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
     }
 
     public function testFailSingleMessage()
@@ -226,9 +226,9 @@ final class ResponseTraitTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
-        $this->assertEquals(500, $this->response->getStatusCode());
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
+        $this->assertSame($this->formatter->format($expected), $this->response->getBody());
+        $this->assertSame(500, $this->response->getStatusCode());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
     }
 
     public function testCreated()
@@ -236,9 +236,9 @@ final class ResponseTraitTest extends CIUnitTestCase
         $controller = $this->makeController();
         $controller->respondCreated(['id' => 3], 'A Custom Reason');
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(201, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format(['id' => 3]), $this->response->getBody());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
+        $this->assertSame(201, $this->response->getStatusCode());
+        $this->assertSame($this->formatter->format(['id' => 3]), $this->response->getBody());
     }
 
     public function testDeleted()
@@ -246,9 +246,9 @@ final class ResponseTraitTest extends CIUnitTestCase
         $controller = $this->makeController();
         $controller->respondDeleted(['id' => 3], 'A Custom Reason');
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(200, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format(['id' => 3]), $this->response->getBody());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
+        $this->assertSame(200, $this->response->getStatusCode());
+        $this->assertSame($this->formatter->format(['id' => 3]), $this->response->getBody());
     }
 
     public function testUpdated()
@@ -256,9 +256,9 @@ final class ResponseTraitTest extends CIUnitTestCase
         $controller = $this->makeController();
         $controller->respondUpdated(['id' => 3], 'A Custom Reason');
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(200, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format(['id' => 3]), $this->response->getBody());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
+        $this->assertSame(200, $this->response->getStatusCode());
+        $this->assertSame($this->formatter->format(['id' => 3]), $this->response->getBody());
     }
 
     public function testUnauthorized()
@@ -274,9 +274,9 @@ final class ResponseTraitTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(401, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
+        $this->assertSame(401, $this->response->getStatusCode());
+        $this->assertSame($this->formatter->format($expected), $this->response->getBody());
     }
 
     public function testForbidden()
@@ -292,9 +292,9 @@ final class ResponseTraitTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(403, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
+        $this->assertSame(403, $this->response->getStatusCode());
+        $this->assertSame($this->formatter->format($expected), $this->response->getBody());
     }
 
     public function testNoContent()
@@ -302,8 +302,8 @@ final class ResponseTraitTest extends CIUnitTestCase
         $controller = $this->makeController();
         $controller->respondNoContent('');
 
-        $this->assertEquals('No Content', $this->response->getReason());
-        $this->assertEquals(204, $this->response->getStatusCode());
+        $this->assertSame('No Content', $this->response->getReason());
+        $this->assertSame(204, $this->response->getStatusCode());
     }
 
     public function testNotFound()
@@ -319,9 +319,9 @@ final class ResponseTraitTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(404, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
+        $this->assertSame(404, $this->response->getStatusCode());
+        $this->assertSame($this->formatter->format($expected), $this->response->getBody());
     }
 
     public function testValidationError()
@@ -337,9 +337,9 @@ final class ResponseTraitTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(400, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
+        $this->assertSame(400, $this->response->getStatusCode());
+        $this->assertSame($this->formatter->format($expected), $this->response->getBody());
     }
 
     public function testValidationErrors()
@@ -356,9 +356,9 @@ final class ResponseTraitTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(400, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
+        $this->assertSame(400, $this->response->getStatusCode());
+        $this->assertSame($this->formatter->format($expected), $this->response->getBody());
     }
 
     public function testResourceExists()
@@ -374,9 +374,9 @@ final class ResponseTraitTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(409, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
+        $this->assertSame(409, $this->response->getStatusCode());
+        $this->assertSame($this->formatter->format($expected), $this->response->getBody());
     }
 
     public function testResourceGone()
@@ -392,9 +392,9 @@ final class ResponseTraitTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(410, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
+        $this->assertSame(410, $this->response->getStatusCode());
+        $this->assertSame($this->formatter->format($expected), $this->response->getBody());
     }
 
     public function testTooManyRequests()
@@ -410,9 +410,9 @@ final class ResponseTraitTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals('A Custom Reason', $this->response->getReason());
-        $this->assertEquals(429, $this->response->getStatusCode());
-        $this->assertEquals($this->formatter->format($expected), $this->response->getBody());
+        $this->assertSame('A Custom Reason', $this->response->getReason());
+        $this->assertSame(429, $this->response->getStatusCode());
+        $this->assertSame($this->formatter->format($expected), $this->response->getBody());
     }
 
     public function testServerError()
@@ -452,9 +452,9 @@ final class ResponseTraitTest extends CIUnitTestCase
         $_SERVER['CONTENT_TYPE'] = $mimeType;
 
         $this->makeController([], 'http://codeigniter.com', ['Accept' => $mimeType]);
-        $this->assertEquals($mimeType, $this->request->getHeaderLine('Accept'), 'Request header...');
+        $this->assertSame($mimeType, $this->request->getHeaderLine('Accept'), 'Request header...');
         $this->response->setContentType($contentType);
-        $this->assertEquals($contentType, $this->response->getHeaderLine('Content-Type'), 'Response header pre-response...');
+        $this->assertSame($contentType, $this->response->getHeaderLine('Content-Type'), 'Response header pre-response...');
 
         $_SERVER = $original;
     }
@@ -479,7 +479,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $this->formatter = new XMLFormatter();
         $controller      = $this->makeController();
 
-        $this->assertEquals('CodeIgniter\Format\XMLFormatter', get_class($this->formatter));
+        $this->assertSame('CodeIgniter\Format\XMLFormatter', get_class($this->formatter));
 
         $controller->respondCreated(['id' => 3], 'A Custom Reason');
         $expected = <<<'EOH'
@@ -487,7 +487,7 @@ final class ResponseTraitTest extends CIUnitTestCase
             <response><id>3</id></response>
 
             EOH;
-        $this->assertEquals($expected, $this->response->getBody());
+        $this->assertSame($expected, $this->response->getBody());
     }
 
     public function testFormatByRequestNegotiateIfFormatIsNotJsonOrXML()
@@ -543,7 +543,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $controller->respond($data, 201);
 
         $this->assertStringStartsWith('application/json', $this->response->getHeaderLine('Content-Type'));
-        $this->assertEquals($this->formatter->format($data), $this->response->getJSON());
+        $this->assertSame($this->formatter->format($data), $this->response->getJSON());
 
         $controller->setResponseFormat('xml');
         $controller->respond($data, 201);
@@ -560,6 +560,6 @@ final class ResponseTraitTest extends CIUnitTestCase
         $controller->respond($data, 201);
 
         $xmlFormatter = new XMLFormatter();
-        $this->assertEquals($xmlFormatter->format($data), $this->response->getXML());
+        $this->assertSame($xmlFormatter->format($data), $this->response->getXML());
     }
 }

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -187,7 +187,7 @@ final class AutoloaderTest extends CIUnitTestCase
         $test     = '${../path}!#/to/some/file.php_';
         $expected = '/path/to/some/file.php';
 
-        $this->assertEquals($expected, $this->loader->sanitizeFilename($test));
+        $this->assertSame($expected, $this->loader->sanitizeFilename($test));
     }
 
     public function testSanitizationAllowUnicodeChars()
@@ -195,14 +195,14 @@ final class AutoloaderTest extends CIUnitTestCase
         $test     = 'Ä/path/to/some/file.php_';
         $expected = 'Ä/path/to/some/file.php';
 
-        $this->assertEquals($expected, $this->loader->sanitizeFilename($test));
+        $this->assertSame($expected, $this->loader->sanitizeFilename($test));
     }
 
     public function testSanitizationAllowsWindowsFilepaths()
     {
         $test = 'C:\path\to\some/file.php';
 
-        $this->assertEquals($test, $this->loader->sanitizeFilename($test));
+        $this->assertSame($test, $this->loader->sanitizeFilename($test));
     }
 
     public function testFindsComposerRoutes()

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -47,7 +47,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
         $expected = APPPATH . 'Controllers/Home.php';
 
-        $this->assertEquals($expected, $this->locator->locateFile($file));
+        $this->assertSame($expected, $this->locator->locateFile($file));
     }
 
     //--------------------------------------------------------------------
@@ -67,7 +67,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
         $expected = APPPATH . 'Views/welcome_message.php';
 
-        $this->assertEquals($expected, $this->locator->locateFile($file, 'Views'));
+        $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
 
     //--------------------------------------------------------------------
@@ -78,7 +78,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
         $expected = APPPATH . 'Common.php';
 
-        $this->assertEquals($expected, $this->locator->locateFile($file));
+        $this->assertSame($expected, $this->locator->locateFile($file));
     }
 
     //--------------------------------------------------------------------
@@ -89,7 +89,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
         $expected = APPPATH . 'Controllers/Home.php';
 
-        $this->assertEquals($expected, $this->locator->locateFile($file, 'Controllers'));
+        $this->assertSame($expected, $this->locator->locateFile($file, 'Controllers'));
     }
 
     //--------------------------------------------------------------------
@@ -100,7 +100,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
         $expected = APPPATH . 'Views/errors/html/error_404.php';
 
-        $this->assertEquals($expected, $this->locator->locateFile($file, 'Views'));
+        $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
 
     //--------------------------------------------------------------------
@@ -111,7 +111,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
         $expected = APPPATH . 'Views/welcome_message.php';
 
-        $this->assertEquals($expected, $this->locator->locateFile($file, 'Views'));
+        $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
 
     //--------------------------------------------------------------------
@@ -122,7 +122,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
         $expected = APPPATH . 'Views/errors/html/error_404.php';
 
-        $this->assertEquals($expected, $this->locator->locateFile($file, 'html'));
+        $this->assertSame($expected, $this->locator->locateFile($file, 'html'));
     }
 
     //--------------------------------------------------------------------
@@ -133,7 +133,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
         $expected = APPPATH . 'Views/errors/html/error_404.php';
 
-        $this->assertEquals($expected, $this->locator->locateFile($file, 'html'));
+        $this->assertSame($expected, $this->locator->locateFile($file, 'html'));
     }
 
     //--------------------------------------------------------------------
@@ -162,7 +162,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
         $foundFiles = $this->locator->search('Config/App.php');
 
-        $this->assertEquals($expected, $foundFiles[0]);
+        $this->assertSame($expected, $foundFiles[0]);
     }
 
     //--------------------------------------------------------------------
@@ -173,7 +173,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
         $foundFiles = $this->locator->search('Config/App', 'php');
 
-        $this->assertEquals($expected, $foundFiles[0]);
+        $this->assertSame($expected, $foundFiles[0]);
     }
 
     //--------------------------------------------------------------------
@@ -204,7 +204,7 @@ final class FileLocatorTest extends CIUnitTestCase
     {
         $foundFiles = $this->locator->search('Language/en/Validation.php', 'php', false);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 SYSTEMPATH . 'Language/en/Validation.php',
                 APPPATH . 'Language/en/Validation.php',
@@ -278,7 +278,7 @@ final class FileLocatorTest extends CIUnitTestCase
         $ClassName = $this->locator->findQualifiedNameFromPath(SYSTEMPATH . 'HTTP/Header.php');
         $expected  = '\CodeIgniter\HTTP\Header';
 
-        $this->assertEquals($expected, $ClassName);
+        $this->assertSame($expected, $ClassName);
     }
 
     public function testFindQNameFromPathWithFileNotExist()
@@ -297,7 +297,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
     public function testGetClassNameFromClassFile()
     {
-        $this->assertEquals(
+        $this->assertSame(
             __CLASS__,
             $this->locator->getClassname(__FILE__)
         );
@@ -305,7 +305,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
     public function testGetClassNameFromNonClassFile()
     {
-        $this->assertEquals(
+        $this->assertSame(
             '',
             $this->locator->getClassname(SYSTEMPATH . 'bootstrap.php')
         );

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -78,8 +78,8 @@ final class CLITest extends CIUnitTestCase
 
     public function testIsWindows()
     {
-        $this->assertEquals(('\\' === DIRECTORY_SEPARATOR), CLI::isWindows());
-        $this->assertEquals(defined('PHP_WINDOWS_VERSION_MAJOR'), CLI::isWindows());
+        $this->assertSame(('\\' === DIRECTORY_SEPARATOR), CLI::isWindows());
+        $this->assertSame(defined('PHP_WINDOWS_VERSION_MAJOR'), CLI::isWindows());
     }
 
     public function testNewLine()
@@ -110,7 +110,7 @@ final class CLITest extends CIUnitTestCase
         putenv('NO_COLOR=1');
 
         CLI::init(); // force re-check on env
-        $this->assertEquals('test', CLI::color('test', 'white', 'green'));
+        $this->assertSame('test', CLI::color('test', 'white', 'green'));
         putenv($nocolor ? "NO_COLOR=$nocolor" : 'NO_COLOR');
     }
 
@@ -120,7 +120,7 @@ final class CLITest extends CIUnitTestCase
         putenv('TERM_PROGRAM=Hyper');
 
         CLI::init(); // force re-check on env
-        $this->assertEquals("\033[1;37m\033[42m\033[4mtest\033[0m", CLI::color('test', 'white', 'green', 'underline'));
+        $this->assertSame("\033[1;37m\033[42m\033[4mtest\033[0m", CLI::color('test', 'white', 'green', 'underline'));
         putenv($termProgram ? "TERM_PROGRAM=$termProgram" : 'TERM_PROGRAM');
     }
 
@@ -135,7 +135,7 @@ final class CLITest extends CIUnitTestCase
         // After the tests on NO_COLOR and TERM_PROGRAM above,
         // the $isColored variable is rigged. So we reset this.
         CLI::init();
-        $this->assertEquals("\033[1;37m\033[42m\033[4mtest\033[0m", CLI::color('test', 'white', 'green', 'underline'));
+        $this->assertSame("\033[1;37m\033[42m\033[4mtest\033[0m", CLI::color('test', 'white', 'green', 'underline'));
     }
 
     public function testPrint()
@@ -143,7 +143,7 @@ final class CLITest extends CIUnitTestCase
         CLI::print('test');
         $expected = 'test';
 
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testPrintForeground()
@@ -151,7 +151,7 @@ final class CLITest extends CIUnitTestCase
         CLI::print('test', 'red');
         $expected = "\033[0;31mtest\033[0m";
 
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testPrintBackground()
@@ -159,42 +159,42 @@ final class CLITest extends CIUnitTestCase
         CLI::print('test', 'red', 'green');
         $expected = "\033[0;31m\033[42mtest\033[0m";
 
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testWrite()
     {
         CLI::write('test');
         $expected = PHP_EOL . 'test' . PHP_EOL;
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testWriteForeground()
     {
         CLI::write('test', 'red');
         $expected = "\033[0;31mtest\033[0m" . PHP_EOL;
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testWriteForegroundWithColorBefore()
     {
         CLI::write(CLI::color('green', 'green') . ' red', 'red');
         $expected = "\033[0;31m\033[0;32mgreen\033[0m\033[0;31m red\033[0m" . PHP_EOL;
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testWriteForegroundWithColorAfter()
     {
         CLI::write('red ' . CLI::color('green', 'green'), 'red');
         $expected = "\033[0;31mred \033[0;32mgreen\033[0m" . PHP_EOL;
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testWriteBackground()
     {
         CLI::write('test', 'red', 'green');
         $expected = "\033[0;31m\033[42mtest\033[0m" . PHP_EOL;
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testError()
@@ -203,7 +203,7 @@ final class CLITest extends CIUnitTestCase
         CLI::error('test');
         // red expected cuz stderr
         $expected = "\033[1;31mtest\033[0m" . PHP_EOL;
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testErrorForeground()
@@ -211,7 +211,7 @@ final class CLITest extends CIUnitTestCase
         $this->stream_filter = stream_filter_append(STDERR, 'CITestStreamFilter');
         CLI::error('test', 'purple');
         $expected = "\033[0;35mtest\033[0m" . PHP_EOL;
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testErrorBackground()
@@ -219,7 +219,7 @@ final class CLITest extends CIUnitTestCase
         $this->stream_filter = stream_filter_append(STDERR, 'CITestStreamFilter');
         CLI::error('test', 'purple', 'green');
         $expected = "\033[0;35m\033[42mtest\033[0m" . PHP_EOL;
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testShowProgress()
@@ -245,7 +245,7 @@ final class CLITest extends CIUnitTestCase
                     "\033[1A[\033[32m##########\033[0m] 100% Complete" . PHP_EOL .
                     'third.' . PHP_EOL .
                     "[\033[32m#.........\033[0m]   5% Complete" . PHP_EOL;
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testShowProgressWithoutBar()
@@ -256,15 +256,15 @@ final class CLITest extends CIUnitTestCase
         CLI::showProgress(false, 20);
 
         $expected = 'first.' . PHP_EOL . "\007\007\007";
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testWrap()
     {
-        $this->assertEquals('', CLI::wrap(''));
-        $this->assertEquals('1234' . PHP_EOL . ' 5678' . PHP_EOL . ' 90' . PHP_EOL . ' abc' . PHP_EOL . ' de' . PHP_EOL . ' fghij' . PHP_EOL . ' 0987654321', CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 5, 1));
-        $this->assertEquals('1234 5678 90' . PHP_EOL . '  abc de fghij' . PHP_EOL . '  0987654321', CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 999, 2));
-        $this->assertEquals('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321'));
+        $this->assertSame('', CLI::wrap(''));
+        $this->assertSame('1234' . PHP_EOL . ' 5678' . PHP_EOL . ' 90' . PHP_EOL . ' abc' . PHP_EOL . ' de' . PHP_EOL . ' fghij' . PHP_EOL . ' 0987654321', CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 5, 1));
+        $this->assertSame('1234 5678 90' . PHP_EOL . '  abc de fghij' . PHP_EOL . '  0987654321', CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 999, 2));
+        $this->assertSame('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321'));
     }
 
     public function testParseCommand()
@@ -277,12 +277,12 @@ final class CLITest extends CIUnitTestCase
         $_SERVER['argc'] = 3;
         CLI::init();
         $this->assertNull(CLI::getSegment(3));
-        $this->assertEquals('b', CLI::getSegment(1));
-        $this->assertEquals('c', CLI::getSegment(2));
-        $this->assertEquals('b/c', CLI::getURI());
-        $this->assertEquals([], CLI::getOptions());
+        $this->assertSame('b', CLI::getSegment(1));
+        $this->assertSame('c', CLI::getSegment(2));
+        $this->assertSame('b/c', CLI::getURI());
+        $this->assertSame([], CLI::getOptions());
         $this->assertEmpty(CLI::getOptionString());
-        $this->assertEquals(['b', 'c'], CLI::getSegments());
+        $this->assertSame(['b', 'c'], CLI::getSegments());
     }
 
     public function testParseCommandMixed()
@@ -302,15 +302,15 @@ final class CLITest extends CIUnitTestCase
         ];
         CLI::init();
         $this->assertNull(CLI::getSegment(7));
-        $this->assertEquals('b', CLI::getSegment(1));
-        $this->assertEquals('c', CLI::getSegment(2));
-        $this->assertEquals('d', CLI::getSegment(3));
-        $this->assertEquals(['b', 'c', 'd', 'd2', 'da-sh'], CLI::getSegments());
-        $this->assertEquals(['parm' => 'pvalue', 'fix' => null, 'opt-in' => 'sure'], CLI::getOptions());
-        $this->assertEquals('-parm pvalue -fix -opt-in sure ', CLI::getOptionString());
-        $this->assertEquals('-parm pvalue -fix -opt-in sure', CLI::getOptionString(false, true));
-        $this->assertEquals('--parm pvalue --fix --opt-in sure ', CLI::getOptionString(true));
-        $this->assertEquals('--parm pvalue --fix --opt-in sure', CLI::getOptionString(true, true));
+        $this->assertSame('b', CLI::getSegment(1));
+        $this->assertSame('c', CLI::getSegment(2));
+        $this->assertSame('d', CLI::getSegment(3));
+        $this->assertSame(['b', 'c', 'd', 'd2', 'da-sh'], CLI::getSegments());
+        $this->assertSame(['parm' => 'pvalue', 'fix' => null, 'opt-in' => 'sure'], CLI::getOptions());
+        $this->assertSame('-parm pvalue -fix -opt-in sure ', CLI::getOptionString());
+        $this->assertSame('-parm pvalue -fix -opt-in sure', CLI::getOptionString(false, true));
+        $this->assertSame('--parm pvalue --fix --opt-in sure ', CLI::getOptionString(true));
+        $this->assertSame('--parm pvalue --fix --opt-in sure', CLI::getOptionString(true, true));
     }
 
     public function testParseCommandOption()
@@ -324,14 +324,14 @@ final class CLITest extends CIUnitTestCase
             'd',
         ];
         CLI::init();
-        $this->assertEquals(['parm' => 'pvalue'], CLI::getOptions());
-        $this->assertEquals('pvalue', CLI::getOption('parm'));
-        $this->assertEquals('-parm pvalue ', CLI::getOptionString());
-        $this->assertEquals('-parm pvalue', CLI::getOptionString(false, true));
-        $this->assertEquals('--parm pvalue ', CLI::getOptionString(true));
-        $this->assertEquals('--parm pvalue', CLI::getOptionString(true, true));
+        $this->assertSame(['parm' => 'pvalue'], CLI::getOptions());
+        $this->assertSame('pvalue', CLI::getOption('parm'));
+        $this->assertSame('-parm pvalue ', CLI::getOptionString());
+        $this->assertSame('-parm pvalue', CLI::getOptionString(false, true));
+        $this->assertSame('--parm pvalue ', CLI::getOptionString(true));
+        $this->assertSame('--parm pvalue', CLI::getOptionString(true, true));
         $this->assertNull(CLI::getOption('bogus'));
-        $this->assertEquals(['b', 'c', 'd'], CLI::getSegments());
+        $this->assertSame(['b', 'c', 'd'], CLI::getSegments());
     }
 
     public function testParseCommandMultipleOptions()
@@ -348,13 +348,13 @@ final class CLITest extends CIUnitTestCase
             'value 3',
         ];
         CLI::init();
-        $this->assertEquals(['parm' => 'pvalue', 'p2' => null, 'p3' => 'value 3'], CLI::getOptions());
-        $this->assertEquals('pvalue', CLI::getOption('parm'));
-        $this->assertEquals('-parm pvalue -p2 -p3 "value 3" ', CLI::getOptionString());
-        $this->assertEquals('-parm pvalue -p2 -p3 "value 3"', CLI::getOptionString(false, true));
-        $this->assertEquals('--parm pvalue --p2 --p3 "value 3" ', CLI::getOptionString(true));
-        $this->assertEquals('--parm pvalue --p2 --p3 "value 3"', CLI::getOptionString(true, true));
-        $this->assertEquals(['b', 'c', 'd'], CLI::getSegments());
+        $this->assertSame(['parm' => 'pvalue', 'p2' => null, 'p3' => 'value 3'], CLI::getOptions());
+        $this->assertSame('pvalue', CLI::getOption('parm'));
+        $this->assertSame('-parm pvalue -p2 -p3 "value 3" ', CLI::getOptionString());
+        $this->assertSame('-parm pvalue -p2 -p3 "value 3"', CLI::getOptionString(false, true));
+        $this->assertSame('--parm pvalue --p2 --p3 "value 3" ', CLI::getOptionString(true));
+        $this->assertSame('--parm pvalue --p2 --p3 "value 3"', CLI::getOptionString(true, true));
+        $this->assertSame(['b', 'c', 'd'], CLI::getSegments());
     }
 
     public function testWindow()
@@ -380,7 +380,7 @@ final class CLITest extends CIUnitTestCase
     public function testTable($tbody, $thead, $expected)
     {
         CLI::table($tbody, $thead);
-        $this->assertEquals(CITestStreamFilter::$buffer, $expected);
+        $this->assertSame(CITestStreamFilter::$buffer, $expected);
     }
 
     public function tableProvider()
@@ -470,8 +470,8 @@ final class CLITest extends CIUnitTestCase
 
     public function testStrlen()
     {
-        $this->assertEquals(18, mb_strlen(CLI::color('success', 'green')));
-        $this->assertEquals(7, CLI::strlen(CLI::color('success', 'green')));
-        $this->assertEquals(0, CLI::strlen(null));
+        $this->assertSame(18, mb_strlen(CLI::color('success', 'green')));
+        $this->assertSame(7, CLI::strlen(CLI::color('success', 'green')));
+        $this->assertSame(0, CLI::strlen(null));
     }
 }

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -250,7 +250,7 @@ final class FileHandlerTest extends CIUnitTestCase
 
         $actual = $this->fileHandler->getCacheInfo();
         $this->assertArrayHasKey(self::$key1, $actual);
-        $this->assertEquals(self::$key1, $actual[self::$key1]['name']);
+        $this->assertSame(self::$key1, $actual[self::$key1]['name']);
         $this->assertArrayHasKey('server_path', $actual[self::$key1]);
     }
 
@@ -276,7 +276,7 @@ final class FileHandlerTest extends CIUnitTestCase
         $file = $config->file['storePath'] . DIRECTORY_SEPARATOR . self::$key1;
         $mode = octal_permissions(fileperms($file));
 
-        $this->assertEquals($string, $mode);
+        $this->assertSame($string, $mode);
     }
 
     public function modeProvider()

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -28,20 +28,18 @@ final class CodeIgniterTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-
         Services::reset();
 
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
 
-        $config            = new App();
-        $this->codeigniter = new MockCodeIgniter($config);
+        $this->codeigniter = new MockCodeIgniter(new App());
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
 
-        if (count( ob_list_handlers() ) > 1) {
+        if (count(ob_list_handlers()) > 1) {
             ob_end_clean();
         }
     }
@@ -50,9 +48,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
     public function testRunEmptyDefaultRoute()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-        ];
+        $_SERVER['argv'] = ['index.php'];
         $_SERVER['argc'] = 1;
 
         ob_start();
@@ -66,10 +62,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
     public function testRunClosureRoute()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            'pages/about',
-        ];
+        $_SERVER['argv'] = ['index.php', 'pages/about'];
         $_SERVER['argc'] = 2;
 
         $_SERVER['REQUEST_URI'] = '/pages/about';
@@ -93,10 +86,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
     public function testRun404Override()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            '/',
-        ];
+        $_SERVER['argv'] = ['index.php', '/'];
         $_SERVER['argc'] = 2;
 
         // Inject mock router.
@@ -117,10 +107,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
     public function testRun404OverrideByClosure()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            '/',
-        ];
+        $_SERVER['argv'] = ['index.php', '/'];
         $_SERVER['argc'] = 2;
 
         // Inject mock router.
@@ -143,11 +130,9 @@ final class CodeIgniterTest extends CIUnitTestCase
 
     public function testControllersCanReturnString()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            'pages/about',
-        ];
-        $_SERVER['argc']        = 2;
+        $_SERVER['argv'] = ['index.php', 'pages/about'];
+        $_SERVER['argc'] = 2;
+
         $_SERVER['REQUEST_URI'] = '/pages/about';
 
         // Inject mock router.
@@ -169,11 +154,9 @@ final class CodeIgniterTest extends CIUnitTestCase
 
     public function testControllersCanReturnResponseObject()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            'pages/about',
-        ];
-        $_SERVER['argc']        = 2;
+        $_SERVER['argv'] = ['index.php', 'pages/about'];
+        $_SERVER['argc'] = 2;
+
         $_SERVER['REQUEST_URI'] = '/pages/about';
 
         // Inject mock router.
@@ -198,10 +181,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
     public function testResponseConfigEmpty()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            '/',
-        ];
+        $_SERVER['argv'] = ['index.php', '/'];
         $_SERVER['argc'] = 2;
 
         $response = Services::response(null, false);
@@ -213,10 +193,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
     public function testRoutesIsEmpty()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            '/',
-        ];
+        $_SERVER['argv'] = ['index.php', '/'];
         $_SERVER['argc'] = 2;
 
         // Inject mock router.
@@ -232,11 +209,9 @@ final class CodeIgniterTest extends CIUnitTestCase
 
     public function testTransfersCorrectHTTPVersion()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            '/',
-        ];
-        $_SERVER['argc']            = 2;
+        $_SERVER['argv'] = ['index.php', '/'];
+        $_SERVER['argc'] = 2;
+
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/2.0';
 
         ob_start();
@@ -245,15 +220,12 @@ final class CodeIgniterTest extends CIUnitTestCase
 
         $response = $this->getPrivateProperty($this->codeigniter, 'response');
 
-        $this->assertEquals(2, $response->getProtocolVersion());
+        $this->assertSame('2.0', $response->getProtocolVersion());
     }
 
     public function testIgnoringErrorSuppressedByAt()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            '/',
-        ];
+        $_SERVER['argv'] = ['index.php', '/'];
         $_SERVER['argc'] = 2;
 
         ob_start();
@@ -268,15 +240,14 @@ final class CodeIgniterTest extends CIUnitTestCase
 
     public function testRunForceSecure()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            '/',
-        ];
+        $_SERVER['argv'] = ['index.php', '/'];
         $_SERVER['argc'] = 2;
 
-        $config                            = new App();
+        $config = new App();
+
         $config->forceGlobalSecureRequests = true;
-        $codeigniter                       = new MockCodeIgniter($config);
+
+        $codeigniter = new MockCodeIgniter($config);
 
         $this->getPrivateMethodInvoker($codeigniter, 'getRequestObject')();
         $this->getPrivateMethodInvoker($codeigniter, 'getResponseObject')();
@@ -288,16 +259,14 @@ final class CodeIgniterTest extends CIUnitTestCase
         $codeigniter->useSafeOutput(true)->run();
         ob_get_clean();
 
-        $this->assertEquals('https://example.com/', $response->header('Location')->getValue());
+        $this->assertSame('https://example.com/', $response->header('Location')->getValue());
     }
 
     public function testRunRedirectionWithNamed()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            'example',
-        ];
-        $_SERVER['argc']        = 2;
+        $_SERVER['argv'] = ['index.php', 'example'];
+        $_SERVER['argc'] = 2;
+
         $_SERVER['REQUEST_URI'] = '/example';
 
         // Inject mock router.
@@ -313,16 +282,14 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter->useSafeOutput(true)->run();
         ob_get_clean();
         $response = $this->getPrivateProperty($this->codeigniter, 'response');
-        $this->assertEquals('http://example.com/pages/named', $response->header('Location')->getValue());
+        $this->assertSame('http://example.com/pages/named', $response->header('Location')->getValue());
     }
 
     public function testRunRedirectionWithURI()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            'example',
-        ];
-        $_SERVER['argc']        = 2;
+        $_SERVER['argv'] = ['index.php', 'example'];
+        $_SERVER['argc'] = 2;
+
         $_SERVER['REQUEST_URI'] = '/example';
 
         // Inject mock router.
@@ -338,7 +305,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter->useSafeOutput(true)->run();
         ob_get_clean();
         $response = $this->getPrivateProperty($this->codeigniter, 'response');
-        $this->assertEquals('http://example.com/pages/uri', $response->header('Location')->getValue());
+        $this->assertSame('http://example.com/pages/uri', $response->header('Location')->getValue());
     }
 
     /**
@@ -346,11 +313,9 @@ final class CodeIgniterTest extends CIUnitTestCase
      */
     public function testRunRedirectionWithURINotSet()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            'example',
-        ];
-        $_SERVER['argc']        = 2;
+        $_SERVER['argv'] = ['index.php', 'example'];
+        $_SERVER['argc'] = 2;
+
         $_SERVER['REQUEST_URI'] = '/example';
 
         // Inject mock router.
@@ -364,16 +329,14 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter->useSafeOutput(true)->run();
         ob_get_clean();
         $response = $this->getPrivateProperty($this->codeigniter, 'response');
-        $this->assertEquals('http://example.com/pages/notset', $response->header('Location')->getValue());
+        $this->assertSame('http://example.com/pages/notset', $response->header('Location')->getValue());
     }
 
     public function testRunRedirectionWithHTTPCode303()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            'example',
-        ];
-        $_SERVER['argc']            = 2;
+        $_SERVER['argv'] = ['index.php', 'example'];
+        $_SERVER['argc'] = 2;
+
         $_SERVER['REQUEST_URI']     = '/example';
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
         $_SERVER['REQUEST_METHOD']  = 'POST';
@@ -388,17 +351,16 @@ final class CodeIgniterTest extends CIUnitTestCase
         ob_start();
         $this->codeigniter->useSafeOutput(true)->run();
         ob_get_clean();
+
         $response = $this->getPrivateProperty($this->codeigniter, 'response');
-        $this->assertEquals('303', $response->getStatusCode());
+        $this->assertSame(303, $response->getStatusCode());
     }
 
     public function testRunRedirectionWithHTTPCode301()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            'example',
-        ];
-        $_SERVER['argc']            = 2;
+        $_SERVER['argv'] = ['index.php', 'example'];
+        $_SERVER['argc'] = 2;
+
         $_SERVER['REQUEST_URI']     = '/example';
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
         $_SERVER['REQUEST_METHOD']  = 'GET';
@@ -414,7 +376,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter->useSafeOutput(true)->run();
         ob_get_clean();
         $response = $this->getPrivateProperty($this->codeigniter, 'response');
-        $this->assertEquals('301', $response->getStatusCode());
+        $this->assertSame(301, $response->getStatusCode());
     }
 
     /**
@@ -424,10 +386,7 @@ final class CodeIgniterTest extends CIUnitTestCase
      */
     public function testRunDefaultRoute()
     {
-        $_SERVER['argv'] = [
-            'index.php',
-            '/',
-        ];
+        $_SERVER['argv'] = ['index.php', '/'];
         $_SERVER['argc'] = 2;
 
         ob_start();

--- a/tests/system/Commands/BaseCommandTest.php
+++ b/tests/system/Commands/BaseCommandTest.php
@@ -40,7 +40,7 @@ final class BaseCommandTest extends CIUnitTestCase
     {
         $command = new AppInfo($this->logger, service('commands'));
 
-        $this->assertEquals('demo', $command->group);
+        $this->assertSame('demo', $command->group);
     }
 
     public function testMagicGetMissing()

--- a/tests/system/Commands/ClearCacheTest.php
+++ b/tests/system/Commands/ClearCacheTest.php
@@ -41,7 +41,7 @@ final class ClearCacheTest extends CIUnitTestCase
     public function testClearCacheWorks()
     {
         cache()->save('foo', 'bar');
-        $this->assertEquals('bar', cache('foo'));
+        $this->assertSame('bar', cache('foo'));
 
         command('cache:clear');
 

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -21,8 +21,9 @@ final class CommandTest extends CIUnitTestCase
         parent::setUp();
 
         CITestStreamFilter::$buffer = '';
-        $this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+
+        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
+        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
 
         $this->logger   = Services::logger();
         $this->commands = Services::commands();
@@ -137,7 +138,7 @@ final class CommandTest extends CIUnitTestCase
         ParamsReveal::$args = null;
         command($input);
 
-        $this->assertEquals($expected, ParamsReveal::$args);
+        $this->assertSame($expected, ParamsReveal::$args);
     }
 
     public function commandArgsProvider(): array
@@ -145,10 +146,7 @@ final class CommandTest extends CIUnitTestCase
         return [
             [
                 'reveal as df',
-                [
-                    'as',
-                    'df',
-                ],
+                ['as', 'df'],
             ],
             [
                 'reveal',
@@ -156,50 +154,23 @@ final class CommandTest extends CIUnitTestCase
             ],
             [
                 'reveal seg1 seg2 -opt1 -opt2',
-                [
-                    'seg1',
-                    'seg2',
-                    'opt1' => null,
-                    'opt2' => null,
-                ],
+                ['seg1', 'seg2', 'opt1' => null, 'opt2' => null],
             ],
             [
                 'reveal seg1 seg2 -opt1 val1 seg3',
-                [
-                    'seg1',
-                    'seg2',
-                    'opt1' => 'val1',
-                    'seg3',
-                ],
+                ['seg1', 'seg2', 'opt1' => 'val1', 'seg3'],
             ],
             [
                 'reveal as df -gh -jk -qw 12 zx cv',
-                [
-                    'as',
-                    'df',
-                    'gh' => null,
-                    'jk' => null,
-                    'qw' => 12,
-                    'zx',
-                    'cv',
-                ],
+                ['as', 'df', 'gh' => null, 'jk' => null, 'qw' => '12', 'zx', 'cv'],
             ],
             [
                 'reveal as -df "some stuff" -jk 12 -sd "Some longer stuff" -fg \'using single quotes\'',
-                [
-                    'as',
-                    'df' => 'some stuff',
-                    'jk' => 12,
-                    'sd' => 'Some longer stuff',
-                    'fg' => 'using single quotes',
-                ],
+                ['as', 'df' => 'some stuff', 'jk' => '12', 'sd' => 'Some longer stuff', 'fg' => 'using single quotes'],
             ],
             [
                 'reveal as -df "using mixed \'quotes\'\" here\""',
-                [
-                    'as',
-                    'df' => 'using mixed \'quotes\'" here"',
-                ],
+                ['as', 'df' => 'using mixed \'quotes\'" here"'],
             ],
         ];
     }

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -41,48 +41,48 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
     public function testStringifyAttributes()
     {
-        $this->assertEquals(' class="foo" id="bar"', stringify_attributes(['class' => 'foo', 'id' => 'bar']));
+        $this->assertSame(' class="foo" id="bar"', stringify_attributes(['class' => 'foo', 'id' => 'bar']));
 
         $atts        = new stdClass();
         $atts->class = 'foo';
         $atts->id    = 'bar';
-        $this->assertEquals(' class="foo" id="bar"', stringify_attributes($atts));
+        $this->assertSame(' class="foo" id="bar"', stringify_attributes($atts));
 
         $atts = new stdClass();
-        $this->assertEquals('', stringify_attributes($atts));
+        $this->assertSame('', stringify_attributes($atts));
 
-        $this->assertEquals(' class="foo" id="bar"', stringify_attributes('class="foo" id="bar"'));
+        $this->assertSame(' class="foo" id="bar"', stringify_attributes('class="foo" id="bar"'));
 
-        $this->assertEquals('', stringify_attributes([]));
+        $this->assertSame('', stringify_attributes([]));
     }
 
     public function testStringifyJsAttributes()
     {
-        $this->assertEquals('width=800,height=600', stringify_attributes(['width' => '800', 'height' => '600'], true));
+        $this->assertSame('width=800,height=600', stringify_attributes(['width' => '800', 'height' => '600'], true));
 
         $atts         = new stdClass();
         $atts->width  = 800;
         $atts->height = 600;
-        $this->assertEquals('width=800,height=600', stringify_attributes($atts, true));
+        $this->assertSame('width=800,height=600', stringify_attributes($atts, true));
     }
 
     public function testEnvReturnsDefault()
     {
-        $this->assertEquals('baz', env('foo', 'baz'));
+        $this->assertSame('baz', env('foo', 'baz'));
     }
 
     public function testEnvGetsFromSERVER()
     {
         $_SERVER['foo'] = 'bar';
 
-        $this->assertEquals('bar', env('foo', 'baz'));
+        $this->assertSame('bar', env('foo', 'baz'));
     }
 
     public function testEnvGetsFromENV()
     {
         $_ENV['foo'] = 'bar';
 
-        $this->assertEquals('bar', env('foo', 'baz'));
+        $this->assertSame('bar', env('foo', 'baz'));
     }
 
     public function testEnvBooleans()
@@ -145,14 +145,14 @@ final class CommonFunctionsTest extends CIUnitTestCase
     public function testViewCell()
     {
         $expected = 'Hello';
-        $this->assertEquals($expected, view_cell('\Tests\Support\View\SampleClass::hello'));
+        $this->assertSame($expected, view_cell('\Tests\Support\View\SampleClass::hello'));
     }
 
     public function testEscapeWithDifferentEncodings()
     {
-        $this->assertEquals('&lt;x', esc('<x', 'html', 'utf-8'));
-        $this->assertEquals('&lt;x', esc('<x', 'html', 'iso-8859-1'));
-        $this->assertEquals('&lt;x', esc('<x', 'html', 'windows-1251'));
+        $this->assertSame('&lt;x', esc('<x', 'html', 'utf-8'));
+        $this->assertSame('&lt;x', esc('<x', 'html', 'iso-8859-1'));
+        $this->assertSame('&lt;x', esc('<x', 'html', 'windows-1251'));
     }
 
     public function testEscapeBadContext()
@@ -182,7 +182,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
         $_SESSION['notbogus'] = 'Hi there';
 
-        $this->assertEquals('Hi there', session('notbogus'));
+        $this->assertSame('Hi there', session('notbogus'));
     }
 
     /**
@@ -203,37 +203,37 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $routes = service('routes');
         $routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2');
 
-        $this->assertEquals('/path/string/to/13', route_to('myController::goto', 'string', 13));
+        $this->assertSame('/path/string/to/13', route_to('myController::goto', 'string', 13));
     }
 
     public function testInvisible()
     {
-        $this->assertEquals('Javascript', remove_invisible_characters("Java\0script"));
+        $this->assertSame('Javascript', remove_invisible_characters("Java\0script"));
     }
 
     public function testInvisibleEncoded()
     {
-        $this->assertEquals('Javascript', remove_invisible_characters('Java%0cscript'));
+        $this->assertSame('Javascript', remove_invisible_characters('Java%0cscript'));
     }
 
     public function testAppTimezone()
     {
-        $this->assertEquals('America/Chicago', app_timezone());
+        $this->assertSame('America/Chicago', app_timezone());
     }
 
     public function testCSRFToken()
     {
-        $this->assertEquals('csrf_test_name', csrf_token());
+        $this->assertSame('csrf_test_name', csrf_token());
     }
 
     public function testCSRFHeader()
     {
-        $this->assertEquals('X-CSRF-TOKEN', csrf_header());
+        $this->assertSame('X-CSRF-TOKEN', csrf_header());
     }
 
     public function testHash()
     {
-        $this->assertEquals(32, strlen(csrf_hash()));
+        $this->assertSame(32, strlen(csrf_hash()));
     }
 
     public function testCSRFField()
@@ -296,9 +296,9 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $response = new RedirectResponse(new App());
         $response->withInput();
 
-        $this->assertEquals('bar', old('foo')); // regular parameter
-        $this->assertEquals('doo', old('yabba dabba', 'doo')); // non-existing parameter
-        $this->assertEquals('fritz', old('zibble')); // serialized parameter
+        $this->assertSame('bar', old('foo')); // regular parameter
+        $this->assertSame('doo', old('yabba dabba', 'doo')); // non-existing parameter
+        $this->assertSame('fritz', old('zibble')); // serialized parameter
     }
 
     /**
@@ -335,7 +335,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $response = new RedirectResponse(new App());
         $response->withInput();
 
-        $this->assertEquals($locations, old('location'));
+        $this->assertSame($locations, old('location'));
     }
 
     public function testReallyWritable()
@@ -346,9 +346,9 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
     public function testSlashItem()
     {
-        $this->assertEquals('/', slash_item('cookiePath')); // slash already there
-        $this->assertEquals('', slash_item('cookieDomain')); // empty, so untouched
-        $this->assertEquals('en/', slash_item('defaultLocale')); // slash appended
+        $this->assertSame('/', slash_item('cookiePath')); // slash already there
+        $this->assertSame('', slash_item('cookieDomain')); // empty, so untouched
+        $this->assertSame('en/', slash_item('defaultLocale')); // slash appended
     }
 
     protected function injectSessionMock()
@@ -425,7 +425,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
         force_https();
 
-        $this->assertEquals('https://example.com/', Services::response()->header('Location')->getValue());
+        $this->assertSame('https://example.com/', Services::response()->header('Location')->getValue());
     }
 
     /**
@@ -433,7 +433,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
      */
     public function testCleanPathActuallyCleaningThePaths($input, $expected)
     {
-        $this->assertEquals($expected, clean_path($input));
+        $this->assertSame($expected, clean_path($input));
     }
 
     public function dirtyPathsProvider()

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -192,7 +192,7 @@ final class BaseConfigTest extends CIUnitTestCase
 
         $config = new SimpleConfig();
 
-        $this->assertEquals(0, $config->QZERO);
+        $this->assertSame(0, (int) $config->QZERO);
         $this->assertSame('0', $config->QZEROSTR);
         $this->assertSame(' ', $config->QEMPTYSTR);
         $this->assertFalse($config->QFALSE);

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -51,10 +51,10 @@ final class DotEnvTest extends CIUnitTestCase
     {
         $dotenv = new DotEnv($this->fixturesFolder);
         $dotenv->load();
-        $this->assertEquals('bar', getenv('FOO'));
-        $this->assertEquals('baz', getenv('BAR'));
-        $this->assertEquals('with spaces', getenv('SPACED'));
-        $this->assertEquals('', getenv('NULL'));
+        $this->assertSame('bar', getenv('FOO'));
+        $this->assertSame('baz', getenv('BAR'));
+        $this->assertSame('with spaces', getenv('SPACED'));
+        $this->assertSame('', getenv('NULL'));
     }
 
     //--------------------------------------------------------------------
@@ -68,9 +68,9 @@ final class DotEnvTest extends CIUnitTestCase
         $dotenv = new DotEnv($this->fixturesFolder, 'encryption.env');
         $dotenv->load();
 
-        $this->assertEquals('hex2bin:f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6', getenv('encryption.key'));
-        $this->assertEquals('hex2bin:f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6', getenv('different.key'));
-        $this->assertEquals('OpenSSL', getenv('encryption.driver'));
+        $this->assertSame('hex2bin:f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6', getenv('encryption.key'));
+        $this->assertSame('hex2bin:f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6', getenv('different.key'));
+        $this->assertSame('OpenSSL', getenv('encryption.driver'));
     }
 
     //--------------------------------------------------------------------
@@ -84,8 +84,8 @@ final class DotEnvTest extends CIUnitTestCase
         $dotenv = new DotEnv($this->fixturesFolder, 'base64encryption.env');
         $dotenv->load();
 
-        $this->assertEquals('base64:L40bKo6b8Nu541LeVeZ1i5RXfGgnkar42CPTfukhGhw=', getenv('encryption.key'));
-        $this->assertEquals('OpenSSL', getenv('encryption.driver'));
+        $this->assertSame('base64:L40bKo6b8Nu541LeVeZ1i5RXfGgnkar42CPTfukhGhw=', getenv('encryption.key'));
+        $this->assertSame('OpenSSL', getenv('encryption.driver'));
     }
 
     //--------------------------------------------------------------------
@@ -94,10 +94,10 @@ final class DotEnvTest extends CIUnitTestCase
     {
         $dotenv = new DotEnv($this->fixturesFolder, 2);
         $dotenv->load();
-        $this->assertEquals('bar', getenv('FOO'));
-        $this->assertEquals('baz', getenv('BAR'));
-        $this->assertEquals('with spaces', getenv('SPACED'));
-        $this->assertEquals('', getenv('NULL'));
+        $this->assertSame('bar', getenv('FOO'));
+        $this->assertSame('baz', getenv('BAR'));
+        $this->assertSame('with spaces', getenv('SPACED'));
+        $this->assertSame('', getenv('NULL'));
     }
 
     //--------------------------------------------------------------------
@@ -106,13 +106,13 @@ final class DotEnvTest extends CIUnitTestCase
     {
         $dotenv = new DotEnv($this->fixturesFolder, 'commented.env');
         $dotenv->load();
-        $this->assertEquals('bar', getenv('CFOO'));
+        $this->assertSame('bar', getenv('CFOO'));
         $this->assertFalse(getenv('CBAR'));
         $this->assertFalse(getenv('CZOO'));
-        $this->assertEquals('with spaces', getenv('CSPACED'));
-        $this->assertEquals('a value with a # character', getenv('CQUOTES'));
-        $this->assertEquals('a value with a # character & a quote " character inside quotes', getenv('CQUOTESWITHQUOTE'));
-        $this->assertEquals('', getenv('CNULL'));
+        $this->assertSame('with spaces', getenv('CSPACED'));
+        $this->assertSame('a value with a # character', getenv('CQUOTES'));
+        $this->assertSame('a value with a # character & a quote " character inside quotes', getenv('CQUOTESWITHQUOTE'));
+        $this->assertSame('', getenv('CNULL'));
     }
 
     //--------------------------------------------------------------------
@@ -134,12 +134,12 @@ final class DotEnvTest extends CIUnitTestCase
     {
         $dotenv = new Dotenv($this->fixturesFolder, 'quoted.env');
         $dotenv->load();
-        $this->assertEquals('bar', getenv('QFOO'));
-        $this->assertEquals('baz', getenv('QBAR'));
-        $this->assertEquals('with spaces', getenv('QSPACED'));
-        $this->assertEquals('', getenv('QNULL'));
-        $this->assertEquals('pgsql:host=localhost;dbname=test', getenv('QEQUALS'));
-        $this->assertEquals('test some escaped characters like a quote (") or maybe a backslash (\\)', getenv('QESCAPED'));
+        $this->assertSame('bar', getenv('QFOO'));
+        $this->assertSame('baz', getenv('QBAR'));
+        $this->assertSame('with spaces', getenv('QSPACED'));
+        $this->assertSame('', getenv('QNULL'));
+        $this->assertSame('pgsql:host=localhost;dbname=test', getenv('QEQUALS'));
+        $this->assertSame('test some escaped characters like a quote (") or maybe a backslash (\\)', getenv('QESCAPED'));
     }
 
     //--------------------------------------------------------------------
@@ -160,10 +160,10 @@ final class DotEnvTest extends CIUnitTestCase
         $dotenv = new Dotenv($this->fixturesFolder, '.env');
         $dotenv->load();
 
-        $this->assertEquals('bar', $_SERVER['FOO']);
-        $this->assertEquals('baz', $_SERVER['BAR']);
-        $this->assertEquals('with spaces', $_SERVER['SPACED']);
-        $this->assertEquals('', $_SERVER['NULL']);
+        $this->assertSame('bar', $_SERVER['FOO']);
+        $this->assertSame('baz', $_SERVER['BAR']);
+        $this->assertSame('with spaces', $_SERVER['SPACED']);
+        $this->assertSame('', $_SERVER['NULL']);
     }
 
     //--------------------------------------------------------------------
@@ -173,7 +173,7 @@ final class DotEnvTest extends CIUnitTestCase
         $dotenv = new Dotenv($this->fixturesFolder, '.env');
         $dotenv->load();
 
-        $this->assertEquals('complex', $_SERVER['SimpleConfig.simple.name']);
+        $this->assertSame('complex', $_SERVER['SimpleConfig.simple.name']);
     }
 
     //--------------------------------------------------------------------
@@ -184,7 +184,7 @@ final class DotEnvTest extends CIUnitTestCase
         $dotenv             = new Dotenv($this->fixturesFolder, 'nested.env');
         $dotenv->load();
 
-        $this->assertEquals('TT', $_ENV['NVAR7']);
+        $this->assertSame('TT', $_ENV['NVAR7']);
     }
 
     //--------------------------------------------------------------------
@@ -193,10 +193,10 @@ final class DotEnvTest extends CIUnitTestCase
     {
         $dotenv = new Dotenv($this->fixturesFolder);
         $dotenv->load();
-        $this->assertEquals('bar', $_ENV['FOO']);
-        $this->assertEquals('baz', $_ENV['BAR']);
-        $this->assertEquals('with spaces', $_ENV['SPACED']);
-        $this->assertEquals('', $_ENV['NULL']);
+        $this->assertSame('bar', $_ENV['FOO']);
+        $this->assertSame('baz', $_ENV['BAR']);
+        $this->assertSame('with spaces', $_ENV['SPACED']);
+        $this->assertSame('', $_ENV['NULL']);
     }
 
     //--------------------------------------------------------------------
@@ -205,10 +205,10 @@ final class DotEnvTest extends CIUnitTestCase
     {
         $dotenv = new Dotenv($this->fixturesFolder, 'nested.env');
         $dotenv->load();
-        $this->assertEquals('{$NVAR1} {$NVAR2}', $_ENV['NVAR3']); // not resolved
-        $this->assertEquals('Hello World!', $_ENV['NVAR4']);
-        $this->assertEquals('$NVAR1 {NVAR2}', $_ENV['NVAR5']); // not resolved
-        $this->assertEquals('Hello/World!', $_ENV['NVAR8']);
+        $this->assertSame('{$NVAR1} {$NVAR2}', $_ENV['NVAR3']); // not resolved
+        $this->assertSame('Hello World!', $_ENV['NVAR4']);
+        $this->assertSame('$NVAR1 {NVAR2}', $_ENV['NVAR5']); // not resolved
+        $this->assertSame('Hello/World!', $_ENV['NVAR8']);
     }
 
     //--------------------------------------------------------------------
@@ -217,11 +217,11 @@ final class DotEnvTest extends CIUnitTestCase
     {
         $dotenv = new Dotenv($this->fixturesFolder, 'specialchars.env');
         $dotenv->load();
-        $this->assertEquals('$a6^C7k%zs+e^.jvjXk', getenv('SPVAR1'));
-        $this->assertEquals('?BUty3koaV3%GA*hMAwH}B', getenv('SPVAR2'));
-        $this->assertEquals('jdgEB4{QgEC]HL))&GcXxokB+wqoN+j>xkV7K?m$r', getenv('SPVAR3'));
-        $this->assertEquals('22222:22#2^{', getenv('SPVAR4'));
-        $this->assertEquals('test some escaped characters like a quote " or maybe a backslash \\', getenv('SPVAR5'));
+        $this->assertSame('$a6^C7k%zs+e^.jvjXk', getenv('SPVAR1'));
+        $this->assertSame('?BUty3koaV3%GA*hMAwH}B', getenv('SPVAR2'));
+        $this->assertSame('jdgEB4{QgEC]HL))&GcXxokB+wqoN+j>xkV7K?m$r', getenv('SPVAR3'));
+        $this->assertSame('22222:22#2^{', getenv('SPVAR4'));
+        $this->assertSame('test some escaped characters like a quote " or maybe a backslash \\', getenv('SPVAR5'));
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -52,7 +52,7 @@ final class FactoriesTest extends CIUnitTestCase
         $result = Factories::getOptions('blahblahs');
 
         $this->assertTrue($result['preferApp']);
-        $this->assertEquals('Blahblahs', $result['path']);
+        $this->assertSame('Blahblahs', $result['path']);
     }
 
     public function testSetsOptions()
@@ -61,7 +61,7 @@ final class FactoriesTest extends CIUnitTestCase
 
         $result = Factories::getOptions('widgets');
 
-        $this->assertEquals('bar', $result['foo']);
+        $this->assertSame('bar', $result['foo']);
         $this->assertTrue($result['preferApp']);
     }
 
@@ -74,7 +74,7 @@ final class FactoriesTest extends CIUnitTestCase
 
         $result = Factories::getOptions('widgets');
 
-        $this->assertEquals('bam', $result['bar']);
+        $this->assertSame('bam', $result['bar']);
     }
 
     public function testSetOptionsResets()
@@ -99,7 +99,7 @@ final class FactoriesTest extends CIUnitTestCase
         Factories::reset();
 
         $result = $this->getFactoriesStaticProperty('options');
-        $this->assertEquals([], $result);
+        $this->assertSame([], $result);
     }
 
     public function testResetsComponentOnly()
@@ -118,22 +118,22 @@ final class FactoriesTest extends CIUnitTestCase
 
     public function testGetsBasenameByBasename()
     {
-        $this->assertEquals('SomeWidget', Factories::getBasename('SomeWidget'));
+        $this->assertSame('SomeWidget', Factories::getBasename('SomeWidget'));
     }
 
     public function testGetsBasenameByClassname()
     {
-        $this->assertEquals('SomeWidget', Factories::getBasename(SomeWidget::class));
+        $this->assertSame('SomeWidget', Factories::getBasename(SomeWidget::class));
     }
 
     public function testGetsBasenameByAbsoluteClassname()
     {
-        $this->assertEquals('UserModel', Factories::getBasename('\Tests\Support\Models\UserModel'));
+        $this->assertSame('UserModel', Factories::getBasename('\Tests\Support\Models\UserModel'));
     }
 
     public function testGetsBasenameInvalid()
     {
-        $this->assertEquals('', Factories::getBasename('Tests\\Support\\'));
+        $this->assertSame('', Factories::getBasename('Tests\\Support\\'));
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Config/MimesTest.php
+++ b/tests/system/Config/MimesTest.php
@@ -46,7 +46,7 @@ final class MimesTest extends CIUnitTestCase
      */
     public function testGuessExtensionFromType($expected, $mime)
     {
-        $this->assertEquals($expected, Mimes::guessExtensionFromType($mime));
+        $this->assertSame($expected, Mimes::guessExtensionFromType($mime));
     }
 
     //--------------------------------------------------------------------
@@ -84,7 +84,7 @@ final class MimesTest extends CIUnitTestCase
      */
     public function testGuessTypeFromExtension($expected, $ext)
     {
-        $this->assertEquals($expected, Mimes::guessTypeFromExtension($ext));
+        $this->assertSame($expected, Mimes::guessTypeFromExtension($ext));
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -171,20 +171,20 @@ final class ServicesTest extends CIUnitTestCase
     {
         $actual = Services::language();
         $this->assertInstanceOf(Language::class, $actual);
-        $this->assertEquals('en', $actual->getLocale());
+        $this->assertSame('en', $actual->getLocale());
 
         Services::language('la');
-        $this->assertEquals('la', $actual->getLocale());
+        $this->assertSame('la', $actual->getLocale());
     }
 
     public function testNewUnsharedLanguage()
     {
         $actual = Services::language(null, false);
         $this->assertInstanceOf(Language::class, $actual);
-        $this->assertEquals('en', $actual->getLocale());
+        $this->assertSame('en', $actual->getLocale());
 
         Services::language('la', false);
-        $this->assertEquals('en', $actual->getLocale());
+        $this->assertSame('en', $actual->getLocale());
     }
 
     public function testNewPager()
@@ -294,7 +294,12 @@ final class ServicesTest extends CIUnitTestCase
         $response2 = service('response');
         $this->assertInstanceOf(MockResponse::class, $response2);
 
-        $this->assertEquals($response, $response2);
+        Services::injectMock('response', $response);
+        $response3 = service('response');
+        $this->assertInstanceOf(MockResponse::class, $response3);
+
+        $this->assertNotSame($response, $response2);
+        $this->assertSame($response, $response3);
     }
 
     /**

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -141,7 +141,7 @@ final class ControllerTest extends CIUnitTestCase
 
         $method = $this->getPrivateMethodInvoker($this->controller, 'validate');
         $this->assertFalse($method('signup'));
-        $this->assertEquals('You must choose a username.', Services::validation()->getError());
+        $this->assertSame('You must choose a username.', Services::validation()->getError());
     }
 
     public function testValidateWithStringRulesFoundUseMessagesParameter()
@@ -161,7 +161,7 @@ final class ControllerTest extends CIUnitTestCase
                 'required' => 'You must choose a username.',
             ],
         ]));
-        $this->assertEquals('You must choose a username.', Services::validation()->getError());
+        $this->assertSame('You must choose a username.', Services::validation()->getError());
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Cookie/CookieTest.php
+++ b/tests/system/Cookie/CookieTest.php
@@ -167,7 +167,7 @@ final class CookieTest extends CIUnitTestCase
     {
         $cookie = Cookie::fromHeaderString($header);
         $cookie = $cookie->toArray();
-        $this->assertEquals($changed + $cookie, $cookie);
+        $this->assertSame(array_merge($cookie, $changed), $cookie);
     }
 
     public static function setCookieHeaderProvider(): iterable

--- a/tests/system/Database/BaseQueryTest.php
+++ b/tests/system/Database/BaseQueryTest.php
@@ -26,7 +26,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $query->setQuery($sql);
 
-        $this->assertEquals($sql, $query->getQuery());
+        $this->assertSame($sql, $query->getQuery());
     }
 
     public function testStoresDuration()
@@ -37,7 +37,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $query->setDuration($start, $start + 5);
 
-        $this->assertEquals(5, $query->getDuration());
+        $this->assertSame(5, (int) $query->getDuration());
     }
 
     public function testGetStartTime()
@@ -48,7 +48,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $query->setDuration($start, $start + 5);
 
-        $this->assertEquals($start, $query->getStartTime(true));
+        $this->assertSame($start, $query->getStartTime(true));
     }
 
     public function testGetStartTimeNumberFormat()
@@ -59,7 +59,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $query->setDuration($start, $start + 5);
 
-        $this->assertEquals(number_format($start, 6), $query->getStartTime());
+        $this->assertSame(number_format($start, 6), $query->getStartTime());
     }
 
     public function testsStoresErrorInformation()
@@ -73,8 +73,8 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $query->setError($code, $msg);
         $this->assertTrue($query->hasError());
-        $this->assertEquals($code, $query->getErrorCode());
-        $this->assertEquals($msg, $query->getErrorMessage());
+        $this->assertSame($code, $query->getErrorCode());
+        $this->assertSame($msg, $query->getErrorMessage());
     }
 
     public function testSwapPrefix()
@@ -90,7 +90,7 @@ final class BaseQueryTest extends CIUnitTestCase
         $query->setQuery($origSQL);
         $query->swapPrefix($origPrefix, $newPrefix);
 
-        $this->assertEquals($newSQL, $query->getQuery());
+        $this->assertSame($newSQL, $query->getQuery());
     }
 
     public function queryTypes()
@@ -190,7 +190,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM users WHERE id = 13';
 
-        $this->assertEquals($expected, $query->getQuery());
+        $this->assertSame($expected, $query->getQuery());
     }
 
     public function testBindingSingleElementInArray()
@@ -201,7 +201,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM users WHERE id = 13';
 
-        $this->assertEquals($expected, $query->getQuery());
+        $this->assertSame($expected, $query->getQuery());
     }
 
     public function testBindingMultipleItems()
@@ -212,7 +212,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $expected = "SELECT * FROM users WHERE id = 13 OR name = 'Vader'";
 
-        $this->assertEquals($expected, $query->getQuery());
+        $this->assertSame($expected, $query->getQuery());
     }
 
     public function testBindingAutoEscapesParameters()
@@ -223,7 +223,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $expected = "SELECT * FROM users WHERE name = 'O''Reilly'";
 
-        $this->assertEquals($expected, $query->getQuery());
+        $this->assertSame($expected, $query->getQuery());
     }
 
     public function testNamedBinds()
@@ -234,7 +234,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $expected = "SELECT * FROM users WHERE id = 13 OR name = 'Geoffrey'";
 
-        $this->assertEquals($expected, $query->getQuery());
+        $this->assertSame($expected, $query->getQuery());
     }
 
     /**
@@ -262,7 +262,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $expected = "SELECT * FROM users WHERE sitemap = 'sitemap' OR site = 'site'";
 
-        $this->assertEquals($expected, $query->getQuery());
+        $this->assertSame($expected, $query->getQuery());
     }
 
     /**
@@ -276,7 +276,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $expected = 'UPDATE user_table SET `x` = NOW() WHERE `id` = 22';
 
-        $this->assertEquals($expected, $query->getQuery());
+        $this->assertSame($expected, $query->getQuery());
     }
 
     /**
@@ -299,7 +299,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $expected = 'UPDATE user_table SET `x` = NOW() WHERE `id` = 22';
 
-        $this->assertEquals($expected, $query->getQuery());
+        $this->assertSame($expected, $query->getQuery());
     }
 
     /**
@@ -318,6 +318,6 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $expected = 'SELECT @factorA := 1, @factorB := 2';
 
-        $this->assertEquals($expected, $query->getQuery());
+        $this->assertSame($expected, $query->getQuery());
     }
 }

--- a/tests/system/Database/Builder/AliasTest.php
+++ b/tests/system/Database/Builder/AliasTest.php
@@ -29,7 +29,7 @@ final class AliasTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" "j"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -40,7 +40,7 @@ final class AliasTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" "j", "users" "u"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -51,7 +51,7 @@ final class AliasTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" "j", "users" "u"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -68,7 +68,7 @@ final class AliasTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "db_jobs" LEFT JOIN "db_users" as "u" ON "u"."id" = "db_jobs"."id"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     /**
@@ -83,6 +83,6 @@ final class AliasTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "db_jobs" LEFT JOIN "db_users" as "u" ON "db_users"."id" = "db_jobs"."id"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 }

--- a/tests/system/Database/Builder/BaseTest.php
+++ b/tests/system/Database/Builder/BaseTest.php
@@ -40,7 +40,7 @@ final class BaseTest extends CIUnitTestCase
         $builder = $this->db->table('jobs');
 
         $result = $builder->getTable();
-        $this->assertEquals('jobs', $result);
+        $this->assertSame('jobs', $result);
     }
 
     public function testGetTableIgnoresFrom()
@@ -49,6 +49,6 @@ final class BaseTest extends CIUnitTestCase
 
         $builder->from('foo');
         $result = $builder->getTable();
-        $this->assertEquals('jobs', $result);
+        $this->assertSame('jobs', $result);
     }
 }

--- a/tests/system/Database/Builder/DistinctTest.php
+++ b/tests/system/Database/Builder/DistinctTest.php
@@ -32,7 +32,7 @@ final class DistinctTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT DISTINCT "country" FROM "user"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Database/Builder/EmptyTest.php
+++ b/tests/system/Database/Builder/EmptyTest.php
@@ -32,7 +32,7 @@ final class EmptyTest extends CIUnitTestCase
 
         $expectedSQL = 'DELETE FROM "jobs"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $answer));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $answer));
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -33,7 +33,7 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user", "jobs"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -46,7 +46,7 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -59,7 +59,7 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user", "jobs", "roles"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -72,7 +72,7 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user", "jobs", "roles"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -85,23 +85,23 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user", "jobs", "roles"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 
         $expectedSQL = 'SELECT * FROM "user"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 
         $expectedSQL = 'SELECT *';
 
         $builder->from(null, true);
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 
         $expectedSQL = 'SELECT * FROM "jobs"';
 
         $builder->from('jobs');
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -116,7 +116,7 @@ final class FromTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "test"."dbo"."user", "test"."dbo"."jobs", "test"."dbo"."roles"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Database/Builder/GetTest.php
+++ b/tests/system/Database/Builder/GetTest.php
@@ -29,7 +29,7 @@ final class GetTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "users"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -45,9 +45,9 @@ final class GetTest extends CIUnitTestCase
         $expectedSQL           = 'SELECT * FROM "users" WHERE "username" = \'bogus\'';
         $expectedSQLafterreset = 'SELECT * FROM "users"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, false)));
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, true)));
-        $this->assertEquals($expectedSQLafterreset, str_replace("\n", ' ', $builder->get(0, 50, true)));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, false)));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, true)));
+        $this->assertSame($expectedSQLafterreset, str_replace("\n", ' ', $builder->get(0, 50, true)));
     }
 
     //--------------------------------------------------------------------
@@ -63,9 +63,9 @@ final class GetTest extends CIUnitTestCase
         $expectedSQL             = 'SELECT * FROM "users" WHERE "username" = \'bogus\'  LIMIT 5';
         $expectedSQLWithoutReset = 'SELECT * FROM "users" WHERE "username" = \'bogus\' AND "username" = \'bogus\'  LIMIT 5';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, null, false)));
-        $this->assertEquals($expectedSQLWithoutReset, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 0, true)));
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, null, true)));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, null, false)));
+        $this->assertSame($expectedSQLWithoutReset, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 0, true)));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, null, true)));
     }
 
     //--------------------------------------------------------------------
@@ -78,9 +78,9 @@ final class GetTest extends CIUnitTestCase
         $expectedSQL             = 'SELECT * FROM "users" WHERE "username" = \'bogus\'  LIMIT 10, 5';
         $expectedSQLWithoutReset = 'SELECT * FROM "users" WHERE "username" = \'bogus\' AND "username" = \'bogus\'  LIMIT 10, 5';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 10, false)));
-        $this->assertEquals($expectedSQLWithoutReset, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 10, true)));
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 10, true)));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 10, false)));
+        $this->assertSame($expectedSQLWithoutReset, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 10, true)));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], 5, 10, true)));
     }
 
     //--------------------------------------------------------------------
@@ -93,9 +93,9 @@ final class GetTest extends CIUnitTestCase
         $expectedSQL             = 'SELECT * FROM "users" WHERE "username" = \'bogus\'';
         $expectedSQLWithoutReset = 'SELECT * FROM "users" WHERE "username" = \'bogus\' AND "username" = \'bogus\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], null, null, false)));
-        $this->assertEquals($expectedSQLWithoutReset, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], null, null, true)));
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], null, null, true)));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], null, null, false)));
+        $this->assertSame($expectedSQLWithoutReset, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], null, null, true)));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getWhere(['username' => 'bogus'], null, null, true)));
     }
 
     //--------------------------------------------------------------------
@@ -107,6 +107,6 @@ final class GetTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "users"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getWhere(null, null, null, true)));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getWhere(null, null, null, true)));
     }
 }

--- a/tests/system/Database/Builder/GroupTest.php
+++ b/tests/system/Database/Builder/GroupTest.php
@@ -32,7 +32,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -47,7 +47,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) > 2';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -63,7 +63,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" > 3 OR SUM(id) > 2';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -78,7 +78,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" IN (1,2)';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -95,7 +95,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -111,7 +111,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" IN (1,2) OR "group_id" IN (5,6)';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -131,7 +131,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3) OR "group_id" IN (SELECT "group_id" FROM "groups" WHERE "group_id" = 6)';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -146,7 +146,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" NOT IN (1,2)';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -163,7 +163,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -179,7 +179,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" NOT IN (1,2) OR "group_id" NOT IN (5,6)';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -199,7 +199,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3) OR "group_id" NOT IN (SELECT "group_id" FROM "groups" WHERE "group_id" = 6)';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -214,7 +214,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a%\' ESCAPE \'!\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -229,7 +229,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a\' ESCAPE \'!\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -244,7 +244,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'a%\' ESCAPE \'!\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -259,7 +259,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" NOT LIKE \'%a%\' ESCAPE \'!\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -274,7 +274,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" NOT LIKE \'%a\' ESCAPE \'!\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -289,7 +289,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" NOT LIKE \'a%\' ESCAPE \'!\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -305,7 +305,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a%\' ESCAPE \'!\' OR  "pet_color" LIKE \'%b%\' ESCAPE \'!\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -321,7 +321,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a\' ESCAPE \'!\' OR  "pet_color" LIKE \'%b\' ESCAPE \'!\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -337,7 +337,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'a%\' ESCAPE \'!\' OR  "pet_color" LIKE \'b%\' ESCAPE \'!\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -353,7 +353,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a%\' ESCAPE \'!\' OR  "pet_color" NOT LIKE \'%b%\' ESCAPE \'!\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -369,7 +369,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'%a\' ESCAPE \'!\' OR  "pet_color" NOT LIKE \'%b\' ESCAPE \'!\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -385,7 +385,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING "pet_name" LIKE \'a%\' ESCAPE \'!\' OR  "pet_color" NOT LIKE \'b%\' ESCAPE \'!\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -404,7 +404,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) < 3 AND   ( SUM(id) = 2 AND "name" = \'adam\'  )';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -423,7 +423,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) > 3 OR   ( SUM(id) = 2 AND "name" = \'adam\'  )';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -442,7 +442,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) < 3 AND NOT   ( SUM(id) = 2 AND "name" = \'adam\'  )';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -461,7 +461,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT "name" FROM "user" GROUP BY "name" HAVING SUM(id) < 3 OR NOT   ( SUM(id) = 2 AND "name" = \'adam\'  )';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -478,7 +478,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" WHERE   ( "id" > 3 AND "name" != \'Luke\'  ) AND "name" = \'Darth\'';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -495,7 +495,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" WHERE "name" = \'Darth\' OR   ( "id" > 3 AND "name" != \'Luke\'  )';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -512,7 +512,7 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" WHERE "name" = \'Darth\' AND NOT   ( "id" > 3 AND "name" != \'Luke\'  )';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -529,6 +529,6 @@ final class GroupTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" WHERE "name" = \'Darth\' OR NOT   ( "id" > 3 AND "name" != \'Luke\'  )';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 }

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -45,8 +45,8 @@ final class InsertTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
-        $this->assertEquals($expectedBinds, $builder->getBinds());
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
     public function testThrowsExceptionOnNoValuesSet()
@@ -83,10 +83,10 @@ final class InsertTest extends CIUnitTestCase
         $this->assertInstanceOf(Query::class, $query);
 
         $raw = 'INSERT INTO "jobs" ("description", "id", "name") VALUES (:description:,:id:,:name:), (:description.1:,:id.1:,:name.1:)';
-        $this->assertEquals($raw, str_replace("\n", ' ', $query->getOriginalQuery() ));
+        $this->assertSame($raw, str_replace("\n", ' ', $query->getOriginalQuery() ));
 
         $expected = "INSERT INTO \"jobs\" (\"description\", \"id\", \"name\") VALUES ('There''s something in your teeth',2,'Commedian'), ('I am yellow',3,'Cab Driver')";
-        $this->assertEquals($expected, str_replace("\n", ' ', $query->getQuery()));
+        $this->assertSame($expected, str_replace("\n", ' ', $query->getQuery()));
     }
 
     /**

--- a/tests/system/Database/Builder/JoinTest.php
+++ b/tests/system/Database/Builder/JoinTest.php
@@ -34,7 +34,7 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" JOIN "job" ON "user"."id" = "job"."id"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -47,7 +47,7 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "table1" JOIN "table2" ON "field" IS NULL';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -60,7 +60,7 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "table1" JOIN "table2" ON "field" IS NOT NULL';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -73,7 +73,7 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = "SELECT * FROM \"table1\" LEFT JOIN \"table2\" ON \"table1\".\"field1\" = \"table2\".\"field2\" AND \"table1\".\"field1\" = 'foo' AND \"table2\".\"field2\" = 0";
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -86,7 +86,7 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" FULL OUTER JOIN "users" as "u" ON "users"."id" = "jobs"."id"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -101,7 +101,7 @@ final class JoinTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "test"."dbo"."jobs" LEFT JOIN "test"."dbo"."users" "u" ON "u"."id" = "jobs"."id"';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Database/Builder/LimitTest.php
+++ b/tests/system/Database/Builder/LimitTest.php
@@ -32,7 +32,7 @@ final class LimitTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user"  LIMIT 5';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -45,7 +45,7 @@ final class LimitTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user"  LIMIT 1, 5';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -58,7 +58,7 @@ final class LimitTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user"  LIMIT 1, 5';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Database/Builder/OrderTest.php
+++ b/tests/system/Database/Builder/OrderTest.php
@@ -32,7 +32,7 @@ final class OrderTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" ORDER BY "name" ASC';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -45,7 +45,7 @@ final class OrderTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" ORDER BY "name" DESC';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -58,7 +58,7 @@ final class OrderTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "user" ORDER BY RAND()';
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Database/Builder/PrefixTest.php
+++ b/tests/system/Database/Builder/PrefixTest.php
@@ -27,7 +27,7 @@ final class PrefixTest extends CIUnitTestCase
     {
         $expected = 'ci_users';
 
-        $this->assertEquals($expected, $this->db->prefixTable('users'));
+        $this->assertSame($expected, $this->db->prefixTable('users'));
     }
 
     //--------------------------------------------------------------------
@@ -43,7 +43,7 @@ final class PrefixTest extends CIUnitTestCase
 
         $builder->where($where);
 
-        $this->assertEquals($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 }

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -32,7 +32,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM "users"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -45,7 +45,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT "name" FROM "users"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -58,7 +58,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT "name", "role" FROM "users"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -71,7 +71,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT "name", "role" FROM "users"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -84,7 +84,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT "name", "role" as "myRole" FROM "users"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -97,7 +97,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT (SELECT SUM(payments.amount) FROM payments WHERE payments.invoice_id=4) AS amount_paid FROM "users"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -110,7 +110,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT MIN("payments") AS "payments" FROM "invoices"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -123,7 +123,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT MIN("payments") AS "myAlias" FROM "invoices"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -136,7 +136,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT MAX("payments") AS "payments" FROM "invoices"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -149,7 +149,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT MAX("payments") AS "myAlias" FROM "invoices"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -162,7 +162,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT AVG("payments") AS "payments" FROM "invoices"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -175,7 +175,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT AVG("payments") AS "myAlias" FROM "invoices"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -188,7 +188,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT SUM("payments") AS "payments" FROM "invoices"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -201,7 +201,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT SUM("payments") AS "myAlias" FROM "invoices"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -214,7 +214,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT COUNT("payments") AS "payments" FROM "invoices"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -227,7 +227,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT COUNT("payments") AS "myAlias" FROM "invoices"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -252,7 +252,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT MAX("db"."payments") AS "payments" FROM "invoices"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------
@@ -277,7 +277,7 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM "test"."dbo"."users"';
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Database/Builder/TruncateTest.php
+++ b/tests/system/Database/Builder/TruncateTest.php
@@ -30,7 +30,7 @@ final class TruncateTest extends CIUnitTestCase
 
         $expectedSQL = 'TRUNCATE "user"';
 
-        $this->assertEquals($expectedSQL, $builder->testMode()->truncate());
+        $this->assertSame($expectedSQL, $builder->testMode()->truncate());
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -104,17 +104,17 @@ final class ConfigTest extends CIUnitTestCase
         $conn = Config::connect($this->group, false);
         $this->assertInstanceOf(BaseConnection::class, $conn);
 
-        $this->assertEquals($this->group['DSN'], $this->getPrivateProperty($conn, 'DSN'));
-        $this->assertEquals($this->group['hostname'], $this->getPrivateProperty($conn, 'hostname'));
-        $this->assertEquals($this->group['username'], $this->getPrivateProperty($conn, 'username'));
-        $this->assertEquals($this->group['password'], $this->getPrivateProperty($conn, 'password'));
-        $this->assertEquals($this->group['database'], $this->getPrivateProperty($conn, 'database'));
-        $this->assertEquals($this->group['port'], $this->getPrivateProperty($conn, 'port'));
-        $this->assertEquals($this->group['DBDriver'], $this->getPrivateProperty($conn, 'DBDriver'));
-        $this->assertEquals($this->group['DBPrefix'], $this->getPrivateProperty($conn, 'DBPrefix'));
-        $this->assertEquals($this->group['pConnect'], $this->getPrivateProperty($conn, 'pConnect'));
-        $this->assertEquals($this->group['charset'], $this->getPrivateProperty($conn, 'charset'));
-        $this->assertEquals($this->group['DBCollat'], $this->getPrivateProperty($conn, 'DBCollat'));
+        $this->assertSame($this->group['DSN'], $this->getPrivateProperty($conn, 'DSN'));
+        $this->assertSame($this->group['hostname'], $this->getPrivateProperty($conn, 'hostname'));
+        $this->assertSame($this->group['username'], $this->getPrivateProperty($conn, 'username'));
+        $this->assertSame($this->group['password'], $this->getPrivateProperty($conn, 'password'));
+        $this->assertSame($this->group['database'], $this->getPrivateProperty($conn, 'database'));
+        $this->assertSame($this->group['port'], $this->getPrivateProperty($conn, 'port'));
+        $this->assertSame($this->group['DBDriver'], $this->getPrivateProperty($conn, 'DBDriver'));
+        $this->assertSame($this->group['DBPrefix'], $this->getPrivateProperty($conn, 'DBPrefix'));
+        $this->assertSame($this->group['pConnect'], $this->getPrivateProperty($conn, 'pConnect'));
+        $this->assertSame($this->group['charset'], $this->getPrivateProperty($conn, 'charset'));
+        $this->assertSame($this->group['DBCollat'], $this->getPrivateProperty($conn, 'DBCollat'));
     }
 
     public function testConnectionGroupWithDSN()
@@ -122,19 +122,19 @@ final class ConfigTest extends CIUnitTestCase
         $conn = Config::connect($this->dsnGroup, false);
         $this->assertInstanceOf(BaseConnection::class, $conn);
 
-        $this->assertEquals('', $this->getPrivateProperty($conn, 'DSN'));
-        $this->assertEquals('localhost', $this->getPrivateProperty($conn, 'hostname'));
-        $this->assertEquals('user', $this->getPrivateProperty($conn, 'username'));
-        $this->assertEquals('pass', $this->getPrivateProperty($conn, 'password'));
-        $this->assertEquals('dbname', $this->getPrivateProperty($conn, 'database'));
-        $this->assertEquals('3306', $this->getPrivateProperty($conn, 'port'));
-        $this->assertEquals('MySQLi', $this->getPrivateProperty($conn, 'DBDriver'));
-        $this->assertEquals('test_', $this->getPrivateProperty($conn, 'DBPrefix'));
+        $this->assertSame('', $this->getPrivateProperty($conn, 'DSN'));
+        $this->assertSame('localhost', $this->getPrivateProperty($conn, 'hostname'));
+        $this->assertSame('user', $this->getPrivateProperty($conn, 'username'));
+        $this->assertSame('pass', $this->getPrivateProperty($conn, 'password'));
+        $this->assertSame('dbname', $this->getPrivateProperty($conn, 'database'));
+        $this->assertSame('3306', $this->getPrivateProperty($conn, 'port'));
+        $this->assertSame('MySQLi', $this->getPrivateProperty($conn, 'DBDriver'));
+        $this->assertSame('test_', $this->getPrivateProperty($conn, 'DBPrefix'));
         $this->assertTrue($this->getPrivateProperty($conn, 'pConnect'));
-        $this->assertEquals('latin1', $this->getPrivateProperty($conn, 'charset'));
-        $this->assertEquals('latin1_swedish_ci', $this->getPrivateProperty($conn, 'DBCollat'));
+        $this->assertSame('latin1', $this->getPrivateProperty($conn, 'charset'));
+        $this->assertSame('latin1_swedish_ci', $this->getPrivateProperty($conn, 'DBCollat'));
         $this->assertTrue($this->getPrivateProperty($conn, 'strictOn'));
-        $this->assertEquals([], $this->getPrivateProperty($conn, 'failover'));
+        $this->assertSame([], $this->getPrivateProperty($conn, 'failover'));
     }
 
     public function testConnectionGroupWithDSNPostgre()
@@ -142,27 +142,27 @@ final class ConfigTest extends CIUnitTestCase
         $conn = Config::connect($this->dsnGroupPostgre, false);
         $this->assertInstanceOf(BaseConnection::class, $conn);
 
-        $this->assertEquals('', $this->getPrivateProperty($conn, 'DSN'));
-        $this->assertEquals('localhost', $this->getPrivateProperty($conn, 'hostname'));
-        $this->assertEquals('user', $this->getPrivateProperty($conn, 'username'));
-        $this->assertEquals('pass', $this->getPrivateProperty($conn, 'password'));
-        $this->assertEquals('dbname', $this->getPrivateProperty($conn, 'database'));
-        $this->assertEquals('5432', $this->getPrivateProperty($conn, 'port'));
-        $this->assertEquals('Postgre', $this->getPrivateProperty($conn, 'DBDriver'));
-        $this->assertEquals('test_', $this->getPrivateProperty($conn, 'DBPrefix'));
+        $this->assertSame('', $this->getPrivateProperty($conn, 'DSN'));
+        $this->assertSame('localhost', $this->getPrivateProperty($conn, 'hostname'));
+        $this->assertSame('user', $this->getPrivateProperty($conn, 'username'));
+        $this->assertSame('pass', $this->getPrivateProperty($conn, 'password'));
+        $this->assertSame('dbname', $this->getPrivateProperty($conn, 'database'));
+        $this->assertSame('5432', $this->getPrivateProperty($conn, 'port'));
+        $this->assertSame('Postgre', $this->getPrivateProperty($conn, 'DBDriver'));
+        $this->assertSame('test_', $this->getPrivateProperty($conn, 'DBPrefix'));
         $this->assertFalse($this->getPrivateProperty($conn, 'pConnect'));
-        $this->assertEquals('utf8', $this->getPrivateProperty($conn, 'charset'));
-        $this->assertEquals('utf8_general_ci', $this->getPrivateProperty($conn, 'DBCollat'));
+        $this->assertSame('utf8', $this->getPrivateProperty($conn, 'charset'));
+        $this->assertSame('utf8_general_ci', $this->getPrivateProperty($conn, 'DBCollat'));
         $this->assertTrue($this->getPrivateProperty($conn, 'strictOn'));
-        $this->assertEquals([], $this->getPrivateProperty($conn, 'failover'));
-        $this->assertEquals('5', $this->getPrivateProperty($conn, 'connect_timeout'));
-        $this->assertEquals('1', $this->getPrivateProperty($conn, 'sslmode'));
+        $this->assertSame([], $this->getPrivateProperty($conn, 'failover'));
+        $this->assertSame('5', $this->getPrivateProperty($conn, 'connect_timeout'));
+        $this->assertSame('1', $this->getPrivateProperty($conn, 'sslmode'));
 
         $method = $this->getPrivateMethodInvoker($conn, 'buildDSN');
         $method();
 
         $expected = "host=localhost port=5432 user=user password='pass' dbname=dbname connect_timeout='5' sslmode='1'";
-        $this->assertEquals($expected, $this->getPrivateProperty($conn, 'DSN'));
+        $this->assertSame($expected, $this->getPrivateProperty($conn, 'DSN'));
     }
 
     public function testConnectionGroupWithDSNPostgreNative()
@@ -170,18 +170,18 @@ final class ConfigTest extends CIUnitTestCase
         $conn = Config::connect($this->dsnGroupPostgreNative, false);
         $this->assertInstanceOf(BaseConnection::class, $conn);
 
-        $this->assertEquals('pgsql:host=localhost;port=5432;dbname=database_name', $this->getPrivateProperty($conn, 'DSN'));
-        $this->assertEquals('', $this->getPrivateProperty($conn, 'hostname'));
-        $this->assertEquals('', $this->getPrivateProperty($conn, 'username'));
-        $this->assertEquals('', $this->getPrivateProperty($conn, 'password'));
-        $this->assertEquals('', $this->getPrivateProperty($conn, 'database'));
-        $this->assertEquals('5432', $this->getPrivateProperty($conn, 'port'));
-        $this->assertEquals('Postgre', $this->getPrivateProperty($conn, 'DBDriver'));
-        $this->assertEquals('t_', $this->getPrivateProperty($conn, 'DBPrefix'));
+        $this->assertSame('pgsql:host=localhost;port=5432;dbname=database_name', $this->getPrivateProperty($conn, 'DSN'));
+        $this->assertSame('', $this->getPrivateProperty($conn, 'hostname'));
+        $this->assertSame('', $this->getPrivateProperty($conn, 'username'));
+        $this->assertSame('', $this->getPrivateProperty($conn, 'password'));
+        $this->assertSame('', $this->getPrivateProperty($conn, 'database'));
+        $this->assertSame(5432, $this->getPrivateProperty($conn, 'port'));
+        $this->assertSame('Postgre', $this->getPrivateProperty($conn, 'DBDriver'));
+        $this->assertSame('t_', $this->getPrivateProperty($conn, 'DBPrefix'));
         $this->assertFalse($this->getPrivateProperty($conn, 'pConnect'));
-        $this->assertEquals('utf8', $this->getPrivateProperty($conn, 'charset'));
-        $this->assertEquals('utf8_general_ci', $this->getPrivateProperty($conn, 'DBCollat'));
+        $this->assertSame('utf8', $this->getPrivateProperty($conn, 'charset'));
+        $this->assertSame('utf8_general_ci', $this->getPrivateProperty($conn, 'DBCollat'));
         $this->assertTrue($this->getPrivateProperty($conn, 'strictOn'));
-        $this->assertEquals([], $this->getPrivateProperty($conn, 'failover'));
+        $this->assertSame([], $this->getPrivateProperty($conn, 'failover'));
     }
 }

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -58,11 +58,11 @@ final class ConnectTest extends CIUnitTestCase
 
         // This will be the tests database
         $db = Database::connect();
-        $this->assertEquals($config->tests['DBDriver'], $this->getPrivateProperty($db, 'DBDriver'));
+        $this->assertSame($config->tests['DBDriver'], $this->getPrivateProperty($db, 'DBDriver'));
 
         // Get an instance of the system's default db so we have something to test with.
         $db1 = Database::connect($this->group1);
-        $this->assertEquals('MySQLi', $this->getPrivateProperty($db1, 'DBDriver'));
+        $this->assertSame('MySQLi', $this->getPrivateProperty($db1, 'DBDriver'));
 
         // If a connection is passed into connect, it should simply be returned to us...
         $db2 = Database::connect($db1);
@@ -74,7 +74,7 @@ final class ConnectTest extends CIUnitTestCase
         $config = config('Database');
 
         $db = Database::connect('tests');
-        $this->assertEquals($config->tests['DBDriver'], $this->getPrivateProperty($db, 'DBDriver'));
+        $this->assertSame($config->tests['DBDriver'], $this->getPrivateProperty($db, 'DBDriver'));
 
         $config                      = config('Database');
         $config->default['DBDriver'] = 'MySQLi';
@@ -82,7 +82,7 @@ final class ConnectTest extends CIUnitTestCase
 
         $db1 = Database::connect('default');
         $this->assertNotInstanceOf(Connection::class, $db1);
-        $this->assertEquals('MySQLi', $this->getPrivateProperty($db1, 'DBDriver'));
+        $this->assertSame('MySQLi', $this->getPrivateProperty($db1, 'DBDriver'));
     }
 
     public function testConnectWithFailover()
@@ -95,7 +95,7 @@ final class ConnectTest extends CIUnitTestCase
 
         $db1 = Database::connect($this->tests);
 
-        $this->assertEquals($this->tests['failover'][0]['DBDriver'], $this->getPrivateProperty($db1, 'DBDriver'));
+        $this->assertSame($this->tests['failover'][0]['DBDriver'], $this->getPrivateProperty($db1, 'DBDriver'));
         $this->assertTrue(count($db1->listTables()) >= 0);
     }
 }

--- a/tests/system/Database/Live/DatabaseTestTraitCaseTest.php
+++ b/tests/system/Database/Live/DatabaseTestTraitCaseTest.php
@@ -39,7 +39,7 @@ final class DatabaseTestTraitCaseTest extends CIUnitTestCase
     {
         $email = $this->grabFromDatabase('user', 'email', ['name' => 'Derek Jones']);
 
-        $this->assertEquals('derek@world.com', $email);
+        $this->assertSame('derek@world.com', $email);
     }
 
     public function testSeeInDatabase()

--- a/tests/system/Database/Live/DbDebugTest.php
+++ b/tests/system/Database/Live/DbDebugTest.php
@@ -10,7 +10,7 @@ use CodeIgniter\Test\DatabaseTestTrait;
  *
  * @internal
  */
-final class DEBugTest extends CIUnitTestCase
+final class DbDebugTest extends CIUnitTestCase
 {
     use DatabaseTestTrait;
 

--- a/tests/system/Database/Live/DbUtilsTest.php
+++ b/tests/system/Database/Live/DbUtilsTest.php
@@ -201,7 +201,7 @@ final class DbUtilsTest extends CIUnitTestCase
 
         $data = array_filter(preg_split('/(\r\n|\n|\r)/', $data));
 
-        $this->assertEquals('"1","Developer","Awesome job, but sometimes makes you bored","","",""', $data[1]);
+        $this->assertSame('"1","Developer","Awesome job, but sometimes makes you bored","","",""', $data[1]);
     }
 
     //--------------------------------------------------------------------
@@ -219,6 +219,6 @@ final class DbUtilsTest extends CIUnitTestCase
         $actual = preg_replace('#\R+#', '', $data);
         $actual = preg_replace('/[ ]{2,}|[\t]/', '', $actual);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/system/Database/Live/EmptyTest.php
+++ b/tests/system/Database/Live/EmptyTest.php
@@ -22,7 +22,7 @@ final class EmptyTest extends CIUnitTestCase
     {
         $this->db->table('misc')->emptyTable();
 
-        $this->assertEquals(0, $this->db->table('misc')->countAll());
+        $this->assertSame(0, $this->db->table('misc')->countAll());
     }
 
     //--------------------------------------------------------------------
@@ -31,7 +31,7 @@ final class EmptyTest extends CIUnitTestCase
     {
         $this->db->table('misc')->truncate();
 
-        $this->assertEquals(0, $this->db->table('misc')->countAll());
+        $this->assertSame(0, $this->db->table('misc')->countAll());
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Database/Live/EscapeTest.php
+++ b/tests/system/Database/Live/EscapeTest.php
@@ -34,7 +34,7 @@ final class EscapeTest extends CIUnitTestCase
      */
     public function testEscapeProtectsNegativeNumbers()
     {
-        $this->assertEquals("'-100'", $this->db->escape(-100));
+        $this->assertSame("'-100'", $this->db->escape(-100));
     }
 
     //--------------------------------------------------------------------
@@ -44,7 +44,7 @@ final class EscapeTest extends CIUnitTestCase
         $expected = "SELECT * FROM brands WHERE name = 'O" . $this->char . "'Doules'";
         $sql      = 'SELECT * FROM brands WHERE name = ' . $this->db->escape("O'Doules");
 
-        $this->assertEquals($expected, $sql);
+        $this->assertSame($expected, $sql);
     }
 
     //--------------------------------------------------------------------
@@ -54,7 +54,7 @@ final class EscapeTest extends CIUnitTestCase
         $expected = "SELECT * FROM brands WHERE name = 'O" . $this->char . "'Doules'";
         $sql      = "SELECT * FROM brands WHERE name = '" . $this->db->escapeString("O'Doules") . "'";
 
-        $this->assertEquals($expected, $sql);
+        $this->assertSame($expected, $sql);
     }
 
     //--------------------------------------------------------------------
@@ -64,7 +64,7 @@ final class EscapeTest extends CIUnitTestCase
         $expected = "SELECT * FROM brands WHERE column LIKE '%10!% more%' ESCAPE '!'";
         $sql      = "SELECT * FROM brands WHERE column LIKE '%" . $this->db->escapeLikeString('10% more') . "%' ESCAPE '!'";
 
-        $this->assertEquals($expected, $sql);
+        $this->assertSame($expected, $sql);
     }
 
     //--------------------------------------------------------------------
@@ -75,7 +75,7 @@ final class EscapeTest extends CIUnitTestCase
             $expected = "SHOW COLUMNS FROM brands WHERE column LIKE 'wild\_chars%'";
             $sql      = "SHOW COLUMNS FROM brands WHERE column LIKE '" . $this->db->escapeLikeStringDirect('wild_chars') . "%'";
 
-            $this->assertEquals($expected, $sql);
+            $this->assertSame($expected, $sql);
         } else {
             $this->expectNotToPerformAssertions();
         }

--- a/tests/system/Database/Live/FabricatorLiveTest.php
+++ b/tests/system/Database/Live/FabricatorLiveTest.php
@@ -64,7 +64,7 @@ final class FabricatorLiveTest extends CIUnitTestCase
 
         $fabricator->create();
 
-        $this->assertEquals($count + 1, Fabricator::getCount('user'));
+        $this->assertSame($count + 1, Fabricator::getCount('user'));
     }
 
     public function testHelperIncrementsCount()
@@ -73,7 +73,7 @@ final class FabricatorLiveTest extends CIUnitTestCase
 
         fake(UserModel::class, ['country' => 'Italy']);
 
-        $this->assertEquals($count + 1, Fabricator::getCount('user'));
+        $this->assertSame($count + 1, Fabricator::getCount('user'));
     }
 
     public function testCreateThrowsOnFailure()
@@ -88,7 +88,7 @@ final class FabricatorLiveTest extends CIUnitTestCase
     {
         helper('test');
         $result = fake(UserModel::class, ['name' => 'Derek'], false);
-        $this->assertEquals('Derek', $result->name);
+        $this->assertSame('Derek', $result->name);
         $this->dontSeeInDatabase('user', ['name' => 'Derek']);
     }
 }

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -20,7 +20,8 @@ final class ForgeTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
+
+    protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
 
     /**
      * @var Forge
@@ -155,13 +156,13 @@ final class ForgeTest extends CIUnitTestCase
 
         $fieldsData = $this->db->getFieldData('forge_test_table');
         if ($this->db->DBDriver === 'MySQLi') {
-            $this->assertEquals(strtolower($fieldsData[0]->type), 'bigint');
+            $this->assertSame(strtolower($fieldsData[0]->type), 'bigint');
         } elseif ($this->db->DBDriver === 'Postgre') {
-            $this->assertEquals(strtolower($fieldsData[0]->type), 'bigint');
+            $this->assertSame(strtolower($fieldsData[0]->type), 'bigint');
         } elseif ($this->db->DBDriver === 'SQLite3') {
-            $this->assertEquals(strtolower($fieldsData[0]->type), 'integer');
+            $this->assertSame(strtolower($fieldsData[0]->type), 'integer');
         } elseif ($this->db->DBDriver === 'SQLSRV') {
-            $this->assertEquals(strtolower($fieldsData[0]->type), 'bigint');
+            $this->assertSame(strtolower($fieldsData[0]->type), 'bigint');
         }
 
         $this->forge->dropTable('forge_test_table', true);
@@ -207,13 +208,13 @@ final class ForgeTest extends CIUnitTestCase
 
             $fields = $this->db->getFieldData('forge_array_constraint');
 
-            $this->assertEquals('status', $fields[0]->name);
+            $this->assertSame('status', $fields[0]->name);
 
             if ($this->db->DBDriver === 'SQLite3') {
                 // SQLite3 converts array constraints to TEXT CHECK(...)
-                $this->assertEquals('TEXT', $fields[0]->type);
+                $this->assertSame('TEXT', $fields[0]->type);
             } else {
-                $this->assertEquals('enum', $fields[0]->type);
+                $this->assertSame('enum', $fields[0]->type);
             }
 
             $this->forge->dropTable('forge_array_constraint', true);
@@ -403,15 +404,15 @@ final class ForgeTest extends CIUnitTestCase
         $foreignKeyData = $this->db->getForeignKeyData('forge_test_invoices');
 
         if ($this->db->DBDriver === 'SQLite3') {
-            $this->assertEquals($foreignKeyData[0]->constraint_name, 'users_id to db_forge_test_users.id');
-            $this->assertEquals($foreignKeyData[0]->sequence, 0);
+            $this->assertSame($foreignKeyData[0]->constraint_name, 'users_id to db_forge_test_users.id');
+            $this->assertSame($foreignKeyData[0]->sequence, 0);
         } else {
-            $this->assertEquals($foreignKeyData[0]->constraint_name, $this->db->DBPrefix . 'forge_test_invoices_users_id_foreign');
-            $this->assertEquals($foreignKeyData[0]->column_name, 'users_id');
-            $this->assertEquals($foreignKeyData[0]->foreign_column_name, 'id');
+            $this->assertSame($foreignKeyData[0]->constraint_name, $this->db->DBPrefix . 'forge_test_invoices_users_id_foreign');
+            $this->assertSame($foreignKeyData[0]->column_name, 'users_id');
+            $this->assertSame($foreignKeyData[0]->foreign_column_name, 'id');
         }
-        $this->assertEquals($foreignKeyData[0]->table_name, $this->db->DBPrefix . 'forge_test_invoices');
-        $this->assertEquals($foreignKeyData[0]->foreign_table_name, $this->db->DBPrefix . 'forge_test_users');
+        $this->assertSame($foreignKeyData[0]->table_name, $this->db->DBPrefix . 'forge_test_invoices');
+        $this->assertSame($foreignKeyData[0]->foreign_table_name, $this->db->DBPrefix . 'forge_test_users');
 
         $this->forge->dropTable('forge_test_invoices', true);
         $this->forge->dropTable('forge_test_users', true);
@@ -543,7 +544,7 @@ final class ForgeTest extends CIUnitTestCase
 
         $this->forge->dropTable('forge_test_table', true);
 
-        $this->assertEquals('username', $fieldNames[1]);
+        $this->assertSame('username', $fieldNames[1]);
     }
 
     public function testAddFields()
@@ -582,58 +583,50 @@ final class ForgeTest extends CIUnitTestCase
 
         $this->forge->dropTable('forge_test_fields', true);
 
-        // Check field names
+        $this->assertIsArray($fieldsNames);
         $this->assertContains('id', $fieldsNames);
         $this->assertContains('username', $fieldsNames);
         $this->assertContains('name', $fieldsNames);
         $this->assertContains('active', $fieldsNames);
 
-        // Check field data
-        $this->assertContains($fieldsData[0]->name, ['id', 'name', 'username', 'active']);
-        $this->assertContains($fieldsData[1]->name, ['id', 'name', 'username', 'active']);
+        $fields = ['id', 'name', 'username', 'active'];
+        $this->assertContains($fieldsData[0]->name, $fields);
+        $this->assertContains($fieldsData[1]->name, $fields);
+        unset($fields);
 
         if ($this->db->DBDriver === 'MySQLi') {
-            // Check types
-            $this->assertEquals($fieldsData[0]->type, 'int');
-            $this->assertEquals($fieldsData[1]->type, 'varchar');
+            $this->assertSame('int', $fieldsData[0]->type);
+            $this->assertSame('varchar', $fieldsData[1]->type);
 
             if (version_compare($this->db->getVersion(), '8.0.17', '<')) {
                 // As of MySQL 8.0.17, the display width attribute for integer data types
                 // is deprecated and is not reported back anymore.
                 // @see https://dev.mysql.com/doc/refman/8.0/en/numeric-type-attributes.html
-                $this->assertEquals($fieldsData[0]->max_length, 11);
+                $this->assertSame(11, $fieldsData[0]->max_length);
             }
 
             $this->assertNull($fieldsData[0]->default);
             $this->assertNull($fieldsData[1]->default);
-
-            $this->assertEquals($fieldsData[0]->primary_key, 1);
-
-            $this->assertEquals($fieldsData[1]->max_length, 255);
+            $this->assertSame(1, (int) $fieldsData[0]->primary_key);
+            $this->assertSame(255, (int) $fieldsData[1]->max_length);
         } elseif ($this->db->DBDriver === 'Postgre') {
-            // Check types
-            $this->assertEquals($fieldsData[0]->type, 'integer', print_r($fieldsData, true));
-            $this->assertEquals($fieldsData[1]->type, 'character varying', print_r($fieldsData, true));
-
-            $this->assertEquals($fieldsData[0]->max_length, 32);
+            $this->assertSame('integer', $fieldsData[0]->type);
+            $this->assertSame('character varying', $fieldsData[1]->type);
+            $this->assertSame(32, (int) $fieldsData[0]->max_length);
             $this->assertNull($fieldsData[1]->default);
-
-            $this->assertEquals($fieldsData[1]->max_length, 255);
+            $this->assertSame(255, (int) $fieldsData[1]->max_length);
         } elseif ($this->db->DBDriver === 'SQLite3') {
-            $this->assertEquals(strtolower($fieldsData[0]->type), 'integer');
-            $this->assertEquals(strtolower($fieldsData[1]->type), 'varchar');
-
-            $this->assertEquals($fieldsData[1]->default, null);
-        } elseif ($this->db->DBDriver === 'SQLSRV') {
-            // Check types
-            $this->assertEquals($fieldsData[0]->type, 'int');
-            $this->assertEquals($fieldsData[0]->max_length, 10);
-
-            $this->assertEquals($fieldsData[1]->type, 'varchar');
+            $this->assertSame('integer', strtolower($fieldsData[0]->type));
+            $this->assertSame('varchar', strtolower($fieldsData[1]->type));
             $this->assertNull($fieldsData[1]->default);
-            $this->assertEquals($fieldsData[1]->max_length, 255);
+        } elseif ($this->db->DBDriver === 'SQLSRV') {
+            $this->assertSame('int', $fieldsData[0]->type);
+            $this->assertSame(10, (int) $fieldsData[0]->max_length);
+            $this->assertSame('varchar', $fieldsData[1]->type);
+            $this->assertNull($fieldsData[1]->default);
+            $this->assertSame(255, (int) $fieldsData[1]->max_length);
         } else {
-            $this->assertTrue(false, 'DB Driver not supported');
+            $this->fail(sprintf('DB driver "%s" is not supported.', $this->db->DBDriver));
         }
     }
 
@@ -669,44 +662,44 @@ final class ForgeTest extends CIUnitTestCase
         $keys = $this->db->getIndexData('forge_test_1');
 
         if ($this->db->DBDriver === 'MySQLi') {
-            $this->assertEquals($keys['PRIMARY']->name, 'PRIMARY');
-            $this->assertEquals($keys['PRIMARY']->fields, ['id']);
-            $this->assertEquals($keys['PRIMARY']->type, 'PRIMARY');
-            $this->assertEquals($keys['code_company']->name, 'code_company');
-            $this->assertEquals($keys['code_company']->fields, ['code', 'company']);
-            $this->assertEquals($keys['code_company']->type, 'INDEX');
-            $this->assertEquals($keys['code_active']->name, 'code_active');
-            $this->assertEquals($keys['code_active']->fields, ['code', 'active']);
-            $this->assertEquals($keys['code_active']->type, 'UNIQUE');
+            $this->assertSame($keys['PRIMARY']->name, 'PRIMARY');
+            $this->assertSame($keys['PRIMARY']->fields, ['id']);
+            $this->assertSame($keys['PRIMARY']->type, 'PRIMARY');
+            $this->assertSame($keys['code_company']->name, 'code_company');
+            $this->assertSame($keys['code_company']->fields, ['code', 'company']);
+            $this->assertSame($keys['code_company']->type, 'INDEX');
+            $this->assertSame($keys['code_active']->name, 'code_active');
+            $this->assertSame($keys['code_active']->fields, ['code', 'active']);
+            $this->assertSame($keys['code_active']->type, 'UNIQUE');
         } elseif ($this->db->DBDriver === 'Postgre') {
-            $this->assertEquals($keys['pk_db_forge_test_1']->name, 'pk_db_forge_test_1');
-            $this->assertEquals($keys['pk_db_forge_test_1']->fields, ['id']);
-            $this->assertEquals($keys['pk_db_forge_test_1']->type, 'PRIMARY');
-            $this->assertEquals($keys['db_forge_test_1_code_company']->name, 'db_forge_test_1_code_company');
-            $this->assertEquals($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
-            $this->assertEquals($keys['db_forge_test_1_code_company']->type, 'INDEX');
-            $this->assertEquals($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');
-            $this->assertEquals($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
-            $this->assertEquals($keys['db_forge_test_1_code_active']->type, 'UNIQUE');
+            $this->assertSame($keys['pk_db_forge_test_1']->name, 'pk_db_forge_test_1');
+            $this->assertSame($keys['pk_db_forge_test_1']->fields, ['id']);
+            $this->assertSame($keys['pk_db_forge_test_1']->type, 'PRIMARY');
+            $this->assertSame($keys['db_forge_test_1_code_company']->name, 'db_forge_test_1_code_company');
+            $this->assertSame($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
+            $this->assertSame($keys['db_forge_test_1_code_company']->type, 'INDEX');
+            $this->assertSame($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');
+            $this->assertSame($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
+            $this->assertSame($keys['db_forge_test_1_code_active']->type, 'UNIQUE');
         } elseif ($this->db->DBDriver === 'SQLite3') {
-            $this->assertEquals($keys['sqlite_autoindex_db_forge_test_1_1']->name, 'sqlite_autoindex_db_forge_test_1_1');
-            $this->assertEquals($keys['sqlite_autoindex_db_forge_test_1_1']->fields, ['id']);
-            $this->assertEquals($keys['db_forge_test_1_code_company']->name, 'db_forge_test_1_code_company');
-            $this->assertEquals($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
-            $this->assertEquals($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');
-            $this->assertEquals($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
+            $this->assertSame($keys['sqlite_autoindex_db_forge_test_1_1']->name, 'sqlite_autoindex_db_forge_test_1_1');
+            $this->assertSame($keys['sqlite_autoindex_db_forge_test_1_1']->fields, ['id']);
+            $this->assertSame($keys['db_forge_test_1_code_company']->name, 'db_forge_test_1_code_company');
+            $this->assertSame($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
+            $this->assertSame($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');
+            $this->assertSame($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
         } elseif ($this->db->DBDriver === 'SQLSRV') {
-            $this->assertEquals($keys['pk_db_forge_test_1']->name, 'pk_db_forge_test_1');
-            $this->assertEquals($keys['pk_db_forge_test_1']->fields, ['id']);
-            $this->assertEquals($keys['pk_db_forge_test_1']->type, 'PRIMARY');
+            $this->assertSame($keys['pk_db_forge_test_1']->name, 'pk_db_forge_test_1');
+            $this->assertSame($keys['pk_db_forge_test_1']->fields, ['id']);
+            $this->assertSame($keys['pk_db_forge_test_1']->type, 'PRIMARY');
 
-            $this->assertEquals($keys['db_forge_test_1_code_company']->name, 'db_forge_test_1_code_company');
-            $this->assertEquals($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
-            $this->assertEquals($keys['db_forge_test_1_code_company']->type, 'INDEX');
+            $this->assertSame($keys['db_forge_test_1_code_company']->name, 'db_forge_test_1_code_company');
+            $this->assertSame($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
+            $this->assertSame($keys['db_forge_test_1_code_company']->type, 'INDEX');
 
-            $this->assertEquals($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');
-            $this->assertEquals($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
-            $this->assertEquals($keys['db_forge_test_1_code_active']->type, 'UNIQUE');
+            $this->assertSame($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');
+            $this->assertSame($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
+            $this->assertSame($keys['db_forge_test_1_code_active']->type, 'UNIQUE');
         }
 
         $this->forge->dropTable('forge_test_1', true);

--- a/tests/system/Database/Live/GetNumRowsTest.php
+++ b/tests/system/Database/Live/GetNumRowsTest.php
@@ -44,6 +44,6 @@ final class GetNumRowsTest extends CIUnitTestCase
     public function testGetRowNum()
     {
         $query = $this->db->table('job')->get();
-        $this->assertEquals(4, $query->getNumRows());
+        $this->assertSame(4, $query->getNumRows());
     }
 }

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -24,10 +24,10 @@ final class GetTest extends CIUnitTestCase
         $jobs = $this->db->table('job')->get()->getResult();
 
         $this->assertCount(4, $jobs);
-        $this->assertEquals('Developer', $jobs[0]->name);
-        $this->assertEquals('Politician', $jobs[1]->name);
-        $this->assertEquals('Accountant', $jobs[2]->name);
-        $this->assertEquals('Musician', $jobs[3]->name);
+        $this->assertSame('Developer', $jobs[0]->name);
+        $this->assertSame('Politician', $jobs[1]->name);
+        $this->assertSame('Accountant', $jobs[2]->name);
+        $this->assertSame('Musician', $jobs[3]->name);
     }
 
     //--------------------------------------------------------------------
@@ -37,8 +37,8 @@ final class GetTest extends CIUnitTestCase
         $jobs = $this->db->table('job')->get(2, 2)->getResult();
 
         $this->assertCount(2, $jobs);
-        $this->assertEquals('Accountant', $jobs[0]->name);
-        $this->assertEquals('Musician', $jobs[1]->name);
+        $this->assertSame('Accountant', $jobs[0]->name);
+        $this->assertSame('Musician', $jobs[1]->name);
     }
 
     //--------------------------------------------------------------------
@@ -50,7 +50,7 @@ final class GetTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(1, $jobs);
-        $this->assertEquals('Developer', $jobs[0]->name);
+        $this->assertSame('Developer', $jobs[0]->name);
     }
 
     //--------------------------------------------------------------------
@@ -62,7 +62,7 @@ final class GetTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(1, $jobs);
-        $this->assertEquals('Accountant', $jobs[0]->name);
+        $this->assertSame('Accountant', $jobs[0]->name);
     }
 
     //--------------------------------------------------------------------
@@ -71,7 +71,7 @@ final class GetTest extends CIUnitTestCase
     {
         $jobs = $this->db->table('job')->get()->getFieldCount();
 
-        $this->assertEquals(6, $jobs);
+        $this->assertSame(6, $jobs);
     }
 
     //--------------------------------------------------------------------
@@ -90,85 +90,85 @@ final class GetTest extends CIUnitTestCase
     {
         $jobs = $this->db->table('job')->get()->getFieldData();
 
-        $this->assertEquals('id', $jobs[0]->name);
-        $this->assertEquals('name', $jobs[1]->name);
+        $this->assertSame('id', $jobs[0]->name);
+        $this->assertSame('name', $jobs[1]->name);
 
         $typeTest = $this->db->table('type_test')->get()->getFieldData();
 
         if ($this->db->DBDriver === 'SQLite3') {
-            $this->assertEquals('integer', $typeTest[0]->type_name); //INTEGER AUTO INC
-            $this->assertEquals('text', $typeTest[1]->type_name);  //VARCHAR
-            $this->assertEquals('text', $typeTest[2]->type_name);  //CHAR
-            $this->assertEquals('text', $typeTest[3]->type_name);  //TEXT
-            $this->assertEquals('integer', $typeTest[4]->type_name);  //SMALLINT
-            $this->assertEquals('integer', $typeTest[5]->type_name);  //INTEGER
-            $this->assertEquals('float', $typeTest[6]->type_name);  //FLOAT
-            $this->assertEquals('float', $typeTest[7]->type_name);  //NUMERIC
-            $this->assertEquals('text', $typeTest[8]->type_name);  //DATE
-            $this->assertEquals('text', $typeTest[9]->type_name);  //TIME
-            $this->assertEquals('text', $typeTest[10]->type_name);  //DATETIME
-            $this->assertEquals('text', $typeTest[11]->type_name);  //TIMESTAMP
-            $this->assertEquals('integer', $typeTest[12]->type_name);  //BIGINT
-            $this->assertEquals('float', $typeTest[13]->type_name);  //REAL
-            $this->assertEquals('text', $typeTest[14]->type_name);  //ENUM
-            $this->assertEquals('text', $typeTest[15]->type_name);  //SET
-            $this->assertEquals('text', $typeTest[16]->type_name);  //MEDIUMTEXT
-            $this->assertEquals('float', $typeTest[17]->type_name);  //DOUBLE
-            $this->assertEquals('float', $typeTest[18]->type_name);  //DECIMAL
-            $this->assertEquals('text', $typeTest[19]->type_name);  //BLOB
+            $this->assertSame('integer', $typeTest[0]->type_name); //INTEGER AUTO INC
+            $this->assertSame('text', $typeTest[1]->type_name);  //VARCHAR
+            $this->assertSame('text', $typeTest[2]->type_name);  //CHAR
+            $this->assertSame('text', $typeTest[3]->type_name);  //TEXT
+            $this->assertSame('integer', $typeTest[4]->type_name);  //SMALLINT
+            $this->assertSame('integer', $typeTest[5]->type_name);  //INTEGER
+            $this->assertSame('float', $typeTest[6]->type_name);  //FLOAT
+            $this->assertSame('float', $typeTest[7]->type_name);  //NUMERIC
+            $this->assertSame('text', $typeTest[8]->type_name);  //DATE
+            $this->assertSame('text', $typeTest[9]->type_name);  //TIME
+            $this->assertSame('text', $typeTest[10]->type_name);  //DATETIME
+            $this->assertSame('text', $typeTest[11]->type_name);  //TIMESTAMP
+            $this->assertSame('integer', $typeTest[12]->type_name);  //BIGINT
+            $this->assertSame('float', $typeTest[13]->type_name);  //REAL
+            $this->assertSame('text', $typeTest[14]->type_name);  //ENUM
+            $this->assertSame('text', $typeTest[15]->type_name);  //SET
+            $this->assertSame('text', $typeTest[16]->type_name);  //MEDIUMTEXT
+            $this->assertSame('float', $typeTest[17]->type_name);  //DOUBLE
+            $this->assertSame('float', $typeTest[18]->type_name);  //DECIMAL
+            $this->assertSame('text', $typeTest[19]->type_name);  //BLOB
         }
         if ($this->db->DBDriver === 'MySQLi') {
-            $this->assertEquals('long', $typeTest[0]->type_name); //INTEGER AUTOINC
-            $this->assertEquals('var_string', $typeTest[1]->type_name);  //VARCHAR
-            $this->assertEquals('string', $typeTest[2]->type_name);  //CHAR
-            $this->assertEquals('blob', $typeTest[3]->type_name);  //TEXT
-            $this->assertEquals('short', $typeTest[4]->type_name);  //SMALLINT
-            $this->assertEquals('long', $typeTest[5]->type_name);  //INTEGER
-            $this->assertEquals('float', $typeTest[6]->type_name);  //FLOAT
-            $this->assertEquals('newdecimal', $typeTest[7]->type_name);  //NUMERIC
-            $this->assertEquals('date', $typeTest[8]->type_name);  //DATE
-            $this->assertEquals('time', $typeTest[9]->type_name);  //TIME
-            $this->assertEquals('datetime', $typeTest[10]->type_name);  //DATETIME
-            $this->assertEquals('timestamp', $typeTest[11]->type_name);  //TIMESTAMP
-            $this->assertEquals('longlong', $typeTest[12]->type_name); //BIGINT
-            $this->assertEquals('double', $typeTest[13]->type_name);  //REAL
-            $this->assertEquals('string', $typeTest[14]->type_name);  //ENUM
-            $this->assertEquals('string', $typeTest[15]->type_name);  //SET
-            $this->assertEquals('blob', $typeTest[16]->type_name);  //MEDIUMTEXT
-            $this->assertEquals('double', $typeTest[17]->type_name);  //DOUBLE
-            $this->assertEquals('newdecimal', $typeTest[18]->type_name);  //DECIMAL
-            $this->assertEquals('blob', $typeTest[19]->type_name);  //BLOB
+            $this->assertSame('long', $typeTest[0]->type_name); //INTEGER AUTOINC
+            $this->assertSame('var_string', $typeTest[1]->type_name);  //VARCHAR
+            $this->assertSame('string', $typeTest[2]->type_name);  //CHAR
+            $this->assertSame('blob', $typeTest[3]->type_name);  //TEXT
+            $this->assertSame('short', $typeTest[4]->type_name);  //SMALLINT
+            $this->assertSame('long', $typeTest[5]->type_name);  //INTEGER
+            $this->assertSame('float', $typeTest[6]->type_name);  //FLOAT
+            $this->assertSame('newdecimal', $typeTest[7]->type_name);  //NUMERIC
+            $this->assertSame('date', $typeTest[8]->type_name);  //DATE
+            $this->assertSame('time', $typeTest[9]->type_name);  //TIME
+            $this->assertSame('datetime', $typeTest[10]->type_name);  //DATETIME
+            $this->assertSame('timestamp', $typeTest[11]->type_name);  //TIMESTAMP
+            $this->assertSame('longlong', $typeTest[12]->type_name); //BIGINT
+            $this->assertSame('double', $typeTest[13]->type_name);  //REAL
+            $this->assertSame('string', $typeTest[14]->type_name);  //ENUM
+            $this->assertSame('string', $typeTest[15]->type_name);  //SET
+            $this->assertSame('blob', $typeTest[16]->type_name);  //MEDIUMTEXT
+            $this->assertSame('double', $typeTest[17]->type_name);  //DOUBLE
+            $this->assertSame('newdecimal', $typeTest[18]->type_name);  //DECIMAL
+            $this->assertSame('blob', $typeTest[19]->type_name);  //BLOB
         }
         if ($this->db->DBDriver === 'Postgre') {
-            $this->assertEquals('int4', $typeTest[0]->type_name); //INTEGER AUTOINC
-            $this->assertEquals('varchar', $typeTest[1]->type_name);  //VARCHAR
-            $this->assertEquals('bpchar', $typeTest[2]->type_name);  //CHAR
-            $this->assertEquals('text', $typeTest[3]->type_name);  //TEXT
-            $this->assertEquals('int2', $typeTest[4]->type_name);  //SMALLINT
-            $this->assertEquals('int4', $typeTest[5]->type_name);  //INTEGER
-            $this->assertEquals('float8', $typeTest[6]->type_name);  //FLOAT
-            $this->assertEquals('numeric', $typeTest[7]->type_name);  //NUMERIC
-            $this->assertEquals('date', $typeTest[8]->type_name);  //DATE
-            $this->assertEquals('time', $typeTest[9]->type_name);  //TIME
-            $this->assertEquals('timestamp', $typeTest[10]->type_name);  //DATETIME
-            $this->assertEquals('timestamp', $typeTest[11]->type_name);  //TIMESTAMP
-            $this->assertEquals('int8', $typeTest[12]->type_name); //BIGINT
+            $this->assertSame('int4', $typeTest[0]->type_name); //INTEGER AUTOINC
+            $this->assertSame('varchar', $typeTest[1]->type_name);  //VARCHAR
+            $this->assertSame('bpchar', $typeTest[2]->type_name);  //CHAR
+            $this->assertSame('text', $typeTest[3]->type_name);  //TEXT
+            $this->assertSame('int2', $typeTest[4]->type_name);  //SMALLINT
+            $this->assertSame('int4', $typeTest[5]->type_name);  //INTEGER
+            $this->assertSame('float8', $typeTest[6]->type_name);  //FLOAT
+            $this->assertSame('numeric', $typeTest[7]->type_name);  //NUMERIC
+            $this->assertSame('date', $typeTest[8]->type_name);  //DATE
+            $this->assertSame('time', $typeTest[9]->type_name);  //TIME
+            $this->assertSame('timestamp', $typeTest[10]->type_name);  //DATETIME
+            $this->assertSame('timestamp', $typeTest[11]->type_name);  //TIMESTAMP
+            $this->assertSame('int8', $typeTest[12]->type_name); //BIGINT
         }
         if ($this->db->DBDriver === 'SQLSRV') {
-            $this->assertEquals('int', $typeTest[0]->type_name); //INTEGER AUTOINC
-            $this->assertEquals('varchar', $typeTest[1]->type_name);  //VARCHAR
-            $this->assertEquals('char', $typeTest[2]->type_name);  //CHAR
-            $this->assertEquals('text', $typeTest[3]->type_name);  //TEXT
-            $this->assertEquals('smallint', $typeTest[4]->type_name);  //SMALLINT
-            $this->assertEquals('int', $typeTest[5]->type_name);  //INTEGER
-            $this->assertEquals('float', $typeTest[6]->type_name);  //FLOAT
-            $this->assertEquals('numeric', $typeTest[7]->type_name);  //NUMERIC
+            $this->assertSame('int', $typeTest[0]->type_name); //INTEGER AUTOINC
+            $this->assertSame('varchar', $typeTest[1]->type_name);  //VARCHAR
+            $this->assertSame('char', $typeTest[2]->type_name);  //CHAR
+            $this->assertSame('text', $typeTest[3]->type_name);  //TEXT
+            $this->assertSame('smallint', $typeTest[4]->type_name);  //SMALLINT
+            $this->assertSame('int', $typeTest[5]->type_name);  //INTEGER
+            $this->assertSame('float', $typeTest[6]->type_name);  //FLOAT
+            $this->assertSame('numeric', $typeTest[7]->type_name);  //NUMERIC
             $this->assertNull($typeTest[8]->type_name);  //DATE
             $this->assertNull($typeTest[9]->type_name);  //TIME
             $this->assertNull($typeTest[10]->type_name);  //DATETIME
-            $this->assertEquals('bigint', $typeTest[11]->type_name); //BIGINT
-            $this->assertEquals('real', $typeTest[12]->type_name);  //REAL
-            $this->assertEquals('decimal', $typeTest[13]->type_name);  //DECIMAL
+            $this->assertSame('bigint', $typeTest[11]->type_name); //BIGINT
+            $this->assertSame('real', $typeTest[12]->type_name);  //REAL
+            $this->assertSame('decimal', $typeTest[13]->type_name);  //DECIMAL
         }
     }
 
@@ -186,7 +186,7 @@ final class GetTest extends CIUnitTestCase
         $data->dataSeek(3);
 
         $details = $data->getResult();
-        $this->assertEquals('Musician', $details[0]->name);
+        $this->assertSame('Musician', $details[0]->name);
     }
 
     //--------------------------------------------------------------------
@@ -198,10 +198,10 @@ final class GetTest extends CIUnitTestCase
 
         $details = $data->getResult();
 
-        $this->assertEquals('Developer', $details[0]->name);
-        $this->assertEquals('Politician', $details[1]->name);
-        $this->assertEquals('Accountant', $details[2]->name);
-        $this->assertEquals('Musician', $details[3]->name);
+        $this->assertSame('Developer', $details[0]->name);
+        $this->assertSame('Politician', $details[1]->name);
+        $this->assertSame('Accountant', $details[2]->name);
+        $this->assertSame('Musician', $details[3]->name);
     }
 
     //--------------------------------------------------------------------
@@ -212,7 +212,7 @@ final class GetTest extends CIUnitTestCase
 
         $details = $data->getResult();
 
-        $this->assertEquals('Musician', $details[0]->name);
+        $this->assertSame('Musician', $details[0]->name);
 
         $data->freeResult();
 
@@ -225,7 +225,7 @@ final class GetTest extends CIUnitTestCase
     {
         $name = $this->db->table('user')->get()->getRow('name', 'array');
 
-        $this->assertEquals('Derek Jones', $name);
+        $this->assertSame('Derek Jones', $name);
     }
 
     //--------------------------------------------------------------------
@@ -234,7 +234,7 @@ final class GetTest extends CIUnitTestCase
     {
         $user = $this->db->table('user')->get()->getRow(0, 'array');
 
-        $this->assertEquals('Derek Jones', $user['name']);
+        $this->assertSame('Derek Jones', $user['name']);
     }
 
     //--------------------------------------------------------------------
@@ -245,7 +245,7 @@ final class GetTest extends CIUnitTestCase
 
         $user = $this->db->table('user')->get()->getRow(0, get_class($testClass));
 
-        $this->assertEquals('Derek Jones', $user->name);
+        $this->assertSame('Derek Jones', $user->name);
     }
 
     //--------------------------------------------------------------------
@@ -254,7 +254,7 @@ final class GetTest extends CIUnitTestCase
     {
         $user = $this->db->table('user')->get()->getFirstRow();
 
-        $this->assertEquals('Derek Jones', $user->name);
+        $this->assertSame('Derek Jones', $user->name);
     }
 
     //--------------------------------------------------------------------
@@ -263,7 +263,7 @@ final class GetTest extends CIUnitTestCase
     {
         $user = $this->db->table('user')->get()->getLastRow();
 
-        $this->assertEquals('Chris Martin', $user->name);
+        $this->assertSame('Chris Martin', $user->name);
     }
 
     //--------------------------------------------------------------------
@@ -272,7 +272,7 @@ final class GetTest extends CIUnitTestCase
     {
         $user = $this->db->table('user')->get()->getNextRow();
 
-        $this->assertEquals('Ahmadinejad', $user->name);
+        $this->assertSame('Ahmadinejad', $user->name);
     }
 
     //--------------------------------------------------------------------
@@ -285,6 +285,6 @@ final class GetTest extends CIUnitTestCase
 
         $user = $user->getPreviousRow();
 
-        $this->assertEquals('Richard A Causey', $user->name);
+        $this->assertSame('Richard A Causey', $user->name);
     }
 }

--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -71,8 +71,8 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(2, $result);
-        $this->assertEquals('Developer', $result[0]->name);
-        $this->assertEquals('Politician', $result[1]->name);
+        $this->assertSame('Developer', $result[0]->name);
+        $this->assertSame('Politician', $result[1]->name);
     }
 
     //--------------------------------------------------------------------
@@ -89,8 +89,8 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(2, $result);
-        $this->assertEquals('Developer', $result[0]->name);
-        $this->assertEquals('Politician', $result[1]->name);
+        $this->assertSame('Developer', $result[0]->name);
+        $this->assertSame('Politician', $result[1]->name);
     }
 
     //--------------------------------------------------------------------
@@ -106,8 +106,8 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(2, $result);
-        $this->assertEquals('Accountant', $result[0]->name);
-        $this->assertEquals('Musician', $result[1]->name);
+        $this->assertSame('Accountant', $result[0]->name);
+        $this->assertSame('Musician', $result[1]->name);
     }
 
     //--------------------------------------------------------------------
@@ -124,8 +124,8 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(2, $result);
-        $this->assertEquals('Accountant', $result[0]->name);
-        $this->assertEquals('Musician', $result[1]->name);
+        $this->assertSame('Accountant', $result[0]->name);
+        $this->assertSame('Musician', $result[1]->name);
     }
 
     //--------------------------------------------------------------------
@@ -140,7 +140,7 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(1, $result);
-        $this->assertEquals('Developer', $result[0]->name);
+        $this->assertSame('Developer', $result[0]->name);
     }
 
     //--------------------------------------------------------------------
@@ -156,8 +156,8 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(2, $result);
-        $this->assertEquals('Accountant', $result[0]->name);
-        $this->assertEquals('Developer', $result[1]->name);
+        $this->assertSame('Accountant', $result[0]->name);
+        $this->assertSame('Developer', $result[1]->name);
     }
 
     //--------------------------------------------------------------------
@@ -174,8 +174,8 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(2, $result);
-        $this->assertEquals('Accountant', $result[0]->name);
-        $this->assertEquals('Developer', $result[1]->name);
+        $this->assertSame('Accountant', $result[0]->name);
+        $this->assertSame('Developer', $result[1]->name);
     }
 
     //--------------------------------------------------------------------
@@ -192,9 +192,9 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(3, $result);
-        $this->assertEquals('Accountant', $result[0]->name);
-        $this->assertEquals('Developer', $result[1]->name);
-        $this->assertEquals('Musician', $result[2]->name);
+        $this->assertSame('Accountant', $result[0]->name);
+        $this->assertSame('Developer', $result[1]->name);
+        $this->assertSame('Musician', $result[2]->name);
     }
 
     //--------------------------------------------------------------------
@@ -214,7 +214,7 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(1, $result);
-        $this->assertEquals('Accountant', $result[0]->name);
+        $this->assertSame('Accountant', $result[0]->name);
     }
 
     //--------------------------------------------------------------------
@@ -234,8 +234,8 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(2, $result);
-        $this->assertEquals('Accountant', $result[0]->name);
-        $this->assertEquals('Musician', $result[1]->name);
+        $this->assertSame('Accountant', $result[0]->name);
+        $this->assertSame('Musician', $result[1]->name);
     }
 
     //--------------------------------------------------------------------
@@ -255,7 +255,7 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(1, $result);
-        $this->assertEquals('Musician', $result[0]->name);
+        $this->assertSame('Musician', $result[0]->name);
     }
 
     //--------------------------------------------------------------------
@@ -275,9 +275,9 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(3, $result);
-        $this->assertEquals('Accountant', $result[0]->name);
-        $this->assertEquals('Musician', $result[1]->name);
-        $this->assertEquals('Politician', $result[2]->name);
+        $this->assertSame('Accountant', $result[0]->name);
+        $this->assertSame('Musician', $result[1]->name);
+        $this->assertSame('Politician', $result[2]->name);
     }
 
     //--------------------------------------------------------------------
@@ -294,7 +294,7 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(1, $result);
-        $this->assertEquals('Richard A Causey', $result[0]->name);
+        $this->assertSame('Richard A Causey', $result[0]->name);
     }
 
     //--------------------------------------------------------------------
@@ -311,8 +311,8 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(2, $result);
-        $this->assertEquals('Ahmadinejad', $result[0]->name);
-        $this->assertEquals('Chris Martin', $result[1]->name);
+        $this->assertSame('Ahmadinejad', $result[0]->name);
+        $this->assertSame('Chris Martin', $result[1]->name);
     }
 
     //--------------------------------------------------------------------
@@ -329,7 +329,7 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(1, $result);
-        $this->assertEquals('Derek Jones', $result[0]->name);
+        $this->assertSame('Derek Jones', $result[0]->name);
     }
 
     //--------------------------------------------------------------------
@@ -346,9 +346,9 @@ final class GroupTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(3, $result);
-        $this->assertEquals('Derek Jones', $result[0]->name);
-        $this->assertEquals('Richard A Causey', $result[1]->name);
-        $this->assertEquals('Chris Martin', $result[2]->name);
+        $this->assertSame('Derek Jones', $result[0]->name);
+        $this->assertSame('Richard A Causey', $result[1]->name);
+        $this->assertSame('Chris Martin', $result[2]->name);
     }
 
     //--------------------------------------------------------------------
@@ -362,6 +362,6 @@ final class GroupTest extends CIUnitTestCase
             ->get()
             ->getResult();
 
-        $this->assertEquals(2, $result[0]->count);
+        $this->assertSame(2, (int) $result[0]->count);
     }
 }

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -67,7 +67,7 @@ final class InsertTest extends CIUnitTestCase
             ->getwhere(['id' => 5])
             ->getRow();
 
-        $this->assertEquals('Cab Driver', $row->name);
+        $this->assertSame('Cab Driver', $row->name);
     }
 
     //--------------------------------------------------------------------
@@ -86,7 +86,7 @@ final class InsertTest extends CIUnitTestCase
             ->getwhere(['id' => 1])
             ->getRow();
 
-        $this->assertEquals('Cab Driver', $row->name);
+        $this->assertSame('Cab Driver', $row->name);
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Database/Live/JoinTest.php
+++ b/tests/system/Database/Live/JoinTest.php
@@ -26,11 +26,9 @@ final class JoinTest extends CIUnitTestCase
             ->get()
             ->getRow();
 
-        $this->assertEquals(1, $row->job_id);
-        $this->assertEquals(1, $row->user_id);
-        $this->assertEquals('Derek Jones', $row->user_name);
-        $this->assertEquals('Developer', $row->job_name);
+        $this->assertSame(1, (int) $row->job_id);
+        $this->assertSame(1, (int) $row->user_id);
+        $this->assertSame('Derek Jones', $row->user_name);
+        $this->assertSame('Developer', $row->job_name);
     }
-
-    //--------------------------------------------------------------------
 }

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -23,55 +23,45 @@ final class LikeTest extends CIUnitTestCase
         $job = $this->db->table('job')->like('name', 'veloper')->get();
         $job = $job->getRow();
 
-        $this->assertEquals(1, $job->id);
-        $this->assertEquals('Developer', $job->name);
+        $this->assertSame(1, (int) $job->id);
+        $this->assertSame('Developer', $job->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testLikeBefore()
     {
         $job = $this->db->table('job')->like('name', 'veloper', 'before')->get();
         $job = $job->getRow();
 
-        $this->assertEquals(1, $job->id);
-        $this->assertEquals('Developer', $job->name);
+        $this->assertSame(1, (int) $job->id);
+        $this->assertSame('Developer', $job->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testLikeAfter()
     {
         $job = $this->db->table('job')->like('name', 'Develop')->get();
         $job = $job->getRow();
 
-        $this->assertEquals(1, $job->id);
-        $this->assertEquals('Developer', $job->name);
+        $this->assertSame(1, (int) $job->id);
+        $this->assertSame('Developer', $job->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testLikeBoth()
     {
         $job = $this->db->table('job')->like('name', 'veloper', 'both')->get();
         $job = $job->getRow();
 
-        $this->assertEquals(1, $job->id);
-        $this->assertEquals('Developer', $job->name);
+        $this->assertSame(1, (int) $job->id);
+        $this->assertSame('Developer', $job->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testLikeCaseInsensitive()
     {
         $job = $this->db->table('job')->like('name', 'VELOPER', 'both', null, true)->get();
         $job = $job->getRow();
 
-        $this->assertEquals(1, $job->id);
-        $this->assertEquals('Developer', $job->name);
+        $this->assertSame(1, (int) $job->id);
+        $this->assertSame('Developer', $job->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testOrLike()
     {
@@ -81,12 +71,10 @@ final class LikeTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(3, $jobs);
-        $this->assertEquals('Developer', $jobs[0]->name);
-        $this->assertEquals('Politician', $jobs[1]->name);
-        $this->assertEquals('Musician', $jobs[2]->name);
+        $this->assertSame('Developer', $jobs[0]->name);
+        $this->assertSame('Politician', $jobs[1]->name);
+        $this->assertSame('Musician', $jobs[2]->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testNotLike()
     {
@@ -96,12 +84,10 @@ final class LikeTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(3, $jobs);
-        $this->assertEquals('Politician', $jobs[0]->name);
-        $this->assertEquals('Accountant', $jobs[1]->name);
-        $this->assertEquals('Musician', $jobs[2]->name);
+        $this->assertSame('Politician', $jobs[0]->name);
+        $this->assertSame('Accountant', $jobs[1]->name);
+        $this->assertSame('Musician', $jobs[2]->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testOrNotLike()
     {
@@ -112,12 +98,10 @@ final class LikeTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(3, $jobs);
-        $this->assertEquals('Politician', $jobs[0]->name);
-        $this->assertEquals('Accountant', $jobs[1]->name);
-        $this->assertEquals('Musician', $jobs[2]->name);
+        $this->assertSame('Politician', $jobs[0]->name);
+        $this->assertSame('Accountant', $jobs[1]->name);
+        $this->assertSame('Musician', $jobs[2]->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testLikeSpacesOrTabs()
     {
@@ -128,6 +112,4 @@ final class LikeTest extends CIUnitTestCase
         $this->assertCount(1, $spaces);
         $this->assertCount(1, $tabs);
     }
-
-    //--------------------------------------------------------------------
 }

--- a/tests/system/Database/Live/LimitTest.php
+++ b/tests/system/Database/Live/LimitTest.php
@@ -25,8 +25,8 @@ final class LimitTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(2, $jobs);
-        $this->assertEquals('Developer', $jobs[0]->name);
-        $this->assertEquals('Politician', $jobs[1]->name);
+        $this->assertSame('Developer', $jobs[0]->name);
+        $this->assertSame('Politician', $jobs[1]->name);
     }
 
     //--------------------------------------------------------------------
@@ -39,8 +39,8 @@ final class LimitTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(2, $jobs);
-        $this->assertEquals('Accountant', $jobs[0]->name);
-        $this->assertEquals('Musician', $jobs[1]->name);
+        $this->assertSame('Accountant', $jobs[0]->name);
+        $this->assertSame('Musician', $jobs[1]->name);
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -49,7 +49,7 @@ final class MetadataTest extends CIUnitTestCase
     {
         $result = $this->db->listTables(true);
 
-        $this->assertEquals($this->expectedTables, array_values($result));
+        $this->assertSame($this->expectedTables, array_values($result));
     }
 
     //--------------------------------------------------------------------
@@ -58,7 +58,7 @@ final class MetadataTest extends CIUnitTestCase
     {
         $result = $this->db->listTables(true);
 
-        $this->assertEquals($this->expectedTables, array_values($result));
+        $this->assertSame($this->expectedTables, array_values($result));
     }
 
     //--------------------------------------------------------------------
@@ -89,7 +89,7 @@ final class MetadataTest extends CIUnitTestCase
         $this->db->setPrefix($DBPrefix);
         $result = $this->db->listTables(true);
 
-        $this->assertEquals($this->expectedTables, array_values($result));
+        $this->assertSame($this->expectedTables, array_values($result));
 
         // Clean up temporary table
         $this->db->setPrefix('tmp_');

--- a/tests/system/Database/Live/OrderTest.php
+++ b/tests/system/Database/Live/OrderTest.php
@@ -26,10 +26,10 @@ final class OrderTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(4, $jobs);
-        $this->assertEquals('Accountant', $jobs[0]->name);
-        $this->assertEquals('Developer', $jobs[1]->name);
-        $this->assertEquals('Musician', $jobs[2]->name);
-        $this->assertEquals('Politician', $jobs[3]->name);
+        $this->assertSame('Accountant', $jobs[0]->name);
+        $this->assertSame('Developer', $jobs[1]->name);
+        $this->assertSame('Musician', $jobs[2]->name);
+        $this->assertSame('Politician', $jobs[3]->name);
     }
 
     //--------------------------------------------------------------------
@@ -42,10 +42,10 @@ final class OrderTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(4, $jobs);
-        $this->assertEquals('Accountant', $jobs[3]->name);
-        $this->assertEquals('Developer', $jobs[2]->name);
-        $this->assertEquals('Musician', $jobs[1]->name);
-        $this->assertEquals('Politician', $jobs[0]->name);
+        $this->assertSame('Accountant', $jobs[3]->name);
+        $this->assertSame('Developer', $jobs[2]->name);
+        $this->assertSame('Musician', $jobs[1]->name);
+        $this->assertSame('Politician', $jobs[0]->name);
     }
 
     //--------------------------------------------------------------------
@@ -59,10 +59,10 @@ final class OrderTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(4, $users);
-        $this->assertEquals('Ahmadinejad', $users[0]->name);
-        $this->assertEquals('Chris Martin', $users[1]->name);
-        $this->assertEquals('Richard A Causey', $users[2]->name);
-        $this->assertEquals('Derek Jones', $users[3]->name);
+        $this->assertSame('Ahmadinejad', $users[0]->name);
+        $this->assertSame('Chris Martin', $users[1]->name);
+        $this->assertSame('Richard A Causey', $users[2]->name);
+        $this->assertSame('Derek Jones', $users[3]->name);
     }
 
     //--------------------------------------------------------------------
@@ -85,6 +85,6 @@ final class OrderTest extends CIUnitTestCase
 
         $expected = 'SELECT * FROM ' . $table . ' ORDER BY ' . $key;
 
-        $this->assertEquals($expected, str_replace("\n", ' ', $sql));
+        $this->assertSame($expected, str_replace("\n", ' ', $sql));
     }
 }

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -47,7 +47,7 @@ final class PreparedQueryTest extends CIUnitTestCase
         } else {
             $expected = "INSERT INTO {$ec}{$pre}user{$ec} ({$ec}name{$ec}, {$ec}email{$ec}) VALUES ({$placeholders})";
         }
-        $this->assertEquals($expected, $query->getQueryString());
+        $this->assertSame($expected, $query->getQueryString());
 
         $query->close();
     }
@@ -71,7 +71,7 @@ final class PreparedQueryTest extends CIUnitTestCase
         }
 
         $expected = "INSERT INTO {$pre}user (name, email, country) VALUES ({$placeholders})";
-        $this->assertEquals($expected, $query->getQueryString());
+        $this->assertSame($expected, $query->getQueryString());
 
         $query->close();
     }

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -88,27 +88,27 @@ final class AlterTableTest extends CIUnitTestCase
         $this->assertArrayHasKey('id', $fields);
         $this->assertNull($fields['id']['default']);
         $this->assertTrue($fields['id']['null']);
-        $this->assertEquals('integer', strtolower($fields['id']['type']));
+        $this->assertSame('integer', strtolower($fields['id']['type']));
 
         $this->assertArrayHasKey('name', $fields);
         $this->assertNull($fields['name']['default']);
         $this->assertFalse($fields['name']['null']);
-        $this->assertEquals('varchar', strtolower($fields['name']['type']));
+        $this->assertSame('varchar', strtolower($fields['name']['type']));
 
         $this->assertArrayHasKey('email', $fields);
         $this->assertNull($fields['email']['default']);
         $this->assertTrue($fields['email']['null']);
-        $this->assertEquals('varchar', strtolower($fields['email']['type']));
+        $this->assertSame('varchar', strtolower($fields['email']['type']));
 
         $keys = $this->getPrivateProperty($this->table, 'keys');
 
         $this->assertCount(3, $keys);
         $this->assertArrayHasKey('foo_name', $keys);
-        $this->assertEquals(['fields' => ['name'], 'type' => 'index'], $keys['foo_name']);
+        $this->assertSame(['fields' => ['name'], 'type' => 'index'], $keys['foo_name']);
         $this->assertArrayHasKey('id', $keys);
-        $this->assertEquals(['fields' => ['id'], 'type' => 'primary'], $keys['id']);
+        $this->assertSame(['fields' => ['id'], 'type' => 'primary'], $keys['id']);
         $this->assertArrayHasKey('id', $keys);
-        $this->assertEquals(['fields' => ['id'], 'type' => 'primary'], $keys['id']);
+        $this->assertSame(['fields' => ['id'], 'type' => 'primary'], $keys['id']);
     }
 
     public function testDropColumnSuccess()
@@ -179,7 +179,7 @@ final class AlterTableTest extends CIUnitTestCase
         $this->createTable('aliens');
 
         $keys = $this->db->getForeignKeyData('aliens');
-        $this->assertEquals('key_id to aliens_fk.id', $keys[0]->constraint_name);
+        $this->assertSame('key_id to aliens_fk.id', $keys[0]->constraint_name);
 
         $result = $this->table
             ->fromTable('aliens')

--- a/tests/system/Database/Live/SelectTest.php
+++ b/tests/system/Database/Live/SelectTest.php
@@ -18,8 +18,6 @@ final class SelectTest extends CIUnitTestCase
 
     protected $seed = 'Tests\Support\Database\Seeds\CITestSeeder';
 
-    //--------------------------------------------------------------------
-
     public function testSelectAllByDefault()
     {
         $row = $this->db->table('job')->get()->getRowArray();
@@ -28,8 +26,6 @@ final class SelectTest extends CIUnitTestCase
         $this->assertArrayHasKey('name', $row);
         $this->assertArrayHasKey('description', $row);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSelectSingleColumn()
     {
@@ -40,8 +36,6 @@ final class SelectTest extends CIUnitTestCase
         $this->assertArrayNotHasKey('description', $row);
     }
 
-    //--------------------------------------------------------------------
-
     public function testSelectMultipleColumns()
     {
         $row = $this->db->table('job')->select('name, description')->get()->getRowArray();
@@ -51,97 +45,75 @@ final class SelectTest extends CIUnitTestCase
         $this->assertArrayHasKey('description', $row);
     }
 
-    //--------------------------------------------------------------------
-
     public function testSelectMax()
     {
         $result = $this->db->table('job')->selectMax('id')->get()->getRow();
 
-        $this->assertEquals(4, $result->id);
+        $this->assertSame(4, (int) $result->id);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSelectMaxWithAlias()
     {
         $result = $this->db->table('job')->selectMax('id', 'xam')->get()->getRow();
 
-        $this->assertEquals(4, $result->xam);
+        $this->assertSame(4, (int) $result->xam);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSelectMin()
     {
         $result = $this->db->table('job')->selectMin('id')->get()->getRow();
 
-        $this->assertEquals(1, $result->id);
+        $this->assertSame(1, (int) $result->id);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSelectMinWithAlias()
     {
         $result = $this->db->table('job')->selectMin('id', 'xam')->get()->getRow();
 
-        $this->assertEquals(1, $result->xam);
+        $this->assertSame(1, (int) $result->xam);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSelectAvg()
     {
         $result = $this->db->table('job')->selectAvg('id')->get()->getRow();
 
-        $this->assertEquals(2.5, $result->id);
+        $this->assertSame(2.5, (float) $result->id);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSelectAvgWithAlias()
     {
         $result = $this->db->table('job')->selectAvg('id', 'xam')->get()->getRow();
 
-        $this->assertEquals(2.5, $result->xam);
+        $this->assertSame(2.5, (float) $result->xam);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSelectSum()
     {
         $result = $this->db->table('job')->selectSum('id')->get()->getRow();
 
-        $this->assertEquals(10, $result->id);
+        $this->assertSame(10, (int) $result->id);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSelectSumWithAlias()
     {
         $result = $this->db->table('job')->selectSum('id', 'xam')->get()->getRow();
 
-        $this->assertEquals(10, $result->xam);
+        $this->assertSame(10, (int) $result->xam);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSelectCount()
     {
         $result = $this->db->table('job')->selectCount('id')->get()->getRow();
 
-        $this->assertEquals(4, $result->id);
+        $this->assertSame(4, (int) $result->id);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSelectCountWithAlias()
     {
         $result = $this->db->table('job')->selectCount('id', 'xam')->get()->getRow();
 
-        $this->assertEquals(4, $result->xam);
+        $this->assertSame(4, (int) $result->xam);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSelectDistinctWorkTogether()
     {
@@ -150,16 +122,12 @@ final class SelectTest extends CIUnitTestCase
         $this->assertCount(3, $users);
     }
 
-    //--------------------------------------------------------------------
-
     public function testSelectDistinctCanBeTurnedOff()
     {
         $users = $this->db->table('user')->select('country')->distinct(false)->get()->getResult();
 
         $this->assertCount(4, $users);
     }
-
-    //--------------------------------------------------------------------
 
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/1226

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -25,10 +25,10 @@ final class UpdateTest extends CIUnitTestCase
 
         $result = $this->db->table('user')->get()->getResult();
 
-        $this->assertEquals('Bobby', $result[0]->name);
-        $this->assertEquals('Bobby', $result[1]->name);
-        $this->assertEquals('Bobby', $result[2]->name);
-        $this->assertEquals('Bobby', $result[3]->name);
+        $this->assertSame('Bobby', $result[0]->name);
+        $this->assertSame('Bobby', $result[1]->name);
+        $this->assertSame('Bobby', $result[2]->name);
+        $this->assertSame('Bobby', $result[3]->name);
     }
 
     //--------------------------------------------------------------------
@@ -43,10 +43,10 @@ final class UpdateTest extends CIUnitTestCase
                 ->get()
                 ->getResult();
 
-            $this->assertEquals('Bobby', $result[0]->name);
-            $this->assertEquals('Ahmadinejad', $result[1]->name);
-            $this->assertEquals('Richard A Causey', $result[2]->name);
-            $this->assertEquals('Chris Martin', $result[3]->name);
+            $this->assertSame('Bobby', $result[0]->name);
+            $this->assertSame('Ahmadinejad', $result[1]->name);
+            $this->assertSame('Richard A Causey', $result[2]->name);
+            $this->assertSame('Chris Martin', $result[3]->name);
         } catch (DatabaseException $e) {
             // This DB doesn't support Where and Limit together
             // but we don't want it called a "Risky" test.
@@ -84,10 +84,10 @@ final class UpdateTest extends CIUnitTestCase
 
             $result = $this->db->table('user')->get()->getResult();
 
-            $this->assertEquals('Bobby', $result[0]->name);
-            $this->assertEquals('Ahmadinejad', $result[1]->name);
-            $this->assertEquals('Richard A Causey', $result[2]->name);
-            $this->assertEquals('Chris Martin', $result[3]->name);
+            $this->assertSame('Bobby', $result[0]->name);
+            $this->assertSame('Ahmadinejad', $result[1]->name);
+            $this->assertSame('Richard A Causey', $result[2]->name);
+            $this->assertSame('Chris Martin', $result[3]->name);
         } catch (DatabaseException $e) {
             // This DB doesn't support Where and Limit together
             // but we don't want it called a "Risky" test.

--- a/tests/system/Database/Live/WhereTest.php
+++ b/tests/system/Database/Live/WhereTest.php
@@ -22,11 +22,9 @@ final class WhereTest extends CIUnitTestCase
     {
         $row = $this->db->table('job')->where('id', 1)->get()->getRow();
 
-        $this->assertEquals(1, $row->id);
-        $this->assertEquals('Developer', $row->name);
+        $this->assertSame(1, (int) $row->id);
+        $this->assertSame('Developer', $row->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testWhereCustomKeyValue()
     {
@@ -34,8 +32,6 @@ final class WhereTest extends CIUnitTestCase
 
         $this->assertCount(3, $jobs);
     }
-
-    //--------------------------------------------------------------------
 
     public function testWhereArray()
     {
@@ -47,10 +43,8 @@ final class WhereTest extends CIUnitTestCase
         $this->assertCount(1, $jobs);
 
         $job = current($jobs);
-        $this->assertEquals('Musician', $job->name);
+        $this->assertSame('Musician', $job->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testWhereCustomString()
     {
@@ -61,10 +55,8 @@ final class WhereTest extends CIUnitTestCase
         $this->assertCount(1, $jobs);
 
         $job = current($jobs);
-        $this->assertEquals('Musician', $job->name);
+        $this->assertSame('Musician', $job->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testOrWhere()
     {
@@ -75,12 +67,10 @@ final class WhereTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(3, $jobs);
-        $this->assertEquals('Developer', $jobs[0]->name);
-        $this->assertEquals('Politician', $jobs[1]->name);
-        $this->assertEquals('Musician', $jobs[2]->name);
+        $this->assertSame('Developer', $jobs[0]->name);
+        $this->assertSame('Politician', $jobs[1]->name);
+        $this->assertSame('Musician', $jobs[2]->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testOrWhereSameColumn()
     {
@@ -91,11 +81,9 @@ final class WhereTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(2, $jobs);
-        $this->assertEquals('Developer', $jobs[0]->name);
-        $this->assertEquals('Politician', $jobs[1]->name);
+        $this->assertSame('Developer', $jobs[0]->name);
+        $this->assertSame('Politician', $jobs[1]->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testWhereIn()
     {
@@ -105,11 +93,9 @@ final class WhereTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(2, $jobs);
-        $this->assertEquals('Politician', $jobs[0]->name);
-        $this->assertEquals('Accountant', $jobs[1]->name);
+        $this->assertSame('Politician', $jobs[0]->name);
+        $this->assertSame('Accountant', $jobs[1]->name);
     }
-
-    //--------------------------------------------------------------------
 
     /**
      * @group single
@@ -122,11 +108,9 @@ final class WhereTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(2, $jobs);
-        $this->assertEquals('Developer', $jobs[0]->name);
-        $this->assertEquals('Musician', $jobs[1]->name);
+        $this->assertSame('Developer', $jobs[0]->name);
+        $this->assertSame('Musician', $jobs[1]->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSubQuery()
     {
@@ -141,12 +125,10 @@ final class WhereTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(3, $jobs);
-        $this->assertEquals('Politician', $jobs[0]->name);
-        $this->assertEquals('Accountant', $jobs[1]->name);
-        $this->assertEquals('Musician', $jobs[2]->name);
+        $this->assertSame('Politician', $jobs[0]->name);
+        $this->assertSame('Accountant', $jobs[1]->name);
+        $this->assertSame('Musician', $jobs[2]->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSubQueryAnotherType()
     {
@@ -161,10 +143,8 @@ final class WhereTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(1, $jobs);
-        $this->assertEquals('Developer', $jobs[0]->name);
+        $this->assertSame('Developer', $jobs[0]->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testWhereNullParam()
     {
@@ -180,10 +160,8 @@ final class WhereTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(1, $jobs);
-        $this->assertEquals('Brewmaster', $jobs[0]->name);
+        $this->assertSame('Brewmaster', $jobs[0]->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testWhereIsNull()
     {
@@ -199,10 +177,8 @@ final class WhereTest extends CIUnitTestCase
             ->getResult();
 
         $this->assertCount(1, $jobs);
-        $this->assertEquals('Brewmaster', $jobs[0]->name);
+        $this->assertSame('Brewmaster', $jobs[0]->name);
     }
-
-    //--------------------------------------------------------------------
 
     public function testWhereIsNotNull()
     {

--- a/tests/system/Database/Migrations/MigrationTest.php
+++ b/tests/system/Database/Migrations/MigrationTest.php
@@ -34,6 +34,6 @@ final class MigrationTest extends CIUnitTestCase
 
         $dbGroup = $migration->getDBGroup();
 
-        $this->assertEquals('tests', $dbGroup);
+        $this->assertSame('tests', $dbGroup);
     }
 }

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -21,7 +21,7 @@ final class ExceptionsTest extends CIUnitTestCase
      */
     public function testCleanPaths($file, $expected)
     {
-        $this->assertEquals($expected, Exceptions::cleanPath($file));
+        $this->assertSame($expected, Exceptions::cleanPath($file));
     }
 
     public function dirtyPathsProvider()

--- a/tests/system/Debug/TimerTest.php
+++ b/tests/system/Debug/TimerTest.php
@@ -68,7 +68,7 @@ final class TimerTest extends CIUnitTestCase
 
         $expected = $timers['test1']['duration'];
 
-        $this->assertEquals($expected, $timer->getElapsedTime('test1'));
+        $this->assertSame($expected, $timer->getElapsedTime('test1'));
     }
 
     public function testThrowsExceptionStoppingNonTimer()

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -41,7 +41,7 @@ final class EmailTest extends CIUnitTestCase
         $this->assertTrue($email->send($autoClear));
 
         if (! $autoClear) {
-            $this->assertEquals('foo@foo.com', $email->archive['recipients'][0]);
+            $this->assertSame('foo@foo.com', $email->archive['recipients'][0]);
         }
     }
 
@@ -57,9 +57,9 @@ final class EmailTest extends CIUnitTestCase
         $this->assertTrue($email->send());
 
         $this->assertNotEmpty($email->archive);
-        $this->assertEquals(['foo@foo.com'], $email->archive['recipients']);
-        $this->assertEquals('bar@foo.com', $email->archive['fromEmail']);
-        $this->assertEquals('Archive Test', $email->archive['subject']);
+        $this->assertSame(['foo@foo.com'], $email->archive['recipients']);
+        $this->assertSame('bar@foo.com', $email->archive['fromEmail']);
+        $this->assertSame('Archive Test', $email->archive['subject']);
     }
 
     public function testAutoClearLeavesArchive()
@@ -87,8 +87,8 @@ final class EmailTest extends CIUnitTestCase
         $email->setSubject('Archive Test');
         $this->assertTrue($email->send());
 
-        $this->assertEquals('', $email->archive['fromEmail']);
-        $this->assertEquals('Archive Test', $email->archive['subject']);
+        $this->assertSame('', $email->archive['fromEmail']);
+        $this->assertSame('Archive Test', $email->archive['subject']);
     }
 
     public function testSuccessDoesTriggerEvent()
@@ -107,7 +107,7 @@ final class EmailTest extends CIUnitTestCase
         $this->assertTrue($email->send());
 
         $this->assertIsArray($result);
-        $this->assertEquals(['foo@foo.com'], $result['recipients']);
+        $this->assertSame(['foo@foo.com'], $result['recipients']);
     }
 
     public function testFailureDoesNotTriggerEvent()

--- a/tests/system/Encryption/EncryptionTest.php
+++ b/tests/system/Encryption/EncryptionTest.php
@@ -41,7 +41,7 @@ final class EncryptionTest extends CIUnitTestCase
         $ikm              = 'Secret stuff';
         $config->key      = $ikm;
         $this->encryption = new Encryption($config);
-        $this->assertEquals($ikm, $this->encryption->key);
+        $this->assertSame($ikm, $this->encryption->key);
     }
 
     /**
@@ -77,8 +77,8 @@ final class EncryptionTest extends CIUnitTestCase
     public function testKeyCreation()
     {
         $this->assertNotEmpty($this->encryption->createKey());
-        $this->assertEquals(32, strlen($this->encryption->createKey()));
-        $this->assertEquals(16, strlen($this->encryption->createKey(16)));
+        $this->assertSame(32, strlen($this->encryption->createKey()));
+        $this->assertSame(16, strlen($this->encryption->createKey(16)));
     }
 
     public function testServiceSuccess()
@@ -120,7 +120,7 @@ final class EncryptionTest extends CIUnitTestCase
 
         $config->key = 'Abracadabra';
         $encrypter   = Services::encrypter($config, true);
-        $this->assertEquals('anything', $encrypter->key);
+        $this->assertSame('anything', $encrypter->key);
     }
 
     public function testMagicIssetTrue()
@@ -135,7 +135,7 @@ final class EncryptionTest extends CIUnitTestCase
 
     public function testMagicGet()
     {
-        $this->assertEquals('SHA512', $this->encryption->digest);
+        $this->assertSame('SHA512', $this->encryption->digest);
     }
 
     public function testMagicGetMissing()

--- a/tests/system/Encryption/Handlers/OpenSSLHandlerTest.php
+++ b/tests/system/Encryption/Handlers/OpenSSLHandlerTest.php
@@ -37,8 +37,8 @@ final class OpenSSLHandlerTest extends CIUnitTestCase
 
         $encrypter = $this->encryption->initialize($params);
 
-        $this->assertEquals('AES-256-CTR', $encrypter->cipher);
-        $this->assertEquals('Something other than an empty string', $encrypter->key);
+        $this->assertSame('AES-256-CTR', $encrypter->cipher);
+        $this->assertSame('Something other than an empty string', $encrypter->key);
     }
 
     /**
@@ -56,14 +56,14 @@ final class OpenSSLHandlerTest extends CIUnitTestCase
         $encrypter = $this->encryption->initialize($params);
 
         // Was the key properly set?
-        $this->assertEquals($params->key, $encrypter->key);
+        $this->assertSame($params->key, $encrypter->key);
 
         // simple encrypt/decrypt, default parameters
         $message1 = 'This is a plain-text message.';
-        $this->assertEquals($message1, $encrypter->decrypt($encrypter->encrypt($message1)));
+        $this->assertSame($message1, $encrypter->decrypt($encrypter->encrypt($message1)));
         $message2 = 'This is a different plain-text message.';
-        $this->assertEquals($message2, $encrypter->decrypt($encrypter->encrypt($message2)));
-        $this->assertNotEquals($message2, $encrypter->decrypt($encrypter->encrypt($message1)));
+        $this->assertSame($message2, $encrypter->decrypt($encrypter->encrypt($message2)));
+        $this->assertNotSame($message2, $encrypter->decrypt($encrypter->encrypt($message1)));
     }
 
     /**
@@ -84,7 +84,7 @@ final class OpenSSLHandlerTest extends CIUnitTestCase
         $encrypter = new OpenSSLHandler();
         $message1  = 'This is a plain-text message.';
         $encoded   = $encrypter->encrypt($message1, $key);
-        $this->assertEquals($message1, $encrypter->decrypt($encoded, $key));
+        $this->assertSame($message1, $encrypter->decrypt($encoded, $key));
     }
 
     /**
@@ -98,9 +98,9 @@ final class OpenSSLHandlerTest extends CIUnitTestCase
         $encrypter = new OpenSSLHandler();
         $message1  = 'This is a plain-text message.';
         $encoded   = $encrypter->encrypt($message1, $key1);
-        $this->assertNotEquals($message1, $encoded);
+        $this->assertNotSame($message1, $encoded);
         $key2 = 'Holy cow, batman!';
-        $this->assertNotEquals($message1, $encrypter->decrypt($encoded, $key2));
+        $this->assertNotSame($message1, $encrypter->decrypt($encoded, $key2));
     }
 
     public function testWithKeyArray()
@@ -109,7 +109,7 @@ final class OpenSSLHandlerTest extends CIUnitTestCase
         $encrypter = new OpenSSLHandler();
         $message1  = 'This is a plain-text message.';
         $encoded   = $encrypter->encrypt($message1, ['key' => $key]);
-        $this->assertEquals($message1, $encrypter->decrypt($encoded, ['key' => $key]));
+        $this->assertSame($message1, $encrypter->decrypt($encoded, ['key' => $key]));
     }
 
     /**
@@ -123,8 +123,8 @@ final class OpenSSLHandlerTest extends CIUnitTestCase
         $encrypter = new OpenSSLHandler();
         $message1  = 'This is a plain-text message.';
         $encoded   = $encrypter->encrypt($message1, ['key' => $key1]);
-        $this->assertNotEquals($message1, $encoded);
+        $this->assertNotSame($message1, $encoded);
         $key2 = 'Holy cow, batman!';
-        $this->assertNotEquals($message1, $encrypter->decrypt($encoded, ['key' => $key2]));
+        $this->assertNotSame($message1, $encrypter->decrypt($encoded, ['key' => $key2]));
     }
 }

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CodeIgniter;
+namespace CodeIgniter\Entity;
 
 use CodeIgniter\Entity\Exceptions\CastException;
 use CodeIgniter\HTTP\URI;
@@ -9,6 +9,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ReflectionHelper;
 use DateTime;
 use ReflectionException;
+use stdClass;
 use Tests\Support\Entity\Cast\CastBase64;
 use Tests\Support\Entity\Cast\CastPassParameters;
 use Tests\Support\Entity\Cast\NotExtendsBaseCast;
@@ -27,10 +28,8 @@ final class EntityTest extends CIUnitTestCase
 
         $entity->foo = 'to wong';
 
-        $this->assertEquals('to wong', $entity->foo);
+        $this->assertSame('to wong', $entity->foo);
     }
-
-    //--------------------------------------------------------------------
 
     public function testGetterSetters()
     {
@@ -38,18 +37,18 @@ final class EntityTest extends CIUnitTestCase
 
         $entity->bar = 'thanks';
 
-        $this->assertEquals('bar:thanks:bar', $entity->bar);
+        $this->assertSame('bar:thanks:bar', $entity->bar);
     }
 
     public function testUnsetUnsetsAttribute()
     {
         $entity = $this->getEntity();
 
-        $this->assertEquals('sumfin', $entity->default);
+        $this->assertSame('sumfin', $entity->default);
 
         $entity->default = 'else';
 
-        $this->assertEquals('else', $entity->default);
+        $this->assertSame('else', $entity->default);
 
         unset($entity->default);
 
@@ -67,8 +66,6 @@ final class EntityTest extends CIUnitTestCase
         $this->assertTrue(isset($attributes['default']));
     }
 
-    //--------------------------------------------------------------------
-
     public function testFill()
     {
         $entity = $this->getEntity();
@@ -79,8 +76,8 @@ final class EntityTest extends CIUnitTestCase
             'baz' => 4556,
         ]);
 
-        $this->assertEquals(123, $entity->foo);
-        $this->assertEquals('bar:234:bar', $entity->bar);
+        $this->assertSame(123, $entity->foo);
+        $this->assertSame('bar:234:bar', $entity->bar);
         $this->assertObjectNotHasAttribute('baz', $entity);
     }
 
@@ -97,11 +94,9 @@ final class EntityTest extends CIUnitTestCase
         ];
         $entity->fill($data);
 
-        $this->assertEquals('foo', $entity->bar);
-        $this->assertEquals('oo:simple:oo', $entity->orig);
+        $this->assertSame('foo', $entity->bar);
+        $this->assertSame('oo:simple:oo', $entity->orig);
     }
-
-    //--------------------------------------------------------------------
 
     public function testDataMappingConvertsOriginalName()
     {
@@ -110,11 +105,11 @@ final class EntityTest extends CIUnitTestCase
         $entity->bar = 'made it';
 
         // Check mapped field
-        $this->assertEquals('made it', $entity->foo);
+        $this->assertSame('made it', $entity->foo);
 
         // Should also get from original name
         // since Model's would be looking for the original name
-        $this->assertEquals('made it', $entity->bar);
+        $this->assertSame('made it', $entity->bar);
 
         // But it shouldn't actually set a class property for the original name...
         $this->expectException(ReflectionException::class);
@@ -128,11 +123,11 @@ final class EntityTest extends CIUnitTestCase
         // Will map to "simple"
         $entity->orig = 'first';
 
-        $this->assertEquals('oo:first:oo', $entity->simple);
+        $this->assertSame('oo:first:oo', $entity->simple);
 
         $entity->simple = 'second';
 
-        $this->assertEquals('oo:second:oo', $entity->simple);
+        $this->assertSame('oo:second:oo', $entity->simple);
     }
 
     public function testIssetWorksWithMapping()
@@ -157,8 +152,8 @@ final class EntityTest extends CIUnitTestCase
 
         // doesn't work on original name
         unset($entity->bar);
-        $this->assertEquals('here', $entity->bar);
-        $this->assertEquals('here', $entity->foo);
+        $this->assertSame('here', $entity->bar);
+        $this->assertSame('here', $entity->foo);
 
         // does work on mapped field
         unset($entity->foo);
@@ -166,20 +161,16 @@ final class EntityTest extends CIUnitTestCase
         $this->assertNull($entity->bar);
     }
 
-    //--------------------------------------------------------------------
-
     public function testDateMutationFromString()
     {
         $entity     = $this->getEntity();
-        $attributes = [
-            'created_at' => '2017-07-15 13:23:34',
-        ];
+        $attributes = ['created_at' => '2017-07-15 13:23:34'];
         $this->setPrivateProperty($entity, 'attributes', $attributes);
 
         $time = $entity->created_at;
 
         $this->assertInstanceOf(Time::class, $time);
-        $this->assertEquals('2017-07-15 13:23:34', $time->format('Y-m-d H:i:s'));
+        $this->assertSame('2017-07-15 13:23:34', $time->format('Y-m-d H:i:s'));
     }
 
     public function testDateMutationFromTimestamp()
@@ -187,9 +178,7 @@ final class EntityTest extends CIUnitTestCase
         $stamp = time();
 
         $entity     = $this->getEntity();
-        $attributes = [
-            'created_at' => $stamp,
-        ];
+        $attributes = ['created_at' => $stamp];
         $this->setPrivateProperty($entity, 'attributes', $attributes);
 
         $time = $entity->created_at;
@@ -202,9 +191,7 @@ final class EntityTest extends CIUnitTestCase
     {
         $dt         = new DateTime('now');
         $entity     = $this->getEntity();
-        $attributes = [
-            'created_at' => $dt,
-        ];
+        $attributes = ['created_at' => $dt];
         $this->setPrivateProperty($entity, 'attributes', $attributes);
 
         $time = $entity->created_at;
@@ -217,9 +204,7 @@ final class EntityTest extends CIUnitTestCase
     {
         $dt         = Time::now();
         $entity     = $this->getEntity();
-        $attributes = [
-            'created_at' => $dt,
-        ];
+        $attributes = ['created_at' => $dt];
         $this->setPrivateProperty($entity, 'attributes', $attributes);
 
         $time = $entity->created_at;
@@ -237,7 +222,7 @@ final class EntityTest extends CIUnitTestCase
         $time = $this->getPrivateProperty($entity, 'attributes')['created_at'];
 
         $this->assertInstanceOf(Time::class, $time);
-        $this->assertEquals('2017-07-15 13:23:34', $time->format('Y-m-d H:i:s'));
+        $this->assertSame('2017-07-15 13:23:34', $time->format('Y-m-d H:i:s'));
     }
 
     public function testDateMutationTimestampToTime()
@@ -279,18 +264,16 @@ final class EntityTest extends CIUnitTestCase
         $this->assertCloseEnoughString($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
     }
 
-    //--------------------------------------------------------------------
-
     public function testCastInteger()
     {
         $entity = $this->getCastEntity();
 
         $entity->first = 3.1;
         $this->assertIsInt($entity->first);
-        $this->assertEquals(3, $entity->first);
+        $this->assertSame(3, $entity->first);
 
         $entity->first = 3.6;
-        $this->assertEquals(3, $entity->first);
+        $this->assertSame(3, $entity->first);
     }
 
     public function testCastFloat()
@@ -299,11 +282,11 @@ final class EntityTest extends CIUnitTestCase
 
         $entity->second = 3;
         $this->assertIsFloat($entity->second);
-        $this->assertEquals(3.0, $entity->second);
+        $this->assertSame(3.0, $entity->second);
 
         $entity->second = '3.6';
         $this->assertIsFloat($entity->second);
-        $this->assertEquals(3.6, $entity->second);
+        $this->assertSame(3.6, $entity->second);
     }
 
     public function testCastDouble()
@@ -345,20 +328,16 @@ final class EntityTest extends CIUnitTestCase
     {
         $entity = $this->getCastEntity();
 
-        $data = [
-            'foo',
-            'bar',
-            'bam',
-        ];
+        $data = ['foo', 'bar', 'bam'];
 
         $entity->twelfth = $data;
 
         $result = $entity->toRawArray();
         $this->assertIsString($result['twelfth']);
-        $this->assertEquals('foo,bar,bam', $result['twelfth']);
+        $this->assertSame('foo,bar,bam', $result['twelfth']);
 
         $this->assertIsArray($entity->twelfth);
-        $this->assertEquals($data, $entity->twelfth);
+        $this->assertSame($data, $entity->twelfth);
     }
 
     public function testCastObject()
@@ -369,7 +348,8 @@ final class EntityTest extends CIUnitTestCase
 
         $entity->sixth = $data;
         $this->assertIsObject($entity->sixth);
-        $this->assertEquals((object) $data, $entity->sixth);
+        $this->assertInstanceOf(stdClass::class, $entity->sixth);
+        $this->assertSame($data, (array) $entity->sixth);
     }
 
     public function testCastDateTime()
@@ -378,7 +358,7 @@ final class EntityTest extends CIUnitTestCase
 
         $entity->eighth = 'March 12, 2017';
         $this->assertInstanceOf('DateTime', $entity->eighth);
-        $this->assertEquals('2017-03-12', $entity->eighth->format('Y-m-d'));
+        $this->assertSame('2017-03-12', $entity->eighth->format('Y-m-d'));
     }
 
     public function testCastTimestamp()
@@ -389,7 +369,7 @@ final class EntityTest extends CIUnitTestCase
 
         $entity->ninth = $date;
         $this->assertIsInt($entity->ninth);
-        $this->assertEquals(strtotime($date), $entity->ninth);
+        $this->assertSame(strtotime($date), $entity->ninth);
     }
 
     public function testCastTimestampException()
@@ -404,8 +384,6 @@ final class EntityTest extends CIUnitTestCase
         $entity->ninth;
     }
 
-    //--------------------------------------------------------------------
-
     public function testCastArray()
     {
         $entity = $this->getCastEntity();
@@ -413,9 +391,9 @@ final class EntityTest extends CIUnitTestCase
         $entity->seventh = ['foo' => 'bar'];
 
         $check = $this->getPrivateProperty($entity, 'attributes')['seventh'];
-        $this->assertEquals(serialize(['foo' => 'bar']), $check);
+        $this->assertSame(serialize(['foo' => 'bar']), $check);
 
-        $this->assertEquals(['foo' => 'bar'], $entity->seventh);
+        $this->assertSame(['foo' => 'bar'], $entity->seventh);
     }
 
     public function testCastArrayByStringSerialize()
@@ -426,9 +404,9 @@ final class EntityTest extends CIUnitTestCase
 
         // Should be a serialized string now...
         $check = $this->getPrivateProperty($entity, 'attributes')['seventh'];
-        $this->assertEquals(serialize('foobar'), $check);
+        $this->assertSame(serialize('foobar'), $check);
 
-        $this->assertEquals(['foobar'], $entity->seventh);
+        $this->assertSame(['foobar'], $entity->seventh);
     }
 
     public function testCastArrayByArraySerialize()
@@ -439,54 +417,40 @@ final class EntityTest extends CIUnitTestCase
 
         // Should be a serialized string now...
         $check = $this->getPrivateProperty($entity, 'attributes')['seventh'];
-        $this->assertEquals(serialize(['foo' => 'bar']), $check);
+        $this->assertSame(serialize(['foo' => 'bar']), $check);
 
-        $this->assertEquals(['foo' => 'bar'], $entity->seventh);
+        $this->assertSame(['foo' => 'bar'], $entity->seventh);
     }
 
     public function testCastArrayByFill()
     {
         $entity = $this->getCastEntity();
 
-        $data = [
-            'seventh' => [
-                1,
-                2,
-                3,
-            ],
-        ];
+        $data = ['seventh' => [1, 2, 3]];
 
         $entity->fill($data);
 
         // Check if serialiazed
         $check = $this->getPrivateProperty($entity, 'attributes')['seventh'];
-        $this->assertEquals(serialize([1, 2, 3]), $check);
+        $this->assertSame(serialize([1, 2, 3]), $check);
 
         // Check if unserialized
-        $this->assertEquals([1, 2, 3], $entity->seventh);
+        $this->assertSame([1, 2, 3], $entity->seventh);
     }
 
     public function testCastArrayByConstructor()
     {
-        $data = [
-            'seventh' => [
-                1,
-                2,
-                3,
-            ],
-        ];
+        $data = ['seventh' => [1, 2, 3]];
 
         $entity = $this->getCastEntity($data);
 
         // Check if serialiazed
         $check = $this->getPrivateProperty($entity, 'attributes')['seventh'];
-        $this->assertEquals(serialize([1, 2, 3]), $check);
+        $this->assertSame(serialize([1, 2, 3]), $check);
 
         // Check if unserialized
-        $this->assertEquals([1, 2, 3], $entity->seventh);
+        $this->assertSame([1, 2, 3], $entity->seventh);
     }
-
-    //--------------------------------------------------------------------
 
     public function testCastNullable()
     {
@@ -498,8 +462,6 @@ final class EntityTest extends CIUnitTestCase
         $this->assertSame(0, $entity->integer_0);
         $this->assertSame('value', $entity->string_value_not_null);
     }
-
-    //--------------------------------------------------------------------
 
     public function testCastURI()
     {
@@ -525,8 +487,6 @@ final class EntityTest extends CIUnitTestCase
         $this->assertSame('/banana', $entity->thirteenth->getPath());
     }
 
-    //--------------------------------------------------------------------
-
     public function testCastAsJSON()
     {
         $entity = $this->getCastEntity();
@@ -535,68 +495,53 @@ final class EntityTest extends CIUnitTestCase
 
         // Should be a JSON-encoded string now...
         $check = $this->getPrivateProperty($entity, 'attributes')['tenth'];
-        $this->assertEquals('{"foo":"bar"}', $check);
+        $this->assertSame('{"foo":"bar"}', $check);
 
-        $this->assertEquals((object) ['foo' => 'bar'], $entity->tenth);
+        $this->assertInstanceOf(stdClass::class, $entity->tenth);
+        $this->assertSame(['foo' => 'bar'], (array) $entity->tenth);
     }
 
     public function testCastAsJSONArray()
     {
         $entity = $this->getCastEntity();
 
-        $data = [
-            'Sun',
-            'Mon',
-            'Tue',
-        ];
+        $data = ['Sun', 'Mon', 'Tue'];
+
         $entity->eleventh = $data;
 
         // Should be a JSON-encoded string now...
         $check = $this->getPrivateProperty($entity, 'attributes')['eleventh'];
-        $this->assertEquals('["Sun","Mon","Tue"]', $check);
+        $this->assertSame('["Sun","Mon","Tue"]', $check);
 
-        $this->assertEquals($data, $entity->eleventh);
+        $this->assertSame($data, $entity->eleventh);
     }
 
     public function testCastAsJsonByFill()
     {
         $entity = $this->getCastEntity();
-        $data   = [
-            'eleventh' => [
-                1,
-                2,
-                3,
-            ],
-        ];
+        $data   = ['eleventh' => [1, 2, 3]];
 
         $entity->fill($data);
 
         // Check if serialiazed
         $check = $this->getPrivateProperty($entity, 'attributes')['eleventh'];
-        $this->assertEquals(json_encode([1, 2, 3]), $check);
+        $this->assertSame(json_encode([1, 2, 3]), $check);
 
         // Check if unserialized
-        $this->assertEquals([1, 2, 3], $entity->eleventh);
+        $this->assertSame([1, 2, 3], $entity->eleventh);
     }
 
     public function testCastAsJsonByConstructor()
     {
-        $data = [
-            'eleventh' => [
-                1,
-                2,
-                3,
-            ],
-        ];
-
+        $data   = ['eleventh' => [1, 2, 3]];
         $entity = $this->getCastEntity($data);
 
         // Check if serialiazed
         $check = $this->getPrivateProperty($entity, 'attributes')['eleventh'];
-        $this->assertEquals(json_encode([1, 2, 3]), $check);
+        $this->assertSame(json_encode([1, 2, 3]), $check);
 
         // Check if unserialized
-        $this->assertEquals([1, 2, 3], $entity->eleventh);
+        $this->assertSame([1, 2, 3], $entity->eleventh);
     }
 
     public function testCastAsJSONErrorDepth()
@@ -662,7 +607,6 @@ final class EntityTest extends CIUnitTestCase
     public function testCastAsJSONControlCharCheck()
     {
         $entity = new Entity();
-
         $method = $this->getPrivateMethodInvoker($entity, 'castAsJson');
 
         $this->expectException(CastException::class);
@@ -676,7 +620,6 @@ final class EntityTest extends CIUnitTestCase
     public function testCastAsJSONStateMismatch()
     {
         $entity = new Entity();
-
         $method = $this->getPrivateMethodInvoker($entity, 'castAsJson');
 
         $this->expectException(CastException::class);
@@ -687,8 +630,6 @@ final class EntityTest extends CIUnitTestCase
         $method($string, true);
     }
 
-    //--------------------------------------------------------------------
-
     public function testCastSetter()
     {
         $string = '321 String with numbers 123';
@@ -698,11 +639,11 @@ final class EntityTest extends CIUnitTestCase
 
         $entity->cast(false);
         $this->assertIsString($entity->first);
-        $this->assertEquals($string, $entity->first);
+        $this->assertSame($string, $entity->first);
 
         $entity->cast(true);
         $this->assertIsInt($entity->first);
-        $this->assertEquals((int) $string, $entity->first);
+        $this->assertSame((int) $string, $entity->first);
     }
 
     public function testCastGetter()
@@ -720,9 +661,9 @@ final class EntityTest extends CIUnitTestCase
 
         $fieldValue = $this->getPrivateProperty($entity, 'attributes')['first'];
 
-        $this->assertEquals(base64_encode('base 64'), $fieldValue);
+        $this->assertSame(base64_encode('base 64'), $fieldValue);
 
-        $this->assertEquals('base 64', $entity->first);
+        $this->assertSame('base 64', $entity->first);
     }
 
     public function testCustomCastException()
@@ -730,10 +671,7 @@ final class EntityTest extends CIUnitTestCase
         $entity = $this->getCustomCastEntity();
 
         $this->expectException(CastException::class);
-        $this->expectErrorMessage(
-            'The "Tests\Support\Entity\Cast\NotExtendsBaseCast" class '
-            . 'must inherit the "CodeIgniter\Entity\Cast\BaseCast" class'
-        );
+        $this->expectErrorMessage('The "Tests\Support\Entity\Cast\NotExtendsBaseCast" class must inherit the "CodeIgniter\Entity\Cast\BaseCast" class');
         $entity->second = 'throw Exception';
     }
 
@@ -743,21 +681,18 @@ final class EntityTest extends CIUnitTestCase
 
         $entity->third = 'value';
 
-        $this->assertEquals('value:["param1","param2","param3"]', $entity->third);
+        $this->assertSame('value:["param1","param2","param3"]', $entity->third);
 
         $entity->fourth = 'test_nullable_type';
-        $this->assertEquals('test_nullable_type:["nullable"]', $entity->fourth);
+        $this->assertSame('test_nullable_type:["nullable"]', $entity->fourth);
     }
-
-    //--------------------------------------------------------------------
 
     public function testAsArray()
     {
         $entity = $this->getEntity();
-
         $result = $entity->toArray();
 
-        $this->assertEquals($result, [
+        $this->assertSame($result, [
             'foo'       => null,
             'bar'       => ':bar',
             'default'   => 'sumfin',
@@ -772,27 +707,26 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toArray(false, true, true);
 
-        $this->assertEquals($result, [
-            'foo'       => null,
-            'bar'       => ':bar',
-            'default'   => 'sumfin',
-            'createdAt' => null,
-            'entity'    => [
+        $this->assertSame([
+            'foo'     => null,
+            'bar'     => ':bar',
+            'default' => 'sumfin',
+            'entity'  => [
                 'foo'       => null,
                 'bar'       => ':bar',
                 'default'   => 'sumfin',
                 'createdAt' => null,
             ],
-        ]);
+            'createdAt' => null,
+        ], $result);
     }
 
     public function testAsArrayMapped()
     {
         $entity = $this->getMappedEntity();
-
         $result = $entity->toArray();
 
-        $this->assertEquals($result, [
+        $this->assertSame($result, [
             'bar'  => null,
             'orig' => ':oo',
         ]);
@@ -801,10 +735,9 @@ final class EntityTest extends CIUnitTestCase
     public function testAsArraySwapped()
     {
         $entity = $this->getSwappedEntity();
-
         $result = $entity->toArray();
 
-        $this->assertEquals($result, [
+        $this->assertSame($result, [
             'bar'          => 'foo',
             'foo'          => 'bar',
             'original_bar' => 'bar',
@@ -822,7 +755,7 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toArray();
 
-        $this->assertEquals($result, [
+        $this->assertSame($result, [
             'bar' => null,
         ]);
     }
@@ -835,7 +768,7 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toArray(true);
 
-        $this->assertEquals($result, [
+        $this->assertSame($result, [
             'bar' => 'bar:foo:bar',
         ]);
     }
@@ -846,7 +779,7 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toRawArray();
 
-        $this->assertEquals($result, [
+        $this->assertSame($result, [
             'foo'        => null,
             'bar'        => null,
             'default'    => 'sumfin',
@@ -861,7 +794,7 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toRawArray(false, true);
 
-        $this->assertEquals($result, [
+        $this->assertSame($result, [
             'foo'        => null,
             'bar'        => null,
             'default'    => 'sumfin',
@@ -883,12 +816,10 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toRawArray(true);
 
-        $this->assertEquals($result, [
+        $this->assertSame($result, [
             'bar' => 'bar:foo',
         ]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testFilledConstruction()
     {
@@ -898,31 +829,25 @@ final class EntityTest extends CIUnitTestCase
         ];
 
         $something = new SomeEntity($data);
-        $this->assertEquals('bar', $something->foo);
-        $this->assertEquals('baz', $something->bar);
+        $this->assertSame('bar', $something->foo);
+        $this->assertSame('baz', $something->bar);
     }
-
-    //--------------------------------------------------------------------
 
     public function testChangedArray()
     {
-        $data = [
-            'bar' => 'baz',
-        ];
+        $data = ['bar' => 'baz'];
 
         $something = new SomeEntity($data);
-        $whatsnew  = $something->toArray(true);
-        $expected  = $data;
-        $this->assertEquals($expected, $whatsnew);
+        $this->assertSame($data, $something->toArray(true));
 
-        $something->magic  = 'rockin';
-        $expected['magic'] = 'rockin';
-        $expected['foo']   = null;
-        $whatsnew          = $something->toArray(false);
-        $this->assertEquals($expected, $whatsnew);
+        $something->magic = 'rockin';
+
+        $this->assertSame([
+            'foo'   => null,
+            'bar'   => 'baz',
+            'magic' => 'rockin',
+        ], $something->toArray(false));
     }
-
-    //--------------------------------------------------------------------
 
     public function testHasChangedNotExists()
     {
@@ -977,10 +902,10 @@ final class EntityTest extends CIUnitTestCase
     {
         $entity = $this->getEntity();
         $entity->setBar('foo');
-        $this->assertEquals(json_encode($entity->toArray()), json_encode($entity));
+        $this->assertSame(json_encode($entity->toArray()), json_encode($entity));
     }
 
-    protected function getEntity() : Entity
+    protected function getEntity()
     {
         return new class() extends Entity {
             protected $attributes = [
@@ -1020,7 +945,7 @@ final class EntityTest extends CIUnitTestCase
         };
     }
 
-    protected function getMappedEntity() : Entity
+    protected function getMappedEntity()
     {
         return new class() extends Entity {
             protected $attributes = [
@@ -1051,7 +976,7 @@ final class EntityTest extends CIUnitTestCase
         };
     }
 
-    protected function getSwappedEntity() : Entity
+    protected function getSwappedEntity()
     {
         return new class() extends Entity {
             protected $attributes = [
@@ -1131,7 +1056,7 @@ final class EntityTest extends CIUnitTestCase
         };
     }
 
-    protected function getCastNullableEntity() : Entity
+    protected function getCastNullableEntity()
     {
         return new class() extends Entity {
             protected $attributes = [
@@ -1161,7 +1086,7 @@ final class EntityTest extends CIUnitTestCase
         };
     }
 
-    protected function getCustomCastEntity() : Entity
+    protected function getCustomCastEntity()
     {
         return new class() extends Entity {
             protected $attributes = [

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -52,15 +52,15 @@ final class EventsTest extends CIUnitTestCase
         $default = [APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'Events.php'];
         $this->manager->unInitialize();
         MockEvents::initialize();
-        $this->assertEquals($default, $this->manager->getFiles());
+        $this->assertSame($default, $this->manager->getFiles());
 
         // but we should be able to change it through the backdoor
         MockEvents::setFiles(['/peanuts']);
-        $this->assertEquals(['/peanuts'], $this->manager->getFiles());
+        $this->assertSame(['/peanuts'], $this->manager->getFiles());
 
         // re-initializing should have no effect
         MockEvents::initialize();
-        $this->assertEquals(['/peanuts'], $this->manager->getFiles());
+        $this->assertSame(['/peanuts'], $this->manager->getFiles());
     }
 
     public function testPerformance()
@@ -86,7 +86,7 @@ final class EventsTest extends CIUnitTestCase
         Events::on('foo', $callback1, EVENT_PRIORITY_HIGH);
         Events::on('foo', $callback2, EVENT_PRIORITY_NORMAL);
 
-        $this->assertEquals([$callback2, $callback1], Events::listeners('foo'));
+        $this->assertSame([$callback1, $callback2], Events::listeners('foo'));
     }
 
     public function testHandleEvent()
@@ -99,7 +99,7 @@ final class EventsTest extends CIUnitTestCase
 
         $this->assertTrue(Events::trigger('foo', 'bar'));
 
-        $this->assertEquals('bar', $result);
+        $this->assertSame('bar', $result);
     }
 
     public function testCancelEvent()
@@ -118,7 +118,7 @@ final class EventsTest extends CIUnitTestCase
         });
 
         $this->assertFalse(Events::trigger('foo', 'bar'));
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testPriority()
@@ -139,7 +139,7 @@ final class EventsTest extends CIUnitTestCase
         }, EVENT_PRIORITY_HIGH);
 
         $this->assertFalse(Events::trigger('foo', 'bar'));
-        $this->assertEquals(2, $result);
+        $this->assertSame(2, $result);
     }
 
     public function testPriorityWithMultiple()
@@ -163,7 +163,7 @@ final class EventsTest extends CIUnitTestCase
         }, 75);
 
         Events::trigger('foo');
-        $this->assertEquals(['c', 'd', 'a', 'b'], $result);
+        $this->assertSame(['c', 'd', 'a', 'b'], $result);
     }
 
     public function testRemoveListener()
@@ -241,7 +241,7 @@ final class EventsTest extends CIUnitTestCase
 
         $listeners = Events::listeners('foo');
 
-        $this->assertEquals([], $listeners);
+        $this->assertSame([], $listeners);
     }
 
     public function testRemoveAllListenersWithMultipleEvents()
@@ -257,8 +257,8 @@ final class EventsTest extends CIUnitTestCase
 
         Events::removeAllListeners();
 
-        $this->assertEquals([], Events::listeners('foo'));
-        $this->assertEquals([], Events::listeners('bar'));
+        $this->assertSame([], Events::listeners('foo'));
+        $this->assertSame([], Events::listeners('bar'));
     }
 
     // Basically if it doesn't crash this should be good...
@@ -284,7 +284,7 @@ final class EventsTest extends CIUnitTestCase
 
         $this->assertTrue(Events::trigger('foo', 'bar'));
 
-        $this->assertEquals('bar', $box->logged);
+        $this->assertSame('bar', $box->logged);
     }
 
     public function testSimulate()
@@ -300,6 +300,6 @@ final class EventsTest extends CIUnitTestCase
         Events::simulate(true);
         Events::trigger('foo');
 
-        $this->assertEquals(0, $result);
+        $this->assertSame(0, $result);
     }
 }

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -13,14 +13,14 @@ final class FileTest extends CIUnitTestCase
     {
         $path = SYSTEMPATH . 'Common.php';
         $file = new File($path, true);
-        $this->assertEquals($path, $file->getRealPath());
+        $this->assertSame($path, $file->getRealPath());
     }
 
     public function testNewGoodUnchecked()
     {
         $path = SYSTEMPATH . 'Common.php';
         $file = new File($path, false);
-        $this->assertEquals($path, $file->getRealPath());
+        $this->assertSame($path, $file->getRealPath());
     }
 
     public function testNewBadUnchecked()
@@ -33,45 +33,45 @@ final class FileTest extends CIUnitTestCase
     public function testGuessExtension()
     {
         $file = new File(SYSTEMPATH . 'Common.php');
-        $this->assertEquals('php', $file->guessExtension());
+        $this->assertSame('php', $file->guessExtension());
         $file = new File(SYSTEMPATH . 'index.html');
-        $this->assertEquals('html', $file->guessExtension());
+        $this->assertSame('html', $file->guessExtension());
         $file = new File(ROOTPATH . 'phpunit.xml.dist');
-        $this->assertEquals('xml', $file->guessExtension());
+        $this->assertSame('xml', $file->guessExtension());
     }
 
     public function testRandomName()
     {
         $file    = new File(SYSTEMPATH . 'Common.php');
         $result1 = $file->getRandomName();
-        $this->assertNotEquals($result1, $file->getRandomName());
+        $this->assertNotSame($result1, $file->getRandomName());
     }
 
     public function testCanAccessSplFileInfoMethods()
     {
         $file = new File(SYSTEMPATH . 'Common.php');
-        $this->assertEquals('file', $file->getType());
+        $this->assertSame('file', $file->getType());
     }
 
     public function testGetSizeReturnsKB()
     {
         $file = new File(SYSTEMPATH . 'Common.php');
         $size = number_format(filesize(SYSTEMPATH . 'Common.php') / 1024, 3);
-        $this->assertEquals($size, $file->getSizeByUnit('kb'));
+        $this->assertSame($size, $file->getSizeByUnit('kb'));
     }
 
     public function testGetSizeReturnsMB()
     {
         $file = new File(SYSTEMPATH . 'Common.php');
         $size = number_format(filesize(SYSTEMPATH . 'Common.php') / 1024 / 1024, 3);
-        $this->assertEquals($size, $file->getSizeByUnit('mb'));
+        $this->assertSame($size, $file->getSizeByUnit('mb'));
     }
 
     public function testGetSizeReturnsBytes()
     {
         $file = new File(SYSTEMPATH . 'Common.php');
         $size = filesize(SYSTEMPATH . 'Common.php');
-        $this->assertEquals($size, $file->getSizeByUnit('b'));
+        $this->assertSame($size, $file->getSizeByUnit('b'));
     }
 
     public function testThrowsExceptionIfNotAFile()

--- a/tests/system/Files/FileWithVfsTest.php
+++ b/tests/system/Files/FileWithVfsTest.php
@@ -42,49 +42,49 @@ final class FileWithVfsTest extends CIUnitTestCase
     public function testDestinationUnknown()
     {
         $destination = $this->start . 'charlie/cherry.php';
-        $this->assertEquals($destination, $this->file->getDestination($destination));
+        $this->assertSame($destination, $this->file->getDestination($destination));
     }
 
     public function testDestinationSameFileSameFolder()
     {
         $destination = $this->start . 'able/apple.php';
-        $this->assertEquals($this->start . 'able/apple_1.php', $this->file->getDestination($destination));
+        $this->assertSame($this->start . 'able/apple_1.php', $this->file->getDestination($destination));
     }
 
     public function testDestinationSameFileDifferentFolder()
     {
         $destination = $this->start . 'baker/apple.php';
-        $this->assertEquals($destination, $this->file->getDestination($destination));
+        $this->assertSame($destination, $this->file->getDestination($destination));
     }
 
     public function testDestinationDifferentFileSameFolder()
     {
         $destination = $this->start . 'able/date.php';
-        $this->assertEquals($destination, $this->file->getDestination($destination));
+        $this->assertSame($destination, $this->file->getDestination($destination));
     }
 
     public function testDestinationDifferentFileDifferentFolder()
     {
         $destination = $this->start . 'baker/date.php';
-        $this->assertEquals($destination, $this->file->getDestination($destination));
+        $this->assertSame($destination, $this->file->getDestination($destination));
     }
 
     public function testDestinationExistingFileDifferentFolder()
     {
         $destination = $this->start . 'baker/banana.php';
-        $this->assertEquals($this->start . 'baker/banana_1.php', $this->file->getDestination($destination));
+        $this->assertSame($this->start . 'baker/banana_1.php', $this->file->getDestination($destination));
     }
 
     public function testDestinationDelimited()
     {
         $destination = $this->start . 'able/fig_3.php';
-        $this->assertEquals($this->start . 'able/fig_4.php', $this->file->getDestination($destination));
+        $this->assertSame($this->start . 'able/fig_4.php', $this->file->getDestination($destination));
     }
 
     public function testDestinationDelimitedAlpha()
     {
         $destination = $this->start . 'able/prune_ripe.php';
-        $this->assertEquals($this->start . 'able/prune_ripe_1.php', $this->file->getDestination($destination));
+        $this->assertSame($this->start . 'able/prune_ripe_1.php', $this->file->getDestination($destination));
     }
 
     public function testMoveNormal()
@@ -140,6 +140,6 @@ final class FileWithVfsTest extends CIUnitTestCase
 
         $this->assertTrue($this->root->hasChild('baker/apple.php'));
         $this->assertInstanceOf(File::class, $file);
-        $this->assertEquals($destination . '/apple.php', $file->getPathname());
+        $this->assertSame($destination . '/apple.php', $file->getPathname());
     }
 }

--- a/tests/system/Filters/CSRFTest.php
+++ b/tests/system/Filters/CSRFTest.php
@@ -39,6 +39,6 @@ final class CSRFTest extends CIUnitTestCase
         // we expect CSRF requests to be ignored in CLI
         $expected = $this->request;
         $request  = $filters->run($uri, 'before');
-        $this->assertEquals($expected, $request);
+        $this->assertSame($expected, $request);
     }
 }

--- a/tests/system/Filters/DebugToolbarTest.php
+++ b/tests/system/Filters/DebugToolbarTest.php
@@ -43,10 +43,10 @@ final class DebugToolbarTest extends CIUnitTestCase
 
         // nothing should change here, since we have no before logic
         $filter->before($this->request);
-        $this->assertEquals($expectedBefore, $this->request);
+        $this->assertSame($expectedBefore, $this->request);
 
         // nothing should change here, since we are running in the CLI
         $filter->after($this->request, $this->response);
-        $this->assertEquals($expectedAfter, $this->response);
+        $this->assertSame($expectedAfter, $this->response);
     }
 }

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -58,7 +58,7 @@ final class FiltersTest extends CIUnitTestCase
             'after'  => [],
         ];
 
-        $this->assertEquals($expected, $filters->initialize()->getFilters());
+        $this->assertSame($expected, $filters->initialize()->getFilters());
     }
 
     public function testProcessMethodDetectsGetRequests()
@@ -78,7 +78,7 @@ final class FiltersTest extends CIUnitTestCase
             'after'  => [],
         ];
 
-        $this->assertEquals($expected, $filters->initialize()->getFilters());
+        $this->assertSame($expected, $filters->initialize()->getFilters());
     }
 
     public function testProcessMethodRespectsMethod()
@@ -102,7 +102,7 @@ final class FiltersTest extends CIUnitTestCase
             'after'  => [],
         ];
 
-        $this->assertEquals($expected, $filters->initialize()->getFilters());
+        $this->assertSame($expected, $filters->initialize()->getFilters());
     }
 
     public function testProcessMethodIgnoresMethod()
@@ -126,7 +126,7 @@ final class FiltersTest extends CIUnitTestCase
             'after'  => [],
         ];
 
-        $this->assertEquals($expected, $filters->initialize()->getFilters());
+        $this->assertSame($expected, $filters->initialize()->getFilters());
     }
 
     public function testProcessMethodProcessGlobals()
@@ -160,7 +160,7 @@ final class FiltersTest extends CIUnitTestCase
             'after' => ['baz'],
         ];
 
-        $this->assertEquals($expected, $filters->initialize()->getFilters());
+        $this->assertSame($expected, $filters->initialize()->getFilters());
     }
 
     public function provideExcept()
@@ -208,7 +208,7 @@ final class FiltersTest extends CIUnitTestCase
             'after' => ['baz'],
         ];
 
-        $this->assertEquals($expected, $filters->initialize($uri)->getFilters());
+        $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }
 
     public function testProcessMethodProcessesFiltersBefore()
@@ -236,7 +236,7 @@ final class FiltersTest extends CIUnitTestCase
             'after'  => [],
         ];
 
-        $this->assertEquals($expected, $filters->initialize($uri)->getFilters());
+        $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }
 
     public function testProcessMethodProcessesFiltersAfter()
@@ -266,7 +266,7 @@ final class FiltersTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $filters->initialize($uri)->getFilters());
+        $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }
 
     public function testProcessMethodProcessesCombined()
@@ -314,7 +314,7 @@ final class FiltersTest extends CIUnitTestCase
             'after' => ['bazg'],
         ];
 
-        $this->assertEquals($expected, $filters->initialize($uri)->getFilters());
+        $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }
 
     public function testProcessMethodProcessesCombinedAfterForToolbar()
@@ -355,7 +355,7 @@ final class FiltersTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $filters->initialize($uri)->getFilters());
+        $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }
 
     public function testRunThrowsWithInvalidAlias()
@@ -395,7 +395,7 @@ final class FiltersTest extends CIUnitTestCase
 
         $request = $filters->run($uri, 'before');
 
-        $this->assertEquals('http://hellowworld.com', $request->url);
+        $this->assertSame('http://hellowworld.com', $request->url);
     }
 
     public function testRunThrowsWithInvalidClassType()
@@ -435,7 +435,7 @@ final class FiltersTest extends CIUnitTestCase
 
         $request = $filters->run($uri, 'before');
 
-        $this->assertEquals('http://google.com', $request->url);
+        $this->assertSame('http://google.com', $request->url);
     }
 
     public function testRunDoesAfter()
@@ -455,7 +455,7 @@ final class FiltersTest extends CIUnitTestCase
 
         $response = $filters->run($uri, 'after');
 
-        $this->assertEquals('http://google.com', $response->csp);
+        $this->assertSame('http://google.com', $response->csp);
     }
 
     public function testShortCircuit()
@@ -475,7 +475,7 @@ final class FiltersTest extends CIUnitTestCase
 
         $response = $filters->run($uri, 'before');
         $this->assertTrue($response instanceof ResponseInterface);
-        $this->assertEquals('http://google.com', $response->csp);
+        $this->assertSame('http://google.com', $response->csp);
     }
 
     public function testOtherResult()
@@ -501,7 +501,7 @@ final class FiltersTest extends CIUnitTestCase
 
         $response = $filters->run($uri, 'before');
 
-        $this->assertEquals('This is curious', $response);
+        $this->assertSame('This is curious', $response);
     }
 
     public function testBeforeExceptString()
@@ -534,7 +534,7 @@ final class FiltersTest extends CIUnitTestCase
             'after' => ['baz'],
         ];
 
-        $this->assertEquals($expected, $filters->initialize($uri)->getFilters());
+        $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }
 
     public function testBeforeExceptInapplicable()
@@ -568,7 +568,7 @@ final class FiltersTest extends CIUnitTestCase
             'after' => ['baz'],
         ];
 
-        $this->assertEquals($expected, $filters->initialize($uri)->getFilters());
+        $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }
 
     public function testAfterExceptString()
@@ -601,7 +601,7 @@ final class FiltersTest extends CIUnitTestCase
             'after' => ['baz'],
         ];
 
-        $this->assertEquals($expected, $filters->initialize($uri)->getFilters());
+        $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }
 
     public function testAfterExceptInapplicable()
@@ -637,7 +637,7 @@ final class FiltersTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $filters->initialize($uri)->getFilters());
+        $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }
 
     public function testAddFilter()
@@ -742,14 +742,14 @@ final class FiltersTest extends CIUnitTestCase
         $found = $filters->getFilters();
 
         $this->assertTrue(in_array('role', $found['before'], true));
-        $this->assertEquals(['admin', 'super'], $filters->getArguments('role'));
-        $this->assertEquals(['role' => ['admin', 'super']], $filters->getArguments());
+        $this->assertSame(['admin', 'super'], $filters->getArguments('role'));
+        $this->assertSame(['role' => ['admin', 'super']], $filters->getArguments());
 
         $response = $filters->run('admin/foo/bar', 'before');
-        $this->assertEquals('admin;super', $response);
+        $this->assertSame('admin;super', $response);
 
         $response = $filters->run('admin/foo/bar', 'after');
-        $this->assertEquals('admin;super', $response->getBody());
+        $this->assertSame('admin;super', $response->getBody());
     }
 
     public function testEnableFilterWithNoArguments()
@@ -776,10 +776,10 @@ final class FiltersTest extends CIUnitTestCase
         $this->assertTrue(in_array('role', $found['before'], true));
 
         $response = $filters->run('admin/foo/bar', 'before');
-        $this->assertEquals('Is null', $response);
+        $this->assertSame('Is null', $response);
 
         $response = $filters->run('admin/foo/bar', 'after');
-        $this->assertEquals('Is null', $response->getBody());
+        $this->assertSame('Is null', $response->getBody());
     }
 
     public function testEnableNonFilter()
@@ -848,7 +848,7 @@ final class FiltersTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $filters->initialize($uri)->getFilters());
+        $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }
 
     /**
@@ -883,7 +883,7 @@ final class FiltersTest extends CIUnitTestCase
         ];
 
         $actual = $filters->initialize($uri)->getFilters();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -925,7 +925,7 @@ final class FiltersTest extends CIUnitTestCase
         ];
 
         $actual = $filters->initialize($uri)->getFilters();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -974,7 +974,7 @@ final class FiltersTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $filters->initialize($uri)->getFilters());
+        $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }
 
     /**
@@ -1018,7 +1018,7 @@ final class FiltersTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $filters->initialize($uri)->getFilters());
+        $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }
 
     /**
@@ -1043,8 +1043,8 @@ final class FiltersTest extends CIUnitTestCase
         $uri     = 'admin/foo/bar';
 
         $request = $filters->run($uri, 'before');
-        $this->assertEquals('http://exampleMultipleURL.com', $request->url);
-        $this->assertEquals('http://exampleMultipleCSP.com', $request->csp);
+        $this->assertSame('http://exampleMultipleURL.com', $request->url);
+        $this->assertSame('http://exampleMultipleCSP.com', $request->csp);
     }
 
     public function testFilterClass()
@@ -1066,13 +1066,13 @@ final class FiltersTest extends CIUnitTestCase
 
         $filters->run('admin/foo/bar', 'before');
         $expected = [
-            'after' => [
+            'before' => [],
+            'after'  => [
                 'CodeIgniter\Filters\fixtures\Multiple1',
                 'CodeIgniter\Filters\fixtures\Multiple2',
             ],
-            'before' => [],
         ];
-        $this->assertEquals($expected, $filters->getFiltersClass());
+        $this->assertSame($expected, $filters->getFiltersClass());
     }
 
     public function testReset()
@@ -1093,7 +1093,7 @@ final class FiltersTest extends CIUnitTestCase
         $filters = new Filters((object) $config, $this->request, $this->response);
         $uri     = 'admin';
 
-        $this->assertEquals(['foo'], $filters->initialize($uri)->getFilters()['before']);
+        $this->assertSame(['foo'], $filters->initialize($uri)->getFilters()['before']);
         $this->assertSame([], $filters->reset()->getFilters()['before']);
     }
 }

--- a/tests/system/Filters/HoneypotTest.php
+++ b/tests/system/Filters/HoneypotTest.php
@@ -66,7 +66,7 @@ final class HoneypotTest extends CIUnitTestCase
         $uri     = 'admin/foo/bar';
 
         $request = $filters->run($uri, 'before');
-        $this->assertEquals($expected, $request);
+        $this->assertSame($expected, $request);
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Format/JSONFormatterTest.php
+++ b/tests/system/Format/JSONFormatterTest.php
@@ -27,7 +27,7 @@ final class JSONFormatterTest extends CIUnitTestCase
     "foo": "bar"
 }';
 
-        $this->assertEquals($expected, $this->jsonFormatter->format($data));
+        $this->assertSame($expected, $this->jsonFormatter->format($data));
     }
 
     public function testUnicodeOutput()
@@ -40,7 +40,7 @@ final class JSONFormatterTest extends CIUnitTestCase
     "foo": "База данни грешка"
 }';
 
-        $this->assertEquals($expected, $this->jsonFormatter->format($data));
+        $this->assertSame($expected, $this->jsonFormatter->format($data));
     }
 
     public function testKeepsURLs()
@@ -53,7 +53,7 @@ final class JSONFormatterTest extends CIUnitTestCase
     "foo": "https://www.example.com/foo/bar"
 }';
 
-        $this->assertEquals($expected, $this->jsonFormatter->format($data));
+        $this->assertSame($expected, $this->jsonFormatter->format($data));
     }
 
     public function testJSONError()
@@ -62,6 +62,6 @@ final class JSONFormatterTest extends CIUnitTestCase
 
         $data     = ["\xB1\x31"];
         $expected = 'Boom';
-        $this->assertEquals($expected, $this->jsonFormatter->format($data));
+        $this->assertSame($expected, $this->jsonFormatter->format($data));
     }
 }

--- a/tests/system/Format/XMLFormatterTest.php
+++ b/tests/system/Format/XMLFormatterTest.php
@@ -30,7 +30,7 @@ final class XMLFormatterTest extends CIUnitTestCase
 
             EOH;
 
-        $this->assertEquals($expected, $this->xmlFormatter->format($data));
+        $this->assertSame($expected, $this->xmlFormatter->format($data));
     }
 
     public function testFormatXMLWithMultilevelArray()
@@ -45,7 +45,7 @@ final class XMLFormatterTest extends CIUnitTestCase
 
             EOH;
 
-        $this->assertEquals($expected, $this->xmlFormatter->format($data));
+        $this->assertSame($expected, $this->xmlFormatter->format($data));
     }
 
     public function testFormatXMLWithMultilevelArrayAndNumericKey()
@@ -60,7 +60,7 @@ final class XMLFormatterTest extends CIUnitTestCase
 
             EOH;
 
-        $this->assertEquals($expected, $this->xmlFormatter->format($data));
+        $this->assertSame($expected, $this->xmlFormatter->format($data));
     }
 
     public function testStringFormatting()
@@ -72,7 +72,7 @@ final class XMLFormatterTest extends CIUnitTestCase
 
             EOH;
 
-        $this->assertEquals($expected, $this->xmlFormatter->format($data));
+        $this->assertSame($expected, $this->xmlFormatter->format($data));
     }
 
     public function testValidatingXmlTags()
@@ -87,7 +87,7 @@ final class XMLFormatterTest extends CIUnitTestCase
 
             EOH;
 
-        $this->assertEquals($expected, $this->xmlFormatter->format($data));
+        $this->assertSame($expected, $this->xmlFormatter->format($data));
     }
 
     /**
@@ -104,7 +104,7 @@ final class XMLFormatterTest extends CIUnitTestCase
 
             EOH;
 
-        $this->assertEquals($expectedXML, $this->xmlFormatter->format($input));
+        $this->assertSame($expectedXML, $this->xmlFormatter->format($input));
     }
 
     public function invalidTagsProvider()
@@ -217,6 +217,6 @@ final class XMLFormatterTest extends CIUnitTestCase
         $dom->formatOutput       = true;
         $dom->loadXML($this->xmlFormatter->format($data));
 
-        $this->assertEquals($expectedXML, $dom->saveXML());
+        $this->assertSame($expectedXML, $dom->saveXML());
     }
 }

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -15,7 +15,6 @@ use Config\App;
  */
 final class CLIRequestTest extends CIUnitTestCase
 {
-
     /**
      * @var CLIRequest
      */
@@ -26,8 +25,9 @@ final class CLIRequestTest extends CIUnitTestCase
         parent::setUp();
 
         $this->request = new CLIRequest(new App());
-        $_POST         = [];
-        $_GET          = [];
+
+        $_POST = [];
+        $_GET  = [];
     }
 
     //--------------------------------------------------------------------
@@ -51,7 +51,7 @@ final class CLIRequestTest extends CIUnitTestCase
             '21',
             'profile',
         ];
-        $this->assertEquals($segments, $this->request->getSegments());
+        $this->assertSame($segments, $this->request->getSegments());
     }
 
     public function testParsingOptions()
@@ -74,7 +74,7 @@ final class CLIRequestTest extends CIUnitTestCase
             'foo'     => 'bar',
             'foo-bar' => 'yes',
         ];
-        $this->assertEquals($options, $this->request->getOptions());
+        $this->assertSame($options, $this->request->getOptions());
     }
 
     public function testParsingOptionDetails()
@@ -91,7 +91,7 @@ final class CLIRequestTest extends CIUnitTestCase
         // reinstantiate it to force parsing
         $this->request = new CLIRequest(new App());
 
-        $this->assertEquals('bar', $this->request->getOption('foo'));
+        $this->assertSame('bar', $this->request->getOption('foo'));
         $this->assertNull($this->request->getOption('notthere'));
     }
 
@@ -111,8 +111,8 @@ final class CLIRequestTest extends CIUnitTestCase
         // reinstantiate it to force parsing
         $this->request = new CLIRequest(new App());
 
-        $this->assertEquals('-foo bar -baz "queue some stuff"', $this->request->getOptionString());
-        $this->assertEquals('--foo bar --baz "queue some stuff"', $this->request->getOptionString(true));
+        $this->assertSame('-foo bar -baz "queue some stuff"', $this->request->getOptionString());
+        $this->assertSame('--foo bar --baz "queue some stuff"', $this->request->getOptionString(true));
     }
 
     public function testParsingNoOptions()
@@ -128,7 +128,7 @@ final class CLIRequestTest extends CIUnitTestCase
         $this->request = new CLIRequest(new App());
 
         $expected = '';
-        $this->assertEquals($expected, $this->request->getOptionString());
+        $this->assertSame($expected, $this->request->getOptionString());
     }
 
     public function testParsingPath()
@@ -145,7 +145,7 @@ final class CLIRequestTest extends CIUnitTestCase
         // reinstantiate it to force parsing
         $this->request = new CLIRequest(new App());
 
-        $this->assertEquals('users/21/profile', $this->request->getPath());
+        $this->assertSame('users/21/profile', $this->request->getPath());
     }
 
     public function testParsingMalformed()
@@ -164,9 +164,9 @@ final class CLIRequestTest extends CIUnitTestCase
         // reinstantiate it to force parsing
         $this->request = new CLIRequest(new App());
 
-        $this->assertEquals('-foo bar -baz "queue some stuff"', $this->request->getOptionString());
-        $this->assertEquals('--foo bar --baz "queue some stuff"', $this->request->getOptionString(true));
-        $this->assertEquals('users/21/pro-file', $this->request->getPath());
+        $this->assertSame('-foo bar -baz "queue some stuff"', $this->request->getOptionString());
+        $this->assertSame('--foo bar --baz "queue some stuff"', $this->request->getOptionString(true));
+        $this->assertSame('users/21/pro-file', $this->request->getPath());
     }
 
     public function testParsingMalformed2()
@@ -185,9 +185,9 @@ final class CLIRequestTest extends CIUnitTestCase
         // reinstantiate it to force parsing
         $this->request = new CLIRequest(new App());
 
-        $this->assertEquals('-foo oops-bar -baz "queue some stuff"', $this->request->getOptionString());
-        $this->assertEquals('--foo oops-bar --baz "queue some stuff"', $this->request->getOptionString(true));
-        $this->assertEquals('users/21/profile', $this->request->getPath());
+        $this->assertSame('-foo oops-bar -baz "queue some stuff"', $this->request->getOptionString());
+        $this->assertSame('--foo oops-bar --baz "queue some stuff"', $this->request->getOptionString(true));
+        $this->assertSame('users/21/profile', $this->request->getPath());
     }
 
     public function testParsingMalformed3()
@@ -207,9 +207,9 @@ final class CLIRequestTest extends CIUnitTestCase
         // reinstantiate it to force parsing
         $this->request = new CLIRequest(new App());
 
-        $this->assertEquals('-foo oops -baz "queue some stuff"', $this->request->getOptionString());
-        $this->assertEquals('--foo oops --baz "queue some stuff"', $this->request->getOptionString(true));
-        $this->assertEquals('users/21/profile/bar', $this->request->getPath());
+        $this->assertSame('-foo oops -baz "queue some stuff"', $this->request->getOptionString());
+        $this->assertSame('--foo oops --baz "queue some stuff"', $this->request->getOptionString(true));
+        $this->assertSame('users/21/profile/bar', $this->request->getPath());
     }
 
     //--------------------------------------------------------------------
@@ -219,8 +219,8 @@ final class CLIRequestTest extends CIUnitTestCase
         $_POST['foo'] = 'bar';
         $_GET['bar']  = 'baz';
 
-        $this->assertEquals('bar', $this->request->fetchGlobal('post', 'foo'));
-        $this->assertEquals('baz', $this->request->fetchGlobal('get', 'bar'));
+        $this->assertSame('bar', $this->request->fetchGlobal('post', 'foo'));
+        $this->assertSame('baz', $this->request->fetchGlobal('get', 'bar'));
     }
 
     public function testFetchGlobalsReturnsNullWhenNotFound()
@@ -235,8 +235,8 @@ final class CLIRequestTest extends CIUnitTestCase
             'bar' => 'baz',
         ]);
 
-        $this->assertEquals('bar%3Cscript%3E', $this->request->fetchGlobal('post', 'foo', FILTER_SANITIZE_ENCODED));
-        $this->assertEquals('baz', $this->request->fetchGlobal('post', 'bar'));
+        $this->assertSame('bar%3Cscript%3E', $this->request->fetchGlobal('post', 'foo', FILTER_SANITIZE_ENCODED));
+        $this->assertSame('baz', $this->request->fetchGlobal('post', 'bar'));
     }
 
     public function testFetchGlobalsWithFilterFlag()
@@ -246,8 +246,8 @@ final class CLIRequestTest extends CIUnitTestCase
             'bar' => 'baz',
         ]);
 
-        $this->assertEquals('bar%3Cscript%3E', $this->request->fetchGlobal('post', 'foo', FILTER_SANITIZE_ENCODED, FILTER_FLAG_STRIP_BACKTICK));
-        $this->assertEquals('baz', $this->request->fetchGlobal('post', 'bar'));
+        $this->assertSame('bar%3Cscript%3E', $this->request->fetchGlobal('post', 'foo', FILTER_SANITIZE_ENCODED, FILTER_FLAG_STRIP_BACKTICK));
+        $this->assertSame('baz', $this->request->fetchGlobal('post', 'bar'));
     }
 
     public function testFetchGlobalReturnsAllWhenEmpty()
@@ -260,7 +260,7 @@ final class CLIRequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals($post, $this->request->fetchGlobal('post'));
+        $this->assertSame($post, $this->request->fetchGlobal('post'));
     }
 
     public function testFetchGlobalFiltersAllValues()
@@ -279,7 +279,7 @@ final class CLIRequestTest extends CIUnitTestCase
             'yyy' => 'zzz%3Cscript%3E',
         ];
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', null, FILTER_SANITIZE_ENCODED));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', null, FILTER_SANITIZE_ENCODED));
     }
 
     public function testFetchGlobalFilterWithFlagAllValues()
@@ -298,7 +298,7 @@ final class CLIRequestTest extends CIUnitTestCase
             'yyy' => 'zzz%3Cscript%3E',
         ];
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', null, FILTER_SANITIZE_ENCODED, FILTER_FLAG_STRIP_BACKTICK));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', null, FILTER_SANITIZE_ENCODED, FILTER_FLAG_STRIP_BACKTICK));
     }
 
     public function testFetchGlobalReturnsSelectedKeys()
@@ -315,7 +315,7 @@ final class CLIRequestTest extends CIUnitTestCase
             'bar' => 'baz',
         ];
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', ['foo', 'bar']));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', ['foo', 'bar']));
     }
 
     public function testFetchGlobalFiltersSelectedValues()
@@ -332,7 +332,7 @@ final class CLIRequestTest extends CIUnitTestCase
             'bar' => 'baz%3Cscript%3E',
         ];
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', ['foo', 'bar'], FILTER_SANITIZE_ENCODED));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', ['foo', 'bar'], FILTER_SANITIZE_ENCODED));
     }
 
     public function testFetchGlobalFilterWithFlagSelectedValues()
@@ -349,7 +349,7 @@ final class CLIRequestTest extends CIUnitTestCase
             'bar' => 'baz%3Cscript%3E',
         ];
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', ['foo', 'bar'], FILTER_SANITIZE_ENCODED, FILTER_FLAG_STRIP_BACKTICK));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', ['foo', 'bar'], FILTER_SANITIZE_ENCODED, FILTER_FLAG_STRIP_BACKTICK));
     }
 
     /**
@@ -371,7 +371,7 @@ final class CLIRequestTest extends CIUnitTestCase
         $this->request->setGlobal('post', $post);
         $result = $this->request->fetchGlobal('post');
 
-        $this->assertEquals($post, $result);
+        $this->assertSame($post, $result);
         $this->assertIsArray($result['ANNOUNCEMENTS']);
         $this->assertCount(2, $result['ANNOUNCEMENTS']);
     }
@@ -387,7 +387,7 @@ final class CLIRequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals(['address' => ['zipcode' => 90210]], $this->request->fetchGlobal('post', 'clients'));
+        $this->assertSame(['address' => ['zipcode' => 90210]], $this->request->fetchGlobal('post', 'clients'));
     }
 
     public function testFetchGlobalWithArrayChildNumeric()
@@ -408,7 +408,7 @@ final class CLIRequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals(['zipcode' => 60610], $this->request->fetchGlobal('post', 'clients[1][address]'));
+        $this->assertSame(['zipcode' => 60610], $this->request->fetchGlobal('post', 'clients[1][address]'));
     }
 
     public function testFetchGlobalWithArrayChildElement()
@@ -422,7 +422,7 @@ final class CLIRequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals(['zipcode' => 90210], $this->request->fetchGlobal('post', 'clients[address]'));
+        $this->assertSame(['zipcode' => 90210], $this->request->fetchGlobal('post', 'clients[address]'));
         $this->assertNull($this->request->fetchGlobal('post', 'clients[zipcode]'));
     }
 
@@ -438,43 +438,27 @@ final class CLIRequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals([['a']], $this->request->fetchGlobal('post', 'clients[stuff]'));
+        $this->assertSame([['a']], $this->request->fetchGlobal('post', 'clients[stuff]'));
     }
 
     public function testFetchGlobalWithArrayLastElement()
     {
-        $post = [
-            'clients' => [
-                'address' => [
-                    'zipcode' => 90210,
-                ],
-            ],
-        ];
+        $post = ['clients' => ['address' => ['zipcode' => 90210]]];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals(90210, $this->request->fetchGlobal('post', 'clients[address][zipcode]'));
+        $this->assertSame('90210', $this->request->fetchGlobal('post', 'clients[address][zipcode]'));
     }
 
     public function testFetchGlobalWithEmptyNotation()
     {
         $expected = [
-            [
-                'address' => [
-                    'zipcode' => 90210,
-                ],
-            ],
-            [
-                'address' => [
-                    'zipcode' => 60610,
-                ],
-            ],
+            ['address' => ['zipcode' => '90210']],
+            ['address' => ['zipcode' => '60610']],
         ];
-        $post = [
-            'clients' => $expected,
-        ];
+        $post = ['clients' => $expected];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', 'clients[]'));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', 'clients[]'));
     }
 
     //--------------------------------------------------------------------
@@ -530,14 +514,14 @@ final class CLIRequestTest extends CIUnitTestCase
      */
     public function testValidIPAddress($expected, $address, $type = null)
     {
-        $this->assertEquals($expected, $this->request->isValidIP($address, $type));
+        $this->assertSame($expected, $this->request->isValidIP($address, $type));
     }
 
     //--------------------------------------------------------------------
 
     public function testGetIPAddressDefault()
     {
-        $this->assertEquals('0.0.0.0', $this->request->getIPAddress());
+        $this->assertSame('0.0.0.0', $this->request->getIPAddress());
     }
 
     public function testGetIPAddressNormal()
@@ -545,9 +529,9 @@ final class CLIRequestTest extends CIUnitTestCase
         $expected               = '123.123.123.123';
         $_SERVER['REMOTE_ADDR'] = $expected;
         $this->request          = new Request(new App());
-        $this->assertEquals($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $this->request->getIPAddress());
         // call a second time to exercise the initial conditional block in getIPAddress()
-        $this->assertEquals($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $this->request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxy()
@@ -560,7 +544,7 @@ final class CLIRequestTest extends CIUnitTestCase
         $this->request                   = new Request($config);
 
         // we should see the original forwarded address
-        $this->assertEquals($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $this->request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyInvalid()
@@ -573,7 +557,7 @@ final class CLIRequestTest extends CIUnitTestCase
         $this->request                   = new Request($config);
 
         // spoofed address invalid
-        $this->assertEquals('10.0.1.200', $this->request->getIPAddress());
+        $this->assertSame('10.0.1.200', $this->request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyNotWhitelisted()
@@ -586,7 +570,7 @@ final class CLIRequestTest extends CIUnitTestCase
         $this->request                   = new Request($config);
 
         // spoofed address invalid
-        $this->assertEquals('10.10.1.200', $this->request->getIPAddress());
+        $this->assertSame('10.10.1.200', $this->request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxySubnet()
@@ -599,7 +583,7 @@ final class CLIRequestTest extends CIUnitTestCase
         $this->request                   = new Request($config);
 
         // we should see the original forwarded address
-        $this->assertEquals($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $this->request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyOutofSubnet()
@@ -612,7 +596,7 @@ final class CLIRequestTest extends CIUnitTestCase
         $this->request                   = new Request($config);
 
         // we should see the original forwarded address
-        $this->assertEquals('192.168.5.21', $this->request->getIPAddress());
+        $this->assertSame('192.168.5.21', $this->request->getIPAddress());
     }
 
     //FIXME getIPAddress should have more testing, to 100% code coverage
@@ -622,8 +606,8 @@ final class CLIRequestTest extends CIUnitTestCase
     public function testMethodReturnsRightStuff()
     {
         // Defaults method to CLI now.
-        $this->assertEquals('cli', $this->request->getMethod());
-        $this->assertEquals('CLI', $this->request->getMethod(true));
+        $this->assertSame('cli', $this->request->getMethod());
+        $this->assertSame('CLI', $this->request->getMethod(true));
     }
 
     //---------------------------------------------------------------------

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -34,8 +34,6 @@ final class CURLRequestTest extends CIUnitTestCase
         return new MockCURLRequest(($app = new App()), $uri, new Response($app), $options);
     }
 
-    //--------------------------------------------------------------------
-
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4707
      */
@@ -43,31 +41,25 @@ final class CURLRequestTest extends CIUnitTestCase
     {
         config('App')->baseURL = 'http://example.com/fruit/';
 
-        $request = $this->getRequest([
-            'base_uri' => 'http://example.com/v1/',
-        ]);
+        $request = $this->getRequest(['base_uri' => 'http://example.com/v1/']);
 
         $method = $this->getPrivateMethodInvoker($request, 'prepareURL');
 
-        $this->assertEquals('http://example.com/v1/bananas', $method('bananas'));
+        $this->assertSame('http://example.com/v1/bananas', $method('bananas'));
     }
-
-    //--------------------------------------------------------------------
 
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/1029
      */
     public function testGetRemembersBaseURI()
     {
-        $request = $this->getRequest([
-            'base_uri' => 'http://www.foo.com/api/v1/',
-        ]);
+        $request = $this->getRequest(['base_uri' => 'http://www.foo.com/api/v1/']);
 
         $request->get('products');
 
         $options = $request->curl_options;
 
-        $this->assertEquals('http://www.foo.com/api/v1/products', $options[CURLOPT_URL]);
+        $this->assertSame('http://www.foo.com/api/v1/products', $options[CURLOPT_URL]);
     }
 
     /**
@@ -75,94 +67,77 @@ final class CURLRequestTest extends CIUnitTestCase
      */
     public function testGetRemembersBaseURIWithHelperMethod()
     {
-        $request = Services::curlrequest([
-            'base_uri' => 'http://www.foo.com/api/v1/',
-        ]);
+        $request = Services::curlrequest(['base_uri' => 'http://www.foo.com/api/v1/']);
 
         $uri = $this->getPrivateProperty($request, 'baseURI');
-        $this->assertEquals('www.foo.com', $uri->getHost());
-        $this->assertEquals('/api/v1/', $uri->getPath());
+        $this->assertSame('www.foo.com', $uri->getHost());
+        $this->assertSame('/api/v1/', $uri->getPath());
     }
-
-    //--------------------------------------------------------------------
 
     public function testSendReturnsResponse()
     {
         $output = 'Howdy Stranger.';
 
-        $response = $this->request->setOutput($output)
-            ->send('get', 'http://example.com');
+        $response = $this->request->setOutput($output)->send('get', 'http://example.com');
 
         $this->assertInstanceOf('CodeIgniter\\HTTP\\Response', $response);
-        $this->assertEquals($output, $response->getBody());
+        $this->assertSame($output, $response->getBody());
     }
-
-    //--------------------------------------------------------------------
 
     public function testGetSetsCorrectMethod()
     {
         $this->request->get('http://example.com');
 
-        $this->assertEquals('get', $this->request->getMethod());
+        $this->assertSame('get', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
-        $this->assertEquals('GET', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame('GET', $options[CURLOPT_CUSTOMREQUEST]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testDeleteSetsCorrectMethod()
     {
         $this->request->delete('http://example.com');
 
-        $this->assertEquals('delete', $this->request->getMethod());
+        $this->assertSame('delete', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
-        $this->assertEquals('DELETE', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame('DELETE', $options[CURLOPT_CUSTOMREQUEST]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testHeadSetsCorrectMethod()
     {
         $this->request->head('http://example.com');
 
-        $this->assertEquals('head', $this->request->getMethod());
+        $this->assertSame('head', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
-        $this->assertEquals('HEAD', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame('HEAD', $options[CURLOPT_CUSTOMREQUEST]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testOptionsSetsCorrectMethod()
     {
         $this->request->options('http://example.com');
 
-        $this->assertEquals('options', $this->request->getMethod());
+        $this->assertSame('options', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
-        $this->assertEquals('OPTIONS', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame('OPTIONS', $options[CURLOPT_CUSTOMREQUEST]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testOptionsBaseURIOption()
     {
-        $options = [
-            'base_uri' => 'http://www.foo.com/api/v1/',
-        ];
+        $options = ['base_uri' => 'http://www.foo.com/api/v1/'];
         $request = $this->getRequest($options);
 
-        $this->assertEquals('http://www.foo.com/api/v1/', $request->getBaseURI());
+        $this->assertSame('http://www.foo.com/api/v1/', $request->getBaseURI()->__toString());
     }
 
     public function testOptionsBaseURIOverride()
@@ -173,10 +148,8 @@ final class CURLRequestTest extends CIUnitTestCase
         ];
         $request = $this->getRequest($options);
 
-        $this->assertEquals('http://bogus/com', $request->getBaseURI());
+        $this->assertSame('http://bogus/com', $request->getBaseURI()->__toString());
     }
-
-    //--------------------------------------------------------------------
 
     public function testOptionsHeaders()
     {
@@ -188,10 +161,8 @@ final class CURLRequestTest extends CIUnitTestCase
         $this->assertNull($request->header('fruit'));
 
         $request = $this->getRequest($options);
-        $this->assertEquals('apple', $request->header('fruit')->getValue());
+        $this->assertSame('apple', $request->header('fruit')->getValue());
     }
-
-    //--------------------------------------------------------------------
 
     /**
      * @backupGlobals enabled
@@ -209,7 +180,7 @@ final class CURLRequestTest extends CIUnitTestCase
         $request = $this->getRequest($options);
         $request->get('example');
         // we fill the Accept-Language header from _SERVER when no headers are defined for the request
-        $this->assertEquals('en-US', $request->header('Accept-Language')->getValue());
+        $this->assertSame('en-US', $request->header('Accept-Language')->getValue());
         // but we skip Host header - since it would corrupt the request
         $this->assertNull($request->header('Host'));
         // and Accept-Encoding
@@ -236,11 +207,9 @@ final class CURLRequestTest extends CIUnitTestCase
         $request->get('example');
         // if headers for the request are defined we use them
         $this->assertNull($request->header('Accept-Language'));
-        $this->assertEquals('www.foo.com', $request->header('Host')->getValue());
-        $this->assertEquals('', $request->header('Accept-Encoding')->getValue());
+        $this->assertSame('www.foo.com', $request->header('Host')->getValue());
+        $this->assertSame('', $request->header('Accept-Encoding')->getValue());
     }
-
-    //--------------------------------------------------------------------
 
     public function testOptionsDelay()
     {
@@ -249,83 +218,71 @@ final class CURLRequestTest extends CIUnitTestCase
             'headers' => ['fruit' => 'apple'],
         ];
         $request = $this->getRequest();
-        $this->assertEquals(0.0, $request->getDelay());
+        $this->assertSame(0.0, $request->getDelay());
 
         $request = $this->getRequest($options);
-        $this->assertEquals(2.0, $request->getDelay());
+        $this->assertSame(2.0, $request->getDelay());
     }
-
-    //--------------------------------------------------------------------
 
     public function testPatchSetsCorrectMethod()
     {
         $this->request->patch('http://example.com');
 
-        $this->assertEquals('patch', $this->request->getMethod());
+        $this->assertSame('patch', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
-        $this->assertEquals('PATCH', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame('PATCH', $options[CURLOPT_CUSTOMREQUEST]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testPostSetsCorrectMethod()
     {
         $this->request->post('http://example.com');
 
-        $this->assertEquals('post', $this->request->getMethod());
+        $this->assertSame('post', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
-        $this->assertEquals('POST', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame('POST', $options[CURLOPT_CUSTOMREQUEST]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testPutSetsCorrectMethod()
     {
         $this->request->put('http://example.com');
 
-        $this->assertEquals('put', $this->request->getMethod());
+        $this->assertSame('put', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
-        $this->assertEquals('PUT', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame('PUT', $options[CURLOPT_CUSTOMREQUEST]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testCustomMethodSetsCorrectMethod()
     {
         $this->request->request('custom', 'http://example.com');
 
-        $this->assertEquals('custom', $this->request->getMethod());
+        $this->assertSame('custom', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
-        $this->assertEquals('CUSTOM', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame('CUSTOM', $options[CURLOPT_CUSTOMREQUEST]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testRequestMethodGetsSanitized()
     {
         $this->request->request('<script>Custom</script>', 'http://example.com');
 
-        $this->assertEquals('custom', $this->request->getMethod());
+        $this->assertSame('custom', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
-        $this->assertEquals('CUSTOM', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame('CUSTOM', $options[CURLOPT_CUSTOMREQUEST]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testRequestSetsBasicCurlOptions()
     {
@@ -334,7 +291,7 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_URL, $options);
-        $this->assertEquals('http://example.com', $options[CURLOPT_URL]);
+        $this->assertSame('http://example.com', $options[CURLOPT_URL]);
 
         $this->assertArrayHasKey(CURLOPT_RETURNTRANSFER, $options);
         $this->assertTrue($options[CURLOPT_RETURNTRANSFER]);
@@ -346,13 +303,11 @@ final class CURLRequestTest extends CIUnitTestCase
         $this->assertTrue($options[CURLOPT_FRESH_CONNECT]);
 
         $this->assertArrayHasKey(CURLOPT_TIMEOUT_MS, $options);
-        $this->assertEquals(0.0, $options[CURLOPT_TIMEOUT_MS]);
+        $this->assertSame(0.0, $options[CURLOPT_TIMEOUT_MS]);
 
         $this->assertArrayHasKey(CURLOPT_CONNECTTIMEOUT_MS, $options);
-        $this->assertEquals(150 * 1000, $options[CURLOPT_CONNECTTIMEOUT_MS]);
+        $this->assertSame(150000.0, $options[CURLOPT_CONNECTTIMEOUT_MS]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testAuthBasicOption()
     {
@@ -366,13 +321,11 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_USERPWD, $options);
-        $this->assertEquals('username:password', $options[CURLOPT_USERPWD]);
+        $this->assertSame('username:password', $options[CURLOPT_USERPWD]);
 
         $this->assertArrayHasKey(CURLOPT_HTTPAUTH, $options);
-        $this->assertEquals(CURLAUTH_BASIC, $options[CURLOPT_HTTPAUTH]);
+        $this->assertSame(CURLAUTH_BASIC, $options[CURLOPT_HTTPAUTH]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testAuthBasicOptionExplicit()
     {
@@ -387,13 +340,11 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_USERPWD, $options);
-        $this->assertEquals('username:password', $options[CURLOPT_USERPWD]);
+        $this->assertSame('username:password', $options[CURLOPT_USERPWD]);
 
         $this->assertArrayHasKey(CURLOPT_HTTPAUTH, $options);
-        $this->assertEquals(CURLAUTH_BASIC, $options[CURLOPT_HTTPAUTH]);
+        $this->assertSame(CURLAUTH_BASIC, $options[CURLOPT_HTTPAUTH]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testAuthDigestOption()
     {
@@ -425,17 +376,15 @@ final class CURLRequestTest extends CIUnitTestCase
 
         $options = $this->request->curl_options;
 
-        $this->assertEquals('<title>Update success! config</title>', $response->getBody());
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('<title>Update success! config</title>', $response->getBody());
+        $this->assertSame(200, $response->getStatusCode());
 
         $this->assertArrayHasKey(CURLOPT_USERPWD, $options);
-        $this->assertEquals('username:password', $options[CURLOPT_USERPWD]);
+        $this->assertSame('username:password', $options[CURLOPT_USERPWD]);
 
         $this->assertArrayHasKey(CURLOPT_HTTPAUTH, $options);
-        $this->assertEquals(CURLAUTH_DIGEST, $options[CURLOPT_HTTPAUTH]);
+        $this->assertSame(CURLAUTH_DIGEST, $options[CURLOPT_HTTPAUTH]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSetAuthBasic()
     {
@@ -444,10 +393,10 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_USERPWD, $options);
-        $this->assertEquals('username:password', $options[CURLOPT_USERPWD]);
+        $this->assertSame('username:password', $options[CURLOPT_USERPWD]);
 
         $this->assertArrayHasKey(CURLOPT_HTTPAUTH, $options);
-        $this->assertEquals(CURLAUTH_BASIC, $options[CURLOPT_HTTPAUTH]);
+        $this->assertSame(CURLAUTH_BASIC, $options[CURLOPT_HTTPAUTH]);
     }
 
     public function testSetAuthDigest()
@@ -474,17 +423,15 @@ final class CURLRequestTest extends CIUnitTestCase
 
         $options = $this->request->curl_options;
 
-        $this->assertEquals('<title>Update success! config</title>', $response->getBody());
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('<title>Update success! config</title>', $response->getBody());
+        $this->assertSame(200, $response->getStatusCode());
 
         $this->assertArrayHasKey(CURLOPT_USERPWD, $options);
-        $this->assertEquals('username:password', $options[CURLOPT_USERPWD]);
+        $this->assertSame('username:password', $options[CURLOPT_USERPWD]);
 
         $this->assertArrayHasKey(CURLOPT_HTTPAUTH, $options);
-        $this->assertEquals(CURLAUTH_DIGEST, $options[CURLOPT_HTTPAUTH]);
+        $this->assertSame(CURLAUTH_DIGEST, $options[CURLOPT_HTTPAUTH]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testCertOption()
     {
@@ -497,7 +444,7 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_SSLCERT, $options);
-        $this->assertEquals($file, $options[CURLOPT_SSLCERT]);
+        $this->assertSame($file, $options[CURLOPT_SSLCERT]);
     }
 
     public function testCertOptionWithPassword()
@@ -514,10 +461,10 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_SSLCERT, $options);
-        $this->assertEquals($file, $options[CURLOPT_SSLCERT]);
+        $this->assertSame($file, $options[CURLOPT_SSLCERT]);
 
         $this->assertArrayHasKey(CURLOPT_SSLCERTPASSWD, $options);
-        $this->assertEquals('password', $options[CURLOPT_SSLCERTPASSWD]);
+        $this->assertSame('password', $options[CURLOPT_SSLCERTPASSWD]);
     }
 
     public function testMissingCertOption()
@@ -529,8 +476,6 @@ final class CURLRequestTest extends CIUnitTestCase
             'cert' => $file,
         ]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSSLVerification()
     {
@@ -544,10 +489,10 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CAINFO, $options);
-        $this->assertEquals($file, $options[CURLOPT_CAINFO]);
+        $this->assertSame($file, $options[CURLOPT_CAINFO]);
 
         $this->assertArrayHasKey(CURLOPT_SSL_VERIFYPEER, $options);
-        $this->assertEquals(1, $options[CURLOPT_SSL_VERIFYPEER]);
+        $this->assertSame(1, $options[CURLOPT_SSL_VERIFYPEER]);
     }
 
     public function testSSLWithBadKey()
@@ -561,8 +506,6 @@ final class CURLRequestTest extends CIUnitTestCase
         ]);
     }
 
-    //--------------------------------------------------------------------
-
     public function testDebugOptionTrue()
     {
         $this->request->request('get', 'http://example.com', [
@@ -572,7 +515,7 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_VERBOSE, $options);
-        $this->assertEquals(1, $options[CURLOPT_VERBOSE]);
+        $this->assertSame(1, $options[CURLOPT_VERBOSE]);
 
         $this->assertArrayHasKey(CURLOPT_STDERR, $options);
         $this->assertIsResource($options[CURLOPT_STDERR]);
@@ -601,13 +544,11 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_VERBOSE, $options);
-        $this->assertEquals(1, $options[CURLOPT_VERBOSE]);
+        $this->assertSame(1, $options[CURLOPT_VERBOSE]);
 
         $this->assertArrayHasKey(CURLOPT_STDERR, $options);
         $this->assertIsResource($options[CURLOPT_STDERR]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testDecodeContent()
     {
@@ -619,7 +560,7 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_ENCODING, $options);
-        $this->assertEquals('cobol', $options[CURLOPT_ENCODING]);
+        $this->assertSame('cobol', $options[CURLOPT_ENCODING]);
     }
 
     public function testDecodeContentWithoutAccept()
@@ -632,12 +573,10 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_ENCODING, $options);
-        $this->assertEquals('', $options[CURLOPT_ENCODING]);
+        $this->assertSame('', $options[CURLOPT_ENCODING]);
         $this->assertArrayHasKey(CURLOPT_HTTPHEADER, $options);
-        $this->assertEquals('Accept-Encoding', $options[CURLOPT_HTTPHEADER]);
+        $this->assertSame('Accept-Encoding', $options[CURLOPT_HTTPHEADER]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testAllowRedirectsOptionFalse()
     {
@@ -648,7 +587,7 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_FOLLOWLOCATION, $options);
-        $this->assertEquals(0, $options[CURLOPT_FOLLOWLOCATION]);
+        $this->assertSame(0, $options[CURLOPT_FOLLOWLOCATION]);
 
         $this->assertArrayNotHasKey(CURLOPT_MAXREDIRS, $options);
         $this->assertArrayNotHasKey(CURLOPT_REDIR_PROTOCOLS, $options);
@@ -663,12 +602,12 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_FOLLOWLOCATION, $options);
-        $this->assertEquals(1, $options[CURLOPT_FOLLOWLOCATION]);
+        $this->assertSame(1, $options[CURLOPT_FOLLOWLOCATION]);
 
         $this->assertArrayHasKey(CURLOPT_MAXREDIRS, $options);
-        $this->assertEquals(5, $options[CURLOPT_MAXREDIRS]);
+        $this->assertSame(5, $options[CURLOPT_MAXREDIRS]);
         $this->assertArrayHasKey(CURLOPT_REDIR_PROTOCOLS, $options);
-        $this->assertEquals(CURLPROTO_HTTP | CURLPROTO_HTTPS, $options[CURLOPT_REDIR_PROTOCOLS]);
+        $this->assertSame(CURLPROTO_HTTP | CURLPROTO_HTTPS, $options[CURLOPT_REDIR_PROTOCOLS]);
     }
 
     public function testAllowRedirectsOptionDefaults()
@@ -680,7 +619,7 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_FOLLOWLOCATION, $options);
-        $this->assertEquals(1, $options[CURLOPT_FOLLOWLOCATION]);
+        $this->assertSame(1, $options[CURLOPT_FOLLOWLOCATION]);
 
         $this->assertArrayHasKey(CURLOPT_MAXREDIRS, $options);
         $this->assertArrayHasKey(CURLOPT_REDIR_PROTOCOLS, $options);
@@ -695,13 +634,11 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_FOLLOWLOCATION, $options);
-        $this->assertEquals(1, $options[CURLOPT_FOLLOWLOCATION]);
+        $this->assertSame(1, $options[CURLOPT_FOLLOWLOCATION]);
 
         $this->assertArrayHasKey(CURLOPT_MAXREDIRS, $options);
-        $this->assertEquals(2, $options[CURLOPT_MAXREDIRS]);
+        $this->assertSame(2, $options[CURLOPT_MAXREDIRS]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSendWithQuery()
     {
@@ -717,7 +654,7 @@ final class CURLRequestTest extends CIUnitTestCase
 
         $options = $request->curl_options;
 
-        $this->assertEquals('http://www.foo.com/api/v1/products?name=Henry&d.t=value', $options[CURLOPT_URL]);
+        $this->assertSame('http://www.foo.com/api/v1/products?name=Henry&d.t=value', $options[CURLOPT_URL]);
     }
 
     //--------------------------------------------------------------------
@@ -731,7 +668,7 @@ final class CURLRequestTest extends CIUnitTestCase
         $request->get('products');
 
         // we still need to check the code coverage to make sure this was done
-        $this->assertEquals(1.0, $request->getDelay());
+        $this->assertSame(1.0, $request->getDelay());
     }
 
     //--------------------------------------------------------------------
@@ -744,7 +681,7 @@ final class CURLRequestTest extends CIUnitTestCase
 
         $request->setOutput("HTTP/1.1 100 Continue\x0d\x0a\x0d\x0aHi there");
         $response = $request->get('answer');
-        $this->assertEquals('Hi there', $response->getBody());
+        $this->assertSame('Hi there', $response->getBody());
     }
 
     /**
@@ -775,7 +712,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $request->setOutput($output);
         $response = $request->get('answer');
 
-        $this->assertEquals('<title>Update success! config</title>', $response->getBody());
+        $this->assertSame('<title>Update success! config</title>', $response->getBody());
 
         $responseHeaderKeys = [
             'Cache-control',
@@ -789,9 +726,9 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
             'Pragma',
             'Transfer-Encoding',
         ];
-        $this->assertEquals($responseHeaderKeys, array_keys($response->headers()));
+        $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     //--------------------------------------------------------------------
@@ -804,7 +741,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
 
         $request->setOutput("Accept: text/html\x0d\x0a\x0d\x0aHi there");
         $response = $request->get('answer');
-        $this->assertEquals('Hi there', $response->getBody());
+        $this->assertSame('Hi there', $response->getBody());
     }
 
     //--------------------------------------------------------------------
@@ -819,8 +756,8 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $request->setOutput('Hi there');
         $response = $request->post('answer');
 
-        $this->assertEquals('Hi there', $response->getBody());
-        $this->assertEquals('name=George', $request->curl_options[CURLOPT_POSTFIELDS]);
+        $this->assertSame('Hi there', $response->getBody());
+        $this->assertSame('name=George', $request->curl_options[CURLOPT_POSTFIELDS]);
     }
 
     //--------------------------------------------------------------------
@@ -834,8 +771,8 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $request->setOutput("HTTP/2.0 234 Ohoh\x0d\x0aAccept: text/html\x0d\x0a\x0d\x0aHi there");
         $response = $request->get('bogus');
 
-        $this->assertEquals('2.0', $response->getProtocolVersion());
-        $this->assertEquals(234, $response->getStatusCode());
+        $this->assertSame('2.0', $response->getProtocolVersion());
+        $this->assertSame(234, $response->getStatusCode());
     }
 
     public function testResponseHeadersShortProtocol()
@@ -848,11 +785,9 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $request->setOutput("HTTP/2 235 Ohoh\x0d\x0aAccept: text/html\x0d\x0a\x0d\x0aHi there shortie");
         $response = $request->get('bogus');
 
-        $this->assertEquals('2.0', $response->getProtocolVersion());
-        $this->assertEquals(235, $response->getStatusCode());
+        $this->assertSame('2.0', $response->getProtocolVersion());
+        $this->assertSame(235, $response->getStatusCode());
     }
-
-    //--------------------------------------------------------------------
 
     public function testPostFormEncoded()
     {
@@ -867,13 +802,13 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
             'form_params' => $params,
         ]);
 
-        $this->assertEquals('post', $this->request->getMethod());
+        $this->assertSame('post', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
         $expected = http_build_query($params);
         $this->assertArrayHasKey(CURLOPT_POSTFIELDS, $options);
-        $this->assertEquals($expected, $options[CURLOPT_POSTFIELDS]);
+        $this->assertSame($expected, $options[CURLOPT_POSTFIELDS]);
     }
 
     public function testPostFormMultipart()
@@ -890,15 +825,13 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
             'multipart' => $params,
         ]);
 
-        $this->assertEquals('post', $this->request->getMethod());
+        $this->assertSame('post', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_POSTFIELDS, $options);
-        $this->assertEquals($params, $options[CURLOPT_POSTFIELDS]);
+        $this->assertSame($params, $options[CURLOPT_POSTFIELDS]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testSetForm()
     {
@@ -912,7 +845,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
 
         $this->request->setForm($params)->post('/post');
 
-        $this->assertEquals(
+        $this->assertSame(
             http_build_query($params),
             $this->request->curl_options[CURLOPT_POSTFIELDS]
         );
@@ -921,13 +854,11 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
 
         $this->request->setForm($params, true)->post('/post');
 
-        $this->assertEquals(
+        $this->assertSame(
             $params,
             $this->request->curl_options[CURLOPT_POSTFIELDS]
         );
     }
-
-    //--------------------------------------------------------------------
 
     public function testJSONData()
     {
@@ -942,13 +873,11 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
             'json' => $params,
         ]);
 
-        $this->assertEquals('post', $this->request->getMethod());
+        $this->assertSame('post', $this->request->getMethod());
 
         $expected = json_encode($params);
-        $this->assertEquals($expected, $this->request->getBody());
+        $this->assertSame($expected, $this->request->getBody());
     }
-
-    //--------------------------------------------------------------------
 
     public function testSetJSON()
     {
@@ -961,11 +890,9 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         ];
         $this->request->setJSON($params)->post('/post');
 
-        $this->assertEquals(json_encode($params), $this->request->getBody());
-        $this->assertEquals('application/json', $this->request->getHeaderLine('Content-Type'));
+        $this->assertSame(json_encode($params), $this->request->getBody());
+        $this->assertSame('application/json', $this->request->getHeaderLine('Content-Type'));
     }
-
-    //--------------------------------------------------------------------
 
     public function testHTTPv1()
     {
@@ -976,7 +903,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_HTTP_VERSION, $options);
-        $this->assertEquals(CURL_HTTP_VERSION_1_0, $options[CURLOPT_HTTP_VERSION]);
+        $this->assertSame(CURL_HTTP_VERSION_1_0, $options[CURLOPT_HTTP_VERSION]);
     }
 
     public function testHTTPv11()
@@ -988,10 +915,8 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_HTTP_VERSION, $options);
-        $this->assertEquals(CURL_HTTP_VERSION_1_1, $options[CURLOPT_HTTP_VERSION]);
+        $this->assertSame(CURL_HTTP_VERSION_1_1, $options[CURLOPT_HTTP_VERSION]);
     }
-
-    //--------------------------------------------------------------------
 
     public function testCookieOption()
     {
@@ -1003,9 +928,9 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_COOKIEJAR, $options);
-        $this->assertEquals($holder, $options[CURLOPT_COOKIEJAR]);
+        $this->assertSame($holder, $options[CURLOPT_COOKIEJAR]);
         $this->assertArrayHasKey(CURLOPT_COOKIEFILE, $options);
-        $this->assertEquals($holder, $options[CURLOPT_COOKIEFILE]);
+        $this->assertSame($holder, $options[CURLOPT_COOKIEFILE]);
     }
 
     public function testUserAgentOption()
@@ -1019,6 +944,6 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_USERAGENT, $options);
-        $this->assertEquals($agent, $options[CURLOPT_USERAGENT]);
+        $this->assertSame($agent, $options[CURLOPT_USERAGENT]);
     }
 }

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -443,7 +443,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $body = '';
         $this->response->setBody($body);
         $this->csp->finalize($this->response);
-        $this->assertEquals($body, $this->response->getBody());
+        $this->assertSame($body, $this->response->getBody());
     }
 
     /**

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -46,7 +46,7 @@ final class DownloadResponseTest extends CIUnitTestCase
 
         $header = $response->getHeaderLine('Date');
 
-        $this->assertEquals($date->format('D, d M Y H:i:s') . ' GMT', $header);
+        $this->assertSame($date->format('D, d M Y H:i:s') . ' GMT', $header);
     }
 
     public function testSetLastModifiedWithDateTimeObject()
@@ -60,7 +60,7 @@ final class DownloadResponseTest extends CIUnitTestCase
 
         $header = $response->getHeaderLine('Last-Modified');
 
-        $this->assertEquals($date->format('D, d M Y H:i:s') . ' GMT', $header);
+        $this->assertSame($date->format('D, d M Y H:i:s') . ' GMT', $header);
     }
 
     public function testSetLastModifiedWithString()
@@ -71,7 +71,7 @@ final class DownloadResponseTest extends CIUnitTestCase
 
         $header = $response->getHeaderLine('Last-Modified');
 
-        $this->assertEquals('2000-03-10 10:23:45', $header);
+        $this->assertSame('2000-03-10 10:23:45', $header);
     }
 
     public function testsentMethodSouldReturnRedirectResponse()
@@ -87,7 +87,7 @@ final class DownloadResponseTest extends CIUnitTestCase
 
         $response->setContentType('text/json');
 
-        $this->assertEquals('text/json; charset=UTF-8', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('text/json; charset=UTF-8', $response->getHeaderLine('Content-Type'));
     }
 
     public function testSetContentTypeNoCharSet()
@@ -96,7 +96,7 @@ final class DownloadResponseTest extends CIUnitTestCase
 
         $response->setContentType('application/octet-stream', '');
 
-        $this->assertEquals('application/octet-stream', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('application/octet-stream', $response->getHeaderLine('Content-Type'));
     }
 
     public function testSetFileName()
@@ -176,11 +176,11 @@ final class DownloadResponseTest extends CIUnitTestCase
         $response->setBinary('test');
         $response->buildHeaders();
 
-        $this->assertEquals('application/octet-stream', $response->getHeaderLine('Content-Type'));
-        $this->assertEquals('attachment; filename="unit test.txt"; filename*=UTF-8\'\'unit%20test.txt', $response->getHeaderLine('Content-Disposition'));
-        $this->assertEquals('0', $response->getHeaderLine('Expires-Disposition'));
-        $this->assertEquals('binary', $response->getHeaderLine('Content-Transfer-Encoding'));
-        $this->assertEquals('4', $response->getHeaderLine('Content-Length'));
+        $this->assertSame('application/octet-stream', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('attachment; filename="unit test.txt"; filename*=UTF-8\'\'unit%20test.txt', $response->getHeaderLine('Content-Disposition'));
+        $this->assertSame('0', $response->getHeaderLine('Expires-Disposition'));
+        $this->assertSame('binary', $response->getHeaderLine('Content-Transfer-Encoding'));
+        $this->assertSame('4', $response->getHeaderLine('Content-Length'));
     }
 
     public function testIsSetDownloadableHeadlersFromFile()
@@ -190,11 +190,11 @@ final class DownloadResponseTest extends CIUnitTestCase
         $response->setFilePath(__FILE__);
         $response->buildHeaders();
 
-        $this->assertEquals('application/octet-stream', $response->getHeaderLine('Content-Type'));
-        $this->assertEquals('attachment; filename="unit-test.php"; filename*=UTF-8\'\'unit-test.php', $response->getHeaderLine('Content-Disposition'));
-        $this->assertEquals('0', $response->getHeaderLine('Expires-Disposition'));
-        $this->assertEquals('binary', $response->getHeaderLine('Content-Transfer-Encoding'));
-        $this->assertEquals(filesize(__FILE__), $response->getHeaderLine('Content-Length'));
+        $this->assertSame('application/octet-stream', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('attachment; filename="unit-test.php"; filename*=UTF-8\'\'unit-test.php', $response->getHeaderLine('Content-Disposition'));
+        $this->assertSame('0', $response->getHeaderLine('Expires-Disposition'));
+        $this->assertSame('binary', $response->getHeaderLine('Content-Transfer-Encoding'));
+        $this->assertSame(filesize(__FILE__), (int) $response->getHeaderLine('Content-Length'));
     }
 
     public function testIfTheCharacterCodeIsOtherThanUtf8ReplaceItWithUtf8AndRawurlencode()
@@ -205,7 +205,7 @@ final class DownloadResponseTest extends CIUnitTestCase
         $response->setContentType('application/octet-stream', 'Shift-JIS');
         $response->buildHeaders();
 
-        $this->assertEquals('attachment; filename="' . mb_convert_encoding('テスト.php', 'Shift-JIS', 'UTF-8') . '"; filename*=UTF-8\'\'%E3%83%86%E3%82%B9%E3%83%88.php', $response->getHeaderLine('Content-Disposition'));
+        $this->assertSame('attachment; filename="' . mb_convert_encoding('テスト.php', 'Shift-JIS', 'UTF-8') . '"; filename*=UTF-8\'\'%E3%83%86%E3%82%B9%E3%83%88.php', $response->getHeaderLine('Content-Disposition'));
     }
 
     public function testFileExtensionIsUpperCaseWhenAndroidOSIs2()
@@ -216,7 +216,7 @@ final class DownloadResponseTest extends CIUnitTestCase
         $response->setFilePath(__FILE__);
         $response->buildHeaders();
 
-        $this->assertEquals('attachment; filename="unit-test.PHP"; filename*=UTF-8\'\'unit-test.PHP', $response->getHeaderLine('Content-Disposition'));
+        $this->assertSame('attachment; filename="unit-test.PHP"; filename*=UTF-8\'\'unit-test.PHP', $response->getHeaderLine('Content-Disposition'));
     }
 
     public function testIsSetContentTypeFromFilename()
@@ -226,7 +226,7 @@ final class DownloadResponseTest extends CIUnitTestCase
         $response->setBinary('test');
         $response->buildHeaders();
 
-        $this->assertEquals('text/plain; charset=UTF-8', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('text/plain; charset=UTF-8', $response->getHeaderLine('Content-Type'));
     }
 
     public function testCanOutputFileBodyFromBinary()
@@ -269,7 +269,7 @@ final class DownloadResponseTest extends CIUnitTestCase
     public function testGetReason()
     {
         $response = new DownloadResponse('unit-test.php', false);
-        $this->assertEquals('OK', $response->getReason());
+        $this->assertSame('OK', $response->getReason());
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/HTTP/Files/FileCollectionTest.php
+++ b/tests/system/HTTP/Files/FileCollectionTest.php
@@ -22,7 +22,7 @@ final class FileCollectionTest extends CIUnitTestCase
     {
         $files = new FileCollection();
 
-        $this->assertEquals([], $files->all());
+        $this->assertSame([], $files->all());
     }
 
     //--------------------------------------------------------------------
@@ -46,8 +46,8 @@ final class FileCollectionTest extends CIUnitTestCase
         $file = array_shift($files);
         $this->assertInstanceOf(UploadedFile::class, $file);
 
-        $this->assertEquals('someFile.txt', $file->getName());
-        $this->assertEquals(124, $file->getSize());
+        $this->assertSame('someFile.txt', $file->getName());
+        $this->assertSame(124, $file->getSize());
     }
 
     //--------------------------------------------------------------------
@@ -79,7 +79,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $collection = new FileCollection();
         $files      = $collection->all();
         $this->assertCount(1, $files);
-        $this->assertEquals('userfile', key($files));
+        $this->assertSame('userfile', key($files));
 
         $files = array_shift($files);
         $this->assertCount(2, $files);
@@ -87,11 +87,11 @@ final class FileCollectionTest extends CIUnitTestCase
         $file = $files[0];
         $this->assertInstanceOf(UploadedFile::class, $file);
 
-        $this->assertEquals('fileA.txt', $file->getName());
-        $this->assertEquals('/tmp/fileA.txt', $file->getTempName());
-        $this->assertEquals('txt', $file->getClientExtension());
-        $this->assertEquals('text/plain', $file->getClientMimeType());
-        $this->assertEquals(124, $file->getSize());
+        $this->assertSame('fileA.txt', $file->getName());
+        $this->assertSame('/tmp/fileA.txt', $file->getTempName());
+        $this->assertSame('txt', $file->getClientExtension());
+        $this->assertSame('text/plain', $file->getClientMimeType());
+        $this->assertSame(124, $file->getSize());
     }
 
     //--------------------------------------------------------------------
@@ -118,27 +118,27 @@ final class FileCollectionTest extends CIUnitTestCase
         $collection = new FileCollection();
         $files      = $collection->all();
         $this->assertCount(2, $files);
-        $this->assertEquals('userfile1', key($files));
+        $this->assertSame('userfile1', key($files));
 
         $file = array_shift($files);
         $this->assertInstanceOf(UploadedFile::class, $file);
 
-        $this->assertEquals('fileA.txt', $file->getName());
-        $this->assertEquals('fileA.txt', $file->getClientName());
-        $this->assertEquals('/tmp/fileA.txt', $file->getTempName());
-        $this->assertEquals('txt', $file->getClientExtension());
-        $this->assertEquals('text/plain', $file->getClientMimeType());
-        $this->assertEquals(124, $file->getSize());
+        $this->assertSame('fileA.txt', $file->getName());
+        $this->assertSame('fileA.txt', $file->getClientName());
+        $this->assertSame('/tmp/fileA.txt', $file->getTempName());
+        $this->assertSame('txt', $file->getClientExtension());
+        $this->assertSame('text/plain', $file->getClientMimeType());
+        $this->assertSame(124, $file->getSize());
 
         $file = array_pop($files);
         $this->assertInstanceOf(UploadedFile::class, $file);
 
-        $this->assertEquals('fileB.txt', $file->getName());
-        $this->assertEquals('fileB.txt', $file->getClientName());
-        $this->assertEquals('/tmp/fileB.txt', $file->getTempName());
-        $this->assertEquals('txt', $file->getClientExtension());
-        $this->assertEquals('text/csv', $file->getClientMimeType());
-        $this->assertEquals(248, $file->getSize());
+        $this->assertSame('fileB.txt', $file->getName());
+        $this->assertSame('fileB.txt', $file->getClientName());
+        $this->assertSame('/tmp/fileB.txt', $file->getTempName());
+        $this->assertSame('txt', $file->getClientExtension());
+        $this->assertSame('text/csv', $file->getClientMimeType());
+        $this->assertSame(248, $file->getSize());
     }
 
     //--------------------------------------------------------------------
@@ -188,12 +188,12 @@ final class FileCollectionTest extends CIUnitTestCase
         // proposed extension matches finfo_open mime type (text/plain)
         $file = $collection->getFile('userfile1');
         $this->assertInstanceOf(UploadedFile::class, $file);
-        $this->assertEquals('txt', $file->getExtension());
+        $this->assertSame('txt', $file->getExtension());
 
         // proposed extension matches finfo_open mime type (text/plain)
         $file = $collection->getFile('userfile2');
         $this->assertInstanceOf(UploadedFile::class, $file);
-        $this->assertEquals('txt', $file->getExtension());
+        $this->assertSame('txt', $file->getExtension());
         // but not client mime type
         $this->assertNull(Mimes::guessExtensionFromType($file->getClientMimeType(), $file->getClientExtension()));
 
@@ -201,22 +201,22 @@ final class FileCollectionTest extends CIUnitTestCase
         // but can be resolved by reverse searching
         $file = $collection->getFile('userfile3');
         $this->assertInstanceOf(UploadedFile::class, $file);
-        $this->assertEquals('csv', $file->getExtension());
+        $this->assertSame('csv', $file->getExtension());
 
         // proposed extension matches finfo_open mime type (application/zip)
         $file = $collection->getFile('userfile4');
         $this->assertInstanceOf(UploadedFile::class, $file);
-        $this->assertEquals('zip', $file->getExtension());
+        $this->assertSame('zip', $file->getExtension());
 
         // proposed extension matches client mime type, but not finfo_open mime type (application/zip)
         // this is a zip file (userFile4) but hat been renamed to 'rar'
         $file = $collection->getFile('userfile5');
         $this->assertInstanceOf(UploadedFile::class, $file);
         // getExtension falls back to clientExtension (insecure)
-        $this->assertEquals('rar', $file->getExtension());
-        $this->assertEquals('rar', Mimes::guessExtensionFromType($file->getClientMimeType(), $file->getClientExtension()));
+        $this->assertSame('rar', $file->getExtension());
+        $this->assertSame('rar', Mimes::guessExtensionFromType($file->getClientMimeType(), $file->getClientExtension()));
         // guessExtension is secure and does not returns empty
-        $this->assertEquals('', $file->guessExtension());
+        $this->assertSame('', $file->guessExtension());
     }
 
     //--------------------------------------------------------------------
@@ -255,18 +255,18 @@ final class FileCollectionTest extends CIUnitTestCase
         $collection = new FileCollection();
         $files      = $collection->all();
         $this->assertCount(1, $files);
-        $this->assertEquals('userfile', key($files));
+        $this->assertSame('userfile', key($files));
 
         $this->assertArrayHasKey('bar', $files['userfile']['foo']);
 
         $file = $files['userfile']['foo']['bar'];
         $this->assertInstanceOf(UploadedFile::class, $file);
 
-        $this->assertEquals('fileA.txt', $file->getName());
-        $this->assertEquals('/tmp/fileA.txt', $file->getTempName());
-        $this->assertEquals('txt', $file->getClientExtension());
-        $this->assertEquals('text/plain', $file->getClientMimeType());
-        $this->assertEquals(124, $file->getSize());
+        $this->assertSame('fileA.txt', $file->getName());
+        $this->assertSame('/tmp/fileA.txt', $file->getTempName());
+        $this->assertSame('txt', $file->getClientExtension());
+        $this->assertSame('text/plain', $file->getClientMimeType());
+        $this->assertSame(124, $file->getSize());
     }
 
     //--------------------------------------------------------------------
@@ -375,7 +375,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $collection = new FileCollection();
         $file       = $collection->getFile('userfile');
 
-        $this->assertEquals($expected, $file->getErrorString());
+        $this->assertSame($expected, $file->getErrorString());
     }
 
     public function testErrorStringWithUnknownError()
@@ -395,7 +395,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $collection = new FileCollection();
         $file       = $collection->getFile('userfile');
 
-        $this->assertEquals($expected, $file->getErrorString());
+        $this->assertSame($expected, $file->getErrorString());
     }
 
     public function testErrorStringWithNoError()
@@ -414,7 +414,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $collection = new FileCollection();
         $file       = $collection->getFile('userfile');
 
-        $this->assertEquals($expected, $file->getErrorString());
+        $this->assertSame($expected, $file->getErrorString());
     }
 
     //--------------------------------------------------------------------
@@ -434,7 +434,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $collection = new FileCollection();
         $file       = $collection->getFile('userfile');
 
-        $this->assertEquals(UPLOAD_ERR_INI_SIZE, $file->getError());
+        $this->assertSame(UPLOAD_ERR_INI_SIZE, $file->getError());
     }
 
     public function testErrorWithUnknownError()
@@ -451,7 +451,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $collection = new FileCollection();
         $file       = $collection->getFile('userfile');
 
-        $this->assertEquals(0, $file->getError());
+        $this->assertSame(0, $file->getError());
     }
 
     public function testErrorWithNoError()
@@ -469,7 +469,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $collection = new FileCollection();
         $file       = $collection->getFile('userfile');
 
-        $this->assertEquals(UPLOAD_ERR_OK, $file->getError());
+        $this->assertSame(UPLOAD_ERR_OK, $file->getError());
     }
 
     //--------------------------------------------------------------------
@@ -490,8 +490,8 @@ final class FileCollectionTest extends CIUnitTestCase
         $file       = $collection->getFile('userfile');
         $this->assertInstanceOf(UploadedFile::class, $file);
 
-        $this->assertEquals('someFile.txt', $file->getName());
-        $this->assertEquals(124, $file->getSize());
+        $this->assertSame('someFile.txt', $file->getName());
+        $this->assertSame(124, $file->getSize());
     }
 
     //--------------------------------------------------------------------
@@ -543,19 +543,19 @@ final class FileCollectionTest extends CIUnitTestCase
 
         $file1 = $collection->getFile('userfile.0');
         $this->assertInstanceOf(UploadedFile::class, $file1);
-        $this->assertEquals('fileA.txt', $file1->getName());
-        $this->assertEquals('/tmp/fileA.txt', $file1->getTempName());
-        $this->assertEquals('txt', $file1->getClientExtension());
-        $this->assertEquals('text/plain', $file1->getClientMimeType());
-        $this->assertEquals(124, $file1->getSize());
+        $this->assertSame('fileA.txt', $file1->getName());
+        $this->assertSame('/tmp/fileA.txt', $file1->getTempName());
+        $this->assertSame('txt', $file1->getClientExtension());
+        $this->assertSame('text/plain', $file1->getClientMimeType());
+        $this->assertSame(124, $file1->getSize());
 
         $file2 = $collection->getFile('userfile.1');
         $this->assertInstanceOf(UploadedFile::class, $file2);
-        $this->assertEquals('fileB.txt', $file2->getName());
-        $this->assertEquals('/tmp/fileB.txt', $file2->getTempName());
-        $this->assertEquals('txt', $file2->getClientExtension());
-        $this->assertEquals('text/csv', $file2->getClientMimeType());
-        $this->assertEquals(248, $file2->getSize());
+        $this->assertSame('fileB.txt', $file2->getName());
+        $this->assertSame('/tmp/fileB.txt', $file2->getTempName());
+        $this->assertSame('txt', $file2->getClientExtension());
+        $this->assertSame('text/csv', $file2->getClientMimeType());
+        $this->assertSame(248, $file2->getSize());
     }
 
     //--------------------------------------------------------------------
@@ -611,19 +611,19 @@ final class FileCollectionTest extends CIUnitTestCase
 
         $file1 = $collection->getFile('my-form.details.avatars.0');
         $this->assertInstanceOf(UploadedFile::class, $file1);
-        $this->assertEquals('fileA.txt', $file1->getName());
-        $this->assertEquals('/tmp/fileA.txt', $file1->getTempName());
-        $this->assertEquals('txt', $file1->getClientExtension());
-        $this->assertEquals('text/plain', $file1->getClientMimeType());
-        $this->assertEquals(125, $file1->getSize());
+        $this->assertSame('fileA.txt', $file1->getName());
+        $this->assertSame('/tmp/fileA.txt', $file1->getTempName());
+        $this->assertSame('txt', $file1->getClientExtension());
+        $this->assertSame('text/plain', $file1->getClientMimeType());
+        $this->assertSame(125, $file1->getSize());
 
         $file2 = $collection->getFile('my-form.details.avatars.1');
         $this->assertInstanceOf(UploadedFile::class, $file2);
-        $this->assertEquals('fileB.txt', $file2->getName());
-        $this->assertEquals('/tmp/fileB.txt', $file2->getTempName());
-        $this->assertEquals('txt', $file2->getClientExtension());
-        $this->assertEquals('text/plain', $file2->getClientMimeType());
-        $this->assertEquals(243, $file2->getSize());
+        $this->assertSame('fileB.txt', $file2->getName());
+        $this->assertSame('/tmp/fileB.txt', $file2->getTempName());
+        $this->assertSame('txt', $file2->getClientExtension());
+        $this->assertSame('text/plain', $file2->getClientMimeType());
+        $this->assertSame(243, $file2->getSize());
     }
 
     //--------------------------------------------------------------------
@@ -770,18 +770,18 @@ final class FileCollectionTest extends CIUnitTestCase
         $this->assertCount(2, $files);
 
         $this->assertInstanceOf(UploadedFile::class, $files[0]);
-        $this->assertEquals('fileA.txt', $files[0]->getName());
-        $this->assertEquals('/tmp/fileA.txt', $files[0]->getTempName());
-        $this->assertEquals('txt', $files[0]->getClientExtension());
-        $this->assertEquals('text/plain', $files[0]->getClientMimeType());
-        $this->assertEquals(125, $files[0]->getSize());
+        $this->assertSame('fileA.txt', $files[0]->getName());
+        $this->assertSame('/tmp/fileA.txt', $files[0]->getTempName());
+        $this->assertSame('txt', $files[0]->getClientExtension());
+        $this->assertSame('text/plain', $files[0]->getClientMimeType());
+        $this->assertSame(125, $files[0]->getSize());
 
         $this->assertInstanceOf(UploadedFile::class, $files[1]);
-        $this->assertEquals('fileB.txt', $files[1]->getName());
-        $this->assertEquals('/tmp/fileB.txt', $files[1]->getTempName());
-        $this->assertEquals('txt', $files[1]->getClientExtension());
-        $this->assertEquals('text/plain', $files[1]->getClientMimeType());
-        $this->assertEquals(243, $files[1]->getSize());
+        $this->assertSame('fileB.txt', $files[1]->getName());
+        $this->assertSame('/tmp/fileB.txt', $files[1]->getTempName());
+        $this->assertSame('txt', $files[1]->getClientExtension());
+        $this->assertSame('text/plain', $files[1]->getClientMimeType());
+        $this->assertSame(243, $files[1]->getSize());
     }
 
     //--------------------------------------------------------------------
@@ -857,18 +857,18 @@ final class FileCollectionTest extends CIUnitTestCase
         $this->assertIsArray( $files);
 
         $this->assertInstanceOf(UploadedFile::class, $files[0]);
-        $this->assertEquals(124, $files[0]->getSize());
-        $this->assertEquals('fileA.txt', $files[0]->getName());
-        $this->assertEquals('/tmp/fileA.txt', $files[0]->getTempName());
-        $this->assertEquals('txt', $files[0]->getClientExtension());
-        $this->assertEquals('text/plain', $files[0]->getClientMimeType());
+        $this->assertSame(124, $files[0]->getSize());
+        $this->assertSame('fileA.txt', $files[0]->getName());
+        $this->assertSame('/tmp/fileA.txt', $files[0]->getTempName());
+        $this->assertSame('txt', $files[0]->getClientExtension());
+        $this->assertSame('text/plain', $files[0]->getClientMimeType());
 
         $this->assertInstanceOf(UploadedFile::class, $files[1]);
-        $this->assertEquals(248, $files[1]->getSize());
-        $this->assertEquals('fileB.txt', $files[1]->getName());
-        $this->assertEquals('/tmp/fileB.txt', $files[1]->getTempName());
-        $this->assertEquals('txt', $files[1]->getClientExtension());
-        $this->assertEquals('text/csv', $files[1]->getClientMimeType());
+        $this->assertSame(248, $files[1]->getSize());
+        $this->assertSame('fileB.txt', $files[1]->getName());
+        $this->assertSame('/tmp/fileB.txt', $files[1]->getTempName());
+        $this->assertSame('txt', $files[1]->getClientExtension());
+        $this->assertSame('text/csv', $files[1]->getClientMimeType());
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -196,7 +196,7 @@ final class FileMovingTest extends CIUnitTestCase
 
         $this->assertInstanceOf(UploadedFile::class, $file);
         $path = $file->store($destination, $file->getName());
-        $this->assertEquals($destination . '/fileA.txt', $path);
+        $this->assertSame($destination . '/fileA.txt', $path);
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/HTTP/HeaderTest.php
+++ b/tests/system/HTTP/HeaderTest.php
@@ -17,8 +17,8 @@ final class HeaderTest extends CIUnitTestCase
 
         $header = new Header($name, $value);
 
-        $this->assertEquals($name, $header->getName());
-        $this->assertEquals($value, $header->getValue());
+        $this->assertSame($name, $header->getName());
+        $this->assertSame($value, $header->getValue());
     }
 
     public function testHeaderStoresBasicsWithNull()
@@ -28,8 +28,8 @@ final class HeaderTest extends CIUnitTestCase
 
         $header = new Header($name, $value);
 
-        $this->assertEquals($name, $header->getName());
-        $this->assertEquals('', $header->getValue());
+        $this->assertSame($name, $header->getName());
+        $this->assertSame('', $header->getValue());
     }
 
     //--------------------------------------------------------------------
@@ -44,8 +44,8 @@ final class HeaderTest extends CIUnitTestCase
 
         $header = new Header($name, $value);
 
-        $this->assertEquals($name, $header->getName());
-        $this->assertEquals($value, $header->getValue());
+        $this->assertSame($name, $header->getName());
+        $this->assertSame($value, $header->getValue());
     }
 
     //--------------------------------------------------------------------
@@ -59,15 +59,15 @@ final class HeaderTest extends CIUnitTestCase
         ];
 
         $header = new Header($name);
-        $this->assertEquals($name, $header->getName());
+        $this->assertSame($name, $header->getName());
         $this->assertEmpty($header->getValue());
-        $this->assertEquals($name . ': ', (string) $header);
+        $this->assertSame($name . ': ', (string) $header);
 
         $name = 'foo2';
         $header->setName($name)->setValue($value);
-        $this->assertEquals($name, $header->getName());
-        $this->assertEquals($value, $header->getValue());
-        $this->assertEquals($name . ': bar, baz', (string) $header);
+        $this->assertSame($name, $header->getName());
+        $this->assertSame($value, $header->getValue());
+        $this->assertSame($name . ': bar, baz', (string) $header);
     }
 
     //--------------------------------------------------------------------
@@ -82,8 +82,8 @@ final class HeaderTest extends CIUnitTestCase
 
         $header->appendValue(null);
 
-        $this->assertEquals($name, $header->getName());
-        $this->assertEquals($expected, $header->getValue());
+        $this->assertSame($name, $header->getName());
+        $this->assertSame($expected, $header->getValue());
     }
 
     public function testHeaderConvertsSingleToArray()
@@ -100,8 +100,8 @@ final class HeaderTest extends CIUnitTestCase
 
         $header->appendValue('baz');
 
-        $this->assertEquals($name, $header->getName());
-        $this->assertEquals($expected, $header->getValue());
+        $this->assertSame($name, $header->getName());
+        $this->assertSame($expected, $header->getValue());
     }
 
     //--------------------------------------------------------------------
@@ -116,8 +116,8 @@ final class HeaderTest extends CIUnitTestCase
 
         $header->prependValue(null);
 
-        $this->assertEquals($name, $header->getName());
-        $this->assertEquals($expected, $header->getValue());
+        $this->assertSame($name, $header->getName());
+        $this->assertSame($expected, $header->getValue());
     }
 
     public function testHeaderPrependsValue()
@@ -134,8 +134,8 @@ final class HeaderTest extends CIUnitTestCase
 
         $header->prependValue('baz');
 
-        $this->assertEquals($name, $header->getName());
-        $this->assertEquals($expected, $header->getValue());
+        $this->assertSame($name, $header->getName());
+        $this->assertSame($expected, $header->getValue());
     }
 
     //--------------------------------------------------------------------
@@ -152,8 +152,8 @@ final class HeaderTest extends CIUnitTestCase
 
         $header = new Header($name, $value);
 
-        $this->assertEquals($name, $header->getName());
-        $this->assertEquals($expected, $header->getValueLine());
+        $this->assertSame($name, $header->getName());
+        $this->assertSame($expected, $header->getValueLine());
     }
 
     public function testHeaderLineValueNotStringOrArray()
@@ -165,8 +165,8 @@ final class HeaderTest extends CIUnitTestCase
 
         $header = new Header($name, $value);
 
-        $this->assertEquals($name, $header->getName());
-        $this->assertEquals($expected, $header->getValueLine());
+        $this->assertSame($name, $header->getName());
+        $this->assertSame($expected, $header->getValueLine());
     }
 
     //--------------------------------------------------------------------
@@ -179,8 +179,8 @@ final class HeaderTest extends CIUnitTestCase
         $header = new Header($name);
         $header->setValue('bar')->setValue(null);
 
-        $this->assertEquals($name, $header->getName());
-        $this->assertEquals($expected, $header->getValueLine());
+        $this->assertSame($name, $header->getName());
+        $this->assertSame($expected, $header->getValueLine());
     }
 
     public function testHeaderLineWithArrayValues()
@@ -193,8 +193,8 @@ final class HeaderTest extends CIUnitTestCase
 
         $header->setValue('bar')->appendValue(['baz' => 'fuzz']);
 
-        $this->assertEquals($name, $header->getName());
-        $this->assertEquals($expected, $header->getValueLine());
+        $this->assertSame($name, $header->getName());
+        $this->assertSame($expected, $header->getValueLine());
     }
 
     //--------------------------------------------------------------------
@@ -209,6 +209,6 @@ final class HeaderTest extends CIUnitTestCase
 
         $header->setValue('bar')->appendValue(['baz' => 'fuzz']);
 
-        $this->assertEquals($expected, (string) $header);
+        $this->assertSame($expected, (string) $header);
     }
 }

--- a/tests/system/HTTP/IncomingRequestDetectingTest.php
+++ b/tests/system/HTTP/IncomingRequestDetectingTest.php
@@ -37,7 +37,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/index.php/woot';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
         $expected               = 'woot';
-        $this->assertEquals($expected, $this->request->detectPath());
+        $this->assertSame($expected, $this->request->detectPath());
     }
 
     public function testPathEmpty()
@@ -46,7 +46,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
         $expected               = '/';
-        $this->assertEquals($expected, $this->request->detectPath());
+        $this->assertSame($expected, $this->request->detectPath());
     }
 
     public function testPathRequestURI()
@@ -55,7 +55,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/index.php/woot';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
         $expected               = 'woot';
-        $this->assertEquals($expected, $this->request->detectPath('REQUEST_URI'));
+        $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     public function testPathRequestURINested()
@@ -64,7 +64,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/index.php/woot';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
         $expected               = 'woot';
-        $this->assertEquals($expected, $this->request->detectPath('REQUEST_URI'));
+        $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     public function testPathRequestURISubfolder()
@@ -73,7 +73,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/ci/index.php/popcorn/woot';
         $_SERVER['SCRIPT_NAME'] = '/ci/index.php';
         $expected               = 'popcorn/woot';
-        $this->assertEquals($expected, $this->request->detectPath('REQUEST_URI'));
+        $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     public function testPathRequestURINoIndex()
@@ -82,7 +82,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/sub/example';
         $_SERVER['SCRIPT_NAME'] = '/sub/index.php';
         $expected               = 'example';
-        $this->assertEquals($expected, $this->request->detectPath('REQUEST_URI'));
+        $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     public function testPathRequestURINginx()
@@ -91,7 +91,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/index.php/woot?code=good';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
         $expected               = 'woot';
-        $this->assertEquals($expected, $this->request->detectPath('REQUEST_URI'));
+        $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     public function testPathRequestURINginxRedirecting()
@@ -100,7 +100,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/?/ci/woot';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
         $expected               = 'ci/woot';
-        $this->assertEquals($expected, $this->request->detectPath('REQUEST_URI'));
+        $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     public function testPathRequestURISuppressed()
@@ -109,7 +109,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/woot';
         $_SERVER['SCRIPT_NAME'] = '/';
         $expected               = 'woot';
-        $this->assertEquals($expected, $this->request->detectPath('REQUEST_URI'));
+        $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     //--------------------------------------------------------------------
@@ -121,7 +121,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['QUERY_STRING'] = '/ci/woot';
         $_SERVER['SCRIPT_NAME']  = '/index.php';
         $expected                = 'ci/woot';
-        $this->assertEquals($expected, $this->request->detectPath('QUERY_STRING'));
+        $this->assertSame($expected, $this->request->detectPath('QUERY_STRING'));
     }
 
     public function testPathQueryStringEmpty()
@@ -131,7 +131,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['QUERY_STRING'] = '';
         $_SERVER['SCRIPT_NAME']  = '/index.php';
         $expected                = '';
-        $this->assertEquals($expected, $this->request->detectPath('QUERY_STRING'));
+        $this->assertSame($expected, $this->request->detectPath('QUERY_STRING'));
     }
 
     //--------------------------------------------------------------------
@@ -145,7 +145,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/index.php/woot';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
         $expected               = 'woot';
-        $this->assertEquals($expected, $this->request->detectPath('PATH_INFO'));
+        $this->assertSame($expected, $this->request->detectPath('PATH_INFO'));
     }
 
     public function testPathPathInfoGlobal()
@@ -159,6 +159,6 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
         $expected = 'silliness';
-        $this->assertEquals($expected, $this->request->detectPath('PATH_INFO'));
+        $this->assertSame($expected, $this->request->detectPath('PATH_INFO'));
     }
 }

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -14,7 +14,6 @@ use Config\App;
  */
 final class IncomingRequestTest extends CIUnitTestCase
 {
-
     /**
      * @var IncomingRequest
      */
@@ -35,7 +34,7 @@ final class IncomingRequestTest extends CIUnitTestCase
     {
         $_REQUEST['TEST'] = 5;
 
-        $this->assertEquals(5, $this->request->getVar('TEST'));
+        $this->assertSame('5', $this->request->getVar('TEST'));
         $this->assertNull($this->request->getVar('TESTY'));
     }
 
@@ -43,7 +42,7 @@ final class IncomingRequestTest extends CIUnitTestCase
     {
         $_GET['TEST'] = 5;
 
-        $this->assertEquals(5, $this->request->getGet('TEST'));
+        $this->assertSame('5', $this->request->getGet('TEST'));
         $this->assertNull($this->request->getGet('TESTY'));
     }
 
@@ -51,7 +50,7 @@ final class IncomingRequestTest extends CIUnitTestCase
     {
         $_POST['TEST'] = 5;
 
-        $this->assertEquals(5, $this->request->getPost('TEST'));
+        $this->assertSame('5', $this->request->getPost('TEST'));
         $this->assertNull($this->request->getPost('TESTY'));
     }
 
@@ -60,8 +59,8 @@ final class IncomingRequestTest extends CIUnitTestCase
         $_POST['TEST'] = 5;
         $_GET['TEST']  = 3;
 
-        $this->assertEquals(5, $this->request->getPostGet('TEST'));
-        $this->assertEquals(3, $this->request->getGetPost('TEST'));
+        $this->assertSame('5', $this->request->getPostGet('TEST'));
+        $this->assertSame('3', $this->request->getGetPost('TEST'));
     }
 
     //--------------------------------------------------------------------
@@ -78,8 +77,8 @@ final class IncomingRequestTest extends CIUnitTestCase
             'post' => ['name' => 'foo'],
         ];
 
-        $this->assertEquals('foo', $this->request->getOldInput('name'));
-        $this->assertEquals('two', $this->request->getOldInput('one'));
+        $this->assertSame('foo', $this->request->getOldInput('name'));
+        $this->assertSame('two', $this->request->getOldInput('one'));
     }
 
     public function testCanGetOldInputDotted()
@@ -89,8 +88,8 @@ final class IncomingRequestTest extends CIUnitTestCase
             'post' => ['banana' => ['name' => 'foo']],
         ];
 
-        $this->assertEquals('foo', $this->request->getOldInput('banana.name'));
-        $this->assertEquals('two', $this->request->getOldInput('apple.name'));
+        $this->assertSame('foo', $this->request->getOldInput('banana.name'));
+        $this->assertSame('two', $this->request->getOldInput('apple.name'));
     }
 
     public function testMissingOldInput()
@@ -111,8 +110,8 @@ final class IncomingRequestTest extends CIUnitTestCase
             'post' => ['banana' => ['name' => 'foo']],
         ];
 
-        $this->assertEquals(['name' => 'two'], $this->request->getOldInput('apple'));
-        $this->assertEquals(['name' => 'foo'], $this->request->getOldInput('banana'));
+        $this->assertSame(['name' => 'two'], $this->request->getOldInput('apple'));
+        $this->assertSame(['name' => 'foo'], $this->request->getOldInput('banana'));
     }
 
     // Reference: https://github.com/codeigniter4/CodeIgniter4/issues/1492
@@ -131,7 +130,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $session = service('session');
         $session->set(['_ci_old_input' => ['post' => ['location' => $locations]]]);
 
-        $this->assertEquals($locations, $this->request->getOldInput('location'));
+        $this->assertSame($locations, $this->request->getOldInput('location'));
     }
 
     //--------------------------------------------------------------------
@@ -142,7 +141,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $server['server']['TEST'] = 5;
         $this->setPrivateProperty($this->request, 'globals', $server);
 
-        $this->assertEquals(5, $this->request->getServer('TEST'));
+        $this->assertSame('5', $this->request->getServer('TEST'));
         $this->assertNull($this->request->getServer('TESTY'));
     }
 
@@ -152,7 +151,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $server['env']['TEST'] = 5;
         $this->setPrivateProperty($this->request, 'globals', $server);
 
-        $this->assertEquals(5, $this->request->getEnv('TEST'));
+        $this->assertSame('5', $this->request->getEnv('TEST'));
         $this->assertNull($this->request->getEnv('TESTY'));
     }
 
@@ -160,7 +159,7 @@ final class IncomingRequestTest extends CIUnitTestCase
     {
         $_COOKIE['TEST'] = 5;
 
-        $this->assertEquals(5, $this->request->getCookie('TEST'));
+        $this->assertSame('5', $this->request->getCookie('TEST'));
         $this->assertNull($this->request->getCookie('TESTY'));
     }
 
@@ -170,40 +169,34 @@ final class IncomingRequestTest extends CIUnitTestCase
     {
         $config = new App();
 
-        $this->assertEquals($config->defaultLocale, $this->request->getDefaultLocale());
-        $this->assertEquals($config->defaultLocale, $this->request->getLocale());
+        $this->assertSame($config->defaultLocale, $this->request->getDefaultLocale());
+        $this->assertSame($config->defaultLocale, $this->request->getLocale());
     }
 
     public function testSetLocaleSaves()
     {
         $config                   = new App();
-        $config->supportedLocales = [
-            'en',
-            'es',
-        ];
-        $config->defaultLocale = 'es';
-        $config->baseURL       = 'http://example.com/';
+        $config->supportedLocales = ['en', 'es'];
+        $config->defaultLocale    = 'es';
+        $config->baseURL          = 'http://example.com/';
 
         $request = new IncomingRequest($config, new URI(), null, new UserAgent());
 
         $request->setLocale('en');
-        $this->assertEquals('en', $request->getLocale());
+        $this->assertSame('en', $request->getLocale());
     }
 
     public function testSetBadLocale()
     {
         $config                   = new App();
-        $config->supportedLocales = [
-            'en',
-            'es',
-        ];
-        $config->defaultLocale = 'es';
-        $config->baseURL       = 'http://example.com/';
+        $config->supportedLocales = ['en', 'es'];
+        $config->defaultLocale    = 'es';
+        $config->baseURL          = 'http://example.com/';
 
         $request = new IncomingRequest($config, new URI(), null, new UserAgent());
 
         $request->setLocale('xx');
-        $this->assertEquals('es', $request->getLocale());
+        $this->assertSame('es', $request->getLocale());
     }
 
     //--------------------------------------------------------------------
@@ -217,16 +210,13 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $config                   = new App();
         $config->negotiateLocale  = true;
-        $config->supportedLocales = [
-            'fr',
-            'en',
-        ];
-        $config->baseURL = 'http://example.com/';
+        $config->supportedLocales = ['fr', 'en'];
+        $config->baseURL          = 'http://example.com/';
 
         $request = new IncomingRequest($config, new URI(), null, new UserAgent());
 
-        $this->assertEquals($config->defaultLocale, $request->getDefaultLocale());
-        $this->assertEquals('fr', $request->getLocale());
+        $this->assertSame($config->defaultLocale, $request->getDefaultLocale());
+        $this->assertSame('fr', $request->getLocale());
     }
 
     public function testNegotiatesLocaleOnlyBroad()
@@ -235,16 +225,13 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $config                   = new App();
         $config->negotiateLocale  = true;
-        $config->supportedLocales = [
-            'fr',
-            'en',
-        ];
-        $config->baseURL = 'http://example.com/';
+        $config->supportedLocales = ['fr', 'en'];
+        $config->baseURL          = 'http://example.com/';
 
         $request = new IncomingRequest($config, new URI(), null, new UserAgent());
 
-        $this->assertEquals($config->defaultLocale, $request->getDefaultLocale());
-        $this->assertEquals('fr', $request->getLocale());
+        $this->assertSame($config->defaultLocale, $request->getDefaultLocale());
+        $this->assertSame('fr', $request->getLocale());
     }
 
     // The negotiation tests below are not intended to exercise the HTTP\Negotiate class -
@@ -264,25 +251,25 @@ final class IncomingRequestTest extends CIUnitTestCase
         //      $_SERVER['HTTP_ACCEPT_CHARSET'] = 'iso-8859-5, unicode-1-1;q=0.8';
         $this->request->setHeader('Accept-Charset', 'iso-8859-5, unicode-1-1;q=0.8');
 
-        $this->assertEquals(strtolower($this->request->config->charset), $this->request->negotiate('charset', ['iso-8859', 'unicode-1-2']));
+        $this->assertSame(strtolower($this->request->config->charset), $this->request->negotiate('charset', ['iso-8859', 'unicode-1-2']));
     }
 
     public function testNegotiatesMedia()
     {
         $this->request->setHeader('Accept', 'text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c');
-        $this->assertEquals('text/html', $this->request->negotiate('media', ['text/html', 'text/x-c', 'text/x-dvi', 'text/plain']));
+        $this->assertSame('text/html', $this->request->negotiate('media', ['text/html', 'text/x-c', 'text/x-dvi', 'text/plain']));
     }
 
     public function testNegotiatesEncoding()
     {
         $this->request->setHeader('Accept-Encoding', 'gzip;q=1.0, identity; q=0.4, compress;q=0.5');
-        $this->assertEquals('gzip', $this->request->negotiate('encoding', ['gzip', 'compress']));
+        $this->assertSame('gzip', $this->request->negotiate('encoding', ['gzip', 'compress']));
     }
 
     public function testNegotiatesLanguage()
     {
         $this->request->setHeader('Accept-Language', 'da, en-gb;q=0.8, en;q=0.7');
-        $this->assertEquals('en', $this->request->negotiate('language', ['en', 'da']));
+        $this->assertSame('en', $this->request->negotiate('language', ['en', 'da']));
     }
 
     //--------------------------------------------------------------------
@@ -291,26 +278,21 @@ final class IncomingRequestTest extends CIUnitTestCase
     {
         $json = '{"code":1, "message":"ok"}';
 
-        $expected = [
-            'code'    => 1,
-            'message' => 'ok',
-        ];
+        $expected = ['code' => 1, 'message' => 'ok'];
 
         $config          = new App();
         $config->baseURL = 'http://example.com/';
 
         $request = new IncomingRequest($config, new URI(), $json, new UserAgent());
 
-        $this->assertEquals($expected, $request->getJSON(true));
+        $this->assertSame($expected, $request->getJSON(true));
     }
 
     public function testCanGetAVariableFromJson()
     {
         $jsonObj = [
             'foo' => 'bar',
-            'baz' => [
-                'fizz' => 'buzz',
-            ],
+            'baz' => ['fizz' => 'buzz'],
         ];
         $json = json_encode($jsonObj);
 
@@ -319,11 +301,11 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $request = new IncomingRequest($config, new URI(), $json, new UserAgent());
 
-        $this->assertEquals('bar', $request->getJsonVar('foo'));
+        $this->assertSame('bar', $request->getJsonVar('foo'));
         $jsonVar = $request->getJsonVar('baz');
         $this->assertIsObject($jsonVar);
-        $this->assertEquals('buzz', $jsonVar->fizz);
-        $this->assertEquals('buzz', $request->getJsonVar('baz.fizz'));
+        $this->assertSame('buzz', $jsonVar->fizz);
+        $this->assertSame('buzz', $request->getJsonVar('baz.fizz'));
     }
 
     public function testGetJsonVarAsArray()
@@ -343,8 +325,8 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $jsonVar = $request->getJsonVar('baz', true);
         $this->assertIsArray($jsonVar);
-        $this->assertEquals('buzz', $jsonVar['fizz']);
-        $this->assertEquals('bar', $jsonVar['foo']);
+        $this->assertSame('buzz', $jsonVar['fizz']);
+        $this->assertSame('bar', $jsonVar['foo']);
     }
 
     public function testGetJsonVarCanFilter()
@@ -373,18 +355,18 @@ final class IncomingRequestTest extends CIUnitTestCase
         $request = new IncomingRequest($config, new URI(), $json, new UserAgent());
         $request->setHeader('Content-Type', 'application/json');
 
-        $this->assertEquals('bar', $request->getVar('foo'));
-        $this->assertEquals('buzz', $request->getVar('fizz'));
+        $this->assertSame('bar', $request->getVar('foo'));
+        $this->assertSame('buzz', $request->getVar('fizz'));
 
         $multiple = $request->getVar(['foo', 'fizz']);
         $this->assertIsArray($multiple);
-        $this->assertEquals('bar', $multiple['foo']);
-        $this->assertEquals('buzz', $multiple['fizz']);
+        $this->assertSame('bar', $multiple['foo']);
+        $this->assertSame('buzz', $multiple['fizz']);
 
         $all = $request->getVar();
         $this->assertIsObject($all);
-        $this->assertEquals('bar', $all->foo);
-        $this->assertEquals('buzz', $all->fizz);
+        $this->assertSame('bar', $all->foo);
+        $this->assertSame('buzz', $all->fizz);
     }
 
     public function testGetVarWorksWithJsonAndGetParams()
@@ -402,18 +384,18 @@ final class IncomingRequestTest extends CIUnitTestCase
         // JSON type
         $request->setHeader('Content-Type', 'application/json');
 
-        $this->assertEquals('bar', $request->getVar('foo'));
-        $this->assertEquals('buzz', $request->getVar('fizz'));
+        $this->assertSame('bar', $request->getVar('foo'));
+        $this->assertSame('buzz', $request->getVar('fizz'));
 
         $multiple = $request->getVar(['foo', 'fizz']);
         $this->assertIsArray($multiple);
-        $this->assertEquals('bar', $multiple['foo']);
-        $this->assertEquals('buzz', $multiple['fizz']);
+        $this->assertSame('bar', $multiple['foo']);
+        $this->assertSame('buzz', $multiple['fizz']);
 
         $all = $request->getVar();
         $this->assertIsArray($all);
-        $this->assertEquals('bar', $all['foo']);
-        $this->assertEquals('buzz', $all['fizz']);
+        $this->assertSame('bar', $all['foo']);
+        $this->assertSame('buzz', $all['fizz']);
     }
 
     public function testCanGrabGetRawInput()
@@ -423,7 +405,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $expected = [
             'username' => 'admin001',
             'role'     => 'administrator',
-            'usepass'  => 0,
+            'usepass'  => '0',
         ];
 
         $config          = new App();
@@ -431,7 +413,7 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $request = new IncomingRequest($config, new URI(), $rawstring, new UserAgent());
 
-        $this->assertEquals($expected, $request->getRawInput());
+        $this->assertSame($expected, $request->getRawInput());
     }
 
     //--------------------------------------------------------------------
@@ -473,9 +455,11 @@ final class IncomingRequestTest extends CIUnitTestCase
     public function testUserAgent()
     {
         $_SERVER['HTTP_USER_AGENT'] = 'Mozilla';
-        $config                     = new App();
-        $request                    = new IncomingRequest($config, new URI(), null, new UserAgent());
-        $this->assertEquals('Mozilla', $request->getUserAgent());
+
+        $config  = new App();
+        $request = new IncomingRequest($config, new URI(), null, new UserAgent());
+
+        $this->assertSame('Mozilla', $request->getUserAgent()->__toString());
     }
 
     //--------------------------------------------------------------------
@@ -498,8 +482,8 @@ final class IncomingRequestTest extends CIUnitTestCase
         $file = array_shift($files);
         $this->assertInstanceOf(UploadedFile::class, $file);
 
-        $this->assertEquals('someFile.txt', $file->getName());
-        $this->assertEquals(124, $file->getSize());
+        $this->assertSame('someFile.txt', $file->getName());
+        $this->assertSame(124, $file->getSize());
     }
 
     //--------------------------------------------------------------------
@@ -532,8 +516,8 @@ final class IncomingRequestTest extends CIUnitTestCase
         ];
 
         $gotit = $this->request->getFileMultiple('userfile');
-        $this->assertEquals(124, $gotit[0]->getSize());
-        $this->assertEquals(125, $gotit[1]->getSize());
+        $this->assertSame(124, $gotit[0]->getSize());
+        $this->assertSame(125, $gotit[1]->getSize());
     }
 
     //--------------------------------------------------------------------
@@ -551,7 +535,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         ];
 
         $gotit = $this->request->getFile('userfile');
-        $this->assertEquals(124, $gotit->getSize());
+        $this->assertSame(124, $gotit->getSize());
     }
 
     //--------------------------------------------------------------------
@@ -559,7 +543,7 @@ final class IncomingRequestTest extends CIUnitTestCase
     public function testSpoofing()
     {
         $this->request->setMethod('WINK');
-        $this->assertEquals('wink', $this->request->getMethod());
+        $this->assertSame('wink', $this->request->getMethod());
     }
 
     /**
@@ -567,10 +551,10 @@ final class IncomingRequestTest extends CIUnitTestCase
      */
     public function testGetPostEmpty()
     {
-        $_POST['TEST'] = 5;
-        $_GET['TEST']  = 3;
-        $this->assertEquals($_POST, $this->request->getPostGet());
-        $this->assertEquals($_GET, $this->request->getGetPost());
+        $_POST['TEST'] = '5';
+        $_GET['TEST']  = '3';
+        $this->assertSame($_POST, $this->request->getPostGet());
+        $this->assertSame($_GET, $this->request->getGetPost());
     }
 
     public function testWithFalseBody()
@@ -618,7 +602,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = $path;
         $_SERVER['SCRIPT_NAME'] = $path;
         $request                = new IncomingRequest($config, new URI($path), null, new UserAgent());
-        $this->assertEquals($detectPath, $request->detectPath());
+        $this->assertSame($detectPath, $request->detectPath());
     }
 
     //--------------------------------------------------------------------
@@ -630,7 +614,7 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $request = new IncomingRequest(new App(), new URI(), null, new UserAgent());
 
-        $this->assertEquals('fruits/banana', $request->getPath());
+        $this->assertSame('fruits/banana', $request->getPath());
     }
 
     public function testGetPathIsRelative()
@@ -640,7 +624,7 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $request = new IncomingRequest(new App(), new URI(), null, new UserAgent());
 
-        $this->assertEquals('fruits/banana', $request->getPath());
+        $this->assertSame('fruits/banana', $request->getPath());
     }
 
     public function testGetPathStoresDetectedValue()
@@ -652,7 +636,7 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $_SERVER['REQUEST_URI'] = '/candy/snickers';
 
-        $this->assertEquals('fruits/banana', $request->getPath());
+        $this->assertSame('fruits/banana', $request->getPath());
     }
 
     public function testGetPathIsRediscovered()
@@ -665,7 +649,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/candy/snickers';
         $request->detectPath();
 
-        $this->assertEquals('candy/snickers', $request->getPath());
+        $this->assertSame('candy/snickers', $request->getPath());
     }
 
     //--------------------------------------------------------------------
@@ -673,10 +657,10 @@ final class IncomingRequestTest extends CIUnitTestCase
     public function testSetPath()
     {
         $request = new IncomingRequest(new App(), new URI(), null, new UserAgent());
-        $this->assertEquals('', $request->getPath());
+        $this->assertSame('', $request->getPath());
 
         $request->setPath('foobar');
-        $this->assertEquals('foobar', $request->getPath());
+        $this->assertSame('foobar', $request->getPath());
     }
 
     public function testSetPathUpdatesURI()
@@ -685,6 +669,6 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $request->setPath('apples');
 
-        $this->assertEquals('apples', $request->uri->getPath());
+        $this->assertSame('apples', $request->uri->getPath());
     }
 }

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -57,7 +57,7 @@ final class MessageTest extends CIUnitTestCase
         $header = $this->message->header('Host');
 
         $this->assertInstanceOf(Header::class, $header);
-        $this->assertEquals('daisyduke.com', $header->getValue());
+        $this->assertSame('daisyduke.com', $header->getValue());
     }
 
     //--------------------------------------------------------------------
@@ -66,8 +66,8 @@ final class MessageTest extends CIUnitTestCase
     {
         $this->message->setHeader('Host', 'daisyduke.com');
 
-        $this->assertEquals('daisyduke.com', $this->message->header('host')->getValue());
-        $this->assertEquals('daisyduke.com', $this->message->header('HOST')->getValue());
+        $this->assertSame('daisyduke.com', $this->message->header('host')->getValue());
+        $this->assertSame('daisyduke.com', $this->message->header('HOST')->getValue());
     }
 
     //--------------------------------------------------------------------
@@ -77,8 +77,8 @@ final class MessageTest extends CIUnitTestCase
         $this->message->setHeader('first', 'kiss');
         $this->message->setHeader('second', ['black', 'book']);
 
-        $this->assertEquals('kiss', $this->message->header('FIRST')->getValue());
-        $this->assertEquals(['black', 'book'], $this->message->header('Second')->getValue());
+        $this->assertSame('kiss', $this->message->header('FIRST')->getValue());
+        $this->assertSame(['black', 'book'], $this->message->header('Second')->getValue());
     }
 
     //--------------------------------------------------------------------
@@ -88,7 +88,7 @@ final class MessageTest extends CIUnitTestCase
         $this->message->setHeader('Pragma', 'cache');
         $this->message->setHeader('Pragma', 'no-cache');
 
-        $this->assertEquals('no-cache', $this->message->header('Pragma')->getValue());
+        $this->assertSame('no-cache', $this->message->header('Pragma')->getValue());
     }
 
     public function testHeaderLineIsReadable()
@@ -96,8 +96,8 @@ final class MessageTest extends CIUnitTestCase
         $this->message->setHeader('Accept', ['json', 'html']);
         $this->message->setHeader('Host', 'daisyduke.com');
 
-        $this->assertEquals('json, html', $this->message->header('Accept')->getValueLine());
-        $this->assertEquals('daisyduke.com', $this->message->header('Host')->getValueLine());
+        $this->assertSame('json, html', $this->message->header('Accept')->getValueLine());
+        $this->assertSame('daisyduke.com', $this->message->header('Host')->getValueLine());
     }
 
     //--------------------------------------------------------------------
@@ -108,7 +108,7 @@ final class MessageTest extends CIUnitTestCase
 
         $this->message->removeHeader('host');
 
-        $this->assertEquals('', $this->message->header('host'));
+        $this->assertNull($this->message->header('host'));
     }
 
     //--------------------------------------------------------------------
@@ -119,7 +119,7 @@ final class MessageTest extends CIUnitTestCase
 
         $this->message->appendHeader('Accept', 'xml');
 
-        $this->assertEquals(['json', 'html', 'xml'], $this->message->header('accept')->getValue());
+        $this->assertSame(['json', 'html', 'xml'], $this->message->header('accept')->getValue());
     }
 
     //--------------------------------------------------------------------
@@ -130,7 +130,7 @@ final class MessageTest extends CIUnitTestCase
 
         $this->message->prependHeader('Accept', 'xml');
 
-        $this->assertEquals(['xml', 'json', 'html'], $this->message->header('accept')->getValue());
+        $this->assertSame(['xml', 'json', 'html'], $this->message->header('accept')->getValue());
     }
 
     //--------------------------------------------------------------------
@@ -139,7 +139,7 @@ final class MessageTest extends CIUnitTestCase
     {
         $this->message->setProtocolVersion('1.1');
 
-        $this->assertEquals('1.1', $this->message->getProtocolVersion());
+        $this->assertSame('1.1', $this->message->getProtocolVersion());
     }
 
     //--------------------------------------------------------------------
@@ -148,7 +148,7 @@ final class MessageTest extends CIUnitTestCase
     {
         $this->message->setProtocolVersion('HTTP/1.1');
 
-        $this->assertEquals('1.1', $this->message->getProtocolVersion());
+        $this->assertSame('1.1', $this->message->getProtocolVersion());
     }
 
     //--------------------------------------------------------------------
@@ -167,7 +167,7 @@ final class MessageTest extends CIUnitTestCase
 
         $this->message->setBody($body);
 
-        $this->assertEquals($body, $this->message->getBody());
+        $this->assertSame($body, $this->message->getBody());
     }
 
     //--------------------------------------------------------------------
@@ -178,7 +178,7 @@ final class MessageTest extends CIUnitTestCase
 
         $this->message->appendBody('\n');
 
-        $this->assertEquals('moo' . '\n', $this->message->getBody());
+        $this->assertSame('moo' . '\n', $this->message->getBody());
     }
 
     //--------------------------------------------------------------------
@@ -187,7 +187,7 @@ final class MessageTest extends CIUnitTestCase
     {
         $this->message->setHeader('Accept', 'json');
 
-        $this->assertEquals('json', $this->message->getHeaderLine('Accept'));
+        $this->assertSame('json', $this->message->getHeaderLine('Accept'));
     }
 
     public function testSetHeaderDuplicateSettings()
@@ -195,7 +195,7 @@ final class MessageTest extends CIUnitTestCase
         $this->message->setHeader('Accept', 'json');
         $this->message->setHeader('Accept', 'xml');
 
-        $this->assertEquals('xml', $this->message->getHeaderLine('Accept'));
+        $this->assertSame('xml', $this->message->getHeaderLine('Accept'));
     }
 
     public function testSetHeaderDuplicateSettingsInsensitive()
@@ -203,14 +203,14 @@ final class MessageTest extends CIUnitTestCase
         $this->message->setHeader('Accept', 'json');
         $this->message->setHeader('accept', 'xml');
 
-        $this->assertEquals('xml', $this->message->getHeaderLine('Accept'));
+        $this->assertSame('xml', $this->message->getHeaderLine('Accept'));
     }
 
     public function testSetHeaderArrayValues()
     {
         $this->message->setHeader('Accept', ['json', 'html', 'xml']);
 
-        $this->assertEquals('json, html, xml', $this->message->getHeaderLine('Accept'));
+        $this->assertSame('json, html, xml', $this->message->getHeaderLine('Accept'));
     }
 
     public function provideArrayHeaderValue()
@@ -240,7 +240,7 @@ final class MessageTest extends CIUnitTestCase
         $this->message->setHeader('Accept', $arrayHeaderValue);
         $this->message->setHeader('Accept', 'xml');
 
-        $this->assertEquals('json, html, xml', $this->message->getHeaderLine('Accept'));
+        $this->assertSame('json, html, xml', $this->message->getHeaderLine('Accept'));
     }
 
     /**
@@ -251,7 +251,7 @@ final class MessageTest extends CIUnitTestCase
         $this->message->setHeader('Accept', $arrayHeaderValue);
         $this->message->setHeader('Accept', ['xml']);
 
-        $this->assertEquals('json, html, xml', $this->message->getHeaderLine('Accept'));
+        $this->assertSame('json, html, xml', $this->message->getHeaderLine('Accept'));
     }
 
     public function testSetHeaderWithExistingArrayValuesAppendNullValue()
@@ -259,7 +259,7 @@ final class MessageTest extends CIUnitTestCase
         $this->message->setHeader('Accept', ['json', 'html', 'xml']);
         $this->message->setHeader('Accept', null);
 
-        $this->assertEquals('json, html, xml', $this->message->getHeaderLine('Accept'));
+        $this->assertSame('json, html, xml', $this->message->getHeaderLine('Accept'));
     }
 
     //--------------------------------------------------------------------
@@ -311,7 +311,7 @@ final class MessageTest extends CIUnitTestCase
 
         $this->message->populateHeaders();
 
-        $this->assertEquals('', $this->message->header('accept-charset')->getValue());
+        $this->assertSame('', $this->message->header('accept-charset')->getValue());
         $this->message->removeHeader('accept-charset');
         $_SERVER = $original; // restore so code coverage doesn't break
     }
@@ -329,8 +329,8 @@ final class MessageTest extends CIUnitTestCase
 
         $this->message->populateHeaders();
 
-        $this->assertEquals('text/html; charset=utf-8', $this->message->header('content-type')->getValue());
-        $this->assertEquals('en-us,en;q=0.50', $this->message->header('accept-language')->getValue());
+        $this->assertSame('text/html; charset=utf-8', $this->message->header('content-type')->getValue());
+        $this->assertSame('en-us,en;q=0.50', $this->message->header('accept-language')->getValue());
         $this->message->removeHeader('content-type');
         $this->message->removeHeader('accept-language');
         $_SERVER = $original; // restore so code coverage doesn't break

--- a/tests/system/HTTP/NegotiateTest.php
+++ b/tests/system/HTTP/NegotiateTest.php
@@ -46,13 +46,13 @@ final class NegotiateTest extends CIUnitTestCase
         $this->request->setHeader('Accept', 'text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c');
         $this->negotiate->setRequest($this->request);
 
-        $this->assertEquals('text/html', $this->negotiate->media(['text/html', 'text/x-c', 'text/x-dvi', 'text/plain']));
-        $this->assertEquals('text/x-c', $this->negotiate->media(['text/x-c', 'text/x-dvi', 'text/plain']));
-        $this->assertEquals('text/x-dvi', $this->negotiate->media(['text/plain', 'text/x-dvi']));
-        $this->assertEquals('text/x-dvi', $this->negotiate->media(['text/x-dvi']));
+        $this->assertSame('text/html', $this->negotiate->media(['text/html', 'text/x-c', 'text/x-dvi', 'text/plain']));
+        $this->assertSame('text/x-c', $this->negotiate->media(['text/x-c', 'text/x-dvi', 'text/plain']));
+        $this->assertSame('text/x-dvi', $this->negotiate->media(['text/plain', 'text/x-dvi']));
+        $this->assertSame('text/x-dvi', $this->negotiate->media(['text/x-dvi']));
 
         // No matches? Return the first that we support...
-        $this->assertEquals('text/md', $this->negotiate->media(['text/md']));
+        $this->assertSame('text/md', $this->negotiate->media(['text/md']));
     }
 
     //--------------------------------------------------------------------
@@ -61,10 +61,10 @@ final class NegotiateTest extends CIUnitTestCase
     {
         $header = $this->negotiate->parseHeader('text/*, text/plain, text/plain;format=flowed, */*');
 
-        $this->assertEquals('text/plain', $header[0]['value']);
-        $this->assertEquals('flowed', $header[0]['params']['format']);
-        $this->assertEquals('text/plain', $header[1]['value']);
-        $this->assertEquals('*/*', $header[3]['value']);
+        $this->assertSame('text/plain', $header[0]['value']);
+        $this->assertSame('flowed', $header[0]['params']['format']);
+        $this->assertSame('text/plain', $header[1]['value']);
+        $this->assertSame('*/*', $header[3]['value']);
     }
 
     //--------------------------------------------------------------------
@@ -73,7 +73,7 @@ final class NegotiateTest extends CIUnitTestCase
     {
         $this->request->setHeader('Accept', 'image/*, text/*');
 
-        $this->assertEquals('text/plain', $this->negotiate->media(['text/plain']));
+        $this->assertSame('text/plain', $this->negotiate->media(['text/plain']));
     }
 
     //--------------------------------------------------------------------
@@ -83,7 +83,7 @@ final class NegotiateTest extends CIUnitTestCase
         // Image has a higher specificity, but is the wrong type...
         $this->request->setHeader('Accept', 'text/*, image/jpeg');
 
-        $this->assertEquals('text/plain', $this->negotiate->media(['text/plain']));
+        $this->assertSame('text/plain', $this->negotiate->media(['text/plain']));
     }
 
     //--------------------------------------------------------------------
@@ -93,8 +93,8 @@ final class NegotiateTest extends CIUnitTestCase
         // Image has a higher specificity, but is the wrong type...
         $this->request->setHeader('Accept', 'text/md, image/jpeg');
 
-        $this->assertEquals('text/plain', $this->negotiate->media(['text/plain']));
-        $this->assertEquals('', $this->negotiate->media(['text/plain'], true));
+        $this->assertSame('text/plain', $this->negotiate->media(['text/plain']));
+        $this->assertSame('', $this->negotiate->media(['text/plain'], true));
     }
 
     //--------------------------------------------------------------------
@@ -106,18 +106,18 @@ final class NegotiateTest extends CIUnitTestCase
     {
         $this->request->setHeader('Accept-Charset', 'iso-8859-5, unicode-1-1;q=0.8');
 
-        $this->assertEquals('iso-8859-5', $this->negotiate->charset(['iso-8859-5', 'unicode-1-1']));
-        $this->assertEquals('unicode-1-1', $this->negotiate->charset(['utf-8', 'unicode-1-1']));
+        $this->assertSame('iso-8859-5', $this->negotiate->charset(['iso-8859-5', 'unicode-1-1']));
+        $this->assertSame('unicode-1-1', $this->negotiate->charset(['utf-8', 'unicode-1-1']));
 
         // No match will default to utf-8
-        $this->assertEquals('utf-8', $this->negotiate->charset(['iso-8859', 'unicode-1-2']));
+        $this->assertSame('utf-8', $this->negotiate->charset(['iso-8859', 'unicode-1-2']));
     }
 
     //--------------------------------------------------------------------
 
     public function testNegotiateEncodingReturnsFirstIfNoAcceptHeaderExists()
     {
-        $this->assertEquals('compress', $this->negotiate->encoding(['compress', 'gzip']));
+        $this->assertSame('compress', $this->negotiate->encoding(['compress', 'gzip']));
     }
 
     //--------------------------------------------------------------------
@@ -126,9 +126,9 @@ final class NegotiateTest extends CIUnitTestCase
     {
         $this->request->setHeader('Accept-Encoding', 'gzip;q=1.0, identity; q=0.4, compress;q=0.5');
 
-        $this->assertEquals('gzip', $this->negotiate->encoding(['gzip', 'compress']));
-        $this->assertEquals('compress', $this->negotiate->encoding(['compress']));
-        $this->assertEquals('identity', $this->negotiate->encoding());
+        $this->assertSame('gzip', $this->negotiate->encoding(['gzip', 'compress']));
+        $this->assertSame('compress', $this->negotiate->encoding(['compress']));
+        $this->assertSame('identity', $this->negotiate->encoding());
     }
 
     //--------------------------------------------------------------------
@@ -137,9 +137,9 @@ final class NegotiateTest extends CIUnitTestCase
     {
         $this->request->setHeader('Accept-Language', 'da, en-gb;q=0.8, en;q=0.7');
 
-        $this->assertEquals('da', $this->negotiate->language(['da', 'en']));
-        $this->assertEquals('en-gb', $this->negotiate->language(['en-gb', 'en']));
-        $this->assertEquals('en', $this->negotiate->language(['en']));
+        $this->assertSame('da', $this->negotiate->language(['da', 'en']));
+        $this->assertSame('en-gb', $this->negotiate->language(['en-gb', 'en']));
+        $this->assertSame('en', $this->negotiate->language(['en']));
     }
 
     //--------------------------------------------------------------------
@@ -151,7 +151,7 @@ final class NegotiateTest extends CIUnitTestCase
     {
         $this->request->setHeader('Accept-Language', 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7');
 
-        $this->assertEquals('fr', $this->negotiate->language(['fr', 'en']));
+        $this->assertSame('fr', $this->negotiate->language(['fr', 'en']));
     }
 
     public function testBestMatchEmpty()
@@ -163,42 +163,42 @@ final class NegotiateTest extends CIUnitTestCase
     public function testBestMatchNoHeader()
     {
         $this->request->setHeader('Accept', '');
-        $this->assertEquals('', $this->negotiate->media(['apple', 'banana'], true));
-        $this->assertEquals('apple/mac', $this->negotiate->media(['apple/mac', 'banana/yellow'], false));
+        $this->assertSame('', $this->negotiate->media(['apple', 'banana'], true));
+        $this->assertSame('apple/mac', $this->negotiate->media(['apple/mac', 'banana/yellow'], false));
     }
 
     public function testBestMatchNotAcceptable()
     {
         $this->request->setHeader('Accept', 'popcorn/cheddar');
-        $this->assertEquals('apple/mac', $this->negotiate->media(['apple/mac', 'banana/yellow'], false));
-        $this->assertEquals('banana/yellow', $this->negotiate->media(['banana/yellow', 'apple/mac'], false));
+        $this->assertSame('apple/mac', $this->negotiate->media(['apple/mac', 'banana/yellow'], false));
+        $this->assertSame('banana/yellow', $this->negotiate->media(['banana/yellow', 'apple/mac'], false));
     }
 
     public function testBestMatchFirstSupported()
     {
         $this->request->setHeader('Accept', 'popcorn/cheddar, */*');
-        $this->assertEquals('apple/mac', $this->negotiate->media(['apple/mac', 'banana/yellow'], false));
+        $this->assertSame('apple/mac', $this->negotiate->media(['apple/mac', 'banana/yellow'], false));
     }
 
     public function testBestMatchLowQuality()
     {
         $this->request->setHeader('Accept', 'popcorn/cheddar;q=0, apple/mac, */*');
-        $this->assertEquals('apple/mac', $this->negotiate->media(['apple/mac', 'popcorn/cheddar'], false));
-        $this->assertEquals('apple/mac', $this->negotiate->media(['popcorn/cheddar', 'apple/mac'], false));
+        $this->assertSame('apple/mac', $this->negotiate->media(['apple/mac', 'popcorn/cheddar'], false));
+        $this->assertSame('apple/mac', $this->negotiate->media(['popcorn/cheddar', 'apple/mac'], false));
     }
 
     public function testBestMatchOnlyLowQuality()
     {
         $this->request->setHeader('Accept', 'popcorn/cheddar;q=0');
         // the first supported should be returned, since nothing will make us happy
-        $this->assertEquals('apple/mac', $this->negotiate->media(['apple/mac', 'popcorn/cheddar'], false));
-        $this->assertEquals('popcorn/cheddar', $this->negotiate->media(['popcorn/cheddar', 'apple/mac'], false));
+        $this->assertSame('apple/mac', $this->negotiate->media(['apple/mac', 'popcorn/cheddar'], false));
+        $this->assertSame('popcorn/cheddar', $this->negotiate->media(['popcorn/cheddar', 'apple/mac'], false));
     }
 
     public function testParameterMatching()
     {
         $this->request->setHeader('Accept', 'popcorn/cheddar;a=0;b=1');
-        $this->assertEquals('popcorn/cheddar;a=2', $this->negotiate->media(['popcorn/cheddar;a=2'], false));
-        $this->assertEquals('popcorn/cheddar;a=0', $this->negotiate->media(['popcorn/cheddar;a=0', 'popcorn/cheddar;a=2;b=1'], false));
+        $this->assertSame('popcorn/cheddar;a=2', $this->negotiate->media(['popcorn/cheddar;a=2'], false));
+        $this->assertSame('popcorn/cheddar;a=0', $this->negotiate->media(['popcorn/cheddar;a=0', 'popcorn/cheddar;a=2;b=1'], false));
     }
 }

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -49,7 +49,7 @@ final class RedirectResponseTest extends CIUnitTestCase
         $response = $response->to('http://example.com/foo');
 
         $this->assertTrue($response->hasHeader('Location'));
-        $this->assertEquals('http://example.com/foo', $response->getHeaderLine('Location'));
+        $this->assertSame('http://example.com/foo', $response->getHeaderLine('Location'));
     }
 
     //--------------------------------------------------------------------
@@ -63,14 +63,14 @@ final class RedirectResponseTest extends CIUnitTestCase
         $response->route('exampleRoute');
 
         $this->assertTrue($response->hasHeader('Location'));
-        $this->assertEquals('http://example.com/index.php/exampleRoute', $response->getHeaderLine('Location'));
+        $this->assertSame('http://example.com/index.php/exampleRoute', $response->getHeaderLine('Location'));
 
         $this->routes->add('exampleRoute', 'Home::index', ['as' => 'home']);
 
         $response->route('home');
 
         $this->assertTrue($response->hasHeader('Location'));
-        $this->assertEquals('http://example.com/index.php/exampleRoute', $response->getHeaderLine('Location'));
+        $this->assertSame('http://example.com/index.php/exampleRoute', $response->getHeaderLine('Location'));
     }
 
     public function testRedirectRouteBad()
@@ -93,7 +93,7 @@ final class RedirectResponseTest extends CIUnitTestCase
         $response = $response->to('/foo');
 
         $this->assertTrue($response->hasHeader('Location'));
-        $this->assertEquals('http://example.com/index.php/foo', $response->getHeaderLine('Location'));
+        $this->assertSame('http://example.com/index.php/foo', $response->getHeaderLine('Location'));
     }
 
     //--------------------------------------------------------------------
@@ -114,8 +114,8 @@ final class RedirectResponseTest extends CIUnitTestCase
 
         $this->assertSame($response, $returned);
         $this->assertArrayHasKey('_ci_old_input', $_SESSION);
-        $this->assertEquals('bar', $_SESSION['_ci_old_input']['get']['foo']);
-        $this->assertEquals('baz', $_SESSION['_ci_old_input']['post']['bar']);
+        $this->assertSame('bar', $_SESSION['_ci_old_input']['get']['foo']);
+        $this->assertSame('baz', $_SESSION['_ci_old_input']['post']['bar']);
     }
 
     //--------------------------------------------------------------------
@@ -173,7 +173,7 @@ final class RedirectResponseTest extends CIUnitTestCase
         $response = new RedirectResponse(new App());
 
         $returned = $response->back();
-        $this->assertEquals('http://somewhere.com', $returned->header('location')->getValue());
+        $this->assertSame('http://somewhere.com', $returned->header('location')->getValue());
     }
 
     /**
@@ -213,7 +213,7 @@ final class RedirectResponseTest extends CIUnitTestCase
         $response->route('exampleRoute');
 
         $this->assertTrue($response->hasHeader('Location'));
-        $this->assertEquals('http://example.com/test/index.php/exampleRoute', $response->getHeaderLine('Location'));
+        $this->assertSame('http://example.com/test/index.php/exampleRoute', $response->getHeaderLine('Location'));
 
         Factories::reset('config');
     }
@@ -260,7 +260,7 @@ final class RedirectResponseTest extends CIUnitTestCase
 
         foreach ($baseResponse->headers() as $name => $header) {
             $this->assertTrue($response->hasHeader($name));
-            $this->assertEquals($header->getValue(), $response->header($name)->getValue());
+            $this->assertSame($header->getValue(), $response->header($name)->getValue());
         }
     }
 

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -23,8 +23,9 @@ final class RequestTest extends CIUnitTestCase
         parent::setUp();
 
         $this->request = new Request(new App());
-        $_POST         = [];
-        $_GET          = [];
+
+        $_POST = [];
+        $_GET  = [];
     }
 
     //--------------------------------------------------------------------
@@ -34,8 +35,8 @@ final class RequestTest extends CIUnitTestCase
         $_POST['foo'] = 'bar';
         $_GET['bar']  = 'baz';
 
-        $this->assertEquals('bar', $this->request->fetchGlobal('post', 'foo'));
-        $this->assertEquals('baz', $this->request->fetchGlobal('get', 'bar'));
+        $this->assertSame('bar', $this->request->fetchGlobal('post', 'foo'));
+        $this->assertSame('baz', $this->request->fetchGlobal('get', 'bar'));
     }
 
     public function testFetchGlobalsReturnsNullWhenNotFound()
@@ -50,8 +51,8 @@ final class RequestTest extends CIUnitTestCase
             'bar' => 'baz',
         ]);
 
-        $this->assertEquals('bar%3Cscript%3E', $this->request->fetchGlobal('post', 'foo', FILTER_SANITIZE_ENCODED));
-        $this->assertEquals('baz', $this->request->fetchGlobal('post', 'bar'));
+        $this->assertSame('bar%3Cscript%3E', $this->request->fetchGlobal('post', 'foo', FILTER_SANITIZE_ENCODED));
+        $this->assertSame('baz', $this->request->fetchGlobal('post', 'bar'));
     }
 
     public function testFetchGlobalsWithFilterFlag()
@@ -61,8 +62,8 @@ final class RequestTest extends CIUnitTestCase
             'bar' => 'baz',
         ]);
 
-        $this->assertEquals('bar%3Cscript%3E', $this->request->fetchGlobal('post', 'foo', FILTER_SANITIZE_ENCODED, FILTER_FLAG_STRIP_BACKTICK));
-        $this->assertEquals('baz', $this->request->fetchGlobal('post', 'bar'));
+        $this->assertSame('bar%3Cscript%3E', $this->request->fetchGlobal('post', 'foo', FILTER_SANITIZE_ENCODED, FILTER_FLAG_STRIP_BACKTICK));
+        $this->assertSame('baz', $this->request->fetchGlobal('post', 'bar'));
     }
 
     public function testFetchGlobalReturnsAllWhenEmpty()
@@ -75,7 +76,7 @@ final class RequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals($post, $this->request->fetchGlobal('post'));
+        $this->assertSame($post, $this->request->fetchGlobal('post'));
     }
 
     public function testFetchGlobalFiltersAllValues()
@@ -94,7 +95,7 @@ final class RequestTest extends CIUnitTestCase
             'yyy' => 'zzz%3Cscript%3E',
         ];
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', null, FILTER_SANITIZE_ENCODED));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', null, FILTER_SANITIZE_ENCODED));
     }
 
     public function testFetchGlobalFilterWithFlagAllValues()
@@ -113,7 +114,7 @@ final class RequestTest extends CIUnitTestCase
             'yyy' => 'zzz%3Cscript%3E',
         ];
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', null, FILTER_SANITIZE_ENCODED, FILTER_FLAG_STRIP_BACKTICK));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', null, FILTER_SANITIZE_ENCODED, FILTER_FLAG_STRIP_BACKTICK));
     }
 
     public function testFetchGlobalReturnsSelectedKeys()
@@ -130,7 +131,7 @@ final class RequestTest extends CIUnitTestCase
             'bar' => 'baz',
         ];
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', ['foo', 'bar']));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', ['foo', 'bar']));
     }
 
     public function testFetchGlobalFiltersSelectedValues()
@@ -147,7 +148,7 @@ final class RequestTest extends CIUnitTestCase
             'bar' => 'baz%3Cscript%3E',
         ];
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', ['foo', 'bar'], FILTER_SANITIZE_ENCODED));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', ['foo', 'bar'], FILTER_SANITIZE_ENCODED));
     }
 
     public function testFetchGlobalFilterWithFlagSelectedValues()
@@ -164,7 +165,7 @@ final class RequestTest extends CIUnitTestCase
             'bar' => 'baz%3Cscript%3E',
         ];
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', ['foo', 'bar'], FILTER_SANITIZE_ENCODED, FILTER_FLAG_STRIP_BACKTICK));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', ['foo', 'bar'], FILTER_SANITIZE_ENCODED, FILTER_FLAG_STRIP_BACKTICK));
     }
 
     /**
@@ -174,19 +175,15 @@ final class RequestTest extends CIUnitTestCase
     {
         $post = [
             'ANNOUNCEMENTS' => [
-                1 => [
-                    'DETAIL' => 'asdf',
-                ],
-                2 => [
-                    'DETAIL' => 'sdfg',
-                ],
+                1 => ['DETAIL' => 'asdf'],
+                2 => ['DETAIL' => 'sdfg'],
             ],
             'submit' => 'SAVE',
         ];
         $this->request->setGlobal('post', $post);
         $result = $this->request->fetchGlobal('post');
 
-        $this->assertEquals($post, $result);
+        $this->assertSame($post, $result);
         $this->assertIsArray($result['ANNOUNCEMENTS']);
         $this->assertCount(2, $result['ANNOUNCEMENTS']);
     }
@@ -202,7 +199,7 @@ final class RequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals(['address' => ['zipcode' => 90210]], $this->request->fetchGlobal('post', 'clients'));
+        $this->assertSame(['address' => ['zipcode' => 90210]], $this->request->fetchGlobal('post', 'clients'));
     }
 
     public function testFetchGlobalWithArrayChildNumeric()
@@ -223,7 +220,7 @@ final class RequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals(['zipcode' => 60610], $this->request->fetchGlobal('post', 'clients[1][address]'));
+        $this->assertSame(['zipcode' => 60610], $this->request->fetchGlobal('post', 'clients[1][address]'));
     }
 
     public function testFetchGlobalWithArrayChildElement()
@@ -237,7 +234,7 @@ final class RequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals(['zipcode' => 90210], $this->request->fetchGlobal('post', 'clients[address]'));
+        $this->assertSame(['zipcode' => 90210], $this->request->fetchGlobal('post', 'clients[address]'));
         $this->assertNull($this->request->fetchGlobal('post', 'clients[zipcode]'));
     }
 
@@ -253,7 +250,7 @@ final class RequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals([['a']], $this->request->fetchGlobal('post', 'clients[stuff]'));
+        $this->assertSame([['a']], $this->request->fetchGlobal('post', 'clients[stuff]'));
     }
 
     public function testFetchGlobalWithArrayLastElement()
@@ -267,7 +264,7 @@ final class RequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals(90210, $this->request->fetchGlobal('post', 'clients[address][zipcode]'));
+        $this->assertSame('90210', $this->request->fetchGlobal('post', 'clients[address][zipcode]'));
     }
 
     public function testFetchGlobalWithEmptyNotation()
@@ -289,7 +286,7 @@ final class RequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', 'clients[]'));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', 'clients[]'));
     }
 
     //--------------------------------------------------------------------
@@ -358,7 +355,7 @@ final class RequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', null, FILTER_VALIDATE_INT));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', null, FILTER_VALIDATE_INT));
     }
 
     public function testFetchGlobalFiltersWithValue()
@@ -417,7 +414,7 @@ final class RequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', 'people', FILTER_VALIDATE_INT));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', 'people', FILTER_VALIDATE_INT));
     }
 
     public function testFetchGlobalFiltersWithValues()
@@ -482,7 +479,7 @@ final class RequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', ['address', 'people'], FILTER_VALIDATE_INT));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', ['address', 'people'], FILTER_VALIDATE_INT));
     }
 
     public function testFetchGlobalFiltersWithArrayChildElement()
@@ -529,7 +526,7 @@ final class RequestTest extends CIUnitTestCase
         ];
         $this->request->setGlobal('post', $post);
 
-        $this->assertEquals($expected, $this->request->fetchGlobal('post', 'people[0]', FILTER_VALIDATE_INT));
+        $this->assertSame($expected, $this->request->fetchGlobal('post', 'people[0]', FILTER_VALIDATE_INT));
     }
 
     //--------------------------------------------------------------------
@@ -585,14 +582,14 @@ final class RequestTest extends CIUnitTestCase
      */
     public function testValidIPAddress($expected, $address, $type = null)
     {
-        $this->assertEquals($expected, $this->request->isValidIP($address, $type));
+        $this->assertSame($expected, $this->request->isValidIP($address, $type));
     }
 
     //--------------------------------------------------------------------
 
     public function testGetIPAddressDefault()
     {
-        $this->assertEquals('0.0.0.0', $this->request->getIPAddress());
+        $this->assertSame('0.0.0.0', $this->request->getIPAddress());
     }
 
     public function testGetIPAddressNormal()
@@ -600,9 +597,9 @@ final class RequestTest extends CIUnitTestCase
         $expected               = '123.123.123.123';
         $_SERVER['REMOTE_ADDR'] = $expected;
         $this->request          = new Request(new App());
-        $this->assertEquals($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $this->request->getIPAddress());
         // call a second time to exercise the initial conditional block in getIPAddress()
-        $this->assertEquals($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $this->request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxy()
@@ -615,7 +612,7 @@ final class RequestTest extends CIUnitTestCase
         $this->request                   = new Request($config);
 
         // we should see the original forwarded address
-        $this->assertEquals($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $this->request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyInvalid()
@@ -628,7 +625,7 @@ final class RequestTest extends CIUnitTestCase
         $this->request                   = new Request($config);
 
         // spoofed address invalid
-        $this->assertEquals('10.0.1.200', $this->request->getIPAddress());
+        $this->assertSame('10.0.1.200', $this->request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyNotWhitelisted()
@@ -641,7 +638,7 @@ final class RequestTest extends CIUnitTestCase
         $this->request                   = new Request($config);
 
         // spoofed address invalid
-        $this->assertEquals('10.10.1.200', $this->request->getIPAddress());
+        $this->assertSame('10.10.1.200', $this->request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxySubnet()
@@ -654,7 +651,7 @@ final class RequestTest extends CIUnitTestCase
         $this->request                   = new Request($config);
 
         // we should see the original forwarded address
-        $this->assertEquals($expected, $this->request->getIPAddress());
+        $this->assertSame($expected, $this->request->getIPAddress());
     }
 
     public function testGetIPAddressThruProxyOutofSubnet()
@@ -667,7 +664,7 @@ final class RequestTest extends CIUnitTestCase
         $this->request                   = new Request($config);
 
         // we should see the original forwarded address
-        $this->assertEquals('192.168.5.21', $this->request->getIPAddress());
+        $this->assertSame('192.168.5.21', $this->request->getIPAddress());
     }
 
     //FIXME getIPAddress should have more testing, to 100% code coverage
@@ -677,7 +674,7 @@ final class RequestTest extends CIUnitTestCase
     public function testMethodReturnsRightStuff()
     {
         // Defaults method to GET now.
-        $this->assertEquals('get', $this->request->getMethod());
-        $this->assertEquals('GET', $this->request->getMethod(true));
+        $this->assertSame('get', $this->request->getMethod());
+        $this->assertSame('GET', $this->request->getMethod(true));
     }
 }

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -37,7 +37,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $response->setStatusCode(200);
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     //--------------------------------------------------------------------
@@ -69,7 +69,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $response->setStatusCode(200);
 
-        $this->assertEquals('OK', $response->getReasonPhrase());
+        $this->assertSame('OK', $response->getReasonPhrase());
     }
 
     //--------------------------------------------------------------------
@@ -80,7 +80,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $response->setStatusCode(200, 'Not the mama');
 
-        $this->assertEquals('Not the mama', $response->getReasonPhrase());
+        $this->assertSame('Not the mama', $response->getReasonPhrase());
     }
 
     //--------------------------------------------------------------------
@@ -124,7 +124,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $response->setStatusCode(300);
 
-        $this->assertEquals('Multiple Choices', $response->getReasonPhrase());
+        $this->assertSame('Multiple Choices', $response->getReasonPhrase());
     }
 
     //--------------------------------------------------------------------
@@ -135,7 +135,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $response->setStatusCode(300, 'My Little Pony');
 
-        $this->assertEquals('My Little Pony', $response->getReasonPhrase());
+        $this->assertSame('My Little Pony', $response->getReasonPhrase());
     }
 
     //--------------------------------------------------------------------
@@ -144,7 +144,7 @@ final class ResponseTest extends CIUnitTestCase
     {
         $response = new Response(new App());
 
-        $this->assertEquals('OK', $response->getReasonPhrase());
+        $this->assertSame('OK', $response->getReasonPhrase());
     }
 
     //--------------------------------------------------------------------
@@ -160,7 +160,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $header = $response->getHeaderLine('Date');
 
-        $this->assertEquals($date->format('D, d M Y H:i:s') . ' GMT', $header);
+        $this->assertSame($date->format('D, d M Y H:i:s') . ' GMT', $header);
     }
 
     //--------------------------------------------------------------------
@@ -178,7 +178,7 @@ final class ResponseTest extends CIUnitTestCase
         $pager->store('default', 3, 10, 200);
         $response->setLink($pager);
 
-        $this->assertEquals(
+        $this->assertSame(
             '<http://example.com/test/index.php?page=1>; rel="first",<http://example.com/test/index.php?page=2>; rel="prev",<http://example.com/test/index.php?page=4>; rel="next",<http://example.com/test/index.php?page=20>; rel="last"',
             $response->header('Link')->getValue()
         );
@@ -186,7 +186,7 @@ final class ResponseTest extends CIUnitTestCase
         $pager->store('default', 1, 10, 200);
         $response->setLink($pager);
 
-        $this->assertEquals(
+        $this->assertSame(
             '<http://example.com/test/index.php?page=2>; rel="next",<http://example.com/test/index.php?page=20>; rel="last"',
             $response->header('Link')->getValue()
         );
@@ -194,7 +194,7 @@ final class ResponseTest extends CIUnitTestCase
         $pager->store('default', 20, 10, 200);
         $response->setLink($pager);
 
-        $this->assertEquals(
+        $this->assertSame(
             '<http://example.com/test/index.php?page=1>; rel="first",<http://example.com/test/index.php?page=19>; rel="prev"',
             $response->header('Link')->getValue()
         );
@@ -208,7 +208,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $response->setContentType('text/json');
 
-        $this->assertEquals('text/json; charset=UTF-8', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('text/json; charset=UTF-8', $response->getHeaderLine('Content-Type'));
     }
 
     //--------------------------------------------------------------------
@@ -219,7 +219,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $response->noCache();
 
-        $this->assertEquals('no-store, max-age=0, no-cache', $response->getHeaderLine('Cache-control'));
+        $this->assertSame('no-store, max-age=0, no-cache', $response->getHeaderLine('Cache-control'));
     }
 
     //--------------------------------------------------------------------
@@ -239,9 +239,9 @@ final class ResponseTest extends CIUnitTestCase
 
         $response->setCache($options);
 
-        $this->assertEquals('12345678', $response->getHeaderLine('ETag'));
-        $this->assertEquals($date, $response->getHeaderLine('Last-Modified'));
-        $this->assertEquals('max-age=300, must-revalidate', $response->getHeaderLine('Cache-Control'));
+        $this->assertSame('12345678', $response->getHeaderLine('ETag'));
+        $this->assertSame($date, $response->getHeaderLine('Last-Modified'));
+        $this->assertSame('max-age=300, must-revalidate', $response->getHeaderLine('Cache-Control'));
     }
 
     public function testSetCacheNoOptions()
@@ -252,7 +252,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $response->setCache($options);
 
-        $this->assertEquals('no-store, max-age=0, no-cache', $response->getHeaderLine('Cache-Control'));
+        $this->assertSame('no-store, max-age=0, no-cache', $response->getHeaderLine('Cache-Control'));
     }
 
     //--------------------------------------------------------------------
@@ -268,7 +268,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $header = $response->getHeaderLine('Last-Modified');
 
-        $this->assertEquals($date->format('D, d M Y H:i:s') . ' GMT', $header);
+        $this->assertSame($date->format('D, d M Y H:i:s') . ' GMT', $header);
     }
 
     //--------------------------------------------------------------------
@@ -280,8 +280,8 @@ final class ResponseTest extends CIUnitTestCase
         $response->redirect('example.com');
 
         $this->assertTrue($response->hasHeader('location'));
-        $this->assertEquals('example.com', $response->getHeaderLine('Location'));
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertSame('example.com', $response->getHeaderLine('Location'));
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     //--------------------------------------------------------------------
@@ -293,8 +293,8 @@ final class ResponseTest extends CIUnitTestCase
         $response->redirect('example.com', 'auto', 307);
 
         $this->assertTrue($response->hasHeader('location'));
-        $this->assertEquals('example.com', $response->getHeaderLine('Location'));
-        $this->assertEquals(307, $response->getStatusCode());
+        $this->assertSame('example.com', $response->getHeaderLine('Location'));
+        $this->assertSame(307, $response->getStatusCode());
     }
 
     //--------------------------------------------------------------------
@@ -304,7 +304,7 @@ final class ResponseTest extends CIUnitTestCase
         $_SERVER['SERVER_SOFTWARE'] = 'Microsoft-IIS';
         $response                   = new Response(new App());
         $response->redirect('example.com', 'auto', 307);
-        $this->assertEquals('0;url=example.com', $response->getHeaderLine('Refresh'));
+        $this->assertSame('0;url=example.com', $response->getHeaderLine('Refresh'));
     }
 
     //--------------------------------------------------------------------
@@ -359,7 +359,7 @@ final class ResponseTest extends CIUnitTestCase
         $response = new Response(new App());
         $response->setJSON($body);
 
-        $this->assertEquals($expected, $response->getJSON());
+        $this->assertSame($expected, $response->getJSON());
         $this->assertTrue(strpos($response->getHeaderLine('content-type'), 'application/json') !== false);
     }
 
@@ -378,7 +378,7 @@ final class ResponseTest extends CIUnitTestCase
         $response = new Response(new App());
         $response->setBody($body);
 
-        $this->assertEquals($expected, $response->getJSON());
+        $this->assertSame($expected, $response->getJSON());
     }
 
     //--------------------------------------------------------------------
@@ -398,7 +398,7 @@ final class ResponseTest extends CIUnitTestCase
         $response = new Response(new App());
         $response->setXML($body);
 
-        $this->assertEquals($expected, $response->getXML());
+        $this->assertSame($expected, $response->getXML());
         $this->assertTrue(strpos($response->getHeaderLine('content-type'), 'application/xml') !== false);
     }
 
@@ -417,7 +417,7 @@ final class ResponseTest extends CIUnitTestCase
         $response = new Response(new App());
         $response->setBody($body);
 
-        $this->assertEquals($expected, $response->getXML());
+        $this->assertSame($expected, $response->getXML());
     }
 
     //--------------------------------------------------------------------
@@ -498,7 +498,7 @@ final class ResponseTest extends CIUnitTestCase
         $response->setProtocolVersion('HTTP/1.1');
         $response->redirect('/foo');
 
-        $this->assertEquals(303, $response->getStatusCode());
+        $this->assertSame(303, $response->getStatusCode());
     }
 
     public function testTemporaryRedirectGet11()
@@ -510,7 +510,7 @@ final class ResponseTest extends CIUnitTestCase
         $response->setProtocolVersion('HTTP/1.1');
         $response->redirect('/foo');
 
-        $this->assertEquals(307, $response->getStatusCode());
+        $this->assertSame(307, $response->getStatusCode());
     }
 
     //--------------------------------------------------------------------
@@ -545,7 +545,7 @@ final class ResponseTest extends CIUnitTestCase
         $actual = ob_get_contents();
         ob_end_clean();
 
-        $this->assertEquals('Happy days', $actual);
+        $this->assertSame('Happy days', $actual);
     }
 
     public function testInvalidSameSiteCookie()

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -33,18 +33,18 @@ final class URITest extends CIUnitTestCase
     {
         $uri = new URI('http://username:password@hostname:9090/path?arg=value#anchor');
 
-        $this->assertEquals('http', $uri->getScheme());
-        $this->assertEquals('username', $uri->getUserInfo());
-        $this->assertEquals('hostname', $uri->getHost());
-        $this->assertEquals('/path', $uri->getPath());
-        $this->assertEquals('arg=value', $uri->getQuery());
-        $this->assertEquals('9090', $uri->getPort());
-        $this->assertEquals('anchor', $uri->getFragment());
+        $this->assertSame('http', $uri->getScheme());
+        $this->assertSame('username', $uri->getUserInfo());
+        $this->assertSame('hostname', $uri->getHost());
+        $this->assertSame('/path', $uri->getPath());
+        $this->assertSame('arg=value', $uri->getQuery());
+        $this->assertSame(9090, $uri->getPort());
+        $this->assertSame('anchor', $uri->getFragment());
 
         // Password ignored by default for security reasons.
-        $this->assertEquals('username@hostname:9090', $uri->getAuthority());
+        $this->assertSame('username@hostname:9090', $uri->getAuthority());
 
-        $this->assertEquals(['path'], $uri->getSegments());
+        $this->assertSame(['path'], $uri->getSegments());
     }
 
     //--------------------------------------------------------------------
@@ -53,13 +53,13 @@ final class URITest extends CIUnitTestCase
     {
         $uri = new URI('http://hostname/path/to/script');
 
-        $this->assertEquals(['path', 'to', 'script'], $uri->getSegments());
-        $this->assertEquals('path', $uri->getSegment(1));
-        $this->assertEquals('to', $uri->getSegment(2));
-        $this->assertEquals('script', $uri->getSegment(3));
-        $this->assertEquals('', $uri->getSegment(4));
+        $this->assertSame(['path', 'to', 'script'], $uri->getSegments());
+        $this->assertSame('path', $uri->getSegment(1));
+        $this->assertSame('to', $uri->getSegment(2));
+        $this->assertSame('script', $uri->getSegment(3));
+        $this->assertSame('', $uri->getSegment(4));
 
-        $this->assertEquals(3, $uri->getTotalSegments());
+        $this->assertSame(3, $uri->getTotalSegments());
     }
 
     //--------------------------------------------------------------------
@@ -77,7 +77,7 @@ final class URITest extends CIUnitTestCase
     {
         $url = 'http://abc.com/a123/b/c';
         $uri = new URI($url);
-        $this->assertEquals('', $uri->setSilent()->getSegment(22));
+        $this->assertSame('', $uri->setSilent()->getSegment(22));
     }
 
     //--------------------------------------------------------------------
@@ -96,7 +96,7 @@ final class URITest extends CIUnitTestCase
     {
         $url = 'http://abc.com/a123/b/c';
         $uri = new URI($url);
-        $this->assertEquals('something', $uri->setSilent()->getSegment(22, 'something'));
+        $this->assertSame('something', $uri->setSilent()->getSegment(22, 'something'));
     }
 
     //--------------------------------------------------------------------
@@ -106,13 +106,13 @@ final class URITest extends CIUnitTestCase
         $uri = new URI('http://hostname/path/to');
         $uri->setSilent();
 
-        $this->assertEquals(['path', 'to'], $uri->getSegments());
-        $this->assertEquals('path', $uri->getSegment(1));
-        $this->assertEquals('to', $uri->getSegment(2, 'different'));
-        $this->assertEquals('script', $uri->getSegment(3, 'script'));
-        $this->assertEquals('', $uri->getSegment(3));
+        $this->assertSame(['path', 'to'], $uri->getSegments());
+        $this->assertSame('path', $uri->getSegment(1));
+        $this->assertSame('to', $uri->getSegment(2, 'different'));
+        $this->assertSame('script', $uri->getSegment(3, 'script'));
+        $this->assertSame('', $uri->getSegment(3));
 
-        $this->assertEquals(2, $uri->getTotalSegments());
+        $this->assertSame(2, $uri->getTotalSegments());
     }
 
     //--------------------------------------------------------------------
@@ -122,11 +122,11 @@ final class URITest extends CIUnitTestCase
         $uri = new URI('http://hostname/path/to/script');
         $uri->setSilent();
 
-        $this->assertEquals('', $uri->getSegment(22));
-        $this->assertEquals('something', $uri->getSegment(33, 'something'));
+        $this->assertSame('', $uri->getSegment(22));
+        $this->assertSame('something', $uri->getSegment(33, 'something'));
 
-        $this->assertEquals(3, $uri->getTotalSegments());
-        $this->assertEquals(['path', 'to', 'script'], $uri->getSegments());
+        $this->assertSame(3, $uri->getTotalSegments());
+        $this->assertSame(['path', 'to', 'script'], $uri->getSegments());
     }
 
     //--------------------------------------------------------------------
@@ -138,7 +138,7 @@ final class URITest extends CIUnitTestCase
 
         $expected = 'http://username@hostname:9090/path?arg=value#anchor';
 
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame($expected, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -147,11 +147,11 @@ final class URITest extends CIUnitTestCase
     {
         $url = 'http://example.com';
         $uri = new URI($url);
-        $this->assertEquals($url, (string) $uri);
+        $this->assertSame($url, (string) $uri);
 
         $url = 'http://example.com/';
         $uri = new URI($url);
-        $this->assertEquals($url, (string) $uri);
+        $this->assertSame($url, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -160,10 +160,10 @@ final class URITest extends CIUnitTestCase
     {
         $url = '';
         $uri = new URI($url);
-        $this->assertEquals('http://' . $url, (string) $uri);
+        $this->assertSame('http://' . $url, (string) $uri);
         $url = '/';
         $uri = new URI($url);
-        $this->assertEquals('http://', (string) $uri);
+        $this->assertSame('http://', (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -181,10 +181,10 @@ final class URITest extends CIUnitTestCase
     {
         $url = 'http://foo.bar/baz';
         $uri = new URI($url);
-        $this->assertEquals('http', $uri->getScheme());
-        $this->assertEquals('foo.bar', $uri->getAuthority());
-        $this->assertEquals('/baz', $uri->getPath());
-        $this->assertEquals($url, (string) $uri);
+        $this->assertSame('http', $uri->getScheme());
+        $this->assertSame('foo.bar', $uri->getAuthority());
+        $this->assertSame('/baz', $uri->getPath());
+        $this->assertSame($url, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -194,7 +194,7 @@ final class URITest extends CIUnitTestCase
         $url = 'example.com';
         $uri = new URI('http://' . $url);
         $uri->setScheme('x');
-        $this->assertEquals('x://' . $url, (string) $uri);
+        $this->assertSame('x://' . $url, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -207,8 +207,8 @@ final class URITest extends CIUnitTestCase
         $expected = 'https://example.com/path';
 
         $uri->setScheme('https');
-        $this->assertEquals('https', $uri->getScheme());
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame('https', $uri->getScheme());
+        $this->assertSame($expected, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -221,8 +221,8 @@ final class URITest extends CIUnitTestCase
         $expected = 'http://user@example.com/path';
 
         $uri->setUserInfo('user', 'password');
-        $this->assertEquals('user', $uri->getUserInfo());
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame('user', $uri->getUserInfo());
+        $this->assertSame($expected, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -235,15 +235,15 @@ final class URITest extends CIUnitTestCase
         $expected = 'http://user@example.com/path';
 
         $uri->setUserInfo('user', 'password');
-        $this->assertEquals('user', $uri->getUserInfo());
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame('user', $uri->getUserInfo());
+        $this->assertSame($expected, (string) $uri);
 
         $uri->showPassword();
 
         $expected = 'http://user:password@example.com/path';
 
-        $this->assertEquals('user:password', $uri->getUserInfo());
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame('user:password', $uri->getUserInfo());
+        $this->assertSame($expected, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -256,8 +256,8 @@ final class URITest extends CIUnitTestCase
         $expected = 'http://another.com/path';
 
         $uri->setHost('another.com');
-        $this->assertEquals('another.com', $uri->getHost());
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame('another.com', $uri->getHost());
+        $this->assertSame($expected, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -270,8 +270,8 @@ final class URITest extends CIUnitTestCase
         $expected = 'http://example.com:9000/path';
 
         $uri->setPort(9000);
-        $this->assertEquals(9000, $uri->getPort());
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame(9000, $uri->getPort());
+        $this->assertSame($expected, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -345,8 +345,8 @@ final class URITest extends CIUnitTestCase
         $expected = 'http://example.com/somewhere/else';
 
         $uri->setPath('somewhere/else');
-        $this->assertEquals('somewhere/else', $uri->getPath());
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame('somewhere/else', $uri->getPath());
+        $this->assertSame($expected, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -390,7 +390,7 @@ final class URITest extends CIUnitTestCase
     {
         $uri = new URI();
         $uri->setPath($path);
-        $this->assertEquals($expected, $uri->getPath());
+        $this->assertSame($expected, $uri->getPath());
     }
 
     //--------------------------------------------------------------------
@@ -403,8 +403,8 @@ final class URITest extends CIUnitTestCase
         $expected = 'http://example.com/path#good-stuff';
 
         $uri->setFragment('#good-stuff');
-        $this->assertEquals('good-stuff', $uri->getFragment());
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame('good-stuff', $uri->getFragment());
+        $this->assertSame($expected, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -417,8 +417,8 @@ final class URITest extends CIUnitTestCase
         $expected = 'http://example.com/path?key=value&second_key=value.2';
 
         $uri->setQuery('?key=value&second.key=value.2');
-        $this->assertEquals('key=value&second_key=value.2', $uri->getQuery());
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame('key=value&second_key=value.2', $uri->getQuery());
+        $this->assertSame($expected, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -431,8 +431,8 @@ final class URITest extends CIUnitTestCase
         $expected = 'http://example.com/path?key=value&second.key=value.2';
 
         $uri->useRawQueryString()->setQuery('?key=value&second.key=value.2');
-        $this->assertEquals('key=value&second.key=value.2', $uri->getQuery());
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame('key=value&second.key=value.2', $uri->getQuery());
+        $this->assertSame($expected, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -445,8 +445,8 @@ final class URITest extends CIUnitTestCase
         $expected = 'http://example.com/path?key=value&second_key=value.2';
 
         $uri->setQueryArray(['key' => 'value', 'second.key' => 'value.2']);
-        $this->assertEquals('key=value&second_key=value.2', $uri->getQuery());
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame('key=value&second_key=value.2', $uri->getQuery());
+        $this->assertSame($expected, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -459,8 +459,8 @@ final class URITest extends CIUnitTestCase
         $expected = 'http://example.com/path?key=value&second.key=value.2';
 
         $uri->useRawQueryString()->setQueryArray(['key' => 'value', 'second.key' => 'value.2']);
-        $this->assertEquals('key=value&second.key=value.2', $uri->getQuery());
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame('key=value&second.key=value.2', $uri->getQuery());
+        $this->assertSame($expected, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -483,7 +483,7 @@ final class URITest extends CIUnitTestCase
 
         $uri->setSilent()->setQuery('?key=value#fragment');
 
-        $this->assertEquals('', $uri->getQuery());
+        $this->assertSame('', $uri->getQuery());
     }
 
     //--------------------------------------------------------------------
@@ -518,7 +518,7 @@ final class URITest extends CIUnitTestCase
     public function testAuthorityReturnsExceptedValues($url, $expected)
     {
         $uri = new URI($url);
-        $this->assertEquals($expected, $uri->getAuthority());
+        $this->assertSame($expected, $uri->getAuthority());
     }
 
     //--------------------------------------------------------------------
@@ -549,7 +549,7 @@ final class URITest extends CIUnitTestCase
 
         $expected = "{$scheme}://example.com/path";
 
-        $this->assertEquals($expected, (string) $uri);
+        $this->assertSame($expected, (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -561,7 +561,7 @@ final class URITest extends CIUnitTestCase
         $uri = new URI();
         $uri->setAuthority($authority);
 
-        $this->assertEquals($authority, $uri->getAuthority());
+        $this->assertSame($authority, $uri->getAuthority());
     }
 
     //--------------------------------------------------------------------
@@ -671,7 +671,7 @@ final class URITest extends CIUnitTestCase
      */
     public function testRemoveDotSegments($path, $expected)
     {
-        $this->assertEquals($expected, URI::removeDotSegments($path));
+        $this->assertSame($expected, URI::removeDotSegments($path));
     }
 
     //--------------------------------------------------------------------
@@ -717,7 +717,7 @@ final class URITest extends CIUnitTestCase
 
         $new = $uri->resolveRelativeURI($rel);
 
-        $this->assertEquals($expected, (string) $new);
+        $this->assertSame($expected, (string) $new);
     }
 
     /**
@@ -734,7 +734,7 @@ final class URITest extends CIUnitTestCase
 
         $new = $uri->resolveRelativeURI($rel);
 
-        $this->assertEquals($expected, (string) $new);
+        $this->assertSame($expected, (string) $new);
     }
 
     public function testResolveRelativeURIWithNoBase()
@@ -745,7 +745,7 @@ final class URITest extends CIUnitTestCase
 
         $new = $uri->resolveRelativeURI('x');
 
-        $this->assertEquals('http://a/x', (string) $new);
+        $this->assertSame('http://a/x', (string) $new);
     }
 
     //--------------------------------------------------------------------
@@ -758,7 +758,7 @@ final class URITest extends CIUnitTestCase
 
         $uri->addQuery('bar', 'baz');
 
-        $this->assertEquals('http://example.com/foo?bar=baz', (string) $uri);
+        $this->assertSame('http://example.com/foo?bar=baz', (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -777,7 +777,7 @@ final class URITest extends CIUnitTestCase
 
         // Should NOT be double-encoded, since http_build_query
         // will encode the value again.
-        $this->assertEquals("q={$encoded}", $uri->getQuery());
+        $this->assertSame("q={$encoded}", $uri->getQuery());
     }
 
     public function testAddQueryVarRespectsExistingQueryVars()
@@ -788,7 +788,7 @@ final class URITest extends CIUnitTestCase
 
         $uri->addQuery('baz', 'foz');
 
-        $this->assertEquals('http://example.com/foo?bar=baz&baz=foz', (string) $uri);
+        $this->assertSame('http://example.com/foo?bar=baz&baz=foz', (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -801,7 +801,7 @@ final class URITest extends CIUnitTestCase
 
         $uri->stripQuery('bar', 'baz');
 
-        $this->assertEquals('http://example.com/foo?foo=bar', (string) $uri);
+        $this->assertSame('http://example.com/foo?foo=bar', (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -814,7 +814,7 @@ final class URITest extends CIUnitTestCase
 
         $uri->keepQuery('bar', 'baz');
 
-        $this->assertEquals('http://example.com/foo?bar=baz&baz=foz', (string) $uri);
+        $this->assertSame('http://example.com/foo?bar=baz&baz=foz', (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -825,7 +825,7 @@ final class URITest extends CIUnitTestCase
 
         $uri = new URI($base);
         $uri->setQuery('foo=&bar=baz&baz=foz');
-        $this->assertEquals('http://example.com/foo?foo=&bar=baz&baz=foz', (string) $uri);
+        $this->assertSame('http://example.com/foo?foo=&bar=baz&baz=foz', (string) $uri);
     }
 
     //--------------------------------------------------------------------
@@ -836,7 +836,7 @@ final class URITest extends CIUnitTestCase
 
         $uri = new URI($base);
 
-        $this->assertEquals('foo=bar&baz=foz', $uri->getQuery(['except' => ['bar']]));
+        $this->assertSame('foo=bar&baz=foz', $uri->getQuery(['except' => ['bar']]));
     }
 
     //--------------------------------------------------------------------
@@ -847,8 +847,8 @@ final class URITest extends CIUnitTestCase
 
         $uri = new URI($base);
 
-        $this->assertEquals('bar=baz', $uri->getQuery(['only' => ['bar']]));
-        $this->assertEquals('foo=bar&baz=foz', $uri->getQuery(['except' => 'bar']));
+        $this->assertSame('bar=baz', $uri->getQuery(['only' => ['bar']]));
+        $this->assertSame('foo=bar&baz=foz', $uri->getQuery(['except' => 'bar']));
     }
 
     //--------------------------------------------------------------------
@@ -859,7 +859,7 @@ final class URITest extends CIUnitTestCase
 
         $uri = new URI($base);
 
-        $this->assertEquals('bar=baz', $uri->getQuery(['only' => 'bar']));
+        $this->assertSame('bar=baz', $uri->getQuery(['only' => 'bar']));
     }
 
     //--------------------------------------------------------------------
@@ -870,9 +870,9 @@ final class URITest extends CIUnitTestCase
      */
     public function testNoExtraSlashes()
     {
-        $this->assertEquals('http://entirely.different.com/subfolder', (string) (new URI('entirely.different.com/subfolder')));
-        $this->assertEquals('http://localhost/subfolder', (string) (new URI('localhost/subfolder')));
-        $this->assertEquals('http://localtest.me/subfolder', (string) (new URI('localtest.me/subfolder')));
+        $this->assertSame('http://entirely.different.com/subfolder', (string) (new URI('entirely.different.com/subfolder')));
+        $this->assertSame('http://localhost/subfolder', (string) (new URI('localhost/subfolder')));
+        $this->assertSame('http://localtest.me/subfolder', (string) (new URI('localtest.me/subfolder')));
     }
 
     //--------------------------------------------------------------------
@@ -884,7 +884,7 @@ final class URITest extends CIUnitTestCase
         $uri = new URI($base);
         $uri->setSegment(2, 'banana');
 
-        $this->assertEquals('foo/banana/baz', $uri->getPath());
+        $this->assertSame('foo/banana/baz', $uri->getPath());
     }
 
     //--------------------------------------------------------------------
@@ -897,19 +897,19 @@ final class URITest extends CIUnitTestCase
         $uri->setSegment(1, 'first');
         $uri->setSegment(3, 'third');
 
-        $this->assertEquals('first/third', $uri->getPath());
+        $this->assertSame('first/third', $uri->getPath());
 
         $uri->setSegment(2, 'second');
 
-        $this->assertEquals('first/second', $uri->getPath());
+        $this->assertSame('first/second', $uri->getPath());
 
         $uri->setSegment(3, 'third');
 
-        $this->assertEquals('first/second/third', $uri->getPath());
+        $this->assertSame('first/second/third', $uri->getPath());
 
         $uri->setSegment(5, 'fifth');
 
-        $this->assertEquals('first/second/third/fifth', $uri->getPath());
+        $this->assertSame('first/second/third/fifth', $uri->getPath());
 
         // sixth or seventh was not set
         $this->expectException(HTTPException::class);
@@ -935,7 +935,7 @@ final class URITest extends CIUnitTestCase
         $segments = $uri->getSegments();
         $uri->setSilent()->setSegment(6, 'banana');
 
-        $this->assertEquals($segments, $uri->getSegments());
+        $this->assertSame($segments, $uri->getSegments());
     }
 
     //--------------------------------------------------------------------
@@ -957,15 +957,15 @@ final class URITest extends CIUnitTestCase
         Services::injectMock('request', $request);
 
         // going through request
-        $this->assertEquals('http://example.com/ci/v4/controller/method', (string) $request->uri);
-        $this->assertEquals('/ci/v4/controller/method', $request->uri->getPath());
+        $this->assertSame('http://example.com/ci/v4/controller/method', (string) $request->uri);
+        $this->assertSame('/ci/v4/controller/method', $request->uri->getPath());
 
         // standalone
         $uri = new URI('http://example.com/ci/v4/controller/method');
-        $this->assertEquals('http://example.com/ci/v4/controller/method', (string) $uri);
-        $this->assertEquals('/ci/v4/controller/method', $uri->getPath());
+        $this->assertSame('http://example.com/ci/v4/controller/method', (string) $uri);
+        $this->assertSame('/ci/v4/controller/method', $uri->getPath());
 
-        $this->assertEquals($uri->getPath(), $request->uri->getPath());
+        $this->assertSame($uri->getPath(), $request->uri->getPath());
     }
 
     public function testBasedWithIndex()
@@ -984,15 +984,15 @@ final class URITest extends CIUnitTestCase
         Services::injectMock('request', $request);
 
         // going through request
-        $this->assertEquals('http://example.com/ci/v4/index.php/controller/method', (string) $request->uri);
-        $this->assertEquals('/ci/v4/index.php/controller/method', $request->uri->getPath());
+        $this->assertSame('http://example.com/ci/v4/index.php/controller/method', (string) $request->uri);
+        $this->assertSame('/ci/v4/index.php/controller/method', $request->uri->getPath());
 
         // standalone
         $uri = new URI('http://example.com/ci/v4/index.php/controller/method');
-        $this->assertEquals('http://example.com/ci/v4/index.php/controller/method', (string) $uri);
-        $this->assertEquals('/ci/v4/index.php/controller/method', $uri->getPath());
+        $this->assertSame('http://example.com/ci/v4/index.php/controller/method', (string) $uri);
+        $this->assertSame('/ci/v4/index.php/controller/method', $uri->getPath());
 
-        $this->assertEquals($uri->getPath(), $request->uri->getPath());
+        $this->assertSame($uri->getPath(), $request->uri->getPath());
     }
 
     public function testForceGlobalSecureRequests()
@@ -1015,29 +1015,29 @@ final class URITest extends CIUnitTestCase
         Services::injectMock('request', $request);
 
         // Detected by request
-        $this->assertEquals('https://example.com/ci/v4/controller/method', (string) $request->uri);
+        $this->assertSame('https://example.com/ci/v4/controller/method', (string) $request->uri);
 
         // Standalone
         $uri = new URI('http://example.com/ci/v4/controller/method');
-        $this->assertEquals('https://example.com/ci/v4/controller/method', (string) $uri);
+        $this->assertSame('https://example.com/ci/v4/controller/method', (string) $uri);
 
-        $this->assertEquals(trim($uri->getPath(), '/'), trim($request->uri->getPath(), '/'));
+        $this->assertSame(trim($uri->getPath(), '/'), trim($request->uri->getPath(), '/'));
     }
 
     public function testZeroAsURIPath()
     {
         $url = 'http://example.com/0';
         $uri = new URI($url);
-        $this->assertEquals($url, (string) $uri);
-        $this->assertEquals('/0', $uri->getPath());
+        $this->assertSame($url, (string) $uri);
+        $this->assertSame('/0', $uri->getPath());
     }
 
     public function testEmptyURIPath()
     {
         $url = 'http://example.com/';
         $uri = new URI($url);
-        $this->assertEquals([], $uri->getSegments());
-        $this->assertEquals(0, $uri->getTotalSegments());
+        $this->assertSame([], $uri->getSegments());
+        $this->assertSame(0, $uri->getTotalSegments());
     }
 
     public function testSetURI()
@@ -1065,6 +1065,6 @@ final class URITest extends CIUnitTestCase
         $expected = 'https://example.com/';
         $uri      = URI::createURIString('https', 'example.com/', '/');
 
-        $this->assertEquals($expected, $uri);
+        $this->assertSame($expected, $uri);
     }
 }

--- a/tests/system/HTTP/UserAgentTest.php
+++ b/tests/system/HTTP/UserAgentTest.php
@@ -36,7 +36,7 @@ final class UserAgentTest extends CIUnitTestCase
     {
         // Mobile Not Set
         $_SERVER['HTTP_USER_AGENT'] = $this->_mobile_ua;
-        $this->assertEquals('', $this->agent->isMobile());
+        $this->assertFalse($this->agent->isMobile());
         unset($_SERVER['HTTP_USER_AGENT']);
     }
 
@@ -57,29 +57,29 @@ final class UserAgentTest extends CIUnitTestCase
     {
         $_SERVER['HTTP_REFERER'] = 'http://codeigniter.com/user_guide/';
         $this->assertTrue($this->agent->isReferral());
-        $this->assertEquals('http://codeigniter.com/user_guide/', $this->agent->getReferrer());
+        $this->assertSame('http://codeigniter.com/user_guide/', $this->agent->getReferrer());
 
         $this->setPrivateProperty($this->agent, 'referrer', null);
         unset($_SERVER['HTTP_REFERER']);
         $this->assertFalse($this->agent->isReferral());
-        $this->assertEquals('', $this->agent->getReferrer());
+        $this->assertSame('', $this->agent->getReferrer());
     }
 
     // --------------------------------------------------------------------
 
     public function testAgentString()
     {
-        $this->assertEquals($this->_user_agent, $this->agent->getAgentString());
+        $this->assertSame($this->_user_agent, $this->agent->getAgentString());
     }
 
     // --------------------------------------------------------------------
 
     public function testBrowserInfo()
     {
-        $this->assertEquals('Mac OS X', $this->agent->getPlatform());
-        $this->assertEquals('Safari', $this->agent->getBrowser());
-        $this->assertEquals('533.20.27', $this->agent->getVersion());
-        $this->assertEquals('', $this->agent->getRobot());
+        $this->assertSame('Mac OS X', $this->agent->getPlatform());
+        $this->assertSame('Safari', $this->agent->getBrowser());
+        $this->assertSame('533.20.27', $this->agent->getVersion());
+        $this->assertSame('', $this->agent->getRobot());
     }
 
     // --------------------------------------------------------------------
@@ -89,12 +89,12 @@ final class UserAgentTest extends CIUnitTestCase
         $newAgent = 'Mozilla/5.0 (Android; Mobile; rv:13.0) Gecko/13.0 Firefox/13.0';
         $this->agent->parse($newAgent);
 
-        $this->assertEquals('Android', $this->agent->getPlatform());
-        $this->assertEquals('Firefox', $this->agent->getBrowser());
-        $this->assertEquals('13.0', $this->agent->getVersion());
-        $this->assertEquals('', $this->agent->getRobot());
-        $this->assertEquals('Android', $this->agent->getMobile());
-        $this->assertEquals($newAgent, $this->agent->getAgentString());
+        $this->assertSame('Android', $this->agent->getPlatform());
+        $this->assertSame('Firefox', $this->agent->getBrowser());
+        $this->assertSame('13.0', $this->agent->getVersion());
+        $this->assertSame('', $this->agent->getRobot());
+        $this->assertSame('Android', $this->agent->getMobile());
+        $this->assertSame($newAgent, $this->agent->getAgentString());
         $this->assertTrue($this->agent->isBrowser());
         $this->assertFalse($this->agent->isRobot());
         $this->assertTrue($this->agent->isMobile());

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -23,7 +23,7 @@ final class ArrayHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals(23, dot_array_search('foo.bar', $data));
+        $this->assertSame(23, dot_array_search('foo.bar', $data));
     }
 
     public function testArrayDotTooManyLevels()
@@ -34,7 +34,7 @@ final class ArrayHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals(23, dot_array_search('foo.bar.baz', $data));
+        $this->assertSame(23, dot_array_search('foo.bar.baz', $data));
     }
 
     public function testArrayDotEscape()
@@ -48,8 +48,8 @@ final class ArrayHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals(23, dot_array_search('foo.bar\.baz', $data));
-        $this->assertEquals(42, dot_array_search('foo\.bar.baz', $data));
+        $this->assertSame(23, dot_array_search('foo.bar\.baz', $data));
+        $this->assertSame(42, dot_array_search('foo\.bar.baz', $data));
     }
 
     public function testArraySearchDotMultiLevels()
@@ -103,7 +103,7 @@ final class ArrayHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals(['bar' => 23], dot_array_search('foo', $data));
+        $this->assertSame(['bar' => 23], dot_array_search('foo', $data));
     }
 
     public function testArrayDotWildcard()
@@ -116,7 +116,7 @@ final class ArrayHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals(23, dot_array_search('foo.*.baz', $data));
+        $this->assertSame(23, dot_array_search('foo.*.baz', $data));
     }
 
     public function testArrayDotWildcardWithMultipleChoices()
@@ -132,8 +132,8 @@ final class ArrayHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals(11, dot_array_search('foo.*.fizz', $data));
-        $this->assertEquals(23, dot_array_search('foo.*.baz', $data));
+        $this->assertSame(11, dot_array_search('foo.*.fizz', $data));
+        $this->assertSame(23, dot_array_search('foo.*.baz', $data));
     }
 
     public function testArrayDotNestedNotFound()
@@ -162,7 +162,7 @@ final class ArrayHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals(['baz' => 23], dot_array_search('foo.bar.*', $data));
+        $this->assertSame(['baz' => 23], dot_array_search('foo.bar.*', $data));
     }
 
     /**
@@ -191,7 +191,7 @@ final class ArrayHelperTest extends CIUnitTestCase
 
         $result = array_deep_search($key, $data);
 
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     public function testArrayDeepSearchReturnNullEmptyArray()
@@ -209,7 +209,7 @@ final class ArrayHelperTest extends CIUnitTestCase
         $success = array_sort_by_multiple_keys($data, $sortColumns);
 
         $this->assertTrue($success);
-        $this->assertEquals($expected, array_column($data, 'name'));
+        $this->assertSame($expected, array_column($data, 'name'));
     }
 
     /**
@@ -225,7 +225,7 @@ final class ArrayHelperTest extends CIUnitTestCase
         $success = array_sort_by_multiple_keys($data, $sortColumns);
 
         $this->assertTrue($success);
-        $this->assertEquals($expected, array_column((array) $data, 'name'));
+        $this->assertSame($expected, array_column((array) $data, 'name'));
     }
 
     /**

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -102,15 +102,15 @@ final class CookieHelperTest extends CIUnitTestCase
         $cookie = $this->response->getCookie($this->name);
 
         // The cookie is set to be cleared when the request is sent....
-        $this->assertEquals('', $cookie->getValue());
-        $this->assertEquals(0, $cookie->getExpiresTimestamp());
+        $this->assertSame('', $cookie->getValue());
+        $this->assertSame(0, $cookie->getExpiresTimestamp());
     }
 
     public function testGetCookie()
     {
         $_COOKIE['TEST'] = 5;
 
-        $this->assertEquals(5, get_cookie('TEST'));
+        $this->assertSame('5', get_cookie('TEST'));
     }
 
     public function testDeleteCookieAfterLastSet()
@@ -119,7 +119,7 @@ final class CookieHelperTest extends CIUnitTestCase
 
         $cookie = $this->response->getCookie($this->name);
         // The cookie is set to be cleared when the request is sent....
-        $this->assertEquals('', $cookie->getValue());
+        $this->assertSame('', $cookie->getValue());
     }
 
     public function testSameSiteDefault()
@@ -134,7 +134,7 @@ final class CookieHelperTest extends CIUnitTestCase
 
         $this->assertTrue($this->response->hasCookie($this->name));
         $theCookie = $this->response->getCookie($this->name);
-        $this->assertEquals('Lax', $theCookie->getSameSite());
+        $this->assertSame('Lax', $theCookie->getSameSite());
 
         delete_cookie($this->name);
     }
@@ -167,7 +167,7 @@ final class CookieHelperTest extends CIUnitTestCase
 
         $this->assertTrue($this->response->hasCookie($this->name));
         $theCookie = $this->response->getCookie($this->name);
-        $this->assertEquals('Strict', $theCookie->getSameSite());
+        $this->assertSame('Strict', $theCookie->getSameSite());
 
         delete_cookie($this->name);
     }
@@ -178,7 +178,7 @@ final class CookieHelperTest extends CIUnitTestCase
 
         $this->assertTrue($this->response->hasCookie($this->name));
         $theCookie = $this->response->getCookie($this->name);
-        $this->assertEquals('Strict', $theCookie->getSameSite());
+        $this->assertSame('Strict', $theCookie->getSameSite());
 
         delete_cookie($this->name);
     }

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -56,7 +56,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
         $root = vfsStream::setup('root', null, $this->structure);
         $this->assertTrue($root->hasChild('foo'));
 
-        $this->assertEquals($expected, directory_map(vfsStream::url('root')));
+        $this->assertSame($expected, directory_map(vfsStream::url('root')));
     }
 
     public function testDirectoryMapShowsHiddenFiles()
@@ -81,7 +81,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
         $root = vfsStream::setup('root', null, $this->structure);
         $this->assertTrue($root->hasChild('foo'));
 
-        $this->assertEquals($expected, directory_map(vfsStream::url('root'), false, true));
+        $this->assertSame($expected, directory_map(vfsStream::url('root'), false, true));
     }
 
     public function testDirectoryMapLimitsRecursion()
@@ -99,12 +99,12 @@ final class FilesystemHelperTest extends CIUnitTestCase
         $root = vfsStream::setup('root', null, $this->structure);
         $this->assertTrue($root->hasChild('foo'));
 
-        $this->assertEquals($expected, directory_map(vfsStream::url('root'), 1, true));
+        $this->assertSame($expected, directory_map(vfsStream::url('root'), 1, true));
     }
 
     public function testDirectoryMapHandlesNotfound()
     {
-        $this->assertEquals([], directory_map(SUPPORTPATH . 'Files/shaker/'));
+        $this->assertSame([], directory_map(SUPPORTPATH . 'Files/shaker/'));
     }
 
     //--------------------------------------------------------------------
@@ -139,7 +139,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
         directory_mirror($root . 'foo', $root . 'boo', true);
         $result = file_get_contents($root . 'boo/faz');
 
-        $this->assertEquals($this->structure['foo']['faz'], $result);
+        $this->assertSame($this->structure['foo']['faz'], $result);
     }
 
     public function testDirectoryMirrorNotOverwrites()
@@ -156,7 +156,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
         directory_mirror($root . 'foo', $root . 'boo', false);
         $result = file_get_contents($root . 'boo/faz');
 
-        $this->assertEquals($this->structure['boo']['faz'], $result);
+        $this->assertSame($this->structure['boo']['faz'], $result);
     }
 
     //--------------------------------------------------------------------
@@ -278,7 +278,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
 
         $vfs = vfsStream::setup('root', null, $this->structure);
 
-        $this->assertEquals($expected, get_filenames($vfs->url(), false));
+        $this->assertSame($expected, get_filenames($vfs->url(), false));
     }
 
     public function testGetFilenamesWithHidden()
@@ -301,7 +301,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
 
         $vfs = vfsStream::setup('root', null, $this->structure);
 
-        $this->assertEquals($expected, get_filenames($vfs->url(), false, true));
+        $this->assertSame($expected, get_filenames($vfs->url(), false, true));
     }
 
     public function testGetFilenamesWithRelativeSource()
@@ -321,7 +321,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
 
         $vfs = vfsStream::setup('root', null, $this->structure);
 
-        $this->assertEquals($expected, get_filenames($vfs->url(), null));
+        $this->assertSame($expected, get_filenames($vfs->url(), null));
     }
 
     public function testGetFilenamesWithFullSource()
@@ -341,12 +341,12 @@ final class FilesystemHelperTest extends CIUnitTestCase
             $vfs->url() . DIRECTORY_SEPARATOR . 'simpleFile',
         ];
 
-        $this->assertEquals($expected, get_filenames($vfs->url(), true));
+        $this->assertSame($expected, get_filenames($vfs->url(), true));
     }
 
     public function testGetFilenamesFailure()
     {
-        $this->assertEquals([], get_filenames(SUPPORTPATH . 'Files/shaker/'));
+        $this->assertSame([], get_filenames(SUPPORTPATH . 'Files/shaker/'));
     }
 
     //--------------------------------------------------------------------
@@ -366,7 +366,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, get_dir_file_info(SUPPORTPATH . 'Files/baker'));
+        $this->assertSame($expected, get_dir_file_info(SUPPORTPATH . 'Files/baker'));
     }
 
     public function testGetDirFileInfoNested()
@@ -386,7 +386,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
     {
         $expected = [];
 
-        $this->assertEquals($expected, get_dir_file_info(SUPPORTPATH . 'Files#baker'));
+        $this->assertSame($expected, get_dir_file_info(SUPPORTPATH . 'Files#baker'));
     }
 
     //--------------------------------------------------------------------
@@ -403,7 +403,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
             'date'        => $info['date'],
         ];
 
-        $this->assertEquals($expected, get_file_info(SUPPORTPATH . 'Files/baker/banana.php'));
+        $this->assertSame($expected, get_file_info(SUPPORTPATH . 'Files/baker/banana.php'));
     }
 
     public function testGetFileInfoCustom()
@@ -414,7 +414,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
             'executable' => false,
         ];
 
-        $this->assertEquals($expected, get_file_info(SUPPORTPATH . 'Files/baker/banana.php', 'readable,writable,executable'));
+        $this->assertSame($expected, get_file_info(SUPPORTPATH . 'Files/baker/banana.php', 'readable,writable,executable'));
     }
 
     public function testGetFileInfoPerms()
@@ -425,14 +425,14 @@ final class FilesystemHelperTest extends CIUnitTestCase
 
         $stuff = get_file_info($file, 'fileperms');
 
-        $this->assertEquals($expected, $stuff['fileperms'] & 0777);
+        $this->assertSame($expected, $stuff['fileperms'] & 0777);
     }
 
     public function testGetFileNotThereInfo()
     {
         $expected = null;
 
-        $this->assertEquals($expected, get_file_info(SUPPORTPATH . 'Files/icer'));
+        $this->assertSame($expected, get_file_info(SUPPORTPATH . 'Files/icer'));
     }
 
     //--------------------------------------------------------------------
@@ -481,9 +481,9 @@ final class FilesystemHelperTest extends CIUnitTestCase
 
     public function testOctalPermissions()
     {
-        $this->assertEquals('777', octal_permissions(0777));
-        $this->assertEquals('655', octal_permissions(0655));
-        $this->assertEquals('123', octal_permissions(0123));
+        $this->assertSame('777', octal_permissions(0777));
+        $this->assertSame('655', octal_permissions(0655));
+        $this->assertSame('123', octal_permissions(0123));
     }
 
     public function testSymbolicPermissions()
@@ -502,7 +502,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
         ];
 
         foreach ($expected as $perm => $value) {
-            $this->assertEquals($value, symbolic_permissions($perm));
+            $this->assertSame($value, symbolic_permissions($perm));
         }
     }
 
@@ -522,6 +522,6 @@ final class FilesystemHelperTest extends CIUnitTestCase
 
     public function testRealPathResolved()
     {
-        $this->assertEquals(SUPPORTPATH . 'Models/', set_realpath(SUPPORTPATH . 'Files/../Models', true));
+        $this->assertSame(SUPPORTPATH . 'Models/', set_realpath(SUPPORTPATH . 'Files/../Models', true));
     }
 }

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -52,7 +52,7 @@ final class FormHelperTest extends CIUnitTestCase
             'id'     => 'form',
             'method' => 'POST',
         ];
-        $this->assertEquals($expected, form_open('foo/bar', $attributes));
+        $this->assertSame($expected, form_open('foo/bar', $attributes));
     }
 
     // ------------------------------------------------------------------------
@@ -75,7 +75,7 @@ final class FormHelperTest extends CIUnitTestCase
             'id'     => 'form',
             'method' => 'POST',
         ];
-        $this->assertEquals($expected, form_open('{locale}/foo/bar', $attributes));
+        $this->assertSame($expected, form_open('{locale}/foo/bar', $attributes));
     }
 
     // ------------------------------------------------------------------------
@@ -109,7 +109,7 @@ final class FormHelperTest extends CIUnitTestCase
             'id'     => 'form',
             'method' => 'POST',
         ];
-        $this->assertEquals($expected, form_open('', $attributes));
+        $this->assertSame($expected, form_open('', $attributes));
     }
 
     // ------------------------------------------------------------------------
@@ -143,7 +143,7 @@ final class FormHelperTest extends CIUnitTestCase
             'name' => 'form',
             'id'   => 'form',
         ];
-        $this->assertEquals($expected, form_open('foo/bar', $attributes));
+        $this->assertSame($expected, form_open('foo/bar', $attributes));
     }
 
     // ------------------------------------------------------------------------
@@ -184,7 +184,7 @@ final class FormHelperTest extends CIUnitTestCase
         $hidden = [
             'foo' => 'bar',
         ];
-        $this->assertEquals($expected, form_open('foo/bar', $attributes, $hidden));
+        $this->assertSame($expected, form_open('foo/bar', $attributes, $hidden));
     }
 
     // ------------------------------------------------------------------------
@@ -218,11 +218,11 @@ final class FormHelperTest extends CIUnitTestCase
             'id'     => 'form',
             'method' => 'POST',
         ];
-        $this->assertEquals($expected, form_open_multipart('foo/bar', $attributes));
+        $this->assertSame($expected, form_open_multipart('foo/bar', $attributes));
 
         // make sure it works with attributes as a string too
         $attributesString = 'name="form" id="form" method="POST"';
-        $this->assertEquals($expected, form_open_multipart('foo/bar', $attributesString));
+        $this->assertSame($expected, form_open_multipart('foo/bar', $attributesString));
     }
 
     // ------------------------------------------------------------------------
@@ -232,7 +232,7 @@ final class FormHelperTest extends CIUnitTestCase
 
             <input type="hidden" name="username" value="johndoe" />\n
             EOH;
-        $this->assertEquals($expected, form_hidden('username', 'johndoe'));
+        $this->assertSame($expected, form_hidden('username', 'johndoe'));
     }
 
     // ------------------------------------------------------------------------
@@ -246,7 +246,7 @@ final class FormHelperTest extends CIUnitTestCase
             <input type="hidden" name="foo" value="bar" />
 
             EOH;
-        $this->assertEquals($expected, form_hidden($data, null));
+        $this->assertSame($expected, form_hidden($data, null));
     }
 
     // ------------------------------------------------------------------------
@@ -260,7 +260,7 @@ final class FormHelperTest extends CIUnitTestCase
             <input type="hidden" name="name[foo]" value="bar" />
 
             EOH;
-        $this->assertEquals($expected, form_hidden('name', $data));
+        $this->assertSame($expected, form_hidden('name', $data));
     }
 
     // ------------------------------------------------------------------------
@@ -277,7 +277,7 @@ final class FormHelperTest extends CIUnitTestCase
             'size'      => '50',
             'style'     => 'width:50%',
         ];
-        $this->assertEquals($expected, form_input($data));
+        $this->assertSame($expected, form_input($data));
     }
 
     public function testFormInputWithExtra()
@@ -293,7 +293,7 @@ final class FormHelperTest extends CIUnitTestCase
         $extra = [
             'class' => 'form-control form-control-lg',
         ];
-        $this->assertEquals($expected, form_input($data, '', $extra));
+        $this->assertSame($expected, form_input($data, '', $extra));
     }
 
     // ------------------------------------------------------------------------
@@ -302,7 +302,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<EOH
             <input type="password" name="password" value="" />\n
             EOH;
-        $this->assertEquals($expected, form_password('password'));
+        $this->assertSame($expected, form_password('password'));
     }
 
     // ------------------------------------------------------------------------
@@ -311,7 +311,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<EOH
             <input type="file" name="attachment" />\n
             EOH;
-        $this->assertEquals($expected, form_upload('attachment'));
+        $this->assertSame($expected, form_upload('attachment'));
     }
 
     // ------------------------------------------------------------------------
@@ -320,7 +320,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<EOH
             <textarea name="notes" cols="40" rows="10">Notes</textarea>\n
             EOH;
-        $this->assertEquals($expected, form_textarea('notes', 'Notes'));
+        $this->assertSame($expected, form_textarea('notes', 'Notes'));
     }
 
     // ------------------------------------------------------------------------
@@ -334,7 +334,7 @@ final class FormHelperTest extends CIUnitTestCase
             <textarea name="foo" cols="40" rows="10">bar</textarea>
 
             EOH;
-        $this->assertEquals($expected, form_textarea($data));
+        $this->assertSame($expected, form_textarea($data));
     }
 
     // ------------------------------------------------------------------------
@@ -347,7 +347,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<EOH
             <textarea name="notes" cols="30" rows="5">Notes</textarea>\n
             EOH;
-        $this->assertEquals($expected, form_textarea('notes', 'Notes', $extra));
+        $this->assertSame($expected, form_textarea('notes', 'Notes', $extra));
     }
 
     // ------------------------------------------------------------------------
@@ -357,7 +357,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<EOH
             <textarea name="notes" cols="30" rows="5">Notes</textarea>\n
             EOH;
-        $this->assertEquals($expected, form_textarea('notes', 'Notes', $extra));
+        $this->assertSame($expected, form_textarea('notes', 'Notes', $extra));
     }
 
     // ------------------------------------------------------------------------
@@ -377,7 +377,7 @@ final class FormHelperTest extends CIUnitTestCase
             'large'  => 'Large Shirt',
             'xlarge' => 'Extra Large Shirt',
         ];
-        $this->assertEquals($expected, form_dropdown('shirts', $options, 'large'));
+        $this->assertSame($expected, form_dropdown('shirts', $options, 'large'));
         $expected = <<<EOH
             <select name="shirts" multiple="multiple">
             <option value="small" selected="selected">Small Shirt</option>
@@ -390,7 +390,7 @@ final class FormHelperTest extends CIUnitTestCase
             'small',
             'large',
         ];
-        $this->assertEquals($expected, form_dropdown('shirts', $options, $shirtsOnSale));
+        $this->assertSame($expected, form_dropdown('shirts', $options, $shirtsOnSale));
         $options = [
             'Swedish Cars' => [
                 'volvo' => 'Volvo',
@@ -413,7 +413,7 @@ final class FormHelperTest extends CIUnitTestCase
             </optgroup>
             </select>\n
             EOH;
-        $this->assertEquals($expected, form_dropdown('cars', $options, ['volvo', 'audi']));
+        $this->assertSame($expected, form_dropdown('cars', $options, ['volvo', 'audi']));
     }
 
     public function testFormDropdownUnselected()
@@ -440,7 +440,7 @@ final class FormHelperTest extends CIUnitTestCase
             </optgroup>
             </select>\n
             EOH;
-        $this->assertEquals($expected, form_dropdown('cars', $options));
+        $this->assertSame($expected, form_dropdown('cars', $options));
     }
 
     public function testFormDropdownInferred()
@@ -468,7 +468,7 @@ final class FormHelperTest extends CIUnitTestCase
             </select>\n
             EOH;
         $_POST['cars'] = 'audi';
-        $this->assertEquals($expected, form_dropdown('cars', $options));
+        $this->assertSame($expected, form_dropdown('cars', $options));
         unset($_POST['cars']);
     }
 
@@ -488,7 +488,7 @@ final class FormHelperTest extends CIUnitTestCase
         $options = [
             'bar' => 'Bar',
         ];
-        $this->assertEquals($expected, form_dropdown($data, $options));
+        $this->assertSame($expected, form_dropdown($data, $options));
     }
 
     // ------------------------------------------------------------------------
@@ -506,7 +506,7 @@ final class FormHelperTest extends CIUnitTestCase
                 'bar' => 'Bar',
             ],
         ];
-        $this->assertEquals($expected, form_dropdown($data));
+        $this->assertSame($expected, form_dropdown($data));
     }
 
     // ------------------------------------------------------------------------
@@ -520,7 +520,7 @@ final class FormHelperTest extends CIUnitTestCase
         $options = [
             'bar' => [],
         ];
-        $this->assertEquals($expected, form_dropdown('foo', $options));
+        $this->assertSame($expected, form_dropdown('foo', $options));
     }
 
     // ------------------------------------------------------------------------
@@ -540,7 +540,7 @@ final class FormHelperTest extends CIUnitTestCase
             'large'  => 'Large Shirt',
             'xlarge' => 'Extra Large Shirt',
         ];
-        $this->assertEquals($expected, form_multiselect('shirts[]', $options, ['med', 'large']));
+        $this->assertSame($expected, form_multiselect('shirts[]', $options, ['med', 'large']));
     }
 
     // ------------------------------------------------------------------------
@@ -570,7 +570,7 @@ final class FormHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, form_multiselect($data));
+        $this->assertSame($expected, form_multiselect($data));
     }
 
     // ------------------------------------------------------------------------
@@ -580,7 +580,7 @@ final class FormHelperTest extends CIUnitTestCase
             <fieldset>
             <legend>Address Information</legend>\n
             EOH;
-        $this->assertEquals($expected, form_fieldset('Address Information'));
+        $this->assertSame($expected, form_fieldset('Address Information'));
     }
 
     // ------------------------------------------------------------------------
@@ -590,7 +590,7 @@ final class FormHelperTest extends CIUnitTestCase
             <fieldset>
 
             EOH;
-        $this->assertEquals($expected, form_fieldset());
+        $this->assertSame($expected, form_fieldset());
     }
 
     // ------------------------------------------------------------------------
@@ -604,7 +604,7 @@ final class FormHelperTest extends CIUnitTestCase
             <legend>Foo</legend>
 
             EOH;
-        $this->assertEquals($expected, form_fieldset('Foo', $attributes));
+        $this->assertSame($expected, form_fieldset('Foo', $attributes));
     }
 
     // ------------------------------------------------------------------------
@@ -613,7 +613,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<'EOH'
             </fieldset></div></div>
             EOH;
-        $this->assertEquals($expected, form_fieldset_close('</div></div>'));
+        $this->assertSame($expected, form_fieldset_close('</div></div>'));
     }
 
     // ------------------------------------------------------------------------
@@ -622,7 +622,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<EOH
             <input type="checkbox" name="newsletter" value="accept" checked="checked" />\n
             EOH;
-        $this->assertEquals($expected, form_checkbox('newsletter', 'accept', true));
+        $this->assertSame($expected, form_checkbox('newsletter', 'accept', true));
     }
 
     // ------------------------------------------------------------------------
@@ -637,7 +637,7 @@ final class FormHelperTest extends CIUnitTestCase
             <input type="checkbox" name="foo" value="bar" checked="checked" />
 
             EOH;
-        $this->assertEquals($expected, form_checkbox($data));
+        $this->assertSame($expected, form_checkbox($data));
     }
 
     // ------------------------------------------------------------------------
@@ -652,7 +652,7 @@ final class FormHelperTest extends CIUnitTestCase
             <input type="checkbox" name="foo" value="bar" />
 
             EOH;
-        $this->assertEquals($expected, form_checkbox($data));
+        $this->assertSame($expected, form_checkbox($data));
     }
 
     // ------------------------------------------------------------------------
@@ -661,7 +661,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<EOH
             <input type="radio" name="newsletter" value="accept" checked="checked" />\n
             EOH;
-        $this->assertEquals($expected, form_radio('newsletter', 'accept', true));
+        $this->assertSame($expected, form_radio('newsletter', 'accept', true));
     }
 
     // ------------------------------------------------------------------------
@@ -670,7 +670,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<EOH
             <input type="submit" name="mysubmit" value="Submit Post!" />\n
             EOH;
-        $this->assertEquals($expected, form_submit('mysubmit', 'Submit Post!'));
+        $this->assertSame($expected, form_submit('mysubmit', 'Submit Post!'));
     }
 
     // ------------------------------------------------------------------------
@@ -679,7 +679,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<'EOH'
             <label for="username">What is your Name</label>
             EOH;
-        $this->assertEquals($expected, form_label('What is your Name', 'username'));
+        $this->assertSame($expected, form_label('What is your Name', 'username'));
     }
 
     // ------------------------------------------------------------------------
@@ -691,7 +691,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<'EOH'
             <label for="foo" id="label1">bar</label>
             EOH;
-        $this->assertEquals($expected, form_label('bar', 'foo', $attributes));
+        $this->assertSame($expected, form_label('bar', 'foo', $attributes));
     }
 
     // ------------------------------------------------------------------------
@@ -700,7 +700,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<EOH
             <input type="reset" name="myreset" value="Reset" />\n
             EOH;
-        $this->assertEquals($expected, form_reset('myreset', 'Reset'));
+        $this->assertSame($expected, form_reset('myreset', 'Reset'));
     }
 
     // ------------------------------------------------------------------------
@@ -709,7 +709,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<EOH
             <button name="name" type="button">content</button>\n
             EOH;
-        $this->assertEquals($expected, form_button('name', 'content'));
+        $this->assertSame($expected, form_button('name', 'content'));
     }
 
     // ------------------------------------------------------------------------
@@ -723,7 +723,7 @@ final class FormHelperTest extends CIUnitTestCase
             <button name="foo" type="button">bar</button>
 
             EOH;
-        $this->assertEquals($expected, form_button($data));
+        $this->assertSame($expected, form_button($data));
     }
 
     // ------------------------------------------------------------------------
@@ -732,7 +732,7 @@ final class FormHelperTest extends CIUnitTestCase
         $expected = <<<'EOH'
             </form></div></div>
             EOH;
-        $this->assertEquals($expected, form_close('</div></div>'));
+        $this->assertSame($expected, form_close('</div></div>'));
     }
 
     // ------------------------------------------------------------------------
@@ -750,31 +750,31 @@ final class FormHelperTest extends CIUnitTestCase
             </datalist>
 
             EOH;
-        $this->assertEquals($expected, form_datalist('foo', 'bar', $options));
+        $this->assertSame($expected, form_datalist('foo', 'bar', $options));
     }
 
     // ------------------------------------------------------------------------
     public function testSetValue()
     {
         $_SESSION['_ci_old_input']['post']['foo'] = '<bar';
-        $this->assertEquals('&lt;bar', set_value('foo'));
+        $this->assertSame('&lt;bar', set_value('foo'));
 
         unset($_SESSION['_ci_old_input']['post']['foo']);
-        $this->assertEquals('baz', set_value('foo', 'baz'));
+        $this->assertSame('baz', set_value('foo', 'baz'));
     }
 
     // ------------------------------------------------------------------------
     public function testSetSelect()
     {
         $_SESSION['_ci_old_input']['post']['foo'] = 'bar';
-        $this->assertEquals(' selected="selected"', set_select('foo', 'bar'));
+        $this->assertSame(' selected="selected"', set_select('foo', 'bar'));
 
         $_SESSION['_ci_old_input']['post']['foo'] = ['foo' => 'bar'];
-        $this->assertEquals(' selected="selected"', set_select('foo', 'bar'));
-        $this->assertEquals('', set_select('foo', 'baz'));
+        $this->assertSame(' selected="selected"', set_select('foo', 'bar'));
+        $this->assertSame('', set_select('foo', 'baz'));
 
         unset($_SESSION['_ci_old_input']['post']['foo']);
-        $this->assertEquals(' selected="selected"', set_select('foo', 'baz', true));
+        $this->assertSame(' selected="selected"', set_select('foo', 'baz', true));
     }
 
     // ------------------------------------------------------------------------
@@ -788,7 +788,7 @@ final class FormHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals(' checked="checked"', set_checkbox('foo', 'bar'));
+        $this->assertSame(' checked="checked"', set_checkbox('foo', 'bar'));
 
         $_SESSION = [
             '_ci_old_input' => [
@@ -797,14 +797,14 @@ final class FormHelperTest extends CIUnitTestCase
                 ],
             ],
         ];
-        $this->assertEquals(' checked="checked"', set_checkbox('foo', 'bar'));
-        $this->assertEquals('', set_checkbox('foo', 'baz'));
+        $this->assertSame(' checked="checked"', set_checkbox('foo', 'bar'));
+        $this->assertSame('', set_checkbox('foo', 'baz'));
 
         $_SESSION = [];
-        $this->assertEquals('', set_checkbox('foo', 'bar'));
+        $this->assertSame('', set_checkbox('foo', 'bar'));
 
         $_SESSION = [];
-        $this->assertEquals(' checked="checked"', set_checkbox('foo', 'bar', true));
+        $this->assertSame(' checked="checked"', set_checkbox('foo', 'bar', true));
     }
 
     // ------------------------------------------------------------------------
@@ -818,7 +818,7 @@ final class FormHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals(' checked="checked"', set_checkbox('foo', '0'));
+        $this->assertSame(' checked="checked"', set_checkbox('foo', '0'));
 
         $_SESSION = [
             '_ci_old_input' => [
@@ -827,14 +827,14 @@ final class FormHelperTest extends CIUnitTestCase
                 ],
             ],
         ];
-        $this->assertEquals(' checked="checked"', set_checkbox('foo', '0'));
-        $this->assertEquals('', set_checkbox('foo', 'baz'));
+        $this->assertSame(' checked="checked"', set_checkbox('foo', '0'));
+        $this->assertSame('', set_checkbox('foo', 'baz'));
 
         $_SESSION = [];
-        $this->assertEquals('', set_checkbox('foo', 'bar'));
+        $this->assertSame('', set_checkbox('foo', 'bar'));
 
         $_SESSION = [];
-        $this->assertEquals(' checked="checked"', set_checkbox('foo', '0', true));
+        $this->assertSame(' checked="checked"', set_checkbox('foo', '0', true));
     }
 
     // ------------------------------------------------------------------------
@@ -853,8 +853,8 @@ final class FormHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals(' checked="checked"', set_radio('foo', 'bar'));
-        $this->assertEquals('', set_radio('foo', 'baz'));
+        $this->assertSame(' checked="checked"', set_radio('foo', 'bar'));
+        $this->assertSame('', set_radio('foo', 'baz'));
         unset($_SESSION['_ci_old_input']);
     }
 
@@ -865,9 +865,9 @@ final class FormHelperTest extends CIUnitTestCase
     public function testSetRadioFromPost()
     {
         $_POST['bar'] = 'baz';
-        $this->assertEquals(' checked="checked"', set_radio('bar', 'baz'));
-        $this->assertEquals('', set_radio('bar', 'boop'));
-        $this->assertEquals(' checked="checked"', set_radio('bar', 'boop', true));
+        $this->assertSame(' checked="checked"', set_radio('bar', 'baz'));
+        $this->assertSame('', set_radio('bar', 'boop'));
+        $this->assertSame(' checked="checked"', set_radio('bar', 'boop', true));
     }
 
     /**
@@ -877,11 +877,11 @@ final class FormHelperTest extends CIUnitTestCase
     public function testSetRadioFromPostWithValueZero()
     {
         $_POST['bar'] = 0;
-        $this->assertEquals(' checked="checked"', set_radio('bar', '0'));
-        $this->assertEquals('', set_radio('bar', 'boop'));
+        $this->assertSame(' checked="checked"', set_radio('bar', '0'));
+        $this->assertSame('', set_radio('bar', 'boop'));
 
         $_POST = [];
-        $this->assertEquals(' checked="checked"', set_radio('bar', '0', true));
+        $this->assertSame(' checked="checked"', set_radio('bar', '0', true));
     }
 
     public function testSetRadioFromPostArray()
@@ -896,8 +896,8 @@ final class FormHelperTest extends CIUnitTestCase
                 ],
             ],
         ];
-        $this->assertEquals(' checked="checked"', set_radio('bar', 'boop'));
-        $this->assertEquals('', set_radio('bar', 'baz'));
+        $this->assertSame(' checked="checked"', set_radio('bar', 'boop'));
+        $this->assertSame('', set_radio('bar', 'baz'));
     }
 
     public function testSetRadioFromPostArrayWithValueZero()
@@ -912,62 +912,62 @@ final class FormHelperTest extends CIUnitTestCase
                 ],
             ],
         ];
-        $this->assertEquals(' checked="checked"', set_radio('bar', '0'));
-        $this->assertEquals('', set_radio('bar', 'baz'));
+        $this->assertSame(' checked="checked"', set_radio('bar', '0'));
+        $this->assertSame('', set_radio('bar', 'baz'));
     }
 
     public function testSetRadioDefault()
     {
-        $this->assertEquals(' checked="checked"', set_radio('code', 'alpha', true));
-        $this->assertEquals('', set_radio('code', 'beta', false));
+        $this->assertSame(' checked="checked"', set_radio('code', 'alpha', true));
+        $this->assertSame('', set_radio('code', 'beta', false));
     }
 
     // ------------------------------------------------------------------------
     public function testFormParseFormAttributesTrue()
     {
         $expected = 'readonly ';
-        $this->assertEquals($expected, parse_form_attributes(['readonly' => true], []));
+        $this->assertSame($expected, parse_form_attributes(['readonly' => true], []));
     }
 
     // ------------------------------------------------------------------------
     public function testFormParseFormAttributesFalse()
     {
         $expected = 'disabled ';
-        $this->assertEquals($expected, parse_form_attributes(['disabled' => false], []));
+        $this->assertSame($expected, parse_form_attributes(['disabled' => false], []));
     }
 
     // ------------------------------------------------------------------------
     public function testFormParseFormAttributesNull()
     {
         $expected = 'bar=""';
-        $this->assertEquals($expected, parse_form_attributes(['bar' => null], []));
+        $this->assertSame($expected, parse_form_attributes(['bar' => null], []));
     }
 
     // ------------------------------------------------------------------------
     public function testFormParseFormAttributesStringEmpty()
     {
         $expected = 'bar=""';
-        $this->assertEquals($expected, parse_form_attributes(['bar' => ''], []));
+        $this->assertSame($expected, parse_form_attributes(['bar' => ''], []));
     }
 
     // ------------------------------------------------------------------------
     public function testFormParseFormAttributesStringFoo()
     {
         $expected = 'bar="foo"';
-        $this->assertEquals($expected, parse_form_attributes(['bar' => 'foo'], []));
+        $this->assertSame($expected, parse_form_attributes(['bar' => 'foo'], []));
     }
 
     // ------------------------------------------------------------------------
     public function testFormParseFormAttributesInt0()
     {
         $expected = 'ok="0"';
-        $this->assertEquals($expected, parse_form_attributes(['ok' => 0], []));
+        $this->assertSame($expected, parse_form_attributes(['ok' => 0], []));
     }
 
     // ------------------------------------------------------------------------
     public function testFormParseFormAttributesInt1()
     {
         $expected = 'ok="1"';
-        $this->assertEquals($expected, parse_form_attributes(['ok' => 1], []));
+        $this->assertSame($expected, parse_form_attributes(['ok' => 1], []));
     }
 }

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -54,7 +54,7 @@ final class HTMLHelperTest extends CIUnitTestCase
             'bar',
         ];
 
-        $this->assertEquals(ltrim($expected), ul($list));
+        $this->assertSame(ltrim($expected), ul($list));
     }
 
     public function testULWithClass()
@@ -73,7 +73,7 @@ final class HTMLHelperTest extends CIUnitTestCase
             'bar',
         ];
 
-        $this->assertEquals($expected, ul($list, 'class="test"'));
+        $this->assertSame($expected, ul($list, 'class="test"'));
     }
 
     public function testMultiLevelUL()
@@ -102,7 +102,7 @@ final class HTMLHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals(ltrim($expected), ul($list));
+        $this->assertSame(ltrim($expected), ul($list));
     }
 
     //--------------------------------------------------------------------
@@ -123,7 +123,7 @@ final class HTMLHelperTest extends CIUnitTestCase
             'bar',
         ];
 
-        $this->assertEquals(ltrim($expected), ol($list));
+        $this->assertSame(ltrim($expected), ol($list));
     }
 
     public function testOLWithClass()
@@ -142,7 +142,7 @@ final class HTMLHelperTest extends CIUnitTestCase
             'bar',
         ];
 
-        $this->assertEquals($expected, ol($list, 'class="test"'));
+        $this->assertSame($expected, ol($list, 'class="test"'));
     }
 
     public function testMultiLevelOL()
@@ -171,7 +171,7 @@ final class HTMLHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals(ltrim($expected), ol($list));
+        $this->assertSame(ltrim($expected), ol($list));
     }
 
     // ------------------------------------------------------------------------
@@ -180,21 +180,21 @@ final class HTMLHelperTest extends CIUnitTestCase
     {
         $target   = 'http://site.com/images/picture.jpg';
         $expected = '<img src="http://site.com/images/picture.jpg" alt="" />';
-        $this->assertEquals($expected, img($target));
+        $this->assertSame($expected, img($target));
     }
 
     public function testIMGWithoutProtocol()
     {
         $target   = 'assets/mugshot.jpg';
         $expected = '<img src="http://example.com/assets/mugshot.jpg" alt="" />';
-        $this->assertEquals($expected, img($target));
+        $this->assertSame($expected, img($target));
     }
 
     public function testIMGWithIndexpage()
     {
         $target   = 'assets/mugshot.jpg';
         $expected = '<img src="http://example.com/index.php/assets/mugshot.jpg" alt="" />';
-        $this->assertEquals($expected, img($target, true));
+        $this->assertSame($expected, img($target, true));
     }
 
     // ------------------------------------------------------------------------
@@ -203,14 +203,14 @@ final class HTMLHelperTest extends CIUnitTestCase
     {
         $expected = 'data:image/gif;base64,' . $this->imgData;
 
-        $this->assertEquals($expected, img_data($this->imgPath));
+        $this->assertSame($expected, img_data($this->imgPath));
     }
 
     public function testImgDataWithMime()
     {
         $expected = 'data:image/png;base64,' . $this->imgData;
 
-        $this->assertEquals($expected, img_data($this->imgPath, 'image/png'));
+        $this->assertSame($expected, img_data($this->imgPath, 'image/png'));
     }
 
     public function testImgDataUnknownMime()
@@ -218,7 +218,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $path   = SUPPORTPATH . 'Validation' . DIRECTORY_SEPARATOR . 'uploads' . DIRECTORY_SEPARATOR . 'phpUxc0ty';
         $result = img_data($path);
 
-        $this->assertEquals(0, strpos($result, 'data:image/jpg'));
+        $this->assertSame(0, strpos($result, 'data:image/jpg'));
     }
 
     public function testImgDataNoFile()
@@ -234,21 +234,21 @@ final class HTMLHelperTest extends CIUnitTestCase
     {
         $target   = 'http://site.com/js/mystyles.js';
         $expected = '<script src="http://site.com/js/mystyles.js" type="text/javascript"></script>';
-        $this->assertEquals($expected, script_tag($target));
+        $this->assertSame($expected, script_tag($target));
     }
 
     public function testScriptTagWithoutProtocol()
     {
         $target   = 'js/mystyles.js';
         $expected = '<script src="http://example.com/js/mystyles.js" type="text/javascript"></script>';
-        $this->assertEquals($expected, script_tag($target));
+        $this->assertSame($expected, script_tag($target));
     }
 
     public function testScriptTagWithIndexpage()
     {
         $target   = 'js/mystyles.js';
         $expected = '<script src="http://example.com/index.php/js/mystyles.js" type="text/javascript"></script>';
-        $this->assertEquals($expected, script_tag($target, true));
+        $this->assertSame($expected, script_tag($target, true));
     }
 
     // ------------------------------------------------------------------------
@@ -257,14 +257,14 @@ final class HTMLHelperTest extends CIUnitTestCase
     {
         $target   = 'css/mystyles.css';
         $expected = '<link href="http://example.com/css/mystyles.css" rel="stylesheet" type="text/css" />';
-        $this->assertEquals($expected, link_tag($target));
+        $this->assertSame($expected, link_tag($target));
     }
 
     public function testLinkTagComplete()
     {
         $target   = 'https://styles.com/css/mystyles.css';
         $expected = '<link href="https://styles.com/css/mystyles.css" rel="banana" type="fruit" media="VHS" title="Go away" />';
-        $this->assertEquals($expected, link_tag($target, 'banana', 'fruit', 'Go away', 'VHS'));
+        $this->assertSame($expected, link_tag($target, 'banana', 'fruit', 'Go away', 'VHS'));
     }
 
     public function testLinkTagArray()
@@ -274,7 +274,7 @@ final class HTMLHelperTest extends CIUnitTestCase
             'indexPage' => true,
         ];
         $expected = '<link href="http://example.com/index.php/css/mystyles.css" rel="stylesheet" type="text/css" />';
-        $this->assertEquals($expected, link_tag($parms));
+        $this->assertSame($expected, link_tag($parms));
     }
 
     // ------------------------------------------------------------------------
@@ -283,13 +283,13 @@ final class HTMLHelperTest extends CIUnitTestCase
     {
         $target   = 'html4-strict';
         $expected = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">';
-        $this->assertEquals($expected, doctype($target));
+        $this->assertSame($expected, doctype($target));
     }
 
     public function testDocTypeDefault()
     {
         $expected = '<!DOCTYPE html>';
-        $this->assertEquals($expected, doctype());
+        $this->assertSame($expected, doctype());
     }
 
     public function testDocTypeInvalid()
@@ -312,7 +312,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $target  = 'http://www.codeigniter.com/test.mp4';
         $message = 'Your browser does not support the video tag.';
         $video   = video($target, $message, 'controls');
-        $this->assertEquals($expected, $video);
+        $this->assertSame($expected, $video);
     }
 
     public function testVideoWithTracks()
@@ -329,7 +329,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $target  = 'test.mp4';
         $message = 'Your browser does not support the video tag.';
         $video   = video($target, $message, 'controls', $this->tracks);
-        $this->assertEquals($expected, $video);
+        $this->assertSame($expected, $video);
     }
 
     public function testVideoWithTracksAndIndex()
@@ -346,7 +346,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $target  = 'test.mp4';
         $message = 'Your browser does not support the video tag.';
         $video   = video($target, $message, 'controls', $this->tracks, true);
-        $this->assertEquals($expected, $video);
+        $this->assertSame($expected, $video);
     }
 
     public function testVideoMultipleSources()
@@ -373,7 +373,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $message = 'Your browser does not support the video tag.';
         $video   = video($sources, $message, 'class="test" controls', $this->tracks);
 
-        $this->assertEquals($expected, $video);
+        $this->assertSame($expected, $video);
     }
 
     // ------------------------------------------------------------------------
@@ -398,7 +398,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $message = 'Your browser does not support the audio tag.';
         $audio   = audio($sources, $message, 'id="test" controls', $this->tracks);
 
-        $this->assertEquals($expected, $audio);
+        $this->assertSame($expected, $audio);
     }
 
     public function testAudioSimple()
@@ -414,7 +414,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $message = 'Your browser does not support the audio tag.';
         $audio   = audio($source, $message, 'type="audio/mpeg" id="test" controls');
 
-        $this->assertEquals($expected, $audio);
+        $this->assertSame($expected, $audio);
     }
 
     public function testAudioWithSource()
@@ -430,7 +430,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $message = 'Your browser does not support the audio tag.';
         $audio   = audio($source, $message, 'type="audio/mpeg" id="test" controls');
 
-        $this->assertEquals($expected, $audio);
+        $this->assertSame($expected, $audio);
     }
 
     public function testAudioWithIndex()
@@ -446,7 +446,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $message = 'Your browser does not support the audio tag.';
         $audio   = audio($source, $message, 'type="audio/mpeg" id="test" controls', [], true);
 
-        $this->assertEquals($expected, $audio);
+        $this->assertSame($expected, $audio);
     }
 
     public function testAudioWithTracks()
@@ -464,7 +464,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $message = 'Your browser does not support the audio tag.';
         $audio   = audio($source, $message, 'type="audio/mpeg" id="test" controls', $this->tracks);
 
-        $this->assertEquals($expected, $audio);
+        $this->assertSame($expected, $audio);
     }
 
     // ------------------------------------------------------------------------
@@ -476,7 +476,7 @@ final class HTMLHelperTest extends CIUnitTestCase
             </av>
 
             EOH;
-        $this->assertEquals($expected, _media('av'));
+        $this->assertSame($expected, _media('av'));
     }
 
     public function testMediaWithSources()
@@ -492,13 +492,13 @@ final class HTMLHelperTest extends CIUnitTestCase
             source('sound.ogg', 'audio/ogg'),
             source('sound.mpeg', 'audio/mpeg'),
         ];
-        $this->assertEquals($expected, _media('av', $sources));
+        $this->assertSame($expected, _media('av', $sources));
     }
 
     public function testSource()
     {
         $expected = '<source src="http://example.com/index.php/sound.mpeg" type="audio/mpeg" />';
-        $this->assertEquals($expected, source('sound.mpeg', 'audio/mpeg', '', true));
+        $this->assertSame($expected, source('sound.mpeg', 'audio/mpeg', '', true));
     }
 
     // ------------------------------------------------------------------------
@@ -512,7 +512,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
         $type  = 'video/quicktime';
         $embed = embed('movie.mov', $type, 'class="test"');
-        $this->assertEquals($expected, $embed);
+        $this->assertSame($expected, $embed);
     }
 
     public function testEmbedIndexed()
@@ -524,7 +524,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
         $type  = 'video/quicktime';
         $embed = embed('movie.mov', $type, 'class="test"', true);
-        $this->assertEquals($expected, $embed, '');
+        $this->assertSame($expected, $embed, '');
     }
 
     public function testObject()
@@ -537,7 +537,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $type   = 'application/x-shockwave-flash';
         $object = object('movie.swf', $type, 'class="test"');
 
-        $this->assertEquals($expected, $object);
+        $this->assertSame($expected, $object);
     }
 
     public function testObjectWithParams()
@@ -556,7 +556,7 @@ final class HTMLHelperTest extends CIUnitTestCase
             param('hello', 'world', 'ref', 'class="test"'),
         ];
         $object = object('movie.swf', $type, 'class="test"', $parms);
-        $this->assertEquals($expected, $object);
+        $this->assertSame($expected, $object);
     }
 
     public function testObjectIndexed()
@@ -569,7 +569,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $type   = 'application/x-shockwave-flash';
         $object = object('movie.swf', $type, 'class="test"', [], true);
 
-        $this->assertEquals($expected, $object);
+        $this->assertSame($expected, $object);
     }
 
     // ------------------------------------------------------------------------

--- a/tests/system/Helpers/InflectorHelperTest.php
+++ b/tests/system/Helpers/InflectorHelperTest.php
@@ -51,7 +51,7 @@ final class InflectorHelperTest extends CIUnitTestCase
 
         foreach ($strings as $pluralizedString => $singularizedString) {
             $singular = singular($pluralizedString);
-            $this->assertEquals($singular, $singularizedString);
+            $this->assertSame($singular, $singularizedString);
         }
     }
 
@@ -89,7 +89,7 @@ final class InflectorHelperTest extends CIUnitTestCase
 
         foreach ($strings as $pluralizedString => $singularizedString) {
             $plural = plural($singularizedString);
-            $this->assertEquals($plural, $pluralizedString);
+            $this->assertSame($plural, $pluralizedString);
         }
     }
 
@@ -147,7 +147,7 @@ final class InflectorHelperTest extends CIUnitTestCase
 
         foreach ($triplets as $triplet) {
             $result = counted($triplet[0], $triplet[1]);
-            $this->assertEquals($triplet[2], $result);
+            $this->assertSame($triplet[2], $result);
         }
     }
 
@@ -162,7 +162,7 @@ final class InflectorHelperTest extends CIUnitTestCase
 
         foreach ($strings as $lowerCasedString => $camelizedString) {
             $camelized = camelize($lowerCasedString);
-            $this->assertEquals($camelized, $camelizedString);
+            $this->assertSame($camelized, $camelizedString);
         }
     }
 
@@ -177,7 +177,7 @@ final class InflectorHelperTest extends CIUnitTestCase
 
         foreach ($strings as $lowerCasedString => $pascalizedString) {
             $pascalized = pascalize($lowerCasedString);
-            $this->assertEquals($pascalized, $pascalizedString);
+            $this->assertSame($pascalized, $pascalizedString);
         }
     }
 
@@ -192,7 +192,7 @@ final class InflectorHelperTest extends CIUnitTestCase
 
         foreach ($strings as $spaced => $underscore) {
             $underscored = underscore($spaced);
-            $this->assertEquals($underscored, $underscore);
+            $this->assertSame($underscored, $underscore);
         }
     }
 
@@ -212,8 +212,8 @@ final class InflectorHelperTest extends CIUnitTestCase
         $humanizedUnderscore = humanize($underscored[0]);
         $humanizedDash       = humanize($dashed[0], '-');
 
-        $this->assertEquals($humanizedUnderscore, $underscored[1]);
-        $this->assertEquals($humanizedDash, $dashed[1]);
+        $this->assertSame($humanizedUnderscore, $underscored[1]);
+        $this->assertSame($humanizedDash, $dashed[1]);
     }
 
     //--------------------------------------------------------------------
@@ -246,7 +246,7 @@ final class InflectorHelperTest extends CIUnitTestCase
 
         foreach ($strings as $underscored => $dashed) {
             $dasherized = dasherize($underscored);
-            $this->assertEquals($dasherized, $dashed);
+            $this->assertSame($dasherized, $dashed);
         }
     }
 
@@ -269,7 +269,7 @@ final class InflectorHelperTest extends CIUnitTestCase
 
         foreach ($suffixes as $suffix => $number) {
             $ordinal = ordinal($number);
-            $this->assertEquals($suffix, $ordinal);
+            $this->assertSame($suffix, $ordinal);
         }
     }
 
@@ -292,7 +292,7 @@ final class InflectorHelperTest extends CIUnitTestCase
 
         foreach ($suffixedNumbers as $suffixed => $number) {
             $ordinalized = ordinalize($number);
-            $this->assertEquals($suffixed, $ordinalized);
+            $this->assertSame($suffixed, $ordinalized);
         }
     }
 }

--- a/tests/system/Helpers/NumberHelperTest.php
+++ b/tests/system/Helpers/NumberHelperTest.php
@@ -18,11 +18,11 @@ final class NumberHelperTest extends CIUnitTestCase
 
     public function testRomanNumber()
     {
-        $this->assertEquals('XCVI', number_to_roman(96));
-        $this->assertEquals('MMDCCCXCV', number_to_roman(2895));
-        $this->assertEquals('CCCXXIX', number_to_roman(329));
-        $this->assertEquals('IV', number_to_roman(4));
-        $this->assertEquals('X', number_to_roman(10));
+        $this->assertSame('XCVI', number_to_roman(96));
+        $this->assertSame('MMDCCCXCV', number_to_roman(2895));
+        $this->assertSame('CCCXXIX', number_to_roman(329));
+        $this->assertSame('IV', number_to_roman(4));
+        $this->assertSame('X', number_to_roman(10));
     }
 
     public function testRomanNumberRange()
@@ -34,13 +34,13 @@ final class NumberHelperTest extends CIUnitTestCase
 
     public function testFormatNumber()
     {
-        $this->assertEquals('123,456', format_number(123456, 0, 'en_US'));
+        $this->assertSame('123,456', format_number(123456, 0, 'en_US'));
     }
 
     public function testFormatNumberWithPrecision()
     {
-        $this->assertEquals('123,456.8', format_number(123456.789, 1, 'en_US'));
-        $this->assertEquals('123,456.79', format_number(123456.789, 2, 'en_US'));
+        $this->assertSame('123,456.8', format_number(123456.789, 1, 'en_US'));
+        $this->assertSame('123,456.79', format_number(123456.789, 2, 'en_US'));
     }
 
     public function testFormattingOptions()
@@ -49,67 +49,67 @@ final class NumberHelperTest extends CIUnitTestCase
             'before' => '<<',
             'after'  => '>>',
         ];
-        $this->assertEquals('<<123,456.79>>', format_number(123456.789, 2, 'en_US', $options));
+        $this->assertSame('<<123,456.79>>', format_number(123456.789, 2, 'en_US', $options));
     }
 
     public function testNumberToSize()
     {
-        $this->assertEquals('456 Bytes', number_to_size(456, 1, 'en_US'));
+        $this->assertSame('456 Bytes', number_to_size(456, 1, 'en_US'));
     }
 
     public function testKbFormat()
     {
-        $this->assertEquals('4.5 KB', number_to_size(4567, 1, 'en_US'));
+        $this->assertSame('4.5 KB', number_to_size(4567, 1, 'en_US'));
     }
 
     public function testKbFormatMedium()
     {
-        $this->assertEquals('44.6 KB', number_to_size(45678, 1, 'en_US'));
+        $this->assertSame('44.6 KB', number_to_size(45678, 1, 'en_US'));
     }
 
     public function testKbFormatLarge()
     {
-        $this->assertEquals('446.1 KB', number_to_size(456789, 1, 'en_US'));
+        $this->assertSame('446.1 KB', number_to_size(456789, 1, 'en_US'));
     }
 
     public function testMbFormat()
     {
-        $this->assertEquals('3.3 MB', number_to_size(3456789, 1, 'en_US'));
+        $this->assertSame('3.3 MB', number_to_size(3456789, 1, 'en_US'));
     }
 
     public function testGbFormat()
     {
-        $this->assertEquals('1.8 GB', number_to_size(1932735283.2, 1, 'en_US'));
+        $this->assertSame('1.8 GB', number_to_size(1932735283.2, 1, 'en_US'));
     }
 
     public function testTbFormat()
     {
-        $this->assertEquals('112,283.3 TB', number_to_size(123456789123456789, 1, 'en_US'));
+        $this->assertSame('112,283.3 TB', number_to_size(123456789123456789, 1, 'en_US'));
     }
 
     public function testThousands()
     {
-        $this->assertEquals('123 thousand', number_to_amount('123,000', 0, 'en_US'));
+        $this->assertSame('123 thousand', number_to_amount('123,000', 0, 'en_US'));
     }
 
     public function testMillions()
     {
-        $this->assertEquals('123.4 million', number_to_amount('123,400,000', 1, 'en_US'));
+        $this->assertSame('123.4 million', number_to_amount('123,400,000', 1, 'en_US'));
     }
 
     public function testBillions()
     {
-        $this->assertEquals('123.46 billion', number_to_amount('123,456,000,000', 2, 'en_US'));
+        $this->assertSame('123.46 billion', number_to_amount('123,456,000,000', 2, 'en_US'));
     }
 
     public function testTrillions()
     {
-        $this->assertEquals('123.457 trillion', number_to_amount('123,456,700,000,000', 3, 'en_US'));
+        $this->assertSame('123.457 trillion', number_to_amount('123,456,700,000,000', 3, 'en_US'));
     }
 
     public function testQuadrillions()
     {
-        $this->assertEquals('123.5 quadrillion', number_to_amount('123,456,700,000,000,000', 1, 'en_US'));
+        $this->assertSame('123.5 quadrillion', number_to_amount('123,456,700,000,000,000', 1, 'en_US'));
     }
 
     /**
@@ -117,9 +117,9 @@ final class NumberHelperTest extends CIUnitTestCase
      */
     public function testCurrencyCurrentLocale()
     {
-        $this->assertEquals('$1,234.56', number_to_currency(1234.56, 'USD', 'en_US', 2));
-        $this->assertEquals('£1,234.56', number_to_currency(1234.56, 'GBP', 'en_GB', 2));
-        $this->assertEquals('1.234,56 RSD', number_to_currency(1234.56, 'RSD', 'sr_RS', 2));
+        $this->assertSame('$1,234.56', number_to_currency(1234.56, 'USD', 'en_US', 2));
+        $this->assertSame('£1,234.56', number_to_currency(1234.56, 'GBP', 'en_GB', 2));
+        $this->assertSame('1.234,56 RSD', number_to_currency(1234.56, 'RSD', 'sr_RS', 2));
     }
 
     public function testNumbersThatArent()

--- a/tests/system/Helpers/SecurityHelperTest.php
+++ b/tests/system/Helpers/SecurityHelperTest.php
@@ -18,24 +18,24 @@ final class SecurityHelperTest extends CIUnitTestCase
 
     public function testSanitizeFilenameSimpleSuccess()
     {
-        $this->assertEquals('hello.doc', sanitize_filename('hello.doc'));
+        $this->assertSame('hello.doc', sanitize_filename('hello.doc'));
     }
 
     public function testSanitizeFilenameStripsExtras()
     {
         $filename = './<!--foo -->';
-        $this->assertEquals('foo ', sanitize_filename($filename));
+        $this->assertSame('foo ', sanitize_filename($filename));
     }
 
     public function testStripImageTags()
     {
-        $this->assertEquals('http://example.com/spacer.gif', strip_image_tags('http://example.com/spacer.gif'));
+        $this->assertSame('http://example.com/spacer.gif', strip_image_tags('http://example.com/spacer.gif'));
 
-        $this->assertEquals('http://example.com/spacer.gif', strip_image_tags('<img src="http://example.com/spacer.gif" alt="Who needs CSS when you have a spacer.gif?" />'));
+        $this->assertSame('http://example.com/spacer.gif', strip_image_tags('<img src="http://example.com/spacer.gif" alt="Who needs CSS when you have a spacer.gif?" />'));
     }
 
     public function testEncodePhpTags()
     {
-        $this->assertEquals('&lt;? echo $foo; ?&gt;', encode_php_tags('<? echo $foo; ?>'));
+        $this->assertSame('&lt;? echo $foo; ?&gt;', encode_php_tags('<? echo $foo; ?>'));
     }
 }

--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -30,7 +30,7 @@ final class TextHelperTest extends CIUnitTestCase
             "Is your name O\'reilly?",
             "No, my name is O\'connor.",
         ];
-        $this->assertEquals($expected, strip_slashes($str));
+        $this->assertSame($expected, strip_slashes($str));
     }
 
     // --------------------------------------------------------------------
@@ -42,7 +42,7 @@ final class TextHelperTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, strip_quotes($str));
+            $this->assertSame($expect, strip_quotes($str));
         }
     }
 
@@ -55,7 +55,7 @@ final class TextHelperTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, quotes_to_entities($str));
+            $this->assertSame($expect, quotes_to_entities($str));
         }
     }
 
@@ -69,7 +69,7 @@ final class TextHelperTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, reduce_double_slashes($str));
+            $this->assertSame($expect, reduce_double_slashes($str));
         }
     }
 
@@ -82,7 +82,7 @@ final class TextHelperTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, reduce_multiples($str));
+            $this->assertSame($expect, reduce_multiples($str));
         }
         $strs = [
             'Fred, Bill,, Joe, Jimmy' => 'Fred, Bill, Joe, Jimmy',
@@ -90,37 +90,37 @@ final class TextHelperTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, reduce_multiples($str, ',', true));
+            $this->assertSame($expect, reduce_multiples($str, ',', true));
         }
     }
 
     // --------------------------------------------------------------------
     public function testRandomString()
     {
-        $this->assertEquals(16, strlen(random_string('alnum', 16)));
-        $this->assertEquals(16, strlen(random_string('alpha', 16)));
-        $this->assertEquals(16, strlen(random_string('nozero', 16)));
-        $this->assertEquals(16, strlen(random_string('numeric', 16)));
-        $this->assertEquals(8, strlen(random_string('numeric')));
+        $this->assertSame(16, strlen(random_string('alnum', 16)));
+        $this->assertSame(16, strlen(random_string('alpha', 16)));
+        $this->assertSame(16, strlen(random_string('nozero', 16)));
+        $this->assertSame(16, strlen(random_string('numeric', 16)));
+        $this->assertSame(8, strlen(random_string('numeric')));
 
         $this->assertIsString(random_string('basic'));
-        $this->assertEquals(16, strlen($random = random_string('crypto', 16)));
+        $this->assertSame(16, strlen($random = random_string('crypto', 16)));
         $this->assertIsString($random);
 
-        $this->assertEquals(32, strlen($random = random_string('md5')));
-        $this->assertEquals(40, strlen($random = random_string('sha1')));
+        $this->assertSame(32, strlen($random = random_string('md5')));
+        $this->assertSame(40, strlen($random = random_string('sha1')));
     }
 
     // --------------------------------------------------------------------
     public function testIncrementString()
     {
-        $this->assertEquals('my-test_1', increment_string('my-test'));
-        $this->assertEquals('my-test-1', increment_string('my-test', '-'));
-        $this->assertEquals('file_5', increment_string('file_4'));
-        $this->assertEquals('file-5', increment_string('file-4', '-'));
-        $this->assertEquals('file-5', increment_string('file-4', '-'));
-        $this->assertEquals('file-1', increment_string('file', '-', '1'));
-        $this->assertEquals(124, increment_string('123', ''));
+        $this->assertSame('my-test_1', increment_string('my-test'));
+        $this->assertSame('my-test-1', increment_string('my-test', '-'));
+        $this->assertSame('file_5', increment_string('file_4'));
+        $this->assertSame('file-5', increment_string('file-4', '-'));
+        $this->assertSame('file-5', increment_string('file-4', '-'));
+        $this->assertSame('file-1', increment_string('file', '-', '1'));
+        $this->assertSame('124', increment_string('123', ''));
     }
 
     // -------------------------------------------------------------------
@@ -129,20 +129,20 @@ final class TextHelperTest extends CIUnitTestCase
 
     public function testWordLimiter()
     {
-        $this->assertEquals('Once upon a time,&#8230;', word_limiter($this->_long_string, 4));
-        $this->assertEquals('Once upon a time,&hellip;', word_limiter($this->_long_string, 4, '&hellip;'));
-        $this->assertEquals('', word_limiter('', 4));
-        $this->assertEquals('Once upon a&hellip;', word_limiter($this->_long_string, 3, '&hellip;'));
-        $this->assertEquals('Once upon a time', word_limiter('Once upon a time', 4, '&hellip;'));
+        $this->assertSame('Once upon a time,&#8230;', word_limiter($this->_long_string, 4));
+        $this->assertSame('Once upon a time,&hellip;', word_limiter($this->_long_string, 4, '&hellip;'));
+        $this->assertSame('', word_limiter('', 4));
+        $this->assertSame('Once upon a&hellip;', word_limiter($this->_long_string, 3, '&hellip;'));
+        $this->assertSame('Once upon a time', word_limiter('Once upon a time', 4, '&hellip;'));
     }
 
     // ------------------------------------------------------------------------
     public function testCharacterLimiter()
     {
-        $this->assertEquals('Once upon a time, a&#8230;', character_limiter($this->_long_string, 20));
-        $this->assertEquals('Once upon a time, a&hellip;', character_limiter($this->_long_string, 20, '&hellip;'));
-        $this->assertEquals('Short', character_limiter('Short', 20));
-        $this->assertEquals('Short', character_limiter('Short', 5));
+        $this->assertSame('Once upon a time, a&#8230;', character_limiter($this->_long_string, 20));
+        $this->assertSame('Once upon a time, a&hellip;', character_limiter($this->_long_string, 20, '&hellip;'));
+        $this->assertSame('Short', character_limiter('Short', 20));
+        $this->assertSame('Short', character_limiter('Short', 5));
     }
 
     // ------------------------------------------------------------------------
@@ -154,7 +154,7 @@ final class TextHelperTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, ascii_to_entities($str));
+            $this->assertSame($expect, ascii_to_entities($str));
         }
     }
 
@@ -167,29 +167,29 @@ final class TextHelperTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, entities_to_ascii($str));
+            $this->assertSame($expect, entities_to_ascii($str));
         }
     }
 
     public function testEntitiesToAsciiUnsafe()
     {
         $str = '&lt;&gt;';
-        $this->assertEquals('<>', entities_to_ascii($str, true));
-        $this->assertEquals('&lt;&gt;', entities_to_ascii($str, false));
+        $this->assertSame('<>', entities_to_ascii($str, true));
+        $this->assertSame('&lt;&gt;', entities_to_ascii($str, false));
     }
 
     public function testEntitiesToAsciiSmallOrdinals()
     {
         $str = '&#07;';
-        $this->assertEquals(pack('c', 7), entities_to_ascii($str));
+        $this->assertSame(pack('c', 7), entities_to_ascii($str));
     }
 
     // ------------------------------------------------------------------------
     public function testConvertAccentedCharacters()
     {
         //$this->ci_vfs_clone('application/Config/ForeignChars.php');
-        $this->assertEquals('AAAeEEEIIOOEUUUeY', convert_accented_characters('ÀÂÄÈÊËÎÏÔŒÙÛÜŸ'));
-        $this->assertEquals('a e i o u n ue', convert_accented_characters('á é í ó ú ñ ü'));
+        $this->assertSame('AAAeEEEIIOOEUUUeY', convert_accented_characters('ÀÂÄÈÊËÎÏÔŒÙÛÜŸ'));
+        $this->assertSame('a e i o u n ue', convert_accented_characters('á é í ó ú ñ ü'));
     }
 
     // ------------------------------------------------------------------------
@@ -211,7 +211,7 @@ final class TextHelperTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, word_censor($str, $censored, '$*#'));
+            $this->assertSame($expect, word_censor($str, $censored, '$*#'));
         }
     }
 
@@ -219,7 +219,7 @@ final class TextHelperTest extends CIUnitTestCase
     public function testHighlightCode()
     {
         $expect = "<code><span style=\"color: #000000\">\n<span style=\"color: #0000BB\">&lt;?php&nbsp;var_dump</span><span style=\"color: #007700\">(</span><span style=\"color: #0000BB\">\$this</span><span style=\"color: #007700\">);&nbsp;</span><span style=\"color: #0000BB\">?&gt;&nbsp;</span>\n</span>\n</code>";
-        $this->assertEquals($expect, highlight_code('<?php var_dump($this); ?>'));
+        $this->assertSame($expect, highlight_code('<?php var_dump($this); ?>'));
     }
 
     // ------------------------------------------------------------------------
@@ -234,10 +234,10 @@ final class TextHelperTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, highlight_phrase($str, 'this is'));
+            $this->assertSame($expect, highlight_phrase($str, 'this is'));
         }
 
-        $this->assertEquals('<strong>this is</strong> a strong test', highlight_phrase('this is a strong test', 'this is', '<strong>', '</strong>'));
+        $this->assertSame('<strong>this is</strong> a strong test', highlight_phrase('this is a strong test', 'this is', '<strong>', '</strong>'));
     }
 
     // ------------------------------------------------------------------------
@@ -266,7 +266,7 @@ final class TextHelperTest extends CIUnitTestCase
 
         foreach ($strs as $pos => $s) {
             foreach ($s as $str => $expect) {
-                $this->assertEquals($expect, ellipsize($str, 10, $pos));
+                $this->assertSame($expect, ellipsize($str, 10, $pos));
             }
         }
     }
@@ -276,26 +276,26 @@ final class TextHelperTest extends CIUnitTestCase
     {
         $string   = 'Here is a simple string of text that will help us demonstrate this function.';
         $expected = "Here is a simple string\nof text that will help us\ndemonstrate this\nfunction.";
-        $this->assertEquals(substr_count(word_wrap($string, 25), "\n"), 3);
-        $this->assertEquals($expected, word_wrap($string, 25));
+        $this->assertSame(substr_count(word_wrap($string, 25), "\n"), 3);
+        $this->assertSame($expected, word_wrap($string, 25));
 
         $string2   = "Here is a\nbroken up sentence\rspanning lines\r\nwoohoo!";
         $expected2 = "Here is a\nbroken up sentence\nspanning lines\nwoohoo!";
-        $this->assertEquals(substr_count(word_wrap($string2, 25), "\n"), 3);
-        $this->assertEquals($expected2, word_wrap($string2, 25));
+        $this->assertSame(substr_count(word_wrap($string2, 25), "\n"), 3);
+        $this->assertSame($expected2, word_wrap($string2, 25));
 
         $string3   = "Here is another slightly longer\nbroken up sentence\rspanning lines\r\nwoohoo!";
         $expected3 = "Here is another slightly\nlonger\nbroken up sentence\nspanning lines\nwoohoo!";
-        $this->assertEquals(substr_count(word_wrap($string3, 25), "\n"), 4);
-        $this->assertEquals($expected3, word_wrap($string3, 25));
+        $this->assertSame(substr_count(word_wrap($string3, 25), "\n"), 4);
+        $this->assertSame($expected3, word_wrap($string3, 25));
     }
 
     public function testWordWrapUnwrap()
     {
         $string   = 'Here is a {unwrap}simple string of text{/unwrap} that will help us demonstrate this function.';
         $expected = "Here is a simple string of text\nthat will help us\ndemonstrate this\nfunction.";
-        $this->assertEquals(substr_count(word_wrap($string, 25), "\n"), 3);
-        $this->assertEquals($expected, word_wrap($string, 25));
+        $this->assertSame(substr_count(word_wrap($string, 25), "\n"), 3);
+        $this->assertSame($expected, word_wrap($string, 25));
     }
 
     public function testWordWrapLongWords()
@@ -303,7 +303,7 @@ final class TextHelperTest extends CIUnitTestCase
         // the really really long word will be split
         $string   = 'Here is an unbelievable super-complicated and reallyreallyquiteextraordinarily sophisticated sentence.';
         $expected = "Here is an unbelievable\nsuper-complicated and\nreallyreallyquiteextraor\ndinarily\nsophisticated sentence.";
-        $this->assertEquals($expected, word_wrap($string, 25));
+        $this->assertSame($expected, word_wrap($string, 25));
     }
 
     public function testWordWrapURL()
@@ -311,14 +311,14 @@ final class TextHelperTest extends CIUnitTestCase
         // the really really long word will be split
         $string   = 'Here is an unbelievable super-complicated and http://www.reallyreallyquiteextraordinarily.com sophisticated sentence.';
         $expected = "Here is an unbelievable\nsuper-complicated and\nhttp://www.reallyreallyquiteextraordinarily.com\nsophisticated sentence.";
-        $this->assertEquals($expected, word_wrap($string, 25));
+        $this->assertSame($expected, word_wrap($string, 25));
     }
 
     // ------------------------------------------------------------------------
     public function testDefaultWordWrapCharlim()
     {
         $string = 'Here is a longer string of text that will help us demonstrate the default charlim of this function.';
-        $this->assertEquals(strpos(word_wrap($string), "\n"), 73);
+        $this->assertSame(strpos(word_wrap($string), "\n"), 73);
     }
 
     // -----------------------------------------------------------------------
@@ -327,7 +327,7 @@ final class TextHelperTest extends CIUnitTestCase
     {
         $string = $this->_long_string;
         $result = ' Once upon a time, a framework had no tests. It sad  So some nice people began to write tests. The more time that went on, the happier it became. ...';
-        $this->assertEquals(excerpt($string), $result);
+        $this->assertSame(excerpt($string), $result);
     }
 
     // -----------------------------------------------------------------------
@@ -337,7 +337,7 @@ final class TextHelperTest extends CIUnitTestCase
         $string = $this->_long_string;
         $phrase = 'began';
         $result = '... people began to ...';
-        $this->assertEquals(excerpt($string, $phrase, 10), $result);
+        $this->assertSame(excerpt($string, $phrase, 10), $result);
     }
 
     // -----------------------------------------------------------------------
@@ -351,7 +351,7 @@ final class TextHelperTest extends CIUnitTestCase
         for ($i = 0; $i < 4; $i++) {
             $result .= alternator('I', 'you', 'we') . $phrase;
         }
-        $this->assertEquals('I scream! you scream! we scream! I scream! ', $result);
+        $this->assertSame('I scream! you scream! we scream! I scream! ', $result);
     }
 
     public function testEmptyAlternator()
@@ -363,6 +363,6 @@ final class TextHelperTest extends CIUnitTestCase
             $result .= alternator() . $phrase;
         }
 
-        $this->assertEquals(' scream!  scream!  scream!  scream! ', $result);
+        $this->assertSame(' scream!  scream!  scream!  scream! ', $result);
     }
 }

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -65,7 +65,7 @@ final class CurrentUrlTest extends CIUnitTestCase
         // Since we're on a CLI, we must provide our own URI
         $this->config->baseURL = 'http://example.com/public';
 
-        $this->assertEquals('http://example.com/public/index.php/', current_url());
+        $this->assertSame('http://example.com/public/index.php/', current_url());
     }
 
     public function testCurrentURLReturnsObject()
@@ -76,7 +76,7 @@ final class CurrentUrlTest extends CIUnitTestCase
         $url = current_url(true);
 
         $this->assertInstanceOf(URI::class, $url);
-        $this->assertEquals('http://example.com/public/index.php/', (string) $url);
+        $this->assertSame('http://example.com/public/index.php/', (string) $url);
     }
 
     public function testCurrentURLEquivalence()
@@ -91,7 +91,7 @@ final class CurrentUrlTest extends CIUnitTestCase
         $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
-        $this->assertEquals(site_url(uri_string()), current_url());
+        $this->assertSame(site_url(uri_string()), current_url());
     }
 
     public function testCurrentURLInSubfolder()
@@ -107,13 +107,13 @@ final class CurrentUrlTest extends CIUnitTestCase
         $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
-        $this->assertEquals('http://example.com/foo/public/index.php/bar', current_url());
-        $this->assertEquals('http://example.com/foo/public/index.php/bar?baz=quip', (string) current_url(true));
+        $this->assertSame('http://example.com/foo/public/index.php/bar', current_url());
+        $this->assertSame('http://example.com/foo/public/index.php/bar?baz=quip', (string) current_url(true));
 
         $uri = current_url(true);
-        $this->assertEquals('foo', $uri->getSegment(1));
-        $this->assertEquals('example.com', $uri->getHost());
-        $this->assertEquals('http', $uri->getScheme());
+        $this->assertSame('foo', $uri->getSegment(1));
+        $this->assertSame('example.com', $uri->getHost());
+        $this->assertSame('http', $uri->getScheme());
     }
 
     public function testCurrentURLWithPortInSubfolder()
@@ -130,15 +130,15 @@ final class CurrentUrlTest extends CIUnitTestCase
         $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
-        $this->assertEquals('http://example.com:8080/foo/public/index.php/bar', current_url());
-        $this->assertEquals('http://example.com:8080/foo/public/index.php/bar?baz=quip', (string) current_url(true));
+        $this->assertSame('http://example.com:8080/foo/public/index.php/bar', current_url());
+        $this->assertSame('http://example.com:8080/foo/public/index.php/bar?baz=quip', (string) current_url(true));
 
         $uri = current_url(true);
-        $this->assertEquals(['foo', 'public', 'index.php', 'bar'], $uri->getSegments());
-        $this->assertEquals('foo', $uri->getSegment(1));
-        $this->assertEquals('example.com', $uri->getHost());
-        $this->assertEquals('http', $uri->getScheme());
-        $this->assertEquals('8080', $uri->getPort());
+        $this->assertSame(['foo', 'public', 'index.php', 'bar'], $uri->getSegments());
+        $this->assertSame('foo', $uri->getSegment(1));
+        $this->assertSame('example.com', $uri->getHost());
+        $this->assertSame('http', $uri->getScheme());
+        $this->assertSame(8080, $uri->getPort());
     }
 
     //--------------------------------------------------------------------
@@ -155,7 +155,7 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals('/assets/image.jpg', uri_string());
+        $this->assertSame('/assets/image.jpg', uri_string());
     }
 
     public function testUriStringRelative()
@@ -168,7 +168,7 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals('assets/image.jpg', uri_string(true));
+        $this->assertSame('assets/image.jpg', uri_string(true));
     }
 
     public function testUriStringNoTrailingSlashAbsolute()
@@ -182,7 +182,7 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals('/assets/image.jpg', uri_string());
+        $this->assertSame('/assets/image.jpg', uri_string());
     }
 
     public function testUriStringNoTrailingSlashRelative()
@@ -196,7 +196,7 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals('assets/image.jpg', uri_string(true));
+        $this->assertSame('assets/image.jpg', uri_string(true));
     }
 
     public function testUriStringEmptyAbsolute()
@@ -206,7 +206,7 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals('/', uri_string());
+        $this->assertSame('/', uri_string());
     }
 
     public function testUriStringEmptyRelative()
@@ -216,7 +216,7 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals('', uri_string(true));
+        $this->assertSame('', uri_string(true));
     }
 
     public function testUriStringSubfolderAbsolute()
@@ -230,7 +230,7 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals('/subfolder/assets/image.jpg', uri_string());
+        $this->assertSame('/subfolder/assets/image.jpg', uri_string());
     }
 
     public function testUriStringSubfolderRelative()
@@ -245,7 +245,7 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals('assets/image.jpg', uri_string(true));
+        $this->assertSame('assets/image.jpg', uri_string(true));
     }
 
     //--------------------------------------------------------------------
@@ -305,7 +305,7 @@ final class CurrentUrlTest extends CIUnitTestCase
         $request->uri = new URI('http://example.com/' . $currentPath);
         Services::injectMock('request', $request);
 
-        $this->assertEquals($expected, url_is($testPath));
+        $this->assertSame($expected, url_is($testPath));
     }
 
     /**
@@ -321,7 +321,7 @@ final class CurrentUrlTest extends CIUnitTestCase
         $request->uri = new URI('http://example.com/' . $currentPath);
         Services::injectMock('request', $request);
 
-        $this->assertEquals($expected, url_is($testPath));
+        $this->assertSame($expected, url_is($testPath));
     }
 
     /**
@@ -338,6 +338,6 @@ final class CurrentUrlTest extends CIUnitTestCase
         $request->uri = new URI('http://example.com/subfolder/' . $currentPath);
         Services::injectMock('request', $request);
 
-        $this->assertEquals($expected, url_is($testPath));
+        $this->assertSame($expected, url_is($testPath));
     }
 }

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -66,7 +66,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals($uri2, previous_url());
+        $this->assertSame($uri2, previous_url());
     }
 
     //--------------------------------------------------------------------
@@ -84,7 +84,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals($uri1, previous_url());
+        $this->assertSame($uri1, previous_url());
     }
 
     //--------------------------------------------------------------------
@@ -97,7 +97,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals('index.php', index_page());
+        $this->assertSame('index.php', index_page());
     }
 
     public function testIndexPageAlt()
@@ -108,7 +108,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals('banana.php', index_page($this->config));
+        $this->assertSame('banana.php', index_page($this->config));
     }
 
     //--------------------------------------------------------------------
@@ -166,7 +166,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $request->uri = new URI('http://example.com/');
 
         Services::injectMock('request', $request);
-        $this->assertEquals($expected, anchor($uri, $title, $attributes, $this->config));
+        $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
     public function anchorNoindexPatterns()
@@ -228,7 +228,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $request->uri            = new URI('http://example.com/');
 
         Services::injectMock('request', $request);
-        $this->assertEquals($expected, anchor($uri, $title, $attributes, $this->config));
+        $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
     public function anchorSubpagePatterns()
@@ -280,7 +280,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $request->uri            = new URI('http://example.com/');
 
         Services::injectMock('request', $request);
-        $this->assertEquals($expected, anchor($uri, $title, $attributes, $this->config));
+        $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
     public function anchorExamplePatterns()
@@ -320,7 +320,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $request->uri = new URI('http://example.com/');
 
         Services::injectMock('request', $request);
-        $this->assertEquals($expected, anchor($uri, $title, $attributes, $this->config));
+        $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
     //--------------------------------------------------------------------
@@ -375,7 +375,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $request->uri = new URI('http://example.com/');
 
         Services::injectMock('request', $request);
-        $this->assertEquals($expected, anchor_popup($uri, $title, $attributes, $this->config));
+        $this->assertSame($expected, anchor_popup($uri, $title, $attributes, $this->config));
     }
 
     //--------------------------------------------------------------------
@@ -412,7 +412,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals($expected, mailto($email, $title, $attributes));
+        $this->assertSame($expected, mailto($email, $title, $attributes));
     }
 
     //--------------------------------------------------------------------
@@ -449,7 +449,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals($expected, safe_mailto($email, $title, $attributes));
+        $this->assertSame($expected, safe_mailto($email, $title, $attributes));
     }
 
     //--------------------------------------------------------------------
@@ -498,7 +498,7 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAutoLinkUrl($in, $out)
     {
-        $this->assertEquals($out, auto_link($in, 'url'));
+        $this->assertSame($out, auto_link($in, 'url'));
     }
 
     public function autolinkEmails()
@@ -544,7 +544,7 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAutoLinkEmail($in, $out)
     {
-        $this->assertEquals($out, auto_link($in, 'email'));
+        $this->assertSame($out, auto_link($in, 'email'));
     }
 
     public function autolinkBoth()
@@ -590,7 +590,7 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAutolinkBoth($in, $out)
     {
-        $this->assertEquals($out, auto_link($in));
+        $this->assertSame($out, auto_link($in));
     }
 
     public function autolinkPopup()
@@ -636,7 +636,7 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAutoLinkPopup($in, $out)
     {
-        $this->assertEquals($out, auto_link($in, 'url', true));
+        $this->assertSame($out, auto_link($in, 'url', true));
     }
 
     //--------------------------------------------------------------------
@@ -739,7 +739,7 @@ final class MiscUrlTest extends CIUnitTestCase
         ];
 
         foreach ($words as $in => $out) {
-            $this->assertEquals($out, url_title($in, '-', true));
+            $this->assertSame($out, url_title($in, '-', true));
         }
     }
 
@@ -752,7 +752,7 @@ final class MiscUrlTest extends CIUnitTestCase
         ];
 
         foreach ($words as $in => $out) {
-            $this->assertEquals($out, url_title($in, '_'));
+            $this->assertSame($out, url_title($in, '_'));
         }
     }
 
@@ -769,7 +769,7 @@ final class MiscUrlTest extends CIUnitTestCase
         ];
 
         foreach ($words as $in => $out) {
-            $this->assertEquals($out, mb_url_title($in, '-', true));
+            $this->assertSame($out, mb_url_title($in, '-', true));
         }
     }
 
@@ -783,7 +783,7 @@ final class MiscUrlTest extends CIUnitTestCase
         ];
 
         foreach ($words as $in => $out) {
-            $this->assertEquals($out, mb_url_title($in, '_'));
+            $this->assertSame($out, mb_url_title($in, '_'));
         }
     }
 
@@ -798,7 +798,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'gotoPage']);
         $routes->add('route/(:any)/to/(:num)', 'myOtherController::goto/$1/$2');
 
-        $this->assertEquals($expected, url_to($input, ...$args));
+        $this->assertSame($expected, url_to($input, ...$args));
     }
 
     /**

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -71,12 +71,12 @@ final class SiteUrlTest extends CIUnitTestCase
         $this->config->indexPage                 = $indexPage;
         $this->config->forceGlobalSecureRequests = $secure;
 
-        $this->assertEquals($expectedSiteUrl, site_url($path, $scheme, $this->config));
+        $this->assertSame($expectedSiteUrl, site_url($path, $scheme, $this->config));
 
         // base_url is always the trimmed site_url without index page
         $expectedBaseUrl = $indexPage === '' ? $expectedSiteUrl : str_replace('/' . $indexPage, '', $expectedSiteUrl);
         $expectedBaseUrl = rtrim($expectedBaseUrl, '/');
-        $this->assertEquals($expectedBaseUrl, base_url($path, $scheme));
+        $this->assertSame($expectedBaseUrl, base_url($path, $scheme));
     }
 
     public function configProvider()
@@ -247,13 +247,13 @@ final class SiteUrlTest extends CIUnitTestCase
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/test';
 
-        $this->assertEquals('http://example.com', base_url());
+        $this->assertSame('http://example.com', base_url());
 
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/test/page';
 
-        $this->assertEquals('http://example.com', base_url());
-        $this->assertEquals('http://example.com/profile', base_url('profile'));
+        $this->assertSame('http://example.com', base_url());
+        $this->assertSame('http://example.com/profile', base_url('profile'));
     }
 
     public function testBaseURLService()
@@ -267,7 +267,7 @@ final class SiteUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertEquals('http://example.com/ci/v4/index.php/controller/method', site_url('controller/method', null, $this->config));
-        $this->assertEquals('http://example.com/ci/v4/controller/method', base_url('controller/method', null));
+        $this->assertSame('http://example.com/ci/v4/index.php/controller/method', site_url('controller/method', null, $this->config));
+        $this->assertSame('http://example.com/ci/v4/controller/method', base_url('controller/method', null));
     }
 }

--- a/tests/system/Helpers/XMLHelperTest.php
+++ b/tests/system/Helpers/XMLHelperTest.php
@@ -22,7 +22,7 @@ final class XMLHelperTest extends CIUnitTestCase
     {
         $original = '<p>Here is a so-so paragraph & an entity (&#123;).</p>';
         $expected = '&lt;p&gt;Here is a so&#45;so paragraph &amp; an entity (&#123;).&lt;/p&gt;';
-        $this->assertEquals($expected, xml_convert($original));
+        $this->assertSame($expected, xml_convert($original));
     }
 
     // --------------------------------------------------------------------
@@ -30,6 +30,6 @@ final class XMLHelperTest extends CIUnitTestCase
     {
         $original = '<p>Here is a so&so; paragraph & an entity (&#123;).</p>';
         $expected = '&lt;p&gt;Here is a so&so; paragraph &amp; an entity (&#123;).&lt;/p&gt;';
-        $this->assertEquals($expected, xml_convert($original, true));
+        $this->assertSame($expected, xml_convert($original, true));
     }
 }

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -54,13 +54,13 @@ final class HoneypotTest extends CIUnitTestCase
         $this->response->setBody('<form></form>');
         $this->honeypot->attachHoneypot($this->response);
         $expected = '<form><div style="display:none"><label>Fill This Field</label><input type="text" name="honeypot" value=""/></div></form>';
-        $this->assertEquals($expected, $this->response->getBody());
+        $this->assertSame($expected, $this->response->getBody());
 
         $this->config->container = '<div class="hidden">{template}</div>';
         $this->response->setBody('<form></form>');
         $this->honeypot->attachHoneypot($this->response);
         $expected = '<form><div class="hidden"><label>Fill This Field</label><input type="text" name="honeypot" value=""/></div></form>';
-        $this->assertEquals($expected, $this->response->getBody());
+        $this->assertSame($expected, $this->response->getBody());
     }
 
     //--------------------------------------------------------------------
@@ -143,7 +143,7 @@ final class HoneypotTest extends CIUnitTestCase
         $config->container = '';
         $honeypot          = new Honeypot($config);
 
-        $this->assertEquals(
+        $this->assertSame(
             '<div style="display:none">{template}</div>',
             $this->getPrivateProperty($honeypot, 'config')->container
         );
@@ -155,7 +155,7 @@ final class HoneypotTest extends CIUnitTestCase
         $config->container = '<div></div>';
         $honeypot          = new Honeypot($config);
 
-        $this->assertEquals(
+        $this->assertSame(
             '<div style="display:none">{template}</div>',
             $this->getPrivateProperty($honeypot, 'config')->container
         );

--- a/tests/system/I18n/TimeDifferenceTest.php
+++ b/tests/system/I18n/TimeDifferenceTest.php
@@ -27,29 +27,29 @@ final class TimeDifferenceTest extends CIUnitTestCase
 
         $obj = $current->difference($test);
 
-        $this->assertEquals(-7, $obj->getYears());
-        $this->assertEquals(-84, $obj->getMonths());
-        $this->assertEquals(-365, $obj->getWeeks());
-        $this->assertEquals(-2557, $obj->getDays());
-        $this->assertEquals(-61368, $obj->getHours());
-        $this->assertEquals(-3682080, $obj->getMinutes());
-        $this->assertEquals(-220924800, $obj->getSeconds());
+        $this->assertSame(-7, $obj->getYears());
+        $this->assertSame(-84, $obj->getMonths());
+        $this->assertSame(-365, $obj->getWeeks());
+        $this->assertSame(-2557, $obj->getDays());
+        $this->assertSame(-61368, $obj->getHours());
+        $this->assertSame(-3682080, $obj->getMinutes());
+        $this->assertSame(-220924800, $obj->getSeconds());
 
-        $this->assertEquals(-7, $obj->years);
-        $this->assertEquals(-84, $obj->months);
-        $this->assertEquals(-365, $obj->weeks);
-        $this->assertEquals(-2557, $obj->days);
-        $this->assertEquals(-61368, $obj->hours);
-        $this->assertEquals(-3682080, $obj->minutes);
-        $this->assertEquals(-220924800, $obj->seconds);
+        $this->assertSame(-7, $obj->years);
+        $this->assertSame(-84, $obj->months);
+        $this->assertSame(-365, $obj->weeks);
+        $this->assertSame(-2557, $obj->days);
+        $this->assertSame(-61368, $obj->hours);
+        $this->assertSame(-3682080, $obj->minutes);
+        $this->assertSame(-220924800, $obj->seconds);
 
-        $this->assertEquals($diff / YEAR, $obj->getYears(true));
-        $this->assertEquals($diff / MONTH, $obj->getMonths(true));
-        $this->assertEquals($diff / WEEK, $obj->getWeeks(true));
-        $this->assertEquals($diff / DAY, $obj->getDays(true));
-        $this->assertEquals($diff / HOUR, $obj->getHours(true));
-        $this->assertEquals($diff / MINUTE, $obj->getMinutes(true));
-        $this->assertEquals($diff / SECOND, $obj->getSeconds(true));
+        $this->assertSame($diff / YEAR, $obj->getYears(true));
+        $this->assertSame($diff / MONTH, $obj->getMonths(true));
+        $this->assertSame($diff / WEEK, $obj->getWeeks(true));
+        $this->assertSame($diff / DAY, $obj->getDays(true));
+        $this->assertSame($diff / HOUR, $obj->getHours(true));
+        $this->assertSame($diff / MINUTE, $obj->getMinutes(true));
+        $this->assertSame($diff / SECOND, $obj->getSeconds(true));
     }
 
     public function testHumanizeYearsSingle()
@@ -58,7 +58,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
 
         $diff = $current->difference('March 9, 2016 12:00:00', 'America/Chicago');
 
-        $this->assertEquals('1 year ago', $diff->humanize('en'));
+        $this->assertSame('1 year ago', $diff->humanize('en'));
     }
 
     public function testHumanizeYearsPlural()
@@ -66,7 +66,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017', 'America/Chicago');
         $diff    = $current->difference('March 9, 2014 12:00:00', 'America/Chicago');
 
-        $this->assertEquals('3 years ago', $diff->humanize('en'));
+        $this->assertSame('3 years ago', $diff->humanize('en'));
     }
 
     public function testHumanizeYearsForward()
@@ -74,7 +74,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('January 1, 2017', 'America/Chicago');
         $diff    = $current->difference('January 1, 2018 12:00:00', 'America/Chicago');
 
-        $this->assertEquals('in 1 year', $diff->humanize('en'));
+        $this->assertSame('in 1 year', $diff->humanize('en'));
     }
 
     public function testHumanizeMonthsSingle()
@@ -82,7 +82,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017', 'America/Chicago');
         $diff    = $current->difference('February 9, 2017', 'America/Chicago');
 
-        $this->assertEquals('1 month ago', $diff->humanize('en'));
+        $this->assertSame('1 month ago', $diff->humanize('en'));
     }
 
     public function testHumanizeMonthsPlural()
@@ -90,7 +90,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 1, 2017', 'America/Chicago');
         $diff    = $current->difference('January 1, 2017', 'America/Chicago');
 
-        $this->assertEquals('2 months ago', $diff->humanize('en'));
+        $this->assertSame('2 months ago', $diff->humanize('en'));
     }
 
     public function testHumanizeMonthsForward()
@@ -98,7 +98,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 1, 2017', 'America/Chicago');
         $diff    = $current->difference('May 1, 2017', 'America/Chicago');
 
-        $this->assertEquals('in 1 month', $diff->humanize('en'));
+        $this->assertSame('in 1 month', $diff->humanize('en'));
     }
 
     public function testHumanizeDaysSingle()
@@ -106,7 +106,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017', 'America/Chicago');
         $diff    = $current->difference('March 9, 2017', 'America/Chicago');
 
-        $this->assertEquals('1 day ago', $diff->humanize('en'));
+        $this->assertSame('1 day ago', $diff->humanize('en'));
     }
 
     public function testHumanizeDaysPlural()
@@ -114,7 +114,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017', 'America/Chicago');
         $diff    = $current->difference('March 8, 2017', 'America/Chicago');
 
-        $this->assertEquals('2 days ago', $diff->humanize('en'));
+        $this->assertSame('2 days ago', $diff->humanize('en'));
     }
 
     public function testHumanizeDaysForward()
@@ -122,7 +122,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017', 'America/Chicago');
         $diff    = $current->difference('March 11, 2017', 'America/Chicago');
 
-        $this->assertEquals('in 1 day', $diff->humanize('en'));
+        $this->assertSame('in 1 day', $diff->humanize('en'));
     }
 
     public function testHumanizeHoursSingle()
@@ -130,7 +130,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017 12:00', 'America/Chicago');
         $diff    = $current->difference('March 10, 2017 11:00', 'America/Chicago');
 
-        $this->assertEquals('1 hour ago', $diff->humanize('en'));
+        $this->assertSame('1 hour ago', $diff->humanize('en'));
     }
 
     public function testHumanizeHoursPlural()
@@ -138,7 +138,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017 12:00', 'America/Chicago');
         $diff    = $current->difference('March 10, 2017 10:00', 'America/Chicago');
 
-        $this->assertEquals('2 hours ago', $diff->humanize('en'));
+        $this->assertSame('2 hours ago', $diff->humanize('en'));
     }
 
     public function testHumanizeHoursForward()
@@ -146,7 +146,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017 12:00', 'America/Chicago');
         $diff    = $current->difference('March 10, 2017 13:00', 'America/Chicago');
 
-        $this->assertEquals('in 1 hour', $diff->humanize('en'));
+        $this->assertSame('in 1 hour', $diff->humanize('en'));
     }
 
     public function testHumanizeMinutesSingle()
@@ -154,7 +154,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017 12:30', 'America/Chicago');
         $diff    = $current->difference('March 10, 2017 12:29', 'America/Chicago');
 
-        $this->assertEquals('1 minute ago', $diff->humanize('en'));
+        $this->assertSame('1 minute ago', $diff->humanize('en'));
     }
 
     public function testHumanizeMinutesPlural()
@@ -162,7 +162,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017 12:30', 'America/Chicago');
         $diff    = $current->difference('March 10, 2017 12:28', 'America/Chicago');
 
-        $this->assertEquals('2 minutes ago', $diff->humanize('en'));
+        $this->assertSame('2 minutes ago', $diff->humanize('en'));
     }
 
     public function testHumanizeMinutesForward()
@@ -170,7 +170,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017 12:30', 'America/Chicago');
         $diff    = $current->difference('March 10, 2017 12:31', 'America/Chicago');
 
-        $this->assertEquals('in 1 minute', $diff->humanize('en'));
+        $this->assertSame('in 1 minute', $diff->humanize('en'));
     }
 
     public function testHumanizeWeeksSingle()
@@ -178,7 +178,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017', 'America/Chicago');
         $diff    = $current->difference('March 2, 2017', 'America/Chicago');
 
-        $this->assertEquals('1 week ago', $diff->humanize('en'));
+        $this->assertSame('1 week ago', $diff->humanize('en'));
     }
 
     public function testHumanizeWeeksPlural()
@@ -186,7 +186,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 30, 2017', 'America/Chicago');
         $diff    = $current->difference('March 15, 2017', 'America/Chicago');
 
-        $this->assertEquals('2 weeks ago', $diff->humanize('en'));
+        $this->assertSame('2 weeks ago', $diff->humanize('en'));
     }
 
     public function testHumanizeWeeksForward()
@@ -194,7 +194,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017', 'America/Chicago');
         $diff    = $current->difference('March 18, 2017', 'America/Chicago');
 
-        $this->assertEquals('in 1 week', $diff->humanize('en'));
+        $this->assertSame('in 1 week', $diff->humanize('en'));
     }
 
     public function testHumanizeNoDifference()
@@ -202,7 +202,7 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017', 'America/Chicago');
         $diff    = $current->difference('March 10, 2017', 'America/Chicago');
 
-        $this->assertEquals('Just now', $diff->humanize('en'));
+        $this->assertSame('Just now', $diff->humanize('en'));
     }
 
     public function testGetterUTC()
@@ -210,9 +210,9 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $current = Time::parse('March 10, 2017', 'UTC');
         $diff    = $current->difference('March 18, 2017', 'UTC');
 
-        $this->assertEquals(8, $diff->getDays());
-        $this->assertEquals(8, $diff->days);
-        $this->assertEquals(-8, (int) round($diff->getDays(true)));
+        $this->assertSame(8, $diff->getDays());
+        $this->assertSame(8, $diff->days);
+        $this->assertSame(-8, (int) round($diff->getDays(true)));
         $this->assertNull($diff->nonsense);
     }
 
@@ -222,11 +222,11 @@ final class TimeDifferenceTest extends CIUnitTestCase
         $diff    = $current->difference('March 18, 2017', 'America/Chicago');
 
         // Daylight Saving Time had begun since Sun, 12 Mar, 02:00.
-        $this->assertEquals(7, $diff->getDays());
-        $this->assertEquals(7, $diff->days);
+        $this->assertSame(7, $diff->getDays());
+        $this->assertSame(7, $diff->days);
 
         // The raw value does not take Daylight Saving Time into account.
-        $this->assertEquals(-8, (int) round($diff->getDays(true)));
+        $this->assertSame(-8, (int) round($diff->getDays(true)));
         $this->assertNull($diff->nonsense);
     }
 

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -35,7 +35,7 @@ final class TimeTest extends CIUnitTestCase
 
         $time = new Time(null, 'America/Chicago');
 
-        $this->assertEquals($formatter->format($time), (string) $time);
+        $this->assertSame($formatter->format($time), (string) $time);
     }
 
     public function testTimeWithTimezone()
@@ -51,7 +51,7 @@ final class TimeTest extends CIUnitTestCase
 
         $time = new Time('now', 'Europe/London');
 
-        $this->assertEquals($formatter->format($time), (string) $time);
+        $this->assertSame($formatter->format($time), (string) $time);
     }
 
     public function testTimeWithTimezoneAndLocale()
@@ -67,7 +67,7 @@ final class TimeTest extends CIUnitTestCase
 
         $time = new Time('now', 'Europe/London', 'fr_FR');
 
-        $this->assertEquals($formatter->format($time), (string) $time);
+        $this->assertSame($formatter->format($time), (string) $time);
     }
 
     public function testTimeWithDateTimeZone()
@@ -83,7 +83,7 @@ final class TimeTest extends CIUnitTestCase
 
         $time = new Time('now', new \DateTimeZone('Europe/London'), 'fr_FR');
 
-        $this->assertEquals($formatter->format($time), (string) $time);
+        $this->assertSame($formatter->format($time), (string) $time);
     }
 
     public function testToDateTime()
@@ -101,7 +101,7 @@ final class TimeTest extends CIUnitTestCase
         $time1 = new \DateTime();
 
         $this->assertInstanceOf(Time::class, $time);
-        $this->assertEquals($time->getTimestamp(), $time1->getTimestamp());
+        $this->assertSame($time->getTimestamp(), $time1->getTimestamp());
     }
 
     public function testParse()
@@ -110,15 +110,15 @@ final class TimeTest extends CIUnitTestCase
         $time1 = new \DateTime('now', new \DateTimeZone('America/Chicago'));
         $time1->modify('next Tuesday');
 
-        $this->assertEquals($time->getTimestamp(), $time1->getTimestamp());
+        $this->assertSame($time->getTimestamp(), $time1->getTimestamp());
     }
 
     public function testToDateTimeString()
     {
         $time = Time::parse('2017-01-12 00:00', 'America/Chicago');
 
-        $this->assertEquals('2017-01-12 00:00:00', (string) $time);
-        $this->assertEquals('2017-01-12 00:00:00', $time->toDateTimeString());
+        $this->assertSame('2017-01-12 00:00:00', (string) $time);
+        $this->assertSame('2017-01-12 00:00:00', $time->toDateTimeString());
     }
 
     public function testToDateTimeStringWithTimeZone()
@@ -127,63 +127,63 @@ final class TimeTest extends CIUnitTestCase
 
         $expects = new \DateTime('2017-01-12', new \DateTimeZone('Europe/London'));
 
-        $this->assertEquals($expects->format('Y-m-d H:i:s'), $time->toDateTimeString());
+        $this->assertSame($expects->format('Y-m-d H:i:s'), $time->toDateTimeString());
     }
 
     public function testToday()
     {
         $time = Time::today();
 
-        $this->assertEquals(date('Y-m-d 00:00:00'), $time->toDateTimeString());
+        $this->assertSame(date('Y-m-d 00:00:00'), $time->toDateTimeString());
     }
 
     public function testTodayLocalized()
     {
         $time = Time::today('Europe/London');
 
-        $this->assertEquals(date('Y-m-d 00:00:00'), $time->toDateTimeString());
+        $this->assertSame(date('Y-m-d 00:00:00'), $time->toDateTimeString());
     }
 
     public function testYesterday()
     {
         $time = Time::yesterday();
 
-        $this->assertEquals(date('Y-m-d 00:00:00', strtotime('-1 day')), $time->toDateTimeString());
+        $this->assertSame(date('Y-m-d 00:00:00', strtotime('-1 day')), $time->toDateTimeString());
     }
 
     public function testTomorrow()
     {
         $time = Time::tomorrow();
 
-        $this->assertEquals(date('Y-m-d 00:00:00', strtotime('+1 day')), $time->toDateTimeString());
+        $this->assertSame(date('Y-m-d 00:00:00', strtotime('+1 day')), $time->toDateTimeString());
     }
 
     public function testCreateFromDate()
     {
         $time = Time::createFromDate(2017, 03, 05, 'America/Chicago');
 
-        $this->assertEquals(date('Y-m-d 00:00:00', strtotime('2017-03-05 00:00:00')), $time->toDateTimeString());
+        $this->assertSame(date('Y-m-d 00:00:00', strtotime('2017-03-05 00:00:00')), $time->toDateTimeString());
     }
 
     public function testCreateFromDateLocalized()
     {
         $time = Time::createFromDate(2017, 03, 05, 'Europe/London');
 
-        $this->assertEquals(date('Y-m-d 00:00:00', strtotime('2017-03-05 00:00:00')), $time->toDateTimeString());
+        $this->assertSame(date('Y-m-d 00:00:00', strtotime('2017-03-05 00:00:00')), $time->toDateTimeString());
     }
 
     public function testCreateFromTime()
     {
         $time = Time::createFromTime(10, 03, 05, 'America/Chicago');
 
-        $this->assertEquals(date('Y-m-d 10:03:05'), $time->toDateTimeString());
+        $this->assertSame(date('Y-m-d 10:03:05'), $time->toDateTimeString());
     }
 
     public function testCreateFromTimeEvening()
     {
         $time = Time::createFromTime(20, 03, 05, 'America/Chicago');
 
-        $this->assertEquals(date('Y-m-d 20:03:05'), $time->toDateTimeString());
+        $this->assertSame(date('Y-m-d 20:03:05'), $time->toDateTimeString());
     }
 
     public function testCreateFromTimeLocalized()
@@ -242,7 +242,7 @@ final class TimeTest extends CIUnitTestCase
 
         $time = Time::createFromTimestamp($timestamp);
 
-        $this->assertEquals(date('2017-03-18 00:00:00'), $time->toDateTimeString());
+        $this->assertSame(date('2017-03-18 00:00:00'), $time->toDateTimeString());
     }
 
     public function testTestNow()
@@ -254,7 +254,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow($t);
 
         $this->assertTrue(Time::hasTestNow());
-        $this->assertEquals('2000-01-02 00:00:00', Time::now()->toDateTimeString());
+        $this->assertSame('2000-01-02 00:00:00', Time::now()->toDateTimeString());
 
         Time::setTestNow();
         $this->assertCloseEnoughString(date('Y-m-d H:i:s', time()), Time::now()->toDateTimeString());
@@ -283,71 +283,71 @@ final class TimeTest extends CIUnitTestCase
         $time  = Time::parse('January 1, 2016');
         $time2 = Time::parse('December 31, 2019');
 
-        $this->assertEquals(2016, $time->year);
-        $this->assertEquals(2019, $time2->year);
+        $this->assertSame('2016', $time->year);
+        $this->assertSame('2019', $time2->year);
     }
 
     public function testGetMonth()
     {
         $time = Time::parse('August 1, 2016');
 
-        $this->assertEquals(8, $time->month);
+        $this->assertSame('8', $time->month);
     }
 
     public function testGetDay()
     {
         $time = Time::parse('August 12, 2016');
 
-        $this->assertEquals(12, $time->day);
+        $this->assertSame('12', $time->day);
     }
 
     public function testGetHour()
     {
         $time = Time::parse('August 12, 2016 4:15pm');
 
-        $this->assertEquals(16, $time->hour);
+        $this->assertSame('16', $time->hour);
     }
 
     public function testGetMinute()
     {
         $time = Time::parse('August 12, 2016 4:15pm');
 
-        $this->assertEquals(15, $time->minute);
+        $this->assertSame('15', $time->minute);
     }
 
     public function testGetSecond()
     {
         $time = Time::parse('August 12, 2016 4:15:23pm');
 
-        $this->assertEquals(23, $time->second);
+        $this->assertSame('23', $time->second);
     }
 
     public function testGetDayOfWeek()
     {
         $time = Time::parse('August 12, 2016 4:15:23pm');
 
-        $this->assertEquals(6, $time->dayOfWeek);
+        $this->assertSame('6', $time->dayOfWeek);
     }
 
     public function testGetDayOfYear()
     {
         $time = Time::parse('August 12, 2016 4:15:23pm');
 
-        $this->assertEquals(225, $time->dayOfYear);
+        $this->assertSame('225', $time->dayOfYear);
     }
 
     public function testGetWeekOfMonth()
     {
         $time = Time::parse('August 12, 2016 4:15:23pm');
 
-        $this->assertEquals(2, $time->weekOfMonth);
+        $this->assertSame('2', $time->weekOfMonth);
     }
 
     public function testGetWeekOfYear()
     {
         $time = Time::parse('August 12, 2016 4:15:23pm');
 
-        $this->assertEquals(33, $time->weekOfYear);
+        $this->assertSame('33', $time->weekOfYear);
     }
 
     public function testGetTimestamp()
@@ -355,32 +355,32 @@ final class TimeTest extends CIUnitTestCase
         $time     = Time::parse('August 12, 2016 4:15:23pm');
         $expected = strtotime('August 12, 2016 4:15:23pm');
 
-        $this->assertEquals($expected, $time->timestamp);
+        $this->assertSame($expected, $time->timestamp);
     }
 
     public function testGetAge()
     {
         $time = Time::parse('5 years ago');
-        $this->assertEquals(5, $time->age);
+        $this->assertSame(5, $time->age);
     }
 
     public function testAgeNow()
     {
         $time = new Time();
-        $this->assertEquals(0, $time->age);
+        $this->assertSame(0, $time->age);
     }
 
     public function testAgeFuture()
     {
         $time = Time::parse('August 12, 2116 4:15:23pm');
-        $this->assertEquals(0, $time->age);
+        $this->assertSame(0, $time->age);
     }
 
     public function testGetQuarter()
     {
         $time = Time::parse('April 15, 2015');
 
-        $this->assertEquals(2, $time->quarter);
+        $this->assertSame('2', $time->quarter);
     }
 
     public function testGetDST()
@@ -422,8 +422,8 @@ final class TimeTest extends CIUnitTestCase
 
     public function testGetTimezonename()
     {
-        $this->assertEquals('America/Chicago', Time::now('America/Chicago')->getTimezoneName());
-        $this->assertEquals('Europe/London', Time::now('Europe/London')->timezoneName);
+        $this->assertSame('America/Chicago', Time::now('America/Chicago')->getTimezoneName());
+        $this->assertSame('Europe/London', Time::now('Europe/London')->timezoneName);
     }
 
     public function testSetYear()
@@ -433,7 +433,7 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Time::class, $time2);
         $this->assertNotSame($time, $time2);
-        $this->assertEquals('2015-05-10 00:00:00', $time2->toDateTimeString());
+        $this->assertSame('2015-05-10 00:00:00', $time2->toDateTimeString());
     }
 
     public function testSetMonthNumber()
@@ -443,7 +443,7 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Time::class, $time2);
         $this->assertNotSame($time, $time2);
-        $this->assertEquals('2017-04-10 00:00:00', $time2->toDateTimeString());
+        $this->assertSame('2017-04-10 00:00:00', $time2->toDateTimeString());
     }
 
     public function testSetMonthLongName()
@@ -453,7 +453,7 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Time::class, $time2);
         $this->assertNotSame($time, $time2);
-        $this->assertEquals('2017-04-10 00:00:00', $time2->toDateTimeString());
+        $this->assertSame('2017-04-10 00:00:00', $time2->toDateTimeString());
     }
 
     public function testSetMonthShortName()
@@ -463,7 +463,7 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Time::class, $time2);
         $this->assertNotSame($time, $time2);
-        $this->assertEquals('2017-02-10 00:00:00', $time2->toDateTimeString());
+        $this->assertSame('2017-02-10 00:00:00', $time2->toDateTimeString());
     }
 
     public function testSetDay()
@@ -473,7 +473,7 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Time::class, $time2);
         $this->assertNotSame($time, $time2);
-        $this->assertEquals('2017-05-15 00:00:00', $time2->toDateTimeString());
+        $this->assertSame('2017-05-15 00:00:00', $time2->toDateTimeString());
     }
 
     public function testSetDayOverMaxInCurrentMonth()
@@ -491,7 +491,7 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Time::class, $time2);
         $this->assertNotSame($time, $time2);
-        $this->assertEquals('2012-02-29 00:00:00', $time2->toDateTimeString());
+        $this->assertSame('2012-02-29 00:00:00', $time2->toDateTimeString());
     }
 
     public function testSetHour()
@@ -501,7 +501,7 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Time::class, $time2);
         $this->assertNotSame($time, $time2);
-        $this->assertEquals('2017-05-10 15:00:00', $time2->toDateTimeString());
+        $this->assertSame('2017-05-10 15:00:00', $time2->toDateTimeString());
     }
 
     public function testSetMinute()
@@ -511,7 +511,7 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Time::class, $time2);
         $this->assertNotSame($time, $time2);
-        $this->assertEquals('2017-05-10 00:30:00', $time2->toDateTimeString());
+        $this->assertSame('2017-05-10 00:30:00', $time2->toDateTimeString());
     }
 
     public function testSetSecond()
@@ -521,7 +521,7 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Time::class, $time2);
         $this->assertNotSame($time, $time2);
-        $this->assertEquals('2017-05-10 00:00:20', $time2->toDateTimeString());
+        $this->assertSame('2017-05-10 00:00:20', $time2->toDateTimeString());
     }
 
     public function testSetMonthTooSmall()
@@ -611,8 +611,8 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Time::class, $time2);
         $this->assertNotSame($time, $time2);
-        $this->assertEquals('America/Chicago', $time->getTimezoneName());
-        $this->assertEquals('Europe/London', $time2->getTimezoneName());
+        $this->assertSame('America/Chicago', $time->getTimezoneName());
+        $this->assertSame('Europe/London', $time2->getTimezoneName());
     }
 
     public function testSetTimestamp()
@@ -623,19 +623,19 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Time::class, $time2);
         $this->assertNotSame($time, $time2);
-        $this->assertEquals('2017-04-01 00:00:00', $time2->toDateTimeString());
+        $this->assertSame('2017-04-01 00:00:00', $time2->toDateTimeString());
     }
 
     public function testToDateString()
     {
         $time = Time::parse('May 10, 2017', 'America/Chicago');
-        $this->assertEquals('2017-05-10', $time->toDateString());
+        $this->assertSame('2017-05-10', $time->toDateString());
     }
 
     public function testToFormattedDateString()
     {
         $time = Time::parse('2017-05-10', 'America/Chicago');
-        $this->assertEquals('May 10, 2017', $time->toFormattedDateString());
+        $this->assertSame('May 10, 2017', $time->toFormattedDateString());
     }
 
     /**
@@ -654,7 +654,7 @@ final class TimeTest extends CIUnitTestCase
     public function testToTimeString()
     {
         $time = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
-        $this->assertEquals('13:20:33', $time->toTimeString());
+        $this->assertSame('13:20:33', $time->toTimeString());
     }
 
     //--------------------------------------------------------------------
@@ -665,104 +665,104 @@ final class TimeTest extends CIUnitTestCase
     {
         $time    = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
         $newTime = $time->addSeconds(10);
-        $this->assertEquals('2017-01-10 13:20:33', $time->toDateTimeString());
-        $this->assertEquals('2017-01-10 13:20:43', $newTime->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:33', $time->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:43', $newTime->toDateTimeString());
     }
 
     public function testCanAddMinutes()
     {
         $time    = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
         $newTime = $time->addMinutes(10);
-        $this->assertEquals('2017-01-10 13:20:33', $time->toDateTimeString());
-        $this->assertEquals('2017-01-10 13:30:33', $newTime->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:33', $time->toDateTimeString());
+        $this->assertSame('2017-01-10 13:30:33', $newTime->toDateTimeString());
     }
 
     public function testCanAddHours()
     {
         $time    = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
         $newTime = $time->addHours(3);
-        $this->assertEquals('2017-01-10 13:20:33', $time->toDateTimeString());
-        $this->assertEquals('2017-01-10 16:20:33', $newTime->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:33', $time->toDateTimeString());
+        $this->assertSame('2017-01-10 16:20:33', $newTime->toDateTimeString());
     }
 
     public function testCanAddDays()
     {
         $time    = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
         $newTime = $time->addDays(3);
-        $this->assertEquals('2017-01-10 13:20:33', $time->toDateTimeString());
-        $this->assertEquals('2017-01-13 13:20:33', $newTime->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:33', $time->toDateTimeString());
+        $this->assertSame('2017-01-13 13:20:33', $newTime->toDateTimeString());
     }
 
     public function testCanAddMonths()
     {
         $time    = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
         $newTime = $time->addMonths(3);
-        $this->assertEquals('2017-01-10 13:20:33', $time->toDateTimeString());
-        $this->assertEquals('2017-04-10 13:20:33', $newTime->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:33', $time->toDateTimeString());
+        $this->assertSame('2017-04-10 13:20:33', $newTime->toDateTimeString());
     }
 
     public function testCanAddMonthsOverYearBoundary()
     {
         $time    = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
         $newTime = $time->addMonths(13);
-        $this->assertEquals('2017-01-10 13:20:33', $time->toDateTimeString());
-        $this->assertEquals('2018-02-10 13:20:33', $newTime->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:33', $time->toDateTimeString());
+        $this->assertSame('2018-02-10 13:20:33', $newTime->toDateTimeString());
     }
 
     public function testCanAddYears()
     {
         $time    = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
         $newTime = $time->addYears(3);
-        $this->assertEquals('2017-01-10 13:20:33', $time->toDateTimeString());
-        $this->assertEquals('2020-01-10 13:20:33', $newTime->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:33', $time->toDateTimeString());
+        $this->assertSame('2020-01-10 13:20:33', $newTime->toDateTimeString());
     }
 
     public function testCanSubtractSeconds()
     {
         $time    = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
         $newTime = $time->subSeconds(10);
-        $this->assertEquals('2017-01-10 13:20:33', $time->toDateTimeString());
-        $this->assertEquals('2017-01-10 13:20:23', $newTime->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:33', $time->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:23', $newTime->toDateTimeString());
     }
 
     public function testCanSubtractMinutes()
     {
         $time    = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
         $newTime = $time->subMinutes(10);
-        $this->assertEquals('2017-01-10 13:20:33', $time->toDateTimeString());
-        $this->assertEquals('2017-01-10 13:10:33', $newTime->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:33', $time->toDateTimeString());
+        $this->assertSame('2017-01-10 13:10:33', $newTime->toDateTimeString());
     }
 
     public function testCanSubtractHours()
     {
         $time    = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
         $newTime = $time->subHours(3);
-        $this->assertEquals('2017-01-10 13:20:33', $time->toDateTimeString());
-        $this->assertEquals('2017-01-10 10:20:33', $newTime->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:33', $time->toDateTimeString());
+        $this->assertSame('2017-01-10 10:20:33', $newTime->toDateTimeString());
     }
 
     public function testCanSubtractDays()
     {
         $time    = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
         $newTime = $time->subDays(3);
-        $this->assertEquals('2017-01-10 13:20:33', $time->toDateTimeString());
-        $this->assertEquals('2017-01-07 13:20:33', $newTime->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:33', $time->toDateTimeString());
+        $this->assertSame('2017-01-07 13:20:33', $newTime->toDateTimeString());
     }
 
     public function testCanSubtractMonths()
     {
         $time    = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
         $newTime = $time->subMonths(3);
-        $this->assertEquals('2017-01-10 13:20:33', $time->toDateTimeString());
-        $this->assertEquals('2016-10-10 13:20:33', $newTime->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:33', $time->toDateTimeString());
+        $this->assertSame('2016-10-10 13:20:33', $newTime->toDateTimeString());
     }
 
     public function testCanSubtractYears()
     {
         $time    = Time::parse('January 10, 2017 13:20:33', 'America/Chicago');
         $newTime = $time->subYears(3);
-        $this->assertEquals('2017-01-10 13:20:33', $time->toDateTimeString());
-        $this->assertEquals('2014-01-10 13:20:33', $newTime->toDateTimeString());
+        $this->assertSame('2017-01-10 13:20:33', $time->toDateTimeString());
+        $this->assertSame('2014-01-10 13:20:33', $newTime->toDateTimeString());
     }
 
     //--------------------------------------------------------------------
@@ -868,7 +868,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017', 'America/Chicago');
         $time = Time::parse('March 9, 2016 12:00:00', 'America/Chicago');
 
-        $this->assertEquals('1 year ago', $time->humanize());
+        $this->assertSame('1 year ago', $time->humanize());
     }
 
     public function testHumanizeYearsPlural()
@@ -876,7 +876,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017', 'America/Chicago');
         $time = Time::parse('March 9, 2014 12:00:00', 'America/Chicago');
 
-        $this->assertEquals('3 years ago', $time->humanize());
+        $this->assertSame('3 years ago', $time->humanize());
     }
 
     public function testHumanizeYearsForward()
@@ -884,7 +884,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('January 1, 2017', 'America/Chicago');
         $time = Time::parse('January 1, 2018 12:00:00', 'America/Chicago');
 
-        $this->assertEquals('in 1 year', $time->humanize());
+        $this->assertSame('in 1 year', $time->humanize());
     }
 
     public function testHumanizeMonthsSingle()
@@ -892,7 +892,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017', 'America/Chicago');
         $time = Time::parse('February 9, 2017', 'America/Chicago');
 
-        $this->assertEquals('1 month ago', $time->humanize());
+        $this->assertSame('1 month ago', $time->humanize());
     }
 
     public function testHumanizeMonthsPlural()
@@ -900,7 +900,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 1, 2017', 'America/Chicago');
         $time = Time::parse('January 1, 2017', 'America/Chicago');
 
-        $this->assertEquals('2 months ago', $time->humanize());
+        $this->assertSame('2 months ago', $time->humanize());
     }
 
     public function testHumanizeMonthsForward()
@@ -908,7 +908,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 1, 2017', 'America/Chicago');
         $time = Time::parse('April 1, 2017', 'America/Chicago');
 
-        $this->assertEquals('in 1 month', $time->humanize());
+        $this->assertSame('in 1 month', $time->humanize());
     }
 
     public function testHumanizeDaysSingle()
@@ -916,7 +916,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017', 'America/Chicago');
         $time = Time::parse('March 8, 2017', 'America/Chicago');
 
-        $this->assertEquals('2 days ago', $time->humanize());
+        $this->assertSame('2 days ago', $time->humanize());
     }
 
     public function testHumanizeDaysPlural()
@@ -924,7 +924,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017', 'America/Chicago');
         $time = Time::parse('March 8, 2017', 'America/Chicago');
 
-        $this->assertEquals('2 days ago', $time->humanize());
+        $this->assertSame('2 days ago', $time->humanize());
     }
 
     public function testHumanizeDaysForward()
@@ -932,7 +932,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017', 'America/Chicago');
         $time = Time::parse('March 12, 2017', 'America/Chicago');
 
-        $this->assertEquals('in 2 days', $time->humanize());
+        $this->assertSame('in 2 days', $time->humanize());
     }
 
     public function testHumanizeDaysTomorrow()
@@ -940,7 +940,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017', 'America/Chicago');
         $time = Time::parse('March 11, 2017', 'America/Chicago');
 
-        $this->assertEquals('Tomorrow', $time->humanize());
+        $this->assertSame('Tomorrow', $time->humanize());
     }
 
     public function testHumanizeDaysYesterday()
@@ -948,7 +948,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017', 'America/Chicago');
         $time = Time::parse('March 9, 2017', 'America/Chicago');
 
-        $this->assertEquals('Yesterday', $time->humanize());
+        $this->assertSame('Yesterday', $time->humanize());
     }
 
     public function testHumanizeHoursAsTime()
@@ -956,7 +956,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017 12:00', 'America/Chicago');
         $time = Time::parse('March 10, 2017 14:00', 'America/Chicago');
 
-        $this->assertEquals('in 2 hours', $time->humanize());
+        $this->assertSame('in 2 hours', $time->humanize());
     }
 
     public function testHumanizeHoursAWhileAgo()
@@ -964,7 +964,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017 12:00', 'America/Chicago');
         $time = Time::parse('March 10, 2017 8:00', 'America/Chicago');
 
-        $this->assertEquals('4 hours ago', $time->humanize());
+        $this->assertSame('4 hours ago', $time->humanize());
     }
 
     public function testHumanizeMinutesSingle()
@@ -972,7 +972,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017 12:30', 'America/Chicago');
         $time = Time::parse('March 10, 2017 12:29', 'America/Chicago');
 
-        $this->assertEquals('1 minute ago', $time->humanize());
+        $this->assertSame('1 minute ago', $time->humanize());
     }
 
     public function testHumanizeMinutesPlural()
@@ -980,7 +980,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017 12:30', 'America/Chicago');
         $time = Time::parse('March 10, 2017 12:28', 'America/Chicago');
 
-        $this->assertEquals('2 minutes ago', $time->humanize());
+        $this->assertSame('2 minutes ago', $time->humanize());
     }
 
     public function testHumanizeMinutesForward()
@@ -988,7 +988,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017 12:30', 'America/Chicago');
         $time = Time::parse('March 10, 2017 12:31', 'America/Chicago');
 
-        $this->assertEquals('in 1 minute', $time->humanize());
+        $this->assertSame('in 1 minute', $time->humanize());
     }
 
     public function testHumanizeWeeksSingle()
@@ -996,7 +996,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017', 'America/Chicago');
         $time = Time::parse('March 2, 2017', 'America/Chicago');
 
-        $this->assertEquals('1 week ago', $time->humanize());
+        $this->assertSame('1 week ago', $time->humanize());
     }
 
     public function testHumanizeWeeksPlural()
@@ -1004,7 +1004,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 30, 2017', 'America/Chicago');
         $time = Time::parse('March 15, 2017', 'America/Chicago');
 
-        $this->assertEquals('2 weeks ago', $time->humanize());
+        $this->assertSame('2 weeks ago', $time->humanize());
     }
 
     public function testHumanizeWeeksForward()
@@ -1012,7 +1012,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017', 'America/Chicago');
         $time = Time::parse('March 18, 2017', 'America/Chicago');
 
-        $this->assertEquals('in 2 weeks', $time->humanize());
+        $this->assertSame('in 2 weeks', $time->humanize());
     }
 
     public function testHumanizeNow()
@@ -1020,18 +1020,16 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('March 10, 2017', 'America/Chicago');
         $time = Time::parse('March 10, 2017', 'America/Chicago');
 
-        $this->assertEquals('Just now', $time->humanize());
+        $this->assertSame('Just now', $time->humanize());
     }
 
     public function testSetTimezoneDate()
     {
         $time  = Time::parse('13 May 2020 10:00', 'GMT');
         $time2 = $time->setTimezone('GMT+8');
-        $this->assertEquals('2020-05-13 10:00:00', $time->toDateTimeString());
-        $this->assertEquals('2020-05-13 18:00:00', $time2->toDateTimeString());
+        $this->assertSame('2020-05-13 10:00:00', $time->toDateTimeString());
+        $this->assertSame('2020-05-13 18:00:00', $time2->toDateTimeString());
     }
-
-    //--------------------------------------------------------------------
 
     public function testCreateFromInstance()
     {
@@ -1056,6 +1054,6 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Time::class, $time2);
         $this->assertTrue($time2->equals($time1));
-        $this->assertEquals($time1, $time2);
+        $this->assertNotSame($time1, $time2);
     }
 }

--- a/tests/system/Images/BaseHandlerTest.php
+++ b/tests/system/Images/BaseHandlerTest.php
@@ -64,8 +64,8 @@ final class BaseHandlerTest extends CIUnitTestCase
 
         $image = $handler->getFile();
         $this->assertTrue($image instanceof Image);
-        $this->assertEquals(155, $image->origWidth);
-        $this->assertEquals($path, $image->getPathname());
+        $this->assertSame(155, $image->origWidth);
+        $this->assertSame($path, $image->getPathname());
     }
 
     public function testMissingFile()
@@ -116,6 +116,6 @@ final class BaseHandlerTest extends CIUnitTestCase
     {
         $handler = Services::image('gd', null, false);
         $handler->withFile($this->path);
-        $this->assertEquals($this->path, $handler->getPathname());
+        $this->assertSame($this->path, $handler->getPathname());
     }
 }

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -63,15 +63,15 @@ final class GDHandlerTest extends CIUnitTestCase
         $file  = $this->handler->getFile();
         $props = $file->getProperties(true);
 
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(155, $props['width']);
-        $this->assertEquals(155, $file->origWidth);
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(155, $props['width']);
+        $this->assertSame(155, $file->origWidth);
 
-        $this->assertEquals(200, $this->handler->getHeight());
-        $this->assertEquals(200, $props['height']);
-        $this->assertEquals(200, $file->origHeight);
+        $this->assertSame(200, $this->handler->getHeight());
+        $this->assertSame(200, $props['height']);
+        $this->assertSame(200, $file->origHeight);
 
-        $this->assertEquals('width="155" height="200"', $props['size_str']);
+        $this->assertSame('width="155" height="200"', $props['size_str']);
     }
 
     public function testImageTypeProperties()
@@ -80,8 +80,8 @@ final class GDHandlerTest extends CIUnitTestCase
         $file  = $this->handler->getFile();
         $props = $file->getProperties(true);
 
-        $this->assertEquals(IMAGETYPE_PNG, $props['image_type']);
-        $this->assertEquals('image/png', $props['mime_type']);
+        $this->assertSame(IMAGETYPE_PNG, $props['image_type']);
+        $this->assertSame('image/png', $props['mime_type']);
     }
 
     //--------------------------------------------------------------------
@@ -90,40 +90,40 @@ final class GDHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->resize(155, 200); // 155x200 result
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     public function testResizeAbsolute()
     {
         $this->handler->withFile($this->path);
         $this->handler->resize(123, 456, false); // 123x456 result
-        $this->assertEquals(123, $this->handler->getWidth());
-        $this->assertEquals(456, $this->handler->getHeight());
+        $this->assertSame(123, $this->handler->getWidth());
+        $this->assertSame(456, $this->handler->getHeight());
     }
 
     public function testResizeAspect()
     {
         $this->handler->withFile($this->path);
         $this->handler->resize(123, 456, true); // 123x159 result
-        $this->assertEquals(123, $this->handler->getWidth());
-        $this->assertEquals(159, $this->handler->getHeight());
+        $this->assertSame(123, $this->handler->getWidth());
+        $this->assertSame(159, $this->handler->getHeight());
     }
 
     public function testResizeAspectWidth()
     {
         $this->handler->withFile($this->path);
         $this->handler->resize(123, 0, true); // 123x159 result
-        $this->assertEquals(123, $this->handler->getWidth());
-        $this->assertEquals(159, $this->handler->getHeight());
+        $this->assertSame(123, $this->handler->getWidth());
+        $this->assertSame(159, $this->handler->getHeight());
     }
 
     public function testResizeAspectHeight()
     {
         $this->handler->withFile($this->path);
         $this->handler->resize(0, 456, true); // 354x456 result
-        $this->assertEquals(354, $this->handler->getWidth());
-        $this->assertEquals(456, $this->handler->getHeight());
+        $this->assertSame(354, $this->handler->getWidth());
+        $this->assertSame(456, $this->handler->getHeight());
     }
 
     //--------------------------------------------------------------------
@@ -132,48 +132,48 @@ final class GDHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->crop(100, 100); // 100x100 result
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(100, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(100, $this->handler->getHeight());
     }
 
     public function testCropMiddle()
     {
         $this->handler->withFile($this->path);
         $this->handler->crop(100, 100, 50, 50, false); // 100x100 result
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(100, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(100, $this->handler->getHeight());
     }
 
     public function testCropMiddlePreserved()
     {
         $this->handler->withFile($this->path);
         $this->handler->crop(100, 100, 50, 50, true); // 78x100 result
-        $this->assertEquals(78, $this->handler->getWidth());
-        $this->assertEquals(100, $this->handler->getHeight());
+        $this->assertSame(78, $this->handler->getWidth());
+        $this->assertSame(100, $this->handler->getHeight());
     }
 
     public function testCropTopLeftPreserveAspect()
     {
         $this->handler->withFile($this->path);
         $this->handler->crop(100, 100); // 100x100 result
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(100, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(100, $this->handler->getHeight());
     }
 
     public function testCropNothing()
     {
         $this->handler->withFile($this->path);
         $this->handler->crop(155, 200); // 155x200 result
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     public function testCropOutOfBounds()
     {
         $this->handler->withFile($this->path);
         $this->handler->crop(100, 100, 100); // 55x100 result in 100x100
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(100, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(100, $this->handler->getHeight());
     }
 
     //--------------------------------------------------------------------
@@ -181,16 +181,16 @@ final class GDHandlerTest extends CIUnitTestCase
     public function testRotate()
     {
         $this->handler->withFile($this->path); // 155x200
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
 
         // first rotation
         $this->handler->rotate(90); // 200x155
-        $this->assertEquals(200, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getWidth());
 
         // check image size again after another rotation
         $this->handler->rotate(180); // 200x155
-        $this->assertEquals(200, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getWidth());
     }
 
     public function testRotateBadAngle()
@@ -206,8 +206,8 @@ final class GDHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->flatten();
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     //--------------------------------------------------------------------
@@ -216,24 +216,24 @@ final class GDHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->flip();
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     public function testHorizontal()
     {
         $this->handler->withFile($this->path);
         $this->handler->flip('horizontal');
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     public function testFlipVertical()
     {
         $this->handler->withFile($this->path);
         $this->handler->flip('vertical');
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     public function testFlipUnknown()
@@ -248,24 +248,24 @@ final class GDHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->fit(100, 100);
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(100, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(100, $this->handler->getHeight());
     }
 
     public function testFitTaller()
     {
         $this->handler->withFile($this->path);
         $this->handler->fit(100, 400);
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(400, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(400, $this->handler->getHeight());
     }
 
     public function testFitAutoHeight()
     {
         $this->handler->withFile($this->path);
         $this->handler->fit(100);
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(129, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(129, $this->handler->getHeight());
     }
 
     public function testFitPositions()
@@ -285,8 +285,8 @@ final class GDHandlerTest extends CIUnitTestCase
 
         foreach ($choices as $position) {
             $this->handler->fit(100, 100, $position);
-            $this->assertEquals(100, $this->handler->getWidth(), 'Position ' . $position . ' failed');
-            $this->assertEquals(100, $this->handler->getHeight(), 'Position ' . $position . ' failed');
+            $this->assertSame(100, $this->handler->getWidth(), 'Position ' . $position . ' failed');
+            $this->assertSame(100, $this->handler->getHeight(), 'Position ' . $position . ' failed');
         }
     }
 
@@ -296,8 +296,8 @@ final class GDHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->text('vertical', ['hAlign' => 'right', 'vAlign' => 'bottom']);
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     //--------------------------------------------------------------------
@@ -306,8 +306,8 @@ final class GDHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->text('vertical', ['vAlign' => 'middle', 'withShadow' => 'sure', 'shadowOffset' => 3]);
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     //--------------------------------------------------------------------
@@ -322,8 +322,8 @@ final class GDHandlerTest extends CIUnitTestCase
 
             $this->handler->withFile($this->origin . 'ci-logo.' . $type);
             $this->handler->text('vertical');
-            $this->assertEquals(155, $this->handler->getWidth());
-            $this->assertEquals(200, $this->handler->getHeight());
+            $this->assertSame(155, $this->handler->getWidth());
+            $this->assertSame(200, $this->handler->getHeight());
         }
     }
 
@@ -341,7 +341,7 @@ final class GDHandlerTest extends CIUnitTestCase
             $this->handler->save($this->start . 'work/ci-logo.' . $type);
             $this->assertTrue($this->root->hasChild('work/ci-logo.' . $type));
 
-            $this->assertNotEquals(
+            $this->assertNotSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
                 $this->root->getChild('work/ci-logo.' . $type)->getContent()
             );
@@ -355,7 +355,7 @@ final class GDHandlerTest extends CIUnitTestCase
             $this->handler->save(null, 100);
             $this->assertFileExists($this->origin . 'ci-logo.' . $type);
 
-            $this->assertEquals(
+            $this->assertSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
                 file_get_contents($this->origin . 'ci-logo.' . $type)
             );
@@ -375,7 +375,7 @@ final class GDHandlerTest extends CIUnitTestCase
             $this->handler->save($this->start . 'work/ci-logo.' . $type);
             $this->assertTrue($this->root->hasChild('work/ci-logo.' . $type));
 
-            $this->assertNotEquals(
+            $this->assertNotSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
                 $this->root->getChild('work/ci-logo.' . $type)->getContent()
             );
@@ -396,7 +396,7 @@ final class GDHandlerTest extends CIUnitTestCase
 
             $this->assertTrue($this->root->hasChild('work/ci-logo.' . $type));
 
-            $this->assertNotEquals(
+            $this->assertNotSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
                 $this->root->getChild('work/ci-logo.' . $type)->getContent()
             );
@@ -409,7 +409,7 @@ final class GDHandlerTest extends CIUnitTestCase
         $this->handler->getResource(); // make sure resource is loaded
         $this->handler->convert(IMAGETYPE_PNG);
         $this->handler->save($this->start . 'work/ci-logo.png');
-        $this->assertEquals(exif_imagetype($this->start . 'work/ci-logo.png'), IMAGETYPE_PNG);
+        $this->assertSame(exif_imagetype($this->start . 'work/ci-logo.png'), IMAGETYPE_PNG);
     }
 
     public function testImageReorientLandscape()
@@ -424,7 +424,7 @@ final class GDHandlerTest extends CIUnitTestCase
             $point    = imagecolorat($resource, 0, 0);
             $rgb      = imagecolorsforindex($resource, $point);
 
-            $this->assertEquals(['red' => 62, 'green' => 62, 'blue' => 62, 'alpha' => 0], $rgb);
+            $this->assertSame(['red' => 62, 'green' => 62, 'blue' => 62, 'alpha' => 0], $rgb);
         }
     }
 
@@ -440,7 +440,7 @@ final class GDHandlerTest extends CIUnitTestCase
             $point    = imagecolorat($resource, 0, 0);
             $rgb      = imagecolorsforindex($resource, $point);
 
-            $this->assertEquals(['red' => 62, 'green' => 62, 'blue' => 62, 'alpha' => 0], $rgb);
+            $this->assertSame(['red' => 62, 'green' => 62, 'blue' => 62, 'alpha' => 0], $rgb);
         }
     }
 }

--- a/tests/system/Images/ImageMagickHandlerTest.php
+++ b/tests/system/Images/ImageMagickHandlerTest.php
@@ -61,15 +61,15 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
         $file  = $this->handler->getFile();
         $props = $file->getProperties(true);
 
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(155, $props['width']);
-        $this->assertEquals(155, $file->origWidth);
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(155, $props['width']);
+        $this->assertSame(155, $file->origWidth);
 
-        $this->assertEquals(200, $this->handler->getHeight());
-        $this->assertEquals(200, $props['height']);
-        $this->assertEquals(200, $file->origHeight);
+        $this->assertSame(200, $this->handler->getHeight());
+        $this->assertSame(200, $props['height']);
+        $this->assertSame(200, $file->origHeight);
 
-        $this->assertEquals('width="155" height="200"', $props['size_str']);
+        $this->assertSame('width="155" height="200"', $props['size_str']);
     }
 
     public function testImageTypeProperties()
@@ -78,8 +78,8 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
         $file  = $this->handler->getFile();
         $props = $file->getProperties(true);
 
-        $this->assertEquals(IMAGETYPE_PNG, $props['image_type']);
-        $this->assertEquals('image/png', $props['mime_type']);
+        $this->assertSame(IMAGETYPE_PNG, $props['image_type']);
+        $this->assertSame('image/png', $props['mime_type']);
     }
 
     //--------------------------------------------------------------------
@@ -88,40 +88,40 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->resize(155, 200); // 155x200 result
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     public function testResizeAbsolute()
     {
         $this->handler->withFile($this->path);
         $this->handler->resize(123, 456, false); // 123x456 result
-        $this->assertEquals(123, $this->handler->getWidth());
-        $this->assertEquals(456, $this->handler->getHeight());
+        $this->assertSame(123, $this->handler->getWidth());
+        $this->assertSame(456, $this->handler->getHeight());
     }
 
     public function testResizeAspect()
     {
         $this->handler->withFile($this->path);
         $this->handler->resize(123, 456, true); // 123x159 result
-        $this->assertEquals(123, $this->handler->getWidth());
-        $this->assertEquals(159, $this->handler->getHeight());
+        $this->assertSame(123, $this->handler->getWidth());
+        $this->assertSame(159, $this->handler->getHeight());
     }
 
     public function testResizeAspectWidth()
     {
         $this->handler->withFile($this->path);
         $this->handler->resize(123, 0, true); // 123x159 result
-        $this->assertEquals(123, $this->handler->getWidth());
-        $this->assertEquals(159, $this->handler->getHeight());
+        $this->assertSame(123, $this->handler->getWidth());
+        $this->assertSame(159, $this->handler->getHeight());
     }
 
     public function testResizeAspectHeight()
     {
         $this->handler->withFile($this->path);
         $this->handler->resize(0, 456, true); // 353x456 result
-        $this->assertEquals(353, $this->handler->getWidth());
-        $this->assertEquals(456, $this->handler->getHeight());
+        $this->assertSame(353, $this->handler->getWidth());
+        $this->assertSame(456, $this->handler->getHeight());
     }
 
     //--------------------------------------------------------------------
@@ -130,48 +130,48 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->crop(100, 100); // 100x100 result
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(100, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(100, $this->handler->getHeight());
     }
 
     public function testCropMiddle()
     {
         $this->handler->withFile($this->path);
         $this->handler->crop(100, 100, 50, 50, false); // 100x100 result
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(100, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(100, $this->handler->getHeight());
     }
 
     public function testCropMiddlePreserved()
     {
         $this->handler->withFile($this->path);
         $this->handler->crop(100, 100, 50, 50, true); // 78x100 result
-        $this->assertEquals(78, $this->handler->getWidth());
-        $this->assertEquals(100, $this->handler->getHeight());
+        $this->assertSame(78, $this->handler->getWidth());
+        $this->assertSame(100, $this->handler->getHeight());
     }
 
     public function testCropTopLeftPreserveAspect()
     {
         $this->handler->withFile($this->path);
         $this->handler->crop(100, 100); // 100x100 result
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(100, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(100, $this->handler->getHeight());
     }
 
     public function testCropNothing()
     {
         $this->handler->withFile($this->path);
         $this->handler->crop(155, 200); // 155x200 result
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     public function testCropOutOfBounds()
     {
         $this->handler->withFile($this->path);
         $this->handler->crop(100, 100, 100); // 55x100 result in 100x100
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(100, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(100, $this->handler->getHeight());
     }
 
     //--------------------------------------------------------------------
@@ -179,16 +179,16 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
     public function testRotate()
     {
         $this->handler->withFile($this->path); // 155x200
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
 
         // first rotation
         $this->handler->rotate(90); // 200x155
-        $this->assertEquals(200, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getWidth());
 
         // check image size again after another rotation
         $this->handler->rotate(180); // 200x155
-        $this->assertEquals(200, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getWidth());
     }
 
     public function testRotateBadAngle()
@@ -204,8 +204,8 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->flatten();
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     //--------------------------------------------------------------------
@@ -214,24 +214,24 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->flip();
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     public function testHorizontal()
     {
         $this->handler->withFile($this->path);
         $this->handler->flip('horizontal');
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     public function testFlipVertical()
     {
         $this->handler->withFile($this->path);
         $this->handler->flip('vertical');
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     public function testFlipUnknown()
@@ -246,24 +246,24 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->fit(100, 100);
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(100, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(100, $this->handler->getHeight());
     }
 
     public function testFitTaller()
     {
         $this->handler->withFile($this->path);
         $this->handler->fit(100, 400);
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(400, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(400, $this->handler->getHeight());
     }
 
     public function testFitAutoHeight()
     {
         $this->handler->withFile($this->path);
         $this->handler->fit(100);
-        $this->assertEquals(100, $this->handler->getWidth());
-        $this->assertEquals(129, $this->handler->getHeight());
+        $this->assertSame(100, $this->handler->getWidth());
+        $this->assertSame(129, $this->handler->getHeight());
     }
 
     public function testFitPositions()
@@ -283,8 +283,8 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
 
         foreach ($choices as $position) {
             $this->handler->fit(100, 100, $position);
-            $this->assertEquals(100, $this->handler->getWidth(), 'Position ' . $position . ' failed');
-            $this->assertEquals(100, $this->handler->getHeight(), 'Position ' . $position . ' failed');
+            $this->assertSame(100, $this->handler->getWidth(), 'Position ' . $position . ' failed');
+            $this->assertSame(100, $this->handler->getHeight(), 'Position ' . $position . ' failed');
         }
     }
 
@@ -294,8 +294,8 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->text('vertical', ['hAlign' => 'right', 'vAlign' => 'bottom']);
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     //--------------------------------------------------------------------
@@ -304,8 +304,8 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
     {
         $this->handler->withFile($this->path);
         $this->handler->text('vertical', ['vAlign' => 'middle', 'withShadow' => 'sure', 'shadowOffset' => 3]);
-        $this->assertEquals(155, $this->handler->getWidth());
-        $this->assertEquals(200, $this->handler->getHeight());
+        $this->assertSame(155, $this->handler->getWidth());
+        $this->assertSame(200, $this->handler->getHeight());
     }
 
     //--------------------------------------------------------------------
@@ -320,8 +320,8 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
 
             $this->handler->withFile($this->origin . 'ci-logo.' . $type);
             $this->handler->text('vertical');
-            $this->assertEquals(155, $this->handler->getWidth());
-            $this->assertEquals(200, $this->handler->getHeight());
+            $this->assertSame(155, $this->handler->getWidth());
+            $this->assertSame(200, $this->handler->getHeight());
         }
     }
 
@@ -339,7 +339,7 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
             $this->handler->save($this->root . 'ci-logo.' . $type);
             $this->assertFileExists($this->root . 'ci-logo.' . $type);
 
-            $this->assertNotEquals(
+            $this->assertNotSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
                 file_get_contents($this->root . 'ci-logo.' . $type)
             );
@@ -353,7 +353,7 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
             $this->handler->save(null, 100);
             $this->assertFileExists($this->origin . 'ci-logo.' . $type);
 
-            $this->assertEquals(
+            $this->assertSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
                 file_get_contents($this->origin . 'ci-logo.' . $type)
             );
@@ -373,7 +373,7 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
             $this->handler->save($this->root . 'ci-logo.' . $type);
             $this->assertFileExists($this->root . 'ci-logo.' . $type);
 
-            $this->assertNotEquals(
+            $this->assertNotSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
                 file_get_contents($this->root . 'ci-logo.' . $type)
             );
@@ -394,7 +394,7 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
 
             $this->assertFileExists($this->root . 'ci-logo.' . $type);
 
-            $this->assertNotEquals(
+            $this->assertNotSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
                 file_get_contents($this->root . 'ci-logo.' . $type)
             );
@@ -407,7 +407,7 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
         $this->handler->getResource(); // make sure resource is loaded
         $this->handler->convert(IMAGETYPE_PNG);
         $this->handler->save($this->root . 'ci-logo.png');
-        $this->assertEquals(exif_imagetype($this->root . 'ci-logo.png'), IMAGETYPE_PNG);
+        $this->assertSame(exif_imagetype($this->root . 'ci-logo.png'), IMAGETYPE_PNG);
     }
 
     public function testImageReorientLandscape()
@@ -425,7 +425,7 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
 
             $this->handler->save($result);
 
-            $this->assertEquals(['red' => 62, 'green' => 62, 'blue' => 62, 'alpha' => 0], $rgb);
+            $this->assertSame(['red' => 62, 'green' => 62, 'blue' => 62, 'alpha' => 0], $rgb);
         }
     }
 
@@ -444,7 +444,7 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
 
             $this->handler->save($result);
 
-            $this->assertEquals(['red' => 62, 'green' => 62, 'blue' => 62, 'alpha' => 0], $rgb);
+            $this->assertSame(['red' => 62, 'green' => 62, 'blue' => 62, 'alpha' => 0], $rgb);
         }
     }
 }

--- a/tests/system/Images/ImageTest.php
+++ b/tests/system/Images/ImageTest.php
@@ -36,10 +36,10 @@ final class ImageTest extends CIUnitTestCase
 
     public function testBasicPropertiesInherited()
     {
-        $this->assertEquals('ci-logo.png', $this->image->getFilename());
-        $this->assertEquals($this->start . 'ci-logo.png', $this->image->getPathname());
-        $this->assertEquals($this->root->url(), $this->image->getPath());
-        $this->assertEquals('ci-logo.png', $this->image->getBasename());
+        $this->assertSame('ci-logo.png', $this->image->getFilename());
+        $this->assertSame($this->start . 'ci-logo.png', $this->image->getPathname());
+        $this->assertSame($this->root->url(), $this->image->getPath());
+        $this->assertSame('ci-logo.png', $this->image->getBasename());
     }
 
     public function testGetProperties()
@@ -52,7 +52,7 @@ final class ImageTest extends CIUnitTestCase
             'mime_type'  => 'image/png',
         ];
 
-        $this->assertEquals($expected, $this->image->getProperties(true));
+        $this->assertSame($expected, $this->image->getProperties(true));
     }
 
     public function testExtractProperties()
@@ -60,11 +60,11 @@ final class ImageTest extends CIUnitTestCase
         // extract properties from the image
         $this->assertTrue($this->image->getProperties(false));
 
-        $this->assertEquals(155, $this->image->origWidth);
-        $this->assertEquals(200, $this->image->origHeight);
-        $this->assertEquals(IMAGETYPE_PNG, $this->image->imageType);
-        $this->assertEquals('width="155" height="200"', $this->image->sizeStr);
-        $this->assertEquals('image/png', $this->image->mime);
+        $this->assertSame(155, $this->image->origWidth);
+        $this->assertSame(200, $this->image->origHeight);
+        $this->assertSame(IMAGETYPE_PNG, $this->image->imageType);
+        $this->assertSame('width="155" height="200"', $this->image->sizeStr);
+        $this->assertSame('image/png', $this->image->mime);
     }
 
     public function testCopyDefaultName()

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -24,7 +24,7 @@ final class LanguageTest extends CIUnitTestCase
 
     public function testReturnsStringWithNoFileInMessage()
     {
-        $this->assertEquals('something', $this->lang->getLine('something'));
+        $this->assertSame('something', $this->lang->getLine('something'));
     }
 
     /**
@@ -49,7 +49,7 @@ final class LanguageTest extends CIUnitTestCase
             'booksSaved' => 'We saved some more',
         ]);
 
-        $this->assertEquals('We saved some more', $this->lang->getLine('books.booksSaved'));
+        $this->assertSame('We saved some more', $this->lang->getLine('books.booksSaved'));
     }
 
     //--------------------------------------------------------------------
@@ -69,11 +69,11 @@ final class LanguageTest extends CIUnitTestCase
                 'slowcoach' => 'slowpoke',
             ], 'en-US');
 
-        $this->assertEquals('lay of the land', $this->lang->getLine('equivalent.lieOfLand'));
-        $this->assertEquals('slowpoke', $this->lang->getLine('equivalent.slowcoach'));
-        $this->assertEquals('a new lease of life', $this->lang->getLine('equivalent.leaseOfLife'));
-        $this->assertEquals('touch wood', $this->lang->getLine('equivalent.touchWood'));
-        $this->assertEquals('equivalent.unknown', $this->lang->getLine('equivalent.unknown'));
+        $this->assertSame('lay of the land', $this->lang->getLine('equivalent.lieOfLand'));
+        $this->assertSame('slowpoke', $this->lang->getLine('equivalent.slowcoach'));
+        $this->assertSame('a new lease of life', $this->lang->getLine('equivalent.leaseOfLife'));
+        $this->assertSame('touch wood', $this->lang->getLine('equivalent.touchWood'));
+        $this->assertSame('equivalent.unknown', $this->lang->getLine('equivalent.unknown'));
     }
 
     //--------------------------------------------------------------------
@@ -87,7 +87,7 @@ final class LanguageTest extends CIUnitTestCase
             ],
         ]);
 
-        $this->assertEquals([
+        $this->assertSame([
             'The Boogeyman',
             'We Saved',
         ], $this->lang->getLine('books.booksList'));
@@ -106,7 +106,7 @@ final class LanguageTest extends CIUnitTestCase
             'bookCount' => '{0, number, integer} books have been saved.',
         ]);
 
-        $this->assertEquals('45 books have been saved.', $this->lang->getLine('books.bookCount', [91 / 2]));
+        $this->assertSame('45 books have been saved.', $this->lang->getLine('books.bookCount', [91 / 2]));
     }
 
     //--------------------------------------------------------------------
@@ -124,7 +124,7 @@ final class LanguageTest extends CIUnitTestCase
             ],
         ]);
 
-        $this->assertEquals(['45 related books.'], $this->lang->getLine('books.bookList', [91 / 2]));
+        $this->assertSame(['45 related books.'], $this->lang->getLine('books.bookList', [91 / 2]));
     }
 
     //--------------------------------------------------------------------
@@ -137,8 +137,8 @@ final class LanguageTest extends CIUnitTestCase
         $str1 = lang('Language.languageGetLineInvalidArgumentException', [], 'en');
         $str2 = lang('Language.languageGetLineInvalidArgumentException', [], 'ru');
 
-        $this->assertEquals('Get line must be a string or array of strings.', $str1);
-        $this->assertEquals('Whatever this would be, translated', $str2);
+        $this->assertSame('Get line must be a string or array of strings.', $str1);
+        $this->assertSame('Whatever this would be, translated', $str2);
     }
 
     //--------------------------------------------------------------------
@@ -153,7 +153,7 @@ final class LanguageTest extends CIUnitTestCase
             ],
         ]);
 
-        $this->assertEquals(['{0, number, integer} related books.'], $this->lang->getLine('books.bookList', [15]));
+        $this->assertSame(['{0, number, integer} related books.'], $this->lang->getLine('books.bookList', [15]));
     }
 
     //--------------------------------------------------------------------
@@ -161,10 +161,10 @@ final class LanguageTest extends CIUnitTestCase
     public function testLanguageDuplicateKey()
     {
         $this->lang = new Language('en');
-        $this->assertEquals('These are not the droids you are looking for', $this->lang->getLine('More.strongForce', []));
-        $this->assertEquals('I have a very bad feeling about this', $this->lang->getLine('More.cannotMove', []));
-        $this->assertEquals('Could not move file {0} to {1} ({2}).', $this->lang->getLine('Files.cannotMove', []));
-        $this->assertEquals('I have a very bad feeling about this', $this->lang->getLine('More.cannotMove', []));
+        $this->assertSame('These are not the droids you are looking for', $this->lang->getLine('More.strongForce', []));
+        $this->assertSame('I have a very bad feeling about this', $this->lang->getLine('More.cannotMove', []));
+        $this->assertSame('Could not move file {0} to {1} ({2}).', $this->lang->getLine('Files.cannotMove', []));
+        $this->assertSame('I have a very bad feeling about this', $this->lang->getLine('More.cannotMove', []));
     }
 
     //--------------------------------------------------------------------
@@ -203,12 +203,12 @@ final class LanguageTest extends CIUnitTestCase
         $this->lang->setData('example', ['message' => 'This is an example message']);
 
         // force loading data into file Example
-        $this->assertEquals('This is an example message', $this->lang->getLine('example.message'));
+        $this->assertSame('This is an example message', $this->lang->getLine('example.message'));
 
         // second file data | another.example
         $this->lang->setData('another', ['example' => 'Another example']);
 
-        $this->assertEquals('Another example', $this->lang->getLine('another.example'));
+        $this->assertSame('Another example', $this->lang->getLine('another.example'));
     }
 
     //--------------------------------------------------------------------
@@ -216,7 +216,7 @@ final class LanguageTest extends CIUnitTestCase
     public function testGetLocale()
     {
         $this->lang = Services::language('en', false);
-        $this->assertEquals('en', $this->lang->getLocale());
+        $this->assertSame('en', $this->lang->getLocale());
     }
 
     //--------------------------------------------------------------------
@@ -225,9 +225,9 @@ final class LanguageTest extends CIUnitTestCase
     {
         // this should load the replacement bundle of messages
         $message = lang('Core.missingExtension', [], 'en');
-        $this->assertEquals('The framework needs the following extension(s) installed and loaded: {0}.', $message);
+        $this->assertSame('The framework needs the following extension(s) installed and loaded: {0}.', $message);
         // and we should have our new message too
-        $this->assertEquals('billions and billions', lang('Core.bazillion', [], 'en'));
+        $this->assertSame('billions and billions', lang('Core.bazillion', [], 'en'));
     }
 
     //--------------------------------------------------------------------
@@ -277,16 +277,16 @@ final class LanguageTest extends CIUnitTestCase
     {
         $this->lang = Services::language('en-ZZ', false);
         // key is in both base and variant; should pick variant
-        $this->assertEquals("It's made of cheese", $this->lang->getLine('More.notaMoon'));
+        $this->assertSame("It's made of cheese", $this->lang->getLine('More.notaMoon'));
 
         // key is in base but not variant; should pick base
-        $this->assertEquals('I have a very bad feeling about this', $this->lang->getLine('More.cannotMove'));
+        $this->assertSame('I have a very bad feeling about this', $this->lang->getLine('More.cannotMove'));
 
         // key is in variant but not base; should pick variant
-        $this->assertEquals('There is no try', $this->lang->getLine('More.wisdom'));
+        $this->assertSame('There is no try', $this->lang->getLine('More.wisdom'));
 
         // key isn't in either base or variant; should return bad key
-        $this->assertEquals('More.shootMe', $this->lang->getLine('More.shootMe'));
+        $this->assertSame('More.shootMe', $this->lang->getLine('More.shootMe'));
     }
 
     //--------------------------------------------------------------------
@@ -307,14 +307,14 @@ final class LanguageTest extends CIUnitTestCase
     public function testAllTheWayFallbacks()
     {
         $this->lang = Services::language('ab-CD', false);
-        $this->assertEquals('Allin.none', $this->lang->getLine('Allin.none'));
-        $this->assertEquals('Pyramid of Giza', $this->lang->getLine('Allin.one'));
-        $this->assertEquals('gluttony', $this->lang->getLine('Allin.two'));
-        $this->assertEquals('Colossus of Rhodes', $this->lang->getLine('Allin.tre'));
-        $this->assertEquals('four calling birds', $this->lang->getLine('Allin.for'));
-        $this->assertEquals('Temple of Artemis', $this->lang->getLine('Allin.fiv'));
-        $this->assertEquals('envy', $this->lang->getLine('Allin.six'));
-        $this->assertEquals('Hanging Gardens of Babylon', $this->lang->getLine('Allin.sev'));
+        $this->assertSame('Allin.none', $this->lang->getLine('Allin.none'));
+        $this->assertSame('Pyramid of Giza', $this->lang->getLine('Allin.one'));
+        $this->assertSame('gluttony', $this->lang->getLine('Allin.two'));
+        $this->assertSame('Colossus of Rhodes', $this->lang->getLine('Allin.tre'));
+        $this->assertSame('four calling birds', $this->lang->getLine('Allin.for'));
+        $this->assertSame('Temple of Artemis', $this->lang->getLine('Allin.fiv'));
+        $this->assertSame('envy', $this->lang->getLine('Allin.six'));
+        $this->assertSame('Hanging Gardens of Babylon', $this->lang->getLine('Allin.sev'));
     }
 
     public function testLanguageNestedArrayDefinition()
@@ -322,7 +322,7 @@ final class LanguageTest extends CIUnitTestCase
         $this->lang = new SecondMockLanguage('en');
         $this->lang->loadem('Nested', 'en');
 
-        $this->assertEquals('e', $this->lang->getLine('Nested.a.b.c.d'));
+        $this->assertSame('e', $this->lang->getLine('Nested.a.b.c.d'));
     }
 
     public function testLanguageKeySeparatedByDot()
@@ -330,7 +330,7 @@ final class LanguageTest extends CIUnitTestCase
         $this->lang = new SecondMockLanguage('en');
         $this->lang->loadem('Foo', 'en');
 
-        $this->assertEquals('The fieldname field is very short.', $this->lang->getLine('Foo.bar.min_length1', ['field' => 'fieldname']));
-        $this->assertEquals('The fieldname field is very short.', $this->lang->getLine('Foo.baz.min_length3.short', ['field' => 'fieldname']));
+        $this->assertSame('The fieldname field is very short.', $this->lang->getLine('Foo.bar.min_length1', ['field' => 'fieldname']));
+        $this->assertSame('The fieldname field is very short.', $this->lang->getLine('Foo.baz.min_length3.short', ['field' => 'fieldname']));
     }
 }

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -69,7 +69,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -103,7 +103,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -122,7 +122,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -141,7 +141,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -160,7 +160,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -178,7 +178,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -198,7 +198,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -255,7 +255,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -272,7 +272,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -289,7 +289,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -306,7 +306,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -323,7 +323,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -340,7 +340,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -357,7 +357,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -374,7 +374,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -391,7 +391,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertEquals($expected, $logs[0]);
+        $this->assertSame($expected, $logs[0]);
     }
 
     //--------------------------------------------------------------------
@@ -420,7 +420,7 @@ final class LoggerTest extends CIUnitTestCase
         $ohoh     = APPPATH . 'LoggerTest';
         $expected = 'APPPATH/LoggerTest';
 
-        $this->assertEquals($expected, $logger->cleanup($ohoh));
+        $this->assertSame($expected, $logger->cleanup($ohoh));
     }
 
     //--------------------------------------------------------------------
@@ -435,6 +435,6 @@ final class LoggerTest extends CIUnitTestCase
             'unknown',
         ];
 
-        $this->assertEquals($expected, $logger->determineFile());
+        $this->assertSame($expected, $logger->determineFile());
     }
 }

--- a/tests/system/Models/ValidationModelTest.php
+++ b/tests/system/Models/ValidationModelTest.php
@@ -30,7 +30,7 @@ final class ValidationModelTest extends LiveModelTestCase
         $this->assertIsInt($this->model->insert($data));
 
         $errors = $this->model->errors();
-        $this->assertEquals([], $errors);
+        $this->assertSame([], $errors);
     }
 
     public function testValidationBasics(): void

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -59,7 +59,7 @@ final class PagerRendererTest extends CIUnitTestCase
         $pager->setSurroundCount(2);
 
         $this->assertTrue($pager->hasPrevious());
-        $this->assertEquals('http://example.com/foo?foo=bar&page=2', $pager->getPrevious());
+        $this->assertSame('http://example.com/foo?foo=bar&page=2', $pager->getPrevious());
     }
 
     //--------------------------------------------------------------------
@@ -80,7 +80,7 @@ final class PagerRendererTest extends CIUnitTestCase
         $pager->setSurroundCount(0);
 
         $this->assertTrue($pager->hasPrevious());
-        $this->assertEquals('http://example.com/foo?foo=bar&page=3', $pager->getPrevious());
+        $this->assertSame('http://example.com/foo?foo=bar&page=3', $pager->getPrevious());
     }
 
     //--------------------------------------------------------------------
@@ -121,7 +121,7 @@ final class PagerRendererTest extends CIUnitTestCase
         $pager->setSurroundCount(2);
 
         $this->assertTrue($pager->hasNext());
-        $this->assertEquals('http://example.com/foo?foo=bar&page=7', $pager->getNext());
+        $this->assertSame('http://example.com/foo?foo=bar&page=7', $pager->getNext());
     }
 
     //--------------------------------------------------------------------
@@ -142,7 +142,7 @@ final class PagerRendererTest extends CIUnitTestCase
         $pager->setSurroundCount(0);
 
         $this->assertTrue($pager->hasNext());
-        $this->assertEquals('http://example.com/foo?foo=bar&page=5', $pager->getNext());
+        $this->assertSame('http://example.com/foo?foo=bar&page=5', $pager->getNext());
     }
 
     //--------------------------------------------------------------------
@@ -177,7 +177,7 @@ final class PagerRendererTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $pager->links());
+        $this->assertSame($expected, $pager->links());
     }
 
     //--------------------------------------------------------------------
@@ -196,8 +196,8 @@ final class PagerRendererTest extends CIUnitTestCase
 
         $pager = new PagerRenderer($details);
 
-        $this->assertEquals('http://example.com/foo?foo=bar&page=1', $pager->getFirst());
-        $this->assertEquals('http://example.com/foo?foo=bar&page=50', $pager->getLast());
+        $this->assertSame('http://example.com/foo?foo=bar&page=1', $pager->getFirst());
+        $this->assertSame('http://example.com/foo?foo=bar&page=50', $pager->getLast());
     }
 
     //--------------------------------------------------------------------
@@ -216,7 +216,7 @@ final class PagerRendererTest extends CIUnitTestCase
 
         $pager = new PagerRenderer($details);
 
-        $this->assertEquals('http://example.com/foo?foo=bar&page=10', $pager->getCurrent());
+        $this->assertSame('http://example.com/foo?foo=bar&page=10', $pager->getCurrent());
     }
 
     //--------------------------------------------------------------------
@@ -236,7 +236,7 @@ final class PagerRendererTest extends CIUnitTestCase
 
         $pager = new PagerRenderer($details);
 
-        $this->assertEquals('http://example.com/foo/10?foo=bar', $pager->getCurrent());
+        $this->assertSame('http://example.com/foo/10?foo=bar', $pager->getCurrent());
     }
 
     //--------------------------------------------------------------------
@@ -260,13 +260,13 @@ final class PagerRendererTest extends CIUnitTestCase
 
         // with surropund count of 2
         $pager->setSurroundCount(2);
-        $this->assertEquals($this->expect . '1', $pager->getPrevious());
-        $this->assertEquals($this->expect . '7', $pager->getNext());
+        $this->assertSame($this->expect . '1', $pager->getPrevious());
+        $this->assertSame($this->expect . '7', $pager->getNext());
 
         // with unchanged surround count
         $pager->setSurroundCount();
-        $this->assertEquals($this->expect . '1', $pager->getPrevious());
-        $this->assertEquals($this->expect . '7', $pager->getNext());
+        $this->assertSame($this->expect . '1', $pager->getPrevious());
+        $this->assertSame($this->expect . '7', $pager->getNext());
 
         // and with huge surround count
         $pager->setSurroundCount(100);
@@ -310,7 +310,7 @@ final class PagerRendererTest extends CIUnitTestCase
         $pager->setSurroundCount(2);
 
         $this->assertTrue($pager->hasPrevious());
-        $this->assertEquals('http://example.com/foo/2?foo=bar', $pager->getPrevious());
+        $this->assertSame('http://example.com/foo/2?foo=bar', $pager->getPrevious());
     }
 
     //--------------------------------------------------------------------
@@ -332,7 +332,7 @@ final class PagerRendererTest extends CIUnitTestCase
         $pager->setSurroundCount(0);
 
         $this->assertTrue($pager->hasPrevious());
-        $this->assertEquals('http://example.com/foo/3?foo=bar', $pager->getPrevious());
+        $this->assertSame('http://example.com/foo/3?foo=bar', $pager->getPrevious());
     }
 
     //--------------------------------------------------------------------
@@ -375,7 +375,7 @@ final class PagerRendererTest extends CIUnitTestCase
         $pager->setSurroundCount(2);
 
         $this->assertTrue($pager->hasNext());
-        $this->assertEquals('http://example.com/foo/7?foo=bar', $pager->getNext());
+        $this->assertSame('http://example.com/foo/7?foo=bar', $pager->getNext());
     }
 
     //--------------------------------------------------------------------
@@ -397,7 +397,7 @@ final class PagerRendererTest extends CIUnitTestCase
         $pager->setSurroundCount(0);
 
         $this->assertTrue($pager->hasNext());
-        $this->assertEquals('http://example.com/foo/5?foo=bar', $pager->getNext());
+        $this->assertSame('http://example.com/foo/5?foo=bar', $pager->getNext());
     }
 
     //--------------------------------------------------------------------
@@ -433,7 +433,7 @@ final class PagerRendererTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $pager->links());
+        $this->assertSame($expected, $pager->links());
     }
 
     //--------------------------------------------------------------------
@@ -453,8 +453,8 @@ final class PagerRendererTest extends CIUnitTestCase
 
         $pager = new PagerRenderer($details);
 
-        $this->assertEquals('http://example.com/foo/1?foo=bar', $pager->getFirst());
-        $this->assertEquals('http://example.com/foo/50?foo=bar', $pager->getLast());
+        $this->assertSame('http://example.com/foo/1?foo=bar', $pager->getFirst());
+        $this->assertSame('http://example.com/foo/50?foo=bar', $pager->getLast());
     }
 
     //--------------------------------------------------------------------
@@ -508,7 +508,7 @@ final class PagerRendererTest extends CIUnitTestCase
 
         $this->assertNotNull($pager->getPreviousPage());
         $this->assertTrue($pager->hasPreviousPage());
-        $this->assertEquals('http://example.com/foo?page=2', $pager->getPreviousPage());
+        $this->assertSame('http://example.com/foo?page=2', $pager->getPreviousPage());
     }
 
     //--------------------------------------------------------------------
@@ -526,7 +526,7 @@ final class PagerRendererTest extends CIUnitTestCase
         ];
 
         $pager = new PagerRenderer($details);
-        $this->assertEquals('http://example.com/foo/2', $pager->getPreviousPage());
+        $this->assertSame('http://example.com/foo/2', $pager->getPreviousPage());
     }
 
     //--------------------------------------------------------------------
@@ -546,7 +546,7 @@ final class PagerRendererTest extends CIUnitTestCase
 
         $this->assertNotNull($pager->getNextPage());
         $this->assertTrue($pager->hasNextPage());
-        $this->assertEquals('http://example.com/foo?page=4', $pager->getNextPage());
+        $this->assertSame('http://example.com/foo?page=4', $pager->getNextPage());
     }
 
     public function testGetNextPageWithSegmentHigherThanZero()
@@ -562,7 +562,7 @@ final class PagerRendererTest extends CIUnitTestCase
         ];
 
         $pager = new PagerRenderer($details);
-        $this->assertEquals('http://example.com/foo/4', $pager->getNextPage());
+        $this->assertSame('http://example.com/foo/4', $pager->getNextPage());
     }
 
     public function testGetPageNumber()
@@ -576,10 +576,10 @@ final class PagerRendererTest extends CIUnitTestCase
         ];
         $pager = new PagerRenderer($details);
 
-        $this->assertEquals(1, $pager->getFirstPageNumber());
-        $this->assertEquals(3, $pager->getCurrentPageNumber());
-        $this->assertEquals(10, $pager->getLastPageNumber());
-        $this->assertEquals(10, $pager->getPageCount());
+        $this->assertSame(1, $pager->getFirstPageNumber());
+        $this->assertSame(3, $pager->getCurrentPageNumber());
+        $this->assertSame(10, $pager->getLastPageNumber());
+        $this->assertSame(10, $pager->getPageCount());
     }
 
     public function testGetPageNumberSetSurroundCount()
@@ -594,9 +594,9 @@ final class PagerRendererTest extends CIUnitTestCase
         $pager = new PagerRenderer($details);
         $pager->setSurroundCount(2);
 
-        $this->assertEquals(3, $pager->getFirstPageNumber());
-        $this->assertEquals(5, $pager->getCurrentPageNumber());
-        $this->assertEquals(7, $pager->getLastPageNumber());
+        $this->assertSame(3, $pager->getFirstPageNumber());
+        $this->assertSame(5, $pager->getCurrentPageNumber());
+        $this->assertSame(7, $pager->getLastPageNumber());
     }
 
     public function testGetPreviousPageNumber()
@@ -611,7 +611,7 @@ final class PagerRendererTest extends CIUnitTestCase
         $pager = new PagerRenderer($details);
         $pager->setSurroundCount(2);
 
-        $this->assertEquals(4, $pager->getPreviousPageNumber());
+        $this->assertSame(4, $pager->getPreviousPageNumber());
     }
 
     public function testGetPreviousPageNumberNull()
@@ -641,7 +641,7 @@ final class PagerRendererTest extends CIUnitTestCase
         $pager = new PagerRenderer($details);
         $pager->setSurroundCount(2);
 
-        $this->assertEquals(6, $pager->getNextPageNumber());
+        $this->assertSame(6, $pager->getNextPageNumber());
     }
 
     public function testGetNextPageNumberNull()

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -50,7 +50,7 @@ final class PagerTest extends CIUnitTestCase
 
         $details = $this->pager->getDetails();
 
-        $this->assertEquals('foo/bar', $details['uri']->getPath());
+        $this->assertSame('foo/bar', $details['uri']->getPath());
     }
 
     public function testGetDetailsRecognizesPageQueryVar()
@@ -62,7 +62,7 @@ final class PagerTest extends CIUnitTestCase
 
         $details = $this->pager->getDetails();
 
-        $this->assertEquals(2, $details['currentPage']);
+        $this->assertSame(2, $details['currentPage']);
     }
 
     public function testGetDetailsRecognizesGroupedPageQueryVar()
@@ -74,7 +74,7 @@ final class PagerTest extends CIUnitTestCase
 
         $details = $this->pager->getDetails('foo');
 
-        $this->assertEquals(2, $details['currentPage']);
+        $this->assertSame(2, $details['currentPage']);
     }
 
     public function testGetDetailsThrowExceptionIfGroupNotFound()
@@ -91,7 +91,7 @@ final class PagerTest extends CIUnitTestCase
 
         $details = $this->pager->getDetails('foo');
 
-        $this->assertEquals($this->config->perPage, $details['perPage']);
+        $this->assertSame($this->config->perPage, $details['perPage']);
     }
 
     public function testStoreDoesBasicCalcs()
@@ -100,9 +100,9 @@ final class PagerTest extends CIUnitTestCase
 
         $details = $this->pager->getDetails('foo');
 
-        $this->assertEquals($details['total'], 100);
-        $this->assertEquals($details['perPage'], 25);
-        $this->assertEquals($details['currentPage'], 3);
+        $this->assertSame($details['total'], 100);
+        $this->assertSame($details['perPage'], 25);
+        $this->assertSame($details['currentPage'], 3);
     }
 
     public function testStoreDoesBasicCalcsOnPerPageReadFromPagerConfig()
@@ -111,9 +111,9 @@ final class PagerTest extends CIUnitTestCase
 
         $details = $this->pager->getDetails('foo');
 
-        $this->assertEquals($details['total'], 100);
-        $this->assertEquals($details['perPage'], 20);
-        $this->assertEquals($details['currentPage'], 3);
+        $this->assertSame($details['total'], 100);
+        $this->assertSame($details['perPage'], 20);
+        $this->assertSame($details['currentPage'], 3);
     }
 
     public function testStoreAndHasMore()
@@ -137,10 +137,10 @@ final class PagerTest extends CIUnitTestCase
 
         $this->pager->store('default', 3, 25, 100);
 
-        $this->assertEquals('http://example.com/index.php?page=2&foo=bar', $this->pager->getPreviousPageURI());
-        $this->assertEquals('http://example.com/index.php?page=4&foo=bar', $this->pager->getNextPageURI());
-        $this->assertEquals('http://example.com/index.php?page=5&foo=bar', $this->pager->getPageURI(5));
-        $this->assertEquals(
+        $this->assertSame('http://example.com/index.php?page=2&foo=bar', $this->pager->getPreviousPageURI());
+        $this->assertSame('http://example.com/index.php?page=4&foo=bar', $this->pager->getNextPageURI());
+        $this->assertSame('http://example.com/index.php?page=5&foo=bar', $this->pager->getPageURI(5));
+        $this->assertSame(
             'http://example.com/index.php?foo=bar&page=5',
             $this->pager->only(['foo'])->getPageURI(5)
         );
@@ -153,10 +153,10 @@ final class PagerTest extends CIUnitTestCase
 
         $this->pager->store('default', 3, 25, 100, 1);
 
-        $this->assertEquals('http://example.com/2?page=3&foo=bar', $this->pager->getPreviousPageURI());
-        $this->assertEquals('http://example.com/4?page=3&foo=bar', $this->pager->getNextPageURI());
-        $this->assertEquals('http://example.com/5?page=3&foo=bar', $this->pager->getPageURI(5));
-        $this->assertEquals(
+        $this->assertSame('http://example.com/2?page=3&foo=bar', $this->pager->getPreviousPageURI());
+        $this->assertSame('http://example.com/4?page=3&foo=bar', $this->pager->getNextPageURI());
+        $this->assertSame('http://example.com/5?page=3&foo=bar', $this->pager->getPageURI(5));
+        $this->assertSame(
             'http://example.com/5?foo=bar',
             $this->pager->only(['foo'])->getPageURI(5)
         );
@@ -169,59 +169,59 @@ final class PagerTest extends CIUnitTestCase
 
     public function testPerPageHasDefaultValue()
     {
-        $this->assertEquals($this->config->perPage, $this->pager->getPerPage());
+        $this->assertSame($this->config->perPage, $this->pager->getPerPage());
     }
 
     public function testPerPageKeepsStoredValue()
     {
         $this->pager->store('foo', 3, 13, 70);
 
-        $this->assertEquals(13, $this->pager->getPerPage('foo'));
+        $this->assertSame(13, $this->pager->getPerPage('foo'));
     }
 
     public function testGetCurrentPageDefaultsToOne()
     {
-        $this->assertEquals(1, $this->pager->getCurrentPage());
+        $this->assertSame(1, $this->pager->getCurrentPage());
     }
 
     public function testGetCurrentPageRemembersStoredPage()
     {
         $this->pager->store('foo', 3, 13, 70);
 
-        $this->assertEquals(3, $this->pager->getCurrentPage('foo'));
+        $this->assertSame(3, $this->pager->getCurrentPage('foo'));
     }
 
     public function testGetCurrentPageDetectsURI()
     {
         $_GET['page'] = 2;
 
-        $this->assertEquals(2, $this->pager->getCurrentPage());
+        $this->assertSame(2, $this->pager->getCurrentPage());
     }
 
     public function testGetCurrentPageDetectsGroupedURI()
     {
         $_GET['page_foo'] = 2;
 
-        $this->assertEquals(2, $this->pager->getCurrentPage('foo'));
+        $this->assertSame(2, $this->pager->getCurrentPage('foo'));
     }
 
     public function testGetTotalPagesDefaultsToOne()
     {
-        $this->assertEquals(1, $this->pager->getPageCount());
+        $this->assertSame(1, $this->pager->getPageCount());
     }
 
     public function testGetTotalCorrectValue()
     {
         $this->pager->store('foo', 3, 12, 70);
 
-        $this->assertEquals(70, $this->pager->getTotal('foo'));
+        $this->assertSame(70, $this->pager->getTotal('foo'));
     }
 
     public function testGetTotalPagesCalcsCorrectValue()
     {
         $this->pager->store('foo', 3, 12, 70);
 
-        $this->assertEquals(6, $this->pager->getPageCount('foo'));
+        $this->assertSame(6, $this->pager->getPageCount('foo'));
     }
 
     public function testGetNextURIUsesCurrentURI()
@@ -233,7 +233,7 @@ final class PagerTest extends CIUnitTestCase
         $expected = current_url(true);
         $expected = (string) $expected->setQuery('page_foo=3');
 
-        $this->assertEquals((string) $expected, $this->pager->getNextPageURI('foo'));
+        $this->assertSame((string) $expected, $this->pager->getNextPageURI('foo'));
     }
 
     public function testGetNextURIReturnsNullOnLastPage()
@@ -250,7 +250,7 @@ final class PagerTest extends CIUnitTestCase
         $expected = current_url(true);
         $expected = (string) $expected->setQuery('page_foo=2');
 
-        $this->assertEquals($expected, $this->pager->getNextPageURI('foo'));
+        $this->assertSame($expected, $this->pager->getNextPageURI('foo'));
     }
 
     public function testGetPreviousURIUsesCurrentURI()
@@ -262,7 +262,7 @@ final class PagerTest extends CIUnitTestCase
         $expected = current_url(true);
         $expected = (string) $expected->setQuery('page_foo=1');
 
-        $this->assertEquals((string) $expected, $this->pager->getPreviousPageURI('foo'));
+        $this->assertSame((string) $expected, $this->pager->getPreviousPageURI('foo'));
     }
 
     public function testGetNextURIReturnsNullOnFirstPage()
@@ -284,7 +284,7 @@ final class PagerTest extends CIUnitTestCase
 
         $this->pager->store('foo', $_GET['page_foo'] - 1, 12, 70);
 
-        $this->assertEquals((string) $expected, $this->pager->getNextPageURI('foo'));
+        $this->assertSame((string) $expected, $this->pager->getNextPageURI('foo'));
     }
 
     public function testGetPreviousURIWithQueryStringUsesCurrentURI()
@@ -298,7 +298,7 @@ final class PagerTest extends CIUnitTestCase
 
         $this->pager->store('foo', $_GET['page_foo'] + 1, 12, 70);
 
-        $this->assertEquals((string) $expected, $this->pager->getPreviousPageURI('foo'));
+        $this->assertSame((string) $expected, $this->pager->getPreviousPageURI('foo'));
     }
 
     public function testGetOnlyQueries()
@@ -319,15 +319,15 @@ final class PagerTest extends CIUnitTestCase
 
         $uri = current_url(true);
 
-        $this->assertEquals(
+        $this->assertSame(
             $this->pager->only($onlyQueries)->getPreviousPageURI(),
             (string) $uri->setQuery('search=foo&order=asc&page=1')
         );
-        $this->assertEquals(
+        $this->assertSame(
             $this->pager->only($onlyQueries)->getNextPageURI(),
             (string) $uri->setQuery('search=foo&order=asc&page=3')
         );
-        $this->assertEquals(
+        $this->assertSame(
             $this->pager->only($onlyQueries)->getPageURI(4),
             (string) $uri->setQuery('search=foo&order=asc&page=4')
         );
@@ -445,18 +445,18 @@ final class PagerTest extends CIUnitTestCase
         $expected = current_url(true);
         $expected = (string) $expected->setQuery('page_foo=1');
 
-        $this->assertEquals((string) $expected, $this->pager->getPreviousPageURI('foo'));
+        $this->assertSame((string) $expected, $this->pager->getPreviousPageURI('foo'));
     }
 
     public function testAccessPageMoreThanPageCountGetLastPage()
     {
         $this->pager->store('default', 11, 1, 10);
-        $this->assertEquals(10, $this->pager->getCurrentPage());
+        $this->assertSame(10, $this->pager->getCurrentPage());
     }
 
     public function testSegmentOutOfBound()
     {
         $this->pager->store('default', 10, 1, 10, 1000);
-        $this->assertEquals(1, $this->pager->getCurrentPage());
+        $this->assertSame(1, $this->pager->getCurrentPage());
     }
 }

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -236,7 +236,7 @@ final class ResourceControllerTest extends CIUnitTestCase
 
         $resource->setModel('Something');
         $this->assertEmpty($resource->getModel());
-        $this->assertEquals('Something', $resource->getModelName());
+        $this->assertSame('Something', $resource->getModelName());
     }
 
     public function testModelByName()
@@ -244,7 +244,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $resource = new MockResourceController();
         $resource->setModel('\Tests\Support\Models\UserModel');
         $this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
-        $this->assertEquals('\Tests\Support\Models\UserModel', $resource->getModelName());
+        $this->assertSame('\Tests\Support\Models\UserModel', $resource->getModelName());
     }
 
     public function testModelByObject()
@@ -255,20 +255,20 @@ final class ResourceControllerTest extends CIUnitTestCase
         $this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
 
         // Note that the leading backslash is missing if we build it this way
-        $this->assertEquals('Tests\Support\Models\UserModel', $resource->getModelName());
+        $this->assertSame('Tests\Support\Models\UserModel', $resource->getModelName());
     }
 
     //--------------------------------------------------------------------
     public function testFormat()
     {
         $resource = new MockResourceController();
-        $this->assertEquals('json', $resource->getFormat());
+        $this->assertSame('json', $resource->getFormat());
 
         $resource->setFormat('Nonsense');
-        $this->assertEquals('json', $resource->getFormat());
+        $this->assertSame('json', $resource->getFormat());
 
         $resource->setFormat('xml');
-        $this->assertEquals('xml', $resource->getFormat());
+        $this->assertSame('xml', $resource->getFormat());
     }
 
     //--------------------------------------------------------------------
@@ -297,7 +297,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $JSONFormatter = new JSONFormatter();
         $expected      = $JSONFormatter->format($data);
 
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     //--------------------------------------------------------------------
@@ -326,6 +326,6 @@ final class ResourceControllerTest extends CIUnitTestCase
         $XMLFormatter = new XMLFormatter();
         $expected     = $XMLFormatter->format($data);
 
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 }

--- a/tests/system/RESTful/ResourcePresenterTest.php
+++ b/tests/system/RESTful/ResourcePresenterTest.php
@@ -80,7 +80,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $this->codeigniter->useSafeOutput(true)->run($this->routes);
         $output = ob_get_clean();
 
-        $this->assertEquals(lang('RESTful.notImplemented', ['index']), $output);
+        $this->assertSame(lang('RESTful.notImplemented', ['index']), $output);
     }
 
     public function testResourceShow()
@@ -237,7 +237,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
 
         $resource->setModel('Something');
         $this->assertEmpty($resource->getModel());
-        $this->assertEquals('Something', $resource->getModelName());
+        $this->assertSame('Something', $resource->getModelName());
     }
 
     public function testModelByName()
@@ -245,7 +245,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $resource = new MockResourcePresenter();
         $resource->setModel('\Tests\Support\Models\UserModel');
         $this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
-        $this->assertEquals('\Tests\Support\Models\UserModel', $resource->getModelName());
+        $this->assertSame('\Tests\Support\Models\UserModel', $resource->getModelName());
     }
 
     public function testModelByObject()
@@ -256,7 +256,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
 
         // Note that the leading backslash is missing if we build it this way
-        $this->assertEquals('Tests\Support\Models\UserModel', $resource->getModelName());
+        $this->assertSame('Tests\Support\Models\UserModel', $resource->getModelName());
     }
 
     public function testChangeSetModelByObject()
@@ -264,12 +264,12 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $resource = new MockResourcePresenter();
         $resource->setModel('\Tests\Support\Models\UserModel');
         $this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
-        $this->assertEquals('\Tests\Support\Models\UserModel', $resource->getModelName());
+        $this->assertSame('\Tests\Support\Models\UserModel', $resource->getModelName());
 
         $model = new EntityModel();
         $resource->setModel($model);
         $this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
-        $this->assertEquals('Tests\Support\Models\EntityModel', $resource->getModelName());
+        $this->assertSame('Tests\Support\Models\EntityModel', $resource->getModelName());
     }
 
     public function testChangeSetModelByName()
@@ -277,10 +277,10 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $resource = new MockResourcePresenter();
         $resource->setModel('\Tests\Support\Models\UserModel');
         $this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
-        $this->assertEquals('\Tests\Support\Models\UserModel', $resource->getModelName());
+        $this->assertSame('\Tests\Support\Models\UserModel', $resource->getModelName());
 
         $resource->setModel('\Tests\Support\Models\EntityModel');
         $this->assertInstanceOf('CodeIgniter\Model', $resource->getModel());
-        $this->assertEquals('\Tests\Support\Models\EntityModel', $resource->getModelName());
+        $this->assertSame('\Tests\Support\Models\EntityModel', $resource->getModelName());
     }
 }

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -18,8 +18,6 @@ final class RouteCollectionTest extends CIUnitTestCase
     {
     }
 
-    //--------------------------------------------------------------------
-
     protected function getCollector(array $config = [], array $files = [], $moduleConfig = null)
     {
         $defaults = [
@@ -52,7 +50,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes = $routes->getRoutes();
 
-        $this->assertEquals($expects, $routes);
+        $this->assertSame($expects, $routes);
     }
 
     //--------------------------------------------------------------------
@@ -69,7 +67,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes = $routes->getRoutes();
 
-        $this->assertEquals($expects, $routes);
+        $this->assertSame($expects, $routes);
     }
 
     //--------------------------------------------------------------------
@@ -86,7 +84,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes = $routes->getRoutes();
 
-        $this->assertEquals($expects, $routes);
+        $this->assertSame($expects, $routes);
     }
 
     //--------------------------------------------------------------------
@@ -105,7 +103,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes = $routes->getRoutes();
 
-        $this->assertEquals($expects, $routes);
+        $this->assertSame($expects, $routes);
     }
 
     //--------------------------------------------------------------------
@@ -122,7 +120,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes = $routes->getRoutes();
 
-        $this->assertEquals($expects, $routes);
+        $this->assertSame($expects, $routes);
     }
 
     //--------------------------------------------------------------------
@@ -137,7 +135,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes = $routes->getRoutes();
 
-        $this->assertEquals([], $routes);
+        $this->assertSame([], $routes);
     }
 
     //--------------------------------------------------------------------
@@ -156,7 +154,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes = $routes->getRoutes();
 
-        $this->assertEquals($expects, $routes);
+        $this->assertSame($expects, $routes);
     }
 
     //--------------------------------------------------------------------
@@ -173,7 +171,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes = $routes->getRoutes();
 
-        $this->assertEquals($expects, $routes);
+        $this->assertSame($expects, $routes);
     }
 
     //--------------------------------------------------------------------
@@ -191,7 +189,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes = $routes->getRoutes();
 
-        $this->assertEquals($expects, $routes);
+        $this->assertSame($expects, $routes);
     }
 
     //--------------------------------------------------------------------
@@ -209,7 +207,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes = $routes->getRoutes();
 
-        $this->assertEquals($expects, $routes);
+        $this->assertSame($expects, $routes);
     }
 
     //--------------------------------------------------------------------
@@ -219,7 +217,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes = $this->getCollector();
         $routes->setDefaultController('godzilla');
 
-        $this->assertEquals('godzilla', $routes->getDefaultController());
+        $this->assertSame('godzilla', $routes->getDefaultController());
     }
 
     //--------------------------------------------------------------------
@@ -229,7 +227,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes = $this->getCollector();
         $routes->setDefaultMethod('biggerBox');
 
-        $this->assertEquals('biggerBox', $routes->getDefaultMethod());
+        $this->assertSame('biggerBox', $routes->getDefaultMethod());
     }
 
     //--------------------------------------------------------------------
@@ -269,7 +267,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'admin/users/list' => '\Users::list',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -289,7 +287,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'admin/users/list' => '\Users::list',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -310,7 +308,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'admin/users/list' => '\Admin\Users::list',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -330,7 +328,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'users/list' => '\Users::list',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -360,7 +358,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'admin/delegate/foo' => '\Users::foo',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -378,7 +376,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'from' => '\to',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -397,7 +395,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'photos/(.*)'      => '\Photos::show/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
 
         $routes = $this->getCollector();
         $routes->setHTTPVerb('post');
@@ -407,7 +405,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'photos' => '\Photos::create',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
 
         $routes = $this->getCollector();
         $routes->setHTTPVerb('put');
@@ -417,7 +415,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'photos/(.*)' => '\Photos::update/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
 
         $routes = $this->getCollector();
         $routes->setHTTPVerb('patch');
@@ -427,7 +425,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'photos/(.*)' => '\Photos::update/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
 
         $routes = $this->getCollector();
         $routes->setHTTPVerb('delete');
@@ -437,7 +435,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'photos/(.*)' => '\Photos::delete/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     // Similar to the above, but with a more typical endpoint
@@ -456,7 +454,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'api/photos/(.*)'      => '\Photos::show/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
 
         $routes = $this->getCollector();
         $routes->setHTTPVerb('post');
@@ -466,7 +464,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'api/photos' => '\Photos::create',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
 
         $routes = $this->getCollector();
         $routes->setHTTPVerb('put');
@@ -476,7 +474,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'api/photos/(.*)' => '\Photos::update/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
 
         $routes = $this->getCollector();
         $routes->setHTTPVerb('patch');
@@ -486,7 +484,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'api/photos/(.*)' => '\Photos::update/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
 
         $routes = $this->getCollector();
         $routes->setHTTPVerb('delete');
@@ -496,7 +494,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'api/photos/(.*)' => '\Photos::delete/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     public function testPresenterScaffoldsCorrectly()
@@ -515,7 +513,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'photos/(.*)'        => '\Photos::show/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
 
         $routes = $this->getCollector();
         $routes->setHTTPVerb('post');
@@ -528,7 +526,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'photos'             => '\Photos::create',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -547,7 +545,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'photos/(.*)'      => '\Gallery::show/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -566,7 +564,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'photos/([0-9]+)'      => '\Photos::show/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     public function testResourcesWithDefaultPlaceholder()
@@ -584,7 +582,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'photos/([0-9]+)'      => '\Photos::show/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     public function testResourcesWithBogusDefaultPlaceholder()
@@ -602,7 +600,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'photos/(.*)'      => '\Photos::show/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -618,7 +616,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'photos' => '\Photos::index',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -635,7 +633,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'photos/(.*)' => '\Photos::show/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -649,11 +647,11 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $expected = [
             'photos'             => '\Photos::create',
-            'photos/(.*)'        => '\Photos::update/$1',
             'photos/(.*)/delete' => '\Photos::delete/$1',
+            'photos/(.*)'        => '\Photos::update/$1',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -666,12 +664,12 @@ final class RouteCollectionTest extends CIUnitTestCase
         $expected = ['here' => '\there'];
 
         $routes->match(['get', 'post'], 'here', 'there');
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
 
         Services::request()->setMethod('post');
         $routes = $this->getCollector();
         $routes->match(['get', 'post'], 'here', 'there');
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -684,7 +682,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $expected = ['here' => '\there'];
 
         $routes->get('here', 'there');
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -697,7 +695,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $expected = ['here' => '\there'];
 
         $routes->post('here', 'there');
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -711,7 +709,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes->get('here', 'there');
         $routes->post('from', 'to');
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -724,7 +722,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $expected = ['here' => '\there'];
 
         $routes->put('here', 'there');
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -737,7 +735,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $expected = ['here' => '\there'];
 
         $routes->delete('here', 'there');
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -750,7 +748,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $expected = ['here' => '\there'];
 
         $routes->head('here', 'there');
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -763,7 +761,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $expected = ['here' => '\there'];
 
         $routes->patch('here', 'there');
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -776,7 +774,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $expected = ['here' => '\there'];
 
         $routes->options('here', 'there');
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -788,7 +786,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $expected = ['here' => '\there'];
 
         $routes->cli('here', 'there');
-        $this->assertEquals($expected, $routes->getRoutes('cli'));
+        $this->assertSame($expected, $routes->getRoutes('cli'));
     }
 
     //--------------------------------------------------------------------
@@ -816,7 +814,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             }
         );
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -829,7 +827,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $match = $routes->reverseRoute('myController::goto', 'string', 13);
 
-        $this->assertEquals('/path/string/to/13', $match);
+        $this->assertSame('/path/string/to/13', $match);
     }
 
     //--------------------------------------------------------------------
@@ -842,7 +840,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $match = $routes->reverseRoute('myController::goto', 'string', 13);
 
-        $this->assertEquals('/en/path/string/to/13', $match);
+        $this->assertSame('/en/path/string/to/13', $match);
     }
 
     //--------------------------------------------------------------------
@@ -887,7 +885,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes->add('{locale}/contact', 'myController::goto');
 
-        $this->assertEquals('/en/contact', $routes->reverseRoute('myController::goto'));
+        $this->assertSame('/en/contact', $routes->reverseRoute('myController::goto'));
     }
 
     //--------------------------------------------------------------------
@@ -898,7 +896,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes->add('users', 'Users::index', ['as' => 'namedRoute']);
 
-        $this->assertEquals('/users', $routes->reverseRoute('namedRoute'));
+        $this->assertSame('/users', $routes->reverseRoute('namedRoute'));
     }
 
     //--------------------------------------------------------------------
@@ -909,7 +907,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes->add('{locale}/users', 'Users::index', ['as' => 'namedRoute']);
 
-        $this->assertEquals('/en/users', $routes->reverseRoute('namedRoute'));
+        $this->assertSame('/en/users', $routes->reverseRoute('namedRoute'));
     }
 
     //--------------------------------------------------------------------
@@ -922,7 +920,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $match = $routes->reverseRoute('namedRoute', 'string', 13);
 
-        $this->assertEquals('/path/string/to/13', $match);
+        $this->assertSame('/path/string/to/13', $match);
     }
 
     //--------------------------------------------------------------------
@@ -935,7 +933,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $match = $routes->reverseRoute('namedRoute', 'string', 13);
 
-        $this->assertEquals('/en/path/string/to/13', $match);
+        $this->assertSame('/en/path/string/to/13', $match);
     }
 
     //--------------------------------------------------------------------
@@ -963,9 +961,9 @@ final class RouteCollectionTest extends CIUnitTestCase
         $match2 = $routes->reverseRoute('namedRoute2');
         $match3 = $routes->reverseRoute('namedRoute3');
 
-        $this->assertEquals('/user/insert', $match1);
-        $this->assertEquals('/user/insert', $match2);
-        $this->assertEquals('/user/insert', $match3);
+        $this->assertSame('/user/insert', $match1);
+        $this->assertSame('/user/insert', $match2);
+        $this->assertSame('/user/insert', $match3);
     }
 
     //--------------------------------------------------------------------
@@ -995,9 +993,9 @@ final class RouteCollectionTest extends CIUnitTestCase
         $match2 = $routes->reverseRoute('namedRoute2');
         $match3 = $routes->reverseRoute('namedRoute3');
 
-        $this->assertEquals('/en/user/insert', $match1);
-        $this->assertEquals('/en/user/insert', $match2);
-        $this->assertEquals('/en/user/insert', $match3);
+        $this->assertSame('/en/user/insert', $match1);
+        $this->assertSame('/en/user/insert', $match2);
+        $this->assertSame('/en/user/insert', $match3);
     }
 
     //--------------------------------------------------------------------
@@ -1011,8 +1009,8 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes->get('/system/(this|that)', 'myController::system/$1', ['as' => 'pipedRoute']);
 
-        $this->assertEquals('/system/this', $routes->reverseRoute('pipedRoute', 'this'));
-        $this->assertEquals('/system/that', $routes->reverseRoute('pipedRoute', 'that'));
+        $this->assertSame('/system/this', $routes->reverseRoute('pipedRoute', 'this'));
+        $this->assertSame('/system/that', $routes->reverseRoute('pipedRoute', 'that'));
     }
 
     //--------------------------------------------------------------------
@@ -1025,7 +1023,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $match = $routes->reverseRoute('testRouter', 1, 2);
 
-        $this->assertEquals('/test/1/2', $match);
+        $this->assertSame('/test/1/2', $match);
     }
 
     //--------------------------------------------------------------------
@@ -1038,7 +1036,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $match = $routes->reverseRoute('testRouter', 1, 2);
 
-        $this->assertEquals('/en/test/1/2', $match);
+        $this->assertSame('/en/test/1/2', $match);
     }
 
     //--------------------------------------------------------------------
@@ -1054,10 +1052,10 @@ final class RouteCollectionTest extends CIUnitTestCase
             'users' => 'users/index',
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
         $this->assertTrue($routes->isRedirect('users'));
-        $this->assertEquals(307, $routes->getRedirectCode('users'));
-        $this->assertEquals(0, $routes->getRedirectCode('bosses'));
+        $this->assertSame(307, $routes->getRedirectCode('users'));
+        $this->assertSame(0, $routes->getRedirectCode('bosses'));
     }
 
     public function testAddRedirectNamed()
@@ -1068,15 +1066,13 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes->addRedirect('users', 'namedRoute', 307);
 
         $expected = [
-            'users' => [
-                'zombies' => '\Zombies::index',
-            ],
             'zombies' => '\Zombies::index',
+            'users'   => ['zombies' => '\Zombies::index'],
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
         $this->assertTrue($routes->isRedirect('users'));
-        $this->assertEquals(307, $routes->getRedirectCode('users'));
+        $this->assertSame(307, $routes->getRedirectCode('users'));
     }
 
     public function testAddRedirectGetMethod()
@@ -1087,15 +1083,13 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes->addRedirect('users', 'namedRoute', 307);
 
         $expected = [
-            'users' => [
-                'zombies' => '\Zombies::index',
-            ],
             'zombies' => '\Zombies::index',
+            'users'   => ['zombies' => '\Zombies::index'],
         ];
 
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
         $this->assertTrue($routes->isRedirect('users'));
-        $this->assertEquals(307, $routes->getRedirectCode('users'));
+        $this->assertSame(307, $routes->getRedirectCode('users'));
     }
 
     //--------------------------------------------------------------------
@@ -1116,7 +1110,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'objects/([a-zA-Z0-9]+)' => '\Admin::objectsList/$1',
         ];
 
-        $this->assertEquals($expects, $routes->getRoutes());
+        $this->assertSame($expects, $routes->getRoutes());
     }
 
     public function testWithSubdomainMissing()
@@ -1132,7 +1126,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'objects/([a-zA-Z0-9]+)' => '\App::objectsList/$1',
         ];
 
-        $this->assertEquals($expects, $routes->getRoutes());
+        $this->assertSame($expects, $routes->getRoutes());
     }
 
     public function testWithDifferentSubdomain()
@@ -1148,7 +1142,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'objects/([a-zA-Z0-9]+)' => '\App::objectsList/$1',
         ];
 
-        $this->assertEquals($expects, $routes->getRoutes());
+        $this->assertSame($expects, $routes->getRoutes());
     }
 
     public function testWithWWWSubdomain()
@@ -1164,7 +1158,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'objects/([a-zA-Z0-9]+)' => '\App::objectsList/$1',
         ];
 
-        $this->assertEquals($expects, $routes->getRoutes());
+        $this->assertSame($expects, $routes->getRoutes());
     }
 
     public function testWithDotCoSubdomain()
@@ -1180,7 +1174,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'objects/([a-zA-Z0-9]+)' => '\App::objectsList/$1',
         ];
 
-        $this->assertEquals($expects, $routes->getRoutes());
+        $this->assertSame($expects, $routes->getRoutes());
     }
 
     public function testWithDifferentSubdomainMissing()
@@ -1196,7 +1190,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'objects/([a-zA-Z0-9]+)' => '\App::objectsList/$1',
         ];
 
-        $this->assertEquals($expects, $routes->getRoutes());
+        $this->assertSame($expects, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -1217,7 +1211,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'objects/([a-zA-Z0-9]+)' => '\Admin::objectsList/$1',
         ];
 
-        $this->assertEquals($expects, $routes->getRoutes());
+        $this->assertSame($expects, $routes->getRoutes());
     }
 
     //--------------------------------------------------------------------
@@ -1234,7 +1228,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $match = $routes->reverseRoute('login');
 
-        $this->assertEquals('/login', $match);
+        $this->assertSame('/login', $match);
     }
 
     public function testReverseRoutingWithClosureNoMatch()
@@ -1251,9 +1245,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testWillDiscoverLocal()
     {
-        $config = [
-            'SampleSpace' => TESTPATH . '_support',
-        ];
+        $config = ['SampleSpace' => TESTPATH . '_support'];
 
         $moduleConfig          = new Modules();
         $moduleConfig->enabled = true;
@@ -1263,7 +1255,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $match = $routes->getRoutes();
 
         $this->assertArrayHasKey('testing', $match);
-        $this->assertEquals($match['testing'], '\TestController::index');
+        $this->assertSame($match['testing'], '\TestController::index');
     }
 
     //--------------------------------------------------------------------
@@ -1284,7 +1276,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $match = $routes->getRoutes();
 
         $this->assertArrayHasKey('testing', $match);
-        $this->assertEquals($match['testing'], '\MainRoutes::index');
+        $this->assertSame($match['testing'], '\MainRoutes::index');
     }
 
     //--------------------------------------------------------------------
@@ -1306,7 +1298,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $options = $routes->getRoutesOptions('administrator');
 
-        $this->assertEquals($options, ['as' => 'admin', 'foo' => 'baz']);
+        $this->assertSame($options, ['as' => 'admin', 'foo' => 'baz']);
     }
 
     public function testRoutesOptionsForDifferentVerbs()
@@ -1343,15 +1335,15 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $options = $routes->getRoutesOptions('administrator');
 
-        $this->assertEquals($options, ['as' => 'admin1', 'foo' => 'baz1', 'bar' => 'baz']);
+        $this->assertSame($options, ['as' => 'admin1', 'foo' => 'baz1', 'bar' => 'baz']);
 
         $options = $routes->setHTTPVerb('post')->getRoutesOptions('administrator');
 
-        $this->assertEquals($options, ['as' => 'admin2', 'foo' => 'baz2', 'bar' => 'baz']);
+        $this->assertSame($options, ['as' => 'admin2', 'foo' => 'baz2', 'bar' => 'baz']);
 
         $options = $routes->setHTTPVerb('get')->getRoutesOptions('administrator', 'post');
 
-        $this->assertEquals($options, ['as' => 'admin2', 'foo' => 'baz2', 'bar' => 'baz']);
+        $this->assertSame($options, ['as' => 'admin2', 'foo' => 'baz2', 'bar' => 'baz']);
     }
 
     public function testRouteGroupWithFilterSimple()
@@ -1369,8 +1361,8 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $this->assertTrue($routes->isFiltered('admin/users'));
         $this->assertFalse($routes->isFiltered('admin/franky'));
-        $this->assertEquals('role', $routes->getFilterForRoute('admin/users'));
-        $this->assertEquals('', $routes->getFilterForRoute('admin/bosses'));
+        $this->assertSame('role', $routes->getFilterForRoute('admin/users'));
+        $this->assertSame('', $routes->getFilterForRoute('admin/bosses'));
     }
 
     public function testRouteGroupWithFilterWithParams()
@@ -1388,7 +1380,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $this->assertTrue($routes->isFiltered('admin/users'));
         $this->assertFalse($routes->isFiltered('admin/franky'));
-        $this->assertEquals('role:admin,manager', $routes->getFilterForRoute('admin/users'));
+        $this->assertSame('role:admin,manager', $routes->getFilterForRoute('admin/users'));
     }
 
     //--------------------------------------------------------------------
@@ -1407,7 +1399,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes = $this->getCollector();
 
         $routes->set404Override('Explode');
-        $this->assertEquals('Explode', $routes->get404Override());
+        $this->assertSame('Explode', $routes->get404Override());
     }
 
     public function test404OverrideCallable()
@@ -1430,7 +1422,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes->get('users/(:num)', 'users/show/$1', ['offset' => 1]);
         $expected = ['users/([0-9]+)' => '\users/show/$2'];
-        $this->assertEquals($expected, $routes->getRoutes());
+        $this->assertSame($expected, $routes->getRoutes());
     }
 
     /**
@@ -1447,7 +1439,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes->get('i/(:any)', 'App\Controllers\Site\CDoc::item/$1', ['subdomain' => 'doc', 'as' => 'doc_item']);
 
-        $this->assertEquals('/i/sth', $routes->reverseRoute('doc_item', 'sth'));
+        $this->assertSame('/i/sth', $routes->reverseRoute('doc_item', 'sth'));
     }
 
     public function testRouteToWithSubdomainMismatch()
@@ -1483,7 +1475,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes->get('i/(:any)', 'App\Controllers\Site\CDoc::item/$1', ['subdomain' => '*', 'as' => 'doc_item']);
 
-        $this->assertEquals('/i/sth', $routes->reverseRoute('doc_item', 'sth'));
+        $this->assertSame('/i/sth', $routes->reverseRoute('doc_item', 'sth'));
     }
 
     public function testRouteToWithGenericSubdomainMismatch()
@@ -1495,7 +1487,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes->get('i/(:any)', 'App\Controllers\Site\CDoc::item/$1', ['subdomain' => '*', 'as' => 'doc_item']);
 
-        $this->assertEquals('/i/sth', $routes->reverseRoute('doc_item', 'sth'));
+        $this->assertSame('/i/sth', $routes->reverseRoute('doc_item', 'sth'));
     }
 
     public function testRouteToWithGenericSubdomainNot()
@@ -1507,7 +1499,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes->get('i/(:any)', 'App\Controllers\Site\CDoc::item/$1', ['subdomain' => '*', 'as' => 'doc_item']);
 
-        $this->assertEquals('/i/sth', $routes->reverseRoute('doc_item', 'sth'));
+        $this->assertSame('/i/sth', $routes->reverseRoute('doc_item', 'sth'));
     }
 
     public function testRouteToWithoutSubdomainMatch()
@@ -1543,7 +1535,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes->get('i/(:any)', 'App\Controllers\Site\CDoc::item/$1', ['hostname' => 'example.com', 'as' => 'doc_item']);
 
-        $this->assertEquals('/i/sth', $routes->reverseRoute('doc_item', 'sth'));
+        $this->assertSame('/i/sth', $routes->reverseRoute('doc_item', 'sth'));
     }
 
     /**
@@ -1569,7 +1561,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $expects = '\App\Controllers\Site\CDoc';
 
-        $this->assertEquals($expects, $router->handle('/'));
+        $this->assertSame($expects, $router->handle('/'));
     }
 
     public function testRouteOverwritingTwoRules()
@@ -1590,7 +1582,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         // the second rule applies, so overwrites the first
         $expects = '\App\Controllers\Home';
 
-        $this->assertEquals($expects, $router->handle('/'));
+        $this->assertSame($expects, $router->handle('/'));
     }
 
     public function testRouteOverwritingTwoRulesLastApplies()
@@ -1610,7 +1602,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $expects = '\App\Controllers\Site\CDoc';
 
-        $this->assertEquals($expects, $router->handle('/'));
+        $this->assertSame($expects, $router->handle('/'));
     }
 
     public function testRouteOverwritingMatchingSubdomain()
@@ -1630,7 +1622,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $expects = '\App\Controllers\Site\CDoc';
 
-        $this->assertEquals($expects, $router->handle('/'));
+        $this->assertSame($expects, $router->handle('/'));
     }
 
     public function testRouteOverwritingMatchingHost()
@@ -1650,7 +1642,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $expects = '\App\Controllers\Site\CDoc';
 
-        $this->assertEquals($expects, $router->handle('/'));
+        $this->assertSame($expects, $router->handle('/'));
     }
 
     /**
@@ -1669,7 +1661,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $expects = '\App\Controllers\Core\Home';
 
-        $this->assertEquals($expects, $router->handle('/'));
+        $this->assertSame($expects, $router->handle('/'));
     }
 
     public function testZeroAsURIPath()
@@ -1683,7 +1675,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $expects = '\App\Controllers\Core\Home';
 
-        $this->assertEquals($expects, $router->handle('/0'));
+        $this->assertSame($expects, $router->handle('/0'));
     }
 
     public function provideRouteDefaultNamespace()
@@ -1706,7 +1698,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $router = new Router($routes, Services::request());
         $router->handle('/product');
 
-        $this->assertEquals('\App\\Controllers\\Product', $router->controllerName());
+        $this->assertSame('\App\\Controllers\\Product', $router->controllerName());
     }
 
     /**
@@ -1722,7 +1714,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $router = new Router($routes, Services::request());
         $router->handle('/product');
 
-        $this->assertEquals('\App\\Controllers\\Product', $router->controllerName());
+        $this->assertSame('\App\\Controllers\\Product', $router->controllerName());
     }
 
     public function testRoutePriorityDetected()
@@ -1745,12 +1737,12 @@ final class RouteCollectionTest extends CIUnitTestCase
         $collection = $this->getCollector();
 
         $collection->add('string', 'Controller::method', ['priority' => 'string']);
-        $this->assertEquals(0, $collection->getRoutesOptions('string')['priority']);
+        $this->assertSame(0, $collection->getRoutesOptions('string')['priority']);
 
         $collection->add('negative-integer', 'Controller::method', ['priority' => -1]);
-        $this->assertEquals(1, $collection->getRoutesOptions('negative-integer')['priority']);
+        $this->assertSame(1, $collection->getRoutesOptions('negative-integer')['priority']);
 
         $collection->add('string-negative-integer', 'Controller::method', ['priority' => '-1']);
-        $this->assertEquals(1, $collection->getRoutesOptions('string-negative-integer')['priority']);
+        $this->assertSame(1, $collection->getRoutesOptions('string-negative-integer')['priority']);
     }
 }

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -62,13 +62,9 @@ final class RouterTest extends CIUnitTestCase
         $this->request->setMethod('get');
     }
 
-    //--------------------------------------------------------------------
-
     protected function tearDown(): void
     {
     }
-
-    //--------------------------------------------------------------------
 
     public function testEmptyURIMatchesDefaults()
     {
@@ -76,11 +72,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('');
 
-        $this->assertEquals($this->collection->getDefaultController(), $router->controllerName());
-        $this->assertEquals($this->collection->getDefaultMethod(), $router->methodName());
+        $this->assertSame($this->collection->getDefaultController(), $router->controllerName());
+        $this->assertSame($this->collection->getDefaultMethod(), $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testZeroAsURIPath()
     {
@@ -91,19 +85,15 @@ final class RouterTest extends CIUnitTestCase
         $router->handle('0');
     }
 
-    //--------------------------------------------------------------------
-
     public function testURIMapsToController()
     {
         $router = new Router($this->collection, $this->request);
 
         $router->handle('users');
 
-        $this->assertEquals('\Users', $router->controllerName());
-        $this->assertEquals('index', $router->methodName());
+        $this->assertSame('\Users', $router->controllerName());
+        $this->assertSame('index', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testURIMapsToControllerAltMethod()
     {
@@ -111,11 +101,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('posts');
 
-        $this->assertEquals('\Blog', $router->controllerName());
-        $this->assertEquals('posts', $router->methodName());
+        $this->assertSame('\Blog', $router->controllerName());
+        $this->assertSame('posts', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testURIMapsToNamespacedController()
     {
@@ -123,11 +111,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('pages');
 
-        $this->assertEquals('\App\Pages', $router->controllerName());
-        $this->assertEquals('list_all', $router->methodName());
+        $this->assertSame('\App\Pages', $router->controllerName());
+        $this->assertSame('list_all', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testURIMapsParamsToBackReferences()
     {
@@ -135,11 +121,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('posts/123');
 
-        $this->assertEquals('show', $router->methodName());
-        $this->assertEquals([123], $router->params());
+        $this->assertSame('show', $router->methodName());
+        $this->assertSame(['123'], $router->params());
     }
-
-    //--------------------------------------------------------------------
 
     public function testURIMapsParamsToRearrangedBackReferences()
     {
@@ -147,11 +131,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('posts/123/edit');
 
-        $this->assertEquals('edit', $router->methodName());
-        $this->assertEquals([123], $router->params());
+        $this->assertSame('edit', $router->methodName());
+        $this->assertSame(['123'], $router->params());
     }
-
-    //--------------------------------------------------------------------
 
     public function testURIMapsParamsToBackReferencesWithUnused()
     {
@@ -159,11 +141,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('books/123/sometitle/456');
 
-        $this->assertEquals('show', $router->methodName());
-        $this->assertEquals([456, 123], $router->params());
+        $this->assertSame('show', $router->methodName());
+        $this->assertSame(['456', '123'], $router->params());
     }
-
-    //--------------------------------------------------------------------
 
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/672
@@ -174,11 +154,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('objects/123/sort/abc/FOO');
 
-        $this->assertEquals('objectsSortCreate', $router->methodName());
-        $this->assertEquals([123, 'abc', 'FOO'], $router->params());
+        $this->assertSame('objectsSortCreate', $router->methodName());
+        $this->assertSame(['123', 'abc', 'FOO'], $router->params());
     }
-
-    //--------------------------------------------------------------------
 
     public function testClosures()
     {
@@ -191,10 +169,8 @@ final class RouterTest extends CIUnitTestCase
         $expects = $closure(...$router->params());
 
         $this->assertIsCallable($router->controllerName());
-        $this->assertEquals($expects, '123-alpha');
+        $this->assertSame($expects, '123-alpha');
     }
-
-    //--------------------------------------------------------------------
 
     public function testAutoRouteFindsControllerWithFileAndMethod()
     {
@@ -202,11 +178,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->autoRoute('myController/someMethod');
 
-        $this->assertEquals('MyController', $router->controllerName());
-        $this->assertEquals('someMethod', $router->methodName());
+        $this->assertSame('MyController', $router->controllerName());
+        $this->assertSame('someMethod', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testAutoRouteFindsControllerWithFile()
     {
@@ -214,11 +188,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->autoRoute('myController');
 
-        $this->assertEquals('MyController', $router->controllerName());
-        $this->assertEquals('index', $router->methodName());
+        $this->assertSame('MyController', $router->controllerName());
+        $this->assertSame('index', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testAutoRouteFindsControllerWithSubfolder()
     {
@@ -230,11 +202,9 @@ final class RouterTest extends CIUnitTestCase
 
         rmdir(APPPATH . 'Controllers/Subfolder');
 
-        $this->assertEquals('MyController', $router->controllerName());
-        $this->assertEquals('someMethod', $router->methodName());
+        $this->assertSame('MyController', $router->controllerName());
+        $this->assertSame('someMethod', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testAutoRouteFindsDashedSubfolder()
     {
@@ -247,12 +217,10 @@ final class RouterTest extends CIUnitTestCase
 
         rmdir(APPPATH . 'Controllers/Dash_folder');
 
-        $this->assertEquals('Dash_folder/', $router->directory());
-        $this->assertEquals('Mycontroller', $router->controllerName());
-        $this->assertEquals('somemethod', $router->methodName());
+        $this->assertSame('Dash_folder/', $router->directory());
+        $this->assertSame('Mycontroller', $router->controllerName());
+        $this->assertSame('somemethod', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testAutoRouteFindsDashedController()
     {
@@ -267,12 +235,10 @@ final class RouterTest extends CIUnitTestCase
         unlink(APPPATH . 'Controllers/Dash_folder/Dash_controller.php');
         rmdir(APPPATH . 'Controllers/Dash_folder');
 
-        $this->assertEquals('Dash_folder/', $router->directory());
-        $this->assertEquals('Dash_controller', $router->controllerName());
-        $this->assertEquals('somemethod', $router->methodName());
+        $this->assertSame('Dash_folder/', $router->directory());
+        $this->assertSame('Dash_controller', $router->controllerName());
+        $this->assertSame('somemethod', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testAutoRouteFindsDashedMethod()
     {
@@ -287,12 +253,10 @@ final class RouterTest extends CIUnitTestCase
         unlink(APPPATH . 'Controllers/Dash_folder/Dash_controller.php');
         rmdir(APPPATH . 'Controllers/Dash_folder');
 
-        $this->assertEquals('Dash_folder/', $router->directory());
-        $this->assertEquals('Dash_controller', $router->controllerName());
-        $this->assertEquals('dash_method', $router->methodName());
+        $this->assertSame('Dash_folder/', $router->directory());
+        $this->assertSame('Dash_controller', $router->controllerName());
+        $this->assertSame('dash_method', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testAutoRouteFindsDefaultDashFolder()
     {
@@ -305,12 +269,10 @@ final class RouterTest extends CIUnitTestCase
 
         rmdir(APPPATH . 'Controllers/Dash_folder');
 
-        $this->assertEquals('Dash_folder/', $router->directory());
-        $this->assertEquals('Home', $router->controllerName());
-        $this->assertEquals('index', $router->methodName());
+        $this->assertSame('Dash_folder/', $router->directory());
+        $this->assertSame('Home', $router->controllerName());
+        $this->assertSame('index', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testAutoRouteFindsMByteDir()
     {
@@ -323,12 +285,10 @@ final class RouterTest extends CIUnitTestCase
 
         rmdir(APPPATH . 'Controllers/Φ');
 
-        $this->assertEquals('Φ/', $router->directory());
-        $this->assertEquals('Home', $router->controllerName());
-        $this->assertEquals('index', $router->methodName());
+        $this->assertSame('Φ/', $router->directory());
+        $this->assertSame('Home', $router->controllerName());
+        $this->assertSame('index', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testAutoRouteFindsMByteController()
     {
@@ -341,11 +301,9 @@ final class RouterTest extends CIUnitTestCase
 
         unlink(APPPATH . 'Controllers/Φ');
 
-        $this->assertEquals('Φ', $router->controllerName());
-        $this->assertEquals('index', $router->methodName());
+        $this->assertSame('Φ', $router->controllerName());
+        $this->assertSame('index', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testAutoRouteRejectsSingleDot()
     {
@@ -357,8 +315,6 @@ final class RouterTest extends CIUnitTestCase
         $router->autoRoute('.');
     }
 
-    //--------------------------------------------------------------------
-
     public function testAutoRouteRejectsDoubleDot()
     {
         $router = new Router($this->collection, $this->request);
@@ -368,8 +324,6 @@ final class RouterTest extends CIUnitTestCase
 
         $router->autoRoute('..');
     }
-
-    //--------------------------------------------------------------------
 
     public function testAutoRouteRejectsMidDot()
     {
@@ -381,8 +335,6 @@ final class RouterTest extends CIUnitTestCase
         $router->autoRoute('Foo.bar');
     }
 
-    //--------------------------------------------------------------------
-
     public function testDetectsLocales()
     {
         $router = new Router($this->collection, $this->request);
@@ -390,10 +342,8 @@ final class RouterTest extends CIUnitTestCase
         $router->handle('fr/pages');
 
         $this->assertTrue($router->hasLocale());
-        $this->assertEquals('fr', $router->getLocale());
+        $this->assertSame('fr', $router->getLocale());
     }
-
-    //--------------------------------------------------------------------
 
     public function testRouteResource()
     {
@@ -401,11 +351,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('Admin/Admins');
 
-        $this->assertEquals('\App\Admin\Admins', $router->controllerName());
-        $this->assertEquals('list_all', $router->methodName());
+        $this->assertSame('\App\Admin\Admins', $router->controllerName());
+        $this->assertSame('list_all', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     public function testRouteWithLeadingSlash()
     {
@@ -413,8 +361,8 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('some/slash');
 
-        $this->assertEquals('\App\Slash', $router->controllerName());
-        $this->assertEquals('index', $router->methodName());
+        $this->assertSame('\App\Slash', $router->controllerName());
+        $this->assertSame('index', $router->methodName());
     }
 
     //--------------------------------------------------------------------
@@ -438,7 +386,7 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('foo');
 
-        $this->assertEquals($router->getMatchedRouteOptions(), ['as' => 'login', 'foo' => 'baz']);
+        $this->assertSame($router->getMatchedRouteOptions(), ['as' => 'login', 'foo' => 'baz']);
     }
 
     public function testRouteWorksWithFilters()
@@ -453,12 +401,10 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('foo/bar');
 
-        $this->assertEquals('\TestController', $router->controllerName());
-        $this->assertEquals('foobar', $router->methodName());
-        $this->assertEquals('test', $router->getFilter());
+        $this->assertSame('\TestController', $router->controllerName());
+        $this->assertSame('foobar', $router->methodName());
+        $this->assertSame('test', $router->getFilter());
     }
-
-    //--------------------------------------------------------------------
 
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/1247
@@ -485,27 +431,27 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('api/posts');
 
-        $this->assertEquals('\App\Controllers\Api\PostController', $router->controllerName());
-        $this->assertEquals('index', $router->methodName());
-        $this->assertEquals('api-auth', $router->getFilter());
+        $this->assertSame('\App\Controllers\Api\PostController', $router->controllerName());
+        $this->assertSame('index', $router->methodName());
+        $this->assertSame('api-auth', $router->getFilter());
 
         $router->handle('api/posts/new');
 
-        $this->assertEquals('\App\Controllers\Api\PostController', $router->controllerName());
-        $this->assertEquals('new', $router->methodName());
-        $this->assertEquals('api-auth', $router->getFilter());
+        $this->assertSame('\App\Controllers\Api\PostController', $router->controllerName());
+        $this->assertSame('new', $router->methodName());
+        $this->assertSame('api-auth', $router->getFilter());
 
         $router->handle('api/posts/50');
 
-        $this->assertEquals('\App\Controllers\Api\PostController', $router->controllerName());
-        $this->assertEquals('show', $router->methodName());
-        $this->assertEquals('api-auth', $router->getFilter());
+        $this->assertSame('\App\Controllers\Api\PostController', $router->controllerName());
+        $this->assertSame('show', $router->methodName());
+        $this->assertSame('api-auth', $router->getFilter());
 
         $router->handle('api/posts/50/edit');
 
-        $this->assertEquals('\App\Controllers\Api\PostController', $router->controllerName());
-        $this->assertEquals('edit', $router->methodName());
-        $this->assertEquals('api-auth', $router->getFilter());
+        $this->assertSame('\App\Controllers\Api\PostController', $router->controllerName());
+        $this->assertSame('edit', $router->methodName());
+        $this->assertSame('api-auth', $router->getFilter());
 
         // POST
         $this->collection->group(...$group);
@@ -515,9 +461,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('api/posts');
 
-        $this->assertEquals('\App\Controllers\Api\PostController', $router->controllerName());
-        $this->assertEquals('create', $router->methodName());
-        $this->assertEquals('api-auth', $router->getFilter());
+        $this->assertSame('\App\Controllers\Api\PostController', $router->controllerName());
+        $this->assertSame('create', $router->methodName());
+        $this->assertSame('api-auth', $router->getFilter());
 
         // PUT
         $this->collection->group(...$group);
@@ -527,9 +473,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('api/posts/50');
 
-        $this->assertEquals('\App\Controllers\Api\PostController', $router->controllerName());
-        $this->assertEquals('update', $router->methodName());
-        $this->assertEquals('api-auth', $router->getFilter());
+        $this->assertSame('\App\Controllers\Api\PostController', $router->controllerName());
+        $this->assertSame('update', $router->methodName());
+        $this->assertSame('api-auth', $router->getFilter());
 
         // PATCH
         $this->collection->group(...$group);
@@ -539,9 +485,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('api/posts/50');
 
-        $this->assertEquals('\App\Controllers\Api\PostController', $router->controllerName());
-        $this->assertEquals('update', $router->methodName());
-        $this->assertEquals('api-auth', $router->getFilter());
+        $this->assertSame('\App\Controllers\Api\PostController', $router->controllerName());
+        $this->assertSame('update', $router->methodName());
+        $this->assertSame('api-auth', $router->getFilter());
 
         // DELETE
         $this->collection->group(...$group);
@@ -551,12 +497,10 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('api/posts/50');
 
-        $this->assertEquals('\App\Controllers\Api\PostController', $router->controllerName());
-        $this->assertEquals('delete', $router->methodName());
-        $this->assertEquals('api-auth', $router->getFilter());
+        $this->assertSame('\App\Controllers\Api\PostController', $router->controllerName());
+        $this->assertSame('delete', $router->methodName());
+        $this->assertSame('api-auth', $router->getFilter());
     }
-
-    //--------------------------------------------------------------------
 
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/1240
@@ -573,23 +517,21 @@ final class RouterTest extends CIUnitTestCase
         $router = new Router($this->collection, $this->request);
 
         $router->handle('/');
-        $this->assertEquals('\Home', $router->controllerName());
-        $this->assertEquals('index', $router->methodName());
+        $this->assertSame('\Home', $router->controllerName());
+        $this->assertSame('index', $router->methodName());
 
         $router->handle('news');
-        $this->assertEquals('\News', $router->controllerName());
-        $this->assertEquals('index', $router->methodName());
+        $this->assertSame('\News', $router->controllerName());
+        $this->assertSame('index', $router->methodName());
 
         $router->handle('news/daily');
-        $this->assertEquals('\News', $router->controllerName());
-        $this->assertEquals('view', $router->methodName());
+        $this->assertSame('\News', $router->controllerName());
+        $this->assertSame('view', $router->methodName());
 
         $router->handle('about');
-        $this->assertEquals('\Pages', $router->controllerName());
-        $this->assertEquals('view', $router->methodName());
+        $this->assertSame('\Pages', $router->controllerName());
+        $this->assertSame('view', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/1354
@@ -603,8 +545,8 @@ final class RouterTest extends CIUnitTestCase
         $this->collection->setHTTPVerb('post');
 
         $router->handle('auth');
-        $this->assertEquals('\Main', $router->controllerName());
-        $this->assertEquals('auth_post', $router->methodName());
+        $this->assertSame('\Main', $router->controllerName());
+        $this->assertSame('auth_post', $router->methodName());
     }
 
     public function testRoutePriorityOrder()
@@ -618,14 +560,14 @@ final class RouterTest extends CIUnitTestCase
         $this->collection->setHTTPVerb('get');
 
         $router->handle('module');
-        $this->assertEquals('\Main', $router->controllerName());
-        $this->assertEquals('wildcard', $router->methodName());
+        $this->assertSame('\Main', $router->controllerName());
+        $this->assertSame('wildcard', $router->methodName());
 
         $this->collection->setPrioritize();
 
         $router->handle('module');
-        $this->assertEquals('\Module', $router->controllerName());
-        $this->assertEquals('index', $router->methodName());
+        $this->assertSame('\Module', $router->controllerName());
+        $this->assertSame('index', $router->methodName());
     }
 
     /**
@@ -639,11 +581,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->setTranslateURIDashes(true);
 
-        $this->assertEquals('\User_setting', $router->controllerName());
-        $this->assertEquals('show_list', $router->methodName());
+        $this->assertSame('\User_setting', $router->controllerName());
+        $this->assertSame('show_list', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/1564
@@ -655,12 +595,10 @@ final class RouterTest extends CIUnitTestCase
 
         $router->handle('user-setting/2018-12-02');
 
-        $this->assertEquals('\User_setting', $router->controllerName());
-        $this->assertEquals('detail', $router->methodName());
-        $this->assertEquals(['2018-12-02'], $router->params());
+        $this->assertSame('\User_setting', $router->controllerName());
+        $this->assertSame('detail', $router->methodName());
+        $this->assertSame(['2018-12-02'], $router->params());
     }
-
-    //--------------------------------------------------------------------
 
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/1564
@@ -672,11 +610,9 @@ final class RouterTest extends CIUnitTestCase
 
         $router->autoRoute('admin-user/show-list');
 
-        $this->assertEquals('Admin_user', $router->controllerName());
-        $this->assertEquals('show_list', $router->methodName());
+        $this->assertSame('Admin_user', $router->controllerName());
+        $this->assertSame('show_list', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/2032
@@ -687,14 +623,14 @@ final class RouterTest extends CIUnitTestCase
 
         $router->autoRoute('myController/someMethod/0/abc');
 
-        $this->assertEquals('MyController', $router->controllerName());
-        $this->assertEquals('someMethod', $router->methodName());
+        $this->assertSame('MyController', $router->controllerName());
+        $this->assertSame('someMethod', $router->methodName());
 
         $expected = [
             '0',
             'abc',
         ];
-        $this->assertEquals($expected, $router->params());
+        $this->assertSame($expected, $router->params());
     }
 
     /**
@@ -704,11 +640,9 @@ final class RouterTest extends CIUnitTestCase
     {
         $router = new Router($this->collection, $this->request);
         $router->handle('Home/');
-        $this->assertEquals('Home', $router->controllerName());
-        $this->assertEquals('index', $router->methodName());
+        $this->assertSame('Home', $router->controllerName());
+        $this->assertSame('index', $router->methodName());
     }
-
-    //--------------------------------------------------------------------
 
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/3169
@@ -720,13 +654,13 @@ final class RouterTest extends CIUnitTestCase
         $router = new Router($this->collection, $this->request);
 
         $router->handle('news/a0%E0%A6%80%E0%A7%BF-');
-        $this->assertEquals('\News', $router->controllerName());
-        $this->assertEquals('view', $router->methodName());
+        $this->assertSame('\News', $router->controllerName());
+        $this->assertSame('view', $router->methodName());
 
         $expected = [
             'a0ঀ৿-',
         ];
-        $this->assertEquals($expected, $router->params());
+        $this->assertSame($expected, $router->params());
     }
 
     /**
@@ -740,13 +674,13 @@ final class RouterTest extends CIUnitTestCase
         $router = new Router($this->collection, $this->request);
 
         $router->handle('news/a0%E0%A6%80%E0%A7%BF-');
-        $this->assertEquals('\News', $router->controllerName());
-        $this->assertEquals('view', $router->methodName());
+        $this->assertSame('\News', $router->controllerName());
+        $this->assertSame('view', $router->methodName());
 
         $expected = [
             'a0ঀ৿-',
         ];
-        $this->assertEquals($expected, $router->params());
+        $this->assertSame($expected, $router->params());
     }
 
     public function testRouterPriorDirectory()
@@ -756,9 +690,9 @@ final class RouterTest extends CIUnitTestCase
         $router->setDirectory('foo/bar/baz', false, true);
         $router->handle('Some_controller/some_method/param1/param2/param3');
 
-        $this->assertEquals('foo/bar/baz/', $router->directory());
-        $this->assertEquals('Some_controller', $router->controllerName());
-        $this->assertEquals('some_method', $router->methodName());
+        $this->assertSame('foo/bar/baz/', $router->directory());
+        $this->assertSame('Some_controller', $router->controllerName());
+        $this->assertSame('some_method', $router->methodName());
     }
 
     public function testSetDirectoryValid()
@@ -766,7 +700,7 @@ final class RouterTest extends CIUnitTestCase
         $router = new Router($this->collection, $this->request);
         $router->setDirectory('foo/bar/baz', false, true);
 
-        $this->assertEquals('foo/bar/baz/', $router->directory());
+        $this->assertSame('foo/bar/baz/', $router->directory());
     }
 
     public function testSetDirectoryInvalid()
@@ -777,6 +711,6 @@ final class RouterTest extends CIUnitTestCase
         $internal = $this->getPrivateProperty($router, 'directory');
 
         $this->assertNull($internal);
-        $this->assertEquals('', $router->directory());
+        $this->assertSame('', $router->directory());
     }
 }

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -36,8 +36,8 @@ final class SecurityTest extends CIUnitTestCase
 
         $hash = $security->getHash();
 
-        $this->assertEquals(32, strlen($hash));
-        $this->assertEquals('csrf_test_name', $security->getTokenName());
+        $this->assertSame(32, strlen($hash));
+        $this->assertSame('csrf_test_name', $security->getTokenName());
     }
 
     public function testHashIsReadFromCookie()
@@ -46,7 +46,7 @@ final class SecurityTest extends CIUnitTestCase
 
         $security = new Security(new MockAppConfig());
 
-        $this->assertEquals('8b9218a55906f9dcc1dc263dce7f005a', $security->getHash());
+        $this->assertSame('8b9218a55906f9dcc1dc263dce7f005a', $security->getHash());
     }
 
     public function testCSRFVerifySetsCookieWhenNotPOST()
@@ -57,7 +57,7 @@ final class SecurityTest extends CIUnitTestCase
 
         $security->verify(new Request(new MockAppConfig()));
 
-        $this->assertEquals($_COOKIE['csrf_cookie_name'], $security->getHash());
+        $this->assertSame($_COOKIE['csrf_cookie_name'], $security->getHash());
     }
 
     public function testCSRFVerifyPostThrowsExceptionOnNoMatch()
@@ -156,7 +156,7 @@ final class SecurityTest extends CIUnitTestCase
 
         $filename = './<!--foo-->';
 
-        $this->assertEquals('foo', $security->sanitizeFilename($filename));
+        $this->assertSame('foo', $security->sanitizeFilename($filename));
     }
 
     public function testRegenerateWithFalseSecurityRegenerateProperty()

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -86,7 +86,7 @@ final class SessionTest extends CIUnitTestCase
 
         $session->set('foo', 'bar');
 
-        $this->assertEquals('bar', $_SESSION['foo']);
+        $this->assertSame('bar', $_SESSION['foo']);
     }
 
     public function testCanSetArray()
@@ -99,8 +99,8 @@ final class SessionTest extends CIUnitTestCase
             'bar' => 'baz',
         ]);
 
-        $this->assertEquals('bar', $_SESSION['foo']);
-        $this->assertEquals('baz', $_SESSION['bar']);
+        $this->assertSame('bar', $_SESSION['foo']);
+        $this->assertSame('baz', $_SESSION['bar']);
         $this->assertArrayNotHasKey('__ci_vars', $_SESSION);
     }
 
@@ -119,7 +119,7 @@ final class SessionTest extends CIUnitTestCase
         ];
         $session->set(['_ci_old_input' => ['location' => $locations]]);
 
-        $this->assertEquals($locations, $session->get('_ci_old_input')['location']);
+        $this->assertSame($locations, $session->get('_ci_old_input')['location']);
     }
 
     public function testGetSimpleKey()
@@ -129,7 +129,7 @@ final class SessionTest extends CIUnitTestCase
 
         $session->set('foo', 'bar');
 
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
     }
 
     public function testGetReturnsNullWhenNotFound()
@@ -161,7 +161,7 @@ final class SessionTest extends CIUnitTestCase
         $session = $this->getInstance();
         $session->start();
 
-        $this->assertEquals([], $session->get());
+        $this->assertSame([], $session->get());
     }
 
     public function testGetReturnsItemValueisZero()
@@ -199,7 +199,7 @@ final class SessionTest extends CIUnitTestCase
 
         $session->set('foo', 'bar');
 
-        $this->assertEquals('bar', $session->foo);
+        $this->assertSame('bar', $session->foo);
     }
 
     public function testGetAsNormal()
@@ -209,7 +209,7 @@ final class SessionTest extends CIUnitTestCase
 
         $session->set('foo', 'bar');
 
-        $this->assertEquals('bar', $_SESSION['foo']);
+        $this->assertSame('bar', $_SESSION['foo']);
     }
 
     public function testHasReturnsTrueOnSuccess()
@@ -260,7 +260,7 @@ final class SessionTest extends CIUnitTestCase
         $session->set('hobbies', ['cooking' => 'baking']);
         $session->push('hobbies', ['sport' => 'tennis']);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 'cooking' => 'baking',
                 'sport'   => 'tennis',
@@ -307,7 +307,7 @@ final class SessionTest extends CIUnitTestCase
         $session->foo = 'bar';
 
         $this->assertArrayHasKey('foo', $_SESSION);
-        $this->assertEquals('bar', $_SESSION['foo']);
+        $this->assertSame('bar', $_SESSION['foo']);
     }
 
     public function testCanFlashData()
@@ -318,13 +318,13 @@ final class SessionTest extends CIUnitTestCase
         $session->setFlashdata('foo', 'bar');
 
         $this->assertTrue($session->has('foo'));
-        $this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
+        $this->assertSame('new', $_SESSION['__ci_vars']['foo']);
 
         // Should reset the 'new' to 'old'
         $session->start();
 
         $this->assertTrue($session->has('foo'));
-        $this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
+        $this->assertSame('old', $_SESSION['__ci_vars']['foo']);
 
         // Should no longer be available
         $session->start();
@@ -343,9 +343,9 @@ final class SessionTest extends CIUnitTestCase
         ]);
 
         $this->assertTrue($session->has('foo'));
-        $this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
+        $this->assertSame('new', $_SESSION['__ci_vars']['foo']);
         $this->assertTrue($session->has('bar'));
-        $this->assertEquals('new', $_SESSION['__ci_vars']['bar']);
+        $this->assertSame('new', $_SESSION['__ci_vars']['bar']);
     }
 
     public function testKeepFlashData()
@@ -356,23 +356,23 @@ final class SessionTest extends CIUnitTestCase
         $session->setFlashdata('foo', 'bar');
 
         $this->assertTrue($session->has('foo'));
-        $this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
+        $this->assertSame('new', $_SESSION['__ci_vars']['foo']);
 
         // Should reset the 'new' to 'old'
         $session->start();
 
         $this->assertTrue($session->has('foo'));
-        $this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
+        $this->assertSame('old', $_SESSION['__ci_vars']['foo']);
 
         $session->keepFlashdata('foo');
 
-        $this->assertEquals('new', $_SESSION['__ci_vars']['foo']);
+        $this->assertSame('new', $_SESSION['__ci_vars']['foo']);
 
         // Should no longer be available
         $session->start();
 
         $this->assertTrue($session->has('foo'));
-        $this->assertEquals('old', $_SESSION['__ci_vars']['foo']);
+        $this->assertSame('old', $_SESSION['__ci_vars']['foo']);
     }
 
     public function testUnmarkFlashDataRemovesData()
@@ -465,7 +465,7 @@ final class SessionTest extends CIUnitTestCase
         $session->setTempdata($data);
         $session->set('baz', 'ballywhoo');
 
-        $this->assertEquals($data, $session->getTempdata());
+        $this->assertSame($data, $session->getTempdata());
     }
 
     public function testGetTestDataReturnsSingle()
@@ -480,7 +480,7 @@ final class SessionTest extends CIUnitTestCase
 
         $session->setTempdata($data);
 
-        $this->assertEquals('bar', $session->getTempdata('foo'));
+        $this->assertSame('bar', $session->getTempdata('foo'));
     }
 
     public function testRemoveTempDataActuallyDeletes()
@@ -496,7 +496,7 @@ final class SessionTest extends CIUnitTestCase
         $session->setTempdata($data);
         $session->removeTempdata('foo');
 
-        $this->assertEquals(['bar' => 'baz'], $session->getTempdata());
+        $this->assertSame(['bar' => 'baz'], $session->getTempdata());
     }
 
     public function testUnMarkTempDataSingle()
@@ -512,7 +512,7 @@ final class SessionTest extends CIUnitTestCase
         $session->setTempdata($data);
         $session->unmarkTempdata('foo');
 
-        $this->assertEquals(['bar' => 'baz'], $session->getTempdata());
+        $this->assertSame(['bar' => 'baz'], $session->getTempdata());
     }
 
     public function testUnMarkTempDataArray()
@@ -528,7 +528,7 @@ final class SessionTest extends CIUnitTestCase
         $session->setTempdata($data);
         $session->unmarkTempdata(['foo', 'bar']);
 
-        $this->assertEquals([], $session->getTempdata());
+        $this->assertSame([], $session->getTempdata());
     }
 
     public function testGetTempdataKeys()
@@ -544,7 +544,7 @@ final class SessionTest extends CIUnitTestCase
         $session->setTempdata($data);
         $session->set('baz', 'ballywhoo');
 
-        $this->assertEquals(['foo', 'bar'], $session->getTempKeys());
+        $this->assertSame(['foo', 'bar'], $session->getTempKeys());
     }
 
     public function testGetDotKey()
@@ -552,7 +552,7 @@ final class SessionTest extends CIUnitTestCase
         $session = $this->getInstance();
         $session->start();
         $session->set('test.1', 'value');
-        $this->assertEquals('value', $session->get('test.1'));
+        $this->assertSame('value', $session->get('test.1'));
     }
 
     public function testLaxSameSite()

--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -41,7 +41,7 @@ final class BootstrapFCPATHTest extends CIUnitTestCase
     {
         $result1     = $this->readOutput($this->file1);
         $correctPath = $this->correctFCPATH();
-        $this->assertEquals($correctPath, $result1);
+        $this->assertSame($correctPath, $result1);
     }
 
     private function correctFCPATH()

--- a/tests/system/Test/ControllerTestTraitTest.php
+++ b/tests/system/Test/ControllerTestTraitTest.php
@@ -83,7 +83,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
             ->execute('index');
 
         $body = $result->response()->getBody();
-        $this->assertEquals('Hi there', $body);
+        $this->assertSame('Hi there', $body);
     }
 
     public function testPopcornFailure()
@@ -94,7 +94,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
             ->controller(Popcorn::class)
             ->execute('pop');
 
-        $this->assertEquals(567, $result->response()->getStatusCode());
+        $this->assertSame(567, $result->response()->getStatusCode());
     }
 
     public function testPopcornException()
@@ -105,7 +105,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
             ->controller(Popcorn::class)
             ->execute('popper');
 
-        $this->assertEquals(500, $result->response()->getStatusCode());
+        $this->assertSame(500, $result->response()->getStatusCode());
     }
 
     public function testPopcornIndexWithSupport()
@@ -124,7 +124,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
             ->execute('index');
 
         $body = $result->response()->getBody();
-        $this->assertEquals('Hi there', $body);
+        $this->assertSame('Hi there', $body);
     }
 
     public function testRequestPassthrough()
@@ -136,7 +136,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
             ->execute('popper');
 
         $req = $result->request();
-        $this->assertEquals('get', $req->getMethod());
+        $this->assertSame('get', $req->getMethod());
     }
 
     public function testFailureResponse()
@@ -148,7 +148,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
             ->execute('oops');
 
         $this->assertFalse($result->isOK());
-        $this->assertEquals(401, $result->response()->getStatusCode());
+        $this->assertSame(401, $result->response()->getStatusCode());
     }
 
     public function testEmptyResponse()
@@ -208,7 +208,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
             ->execute('index3');
 
         $response = json_decode($result->response()->getBody());
-        $this->assertEquals('en', $response->lang);
+        $this->assertSame('en', $response->lang);
     }
 
     /**

--- a/tests/system/Test/DOMParserTest.php
+++ b/tests/system/Test/DOMParserTest.php
@@ -26,7 +26,7 @@ final class DOMParserTest extends CIUnitTestCase
         $expected = '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">' . "\n"
                 . '<html><body><div><h1>Hello</h1></div></body></html>';
 
-        $this->assertEquals($expected . "\n", $dom->withString($html)->getBody());
+        $this->assertSame($expected . "\n", $dom->withString($html)->getBody());
     }
 
     public function testParseSelectorWithID()
@@ -35,8 +35,8 @@ final class DOMParserTest extends CIUnitTestCase
 
         $selector = $dom->parseSelector('div#row');
 
-        $this->assertEquals('div', $selector['tag']);
-        $this->assertEquals('row', $selector['id']);
+        $this->assertSame('div', $selector['tag']);
+        $this->assertSame('row', $selector['id']);
     }
 
     public function testParseSelectorWithClass()
@@ -45,8 +45,8 @@ final class DOMParserTest extends CIUnitTestCase
 
         $selector = $dom->parseSelector('div.row');
 
-        $this->assertEquals('div', $selector['tag']);
-        $this->assertEquals('row', $selector['class']);
+        $this->assertSame('div', $selector['tag']);
+        $this->assertSame('row', $selector['class']);
     }
 
     public function testParseSelectorWithClassMultiple()
@@ -55,9 +55,9 @@ final class DOMParserTest extends CIUnitTestCase
 
         $selector = $dom->parseSelector('div.row.another');
 
-        $this->assertEquals('div', $selector['tag']);
+        $this->assertSame('div', $selector['tag']);
         // Only parses the first class
-        $this->assertEquals('row', $selector['class']);
+        $this->assertSame('row', $selector['class']);
     }
 
     public function testParseSelectorWithAttribute()
@@ -66,8 +66,8 @@ final class DOMParserTest extends CIUnitTestCase
 
         $selector = $dom->parseSelector('a[ href = http://example.com ]');
 
-        $this->assertEquals('a', $selector['tag']);
-        $this->assertEquals(['href' => 'http://example.com'], $selector['attr']);
+        $this->assertSame('a', $selector['tag']);
+        $this->assertSame(['href' => 'http://example.com'], $selector['attr']);
     }
 
     public function provideText()
@@ -394,7 +394,7 @@ final class DOMParserTest extends CIUnitTestCase
         $path     = '[ name = user ]';
         $selector = $dom->parseSelector($path);
 
-        $this->assertEquals(['name' => 'user'], $selector['attr']);
+        $this->assertSame(['name' => 'user'], $selector['attr']);
 
         $html = '<html><body><div name="user">George</div></body></html>';
         $dom->withString($html);

--- a/tests/system/Test/FabricatorTest.php
+++ b/tests/system/Test/FabricatorTest.php
@@ -65,21 +65,21 @@ final class FabricatorTest extends CIUnitTestCase
     {
         $fabricator = new Fabricator(UserModel::class, $this->formatters);
 
-        $this->assertEquals($this->formatters, $fabricator->getFormatters());
+        $this->assertSame($this->formatters, $fabricator->getFormatters());
     }
 
     public function testConstructorGuessesFormatters()
     {
         $fabricator = new Fabricator(UserModel::class, null);
 
-        $this->assertEquals($this->formatters, $fabricator->getFormatters());
+        $this->assertSame($this->formatters, $fabricator->getFormatters());
     }
 
     public function testConstructorDefaultsToAppLocale()
     {
         $fabricator = new Fabricator(UserModel::class);
 
-        $this->assertEquals(config('App')->defaultLocale, $fabricator->getLocale());
+        $this->assertSame(config('App')->defaultLocale, $fabricator->getLocale());
     }
 
     public function testConstructorUsesProvidedLocale()
@@ -88,7 +88,7 @@ final class FabricatorTest extends CIUnitTestCase
 
         $fabricator = new Fabricator(UserModel::class, null, $locale);
 
-        $this->assertEquals($locale, $fabricator->getLocale());
+        $this->assertSame($locale, $fabricator->getLocale());
     }
 
     //--------------------------------------------------------------------
@@ -131,7 +131,7 @@ final class FabricatorTest extends CIUnitTestCase
 
         $fabricator->setFormatters($formatters);
 
-        $this->assertEquals($formatters, $fabricator->getFormatters());
+        $this->assertSame($formatters, $fabricator->getFormatters());
     }
 
     public function testSetFormattersDetectsFormatters()
@@ -141,7 +141,7 @@ final class FabricatorTest extends CIUnitTestCase
 
         $fabricator->setFormatters();
 
-        $this->assertEquals($this->formatters, $fabricator->getFormatters());
+        $this->assertSame($this->formatters, $fabricator->getFormatters());
     }
 
     public function testDetectFormattersDetectsFormatters()
@@ -153,7 +153,7 @@ final class FabricatorTest extends CIUnitTestCase
 
         $method();
 
-        $this->assertEquals($this->formatters, $fabricator->getFormatters());
+        $this->assertSame($this->formatters, $fabricator->getFormatters());
     }
 
     //--------------------------------------------------------------------
@@ -165,7 +165,7 @@ final class FabricatorTest extends CIUnitTestCase
 
         $fabricator->setOverrides($overrides);
 
-        $this->assertEquals($overrides, $fabricator->getOverrides());
+        $this->assertSame($overrides, $fabricator->getOverrides());
     }
 
     public function testSetOverridesDefaultPersists()
@@ -176,7 +176,7 @@ final class FabricatorTest extends CIUnitTestCase
         $fabricator->setOverrides($overrides);
         $fabricator->getOverrides();
 
-        $this->assertEquals($overrides, $fabricator->getOverrides());
+        $this->assertSame($overrides, $fabricator->getOverrides());
     }
 
     public function testSetOverridesOnce()
@@ -187,7 +187,7 @@ final class FabricatorTest extends CIUnitTestCase
         $fabricator->setOverrides($overrides, false);
         $fabricator->getOverrides();
 
-        $this->assertEquals([], $fabricator->getOverrides());
+        $this->assertSame([], $fabricator->getOverrides());
     }
 
     //--------------------------------------------------------------------
@@ -201,7 +201,7 @@ final class FabricatorTest extends CIUnitTestCase
         $field     = 'catchPhrase';
         $formatter = $method($field);
 
-        $this->assertEquals($field, $formatter);
+        $this->assertSame($field, $formatter);
     }
 
     public function testGuessFormattersFieldReturnsDateFormat()
@@ -213,7 +213,7 @@ final class FabricatorTest extends CIUnitTestCase
         $field     = 'created_at';
         $formatter = $method($field);
 
-        $this->assertEquals('date', $formatter);
+        $this->assertSame('date', $formatter);
     }
 
     public function testGuessFormattersPrimaryReturnsNumberBetween()
@@ -225,7 +225,7 @@ final class FabricatorTest extends CIUnitTestCase
         $field     = 'id';
         $formatter = $method($field);
 
-        $this->assertEquals('numberBetween', $formatter);
+        $this->assertSame('numberBetween', $formatter);
     }
 
     public function testGuessFormattersMatchesPartial()
@@ -237,7 +237,7 @@ final class FabricatorTest extends CIUnitTestCase
         $field     = 'business_email';
         $formatter = $method($field);
 
-        $this->assertEquals('email', $formatter);
+        $this->assertSame('email', $formatter);
     }
 
     public function testGuessFormattersFallback()
@@ -249,7 +249,7 @@ final class FabricatorTest extends CIUnitTestCase
         $field     = 'zaboomafoo';
         $formatter = $method($field);
 
-        $this->assertEquals($fabricator->defaultFormatter, $formatter);
+        $this->assertSame($fabricator->defaultFormatter, $formatter);
     }
 
     //--------------------------------------------------------------------
@@ -272,7 +272,7 @@ final class FabricatorTest extends CIUnitTestCase
 
         $result = $fabricator->makeArray();
 
-        $this->assertEquals($overrides['name'], $result['name']);
+        $this->assertSame($overrides['name'], $result['name']);
     }
 
     public function testMakeArrayReturnsValidData()
@@ -281,7 +281,7 @@ final class FabricatorTest extends CIUnitTestCase
 
         $result = $fabricator->makeArray();
 
-        $this->assertEquals($result['email'], filter_var($result['email'], FILTER_VALIDATE_EMAIL));
+        $this->assertSame($result['email'], filter_var($result['email'], FILTER_VALIDATE_EMAIL));
     }
 
     public function testMakeArrayUsesFakeMethod()
@@ -290,7 +290,7 @@ final class FabricatorTest extends CIUnitTestCase
 
         $result = $fabricator->makeArray();
 
-        $this->assertEquals($result['name'], filter_var($result['name'], FILTER_VALIDATE_IP));
+        $this->assertSame($result['name'], filter_var($result['name'], FILTER_VALIDATE_IP));
     }
 
     //--------------------------------------------------------------------
@@ -342,7 +342,7 @@ final class FabricatorTest extends CIUnitTestCase
 
         $result = $fabricator->makeObject();
 
-        $this->assertEquals($overrides['name'], $result->name);
+        $this->assertSame($overrides['name'], $result->name);
     }
 
     public function testMakeObjectReturnsValidData()
@@ -351,7 +351,7 @@ final class FabricatorTest extends CIUnitTestCase
 
         $result = $fabricator->makeObject();
 
-        $this->assertEquals($result->email, filter_var($result->email, FILTER_VALIDATE_EMAIL));
+        $this->assertSame($result->email, filter_var($result->email, FILTER_VALIDATE_EMAIL));
     }
 
     public function testMakeObjectUsesFakeMethod()
@@ -360,7 +360,7 @@ final class FabricatorTest extends CIUnitTestCase
 
         $result = $fabricator->makeObject();
 
-        $this->assertEquals($result->name, filter_var($result->name, FILTER_VALIDATE_IP));
+        $this->assertSame($result->name, filter_var($result->name, FILTER_VALIDATE_IP));
     }
 
     //--------------------------------------------------------------------
@@ -427,7 +427,7 @@ final class FabricatorTest extends CIUnitTestCase
     {
         $result = Fabricator::setCount('goblins', 42);
 
-        $this->assertEquals(42, $result);
+        $this->assertSame(42, $result);
     }
 
     public function testSetCountSetsValue()
@@ -435,14 +435,14 @@ final class FabricatorTest extends CIUnitTestCase
         Fabricator::setCount('trolls', 3);
         $result = Fabricator::getCount('trolls');
 
-        $this->assertEquals(3, $result);
+        $this->assertSame(3, $result);
     }
 
     public function testGetCountNewTableReturnsZero()
     {
         $result = Fabricator::getCount('gremlins');
 
-        $this->assertEquals(0, $result);
+        $this->assertSame(0, $result);
     }
 
     public function testUpCountIncrementsValue()
@@ -450,7 +450,7 @@ final class FabricatorTest extends CIUnitTestCase
         Fabricator::setCount('orcs', 12);
         Fabricator::upCount('orcs');
 
-        $this->assertEquals(13, Fabricator::getCount('orcs'));
+        $this->assertSame(13, Fabricator::getCount('orcs'));
     }
 
     public function testUpCountReturnsValue()
@@ -458,14 +458,14 @@ final class FabricatorTest extends CIUnitTestCase
         Fabricator::setCount('hobgoblins', 12);
         $result = Fabricator::upCount('hobgoblins');
 
-        $this->assertEquals(13, $result);
+        $this->assertSame(13, $result);
     }
 
     public function testUpCountNewTableReturnsOne()
     {
         $result = Fabricator::upCount('ogres');
 
-        $this->assertEquals(1, $result);
+        $this->assertSame(1, $result);
     }
 
     public function testDownCountDecrementsValue()
@@ -473,7 +473,7 @@ final class FabricatorTest extends CIUnitTestCase
         Fabricator::setCount('orcs', 12);
         Fabricator::downCount('orcs');
 
-        $this->assertEquals(11, Fabricator::getCount('orcs'));
+        $this->assertSame(11, Fabricator::getCount('orcs'));
     }
 
     public function testDownCountReturnsValue()
@@ -481,14 +481,14 @@ final class FabricatorTest extends CIUnitTestCase
         Fabricator::setCount('hobgoblins', 12);
         $result = Fabricator::downCount('hobgoblins');
 
-        $this->assertEquals(11, $result);
+        $this->assertSame(11, $result);
     }
 
     public function testDownCountNewTableReturnsNegativeOne()
     {
         $result = Fabricator::downCount('ogres');
 
-        $this->assertEquals(-1, $result);
+        $this->assertSame(-1, $result);
     }
 
     public function testResetClearsValue()
@@ -496,6 +496,6 @@ final class FabricatorTest extends CIUnitTestCase
         Fabricator::setCount('giants', 1000);
         Fabricator::resetCounts();
 
-        $this->assertEquals(0, Fabricator::getCount('giants'));
+        $this->assertSame(0, Fabricator::getCount('giants'));
     }
 }

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -59,8 +59,8 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->assertInstanceOf(TestResponse::class, $response);
         $this->assertInstanceOf(Response::class, $response->response());
         $this->assertTrue($response->isOK());
-        $this->assertEquals('Hello Earth', $response->response()->getBody());
-        $this->assertEquals(200, $response->response()->getStatusCode());
+        $this->assertSame('Hello Earth', $response->response()->getBody());
+        $this->assertSame(200, $response->response()->getStatusCode());
     }
 
     public function testCallPost()
@@ -369,7 +369,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
 <response><foo>bar</foo></response>
 ';
 
-        $this->assertEquals($expectedXml, $request->getBody());
+        $this->assertSame($expectedXml, $request->getBody());
         $this->assertTrue($request->header('Content-Type')->getValue() === 'application/xml');
     }
 
@@ -379,6 +379,6 @@ final class FeatureTestTraitTest extends CIUnitTestCase
 
         $request = $this->withBody('test')->setRequestBody($request);
 
-        $this->assertEquals('test', $request->getBody());
+        $this->assertSame('test', $request->getBody());
     }
 }

--- a/tests/system/Test/FilterTestTraitTest.php
+++ b/tests/system/Test/FilterTestTraitTest.php
@@ -67,14 +67,14 @@ final class FilterTestTraitTest extends CIUnitTestCase
         $this->assertObjectNotHasAttribute('url', $this->request);
 
         $this->assertObjectHasAttribute('url', $result);
-        $this->assertEquals('http://hellowworld.com', $result->url);
+        $this->assertSame('http://hellowworld.com', $result->url);
     }
 
     public function testGetFiltersForRoute()
     {
         $result = $this->getFiltersForRoute('/', 'before');
 
-        $this->assertEquals(['test-customfilter'], $result);
+        $this->assertSame(['test-customfilter'], $result);
     }
 
     public function testAssertFilter()

--- a/tests/system/Test/ReflectionHelperTest.php
+++ b/tests/system/Test/ReflectionHelperTest.php
@@ -11,14 +11,14 @@ final class ReflectionHelperTest extends CIUnitTestCase
     {
         $obj    = new __TestForReflectionHelper();
         $actual = $this->getPrivateProperty($obj, 'private');
-        $this->assertEquals('secret', $actual);
+        $this->assertSame('secret', $actual);
     }
 
     public function testGetPrivatePropertyWithObjectStaticCall()
     {
         $obj    = new __TestForReflectionHelper();
         $actual = CIUnitTestCase::getPrivateProperty($obj, 'private');
-        $this->assertEquals('secret', $actual);
+        $this->assertSame('secret', $actual);
     }
 
     public function testGetPrivatePropertyWithStatic()
@@ -27,7 +27,7 @@ final class ReflectionHelperTest extends CIUnitTestCase
             __TestForReflectionHelper::class,
             'static_private'
         );
-        $this->assertEquals('xyz', $actual);
+        $this->assertSame('xyz', $actual);
     }
 
     public function testSetPrivatePropertyWithObject()
@@ -38,7 +38,7 @@ final class ReflectionHelperTest extends CIUnitTestCase
             'private',
             'open'
         );
-        $this->assertEquals('open', $obj->getPrivate());
+        $this->assertSame('open', $obj->getPrivate());
     }
 
     public function testSetPrivatePropertyWithStatic()
@@ -48,7 +48,7 @@ final class ReflectionHelperTest extends CIUnitTestCase
             'static_private',
             'abc'
         );
-        $this->assertEquals(
+        $this->assertSame(
             'abc',
             __TestForReflectionHelper::getStaticPrivate()
         );
@@ -61,7 +61,7 @@ final class ReflectionHelperTest extends CIUnitTestCase
             $obj,
             'privateMethod'
         );
-        $this->assertEquals(
+        $this->assertSame(
             'private param1param2',
             $method('param1', 'param2')
         );
@@ -73,7 +73,7 @@ final class ReflectionHelperTest extends CIUnitTestCase
             __TestForReflectionHelper::class,
             'privateStaticMethod'
         );
-        $this->assertEquals(
+        $this->assertSame(
             'private_static param1param2',
             $method('param1', 'param2')
         );

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -26,7 +26,7 @@ final class TestCaseTest extends CIUnitTestCase
     {
         $obj    = new __TestForReflectionHelper();
         $actual = $this->getPrivateProperty($obj, 'private');
-        $this->assertEquals('secret', $actual);
+        $this->assertSame('secret', $actual);
     }
 
     //--------------------------------------------------------------------
@@ -58,7 +58,7 @@ final class TestCaseTest extends CIUnitTestCase
         $this->stream_filter        = stream_filter_append(STDOUT, 'CITestStreamFilter');
         CLI::write('first.');
         $expected = "first.\n";
-        $this->assertEquals($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
         stream_filter_remove($this->stream_filter);
     }
 

--- a/tests/system/Test/TestResponseTest.php
+++ b/tests/system/Test/TestResponseTest.php
@@ -38,7 +38,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->getTestResponse('Hello World');
         $this->response->setStatusCode($code);
 
-        $this->assertEquals($isOk, $this->testResponse->isOK());
+        $this->assertSame($isOk, $this->testResponse->isOK());
     }
 
     /**
@@ -167,7 +167,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->assertFalse($this->testResponse->response() instanceof RedirectResponse);
         $this->assertTrue($this->testResponse->isRedirect());
         $this->testResponse->assertRedirect();
-        $this->assertEquals('foo/bar', $this->testResponse->getRedirectUrl());
+        $this->assertSame('foo/bar', $this->testResponse->getRedirectUrl());
     }
 
     public function testGetRedirectUrlReturnsUrl()
@@ -176,7 +176,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->testResponse->setResponse(new RedirectResponse(new App()));
         $this->testResponse->response()->redirect('foo/bar');
 
-        $this->assertEquals('foo/bar', $this->testResponse->getRedirectUrl());
+        $this->assertSame('foo/bar', $this->testResponse->getRedirectUrl());
     }
 
     public function testGetRedirectUrlReturnsNull()
@@ -300,7 +300,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->getTestResponse(['foo' => 'bar']);
         $formatter = Services::format()->getFormatter('application/json');
 
-        $this->assertEquals($formatter->format(['foo' => 'bar']), $this->testResponse->getJSON());
+        $this->assertSame($formatter->format(['foo' => 'bar']), $this->testResponse->getJSON());
     }
 
     public function testEmptyJSON()
@@ -309,7 +309,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->response->setJSON('', true);
 
         // this should be "" - json_encode('');
-        $this->assertEquals('""', $this->testResponse->getJSON());
+        $this->assertSame('""', $this->testResponse->getJSON());
     }
 
     public function testFalseJSON()
@@ -318,7 +318,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->response->setJSON(false, true);
 
         // this should be FALSE - json_encode(false)
-        $this->assertEquals('false', $this->testResponse->getJSON());
+        $this->assertSame('false', $this->testResponse->getJSON());
     }
 
     public function testTrueJSON()
@@ -327,7 +327,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->response->setJSON(true, true);
 
         // this should be TRUE - json_encode(true)
-        $this->assertEquals('true', $this->testResponse->getJSON());
+        $this->assertSame('true', $this->testResponse->getJSON());
     }
 
     public function testInvalidJSON()
@@ -345,7 +345,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->getTestResponse(['foo' => 'bar']);
         $formatter = Services::format()->getFormatter('application/xml');
 
-        $this->assertEquals($formatter->format(['foo' => 'bar']), $this->testResponse->getXML());
+        $this->assertSame($formatter->format(['foo' => 'bar']), $this->testResponse->getXML());
     }
 
     public function testJsonFragment()

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -22,14 +22,14 @@ final class ThrottleTest extends CIUnitTestCase
         $throttler = new Throttler($this->cache);
 
         // tokenTime should be 0 to start
-        $this->assertEquals(0, $throttler->getTokenTime());
+        $this->assertSame(0, $throttler->getTokenTime());
 
         // set $rate
         $rate = 1;    // allow 1 request per minute
 
         // first check just creates a bucket, so tokenTime should be 0
         $throttler->check('127.0.0.1', $rate, MINUTE);
-        $this->assertEquals(0, $throttler->getTokenTime());
+        $this->assertSame(0, $throttler->getTokenTime());
 
         // additional check affects tokenTime, so tokenTime should be 1 or greater
         $throttler->check('127.0.0.1', $rate, MINUTE);
@@ -41,7 +41,7 @@ final class ThrottleTest extends CIUnitTestCase
         $throttler = new Throttler($this->cache);
 
         $this->assertTrue($throttler->check('127.0.0.1', 60, MINUTE));
-        $this->assertEquals(59, $this->cache->get('throttler_127.0.0.1'));
+        $this->assertSame(59, $this->cache->get('throttler_127.0.0.1'));
     }
 
     public function testRemove()
@@ -68,7 +68,7 @@ final class ThrottleTest extends CIUnitTestCase
         $throttler->check('127.0.0.1', 60, MINUTE);
         $throttler->check('127.0.0.1', 60, MINUTE);
 
-        $this->assertEquals(57, $this->cache->get('throttler_127.0.0.1'));
+        $this->assertSame(57, $this->cache->get('throttler_127.0.0.1'));
     }
 
     public function testReturnsFalseIfBucketEmpty()
@@ -87,7 +87,7 @@ final class ThrottleTest extends CIUnitTestCase
         $rate = 60; // allow 1 per second
         $cost = 10;
         $throttler->check('127.0.0.1', $rate, MINUTE, $cost);
-        $this->assertEquals($rate - $cost, $this->cache->get('throttler_127.0.0.1'));
+        $this->assertSame($rate - $cost, $this->cache->get('throttler_127.0.0.1'));
     }
 
     public function testUnderload()
@@ -96,12 +96,12 @@ final class ThrottleTest extends CIUnitTestCase
 
         $rate = 120; // allow 2 per second, in theory
         $throttler->check('127.0.0.1', $rate, MINUTE);
-        $this->assertEquals($rate - 1, $this->cache->get('throttler_127.0.0.1'));
+        $this->assertSame($rate - 1, $this->cache->get('throttler_127.0.0.1'));
 
         $throttler->setTestTime(strtotime('+2 seconds')); // should be more tokens available
         $this->assertTrue($throttler->check('127.0.0.1', $rate, MINUTE));
         // but the bucket should not be over-filled
-        $this->assertEquals($rate - 1, $this->cache->get('throttler_127.0.0.1'));
+        $this->assertSame($rate - 1, $this->cache->get('throttler_127.0.0.1'));
     }
 
     public function testOverload()
@@ -130,11 +130,11 @@ final class ThrottleTest extends CIUnitTestCase
 
         // Should be empty now.
         $this->assertFalse($throttler->check('127.0.0.1', $rate, MINUTE, $cost));
-        $this->assertEquals(0, $this->cache->get('throttler_127.0.0.1'));
+        $this->assertSame(0, $this->cache->get('throttler_127.0.0.1'));
 
         $throttler = $throttler->setTestTime(strtotime('+10 seconds'));
 
         $this->assertTrue($throttler->check('127.0.0.1', $rate, MINUTE, 0));
-        $this->assertEquals(10, round($this->cache->get('throttler_127.0.0.1')));
+        $this->assertSame(10.0, round($this->cache->get('throttler_127.0.0.1')));
     }
 }

--- a/tests/system/Typography/TypographyTest.php
+++ b/tests/system/Typography/TypographyTest.php
@@ -19,7 +19,7 @@ final class TypographyTest extends CIUnitTestCase
 
     public function testAutoTypographyEmptyString()
     {
-        $this->assertEquals('', $this->typography->autoTypography(''));
+        $this->assertSame('', $this->typography->autoTypography(''));
     }
 
     public function testAutoTypographyNormalString()
@@ -30,7 +30,7 @@ final class TypographyTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, $this->typography->autoTypography($str));
+            $this->assertSame($expect, $this->typography->autoTypography($str));
         }
     }
 
@@ -42,7 +42,7 @@ final class TypographyTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, $this->typography->autoTypography($str));
+            $this->assertSame($expect, $this->typography->autoTypography($str));
         }
     }
 
@@ -62,7 +62,7 @@ final class TypographyTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, $this->typography->autoTypography($str));
+            $this->assertSame($expect, $this->typography->autoTypography($str));
         }
     }
 
@@ -82,7 +82,7 @@ final class TypographyTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, $this->typography->autoTypography($str, true));
+            $this->assertSame($expect, $this->typography->autoTypography($str, true));
         }
     }
 
@@ -95,7 +95,7 @@ final class TypographyTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, $this->typography->autoTypography($str));
+            $this->assertSame($expect, $this->typography->autoTypography($str));
         }
     }
 
@@ -110,7 +110,7 @@ final class TypographyTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, $this->typography->autoTypography($str));
+            $this->assertSame($expect, $this->typography->autoTypography($str));
         }
     }
 
@@ -123,7 +123,7 @@ final class TypographyTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, $this->typography->autoTypography($str));
+            $this->assertSame($expect, $this->typography->autoTypography($str));
         }
     }
 
@@ -136,7 +136,7 @@ final class TypographyTest extends CIUnitTestCase
         ];
 
         foreach ($strs as $str => $expect) {
-            $this->assertEquals($expect, $this->typography->nl2brExceptPre($str));
+            $this->assertSame($expect, $this->typography->nl2brExceptPre($str));
         }
     }
 }

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -66,7 +66,7 @@ final class CreditCardRulesTest extends CIUnitTestCase
             'cc' => "valid_cc_number[{$type}]",
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -88,7 +88,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'valid_url',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function urlProvider()
@@ -171,7 +171,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'valid_email',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     /**
@@ -190,7 +190,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'valid_emails',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function emailProviderSingle()
@@ -258,7 +258,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => "valid_ip[{$which}]",
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function ipProvider()
@@ -328,7 +328,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'string',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function stringProvider()
@@ -365,7 +365,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'alpha',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function alphaProvider()
@@ -412,7 +412,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'alpha_space',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function alphaSpaceProvider()
@@ -461,7 +461,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'alpha_numeric',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function alphaNumericProvider()
@@ -502,7 +502,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'alpha_numeric_punct',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function alphaNumericPunctProvider()
@@ -599,7 +599,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'alpha_numeric_space',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function alphaNumericSpaceProvider()
@@ -640,7 +640,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'alpha_dash',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function alphaDashProvider()
@@ -681,7 +681,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'hex',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function hexProvider()
@@ -722,7 +722,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'numeric',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function numericProvider()
@@ -779,7 +779,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'integer',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function integerProvider()
@@ -836,7 +836,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'decimal',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function decimalProvider()
@@ -897,7 +897,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'is_natural',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function naturalProvider()
@@ -942,7 +942,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'is_natural_no_zero',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function naturalZeroProvider()
@@ -987,7 +987,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'valid_base64',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function base64Provider()
@@ -1024,7 +1024,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'valid_json',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function jsonProvider()
@@ -1085,7 +1085,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'timezone',
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function timezoneProvider()
@@ -1127,7 +1127,7 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => "valid_date[{$format}]",
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function validDateProvider()

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -158,7 +158,7 @@ final class RulesTest extends CIUnitTestCase
     {
         $this->validation->setRules($rules);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     //--------------------------------------------------------------------
@@ -214,7 +214,7 @@ final class RulesTest extends CIUnitTestCase
     {
         $this->validation->setRules($rules);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     //--------------------------------------------------------------------
@@ -1167,7 +1167,7 @@ final class RulesTest extends CIUnitTestCase
             'foo' => "greater_than[{$second}]",
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     //--------------------------------------------------------------------
@@ -1226,7 +1226,7 @@ final class RulesTest extends CIUnitTestCase
             'foo' => "greater_than_equal_to[{$second}]",
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     //--------------------------------------------------------------------
@@ -1290,7 +1290,7 @@ final class RulesTest extends CIUnitTestCase
             'foo' => "less_than[{$second}]",
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     //--------------------------------------------------------------------
@@ -1354,7 +1354,7 @@ final class RulesTest extends CIUnitTestCase
             'foo' => "less_than_equal_to[{$second}]",
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     //--------------------------------------------------------------------
@@ -1424,7 +1424,7 @@ final class RulesTest extends CIUnitTestCase
             'foo' => "in_list[{$second}]",
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     //--------------------------------------------------------------------
@@ -1448,7 +1448,7 @@ final class RulesTest extends CIUnitTestCase
             'foo' => "not_in_list[{$second}]",
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     //--------------------------------------------------------------------
@@ -1530,7 +1530,7 @@ final class RulesTest extends CIUnitTestCase
             $field => "required_with[{$check}]",
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     //--------------------------------------------------------------------
@@ -1617,7 +1617,7 @@ final class RulesTest extends CIUnitTestCase
             $field => "required_without[{$check}]",
         ]);
 
-        $this->assertEquals($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     //--------------------------------------------------------------------

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -84,7 +84,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $this->validation->setRules($rules);
 
-        $this->assertEquals($rules, $this->validation->getRules());
+        $this->assertSame($rules, $this->validation->getRules());
     }
 
     //--------------------------------------------------------------------
@@ -124,7 +124,7 @@ final class ValidationTest extends CIUnitTestCase
         ]);
 
         $this->assertFalse($this->validation->run($data));
-        $this->assertEquals('Validation.is_numeric', $this->validation->getError('foo'));
+        $this->assertSame('Validation.is_numeric', $this->validation->getError('foo'));
     }
 
     //--------------------------------------------------------------------
@@ -146,7 +146,7 @@ final class ValidationTest extends CIUnitTestCase
         ], $messages);
 
         $this->validation->run($data);
-        $this->assertEquals('Nope. Not a number.', $this->validation->getError('foo'));
+        $this->assertSame('Nope. Not a number.', $this->validation->getError('foo'));
     }
 
     //--------------------------------------------------------------------
@@ -161,7 +161,7 @@ final class ValidationTest extends CIUnitTestCase
     public function testCheckLocalizedError()
     {
         $this->assertFalse($this->validation->check('notanumber', 'is_numeric'));
-        $this->assertEquals('Validation.is_numeric', $this->validation->getError());
+        $this->assertSame('Validation.is_numeric', $this->validation->getError());
     }
 
     //--------------------------------------------------------------------
@@ -171,7 +171,7 @@ final class ValidationTest extends CIUnitTestCase
         $this->validation->check('notanumber', 'is_numeric', [
             'is_numeric' => 'Nope. Not a number.',
         ]);
-        $this->assertEquals('Nope. Not a number.', $this->validation->getError());
+        $this->assertSame('Nope. Not a number.', $this->validation->getError());
     }
 
     //--------------------------------------------------------------------
@@ -188,7 +188,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $this->validation->run($data);
 
-        $this->assertEquals(['foo' => 'Validation.is_numeric'], $this->validation->getErrors());
+        $this->assertSame(['foo' => 'Validation.is_numeric'], $this->validation->getErrors());
     }
 
     //--------------------------------------------------------------------
@@ -207,7 +207,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $this->validation->run($data);
 
-        $this->assertEquals([], $this->validation->getErrors());
+        $this->assertSame([], $this->validation->getErrors());
     }
 
     //--------------------------------------------------------------------
@@ -220,7 +220,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $this->validation->setError('foo', 'Nadda');
 
-        $this->assertEquals(['foo' => 'Nadda'], $this->validation->getErrors());
+        $this->assertSame(['foo' => 'Nadda'], $this->validation->getErrors());
     }
 
     //--------------------------------------------------------------------
@@ -233,7 +233,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $this->validation->run(['foo' => 'bar']);
 
-        $this->assertEquals(['foo' => 'My lovely error'], $this->validation->getErrors());
+        $this->assertSame(['foo' => 'My lovely error'], $this->validation->getErrors());
     }
 
     //--------------------------------------------------------------------
@@ -245,7 +245,7 @@ final class ValidationTest extends CIUnitTestCase
         ];
 
         $this->assertFalse($this->validation->run($data, 'groupA'));
-        $this->assertEquals('Shame, shame. Too short.', $this->validation->getError('foo'));
+        $this->assertSame('Shame, shame. Too short.', $this->validation->getError('foo'));
     }
 
     //--------------------------------------------------------------------
@@ -263,7 +263,7 @@ final class ValidationTest extends CIUnitTestCase
 
     public function testGetRuleGroup()
     {
-        $this->assertEquals([
+        $this->assertSame([
             'foo' => 'required|min_length[5]',
         ], $this->validation->getRuleGroup('groupA'));
     }
@@ -282,7 +282,7 @@ final class ValidationTest extends CIUnitTestCase
     {
         $this->validation->setRuleGroup('groupA');
 
-        $this->assertEquals([
+        $this->assertSame([
             'foo' => 'required|min_length[5]',
         ], $this->validation->getRules());
     }
@@ -306,7 +306,7 @@ final class ValidationTest extends CIUnitTestCase
             'username' => 'codeigniter',
         ]);
 
-        $this->assertEquals([
+        $this->assertSame([
             'password' => 'custom password required error msg.',
         ], $this->validation->getErrors());
     }
@@ -320,7 +320,7 @@ final class ValidationTest extends CIUnitTestCase
             'username' => 'codeigniter',
         ], 'login');
 
-        $this->assertEquals([
+        $this->assertSame([
             'password' => 'custom password required error msg.',
         ], $this->validation->getErrors());
     }
@@ -342,7 +342,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $this->validation->run($data);
 
-        $this->assertEquals($expected, $this->validation->getError('foo'));
+        $this->assertSame($expected, $this->validation->getError('foo'));
     }
 
     //--------------------------------------------------------------------
@@ -416,7 +416,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $this->validation->run(['foo' => 'abc']);
 
-        $this->assertEquals('The Foo Bar field is very short.', $this->validation->getError('foo'));
+        $this->assertSame('The Foo Bar field is very short.', $this->validation->getError('foo'));
     }
 
     public function testInvalidRule()
@@ -452,7 +452,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $request = new IncomingRequest($config, new URI(), $rawstring, new UserAgent());
         $this->validation->withRequest($request->withMethod('patch'))->run($data);
-        $this->assertEquals([], $this->validation->getErrors());
+        $this->assertSame([], $this->validation->getErrors());
     }
 
     //--------------------------------------------------------------------
@@ -482,7 +482,7 @@ final class ValidationTest extends CIUnitTestCase
             ->run();
 
         $this->assertTrue($validated);
-        $this->assertEquals([], $this->validation->getErrors());
+        $this->assertSame([], $this->validation->getErrors());
 
         unset($_SERVER['CONTENT_TYPE']);
     }
@@ -523,7 +523,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $this->validation->setError('foo', 'Nadda');
 
-        $this->assertEquals('', $this->validation->showError('bogus'));
+        $this->assertSame('', $this->validation->showError('bogus'));
     }
 
     //--------------------------------------------------------------------
@@ -537,7 +537,7 @@ final class ValidationTest extends CIUnitTestCase
         ]);
         $this->validation->setError('foo', 'Nadda');
 
-        $this->assertEquals('We should never get here', $this->validation->showError('foo', 'bogus_template'));
+        $this->assertSame('We should never get here', $this->validation->showError('foo', 'bogus_template'));
     }
 
     //--------------------------------------------------------------------
@@ -641,7 +641,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $result = $method('uploaded[avatar]|max_size[avatar,1024]');
 
-        $this->assertEquals('uploaded[avatar]', $result[0]);
+        $this->assertSame('uploaded[avatar]', $result[0]);
     }
 
     public function testSplitRegex()
@@ -650,7 +650,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $result = $method('required|regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]|max_length[10]');
 
-        $this->assertEquals('regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]', $result[1]);
+        $this->assertSame('regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]', $result[1]);
     }
 
     //--------------------------------------------------------------------
@@ -686,7 +686,7 @@ final class ValidationTest extends CIUnitTestCase
         $expected = 'Supplied value (Pizza) for Username must have at least 6 characters.';
 
         // check if they are the same!
-        $this->assertEquals($expected, $errors['Username']);
+        $this->assertSame($expected, $errors['Username']);
     }
 
     //--------------------------------------------------------------------
@@ -703,7 +703,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $this->validation->setRules($rules);
         $this->validation->withRequest($request->withMethod('post'))->run($body);
-        $this->assertEquals($results, $this->validation->getErrors());
+        $this->assertSame($results, $this->validation->getErrors());
     }
 
     //--------------------------------------------------------------------
@@ -790,7 +790,7 @@ final class ValidationTest extends CIUnitTestCase
         ]);
 
         $this->validation->withRequest($request->withMethod('post'))->run();
-        $this->assertEquals([], $this->validation->getErrors());
+        $this->assertSame([], $this->validation->getErrors());
     }
 
     //--------------------------------------------------------------------
@@ -819,7 +819,7 @@ final class ValidationTest extends CIUnitTestCase
         ]);
 
         $this->validation->withRequest($request->withMethod('post'))->run();
-        $this->assertEquals([
+        $this->assertSame([
             'id_user.*'   => 'The id_user.* field must contain only numbers.',
             'name_user.*' => 'The name_user.* field may only contain alphabetical characters.',
         ], $this->validation->getErrors());
@@ -843,7 +843,7 @@ final class ValidationTest extends CIUnitTestCase
         ]);
 
         $this->validation->withRequest($request->withMethod('post'))->run();
-        $this->assertEquals([
+        $this->assertSame([
             'id_user' => 'The id_user field must contain only numbers.',
         ], $this->validation->getErrors());
     }
@@ -863,7 +863,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $this->validation->run(['foo' => 'abc']);
 
-        $this->assertEquals('The Foo Bar Translated field must be at least 10 characters in length.', $this->validation->getError('foo'));
+        $this->assertSame('The Foo Bar Translated field must be at least 10 characters in length.', $this->validation->getError('foo'));
     }
 
     //--------------------------------------------------------------------
@@ -881,7 +881,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $this->validation->run(['foo' => 'abc']);
 
-        $this->assertEquals('The Foo.bar.is.missing field must be at least 10 characters in length.', $this->validation->getError('foo'));
+        $this->assertSame('The Foo.bar.is.missing field must be at least 10 characters in length.', $this->validation->getError('foo'));
     }
 
     //--------------------------------------------------------------------
@@ -902,7 +902,7 @@ final class ValidationTest extends CIUnitTestCase
 
         $this->validation->run(['foo' => 'abc']);
 
-        $this->assertEquals('The Foo Bar Translated field is very short.', $this->validation->getError('foo'));
+        $this->assertSame('The Foo Bar Translated field is very short.', $this->validation->getError('foo'));
     }
 
     //--------------------------------------------------------------------
@@ -941,7 +941,7 @@ final class ValidationTest extends CIUnitTestCase
         $expected = 'Supplied value (Pizza) for Foo Bar Translated must have at least 6 characters.';
 
         // check if they are the same!
-        $this->assertEquals($expected, $errors['Username']);
+        $this->assertSame($expected, $errors['Username']);
     }
 
     /**

--- a/tests/system/View/CellTest.php
+++ b/tests/system/View/CellTest.php
@@ -33,14 +33,14 @@ final class CellTest extends CIUnitTestCase
 
     public function testPrepareParamsReturnsEmptyArrayWithInvalidParam()
     {
-        $this->assertEquals([], $this->cell->prepareParams(1.023));
+        $this->assertSame([], $this->cell->prepareParams(1.023));
     }
 
     //--------------------------------------------------------------------
 
     public function testPrepareParamsReturnsNullWithEmptyString()
     {
-        $this->assertEquals([], $this->cell->prepareParams(''));
+        $this->assertSame([], $this->cell->prepareParams(''));
     }
 
     //--------------------------------------------------------------------
@@ -52,14 +52,14 @@ final class CellTest extends CIUnitTestCase
             'three' => 'four',
         ];
 
-        $this->assertEquals($object, $this->cell->prepareParams($object));
+        $this->assertSame($object, $this->cell->prepareParams($object));
     }
 
     //--------------------------------------------------------------------
 
     public function testPrepareParamsReturnsEmptyArrayWithEmptyArray()
     {
-        $this->assertEquals([], $this->cell->prepareParams([]));
+        $this->assertSame([], $this->cell->prepareParams([]));
     }
 
     //--------------------------------------------------------------------
@@ -72,7 +72,7 @@ final class CellTest extends CIUnitTestCase
             'three' => 'four',
         ];
 
-        $this->assertEquals($expected, $this->cell->prepareParams($params));
+        $this->assertSame($expected, $this->cell->prepareParams($params));
     }
 
     //--------------------------------------------------------------------
@@ -81,11 +81,11 @@ final class CellTest extends CIUnitTestCase
     {
         $params   = 'one=2, three=4.15';
         $expected = [
-            'one'   => 2,
-            'three' => 4.15,
+            'one'   => '2',
+            'three' => '4.15',
         ];
 
-        $this->assertEquals($expected, $this->cell->prepareParams($params));
+        $this->assertSame($expected, $this->cell->prepareParams($params));
     }
 
     //--------------------------------------------------------------------
@@ -98,7 +98,7 @@ final class CellTest extends CIUnitTestCase
             'three' => 'four',
         ];
 
-        $this->assertEquals($expected, $this->cell->prepareParams($params));
+        $this->assertSame($expected, $this->cell->prepareParams($params));
     }
 
     //--------------------------------------------------------------------
@@ -112,7 +112,7 @@ final class CellTest extends CIUnitTestCase
             'five'  => 'six',
         ];
 
-        $this->assertEquals($expected, $this->cell->prepareParams($params));
+        $this->assertSame($expected, $this->cell->prepareParams($params));
     }
 
     //--------------------------------------------------------------------
@@ -124,7 +124,7 @@ final class CellTest extends CIUnitTestCase
     {
         $expected = 'Hello';
 
-        $this->assertEquals($expected, $this->cell->render('\Tests\Support\View\SampleClass::hello'));
+        $this->assertSame($expected, $this->cell->render('\Tests\Support\View\SampleClass::hello'));
     }
 
     //--------------------------------------------------------------------
@@ -137,7 +137,7 @@ final class CellTest extends CIUnitTestCase
             'three' => 'four',
         ];
 
-        $this->assertEquals(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::echobox', $params));
+        $this->assertSame(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::echobox', $params));
     }
 
     //--------------------------------------------------------------------
@@ -150,7 +150,7 @@ final class CellTest extends CIUnitTestCase
             'three' => 'four',
         ];
 
-        $this->assertEquals(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::staticEcho', $params));
+        $this->assertSame(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::staticEcho', $params));
     }
 
     //--------------------------------------------------------------------
@@ -160,14 +160,14 @@ final class CellTest extends CIUnitTestCase
         $params   = [];
         $expected = [];
 
-        $this->assertEquals(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::staticEcho', $params));
+        $this->assertSame(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::staticEcho', $params));
     }
 
     public function testOptionsNoParams()
     {
         $expected = [];
 
-        $this->assertEquals(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::staticEcho'));
+        $this->assertSame(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::staticEcho'));
     }
 
     public function testCellEmptyParams()
@@ -175,7 +175,7 @@ final class CellTest extends CIUnitTestCase
         $params   = ',';
         $expected = 'Hello World';
 
-        $this->assertEquals($expected, $this->cell->render('\Tests\Support\View\SampleClass::index', $params));
+        $this->assertSame($expected, $this->cell->render('\Tests\Support\View\SampleClass::index', $params));
     }
 
     //--------------------------------------------------------------------
@@ -189,7 +189,7 @@ final class CellTest extends CIUnitTestCase
             'three' => 'four',
         ];
 
-        $this->assertEquals(implode(',', $expected), $this->cell->render('::echobox', $params));
+        $this->assertSame(implode(',', $expected), $this->cell->render('::echobox', $params));
     }
 
     public function testCellMethodMissing()
@@ -201,7 +201,7 @@ final class CellTest extends CIUnitTestCase
             'three' => 'four',
         ];
 
-        $this->assertEquals(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::', $params));
+        $this->assertSame(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::', $params));
     }
 
     public function testCellBadClass()
@@ -210,7 +210,7 @@ final class CellTest extends CIUnitTestCase
         $params   = 'one=two,three=four';
         $expected = 'Hello World';
 
-        $this->assertEquals($expected, $this->cell->render('\CodeIgniter\View\GoodQuestion::', $params));
+        $this->assertSame($expected, $this->cell->render('\CodeIgniter\View\GoodQuestion::', $params));
     }
 
     public function testCellBadMethod()
@@ -219,7 +219,7 @@ final class CellTest extends CIUnitTestCase
         $params   = 'one=two,three=four';
         $expected = 'Hello World';
 
-        $this->assertEquals($expected, $this->cell->render('\Tests\Support\View\SampleClass::notThere', $params));
+        $this->assertSame($expected, $this->cell->render('\Tests\Support\View\SampleClass::notThere', $params));
     }
 
     //--------------------------------------------------------------------
@@ -232,9 +232,9 @@ final class CellTest extends CIUnitTestCase
             'three' => 'four',
         ];
 
-        $this->assertEquals(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::echobox', $params, 60, 'rememberme'));
+        $this->assertSame(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::echobox', $params, 60, 'rememberme'));
         $params = 'one=six,three=five';
-        $this->assertEquals(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::echobox', $params, 1, 'rememberme'));
+        $this->assertSame(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::echobox', $params, 1, 'rememberme'));
     }
 
     public function testRenderCachedAutoName()
@@ -245,11 +245,11 @@ final class CellTest extends CIUnitTestCase
             'three' => 'four',
         ];
 
-        $this->assertEquals(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::echobox', $params, 60));
+        $this->assertSame(implode(',', $expected), $this->cell->render('\Tests\Support\View\SampleClass::echobox', $params, 60));
         $params = 'one=six,three=five';
         // When auto-generating it takes the params as part of cachename, so it wouldn't have actually cached this, but
         // we want to make sure it doesn't throw us a curveball here.
-        $this->assertEquals('six,five', $this->cell->render('\Tests\Support\View\SampleClass::echobox', $params, 1));
+        $this->assertSame('six,five', $this->cell->render('\Tests\Support\View\SampleClass::echobox', $params, 1));
     }
 
     //--------------------------------------------------------------------
@@ -263,7 +263,7 @@ final class CellTest extends CIUnitTestCase
         ];
         $expected = 'Right on';
 
-        $this->assertEquals($expected, $this->cell->render('\Tests\Support\View\SampleClass::work', $params));
+        $this->assertSame($expected, $this->cell->render('\Tests\Support\View\SampleClass::work', $params));
     }
 
     public function testParametersDontMatch()
@@ -272,11 +272,11 @@ final class CellTest extends CIUnitTestCase
         $params   = 'p1=one,p2=two,p3=three';
         $expected = 'Right on';
 
-        $this->assertEquals($expected, $this->cell->render('\Tests\Support\View\SampleClass::work', $params));
+        $this->assertSame($expected, $this->cell->render('\Tests\Support\View\SampleClass::work', $params));
     }
 
     public function testCallInitControllerIfMethodExists()
     {
-        $this->assertEquals('CodeIgniter\HTTP\Response', $this->cell->render('\Tests\Support\View\SampleClassWithInitController::index'));
+        $this->assertSame('CodeIgniter\HTTP\Response', $this->cell->render('\Tests\Support\View\SampleClassWithInitController::index'));
     }
 }

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -39,7 +39,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|abs }{ value2|abs }';
 
         $parser->setData($data);
-        $this->assertEquals('55', $parser->renderString($template));
+        $this->assertSame('55', $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -56,7 +56,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|capitalize } { value2|capitalize }';
 
         $parser->setData($data);
-        $this->assertEquals('Wonder Twins', $parser->renderString($template));
+        $this->assertSame('Wonder Twins', $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -80,7 +80,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|date(Y-m-d) } { value2|date(Y-m-d) } { value1|date(Y.m.d) } { value1|date(Y m d) } { value1|date(Y:m:d) } { value1|date(Y/m/d) } { value1|date(Y\\\m\\\d) }';
 
         $parser->setData($data);
-        $this->assertEquals("{$todayDash} {$todayDash} {$todayDot} {$todaySpace} {$todayColon} {$todaySlash} {$todayBackslash}", $parser->renderString($template));
+        $this->assertSame("{$todayDash} {$todayDash} {$todayDot} {$todaySpace} {$todayColon} {$todaySlash} {$todayBackslash}", $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -98,7 +98,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|date_modify(+1 day)|date(Y-m-d) } { value2|date_modify(+1 day)|date(Y-m-d) }';
 
         $parser->setData($data);
-        $this->assertEquals("{$tommorrow} {$tommorrow}", $parser->renderString($template));
+        $this->assertSame("{$tommorrow} {$tommorrow}", $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -116,7 +116,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|default(foo) } { value2|default(bar) } { value3|default(baz) }';
 
         $parser->setData($data);
-        $this->assertEquals('foo bar test', $parser->renderString($template));
+        $this->assertSame('foo bar test', $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -135,7 +135,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|esc(html) } { value1|esc(js) }';
 
         $parser->setData($data);
-        $this->assertEquals("{$value1} {$value2}", $parser->renderString($template));
+        $this->assertSame("{$value1} {$value2}", $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -151,7 +151,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|excerpt(jumped, 10) }';
 
         $parser->setData($data);
-        $this->assertEquals('... red fox jumped over ...', $parser->renderString($template));
+        $this->assertSame('... red fox jumped over ...', $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -167,7 +167,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|highlight(jumped over) }';
 
         $parser->setData($data);
-        $this->assertEquals('The quick red fox <mark>jumped over</mark> the lazy brown dog', $parser->renderString($template));
+        $this->assertSame('The quick red fox <mark>jumped over</mark> the lazy brown dog', $parser->renderString($template));
     }
 
     public function testHighlightCode()
@@ -186,7 +186,7 @@ final class ParserFilterTest extends CIUnitTestCase
             </span>
             </code>
             EOF;
-        $this->assertEquals($expected, $parser->renderString($template));
+        $this->assertSame($expected, $parser->renderString($template));
     }
 
     public function testProse()
@@ -200,7 +200,7 @@ final class ParserFilterTest extends CIUnitTestCase
 
         $template = '{ value1|prose }';
         $expected = '<p>Sincerely\nMe</p>';
-        $this->assertEquals($expected, $parser->renderString($template));
+        $this->assertSame($expected, $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -216,7 +216,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|limit_chars(10) }';
 
         $parser->setData($data);
-        $this->assertEquals('The quick&#8230;', $parser->renderString($template));
+        $this->assertSame('The quick&#8230;', $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -232,7 +232,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|limit_words(4) }';
 
         $parser->setData($data);
-        $this->assertEquals('The quick red fox&#8230;', $parser->renderString($template));
+        $this->assertSame('The quick red fox&#8230;', $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -248,7 +248,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|lower }';
 
         $parser->setData($data);
-        $this->assertEquals('something', $parser->renderString($template));
+        $this->assertSame('something', $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -264,7 +264,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|nl2br }';
 
         $parser->setData($data);
-        $this->assertEquals("first<br />\nsecond", $parser->renderString($template));
+        $this->assertSame("first<br />\nsecond", $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -280,7 +280,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|number_format(2) }';
 
         $parser->setData($data);
-        $this->assertEquals('1,098.35', $parser->renderString($template));
+        $this->assertSame('1,098.35', $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -296,7 +296,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|round(1) } { value1|round(1, common) } { value1|round(ceil) } { value1|round(floor) } { value1|round(unknown) }';
 
         $parser->setData($data);
-        $this->assertEquals('5.6 5.6 6 5 5.55', $parser->renderString($template));
+        $this->assertSame('5.6 5.6 6 5 5.55', $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -312,7 +312,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|strip_tags } { value1|strip_tags(<b>) }';
 
         $parser->setData($data);
-        $this->assertEquals('Middle <b>Middle</b>', $parser->renderString($template));
+        $this->assertSame('Middle <b>Middle</b>', $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -328,7 +328,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|title }';
 
         $parser->setData($data);
-        $this->assertEquals('Though She Be Little', $parser->renderString($template));
+        $this->assertSame('Though She Be Little', $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -344,7 +344,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|upper }';
 
         $parser->setData($data);
-        $this->assertEquals('THOUGH SHE BE LITTLE', $parser->renderString($template));
+        $this->assertSame('THOUGH SHE BE LITTLE', $parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -360,7 +360,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ mynum|local_number }';
 
         $parser->setData($data);
-        $this->assertEquals('1,234,567.8912', $parser->renderString($template));
+        $this->assertSame('1,234,567.8912', $parser->renderString($template));
     }
 
     public function testLocalNumberPrecision()
@@ -374,7 +374,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ mynum|local_number(decimal,2) }';
 
         $parser->setData($data);
-        $this->assertEquals('1,234,567.89', $parser->renderString($template));
+        $this->assertSame('1,234,567.89', $parser->renderString($template));
     }
 
     public function testLocalNumberType()
@@ -388,7 +388,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ mynum|local_number(spellout) }';
 
         $parser->setData($data);
-        $this->assertEquals('one million two hundred thirty-four thousand five hundred sixty-seven point eight nine one two three four six', $parser->renderString($template));
+        $this->assertSame('one million two hundred thirty-four thousand five hundred sixty-seven point eight nine one two three four six', $parser->renderString($template));
     }
 
     public function testLocalNumberLocale()
@@ -402,7 +402,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ mynum|local_number(decimal,4,de_DE) }';
 
         $parser->setData($data);
-        $this->assertEquals('1.234.567,8912', $parser->renderString($template));
+        $this->assertSame('1.234.567,8912', $parser->renderString($template));
     }
 
     public function testLocalCurrency()
@@ -416,7 +416,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ mynum|local_currency(EUR,de_DE,2) }';
 
         $parser->setData($data);
-        $this->assertEquals('1.234.567,89 €', $parser->renderString($template));
+        $this->assertSame('1.234.567,89 €', $parser->renderString($template));
     }
 
     public function testParsePairWithAbs()
@@ -472,6 +472,6 @@ final class ParserFilterTest extends CIUnitTestCase
             . '{/nested}';
 
         $parser->setData($data);
-        $this->assertEquals('112233445566', $parser->renderString($template));
+        $this->assertSame('112233445566', $parser->renderString($template));
     }
 }

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -35,7 +35,7 @@ final class ParserPluginTest extends CIUnitTestCase
         helper('url');
         $template = '{+ current_url +}';
 
-        $this->assertEquals(current_url(), $this->parser->renderString($template));
+        $this->assertSame(current_url(), $this->parser->renderString($template));
     }
 
     public function testPreviousURL()
@@ -46,7 +46,7 @@ final class ParserPluginTest extends CIUnitTestCase
         // Ensure a previous URL exists to work with.
         $_SESSION['_ci_previous_url'] = 'http://example.com/foo';
 
-        $this->assertEquals(previous_url(), $this->parser->renderString($template));
+        $this->assertSame(previous_url(), $this->parser->renderString($template));
     }
 
     public function testMailto()
@@ -54,7 +54,7 @@ final class ParserPluginTest extends CIUnitTestCase
         helper('url');
         $template = '{+ mailto email=foo@example.com title=Silly +}';
 
-        $this->assertEquals(mailto('foo@example.com', 'Silly'), $this->parser->renderString($template));
+        $this->assertSame(mailto('foo@example.com', 'Silly'), $this->parser->renderString($template));
     }
 
     /**
@@ -73,14 +73,14 @@ final class ParserPluginTest extends CIUnitTestCase
         helper('url');
         $template = '{+ safe_mailto email=foo@example.com title=Silly +}';
 
-        $this->assertEquals(safe_mailto('foo@example.com', 'Silly'), $this->parser->renderString($template));
+        $this->assertSame(safe_mailto('foo@example.com', 'Silly'), $this->parser->renderString($template));
     }
 
     public function testLang()
     {
         $template = '{+ lang Number.terabyteAbbr +}';
 
-        $this->assertEquals('TB', $this->parser->renderString($template));
+        $this->assertSame('TB', $this->parser->renderString($template));
     }
 
     public function testValidationErrors()
@@ -89,7 +89,7 @@ final class ParserPluginTest extends CIUnitTestCase
 
         $template = '{+ validation_errors field=email +}';
 
-        $this->assertEquals($this->setHints($this->validator->showError('email')), $this->setHints($this->parser->renderString($template)));
+        $this->assertSame($this->setHints($this->validator->showError('email')), $this->setHints($this->parser->renderString($template)));
     }
 
     public function testRoute()
@@ -100,14 +100,14 @@ final class ParserPluginTest extends CIUnitTestCase
 
         $template = '{+ route myController::goto string 13 +}';
 
-        $this->assertEquals('/path/string/to/13', $this->parser->renderString($template));
+        $this->assertSame('/path/string/to/13', $this->parser->renderString($template));
     }
 
     public function testSiteURL()
     {
         $template = '{+ siteURL +}';
 
-        $this->assertEquals('http://example.com/index.php', $this->parser->renderString($template));
+        $this->assertSame('http://example.com/index.php', $this->parser->renderString($template));
     }
 
     public function testValidationErrorsList()
@@ -116,7 +116,7 @@ final class ParserPluginTest extends CIUnitTestCase
         $this->validator->setError('username', 'User name must be unique');
         $template = '{+ validation_errors +}';
 
-        $this->assertEquals($this->setHints($this->validator->listErrors()), $this->setHints($this->parser->renderString($template)));
+        $this->assertSame($this->setHints($this->validator->listErrors()), $this->setHints($this->parser->renderString($template)));
     }
 
     public function setHints($output)

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -50,22 +50,22 @@ final class ParserTest extends CIUnitTestCase
     public function testSetDelimiters()
     {
         // Make sure default delimiters are there
-        $this->assertEquals('{', $this->parser->leftDelimiter);
-        $this->assertEquals('}', $this->parser->rightDelimiter);
+        $this->assertSame('{', $this->parser->leftDelimiter);
+        $this->assertSame('}', $this->parser->rightDelimiter);
 
         // Change them to square brackets
         $this->parser->setDelimiters('[', ']');
 
         // Make sure they changed
-        $this->assertEquals('[', $this->parser->leftDelimiter);
-        $this->assertEquals(']', $this->parser->rightDelimiter);
+        $this->assertSame('[', $this->parser->leftDelimiter);
+        $this->assertSame(']', $this->parser->rightDelimiter);
 
         // Reset them
         $this->parser->setDelimiters();
 
         // Make sure default delimiters are there
-        $this->assertEquals('{', $this->parser->leftDelimiter);
-        $this->assertEquals('}', $this->parser->rightDelimiter);
+        $this->assertSame('{', $this->parser->leftDelimiter);
+        $this->assertSame('}', $this->parser->rightDelimiter);
     }
 
     // --------------------------------------------------------------------
@@ -73,7 +73,7 @@ final class ParserTest extends CIUnitTestCase
     public function testParseSimple()
     {
         $this->parser->setVar('teststring', 'Hello World');
-        $this->assertEquals("<h1>Hello World</h1>\n", $this->parser->render('template1'));
+        $this->assertSame("<h1>Hello World</h1>\n", $this->parser->render('template1'));
     }
 
     // --------------------------------------------------------------------
@@ -90,7 +90,7 @@ final class ParserTest extends CIUnitTestCase
         $result = implode("\n", $data);
 
         $this->parser->setData($data);
-        $this->assertEquals($result, $this->parser->renderString($template));
+        $this->assertSame($result, $this->parser->renderString($template));
     }
 
     // --------------------------------------------------------------------
@@ -107,7 +107,7 @@ final class ParserTest extends CIUnitTestCase
         $result = implode("\n", $data) . "\n{name}";
 
         $this->parser->setData($data);
-        $this->assertEquals($result, $this->parser->renderString($template));
+        $this->assertSame($result, $this->parser->renderString($template));
     }
 
     // --------------------------------------------------------------------
@@ -125,14 +125,14 @@ final class ParserTest extends CIUnitTestCase
         $result = "Page Title\nLorem ipsum dolor sit amet.";
 
         $this->parser->setData($data);
-        $this->assertEquals($result, $this->parser->renderString($template));
+        $this->assertSame($result, $this->parser->renderString($template));
     }
 
     // --------------------------------------------------------------------
 
     public function testParseNoTemplate()
     {
-        $this->assertEquals('', $this->parser->renderString(''));
+        $this->assertSame('', $this->parser->renderString(''));
     }
 
     // --------------------------------------------------------------------
@@ -152,7 +152,7 @@ final class ParserTest extends CIUnitTestCase
         $template = "{title}\n{powers}{invisibility}\n{flying}{/powers}";
 
         $this->parser->setData($data);
-        $this->assertEquals("Super Heroes\nyes\nno", $this->parser->renderString($template));
+        $this->assertSame("Super Heroes\nyes\nno", $this->parser->renderString($template));
     }
 
     public function testParseArrayMulti()
@@ -169,7 +169,7 @@ final class ParserTest extends CIUnitTestCase
         $template = "{powers}{invisibility}\n{flying}{/powers}\nsecond:{powers} {invisibility} {flying}{ /powers}";
 
         $this->parser->setData($data);
-        $this->assertEquals("yes\nno\nsecond: yes no", $this->parser->renderString($template));
+        $this->assertSame("yes\nno\nsecond: yes no", $this->parser->renderString($template));
     }
 
     public function testParseArrayNested()
@@ -193,7 +193,7 @@ final class ParserTest extends CIUnitTestCase
         $template = "{title}\n{powers}{invisibility}\n{flying}{by} {with}{/flying}{/powers}";
 
         $this->parser->setData($data);
-        $this->assertEquals("Super Heroes\nyes\nplane broomstick", $this->parser->renderString($template));
+        $this->assertSame("Super Heroes\nyes\nplane broomstick", $this->parser->renderString($template));
     }
 
     public function testParseArrayNestedObject()
@@ -220,7 +220,7 @@ final class ParserTest extends CIUnitTestCase
         $template = '{birds}{mom} and {pop} work at {home}{/birds}';
 
         $this->parser->setData($data);
-        $this->assertEquals('Owl and Class: stdClass work at Resource', $this->parser->renderString($template));
+        $this->assertSame('Owl and Class: stdClass work at Resource', $this->parser->renderString($template));
     }
 
     // --------------------------------------------------------------------
@@ -239,7 +239,7 @@ final class ParserTest extends CIUnitTestCase
         $template = "{title}\n{powers}{name} {/powers}";
 
         $this->parser->setData($data);
-        $this->assertEquals("Super Heroes\nTom Dick Henry ", $this->parser->renderString($template));
+        $this->assertSame("Super Heroes\nTom Dick Henry ", $this->parser->renderString($template));
     }
 
     public function testParseLoopObjectProperties()
@@ -264,7 +264,7 @@ final class ParserTest extends CIUnitTestCase
         $template = "{title}\n{powers}{name} {/powers}";
 
         $this->parser->setData($data, 'html');
-        $this->assertEquals("Super Heroes\nTom Dick Henry ", $this->parser->renderString($template));
+        $this->assertSame("Super Heroes\nTom Dick Henry ", $this->parser->renderString($template));
     }
 
     // --------------------------------------------------------------------
@@ -296,7 +296,7 @@ final class ParserTest extends CIUnitTestCase
         $template = "{title}\n{powers} {foo} {bar} {bobbles}{name} {/bobbles}{/powers}";
 
         $this->parser->setData($data);
-        $this->assertEquals("Super Heroes\n bar baz first second ", $this->parser->renderString($template));
+        $this->assertSame("Super Heroes\n bar baz first second ", $this->parser->renderString($template));
     }
 
     public function testParseLoopEntityObjectProperties()
@@ -333,7 +333,7 @@ final class ParserTest extends CIUnitTestCase
         $template = "{title}\n{powers} {foo} {bar} {bobbles}{name} {/bobbles}{/powers}";
 
         $this->parser->setData($data, 'html');
-        $this->assertEquals("Super Heroes\n bar baz first second ", $this->parser->renderString($template));
+        $this->assertSame("Super Heroes\n bar baz first second ", $this->parser->renderString($template));
     }
 
     // --------------------------------------------------------------------
@@ -354,7 +354,7 @@ final class ParserTest extends CIUnitTestCase
         $result   = "Super Heroes\n{powers}{invisibility}\n{flying}";
 
         $this->parser->setData($data);
-        $this->assertEquals($result, $this->parser->renderString($template));
+        $this->assertSame($result, $this->parser->renderString($template));
     }
 
     public function escValueTypes()
@@ -419,7 +419,7 @@ final class ParserTest extends CIUnitTestCase
         if ($expected === null) {
             $expected = $value;
         }
-        $this->assertEquals($expected, \esc($value));
+        $this->assertSame($expected, \esc($value));
     }
 
     //------------------------------------------------------------------------
@@ -432,7 +432,7 @@ final class ParserTest extends CIUnitTestCase
         $template = '{foo} {foo_bar}';
 
         $this->parser->setData(['foo' => 'bar', 'foo_bar' => 'foo-bar'], 'raw');
-        $this->assertEquals('bar foo-bar', $this->parser->renderString($template));
+        $this->assertSame('bar foo-bar', $this->parser->renderString($template));
     }
 
     public function testParsePairSimilarVariableNames()
@@ -449,7 +449,7 @@ final class ParserTest extends CIUnitTestCase
 
         $template = '{title} {powers}{link} {link_second}{/powers}';
         $this->parser->setData($data);
-        $this->assertEquals('&lt;script&gt;Heroes&lt;/script&gt; &lt;a href=&#039;test&#039;&gt;Link&lt;/a&gt; &lt;a href=&#039;test2&#039;&gt;Link second&lt;/a&gt;', $this->parser->renderString($template));
+        $this->assertSame('&lt;script&gt;Heroes&lt;/script&gt; &lt;a href=&#039;test&#039;&gt;Link&lt;/a&gt; &lt;a href=&#039;test2&#039;&gt;Link second&lt;/a&gt;', $this->parser->renderString($template));
     }
 
     //------------------------------------------------------------------------
@@ -462,7 +462,7 @@ final class ParserTest extends CIUnitTestCase
         $template = '{ foo }';
 
         $this->parser->setData(['foo' => '<script>'], 'raw');
-        $this->assertEquals('<script>', $this->parser->renderString($template));
+        $this->assertSame('<script>', $this->parser->renderString($template));
     }
 
     public function testEscapingSetDataWithOtherContext()
@@ -470,7 +470,7 @@ final class ParserTest extends CIUnitTestCase
         $template = '{ foo }';
 
         $this->parser->setData(['foo' => 'http://foo.com'], 'url');
-        $this->assertEquals('http%3A%2F%2Ffoo.com', $this->parser->renderString($template));
+        $this->assertSame('http%3A%2F%2Ffoo.com', $this->parser->renderString($template));
     }
 
     public function testNoEscapingSetData()
@@ -478,14 +478,14 @@ final class ParserTest extends CIUnitTestCase
         $template = '{ foo | noescape}';
 
         $this->parser->setData(['foo' => 'http://foo.com'], 'unknown');
-        $this->assertEquals('http://foo.com', $this->parser->renderString($template));
+        $this->assertSame('http://foo.com', $this->parser->renderString($template));
     }
 
     public function testAutoEscaping()
     {
         $this->parser->setData(['foo' => 'http://foo.com'], 'unknown');
 
-        $this->assertEquals('html', $this->parser->shouldAddEscaping('{ foo | this | that }'));
+        $this->assertSame('html', $this->parser->shouldAddEscaping('{ foo | this | that }'));
     }
 
     public function testAutoEscapingNot()
@@ -505,7 +505,7 @@ final class ParserTest extends CIUnitTestCase
         $template = '{ that_thing|esc }';
 
         $this->parser->setData($data);
-        $this->assertEquals('&lt;script&gt;alert(&quot;ci4&quot;)&lt;/script&gt;', $this->parser->renderString($template));
+        $this->assertSame('&lt;script&gt;alert(&quot;ci4&quot;)&lt;/script&gt;', $this->parser->renderString($template));
     }
 
     public function testFilterWithArgument()
@@ -519,7 +519,7 @@ final class ParserTest extends CIUnitTestCase
         $template = '{ my_date| date(Y-m-d ) }';
 
         $this->parser->setData($data);
-        $this->assertEquals(date('Y-m-d', $date), $this->parser->renderString($template));
+        $this->assertSame(date('Y-m-d', $date), $this->parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -535,7 +535,7 @@ final class ParserTest extends CIUnitTestCase
 
         $template = '{title} {powers}{link}{/powers}';
         $this->parser->setData($data);
-        $this->assertEquals('&lt;script&gt;Heroes&lt;/script&gt; &lt;a href=&#039;test&#039;&gt;Link&lt;/a&gt;', $this->parser->renderString($template));
+        $this->assertSame('&lt;script&gt;Heroes&lt;/script&gt; &lt;a href=&#039;test&#039;&gt;Link&lt;/a&gt;', $this->parser->renderString($template));
     }
 
     public function testParserNoEscape()
@@ -546,7 +546,7 @@ final class ParserTest extends CIUnitTestCase
 
         $template = '{! title!}';
         $this->parser->setData($data);
-        $this->assertEquals('<script>Heroes</script>', $this->parser->renderString($template));
+        $this->assertSame('<script>Heroes</script>', $this->parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -567,7 +567,7 @@ final class ParserTest extends CIUnitTestCase
         $result   = "Super Heroes\n{powers}{invisibility}\n{flying}";
 
         $this->parser->setData($data);
-        $this->assertEquals($result, $this->parser->renderString($template));
+        $this->assertSame($result, $this->parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -588,7 +588,7 @@ final class ParserTest extends CIUnitTestCase
         $result   = "{title}\n{powers}{invisibility}\n{flying}";
 
         $this->parser->setData($data);
-        $this->assertEquals($result, $this->parser->renderString($template));
+        $this->assertSame($result, $this->parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -603,7 +603,7 @@ final class ParserTest extends CIUnitTestCase
         $template = '{if $doit}Howdy{endif}{ if $dontdoit === false}Welcome{ endif }';
         $this->parser->setData($data);
 
-        $this->assertEquals('HowdyWelcome', $this->parser->renderString($template));
+        $this->assertSame('HowdyWelcome', $this->parser->renderString($template));
     }
 
     public function testElseConditionalFalse()
@@ -615,7 +615,7 @@ final class ParserTest extends CIUnitTestCase
         $template = '{if $doit}Howdy{else}Welcome{ endif }';
         $this->parser->setData($data);
 
-        $this->assertEquals('Howdy', $this->parser->renderString($template));
+        $this->assertSame('Howdy', $this->parser->renderString($template));
     }
 
     public function testElseConditionalTrue()
@@ -627,7 +627,7 @@ final class ParserTest extends CIUnitTestCase
         $template = '{if $doit}Howdy{else}Welcome{ endif }';
         $this->parser->setData($data);
 
-        $this->assertEquals('Welcome', $this->parser->renderString($template));
+        $this->assertSame('Welcome', $this->parser->renderString($template));
     }
 
     public function testElseifConditionalTrue()
@@ -640,7 +640,7 @@ final class ParserTest extends CIUnitTestCase
         $template = '{if $doit}Howdy{elseif $dontdoit}Welcome{ endif }';
         $this->parser->setData($data);
 
-        $this->assertEquals('Welcome', $this->parser->renderString($template));
+        $this->assertSame('Welcome', $this->parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -657,7 +657,7 @@ final class ParserTest extends CIUnitTestCase
         $template = '{if doit}Howdy{elseif doit}Welcome{ endif )}';
 
         $this->parser->setData($data);
-        $this->assertEquals('HowdyWelcome', $this->parser->renderString($template));
+        $this->assertSame('HowdyWelcome', $this->parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -665,7 +665,7 @@ final class ParserTest extends CIUnitTestCase
     public function testWontParsePHP()
     {
         $template = "<?php echo 'Foo' ?> - <?= 'Bar' ?>";
-        $this->assertEquals('&lt;?php echo \'Foo\' ?&gt; - &lt;?= \'Bar\' ?&gt;', $this->parser->renderString($template));
+        $this->assertSame('&lt;?php echo \'Foo\' ?&gt; - &lt;?= \'Bar\' ?&gt;', $this->parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -682,7 +682,7 @@ final class ParserTest extends CIUnitTestCase
         $result = implode("\n", $data);
 
         $this->parser->setData($data);
-        $this->assertEquals($result, $this->parser->renderString($template));
+        $this->assertSame($result, $this->parser->renderString($template));
     }
 
     // --------------------------------------------------------------------
@@ -699,7 +699,7 @@ final class ParserTest extends CIUnitTestCase
         $result = implode("\n", $data);
 
         $this->parser->setData($data);
-        $this->assertEquals($result, $this->parser->renderString($template));
+        $this->assertSame($result, $this->parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -733,7 +733,7 @@ final class ParserTest extends CIUnitTestCase
     {
         $template = 'hit:it';
 
-        $this->assertEquals('hit:it', $this->parser->renderString($template));
+        $this->assertSame('hit:it', $this->parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -749,7 +749,7 @@ final class ParserTest extends CIUnitTestCase
 
         $template = '{+ hit:it +} stuff here {+ /hit:it +}';
 
-        $this->assertEquals(' stuff Hip to the Hop ', $this->parser->renderString($template));
+        $this->assertSame(' stuff Hip to the Hop ', $this->parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -768,7 +768,7 @@ final class ParserTest extends CIUnitTestCase
 
         $template = '{+ hello world +}';
 
-        $this->assertEquals('Hello, world', $this->parser->renderString($template));
+        $this->assertSame('Hello, world', $this->parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -793,7 +793,7 @@ final class ParserTest extends CIUnitTestCase
 
         $template = '{+ growth step=2 count=4 +}  {+ /growth +}';
 
-        $this->assertEquals(' 2 4 6 8', $this->parser->renderString($template));
+        $this->assertSame(' 2 4 6 8', $this->parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -809,7 +809,7 @@ final class ParserTest extends CIUnitTestCase
 
         $template = '{+ hit:it +}';
 
-        $this->assertEquals('Hip to the Hop', $this->parser->renderString($template));
+        $this->assertSame('Hip to the Hop', $this->parser->renderString($template));
     }
 
     /**
@@ -823,7 +823,7 @@ final class ParserTest extends CIUnitTestCase
 
         $template = '{+ hit:it first=foo last=bar +}';
 
-        $this->assertEquals('foo to the bar', $this->parser->renderString($template));
+        $this->assertSame('foo to the bar', $this->parser->renderString($template));
     }
 
     /**
@@ -837,7 +837,7 @@ final class ParserTest extends CIUnitTestCase
 
         $template = '{+ hit:it foo bar +}';
 
-        $this->assertEquals('foo to the bar', $this->parser->renderString($template));
+        $this->assertSame('foo to the bar', $this->parser->renderString($template));
     }
 
     /**
@@ -857,7 +857,7 @@ final class ParserTest extends CIUnitTestCase
 
         $template = '{+ count "foo bar" baz "foo bar" +}';
 
-        $this->assertEquals('0. foo bar 1. baz 2. foo bar ', $this->parser->renderString($template));
+        $this->assertSame('0. foo bar 1. baz 2. foo bar ', $this->parser->renderString($template));
     }
 
     /**
@@ -877,7 +877,7 @@ final class ParserTest extends CIUnitTestCase
 
         $template = '{+ read_params title="Hello world" page=5 email=test@test.net +}';
 
-        $this->assertEquals('title: Hello world. page: 5. email: test@test.net. ', $this->parser->renderString($template));
+        $this->assertSame('title: Hello world. page: 5. email: test@test.net. ', $this->parser->renderString($template));
     }
 
     //--------------------------------------------------------------------
@@ -896,7 +896,7 @@ final class ParserTest extends CIUnitTestCase
         $template = '{books}<p>Price $: {price}</p>{/books}';
 
         $this->parser->setData($data);
-        $this->assertEquals('<p>Price $: 12.50</p>', $this->parser->renderString($template));
+        $this->assertSame('<p>Price $: 12.50</p>', $this->parser->renderString($template));
     }
 
     /**
@@ -958,9 +958,9 @@ final class ParserTest extends CIUnitTestCase
         $this->parser->setVar('teststring', 'Hello World');
 
         $expected = "<h1>Hello World</h1>\n";
-        $this->assertEquals($expected, $this->parser->render('template1', ['cache' => 10, 'cache_name' => 'HelloWorld']));
+        $this->assertSame($expected, $this->parser->render('template1', ['cache' => 10, 'cache_name' => 'HelloWorld']));
         // this second renderings should go thru the cache
-        $this->assertEquals($expected, $this->parser->render('template1', ['cache' => 10, 'cache_name' => 'HelloWorld']));
+        $this->assertSame($expected, $this->parser->render('template1', ['cache' => 10, 'cache_name' => 'HelloWorld']));
     }
 
     //--------------------------------------------------------------------
@@ -968,7 +968,7 @@ final class ParserTest extends CIUnitTestCase
     public function testRenderFindsView()
     {
         $this->parser->setData(['testString' => 'Hello World']);
-        $this->assertEquals("<h1>Hello World</h1>\n", $this->parser->render('Simpler'));
+        $this->assertSame("<h1>Hello World</h1>\n", $this->parser->render('Simpler'));
     }
 
     public function testRenderCannotFindView()
@@ -987,11 +987,11 @@ final class ParserTest extends CIUnitTestCase
         $expected = "<h1>Hello World</h1>\n";
 
         $this->parser->setData(['testString' => 'Hello World']);
-        $this->assertEquals($expected, $this->parser->render('Simpler', [], false));
+        $this->assertSame($expected, $this->parser->render('Simpler', [], false));
         $this->assertArrayNotHasKey('testString', $this->parser->getData());
 
         $this->parser->setData(['testString' => 'Hello World']);
-        $this->assertEquals($expected, $this->parser->render('Simpler', [], true));
+        $this->assertSame($expected, $this->parser->render('Simpler', [], true));
         $this->assertArrayHasKey('testString', $this->parser->getData());
     }
 
@@ -1001,11 +1001,11 @@ final class ParserTest extends CIUnitTestCase
         $pattern  = '<h1>{testString}</h1>';
 
         $this->parser->setData(['testString' => 'Hello World']);
-        $this->assertEquals($expected, $this->parser->renderString($pattern, [], false));
+        $this->assertSame($expected, $this->parser->renderString($pattern, [], false));
         $this->assertArrayNotHasKey('testString', $this->parser->getData());
         //last set data is not saved
         $this->parser->setData(['testString' => 'Hello World']);
-        $this->assertEquals($expected, $this->parser->renderString($pattern, [], true));
+        $this->assertSame($expected, $this->parser->renderString($pattern, [], true));
         $this->assertArrayHasKey('testString', $this->parser->getData());
     }
 
@@ -1013,6 +1013,6 @@ final class ParserTest extends CIUnitTestCase
     {
         $this->parser->setData(['testString' => 'Hello World']);
         $expected = '<h1>Hello World</h1>';
-        $this->assertEquals($expected, $this->parser->render('Simpler.html'));
+        $this->assertSame($expected, $this->parser->render('Simpler.html'));
     }
 }

--- a/tests/system/View/TableTest.php
+++ b/tests/system/View/TableTest.php
@@ -27,19 +27,19 @@ final class TableTest extends CIUnitTestCase
         $template = ['a' => 'b'];
 
         $this->table->setTemplate($template);
-        $this->assertEquals($template, $this->table->template);
+        $this->assertSame($template, $this->table->template);
     }
 
     public function testSetEmpty()
     {
         $this->table->setEmpty('nada');
-        $this->assertEquals('nada', $this->table->emptyCells);
+        $this->assertSame('nada', $this->table->emptyCells);
     }
 
     public function testSetCaption()
     {
         $this->table->setCaption('awesome cap');
-        $this->assertEquals('awesome cap', $this->table->caption);
+        $this->assertSame('awesome cap', $this->table->caption);
     }
 
     /**
@@ -53,7 +53,7 @@ final class TableTest extends CIUnitTestCase
 
         $this->table->setHeading('name', 'color', 'size');
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 ['data' => 'name'],
                 ['data' => 'color'],
@@ -73,7 +73,7 @@ final class TableTest extends CIUnitTestCase
 
         $this->table->setFooting('Subtotal', $subtotal);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 ['data' => 'Subtotal'],
                 ['data' => $subtotal],
@@ -97,7 +97,7 @@ final class TableTest extends CIUnitTestCase
 
         $this->assertCount(3, $this->table->rows);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 ['data' => 'your'],
                 ['data' => 'pony'],
@@ -118,7 +118,7 @@ final class TableTest extends CIUnitTestCase
             ['data' => 'size'],
         ];
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $this->table->prepArgs(['name', 'color', 'size'])
         );
@@ -130,7 +130,7 @@ final class TableTest extends CIUnitTestCase
             'class' => 'awesome',
         ];
 
-        $this->assertEquals(
+        $this->assertSame(
             $expected,
             $this->table->prepArgs(['name', 'color', 'size', ['data' => 'weight', 'class' => 'awesome']])
         );
@@ -173,14 +173,14 @@ final class TableTest extends CIUnitTestCase
         $this->table->compileTemplate();
 
         $this->assertArrayHasKey('nonsense', $this->table->template);
-        $this->assertEquals('foo', $this->table->template['nonsense']);
+        $this->assertSame('foo', $this->table->template['nonsense']);
 
         // override default
         $this->table->setTemplate(['table_close' => '</table junk>']);
         $this->table->compileTemplate();
 
         $this->assertArrayHasKey('table_close', $this->table->template);
-        $this->assertEquals('</table junk>', $this->table->template['table_close']);
+        $this->assertSame('</table junk>', $this->table->template['table_close']);
     }
 
     public function testMakeColumns()
@@ -201,13 +201,13 @@ final class TableTest extends CIUnitTestCase
         ];
 
         // No column count - no changes to the array
-        $this->assertEquals(
+        $this->assertSame(
             $fiveValues,
             $this->table->makeColumns($fiveValues)
         );
 
         // Column count of 3 leaves us with one &nbsp;
-        $this->assertEquals(
+        $this->assertSame(
             [
                 ['Laura', 'Red', '15'],
                 ['Katie', 'Blue', '&nbsp;'],
@@ -278,14 +278,14 @@ final class TableTest extends CIUnitTestCase
             ['data' => 'number'],
         ];
 
-        $this->assertEquals($expected, $this->table->heading);
+        $this->assertSame($expected, $this->table->heading);
 
         $expected = [
             ['data' => 'Katie'],
             ['data' => 'Blue'],
         ];
 
-        $this->assertEquals($expected, $this->table->rows[1]);
+        $this->assertSame($expected, $this->table->rows[1]);
     }
 
     public function testSetFromObject()
@@ -304,14 +304,14 @@ final class TableTest extends CIUnitTestCase
             ['data' => 'email'],
         ];
 
-        $this->assertEquals($expected, $this->table->heading);
+        $this->assertSame($expected, $this->table->heading);
 
         $expected = [
             'name'  => ['data' => 'Foo Bar'],
             'email' => ['data' => 'foo@bar.com'],
         ];
 
-        $this->assertEquals($expected, $this->table->rows[1]);
+        $this->assertSame($expected, $this->table->rows[1]);
     }
 
     public function testGenerate()
@@ -464,7 +464,7 @@ final class TableTest extends CIUnitTestCase
 
         $table = $this->table->generate($data);
 
-        $this->assertEquals('Undefined table data', $table);
+        $this->assertSame('Undefined table data', $table);
     }
 
     // --------------------------------------------------------------------

--- a/tests/system/View/ViewTest.php
+++ b/tests/system/View/ViewTest.php
@@ -37,7 +37,7 @@ final class ViewTest extends CIUnitTestCase
 
         $view->setVar('foo', 'bar');
 
-        $this->assertEquals(['foo' => 'bar'], $view->getData());
+        $this->assertSame(['foo' => 'bar'], $view->getData());
     }
 
     public function testSetVarOverwrites()
@@ -47,7 +47,7 @@ final class ViewTest extends CIUnitTestCase
         $view->setVar('foo', 'bar');
         $view->setVar('foo', 'baz');
 
-        $this->assertEquals(['foo' => 'baz'], $view->getData());
+        $this->assertSame(['foo' => 'baz'], $view->getData());
     }
 
     //--------------------------------------------------------------------
@@ -63,7 +63,7 @@ final class ViewTest extends CIUnitTestCase
 
         $view->setData($expected);
 
-        $this->assertEquals($expected, $view->getData());
+        $this->assertSame($expected, $view->getData());
     }
 
     public function testSetDataMergesData()
@@ -82,7 +82,7 @@ final class ViewTest extends CIUnitTestCase
             'bar' => 'baz',
         ]);
 
-        $this->assertEquals($expected, $view->getData());
+        $this->assertSame($expected, $view->getData());
     }
 
     public function testSetDataOverwritesData()
@@ -100,7 +100,7 @@ final class ViewTest extends CIUnitTestCase
             'bar' => 'baz',
         ]);
 
-        $this->assertEquals($expected, $view->getData());
+        $this->assertSame($expected, $view->getData());
     }
 
     //--------------------------------------------------------------------
@@ -111,7 +111,7 @@ final class ViewTest extends CIUnitTestCase
 
         $view->setVar('foo', 'bar&', 'html');
 
-        $this->assertEquals(['foo' => 'bar&amp;'], $view->getData());
+        $this->assertSame(['foo' => 'bar&amp;'], $view->getData());
     }
 
     public function testSetDataWillEscapeAll()
@@ -128,7 +128,7 @@ final class ViewTest extends CIUnitTestCase
             'bar' => 'baz<',
         ], 'html');
 
-        $this->assertEquals($expected, $view->getData());
+        $this->assertSame($expected, $view->getData());
     }
 
     //--------------------------------------------------------------------
@@ -152,13 +152,13 @@ final class ViewTest extends CIUnitTestCase
         $view->setVar('testString', 'Hello World');
         $expected = '<h1>Hello World</h1>';
 
-        $this->assertEquals($expected, $view->renderString('<h1><?= $testString ?></h1>'));
+        $this->assertSame($expected, $view->renderString('<h1><?= $testString ?></h1>'));
     }
 
     public function testRenderStringNullTempdata()
     {
         $view = new View($this->config, $this->viewsDir, $this->loader);
-        $this->assertEquals('test string', $view->renderString('test string'));
+        $this->assertSame('test string', $view->renderString('test string'));
     }
 
     //--------------------------------------------------------------------
@@ -196,7 +196,7 @@ final class ViewTest extends CIUnitTestCase
 
         $expected = ['testString' => 'Hello World'];
 
-        $this->assertEquals($expected, $view->getData());
+        $this->assertSame($expected, $view->getData());
     }
 
     public function testRenderCanSaveDataThroughConfigSetting()
@@ -210,7 +210,7 @@ final class ViewTest extends CIUnitTestCase
 
         $expected = ['testString' => 'Hello World'];
 
-        $this->assertEquals($expected, $view->getData());
+        $this->assertSame($expected, $view->getData());
     }
 
     //--------------------------------------------------------------------
@@ -224,7 +224,7 @@ final class ViewTest extends CIUnitTestCase
 
         $view->resetData();
 
-        $this->assertEquals([], $view->getData());
+        $this->assertSame([], $view->getData());
     }
 
     //--------------------------------------------------------------------
@@ -250,11 +250,11 @@ final class ViewTest extends CIUnitTestCase
 
         //I think saveData is sava current data, is not clean already set data.
         $view->setVar('testString', 'Hello World');
-        $this->assertEquals($expected, $view->renderString('<h1><?= $testString ?></h1>', [], false));
+        $this->assertSame($expected, $view->renderString('<h1><?= $testString ?></h1>', [], false));
         $this->assertArrayNotHasKey('testString', $view->getData());
 
         $view->setVar('testString', 'Hello World');
-        $this->assertEquals($expected, $view->renderString('<h1><?= $testString ?></h1>', [], true));
+        $this->assertSame($expected, $view->renderString('<h1><?= $testString ?></h1>', [], true));
         $this->assertArrayHasKey('testString', $view->getData());
     }
 
@@ -268,7 +268,7 @@ final class ViewTest extends CIUnitTestCase
 
         $view->setVar('testString', 'Hello World');
         $expected = '<h1>Hello World</h1>';
-        $this->assertEquals($expected, $view->renderString('<h1><?= $testString ?></h1>', [], true));
+        $this->assertSame($expected, $view->renderString('<h1><?= $testString ?></h1>', [], true));
         $this->assertCount(1, $view->getPerformanceData());
     }
 
@@ -280,7 +280,7 @@ final class ViewTest extends CIUnitTestCase
 
         $view->setVar('testString', 'Hello World');
         $expected = '<h1>Hello World</h1>';
-        $this->assertEquals($expected, $view->renderString('<h1><?= $testString ?></h1>', [], true));
+        $this->assertSame($expected, $view->renderString('<h1><?= $testString ?></h1>', [], true));
         $this->assertCount(0, $view->getPerformanceData());
     }
 
@@ -336,7 +336,7 @@ final class ViewTest extends CIUnitTestCase
 
         $this->assertTrue(strpos($content, '<p>Open</p>') !== false);
         $this->assertTrue(strpos($content, '<h1>Hello World</h1>') !== false);
-        $this->assertEquals(2, substr_count($content, 'Hello World'));
+        $this->assertSame(2, substr_count($content, 'Hello World'));
     }
 
     public function testRenderLayoutBroken()

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -165,8 +165,16 @@ final class CodeIgniter4 extends AbstractRuleset
                 'target'          => 'newest',
                 'use_class_const' => true,
             ],
-            'php_unit_set_up_tear_down_visibility'   => true,
-            'php_unit_size_class'                    => false,
+            'php_unit_set_up_tear_down_visibility' => true,
+            'php_unit_size_class'                  => false,
+            'php_unit_strict'                      => [
+                'assertions' => [
+                    'assertAttributeEquals',
+                    'assertAttributeNotEquals',
+                    'assertEquals',
+                    'assertNotEquals',
+                ],
+            ],
             'php_unit_test_annotation'               => ['style' => 'prefix'],
             'php_unit_test_case_static_method_calls' => [
                 'call_type' => 'this',


### PR DESCRIPTION
**Description**
Since we're advocating for identity checks with `===` , we should do the same with testing.

Expecting this to be breaking the builds. 😂

**Checklist:**
- [x] Securely signed commits
