### PR TITLE
Fix bug with respecting TTL in Predis and File cache

### DIFF
--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -278,7 +278,7 @@ class FileHandler extends BaseHandler
         }
 
         return [
-            'expire' => $data['time'] + $data['ttl'],
+            'expire' => $data['ttl'] > 0 ? $data['time'] + $data['ttl'] : null,
             'mtime'  => filemtime($this->path . $key),
             'data'   => $data['data'],
         ];

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -158,7 +158,9 @@ class PredisHandler extends BaseHandler
             return false;
         }
 
-        $this->redis->expireat($key, time() + $ttl);
+        if ($ttl) {
+            $this->redis->expireat($key, time() + $ttl);
+        }
 
         return true;
     }

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -144,6 +144,18 @@ final class FileHandlerTest extends CIUnitTestCase
         unlink($file);
     }
 
+    public function testSavePermanent()
+    {
+        $this->assertTrue($this->fileHandler->save(self::$key1, 'value', 0));
+        $metaData = $this->fileHandler->getMetaData(self::$key1);
+
+        $this->assertSame(null, $metaData['expire']);
+        $this->assertLessThanOrEqual(1, $metaData['mtime'] - time());
+        $this->assertSame('value', $metaData['data']);
+
+        $this->assertTrue($this->fileHandler->delete(self::$key1));
+    }
+
     public function testDelete()
     {
         $this->fileHandler->save(self::$key1, 'value');

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -90,6 +90,18 @@ final class MemcachedHandlerTest extends CIUnitTestCase
         $this->assertTrue($this->memcachedHandler->save(self::$key1, 'value'));
     }
 
+    public function testSavePermanent()
+    {
+        $this->assertTrue($this->memcachedHandler->save(self::$key1, 'value', 0));
+        $metaData = $this->memcachedHandler->getMetaData(self::$key1);
+
+        $this->assertSame(null, $metaData['expire']);
+        $this->assertLessThanOrEqual(1, $metaData['mtime'] - time());
+        $this->assertSame('value', $metaData['data']);
+
+        $this->assertTrue($this->memcachedHandler->delete(self::$key1));
+    }
+
     public function testDelete()
     {
         $this->memcachedHandler->save(self::$key1, 'value');

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -50,10 +50,10 @@ final class PredisHandlerTest extends CIUnitTestCase
 
     public function testDestruct()
     {
-        $this->PredisHandler = new PRedisHandler($this->config);
+        $this->PredisHandler = new PredisHandler($this->config);
         $this->PredisHandler->initialize();
 
-        $this->assertInstanceOf(PRedisHandler::class, $this->PredisHandler);
+        $this->assertInstanceOf(PredisHandler::class, $this->PredisHandler);
     }
 
     /**
@@ -95,6 +95,18 @@ final class PredisHandlerTest extends CIUnitTestCase
     public function testSave()
     {
         $this->assertTrue($this->PredisHandler->save(self::$key1, 'value'));
+    }
+
+    public function testSavePermanent()
+    {
+        $this->assertTrue($this->PredisHandler->save(self::$key1, 'value', 0));
+        $metaData = $this->PredisHandler->getMetaData(self::$key1);
+
+        $this->assertSame(null, $metaData['expire']);
+        $this->assertLessThanOrEqual(1, $metaData['mtime'] - time());
+        $this->assertSame('value', $metaData['data']);
+
+        $this->assertTrue($this->PredisHandler->delete(self::$key1));
     }
 
     public function testDelete()

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -97,6 +97,18 @@ final class RedisHandlerTest extends CIUnitTestCase
         $this->assertTrue($this->redisHandler->save(self::$key1, 'value'));
     }
 
+    public function testSavePermanent()
+    {
+        $this->assertTrue($this->redisHandler->save(self::$key1, 'value', 0));
+        $metaData = $this->redisHandler->getMetaData(self::$key1);
+
+        $this->assertSame(null, $metaData['expire']);
+        $this->assertLessThanOrEqual(1, $metaData['mtime'] - time());
+        $this->assertSame('value', $metaData['data']);
+
+        $this->assertTrue($this->redisHandler->delete(self::$key1));
+    }
+
     public function testDelete()
     {
         $this->redisHandler->save(self::$key1, 'value');


### PR DESCRIPTION
**Description**
After answering a question on Slack I noticed some small bugs in the Predis and File cache handler.

* In Predis, we couldn't set the cache as permanent even if we specified `0` as TTL.
* In the File cache, we were getting the incorrect `expire` metadata when a given key was stored as permanent.

This PR fixes these bugs.

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide
