### PR TITLE
Update to rector 0.11.29

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "phpstan/phpstan": "0.12.90",
         "phpunit/phpunit": "^9.1",
         "predis/predis": "^1.1",
-        "rector/rector": "0.11.28",
+        "rector/rector": "0.11.29",
         "symplify/package-builder": "^9.3"
     },
     "suggest": {


### PR DESCRIPTION
Fix the notice error `Call to a member function getType() on null`

https://github.com/codeigniter4/CodeIgniter4/runs/2934093327#step:10:5

**Checklist:**
- [x] Securely signed commits
