### PR TITLE
Remove 'memory_usage' from 'displayPerformanceMetrics()' comment

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -725,7 +725,7 @@ class CodeIgniter
     //--------------------------------------------------------------------
 
     /**
-     * Replaces the memory_usage and elapsed_time tags.
+     * Replaces the elapsed_time tag.
      *
      * @param string $output
      *


### PR DESCRIPTION
**Description**
I came across the `displayPerformanceMetrics()` function in `system/CodeIgniter.php` and noticed that the `memory_usage ` tag, is not getting replaced by this function. Although the php doc describes it does.

This PR removes the `memory_usage` mention from the comment as this behaviour is intended: see issue #197.

**Checklist:**
- [x] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
