### PR TITLE
Convert to explicit those implicit string variables

### DIFF
--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -92,7 +92,7 @@
 
                                         foreach ($row['args'] as $key => $value) : ?>
 											<tr>
-												<td><code><?= esc(isset($params[$key]) ? '$' . $params[$key]->name : "#$key") ?></code></td>
+												<td><code><?= esc(isset($params[$key]) ? '$' . $params[$key]->name : "#{$key}") ?></code></td>
 												<td><pre><?= esc(print_r($value, true)) ?></pre></td>
 											</tr>
 										<?php endforeach ?>

--- a/system/Commands/Encryption/GenerateKey.php
+++ b/system/Commands/Encryption/GenerateKey.php
@@ -190,7 +190,7 @@ class GenerateKey extends BaseCommand
 
         $ret = file_put_contents($envFile, preg_replace(
             $this->keyPattern($oldKey),
-            "\nencryption.key = $newKey",
+            "\nencryption.key = {$newKey}",
             file_get_contents($envFile)
         ));
 
@@ -209,7 +209,7 @@ class GenerateKey extends BaseCommand
         $escaped = preg_quote($oldKey, '/');
 
         if ($escaped !== '') {
-            $escaped = "[$escaped]*";
+            $escaped = "[{$escaped}]*";
         }
 
         return "/^[#\s]*encryption.key[=\s]*{$escaped}$/m";

