### PR TITLE
Fix getVar() method when trying to get JSON variable that does not exists

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -583,6 +583,10 @@ class IncomingRequest extends Request
 
         $data = dot_array_search($index, $this->getJSON(true));
 
+        if ($data === null) {
+            return null;
+        }
+
         if (! is_array($data)) {
             $filter = $filter ?? FILTER_DEFAULT;
             $flags  = is_array($flags) ? $flags : (is_numeric($flags) ? (int) $flags : 0);

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -374,7 +374,7 @@ class IncomingRequestTest extends CIUnitTestCase
 
         $this->assertEquals('bar', $request->getVar('foo'));
         $this->assertEquals('buzz', $request->getVar('fizz'));
-        $this->assertSame(null, $request->getVar('notExists'));
+        $this->assertNull($request->getVar('notExists'));
 
         $multiple = $request->getVar(['foo', 'fizz']);
         $this->assertIsArray($multiple);

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -318,6 +318,7 @@ class IncomingRequestTest extends CIUnitTestCase
         $request = new IncomingRequest($config, new URI(), $json, new UserAgent());
 
         $this->assertEquals('bar', $request->getJsonVar('foo'));
+        $this->assertSame(null, $request->getJsonVar('notExists'));
         $jsonVar = $request->getJsonVar('baz');
         $this->assertIsObject($jsonVar);
         $this->assertEquals('buzz', $jsonVar->fizz);
@@ -373,6 +374,7 @@ class IncomingRequestTest extends CIUnitTestCase
 
         $this->assertEquals('bar', $request->getVar('foo'));
         $this->assertEquals('buzz', $request->getVar('fizz'));
+        $this->assertSame(null, $request->getVar('notExists'));
 
         $multiple = $request->getVar(['foo', 'fizz']);
         $this->assertIsArray($multiple);

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -318,7 +318,7 @@ class IncomingRequestTest extends CIUnitTestCase
         $request = new IncomingRequest($config, new URI(), $json, new UserAgent());
 
         $this->assertEquals('bar', $request->getJsonVar('foo'));
-        $this->assertSame(null, $request->getJsonVar('notExists'));
+        $this->assertNull($request->getJsonVar('notExists'));
         $jsonVar = $request->getJsonVar('baz');
         $this->assertIsObject($jsonVar);
         $this->assertEquals('buzz', $jsonVar->fizz);


### PR DESCRIPTION
**Description**
Fixes #4906

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide