### PR TITLE
Define initial "s" rules

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -768,11 +768,11 @@ class CLI
         }
 
         if ($max === 0) {
-            $max = CLI::getWidth();
+            $max = self::getWidth();
         }
 
-        if (CLI::getWidth() < $max) {
-            $max = CLI::getWidth();
+        if (self::getWidth() < $max) {
+            $max = self::getWidth();
         }
 
         $max = $max - $padLeft;

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -319,7 +319,7 @@ class Toolbar
                 return;
             }
 
-            $toolbar = Services::toolbar(config(Toolbar::class));
+            $toolbar = Services::toolbar(config(self::class));
             $stats   = $app->getPerformanceStats();
             $data    = $toolbar->run(
                 $stats['startTime'],

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -179,7 +179,7 @@ class Entity implements JsonSerializable
             $return[$key] = $this->__get($key);
 
             if ($recursive) {
-                if ($return[$key] instanceof Entity) {
+                if ($return[$key] instanceof self) {
                     $return[$key] = $return[$key]->toArray($onlyChanged, $cast, $recursive);
                 } elseif (is_callable([$return[$key], 'toArray'])) {
                     $return[$key] = $return[$key]->toArray();
@@ -207,7 +207,7 @@ class Entity implements JsonSerializable
         if (! $onlyChanged) {
             if ($recursive) {
                 return array_map(static function ($value) use ($onlyChanged, $recursive) {
-                    if ($value instanceof Entity) {
+                    if ($value instanceof self) {
                         $value = $value->toRawArray($onlyChanged, $recursive);
                     } elseif (is_callable([$value, 'toRawArray'])) {
                         $value = $value->toRawArray();
@@ -226,7 +226,7 @@ class Entity implements JsonSerializable
             }
 
             if ($recursive) {
-                if ($value instanceof Entity) {
+                if ($value instanceof self) {
                     $value = $value->toRawArray($onlyChanged, $recursive);
                 } elseif (is_callable([$value, 'toRawArray'])) {
                     $value = $value->toRawArray();

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -170,7 +170,7 @@ class File extends SplFileInfo
 
         @chmod($destination, 0777 & ~umask());
 
-        return new File($destination);
+        return new self($destination);
     }
 
     //--------------------------------------------------------------------

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -1123,7 +1123,7 @@ class URI
      *
      * @return string
      */
-    protected function mergePaths(URI $base, URI $reference): string
+    protected function mergePaths(self $base, self $reference): string
     {
         if (! empty($base->getAuthority()) && $base->getPath() === '') {
             return '/' . ltrim($reference->getPath(), '/ ');

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -82,7 +82,7 @@ class Time extends DateTime
         $this->locale = ! empty($locale) ? $locale : Locale::getDefault();
 
         // If a test instance has been provided, use it instead.
-        if ($time === null && static::$testNow instanceof Time) {
+        if ($time === null && static::$testNow instanceof self) {
             if (empty($timezone)) {
                 $timezone = static::$testNow->getTimezone();
             }
@@ -119,7 +119,7 @@ class Time extends DateTime
      */
     public static function now($timezone = null, ?string $locale = null)
     {
-        return new Time(null, $timezone, $locale);
+        return new self(null, $timezone, $locale);
     }
 
     //--------------------------------------------------------------------
@@ -140,7 +140,7 @@ class Time extends DateTime
      */
     public static function parse(string $datetime, $timezone = null, ?string $locale = null)
     {
-        return new Time($datetime, $timezone, $locale);
+        return new self($datetime, $timezone, $locale);
     }
 
     //--------------------------------------------------------------------
@@ -157,7 +157,7 @@ class Time extends DateTime
      */
     public static function today($timezone = null, ?string $locale = null)
     {
-        return new Time(date('Y-m-d 00:00:00'), $timezone, $locale);
+        return new self(date('Y-m-d 00:00:00'), $timezone, $locale);
     }
 
     //--------------------------------------------------------------------
@@ -174,7 +174,7 @@ class Time extends DateTime
      */
     public static function yesterday($timezone = null, ?string $locale = null)
     {
-        return new Time(date('Y-m-d 00:00:00', strtotime('-1 day')), $timezone, $locale);
+        return new self(date('Y-m-d 00:00:00', strtotime('-1 day')), $timezone, $locale);
     }
 
     //--------------------------------------------------------------------
@@ -191,7 +191,7 @@ class Time extends DateTime
      */
     public static function tomorrow($timezone = null, ?string $locale = null)
     {
-        return new Time(date('Y-m-d 00:00:00', strtotime('+1 day')), $timezone, $locale);
+        return new self(date('Y-m-d 00:00:00', strtotime('+1 day')), $timezone, $locale);
     }
 
     //--------------------------------------------------------------------
@@ -262,7 +262,7 @@ class Time extends DateTime
         $minutes = empty($minutes) ? 0 : $minutes;
         $seconds = empty($seconds) ? 0 : $seconds;
 
-        return new Time(date('Y-m-d H:i:s', strtotime("{$year}-{$month}-{$day} {$hour}:{$minutes}:{$seconds}")), $timezone, $locale);
+        return new self(date('Y-m-d H:i:s', strtotime("{$year}-{$month}-{$day} {$hour}:{$minutes}:{$seconds}")), $timezone, $locale);
     }
 
     //--------------------------------------------------------------------
@@ -285,7 +285,7 @@ class Time extends DateTime
             throw I18nException::forInvalidFormat($format);
         }
 
-        return new Time($date->format('Y-m-d H:i:s'), $timeZone);
+        return new self($date->format('Y-m-d H:i:s'), $timeZone);
     }
 
     //--------------------------------------------------------------------
@@ -303,7 +303,7 @@ class Time extends DateTime
      */
     public static function createFromTimestamp(int $timestamp, $timezone = null, ?string $locale = null)
     {
-        return new Time(gmdate('Y-m-d H:i:s', $timestamp), $timezone ?? 'UTC', $locale);
+        return new self(gmdate('Y-m-d H:i:s', $timestamp), $timezone ?? 'UTC', $locale);
     }
 
     //--------------------------------------------------------------------
@@ -323,7 +323,7 @@ class Time extends DateTime
         $date     = $dateTime->format('Y-m-d H:i:s');
         $timezone = $dateTime->getTimezone();
 
-        return new Time($date, $timezone, $locale);
+        return new self($date, $timezone, $locale);
     }
 
     //--------------------------------------------------------------------
@@ -388,9 +388,9 @@ class Time extends DateTime
 
         // Convert to a Time instance
         if (is_string($datetime)) {
-            $datetime = new Time($datetime, $timezone, $locale);
-        } elseif ($datetime instanceof DateTimeInterface && ! $datetime instanceof Time) {
-            $datetime = new Time($datetime->format('Y-m-d H:i:s'), $timezone);
+            $datetime = new self($datetime, $timezone, $locale);
+        } elseif ($datetime instanceof DateTimeInterface && ! $datetime instanceof self) {
+            $datetime = new self($datetime->format('Y-m-d H:i:s'), $timezone);
         }
 
         static::$testNow = $datetime;
@@ -562,7 +562,7 @@ class Time extends DateTime
      */
     public function getAge()
     {
-        $now  = Time::now()->getTimestamp();
+        $now  = self::now()->getTimestamp();
         $time = $this->getTimestamp();
 
         // future dates have no age
@@ -780,7 +780,7 @@ class Time extends DateTime
 
         ${$name} = $value;
 
-        return Time::create(
+        return self::create(
             (int) $year,
             (int) $month,
             (int) $day,
@@ -805,7 +805,7 @@ class Time extends DateTime
     {
         $timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone);
 
-        return Time::createFromInstance($this->toDateTime()->setTimezone($timezone), $this->locale);
+        return self::createFromInstance($this->toDateTime()->setTimezone($timezone), $this->locale);
     }
 
     /**
@@ -821,7 +821,7 @@ class Time extends DateTime
     {
         $time = date('Y-m-d H:i:s', $timestamp);
 
-        return Time::parse($time, $this->timezone, $this->locale);
+        return self::parse($time, $this->timezone, $this->locale);
     }
 
     //--------------------------------------------------------------------
@@ -1192,7 +1192,7 @@ class Time extends DateTime
      */
     public function humanize()
     {
-        $now  = IntlCalendar::fromDateTime(Time::now($this->timezone)->toDateTimeString());
+        $now  = IntlCalendar::fromDateTime(self::now($this->timezone)->toDateTimeString());
         $time = $this->getCalendar()->getTime();
 
         $years   = $now->fieldDifference($time, IntlCalendar::FIELD_YEAR);
@@ -1267,7 +1267,7 @@ class Time extends DateTime
      */
     public function getUTCObject($time, ?string $timezone = null)
     {
-        if ($time instanceof Time) {
+        if ($time instanceof self) {
             $time = $time->toDateTime();
         } elseif (is_string($time)) {
             $timezone = $timezone ?: $this->timezone;

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -481,7 +481,7 @@ class Pager implements PagerInterface
      *
      * @return Pager
      */
-    public function only(array $queries): Pager
+    public function only(array $queries): self
     {
         $this->only = $queries;
 

--- a/system/Validation/ValidationInterface.php
+++ b/system/Validation/ValidationInterface.php
@@ -53,7 +53,7 @@ interface ValidationInterface
      *
      * @return ValidationInterface
      */
-    public function withRequest(RequestInterface $request): ValidationInterface;
+    public function withRequest(RequestInterface $request): self;
 
     //--------------------------------------------------------------------
     // Rules
@@ -67,7 +67,7 @@ interface ValidationInterface
      *
      * @return ValidationInterface
      */
-    public function setRules(array $rules, array $messages = []): ValidationInterface;
+    public function setRules(array $rules, array $messages = []): self;
 
     //--------------------------------------------------------------------
 
@@ -119,7 +119,7 @@ interface ValidationInterface
      *
      * @return ValidationInterface
      */
-    public function setError(string $alias, string $error): ValidationInterface;
+    public function setError(string $alias, string $error): self;
 
     //--------------------------------------------------------------------
     // Misc
@@ -131,7 +131,7 @@ interface ValidationInterface
      *
      * @return ValidationInterface
      */
-    public function reset(): ValidationInterface;
+    public function reset(): self;
 
     //--------------------------------------------------------------------
 }

--- a/system/Validation/ValidationInterface.php
+++ b/system/Validation/ValidationInterface.php
@@ -53,7 +53,7 @@ interface ValidationInterface
      *
      * @return ValidationInterface
      */
-    public function withRequest(RequestInterface $request): self;
+    public function withRequest(RequestInterface $request): ValidationInterface;
 
     //--------------------------------------------------------------------
     // Rules
@@ -67,7 +67,7 @@ interface ValidationInterface
      *
      * @return ValidationInterface
      */
-    public function setRules(array $rules, array $messages = []): self;
+    public function setRules(array $rules, array $messages = []): ValidationInterface;
 
     //--------------------------------------------------------------------
 
@@ -119,7 +119,7 @@ interface ValidationInterface
      *
      * @return ValidationInterface
      */
-    public function setError(string $alias, string $error): self;
+    public function setError(string $alias, string $error): ValidationInterface;
 
     //--------------------------------------------------------------------
     // Misc
@@ -131,7 +131,7 @@ interface ValidationInterface
      *
      * @return ValidationInterface
      */
-    public function reset(): self;
+    public function reset(): ValidationInterface;
 
     //--------------------------------------------------------------------
 }

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -372,19 +372,19 @@ final class FormatRulesTest extends CIUnitTestCase
     {
         return [
             [
-                FormatRulesTest::ALPHABET,
+                self::ALPHABET,
                 true,
             ],
             [
-                FormatRulesTest::ALPHABET . ' ',
+                self::ALPHABET . ' ',
                 false,
             ],
             [
-                FormatRulesTest::ALPHABET . '1',
+                self::ALPHABET . '1',
                 false,
             ],
             [
-                FormatRulesTest::ALPHABET . '*',
+                self::ALPHABET . '*',
                 false,
             ],
             [
@@ -423,23 +423,23 @@ final class FormatRulesTest extends CIUnitTestCase
                 true,
             ],
             [
-                FormatRulesTest::ALPHABET,
+                self::ALPHABET,
                 true,
             ],
             [
-                FormatRulesTest::ALPHABET . ' ',
+                self::ALPHABET . ' ',
                 true,
             ],
             [
-                FormatRulesTest::ALPHABET . "\n",
+                self::ALPHABET . "\n",
                 false,
             ],
             [
-                FormatRulesTest::ALPHABET . '1',
+                self::ALPHABET . '1',
                 false,
             ],
             [
-                FormatRulesTest::ALPHABET . '*',
+                self::ALPHABET . '*',
                 false,
             ],
         ];
@@ -468,15 +468,15 @@ final class FormatRulesTest extends CIUnitTestCase
     {
         return [
             [
-                FormatRulesTest::ALPHANUMERIC,
+                self::ALPHANUMERIC,
                 true,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '\ ',
+                self::ALPHANUMERIC . '\ ',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '_',
+                self::ALPHANUMERIC . '_',
                 false,
             ],
             [
@@ -509,71 +509,71 @@ final class FormatRulesTest extends CIUnitTestCase
     {
         return [
             [
-                FormatRulesTest::ALPHANUMERIC . ' ~!#$%&*-_+=|:.',
+                self::ALPHANUMERIC . ' ~!#$%&*-_+=|:.',
                 true,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '`',
+                self::ALPHANUMERIC . '`',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . "\n",
+                self::ALPHANUMERIC . "\n",
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '@',
+                self::ALPHANUMERIC . '@',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '^',
+                self::ALPHANUMERIC . '^',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '(',
+                self::ALPHANUMERIC . '(',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . ')',
+                self::ALPHANUMERIC . ')',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '\\',
+                self::ALPHANUMERIC . '\\',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '{',
+                self::ALPHANUMERIC . '{',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '}',
+                self::ALPHANUMERIC . '}',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '[',
+                self::ALPHANUMERIC . '[',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . ']',
+                self::ALPHANUMERIC . ']',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '"',
+                self::ALPHANUMERIC . '"',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . "'",
+                self::ALPHANUMERIC . "'",
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '<',
+                self::ALPHANUMERIC . '<',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '>',
+                self::ALPHANUMERIC . '>',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '/',
+                self::ALPHANUMERIC . '/',
                 false,
             ],
             [
@@ -606,15 +606,15 @@ final class FormatRulesTest extends CIUnitTestCase
     {
         return [
             [
-                ' ' . FormatRulesTest::ALPHANUMERIC,
+                ' ' . self::ALPHANUMERIC,
                 true,
             ],
             [
-                ' ' . FormatRulesTest::ALPHANUMERIC . '-',
+                ' ' . self::ALPHANUMERIC . '-',
                 false,
             ],
             [
-                ' ' . FormatRulesTest::ALPHANUMERIC . "\n",
+                ' ' . self::ALPHANUMERIC . "\n",
                 false,
             ],
             [
@@ -647,15 +647,15 @@ final class FormatRulesTest extends CIUnitTestCase
     {
         return [
             [
-                FormatRulesTest::ALPHANUMERIC . '-',
+                self::ALPHANUMERIC . '-',
                 true,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . '-\ ',
+                self::ALPHANUMERIC . '-\ ',
                 false,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC . "-\n",
+                self::ALPHANUMERIC . "-\n",
                 false,
             ],
             [
@@ -692,7 +692,7 @@ final class FormatRulesTest extends CIUnitTestCase
                 true,
             ],
             [
-                FormatRulesTest::ALPHANUMERIC,
+                self::ALPHANUMERIC,
                 false,
             ],
             [

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -393,6 +393,8 @@ final class CodeIgniter4 extends AbstractRuleset
             'set_type_to_cast'                   => true,
             'short_scalar_cast'                  => true,
             'simple_to_complex_string_variable'  => true,
+            'simplified_if_return'               => true,
+            'simplified_null_return'             => false,
             'single_blank_line_at_eof'           => true,
             'single_blank_line_before_namespace' => true,
             'single_class_element_per_statement' => ['elements' => ['const', 'property']],

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -389,6 +389,7 @@ final class CodeIgniter4 extends AbstractRuleset
             'return_type_declaration'            => ['space_before' => 'none'],
             'self_accessor'                      => false,
             'self_static_accessor'               => true,
+            'semicolon_after_instruction'        => false,
             'set_type_to_cast'                   => true,
             'short_scalar_cast'                  => true,
             'simple_to_complex_string_variable'  => true,

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -387,6 +387,8 @@ final class CodeIgniter4 extends AbstractRuleset
             'regular_callable_call'              => true,
             'return_assignment'                  => true,
             'return_type_declaration'            => ['space_before' => 'none'],
+            'self_accessor'                      => false,
+            'self_static_accessor'               => true,
             'set_type_to_cast'                   => true,
             'short_scalar_cast'                  => true,
             'simple_to_complex_string_variable'  => true,


### PR DESCRIPTION
**Description**
- Inside class or interface element `self` should be preferred to the class name itself.
- Inside a final class or anonymous class `self` should be preferred to `static`.
- ~Instructions must be terminated with a semicolon.~
- Simplify if control structures that return the boolean result of their condition.

**Checklist:**
- [x] Securely signed commits