--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -107,7 +107,7 @@ class DotEnv
     protected function setVariable(string $name, string $value = '')
     {
         if (! getenv($name, true)) {
-            putenv("$name=$value");
+            putenv("{$name}={$value}");
         }
 
         if (empty($_ENV[$name])) {
@@ -192,7 +192,7 @@ class DotEnv
             );
 
             $value = preg_replace($regexPattern, '$1', $value);
-            $value = str_replace("\\$quote", $quote, $value);
+            $value = str_replace("\\{$quote}", $quote, $value);
             $value = str_replace('\\\\', '\\', $value);
         } else {
             $parts = explode(' #', $value, 2);

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -776,14 +776,14 @@ class BaseBuilder
                 if (empty($op)) {
                     $k .= ' =';
                 } else {
-                    $k .= " $op";
+                    $k .= " {$op}";
                 }
 
                 if ($v instanceof Closure) {
                     $builder = $this->cleanClone();
                     $v       = '(' . str_replace("\n", ' ', $v($builder)->getCompiledSelect()) . ')';
                 } else {
-                    $v = " :$bind:";
+                    $v = " :{$bind}:";
                 }
             } elseif (! $this->hasOperator($k) && $qbKey !== 'QBHaving') {
                 // value appears not to have been set, assign the test to IS NULL
@@ -989,9 +989,8 @@ class BaseBuilder
             if (CI_DEBUG) {
                 throw new InvalidArgumentException(sprintf('%s() expects $values to be of type array or closure', debug_backtrace(0, 2)[1]['function']));
             }
-            // @codeCoverageIgnoreStart
-            return $this;
-            // @codeCoverageIgnoreEnd
+
+            return $this; // @codeCoverageIgnore
         }
 
         if (! is_bool($escape)) {
@@ -1017,7 +1016,7 @@ class BaseBuilder
         $prefix = empty($this->$clause) ? $this->groupGetType('') : $this->groupGetType($type);
 
         $whereIn = [
-            'condition' => $prefix . $key . $not . ($values instanceof Closure ? " IN ($ok)" : " IN :{$ok}:"),
+            'condition' => $prefix . $key . $not . ($values instanceof Closure ? " IN ({$ok})" : " IN :{$ok}:"),
             'escape'    => false,
         ];
 
@@ -1236,11 +1235,11 @@ class BaseBuilder
             if ($side === 'none') {
                 $bind = $this->setBind($k, $v, $escape);
             } elseif ($side === 'before') {
-                $bind = $this->setBind($k, "%$v", $escape);
+                $bind = $this->setBind($k, "%{$v}", $escape);
             } elseif ($side === 'after') {
-                $bind = $this->setBind($k, "$v%", $escape);
+                $bind = $this->setBind($k, "{$v}%", $escape);
             } else {
-                $bind = $this->setBind($k, "%$v%", $escape);
+                $bind = $this->setBind($k, "%{$v}%", $escape);
             }
 
             $likeStatement = $this->_like_statement($prefix, $k, $not, $bind, $insensitiveSearch);
@@ -1691,7 +1690,7 @@ class BaseBuilder
         foreach ($key as $k => $v) {
             if ($escape) {
                 $bind                                                           = $this->setBind($k, $v, $escape);
-                $this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = ":$bind:";
+                $this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = ":{$bind}:";
             } else {
                 $this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = $v;
             }
@@ -2573,7 +2572,7 @@ class BaseBuilder
 
                 $bind = $this->setBind($k2, $v2, $escape);
 
-                $clean[$this->db->protectIdentifiers($k2, false, $escape)] = ":$bind:";
+                $clean[$this->db->protectIdentifiers($k2, false, $escape)] = ":{$bind}:";
             }
 
             if ($indexSet === false) {

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -173,13 +173,13 @@ class Builder extends BaseBuilder
         $value = $set[$key];
 
         $builder = $this->db->table($table);
-        $exists  = $builder->where("$key = $value", null, false)->get()->getFirstRow();
+        $exists  = $builder->where("{$key} = {$value}", null, false)->get()->getFirstRow();
 
         if (empty($exists)) {
             $result = $builder->insert($set);
         } else {
             array_pop($set);
-            $result = $builder->update($set, "$key = $value");
+            $result = $builder->update($set, "{$key} = {$value}");
         }
 
         unset($builder);

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -643,14 +643,14 @@ class Builder extends BaseBuilder
                 if (empty($op)) {
                     $k .= ' =';
                 } else {
-                    $k .= " $op";
+                    $k .= " {$op}";
                 }
 
                 if ($v instanceof Closure) {
                     $builder = $this->cleanClone();
                     $v       = '(' . str_replace("\n", ' ', $v($builder)->getCompiledSelect()) . ')';
                 } else {
-                    $v = " :$bind:";
+                    $v = " :{$bind}:";
                 }
             } elseif (! $this->hasOperator($k) && $qbKey !== 'QBHaving') {
                 // value appears not to have been set, assign the test to IS NULL

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -345,7 +345,7 @@ class Toolbar
             // then we send headers saying where to find the debug data
             // for this response
             if ($request->isAJAX() || strpos($format, 'html') === false) {
-                $response->setHeader('Debugbar-Time', "$time")
+                $response->setHeader('Debugbar-Time', "{$time}")
                     ->setHeader('Debugbar-Link', site_url("?debugbar_time={$time}"))
                     ->getBody();
 

--- a/system/Format/XMLFormatter.php
+++ b/system/Format/XMLFormatter.php
@@ -64,10 +64,10 @@ class XMLFormatter implements FormatterInterface
             $key = $this->normalizeXMLTag($key);
 
             if (is_array($value)) {
-                $subnode = $output->addChild("$key");
+                $subnode = $output->addChild("{$key}");
                 $this->arrayToXML($value, $subnode);
             } else {
-                $output->addChild("$key", htmlspecialchars("$value"));
+                $output->addChild("{$key}", htmlspecialchars("{$value}"));
             }
         }
     }

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -571,7 +571,7 @@ if (! function_exists('form_datalist')) {
         $out .= "<datalist id='" . $name . '_list' . "'>";
 
         foreach ($options as $option) {
-            $out .= "<option value='$option'>" . "\n";
+            $out .= "<option value='{$option}'>" . "\n";
         }
 
         return $out . ('</datalist>' . "\n");

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -111,7 +111,7 @@ final class CLITest extends CIUnitTestCase
 
         CLI::init(); // force re-check on env
         $this->assertEquals('test', CLI::color('test', 'white', 'green'));
-        putenv($nocolor ? "NO_COLOR=$nocolor" : 'NO_COLOR');
+        putenv($nocolor ? "NO_COLOR={$nocolor}" : 'NO_COLOR');
     }
 
     public function testColorSupportOnHyperTerminals()
@@ -121,7 +121,7 @@ final class CLITest extends CIUnitTestCase
 
         CLI::init(); // force re-check on env
         $this->assertEquals("\033[1;37m\033[42m\033[4mtest\033[0m", CLI::color('test', 'white', 'green', 'underline'));
-        putenv($termProgram ? "TERM_PROGRAM=$termProgram" : 'TERM_PROGRAM');
+        putenv($termProgram ? "TERM_PROGRAM={$termProgram}" : 'TERM_PROGRAM');
     }
 
     public function testStreamSupports()

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -275,7 +275,7 @@ final class MessageTest extends CIUnitTestCase
         $this->message->populateHeaders();
 
         $this->assertNull($this->message->header('content-type'));
