### PR TITLE
[4.2][Debug] Do not overwrite startTime.

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -511,7 +511,9 @@ class CodeIgniter
      */
     protected function startBenchmark()
     {
-        $this->startTime = microtime(true);
+        if($this->startTime === null) {
+            $this->startTime = microtime(true);
+        }
 
         $this->benchmark = Services::timer();
         $this->benchmark->start('total_execution', $this->startTime);


### PR DESCRIPTION
This PR gives a little change to the execution time collection, by only overwriting the `startTime` property of the `CodeIgniter4` object, if it is not yet set.

This property gets first set here in the constructor:
https://github.com/codeigniter4/CodeIgniter4/blob/9ceb5e3c023afd083ebeb9dfb8b47e5bcabf6770/system/CodeIgniter.php#L160

After that, it gets overwritten from `bootstrap.php` during `$app->run()` via:
https://github.com/codeigniter4/CodeIgniter4/blob/9ceb5e3c023afd083ebeb9dfb8b47e5bcabf6770/system/CodeIgniter.php#L514

I am not sure what was the goal here. In the current state, we basically restart the "total execution" timer and possibly miss some ms (i.e., the time that `$app->initialize();` takes).  This is not really helpful I think.

As far as I can tell, the part now included in the `if` could be removed completely, as `startTime` will likely never be `null` at this point.

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide