### PR TITLE
Updated Query Build custom string option for where to remove make it clear the values do not get escaped.

### DIFF
--- a/user_guide_src/source/database/queries.rst
+++ b/user_guide_src/source/database/queries.rst
@@ -15,6 +15,7 @@ Regular Queries
 
 To submit a query, use the **query** function::
 
+    $db = db_connect();
     $db->query('YOUR QUERY HERE');
 
 The ``query()`` function returns a database result **object** when "read"

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -245,7 +245,10 @@ This function enables you to set **WHERE** clauses using one of four
 methods:
 
 .. note:: All values passed to this function are escaped automatically,
-    producing safer queries.
+    producing safer queries, except when using a custom string.
+
+.. note:: ``$builder->where()`` accepts an optional third parameter. If you set it to
+    ``false``, CodeIgniter will not try to protect your field or table names.
 
 #. **Simple key/value method:**
 
@@ -295,15 +298,18 @@ methods:
 #. **Custom string:**
     You can write your own clauses manually::
 
+
         $where = "name='Joe' AND status='boss' OR status='active'";
         $builder->where($where);
 
-    ``$builder->where()`` accepts an optional third parameter. If you set it to
-    ``false``, CodeIgniter will not try to protect your field or table names.
+    If you are using user-supplied data within the string, you MUST escape the
+    data manually. Failure to do so could result in SQL injections.
+::
 
-    ::
+        $name = $builder->db->escape('Joe');
+        $where = "name={$name} AND status='boss' OR status='active'";
+        $builder->where($where);
 
-        $builder->where('MATCH (field) AGAINST ("value")', null, false);
 
 #. **Subqueries:**
     You can use an anonymous function to create a subquery.


### PR DESCRIPTION
The current version of the user guide presents some confusion making it appear that the custom string option of the `where` function in the Query Builder would escape the data. That was incorrect. It appears that NO escaping is done in that case. 

The user guide has been updated to make it very clear that user-supplied data MUST be escaped manually when using that option. 