### PR TITLE
Fix mysqli ssl connection

### DIFF
--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -160,12 +160,13 @@ class Connection extends BaseConnection
                     }
                 }
 
-                $clientFlags += MYSQLI_CLIENT_SSL;
                 $this->mysqli->ssl_set(
                     $ssl['key'] ?? null, $ssl['cert'] ?? null, $ssl['ca'] ?? null,
                     $ssl['capath'] ?? null, $ssl['cipher'] ?? null
                 );
             }
+
+            $clientFlags += MYSQLI_CLIENT_SSL;
         }
 
         try {


### PR DESCRIPTION
**Description**
This PR fixes MySQLi SSL connection - a certificate should not be required to establish a secure connection.

Closes #4616

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
