### PR TITLE
[4.2] Scalar values convertion for setHeader / Cookie settings improved

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -311,7 +311,9 @@ class CURLRequest extends Request
             foreach ($options['headers'] as $name => $value) {
                 if (is_scalar($value)) {
                     $this->setHeader($name, $value);
-                }
+                } else {
+					throw HTTPException::forNonScalarHeaderValue();
+				}
             }
 
             unset($options['headers']);

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -309,7 +309,9 @@ class CURLRequest extends Request
 
         if (array_key_exists('headers', $options) && is_array($options['headers'])) {
             foreach ($options['headers'] as $name => $value) {
-                $this->setHeader($name, $value);
+                if (is_scalar($value)) {
+                    $this->setHeader($name, $value);
+                }
             }
 
             unset($options['headers']);
@@ -705,9 +707,16 @@ class CURLRequest extends Request
         }
 
         // Cookie
-        if (isset($config['cookie'])) {
-            $curlOptions[CURLOPT_COOKIEJAR]  = $config['cookie'];
-            $curlOptions[CURLOPT_COOKIEFILE] = $config['cookie'];
+        if ($cookie = ($config['cookie_jar'] ?? $config['cookie'] ?? false)) {
+            $curlOptions[CURLOPT_COOKIEJAR] = $cookie;
+        }
+
+        if ($cookie = ($config['cookie_file'] ?? $config['cookie'] ?? false)) {
+            $curlOptions[CURLOPT_COOKIEFILE] = $cookie;
+        }
+
+        if ($cookie = ($config['cookie_session'] ?? false)) {
+            $curlOptions[CURLOPT_COOKIESESSION] = $cookie;
         }
 
         // User Agent

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -716,16 +716,12 @@ class CURLRequest extends Request
         }
 
         // Cookie
