### PR TITLE
Fix bug with handling boolean values in set() method

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1673,12 +1673,12 @@ class BaseBuilder
      * Allows key/value pairs to be set for insert(), update() or replace().
      *
      * @param string|array|object $key    Field name, or an array of field/value pairs
-     * @param string              $value  Field value, if $key is a single field
+     * @param mixed               $value  Field value, if $key is a single field
      * @param bool                $escape Whether to escape values and identifiers
      *
      * @return $this
      */
-    public function set($key, ?string $value = '', bool $escape = null)
+    public function set($key, $value = '', bool $escape = null)
     {
         $key = $this->objectToArray($key);
 

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -401,6 +401,10 @@ class Forge extends BaseForge
                 $attributes['TYPE'] = 'DATETIME';
                 break;
 
+            case 'BOOLEAN':
+                $attributes['TYPE'] = 'BIT';
+                break;
+
             default:
                 break;
         }

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -233,6 +233,10 @@ class Forge extends BaseForge
                 $attributes['TYPE'] = 'TEXT';
                 break;
 
+            case 'BOOLEAN':
+                $attributes['TYPE'] = 'INT';
+                break;
+
             default:
                 break;
         }

--- a/system/Model.php
+++ b/system/Model.php
@@ -579,13 +579,13 @@ class Model extends BaseModel
      * data here. This allows it to be used with any of the other
      * builder methods and still get validated data, like replace.
      *
-     * @param mixed       $key    Field name, or an array of field/value pairs
-     * @param string|null $value  Field value, if $key is a single field
-     * @param bool|null   $escape Whether to escape values and identifiers
+     * @param mixed     $key    Field name, or an array of field/value pairs
+     * @param mixed     $value  Field value, if $key is a single field
+     * @param bool|null $escape Whether to escape values and identifiers
      *
      * @return $this
      */
-    public function set($key, ?string $value = '', ?bool $escape = null)
+    public function set($key, $value = '', ?bool $escape = null)
     {
         $data = is_array($key) ? $key : [$key => $value];
 

--- a/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
+++ b/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
@@ -61,6 +61,7 @@ class Migration_Create_test_tables extends Migration
             'type_double'     => ['type' => 'DOUBLE', 'null' => true],
             'type_decimal'    => ['type' => 'DECIMAL', 'constraint' => '18,4', 'null' => true],
             'type_blob'       => ['type' => 'BLOB', 'null' => true],
+            'type_boolean'    => ['type' => 'BOOLEAN', 'null' => true],
         ];
 
         if ($this->db->DBDriver === 'Postgre') {

--- a/tests/_support/Database/Seeds/CITestSeeder.php
+++ b/tests/_support/Database/Seeds/CITestSeeder.php
@@ -97,6 +97,7 @@ class CITestSeeder extends Seeder
                     'type_datetime'   => '2020-06-18T05:12:24.000+02:00',
                     'type_timestamp'  => '2019-07-18T21:53:21.000+02:00',
                     'type_bigint'     => 2342342,
+                    'type_boolean'    => 1,
                 ],
             ],
         ];
@@ -110,7 +111,8 @@ class CITestSeeder extends Seeder
         }
 
         if ($this->db->DBDriver === 'Postgre') {
-            $data['type_test'][0]['type_time'] = '15:22:00';
+            $data['type_test'][0]['type_time']    = '15:22:00';
+            $data['type_test'][0]['type_boolean'] = true;
             unset(
                 $data['type_test'][0]['type_enum'],
                 $data['type_test'][0]['type_set'],

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -85,6 +85,80 @@ class UpdateTest extends CIUnitTestCase
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
+    public function testUpdateWithSetAsInt()
+    {
+        $builder = new BaseBuilder('jobs', $this->db);
+
+        $builder->testMode()->set('age', 22)->where('id', 1)->update(null, null, null);
+
+        $expectedSQL   = 'UPDATE "jobs" SET "age" = 22 WHERE "id" = 1';
+        $expectedBinds = [
+            'age' => [
+                22,
+                true,
+            ],
+            'id' => [
+                1,
+                true,
+            ],
+        ];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testUpdateWithSetAsBoolean()
+    {
+        $builder = new BaseBuilder('jobs', $this->db);
+
+        $builder->testMode()->set('manager', true)->where('id', 1)->update(null, null, null);
+
+        $expectedSQL   = 'UPDATE "jobs" SET "manager" = 1 WHERE "id" = 1';
+        $expectedBinds = [
+            'manager' => [
+                true,
+                true,
+            ],
+            'id' => [
+                1,
+                true,
+            ],
+        ];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testUpdateWithSetAsArray()
+    {
+        $builder = new BaseBuilder('jobs', $this->db);
+
+        $builder->testMode()->set(['name' => 'Programmer', 'age' => 22, 'manager' => true])->where('id', 1)->update(null, null, null);
+
+        $expectedSQL   = 'UPDATE "jobs" SET "name" = \'Programmer\', "age" = 22, "manager" = 1 WHERE "id" = 1';
+        $expectedBinds = [
+            'name' => [
+                'Programmer',
+                true,
+            ],
+            'age' => [
+                22,
+                true,
+            ],
+            'manager' => [
+                true,
+                true,
+            ],
+            'id' => [
+                1,
+                true,
+            ],
+        ];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
     public function testUpdateThrowsExceptionWithNoData()
     {
         $builder = new BaseBuilder('jobs', $this->db);

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -230,4 +230,23 @@ class UpdateTest extends CIUnitTestCase
             'description' => 'Developer',
         ]);
     }
+
+    public function testSetWithBoolean()
+    {
+        $this->db->table('type_test')
+            ->set('type_boolean', false)
+            ->update();
+
+        $this->seeInDatabase('type_test', [
+            'type_boolean' => false,
+        ]);
+
+        $this->db->table('type_test')
+            ->set('type_boolean', true)
+            ->update();
+
+        $this->seeInDatabase('type_test', [
+            'type_boolean' => true,
+        ]);
+    }
 }

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -12,6 +12,7 @@ See all the changes.
 .. toctree::
     :titlesonly:
 
+    v4.2.0
     v4.1.4
     v4.1.3
     v4.1.2

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1727,7 +1727,7 @@ Class Reference
     .. php:method:: set($key[, $value = ''[, $escape = null]])
 
         :param mixed $key: Field name, or an array of field/value pairs
-        :param string $value: Field value, if $key is a single field
+        :param mixed $value: Field value, if $key is a single field
         :param bool	$escape: Whether to escape values and identifiers
         :returns: ``BaseBuilder`` instance (method chaining)
         :rtype:	``BaseBuilder``

--- a/user_guide_src/source/installation/upgrade_420.rst
+++ b/user_guide_src/source/installation/upgrade_420.rst
@@ -1,0 +1,12 @@
+#############################
+Upgrading from 4.1.3 to 4.2.0
+#############################
+
+**Changes for set() method in BaseBuilder and Model class**
+
+The casting for the ``$value`` parameter has been removed to fix a bug where passing parameters as array and string
+to the ``set()`` method were handled differently. If you extended the ``BaseBuilder`` class or ``Model`` class yourself
+and modified the ``set()`` method, then you need to change its definition from
+``public function set($key, ?string $value = '', ?bool $escape = null)`` to
+``public function set($key, $value = '', ?bool $escape = null)``.
+


### PR DESCRIPTION
**Description**
This PR introduces some potential BC but I treat this as a bug that has to be fixed. At the end of the day calling
`$builder->set('bool', true);` and `$builder->set(['bool' => true]);` should have the same effect.

I have added additional tests for boolean values and upgrade instructions.

Fixes #4761

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide