### PR TITLE
Add missing [] on USE command

### DIFF
--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -472,7 +472,7 @@ class Connection extends BaseConnection
             $this->initialize();
         }
 
-        if ($this->execute('USE ' . $this->_escapeString($databaseName))) {
+        if ($this->execute('USE [' . $this->_escapeString($databaseName). ']')) {
             $this->database  = $databaseName;
             $this->dataCache = [];
 


### PR DESCRIPTION
A syntax error occurs when selecting a database. 
I noticed a missing [] in the USE command.