-        if (isset($config['cookie_jar'])) {
-            $curlOptions[CURLOPT_COOKIEJAR] = $config['cookie_jar'];
-        } elseif ($config['cookie']) {
-            $curlOptions[CURLOPT_COOKIEJAR] = $config['cookie'];
+        if ($cookieJar = ($config['cookie_jar'] ?? $config['cookie'] ?? false)) {
+            $curlOptions[CURLOPT_COOKIEJAR] = $cookieJar;
         }
 
-        if (isset($config['cookie_file'])) {
-            $curlOptions[CURLOPT_COOKIEFILE] = $config['cookie_file'];
-        } elseif ($config['cookie']) {
-            $curlOptions[CURLOPT_COOKIEFILE] = $config['cookie'];
+        if ($cookieFile = ($config['cookie_file'] ?? $config['cookie'] ?? false)) {
+            $curlOptions[CURLOPT_COOKIEFILE] = $cookieFile;
         }
 
         // false - libcurl default value; true - to mark query as new cookie "session"

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -698,25 +698,39 @@ class CURLRequest extends Request
         }
 
         // version
+        // version
         if (! empty($config['version'])) {
             if ($config['version'] === 1.0) {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_0;
             } elseif ($config['version'] === 1.1) {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_1;
+            } elseif ($config['version'] === 2) {
+                $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2;
+            } elseif ($config['version'] === 2.0) {
+                $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_0;
+            } elseif ($config['version'] === '2TLS') {
+                $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2TLS;
+            } elseif ($config['version'] === '2PK') {
+                $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE;
             }
         }
 
         // Cookie
-        if ($cookie = ($config['cookie_jar'] ?? $config['cookie'] ?? false)) {
-            $curlOptions[CURLOPT_COOKIEJAR] = $cookie;
+        if (isset($config['cookie_jar'])) {
+            $curlOptions[CURLOPT_COOKIEJAR] = $config['cookie_jar'];
+        } elseif ($config['cookie']) {
+            $curlOptions[CURLOPT_COOKIEJAR] = $config['cookie'];
         }
 
-        if ($cookie = ($config['cookie_file'] ?? $config['cookie'] ?? false)) {
-            $curlOptions[CURLOPT_COOKIEFILE] = $cookie;
+        if (isset($config['cookie_file'])) {
+            $curlOptions[CURLOPT_COOKIEFILE] = $config['cookie_file'];
+        } elseif ($config['cookie']) {
+            $curlOptions[CURLOPT_COOKIEFILE] = $config['cookie'];
         }
 
-        if ($cookie = ($config['cookie_session'] ?? false)) {
-            $curlOptions[CURLOPT_COOKIESESSION] = $cookie;
+        // false - libcurl default value; true - to mark query as new cookie "session"
+        if (isset($config['cookie_session'])) {
+            $curlOptions[CURLOPT_COOKIESESSION] = (bool) $config['cookie_session'];
         }
 
         // User Agent

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -698,7 +698,6 @@ class CURLRequest extends Request
         }
 
         // version
-        // version
         if (! empty($config['version'])) {
             if ($config['version'] === 1.0) {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_0;

--- a/system/HTTP/Exceptions/HTTPException.php
+++ b/system/HTTP/Exceptions/HTTPException.php
@@ -231,6 +231,18 @@ class HTTPException extends FrameworkException
         return new static(lang('HTTP.moveFailed', [$source, $target, $error]));
     }
 
+
+    /**
+     * For non scalar value passed to setHeader
+     *
+     * @return HTTPException
+     */
+    public static function forNonScalarHeaderValue()
+    {
+        return new static(lang('HTTP.nonScalarHeaderValue'));
+    }
+
+
     /**
      * For Invalid SameSite attribute setting
      *

--- a/system/Language/en/HTTP.php
+++ b/system/Language/en/HTTP.php
@@ -61,6 +61,7 @@ return [
     'alreadyMoved' => 'The uploaded file has already been moved.',
     'invalidFile'  => 'The original file is not a valid file.',
     'moveFailed'   => 'Could not move file {0} to {1} ({2})',
+    'nonScalarHeaderValue'       => 'Only scalar values are allowed',
 
     'uploadErrOk'        => 'The file uploaded with success.',
     'uploadErrIniSize'   => 'The file "%s" exceeds your upload_max_filesize ini directive.',

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -243,6 +243,14 @@ An example::
 
 	$response->request('GET', 'http://example.com', ['cookie' => WRITEPATH . 'CookieSaver.txt']);
 
+If your use case require you to store those data in separate files you could use: ``cookie_jar`` and ``cookie_file`` instead.
+An example::
+
+	$response->request('GET', 'http://example.com', ['cookie_jar' => WRITEPATH . 'CookieJar.txt']);
+	$response->request('GET', 'http://example.com', ['cookie_file' => WRITEPATH . 'CookieFile.txt']);
+
+
+
 debug
 =====
 
@@ -388,8 +396,16 @@ is true::
 version
 =======
 
-To set the HTTP protocol to use, you can pass a string or float with the version number (typically either 1.0
-or 1.1, 2.0 is currently unsupported.)::
+To set the HTTP protocol to use, you can pass a string or float with the version number (typically either 1.0, 1.1 or 2)::
 
-	// Force HTTP/1.0
+	// Force HTTP/1.0 (CURL_HTTP_VERSION_1_0)
 	$client->request('GET', '/', ['version' => 1.0]);
+	// Force HTTP/1.1 (CURL_HTTP_VERSION_1_1)
+	$client->request('GET', '/', ['version' => 1.1]);
+	// Force HTTP/2.0 (CURL_HTTP_VERSION_2)
+	$client->request('GET', '/', ['version' => 2]);
+	// HTTP 2 over TLS (HTTPS) only (CURL_HTTP_VERSION_2TLS)
+	$client->request('GET', '/', ['version' => '2TLS']);
+	// Issues non-TLS HTTP requests using HTTP/2 without HTTP/1.1 Upgrade (CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE)
+	$client->request('GET', '/', ['version' => '2PK']);
+	


### PR DESCRIPTION
PR contains:
1. changes related to PR #4851  (I closed it)
2. ability to define different files for COOKIEJAR and COOKIEFILE (there was no such an option; and those are different type of files). Backward compatibility is provided
3. ability to define CURLOPT_COOKIESESSION

File has been fixed with php-cs-fixer.

I'm calling all the folks who wrote under #4851 @samsonasik , @MGatner , @paulbalandan
