### PR TITLE
Fix bug with DB-Forge composite foreign keys

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -416,27 +416,38 @@ class Forge
     /**
      * Add Foreign Key
      *
-     * @param string $fieldName
-     * @param string $tableName
-     * @param string $tableField
-     * @param string $onUpdate
-     * @param string $onDelete
-     *
-     * @return Forge
+     * @param string|string[] $fieldName
+     * @param string          $tableName
+     * @param string|string[] $tableField
+     * @param string          $onUpdate
+     * @param string          $onDelete
      *
      * @throws DatabaseException
+     *
+     * @return Forge
      */
-    public function addForeignKey(string $fieldName = '', string $tableName = '', string $tableField = '', string $onUpdate = '', string $onDelete = '')
+    public function addForeignKey($fieldName = '', string $tableName = '', $tableField = '', string $onUpdate = '', string $onDelete = '')
     {
-        if (! isset($this->fields[$fieldName])) {
-            throw new DatabaseException(lang('Database.fieldNotExists', [$fieldName]));
+        $fieldName  = (array) $fieldName;
+        $tableField = (array) $tableField;
+        $errorNames = [];
+
+        foreach ($fieldName as $name) {
+            if (! isset($this->fields[$name])) {
+                $errorNames[] = $name;
+            }
         }
 
-        $this->foreignKeys[$fieldName] = [
-            'table'    => $tableName,
-            'field'    => $tableField,
-            'onDelete' => strtoupper($onDelete),
-            'onUpdate' => strtoupper($onUpdate),
+        if ($errorNames !== []) {
+            throw new DatabaseException(lang('Database.fieldNotExists', $errorNames));
+        }
+
+        $this->foreignKeys[] = [
+            'field'          => $fieldName,
+            'referenceTable' => $tableName,
+            'referenceField' => $tableField,
+            'onDelete'       => strtoupper($onDelete),
+            'onUpdate'       => strtoupper($onUpdate),
         ];
 
         return $this;
@@ -1204,11 +1215,15 @@ class Forge
         ];
 
         if ($this->foreignKeys !== []) {
-            foreach ($this->foreignKeys as $field => $fkey) {
-                $nameIndex = $table . '_' . $field . '_foreign';
+            foreach ($this->foreignKeys as $fkey) {
+                $nameIndex            = $table . '_' . implode('_', $fkey['field']) . '_foreign';
+                $nameIndexFilled      = $this->db->escapeIdentifiers($nameIndex);
+                $foreignKeyFilled     = implode(', ', $this->db->escapeIdentifiers($fkey['field']));
+                $referenceTableFilled = $this->db->escapeIdentifiers($this->db->DBPrefix . $fkey['referenceTable']);
+                $referenceFieldFilled = implode(', ', $this->db->escapeIdentifiers($fkey['referenceField']));
 
-                $sql .= ",\n\tCONSTRAINT " . $this->db->escapeIdentifiers($nameIndex)
-                    . ' FOREIGN KEY(' . $this->db->escapeIdentifiers($field) . ') REFERENCES ' . $this->db->escapeIdentifiers($this->db->DBPrefix . $fkey['table']) . ' (' . $this->db->escapeIdentifiers($fkey['field']) . ')';
+                $formatSql = ",\n\tCONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s(%s)";
+                $sql .= sprintf($formatSql, $nameIndexFilled, $foreignKeyFilled, $referenceTableFilled, $referenceFieldFilled);
 
                 if ($fkey['onDelete'] !== false && in_array($fkey['onDelete'], $allowActions, true)) {
                     $sql .= ' ON DELETE ' . $fkey['onDelete'];

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -439,6 +439,8 @@ class Forge
         }
 
         if ($errorNames !== []) {
+            $errorNames[0] = implode(', ',$errorNames);
+
             throw new DatabaseException(lang('Database.fieldNotExists', $errorNames));
         }
 

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -319,12 +319,15 @@ class Forge extends BaseForge
         ];
 
         if ($this->foreignKeys !== []) {
-            foreach ($this->foreignKeys as $field => $fkey) {
-                $nameIndex = $table . '_' . $field . '_foreign';
+            foreach ($this->foreignKeys as $fkey) {
+                $nameIndex            = $table . '_' . implode('_', $fkey['field']) . '_foreign';
+                $nameIndexFilled      = $this->db->escapeIdentifiers($nameIndex);
+                $foreignKeyFilled     = implode(', ', $this->db->escapeIdentifiers($fkey['field']));
+                $referenceTableFilled = $this->db->escapeIdentifiers($this->db->DBPrefix . $fkey['referenceTable']);
+                $referenceFieldFilled = implode(', ', $this->db->escapeIdentifiers($fkey['referenceField']));
 
-                $sql .= ",\n\t CONSTRAINT " . $this->db->escapeIdentifiers($nameIndex)
-                    . ' FOREIGN KEY (' . $this->db->escapeIdentifiers($field) . ') '
-                    . ' REFERENCES ' . $this->db->escapeIdentifiers($this->db->schema) . '.' . $this->db->escapeIdentifiers($this->db->getPrefix() . $fkey['table']) . ' (' . $this->db->escapeIdentifiers($fkey['field']) . ')';
+                $formatSql = ",\n\tCONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s(%s)";
+                $sql .= sprintf($formatSql, $nameIndexFilled, $foreignKeyFilled, $referenceTableFilled, $referenceFieldFilled);
 
                 if ($fkey['onDelete'] !== false && in_array($fkey['onDelete'], $allowActions, true)) {
                     $sql .= ' ON DELETE ' . $fkey['onDelete'];

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -508,21 +508,21 @@ class ForgeTest extends CIUnitTestCase
         $foreignKeyData = $this->db->getForeignKeyData('forge_test_invoices');
 
         if ($this->db->DBDriver === 'SQLite3') {
-            $this->assertSame($foreignKeyData[0]->constraint_name, 'users_id to db_forge_test_users.id');
-            $this->assertSame($foreignKeyData[0]->sequence, 0);
-            $this->assertSame($foreignKeyData[1]->constraint_name, 'users_second_id to db_forge_test_users.second_id');
-            $this->assertSame($foreignKeyData[1]->sequence, 1);
+            $this->assertSame('users_id to db_forge_test_users.id', $foreignKeyData[0]->constraint_name);
+            $this->assertSame(0, $foreignKeyData[0]->sequence);
+            $this->assertSame('users_second_id to db_forge_test_users.second_id', $foreignKeyData[1]->constraint_name);
+            $this->assertSame(1, $foreignKeyData[1]->sequence);
         } else {
             $haystack = ['users_id', 'users_second_id'];
-            $this->assertSame($foreignKeyData[0]->constraint_name, $this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign');
+            $this->assertSame($this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign', $foreignKeyData[0]->constraint_name);
             $this->assertContains($foreignKeyData[0]->column_name, $haystack);
 
             $secondIdKey = $this->db->DBDriver === 'Postgre' ? 2 : 1;
-            $this->assertSame($foreignKeyData[$secondIdKey]->constraint_name, $this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign');
+            $this->assertSame($this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign', $foreignKeyData[$secondIdKey]->constraint_name);
             $this->assertContains($foreignKeyData[$secondIdKey]->column_name, $haystack);
         }
-        $this->assertSame($foreignKeyData[0]->table_name, $this->db->DBPrefix . 'forge_test_invoices');
-        $this->assertSame($foreignKeyData[0]->foreign_table_name, $this->db->DBPrefix . 'forge_test_users');
+        $this->assertSame($this->db->DBPrefix . 'forge_test_invoices', $foreignKeyData[0]->table_name);
+        $this->assertSame($this->db->DBPrefix . 'forge_test_users', $foreignKeyData[0]->foreign_table_name);
 
         $this->forge->dropTable('forge_test_invoices', true);
         $this->forge->dropTable('forge_test_users', true);

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -360,6 +360,8 @@ class ForgeTest extends CIUnitTestCase
 
     public function testForeignKey()
     {
+        $this->forge->dropTable('forge_test_users', true);
+
         $attributes = [];
 
         if ($this->db->DBDriver === 'MySQLi') {
@@ -627,6 +629,8 @@ class ForgeTest extends CIUnitTestCase
 
     public function testDropForeignKey()
     {
+        $this->forge->dropTable('forge_test_users', true);
+
         $attributes = [];
 
         if ($this->db->DBDriver === 'MySQLi') {

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -452,6 +452,135 @@ class ForgeTest extends CIUnitTestCase
         $this->forge->dropTable('forge_test_users', true);
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/4310
+     */
+    public function testCompositeForeignKey()
+    {
+        $attributes = [];
+
+        if ($this->db->DBDriver === 'MySQLi') {
+            $attributes = ['ENGINE' => 'InnoDB'];
+        }
+
+        $this->forge->addField([
+            'id' => [
+                'type'       => 'INTEGER',
+                'constraint' => 11,
+            ],
+            'second_id' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 50,
+            ],
+            'name' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 255,
+            ],
+        ]);
+        $this->forge->addPrimaryKey(['id', 'second_id']);
+        $this->forge->createTable('forge_test_users', true, $attributes);
+
+        $this->forge->addField([
+            'id' => [
+                'type'       => 'INTEGER',
+                'constraint' => 11,
+            ],
+            'users_id' => [
+                'type'       => 'INTEGER',
+                'constraint' => 11,
+            ],
+            'users_second_id' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 50,
+            ],
+            'name' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 255,
+            ],
+        ]);
+        $this->forge->addPrimaryKey('id');
+        $this->forge->addForeignKey(['users_id', 'users_second_id'], 'forge_test_users', ['id', 'second_id'], 'CASCADE', 'CASCADE');
+
+        $this->forge->createTable('forge_test_invoices', true, $attributes);
+
+        $foreignKeyData = $this->db->getForeignKeyData('forge_test_invoices');
+
+        if ($this->db->DBDriver === 'SQLite3') {
+            $this->assertSame($foreignKeyData[0]->constraint_name, 'users_id to db_forge_test_users.id');
+            $this->assertSame($foreignKeyData[0]->sequence, 0);
+            $this->assertSame($foreignKeyData[1]->constraint_name, 'users_second_id to db_forge_test_users.second_id');
+            $this->assertSame($foreignKeyData[1]->sequence, 1);
+        } else {
+            $haystack = ['users_id', 'users_second_id'];
+            $this->assertSame($foreignKeyData[0]->constraint_name, $this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign');
+            $this->assertContains($foreignKeyData[0]->column_name, $haystack);
+
+            $secondIdKey = $this->db->DBDriver === 'Postgre' ? 2 : 1;
+            $this->assertSame($foreignKeyData[$secondIdKey]->constraint_name, $this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign');
+            $this->assertContains($foreignKeyData[$secondIdKey]->column_name, $haystack);
+        }
+        $this->assertSame($foreignKeyData[0]->table_name, $this->db->DBPrefix . 'forge_test_invoices');
+        $this->assertSame($foreignKeyData[0]->foreign_table_name, $this->db->DBPrefix . 'forge_test_users');
+
+        $this->forge->dropTable('forge_test_invoices', true);
+        $this->forge->dropTable('forge_test_users', true);
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/4310
+     */
+    public function testCompositeForeignKeyFieldNotExistException()
+    {
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('Field `user_id, user_second_id` not found.');
+
+        $attributes = [];
+
+        if ($this->db->DBDriver === 'MySQLi') {
+            $attributes = ['ENGINE' => 'InnoDB'];
+        }
+
+        $this->forge->addField([
+            'id' => [
+                'type'       => 'INTEGER',
+                'constraint' => 11,
+            ],
+            'second_id' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 50,
+            ],
+            'name' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 255,
+            ],
+        ]);
+        $this->forge->addPrimaryKey(['id', 'second_id']);
+        $this->forge->createTable('forge_test_users', true, $attributes);
+
+        $this->forge->addField([
+            'id' => [
+                'type'       => 'INTEGER',
+                'constraint' => 11,
+            ],
+            'users_id' => [
+                'type'       => 'INTEGER',
+                'constraint' => 11,
+            ],
+            'users_second_id' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 50,
+            ],
+            'name' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 255,
+            ],
+        ]);
+        $this->forge->addKey('id', true);
+        $this->forge->addForeignKey(['user_id', 'user_second_id'], 'forge_test_users', ['id', 'second_id'], 'CASCADE', 'CASCADE');
+
+        $this->forge->createTable('forge_test_invoices', true, $attributes);
+    }
+
     public function testForeignKeyFieldNotExistException()
     {
         $this->expectException(DatabaseException::class);

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -8,6 +8,7 @@ Release Date: Not released
 Enhancements:
 
 - Added Cache config for reserved characters
+- The ``addForeignKey`` function of the ``Forge`` class can now define composite foreign keys in an array
 
 Changes:
 

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -232,13 +232,19 @@ Adding Foreign Keys
 Foreign Keys help to enforce relationships and actions across your tables. For tables that support Foreign Keys,
 you may add them directly in forge::
 
-        $forge->addForeignKey('users_id','users','id');
-        // gives CONSTRAINT `TABLENAME_users_foreign` FOREIGN KEY(`users_id`) REFERENCES `users`(`id`)
+	$forge->addForeignKey('users_id','users','id');
+	// gives CONSTRAINT `TABLENAME_users_foreign` FOREIGN KEY(`users_id`) REFERENCES `users`(`id`)
+
+	$forge->addForeignKey(['users_id', 'users_name'],'users',['id', 'name']);
+	// gives CONSTRAINT `TABLENAME_users_foreign` FOREIGN KEY(`users_id`, `users_name`) REFERENCES `users`(`id`, `name`)
 
 You can specify the desired action for the "on delete" and "on update" properties of the constraint::
 
-        $forge->addForeignKey('users_id','users','id','CASCADE','CASCADE');
-        // gives CONSTRAINT `TABLENAME_users_foreign` FOREIGN KEY(`users_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
+	$forge->addForeignKey('users_id','users','id','CASCADE','CASCADE');
+	// gives CONSTRAINT `TABLENAME_users_foreign` FOREIGN KEY(`users_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
+
+	$forge->addForeignKey(['users_id', 'users_name'],'users',['id', 'name'],'CASCADE','CASCADE');
+	// gives CONSTRAINT `TABLENAME_users_foreign` FOREIGN KEY(`users_id`, `users_name`) REFERENCES `users`(`id`, `name`) ON DELETE CASCADE ON UPDATE CASCADE
 
 Creating a table
 ================


### PR DESCRIPTION
**Description**
Fixes #4310 
Original PR #4931 

Change the branch base to 4.2.

I edited the `addForeignKey` method and `_processForeignKeys` method of `CodeIgniter\Database\Forge` so that they can define composite foreign keys in an array.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide