### PR TITLE
Fix for generating session table structure via migrations

### DIFF
--- a/system/Commands/Generators/MigrationGenerator.php
+++ b/system/Commands/Generators/MigrationGenerator.php
@@ -107,10 +107,11 @@ class MigrationGenerator extends BaseCommand
             $table   = $this->getOption('table');
             $DBGroup = $this->getOption('dbgroup');
 
-            $data['session'] = true;
-            $data['table']   = is_string($table) ? $table : 'ci_sessions';
-            $data['DBGroup'] = is_string($DBGroup) ? $DBGroup : 'default';
-            $data['matchIP'] = config('App')->sessionMatchIP;
+            $data['session']  = true;
+            $data['table']    = is_string($table) ? $table : 'ci_sessions';
+            $data['DBGroup']  = is_string($DBGroup) ? $DBGroup : 'default';
+            $data['DBDriver'] = config('Database')->{$data['DBGroup']}['DBDriver'];
+            $data['matchIP']  = config('App')->sessionMatchIP;
         }
 
         return $this->parseTemplate($class, [], [], $data);

--- a/system/Commands/Generators/Views/migration.tpl.php
+++ b/system/Commands/Generators/Views/migration.tpl.php
@@ -12,17 +12,23 @@ class {class} extends Migration
     public function up()
     {
         $this->forge->addField([
-            'id'         => ['type' => 'VARCHAR', 'constraint' => 128, 'null' => false],
+            'id' => ['type' => 'VARCHAR', 'constraint' => 128, 'null' => false],
+<?php if ($DBDriver === 'MySQLi'): ?>
             'ip_address' => ['type' => 'VARCHAR', 'constraint' => 45, 'null' => false],
-            'timestamp'  => ['type' => 'INT', 'unsigned' => true, 'null' => false, 'default' => 0],
-            'data'       => ['type' => 'TEXT', 'null' => false, 'default' => ''],
+            'timestamp timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL',
+            'data' => ['type' => 'BLOB', 'null' => false],
+ <?php elseif ($DBDriver === 'Postgre'): ?>
+            'ip_address inet NOT NULL',
+            'timestamp timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL',
+            "data bytea DEFAULT '' NOT NULL",
+<?php endif; ?>
         ]);
-    <?php if ($matchIP) : ?>
-    $this->forge->addKey(['id', 'ip_address'], true);
-    <?php else: ?>
-    $this->forge->addKey('id', true);
-    <?php endif ?>
-    $this->forge->addKey('timestamp');
+<?php if ($matchIP) : ?>
+        $this->forge->addKey(['id', 'ip_address'], true);
+<?php else: ?>
+        $this->forge->addKey('id', true);
+<?php endif ?>
+        $this->forge->addKey('timestamp');
         $this->forge->createTable('<?= $table ?>', true);
     }
 


### PR DESCRIPTION
**Description**
This PR fixes the invalid table structure that is generated by migrations: `php spark make:migration --session`

Ref: #4827

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
