### PR TITLE
[4.2][Debug] Add benchmarking for filters.

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -374,7 +374,7 @@ class CodeIgniter
     {
         $routeFilter = $this->tryToRouteIt($routes);
 
-        // Run "before" filters
+        // Start up the filters
         $filters = Services::filters();
 
         // If any filters were specified within the routes file,
@@ -388,7 +388,10 @@ class CodeIgniter
 
         // Never run filters when running through Spark cli
         if (! defined('SPARKED')) {
+            // Run "before" filters
+            $this->benchmark->start('before_filters');
             $possibleResponse = $filters->run($uri, 'before');
+            $this->benchmark->stop('before_filters');
 
             // If a ResponseInterface instance is returned then send it back to the client and stop
             if ($possibleResponse instanceof ResponseInterface) {
@@ -427,8 +430,11 @@ class CodeIgniter
         // Never run filters when running through Spark cli
         if (! defined('SPARKED')) {
             $filters->setResponse($this->response);
+
             // Run "after" filters
+            $this->benchmark->start('after_filters');
             $response = $filters->run($uri, 'after');
+            $this->benchmark->stop('after_filters');
         } else {
             $response = $this->response;
 


### PR DESCRIPTION
This PR adds timers for the `before` and `after` filters.

During #4863, I found that significant gaps in the timeline can be produced by the `filters`.
As far as I could find, these are the only parts missing in the benchmarking.

For now, I opted to

- start the timers in `CodeIgniter4::handleRequest`,
- not divide the filter timers further into the individual filters.

In the current state, the `Filters` timer is displayed even if no filters are defined for the `$position`, this is not really the best solution in my opinion, however, `$filters->run` is called  each time anyway, so why not log those ms, too.

The alternative would be to run `$filters->initialize($uri)` in `handelRequest` and then check the `$filters->filtersClass` property for defined filters.

On another note, I would like to explicitly time each running filter, too. However, the only way to achieve this currently would be to use the `timer()` helper in `Filters::run()` or to inject `Services::timer` into the `Filters`. Not sure if any of these options is feasible right now.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Conforms to style guide