### PR TITLE
Define remaining rules

### DIFF
--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -156,7 +156,9 @@ final class CodeIgniter4 extends AbstractRuleset
                 'fix_inline'     => true,
                 'replacements'   => ['inheritDocs' => 'inheritDoc'],
             ],
+            'global_namespace_import'     => false,
             'group_import'                => false,
+            'header_comment'              => false, // false by default
             'heredoc_indentation'         => ['indentation' => 'start_plus_one'],
             'heredoc_to_nowdoc'           => true,
             'implode_call'                => true,
@@ -184,7 +186,9 @@ final class CodeIgniter4 extends AbstractRuleset
             'modernize_types_casting'                     => true,
             'multiline_comment_opening_closing'           => true,
             'multiline_whitespace_before_semicolons'      => ['strategy' => 'no_multi_line'],
+            'native_constant_invocation'                  => false,
             'native_function_casing'                      => true,
+            'native_function_invocation'                  => false,
             'native_function_type_declaration_casing'     => true,
             'new_with_braces'                             => true,
             'no_alias_functions'                          => ['sets' => ['@all']],
@@ -483,7 +487,9 @@ final class CodeIgniter4 extends AbstractRuleset
             ],
             'trim_array_spaces'               => true,
             'unary_operator_spaces'           => true,
+            'use_arrow_functions'             => false, // requires PHP7.4+
             'visibility_required'             => ['elements' => ['const', 'method', 'property']],
+            'void_return'                     => false, // changes method signature
             'whitespace_after_comma_in_array' => true,
             'yoda_style'                      => [
                 'equal'                => false,


### PR DESCRIPTION
**Description**
Aside from #4933 , this defines the last remaining built-in fixers from php-cs-fixer into our ruleset. However, these are turned off by default.

- global_namespace_import, native_function_invocation, native_constant_invocation are depending on #4890 / #4899 
- header_comment is off by default. this is turned on by using `Factory::forLibrary()`
- use_arrow_functions is available only for PHP7.4+ code
- void_return adds the void return typehint so this breaks signature

**Checklist:**
- [x] Securely signed commits