-        putenv("CONTENT_TYPE=$originalEnv");
+        putenv("CONTENT_TYPE={$originalEnv}");
         $this->message->removeHeader('accept-language');
         $_SERVER = $original; // restore so code coverage doesn't break
     }

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -78,8 +78,8 @@ final class CookieHelperTest extends CIUnitTestCase
     {
         $pre       = 'Hello, I try to';
         $pst       = 'your site';
-        $unsec     = "$pre <script>alert('Hack');</script> $pst";
-        $sec       = "$pre [removed]alert&#40;&#39;Hack&#39;&#41;;[removed] $pst";
+        $unsec     = "{$pre} <script>alert('Hack');</script> {$pst}";
+        $sec       = "{$pre} [removed]alert&#40;&#39;Hack&#39;&#41;;[removed] {$pst}";
         $unsecured = 'unsecured';
         $secured   = 'secured';
 

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -37,7 +37,7 @@ final class FormHelperTest extends CIUnitTestCase
             $Name     = csrf_token();
             $expected = <<<EOH
                 <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
-                <input type="hidden" name="$Name" value="$Value" style="display:none;" />
+                <input type="hidden" name="{$Name}" value="{$Value}" style="display:none;" />
 
                 EOH;
         } else {
@@ -95,7 +95,7 @@ final class FormHelperTest extends CIUnitTestCase
             $Name     = csrf_token();
             $expected = <<<EOH
                 <form action="http://example.com/index.php" name="form" id="form" method="POST" accept-charset="utf-8">
-                <input type="hidden" name="$Name" value="$Value" style="display:none;" />
+                <input type="hidden" name="{$Name}" value="{$Value}" style="display:none;" />
 
                 EOH;
         } else {
@@ -129,7 +129,7 @@ final class FormHelperTest extends CIUnitTestCase
             $Name     = csrf_token();
             $expected = <<<EOH
                 <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="post" accept-charset="utf-8">
-                <input type="hidden" name="$Name" value="$Value" style="display:none;" />
+                <input type="hidden" name="{$Name}" value="{$Value}" style="display:none;" />
 
                 EOH;
         } else {
@@ -164,7 +164,7 @@ final class FormHelperTest extends CIUnitTestCase
             $expected = <<<EOH
                 <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
                 <input type="hidden" name="foo" value="bar" />
-                <input type="hidden" name="$Name" value="$Value" />
+                <input type="hidden" name="{$Name}" value="{$Value}" />
 
                 EOH;
         } else {
@@ -204,7 +204,7 @@ final class FormHelperTest extends CIUnitTestCase
             $Name     = csrf_token();
             $expected = <<<EOH
                 <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" enctype="multipart/form-data" accept-charset="utf-8">
-                <input type="hidden" name="$Name" value="$Value" style="display:none;" />
+                <input type="hidden" name="{$Name}" value="{$Value}" style="display:none;" />
 
                 EOH;
         } else {

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -213,7 +213,7 @@ final class LoggerTest extends CIUnitTestCase
 
         $logger->log('debug', 'Test message {file} {line}');
         $line     = __LINE__ - 1;
-        $expected = "LoggerTest.php $line";
+        $expected = "LoggerTest.php {$line}";
 
         $logs = TestHandler::getLogs();
 

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -100,6 +100,7 @@ final class CodeIgniter4 extends AbstractRuleset
             'doctrine_annotation_braces'           => false,
             'doctrine_annotation_indentation'      => false,
             'doctrine_annotation_spaces'           => false,
+            'explicit_string_variable'             => true,
             'final_class'                          => false,
             'final_internal_class'                 => [
                 'annotation_exclude'                         => ['@no-final'],
@@ -249,6 +250,7 @@ final class CodeIgniter4 extends AbstractRuleset
             'psr_autoloading'                     => ['dir' => null],
             'set_type_to_cast'                    => true,
             'short_scalar_cast'                   => true,
+            'simple_to_complex_string_variable'   => true,
             'standardize_increment'               => true,
             'static_lambda'                       => true,
             'switch_case_semicolon_to_colon'      => true,


### PR DESCRIPTION
**Description**
_(excerpted from the fixers' summary and description)_

- `explicit_string_variable`
Converts implicit variables into explicit ones in double-quoted strings or heredoc syntax. The reasoning behind this rule is the following: - When there are two valid ways of doing the same thing, using both is confusing, there should be a coding standard to follow - PHP manual marks `"$var"` syntax as implicit and `"${var}"` syntax as explicit: explicit code should always be preferred - Explicit syntax allows word concatenation inside strings, e.g. `"${var}IsAVar"`, implicit doesn't - Explicit syntax is easier to detect for IDE/editors and therefore has colors/highlight with higher contrast, which is easier to read Backtick operator is skipped because it is harder to handle; you can use `backtick_to_shell_exec` fixer to normalize backticks to strings

- `simple_to_complex_string_variable`
Converts explicit variables in double-quoted strings and heredoc syntax from simple to complex format (`${` to `{$`). Doesn't touch implicit variables. Works together nicely with `explicit_string_variable`.

**Checklist:**
- [x] Securely signed commits
