### PR TITLE
Remove superfluous phpdoc tags

### DIFF
--- a/app/Config/Format.php
+++ b/app/Config/Format.php
@@ -64,8 +64,6 @@ class Format extends BaseConfig
     /**
      * A Factory method to return the appropriate formatter for the given mime type.
      *
-     * @param string $mime
-     *
      * @return FormatterInterface
      *
      * @deprecated This is an alias of `\CodeIgniter\Format\Format::getFormatter`. Use that instead.

--- a/app/Config/Mimes.php
+++ b/app/Config/Mimes.php
@@ -485,8 +485,6 @@ class Mimes
     /**
      * Attempts to determine the best mime type for the given file extension.
      *
-     * @param string $extension
-     *
      * @return string|null The mime type found, or none if unable to determine.
      */
     public static function guessTypeFromExtension(string $extension)
@@ -503,7 +501,6 @@ class Mimes
     /**
      * Attempts to determine the best file extension for a given mime type.
      *
-     * @param string      $type
      * @param string|null $proposedExtension - default extension (in case there is more than one with the same mime type)
      *
      * @return string|null The extension determined, or null if unable to match.

--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -39,10 +39,6 @@ class BaseController extends Controller
 
     /**
      * Constructor.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     * @param LoggerInterface   $logger
      */
     public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
     {

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -87,7 +87,6 @@ trait ResponseTrait
      *
      * @param array|string|null $data
      * @param int               $status
-     * @param string            $message
      *
      * @return mixed
      */
@@ -125,9 +124,8 @@ trait ResponseTrait
      * Used for generic failures that no custom methods exist for.
      *
      * @param array|string $messages
-     * @param int          $status        HTTP status code
-     * @param string|null  $code          Custom, API-specific, error code
-     * @param string       $customMessage
+     * @param int          $status   HTTP status code
+     * @param string|null  $code     Custom, API-specific, error code
      *
      * @return mixed
      */
@@ -207,9 +205,7 @@ trait ResponseTrait
      * or had bad authorization credentials. User is encouraged to try again
      * with the proper information.
      *
-     * @param string $description
      * @param string $code
-     * @param string $message
      *
      * @return mixed
      */
@@ -222,9 +218,7 @@ trait ResponseTrait
      * Used when access is always denied to this resource and no amount
      * of trying again will help.
      *
-     * @param string $description
      * @param string $code
-     * @param string $message
      *
      * @return mixed
      */
@@ -236,9 +230,7 @@ trait ResponseTrait
     /**
      * Used when a specified resource cannot be found.
      *
-     * @param string $description
      * @param string $code
-     * @param string $message
      *
      * @return mixed
      */
@@ -250,9 +242,7 @@ trait ResponseTrait
     /**
      * Used when the data provided by the client cannot be validated.
      *
-     * @param string $description
      * @param string $code
-     * @param string $message
      *
      * @return mixed
      *
@@ -267,8 +257,6 @@ trait ResponseTrait
      * Used when the data provided by the client cannot be validated on one or more fields.
      *
      * @param string|string[] $errors
-     * @param string|null     $code
-     * @param string          $message
      *
      * @return mixed
      */
@@ -280,9 +268,7 @@ trait ResponseTrait
     /**
      * Use when trying to create a new resource and it already exists.
      *
-     * @param string $description
      * @param string $code
-     * @param string $message
      *
      * @return mixed
      */
@@ -296,9 +282,7 @@ trait ResponseTrait
      * Not Found, because here we know the data previously existed, but is now gone,
      * where Not Found means we simply cannot find any information about it.
      *
-     * @param string $description
      * @param string $code
-     * @param string $message
      *
      * @return mixed
      */
@@ -310,9 +294,7 @@ trait ResponseTrait
     /**
      * Used when the user has made too many requests for the resource recently.
      *
-     * @param string $description
      * @param string $code
-     * @param string $message
      *
      * @return mixed
      */

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -80,9 +80,6 @@ class Autoloader
      * Reads in the configuration array (described above) and stores
      * the valid parts that we'll need.
      *
-     * @param Autoload $config
-     * @param Modules  $modules
-     *
      * @return $this
      */
     public function initialize(Autoload $config, Modules $modules)
@@ -136,7 +133,6 @@ class Autoloader
      * Registers namespaces with the autoloader.
      *
      * @param array|string $namespace
-     * @param string|null  $path
      *
      * @return $this
      */
@@ -168,8 +164,6 @@ class Autoloader
      *
      * If a prefix param is set, returns only paths to the given prefix.
      *
-     * @param string|null $prefix
-     *
      * @return array
      */
     public function getNamespace(?string $prefix = null)
@@ -184,8 +178,6 @@ class Autoloader
     /**
      * Removes a single namespace from the psr4 settings.
      *
-     * @param string $namespace
-     *
      * @return $this
      */
     public function removeNamespace(string $namespace)
@@ -199,8 +191,6 @@ class Autoloader
 
     /**
      * Load a class using available class mapping.
-     *
-     * @param string $class
      *
      * @return false|string
      */
@@ -266,8 +256,6 @@ class Autoloader
     /**
      * A central way to include a file. Split out primarily for testing purposes.
      *
-     * @param string $file
-     *
      * @return false|string The filename on success, false if the file is not loaded
      */
     protected function includeFile(string $file)
@@ -291,8 +279,6 @@ class Autoloader
      * to manipulate at the command line. Replaces spaces and consecutive
      * dashes with a single dash. Trim period, dash and underscore from beginning
      * and end of filename.
-     *
-     * @param string $filename
      *
      * @return string The sanitized filename
      */

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -28,8 +28,6 @@ class FileLocator
 
     /**
      * Constructor
-     *
-     * @param Autoloader $autoloader
      */
     public function __construct(Autoloader $autoloader)
     {
@@ -118,10 +116,6 @@ class FileLocator
 
     /**
      * Examines a file and returns the fully qualified domain name.
-     *
-     * @param string $file
-     *
-     * @return string
      */
     public function getClassname(string $file): string
     {
@@ -175,12 +169,6 @@ class FileLocator
      *      'app/Modules/foo/Config/Routes.php',
      *      'app/Modules/bar/Config/Routes.php',
      *  ]
-     *
-     * @param string $path
-     * @param string $ext
-     * @param bool   $prioritizeApp
-     *
-     * @return array
      */
     public function search(string $path, string $ext = 'php', bool $prioritizeApp = true): array
     {
@@ -214,11 +202,6 @@ class FileLocator
 
     /**
      * Ensures a extension is at the end of a filename
-     *
-     * @param string $path
-     * @param string $ext
-     *
-     * @return string
      */
     protected function ensureExt(string $path, string $ext): string
     {
@@ -272,8 +255,6 @@ class FileLocator
      * Find the qualified name of a file according to
      * the namespace of the first matched namespace path.
      *
-     * @param string $path
-     *
      * @return false|string The qualified name or false if the path is not found
      */
     public function findQualifiedNameFromPath(string $path)
@@ -315,10 +296,6 @@ class FileLocator
     /**
      * Scans the defined namespaces, returning a list of all files
      * that are contained within the subpath specified by $path.
-     *
-     * @param string $path
-     *
-     * @return array
      */
     public function listFiles(string $path): array
     {
@@ -350,11 +327,6 @@ class FileLocator
     /**
      * Scans the provided namespace, returning a list of all files
      * that are contained within the subpath specified by $path.
-     *
-     * @param string $prefix
-     * @param string $path
-     *
-     * @return array
      */
     public function listNamespaceFiles(string $prefix, string $path): array
     {
@@ -387,9 +359,6 @@ class FileLocator
     /**
      * Checks the app folder to see if the file can be found.
      * Only for use with filenames that DO NOT include namespacing.
-     *
-     * @param string      $file
-     * @param string|null $folder
      *
      * @return false|string The path to the file, or false if not found.
      */

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -387,8 +387,6 @@ abstract class BaseModel
      *
      * @param array|int|string|null $id   ID
      * @param array|null            $data Data
-     *
-     * @return bool
      */
     abstract protected function doUpdate($id = null, $data = null): bool;
 
@@ -658,8 +656,6 @@ abstract class BaseModel
      * @param array|object $data Data
      *
      * @throws ReflectionException
-     *
-     * @return bool
      */
     public function save($data): bool
     {
@@ -685,8 +681,6 @@ abstract class BaseModel
      * If this method return false insert operation will be executed
      *
      * @param array|object $data Data
-     *
-     * @return bool
      */
     protected function shouldUpdate($data): bool
     {
@@ -839,8 +833,6 @@ abstract class BaseModel
      * @param array|object|null     $data Data
      *
      * @throws ReflectionException
-     *
-     * @return bool
      */
     public function update($id = null, $data = null): bool
     {
@@ -1142,8 +1134,6 @@ abstract class BaseModel
      * @param array $data Data
      *
      * @throws DataException
-     *
-     * @return array
      */
     protected function doProtectFields(array $data): array
     {
@@ -1339,8 +1329,6 @@ abstract class BaseModel
      * specified in the class property, $validationRules.
      *
      * @param array|object $data Data
-     *
-     * @return bool
      */
     public function validate($data): bool
     {
@@ -1371,8 +1359,6 @@ abstract class BaseModel
      * can be used elsewhere, if needed.
      *
      * @param array $options Options
-     *
-     * @return array
      */
     public function getValidationRules(array $options = []): array
     {
@@ -1396,8 +1382,6 @@ abstract class BaseModel
     /**
      * Returns the model's define validation messages so they
      * can be used elsewhere, if needed.
-     *
-     * @return array
      */
     public function getValidationMessages(): array
     {
@@ -1411,8 +1395,6 @@ abstract class BaseModel
      *
      * @param array      $rules Array containing field name and rule
      * @param array|null $data  Data
-     *
-     * @return array
      */
     protected function cleanValidationRules(array $rules, ?array $data = null): array
     {
@@ -1588,8 +1570,6 @@ abstract class BaseModel
      * @throws DataException
      * @throws InvalidArgumentException
      * @throws ReflectionException
-     *
-     * @return array
      */
     protected function transformDataToArray($data, string $type): array
     {
@@ -1643,8 +1623,6 @@ abstract class BaseModel
      * Checks for the existence of properties across this model, and db connection.
      *
      * @param string $name Name
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -1693,8 +1671,6 @@ abstract class BaseModel
      * @codeCoverageIgnore
      *
      * @deprecated use fillPlaceholders($rules, $data) from Validation instead
-     *
-     * @return array
      */
     protected function fillPlaceholders(array $rules, array $data): array
     {

--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -89,9 +89,6 @@ abstract class BaseCommand
 
     /**
      * BaseCommand constructor.
-     *
-     * @param LoggerInterface $logger
-     * @param Commands        $commands
      */
     public function __construct(LoggerInterface $logger, Commands $commands)
     {
@@ -102,16 +99,11 @@ abstract class BaseCommand
     /**
      * Actually execute a command.
      * This has to be over-ridden in any concrete implementation.
-     *
-     * @param array $params
      */
     abstract public function run(array $params);
 
     /**
      * Can be used by a command to run other commands.
-     *
-     * @param string $command
-     * @param array  $params
      *
      * @throws ReflectionException
      *
@@ -124,8 +116,6 @@ abstract class BaseCommand
 
     /**
      * A simple method to display an error with line/file, in child commands.
-     *
-     * @param Throwable $e
      */
     protected function showError(Throwable $e)
     {
@@ -184,12 +174,7 @@ abstract class BaseCommand
     /**
      * Pads our string out so that all titles are the same length to nicely line up descriptions.
      *
-     * @param string $item
-     * @param int    $max
-     * @param int    $extra  How many extra spaces to add at the end
-     * @param int    $indent
-     *
-     * @return string
+     * @param int $extra How many extra spaces to add at the end
      */
     public function setPad(string $item, int $max, int $extra = 2, int $indent = 0): string
     {
@@ -200,11 +185,6 @@ abstract class BaseCommand
 
     /**
      * Get pad for $key => $value array output
-     *
-     * @param array $array
-     * @param int   $pad
-     *
-     * @return int
      *
      * @deprecated Use setPad() instead.
      *
@@ -224,8 +204,6 @@ abstract class BaseCommand
     /**
      * Makes it simple to access our protected properties.
      *
-     * @param string $key
-     *
      * @return mixed
      */
     public function __get(string $key)
@@ -235,10 +213,6 @@ abstract class BaseCommand
 
     /**
      * Makes it simple to check our protected properties.
-     *
-     * @param string $key
-     *
-     * @return bool
      */
     public function __isset(string $key): bool
     {

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -178,8 +178,6 @@ class CLI
      *
      * @param string $prefix
      *
-     * @return string
-     *
      * @codeCoverageIgnore
      */
     public static function input(?string $prefix = null): string
@@ -273,8 +271,6 @@ class CLI
      * @param string       $value Input value
      * @param array|string $rules Validation rules
      *
-     * @return bool
-     *
      * @codeCoverageIgnore
      */
     protected static function validate(string $field, string $value, $rules): bool
@@ -302,10 +298,6 @@ class CLI
     /**
      * Outputs a string to the CLI without any surrounding newlines.
      * Useful for showing repeating elements on a single line.
-     *
-     * @param string      $text
-     * @param string|null $foreground
-     * @param string|null $background
      */
     public static function print(string $text = '', ?string $foreground = null, ?string $background = null)
     {
@@ -342,9 +334,7 @@ class CLI
     /**
      * Outputs an error to the CLI using STDERR instead of STDOUT
      *
-     * @param string      $text       The text to output, or array of errors
-     * @param string      $foreground
-     * @param string|null $background
+     * @param string $text The text to output, or array of errors
      */
     public static function error(string $text, string $foreground = 'light_red', ?string $background = null)
     {
@@ -404,8 +394,6 @@ class CLI
 
     /**
      * if operating system === windows
-     *
-     * @return bool
      */
     public static function isWindows(): bool
     {
@@ -510,8 +498,6 @@ class CLI
      * and ignores styles set by the color() function
      *
      * @param string $string
-     *
-     * @return int
      */
     public static function strlen(?string $string): int
     {
@@ -536,10 +522,7 @@ class CLI
      * Checks whether the current stream resource supports or
      * refers to a valid terminal type device.
      *
-     * @param string   $function
      * @param resource $resource
-     *
-     * @return bool
      */
     public static function streamSupports(string $function, $resource): bool
     {
@@ -564,8 +547,6 @@ class CLI
      * Reference: https://github.com/composer/xdebug-handler/blob/master/src/Process.php
      *
      * @param resource $resource
-     *
-     * @return bool
      */
     public static function hasColorSupport($resource): bool
     {
@@ -593,10 +574,6 @@ class CLI
 
     /**
      * Attempts to determine the width of the viewable CLI window.
-     *
-     * @param int $default
-     *
-     * @return int
      */
     public static function getWidth(int $default = 80): int
     {
@@ -609,10 +586,6 @@ class CLI
 
     /**
      * Attempts to determine the height of the viewable CLI window.
-     *
-     * @param int $default
-     *
-     * @return int
      */
     public static function getHeight(int $default = 32): int
     {
@@ -677,7 +650,6 @@ class CLI
      * to update it. Set $thisStep = false to erase the progress bar.
      *
      * @param bool|int $thisStep
-     * @param int      $totalSteps
      */
     public static function showProgress($thisStep = 1, int $totalSteps = 10)
     {
@@ -716,10 +688,6 @@ class CLI
      * short descriptions that need to start on an existing line.
      *
      * @param string $string
-     * @param int    $max
-     * @param int    $padLeft
-     *
-     * @return string
      */
     public static function wrap(?string $string = null, int $max = 0, int $padLeft = 0): string
     {
@@ -804,8 +772,6 @@ class CLI
      * Returns the command line string portions of the arguments, minus
      * any options, as a string. This is used to pass along to the main
      * CodeIgniter application.
-     *
-     * @return string
      */
     public static function getURI(): string
     {
@@ -823,8 +789,6 @@ class CLI
      *
      * **IMPORTANT:** The index here is one-based instead of zero-based.
      *
-     * @param int $index
-     *
      * @return mixed|null
      */
     public static function getSegment(int $index)
@@ -834,8 +798,6 @@ class CLI
 
     /**
      * Returns the raw array of segments found.
-     *
-     * @return array
      */
     public static function getSegments(): array
     {
@@ -845,8 +807,6 @@ class CLI
     /**
      * Gets a single command-line option. Returns TRUE if the option
      * exists, but doesn't have a value, and is simply acting as a flag.
-     *
-     * @param string $name
      *
      * @return bool|mixed|null
      */
@@ -865,8 +825,6 @@ class CLI
 
     /**
      * Returns the raw array of options found.
-     *
-     * @return array
      */
     public static function getOptions(): array
     {
@@ -879,8 +837,6 @@ class CLI
      *
      * @param bool $useLongOpts Use '--' for long options?
      * @param bool $trim        Trim final string output?
-     *
-     * @return string
      */
     public static function getOptionString(bool $useLongOpts = false, bool $trim = false): string
     {
@@ -1013,7 +969,6 @@ class CLI
      * solution down the road.
      *
      * @param resource $handle
-     * @param string   $string
      *
      * @return void
      */

--- a/system/CLI/CommandRunner.php
+++ b/system/CLI/CommandRunner.php
@@ -59,8 +59,6 @@ class CommandRunner extends Controller
     /**
      * Default command.
      *
-     * @param array $params
-     *
      * @throws ReflectionException
      *
      * @return mixed
@@ -74,8 +72,6 @@ class CommandRunner extends Controller
 
     /**
      * Allows access to the current commands that have been found.
-     *
-     * @return array
      */
     public function getCommands(): array
     {

--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -48,9 +48,6 @@ class Commands
 
     /**
      * Runs a command given
-     *
-     * @param string $command
-     * @param array  $params
      */
     public function run(string $command, array $params)
     {
@@ -138,11 +135,6 @@ class Commands
     /**
      * Verifies if the command being sought is found
      * in the commands list.
-     *
-     * @param string $command
-     * @param array  $commands
-     *
-     * @return bool
      */
     public function verifyCommand(string $command, array $commands): bool
     {
@@ -171,11 +163,6 @@ class Commands
     /**
      * Finds alternative of `$name` among collection
      * of commands.
-     *
-     * @param string $name
-     * @param array  $collection
-     *
-     * @return array
      */
     protected function getCommandAlternatives(string $name, array $collection): array
     {

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -31,8 +31,6 @@ class Console
 
     /**
      * Console constructor.
-     *
-     * @param CodeIgniter $app
      */
     public function __construct(CodeIgniter $app)
     {
@@ -41,8 +39,6 @@ class Console
 
     /**
      * Runs the current command discovered on the CLI.
-     *
-     * @param bool $useSafeOutput
      *
      * @throws Exception
      *
@@ -60,8 +56,6 @@ class Console
 
     /**
      * Displays basic information about the Console.
-     *
-     * @param bool $suppress
      */
     public function showHeader(bool $suppress = false)
     {

--- a/system/CLI/Exceptions/CLIException.php
+++ b/system/CLI/Exceptions/CLIException.php
@@ -25,9 +25,6 @@ class CLIException extends RuntimeException
      * Thrown when `$color` specified for `$type` is not within the
      * allowed list of colors.
      *
-     * @param string $type
-     * @param string $color
-     *
      * @return CLIException
      */
     public static function forInvalidColor(string $type, string $color)

--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -86,10 +86,6 @@ trait GeneratorTrait
 
     /**
      * Execute the command.
-     *
-     * @param array $params
-     *
-     * @return void
      */
     protected function execute(array $params): void
     {
@@ -167,10 +163,6 @@ trait GeneratorTrait
 
     /**
      * Prepare options and do the necessary replacements.
-     *
-     * @param string $class
-     *
-     * @return string
      */
     protected function prepare(string $class): string
     {
@@ -181,10 +173,6 @@ trait GeneratorTrait
      * Change file basename before saving.
      *
      * Useful for components where the file name has a date.
-     *
-     * @param string $filename
-     *
-     * @return string
      */
     protected function basename(string $filename): string
     {
@@ -193,8 +181,6 @@ trait GeneratorTrait
 
     /**
      * Parses the class name and checks if it is already qualified.
-     *
-     * @return string
      */
     protected function qualifyClassName(): string
     {
@@ -244,8 +230,6 @@ trait GeneratorTrait
      * with fallback to `$template` when the defined view does not exist.
      *
      * @param array $data Data to be passed to the view.
-     *
-     * @return string
      */
     protected function renderTemplate(array $data = []): string
     {
@@ -260,13 +244,6 @@ trait GeneratorTrait
 
     /**
      * Performs pseudo-variables contained within view file.
-     *
-     * @param string $class
-     * @param array  $search
-     * @param array  $replace
-     * @param array  $data
-     *
-     * @return string
      */
     protected function parseTemplate(string $class, array $search = [], array $replace = [], array $data = []): string
     {
@@ -286,10 +263,6 @@ trait GeneratorTrait
      * Builds the contents for class being generated, doing all
      * the replacements necessary, and alphabetically sorts the
      * imports for a given template.
-     *
-     * @param string $class
-     *
-     * @return string
      */
     protected function buildContent(string $class): string
     {
@@ -307,10 +280,6 @@ trait GeneratorTrait
 
     /**
      * Builds the file path from the class name.
-     *
-     * @param string $class
-     *
-     * @return string
      */
     protected function buildPath(string $class): string
     {
@@ -335,8 +304,6 @@ trait GeneratorTrait
     /**
      * Allows child generators to modify the internal `$hasClassName` flag.
      *
-     * @param bool $hasClassName
-     *
      * @return $this
      */
     protected function setHasClassName(bool $hasClassName)
@@ -348,8 +315,6 @@ trait GeneratorTrait
 
     /**
      * Allows child generators to modify the internal `$sortImports` flag.
-     *
-     * @param bool $sortImports
      *
      * @return $this
      */
@@ -363,8 +328,6 @@ trait GeneratorTrait
     /**
      * Allows child generators to modify the internal `$enabledSuffixing` flag.
      *
-     * @param bool $enabledSuffixing
-     *
      * @return $this
      */
     protected function setEnabledSuffixing(bool $enabledSuffixing)
@@ -377,8 +340,6 @@ trait GeneratorTrait
     /**
      * Gets a single command-line option. Returns TRUE if the option exists,
      * but doesn't have a value, and is simply acting as a flag.
-     *
-     * @param string $name
      *
      * @return mixed
      */

--- a/system/Cache/CacheFactory.php
+++ b/system/Cache/CacheFactory.php
@@ -25,10 +25,6 @@ class CacheFactory
     /**
      * Attempts to create the desired cache handler, based upon the
      *
-     * @param Cache       $config
-     * @param string|null $handler
-     * @param string|null $backup
-     *
      * @return CacheInterface
      */
     public static function getHandler(Cache $config, ?string $handler = null, ?string $backup = null)

--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -101,8 +101,6 @@ interface CacheInterface
 
     /**
      * Determines if the driver is supported on this system.
-     *
-     * @return bool
      */
     public function isSupported(): bool;
 }

--- a/system/Cache/Exceptions/CacheException.php
+++ b/system/Cache/Exceptions/CacheException.php
@@ -25,8 +25,6 @@ class CacheException extends RuntimeException implements ExceptionInterface
     /**
      * Thrown when handler has no permission to write cache.
      *
-     * @param string $path
-     *
      * @return CacheException
      */
     public static function forUnableToWrite(string $path)

--- a/system/Cache/Handlers/DummyHandler.php
+++ b/system/Cache/Handlers/DummyHandler.php
@@ -152,8 +152,6 @@ class DummyHandler extends BaseHandler
 
     /**
      * Determines if the driver is supported on this system.
-     *
-     * @return bool
      */
     public function isSupported(): bool
     {

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -45,8 +45,6 @@ class FileHandler extends BaseHandler
     /**
      * Constructor.
      *
-     * @param Cache $config
-     *
      * @throws CacheException
      */
     public function __construct(Cache $config)
@@ -264,8 +262,6 @@ class FileHandler extends BaseHandler
 
     /**
      * Determines if the driver is supported on this system.
-     *
-     * @return bool
      */
     public function isSupported(): bool
     {
@@ -275,8 +271,6 @@ class FileHandler extends BaseHandler
     /**
      * Does the heavy lifting of actually retrieving the file and
      * verifying it's age.
-     *
-     * @param string $filename
      *
      * @return bool|mixed
      */
@@ -345,8 +339,6 @@ class FileHandler extends BaseHandler
      * @param bool   $delDir Whether to delete any directories found in the path
      * @param bool   $htdocs Whether to skip deleting .htaccess and index page files
      * @param int    $_level Current directory depth level (default: 0; internal use only)
-     *
-     * @return bool
      */
     protected function deleteFiles(string $path, bool $delDir = false, bool $htdocs = false, int $_level = 0): bool
     {

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -43,8 +43,6 @@ class MemcachedHandler extends BaseHandler
 
     /**
      * Constructor.
-     *
-     * @param Cache $config
      */
     public function __construct(Cache $config)
     {
@@ -316,8 +314,6 @@ class MemcachedHandler extends BaseHandler
 
     /**
      * Determines if the driver is supported on this system.
-     *
-     * @return bool
      */
     public function isSupported(): bool
     {

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -44,8 +44,6 @@ class PredisHandler extends BaseHandler
 
     /**
      * Constructor.
-     *
-     * @param Cache $config
      */
     public function __construct(Cache $config)
     {
@@ -269,8 +267,6 @@ class PredisHandler extends BaseHandler
 
     /**
      * Determines if the driver is supported on this system.
-     *
-     * @return bool
      */
     public function isSupported(): bool
     {

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -43,8 +43,6 @@ class RedisHandler extends BaseHandler
 
     /**
      * Constructor.
-     *
-     * @param Cache $config
      */
     public function __construct(Cache $config)
     {
@@ -307,8 +305,6 @@ class RedisHandler extends BaseHandler
 
     /**
      * Determines if the driver is supported on this system.
-     *
-     * @return bool
      */
     public function isSupported(): bool
     {

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -23,8 +23,6 @@ class WincacheHandler extends BaseHandler
 {
     /**
      * Constructor.
-     *
-     * @param Cache $config
      */
     public function __construct(Cache $config)
     {
@@ -183,8 +181,6 @@ class WincacheHandler extends BaseHandler
 
     /**
      * Determines if the driver is supported on this system.
-     *
-     * @return bool
      */
     public function isSupported(): bool
     {

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -142,8 +142,6 @@ class CodeIgniter
 
     /**
      * Constructor.
-     *
-     * @param App $config
      */
     public function __construct(App $config)
     {
@@ -284,9 +282,6 @@ class CodeIgniter
      * tries to route the response, loads the controller and generally
      * makes all of the pieces work together.
      *
-     * @param RouteCollectionInterface|null $routes
-     * @param bool                          $returnResponse
-     *
      * @throws Exception
      * @throws RedirectException
      *
@@ -344,8 +339,6 @@ class CodeIgniter
      * cookies and headers are not actually sent, allowing PHP 7.2+ to
      * not complain when ini_set() function is used.
      *
-     * @param bool $safe
-     *
      * @return $this
      */
     public function useSafeOutput(bool $safe = true)
@@ -357,10 +350,6 @@ class CodeIgniter
 
     /**
      * Handles the main request logic and fires the controller.
-     *
-     * @param RouteCollectionInterface|null $routes
-     * @param Cache                         $cacheConfig
-     * @param bool                          $returnResponse
      *
      * @throws RedirectException
      *
@@ -514,8 +503,6 @@ class CodeIgniter
      * Sets a Request object to be used for this request.
      * Used when running certain tests.
      *
-     * @param Request $request
-     *
      * @return $this
      */
     public function setRequest(Request $request)
@@ -586,8 +573,6 @@ class CodeIgniter
     /**
      * Determines if a response has been cached for the given URI.
      *
-     * @param Cache $config
-     *
      * @throws Exception
      *
      * @return bool|ResponseInterface
@@ -625,8 +610,6 @@ class CodeIgniter
     /**
      * Tells the app that the final output should be cached.
      *
-     * @param int $time
-     *
      * @return void
      */
     public static function cache(int $time)
@@ -637,8 +620,6 @@ class CodeIgniter
     /**
      * Caches the full response from the current request. Used for
      * full-page caching for very high performance.
-     *
-     * @param Cache $config
      *
      * @return mixed
      */
@@ -655,8 +636,6 @@ class CodeIgniter
 
     /**
      * Returns an array with our basic performance stats collected.
-     *
-     * @return array
      */
     public function getPerformanceStats(): array
     {
@@ -668,10 +647,6 @@ class CodeIgniter
 
     /**
      * Generates the cache name to use for our full-page caching.
-     *
-     * @param Cache $config
-     *
-     * @return string
      */
     protected function generateCacheName(Cache $config): string
     {
@@ -692,10 +667,6 @@ class CodeIgniter
 
     /**
      * Replaces the elapsed_time tag.
-     *
-     * @param string $output
-     *
-     * @return string
      */
     public function displayPerformanceMetrics(string $output): string
     {
@@ -764,8 +735,6 @@ class CodeIgniter
      * instead of relying on CLIRequest or IncomingRequest for the path.
      *
      * This is primarily used by the Console.
-     *
-     * @param string $path
      *
      * @return $this
      */
@@ -845,8 +814,6 @@ class CodeIgniter
     /**
      * Displays a 404 Page Not Found error. If set, will try to
      * call the 404Override controller/method that was set in routing config.
-     *
-     * @param PageNotFoundException $e
      */
     protected function display404errors(PageNotFoundException $e)
     {
@@ -896,7 +863,6 @@ class CodeIgniter
      * Gathers the script output from the buffer, replaces some execution
      * time tag in the output and displays the debug toolbar, if required.
      *
-     * @param Cache|null $cacheConfig
      * @param mixed|null $returned
      */
     protected function gatherOutput(?Cache $cacheConfig = null, $returned = null)

--- a/system/Commands/Cache/ClearCache.php
+++ b/system/Commands/Cache/ClearCache.php
@@ -59,8 +59,6 @@ class ClearCache extends BaseCommand
 
     /**
      * Clears the cache
-     *
-     * @param array $params
      */
     public function run(array $params)
     {

--- a/system/Commands/Cache/InfoCache.php
+++ b/system/Commands/Cache/InfoCache.php
@@ -51,8 +51,6 @@ class InfoCache extends BaseCommand
 
     /**
      * Clears the cache
-     *
-     * @param array $params
      */
     public function run(array $params)
     {

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -73,8 +73,6 @@ class CreateDatabase extends BaseCommand
     /**
      * Creates a new database.
      *
-     * @param array $params
-     *
      * @return void
      */
     public function run(array $params)

--- a/system/Commands/Database/Migrate.php
+++ b/system/Commands/Database/Migrate.php
@@ -64,8 +64,6 @@ class Migrate extends BaseCommand
     /**
      * Ensures that all migrations have been run.
      *
-     * @param array $params
-     *
      * @return void
      */
     public function run(array $params)

--- a/system/Commands/Database/MigrateRefresh.php
+++ b/system/Commands/Database/MigrateRefresh.php
@@ -65,8 +65,6 @@ class MigrateRefresh extends BaseCommand
      * Does a rollback followed by a latest to refresh the current state
      * of the database.
      *
-     * @param array $params
-     *
      * @return void
      */
     public function run(array $params)

--- a/system/Commands/Database/MigrateRollback.php
+++ b/system/Commands/Database/MigrateRollback.php
@@ -66,8 +66,6 @@ class MigrateRollback extends BaseCommand
      * Runs all of the migrations in reverse order, until they have
      * all been unapplied.
      *
-     * @param array $params
-     *
      * @return void
      */
     public function run(array $params)

--- a/system/Commands/Database/Seed.php
+++ b/system/Commands/Database/Seed.php
@@ -64,8 +64,6 @@ class Seed extends BaseCommand
     /**
      * Passes to Seeder to populate the database.
      *
-     * @param array $params
-     *
      * @return void
      */
     public function run(array $params)

--- a/system/Commands/Encryption/GenerateKey.php
+++ b/system/Commands/Encryption/GenerateKey.php
@@ -64,8 +64,6 @@ class GenerateKey extends BaseCommand
     /**
      * Actually execute the command.
      *
-     * @param array $params
-     *
      * @return void
      */
     public function run(array $params)
@@ -112,11 +110,6 @@ class GenerateKey extends BaseCommand
 
     /**
      * Generates a key and encodes it.
-     *
-     * @param string $prefix
-     * @param int    $length
-     *
-     * @return string
      */
     protected function generateRandomKey(string $prefix, int $length): string
     {
@@ -131,11 +124,6 @@ class GenerateKey extends BaseCommand
 
     /**
      * Sets the new encryption key in your .env file.
-     *
-     * @param string $key
-     * @param array  $params
-     *
-     * @return bool
      */
     protected function setNewEncryptionKey(string $key, array $params): bool
     {
@@ -153,10 +141,6 @@ class GenerateKey extends BaseCommand
 
     /**
      * Checks whether to overwrite existing encryption key.
-     *
-     * @param array $params
-     *
-     * @return bool
      */
     protected function confirmOverwrite(array $params): bool
     {
@@ -165,11 +149,6 @@ class GenerateKey extends BaseCommand
 
     /**
      * Writes the new encryption key to .env file.
-     *
-     * @param string $oldKey
-     * @param string $newKey
-     *
-     * @return bool
      */
     protected function writeNewEncryptionKeyToFile(string $oldKey, string $newKey): bool
     {
@@ -199,10 +178,6 @@ class GenerateKey extends BaseCommand
 
     /**
      * Get the regex of the current encryption key.
-     *
-     * @param string $oldKey
-     *
-     * @return string
      */
     protected function keyPattern(string $oldKey): string
     {

--- a/system/Commands/Generators/CommandGenerator.php
+++ b/system/Commands/Generators/CommandGenerator.php
@@ -75,8 +75,6 @@ class CommandGenerator extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {
@@ -90,10 +88,6 @@ class CommandGenerator extends BaseCommand
 
     /**
      * Prepare options and do the necessary replacements.
-     *
-     * @param string $class
-     *
-     * @return string
      */
     protected function prepare(string $class): string
     {

--- a/system/Commands/Generators/ConfigGenerator.php
+++ b/system/Commands/Generators/ConfigGenerator.php
@@ -71,8 +71,6 @@ class ConfigGenerator extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {
@@ -86,10 +84,6 @@ class ConfigGenerator extends BaseCommand
 
     /**
      * Prepare options and do the necessary replacements.
-     *
-     * @param string $class
-     *
-     * @return string
      */
     protected function prepare(string $class): string
     {

--- a/system/Commands/Generators/ControllerGenerator.php
+++ b/system/Commands/Generators/ControllerGenerator.php
@@ -74,8 +74,6 @@ class ControllerGenerator extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {
@@ -89,10 +87,6 @@ class ControllerGenerator extends BaseCommand
 
     /**
      * Prepare options and do the necessary replacements.
-     *
-     * @param string $class
-     *
-     * @return string
      */
     protected function prepare(string $class): string
     {

--- a/system/Commands/Generators/EntityGenerator.php
+++ b/system/Commands/Generators/EntityGenerator.php
@@ -71,8 +71,6 @@ class EntityGenerator extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {

--- a/system/Commands/Generators/FilterGenerator.php
+++ b/system/Commands/Generators/FilterGenerator.php
@@ -71,8 +71,6 @@ class FilterGenerator extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {

--- a/system/Commands/Generators/MigrateCreate.php
+++ b/system/Commands/Generators/MigrateCreate.php
@@ -73,8 +73,6 @@ class MigrateCreate extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {

--- a/system/Commands/Generators/MigrationGenerator.php
+++ b/system/Commands/Generators/MigrationGenerator.php
@@ -74,8 +74,6 @@ class MigrationGenerator extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {
@@ -94,10 +92,6 @@ class MigrationGenerator extends BaseCommand
 
     /**
      * Prepare options and do the necessary replacements.
-     *
-     * @param string $class
-     *
-     * @return string
      */
     protected function prepare(string $class): string
     {
@@ -118,10 +112,6 @@ class MigrationGenerator extends BaseCommand
 
     /**
      * Change file basename before saving.
-     *
-     * @param string $filename
-     *
-     * @return string
      */
     protected function basename(string $filename): string
     {

--- a/system/Commands/Generators/ModelGenerator.php
+++ b/system/Commands/Generators/ModelGenerator.php
@@ -75,8 +75,6 @@ class ModelGenerator extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {
@@ -90,10 +88,6 @@ class ModelGenerator extends BaseCommand
 
     /**
      * Prepare options and do the necessary replacements.
-     *
-     * @param string $class
-     *
-     * @return string
      */
     protected function prepare(string $class): string
     {

--- a/system/Commands/Generators/ScaffoldGenerator.php
+++ b/system/Commands/Generators/ScaffoldGenerator.php
@@ -77,8 +77,6 @@ class ScaffoldGenerator extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {

--- a/system/Commands/Generators/SeederGenerator.php
+++ b/system/Commands/Generators/SeederGenerator.php
@@ -71,8 +71,6 @@ class SeederGenerator extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {

--- a/system/Commands/Generators/SessionMigrationGenerator.php
+++ b/system/Commands/Generators/SessionMigrationGenerator.php
@@ -66,8 +66,6 @@ class SessionMigrationGenerator extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {
@@ -88,10 +86,6 @@ class SessionMigrationGenerator extends BaseCommand
 
     /**
      * Performs the necessary replacements.
-     *
-     * @param string $class
-     *
-     * @return string
      */
     protected function prepare(string $class): string
     {
@@ -108,10 +102,6 @@ class SessionMigrationGenerator extends BaseCommand
 
     /**
      * Change file basename before saving.
-     *
-     * @param string $filename
-     *
-     * @return string
      */
     protected function basename(string $filename): string
     {

--- a/system/Commands/Generators/ValidationGenerator.php
+++ b/system/Commands/Generators/ValidationGenerator.php
@@ -71,8 +71,6 @@ class ValidationGenerator extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {

--- a/system/Commands/Help.php
+++ b/system/Commands/Help.php
@@ -68,8 +68,6 @@ class Help extends BaseCommand
 
     /**
      * Displays the help for spark commands.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {

--- a/system/Commands/Housekeeping/ClearDebugbar.php
+++ b/system/Commands/Housekeeping/ClearDebugbar.php
@@ -51,8 +51,6 @@ class ClearDebugbar extends BaseCommand
     /**
      * Actually runs the command.
      *
-     * @param array $params
-     *
      * @return void
      */
     public function run(array $params)

--- a/system/Commands/Housekeeping/ClearLogs.php
+++ b/system/Commands/Housekeeping/ClearLogs.php
@@ -59,8 +59,6 @@ class ClearLogs extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {

--- a/system/Commands/ListCommands.php
+++ b/system/Commands/ListCommands.php
@@ -69,8 +69,6 @@ class ListCommands extends BaseCommand
 
     /**
      * Displays the help for the spark cli script itself.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {
@@ -85,8 +83,6 @@ class ListCommands extends BaseCommand
 
     /**
      * Lists the commands with accompanying info.
-     *
-     * @param array $commands
      */
     protected function listFull(array $commands)
     {
@@ -128,8 +124,6 @@ class ListCommands extends BaseCommand
 
     /**
      * Lists the commands only.
-     *
-     * @param array $commands
      */
     protected function listSimple(array $commands)
     {

--- a/system/Commands/Utilities/Environment.php
+++ b/system/Commands/Utilities/Environment.php
@@ -130,10 +130,6 @@ final class Environment extends BaseCommand
 
     /**
      * @see https://regex101.com/r/4sSORp/1 for the regex in action
-     *
-     * @param string $newEnv
-     *
-     * @return bool
      */
     private function writeNewEnvironmentToEnvFile(string $newEnv): bool
     {

--- a/system/Commands/Utilities/Namespaces.php
+++ b/system/Commands/Utilities/Namespaces.php
@@ -67,8 +67,6 @@ class Namespaces extends BaseCommand
 
     /**
      * Displays the help for the spark cli script itself.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -67,8 +67,6 @@ class Routes extends BaseCommand
 
     /**
      * Displays the help for the spark cli script itself.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {

--- a/system/Common.php
+++ b/system/Common.php
@@ -40,8 +40,6 @@ if (! function_exists('app_timezone')) {
      * dates in. This might be different than the timezone set
      * at the server level, as you often want to stores dates in UTC
      * and convert them on the fly for the user.
-     *
-     * @return string
      */
     function app_timezone(): string
     {
@@ -60,8 +58,6 @@ if (! function_exists('cache')) {
      * Examples:
      *    cache()->save('foo', 'bar');
      *    $foo = cache('bar');
-     *
-     * @param string|null $key
      *
      * @return CacheInterface|mixed
      */
@@ -84,10 +80,6 @@ if (! function_exists('clean_path')) {
      * A convenience method to clean paths for
      * a nicer looking output. Useful for exception
      * handling, error logging, etc.
-     *
-     * @param string $path
-     *
-     * @return string
      */
     function clean_path(string $path): string
     {
@@ -123,8 +115,6 @@ if (! function_exists('command')) {
      * be used on the command line itself:
      *
      *  > command('migrate:create SomeMigration');
-     *
-     * @param string $command
      *
      * @return false|string
      */
@@ -200,9 +190,6 @@ if (! function_exists('config')) {
     /**
      * More simple way of getting config instances from Factories
      *
-     * @param string $name
-     * @param bool   $getShared
-     *
      * @return mixed
      */
     function config(string $name, bool $getShared = true)
@@ -220,8 +207,6 @@ if (! function_exists('cookie')) {
      * @param array  $options Array of options to be passed to the cookie
      *
      * @throws CookieException
-     *
-     * @return Cookie
      */
     function cookie(string $name, string $value = '', array $options = []): Cookie
     {
@@ -235,8 +220,6 @@ if (! function_exists('cookies')) {
      *
      * @param Cookie[] $cookies   If `getGlobal` is false, this is passed to CookieStore's constructor
      * @param bool     $getGlobal If false, creates a new instance of CookieStore
-     *
-     * @return CookieStore
      */
     function cookies(array $cookies = [], bool $getGlobal = true): CookieStore
     {
@@ -253,8 +236,6 @@ if (! function_exists('csrf_token')) {
      * Returns the CSRF token name.
      * Can be used in Views when building hidden inputs manually,
      * or used in javascript vars when using APIs.
-     *
-     * @return string
      */
     function csrf_token(): string
     {
@@ -267,8 +248,6 @@ if (! function_exists('csrf_header')) {
      * Returns the CSRF header name.
      * Can be used in Views by adding it to the meta tag
      * or used in javascript to define a header name when using APIs.
-     *
-     * @return string
      */
     function csrf_header(): string
     {
@@ -281,8 +260,6 @@ if (! function_exists('csrf_hash')) {
      * Returns the current hash value for the CSRF protection.
      * Can be used in Views when building hidden inputs manually,
      * or used in javascript vars for API usage.
-     *
-     * @return string
      */
     function csrf_hash(): string
     {
@@ -293,10 +270,6 @@ if (! function_exists('csrf_hash')) {
 if (! function_exists('csrf_field')) {
     /**
      * Generates a hidden input field for use within manually generated forms.
-     *
-     * @param string|null $id
-     *
-     * @return string
      */
     function csrf_field(?string $id = null): string
     {
@@ -307,10 +280,6 @@ if (! function_exists('csrf_field')) {
 if (! function_exists('csrf_meta')) {
     /**
      * Generates a meta tag for use within javascript calls.
-     *
-     * @param string|null $id
-     *
-     * @return string
      */
     function csrf_meta(?string $id = null): string
     {
@@ -334,7 +303,6 @@ if (! function_exists('db_connect')) {
      * otherwise it will all calls will return the same instance.
      *
      * @param array|ConnectionInterface|string|null $db
-     * @param bool                                  $getShared
      *
      * @return BaseConnection
      */
@@ -370,7 +338,6 @@ if (! function_exists('env')) {
      * retrieving values set from the .env file for
      * use in config files.
      *
-     * @param string      $key
      * @param string|null $default
      *
      * @return mixed
@@ -415,7 +382,6 @@ if (! function_exists('esc')) {
      * Valid context values: html, js, css, url, attr, raw, null
      *
      * @param array|string $data
-     * @param string       $context
      * @param string       $encoding
      *
      * @throws InvalidArgumentException
@@ -682,8 +648,6 @@ if (! function_exists('is_cli')) {
     /**
      * Check if PHP was invoked from the command line.
      *
-     * @return bool
-     *
      * @codeCoverageIgnore Cannot be tested fully as PHPUnit always run in CLI
      */
     function is_cli(): bool
@@ -719,11 +683,7 @@ if (! function_exists('is_really_writable')) {
      *
      * @see https://bugs.php.net/bug.php?id=54709
      *
-     * @param string $file
-     *
      * @throws Exception
-     *
-     * @return bool
      *
      * @codeCoverageIgnore Not practical to test, as travis runs on linux
      */
@@ -765,10 +725,6 @@ if (! function_exists('lang')) {
      * A convenience method to translate a string or array of them and format
      * the result with the intl extension's MessageFormatter.
      *
-     * @param string      $line
-     * @param array       $args
-     * @param string|null $locale
-     *
      * @return string
      */
     function lang(string $line, array $args = [], ?string $locale = null)
@@ -792,10 +748,6 @@ if (! function_exists('log_message')) {
      *  - notice
      *  - info
      *  - debug
-     *
-     * @param string $level
-     * @param string $message
-     * @param array  $context
      *
      * @return mixed
      */
@@ -821,10 +773,6 @@ if (! function_exists('model')) {
     /**
      * More simple way of getting model instances from Factories
      *
-     * @param string                   $name
-     * @param bool                     $getShared
-     * @param ConnectionInterface|null $conn
-     *
      * @return mixed
      */
     function model(string $name, bool $getShared = true, ?ConnectionInterface &$conn = null)
@@ -838,7 +786,6 @@ if (! function_exists('old')) {
      * Provides access to "old input" that was set in the session
      * during a redirect()->withInput().
      *
-     * @param string      $key
      * @param null        $default
      * @param bool|string $escape
      *
@@ -883,8 +830,6 @@ if (! function_exists('redirect')) {
      * If more control is needed, you must use $response->redirect explicitly.
      *
      * @param string $route
-     *
-     * @return RedirectResponse
      */
     function redirect(?string $route = null): RedirectResponse
     {
@@ -904,11 +849,6 @@ if (! function_exists('remove_invisible_characters')) {
      *
      * This prevents sandwiching null characters
      * between ascii characters, like Java\0script.
-     *
-     * @param string $str
-     * @param bool   $urlEncoded
-     *
-     * @return string
      */
     function remove_invisible_characters(string $str, bool $urlEncoded = true): string
     {
@@ -940,8 +880,7 @@ if (! function_exists('route_to')) {
      * NOTE: This requires the controller/method to
      * have a route defined in the routes Config file.
      *
-     * @param string $method
-     * @param mixed  ...$params
+     * @param mixed ...$params
      *
      * @return false|string
      */
@@ -988,8 +927,7 @@ if (! function_exists('service')) {
      *  - $timer = service('timer')
      *  - $timer = \CodeIgniter\Config\Services::timer();
      *
-     * @param string $name
-     * @param mixed  ...$params
+     * @param mixed ...$params
      *
      * @return mixed
      */
@@ -1003,8 +941,7 @@ if (! function_exists('single_service')) {
     /**
      * Always returns a new instance of the class.
      *
-     * @param string $name
-     * @param mixed  ...$params
+     * @param mixed ...$params
      *
      * @return mixed
      */
@@ -1072,9 +1009,6 @@ if (! function_exists('stringify_attributes')) {
      * of attributes to a string.
      *
      * @param mixed $attributes string, array, object
-     * @param bool  $js
-     *
-     * @return string
      */
     function stringify_attributes($attributes, bool $js = false): string
     {
@@ -1103,8 +1037,6 @@ if (! function_exists('timer')) {
      * A convenience method for working with the timer.
      * If no parameter is passed, it will return the timer instance,
      * otherwise will start or stop the timer intelligently.
-     *
-     * @param string|null $name
      *
      * @return mixed|Timer
      */
@@ -1145,11 +1077,7 @@ if (! function_exists('view')) {
      * NOTE: Does not provide any escaping of the data, so that must
      * all be handled manually by the developer.
      *
-     * @param string $name
-     * @param array  $data
-     * @param array  $options Unused - reserved for third-party extensions.
-     *
-     * @return string
+     * @param array $options Unused - reserved for third-party extensions.
      */
     function view(string $name, array $data = [], array $options = []): string
     {
@@ -1174,14 +1102,9 @@ if (! function_exists('view_cell')) {
      * View cells are used within views to insert HTML chunks that are managed
      * by other classes.
      *
-     * @param string      $library
-     * @param null        $params
-     * @param int         $ttl
-     * @param string|null $cacheName
+     * @param null $params
      *
      * @throws ReflectionException
-     *
-     * @return string
      */
     function view_cell(string $library, $params = null, int $ttl = 0, ?string $cacheName = null): string
     {

--- a/system/ComposerScripts.php
+++ b/system/ComposerScripts.php
@@ -80,10 +80,6 @@ final class ComposerScripts
 
     /**
      * Recursively remove the contents of the previous `system/ThirdParty`.
-     *
-     * @param string $directory
-     *
-     * @return void
      */
     private static function recursiveDelete(string $directory): void
     {
@@ -109,11 +105,6 @@ final class ComposerScripts
     /**
      * Recursively copy the files and directories of the origin directory
      * into the target directory, i.e. "mirror" its contents.
-     *
-     * @param string $originDir
-     * @param string $targetDir
-     *
-     * @return void
      */
     private static function recursiveMirror(string $originDir, string $targetDir): void
     {
@@ -154,8 +145,6 @@ final class ComposerScripts
 
     /**
      * Copy Kint's init files into `system/ThirdParty/Kint/`
-     *
-     * @return void
      */
     private static function copyKintInitFiles(): void
     {

--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -86,10 +86,7 @@ class BaseConfig
     /**
      * Initialization an environment-specific configuration setting
      *
-     * @param mixed  $property
-     * @param string $name
-     * @param string $prefix
-     * @param string $shortPrefix
+     * @param mixed $property
      *
      * @return mixed
      */
@@ -113,10 +110,6 @@ class BaseConfig
 
     /**
      * Retrieve an environment-specific configuration setting
-     *
-     * @param string $property
-     * @param string $prefix
-     * @param string $shortPrefix
      *
      * @return mixed
      */

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -169,8 +169,7 @@ class BaseService
      *
      * $key must be a name matching a service.
      *
-     * @param string $key
-     * @param mixed  ...$params
+     * @param mixed ...$params
      *
      * @return mixed
      */
@@ -197,8 +196,6 @@ class BaseService
      * The Autoloader class is the central class that handles our
      * spl_autoload_register method, and helper methods.
      *
-     * @param bool $getShared
-     *
      * @return Autoloader
      */
     public static function autoloader(bool $getShared = true)
@@ -219,8 +216,6 @@ class BaseService
      * within namespaced folders, as well as convenience methods for
      * loading 'helpers', and 'libraries'.
      *
-     * @param bool $getShared
-     *
      * @return FileLocator
      */
     public static function locator(bool $getShared = true)
@@ -240,9 +235,6 @@ class BaseService
      * Provides the ability to perform case-insensitive calling of service
      * names.
      *
-     * @param string $name
-     * @param array  $arguments
-     *
      * @return mixed
      */
     public static function __callStatic(string $name, array $arguments)
@@ -259,10 +251,6 @@ class BaseService
     /**
      * Check if the requested service is defined and return the declaring
      * class. Return null if not found.
-     *
-     * @param string $name
-     *
-     * @return string|null
      */
     public static function serviceExists(string $name): ?string
     {
@@ -296,8 +284,6 @@ class BaseService
 
     /**
      * Resets any mock and shared instances for a single service.
-     *
-     * @param string $name
      */
     public static function resetSingle(string $name)
     {
@@ -307,8 +293,7 @@ class BaseService
     /**
      * Inject mock object for testing.
      *
-     * @param string $name
-     * @param mixed  $mock
+     * @param mixed $mock
      */
     public static function injectMock(string $name, $mock)
     {
@@ -320,9 +305,6 @@ class BaseService
      * for new Config\Services files. Caches a copy of each one, then
      * looks for the service method in each, returning an instance of
      * the service, if available.
-     *
-     * @param string $name
-     * @param array  $arguments
      *
      * @return mixed
      *

--- a/system/Config/Config.php
+++ b/system/Config/Config.php
@@ -35,7 +35,6 @@ class Config
     /**
      * Helper method for injecting mock instances while testing.
      *
-     * @param string $name
      * @param object $instance
      */
     public static function injectMock(string $name, $instance)

--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -27,9 +27,6 @@ class DotEnv
 
     /**
      * Builds the path to our file.
-     *
-     * @param string $path
-     * @param string $file
      */
     public function __construct(string $path, string $file = '.env')
     {
@@ -40,8 +37,6 @@ class DotEnv
      * The main entry point, will load the .env file and process it
      * so that we end up with all settings in the PHP environment vars
      * (i.e. getenv(), $_ENV, and $_SERVER)
-     *
-     * @return bool
      */
     public function load(): bool
     {
@@ -52,8 +47,6 @@ class DotEnv
 
     /**
      * Parse the .env file into an array of key => value
-     *
-     * @return array|null
      */
     public function parse(): ?array
     {
@@ -92,9 +85,6 @@ class DotEnv
      * Sets the variable into the environment. Will parse the string
      * first to look for {name}={value} pattern, ensure that nested
      * variables are handled, and strip it of single and double quotes.
-     *
-     * @param string $name
-     * @param string $value
      */
     protected function setVariable(string $name, string $value = '')
     {
@@ -114,11 +104,6 @@ class DotEnv
     /**
      * Parses for assignment, cleans the $name and $value, and ensures
      * that nested variables are handled.
-     *
-     * @param string $name
-     * @param string $value
-     *
-     * @return array
      */
     public function normaliseVariable(string $name, string $value = ''): array
     {
@@ -146,11 +131,7 @@ class DotEnv
      * This was borrowed from the excellent phpdotenv with very few changes.
      * https://github.com/vlucas/phpdotenv
      *
-     * @param string $value
-     *
      * @throws InvalidArgumentException
-     *
-     * @return string
      */
     protected function sanitizeValue(string $value): string
     {
@@ -203,10 +184,6 @@ class DotEnv
      *
      * This was borrowed from the excellent phpdotenv with very few changes.
      * https://github.com/vlucas/phpdotenv
-     *
-     * @param string $value
-     *
-     * @return string
      */
     protected function resolveNestedVariables(string $value): string
     {
@@ -234,8 +211,6 @@ class DotEnv
      *
      * This was borrowed from the excellent phpdotenv with very few changes.
      * https://github.com/vlucas/phpdotenv
-     *
-     * @param string $name
      *
      * @return string|null
      */

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -71,9 +71,6 @@ class Factories
      * Loads instances based on the method component name. Either
      * creates a new instance or returns an existing shared instance.
      *
-     * @param string $component
-     * @param array  $arguments
-     *
      * @return mixed
      */
     public static function __callStatic(string $component, array $arguments)
@@ -121,8 +118,6 @@ class Factories
      *
      * @param array  $options The array of component-specific directives
      * @param string $name    Class name, namespace optional
-     *
-     * @return string|null
      */
     protected static function locateClass(array $options, string $name): ?string
     {
@@ -180,8 +175,6 @@ class Factories
      *
      * @param array  $options The array of component-specific directives
      * @param string $name    Class name, namespace optional
-     *
-     * @return bool
      */
     protected static function verifyPreferApp(array $options, string $name): bool
     {
@@ -203,8 +196,6 @@ class Factories
      *
      * @param array  $options The array of component-specific directives
      * @param string $name    Class name, namespace optional
-     *
-     * @return bool
      */
     protected static function verifyInstanceOf(array $options, string $name): bool
     {
@@ -245,7 +236,6 @@ class Factories
      * Normalizes, stores, and returns the configuration for a specific component
      *
      * @param string $component Lowercase, plural component name
-     * @param array  $values
      *
      * @return array<string, mixed> The result after applying defaults and normalization
      */
@@ -297,7 +287,6 @@ class Factories
      *
      * @param string $component Lowercase, plural component name
      * @param string $name      The name of the instance
-     * @param object $instance
      */
     public static function injectMock(string $component, string $name, object $instance)
     {
@@ -314,10 +303,6 @@ class Factories
 
     /**
      * Gets a basename from a class name, namespaced or not.
-     *
-     * @param string $name
-     *
-     * @return string
      */
     public static function getBasename(string $name): string
     {

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -93,9 +93,6 @@ class Services extends BaseService
      * The cache class provides a simple way to store and retrieve
      * complex data for later.
      *
-     * @param Cache|null $config
-     * @param bool       $getShared
-     *
      * @return CacheInterface
      */
     public static function cache(?Cache $config = null, bool $getShared = true)
@@ -113,9 +110,6 @@ class Services extends BaseService
      * The CLI Request class provides for ways to interact with
      * a command line request.
      *
-     * @param App|null $config
-     * @param bool     $getShared
-     *
      * @return CLIRequest
      */
     public static function clirequest(?App $config = null, bool $getShared = true)
@@ -131,9 +125,6 @@ class Services extends BaseService
 
     /**
      * CodeIgniter, the core of the framework.
-     *
-     * @param App|null $config
-     * @param bool     $getShared
      *
      * @return CodeIgniter
      */
@@ -151,8 +142,6 @@ class Services extends BaseService
     /**
      * The commands utility for running and working with CLI commands.
      *
-     * @param bool $getShared
-     *
      * @return Commands
      */
     public static function commands(bool $getShared = true)
@@ -167,11 +156,6 @@ class Services extends BaseService
     /**
      * The CURL Request class acts as a simple HTTP client for interacting
      * with other servers, typically through APIs.
-     *
-     * @param array                  $options
-     * @param ResponseInterface|null $response
-     * @param App|null               $config
-     * @param bool                   $getShared
      *
      * @return CURLRequest
      */
@@ -196,7 +180,6 @@ class Services extends BaseService
      * The Email class allows you to send email via mail, sendmail, SMTP.
      *
      * @param array|EmailConfig|null $config
-     * @param bool                   $getShared
      *
      * @return Email
      */
@@ -216,8 +199,7 @@ class Services extends BaseService
     /**
      * The Encryption class provides two-way encryption.
      *
-     * @param EncryptionConfig|null $config
-     * @param bool                  $getShared
+     * @param bool $getShared
      *
      * @return EncrypterInterface Encryption handler
      */
@@ -239,11 +221,6 @@ class Services extends BaseService
      *  - set_exception_handler
      *  - set_error_handler
      *  - register_shutdown_function
-     *
-     * @param ExceptionsConfig|null $config
-     * @param IncomingRequest|null  $request
-     * @param Response|null         $response
-     * @param bool                  $getShared
      *
      * @return Exceptions
      */
@@ -270,9 +247,6 @@ class Services extends BaseService
      * and actions taken based on the request, while after filters can
      * act on or modify the response itself before it is sent to the client.
      *
-     * @param FiltersConfig|null $config
-     * @param bool               $getShared
-     *
      * @return Filters
      */
     public static function filters(?FiltersConfig $config = null, bool $getShared = true)
@@ -288,9 +262,6 @@ class Services extends BaseService
 
     /**
      * The Format class is a convenient place to create Formatters.
-     *
-     * @param FormatConfig|null $config
-     * @param bool              $getShared
      *
      * @return Format
      */
@@ -309,9 +280,6 @@ class Services extends BaseService
      * The Honeypot provides a secret input on forms that bots should NOT
      * fill in, providing an additional safeguard when accepting user input.
      *
-     * @param HoneypotConfig|null $config
-     * @param bool                $getShared
-     *
      * @return Honeypot
      */
     public static function honeypot(?HoneypotConfig $config = null, bool $getShared = true)
@@ -328,10 +296,6 @@ class Services extends BaseService
     /**
      * Acts as a factory for ImageHandler classes and returns an instance
      * of the handler. Used like Services::image()->withFile($path)->rotate(90)->save();
-     *
-     * @param string|null $handler
-     * @param Images|null $config
-     * @param bool        $getShared
      *
      * @return BaseHandler
      */
@@ -353,8 +317,6 @@ class Services extends BaseService
      * and timing the results and memory usage. Used when debugging and
      * optimizing applications.
      *
-     * @param bool $getShared
-     *
      * @return Iterator
      */
     public static function iterator(bool $getShared = true)
@@ -368,9 +330,6 @@ class Services extends BaseService
 
     /**
      * Responsible for loading the language string translations.
-     *
-     * @param string|null $locale
-     * @param bool        $getShared
      *
      * @return Language
      */
@@ -390,8 +349,6 @@ class Services extends BaseService
      * The Logger class is a PSR-3 compatible Logging class that supports
      * multiple handlers that process the actual logging.
      *
-     * @param bool $getShared
-     *
      * @return Logger
      */
     public static function logger(bool $getShared = true)
@@ -405,10 +362,6 @@ class Services extends BaseService
 
     /**
      * Return the appropriate Migration runner.
-     *
-     * @param Migrations|null          $config
-     * @param ConnectionInterface|null $db
-     * @param bool                     $getShared
      *
      * @return MigrationRunner
      */
@@ -428,9 +381,6 @@ class Services extends BaseService
      * working the request to determine correct language, encoding, charset,
      * and more.
      *
-     * @param RequestInterface|null $request
-     * @param bool                  $getShared
-     *
      * @return Negotiate
      */
     public static function negotiator(?RequestInterface $request = null, bool $getShared = true)
@@ -446,10 +396,6 @@ class Services extends BaseService
 
     /**
      * Return the appropriate pagination handler.
-     *
-     * @param PagerConfig|null       $config
-     * @param RendererInterface|null $view
-     * @param bool                   $getShared
      *
      * @return Pager
      */
@@ -467,10 +413,6 @@ class Services extends BaseService
 
     /**
      * The Parser is a simple template parser.
-     *
-     * @param string|null     $viewPath
-     * @param ViewConfig|null $config
-     * @param bool            $getShared
      *
      * @return Parser
      */
@@ -491,10 +433,6 @@ class Services extends BaseService
      * The default View class within CodeIgniter is intentionally simple, but this
      * service could easily be replaced by a template engine if the user needed to.
      *
-     * @param string|null     $viewPath
-     * @param ViewConfig|null $config
-     * @param bool            $getShared
-     *
      * @return View
      */
     public static function renderer(?string $viewPath = null, ?ViewConfig $config = null, bool $getShared = true)
@@ -511,9 +449,6 @@ class Services extends BaseService
 
     /**
      * The Request class models an HTTP request.
-     *
-     * @param App|null $config
-     * @param bool     $getShared
      *
      * @return IncomingRequest
      */
@@ -536,9 +471,6 @@ class Services extends BaseService
     /**
      * The Response class models an HTTP response.
      *
-     * @param App|null $config
-     * @param bool     $getShared
-     *
      * @return Response
      */
     public static function response(?App $config = null, bool $getShared = true)
@@ -554,9 +486,6 @@ class Services extends BaseService
 
     /**
      * The Redirect class provides nice way of working with redirects.
-     *
-     * @param App|null $config
-     * @param bool     $getShared
      *
      * @return RedirectResponse
      */
@@ -577,8 +506,6 @@ class Services extends BaseService
      * The Routes service is a class that allows for easily building
      * a collection of routes.
      *
-     * @param bool $getShared
-     *
      * @return RouteCollection
      */
     public static function routes(bool $getShared = true)
@@ -593,10 +520,6 @@ class Services extends BaseService
     /**
      * The Router class uses a RouteCollection's array of routes, and determines
      * the correct Controller and Method to execute.
-     *
-     * @param RouteCollectionInterface|null $routes
-     * @param Request|null                  $request
-     * @param bool                          $getShared
      *
      * @return Router
      */
@@ -616,9 +539,6 @@ class Services extends BaseService
      * The Security class provides a few handy tools for keeping the site
      * secure, most notably the CSRF protection tools.
      *
-     * @param App|null $config
-     * @param bool     $getShared
-     *
      * @return Security
      */
     public static function security(?App $config = null, bool $getShared = true)
@@ -634,9 +554,6 @@ class Services extends BaseService
 
     /**
      * Return the session manager.
-     *
-     * @param App|null $config
-     * @param bool     $getShared
      *
      * @return Session
      */
@@ -667,8 +584,6 @@ class Services extends BaseService
      * The Throttler class provides a simple method for implementing
      * rate limiting in your applications.
      *
-     * @param bool $getShared
-     *
      * @return Throttler
      */
     public static function throttler(bool $getShared = true)
@@ -684,8 +599,6 @@ class Services extends BaseService
      * The Timer class provides a simple way to Benchmark portions of your
      * application.
      *
-     * @param bool $getShared
-     *
      * @return Timer
      */
     public static function timer(bool $getShared = true)
@@ -699,9 +612,6 @@ class Services extends BaseService
 
     /**
      * Return the debug toolbar.
-     *
-     * @param ToolbarConfig|null $config
-     * @param bool               $getShared
      *
      * @return Toolbar
      */
@@ -720,7 +630,6 @@ class Services extends BaseService
      * The URI class provides a way to model and manipulate URIs.
      *
      * @param string $uri
-     * @param bool   $getShared
      *
      * @return URI
      */
@@ -735,9 +644,6 @@ class Services extends BaseService
 
     /**
      * The Validation class provides tools for validating input data.
-     *
-     * @param ValidationConfig|null $config
-     * @param bool                  $getShared
      *
      * @return Validation
      */
@@ -756,8 +662,6 @@ class Services extends BaseService
      * View cells are intended to let you insert HTML into view
      * that has been generated by any callable in the system.
      *
-     * @param bool $getShared
-     *
      * @return Cell
      */
     public static function viewcell(bool $getShared = true)
@@ -771,8 +675,6 @@ class Services extends BaseService
 
     /**
      * The Typography class provides a way to format text in semantically relevant ways.
-     *
-     * @param bool $getShared
      *
      * @return Typography
      */

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -69,10 +69,6 @@ class Controller
     /**
      * Constructor.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     * @param LoggerInterface   $logger
-     *
      * @throws HTTPException
      */
     public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
@@ -109,8 +105,6 @@ class Controller
     /**
      * Provides a simple way to tie into the main CodeIgniter class and
      * tell it how long to cache the current page for.
-     *
-     * @param int $time
      */
     protected function cachePage(int $time)
     {
@@ -139,8 +133,6 @@ class Controller
      *
      * @param array|string $rules
      * @param array        $messages An array of custom error messages
-     *
-     * @return bool
      */
     protected function validate($rules, array $messages = []): bool
     {

--- a/system/Cookie/CloneableCookieInterface.php
+++ b/system/Cookie/CloneableCookieInterface.php
@@ -22,8 +22,6 @@ interface CloneableCookieInterface extends CookieInterface
     /**
      * Creates a new Cookie with a new cookie prefix.
      *
-     * @param string $prefix
-     *
      * @return static
      */
     public function withPrefix(string $prefix = '');
@@ -31,16 +29,12 @@ interface CloneableCookieInterface extends CookieInterface
     /**
      * Creates a new Cookie with a new name.
      *
-     * @param string $name
-     *
      * @return static
      */
     public function withName(string $name);
 
     /**
      * Creates a new Cookie with new value.
-     *
-     * @param string $value
      *
      * @return static
      */
@@ -72,16 +66,12 @@ interface CloneableCookieInterface extends CookieInterface
     /**
      * Creates a new Cookie with a new path on the server the cookie is available.
      *
-     * @param string|null $path
-     *
      * @return static
      */
     public function withPath(?string $path);
 
     /**
      * Creates a new Cookie with a new domain the cookie is available.
-     *
-     * @param string|null $domain
      *
      * @return static
      */
@@ -90,16 +80,12 @@ interface CloneableCookieInterface extends CookieInterface
     /**
      * Creates a new Cookie with a new "Secure" attribute.
      *
-     * @param bool $secure
-     *
      * @return static
      */
     public function withSecure(bool $secure = true);
 
     /**
      * Creates a new Cookie with a new "HttpOnly" attribute
-     *
-     * @param bool $httponly
      *
      * @return static
      */
@@ -108,16 +94,12 @@ interface CloneableCookieInterface extends CookieInterface
     /**
      * Creates a new Cookie with a new "SameSite" attribute.
      *
-     * @param string $samesite
-     *
      * @return static
      */
     public function withSameSite(string $samesite);
 
     /**
      * Creates a new Cookie with URL encoding option updated.
-     *
-     * @param bool $raw
      *
      * @return static
      */

--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -158,9 +158,6 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
     /**
      * Create a new Cookie instance from a `Set-Cookie` header.
      *
-     * @param string $cookie
-     * @param bool   $raw
-     *
      * @throws CookieException
      *
      * @return static
@@ -701,8 +698,6 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
      * Converts expires time to Unix format.
      *
      * @param DateTimeInterface|int|string $expires
-     *
-     * @return int
      */
     protected static function convertExpiresTimestamp($expires = 0): int
     {
@@ -735,12 +730,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
      * If `$raw` is true, names should not contain invalid characters
      * as `setrawcookie()` will reject this.
      *
-     * @param string $name
-     * @param bool   $raw
-     *
      * @throws CookieException
-     *
-     * @return void
      */
     protected function validateName(string $name, bool $raw): void
     {
@@ -756,14 +746,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
     /**
      * Validates the special prefixes if some attribute requirements are met.
      *
-     * @param string $prefix
-     * @param bool   $secure
-     * @param string $path
-     * @param string $domain
-     *
      * @throws CookieException
-     *
-     * @return void
      */
     protected function validatePrefix(string $prefix, bool $secure, string $path, string $domain): void
     {
@@ -779,12 +762,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
     /**
      * Validates the `SameSite` to be within the allowed types.
      *
-     * @param string $samesite
-     * @param bool   $secure
-     *
      * @throws CookieException
-     *
-     * @return void
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
      */

--- a/system/Cookie/CookieInterface.php
+++ b/system/Cookie/CookieInterface.php
@@ -60,78 +60,56 @@ interface CookieInterface
     /**
      * Returns a unique identifier for the cookie consisting
      * of its prefixed name, path, and domain.
-     *
-     * @return string
      */
     public function getId(): string;
 
     /**
      * Gets the cookie prefix.
-     *
-     * @return string
      */
     public function getPrefix(): string;
 
     /**
      * Gets the cookie name.
-     *
-     * @return string
      */
     public function getName(): string;
 
     /**
      * Gets the cookie name prepended with the prefix, if any.
-     *
-     * @return string
      */
     public function getPrefixedName(): string;
 
     /**
      * Gets the cookie value.
-     *
-     * @return string
      */
     public function getValue(): string;
 
     /**
      * Gets the time in Unix timestamp the cookie expires.
-     *
-     * @return int
      */
     public function getExpiresTimestamp(): int;
 
     /**
      * Gets the formatted expires time.
-     *
-     * @return string
      */
     public function getExpiresString(): string;
 
     /**
      * Checks if the cookie is expired.
-     *
-     * @return bool
      */
     public function isExpired(): bool;
 
     /**
      * Gets the "Max-Age" cookie attribute.
-     *
-     * @return int
      */
     public function getMaxAge(): int;
 
     /**
      * Gets the "Path" cookie attribute.
-     *
-     * @return string
      */
     public function getPath(): string;
 
     /**
      * Gets the "Domain" cookie attribute.
-     *
-     * @return string
      */
     public function getDomain(): string;
 
@@ -141,8 +119,6 @@ interface CookieInterface
      * Checks if the cookie is only sent to the server when a request is made
      * with the `https:` scheme (except on `localhost`), and therefore is more
      * resistent to man-in-the-middle attacks.
-     *
-     * @return bool
      */
     public function isSecure(): bool;
 
@@ -150,22 +126,16 @@ interface CookieInterface
      * Gets the "HttpOnly" cookie attribute.
      *
      * Checks if JavaScript is forbidden from accessing the cookie.
-     *
-     * @return bool
      */
     public function isHTTPOnly(): bool;
 
     /**
      * Gets the "SameSite" cookie attribute.
-     *
-     * @return string
      */
     public function getSameSite(): string;
 
     /**
      * Checks if the cookie should be sent with no URL encoding.
-     *
-     * @return bool
      */
     public function isRaw(): bool;
 
@@ -179,8 +149,6 @@ interface CookieInterface
 
     /**
      * Returns the Cookie as a header value.
-     *
-     * @return string
      */
     public function toHeaderString(): string;
 

--- a/system/Cookie/CookieStore.php
+++ b/system/Cookie/CookieStore.php
@@ -35,7 +35,6 @@ class CookieStore implements Countable, IteratorAggregate
      * Creates a CookieStore from an array of `Set-Cookie` headers.
      *
      * @param string[] $headers
-     * @param bool     $raw
      *
      * @throws CookieException
      *
@@ -76,12 +75,6 @@ class CookieStore implements Countable, IteratorAggregate
     /**
      * Checks if a `Cookie` object identified by name and
      * prefix is present in the collection.
-     *
-     * @param string      $name
-     * @param string      $prefix
-     * @param string|null $value
-     *
-     * @return bool
      */
     public function has(string $name, string $prefix = '', ?string $value = null): bool
     {
@@ -106,12 +99,7 @@ class CookieStore implements Countable, IteratorAggregate
      * Retrieves an instance of `Cookie` identified by a name and prefix.
      * This throws an exception if not found.
      *
-     * @param string $name
-     * @param string $prefix
-     *
      * @throws CookieException
-     *
-     * @return Cookie
      */
     public function get(string $name, string $prefix = ''): Cookie
     {
@@ -129,8 +117,6 @@ class CookieStore implements Countable, IteratorAggregate
     /**
      * Store a new cookie and return a new collection. The original collection
      * is left unchanged.
-     *
-     * @param Cookie $cookie
      *
      * @return static
      */
@@ -150,9 +136,6 @@ class CookieStore implements Countable, IteratorAggregate
      * Removing a cookie from the store **DOES NOT** delete it from the browser.
      * If you intend to delete a cookie *from the browser*, you must put an empty
      * value cookie with the same name to the store.
-     *
-     * @param string $name
-     * @param string $prefix
      *
      * @return static
      */
@@ -175,8 +158,6 @@ class CookieStore implements Countable, IteratorAggregate
 
     /**
      * Dispatches all cookies in store.
-     *
-     * @return void
      */
     public function dispatch(): void
     {
@@ -207,8 +188,6 @@ class CookieStore implements Countable, IteratorAggregate
 
     /**
      * Clears the cookie collection.
-     *
-     * @return void
      */
     public function clear(): void
     {
@@ -217,8 +196,6 @@ class CookieStore implements Countable, IteratorAggregate
 
     /**
      * Gets the Cookie count in this collection.
-     *
-     * @return int
      */
     public function count(): int
     {
@@ -238,11 +215,7 @@ class CookieStore implements Countable, IteratorAggregate
     /**
      * Validates all cookies passed to be instances of Cookie.
      *
-     * @param array $cookies
-     *
      * @throws CookieException
-     *
-     * @return void
      */
     protected function validateCookies(array $cookies): void
     {
@@ -259,12 +232,6 @@ class CookieStore implements Countable, IteratorAggregate
      * Extracted call to `setrawcookie()` in order to run unit tests on it.
      *
      * @codeCoverageIgnore
-     *
-     * @param string $name
-     * @param string $value
-     * @param array  $options
-     *
-     * @return void
      */
     protected function setRawCookie(string $name, string $value, array $options): void
     {
@@ -275,12 +242,6 @@ class CookieStore implements Countable, IteratorAggregate
      * Extracted call to `setcookie()` in order to run unit tests on it.
      *
      * @codeCoverageIgnore
-     *
-     * @param string $name
-     * @param string $value
-     * @param array  $options
-     *
-     * @return void
      */
     protected function setCookie(string $name, string $value, array $options): void
     {

--- a/system/Cookie/Exceptions/CookieException.php
+++ b/system/Cookie/Exceptions/CookieException.php
@@ -21,8 +21,6 @@ class CookieException extends FrameworkException
     /**
      * Thrown for invalid type given for the "Expires" attribute.
      *
-     * @param string $type
-     *
      * @return static
      */
     public static function forInvalidExpiresTime(string $type)
@@ -42,8 +40,6 @@ class CookieException extends FrameworkException
 
     /**
      * Thrown when the cookie name contains invalid characters per RFC 2616.
-     *
-     * @param string $name
      *
      * @return static
      */
@@ -86,8 +82,6 @@ class CookieException extends FrameworkException
 
     /**
      * Thrown when the `SameSite` attribute given is not of the valid types.
-     *
-     * @param string $sameSite
      *
      * @return static
      */

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -247,9 +247,7 @@ class BaseBuilder
     /**
      * Constructor
      *
-     * @param array|string        $tableName
-     * @param ConnectionInterface $db
-     * @param array               $options
+     * @param array|string $tableName
      *
      * @throws DatabaseException
      */
@@ -302,8 +300,6 @@ class BaseBuilder
 
     /**
      * Gets the name of the primary table.
-     *
-     * @return string
      */
     public function getTable(): string
     {
@@ -313,8 +309,6 @@ class BaseBuilder
     /**
      * Returns an array of bind values and their
      * named parameters for binding in the Query object later.
-     *
-     * @return array
      */
     public function getBinds(): array
     {
@@ -326,8 +320,6 @@ class BaseBuilder
      *
      * Set ignore Flag for next insert,
      * update or delete query.
-     *
-     * @param bool $ignore
      *
      * @return $this
      */
@@ -467,8 +459,6 @@ class BaseBuilder
      * @used-by selectSum()
      *
      * @param string $select Field name
-     * @param string $alias
-     * @param string $type
      *
      * @throws DatabaseException
      * @throws DataException
@@ -505,10 +495,6 @@ class BaseBuilder
 
     /**
      * Determines the alias name based on the table
-     *
-     * @param string $item
-     *
-     * @return string
      */
     protected function createAliasFromTable(string $item): string
     {
@@ -525,8 +511,6 @@ class BaseBuilder
      * DISTINCT
      *
      * Sets a flag which tells the query string compiler to add DISTINCT
-     *
-     * @param bool $val
      *
      * @return $this
      */
@@ -581,7 +565,6 @@ class BaseBuilder
      *
      * Generates the JOIN portion of the query
      *
-     * @param string $table
      * @param string $cond   The join condition
      * @param string $type   The type of join
      * @param bool   $escape Whether not to try to escape identifiers
@@ -697,7 +680,6 @@ class BaseBuilder
      * @param string $qbKey  'QBWhere' or 'QBHaving'
      * @param mixed  $key
      * @param mixed  $value
-     * @param string $type
      * @param bool   $escape
      *
      * @return $this
@@ -908,7 +890,6 @@ class BaseBuilder
      * @param string             $key    The field to search
      * @param array|Closure|null $values The values searched on, or anonymous function with subquery
      * @param bool               $not    If the statement would be IN or NOT IN
-     * @param string             $type
      * @param bool               $escape
      * @param string             $clause (Internal use only)
      *
@@ -973,11 +954,9 @@ class BaseBuilder
      * Generates a %LIKE% portion of the query.
      * Separates multiple calls with 'AND'.
      *
-     * @param mixed  $field
-     * @param string $match
-     * @param string $side
-     * @param bool   $escape
-     * @param bool   $insensitiveSearch IF true, will force a case-insensitive search
+     * @param mixed $field
+     * @param bool  $escape
+     * @param bool  $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -992,11 +971,9 @@ class BaseBuilder
      * Generates a NOT LIKE portion of the query.
      * Separates multiple calls with 'AND'.
      *
-     * @param mixed  $field
-     * @param string $match
-     * @param string $side
-     * @param bool   $escape
-     * @param bool   $insensitiveSearch IF true, will force a case-insensitive search
+     * @param mixed $field
+     * @param bool  $escape
+     * @param bool  $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -1011,11 +988,9 @@ class BaseBuilder
      * Generates a %LIKE% portion of the query.
      * Separates multiple calls with 'OR'.
      *
-     * @param mixed  $field
-     * @param string $match
-     * @param string $side
-     * @param bool   $escape
-     * @param bool   $insensitiveSearch IF true, will force a case-insensitive search
+     * @param mixed $field
+     * @param bool  $escape
+     * @param bool  $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -1030,11 +1005,9 @@ class BaseBuilder
      * Generates a NOT LIKE portion of the query.
      * Separates multiple calls with 'OR'.
      *
-     * @param mixed  $field
-     * @param string $match
-     * @param string $side
-     * @param bool   $escape
-     * @param bool   $insensitiveSearch IF true, will force a case-insensitive search
+     * @param mixed $field
+     * @param bool  $escape
+     * @param bool  $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -1049,10 +1022,8 @@ class BaseBuilder
      * Generates a %LIKE% portion of the query.
      * Separates multiple calls with 'AND'.
      *
-     * @param mixed  $field
-     * @param string $match
-     * @param string $side
-     * @param bool   $escape
+     * @param mixed $field
+     * @param bool  $escape
      *
      * @return $this
      */
@@ -1067,10 +1038,8 @@ class BaseBuilder
      * Generates a NOT LIKE portion of the query.
      * Separates multiple calls with 'AND'.
      *
-     * @param mixed  $field
-     * @param string $match
-     * @param string $side
-     * @param bool   $escape
+     * @param mixed $field
+     * @param bool  $escape
      *
      * @return $this
      */
@@ -1085,10 +1054,8 @@ class BaseBuilder
      * Generates a %LIKE% portion of the query.
      * Separates multiple calls with 'OR'.
      *
-     * @param mixed  $field
-     * @param string $match
-     * @param string $side
-     * @param bool   $escape
+     * @param mixed $field
+     * @param bool  $escape
      *
      * @return $this
      */
@@ -1103,10 +1070,8 @@ class BaseBuilder
      * Generates a NOT LIKE portion of the query.
      * Separates multiple calls with 'OR'.
      *
-     * @param mixed  $field
-     * @param string $match
-     * @param string $side
-     * @param bool   $escape
+     * @param mixed $field
+     * @param bool  $escape
      *
      * @return $this
      */
@@ -1128,10 +1093,6 @@ class BaseBuilder
      * @used-by orNotHavingLike()
      *
      * @param mixed  $field
-     * @param string $match
-     * @param string $type
-     * @param string $side
-     * @param string $not
      * @param bool   $escape
      * @param bool   $insensitiveSearch IF true, will force a case-insensitive search
      * @param string $clause            (Internal use only)
@@ -1184,12 +1145,6 @@ class BaseBuilder
 
     /**
      * Platform independent LIKE statement builder.
-     *
-     * @param string|null $prefix
-     * @param string      $column
-     * @param string|null $not
-     * @param string      $bind
-     * @param bool        $insensitiveSearch
      *
      * @return string $like_statement
      */
@@ -1305,10 +1260,6 @@ class BaseBuilder
     /**
      * Prepate a query group start.
      *
-     * @param string $not
-     * @param string $type
-     * @param string $clause
-     *
      * @return $this
      */
     protected function groupStartPrepare(string $not = '', string $type = 'AND ', string $clause = 'QBWhere')
@@ -1329,8 +1280,6 @@ class BaseBuilder
 
     /**
      * Prepate a query group end.
-     *
-     * @param string $clause
      *
      * @return $this
      */
@@ -1355,10 +1304,6 @@ class BaseBuilder
      * @used-by whereHaving()
      * @used-by _whereIn()
      * @used-by havingGroupStart()
-     *
-     * @param string $type
-     *
-     * @return string
      */
     protected function groupGetType(string $type): string
     {
@@ -1439,7 +1384,6 @@ class BaseBuilder
     /**
      * ORDER BY
      *
-     * @param string $orderBy
      * @param string $direction ASC, DESC or RANDOM
      * @param bool   $escape
      *
@@ -1538,8 +1482,6 @@ class BaseBuilder
      * Generates a platform-specific LIMIT clause.
      *
      * @param string $sql SQL Query
-     *
-     * @return string
      */
     protected function _limit(string $sql, bool $offsetIgnore = false): string
     {
@@ -1582,10 +1524,6 @@ class BaseBuilder
     /**
      * Returns the previously set() data, alternatively resetting it
      * if needed.
-     *
-     * @param bool $clean
-     *
-     * @return array
      */
     public function getSetData(bool $clean = false): array
     {
@@ -1604,8 +1542,6 @@ class BaseBuilder
      * Compiles a SELECT query string and returns the sql.
      *
      * @param bool $reset TRUE: resets QB values; FALSE: leave QB values alone
-     *
-     * @return string
      */
     public function getCompiledSelect(bool $reset = true): string
     {
@@ -1621,10 +1557,6 @@ class BaseBuilder
     /**
      * Returns a finalized, compiled query string with the bindings
      * inserted and prefixes swapped out.
-     *
-     * @param string $sql
-     *
-     * @return string
      */
     protected function compileFinalQuery(string $sql): string
     {
@@ -1710,8 +1642,6 @@ class BaseBuilder
      *
      * Generates a platform-specific query string that counts all records
      * returned by an Query Builder query.
-     *
-     * @param bool $reset
      *
      * @return int|string when $test = true
      */
@@ -1884,8 +1814,6 @@ class BaseBuilder
      * @param string $table  Table name
      * @param array  $keys   INSERT keys
      * @param array  $values INSERT values
-     *
-     * @return string
      */
     protected function _insertBatch(string $table, array $keys, array $values): string
     {
@@ -1895,9 +1823,8 @@ class BaseBuilder
     /**
      * The "setInsertBatch" function.  Allows key/value pairs to be set for batch inserts
      *
-     * @param mixed  $key
-     * @param string $value
-     * @param bool   $escape
+     * @param mixed $key
+     * @param bool  $escape
      *
      * @return $this|null
      */
@@ -2033,8 +1960,6 @@ class BaseBuilder
      * has been chosen to be inserted into.
      *
      * @throws DatabaseException
-     *
-     * @return bool
      */
     protected function validateInsert(): bool
     {
@@ -2058,8 +1983,6 @@ class BaseBuilder
      * @param string $table         The table name
      * @param array  $keys          The insert keys
      * @param array  $unescapedKeys The insert values
-     *
-     * @return string
      */
     protected function _insert(string $table, array $keys, array $unescapedKeys): string
     {
@@ -2109,8 +2032,6 @@ class BaseBuilder
      * @param string $table  The table name
      * @param array  $keys   The insert keys
      * @param array  $values The insert values
-     *
-     * @return string
      */
     protected function _replace(string $table, array $keys, array $values): string
     {
@@ -2124,8 +2045,6 @@ class BaseBuilder
      * about operator precedence.
      *
      * Note: This is only used (and overridden) by MySQL and SQLSRV.
-     *
-     * @return string
      */
     protected function _fromTables(): string
     {
@@ -2218,8 +2137,6 @@ class BaseBuilder
      *
      * @param string $table  the Table name
      * @param array  $values the Update data
-     *
-     * @return string
      */
     protected function _update(string $table, array $values): string
     {
@@ -2243,8 +2160,6 @@ class BaseBuilder
      * chosen to be update.
      *
      * @throws DatabaseException
-     *
-     * @return bool
      */
     protected function validateUpdate(): bool
     {
@@ -2343,8 +2258,6 @@ class BaseBuilder
      * @param string $table  Table name
      * @param array  $values Update data
      * @param string $index  WHERE key
-     *
-     * @return string
      */
     protected function _updateBatch(string $table, array $values, string $index): string
     {
@@ -2378,7 +2291,6 @@ class BaseBuilder
      * The "setUpdateBatch" function.  Allows key/value pairs to be set for batch updating
      *
      * @param array|object $key
-     * @param string       $index
      * @param bool         $escape
      *
      * @throws DatabaseException
@@ -2476,8 +2388,6 @@ class BaseBuilder
      * then this method maps to 'DELETE FROM table'
      *
      * @param string $table The table name
-     *
-     * @return string
      */
     protected function _truncate(string $table): string
     {
@@ -2490,8 +2400,6 @@ class BaseBuilder
      * Compiles a delete query string and returns the sql
      *
      * @param bool $reset TRUE: reset QB values; FALSE: leave QB values alone
-     *
-     * @return string
      */
     public function getCompiledDelete(bool $reset = true): string
     {
@@ -2506,9 +2414,8 @@ class BaseBuilder
      *
      * Compiles a delete string and runs the query
      *
-     * @param mixed $where     The where clause
-     * @param int   $limit     The limit clause
-     * @param bool  $resetData
+     * @param mixed $where The where clause
+     * @param int   $limit The limit clause
      *
      * @throws DatabaseException
      *
@@ -2555,9 +2462,6 @@ class BaseBuilder
     /**
      * Increments a numeric column by the specified value.
      *
-     * @param string $column
-     * @param int    $value
-     *
      * @return bool
      */
     public function increment(string $column, int $value = 1)
@@ -2571,9 +2475,6 @@ class BaseBuilder
 
     /**
      * Decrements a numeric column by the specified value.
-     *
-     * @param string $column
-     * @param int    $value
      *
      * @return bool
      */
@@ -2592,8 +2493,6 @@ class BaseBuilder
      * Generates a platform-specific delete string from the supplied data
      *
      * @param string $table The table name
-     *
-     * @return string
      */
     protected function _delete(string $table): string
     {
@@ -2645,8 +2544,6 @@ class BaseBuilder
      * Should not be called directly.
      *
      * @param mixed $selectOverride
-     *
-     * @return string
      */
     protected function compileSelect($selectOverride = false): string
     {
@@ -2698,8 +2595,6 @@ class BaseBuilder
      *
      * Checks if the ignore option is supported by
      * the Database Driver for the specific statement.
-     *
-     * @param string $statement
      *
      * @return string
      */
@@ -2919,10 +2814,6 @@ class BaseBuilder
      * Is literal
      *
      * Determines if a string represents a literal value or a field name
-     *
-     * @param string $str
-     *
-     * @return bool
      */
     protected function isLiteral(string $str): bool
     {
@@ -3022,10 +2913,6 @@ class BaseBuilder
 
     /**
      * Tests whether the string has an SQL operator
-     *
-     * @param string $str
-     *
-     * @return bool
      */
     protected function hasOperator(string $str): bool
     {
@@ -3034,9 +2921,6 @@ class BaseBuilder
 
     /**
      * Returns the SQL string operator
-     *
-     * @param string $str
-     * @param bool   $list
      *
      * @return mixed
      */
@@ -3071,11 +2955,7 @@ class BaseBuilder
      * with PHP 7+ we get a huge memory/performance gain with indexed
      * arrays instead, so lets take advantage of that here.
      *
-     * @param string $key
-     * @param mixed  $value
-     * @param bool   $escape
-     *
-     * @return string
+     * @param mixed $value
      */
     protected function setBind(string $key, $value = null, bool $escape = true): string
     {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -297,8 +297,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Saves our connection settings.
-     *
-     * @param array $params
      */
     public function __construct(array $params)
     {
@@ -387,8 +385,6 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Connect to the database.
      *
-     * @param bool $persistent
-     *
      * @return mixed
      */
     abstract public function connect(bool $persistent = false);
@@ -437,8 +433,6 @@ abstract class BaseConnection implements ConnectionInterface
      * get that connection. If you pass either alias in and only a single
      * connection is present, it must return the sole connection.
      *
-     * @param string|null $alias
-     *
      * @return mixed
      */
     public function getConnection(?string $alias = null)
@@ -450,16 +444,12 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Select a specific database table to use.
      *
-     * @param string $databaseName
-     *
      * @return mixed
      */
     abstract public function setDatabase(string $databaseName);
 
     /**
      * Returns the name of the current database being used.
-     *
-     * @return string
      */
     public function getDatabase(): string
     {
@@ -472,8 +462,6 @@ abstract class BaseConnection implements ConnectionInterface
      * Set's the DB Prefix to something new without needing to reconnect
      *
      * @param string $prefix The prefix
-     *
-     * @return string
      */
     public function setPrefix(string $prefix = ''): string
     {
@@ -482,8 +470,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Returns the database prefix.
-     *
-     * @return string
      */
     public function getPrefix(): string
     {
@@ -492,8 +478,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * The name of the platform in use (MySQLi, mssql, etc)
-     *
-     * @return string
      */
     public function getPlatform(): string
     {
@@ -502,8 +486,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Returns a string containing the version of the database being used.
-     *
-     * @return string
      */
     abstract public function getVersion(): string;
 
@@ -511,8 +493,6 @@ abstract class BaseConnection implements ConnectionInterface
      * Sets the Table Aliases to use. These are typically
      * collected during use of the Builder, and set here
      * so queries are built correctly.
-     *
-     * @param array $aliases
      *
      * @return $this
      */
@@ -525,8 +505,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Add a table alias to our list.
-     *
-     * @param string $table
      *
      * @return $this
      */
@@ -542,8 +520,6 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Executes the query against the database.
      *
-     * @param string $sql
-     *
      * @return mixed
      */
     abstract protected function execute(string $sql);
@@ -556,10 +532,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Should automatically handle different connections for read/write
      * queries if needed.
      *
-     * @param string $sql
-     * @param mixed  ...$binds
-     * @param bool   $setEscapeFlags
-     * @param string $queryClass
+     * @param mixed ...$binds
      *
      * @return BaseResult|bool|Query
      *
@@ -655,8 +628,6 @@ abstract class BaseConnection implements ConnectionInterface
      * is performed, nor are transactions handled. Simply takes a raw
      * query string and returns the database-specific result id.
      *
-     * @param string $sql
-     *
      * @return mixed
      */
     public function simpleQuery(string $sql)
@@ -703,10 +674,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Start Transaction
-     *
-     * @param bool $testMode
-     *
-     * @return bool
      */
     public function transStart(bool $testMode = false): bool
     {
@@ -719,8 +686,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Complete Transaction
-     *
-     * @return bool
      */
     public function transComplete(): bool
     {
@@ -748,8 +713,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Lets you retrieve the transaction flag to determine if it has failed
-     *
-     * @return bool
      */
     public function transStatus(): bool
     {
@@ -758,10 +721,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Begin Transaction
-     *
-     * @param bool $testMode
-     *
-     * @return bool
      */
     public function transBegin(bool $testMode = false): bool
     {
@@ -796,8 +755,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Commit Transaction
-     *
-     * @return bool
      */
     public function transCommit(): bool
     {
@@ -817,8 +774,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Rollback Transaction
-     *
-     * @return bool
      */
     public function transRollback(): bool
     {
@@ -838,22 +793,16 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Begin Transaction
-     *
-     * @return bool
      */
     abstract protected function _transBegin(): bool;
 
     /**
      * Commit Transaction
-     *
-     * @return bool
      */
     abstract protected function _transCommit(): bool;
 
     /**
      * Rollback Transaction
-     *
-     * @return bool
      */
     abstract protected function _transRollback(): bool;
 
@@ -891,8 +840,7 @@ abstract class BaseConnection implements ConnectionInterface
      *                     ->get();
      *           })
      *
-     * @param Closure $func
-     * @param array   $options Passed to the prepare() method
+     * @param array $options Passed to the prepare() method
      *
      * @return BasePreparedQuery|null
      */
@@ -934,8 +882,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Returns a string representation of the last query's statement object.
-     *
-     * @return string
      */
     public function showLastQuery(): string
     {
@@ -947,8 +893,6 @@ abstract class BaseConnection implements ConnectionInterface
      * seconds with microseconds.
      *
      * Used by the Debug Toolbar's timeline.
-     *
-     * @return float|null
      */
     public function getConnectStart(): ?float
     {
@@ -960,10 +904,6 @@ abstract class BaseConnection implements ConnectionInterface
      * to connect to the database.
      *
      * Used by the Debug Toolbar's timeline.
-     *
-     * @param int $decimals
-     *
-     * @return string
      */
     public function getConnectDuration(int $decimals = 6): string
     {
@@ -991,9 +931,7 @@ abstract class BaseConnection implements ConnectionInterface
      * the correct identifiers.
      *
      * @param array|string $item
-     * @param bool         $prefixSingle
      * @param bool         $protectIdentifiers
-     * @param bool         $fieldExists
      *
      * @return array|string
      */
@@ -1196,8 +1134,6 @@ abstract class BaseConnection implements ConnectionInterface
      * @param string $table the table
      *
      * @throws DatabaseException
-     *
-     * @return string
      */
     public function prefixTable(string $table = ''): string
     {
@@ -1210,8 +1146,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Returns the total number of rows affected by this query.
-     *
-     * @return int
      */
     abstract public function affectedRows(): int;
 
@@ -1305,10 +1239,6 @@ abstract class BaseConnection implements ConnectionInterface
      * Platform independent string escape.
      *
      * Will likely be overridden in child classes.
-     *
-     * @param string $str
-     *
-     * @return string
      */
     protected function _escapeString(string $str): string
     {
@@ -1319,12 +1249,9 @@ abstract class BaseConnection implements ConnectionInterface
      * This function enables you to call PHP database functions that are not natively included
      * in CodeIgniter, in a platform independent manner.
      *
-     * @param string $functionName
-     * @param array  ...$params
+     * @param array ...$params
      *
      * @throws DatabaseException
-     *
-     * @return bool
      */
     public function callFunction(string $functionName, ...$params): bool
     {
@@ -1405,10 +1332,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Determine if a particular table exists
-     *
-     * @param string $tableName
-     *
-     * @return bool
      */
     public function tableExists(string $tableName): bool
     {
@@ -1467,11 +1390,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Determine if a particular field exists
-     *
-     * @param string $fieldName
-     * @param string $tableName
-     *
-     * @return bool
      */
     public function fieldExists(string $fieldName, string $tableName): bool
     {
@@ -1540,8 +1458,6 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * This is primarily used by the prepared query functionality.
      *
-     * @param bool $pretend
-     *
      * @return $this
      */
     public function pretend(bool $pretend = true)
@@ -1567,8 +1483,6 @@ abstract class BaseConnection implements ConnectionInterface
      * Determines if the statement is a write-type query or not.
      *
      * @param string $sql
-     *
-     * @return bool
      */
     public function isWriteType($sql): bool
     {
@@ -1581,8 +1495,6 @@ abstract class BaseConnection implements ConnectionInterface
      * Must return an array with keys 'code' and 'message':
      *
      *  return ['code' => null, 'message' => null);
-     *
-     * @return array
      */
     abstract public function error(): array;
 
@@ -1596,16 +1508,12 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param bool $constrainByPrefix
-     *
      * @return false|string
      */
     abstract protected function _listTables(bool $constrainByPrefix = false);
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
-     *
-     * @param string $table
      *
      * @return false|string
      */
@@ -1614,40 +1522,26 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Platform-specific field data information.
      *
-     * @param string $table
-     *
      * @see    getFieldData()
-     *
-     * @return array
      */
     abstract protected function _fieldData(string $table): array;
 
     /**
      * Platform-specific index data.
      *
-     * @param string $table
-     *
      * @see    getIndexData()
-     *
-     * @return array
      */
     abstract protected function _indexData(string $table): array;
 
     /**
      * Platform-specific foreign keys data.
      *
-     * @param string $table
-     *
      * @see    getForeignKeyData()
-     *
-     * @return array
      */
     abstract protected function _foreignKeyData(string $table): array;
 
     /**
      * Accessor for properties if they exist.
-     *
-     * @param string $key
      *
      * @return mixed
      */
@@ -1662,10 +1556,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Checker for properties existence.
-     *
-     * @param string $key
-     *
-     * @return bool
      */
     public function __isset(string $key): bool
     {

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -57,8 +57,6 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 
     /**
      * Constructor.
-     *
-     * @param BaseConnection $db
      */
     public function __construct(BaseConnection $db)
     {
@@ -72,9 +70,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
      * NOTE: This version is based on SQL code. Child classes should
      * override this method.
      *
-     * @param string $sql
-     * @param array  $options    Passed to the connection's prepare statement.
-     * @param string $queryClass
+     * @param array $options Passed to the connection's prepare statement.
      *
      * @return mixed
      */
@@ -104,8 +100,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
     /**
      * The database-dependent portion of the prepare statement.
      *
-     * @param string $sql
-     * @param array  $options Passed to the connection's prepare statement.
+     * @param array $options Passed to the connection's prepare statement.
      *
      * @return mixed
      */
@@ -145,10 +140,6 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 
     /**
      * The database dependant version of the execute method.
-     *
-     * @param array $data
-     *
-     * @return bool
      */
     abstract public function _execute(array $data): bool;
 
@@ -175,8 +166,6 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 
     /**
      * Returns the SQL that has been prepared.
-     *
-     * @return string
      */
     public function getQueryString(): string
     {
@@ -189,8 +178,6 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 
     /**
      * A helper to determine if any error exists.
-     *
-     * @return bool
      */
     public function hasError(): bool
     {
@@ -199,8 +186,6 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 
     /**
      * Returns the error code created while executing this statement.
-     *
-     * @return int
      */
     public function getErrorCode(): int
     {
@@ -209,8 +194,6 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 
     /**
      * Returns the error message created while executing this statement.
-     *
-     * @return string
      */
     public function getErrorMessage(): string
     {

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -92,8 +92,6 @@ abstract class BaseResult implements ResultInterface
      * 'object', or a custom class name.
      *
      * @param string $type The row type. Either 'array', 'object', or a class name to use
-     *
-     * @return array
      */
     public function getResult(string $type = 'object'): array
     {
@@ -166,8 +164,6 @@ abstract class BaseResult implements ResultInterface
      * Returns the results as an array of arrays.
      *
      * If no results, an empty array is returned.
-     *
-     * @return array
      */
     public function getResultArray(): array
     {
@@ -205,8 +201,6 @@ abstract class BaseResult implements ResultInterface
      * Returns the results as an array of objects.
      *
      * If no results, an empty array is returned.
-     *
-     * @return array
      */
     public function getResultObject(): array
     {
@@ -288,9 +282,6 @@ abstract class BaseResult implements ResultInterface
      *
      * If row doesn't exists, returns null.
      *
-     * @param int    $n
-     * @param string $className
-     *
      * @return mixed
      */
     public function getCustomRowObject(int $n, string $className)
@@ -315,8 +306,6 @@ abstract class BaseResult implements ResultInterface
      *
      * If row doesn't exist, returns null.
      *
-     * @param int $n
-     *
      * @return mixed
      */
     public function getRowArray(int $n = 0)
@@ -337,8 +326,6 @@ abstract class BaseResult implements ResultInterface
      * Returns a single row from the results as an object.
      *
      * If row doesn't exist, returns null.
-     *
-     * @param int $n
      *
      * @return mixed
      */
@@ -387,8 +374,6 @@ abstract class BaseResult implements ResultInterface
     /**
      * Returns the "first" row of the current results.
      *
-     * @param string $type
-     *
      * @return mixed
      */
     public function getFirstRow(string $type = 'object')
@@ -401,8 +386,6 @@ abstract class BaseResult implements ResultInterface
     /**
      * Returns the "last" row of the current results.
      *
-     * @param string $type
-     *
      * @return mixed
      */
     public function getLastRow(string $type = 'object')
@@ -414,8 +397,6 @@ abstract class BaseResult implements ResultInterface
 
     /**
      * Returns the "next" row of the current results.
-     *
-     * @param string $type
      *
      * @return mixed
      */
@@ -431,8 +412,6 @@ abstract class BaseResult implements ResultInterface
 
     /**
      * Returns the "previous" row of the current results.
-     *
-     * @param string $type
      *
      * @return mixed
      */
@@ -453,8 +432,6 @@ abstract class BaseResult implements ResultInterface
     /**
      * Returns an unbuffered row and move the pointer to the next row.
      *
-     * @param string $type
-     *
      * @return mixed
      */
     public function getUnbufferedRow(string $type = 'object')
@@ -474,8 +451,6 @@ abstract class BaseResult implements ResultInterface
      * Number of rows in the result set; checks for previous count, falls
      * back on counting resultArray or resultObject, finally fetching resultArray
      * if nothing was previously fetched
-     *
-     * @return int
      */
     public function getNumRows(): int
     {
@@ -494,22 +469,16 @@ abstract class BaseResult implements ResultInterface
 
     /**
      * Gets the number of fields in the result set.
-     *
-     * @return int
      */
     abstract public function getFieldCount(): int;
 
     /**
      * Generates an array of column names in the result set.
-     *
-     * @return array
      */
     abstract public function getFieldNames(): array;
 
     /**
      * Generates an array of objects representing field meta-data.
-     *
-     * @return array
      */
     abstract public function getFieldData(): array;
 
@@ -524,8 +493,6 @@ abstract class BaseResult implements ResultInterface
      * Moves the internal pointer to the desired offset. This is called
      * internally before fetching results to make sure the result set
      * starts at zero.
-     *
-     * @param int $n
      *
      * @return mixed
      */
@@ -544,8 +511,6 @@ abstract class BaseResult implements ResultInterface
      * Returns the result set as an object.
      *
      * Overridden by child classes.
-     *
-     * @param string $className
      *
      * @return object
      */

--- a/system/Database/BaseUtils.php
+++ b/system/Database/BaseUtils.php
@@ -48,8 +48,6 @@ abstract class BaseUtils
 
     /**
      * Class constructor
-     *
-     * @param ConnectionInterface $db
      */
     public function __construct(ConnectionInterface &$db)
     {
@@ -94,10 +92,6 @@ abstract class BaseUtils
 
     /**
      * Determine if a particular database exists
-     *
-     * @param string $databaseName
-     *
-     * @return bool
      */
     public function databaseExists(string $databaseName): bool
     {
@@ -106,8 +100,6 @@ abstract class BaseUtils
 
     /**
      * Optimize Table
-     *
-     * @param string $tableName
      *
      * @throws DatabaseException
      *
@@ -176,8 +168,6 @@ abstract class BaseUtils
     /**
      * Repair Table
      *
-     * @param string $tableName
-     *
      * @throws DatabaseException
      *
      * @return mixed
@@ -241,8 +231,6 @@ abstract class BaseUtils
      *
      * @param ResultInterface $query  Query result object
      * @param array           $params Any preferences
-     *
-     * @return string
      */
     public function getXMLFromResult(ResultInterface $query, array $params = []): string
     {
@@ -348,8 +336,6 @@ abstract class BaseUtils
 
     /**
      * Platform dependent version of the backup function.
-     *
-     * @param array|null $prefs
      *
      * @return mixed
      */

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -85,8 +85,6 @@ class Config extends BaseConfig
 
     /**
      * Returns an array of all db connections currently made.
-     *
-     * @return array
      */
     public static function getConnections(): array
     {
@@ -124,8 +122,6 @@ class Config extends BaseConfig
 
     /**
      * Returns a new instance of the Database Seeder.
-     *
-     * @param string|null $group
      *
      * @return Seeder
      */

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -26,8 +26,6 @@ interface ConnectionInterface
     /**
      * Connect to the database.
      *
-     * @param bool $persistent
-     *
      * @return mixed
      */
     public function connect(bool $persistent = false);
@@ -53,8 +51,6 @@ interface ConnectionInterface
      * get that connection. If you pass either alias in and only a single
      * connection is present, it must return the sole connection.
      *
-     * @param string|null $alias
-     *
      * @return mixed
      */
     public function getConnection(?string $alias = null);
@@ -62,16 +58,12 @@ interface ConnectionInterface
     /**
      * Select a specific database table to use.
      *
-     * @param string $databaseName
-     *
      * @return mixed
      */
     public function setDatabase(string $databaseName);
 
     /**
      * Returns the name of the current database being used.
-     *
-     * @return string
      */
     public function getDatabase(): string;
 
@@ -80,21 +72,17 @@ interface ConnectionInterface
      * Must return this format: ['code' => string|int, 'message' => string]
      * intval(code) === 0 means "no error".
      *
-     * @return array<string,int|string>
+     * @return array<string, int|string>
      */
     public function error(): array;
 
     /**
      * The name of the platform in use (MySQLi, mssql, etc)
-     *
-     * @return string
      */
     public function getPlatform(): string;
 
     /**
      * Returns a string containing the version of the database being used.
-     *
-     * @return string
      */
     public function getVersion(): string;
 
@@ -106,8 +94,7 @@ interface ConnectionInterface
      * Should automatically handle different connections for read/write
      * queries if needed.
      *
-     * @param string $sql
-     * @param mixed  ...$binds
+     * @param mixed ...$binds
      *
      * @return BaseResult|bool|Query
      */
@@ -117,8 +104,6 @@ interface ConnectionInterface
      * Performs a basic query against the database. No binding or caching
      * is performed, nor are transactions handled. Simply takes a raw
      * query string and returns the database-specific result id.
-     *
-     * @param string $sql
      *
      * @return mixed
      */
@@ -156,8 +141,7 @@ interface ConnectionInterface
      * Allows for custom calls to the database engine that are not
      * supported through our database layer.
      *
-     * @param string $functionName
-     * @param array  ...$params
+     * @param array ...$params
      *
      * @return mixed
      */
@@ -167,8 +151,6 @@ interface ConnectionInterface
      * Determines if the statement is a write-type query or not.
      *
      * @param string $sql
-     *
-     * @return bool
      */
     public function isWriteType($sql): bool;
 }

--- a/system/Database/Database.php
+++ b/system/Database/Database.php
@@ -35,9 +35,6 @@ class Database
      * Parses the connection binds and returns an instance of the driver
      * ready to go.
      *
-     * @param array  $params
-     * @param string $alias
-     *
      * @throws InvalidArgumentException
      *
      * @return mixed
@@ -68,10 +65,6 @@ class Database
 
     /**
      * Creates a Forge instance for the current database type.
-     *
-     * @param ConnectionInterface $db
-     *
-     * @return object
      */
     public function loadForge(ConnectionInterface $db): object
     {
@@ -85,10 +78,6 @@ class Database
 
     /**
      * Creates a Utils instance for the current database type.
-     *
-     * @param ConnectionInterface $db
-     *
-     * @return object
      */
     public function loadUtils(ConnectionInterface $db): object
     {
@@ -103,11 +92,7 @@ class Database
     /**
      * Parse universal DSN string
      *
-     * @param array $params
-     *
      * @throws InvalidArgumentException
-     *
-     * @return array
      */
     protected function parseDSN(array $params): array
     {
@@ -149,8 +134,6 @@ class Database
      * @param string       $driver   Database driver name (e.g. 'MySQLi')
      * @param string       $class    Database class name (e.g. 'Forge')
      * @param array|object $argument
-     *
-     * @return object
      */
     protected function initDriver(string $driver, string $class, $argument): object
     {

--- a/system/Database/Exceptions/DataException.php
+++ b/system/Database/Exceptions/DataException.php
@@ -21,8 +21,6 @@ class DataException extends RuntimeException implements ExceptionInterface
     /**
      * Used by the Model's trigger() method when the callback cannot be found.
      *
-     * @param string $method
-     *
      * @return DataException
      */
     public static function forInvalidMethodTriggered(string $method)
@@ -33,8 +31,6 @@ class DataException extends RuntimeException implements ExceptionInterface
     /**
      * Used by Model's insert/update methods when there isn't
      * any data to actually work with.
-     *
-     * @param string $mode
      *
      * @return DataException
      */
@@ -48,8 +44,6 @@ class DataException extends RuntimeException implements ExceptionInterface
      * primary key defined and Model has option `useAutoIncrement`
      * set to false.
      *
-     * @param string $mode
-     *
      * @return DataException
      */
     public static function forEmptyPrimaryKey(string $mode)
@@ -61,8 +55,6 @@ class DataException extends RuntimeException implements ExceptionInterface
      * Thrown when an argument for one of the Model's methods
      * were empty or otherwise invalid, and they could not be
      * to work correctly for that method.
-     *
-     * @param string $argument
      *
      * @return DataException
      */

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -162,8 +162,6 @@ class Forge
 
     /**
      * Constructor.
-     *
-     * @param BaseConnection $db
      */
     public function __construct(BaseConnection $db)
     {
@@ -183,12 +181,9 @@ class Forge
     /**
      * Create database
      *
-     * @param string $dbName
-     * @param bool   $ifNotExists Whether to add IF NOT EXISTS condition
+     * @param bool $ifNotExists Whether to add IF NOT EXISTS condition
      *
      * @throws DatabaseException
-     *
-     * @return bool
      */
     public function createDatabase(string $dbName, bool $ifNotExists = false): bool
     {
@@ -237,11 +232,7 @@ class Forge
     /**
      * Determine if a database exists
      *
-     * @param string $dbName
-     *
      * @throws DatabaseException
-     *
-     * @return bool
      */
     private function databaseExists(string $dbName): bool
     {
@@ -259,11 +250,7 @@ class Forge
     /**
      * Drop database
      *
-     * @param string $dbName
-     *
      * @throws DatabaseException
-     *
-     * @return bool
      */
     public function dropDatabase(string $dbName): bool
     {
@@ -297,8 +284,6 @@ class Forge
      * Add Key
      *
      * @param array|string $key
-     * @param bool         $primary
-     * @param bool         $unique
      *
      * @return Forge
      */
@@ -380,12 +365,6 @@ class Forge
 
     /**
      * Add Foreign Key
-     *
-     * @param string $fieldName
-     * @param string $tableName
-     * @param string $tableField
-     * @param string $onUpdate
-     * @param string $onDelete
      *
      * @throws DatabaseException
      *
@@ -547,8 +526,6 @@ class Forge
      * CREATE TABLE attributes
      *
      * @param array $attributes Associative array of table attributes
-     *
-     * @return string
      */
     protected function _createTableAttributes(array $attributes): string
     {
@@ -695,8 +672,6 @@ class Forge
      * @param array|string $field Column definition
      *
      * @throws DatabaseException
-     *
-     * @return bool
      */
     public function addColumn(string $table, $field): bool
     {
@@ -759,8 +734,6 @@ class Forge
      * @param array|string $field Column definition
      *
      * @throws DatabaseException
-     *
-     * @return bool
      */
     public function modifyColumn(string $table, $field): bool
     {
@@ -839,10 +812,6 @@ class Forge
 
     /**
      * Process fields
-     *
-     * @param bool $createTable
-     *
-     * @return array
      */
     protected function _processFields(bool $createTable = false): array
     {
@@ -926,10 +895,6 @@ class Forge
 
     /**
      * Process column
-     *
-     * @param array $field
-     *
-     * @return string
      */
     protected function _processColumn(array $field): string
     {
@@ -946,8 +911,6 @@ class Forge
      * Field attribute TYPE
      *
      * Performs a data type mapping between different databases.
-     *
-     * @param array $attributes
      *
      * @return void
      */
@@ -967,9 +930,6 @@ class Forge
      *        if $attributes['TYPE'] is found in the array
      *    - array(TYPE => UTYPE) will change $field['type'],
      *        from TYPE to UTYPE in case of a match
-     *
-     * @param array $attributes
-     * @param array $field
      *
      * @return void|null
      */
@@ -1006,9 +966,6 @@ class Forge
     /**
      * Field attribute DEFAULT
      *
-     * @param array $attributes
-     * @param array $field
-     *
      * @return void|null
      */
     protected function _attributeDefault(array &$attributes, array &$field)
@@ -1033,9 +990,6 @@ class Forge
     /**
      * Field attribute UNIQUE
      *
-     * @param array $attributes
-     * @param array $field
-     *
      * @return void
      */
     protected function _attributeUnique(array &$attributes, array &$field)
@@ -1047,9 +1001,6 @@ class Forge
 
     /**
      * Field attribute AUTO_INCREMENT
-     *
-     * @param array $attributes
-     * @param array $field
      *
      * @return void
      */
@@ -1066,8 +1017,6 @@ class Forge
      * Process primary keys
      *
      * @param string $table Table name
-     *
-     * @return string
      */
     protected function _processPrimaryKeys(string $table): string
     {
@@ -1089,8 +1038,6 @@ class Forge
 
     /**
      * Process indexes
-     *
-     * @param string $table
      *
      * @return array|string
      */
@@ -1130,8 +1077,6 @@ class Forge
      * Process foreign keys
      *
      * @param string $table Table name
-     *
-     * @return string
      */
     protected function _processForeignKeys(string $table): string
     {

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -127,7 +127,6 @@ class MigrationRunner
      * - existing connection instance
      * - array of database configuration values
      *
-     * @param MigrationsConfig                      $config
      * @param array|ConnectionInterface|string|null $db
      *
      * @throws ConfigException
@@ -152,8 +151,6 @@ class MigrationRunner
 
     /**
      * Locate and run all new migrations
-     *
-     * @param string|null $group
      *
      * @throws ConfigException
      * @throws RuntimeException
@@ -229,8 +226,7 @@ class MigrationRunner
      *
      * Calls each migration step required to get to the provided batch
      *
-     * @param int         $targetBatch Target batch number, or negative for a relative batch, 0 for all
-     * @param string|null $group
+     * @param int $targetBatch Target batch number, or negative for a relative batch, 0 for all
      *
      * @throws ConfigException
      * @throws RuntimeException
@@ -351,9 +347,8 @@ class MigrationRunner
      * Method "up" or "down" determined by presence in history.
      * NOTE: This is not recommended and provided mostly for testing.
      *
-     * @param string      $path  Full path to a valid migration file
-     * @param string      $path  Namespace of the target migration
-     * @param string|null $group
+     * @param string $path Full path to a valid migration file
+     * @param string $path Namespace of the target migration
      */
     public function force(string $path, string $namespace, ?string $group = null)
     {
@@ -548,8 +543,6 @@ class MigrationRunner
      * Set database Group.
      * Allows other scripts to modify on the fly as needed.
      *
-     * @param string $group
-     *
      * @return MigrationRunner
      */
     public function setGroup(string $group)
@@ -561,8 +554,6 @@ class MigrationRunner
 
     /**
      * Set migration Name.
-     *
-     * @param string $name
      *
      * @return MigrationRunner
      */
@@ -577,8 +568,6 @@ class MigrationRunner
      * If $silent == true, then will not throw exceptions and will
      * attempt to continue gracefully.
      *
-     * @param bool $silent
-     *
      * @return MigrationRunner
      */
     public function setSilent(bool $silent)
@@ -591,8 +580,6 @@ class MigrationRunner
     /**
      * Extracts the migration number from a filename
      *
-     * @param string $migration
-     *
      * @return string Numeric portion of a migration filename
      */
     protected function getMigrationNumber(string $migration): string
@@ -604,8 +591,6 @@ class MigrationRunner
 
     /**
      * Extracts the migration class name from a filename
-     *
-     * @param string $migration
      *
      * @return string text portion of a migration filename
      */
@@ -622,8 +607,6 @@ class MigrationRunner
      * to create a sortable unique key
      *
      * @param object $object migration or $history
-     *
-     * @return string
      */
     public function getObjectUid($object): string
     {
@@ -668,7 +651,6 @@ class MigrationRunner
      * Add a history to the table.
      *
      * @param object $migration
-     * @param int    $batch
      *
      * @return void
      */
@@ -718,10 +700,6 @@ class MigrationRunner
 
     /**
      * Grabs the full migration history from the database for a group
-     *
-     * @param string $group
-     *
-     * @return array
      */
     public function getHistory(string $group = 'default'): array
     {
@@ -747,9 +725,7 @@ class MigrationRunner
     /**
      * Returns the migration history for a single batch.
      *
-     * @param int $batch
-     *
-     * @return array
+     * @param mixed $order
      */
     public function getBatchHistory(int $batch, $order = 'asc'): array
     {
@@ -765,8 +741,6 @@ class MigrationRunner
 
     /**
      * Returns all the batches from the database history in order
-     *
-     * @return array
      */
     public function getBatches(): array
     {
@@ -784,8 +758,6 @@ class MigrationRunner
 
     /**
      * Returns the value of the last batch in the database.
-     *
-     * @return int
      */
     public function getLastBatch(): int
     {
@@ -806,10 +778,6 @@ class MigrationRunner
     /**
      * Returns the version number of the first migration for a batch.
      * Mostly just for tests.
-     *
-     * @param int $batch
-     *
-     * @return string
      */
     public function getBatchStart(int $batch): string
     {
@@ -832,10 +800,6 @@ class MigrationRunner
     /**
      * Returns the version number of the last migration for a batch.
      * Mostly just for tests.
-     *
-     * @param int $batch
-     *
-     * @return string
      */
     public function getBatchEnd(int $batch): string
     {
@@ -918,8 +882,6 @@ class MigrationRunner
      *
      * @param string $direction "up" or "down"
      * @param object $migration The migration to run
-     *
-     * @return bool
      */
     protected function migrate($direction, $migration): bool
     {

--- a/system/Database/ModelFactory.php
+++ b/system/Database/ModelFactory.php
@@ -39,7 +39,6 @@ class ModelFactory
     /**
      * Helper method for injecting mock instances while testing.
      *
-     * @param string $name
      * @param object $instance
      */
     public static function injectMock(string $name, $instance)

--- a/system/Database/MySQLi/Builder.php
+++ b/system/Database/MySQLi/Builder.php
@@ -44,8 +44,6 @@ class Builder extends BaseBuilder
      * about operator precedence.
      *
      * Note: This is only used (and overridden) by MySQL.
-     *
-     * @return string
      */
     protected function _fromTables(): string
     {

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -61,8 +61,6 @@ class Connection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @param bool $persistent
-     *
      * @throws DatabaseException
      *
      * @return mixed
@@ -232,10 +230,6 @@ class Connection extends BaseConnection
 
     /**
      * Select a specific database table to use.
-     *
-     * @param string $databaseName
-     *
-     * @return bool
      */
     public function setDatabase(string $databaseName): bool
     {
@@ -258,8 +252,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns a string containing the version of the database being used.
-     *
-     * @return string
      */
     public function getVersion(): string
     {
@@ -276,8 +268,6 @@ class Connection extends BaseConnection
 
     /**
      * Executes the query against the database.
-     *
-     * @param string $sql
      *
      * @return mixed
      */
@@ -309,8 +299,6 @@ class Connection extends BaseConnection
      * If needed, each database adapter can prep the query string
      *
      * @param string $sql an SQL query
-     *
-     * @return string
      */
     protected function prepQuery(string $sql): string
     {
@@ -325,8 +313,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns the total number of rows affected by this query.
-     *
-     * @return int
      */
     public function affectedRows(): int
     {
@@ -335,10 +321,6 @@ class Connection extends BaseConnection
 
     /**
      * Platform-dependant string escape
-     *
-     * @param string $str
-     *
-     * @return string
      */
     protected function _escapeString(string $str): string
     {
@@ -382,10 +364,6 @@ class Connection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      * Uses escapeLikeStringDirect().
-     *
-     * @param bool $prefixLimit
-     *
-     * @return string
      */
     protected function _listTables(bool $prefixLimit = false): string
     {
@@ -400,10 +378,6 @@ class Connection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
-     *
-     * @param string $table
-     *
-     * @return string
      */
     protected function _listColumns(string $table = ''): string
     {
@@ -412,8 +386,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns an array of objects with field data
-     *
-     * @param string $table
      *
      * @throws DatabaseException
      *
@@ -446,8 +418,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns an array of objects with index data
-     *
-     * @param string $table
      *
      * @throws DatabaseException
      * @throws LogicException
@@ -494,8 +464,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns an array of objects with Foreign key data
-     *
-     * @param string $table
      *
      * @throws DatabaseException
      *
@@ -585,8 +553,6 @@ class Connection extends BaseConnection
 
     /**
      * Insert ID
-     *
-     * @return int
      */
     public function insertID(): int
     {
@@ -595,8 +561,6 @@ class Connection extends BaseConnection
 
     /**
      * Begin Transaction
-     *
-     * @return bool
      */
     protected function _transBegin(): bool
     {
@@ -607,8 +571,6 @@ class Connection extends BaseConnection
 
     /**
      * Commit Transaction
-     *
-     * @return bool
      */
     protected function _transCommit(): bool
     {
@@ -623,8 +585,6 @@ class Connection extends BaseConnection
 
     /**
      * Rollback Transaction
-     *
-     * @return bool
      */
     protected function _transRollback(): bool
     {

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -97,8 +97,6 @@ class Forge extends BaseForge
      * CREATE TABLE attributes
      *
      * @param array $attributes Associative array of table attributes
-     *
-     * @return string
      */
     protected function _createTableAttributes(array $attributes): string
     {
@@ -163,10 +161,6 @@ class Forge extends BaseForge
 
     /**
      * Process column
-     *
-     * @param array $field
-     *
-     * @return string
      */
     protected function _processColumn(array $field): string
     {
@@ -192,8 +186,6 @@ class Forge extends BaseForge
      * Process indexes
      *
      * @param string $table (ignored)
-     *
-     * @return string
      */
     protected function _processIndexes(string $table): string
     {

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -26,9 +26,8 @@ class PreparedQuery extends BasePreparedQuery
      * NOTE: This version is based on SQL code. Child classes should
      * override this method.
      *
-     * @param string $sql
-     * @param array  $options Passed to the connection's prepare statement.
-     *                        Unused in the MySQLi driver.
+     * @param array $options Passed to the connection's prepare statement.
+     *                       Unused in the MySQLi driver.
      *
      * @return mixed
      */
@@ -49,10 +48,6 @@ class PreparedQuery extends BasePreparedQuery
     /**
      * Takes a new set of data and runs it against the currently
      * prepared query. Upon success, will return a Results object.
-     *
-     * @param array $data
-     *
-     * @return bool
      */
     public function _execute(array $data): bool
     {

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -22,8 +22,6 @@ class Result extends BaseResult
 {
     /**
      * Gets the number of fields in the result set.
-     *
-     * @return int
      */
     public function getFieldCount(): int
     {
@@ -32,8 +30,6 @@ class Result extends BaseResult
 
     /**
      * Generates an array of column names in the result set.
-     *
-     * @return array
      */
     public function getFieldNames(): array
     {
@@ -49,8 +45,6 @@ class Result extends BaseResult
 
     /**
      * Generates an array of objects representing field meta-data.
-     *
-     * @return array
      */
     public function getFieldData(): array
     {
@@ -121,8 +115,6 @@ class Result extends BaseResult
      * internally before fetching results to make sure the result set
      * starts at zero.
      *
-     * @param int $n
-     *
      * @return mixed
      */
     public function dataSeek(int $n = 0)
@@ -146,8 +138,6 @@ class Result extends BaseResult
      * Returns the result set as an object.
      *
      * Overridden by child classes.
-     *
-     * @param string $className
      *
      * @return bool|Entity|object
      */

--- a/system/Database/MySQLi/Utils.php
+++ b/system/Database/MySQLi/Utils.php
@@ -36,8 +36,6 @@ class Utils extends BaseUtils
     /**
      * Platform dependent version of the backup function.
      *
-     * @param array|null $prefs
-     *
      * @return mixed
      */
     public function _backup(?array $prefs = null)

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -44,8 +44,6 @@ class Builder extends BaseBuilder
      * Checks if the ignore option is supported by
      * the Database Driver for the specific statement.
      *
-     * @param string $statement
-     *
      * @return string
      */
     protected function compileIgnore(string $statement)
@@ -62,7 +60,6 @@ class Builder extends BaseBuilder
     /**
      * ORDER BY
      *
-     * @param string $orderBy
      * @param string $direction ASC, DESC or RANDOM
      * @param bool   $escape
      *
@@ -91,9 +88,6 @@ class Builder extends BaseBuilder
     /**
      * Increments a numeric column by the specified value.
      *
-     * @param string $column
-     * @param int    $value
-     *
      * @throws DatabaseException
      *
      * @return mixed
@@ -109,9 +103,6 @@ class Builder extends BaseBuilder
 
     /**
      * Decrements a numeric column by the specified value.
-     *
-     * @param string $column
-     * @param int    $value
      *
      * @throws DatabaseException
      *
@@ -186,8 +177,6 @@ class Builder extends BaseBuilder
      * @param string $table         The table name
      * @param array  $keys          The insert keys
      * @param array  $unescapedKeys The insert values
-     *
-     * @return string
      */
     protected function _insert(string $table, array $keys, array $unescapedKeys): string
     {
@@ -202,8 +191,6 @@ class Builder extends BaseBuilder
      * @param string $table  Table name
      * @param array  $keys   INSERT keys
      * @param array  $values INSERT values
-     *
-     * @return string
      */
     protected function _insertBatch(string $table, array $keys, array $values): string
     {
@@ -217,7 +204,6 @@ class Builder extends BaseBuilder
      *
      * @param mixed $where
      * @param int   $limit
-     * @param bool  $resetData
      *
      * @throws DatabaseException
      *
@@ -242,8 +228,6 @@ class Builder extends BaseBuilder
      * Generates a platform-specific LIMIT clause.
      *
      * @param string $sql SQL Query
-     *
-     * @return string
      */
     protected function _limit(string $sql, bool $offsetIgnore = false): string
     {
@@ -255,12 +239,7 @@ class Builder extends BaseBuilder
      *
      * Generates a platform-specific update string from the supplied data
      *
-     * @param string $table
-     * @param array  $values
-     *
      * @throws DatabaseException
-     *
-     * @return string
      *
      * @internal param the $array update data
      * @internal param the $string table name
@@ -284,8 +263,6 @@ class Builder extends BaseBuilder
      * @param string $table  Table name
      * @param array  $values Update data
      * @param string $index  WHERE key
-     *
-     * @return string
      */
     protected function _updateBatch(string $table, array $values, string $index): string
     {
@@ -323,8 +300,6 @@ class Builder extends BaseBuilder
      * Generates a platform-specific delete string from the supplied data
      *
      * @param string $table The table name
-     *
-     * @return string
      */
     protected function _delete(string $table): string
     {
@@ -342,8 +317,6 @@ class Builder extends BaseBuilder
      * then this method maps to 'DELETE FROM table'
      *
      * @param string $table The table name
-     *
-     * @return string
      */
     protected function _truncate(string $table): string
     {
@@ -357,12 +330,6 @@ class Builder extends BaseBuilder
      * searches according to the current locale.
      *
      * @see https://www.postgresql.org/docs/9.2/static/functions-matching.html
-     *
-     * @param string|null $prefix
-     * @param string      $column
-     * @param string|null $not
-     * @param string      $bind
-     * @param bool        $insensitiveSearch
      *
      * @return string $like_statement
      */
@@ -378,7 +345,6 @@ class Builder extends BaseBuilder
      *
      * Generates the JOIN portion of the query
      *
-     * @param string $table
      * @param string $cond   The join condition
      * @param string $type   The type of join
      * @param bool   $escape Whether not to try to escape identifiers

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -45,8 +45,6 @@ class Connection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @param bool $persistent
-     *
      * @return mixed
      */
     public function connect(bool $persistent = false)
@@ -108,10 +106,6 @@ class Connection extends BaseConnection
 
     /**
      * Select a specific database table to use.
-     *
-     * @param string $databaseName
-     *
-     * @return bool
      */
     public function setDatabase(string $databaseName): bool
     {
@@ -120,8 +114,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns a string containing the version of the database being used.
-     *
-     * @return string
      */
     public function getVersion(): string
     {
@@ -139,8 +131,6 @@ class Connection extends BaseConnection
 
     /**
      * Executes the query against the database.
-     *
-     * @param string $sql
      *
      * @return mixed
      */
@@ -160,8 +150,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns the total number of rows affected by this query.
-     *
-     * @return int
      */
     public function affectedRows(): int
     {
@@ -196,10 +184,6 @@ class Connection extends BaseConnection
 
     /**
      * Platform-dependant string escape
-     *
-     * @param string $str
-     *
-     * @return string
      */
     protected function _escapeString(string $str): string
     {
@@ -212,10 +196,6 @@ class Connection extends BaseConnection
 
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
-     *
-     * @param bool $prefixLimit
-     *
-     * @return string
      */
     protected function _listTables(bool $prefixLimit = false): string
     {
@@ -232,10 +212,6 @@ class Connection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
-     *
-     * @param string $table
-     *
-     * @return string
      */
     protected function _listColumns(string $table = ''): string
     {
@@ -248,8 +224,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns an array of objects with field data
-     *
-     * @param string $table
      *
      * @throws DatabaseException
      *
@@ -284,8 +258,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns an array of objects with index data
-     *
-     * @param string $table
      *
      * @throws DatabaseException
      *
@@ -327,8 +299,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns an array of objects with Foreign key data
-     *
-     * @param string $table
      *
      * @throws DatabaseException
      *
@@ -499,8 +469,6 @@ class Connection extends BaseConnection
      * Set client encoding
      *
      * @param string $charset The client encoding to which the data will be converted.
-     *
-     * @return bool
      */
     protected function setClientEncoding(string $charset): bool
     {
@@ -509,8 +477,6 @@ class Connection extends BaseConnection
 
     /**
      * Begin Transaction
-     *
-     * @return bool
      */
     protected function _transBegin(): bool
     {
@@ -519,8 +485,6 @@ class Connection extends BaseConnection
 
     /**
      * Commit Transaction
-     *
-     * @return bool
      */
     protected function _transCommit(): bool
     {
@@ -529,8 +493,6 @@ class Connection extends BaseConnection
 
     /**
      * Rollback Transaction
-     *
-     * @return bool
      */
     protected function _transRollback(): bool
     {
@@ -543,8 +505,6 @@ class Connection extends BaseConnection
      * Overrides BaseConnection::isWriteType, adding additional read query types.
      *
      * @param string $sql An SQL query string
-     *
-     * @return bool
      */
     public function isWriteType($sql): bool
     {

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -62,8 +62,6 @@ class Forge extends BaseForge
      * CREATE TABLE attributes
      *
      * @param array $attributes Associative array of table attributes
-     *
-     * @return string
      */
     protected function _createTableAttributes(array $attributes): string
     {
@@ -125,10 +123,6 @@ class Forge extends BaseForge
 
     /**
      * Process column
-     *
-     * @param array $field
-     *
-     * @return string
      */
     protected function _processColumn(array $field): string
     {
@@ -144,8 +138,6 @@ class Forge extends BaseForge
      * Field attribute TYPE
      *
      * Performs a data type mapping between different databases.
-     *
-     * @param array $attributes
      *
      * @return void
      */
@@ -179,9 +171,6 @@ class Forge extends BaseForge
     /**
      * Field attribute AUTO_INCREMENT
      *
-     * @param array $attributes
-     * @param array $field
-     *
      * @return void
      */
     protected function _attributeAutoIncrement(array &$attributes, array &$field)
@@ -198,9 +187,6 @@ class Forge extends BaseForge
      *
      * @param string $table    Table name
      * @param bool   $ifExists Whether to add an IF EXISTS condition
-     * @param bool   $cascade
-     *
-     * @return string
      */
     protected function _dropTable(string $table, bool $ifExists, bool $cascade): string
     {

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -43,9 +43,8 @@ class PreparedQuery extends BasePreparedQuery
      * NOTE: This version is based on SQL code. Child classes should
      * override this method.
      *
-     * @param string $sql
-     * @param array  $options Passed to the connection's prepare statement.
-     *                        Unused in the MySQLi driver.
+     * @param array $options Passed to the connection's prepare statement.
+     *                       Unused in the MySQLi driver.
      *
      * @throws Exception
      *
@@ -72,10 +71,6 @@ class PreparedQuery extends BasePreparedQuery
     /**
      * Takes a new set of data and runs it against the currently
      * prepared query. Upon success, will return a Results object.
-     *
-     * @param array $data
-     *
-     * @return bool
      */
     public function _execute(array $data): bool
     {
@@ -101,10 +96,6 @@ class PreparedQuery extends BasePreparedQuery
     /**
      * Replaces the ? placeholders with $1, $2, etc parameters for use
      * within the prepared query.
-     *
-     * @param string $sql
-     *
-     * @return string
      */
     public function parameterize(string $sql): string
     {

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -22,8 +22,6 @@ class Result extends BaseResult
 {
     /**
      * Gets the number of fields in the result set.
-     *
-     * @return int
      */
     public function getFieldCount(): int
     {
@@ -32,8 +30,6 @@ class Result extends BaseResult
 
     /**
      * Generates an array of column names in the result set.
-     *
-     * @return array
      */
     public function getFieldNames(): array
     {
@@ -48,8 +44,6 @@ class Result extends BaseResult
 
     /**
      * Generates an array of objects representing field meta-data.
-     *
-     * @return array
      */
     public function getFieldData(): array
     {
@@ -87,8 +81,6 @@ class Result extends BaseResult
      * internally before fetching results to make sure the result set
      * starts at zero.
      *
-     * @param int $n
-     *
      * @return mixed
      */
     public function dataSeek(int $n = 0)
@@ -112,8 +104,6 @@ class Result extends BaseResult
      * Returns the result set as an object.
      *
      * Overridden by child classes.
-     *
-     * @param string $className
      *
      * @return bool|Entity|object
      */

--- a/system/Database/Postgre/Utils.php
+++ b/system/Database/Postgre/Utils.php
@@ -36,8 +36,6 @@ class Utils extends BaseUtils
     /**
      * Platform dependent version of the backup function.
      *
-     * @param array|null $prefs
-     *
      * @return mixed
      */
     public function _backup(?array $prefs = null)

--- a/system/Database/PreparedQueryInterface.php
+++ b/system/Database/PreparedQueryInterface.php
@@ -30,8 +30,7 @@ interface PreparedQueryInterface
      * Prepares the query against the database, and saves the connection
      * info necessary to execute the query later.
      *
-     * @param string $sql
-     * @param array  $options Passed to the connection's prepare statement.
+     * @param array $options Passed to the connection's prepare statement.
      *
      * @return mixed
      */
@@ -44,22 +43,16 @@ interface PreparedQueryInterface
 
     /**
      * Returns the SQL that has been prepared.
-     *
-     * @return string
      */
     public function getQueryString(): string;
 
     /**
      * Returns the error code created while executing this statement.
-     *
-     * @return int
      */
     public function getErrorCode(): int;
 
     /**
      * Returns the error message created while executing this statement.
-     *
-     * @return string
      */
     public function getErrorMessage(): string;
 }

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -86,8 +86,6 @@ class Query implements QueryInterface
 
     /**
      * BaseQuery constructor.
-     *
-     * @param ConnectionInterface $db
      */
     public function __construct(ConnectionInterface &$db)
     {
@@ -97,9 +95,7 @@ class Query implements QueryInterface
     /**
      * Sets the raw query string to use for this statement.
      *
-     * @param string $sql
-     * @param mixed  $binds
-     * @param bool   $setEscape
+     * @param mixed $binds
      *
      * @return $this
      */
@@ -129,9 +125,6 @@ class Query implements QueryInterface
     /**
      * Will store the variables to bind into the query later.
      *
-     * @param array $binds
-     * @param bool  $setEscape
-     *
      * @return $this
      */
     public function setBinds(array $binds, bool $setEscape = true)
@@ -153,8 +146,6 @@ class Query implements QueryInterface
     /**
      * Returns the final, processed query string after binding, etal
      * has been performed.
-     *
-     * @return string
      */
     public function getQuery(): string
     {
@@ -172,7 +163,6 @@ class Query implements QueryInterface
      * for it's start and end values. If no end value is present, will
      * use the current time to determine total duration.
      *
-     * @param float $start
      * @param float $end
      *
      * @return $this
@@ -193,9 +183,6 @@ class Query implements QueryInterface
     /**
      * Returns the start time in seconds with microseconds.
      *
-     * @param bool $returnRaw
-     * @param int  $decimals
-     *
      * @return float|string
      */
     public function getStartTime(bool $returnRaw = false, int $decimals = 6)
@@ -212,8 +199,6 @@ class Query implements QueryInterface
      * the query has not been executed yet.
      *
      * @param int $decimals The accuracy of the returned time.
-     *
-     * @return string
      */
     public function getDuration(int $decimals = 6): string
     {
@@ -222,9 +207,6 @@ class Query implements QueryInterface
 
     /**
      * Stores the error description that happened for this query.
-     *
-     * @param int    $code
-     * @param string $error
      *
      * @return $this
      */
@@ -238,8 +220,6 @@ class Query implements QueryInterface
 
     /**
      * Reports whether this statement created an error not.
-     *
-     * @return bool
      */
     public function hasError(): bool
     {
@@ -248,8 +228,6 @@ class Query implements QueryInterface
 
     /**
      * Returns the error code created while executing this statement.
-     *
-     * @return int
      */
     public function getErrorCode(): int
     {
@@ -258,8 +236,6 @@ class Query implements QueryInterface
 
     /**
      * Returns the error message created while executing this statement.
-     *
-     * @return string
      */
     public function getErrorMessage(): string
     {
@@ -268,8 +244,6 @@ class Query implements QueryInterface
 
     /**
      * Determines if the statement is a write-type query or not.
-     *
-     * @return bool
      */
     public function isWriteType(): bool
     {
@@ -278,9 +252,6 @@ class Query implements QueryInterface
 
     /**
      * Swaps out one table prefix for a new one.
-     *
-     * @param string $orig
-     * @param string $swap
      *
      * @return $this
      */
@@ -295,8 +266,6 @@ class Query implements QueryInterface
 
     /**
      * Returns the original SQL that was passed into the system.
-     *
-     * @return string
      */
     public function getOriginalQuery(): string
     {
@@ -347,11 +316,6 @@ class Query implements QueryInterface
 
     /**
      * Match bindings
-     *
-     * @param string $sql
-     * @param array  $binds
-     *
-     * @return string
      */
     protected function matchNamedBinds(string $sql, array $binds): string
     {
@@ -376,13 +340,6 @@ class Query implements QueryInterface
 
     /**
      * Match bindings
-     *
-     * @param string $sql
-     * @param array  $binds
-     * @param int    $bindCount
-     * @param int    $ml
-     *
-     * @return string
      */
     protected function matchSimpleBinds(string $sql, array $binds, int $bindCount, int $ml): string
     {
@@ -414,8 +371,6 @@ class Query implements QueryInterface
 
     /**
      * Returns string to display in debug toolbar
-     *
-     * @return string
      */
     public function debugToolbarDisplay(): string
     {
@@ -469,8 +424,6 @@ class Query implements QueryInterface
 
     /**
      * Return text representation of the query
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/system/Database/QueryInterface.php
+++ b/system/Database/QueryInterface.php
@@ -22,9 +22,7 @@ interface QueryInterface
     /**
      * Sets the raw query string to use for this statement.
      *
-     * @param string $sql
-     * @param mixed  $binds
-     * @param bool   $setEscape
+     * @param mixed $binds
      *
      * @return mixed
      */
@@ -43,7 +41,6 @@ interface QueryInterface
      * for it's start and end values. If no end value is present, will
      * use the current time to determine total duration.
      *
-     * @param float $start
      * @param float $end
      *
      * @return mixed
@@ -55,52 +52,36 @@ interface QueryInterface
      * the query has not been executed yet.
      *
      * @param int $decimals The accuracy of the returned time.
-     *
-     * @return string
      */
     public function getDuration(int $decimals = 6): string;
 
     /**
      * Stores the error description that happened for this query.
-     *
-     * @param int    $code
-     * @param string $error
      */
     public function setError(int $code, string $error);
 
     /**
      * Reports whether this statement created an error not.
-     *
-     * @return bool
      */
     public function hasError(): bool;
 
     /**
      * Returns the error code created while executing this statement.
-     *
-     * @return int
      */
     public function getErrorCode(): int;
 
     /**
      * Returns the error message created while executing this statement.
-     *
-     * @return string
      */
     public function getErrorMessage(): string;
 
     /**
      * Determines if the statement is a write-type query or not.
-     *
-     * @return bool
      */
     public function isWriteType(): bool;
 
     /**
      * Swaps out one table prefix for a new one.
-     *
-     * @param string $orig
-     * @param string $swap
      *
      * @return mixed
      */

--- a/system/Database/ResultInterface.php
+++ b/system/Database/ResultInterface.php
@@ -22,8 +22,6 @@ interface ResultInterface
      * 'object', or a custom class name.
      *
      * @param string $type The row type. Either 'array', 'object', or a class name to use
-     *
-     * @return array
      */
     public function getResult(string $type = 'object'): array;
 
@@ -40,8 +38,6 @@ interface ResultInterface
      * Returns the results as an array of arrays.
      *
      * If no results, an empty array is returned.
-     *
-     * @return array
      */
     public function getResultArray(): array;
 
@@ -49,8 +45,6 @@ interface ResultInterface
      * Returns the results as an array of objects.
      *
      * If no results, an empty array is returned.
-     *
-     * @return array
      */
     public function getResultObject(): array;
 
@@ -72,9 +66,6 @@ interface ResultInterface
      *
      * If row doesn't exists, returns null.
      *
-     * @param int    $n
-     * @param string $className
-     *
      * @return mixed
      */
     public function getCustomRowObject(int $n, string $className);
@@ -84,8 +75,6 @@ interface ResultInterface
      *
      * If row doesn't exist, returns null.
      *
-     * @param int $n
-     *
      * @return mixed
      */
     public function getRowArray(int $n = 0);
@@ -94,8 +83,6 @@ interface ResultInterface
      * Returns a single row from the results as an object.
      *
      * If row doesn't exist, returns null.
-     *
-     * @param int $n
      *
      * @return mixed
      */
@@ -114,16 +101,12 @@ interface ResultInterface
     /**
      * Returns the "first" row of the current results.
      *
-     * @param string $type
-     *
      * @return mixed
      */
     public function getFirstRow(string $type = 'object');
 
     /**
      * Returns the "last" row of the current results.
-     *
-     * @param string $type
      *
      * @return mixed
      */
@@ -132,16 +115,12 @@ interface ResultInterface
     /**
      * Returns the "next" row of the current results.
      *
-     * @param string $type
-     *
      * @return mixed
      */
     public function getNextRow(string $type = 'object');
 
     /**
      * Returns the "previous" row of the current results.
-     *
-     * @param string $type
      *
      * @return mixed
      */
@@ -150,30 +129,22 @@ interface ResultInterface
     /**
      * Returns an unbuffered row and move the pointer to the next row.
      *
-     * @param string $type
-     *
      * @return mixed
      */
     public function getUnbufferedRow(string $type = 'object');
 
     /**
      * Gets the number of fields in the result set.
-     *
-     * @return int
      */
     public function getFieldCount(): int;
 
     /**
      * Generates an array of column names in the result set.
-     *
-     * @return array
      */
     public function getFieldNames(): array;
 
     /**
      * Generates an array of objects representing field meta-data.
-     *
-     * @return array
      */
     public function getFieldData(): array;
 
@@ -188,8 +159,6 @@ interface ResultInterface
      * Moves the internal pointer to the desired offset. This is called
      * internally before fetching results to make sure the result set
      * starts at zero.
-     *
-     * @param int $n
      *
      * @return mixed
      */

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -65,8 +65,6 @@ class Builder extends BaseBuilder
      *
      * Groups tables in FROM clauses if needed, so there is no confusion
      * about operator precedence.
-     *
-     * @return string
      */
     protected function _fromTables(): string
     {
@@ -88,8 +86,6 @@ class Builder extends BaseBuilder
      * then this method maps to 'DELETE FROM table'
      *
      * @param string $table The table name
-     *
-     * @return string
      */
     protected function _truncate(string $table): string
     {
@@ -101,7 +97,6 @@ class Builder extends BaseBuilder
      *
      * Generates the JOIN portion of the query
      *
-     * @param string $table
      * @param string $cond   The join condition
      * @param string $type   The type of join
      * @param bool   $escape Whether not to try to escape identifiers
@@ -184,8 +179,6 @@ class Builder extends BaseBuilder
      * @param string $table         The table name
      * @param array  $keys          The insert keys
      * @param array  $unescapedKeys The insert values
-     *
-     * @return string
      */
     protected function _insert(string $table, array $keys, array $unescapedKeys): string
     {
@@ -204,8 +197,6 @@ class Builder extends BaseBuilder
      *
      * @param string $table  the Table name
      * @param array  $values the Update data
-     *
-     * @return string
      */
     protected function _update(string $table, array $values): string
     {
@@ -226,9 +217,6 @@ class Builder extends BaseBuilder
     /**
      * Increments a numeric column by the specified value.
      *
-     * @param string $column
-     * @param int    $value
-     *
      * @return bool
      */
     public function increment(string $column, int $value = 1)
@@ -248,9 +236,6 @@ class Builder extends BaseBuilder
     /**
      * Decrements a numeric column by the specified value.
      *
-     * @param string $column
-     * @param int    $value
-     *
      * @return bool
      */
     public function decrement(string $column, int $value = 1)
@@ -269,10 +254,6 @@ class Builder extends BaseBuilder
 
     /**
      * Get full name of the table
-     *
-     * @param string $table
-     *
-     * @return string
      */
     private function getFullName(string $table): string
     {
@@ -296,8 +277,6 @@ class Builder extends BaseBuilder
      *
      * @param string $fullTable full table name
      * @param string $insert    statement
-     *
-     * @return string
      */
     private function addIdentity(string $fullTable, string $insert): string
     {
@@ -306,11 +285,6 @@ class Builder extends BaseBuilder
 
     /**
      * Local implementation of limit
-     *
-     * @param string $sql
-     * @param bool   $offsetIgnore
-     *
-     * @return string
      */
     protected function _limit(string $sql, bool $offsetIgnore = false): string
     {
@@ -379,8 +353,6 @@ class Builder extends BaseBuilder
      * @param string $table  The table name
      * @param array  $keys   The insert keys
      * @param array  $values The insert values
-     *
-     * @return string
      */
     protected function _replace(string $table, array $keys, array $values): string
     {
@@ -449,8 +421,6 @@ class Builder extends BaseBuilder
      * Handle float return value
      *
      * @param string $select Field name
-     * @param string $alias
-     * @param string $type
      *
      * @return BaseBuilder
      */
@@ -485,8 +455,6 @@ class Builder extends BaseBuilder
      * Delete statement
      *
      * @param string $table The table name
-     *
-     * @return string
      */
     protected function _delete(string $table): string
     {
@@ -498,9 +466,8 @@ class Builder extends BaseBuilder
      *
      * Compiles a delete string and runs the query
      *
-     * @param mixed $where     The where clause
-     * @param int   $limit     The limit clause
-     * @param bool  $resetData
+     * @param mixed $where The where clause
+     * @param int   $limit The limit clause
      *
      * @throws DatabaseException
      *
@@ -541,8 +508,6 @@ class Builder extends BaseBuilder
      * Generates a query string based on which functions were used.
      *
      * @param mixed $selectOverride
-     *
-     * @return string
      */
     protected function compileSelect($selectOverride = false): string
     {
@@ -602,7 +567,6 @@ class Builder extends BaseBuilder
      * @param string $qbKey  'QBWhere' or 'QBHaving'
      * @param mixed  $key
      * @param mixed  $value
-     * @param string $type
      * @param bool   $escape
      *
      * @return $this

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -100,8 +100,6 @@ class Connection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @param bool $persistent
-     *
      * @throws DatabaseException
      *
      * @return mixed
@@ -173,10 +171,6 @@ class Connection extends BaseConnection
 
     /**
      * Platform-dependant string escape
-     *
-     * @param string $str
-     *
-     * @return string
      */
     protected function _escapeString(string $str): string
     {
@@ -185,8 +179,6 @@ class Connection extends BaseConnection
 
     /**
      * Insert ID
-     *
-     * @return int
      */
     public function insertID(): int
     {
@@ -195,10 +187,6 @@ class Connection extends BaseConnection
 
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
-     *
-     * @param bool $prefixLimit
-     *
-     * @return string
      */
     protected function _listTables(bool $prefixLimit = false): string
     {
@@ -217,10 +205,6 @@ class Connection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
-     *
-     * @param string $table
-     *
-     * @return string
      */
     protected function _listColumns(string $table = ''): string
     {
@@ -232,8 +216,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns an array of objects with index data
-     *
-     * @param string $table
      *
      * @throws DatabaseException
      *
@@ -274,8 +256,6 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with Foreign key data
      * referenced_object_id  parent_object_id
-     *
-     * @param string $table
      *
      * @throws DatabaseException
      *
@@ -345,8 +325,6 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with field data
      *
-     * @param string $table
-     *
      * @throws DatabaseException
      *
      * @return stdClass[]
@@ -381,8 +359,6 @@ class Connection extends BaseConnection
 
     /**
      * Begin Transaction
-     *
-     * @return bool
      */
     protected function _transBegin(): bool
     {
@@ -391,8 +367,6 @@ class Connection extends BaseConnection
 
     /**
      * Commit Transaction
-     *
-     * @return bool
      */
     protected function _transCommit(): bool
     {
@@ -401,8 +375,6 @@ class Connection extends BaseConnection
 
     /**
      * Rollback Transaction
-     *
-     * @return bool
      */
     protected function _transRollback(): bool
     {
@@ -445,8 +417,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns the total number of rows affected by this query.
-     *
-     * @return int
      */
     public function affectedRows(): int
     {
@@ -455,8 +425,6 @@ class Connection extends BaseConnection
 
     /**
      * Select a specific database table to use.
-     *
-     * @param string|null $databaseName
      *
      * @return mixed
      */
@@ -482,8 +450,6 @@ class Connection extends BaseConnection
 
     /**
      * Executes the query against the database.
-     *
-     * @param string $sql
      *
      * @return mixed
      */
@@ -539,8 +505,6 @@ class Connection extends BaseConnection
 
     /**
      * The name of the platform in use (MySQLi, mssql, etc)
-     *
-     * @return string
      */
     public function getPlatform(): string
     {
@@ -549,8 +513,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns a string containing the version of the database being used.
-     *
-     * @return string
      */
     public function getVersion(): string
     {
@@ -571,8 +533,6 @@ class Connection extends BaseConnection
      * Overrides BaseConnection::isWriteType, adding additional read query types.
      *
      * @param string $sql An SQL query string
-     *
-     * @return bool
      */
     public function isWriteType($sql): bool
     {

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -100,8 +100,6 @@ class Forge extends BaseForge
      * CREATE TABLE attributes
      *
      * @param array $attributes Associative array of table attributes
-     *
-     * @return string
      */
     protected function _createTableAttributes(array $attributes): string
     {
@@ -194,9 +192,6 @@ class Forge extends BaseForge
     /**
      * Drop index for table
      *
-     * @param string $table
-     * @param object $indexData
-     *
      * @return mixed
      */
     protected function _dropIndex(string $table, object $indexData)
@@ -212,10 +207,6 @@ class Forge extends BaseForge
 
     /**
      * Process column
-     *
-     * @param array $field
-     *
-     * @return string
      */
     protected function _processColumn(array $field): string
     {
@@ -233,8 +224,6 @@ class Forge extends BaseForge
      * Process foreign keys
      *
      * @param string $table Table name
-     *
-     * @return string
      */
     protected function _processForeignKeys(string $table): string
     {
@@ -273,8 +262,6 @@ class Forge extends BaseForge
      * Process primary keys
      *
      * @param string $table Table name
-     *
-     * @return string
      */
     protected function _processPrimaryKeys(string $table): string
     {
@@ -296,8 +283,6 @@ class Forge extends BaseForge
      * Field attribute TYPE
      *
      * Performs a data type mapping between different databases.
-     *
-     * @param array $attributes
      *
      * @return void
      */
@@ -339,9 +324,6 @@ class Forge extends BaseForge
     /**
      * Field attribute AUTO_INCREMENT
      *
-     * @param array $attributes
-     * @param array $field
-     *
      * @return void
      */
     protected function _attributeAutoIncrement(array &$attributes, array &$field)
@@ -360,9 +342,6 @@ class Forge extends BaseForge
      *
      * @param string $table    Table name
      * @param bool   $ifExists Whether to add an IF EXISTS condition
-     * @param bool   $cascade
-     *
-     * @return string
      */
     protected function _dropTable(string $table, bool $ifExists, bool $cascade): string
     {

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -41,8 +41,7 @@ class PreparedQuery extends BasePreparedQuery
      * NOTE: This version is based on SQL code. Child classes should
      * override this method.
      *
-     * @param string $sql
-     * @param array  $options Options takes an associative array;
+     * @param array $options Options takes an associative array;
      *
      * @throws Exception
      *
@@ -70,10 +69,6 @@ class PreparedQuery extends BasePreparedQuery
     /**
      * Takes a new set of data and runs it against the currently
      * prepared query. Upon success, will return a Results object.
-     *
-     * @param array $data
-     *
-     * @return bool
      */
     public function _execute(array $data): bool
     {
@@ -102,10 +97,6 @@ class PreparedQuery extends BasePreparedQuery
 
     /**
      * Handle parameters
-     *
-     * @param string $queryString
-     *
-     * @return array
      */
     protected function parameterize(string $queryString): array
     {

--- a/system/Database/SQLSRV/Result.php
+++ b/system/Database/SQLSRV/Result.php
@@ -22,8 +22,6 @@ class Result extends BaseResult
 {
     /**
      * Gets the number of fields in the result set.
-     *
-     * @return int
      */
     public function getFieldCount(): int
     {
@@ -32,8 +30,6 @@ class Result extends BaseResult
 
     /**
      * Generates an array of column names in the result set.
-     *
-     * @return array
      */
     public function getFieldNames(): array
     {
@@ -48,8 +44,6 @@ class Result extends BaseResult
 
     /**
      * Generates an array of objects representing field meta-data.
-     *
-     * @return array
      */
     public function getFieldData(): array
     {
@@ -123,8 +117,6 @@ class Result extends BaseResult
      * internally before fetching results to make sure the result set
      * starts at zero.
      *
-     * @param int $n
-     *
      * @return mixed
      */
     public function dataSeek(int $n = 0)
@@ -156,8 +148,6 @@ class Result extends BaseResult
      * Returns the result set as an object.
      *
      * Overridden by child classes.
-     *
-     * @param string $className
      *
      * @return bool|Entity|object
      */

--- a/system/Database/SQLSRV/Utils.php
+++ b/system/Database/SQLSRV/Utils.php
@@ -36,8 +36,6 @@ class Utils extends BaseUtils
     /**
      * Platform dependent version of the backup function.
      *
-     * @param array|null $prefs
-     *
      * @return mixed
      */
     public function _backup(?array $prefs = null)

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -58,8 +58,6 @@ class Builder extends BaseBuilder
      * @param string $table  the table name
      * @param array  $keys   the insert keys
      * @param array  $values the insert values
-     *
-     * @return string
      */
     protected function _replace(string $table, array $keys, array $values): string
     {
@@ -73,10 +71,6 @@ class Builder extends BaseBuilder
      *
      * If the database does not support the TRUNCATE statement,
      * then this method maps to 'DELETE FROM table'
-     *
-     * @param string $table
-     *
-     * @return string
      */
     protected function _truncate(string $table): string
     {

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -40,8 +40,6 @@ class Connection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @param bool $persistent
-     *
      * @throws DatabaseException
      *
      * @return mixed
@@ -89,10 +87,6 @@ class Connection extends BaseConnection
 
     /**
      * Select a specific database table to use.
-     *
-     * @param string $databaseName
-     *
-     * @return bool
      */
     public function setDatabase(string $databaseName): bool
     {
@@ -101,8 +95,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns a string containing the version of the database being used.
-     *
-     * @return string
      */
     public function getVersion(): string
     {
@@ -117,8 +109,6 @@ class Connection extends BaseConnection
 
     /**
      * Execute the query
-     *
-     * @param string $sql
      *
      * @return mixed \SQLite3Result object or bool
      */
@@ -140,8 +130,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns the total number of rows affected by this query.
-     *
-     * @return int
      */
     public function affectedRows(): int
     {
@@ -150,10 +138,6 @@ class Connection extends BaseConnection
 
     /**
      * Platform-dependant string escape
-     *
-     * @param string $str
-     *
-     * @return string
      */
     protected function _escapeString(string $str): string
     {
@@ -162,10 +146,6 @@ class Connection extends BaseConnection
 
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
-     *
-     * @param bool $prefixLimit
-     *
-     * @return string
      */
     protected function _listTables(bool $prefixLimit = false): string
     {
@@ -178,10 +158,6 @@ class Connection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
-     *
-     * @param string $table
-     *
-     * @return string
      */
     protected function _listColumns(string $table = ''): string
     {
@@ -237,8 +213,6 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with field data
      *
-     * @param string $table
-     *
      * @throws DatabaseException
      *
      * @return stdClass[]
@@ -273,8 +247,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns an array of objects with index data
-     *
-     * @param string $table
      *
      * @throws DatabaseException
      *
@@ -318,8 +290,6 @@ class Connection extends BaseConnection
 
     /**
      * Returns an array of objects with Foreign key data
-     *
-     * @param string $table
      *
      * @return stdClass[]
      */
@@ -391,8 +361,6 @@ class Connection extends BaseConnection
 
     /**
      * Insert ID
-     *
-     * @return int
      */
     public function insertID(): int
     {
@@ -401,8 +369,6 @@ class Connection extends BaseConnection
 
     /**
      * Begin Transaction
-     *
-     * @return bool
      */
     protected function _transBegin(): bool
     {
@@ -411,8 +377,6 @@ class Connection extends BaseConnection
 
     /**
      * Commit Transaction
-     *
-     * @return bool
      */
     protected function _transCommit(): bool
     {
@@ -421,8 +385,6 @@ class Connection extends BaseConnection
 
     /**
      * Rollback Transaction
-     *
-     * @return bool
      */
     protected function _transRollback(): bool
     {
@@ -432,8 +394,6 @@ class Connection extends BaseConnection
     /**
      * Checks to see if the current install supports Foreign Keys
      * and has them enabled.
-     *
-     * @return bool
      */
     public function supportsForeignKeys(): bool
     {

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -38,8 +38,6 @@ class Forge extends BaseForge
 
     /**
      * Constructor.
-     *
-     * @param BaseConnection $db
      */
     public function __construct(BaseConnection $db)
     {
@@ -54,10 +52,7 @@ class Forge extends BaseForge
     /**
      * Create database
      *
-     * @param string $dbName
-     * @param bool   $ifNotExists Whether to add IF NOT EXISTS condition
-     *
-     * @return bool
+     * @param bool $ifNotExists Whether to add IF NOT EXISTS condition
      */
     public function createDatabase(string $dbName, bool $ifNotExists = false): bool
     {
@@ -69,11 +64,7 @@ class Forge extends BaseForge
     /**
      * Drop database
      *
-     * @param string $dbName
-     *
      * @throws DatabaseException
-     *
-     * @return bool
      */
     public function dropDatabase(string $dbName): bool
     {
@@ -142,10 +133,6 @@ class Forge extends BaseForge
 
     /**
      * Process column
-     *
-     * @param array $field
-     *
-     * @return string
      */
     protected function _processColumn(array $field): string
     {
@@ -164,10 +151,6 @@ class Forge extends BaseForge
 
     /**
      * Process indexes
-     *
-     * @param string $table
-     *
-     * @return array
      */
     protected function _processIndexes(string $table): array
     {
@@ -206,8 +189,6 @@ class Forge extends BaseForge
      *
      * Performs a data type mapping between different databases.
      *
-     * @param array $attributes
-     *
      * @return void
      */
     protected function _attributeType(array &$attributes)
@@ -225,9 +206,6 @@ class Forge extends BaseForge
 
     /**
      * Field attribute AUTO_INCREMENT
-     *
-     * @param array $attributes
-     * @param array $field
      *
      * @return void
      */
@@ -252,8 +230,6 @@ class Forge extends BaseForge
      * @param string $foreignName Foreign name
      *
      * @throws DatabaseException
-     *
-     * @return bool
      */
     public function dropForeignKey(string $table, string $foreignName): bool
     {

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -33,9 +33,8 @@ class PreparedQuery extends BasePreparedQuery
      * NOTE: This version is based on SQL code. Child classes should
      * override this method.
      *
-     * @param string $sql
-     * @param array  $options Passed to the connection's prepare statement.
-     *                        Unused in the MySQLi driver.
+     * @param array $options Passed to the connection's prepare statement.
+     *                       Unused in the MySQLi driver.
      *
      * @return mixed
      */
@@ -54,10 +53,6 @@ class PreparedQuery extends BasePreparedQuery
      * prepared query. Upon success, will return a Results object.
      *
      * @todo finalize()
-     *
-     * @param array $data
-     *
-     * @return bool
      */
     public function _execute(array $data): bool
     {

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -24,8 +24,6 @@ class Result extends BaseResult
 {
     /**
      * Gets the number of fields in the result set.
-     *
-     * @return int
      */
     public function getFieldCount(): int
     {
@@ -34,8 +32,6 @@ class Result extends BaseResult
 
     /**
      * Generates an array of column names in the result set.
-     *
-     * @return array
      */
     public function getFieldNames(): array
     {
@@ -50,8 +46,6 @@ class Result extends BaseResult
 
     /**
      * Generates an array of objects representing field meta-data.
-     *
-     * @return array
      */
     public function getFieldData(): array
     {
@@ -98,8 +92,6 @@ class Result extends BaseResult
      * internally before fetching results to make sure the result set
      * starts at zero.
      *
-     * @param int $n
-     *
      * @throws DatabaseException
      *
      * @return mixed
@@ -129,8 +121,6 @@ class Result extends BaseResult
      * Returns the result set as an object.
      *
      * Overridden by child classes.
-     *
-     * @param string $className
      *
      * @return bool|object
      */

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -75,9 +75,6 @@ class Table
 
     /**
      * Table constructor.
-     *
-     * @param Connection $db
-     * @param Forge      $forge
      */
     public function __construct(Connection $db, Forge $forge)
     {
@@ -89,8 +86,6 @@ class Table
      * Reads an existing database table and
      * collects all of the information needed to
      * recreate this table.
-     *
-     * @param string $table
      *
      * @return Table
      */
@@ -125,8 +120,6 @@ class Table
      * to finalize the action. It creates a temp table, creates the new
      * table with modifications, and copies the data over to the new table.
      * Resets the connection dataCache to be sure changes are collected.
-     *
-     * @return bool
      */
     public function run(): bool
     {
@@ -182,8 +175,6 @@ class Table
      * Modifies a field, including changing data type,
      * renaming, etc.
      *
-     * @param array $field
-     *
      * @return Table
      */
     public function modifyColumn(array $field)
@@ -201,8 +192,6 @@ class Table
     /**
      * Drops a foreign key from this table so that
      * it won't be recreated in the future.
-     *
-     * @param string $column
      *
      * @return Table
      */

--- a/system/Database/SQLite3/Utils.php
+++ b/system/Database/SQLite3/Utils.php
@@ -29,8 +29,6 @@ class Utils extends BaseUtils
     /**
      * Platform dependent version of the backup function.
      *
-     * @param array|null $prefs
-     *
      * @return mixed
      */
     public function _backup(?array $prefs = null)

--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -73,9 +73,6 @@ class Seeder
 
     /**
      * Seeder constructor.
-     *
-     * @param Database            $config
-     * @param BaseConnection|null $db
      */
     public function __construct(Database $config, ?BaseConnection $db = null)
     {
@@ -101,8 +98,6 @@ class Seeder
 
     /**
      * Gets the Faker Generator instance.
-     *
-     * @return Generator|null
      */
     public static function faker(): ?Generator
     {
@@ -115,8 +110,6 @@ class Seeder
 
     /**
      * Loads the specified seeder and runs it.
-     *
-     * @param string $class
      *
      * @throws InvalidArgumentException
      *
@@ -163,8 +156,6 @@ class Seeder
     /**
      * Sets the location of the directory that seed files can be located in.
      *
-     * @param string $path
-     *
      * @return $this
      */
     public function setPath(string $path)
@@ -176,8 +167,6 @@ class Seeder
 
     /**
      * Sets the silent treatment.
-     *
-     * @param bool $silent
      *
      * @return $this
      */

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -66,10 +66,6 @@ class Exceptions
 
     /**
      * Constructor.
-     *
-     * @param ExceptionsConfig $config
-     * @param IncomingRequest  $request
-     * @param Response         $response
      */
     public function __construct(ExceptionsConfig $config, IncomingRequest $request, Response $response)
     {
@@ -104,8 +100,6 @@ class Exceptions
      * Catches any uncaught errors and exceptions, including most Fatal errors
      * (Yay PHP7!). Will log the error, display it if display_errors is on,
      * and fire an event that allows custom actions to be taken at this point.
-     *
-     * @param Throwable $exception
      *
      * @codeCoverageIgnore
      */
@@ -147,11 +141,6 @@ class Exceptions
      *
      * This seems to be primarily when a user triggers it with trigger_error().
      *
-     * @param int         $severity
-     * @param string      $message
-     * @param string|null $file
-     * @param int|null    $line
-     *
      * @throws ErrorException
      */
     public function errorHandler(int $severity, string $message, ?string $file = null, ?int $line = null)
@@ -185,9 +174,6 @@ class Exceptions
      * Determines the view to display based on the exception thrown,
      * whether an HTTP or CLI request, etc.
      *
-     * @param Throwable $exception
-     * @param string    $templatePath
-     *
      * @return string The path and filename of the view file to use
      */
     protected function determineView(Throwable $exception, string $templatePath): string
@@ -215,9 +201,6 @@ class Exceptions
 
     /**
      * Given an exception and status code will display the error to the client.
-     *
-     * @param Throwable $exception
-     * @param int       $statusCode
      */
     protected function render(Throwable $exception, int $statusCode)
     {
@@ -257,11 +240,6 @@ class Exceptions
 
     /**
      * Gathers the variables that will be made available to the view.
-     *
-     * @param Throwable $exception
-     * @param int       $statusCode
-     *
-     * @return array
      */
     protected function collectVars(Throwable $exception, int $statusCode): array
     {
@@ -285,8 +263,6 @@ class Exceptions
      * Mask sensitive data in the trace.
      *
      * @param array|object $trace
-     * @param array        $keysToMask
-     * @param string       $path
      */
     protected function maskSensitiveData(&$trace, array $keysToMask, string $path = '')
     {
@@ -316,10 +292,6 @@ class Exceptions
 
     /**
      * Determines the HTTP status code and the exit status code for this request.
-     *
-     * @param Throwable $exception
-     *
-     * @return array
      */
     protected function determineCodes(Throwable $exception): array
     {
@@ -349,10 +321,6 @@ class Exceptions
      * Clean Path
      *
      * This makes nicer looking paths for the error output.
-     *
-     * @param string $file
-     *
-     * @return string
      */
     public static function cleanPath(string $file): string
     {
@@ -380,10 +348,6 @@ class Exceptions
     /**
      * Describes memory usage in real-world units. Intended for use
      * with memory_get_usage, etc.
-     *
-     * @param int $bytes
-     *
-     * @return string
      */
     public static function describeMemory(int $bytes): string
     {
@@ -399,10 +363,6 @@ class Exceptions
 
     /**
      * Creates a syntax-highlighted version of a PHP file.
-     *
-     * @param string $file
-     * @param int    $lineNumber
-     * @param int    $lines
      *
      * @return bool|string
      */

--- a/system/Debug/Iterator.php
+++ b/system/Debug/Iterator.php
@@ -38,9 +38,6 @@ class Iterator
      * Tests are simply closures that the user can define any sequence of
      * things to happen during the test.
      *
-     * @param string  $name
-     * @param Closure $closure
-     *
      * @return $this
      */
     public function add(string $name, Closure $closure)
@@ -56,9 +53,6 @@ class Iterator
      * Runs through all of the tests that have been added, recording
      * time to execute the desired number of iterations, and the approximate
      * memory usage used during those iterations.
-     *
-     * @param int  $iterations
-     * @param bool $output
      *
      * @return string|null
      */
@@ -94,8 +88,6 @@ class Iterator
 
     /**
      * Get results.
-     *
-     * @return string
      */
     public function getReport(): string
     {

--- a/system/Debug/Timer.php
+++ b/system/Debug/Timer.php
@@ -103,8 +103,6 @@ class Timer
      * Returns the array of timers, with the duration pre-calculated for you.
      *
      * @param int $decimals Number of decimal places
-     *
-     * @return array
      */
     public function getTimers(int $decimals = 4): array
     {
@@ -123,10 +121,6 @@ class Timer
 
     /**
      * Checks whether or not a timer with the specified name exists.
-     *
-     * @param string $name
-     *
-     * @return bool
      */
     public function has(string $name): bool
     {

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -51,8 +51,6 @@ class Toolbar
 
     /**
      * Constructor
-     *
-     * @param ToolbarConfig $config
      */
     public function __construct(ToolbarConfig $config)
     {
@@ -73,10 +71,7 @@ class Toolbar
     /**
      * Returns all the data required by Debug Bar
      *
-     * @param float             $startTime App start time
-     * @param float             $totalTime
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
+     * @param float $startTime App start time
      *
      * @return string JSON encoded data
      */
@@ -177,14 +172,6 @@ class Toolbar
 
     /**
      * Called within the view to display the timeline itself.
-     *
-     * @param array $collectors
-     * @param float $startTime
-     * @param int   $segmentCount
-     * @param int   $segmentDuration
-     * @param array $styles
-     *
-     * @return string
      */
     protected function renderTimeline(array $collectors, float $startTime, int $segmentCount, int $segmentDuration, array &$styles): string
     {
@@ -219,8 +206,6 @@ class Toolbar
      * Returns a sorted array of timeline data arrays from the collectors.
      *
      * @param array $collectors
-     *
-     * @return array
      */
     protected function collectTimelineData($collectors): array
     {
@@ -243,8 +228,6 @@ class Toolbar
     /**
      * Returns an array of data from all of the modules
      * that should be displayed in the 'Vars' tab.
-     *
-     * @return array
      */
     protected function collectVarData(): array
     {
@@ -263,11 +246,6 @@ class Toolbar
 
     /**
      * Rounds a number to the nearest incremental value.
-     *
-     * @param float $number
-     * @param int   $increments
-     *
-     * @return float
      */
     protected function roundTo(float $number, int $increments = 5): float
     {
@@ -422,8 +400,6 @@ class Toolbar
      *
      * @param string $data   JSON encoded Toolbar data
      * @param string $format html, json, xml
-     *
-     * @return string
      */
     protected function format(string $data, string $format = 'html'): string
     {

--- a/system/Debug/Toolbar/Collectors/BaseCollector.php
+++ b/system/Debug/Toolbar/Collectors/BaseCollector.php
@@ -60,10 +60,6 @@ class BaseCollector
 
     /**
      * Gets the Collector's title.
-     *
-     * @param bool $safe
-     *
-     * @return string
      */
     public function getTitle(bool $safe = false): string
     {
@@ -76,8 +72,6 @@ class BaseCollector
 
     /**
      * Returns any information that should be shown next to the title.
-     *
-     * @return string
      */
     public function getTitleDetails(): string
     {
@@ -86,8 +80,6 @@ class BaseCollector
 
     /**
      * Does this collector need it's own tab?
-     *
-     * @return bool
      */
     public function hasTabContent(): bool
     {
@@ -96,8 +88,6 @@ class BaseCollector
 
     /**
      * Does this collector have a label?
-     *
-     * @return bool
      */
     public function hasLabel(): bool
     {
@@ -106,8 +96,6 @@ class BaseCollector
 
     /**
      * Does this collector have information for the timeline?
-     *
-     * @return bool
      */
     public function hasTimelineData(): bool
     {
@@ -117,8 +105,6 @@ class BaseCollector
     /**
      * Grabs the data for the timeline, properly formatted,
      * or returns an empty array.
-     *
-     * @return array
      */
     public function timelineData(): array
     {
@@ -132,8 +118,6 @@ class BaseCollector
     /**
      * Does this Collector have data that should be shown in the
      * 'Vars' tab?
-     *
-     * @return bool
      */
     public function hasVarData(): bool
     {
@@ -173,8 +157,6 @@ class BaseCollector
      *      'start'     => 10       // milliseconds
      *      'duration'  => 15       // milliseconds
      *  ]
-     *
-     * @return array
      */
     protected function formatTimelineData(): array
     {
@@ -195,10 +177,6 @@ class BaseCollector
      * Clean Path
      *
      * This makes nicer looking paths for the error output.
-     *
-     * @param string $file
-     *
-     * @return string
      */
     public function cleanPath(string $file): string
     {
@@ -217,8 +195,6 @@ class BaseCollector
      * Does this collector have any data collected?
      *
      * If not, then the toolbar button won't get shown.
-     *
-     * @return bool
      */
     public function isEmpty(): bool
     {
@@ -230,8 +206,6 @@ class BaseCollector
      * be SVG, or a base-64 encoded.
      *
      * Recommended dimensions are 24px x 24px
-     *
-     * @return string
      */
     public function icon(): string
     {
@@ -240,8 +214,6 @@ class BaseCollector
 
     /**
      * Return settings as an array.
-     *
-     * @return array
      */
     public function getAsArray(): array
     {

--- a/system/Debug/Toolbar/Collectors/Config.php
+++ b/system/Debug/Toolbar/Collectors/Config.php
@@ -22,8 +22,6 @@ class Config
 {
     /**
      * Return toolbar config values as an array.
-     *
-     * @return array
      */
     public static function display(): array
     {

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -73,8 +73,6 @@ class Database extends BaseCollector
      * The static method used during Events to collect
      * data.
      *
-     * @param Query $query
-     *
      * @internal param $ array \CodeIgniter\Database\Query
      */
     public static function collect(Query $query)
@@ -122,8 +120,6 @@ class Database extends BaseCollector
 
     /**
      * Returns the data of this collector to be formatted in the toolbar
-     *
-     * @return array
      */
     public function display(): array
     {
@@ -139,8 +135,6 @@ class Database extends BaseCollector
 
     /**
      * Gets the "badge" value for the button.
-     *
-     * @return int
      */
     public function getBadgeValue(): int
     {
@@ -160,8 +154,6 @@ class Database extends BaseCollector
 
     /**
      * Does this collector have any data collected?
-     *
-     * @return bool
      */
     public function isEmpty(): bool
     {
@@ -172,8 +164,6 @@ class Database extends BaseCollector
      * Display the icon.
      *
      * Icon from https://icons8.com - 1em package
-     *
-     * @return string
      */
     public function icon(): string
     {

--- a/system/Debug/Toolbar/Collectors/Events.php
+++ b/system/Debug/Toolbar/Collectors/Events.php
@@ -69,8 +69,6 @@ class Events extends BaseCollector
     /**
      * Child classes should implement this to return the timeline data
      * formatted for correct usage.
-     *
-     * @return array
      */
     protected function formatTimelineData(): array
     {
@@ -92,8 +90,6 @@ class Events extends BaseCollector
 
     /**
      * Returns the data of this collector to be formatted in the toolbar
-     *
-     * @return array
      */
     public function display(): array
     {
@@ -127,8 +123,6 @@ class Events extends BaseCollector
 
     /**
      * Gets the "badge" value for the button.
-     *
-     * @return int
      */
     public function getBadgeValue(): int
     {
@@ -139,8 +133,6 @@ class Events extends BaseCollector
      * Display the icon.
      *
      * Icon from https://icons8.com - 1em package
-     *
-     * @return string
      */
     public function icon(): string
     {

--- a/system/Debug/Toolbar/Collectors/Files.php
+++ b/system/Debug/Toolbar/Collectors/Files.php
@@ -42,8 +42,6 @@ class Files extends BaseCollector
 
     /**
      * Returns any information that should be shown next to the title.
-     *
-     * @return string
      */
     public function getTitleDetails(): string
     {
@@ -52,8 +50,6 @@ class Files extends BaseCollector
 
     /**
      * Returns the data of this collector to be formatted in the toolbar
-     *
-     * @return array
      */
     public function display(): array
     {
@@ -88,8 +84,6 @@ class Files extends BaseCollector
 
     /**
      * Displays the number of included files as a badge in the tab button.
-     *
-     * @return int
      */
     public function getBadgeValue(): int
     {
@@ -100,8 +94,6 @@ class Files extends BaseCollector
      * Display the icon.
      *
      * Icon from https://icons8.com - 1em package
-     *
-     * @return string
      */
     public function icon(): string
     {

--- a/system/Debug/Toolbar/Collectors/History.php
+++ b/system/Debug/Toolbar/Collectors/History.php
@@ -103,8 +103,6 @@ class History extends BaseCollector
 
     /**
      * Returns the data of this collector to be formatted in the toolbar
-     *
-     * @return array
      */
     public function display(): array
     {
@@ -113,8 +111,6 @@ class History extends BaseCollector
 
     /**
      * Displays the number of included files as a badge in the tab button.
-     *
-     * @return int
      */
     public function getBadgeValue(): int
     {
@@ -123,8 +119,6 @@ class History extends BaseCollector
 
     /**
      * Return true if there are no history files.
-     *
-     * @return bool
      */
     public function isEmpty(): bool
     {
@@ -135,8 +129,6 @@ class History extends BaseCollector
      * Display the icon.
      *
      * Icon from https://icons8.com - 1em package
-     *
-     * @return string
      */
     public function icon(): string
     {

--- a/system/Debug/Toolbar/Collectors/Logs.php
+++ b/system/Debug/Toolbar/Collectors/Logs.php
@@ -51,8 +51,6 @@ class Logs extends BaseCollector
 
     /**
      * Returns the data of this collector to be formatted in the toolbar
-     *
-     * @return array
      */
     public function display(): array
     {
@@ -63,8 +61,6 @@ class Logs extends BaseCollector
 
     /**
      * Does this collector actually have any data to display?
-     *
-     * @return bool
      */
     public function isEmpty(): bool
     {
@@ -77,8 +73,6 @@ class Logs extends BaseCollector
      * Display the icon.
      *
      * Icon from https://icons8.com - 1em package
-     *
-     * @return string
      */
     public function icon(): string
     {

--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -49,8 +49,6 @@ class Routes extends BaseCollector
      * Returns the data of this collector to be formatted in the toolbar
      *
      * @throws ReflectionException
-     *
-     * @return array
      */
     public function display(): array
     {
@@ -135,8 +133,6 @@ class Routes extends BaseCollector
 
     /**
      * Returns a count of all the routes in the system.
-     *
-     * @return int
      */
     public function getBadgeValue(): int
     {
@@ -149,8 +145,6 @@ class Routes extends BaseCollector
      * Display the icon.
      *
      * Icon from https://icons8.com - 1em package
-     *
-     * @return string
      */
     public function icon(): string
     {

--- a/system/Debug/Toolbar/Collectors/Timers.php
+++ b/system/Debug/Toolbar/Collectors/Timers.php
@@ -45,8 +45,6 @@ class Timers extends BaseCollector
     /**
      * Child classes should implement this to return the timeline data
      * formatted for correct usage.
-     *
-     * @return array
      */
     protected function formatTimelineData(): array
     {

--- a/system/Debug/Toolbar/Collectors/Views.php
+++ b/system/Debug/Toolbar/Collectors/Views.php
@@ -84,8 +84,6 @@ class Views extends BaseCollector
     /**
      * Child classes should implement this to return the timeline data
      * formatted for correct usage.
-     *
-     * @return array
      */
     protected function formatTimelineData(): array
     {
@@ -120,8 +118,6 @@ class Views extends BaseCollector
      *          'bar' => 'baz'
      *      ],
      *  ];
-     *
-     * @return array
      */
     public function getVarData(): array
     {
@@ -133,8 +129,6 @@ class Views extends BaseCollector
 
     /**
      * Returns a count of all views.
-     *
-     * @return int
      */
     public function getBadgeValue(): int
     {
@@ -145,8 +139,6 @@ class Views extends BaseCollector
      * Display the icon.
      *
      * Icon from https://icons8.com - 1em package
-     *
-     * @return string
      */
     public function icon(): string
     {

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -1317,6 +1317,8 @@ class Email
     }
 
     /**
+     * @param mixed $type
+     *
      * @return bool
      */
     protected function attachmentsHaveMultipart($type)

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -179,8 +179,6 @@ class Encryption
      * __isset() magic, providing checking for some of our protected properties
      *
      * @param string $key Property name
-     *
-     * @return bool
      */
     public function __isset($key): bool
     {

--- a/system/Encryption/Exceptions/EncryptionException.php
+++ b/system/Encryption/Exceptions/EncryptionException.php
@@ -35,8 +35,6 @@ class EncryptionException extends RuntimeException implements ExceptionInterface
     /**
      * Thrown when the handler requested is not available.
      *
-     * @param string $handler
-     *
      * @return static
      */
     public static function forNoHandlerAvailable(string $handler)

--- a/system/Encryption/Handlers/BaseHandler.php
+++ b/system/Encryption/Handlers/BaseHandler.php
@@ -29,8 +29,6 @@ abstract class BaseHandler implements EncrypterInterface
 
     /**
      * Constructor
-     *
-     * @param Encryption|null $config
      */
     public function __construct(?Encryption $config = null)
     {
@@ -78,8 +76,6 @@ abstract class BaseHandler implements EncrypterInterface
      * __isset() magic, providing checking for some of our properties
      *
      * @param string $key Property name
-     *
-     * @return bool
      */
     public function __isset($key): bool
     {

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -111,8 +111,6 @@ class Entity implements JsonSerializable
 
     /**
      * Allows filling in Entity parameters during construction.
-     *
-     * @param array|null $data
      */
     public function __construct(?array $data = null)
     {
@@ -151,8 +149,6 @@ class Entity implements JsonSerializable
      * @param bool $onlyChanged If true, only return values that have changed since object creation
      * @param bool $cast        If true, properties will be casted.
      * @param bool $recursive   If true, inner entities will be casted as array as well.
-     *
-     * @return array
      */
     public function toArray(bool $onlyChanged = false, bool $cast = true, bool $recursive = false): array
     {
@@ -197,8 +193,6 @@ class Entity implements JsonSerializable
      *
      * @param bool $onlyChanged If true, only return values that have changed since object creation
      * @param bool $recursive   If true, inner entities will be casted as array as well.
-     *
-     * @return array
      */
     public function toRawArray(bool $onlyChanged = false, bool $recursive = false): array
     {
@@ -257,8 +251,6 @@ class Entity implements JsonSerializable
      * properties have changed.
      *
      * @param string $key
-     *
-     * @return bool
      */
     public function hasChanged(?string $key = null): bool
     {
@@ -283,8 +275,6 @@ class Entity implements JsonSerializable
     /**
      * Set raw data array without any mutations
      *
-     * @param array $data
-     *
      * @return $this
      */
     public function setAttributes(array $data)
@@ -299,8 +289,6 @@ class Entity implements JsonSerializable
     /**
      * Checks the datamap to see if this column name is being mapped,
      * and returns the mapped name, if any, or the original name.
-     *
-     * @param string $key
      *
      * @return mixed|string
      */
@@ -405,7 +393,6 @@ class Entity implements JsonSerializable
      * Cast as JSON
      *
      * @param mixed $value
-     * @param bool  $asArray
      *
      * @throws CastException
      *
@@ -429,8 +416,6 @@ class Entity implements JsonSerializable
     /**
      * Change the value of the private $_cast property
      *
-     * @param bool|null $cast
-     *
      * @return bool|Entity
      */
     public function cast(?bool $cast = null)
@@ -453,7 +438,6 @@ class Entity implements JsonSerializable
      *  $this->my_property = $p;
      *  $this->setMyProperty() = $p;
      *
-     * @param string     $key
      * @param mixed|null $value
      *
      * @throws Exception
@@ -499,8 +483,6 @@ class Entity implements JsonSerializable
      *  $p = $this->my_property
      *  $p = $this->getMyProperty()
      *
-     * @param string $key
-     *
      * @throws Exception
      *
      * @return mixed
@@ -541,10 +523,6 @@ class Entity implements JsonSerializable
     /**
      * Returns true if a property exists names $key, or a getter method
      * exists named like for __get().
-     *
-     * @param string $key
-     *
-     * @return bool
      */
     public function __isset(string $key): bool
     {
@@ -561,10 +539,6 @@ class Entity implements JsonSerializable
 
     /**
      * Unsets an attribute property.
-     *
-     * @param string $key
-     *
-     * @return void
      */
     public function __unset(string $key): void
     {

--- a/system/Entity/Exceptions/CastException.php
+++ b/system/Entity/Exceptions/CastException.php
@@ -21,8 +21,6 @@ class CastException extends FrameworkException
     /**
      * Thrown when the cast class does not extends BaseCast.
      *
-     * @param string $class
-     *
      * @return static
      */
     public static function forInvalidInterface(string $class)
@@ -32,8 +30,6 @@ class CastException extends FrameworkException
 
     /**
      * Thrown when the Json format is invalid.
-     *
-     * @param int $error
      *
      * @return static
      */
@@ -62,8 +58,6 @@ class CastException extends FrameworkException
 
     /**
      * Thrown when the cast method is not `get` or `set`.
-     *
-     * @param string $method
      *
      * @return static
      */

--- a/system/Events/Events.php
+++ b/system/Events/Events.php
@@ -139,8 +139,6 @@ class Events
      *
      * @param string $eventName
      * @param mixed  $arguments
-     *
-     * @return bool
      */
     public static function trigger($eventName, ...$arguments): bool
     {
@@ -177,8 +175,6 @@ class Events
      * sorted by priority.
      *
      * @param string $eventName
-     *
-     * @return array
      */
     public static function listeners($eventName): array
     {
@@ -204,10 +200,7 @@ class Events
      * If the listener couldn't be found, returns FALSE, else TRUE if
      * it was removed.
      *
-     * @param string   $eventName
-     * @param callable $listener
-     *
-     * @return bool
+     * @param string $eventName
      */
     public static function removeListener($eventName, callable $listener): bool
     {
@@ -251,8 +244,6 @@ class Events
     /**
      * Sets the path to the file that routes are read from.
      *
-     * @param array $files
-     *
      * @return void
      */
     public static function setFiles(array $files)
@@ -274,8 +265,6 @@ class Events
      * Turns simulation on or off. When on, events will not be triggered,
      * simply logged. Useful during testing when you don't actually want
      * the tests to run.
-     *
-     * @param bool $choice
      *
      * @return void
      */

--- a/system/Exceptions/DebugTraceableTrait.php
+++ b/system/Exceptions/DebugTraceableTrait.php
@@ -24,10 +24,6 @@ trait DebugTraceableTrait
     /**
      * Tweaks the exception's constructor to assign the file/line to where
      * it is actually raised rather than were it is instantiated.
-     *
-     * @param string         $message
-     * @param int            $code
-     * @param Throwable|null $previous
      */
     final public function __construct(string $message = '', int $code = 0, ?Throwable $previous = null)
     {

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -38,9 +38,6 @@ class File extends SplFileInfo
     /**
      * Run our SplFileInfo constructor with an optional verification
      * that the path is really a file.
-     *
-     * @param string $path
-     * @param bool   $checkFile
      */
     public function __construct(string $path, bool $checkFile = false)
     {
@@ -68,8 +65,6 @@ class File extends SplFileInfo
     /**
      * Retrieve the file size by unit.
      *
-     * @param string $unit
-     *
      * @return int|string
      */
     public function getSizeByUnit(string $unit = 'b')
@@ -89,8 +84,6 @@ class File extends SplFileInfo
     /**
      * Attempts to determine the file extension based on the trusted
      * getType() method. If the mime type is unknown, will return null.
-     *
-     * @return string|null
      */
     public function guessExtension(): ?string
     {
@@ -122,8 +115,6 @@ class File extends SplFileInfo
     /**
      * Generates a random names based on a simple hash and the time, with
      * the correct file extension attached.
-     *
-     * @return string
      */
     public function getRandomName(): string
     {
@@ -135,10 +126,6 @@ class File extends SplFileInfo
 
     /**
      * Moves a file to a new location.
-     *
-     * @param string      $targetPath
-     * @param string|null $name
-     * @param bool        $overwrite
      *
      * @return File
      */
@@ -167,12 +154,6 @@ class File extends SplFileInfo
      * First, it checks whether the delimiter is present in the filename, if it is, then it checks whether the
      * last element is an integer as there may be cases that the delimiter may be present in the filename.
      * For the all other cases, it appends an integer starting from zero before the file's extension.
-     *
-     * @param string $destination
-     * @param string $delimiter
-     * @param int    $i
-     *
-     * @return string
      */
     public function getDestination(string $destination, string $delimiter = '_', int $i = 0): string
     {

--- a/system/Filters/Exceptions/FilterException.php
+++ b/system/Filters/Exceptions/FilterException.php
@@ -23,8 +23,6 @@ class FilterException extends ConfigException implements ExceptionInterface
      * Thrown when the provided alias is not within
      * the list of configured filter aliases.
      *
-     * @param string $alias
-     *
      * @return static
      */
     public static function forNoAlias(string $alias)
@@ -34,8 +32,6 @@ class FilterException extends ConfigException implements ExceptionInterface
 
     /**
      * Thrown when the filter class does not implement FilterInterface.
-     *
-     * @param string $class
      *
      * @return static
      */

--- a/system/Filters/FilterInterface.php
+++ b/system/Filters/FilterInterface.php
@@ -29,8 +29,7 @@ interface FilterInterface
      * sent back to the client, allowing for error pages,
      * redirects, etc.
      *
-     * @param RequestInterface $request
-     * @param null             $arguments
+     * @param null $arguments
      *
      * @return mixed
      */
@@ -42,9 +41,7 @@ interface FilterInterface
      * to stop execution of other after filters, short of
      * throwing an Exception or Error.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     * @param null              $arguments
+     * @param null $arguments
      *
      * @return mixed
      */

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -98,10 +98,7 @@ class Filters
     /**
      * Constructor.
      *
-     * @param FiltersConfig     $config
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     * @param Modules|null      $modules
+     * @param FiltersConfig $config
      */
     public function __construct($config, RequestInterface $request, ResponseInterface $response, ?Modules $modules = null)
     {
@@ -143,8 +140,6 @@ class Filters
 
     /**
      * Set the response explicity.
-     *
-     * @param ResponseInterface $response
      */
     public function setResponse(ResponseInterface $response)
     {
@@ -154,9 +149,6 @@ class Filters
     /**
      * Runs through all of the filters for the specified
      * uri and position.
-     *
-     * @param string $uri
-     * @param string $position
      *
      * @throws FilterException
      *
@@ -281,8 +273,6 @@ class Filters
 
     /**
      * Returns the processed filters array.
-     *
-     * @return array
      */
     public function getFilters(): array
     {
@@ -291,8 +281,6 @@ class Filters
 
     /**
      * Returns the filtersClass array.
-     *
-     * @return array
      */
     public function getFiltersClass(): array
     {
@@ -303,11 +291,6 @@ class Filters
      * Adds a new alias to the config file.
      * MUST be called prior to initialize();
      * Intended for use within routes files.
-     *
-     * @param string      $class
-     * @param string|null $alias
-     * @param string      $when
-     * @param string      $section
      *
      * @return $this
      */
@@ -336,9 +319,6 @@ class Filters
      * Filters can have "arguments". This is done by placing a colon immediately
      * after the filter name, followed by a comma-separated list of arguments that
      * are passed to the filter when executed.
-     *
-     * @param string $name
-     * @param string $when
      *
      * @return Filters
      */
@@ -376,8 +356,6 @@ class Filters
 
     /**
      * Returns the arguments for a specified key, or all.
-     *
-     * @param string|null $key
      *
      * @return mixed
      */
@@ -494,8 +472,6 @@ class Filters
 
     /**
      * Maps filter aliases to the equivalent filter classes
-     *
-     * @param string $position
      *
      * @throws FilterException
      *

--- a/system/Filters/Honeypot.php
+++ b/system/Filters/Honeypot.php
@@ -25,8 +25,7 @@ class Honeypot implements FilterInterface
      * Checks if Honeypot field is empty; if not
      * then the requester is a bot
      *
-     * @param RequestInterface $request
-     * @param array|null       $arguments
+     * @param array|null $arguments
      *
      * @return void
      */
@@ -41,9 +40,7 @@ class Honeypot implements FilterInterface
     /**
      * Attach a honeypot to the current response.
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     * @param array|null        $arguments
+     * @param array|null $arguments
      *
      * @return void
      */

--- a/system/Format/Exceptions/FormatException.php
+++ b/system/Format/Exceptions/FormatException.php
@@ -25,8 +25,6 @@ class FormatException extends RuntimeException implements ExceptionInterface
     /**
      * Thrown when the instantiated class does not exist.
      *
-     * @param string $class
-     *
      * @return FormatException
      */
     public static function forInvalidFormatter(string $class)
@@ -50,8 +48,6 @@ class FormatException extends RuntimeException implements ExceptionInterface
     /**
      * Thrown when the supplied MIME type has no
      * defined Formatter class.
-     *
-     * @param string $mime
      *
      * @return FormatException
      */

--- a/system/Format/Format.php
+++ b/system/Format/Format.php
@@ -28,8 +28,6 @@ class Format
 
     /**
      * Constructor.
-     *
-     * @param FormatConfig $config
      */
     public function __construct(FormatConfig $config)
     {
@@ -49,11 +47,7 @@ class Format
     /**
      * A Factory method to return the appropriate formatter for the given mime type.
      *
-     * @param string $mime
-     *
      * @throws FormatException
-     *
-     * @return FormatterInterface
      */
     public function getFormatter(string $mime): FormatterInterface
     {

--- a/system/Format/XMLFormatter.php
+++ b/system/Format/XMLFormatter.php
@@ -55,7 +55,6 @@ class XMLFormatter implements FormatterInterface
      *
      * @see http://www.codexworld.com/convert-array-to-xml-in-php/
      *
-     * @param array            $data
      * @param SimpleXMLElement $output
      */
     protected function arrayToXML(array $data, &$output)

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -52,8 +52,6 @@ class CLIRequest extends Request
 
     /**
      * Constructor
-     *
-     * @param App $config
      */
     public function __construct(App $config)
     {
@@ -81,8 +79,6 @@ class CLIRequest extends Request
      *
      *      // Routes to /users/21/profile (index is removed for routing sake)
      *      // with the option foo = bar.
-     *
-     * @return string
      */
     public function getPath(): string
     {
@@ -94,8 +90,6 @@ class CLIRequest extends Request
     /**
      * Returns an associative array of all CLI options found, with
      * their values.
-     *
-     * @return array
      */
     public function getOptions(): array
     {
@@ -104,8 +98,6 @@ class CLIRequest extends Request
 
     /**
      * Returns the path segments.
-     *
-     * @return array
      */
     public function getSegments(): array
     {
@@ -114,8 +106,6 @@ class CLIRequest extends Request
 
     /**
      * Returns the value for a single CLI option that was passed in.
-     *
-     * @param string $key
      *
      * @return string|null
      */
@@ -135,10 +125,6 @@ class CLIRequest extends Request
      *      ];
      *
      *      getOptionString() = '-foo bar -baz "queue some stuff"'
-     *
-     * @param bool $useLongOpts
-     *
-     * @return string
      */
     public function getOptionString(bool $useLongOpts = false): string
     {
@@ -206,8 +192,6 @@ class CLIRequest extends Request
 
     /**
      * Determines if this request was made from the command line (CLI).
-     *
-     * @return bool
      */
     public function isCLI(): bool
     {

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -79,10 +79,7 @@ class CURLRequest extends Request
      *  - timeout
      *  - any other request options to use as defaults.
      *
-     * @param App               $config
-     * @param URI               $uri
      * @param ResponseInterface $response
-     * @param array             $options
      */
     public function __construct(App $config, URI $uri, ?ResponseInterface $response = null, array $options = [])
     {
@@ -106,10 +103,6 @@ class CURLRequest extends Request
      * URL, it will be merged with $this->baseURI to form a complete URL.
      *
      * @param string $method
-     * @param string $url
-     * @param array  $options
-     *
-     * @return ResponseInterface
      */
     public function request($method, string $url, array $options = []): ResponseInterface
     {
@@ -126,11 +119,6 @@ class CURLRequest extends Request
 
     /**
      * Convenience method for sending a GET request.
-     *
-     * @param string $url
-     * @param array  $options
-     *
-     * @return ResponseInterface
      */
     public function get(string $url, array $options = []): ResponseInterface
     {
@@ -139,11 +127,6 @@ class CURLRequest extends Request
 
     /**
      * Convenience method for sending a DELETE request.
-     *
-     * @param string $url
-     * @param array  $options
-     *
-     * @return ResponseInterface
      */
     public function delete(string $url, array $options = []): ResponseInterface
     {
@@ -152,11 +135,6 @@ class CURLRequest extends Request
 
     /**
      * Convenience method for sending a HEAD request.
-     *
-     * @param string $url
-     * @param array  $options
-     *
-     * @return ResponseInterface
      */
     public function head(string $url, array $options = []): ResponseInterface
     {
@@ -165,11 +143,6 @@ class CURLRequest extends Request
 
     /**
      * Convenience method for sending an OPTIONS request.
-     *
-     * @param string $url
-     * @param array  $options
-     *
-     * @return ResponseInterface
      */
     public function options(string $url, array $options = []): ResponseInterface
     {
@@ -178,11 +151,6 @@ class CURLRequest extends Request
 
     /**
      * Convenience method for sending a PATCH request.
-     *
-     * @param string $url
-     * @param array  $options
-     *
-     * @return ResponseInterface
      */
     public function patch(string $url, array $options = []): ResponseInterface
     {
@@ -191,11 +159,6 @@ class CURLRequest extends Request
 
     /**
      * Convenience method for sending a POST request.
-     *
-     * @param string $url
-     * @param array  $options
-     *
-     * @return ResponseInterface
      */
     public function post(string $url, array $options = []): ResponseInterface
     {
@@ -204,11 +167,6 @@ class CURLRequest extends Request
 
     /**
      * Convenience method for sending a PUT request.
-     *
-     * @param string $url
-     * @param array  $options
-     *
-     * @return ResponseInterface
      */
     public function put(string $url, array $options = []): ResponseInterface
     {
@@ -218,9 +176,7 @@ class CURLRequest extends Request
     /**
      * Set the HTTP Authentication.
      *
-     * @param string $username
-     * @param string $password
-     * @param string $type     basic or digest
+     * @param string $type basic or digest
      *
      * @return $this
      */
@@ -238,8 +194,7 @@ class CURLRequest extends Request
     /**
      * Set form data to be sent.
      *
-     * @param array $params
-     * @param bool  $multipart Set TRUE if you are sending CURLFiles
+     * @param bool $multipart Set TRUE if you are sending CURLFiles
      *
      * @return $this
      */
@@ -271,8 +226,6 @@ class CURLRequest extends Request
     /**
      * Sets the correct settings based on the options array
      * passed in.
-     *
-     * @param array $options
      */
     protected function parseOptions(array $options)
     {
@@ -304,10 +257,6 @@ class CURLRequest extends Request
     /**
      * If the $url is a relative URL, will attempt to create
      * a full URL by prepending $this->baseURI to it.
-     *
-     * @param string $url
-     *
-     * @return string
      */
     protected function prepareURL(string $url): string
     {
@@ -327,8 +276,6 @@ class CURLRequest extends Request
      * since users expect a different answer here.
      *
      * @param bool|false $upper Whether to return in upper or lower case.
-     *
-     * @return string
      */
     public function getMethod(bool $upper = false): string
     {
@@ -337,9 +284,6 @@ class CURLRequest extends Request
 
     /**
      * Fires the actual cURL request.
-     *
-     * @param string $method
-     * @param string $url
      *
      * @return ResponseInterface
      */
@@ -408,10 +352,6 @@ class CURLRequest extends Request
     /**
      * Takes all headers current part of this request and adds them
      * to the cURL request.
-     *
-     * @param array $curlOptions
-     *
-     * @return array
      */
     protected function applyRequestHeaders(array $curlOptions = []): array
     {
@@ -441,11 +381,6 @@ class CURLRequest extends Request
 
     /**
      * Apply method
-     *
-     * @param string $method
-     * @param array  $curlOptions
-     *
-     * @return array
      */
     protected function applyMethod(string $method, array $curlOptions): array
     {
@@ -475,10 +410,6 @@ class CURLRequest extends Request
 
     /**
      * Apply body
-     *
-     * @param array $curlOptions
-     *
-     * @return array
      */
     protected function applyBody(array $curlOptions = []): array
     {
@@ -492,8 +423,6 @@ class CURLRequest extends Request
     /**
      * Parses the header retrieved from the cURL response into
      * our Response object.
-     *
-     * @param array $headers
      */
     protected function setResponseHeaders(array $headers = [])
     {
@@ -519,9 +448,6 @@ class CURLRequest extends Request
 
     /**
      * Set CURL options
-     *
-     * @param array $curlOptions
-     * @param array $config
      *
      * @throws InvalidArgumentException
      *
@@ -681,10 +607,6 @@ class CURLRequest extends Request
      * and grabbing the output.
      *
      * @codeCoverageIgnore
-     *
-     * @param array $curlOptions
-     *
-     * @return string
      */
     protected function sendRequest(array $curlOptions = []): string
     {

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -196,8 +196,6 @@ class ContentSecurityPolicy
      * Constructor.
      *
      * Stores our default values from the Config file.
-     *
-     * @param ContentSecurityPolicyConfig $config
      */
     public function __construct(ContentSecurityPolicyConfig $config)
     {
@@ -213,8 +211,6 @@ class ContentSecurityPolicy
      *
      * Should be called just prior to sending the response to the user agent.
      *
-     * @param ResponseInterface $response
-     *
      * @return void
      */
     public function finalize(ResponseInterface &$response)
@@ -229,8 +225,6 @@ class ContentSecurityPolicy
      * you are just starting to implement the policy, and will help
      * determine what errors need to be addressed before you turn on
      * all filtering.
-     *
-     * @param bool $value
      *
      * @return $this
      */
@@ -249,7 +243,6 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-base-uri
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -271,7 +264,6 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-child-src
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -292,7 +284,6 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-connect-src
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -313,7 +304,6 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-default-src
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -333,7 +323,6 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-font-src
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -351,7 +340,6 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-form-action
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -369,7 +357,6 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-frame-ancestors
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -387,7 +374,6 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-frame-src
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -405,7 +391,6 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-img-src
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -423,7 +408,6 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-media-src
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -441,7 +425,6 @@ class ContentSecurityPolicy
      * @see https://www.w3.org/TR/CSP/#directive-manifest-src
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -459,7 +442,6 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-object-src
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -476,8 +458,7 @@ class ContentSecurityPolicy
      *
      * @see http://www.w3.org/TR/CSP/#directive-plugin-types
      *
-     * @param array|string $mime              One or more plugin mime types, separate by spaces
-     * @param bool|null    $explicitReporting
+     * @param array|string $mime One or more plugin mime types, separate by spaces
      *
      * @return $this
      */
@@ -494,8 +475,6 @@ class ContentSecurityPolicy
      *
      * @see http://www.w3.org/TR/CSP/#directive-report-uri
      *
-     * @param string $uri
-     *
      * @return $this
      */
     public function setReportURI(string $uri)
@@ -511,8 +490,7 @@ class ContentSecurityPolicy
      *
      * @see http://www.w3.org/TR/CSP/#directive-sandbox
      *
-     * @param array|string $flags             An array of sandbox flags that can be added to the directive.
-     * @param bool|null    $explicitReporting
+     * @param array|string $flags An array of sandbox flags that can be added to the directive.
      *
      * @return $this
      */
@@ -530,7 +508,6 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-connect-src
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -548,7 +525,6 @@ class ContentSecurityPolicy
      * @see http://www.w3.org/TR/CSP/#directive-connect-src
      *
      * @param array|string $uri
-     * @param bool|null    $explicitReporting
      *
      * @return $this
      */
@@ -563,8 +539,6 @@ class ContentSecurityPolicy
      * Sets whether the user agents should rewrite URL schemes, changing
      * HTTP to HTTPS.
      *
-     * @param bool $value
-     *
      * @return $this
      */
     public function upgradeInsecureRequests(bool $value = true)
@@ -578,8 +552,6 @@ class ContentSecurityPolicy
      * DRY method to add an string or array to a class property.
      *
      * @param array|string $options
-     * @param string       $target
-     * @param bool|null    $explicitReporting
      *
      * @return void
      */
@@ -603,8 +575,6 @@ class ContentSecurityPolicy
      * Scans the body of the request message and replaces any nonce
      * placeholders with actual nonces, that we'll then add to our
      * headers.
-     *
-     * @param ResponseInterface $response
      *
      * @return void
      */
@@ -649,8 +619,6 @@ class ContentSecurityPolicy
      * Based on the current state of the elements, will add the appropriate
      * Content-Security-Policy and Content-Security-Policy-Report-Only headers
      * with their values to the response object.
-     *
-     * @param ResponseInterface $response
      *
      * @return void
      */
@@ -736,7 +704,6 @@ class ContentSecurityPolicy
      * array might have options that are geared toward either the regular or the
      * reportOnly header, since it's viable to have both simultaneously.
      *
-     * @param string            $name
      * @param array|string|null $values
      *
      * @return void

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -71,9 +71,6 @@ class DownloadResponse extends Response
 
     /**
      * Constructor.
-     *
-     * @param string $filename
-     * @param bool   $setMime
      */
     public function __construct(string $filename, bool $setMime)
     {
@@ -88,8 +85,6 @@ class DownloadResponse extends Response
 
     /**
      * set download for binary string.
-     *
-     * @param string $binary
      */
     public function setBinary(string $binary)
     {
@@ -102,8 +97,6 @@ class DownloadResponse extends Response
 
     /**
      * set download for file.
-     *
-     * @param string $filepath
      */
     public function setFilePath(string $filepath)
     {
@@ -117,8 +110,6 @@ class DownloadResponse extends Response
     /**
      * set name for the download.
      *
-     * @param string $filename
-     *
      * @return $this
      */
     public function setFileName(string $filename)
@@ -130,8 +121,6 @@ class DownloadResponse extends Response
 
     /**
      * get content length.
-     *
-     * @return int
      */
     public function getContentLength(): int
     {
@@ -170,8 +159,6 @@ class DownloadResponse extends Response
 
     /**
      * get download filename.
-     *
-     * @return string
      */
     private function getDownloadFileName(): string
     {
@@ -197,8 +184,6 @@ class DownloadResponse extends Response
 
     /**
      * get Content-Disposition Header string.
-     *
-     * @return string
      */
     private function getContentDisposition(): string
     {
@@ -222,9 +207,6 @@ class DownloadResponse extends Response
     /**
      * Disallows status changing.
      *
-     * @param int    $code
-     * @param string $reason
-     *
      * @throws DownloadException
      */
     public function setStatusCode(int $code, string $reason = '')
@@ -235,9 +217,6 @@ class DownloadResponse extends Response
     /**
      * Sets the Content Type header for this response with the mime type
      * and, optionally, the charset.
-     *
-     * @param string $mime
-     * @param string $charset
      *
      * @return ResponseInterface
      */
@@ -267,8 +246,6 @@ class DownloadResponse extends Response
 
     /**
      * Disables cache configuration.
-     *
-     * @param array $options
      *
      * @throws DownloadException
      */

--- a/system/HTTP/Exceptions/HTTPException.php
+++ b/system/HTTP/Exceptions/HTTPException.php
@@ -33,8 +33,6 @@ class HTTPException extends FrameworkException
     /**
      * For CurlRequest
      *
-     * @param string $cert
-     *
      * @return HTTPException
      */
     public static function forSSLCertNotFound(string $cert)
@@ -45,8 +43,6 @@ class HTTPException extends FrameworkException
     /**
      * For CurlRequest
      *
-     * @param string $key
-     *
      * @return HTTPException
      */
     public static function forInvalidSSLKey(string $key)
@@ -56,9 +52,6 @@ class HTTPException extends FrameworkException
 
     /**
      * For CurlRequest
-     *
-     * @param string $errorNum
-     * @param string $error
      *
      * @return HTTPException
      *
@@ -72,8 +65,6 @@ class HTTPException extends FrameworkException
     /**
      * For IncomingRequest
      *
-     * @param string $type
-     *
      * @return HTTPException
      */
     public static function forInvalidNegotiationType(string $type)
@@ -83,8 +74,6 @@ class HTTPException extends FrameworkException
 
     /**
      * For Message
-     *
-     * @param string $protocols
      *
      * @return HTTPException
      */
@@ -106,8 +95,6 @@ class HTTPException extends FrameworkException
     /**
      * For RedirectResponse
      *
-     * @param string $route
-     *
      * @return HTTPException
      */
     public static function forInvalidRedirectRoute(string $route)
@@ -128,8 +115,6 @@ class HTTPException extends FrameworkException
     /**
      * For Response
      *
-     * @param int $code
-     *
      * @return HTTPException
      */
     public static function forInvalidStatusCode(int $code)
@@ -139,8 +124,6 @@ class HTTPException extends FrameworkException
 
     /**
      * For Response
-     *
-     * @param int $code
      *
      * @return HTTPException
      */
@@ -152,8 +135,6 @@ class HTTPException extends FrameworkException
     /**
      * For URI
      *
-     * @param string $uri
-     *
      * @return HTTPException
      */
     public static function forUnableToParseURI(string $uri)
@@ -164,8 +145,6 @@ class HTTPException extends FrameworkException
     /**
      * For URI
      *
-     * @param int $segment
-     *
      * @return HTTPException
      */
     public static function forURISegmentOutOfRange(int $segment)
@@ -175,8 +154,6 @@ class HTTPException extends FrameworkException
 
     /**
      * For URI
-     *
-     * @param int $port
      *
      * @return HTTPException
      */
@@ -208,8 +185,6 @@ class HTTPException extends FrameworkException
     /**
      * For Uploaded file move
      *
-     * @param string|null $path
-     *
      * @return HTTPException
      */
     public static function forInvalidFile(?string $path = null)
@@ -220,10 +195,6 @@ class HTTPException extends FrameworkException
     /**
      * For Uploaded file move
      *
-     * @param string $source
-     * @param string $target
-     * @param string $error
-     *
      * @return HTTPException
      */
     public static function forMoveFailed(string $source, string $target, string $error)
@@ -233,8 +204,6 @@ class HTTPException extends FrameworkException
 
     /**
      * For Invalid SameSite attribute setting
-     *
-     * @param string $samesite
      *
      * @return HTTPException
      *

--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -48,8 +48,6 @@ class FileCollection
     /**
      * Attempts to get a single file from the collection of uploaded files.
      *
-     * @param string $name
-     *
      * @return UploadedFile|null
      */
     public function getFile(string $name)
@@ -76,8 +74,6 @@ class FileCollection
 
     /**
      * Verify if a file exist in the collection of uploaded files and is have been uploaded with multiple option.
-     *
-     * @param string $name
      *
      * @return array|null
      */
@@ -110,8 +106,6 @@ class FileCollection
      * this request.
      *
      * @param string $fileID The name of the uploaded file (from the input)
-     *
-     * @return bool
      */
     public function hasFile(string $fileID): bool
     {
@@ -165,8 +159,6 @@ class FileCollection
      * Given a file array, will create UploadedFile instances. Will
      * loop over an array and create objects for each.
      *
-     * @param array $array
-     *
      * @return array|UploadedFile
      */
     protected function createFileObject(array $array)
@@ -202,10 +194,6 @@ class FileCollection
      * of this method.
      *
      * @see http://php.net/manual/en/reserved.variables.files.php#118294
-     *
-     * @param array $data
-     *
-     * @return array
      */
     protected function fixFilesArray(array $data): array
     {

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -163,8 +163,6 @@ class UploadedFile extends File implements UploadedFileInterface
      * create file target path if
      * the set path does not exist
      *
-     * @param string $path
-     *
      * @return string The path set or created.
      */
     protected function setPath(string $path): string
@@ -185,8 +183,6 @@ class UploadedFile extends File implements UploadedFileInterface
      * Returns whether the file has been moved or not. If it has,
      * the move() method will not work and certain properties, like
      * the tempName, will no longer be available.
-     *
-     * @return bool
      */
     public function hasMoved(): bool
     {
@@ -215,8 +211,6 @@ class UploadedFile extends File implements UploadedFileInterface
 
     /**
      * Get error string
-     *
-     * @return string
      */
     public function getErrorString(): string
     {
@@ -262,8 +256,6 @@ class UploadedFile extends File implements UploadedFileInterface
 
     /**
      * Returns the name of the file as provided by the client during upload.
-     *
-     * @return string
      */
     public function getClientName(): string
     {
@@ -272,8 +264,6 @@ class UploadedFile extends File implements UploadedFileInterface
 
     /**
      * Gets the temporary filename where the file was uploaded to.
-     *
-     * @return string
      */
     public function getTempName(): string
     {
@@ -301,8 +291,6 @@ class UploadedFile extends File implements UploadedFileInterface
      * mime type. In contrast to getExtension, this method will return
      * an empty string if it fails to determine an extension instead of
      * falling back to the unsecure clientExtension.
-     *
-     * @return string
      */
     public function guessExtension(): string
     {
@@ -313,8 +301,6 @@ class UploadedFile extends File implements UploadedFileInterface
      * Returns the original file extension, based on the file name that
      * was uploaded. This is NOT a trusted source.
      * For a trusted version, use guessExtension() instead.
-     *
-     * @return string
      */
     public function getClientExtension(): string
     {
@@ -324,8 +310,6 @@ class UploadedFile extends File implements UploadedFileInterface
     /**
      * Returns whether the file was uploaded successfully, based on whether
      * it was uploaded via HTTP and has no errors.
-     *
-     * @return bool
      */
     public function isValid(): bool
     {

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -69,8 +69,6 @@ interface UploadedFileInterface
      * Returns whether the file has been moved or not. If it has,
      * the move() method will not work and certain properties, like
      * the tempName, will no longer be available.
-     *
-     * @return bool
      */
     public function hasMoved(): bool;
 
@@ -108,8 +106,6 @@ interface UploadedFileInterface
 
     /**
      * Gets the temporary filename where the file was uploaded to.
-     *
-     * @return string
      */
     public function getTempName(): string;
 
@@ -117,8 +113,6 @@ interface UploadedFileInterface
      * Returns the original file extension, based on the file name that
      * was uploaded. This is NOT a trusted source.
      * For a trusted version, use guessExtension() instead.
-     *
-     * @return string
      */
     public function getClientExtension(): string;
 
@@ -126,16 +120,12 @@ interface UploadedFileInterface
      * Returns the mime type as provided by the client.
      * This is NOT a trusted value.
      * For a trusted version, use getMimeType() instead.
-     *
-     * @return string
      */
     public function getClientMimeType(): string;
 
     /**
      * Returns whether the file was uploaded successfully, based on whether
      * it was uploaded via HTTP and has no errors.
-     *
-     * @return bool
      */
     public function isValid(): bool;
 
@@ -145,12 +135,6 @@ interface UploadedFileInterface
      * First, it checks whether the delimiter is present in the filename, if it is, then it checks whether the
      * last element is an integer as there may be cases that the delimiter may be present in the filename.
      * For the all other cases, it appends an integer starting from zero before the file's extension.
-     *
-     * @param string $destination
-     * @param string $delimiter
-     * @param int    $i
-     *
-     * @return string
      */
     public function getDestination(string $destination, string $delimiter = '_', int $i = 0): string;
 }

--- a/system/HTTP/Header.php
+++ b/system/HTTP/Header.php
@@ -36,7 +36,6 @@ class Header
     /**
      * Header constructor. name is mandatory, if a value is provided, it will be set.
      *
-     * @param string            $name
      * @param array|string|null $value
      */
     public function __construct(string $name, $value = null)
@@ -47,8 +46,6 @@ class Header
 
     /**
      * Returns the name of the header, in the same case it was set.
-     *
-     * @return string
      */
     public function getName(): string
     {
@@ -68,8 +65,6 @@ class Header
 
     /**
      * Sets the name of the header, overwriting any previous value.
-     *
-     * @param string $name
      *
      * @return $this
      */
@@ -179,8 +174,6 @@ class Header
     /**
      * Returns a representation of the entire header string, including
      * the header name and all values converted to the proper format.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -188,9 +188,6 @@ class IncomingRequest extends Request
      * Sets up our URI object based on the information we have. This is
      * either provided by the user in the baseURL Config setting, or
      * determined from the environment as needed.
-     *
-     * @param string $protocol
-     * @param string $baseURL
      */
     protected function detectURI(string $protocol, string $baseURL)
     {
@@ -204,10 +201,6 @@ class IncomingRequest extends Request
     /**
      * Detects the relative path based on
      * the URIProtocol Config setting.
-     *
-     * @param string $protocol
-     *
-     * @return string
      */
     public function detectPath(string $protocol = ''): string
     {
@@ -293,8 +286,6 @@ class IncomingRequest extends Request
      * Parse QUERY_STRING
      *
      * Will parse QUERY_STRING and automatically detect the URI from it.
-     *
-     * @return string
      */
     protected function parseQueryString(): string
     {
@@ -323,12 +314,6 @@ class IncomingRequest extends Request
     /**
      * Provides a convenient way to work with the Negotiate class
      * for content negotiation.
-     *
-     * @param string $type
-     * @param array  $supported
-     * @param bool   $strictMatch
-     *
-     * @return string
      */
     public function negotiate(string $type, array $supported, bool $strictMatch = false): string
     {
@@ -355,8 +340,6 @@ class IncomingRequest extends Request
 
     /**
      * Determines if this request was made from the command line (CLI).
-     *
-     * @return bool
      */
     public function isCLI(): bool
     {
@@ -365,8 +348,6 @@ class IncomingRequest extends Request
 
     /**
      * Test to see if a request contains the HTTP_X_REQUESTED_WITH header.
-     *
-     * @return bool
      */
     public function isAJAX(): bool
     {
@@ -376,8 +357,6 @@ class IncomingRequest extends Request
     /**
      * Attempts to detect if the current connection is secure through
      * a few different methods.
-     *
-     * @return bool
      */
     public function isSecure(): bool
     {
@@ -440,8 +419,6 @@ class IncomingRequest extends Request
     /**
      * Returns the path relative to SCRIPT_NAME,
      * running detection as necessary.
-     *
-     * @return string
      */
     public function getPath(): string
     {
@@ -454,8 +431,6 @@ class IncomingRequest extends Request
 
     /**
      * Sets the locale string for this request.
-     *
-     * @param string $locale
      *
      * @return IncomingRequest
      */
@@ -476,8 +451,6 @@ class IncomingRequest extends Request
     /**
      * Gets the current locale, with a fallback to the default
      * locale if none is set.
-     *
-     * @return string
      */
     public function getLocale(): string
     {
@@ -486,8 +459,6 @@ class IncomingRequest extends Request
 
     /**
      * Returns the default locale as set in Config\App.php
-     *
-     * @return string
      */
     public function getDefaultLocale(): string
     {
@@ -682,8 +653,6 @@ class IncomingRequest extends Request
      * with redirect_with_input(). It first checks for the data in the old
      * POST data, then the old GET data and finally check for dot arrays
      *
-     * @param string $key
-     *
      * @return mixed
      */
     public function getOldInput(string $key)
@@ -729,8 +698,6 @@ class IncomingRequest extends Request
     /**
      * Returns an array of all files that have been uploaded with this
      * request. Each file is represented by an UploadedFile instance.
-     *
-     * @return array
      */
     public function getFiles(): array
     {
@@ -744,8 +711,6 @@ class IncomingRequest extends Request
     /**
      * Verify if a file exist, by the name of the input field used to upload it, in the collection
      * of uploaded files and if is have been uploaded with multiple option.
-     *
-     * @param string $fileID
      *
      * @return array|null
      */
@@ -762,8 +727,6 @@ class IncomingRequest extends Request
      * Retrieves a single file by the name of the input field used
      * to upload it.
      *
-     * @param string $fileID
-     *
      * @return UploadedFile|null
      */
     public function getFile(string $fileID)
@@ -779,10 +742,6 @@ class IncomingRequest extends Request
      * Remove relative directory (../) and multi slashes (///)
      *
      * Do some final cleaning of the URI and return it, currently only used in static::_parse_request_uri()
-     *
-     * @param string $uri
-     *
-     * @return string
      *
      * @deprecated Use URI::removeDotSegments() directly
      */

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -71,8 +71,6 @@ class Message implements MessageInterface
      * Returns a single header object. If multiple headers with the same
      * name exist, then will return an array of header objects.
      *
-     * @param string $name
-     *
      * @return array|Header|null
      *
      * @deprecated Use Message::header() to make room for PSR-7
@@ -86,10 +84,6 @@ class Message implements MessageInterface
 
     /**
      * Determines whether a header exists.
-     *
-     * @param string $name
-     *
-     * @return bool
      */
     public function hasHeader(string $name): bool
     {
@@ -108,10 +102,6 @@ class Message implements MessageInterface
      * NOTE: Not all header values may be appropriately represented using
      * comma concatenation. For such headers, use getHeader() instead
      * and supply your own delimiter when concatenating.
-     *
-     * @param string $name
-     *
-     * @return string
      */
     public function getHeaderLine(string $name): string
     {
@@ -126,8 +116,6 @@ class Message implements MessageInterface
 
     /**
      * Returns the HTTP Protocol Version.
-     *
-     * @return string
      */
     public function getProtocolVersion(): string
     {

--- a/system/HTTP/MessageInterface.php
+++ b/system/HTTP/MessageInterface.php
@@ -61,7 +61,6 @@ interface MessageInterface
     /**
      * Sets a header and it's value.
      *
-     * @param string            $name
      * @param array|string|null $value
      *
      * @return $this
@@ -71,8 +70,6 @@ interface MessageInterface
     /**
      * Removes a header from the list of headers we track.
      *
-     * @param string $name
-     *
      * @return $this
      */
     public function removeHeader(string $name);
@@ -80,9 +77,6 @@ interface MessageInterface
     /**
      * Adds an additional header value to any headers that accept
      * multiple values (i.e. are an array or implement ArrayAccess)
-     *
-     * @param string      $name
-     * @param string|null $value
      *
      * @return $this
      */
@@ -92,17 +86,12 @@ interface MessageInterface
      * Adds an additional header value to any headers that accept
      * multiple values (i.e. are an array or implement ArrayAccess)
      *
-     * @param string $name
-     * @param string $value
-     *
      * @return $this
      */
     public function prependHeader(string $name, string $value);
 
     /**
      * Sets the HTTP protocol version.
-     *
-     * @param string $version
      *
      * @throws HTTPException For invalid protocols
      *

--- a/system/HTTP/MessageTrait.php
+++ b/system/HTTP/MessageTrait.php
@@ -134,7 +134,6 @@ trait MessageTrait
     /**
      * Sets a header and it's value.
      *
-     * @param string            $name
      * @param array|string|null $value
      *
      * @return $this
@@ -162,8 +161,6 @@ trait MessageTrait
     /**
      * Removes a header from the list of headers we track.
      *
-     * @param string $name
-     *
      * @return $this
      */
     public function removeHeader(string $name): self
@@ -177,9 +174,6 @@ trait MessageTrait
     /**
      * Adds an additional header value to any headers that accept
      * multiple values (i.e. are an array or implement ArrayAccess)
-     *
-     * @param string      $name
-     * @param string|null $value
      *
      * @return $this
      */
@@ -198,9 +192,6 @@ trait MessageTrait
      * Adds an additional header value to any headers that accept
      * multiple values (i.e. are an array or implement ArrayAccess)
      *
-     * @param string $name
-     * @param string $value
-     *
      * @return $this
      */
     public function prependHeader(string $name, string $value): self
@@ -215,10 +206,6 @@ trait MessageTrait
     /**
      * Takes a header name in any case, and returns the
      * normal-case version of the header.
-     *
-     * @param string $name
-     *
-     * @return string
      */
     protected function getHeaderName(string $name): string
     {
@@ -227,8 +214,6 @@ trait MessageTrait
 
     /**
      * Sets the HTTP protocol version.
-     *
-     * @param string $version
      *
      * @throws HTTPException For invalid protocols
      *

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -33,8 +33,6 @@ class Negotiate
 
     /**
      * Constructor
-     *
-     * @param RequestInterface|null $request
      */
     public function __construct(?RequestInterface $request = null)
     {
@@ -45,8 +43,6 @@ class Negotiate
 
     /**
      * Stores the request instance to grab the headers from.
-     *
-     * @param RequestInterface $request
      *
      * @return $this
      */
@@ -65,11 +61,8 @@ class Negotiate
      * If no match is found, the first, highest-ranking client requested
      * type is returned.
      *
-     * @param array $supported
-     * @param bool  $strictMatch If TRUE, will return an empty string when no match found.
-     *                           If FALSE, will return the first supported element.
-     *
-     * @return string
+     * @param bool $strictMatch If TRUE, will return an empty string when no match found.
+     *                          If FALSE, will return the first supported element.
      */
     public function media(array $supported, bool $strictMatch = false): string
     {
@@ -83,10 +76,6 @@ class Negotiate
      *
      * If no match is found, the first, highest-ranking client requested
      * type is returned.
-     *
-     * @param array $supported
-     *
-     * @return string
      */
     public function charset(array $supported): string
     {
@@ -108,10 +97,6 @@ class Negotiate
      *
      * If no match is found, the first, highest-ranking client requested
      * type is returned.
-     *
-     * @param array $supported
-     *
-     * @return string
      */
     public function encoding(array $supported = []): string
     {
@@ -127,10 +112,6 @@ class Negotiate
      *
      * If no match is found, the first, highest-ranking client requested
      * type is returned.
-     *
-     * @param array $supported
-     *
-     * @return string
      */
     public function language(array $supported): string
     {
@@ -195,10 +176,6 @@ class Negotiate
      * Parses an Accept* header into it's multiple values.
      *
      * This is based on code from Aura.Accept library.
-     *
-     * @param string $header
-     *
-     * @return array
      */
     public function parseHeader(string $header): array
     {
@@ -277,12 +254,7 @@ class Negotiate
     /**
      * Match-maker
      *
-     * @param array  $acceptable
-     * @param string $supported
-     * @param bool   $enforceTypes
-     * @param bool   $matchLocales
-     *
-     * @return bool
+     * @param bool $matchLocales
      */
     protected function match(array $acceptable, string $supported, bool $enforceTypes = false, $matchLocales = false): bool
     {
@@ -313,11 +285,6 @@ class Negotiate
     /**
      * Checks two Accept values with matching 'values' to see if their
      * 'params' are the same.
-     *
-     * @param array $acceptable
-     * @param array $supported
-     *
-     * @return bool
      */
     protected function matchParameters(array $acceptable, array $supported): bool
     {
@@ -339,11 +306,6 @@ class Negotiate
     /**
      * Compares the types/subtypes of an acceptable Media type and
      * the supported string.
-     *
-     * @param array $acceptable
-     * @param array $supported
-     *
-     * @return bool
      */
     public function matchTypes(array $acceptable, array $supported): bool
     {
@@ -369,11 +331,6 @@ class Negotiate
     /**
      * Will match locales against their broader pairs, so that fr-FR would
      * match a supported localed of fr
-     *
-     * @param array $acceptable
-     * @param array $supported
-     *
-     * @return bool
      */
     public function matchLocales(array $acceptable, array $supported): bool
     {

--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -24,9 +24,8 @@ class RedirectResponse extends Response
      * Sets the URI to redirect to and, optionally, the HTTP status code to use.
      * If no code is provided it will be automatically determined.
      *
-     * @param string   $uri    The URI to redirect to
-     * @param int|null $code   HTTP status code
-     * @param string   $method
+     * @param string   $uri  The URI to redirect to
+     * @param int|null $code HTTP status code
      *
      * @return $this
      */
@@ -44,11 +43,6 @@ class RedirectResponse extends Response
     /**
      * Sets the URI to redirect to but as a reverse-routed or named route
      * instead of a raw URI.
-     *
-     * @param string $route
-     * @param array  $params
-     * @param int    $code
-     * @param string $method
      *
      * @throws HTTPException
      *
@@ -70,9 +64,6 @@ class RedirectResponse extends Response
      *
      * Example:
      *  return redirect()->back();
-     *
-     * @param int|null $code
-     * @param string   $method
      *
      * @return $this
      */
@@ -115,7 +106,6 @@ class RedirectResponse extends Response
     /**
      * Adds a key and message to the session as Flashdata.
      *
-     * @param string       $key
      * @param array|string $message
      *
      * @return $this

--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -72,8 +72,6 @@ class Request extends Message implements MessageInterface, RequestInterface
      * @param string $ip    IP Address
      * @param string $which IP protocol: 'ipv4' or 'ipv6'
      *
-     * @return bool
-     *
      * @deprecated Use Validation instead
      *
      * @codeCoverageIgnore
@@ -88,8 +86,6 @@ class Request extends Message implements MessageInterface, RequestInterface
      *
      * @param bool $upper Whether to return in upper or lower case.
      *
-     * @return string
-     *
      * @deprecated The $upper functionality will be removed and this will revert to its PSR-7 equivalent
      *
      * @codeCoverageIgnore
@@ -101,8 +97,6 @@ class Request extends Message implements MessageInterface, RequestInterface
 
     /**
      * Sets the request method. Used when spoofing the request.
-     *
-     * @param string $method
      *
      * @return Request
      *

--- a/system/HTTP/RequestInterface.php
+++ b/system/HTTP/RequestInterface.php
@@ -34,8 +34,6 @@ interface RequestInterface
      * @param string $ip    IP Address
      * @param string $which IP protocol: 'ipv4' or 'ipv6'
      *
-     * @return bool
-     *
      * @deprecated Use Validation instead
      */
     public function isValidIP(string $ip, ?string $which = null): bool;
@@ -45,8 +43,6 @@ interface RequestInterface
      * An extension of PSR-7's getMethod to allow casing.
      *
      * @param bool $upper Whether to return in upper or lower case.
-     *
-     * @return string
      *
      * @deprecated The $upper functionality will be removed and this will revert to its PSR-7 equivalent
      */

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -186,8 +186,7 @@ trait RequestTrait
     /**
      * Allows manually setting the value of PHP global, like $_GET, $_POST, etc.
      *
-     * @param string $method
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return $this
      */
@@ -303,8 +302,6 @@ trait RequestTrait
     /**
      * Saves a copy of the current state of one of several PHP globals
      * so we can retrieve them later.
-     *
-     * @param string $method
      */
     protected function populateGlobals(string $method)
     {

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -191,8 +191,6 @@ class Response extends Message implements MessageInterface, ResponseInterface
      * Note that this is not a part of the interface so
      * should not be relied on outside of internal testing.
      *
-     * @param bool $pretend
-     *
      * @return $this
      */
     public function pretend(bool $pretend = true)
@@ -224,9 +222,6 @@ class Response extends Message implements MessageInterface, ResponseInterface
      *
      * @see http://tools.ietf.org/html/rfc7231#section-6
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-     *
-     * @return string
-     *
      * @deprecated Use getReasonPhrase()
      *
      * @codeCoverageIgnore

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -141,9 +141,6 @@ interface ResponseInterface
      *
      * @see http://tools.ietf.org/html/rfc7231#section-6
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-     *
-     * @return string
-     *
      * @deprecated Use getReasonPhrase()
      */
     public function getReason(): string;
@@ -154,8 +151,6 @@ interface ResponseInterface
 
     /**
      * Sets the date header
-     *
-     * @param DateTime $date
      *
      * @return ResponseInterface
      */
@@ -174,8 +169,6 @@ interface ResponseInterface
     /**
      * Set the Link Header
      *
-     * @param PagerInterface $pager
-     *
      * @see http://tools.ietf.org/html/rfc5988
      *
      * @return Response
@@ -187,9 +180,6 @@ interface ResponseInterface
     /**
      * Sets the Content Type header for this response with the mime type
      * and, optionally, the charset.
-     *
-     * @param string $mime
-     * @param string $charset
      *
      * @return ResponseInterface
      */
@@ -203,7 +193,6 @@ interface ResponseInterface
      * Converts the $body into JSON and sets the Content Type header.
      *
      * @param array|string $body
-     * @param bool         $unencoded
      *
      * @return $this
      */
@@ -272,8 +261,6 @@ interface ResponseInterface
      *  - proxy-revalidate
      *  - no-transform
      *
-     * @param array $options
-     *
      * @return ResponseInterface
      */
     public function setCache(array $options = []);
@@ -339,20 +326,11 @@ interface ResponseInterface
 
     /**
      * Checks to see if the Response has a specified cookie or not.
-     *
-     * @param string      $name
-     * @param string|null $value
-     * @param string      $prefix
-     *
-     * @return bool
      */
     public function hasCookie(string $name, ?string $value = null, string $prefix = ''): bool;
 
     /**
      * Returns the cookie
-     *
-     * @param string|null $name
-     * @param string      $prefix
      *
      * @return Cookie|Cookie[]|null
      */
@@ -360,11 +338,6 @@ interface ResponseInterface
 
     /**
      * Sets a cookie to be deleted when the response is sent.
-     *
-     * @param string $name
-     * @param string $domain
-     * @param string $path
-     * @param string $prefix
      *
      * @return $this
      */
@@ -384,9 +357,8 @@ interface ResponseInterface
     /**
      * Perform a redirect to a new URL, in two flavors: header or location.
      *
-     * @param string $uri    The URI to redirect to
-     * @param string $method
-     * @param int    $code   The type of redirection, defaults to 302
+     * @param string $uri  The URI to redirect to
+     * @param int    $code The type of redirection, defaults to 302
      *
      * @throws HTTPException For invalid status code.
      *

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -169,8 +169,6 @@ trait ResponseTrait
     /**
      * Sets the date header
      *
-     * @param DateTime $date
-     *
      * @return Response
      */
     public function setDate(DateTime $date)
@@ -184,8 +182,6 @@ trait ResponseTrait
 
     /**
      * Set the Link Header
-     *
-     * @param PagerInterface $pager
      *
      * @see http://tools.ietf.org/html/rfc5988
      *
@@ -220,9 +216,6 @@ trait ResponseTrait
      * Sets the Content Type header for this response with the mime type
      * and, optionally, the charset.
      *
-     * @param string $mime
-     * @param string $charset
-     *
      * @return Response
      */
     public function setContentType(string $mime, string $charset = 'UTF-8')
@@ -242,7 +235,6 @@ trait ResponseTrait
      * Converts the $body into JSON and sets the Content Type header.
      *
      * @param array|string $body
-     * @param bool         $unencoded
      *
      * @return $this
      */
@@ -376,8 +368,6 @@ trait ResponseTrait
      *  - proxy-revalidate
      *  - no-transform
      *
-     * @param array $options
-     *
      * @return Response
      */
     public function setCache(array $options = [])
@@ -499,9 +489,8 @@ trait ResponseTrait
     /**
      * Perform a redirect to a new URL, in two flavors: header or location.
      *
-     * @param string $uri    The URI to redirect to
-     * @param string $method
-     * @param int    $code   The type of redirection, defaults to 302
+     * @param string $uri  The URI to redirect to
+     * @param int    $code The type of redirection, defaults to 302
      *
      * @throws HTTPException For invalid status code.
      *
@@ -609,12 +598,6 @@ trait ResponseTrait
 
     /**
      * Checks to see if the Response has a specified cookie or not.
-     *
-     * @param string      $name
-     * @param string|null $value
-     * @param string      $prefix
-     *
-     * @return bool
      */
     public function hasCookie(string $name, ?string $value = null, string $prefix = ''): bool
     {
@@ -625,9 +608,6 @@ trait ResponseTrait
 
     /**
      * Returns the cookie
-     *
-     * @param string|null $name
-     * @param string      $prefix
      *
      * @return Cookie|Cookie[]|null
      */
@@ -650,11 +630,6 @@ trait ResponseTrait
 
     /**
      * Sets a cookie to be deleted when the response is sent.
-     *
-     * @param string $name
-     * @param string $domain
-     * @param string $path
-     * @param string $prefix
      *
      * @return $this
      */

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -143,8 +143,6 @@ class URI
      * @param string $path
      * @param string $query
      * @param string $fragment
-     *
-     * @return string
      */
     public static function createURIString(?string $scheme = null, ?string $authority = null, ?string $path = null, ?string $query = null, ?string $fragment = null): string
     {
@@ -178,10 +176,6 @@ class URI
      * RFC 3986 Section 5.2.4
      *
      * @see http://tools.ietf.org/html/rfc3986#section-5.2.4
-     *
-     * @param string $path
-     *
-     * @return string
      *
      * @internal
      */
@@ -246,8 +240,6 @@ class URI
      * If $silent == true, then will not throw exceptions and will
      * attempt to continue gracefully.
      *
-     * @param bool $silent
-     *
      * @return URI
      */
     public function setSilent(bool $silent = true)
@@ -261,8 +253,6 @@ class URI
      * If $raw == true, then will use parseStr() method
      * instead of native parse_str() function.
      *
-     * @param bool $raw
-     *
      * @return URI
      */
     public function useRawQueryString(bool $raw = true)
@@ -274,8 +264,6 @@ class URI
 
     /**
      * Sets and overwrites any current URI information.
-     *
-     * @param string|null $uri
      *
      * @return URI
      */
@@ -334,8 +322,6 @@ class URI
      * scheme, it SHOULD NOT be included.
      *
      * @see https://tools.ietf.org/html/rfc3986#section-3.2
-     *
-     * @param bool $ignorePort
      *
      * @return string The URI authority, in "[user-info@]host[:port]" format.
      */
@@ -396,8 +382,6 @@ class URI
     /**
      * Temporarily sets the URI to show a password in userInfo. Will
      * reset itself after the first call to authority().
-     *
-     * @param bool $val
      *
      * @return URI
      */
@@ -478,10 +462,6 @@ class URI
 
     /**
      * Retrieve the query string
-     *
-     * @param array $options
-     *
-     * @return string
      */
     public function getQuery(array $options = []): string
     {
@@ -516,8 +496,6 @@ class URI
 
     /**
      * Retrieve a URI fragment
-     *
-     * @return string
      */
     public function getFragment(): string
     {
@@ -526,8 +504,6 @@ class URI
 
     /**
      * Returns the segments of the path as an array.
-     *
-     * @return array
      */
     public function getSegments(): array
     {
@@ -560,8 +536,7 @@ class URI
      * Set the value of a specific segment of the URI path.
      * Allows to set only existing segments or add new one.
      *
-     * @param int   $number
-     * @param mixed $value  (string or int)
+     * @param mixed $value (string or int)
      *
      * @return $this
      */
@@ -587,8 +562,6 @@ class URI
 
     /**
      * Returns the total number of segments.
-     *
-     * @return int
      */
     public function getTotalSegments(): int
     {
@@ -602,8 +575,6 @@ class URI
      * assumes URIs with the same host as baseURL should
      * be relative to the project's configuration.
      * This aspect of __toString() is deprecated and should be avoided.
-     *
-     * @return string
      */
     public function __toString(): string
     {
@@ -642,8 +613,6 @@ class URI
     /**
      * Parses the given string and saves the appropriate authority pieces.
      *
-     * @param string $str
-     *
      * @return $this
      */
     public function setAuthority(string $str)
@@ -671,8 +640,6 @@ class URI
      * to only http or https.
      *
      * @see https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
-     *
-     * @param string $str
      *
      * @return $this
      */
@@ -704,8 +671,6 @@ class URI
 
     /**
      * Sets the host name to use.
-     *
-     * @param string $str
      *
      * @return $this
      */
@@ -745,8 +710,6 @@ class URI
     /**
      * Sets the path portion of the URI.
      *
-     * @param string $path
-     *
      * @return $this
      */
     public function setPath(string $path)
@@ -780,8 +743,6 @@ class URI
      * Sets the query portion of the URI, while attempting
      * to clean the various parts of the query keys and values.
      *
-     * @param string $query
-     *
      * @return $this
      */
     public function setQuery(string $query)
@@ -812,8 +773,6 @@ class URI
      * A convenience method to pass an array of items in as the Query
      * portion of the URI.
      *
-     * @param array $query
-     *
      * @return URI
      */
     public function setQueryArray(array $query)
@@ -826,8 +785,7 @@ class URI
     /**
      * Adds a single new element to the query vars.
      *
-     * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return $this
      */
@@ -884,8 +842,6 @@ class URI
      *
      * @see https://tools.ietf.org/html/rfc3986#section-3.5
      *
-     * @param string $string
-     *
      * @return $this
      */
     public function setFragment(string $string)
@@ -899,10 +855,6 @@ class URI
      * Encodes any dangerous characters, and removes dot segments.
      * While dot segments have valid uses according to the spec,
      * this URI class does not allow them.
-     *
-     * @param string|null $path
-     *
-     * @return string
      */
     protected function filterPath(?string $path = null): string
     {
@@ -937,8 +889,6 @@ class URI
 
     /**
      * Saves our parts from a parse_url call.
-     *
-     * @param array $parts
      */
     protected function applyParts(array $parts)
     {
@@ -989,8 +939,6 @@ class URI
      * RFC 3986 Section 2
      *
      * @see http://tools.ietf.org/html/rfc3986#section-5.2
-     *
-     * @param string $uri
      *
      * @return URI
      */
@@ -1052,8 +1000,6 @@ class URI
      *
      * @param URI $base
      * @param URI $reference
-     *
-     * @return string
      */
     protected function mergePaths(self $base, self $reference): string
     {
@@ -1076,10 +1022,6 @@ class URI
     /**
      * This is equivalent to the native PHP parse_str() function.
      * This version allows the dot to be used as a key of the query string.
-     *
-     * @param string $query
-     *
-     * @return array
      */
     protected function parseStr(string $query): array
     {

--- a/system/HTTP/UserAgent.php
+++ b/system/HTTP/UserAgent.php
@@ -99,8 +99,6 @@ class UserAgent
      * Constructor
      *
      * Sets the User Agent and runs the compilation routine
-     *
-     * @param UserAgents|null $config
      */
     public function __construct(?UserAgents $config = null)
     {
@@ -116,8 +114,6 @@ class UserAgent
      * Is Browser
      *
      * @param string $key
-     *
-     * @return bool
      */
     public function isBrowser(?string $key = null): bool
     {
@@ -138,8 +134,6 @@ class UserAgent
      * Is Robot
      *
      * @param string $key
-     *
-     * @return bool
      */
     public function isRobot(?string $key = null): bool
     {
@@ -160,8 +154,6 @@ class UserAgent
      * Is Mobile
      *
      * @param string $key
-     *
-     * @return bool
      */
     public function isMobile(?string $key = null): bool
     {
@@ -180,8 +172,6 @@ class UserAgent
 
     /**
      * Is this a referral from another site?
-     *
-     * @return bool
      */
     public function isReferral(): bool
     {
@@ -201,8 +191,6 @@ class UserAgent
 
     /**
      * Agent String
-     *
-     * @return string
      */
     public function getAgentString(): string
     {
@@ -211,8 +199,6 @@ class UserAgent
 
     /**
      * Get Platform
-     *
-     * @return string
      */
     public function getPlatform(): string
     {
@@ -221,8 +207,6 @@ class UserAgent
 
     /**
      * Get Browser Name
-     *
-     * @return string
      */
     public function getBrowser(): string
     {
@@ -231,8 +215,6 @@ class UserAgent
 
     /**
      * Get the Browser Version
-     *
-     * @return string
      */
     public function getVersion(): string
     {
@@ -241,8 +223,6 @@ class UserAgent
 
     /**
      * Get The Robot Name
-     *
-     * @return string
      */
     public function getRobot(): string
     {
@@ -251,8 +231,6 @@ class UserAgent
 
     /**
      * Get the Mobile Device
-     *
-     * @return string
      */
     public function getMobile(): string
     {
@@ -261,8 +239,6 @@ class UserAgent
 
     /**
      * Get the referrer
-     *
-     * @return string
      */
     public function getReferrer(): string
     {
@@ -271,8 +247,6 @@ class UserAgent
 
     /**
      * Parse a custom user-agent string
-     *
-     * @param string $string
      *
      * @return void
      */
@@ -313,8 +287,6 @@ class UserAgent
 
     /**
      * Set the Platform
-     *
-     * @return bool
      */
     protected function setPlatform(): bool
     {
@@ -335,8 +307,6 @@ class UserAgent
 
     /**
      * Set the Browser
-     *
-     * @return bool
      */
     protected function setBrowser(): bool
     {
@@ -358,8 +328,6 @@ class UserAgent
 
     /**
      * Set the Robot
-     *
-     * @return bool
      */
     protected function setRobot(): bool
     {
@@ -380,8 +348,6 @@ class UserAgent
 
     /**
      * Set the Mobile Device
-     *
-     * @return bool
      */
     protected function setMobile(): bool
     {
@@ -401,8 +367,6 @@ class UserAgent
 
     /**
      * Outputs the original Agent String when cast as a string.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -16,9 +16,6 @@ if (! function_exists('dot_array_search')) {
      * Searches an array through dot syntax. Supports
      * wildcard searches, like foo.*.bar
      *
-     * @param string $index
-     * @param array  $array
-     *
      * @return mixed
      */
     function dot_array_search(string $index, array $array)
@@ -39,9 +36,6 @@ if (! function_exists('_array_search_dot')) {
      * array with wildcards.
      *
      * @internal This should not be used on its own.
-     *
-     * @param array $indexes
-     * @param array $array
      *
      * @return mixed
      */
@@ -99,7 +93,6 @@ if (! function_exists('array_deep_search')) {
      * Returns the value of an element at a key in an array of uncertain depth.
      *
      * @param mixed $key
-     * @param array $array
      *
      * @return mixed|null
      */
@@ -144,8 +137,6 @@ if (! function_exists('array_sort_by_multiple_keys')) {
      * @param array $array       the reference of the array to be sorted
      * @param array $sortColumns an associative array of columns to sort
      *                           after and their sorting flags
-     *
-     * @return bool
      */
     function array_sort_by_multiple_keys(array &$array, array $sortColumns): bool
     {

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -56,7 +56,6 @@ if (! function_exists('get_cookie')) {
      * Fetch an item from the $_COOKIE array
      *
      * @param string $index
-     * @param bool   $xssClean
      *
      * @return mixed
      *
@@ -94,12 +93,6 @@ if (! function_exists('delete_cookie')) {
 if (! function_exists('has_cookie')) {
     /**
      * Checks if a cookie exists by name.
-     *
-     * @param string      $name
-     * @param string|null $value
-     * @param string      $prefix
-     *
-     * @return bool
      */
     function has_cookie(string $name, ?string $value = null, string $prefix = ''): bool
     {

--- a/system/Helpers/date_helper.php
+++ b/system/Helpers/date_helper.php
@@ -21,8 +21,6 @@ if (! function_exists('now')) {
      * @param string $timezone
      *
      * @throws Exception
-     *
-     * @return int
      */
     function now(?string $timezone = null): int
     {
@@ -51,8 +49,6 @@ if (! function_exists('timezone_select')) {
      * @param string $country A two-letter ISO 3166-1 compatible country code (for listIdentifiers)
      *
      * @throws Exception
-     *
-     * @return string
      */
     function timezone_select(string $class = '', string $default = '', int $what = DateTimeZone::ALL, ?string $country = null): string
     {

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -23,8 +23,6 @@ if (! function_exists('directory_map')) {
      * @param int    $directoryDepth Depth of directories to traverse
      *                               (0 = fully recursive, 1 = current dir, etc)
      * @param bool   $hidden         Whether to show hidden files
-     *
-     * @return array
      */
     function directory_map(string $sourceDir, int $directoryDepth = 0, bool $hidden = false): array
     {
@@ -66,13 +64,9 @@ if (! function_exists('directory_mirror')) {
      * Recursively copies the files and directories of the origin directory
      * into the target directory, i.e. "mirror" its contents.
      *
-     * @param string $originDir
-     * @param string $targetDir
-     * @param bool   $overwrite Whether individual files overwrite on collision
+     * @param bool $overwrite Whether individual files overwrite on collision
      *
      * @throws InvalidArgumentException
-     *
-     * @return void
      */
     function directory_mirror(string $originDir, string $targetDir, bool $overwrite = true): void
     {
@@ -115,8 +109,6 @@ if (! function_exists('write_file')) {
      * @param string $path File path
      * @param string $data Data to write
      * @param string $mode fopen() mode (default: 'wb')
-     *
-     * @return bool
      */
     function write_file(string $path, string $data, string $mode = 'wb'): bool
     {
@@ -154,8 +146,6 @@ if (! function_exists('delete_files')) {
      * @param bool   $delDir Whether to delete any directories found in the path
      * @param bool   $htdocs Whether to skip deleting .htaccess and index page files
      * @param bool   $hidden Whether to include hidden files (files beginning with a period)
-     *
-     * @return bool
      */
     function delete_files(string $path, bool $delDir = false, bool $htdocs = false, bool $hidden = false): bool
     {
@@ -202,8 +192,6 @@ if (! function_exists('get_filenames')) {
      * @param string    $sourceDir   Path to source
      * @param bool|null $includePath Whether to include the path as part of the filename; false for no path, null for a relative path, true for full path
      * @param bool      $hidden      Whether to include hidden files (files beginning with a period)
-     *
-     * @return array
      */
     function get_filenames(string $sourceDir, ?bool $includePath = false, bool $hidden = false): array
     {
@@ -252,8 +240,6 @@ if (! function_exists('get_dir_file_info')) {
      * @param string $sourceDir    Path to source
      * @param bool   $topLevelOnly Look only at the top level directory specified?
      * @param bool   $recursion    Internal variable to determine recursion status - do not use in calls
-     *
-     * @return array
      */
     function get_dir_file_info(string $sourceDir, bool $topLevelOnly = true, bool $recursion = false): array
     {
@@ -362,8 +348,6 @@ if (! function_exists('symbolic_permissions')) {
      * standard symbolic notation representing that value
      *
      * @param int $perms Permissions
-     *
-     * @return string
      */
     function symbolic_permissions(int $perms): string
     {
@@ -412,8 +396,6 @@ if (! function_exists('octal_permissions')) {
      * a three character string representing the file's octal permissions
      *
      * @param int $perms Permissions
-     *
-     * @return string
      */
     function octal_permissions(int $perms): string
     {
@@ -424,9 +406,6 @@ if (! function_exists('octal_permissions')) {
 if (! function_exists('same_file')) {
     /**
      * Checks if two files both exist and have identical hashes
-     *
-     * @param string $file1
-     * @param string $file2
      *
      * @return bool Same or not
      */
@@ -440,10 +419,7 @@ if (! function_exists('set_realpath')) {
     /**
      * Set Realpath
      *
-     * @param string $path
-     * @param bool   $checkExistence Checks to see if the path exists
-     *
-     * @return string
+     * @param bool $checkExistence Checks to see if the path exists
      */
     function set_realpath(string $path, bool $checkExistence = false): string
     {

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -23,8 +23,6 @@ if (! function_exists('form_open')) {
      * @param string       $action     the URI segments of the form destination
      * @param array|string $attributes a key/value pair of attributes, or string representation
      * @param array        $hidden     a key/value pair hidden data
-     *
-     * @return string
      */
     function form_open(string $action = '', $attributes = [], array $hidden = []): string
     {
@@ -84,8 +82,6 @@ if (! function_exists('form_open_multipart')) {
      * @param string       $action     The URI segments of the form destination
      * @param array|string $attributes A key/value pair of attributes, or the same as a string
      * @param array        $hidden     A key/value pair hidden data
-     *
-     * @return string
      */
     function form_open_multipart(string $action = '', $attributes = [], array $hidden = []): string
     {
@@ -106,11 +102,8 @@ if (! function_exists('form_hidden')) {
      * Generates hidden fields. You can pass a simple key/value string or
      * an associative array with multiple values.
      *
-     * @param array|string $name      Field name or associative array to create multiple fields
-     * @param array|string $value     Field value
-     * @param bool         $recursing
-     *
-     * @return string
+     * @param array|string $name  Field name or associative array to create multiple fields
+     * @param array|string $value Field value
      */
     function form_hidden($name, $value = '', bool $recursing = false): string
     {
@@ -146,12 +139,8 @@ if (! function_exists('form_input')) {
      * Text Input Field. If 'type' is passed in the $type field, it will be
      * used as the input type, for making 'email', 'phone', etc input fields.
      *
-     * @param mixed  $data
-     * @param string $value
-     * @param mixed  $extra
-     * @param string $type
-     *
-     * @return string
+     * @param mixed $data
+     * @param mixed $extra
      */
     function form_input($data = '', string $value = '', $extra = '', string $type = 'text'): string
     {
@@ -171,11 +160,8 @@ if (! function_exists('form_password')) {
      *
      * Identical to the input function but adds the "password" type
      *
-     * @param mixed  $data
-     * @param string $value
-     * @param mixed  $extra
-     *
-     * @return string
+     * @param mixed $data
+     * @param mixed $extra
      */
     function form_password($data = '', string $value = '', $extra = ''): string
     {
@@ -194,11 +180,8 @@ if (! function_exists('form_upload')) {
      *
      * Identical to the input function but adds the "file" type
      *
-     * @param mixed  $data
-     * @param string $value
-     * @param mixed  $extra
-     *
-     * @return string
+     * @param mixed $data
+     * @param mixed $extra
      */
     function form_upload($data = '', string $value = '', $extra = ''): string
     {
@@ -221,11 +204,8 @@ if (! function_exists('form_textarea')) {
     /**
      * Textarea field
      *
-     * @param mixed  $data
-     * @param string $value
-     * @param mixed  $extra
-     *
-     * @return string
+     * @param mixed $data
+     * @param mixed $extra
      */
     function form_textarea($data = '', string $value = '', $extra = ''): string
     {
@@ -261,11 +241,7 @@ if (! function_exists('form_multiselect')) {
      * Multi-select menu
      *
      * @param mixed $name
-     * @param array $options
-     * @param array $selected
      * @param mixed $extra
-     *
-     * @return string
      */
     function form_multiselect($name = '', array $options = [], array $selected = [], $extra = ''): string
     {
@@ -287,8 +263,6 @@ if (! function_exists('form_dropdown')) {
      * @param mixed $options
      * @param mixed $selected
      * @param mixed $extra
-     *
-     * @return string
      */
     function form_dropdown($data = '', $options = [], $selected = [], $extra = ''): string
     {
@@ -364,12 +338,8 @@ if (! function_exists('form_checkbox')) {
     /**
      * Checkbox Field
      *
-     * @param mixed  $data
-     * @param string $value
-     * @param bool   $checked
-     * @param mixed  $extra
-     *
-     * @return string
+     * @param mixed $data
+     * @param mixed $extra
      */
     function form_checkbox($data = '', string $value = '', bool $checked = false, $extra = ''): string
     {
@@ -402,12 +372,8 @@ if (! function_exists('form_radio')) {
     /**
      * Radio Button
      *
-     * @param mixed  $data
-     * @param string $value
-     * @param bool   $checked
-     * @param mixed  $extra
-     *
-     * @return string
+     * @param mixed $data
+     * @param mixed $extra
      */
     function form_radio($data = '', string $value = '', bool $checked = false, $extra = ''): string
     {
@@ -424,11 +390,8 @@ if (! function_exists('form_submit')) {
     /**
      * Submit Button
      *
-     * @param mixed  $data
-     * @param string $value
-     * @param mixed  $extra
-     *
-     * @return string
+     * @param mixed $data
+     * @param mixed $extra
      */
     function form_submit($data = '', string $value = '', $extra = ''): string
     {
@@ -440,11 +403,8 @@ if (! function_exists('form_reset')) {
     /**
      * Reset Button
      *
-     * @param mixed  $data
-     * @param string $value
-     * @param mixed  $extra
-     *
-     * @return string
+     * @param mixed $data
+     * @param mixed $extra
      */
     function form_reset($data = '', string $value = '', $extra = ''): string
     {
@@ -456,11 +416,8 @@ if (! function_exists('form_button')) {
     /**
      * Form Button
      *
-     * @param mixed  $data
-     * @param string $content
-     * @param mixed  $extra
-     *
-     * @return string
+     * @param mixed $data
+     * @param mixed $extra
      */
     function form_button($data = '', string $content = '', $extra = ''): string
     {
@@ -487,8 +444,6 @@ if (! function_exists('form_label')) {
      * @param string $labelText  The text to appear onscreen
      * @param string $id         The id the label applies to
      * @param array  $attributes Additional attributes
-     *
-     * @return string
      */
     function form_label(string $labelText = '', string $id = '', array $attributes = []): string
     {
@@ -515,12 +470,6 @@ if (! function_exists('form_datalist')) {
      * The <datalist> element specifies a list of pre-defined options for an <input> element.
      * Users will see a drop-down list of pre-defined options as they input data.
      * The list attribute of the <input> element, must refer to the id attribute of the <datalist> element.
-     *
-     * @param string $name
-     * @param string $value
-     * @param array  $options
-     *
-     * @return string
      */
     function form_datalist(string $name, string $value, array $options): string
     {
@@ -552,8 +501,6 @@ if (! function_exists('form_fieldset')) {
      *
      * @param string $legendText The legend text
      * @param array  $attributes Additional attributes
-     *
-     * @return string
      */
     function form_fieldset(string $legendText = '', array $attributes = []): string
     {
@@ -570,10 +517,6 @@ if (! function_exists('form_fieldset')) {
 if (! function_exists('form_fieldset_close')) {
     /**
      * Fieldset Close Tag
-     *
-     * @param string $extra
-     *
-     * @return string
      */
     function form_fieldset_close(string $extra = ''): string
     {
@@ -584,10 +527,6 @@ if (! function_exists('form_fieldset_close')) {
 if (! function_exists('form_close')) {
     /**
      * Form Close Tag
-     *
-     * @param string $extra
-     *
-     * @return string
      */
     function form_close(string $extra = ''): string
     {
@@ -629,12 +568,6 @@ if (! function_exists('set_select')) {
      *
      * Let's you set the selected value of a <select> menu via data in the POST array.
      * If Form Validation is active it retrieves the info from the validation class
-     *
-     * @param string $field
-     * @param string $value
-     * @param bool   $default
-     *
-     * @return string
      */
     function set_select(string $field, string $value = '', bool $default = false): string
     {
@@ -672,12 +605,6 @@ if (! function_exists('set_checkbox')) {
      *
      * Let's you set the selected value of a checkbox via the value in the POST array.
      * If Form Validation is active it retrieves the info from the validation class
-     *
-     * @param string $field
-     * @param string $value
-     * @param bool   $default
-     *
-     * @return string
      */
     function set_checkbox(string $field, string $value = '', bool $default = false): string
     {
@@ -716,12 +643,6 @@ if (! function_exists('set_radio')) {
      *
      * Let's you set the selected value of a radio field via info in the POST array.
      * If Form Validation is active it retrieves the info from the validation class
-     *
-     * @param string $field
-     * @param string $value
-     * @param bool   $default
-     *
-     * @return string
      */
     function set_radio(string $field, string $value = '', bool $default = false): string
     {
@@ -766,8 +687,6 @@ if (! function_exists('parse_form_attributes')) {
      *
      * @param array|string $attributes List of attributes
      * @param array        $default    Default values
-     *
-     * @return string
      */
     function parse_form_attributes($attributes, array $default): string
     {

--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -22,10 +22,7 @@ if (! function_exists('ul')) {
      * Generates an HTML unordered list from an single or
      * multi-dimensional array.
      *
-     * @param array $list
      * @param mixed $attributes HTML attributes string, array, object
-     *
-     * @return string
      */
     function ul(array $list, $attributes = ''): string
     {
@@ -39,10 +36,7 @@ if (! function_exists('ol')) {
      *
      * Generates an HTML ordered list from an single or multi-dimensional array.
      *
-     * @param array $list
      * @param mixed $attributes HTML attributes string, array, object
-     *
-     * @return string
      */
     function ol(array $list, $attributes = ''): string
     {
@@ -56,12 +50,8 @@ if (! function_exists('_list')) {
      *
      * Generates an HTML ordered list from an single or multi-dimensional array.
      *
-     * @param string $type
-     * @param mixed  $list
-     * @param mixed  $attributes string, array, object
-     * @param int    $depth
-     *
-     * @return string
+     * @param mixed $list
+     * @param mixed $attributes string, array, object
      */
     function _list(string $type = 'ul', $list = [], $attributes = '', int $depth = 0): string
     {
@@ -102,8 +92,6 @@ if (! function_exists('img')) {
      * @param array|string        $src        Image source URI, or array of attributes and values
      * @param bool                $indexPage  Whether to treat $src as a routed URI string
      * @param array|object|string $attributes Additional HTML attributes
-     *
-     * @return string
      */
     function img($src = '', bool $indexPage = false, $attributes = ''): string
     {
@@ -152,8 +140,6 @@ if (! function_exists('img_data')) {
      *
      * @param string      $path Image source path
      * @param string|null $mime MIME type to use, or null to guess
-     *
-     * @return string
      */
     function img_data(string $path, ?string $mime = null): string
     {
@@ -187,8 +173,6 @@ if (! function_exists('doctype')) {
      * All values are saved in the doctypes config file.
      *
      * @param string $type The doctype to be generated
-     *
-     * @return string
      */
     function doctype(string $type = 'html5'): string
     {
@@ -207,8 +191,6 @@ if (! function_exists('script_tag')) {
      *
      * @param mixed $src       Script source or an array
      * @param bool  $indexPage Should indexPage be added to the JS path
-     *
-     * @return string
      */
     function script_tag($src = '', bool $indexPage = false): string
     {
@@ -239,15 +221,8 @@ if (! function_exists('link_tag')) {
      *
      * Generates link to a CSS file
      *
-     * @param mixed  $href      Stylesheet href or an array
-     * @param string $rel
-     * @param string $type
-     * @param string $title
-     * @param string $media
-     * @param bool   $indexPage should indexPage be added to the CSS path.
-     * @param string $hreflang
-     *
-     * @return string
+     * @param mixed $href      Stylesheet href or an array
+     * @param bool  $indexPage should indexPage be added to the CSS path.
      */
     function link_tag($href = '', string $rel = 'stylesheet', string $type = 'text/css', string $title = '', string $media = '', bool $indexPage = false, string $hreflang = ''): string
     {
@@ -306,10 +281,6 @@ if (! function_exists('video')) {
      * @param mixed  $src                Either a source string or an array of sources
      * @param string $unsupportedMessage The message to display if the media tag is not supported by the browser
      * @param string $attributes         HTML attributes
-     * @param array  $tracks
-     * @param bool   $indexPage
-     *
-     * @return string
      */
     function video($src, string $unsupportedMessage = '', string $attributes = '', array $tracks = [], bool $indexPage = false): string
     {
@@ -358,10 +329,6 @@ if (! function_exists('audio')) {
      * @param mixed  $src                Either a source string or an array of sources
      * @param string $unsupportedMessage The message to display if the media tag is not supported by the browser.
      * @param string $attributes         HTML attributes
-     * @param array  $tracks
-     * @param bool   $indexPage
-     *
-     * @return string
      */
     function audio($src, string $unsupportedMessage = '', string $attributes = '', array $tracks = [], bool $indexPage = false): string
     {
@@ -403,13 +370,7 @@ if (! function_exists('_media')) {
     /**
      * Generate media based tag
      *
-     * @param string $name
-     * @param array  $types
      * @param string $unsupportedMessage The message to display if the media tag is not supported by the browser.
-     * @param string $attributes
-     * @param array  $tracks
-     *
-     * @return string
      */
     function _media(string $name, array $types = [], string $unsupportedMessage = '', string $attributes = '', array $tracks = []): string
     {
@@ -451,9 +412,6 @@ if (! function_exists('source')) {
      * @param string $src        The path of the media resource
      * @param string $type       The MIME-type of the resource with optional codecs parameters
      * @param string $attributes HTML attributes
-     * @param bool   $indexPage
-     *
-     * @return string
      */
     function source(string $src, string $type = 'unknown', string $attributes = '', bool $indexPage = false): string
     {
@@ -479,12 +437,7 @@ if (! function_exists('track')) {
      * Generates a track element to specify timed tracks. The tracks are
      * formatted in WebVTT format.
      *
-     * @param string $src         The path of the .VTT file
-     * @param string $kind
-     * @param string $srcLanguage
-     * @param string $label
-     *
-     * @return string
+     * @param string $src The path of the .VTT file
      */
     function track(string $src, string $kind, string $srcLanguage, string $label): string
     {
@@ -507,10 +460,6 @@ if (! function_exists('object')) {
      * @param string $data       A resource URL
      * @param string $type       Content-type of the resource
      * @param string $attributes HTML attributes
-     * @param array  $params
-     * @param bool   $indexPage
-     *
-     * @return string
      */
     function object(string $data, string $type = 'unknown', string $attributes = '', array $params = [], bool $indexPage = false): string
     {
@@ -544,8 +493,6 @@ if (! function_exists('param')) {
      * @param string $value      The value of the parameter
      * @param string $type       The MIME-type
      * @param string $attributes HTML attributes
-     *
-     * @return string
      */
     function param(string $name, string $value, string $type = 'ref', string $attributes = ''): string
     {
@@ -565,9 +512,6 @@ if (! function_exists('embed')) {
      * @param string $src        The path of the resource to embed
      * @param string $type       MIME-type
      * @param string $attributes HTML attributes
-     * @param bool   $indexPage
-     *
-     * @return string
      */
     function embed(string $src, string $type = 'unknown', string $attributes = '', bool $indexPage = false): string
     {
@@ -585,8 +529,6 @@ if (! function_exists('_has_protocol')) {
     /**
      * Test the protocol of a URI.
      *
-     * @param string $url
-     *
      * @return false|int
      */
     function _has_protocol(string $url)
@@ -598,10 +540,6 @@ if (! function_exists('_has_protocol')) {
 if (! function_exists('_space_indent')) {
     /**
      * Provide space indenting.
-     *
-     * @param int $depth
-     *
-     * @return string
      */
     function _space_indent(int $depth = 2): string
     {

--- a/system/Helpers/inflector_helper.php
+++ b/system/Helpers/inflector_helper.php
@@ -18,8 +18,6 @@ if (! function_exists('singular')) {
      * Takes a plural word and makes it singular
      *
      * @param string $string Input string
-     *
-     * @return string
      */
     function singular(string $string): string
     {
@@ -79,8 +77,6 @@ if (! function_exists('plural')) {
      * Takes a singular word and makes it plural
      *
      * @param string $string Input string
-     *
-     * @return string
      */
     function plural(string $string): string
     {
@@ -133,8 +129,6 @@ if (! function_exists('counted')) {
      *
      * @param int    $count  Number of items
      * @param string $string Input string
-     *
-     * @return string
      */
     function counted(int $count, string $string): string
     {
@@ -152,8 +146,6 @@ if (! function_exists('camelize')) {
      * underscores and converts them to camel case.
      *
      * @param string $string Input string
-     *
-     * @return string
      */
     function camelize(string $string): string
     {
@@ -170,8 +162,6 @@ if (! function_exists('pascalize')) {
      * which is camel case with an uppercase first letter.
      *
      * @param string $string Input string
-     *
-     * @return string
      */
     function pascalize(string $string): string
     {
@@ -186,8 +176,6 @@ if (! function_exists('underscore')) {
      * Takes multiple words separated by spaces and underscores them
      *
      * @param string $string Input string
-     *
-     * @return string
      */
     function underscore(string $string): string
     {
@@ -206,8 +194,6 @@ if (! function_exists('humanize')) {
      *
      * @param string $string    Input string
      * @param string $separator Input separator
-     *
-     * @return string
      */
     function humanize(string $string, string $separator = '_'): string
     {
@@ -222,8 +208,6 @@ if (! function_exists('is_pluralizable')) {
      * Checks if the given word has a plural version.
      *
      * @param string $word Word to check
-     *
-     * @return bool
      */
     function is_pluralizable(string $word): bool
     {
@@ -289,8 +273,6 @@ if (! function_exists('dasherize')) {
      * Replaces underscores with dashes in the string.
      *
      * @param string $string Input string
-     *
-     * @return string
      */
     function dasherize(string $string): string
     {
@@ -305,8 +287,6 @@ if (! function_exists('ordinal')) {
      * sequence such as 1st, 2nd, 3rd, 4th.
      *
      * @param int $integer The integer to determine the suffix
-     *
-     * @return string
      */
     function ordinal(int $integer): string
     {
@@ -334,8 +314,6 @@ if (! function_exists('ordinalize')) {
      * such as 1st, 2nd, 3rd, 4th.
      *
      * @param int $integer The integer to ordinalize
-     *
-     * @return string
      */
     function ordinalize(int $integer): string
     {

--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -17,8 +17,7 @@ if (! function_exists('number_to_size')) {
     /**
      * Formats a numbers as bytes, based on size, and adds the appropriate suffix
      *
-     * @param mixed  $num       Will be cast as int
-     * @param int    $precision
+     * @param mixed  $num    Will be cast as int
      * @param string $locale
      *
      * @return bool|string
@@ -70,9 +69,7 @@ if (! function_exists('number_to_amount')) {
      *
      * @see https://simple.wikipedia.org/wiki/Names_for_large_numbers
      *
-     * @param string      $num
-     * @param int         $precision
-     * @param string|null $locale
+     * @param string $num
      *
      * @return bool|string
      */
@@ -116,12 +113,8 @@ if (! function_exists('number_to_amount')) {
 
 if (! function_exists('number_to_currency')) {
     /**
-     * @param float  $num
-     * @param string $currency
      * @param string $locale
      * @param int    $fraction
-     *
-     * @return string
      */
     function number_to_currency(float $num, string $currency, ?string $locale = null, ?int $fraction = null): string
     {
@@ -137,13 +130,6 @@ if (! function_exists('format_number')) {
     /**
      * A general purpose, locale-aware, number_format method.
      * Used by all of the functions of the number_helper.
-     *
-     * @param float       $num
-     * @param int         $precision
-     * @param string|null $locale
-     * @param array       $options
-     *
-     * @return string
      */
     function format_number(float $num, int $precision = 1, ?string $locale = null, array $options = []): string
     {
@@ -193,8 +179,6 @@ if (! function_exists('number_to_roman')) {
      * Convert a number to a roman numeral.
      *
      * @param string $num it will convert to int
-     *
-     * @return string|null
      */
     function number_to_roman(string $num): ?string
     {

--- a/system/Helpers/security_helper.php
+++ b/system/Helpers/security_helper.php
@@ -16,10 +16,6 @@ use Config\Services;
 if (! function_exists('sanitize_filename')) {
     /**
      * Sanitize a filename to use in a URI.
-     *
-     * @param string $filename
-     *
-     * @return string
      */
     function sanitize_filename(string $filename): string
     {
@@ -30,10 +26,6 @@ if (! function_exists('sanitize_filename')) {
 if (! function_exists('strip_image_tags')) {
     /**
      * Strip Image Tags
-     *
-     * @param string $str
-     *
-     * @return string
      */
     function strip_image_tags(string $str): string
     {
@@ -51,10 +43,6 @@ if (! function_exists('strip_image_tags')) {
 if (! function_exists('encode_php_tags')) {
     /**
      * Convert PHP tags to entities
-     *
-     * @param string $str
-     *
-     * @return string
      */
     function encode_php_tags(string $str): string
     {

--- a/system/Helpers/test_helper.php
+++ b/system/Helpers/test_helper.php
@@ -20,6 +20,7 @@ if (! function_exists('fake')) {
      *
      * @param Model|object|string $model     Instance or name of the model
      * @param array|null          $overrides Overriding data to pass to Fabricator::setOverrides()
+     * @param mixed               $persist
      *
      * @return array|object
      */

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -19,11 +19,7 @@ if (! function_exists('word_limiter')) {
      *
      * Limits a string to X number of words.
      *
-     * @param string $str
-     * @param int    $limit
      * @param string $endChar the end character. Usually an ellipsis
-     *
-     * @return string
      */
     function word_limiter(string $str, int $limit = 100, string $endChar = '&#8230;'): string
     {
@@ -48,11 +44,7 @@ if (! function_exists('character_limiter')) {
      * Limits the string based on the character count.  Preserves complete words
      * so the character count may not be exactly as specified.
      *
-     * @param string $str
-     * @param int    $n
      * @param string $endChar the end character. Usually an ellipsis
-     *
-     * @return string
      */
     function character_limiter(string $str, int $n = 500, string $endChar = '&#8230;'): string
     {
@@ -86,10 +78,6 @@ if (! function_exists('ascii_to_entities')) {
      * High ASCII to Entities
      *
      * Converts high ASCII text and MS Word special characters to character entities
-     *
-     * @param string $str
-     *
-     * @return string
      */
     function ascii_to_entities(string $str): string
     {
@@ -138,11 +126,6 @@ if (! function_exists('entities_to_ascii')) {
      * Entities to ASCII
      *
      * Converts character entities back to ASCII
-     *
-     * @param string $str
-     * @param bool   $all
-     *
-     * @return string
      */
     function entities_to_ascii(string $str, bool $all = true): string
     {
@@ -186,8 +169,6 @@ if (! function_exists('word_censor')) {
      * @param string $str         the text string
      * @param array  $censored    the array of censored words
      * @param string $replacement the optional replacement value
-     *
-     * @return string
      */
     function word_censor(string $str, array $censored, string $replacement = ''): string
     {
@@ -239,8 +220,6 @@ if (! function_exists('highlight_code')) {
      * Colorizes code strings
      *
      * @param string $str the text string
-     *
-     * @return string
      */
     function highlight_code(string $str): string
     {
@@ -309,8 +288,6 @@ if (! function_exists('highlight_phrase')) {
      * @param string $phrase   the phrase you'd like to highlight
      * @param string $tagOpen  the opening tag to precede the phrase with
      * @param string $tagClose the closing tag to end the phrase with
-     *
-     * @return string
      */
     function highlight_phrase(string $str, string $phrase, string $tagOpen = '<mark>', string $tagClose = '</mark>'): string
     {
@@ -323,8 +300,6 @@ if (! function_exists('convert_accented_characters')) {
      * Convert Accented Foreign Characters to ASCII
      *
      * @param string $str Input string
-     *
-     * @return string
      */
     function convert_accented_characters(string $str): string
     {
@@ -359,8 +334,6 @@ if (! function_exists('word_wrap')) {
      *
      * @param string $str     the text string
      * @param int    $charlim = 76    the number of characters to wrap at
-     *
-     * @return string
      */
     function word_wrap(string $str, int $charlim = 76): string
     {
@@ -498,10 +471,6 @@ if (! function_exists('strip_quotes')) {
      * Strip Quotes
      *
      * Removes single and double quotes from a string
-     *
-     * @param string $str
-     *
-     * @return string
      */
     function strip_quotes(string $str): string
     {
@@ -514,10 +483,6 @@ if (! function_exists('quotes_to_entities')) {
      * Quotes to Entities
      *
      * Converts single and double quotes to entities
-     *
-     * @param string $str
-     *
-     * @return string
      */
     function quotes_to_entities(string $str): string
     {
@@ -537,10 +502,6 @@ if (! function_exists('reduce_double_slashes')) {
      * becomes:
      *
      * http://www.some-site.com/index.php
-     *
-     * @param string $str
-     *
-     * @return string
      */
     function reduce_double_slashes(string $str): string
     {
@@ -560,11 +521,8 @@ if (! function_exists('reduce_multiples')) {
      *
      * Fred, Bill, Joe, Jimmy
      *
-     * @param string $str
      * @param string $character the character you wish to reduce
      * @param bool   $trim      TRUE/FALSE - whether to trim the character from the beginning/end
-     *
-     * @return string
      */
     function reduce_multiples(string $str, string $character = ',', bool $trim = false): string
     {
@@ -582,8 +540,6 @@ if (! function_exists('random_string')) {
      *
      * @param string $type Type of random string.  basic, alpha, alnum, numeric, nozero, md5, sha1, and crypto
      * @param int    $len  Number of characters
-     *
-     * @return string
      */
     function random_string(string $type = 'alnum', int $len = 8): string
     {
@@ -634,8 +590,6 @@ if (! function_exists('increment_string')) {
      * @param string $str       Required
      * @param string $separator What should the duplicate number be appended with
      * @param int    $first     Which number should be used for the first dupe increment
-     *
-     * @return string
      */
     function increment_string(string $str, string $separator = '_', int $first = 1): string
     {
@@ -654,8 +608,6 @@ if (! function_exists('alternator')) {
      * @phpstan-ignore-next-line
      *
      * @param string (as many parameters as needed)
-     *
-     * @return string
      */
     function alternator(): string
     {

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -24,12 +24,9 @@ if (! function_exists('_get_uri')) {
      *
      * @internal Outside of the framework this should not be used directly.
      *
-     * @param string   $relativePath May include queries or fragments
-     * @param App|null $config
+     * @param string $relativePath May include queries or fragments
      *
      * @throws InvalidArgumentException For invalid paths or config
-     *
-     * @return URI
      */
     function _get_uri(string $relativePath = '', ?App $config = null): URI
     {
@@ -77,11 +74,8 @@ if (! function_exists('site_url')) {
     /**
      * Returns a site URL as defined by the App config.
      *
-     * @param mixed       $relativePath URI string or array of URI segments
-     * @param string|null $scheme
-     * @param App|null    $config       Alternate configuration to use
-     *
-     * @return string
+     * @param mixed    $relativePath URI string or array of URI segments
+     * @param App|null $config       Alternate configuration to use
      */
     function site_url($relativePath = '', ?string $scheme = null, ?App $config = null): string
     {
@@ -103,8 +97,6 @@ if (! function_exists('base_url')) {
      *
      * @param mixed  $relativePath URI string or array of URI segments
      * @param string $scheme
-     *
-     * @return string
      */
     function base_url($relativePath = '', ?string $scheme = null): string
     {
@@ -151,8 +143,6 @@ if (! function_exists('previous_url')) {
      * If that's not available, however, we'll use a sanitized url from $_SERVER['HTTP_REFERER']
      * which can be set by the user so is untrusted and not set by certain browsers/servers.
      *
-     * @param bool $returnObject
-     *
      * @return mixed|string|URI
      */
     function previous_url(bool $returnObject = false)
@@ -175,8 +165,6 @@ if (! function_exists('uri_string')) {
      * Returns the path part of the current URL
      *
      * @param bool $relative Whether the resulting path should be relative to baseURL
-     *
-     * @return string
      */
     function uri_string(bool $relative = false): string
     {
@@ -193,8 +181,6 @@ if (! function_exists('index_page')) {
      * Returns the "index_page" from your config file
      *
      * @param App|null $altConfig Alternate configuration to use
-     *
-     * @return string
      */
     function index_page(?App $altConfig = null): string
     {
@@ -215,8 +201,6 @@ if (! function_exists('anchor')) {
      * @param string   $title      The link title
      * @param mixed    $attributes Any attributes
      * @param App|null $altConfig  Alternate configuration to use
-     *
-     * @return string
      */
     function anchor($uri = '', string $title = '', $attributes = '', ?App $altConfig = null): string
     {
@@ -250,8 +234,6 @@ if (! function_exists('anchor_popup')) {
      * @param string   $title      the link title
      * @param mixed    $attributes any attributes
      * @param App|null $altConfig  Alternate configuration to use
-     *
-     * @return string
      */
     function anchor_popup($uri = '', string $title = '', $attributes = false, ?App $altConfig = null): string
     {
@@ -301,8 +283,6 @@ if (! function_exists('mailto')) {
      * @param string $email      the email address
      * @param string $title      the link title
      * @param mixed  $attributes any attributes
-     *
-     * @return string
      */
     function mailto(string $email, string $title = '', $attributes = ''): string
     {
@@ -323,8 +303,6 @@ if (! function_exists('safe_mailto')) {
      * @param string $email      the email address
      * @param string $title      the link title
      * @param mixed  $attributes any attributes
-     *
-     * @return string
      */
     function safe_mailto(string $email, string $title = '', $attributes = ''): string
     {
@@ -418,8 +396,6 @@ if (! function_exists('auto_link')) {
      * @param string $str   the string
      * @param string $type  the type: email, url, or both
      * @param bool   $popup whether to create pop-up links
-     *
-     * @return string
      */
     function auto_link(string $str, string $type = 'both', bool $popup = false): string
     {
@@ -464,8 +440,6 @@ if (! function_exists('prep_url')) {
      *
      * @param string $str    the URL
      * @param bool   $secure set true if you want to force https://
-     *
-     * @return string
      */
     function prep_url(string $str = '', bool $secure = false): string
     {
@@ -497,8 +471,6 @@ if (! function_exists('url_title')) {
      * @param string $str       Input string
      * @param string $separator Word separator (usually '-' or '_')
      * @param bool   $lowercase Whether to transform the output string to lowercase
-     *
-     * @return string
      */
     function url_title(string $str, string $separator = '-', bool $lowercase = false): string
     {
@@ -536,8 +508,6 @@ if (! function_exists('mb_url_title')) {
      * @param string $str       Input string
      * @param string $separator Word separator (usually '-' or '_')
      * @param bool   $lowercase Whether to transform the output string to lowercase
-     *
-     * @return string
      */
     function mb_url_title(string $str, string $separator = '-', bool $lowercase = false): string
     {
@@ -552,12 +522,9 @@ if (! function_exists('url_to')) {
      * Get the full, absolute URL to a controller method
      * (with additional arguments)
      *
-     * @param string $controller
-     * @param mixed  ...$args
+     * @param mixed ...$args
      *
      * @throws RouterException
-     *
-     * @return string
      */
     function url_to(string $controller, ...$args): string
     {
@@ -583,10 +550,6 @@ if (! function_exists('url_is')) {
      *
      * Example:
      *   if (url_is('admin*)) ...
-     *
-     * @param string $path
-     *
-     * @return bool
      */
     function url_is(string $path): bool
     {

--- a/system/Helpers/xml_helper.php
+++ b/system/Helpers/xml_helper.php
@@ -14,11 +14,6 @@
 if (! function_exists('xml_convert')) {
     /**
      * Convert Reserved XML characters to Entities
-     *
-     * @param string $str
-     * @param bool   $protectAll
-     *
-     * @return string
      */
     function xml_convert(string $str, bool $protectAll = false): string
     {

--- a/system/Honeypot/Honeypot.php
+++ b/system/Honeypot/Honeypot.php
@@ -31,8 +31,6 @@ class Honeypot
     /**
      * Constructor.
      *
-     * @param HoneypotConfig $config
-     *
      * @throws HoneypotException
      */
     public function __construct(HoneypotConfig $config)
@@ -58,8 +56,6 @@ class Honeypot
 
     /**
      * Checks the request if honeypot field has data.
-     *
-     * @param RequestInterface $request
      */
     public function hasContent(RequestInterface $request)
     {
@@ -68,8 +64,6 @@ class Honeypot
 
     /**
      * Attaches Honeypot template to response.
-     *
-     * @param ResponseInterface $response
      */
     public function attachHoneypot(ResponseInterface $response)
     {
@@ -83,10 +77,6 @@ class Honeypot
     /**
      * Prepares the template by adding label
      * content and field name.
-     *
-     * @param string $template
-     *
-     * @return string
      */
     protected function prepareTemplate(string $template): string
     {

--- a/system/I18n/Exceptions/I18nException.php
+++ b/system/I18n/Exceptions/I18nException.php
@@ -22,8 +22,6 @@ class I18nException extends FrameworkException
      * Thrown when createFromFormat fails to receive a valid
      * DateTime back from DateTime::createFromFormat.
      *
-     * @param string $format
-     *
      * @return static
      */
     public static function forInvalidFormat(string $format)
@@ -34,8 +32,6 @@ class I18nException extends FrameworkException
     /**
      * Thrown when the numeric representation of the month falls
      * outside the range of allowed months.
-     *
-     * @param string $month
      *
      * @return static
      */
@@ -48,8 +44,6 @@ class I18nException extends FrameworkException
      * Thrown when the supplied day falls outside the range
      * of allowed days.
      *
-     * @param string $day
-     *
      * @return static
      */
     public static function forInvalidDay(string $day)
@@ -60,9 +54,6 @@ class I18nException extends FrameworkException
     /**
      * Thrown when the day provided falls outside the allowed
      * last day for the given month.
-     *
-     * @param string $lastDay
-     * @param string $day
      *
      * @return static
      */
@@ -75,8 +66,6 @@ class I18nException extends FrameworkException
      * Thrown when the supplied hour falls outside the
      * range of allowed hours.
      *
-     * @param string $hour
-     *
      * @return static
      */
     public static function forInvalidHour(string $hour)
@@ -88,8 +77,6 @@ class I18nException extends FrameworkException
      * Thrown when the supplied minutes falls outside the
      * range of allowed minutes.
      *
-     * @param string $minutes
-     *
      * @return static
      */
     public static function forInvalidMinutes(string $minutes)
@@ -100,8 +87,6 @@ class I18nException extends FrameworkException
     /**
      * Thrown when the supplied seconds falls outside the
      * range of allowed seconds.
-     *
-     * @param string $seconds
      *
      * @return static
      */

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -70,9 +70,7 @@ class Time extends DateTime
     /**
      * Time constructor.
      *
-     * @param string|null              $time
      * @param DateTimeZone|string|null $timezone
-     * @param string|null              $locale
      *
      * @throws Exception
      */
@@ -109,7 +107,6 @@ class Time extends DateTime
      * Returns a new Time instance with the timezone set.
      *
      * @param DateTimeZone|string|null $timezone
-     * @param string|null              $locale
      *
      * @throws Exception
      *
@@ -126,9 +123,7 @@ class Time extends DateTime
      * Example:
      *  $time = Time::parse('first day of December 2008');
      *
-     * @param string                   $datetime
      * @param DateTimeZone|string|null $timezone
-     * @param string|null              $locale
      *
      * @throws Exception
      *
@@ -143,7 +138,6 @@ class Time extends DateTime
      * Return a new time with the time set to midnight.
      *
      * @param DateTimeZone|string|null $timezone
-     * @param string|null              $locale
      *
      * @throws Exception
      *
@@ -158,7 +152,6 @@ class Time extends DateTime
      * Returns an instance set to midnight yesterday morning.
      *
      * @param DateTimeZone|string|null $timezone
-     * @param string|null              $locale
      *
      * @throws Exception
      *
@@ -173,7 +166,6 @@ class Time extends DateTime
      * Returns an instance set to midnight tomorrow morning.
      *
      * @param DateTimeZone|string|null $timezone
-     * @param string|null              $locale
      *
      * @throws Exception
      *
@@ -188,11 +180,7 @@ class Time extends DateTime
      * Returns a new instance based on the year, month and day. If any of those three
      * are left empty, will default to the current value.
      *
-     * @param int|null                 $year
-     * @param int|null                 $month
-     * @param int|null                 $day
      * @param DateTimeZone|string|null $timezone
-     * @param string|null              $locale
      *
      * @throws Exception
      *
@@ -206,11 +194,7 @@ class Time extends DateTime
     /**
      * Returns a new instance with the date set to today, and the time set to the values passed in.
      *
-     * @param int|null                 $hour
-     * @param int|null                 $minutes
-     * @param int|null                 $seconds
      * @param DateTimeZone|string|null $timezone
-     * @param string|null              $locale
      *
      * @throws Exception
      *
@@ -224,14 +208,7 @@ class Time extends DateTime
     /**
      * Returns a new instance with the date time values individually set.
      *
-     * @param int|null                 $year
-     * @param int|null                 $month
-     * @param int|null                 $day
-     * @param int|null                 $hour
-     * @param int|null                 $minutes
-     * @param int|null                 $seconds
      * @param DateTimeZone|string|null $timezone
-     * @param string|null              $locale
      *
      * @throws Exception
      *
@@ -273,9 +250,7 @@ class Time extends DateTime
     /**
      * Returns a new instance with the datetime set based on the provided UNIX timestamp.
      *
-     * @param int                      $timestamp
      * @param DateTimeZone|string|null $timezone
-     * @param string|null              $locale
      *
      * @throws Exception
      *
@@ -288,9 +263,6 @@ class Time extends DateTime
 
     /**
      * Takes an instance of DateTimeInterface and returns an instance of Time with it's same values.
-     *
-     * @param DateTimeInterface $dateTime
-     * @param string|null       $locale
      *
      * @throws Exception
      *
@@ -306,9 +278,6 @@ class Time extends DateTime
 
     /**
      * Takes an instance of DateTime and returns an instance of Time with it's same values.
-     *
-     * @param DateTime    $dateTime
-     * @param string|null $locale
      *
      * @throws Exception
      *
@@ -347,7 +316,6 @@ class Time extends DateTime
      *
      * @param DateTimeInterface|string|Time|null $datetime
      * @param DateTimeZone|string|null           $timezone
-     * @param string|null                        $locale
      *
      * @throws Exception
      */
@@ -372,8 +340,6 @@ class Time extends DateTime
 
     /**
      * Returns whether we have a testNow instance saved.
-     *
-     * @return bool
      */
     public static function hasTestNow(): bool
     {
@@ -388,8 +354,6 @@ class Time extends DateTime
      * Returns the localized Year
      *
      * @throws Exception
-     *
-     * @return string
      */
     public function getYear(): string
     {
@@ -400,8 +364,6 @@ class Time extends DateTime
      * Returns the localized Month
      *
      * @throws Exception
-     *
-     * @return string
      */
     public function getMonth(): string
     {
@@ -412,8 +374,6 @@ class Time extends DateTime
      * Return the localized day of the month.
      *
      * @throws Exception
-     *
-     * @return string
      */
     public function getDay(): string
     {
@@ -424,8 +384,6 @@ class Time extends DateTime
      * Return the localized hour (in 24-hour format).
      *
      * @throws Exception
-     *
-     * @return string
      */
     public function getHour(): string
     {
@@ -436,8 +394,6 @@ class Time extends DateTime
      * Return the localized minutes in the hour.
      *
      * @throws Exception
-     *
-     * @return string
      */
     public function getMinute(): string
     {
@@ -448,8 +404,6 @@ class Time extends DateTime
      * Return the localized seconds
      *
      * @throws Exception
-     *
-     * @return string
      */
     public function getSecond(): string
     {
@@ -460,8 +414,6 @@ class Time extends DateTime
      * Return the index of the day of the week
      *
      * @throws Exception
-     *
-     * @return string
      */
     public function getDayOfWeek(): string
     {
@@ -472,8 +424,6 @@ class Time extends DateTime
      * Return the index of the day of the year
      *
      * @throws Exception
-     *
-     * @return string
      */
     public function getDayOfYear(): string
     {
@@ -484,8 +434,6 @@ class Time extends DateTime
      * Return the index of the week in the month
      *
      * @throws Exception
-     *
-     * @return string
      */
     public function getWeekOfMonth(): string
     {
@@ -496,8 +444,6 @@ class Time extends DateTime
      * Return the index of the week in the year
      *
      * @throws Exception
-     *
-     * @return string
      */
     public function getWeekOfYear(): string
     {
@@ -524,8 +470,6 @@ class Time extends DateTime
      * Returns the number of the current quarter for the year.
      *
      * @throws Exception
-     *
-     * @return string
      */
     public function getQuarter(): string
     {
@@ -534,8 +478,6 @@ class Time extends DateTime
 
     /**
      * Are we in daylight savings time currently?
-     *
-     * @return bool
      */
     public function getDst(): bool
     {
@@ -559,8 +501,6 @@ class Time extends DateTime
     /**
      * Returns boolean whether the passed timezone is the same as
      * the local timezone.
-     *
-     * @return bool
      */
     public function getLocal(): bool
     {
@@ -571,8 +511,6 @@ class Time extends DateTime
 
     /**
      * Returns boolean whether object is in UTC.
-     *
-     * @return bool
      */
     public function getUtc(): bool
     {
@@ -581,8 +519,6 @@ class Time extends DateTime
 
     /**
      * Returns the name of the current timezone.
-     *
-     * @return string
      */
     public function getTimezoneName(): string
     {
@@ -710,8 +646,7 @@ class Time extends DateTime
     /**
      * Helper method to do the heavy lifting of the 'setX' methods.
      *
-     * @param string $name
-     * @param int    $value
+     * @param int $value
      *
      * @throws Exception
      *
@@ -774,8 +709,6 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $seconds added to the time.
      *
-     * @param int $seconds
-     *
      * @return static
      */
     public function addSeconds(int $seconds)
@@ -787,8 +720,6 @@ class Time extends DateTime
 
     /**
      * Returns a new Time instance with $minutes added to the time.
-     *
-     * @param int $minutes
      *
      * @return static
      */
@@ -802,8 +733,6 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $hours added to the time.
      *
-     * @param int $hours
-     *
      * @return static
      */
     public function addHours(int $hours)
@@ -815,8 +744,6 @@ class Time extends DateTime
 
     /**
      * Returns a new Time instance with $days added to the time.
-     *
-     * @param int $days
      *
      * @return static
      */
@@ -830,8 +757,6 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $months added to the time.
      *
-     * @param int $months
-     *
      * @return static
      */
     public function addMonths(int $months)
@@ -843,8 +768,6 @@ class Time extends DateTime
 
     /**
      * Returns a new Time instance with $years added to the time.
-     *
-     * @param int $years
      *
      * @return static
      */
@@ -858,8 +781,6 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $seconds subtracted from the time.
      *
-     * @param int $seconds
-     *
      * @return static
      */
     public function subSeconds(int $seconds)
@@ -871,8 +792,6 @@ class Time extends DateTime
 
     /**
      * Returns a new Time instance with $minutes subtracted from the time.
-     *
-     * @param int $minutes
      *
      * @return static
      */
@@ -886,8 +805,6 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $hours subtracted from the time.
      *
-     * @param int $hours
-     *
      * @return static
      */
     public function subHours(int $hours)
@@ -899,8 +816,6 @@ class Time extends DateTime
 
     /**
      * Returns a new Time instance with $days subtracted from the time.
-     *
-     * @param int $days
      *
      * @return static
      */
@@ -914,8 +829,6 @@ class Time extends DateTime
     /**
      * Returns a new Time instance with $months subtracted from the time.
      *
-     * @param int $months
-     *
      * @return static
      */
     public function subMonths(int $months)
@@ -927,8 +840,6 @@ class Time extends DateTime
 
     /**
      * Returns a new Time instance with $hours subtracted from the time.
-     *
-     * @param int $years
      *
      * @return static
      */
@@ -996,8 +907,6 @@ class Time extends DateTime
     /**
      * Returns the localized value of this instance in $format.
      *
-     * @param string|null $format
-     *
      * @throws Exception
      *
      * @return bool|string
@@ -1020,11 +929,8 @@ class Time extends DateTime
      * converted to UTC and compared that way.
      *
      * @param DateTimeInterface|string|Time $testTime
-     * @param string|null                   $timezone
      *
      * @throws Exception
-     *
-     * @return bool
      */
     public function equals($testTime, ?string $timezone = null): bool
     {
@@ -1041,11 +947,8 @@ class Time extends DateTime
      * Ensures that the times are identical, taking timezone into account.
      *
      * @param DateTimeInterface|string|Time $testTime
-     * @param string|null                   $timezone
      *
      * @throws Exception
-     *
-     * @return bool
      */
     public function sameAs($testTime, ?string $timezone = null): bool
     {
@@ -1067,12 +970,9 @@ class Time extends DateTime
      * Determines if the current instance's time is before $testTime,
      * after converting to UTC.
      *
-     * @param mixed       $testTime
-     * @param string|null $timezone
+     * @param mixed $testTime
      *
      * @throws Exception
-     *
-     * @return bool
      */
     public function isBefore($testTime, ?string $timezone = null): bool
     {
@@ -1086,12 +986,9 @@ class Time extends DateTime
      * Determines if the current instance's time is after $testTime,
      * after converting in UTC.
      *
-     * @param mixed       $testTime
-     * @param string|null $timezone
+     * @param mixed $testTime
      *
      * @throws Exception
-     *
-     * @return bool
      */
     public function isAfter($testTime, ?string $timezone = null): bool
     {
@@ -1163,8 +1060,7 @@ class Time extends DateTime
     }
 
     /**
-     * @param mixed       $testTime
-     * @param string|null $timezone
+     * @param mixed $testTime
      *
      * @throws Exception
      *
@@ -1185,8 +1081,7 @@ class Time extends DateTime
     /**
      * Returns a Time instance with the timezone converted to UTC.
      *
-     * @param mixed       $time
-     * @param string|null $timezone
+     * @param mixed $time
      *
      * @throws Exception
      *
@@ -1227,10 +1122,6 @@ class Time extends DateTime
 
     /**
      * Check a time string to see if it includes a relative date (like 'next Tuesday').
-     *
-     * @param string $time
-     *
-     * @return bool
      */
     protected static function hasRelativeKeywords(string $time): bool
     {
@@ -1246,8 +1137,6 @@ class Time extends DateTime
      * Outputs a short format version of the datetime.
      *
      * @throws Exception
-     *
-     * @return string
      */
     public function __toString(): string
     {
@@ -1281,8 +1170,6 @@ class Time extends DateTime
      * Allow for property-type checking to any getX method...
      *
      * @param string $name
-     *
-     * @return bool
      */
     public function __isset($name): bool
     {

--- a/system/I18n/TimeDifference.php
+++ b/system/I18n/TimeDifference.php
@@ -99,9 +99,6 @@ class TimeDifference
     /**
      * Note: both parameters are required to be in the same timezone. No timezone
      * shifting is done internally.
-     *
-     * @param DateTime $currentTime
-     * @param DateTime $testTime
      */
     public function __construct(DateTime $currentTime, DateTime $testTime)
     {
@@ -116,8 +113,6 @@ class TimeDifference
 
     /**
      * Returns the number of years of difference between the two.
-     *
-     * @param bool $raw
      *
      * @return float|int
      */
@@ -135,8 +130,6 @@ class TimeDifference
     /**
      * Returns the number of months difference between the two dates.
      *
-     * @param bool $raw
-     *
      * @return float|int
      */
     public function getMonths(bool $raw = false)
@@ -152,8 +145,6 @@ class TimeDifference
 
     /**
      * Returns the number of weeks difference between the two dates.
-     *
-     * @param bool $raw
      *
      * @return float|int
      */
@@ -171,8 +162,6 @@ class TimeDifference
     /**
      * Returns the number of days difference between the two dates.
      *
-     * @param bool $raw
-     *
      * @return float|int
      */
     public function getDays(bool $raw = false)
@@ -188,8 +177,6 @@ class TimeDifference
 
     /**
      * Returns the number of hours difference between the two dates.
-     *
-     * @param bool $raw
      *
      * @return float|int
      */
@@ -207,8 +194,6 @@ class TimeDifference
     /**
      * Returns the number of minutes difference between the two dates.
      *
-     * @param bool $raw
-     *
      * @return float|int
      */
     public function getMinutes(bool $raw = false)
@@ -225,8 +210,6 @@ class TimeDifference
     /**
      * Returns the number of seconds difference between the two dates.
      *
-     * @param bool $raw
-     *
      * @return int
      */
     public function getSeconds(bool $raw = false)
@@ -242,10 +225,6 @@ class TimeDifference
 
     /**
      * Convert the time to human readable format
-     *
-     * @param string|null $locale
-     *
-     * @return string
      */
     public function humanize(?string $locale = null): string
     {

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -136,8 +136,6 @@ abstract class BaseHandler implements ImageHandlerInterface
      * Sets another image for this handler to work on.
      * Keeps us from needing to continually instantiate the handler.
      *
-     * @param string $path
-     *
      * @return $this
      */
     public function withFile(string $path)
@@ -236,10 +234,7 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Resize the image
      *
-     * @param int    $width
-     * @param int    $height
-     * @param bool   $maintainRatio If true, will get the closest match possible while keeping aspect ratio true.
-     * @param string $masterDim
+     * @param bool $maintainRatio If true, will get the closest match possible while keeping aspect ratio true.
      *
      * @return BaseHandler
      */
@@ -266,12 +261,8 @@ abstract class BaseHandler implements ImageHandlerInterface
      * is not provided, that value will be set the appropriate value based on offsets and
      * image dimensions.
      *
-     * @param int|null $width
-     * @param int|null $height
-     * @param int|null $x             X-axis coord to start cropping from the left of image
-     * @param int|null $y             Y-axis coord to start cropping from the top of image
-     * @param bool     $maintainRatio
-     * @param string   $masterDim
+     * @param int|null $x X-axis coord to start cropping from the left of image
+     * @param int|null $y Y-axis coord to start cropping from the top of image
      *
      * @return $this
      */
@@ -313,8 +304,6 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Rotates the image on the current canvas.
      *
-     * @param float $angle
-     *
      * @return $this
      */
     public function rotate(float $angle)
@@ -349,10 +338,6 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Flattens transparencies, default white background
      *
-     * @param int $red
-     * @param int $green
-     * @param int $blue
-     *
      * @return $this
      */
     public function flatten(int $red = 255, int $green = 255, int $blue = 255)
@@ -366,10 +351,6 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Handler-specific method to flattening an image's transparencies.
      *
-     * @param int $red
-     * @param int $green
-     * @param int $blue
-     *
      * @return $this
      *
      * @internal
@@ -378,8 +359,6 @@ abstract class BaseHandler implements ImageHandlerInterface
 
     /**
      * Handler-specific method to handle rotating an image in 90 degree increments.
-     *
-     * @param int $angle
      *
      * @return mixed
      */
@@ -407,8 +386,6 @@ abstract class BaseHandler implements ImageHandlerInterface
      * Handler-specific method to handle flipping an image along its
      * horizontal or vertical axis.
      *
-     * @param string $direction
-     *
      * @return $this
      */
     abstract protected function _flip(string $direction);
@@ -428,9 +405,6 @@ abstract class BaseHandler implements ImageHandlerInterface
      *  - fontSize
      *  - shadowOffset
      *
-     * @param string $text
-     * @param array  $options
-     *
      * @return $this
      */
     public function text(string $text, array $options = [])
@@ -446,16 +420,11 @@ abstract class BaseHandler implements ImageHandlerInterface
 
     /**
      * Handler-specific method for overlaying text on an image.
-     *
-     * @param string $text
-     * @param array  $options
      */
     abstract protected function _text(string $text, array $options = []);
 
     /**
      * Handles the actual resizing of the image.
-     *
-     * @param bool $maintainRatio
      *
      * @return $this
      */
@@ -574,9 +543,7 @@ abstract class BaseHandler implements ImageHandlerInterface
      *  - bottom
      *  - bottom-right
      *
-     * @param int    $width
-     * @param int    $height
-     * @param string $position
+     * @param int $height
      *
      * @return BaseHandler
      */
@@ -603,8 +570,6 @@ abstract class BaseHandler implements ImageHandlerInterface
      * @param float|int|null $height
      * @param float|int      $origWidth
      * @param float|int      $origHeight
-     *
-     * @return array
      */
     protected function calcAspectRatio($width, $height = null, $origWidth = 0, $origHeight = 0): array
     {
@@ -648,8 +613,6 @@ abstract class BaseHandler implements ImageHandlerInterface
      * @param float|int $origWidth
      * @param float|int $origHeight
      * @param string    $position
-     *
-     * @return array
      */
     protected function calcCropCoords($width, $height, $origWidth, $origHeight, $position): array
     {
@@ -724,17 +687,12 @@ abstract class BaseHandler implements ImageHandlerInterface
      *    $image->resize(100, 200, true)
      *          ->save($target);
      *
-     * @param string|null $target
-     * @param int         $quality
-     *
      * @return bool
      */
     abstract public function save(?string $target = null, int $quality = 90);
 
     /**
      * Does the driver-specific processing of the image.
-     *
-     * @param string $action
      *
      * @return mixed
      */
@@ -743,9 +701,6 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Provide access to the Image class' methods if they don't exist
      * on the handler itself.
-     *
-     * @param string $name
-     * @param array  $args
      *
      * @return mixed
      */

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -41,10 +41,6 @@ class GDHandler extends BaseHandler
     /**
      * Handles the rotation of an image resource.
      * Doesn't save the image, but replaces the current resource.
-     *
-     * @param int $angle
-     *
-     * @return bool
      */
     protected function _rotate(int $angle): bool
     {
@@ -71,10 +67,6 @@ class GDHandler extends BaseHandler
 
     /**
      * Flattens transparencies
-     *
-     * @param int $red
-     * @param int $green
-     * @param int $blue
      *
      * @return $this
      */
@@ -106,8 +98,6 @@ class GDHandler extends BaseHandler
 
     /**
      * Flips an image along it's vertical or horizontal axis.
-     *
-     * @param string $direction
      *
      * @return $this
      */
@@ -163,8 +153,6 @@ class GDHandler extends BaseHandler
     /**
      * Handles all of the grunt work of resizing, etc.
      *
-     * @param string $action
-     *
      * @return $this
      */
     protected function process(string $action)
@@ -219,11 +207,6 @@ class GDHandler extends BaseHandler
      * Example:
      *    $image->resize(100, 200, true)
      *          ->save();
-     *
-     * @param string|null $target
-     * @param int         $quality
-     *
-     * @return bool
      */
     public function save(?string $target = null, int $quality = 90): bool
     {
@@ -302,9 +285,6 @@ class GDHandler extends BaseHandler
      *
      * This simply creates an image resource handle
      * based on the type of image being processed
-     *
-     * @param string $path
-     * @param string $imageType
      *
      * @return bool|resource
      */
@@ -388,9 +368,6 @@ class GDHandler extends BaseHandler
     /**
      * Add text overlay to an image.
      *
-     * @param string $text
-     * @param array  $options
-     *
      * @return void
      */
     protected function _text(string $text, array $options = [])
@@ -468,9 +445,7 @@ class GDHandler extends BaseHandler
     /**
      * Handler-specific method for overlaying text on an image.
      *
-     * @param string $text
-     * @param array  $options
-     * @param bool   $isShadow Whether we are drawing the dropshadow or actual text
+     * @param bool $isShadow Whether we are drawing the dropshadow or actual text
      *
      * @return void
      */

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -58,8 +58,6 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Handles the actual resizing of the image.
      *
-     * @param bool $maintainRatio
-     *
      * @throws Exception
      *
      * @return ImageMagickHandler
@@ -112,8 +110,6 @@ class ImageMagickHandler extends BaseHandler
      * Handles the rotation of an image resource.
      * Doesn't save the image, but replaces the current resource.
      *
-     * @param int $angle
-     *
      * @throws Exception
      *
      * @return $this
@@ -134,10 +130,6 @@ class ImageMagickHandler extends BaseHandler
 
     /**
      * Flattens transparencies, default white background
-     *
-     * @param int $red
-     * @param int $green
-     * @param int $blue
      *
      * @throws Exception
      *
@@ -160,8 +152,6 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Flips an image along it's vertical or horizontal axis.
      *
-     * @param string $direction
-     *
      * @throws Exception
      *
      * @return $this
@@ -182,8 +172,6 @@ class ImageMagickHandler extends BaseHandler
 
     /**
      * Get driver version
-     *
-     * @return string
      */
     public function getVersion(): string
     {
@@ -197,9 +185,6 @@ class ImageMagickHandler extends BaseHandler
 
     /**
      * Handles all of the grunt work of resizing, etc.
-     *
-     * @param string $action
-     * @param int    $quality
      *
      * @throws Exception
      *
@@ -246,11 +231,6 @@ class ImageMagickHandler extends BaseHandler
      * Example:
      *    $image->resize(100, 200, true)
      *          ->save();
-     *
-     * @param string|null $target
-     * @param int         $quality
-     *
-     * @return bool
      */
     public function save(?string $target = null, int $quality = 90): bool
     {
@@ -345,9 +325,6 @@ class ImageMagickHandler extends BaseHandler
 
     /**
      * Handler-specific method for overlaying text on an image.
-     *
-     * @param string $text
-     * @param array  $options
      *
      * @throws Exception
      */

--- a/system/Images/Image.php
+++ b/system/Images/Image.php
@@ -64,8 +64,6 @@ class Image extends File
      * @param string      $targetPath The directory to store the file in
      * @param string|null $targetName The new name of the copied file.
      * @param int         $perms      File permissions to be applied after copy.
-     *
-     * @return bool
      */
     public function copy(string $targetPath, ?string $targetName = null, int $perms = 0644): bool
     {
@@ -94,8 +92,6 @@ class Image extends File
      * Get image properties
      *
      * A helper function that gets info about the file
-     *
-     * @param bool $return
      *
      * @return array|bool
      */

--- a/system/Images/ImageHandlerInterface.php
+++ b/system/Images/ImageHandlerInterface.php
@@ -19,10 +19,7 @@ interface ImageHandlerInterface
     /**
      * Resize the image
      *
-     * @param int    $width
-     * @param int    $height
-     * @param bool   $maintainRatio If true, will get the closest match possible while keeping aspect ratio true.
-     * @param string $masterDim
+     * @param bool $maintainRatio If true, will get the closest match possible while keeping aspect ratio true.
      *
      * @return $this
      */
@@ -33,12 +30,8 @@ interface ImageHandlerInterface
      * is not provided, that value will be set the appropriate value based on offsets and
      * image dimensions.
      *
-     * @param int|null $width
-     * @param int|null $height
-     * @param int|null $x             X-axis coord to start cropping from the left of image
-     * @param int|null $y             Y-axis coord to start cropping from the top of image
-     * @param bool     $maintainRatio
-     * @param string   $masterDim
+     * @param int|null $x X-axis coord to start cropping from the left of image
+     * @param int|null $y Y-axis coord to start cropping from the top of image
      *
      * @return $this
      */
@@ -57,18 +50,12 @@ interface ImageHandlerInterface
     /**
      * Rotates the image on the current canvas.
      *
-     * @param float $angle
-     *
      * @return $this
      */
     public function rotate(float $angle);
 
     /**
      * Flattens transparencies, default white background
-     *
-     * @param int $red
-     * @param int $green
-     * @param int $blue
      *
      * @return $this
      */
@@ -115,10 +102,6 @@ interface ImageHandlerInterface
      *  - bottom
      *  - bottom-right
      *
-     * @param int    $width
-     * @param int    $height
-     * @param string $position
-     *
      * @return $this
      */
     public function fit(int $width, int $height, string $position);
@@ -138,9 +121,6 @@ interface ImageHandlerInterface
      *  - fontSize
      *  - shadowOffset
      *
-     * @param string $text
-     * @param array  $options
-     *
      * @return $this
      */
     public function text(string $text, array $options = []);
@@ -153,7 +133,6 @@ interface ImageHandlerInterface
      *          ->save($target);
      *
      * @param string $target
-     * @param int    $quality
      *
      * @return bool
      */

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -65,8 +65,6 @@ class Language
     /**
      * Sets the current locale to use when performing string lookups.
      *
-     * @param string $locale
-     *
      * @return $this
      */
     public function setLocale(?string $locale = null)
@@ -78,9 +76,6 @@ class Language
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getLocale(): string
     {
         return $this->locale;
@@ -90,10 +85,7 @@ class Language
      * Parses the language string for a file, loads the file, if necessary,
      * getting the line.
      *
-     * @param string $line Line.
-     * @param array  $args Arguments.
-     *
-     * @return string|string[] Returns line.
+     * @return string|string[]
      */
     public function getLine(string $line, array $args = [])
     {
@@ -162,11 +154,6 @@ class Language
     /**
      * Parses the language string which should include the
      * filename as the first segment (separated by period).
-     *
-     * @param string $line
-     * @param string $locale
-     *
-     * @return array
      */
     protected function parseLine(string $line, string $locale): array
     {
@@ -177,19 +164,16 @@ class Language
             $this->load($file, $locale);
         }
 
-        return [
-            $file,
-            $line,
-        ];
+        return [$file, $line];
     }
 
     /**
      * Advanced message formatting.
      *
-     * @param array|string $message Message.
-     * @param array        $args    Arguments.
+     * @param array|string $message
+     * @param string[]     $args
      *
-     * @return array|string Returns formatted message.
+     * @return array|string
      */
     protected function formatMessage($message, array $args = [])
     {
@@ -212,10 +196,6 @@ class Language
      * Loads a language file in the current locale. If $return is true,
      * will return the file's contents, otherwise will merge with
      * the existing language lines.
-     *
-     * @param string $file
-     * @param string $locale
-     * @param bool   $return
      *
      * @return array|void
      */
@@ -255,10 +235,6 @@ class Language
     /**
      * A simple method for including files that can be
      * overridden during testing.
-     *
-     * @param string $path
-     *
-     * @return array
      */
     protected function requireFile(string $path): array
     {

--- a/system/Log/Handlers/BaseHandler.php
+++ b/system/Log/Handlers/BaseHandler.php
@@ -32,8 +32,6 @@ abstract class BaseHandler implements HandlerInterface
 
     /**
      * Constructor
-     *
-     * @param array $config
      */
     public function __construct(array $config)
     {
@@ -43,10 +41,6 @@ abstract class BaseHandler implements HandlerInterface
     /**
      * Checks whether the Handler will handle logging items of this
      * log Level.
-     *
-     * @param string $level
-     *
-     * @return bool
      */
     public function canHandle(string $level): bool
     {
@@ -61,17 +55,11 @@ abstract class BaseHandler implements HandlerInterface
      *
      * @param string $level
      * @param string $message
-     *
-     * @return bool
      */
     abstract public function handle($level, $message): bool;
 
     /**
      * Stores the date format to use while logging messages.
-     *
-     * @param string $format
-     *
-     * @return HandlerInterface
      */
     public function setDateFormat(string $format): HandlerInterface
     {

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -76,8 +76,6 @@ class ChromeLoggerHandler extends BaseHandler
 
     /**
      * Constructor
-     *
-     * @param array $config
      */
     public function __construct(array $config = [])
     {
@@ -94,8 +92,6 @@ class ChromeLoggerHandler extends BaseHandler
      *
      * @param string $level
      * @param string $message
-     *
-     * @return bool
      */
     public function handle($level, $message): bool
     {

--- a/system/Log/Handlers/ErrorlogHandler.php
+++ b/system/Log/Handlers/ErrorlogHandler.php
@@ -64,8 +64,6 @@ class ErrorlogHandler extends BaseHandler
      *
      * @param string $level
      * @param string $message
-     *
-     * @return bool
      */
     public function handle($level, $message): bool
     {
@@ -76,11 +74,6 @@ class ErrorlogHandler extends BaseHandler
 
     /**
      * Extracted call to `error_log()` in order to be tested.
-     *
-     * @param string $message
-     * @param int    $messageType
-     *
-     * @return bool
      *
      * @codeCoverageIgnore
      */

--- a/system/Log/Handlers/FileHandler.php
+++ b/system/Log/Handlers/FileHandler.php
@@ -42,8 +42,6 @@ class FileHandler extends BaseHandler
 
     /**
      * Constructor
-     *
-     * @param array $config
      */
     public function __construct(array $config = [])
     {
@@ -67,8 +65,6 @@ class FileHandler extends BaseHandler
      * @param string $message
      *
      * @throws Exception
-     *
-     * @return bool
      */
     public function handle($level, $message): bool
     {

--- a/system/Log/Handlers/HandlerInterface.php
+++ b/system/Log/Handlers/HandlerInterface.php
@@ -24,25 +24,17 @@ interface HandlerInterface
      *
      * @param string $level
      * @param string $message
-     *
-     * @return bool
      */
     public function handle($level, $message): bool;
 
     /**
      * Checks whether the Handler will handle logging items of this
      * log Level.
-     *
-     * @param string $level
-     *
-     * @return bool
      */
     public function canHandle(string $level): bool;
 
     /**
      * Sets the preferred date format to use when logging.
-     *
-     * @param string $format
      *
      * @return HandlerInterface
      */

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -113,7 +113,6 @@ class Logger implements LoggerInterface
      * Constructor.
      *
      * @param \Config\Logger $config
-     * @param bool           $debug
      *
      * @throws RuntimeException
      */
@@ -154,9 +153,6 @@ class Logger implements LoggerInterface
      * System is unusable.
      *
      * @param string $message
-     * @param array  $context
-     *
-     * @return bool
      */
     public function emergency($message, array $context = []): bool
     {
@@ -170,9 +166,6 @@ class Logger implements LoggerInterface
      * trigger the SMS alerts and wake you up.
      *
      * @param string $message
-     * @param array  $context
-     *
-     * @return bool
      */
     public function alert($message, array $context = []): bool
     {
@@ -185,9 +178,6 @@ class Logger implements LoggerInterface
      * Example: Application component unavailable, unexpected exception.
      *
      * @param string $message
-     * @param array  $context
-     *
-     * @return bool
      */
     public function critical($message, array $context = []): bool
     {
@@ -199,9 +189,6 @@ class Logger implements LoggerInterface
      * be logged and monitored.
      *
      * @param string $message
-     * @param array  $context
-     *
-     * @return bool
      */
     public function error($message, array $context = []): bool
     {
@@ -215,9 +202,6 @@ class Logger implements LoggerInterface
      * that are not necessarily wrong.
      *
      * @param string $message
-     * @param array  $context
-     *
-     * @return bool
      */
     public function warning($message, array $context = []): bool
     {
@@ -228,9 +212,6 @@ class Logger implements LoggerInterface
      * Normal but significant events.
      *
      * @param string $message
-     * @param array  $context
-     *
-     * @return bool
      */
     public function notice($message, array $context = []): bool
     {
@@ -243,9 +224,6 @@ class Logger implements LoggerInterface
      * Example: User logs in, SQL logs.
      *
      * @param string $message
-     * @param array  $context
-     *
-     * @return bool
      */
     public function info($message, array $context = []): bool
     {
@@ -256,9 +234,6 @@ class Logger implements LoggerInterface
      * Detailed debug information.
      *
      * @param string $message
-     * @param array  $context
-     *
-     * @return bool
      */
     public function debug($message, array $context = []): bool
     {
@@ -270,9 +245,6 @@ class Logger implements LoggerInterface
      *
      * @param mixed  $level
      * @param string $message
-     * @param array  $context
-     *
-     * @return bool
      */
     public function log($level, $message, array $context = []): bool
     {
@@ -341,7 +313,6 @@ class Logger implements LoggerInterface
      * {line}
      *
      * @param mixed $message
-     * @param array $context
      *
      * @return mixed
      */
@@ -402,8 +373,6 @@ class Logger implements LoggerInterface
      * Determines the file and line that the logging call
      * was made from by analyzing the backtrace.
      * Find the earliest stack frame that is part of our logging system.
-     *
-     * @return array
      */
     public function determineFile(): array
     {
@@ -452,10 +421,6 @@ class Logger implements LoggerInterface
      *  /var/www/site/app/Controllers/Home.php
      *      becomes:
      *  APPPATH/Controllers/Home.php
-     *
-     * @param string $file
-     *
-     * @return string
      */
     protected function cleanFileNames(string $file): string
     {

--- a/system/Model.php
+++ b/system/Model.php
@@ -286,8 +286,6 @@ class Model extends BaseModel
      *
      * @param array|int|string|null $id   ID
      * @param array|null            $data Data
-     *
-     * @return bool
      */
     protected function doUpdate($id = null, $data = null): bool
     {
@@ -603,8 +601,6 @@ class Model extends BaseModel
      * If this method return false insert operation will be executed
      *
      * @param array|object $data Data
-     *
-     * @return bool
      */
     protected function shouldUpdate($data): bool
     {
@@ -652,8 +648,6 @@ class Model extends BaseModel
      * @param array|object|null     $data Data
      *
      * @throws ReflectionException
-     *
-     * @return bool
      */
     public function update($id = null, $data = null): bool
     {
@@ -721,8 +715,6 @@ class Model extends BaseModel
      * Checks for the existence of properties across this model, builder, and db connection.
      *
      * @param string $name Name
-     *
-     * @return bool
      */
     public function __isset(string $name): bool
     {
@@ -777,8 +769,6 @@ class Model extends BaseModel
      * @param bool          $onlyChanged Only Changed
      *
      * @throws ReflectionException
-     *
-     * @return array
      *
      * @codeCoverageIgnore
      *

--- a/system/Modules/Modules.php
+++ b/system/Modules/Modules.php
@@ -41,10 +41,6 @@ class Modules
 
     /**
      * Should the application auto-discover the requested resource.
-     *
-     * @param string $alias
-     *
-     * @return bool
      */
     public function shouldDiscover(string $alias): bool
     {

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -64,9 +64,6 @@ class Pager implements PagerInterface
 
     /**
      * Constructor.
-     *
-     * @param PagerConfig       $config
-     * @param RendererInterface $view
      */
     public function __construct(PagerConfig $config, RendererInterface $view)
     {
@@ -77,10 +74,7 @@ class Pager implements PagerInterface
     /**
      * Handles creating and displaying the
      *
-     * @param string $group
      * @param string $template The output template alias to render.
-     *
-     * @return string
      */
     public function links(string $group = 'default', string $template = 'default_full'): string
     {
@@ -91,11 +85,6 @@ class Pager implements PagerInterface
 
     /**
      * Creates simple Next/Previous links, instead of full pagination.
-     *
-     * @param string $group
-     * @param string $template
-     *
-     * @return string
      */
     public function simpleLinks(string $group = 'default', string $template = 'default_simple'): string
     {
@@ -108,14 +97,9 @@ class Pager implements PagerInterface
      * Allows for a simple, manual, form of pagination where all of the data
      * is provided by the user. The URL is the current URI.
      *
-     * @param int         $page
-     * @param int|null    $perPage
-     * @param int         $total
      * @param string      $template The output template alias to render.
      * @param int         $segment  (whether page number is provided by URI segment)
      * @param string|null $group    optional group (i.e. if we'd like to define custom path)
-     *
-     * @return string
      */
     public function makeLinks(int $page, ?int $perPage, int $total, string $template = 'default_full', int $segment = 0, ?string $group = 'default'): string
     {
@@ -129,11 +113,6 @@ class Pager implements PagerInterface
     /**
      * Does the actual work of displaying the view file. Used internally
      * by links(), simpleLinks(), and makeLinks().
-     *
-     * @param string $group
-     * @param string $template
-     *
-     * @return string
      */
     protected function displayLinks(string $group, string $template): string
     {
@@ -149,12 +128,6 @@ class Pager implements PagerInterface
     /**
      * Stores a set of pagination data for later display. Most commonly used
      * by the model to automate the process.
-     *
-     * @param string   $group
-     * @param int      $page
-     * @param int|null $perPage
-     * @param int      $total
-     * @param int      $segment
      *
      * @return $this
      */
@@ -184,9 +157,6 @@ class Pager implements PagerInterface
     /**
      * Sets segment for a group.
      *
-     * @param int    $number
-     * @param string $group
-     *
      * @return mixed
      */
     public function setSegment(int $number, string $group = 'default')
@@ -198,9 +168,6 @@ class Pager implements PagerInterface
 
     /**
      * Sets the path that an aliased group of links will use.
-     *
-     * @param string $path
-     * @param string $group
      *
      * @return mixed
      */
@@ -215,10 +182,6 @@ class Pager implements PagerInterface
 
     /**
      * Returns the total number of items in data store.
-     *
-     * @param string $group
-     *
-     * @return int
      */
     public function getTotal(string $group = 'default'): int
     {
@@ -229,10 +192,6 @@ class Pager implements PagerInterface
 
     /**
      * Returns the total number of pages.
-     *
-     * @param string $group
-     *
-     * @return int
      */
     public function getPageCount(string $group = 'default'): int
     {
@@ -243,10 +202,6 @@ class Pager implements PagerInterface
 
     /**
      * Returns the number of the current page of results.
-     *
-     * @param string $group
-     *
-     * @return int
      */
     public function getCurrentPage(string $group = 'default'): int
     {
@@ -257,10 +212,6 @@ class Pager implements PagerInterface
 
     /**
      * Tells whether this group of results has any more pages of results.
-     *
-     * @param string $group
-     *
-     * @return bool
      */
     public function hasMore(string $group = 'default'): bool
     {
@@ -271,8 +222,6 @@ class Pager implements PagerInterface
 
     /**
      * Returns the last page, if we have a total that we can calculate with.
-     *
-     * @param string $group
      *
      * @return int|null
      */
@@ -289,10 +238,6 @@ class Pager implements PagerInterface
 
     /**
      * Determines the first page # that should be shown.
-     *
-     * @param string $group
-     *
-     * @return int
      */
     public function getFirstPage(string $group = 'default'): int
     {
@@ -304,10 +249,6 @@ class Pager implements PagerInterface
 
     /**
      * Returns the URI for a specific page for the specified group.
-     *
-     * @param int|null $page
-     * @param string   $group
-     * @param bool     $returnObject
      *
      * @return string|URI
      */
@@ -344,9 +285,6 @@ class Pager implements PagerInterface
     /**
      * Returns the full URI to the next page of results, or null.
      *
-     * @param string $group
-     * @param bool   $returnObject
-     *
      * @return string|null
      */
     public function getNextPageURI(string $group = 'default', bool $returnObject = false)
@@ -371,9 +309,6 @@ class Pager implements PagerInterface
     /**
      * Returns the full URL to the previous page of results, or null.
      *
-     * @param string $group
-     * @param bool   $returnObject
-     *
      * @return string|null
      */
     public function getPreviousPageURI(string $group = 'default', bool $returnObject = false)
@@ -397,10 +332,6 @@ class Pager implements PagerInterface
 
     /**
      * Returns the number of results per page that should be shown.
-     *
-     * @param string $group
-     *
-     * @return int
      */
     public function getPerPage(string $group = 'default'): int
     {
@@ -414,10 +345,6 @@ class Pager implements PagerInterface
      * total, per_page, current_page, last_page, next_url, prev_url, from, to.
      * Does not include the actual data. This data is suitable for adding
      * a 'data' object to with the result set and converting to JSON.
-     *
-     * @param string $group
-     *
-     * @return array
      */
     public function getDetails(string $group = 'default'): array
     {
@@ -437,8 +364,6 @@ class Pager implements PagerInterface
     /**
      * Sets only allowed queries on pagination links.
      *
-     * @param array $queries
-     *
      * @return Pager
      */
     public function only(array $queries): self
@@ -451,8 +376,7 @@ class Pager implements PagerInterface
     /**
      * Ensures that an array exists for the group specified.
      *
-     * @param string $group
-     * @param int    $perPage
+     * @param int $perPage
      */
     protected function ensureGroup(string $group, ?int $perPage = null)
     {
@@ -478,8 +402,6 @@ class Pager implements PagerInterface
 
     /**
      * Calculating the current page
-     *
-     * @param string $group
      */
     protected function calculateCurrentPage(string $group)
     {

--- a/system/Pager/PagerInterface.php
+++ b/system/Pager/PagerInterface.php
@@ -21,20 +21,12 @@ interface PagerInterface
     /**
      * Handles creating and displaying the
      *
-     * @param string $group
      * @param string $template The output template alias to render.
-     *
-     * @return string
      */
     public function links(string $group = 'default', string $template = 'default'): string;
 
     /**
      * Creates simple Next/Previous links, instead of full pagination.
-     *
-     * @param string $group
-     * @param string $template
-     *
-     * @return string
      */
     public function simpleLinks(string $group = 'default', string $template = 'default'): string;
 
@@ -42,23 +34,13 @@ interface PagerInterface
      * Allows for a simple, manual, form of pagination where all of the data
      * is provided by the user. The URL is the current URI.
      *
-     * @param int    $page
-     * @param int    $perPage
-     * @param int    $total
      * @param string $template The output template alias to render.
-     *
-     * @return string
      */
     public function makeLinks(int $page, int $perPage, int $total, string $template = 'default'): string;
 
     /**
      * Stores a set of pagination data for later display. Most commonly used
      * by the model to automate the process.
-     *
-     * @param string $group
-     * @param int    $page
-     * @param int    $perPage
-     * @param int    $total
      *
      * @return mixed
      */
@@ -67,37 +49,22 @@ interface PagerInterface
     /**
      * Sets the path that an aliased group of links will use.
      *
-     * @param string $path
-     * @param string $group
-     *
      * @return mixed
      */
     public function setPath(string $path, string $group = 'default');
 
     /**
      * Returns the total number of pages.
-     *
-     * @param string $group
-     *
-     * @return int
      */
     public function getPageCount(string $group = 'default'): int;
 
     /**
      * Returns the number of the current page of results.
-     *
-     * @param string $group
-     *
-     * @return int
      */
     public function getCurrentPage(string $group = 'default'): int;
 
     /**
      * Returns the URI for a specific page for the specified group.
-     *
-     * @param int|null $page
-     * @param string   $group
-     * @param bool     $returnObject
      *
      * @return string|URI
      */
@@ -105,17 +72,11 @@ interface PagerInterface
 
     /**
      * Tells whether this group of results has any more pages of results.
-     *
-     * @param string $group
-     *
-     * @return bool
      */
     public function hasMore(string $group = 'default'): bool;
 
     /**
      * Returns the first page.
-     *
-     * @param string $group
      *
      * @return int
      */
@@ -124,16 +85,12 @@ interface PagerInterface
     /**
      * Returns the last page, if we have a total that we can calculate with.
      *
-     * @param string $group
-     *
      * @return int|null
      */
     public function getLastPage(string $group = 'default');
 
     /**
      * Returns the full URI to the next page of results, or null.
-     *
-     * @param string $group
      *
      * @return string|null
      */
@@ -142,18 +99,12 @@ interface PagerInterface
     /**
      * Returns the full URL to the previous page of results, or null.
      *
-     * @param string $group
-     *
      * @return string|null
      */
     public function getPreviousPageURI(string $group = 'default');
 
     /**
      * Returns the number of results per page that should be shown.
-     *
-     * @param string $group
-     *
-     * @return int
      */
     public function getPerPage(string $group = 'default'): int;
 
@@ -162,10 +113,6 @@ interface PagerInterface
      * total, per_page, current_page, last_page, next_url, prev_url, from, to.
      * Does not include the actual data. This data is suitable for adding
      * a 'data' object to with the result set and converting to JSON.
-     *
-     * @param string $group
-     *
-     * @return array
      */
     public function getDetails(string $group = 'default'): array;
 }

--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -80,8 +80,6 @@ class PagerRenderer
 
     /**
      * Constructor.
-     *
-     * @param array $details
      */
     public function __construct(array $details)
     {
@@ -100,8 +98,6 @@ class PagerRenderer
      * side of the current page. Adjusts the first and last counts
      * to reflect it.
      *
-     * @param int|null $count
-     *
      * @return PagerRenderer
      */
     public function setSurroundCount(?int $count = null)
@@ -113,8 +109,6 @@ class PagerRenderer
 
     /**
      * Checks to see if there is a "previous" page before our "first" page.
-     *
-     * @return bool
      */
     public function hasPrevious(): bool
     {
@@ -149,8 +143,6 @@ class PagerRenderer
 
     /**
      * Checks to see if there is a "next" page after our "last" page.
-     *
-     * @return bool
      */
     public function hasNext(): bool
     {
@@ -185,8 +177,6 @@ class PagerRenderer
 
     /**
      * Returns the URI of the first page.
-     *
-     * @return string
      */
     public function getFirst(): string
     {
@@ -203,8 +193,6 @@ class PagerRenderer
 
     /**
      * Returns the URI of the last page.
-     *
-     * @return string
      */
     public function getLast(): string
     {
@@ -221,8 +209,6 @@ class PagerRenderer
 
     /**
      * Returns the URI of the current page.
-     *
-     * @return string
      */
     public function getCurrent(): string
     {
@@ -242,8 +228,6 @@ class PagerRenderer
      * is represented by another array containing of the URI the link
      * should go to, the title (number) of the link, and a boolean
      * value representing whether this link is active or not.
-     *
-     * @return array
      */
     public function links(): array
     {
@@ -282,8 +266,6 @@ class PagerRenderer
 
     /**
      * Checks to see if there is a "previous" page before our "first" page.
-     *
-     * @return bool
      */
     public function hasPreviousPage(): bool
     {
@@ -316,8 +298,6 @@ class PagerRenderer
 
     /**
      * Checks to see if there is a "next" page after our "last" page.
-     *
-     * @return bool
      */
     public function hasNextPage(): bool
     {
@@ -350,8 +330,6 @@ class PagerRenderer
 
     /**
      * Returns the page number of the first page.
-     *
-     * @return int
      */
     public function getFirstPageNumber(): int
     {
@@ -360,8 +338,6 @@ class PagerRenderer
 
     /**
      * Returns the page number of the current page.
-     *
-     * @return int
      */
     public function getCurrentPageNumber(): int
     {
@@ -370,8 +346,6 @@ class PagerRenderer
 
     /**
      * Returns the page number of the last page.
-     *
-     * @return int
      */
     public function getLastPageNumber(): int
     {
@@ -380,8 +354,6 @@ class PagerRenderer
 
     /**
      * Returns total number of pages.
-     *
-     * @return int
      */
     public function getPageCount(): int
     {
@@ -390,8 +362,6 @@ class PagerRenderer
 
     /**
      * Returns the previous page number.
-     *
-     * @return int|null
      */
     public function getPreviousPageNumber(): ?int
     {
@@ -400,8 +370,6 @@ class PagerRenderer
 
     /**
      * Returns the next page number.
-     *
-     * @return int|null
      */
     public function getNextPageNumber(): ?int
     {

--- a/system/RESTful/BaseResource.php
+++ b/system/RESTful/BaseResource.php
@@ -30,10 +30,6 @@ abstract class BaseResource extends Controller
 
     /**
      * Constructor.
-     *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     * @param LoggerInterface   $logger
      */
     public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
     {

--- a/system/RESTful/ResourceController.php
+++ b/system/RESTful/ResourceController.php
@@ -101,8 +101,6 @@ class ResourceController extends BaseResource
     /**
      * Set/change the expected response representation for returned objects
      *
-     * @param string $format
-     *
      * @return void
      */
     public function setFormat(string $format = 'json')

--- a/system/Router/Exceptions/RouterException.php
+++ b/system/Router/Exceptions/RouterException.php
@@ -42,9 +42,6 @@ class RouterException extends FrameworkException
     /**
      * Throw when controller or its method is not found.
      *
-     * @param string $controller
-     * @param string $method
-     *
      * @return RouterException
      */
     public static function forControllerNotFound(string $controller, string $method)
@@ -54,8 +51,6 @@ class RouterException extends FrameworkException
 
     /**
      * Throw when route is not valid.
-     *
-     * @param string $route
      *
      * @return RouterException
      */

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -212,9 +212,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Constructor
-     *
-     * @param FileLocator $locator
-     * @param Modules     $moduleConfig
      */
     public function __construct(FileLocator $locator, Modules $moduleConfig)
     {
@@ -231,9 +228,6 @@ class RouteCollection implements RouteCollectionInterface
      * multiple placeholders added at once.
      *
      * @param array|string $placeholder
-     * @param string|null  $pattern
-     *
-     * @return RouteCollectionInterface
      */
     public function addPlaceholder($placeholder, ?string $pattern = null): RouteCollectionInterface
     {
@@ -249,10 +243,6 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Sets the default namespace to use for Controllers when no other
      * namespace has been specified.
-     *
-     * @param string $value
-     *
-     * @return RouteCollectionInterface
      */
     public function setDefaultNamespace(string $value): RouteCollectionInterface
     {
@@ -265,10 +255,6 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Sets the default controller to use when no other controller has been
      * specified.
-     *
-     * @param string $value
-     *
-     * @return RouteCollectionInterface
      */
     public function setDefaultController(string $value): RouteCollectionInterface
     {
@@ -280,10 +266,6 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Sets the default method to call on the controller when no other
      * method has been set in the route.
-     *
-     * @param string $value
-     *
-     * @return RouteCollectionInterface
      */
     public function setDefaultMethod(string $value): RouteCollectionInterface
     {
@@ -298,10 +280,6 @@ class RouteCollection implements RouteCollectionInterface
      * create more meaning and make it easier for the search engine to
      * find words and meaning in the URI for better SEO. But it
      * doesn't work well with PHP method names....
-     *
-     * @param bool $value
-     *
-     * @return RouteCollectionInterface
      */
     public function setTranslateURIDashes(bool $value): RouteCollectionInterface
     {
@@ -317,10 +295,6 @@ class RouteCollection implements RouteCollectionInterface
      * defined routes.
      *
      * If FALSE, will stop searching and do NO automatic routing.
-     *
-     * @param bool $value
-     *
-     * @return RouteCollectionInterface
      */
     public function setAutoRoute(bool $value): RouteCollectionInterface
     {
@@ -337,8 +311,6 @@ class RouteCollection implements RouteCollectionInterface
      * This setting is passed to the Router class and handled there.
      *
      * @param callable|null $callable
-     *
-     * @return RouteCollectionInterface
      */
     public function set404Override($callable = null): RouteCollectionInterface
     {
@@ -391,10 +363,6 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Sets the default constraint to be used in the system. Typically
      * for use with the 'resource' method.
-     *
-     * @param string $placeholder
-     *
-     * @return RouteCollectionInterface
      */
     public function setDefaultConstraint(string $placeholder): RouteCollectionInterface
     {
@@ -407,8 +375,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Returns the name of the default controller. With Namespace.
-     *
-     * @return string
      */
     public function getDefaultController(): string
     {
@@ -417,8 +383,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Returns the name of the default method to use within the controller.
-     *
-     * @return string
      */
     public function getDefaultMethod(): string
     {
@@ -427,8 +391,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Returns the default namespace as set in the Routes config file.
-     *
-     * @return string
      */
     public function getDefaultNamespace(): string
     {
@@ -437,8 +399,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Returns the current value of the translateURIDashes setting.
-     *
-     * @return bool
      */
     public function shouldTranslateURIDashes(): bool
     {
@@ -447,8 +407,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Returns the flag that tells whether to autoRoute URI against Controllers.
-     *
-     * @return bool
      */
     public function shouldAutoRoute(): bool
     {
@@ -457,10 +415,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Returns the raw array of available routes.
-     *
-     * @param string|null $verb
-     *
-     * @return array
      */
     public function getRoutes(?string $verb = null): array
     {
@@ -509,11 +463,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Returns one or all routes options
-     *
-     * @param string|null $from
-     * @param string|null $verb
-     *
-     * @return array
      */
     public function getRoutesOptions(?string $from = null, ?string $verb = null): array
     {
@@ -524,8 +473,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Returns the current HTTP Verb being used.
-     *
-     * @return string
      */
     public function getHTTPVerb(): string
     {
@@ -535,8 +482,6 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Sets the current HTTP verb.
      * Used primarily for testing.
-     *
-     * @param string $verb
      *
      * @return $this
      */
@@ -551,11 +496,6 @@ class RouteCollection implements RouteCollectionInterface
      * A shortcut method to add a number of routes at a single time.
      * It does not allow any options to be set on the route, or to
      * define the method used.
-     *
-     * @param array      $routes
-     * @param array|null $options
-     *
-     * @return RouteCollectionInterface
      */
     public function map(array $routes = [], ?array $options = null): RouteCollectionInterface
     {
@@ -572,11 +512,7 @@ class RouteCollection implements RouteCollectionInterface
      * Example:
      *      $routes->add('news', 'Posts::index');
      *
-     * @param string       $from
      * @param array|string $to
-     * @param array|null   $options
-     *
-     * @return RouteCollectionInterface
      */
     public function add(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -612,10 +548,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Determines if the route is a redirecting route.
-     *
-     * @param string $from
-     *
-     * @return bool
      */
     public function isRedirect(string $from): bool
     {
@@ -631,10 +563,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Grabs the HTTP status code from a redirecting Route.
-     *
-     * @param string $from
-     *
-     * @return int
      */
     public function getRedirectCode(string $from): int
     {
@@ -730,8 +658,6 @@ class RouteCollection implements RouteCollectionInterface
      *
      * @param string     $name    The name of the resource/controller to route to.
      * @param array|null $options An list of possible ways to customize the routing.
-     *
-     * @return RouteCollectionInterface
      */
     public function resource(string $name, ?array $options = null): RouteCollectionInterface
     {
@@ -825,8 +751,6 @@ class RouteCollection implements RouteCollectionInterface
      *
      * @param string     $name    The name of the controller to route to.
      * @param array|null $options An list of possible ways to customize the routing.
-     *
-     * @return RouteCollectionInterface
      */
     public function presenter(string $name, ?array $options = null): RouteCollectionInterface
     {
@@ -899,12 +823,7 @@ class RouteCollection implements RouteCollectionInterface
      * Example:
      *  $route->match( ['get', 'post'], 'users/(:num)', 'users/$1);
      *
-     * @param array        $verbs
-     * @param string       $from
      * @param array|string $to
-     * @param array|null   $options
-     *
-     * @return RouteCollectionInterface
      */
     public function match(array $verbs = [], string $from = '', $to = '', ?array $options = null): RouteCollectionInterface
     {
@@ -924,11 +843,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to GET requests.
      *
-     * @param string       $from
      * @param array|string $to
-     * @param array|null   $options
-     *
-     * @return RouteCollectionInterface
      */
     public function get(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -940,11 +855,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to POST requests.
      *
-     * @param string       $from
      * @param array|string $to
-     * @param array|null   $options
-     *
-     * @return RouteCollectionInterface
      */
     public function post(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -956,11 +867,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to PUT requests.
      *
-     * @param string       $from
      * @param array|string $to
-     * @param array|null   $options
-     *
-     * @return RouteCollectionInterface
      */
     public function put(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -972,11 +879,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to DELETE requests.
      *
-     * @param string       $from
      * @param array|string $to
-     * @param array|null   $options
-     *
-     * @return RouteCollectionInterface
      */
     public function delete(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -988,11 +891,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to HEAD requests.
      *
-     * @param string       $from
      * @param array|string $to
-     * @param array|null   $options
-     *
-     * @return RouteCollectionInterface
      */
     public function head(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -1004,11 +903,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to PATCH requests.
      *
-     * @param string       $from
      * @param array|string $to
-     * @param array|null   $options
-     *
-     * @return RouteCollectionInterface
      */
     public function patch(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -1020,11 +915,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to OPTIONS requests.
      *
-     * @param string       $from
      * @param array|string $to
-     * @param array|null   $options
-     *
-     * @return RouteCollectionInterface
      */
     public function options(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -1036,11 +927,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to command-line requests.
      *
-     * @param string       $from
      * @param array|string $to
-     * @param array|null   $options
-     *
-     * @return RouteCollectionInterface
      */
     public function cli(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -1051,11 +938,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Limits the routes to a specified ENVIRONMENT or they won't run.
-     *
-     * @param string  $env
-     * @param Closure $callback
-     *
-     * @return RouteCollectionInterface
      */
     public function environment(string $env, Closure $callback): RouteCollectionInterface
     {
@@ -1079,8 +961,7 @@ class RouteCollection implements RouteCollectionInterface
      *      // Equals 'path/$param1/$param2'
      *      reverseRoute('Controller::method', $param1, $param2);
      *
-     * @param string $search
-     * @param mixed  ...$params
+     * @param mixed ...$params
      *
      * @return false|string
      */
@@ -1136,10 +1017,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Replaces the {locale} tag with the current application locale
-     *
-     * @param string $route
-     *
-     * @return string
      */
     protected function localizeRoute(string $route): string
     {
@@ -1148,11 +1025,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Checks a route (using the "from") to see if it's filtered or not.
-     *
-     * @param string      $search
-     * @param string|null $verb
-     *
-     * @return bool
      */
     public function isFiltered(string $search, ?string $verb = null): bool
     {
@@ -1170,11 +1042,6 @@ class RouteCollection implements RouteCollectionInterface
      *    'role:admin,manager'
      *
      * has a filter of "role", with parameters of ['admin', 'manager'].
-     *
-     * @param string      $search
-     * @param string|null $verb
-     *
-     * @return string
      */
     public function getFilterForRoute(string $search, ?string $verb = null): string
     {
@@ -1186,12 +1053,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Given a
      *
-     * @param string     $from
-     * @param array|null $params
-     *
      * @throws RouterException
-     *
-     * @return string
      */
     protected function fillRouteParams(string $from, ?array $params = null): string
     {
@@ -1223,10 +1085,7 @@ class RouteCollection implements RouteCollectionInterface
      * the request method(s) that this route will work for. They can be separated
      * by a pipe character "|" if there is more than one.
      *
-     * @param string       $verb
-     * @param string       $from
      * @param array|string $to
-     * @param array|null   $options
      */
     protected function create(string $verb, string $from, $to, ?array $options = null)
     {
@@ -1338,8 +1197,6 @@ class RouteCollection implements RouteCollectionInterface
      * on this page request.
      *
      * @param mixed $subdomains
-     *
-     * @return bool
      */
     private function checkSubdomains($subdomains): bool
     {
@@ -1426,10 +1283,6 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Load routes options based on verb
-     *
-     * @param string|null $verb
-     *
-     * @return array
      */
     protected function loadRoutesOptions(?string $verb = null): array
     {

--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -28,7 +28,6 @@ interface RouteCollectionInterface
     /**
      * Adds a single route to the collection.
      *
-     * @param string       $from
      * @param array|string $to
      * @param array        $options
      *
@@ -55,8 +54,6 @@ interface RouteCollectionInterface
      * Sets the default namespace to use for Controllers when no other
      * namespace has been specified.
      *
-     * @param string $value
-     *
      * @return mixed
      */
     public function setDefaultNamespace(string $value);
@@ -65,8 +62,6 @@ interface RouteCollectionInterface
      * Sets the default controller to use when no other controller has been
      * specified.
      *
-     * @param string $value
-     *
      * @return mixed
      */
     public function setDefaultController(string $value);
@@ -74,8 +69,6 @@ interface RouteCollectionInterface
     /**
      * Sets the default method to call on the controller when no other
      * method has been set in the route.
-     *
-     * @param string $value
      *
      * @return mixed
      */
@@ -88,8 +81,6 @@ interface RouteCollectionInterface
      * find words and meaning in the URI for better SEO. But it
      * doesn't work well with PHP method names....
      *
-     * @param bool $value
-     *
      * @return mixed
      */
     public function setTranslateURIDashes(bool $value);
@@ -101,8 +92,6 @@ interface RouteCollectionInterface
      * defined routes.
      *
      * If FALSE, will stop searching and do NO automatic routing.
-     *
-     * @param bool $value
      *
      * @return RouteCollectionInterface
      */
@@ -184,8 +173,7 @@ interface RouteCollectionInterface
      *      // Equals 'path/$param1/$param2'
      *      reverseRoute('Controller::method', $param1, $param2);
      *
-     * @param string $search
-     * @param array  ...$params
+     * @param array ...$params
      *
      * @return false|string
      */
@@ -193,19 +181,11 @@ interface RouteCollectionInterface
 
     /**
      * Determines if the route is a redirecting route.
-     *
-     * @param string $from
-     *
-     * @return bool
      */
     public function isRedirect(string $from): bool;
 
     /**
      * Grabs the HTTP status code from a redirecting Route.
-     *
-     * @param string $from
-     *
-     * @return int
      */
     public function getRedirectCode(string $from): int;
 }

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -105,8 +105,7 @@ class Router implements RouterInterface
     /**
      * Stores a reference to the RouteCollection object.
      *
-     * @param RouteCollectionInterface $routes
-     * @param Request                  $request
+     * @param Request $request
      */
     public function __construct(RouteCollectionInterface $routes, ?Request $request = null)
     {
@@ -120,8 +119,6 @@ class Router implements RouterInterface
     }
 
     /**
-     * @param string|null $uri
-     *
      * @throws PageNotFoundException
      * @throws RedirectException
      *
@@ -190,8 +187,6 @@ class Router implements RouterInterface
     /**
      * Returns the name of the method to run in the
      * chosen container.
-     *
-     * @return string
      */
     public function methodName(): string
     {
@@ -228,8 +223,6 @@ class Router implements RouterInterface
      * Returns the binds that have been matched and collected
      * during the parsing process as an array, ready to send to
      * instance->method(...$params).
-     *
-     * @return array
      */
     public function params(): array
     {
@@ -241,8 +234,6 @@ class Router implements RouterInterface
      * if any. Relative to APPPATH.'Controllers'.
      *
      * Only used when auto-routing is turned on.
-     *
-     * @return string
      */
     public function directory(): string
     {
@@ -443,8 +434,6 @@ class Router implements RouterInterface
     /**
      * Attempts to match a URI path against Controllers and directories
      * found in APPPATH/Controllers, to find a matching route.
-     *
-     * @param string $uri
      */
     public function autoRoute(string $uri)
     {
@@ -582,9 +571,7 @@ class Router implements RouterInterface
     /**
      * Sets the sub-directory that the controller is in.
      *
-     * @param string|null $dir
-     * @param bool        $append
-     * @param bool        $validate if true, checks to make sure $dir consists of only PSR4 compliant segments
+     * @param bool $validate if true, checks to make sure $dir consists of only PSR4 compliant segments
      */
     public function setDirectory(?string $dir = null, bool $append = false, bool $validate = true)
     {
@@ -615,10 +602,6 @@ class Router implements RouterInterface
      * Returns true if the supplied $segment string represents a valid PSR-4 compliant namespace/directory segment
      *
      * regex comes from https://www.php.net/manual/en/language.variables.basics.php
-     *
-     * @param string $segment
-     *
-     * @return bool
      */
     private function isValidSegment(string $segment): bool
     {

--- a/system/Router/RouterInterface.php
+++ b/system/Router/RouterInterface.php
@@ -21,8 +21,7 @@ interface RouterInterface
     /**
      * Stores a reference to the RouteCollection object.
      *
-     * @param RouteCollectionInterface $routes
-     * @param Request                  $request
+     * @param Request $request
      */
     public function __construct(RouteCollectionInterface $routes, ?Request $request = null);
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -122,8 +122,6 @@ class Security implements SecurityInterface
      *
      * Stores our configuration and fires off the init() method to setup
      * initial state.
-     *
-     * @param App $config
      */
     public function __construct(App $config)
     {
@@ -153,8 +151,6 @@ class Security implements SecurityInterface
     /**
      * CSRF Verify
      *
-     * @param RequestInterface $request
-     *
      * @throws SecurityException
      *
      * @return $this|false
@@ -171,8 +167,6 @@ class Security implements SecurityInterface
     /**
      * Returns the CSRF Hash.
      *
-     * @return string|null
-     *
      * @deprecated Use `CodeIgniter\Security\Security::getHash()` instead of using this method.
      *
      * @codeCoverageIgnore
@@ -185,8 +179,6 @@ class Security implements SecurityInterface
     /**
      * Returns the CSRF Token Name.
      *
-     * @return string
-     *
      * @deprecated Use `CodeIgniter\Security\Security::getTokenName()` instead of using this method.
      *
      * @codeCoverageIgnore
@@ -198,8 +190,6 @@ class Security implements SecurityInterface
 
     /**
      * CSRF Verify
-     *
-     * @param RequestInterface $request
      *
      * @throws SecurityException
      *
@@ -257,8 +247,6 @@ class Security implements SecurityInterface
 
     /**
      * Returns the CSRF Hash.
-     *
-     * @return string|null
      */
     public function getHash(): ?string
     {
@@ -267,8 +255,6 @@ class Security implements SecurityInterface
 
     /**
      * Returns the CSRF Token Name.
-     *
-     * @return string
      */
     public function getTokenName(): string
     {
@@ -277,8 +263,6 @@ class Security implements SecurityInterface
 
     /**
      * Returns the CSRF Header Name.
-     *
-     * @return string
      */
     public function getHeaderName(): string
     {
@@ -287,8 +271,6 @@ class Security implements SecurityInterface
 
     /**
      * Returns the CSRF Cookie Name.
-     *
-     * @return string
      */
     public function getCookieName(): string
     {
@@ -297,8 +279,6 @@ class Security implements SecurityInterface
 
     /**
      * Check if CSRF cookie is expired.
-     *
-     * @return bool
      *
      * @deprecated
      *
@@ -311,8 +291,6 @@ class Security implements SecurityInterface
 
     /**
      * Check if request should be redirect on failure.
-     *
-     * @return bool
      */
     public function shouldRedirect(): bool
     {
@@ -332,8 +310,6 @@ class Security implements SecurityInterface
      *
      * @param string $str          Input file name
      * @param bool   $relativePath Whether to preserve paths
-     *
-     * @return string
      */
     public function sanitizeFilename(string $str, bool $relativePath = false): string
     {
@@ -389,8 +365,6 @@ class Security implements SecurityInterface
 
     /**
      * Generates the CSRF Hash.
-     *
-     * @return string
      */
     protected function generateHash(): string
     {
@@ -415,8 +389,6 @@ class Security implements SecurityInterface
     /**
      * CSRF Send Cookie
      *
-     * @param RequestInterface $request
-     *
      * @return false|Security
      */
     protected function sendCookie(RequestInterface $request)
@@ -436,8 +408,6 @@ class Security implements SecurityInterface
      * Extracted for this to be unit tested.
      *
      * @codeCoverageIgnore
-     *
-     * @return void
      */
     protected function doSendCookie(): void
     {

--- a/system/Security/SecurityInterface.php
+++ b/system/Security/SecurityInterface.php
@@ -22,8 +22,6 @@ interface SecurityInterface
     /**
      * CSRF Verify
      *
-     * @param RequestInterface $request
-     *
      * @throws SecurityException
      *
      * @return $this|false
@@ -32,36 +30,26 @@ interface SecurityInterface
 
     /**
      * Returns the CSRF Hash.
-     *
-     * @return string|null
      */
     public function getHash(): ?string;
 
     /**
      * Returns the CSRF Token Name.
-     *
-     * @return string
      */
     public function getTokenName(): string;
 
     /**
      * Returns the CSRF Header Name.
-     *
-     * @return string
      */
     public function getHeaderName(): string;
 
     /**
      * Returns the CSRF Cookie Name.
-     *
-     * @return string
      */
     public function getCookieName(): string;
 
     /**
      * Check if CSRF cookie is expired.
-     *
-     * @return bool
      *
      * @deprecated
      */
@@ -69,8 +57,6 @@ interface SecurityInterface
 
     /**
      * Check if request should be redirect on failure.
-     *
-     * @return bool
      */
     public function shouldRedirect(): bool;
 
@@ -87,8 +73,6 @@ interface SecurityInterface
      *
      * @param string $str          Input file name
      * @param bool   $relativePath Whether to preserve paths
-     *
-     * @return string
      */
     public function sanitizeFilename(string $str, bool $relativePath = false): string;
 }

--- a/system/Session/Handlers/ArrayHandler.php
+++ b/system/Session/Handlers/ArrayHandler.php
@@ -30,8 +30,6 @@ class ArrayHandler extends BaseHandler
      * @param string $name     Session cookie name
      *
      * @throws Exception
-     *
-     * @return bool
      */
     public function open($savePath, $name): bool
     {
@@ -59,8 +57,6 @@ class ArrayHandler extends BaseHandler
      *
      * @param string $sessionID   Session ID
      * @param string $sessionData Serialized session data
-     *
-     * @return bool
      */
     public function write($sessionID, $sessionData): bool
     {
@@ -71,8 +67,6 @@ class ArrayHandler extends BaseHandler
      * Close
      *
      * Releases locks and closes file descriptor.
-     *
-     * @return bool
      */
     public function close(): bool
     {
@@ -85,8 +79,6 @@ class ArrayHandler extends BaseHandler
      * Destroys the current session.
      *
      * @param string $sessionID
-     *
-     * @return bool
      */
     public function destroy($sessionID): bool
     {
@@ -99,8 +91,6 @@ class ArrayHandler extends BaseHandler
      * Deletes expired sessions
      *
      * @param int $maxlifetime Maximum lifetime of sessions
-     *
-     * @return bool
      */
     public function gc($maxlifetime): bool
     {

--- a/system/Session/Handlers/BaseHandler.php
+++ b/system/Session/Handlers/BaseHandler.php
@@ -102,9 +102,6 @@ abstract class BaseHandler implements SessionHandlerInterface
 
     /**
      * Constructor
-     *
-     * @param AppConfig $config
-     * @param string    $ipAddress
      */
     public function __construct(AppConfig $config, string $ipAddress)
     {
@@ -121,8 +118,6 @@ abstract class BaseHandler implements SessionHandlerInterface
     /**
      * Internal method to force removal of a cookie by the client
      * when session_destroy() is called.
-     *
-     * @return bool
      */
     protected function destroyCookie(): bool
     {
@@ -141,10 +136,6 @@ abstract class BaseHandler implements SessionHandlerInterface
      * A dummy method allowing drivers with no locking functionality
      * (databases other than PostgreSQL and MySQL) to act as if they
      * do acquire a lock.
-     *
-     * @param string $sessionID
-     *
-     * @return bool
      */
     protected function lockSession(string $sessionID): bool
     {
@@ -155,8 +146,6 @@ abstract class BaseHandler implements SessionHandlerInterface
 
     /**
      * Releases the lock, if any.
-     *
-     * @return bool
      */
     protected function releaseLock(): bool
     {
@@ -175,8 +164,6 @@ abstract class BaseHandler implements SessionHandlerInterface
      * To work around the problem, the drivers will call this method
      * so that the INI is set just in time for the error message to
      * be properly generated.
-     *
-     * @return bool
      */
     protected function fail(): bool
     {

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -59,9 +59,6 @@ class DatabaseHandler extends BaseHandler
 
     /**
      * Constructor
-     *
-     * @param AppConfig $config
-     * @param string    $ipAddress
      */
     public function __construct(AppConfig $config, string $ipAddress)
     {
@@ -98,8 +95,6 @@ class DatabaseHandler extends BaseHandler
      * @param string $name     Session cookie name
      *
      * @throws Exception
-     *
-     * @return bool
      */
     public function open($savePath, $name): bool
     {
@@ -171,8 +166,6 @@ class DatabaseHandler extends BaseHandler
      *
      * @param string $sessionID   Session ID
      * @param string $sessionData Serialized session data
-     *
-     * @return bool
      */
     public function write($sessionID, $sessionData): bool
     {
@@ -231,8 +224,6 @@ class DatabaseHandler extends BaseHandler
      * Close
      *
      * Releases locks and closes file descriptor.
-     *
-     * @return bool
      */
     public function close(): bool
     {
@@ -245,8 +236,6 @@ class DatabaseHandler extends BaseHandler
      * Destroys the current session.
      *
      * @param string $sessionID
-     *
-     * @return bool
      */
     public function destroy($sessionID): bool
     {
@@ -277,8 +266,6 @@ class DatabaseHandler extends BaseHandler
      * Deletes expired sessions
      *
      * @param int $maxlifetime Maximum lifetime of sessions
-     *
-     * @return bool
      */
     public function gc($maxlifetime): bool
     {
@@ -290,10 +277,6 @@ class DatabaseHandler extends BaseHandler
 
     /**
      * Lock the session.
-     *
-     * @param string $sessionID
-     *
-     * @return bool
      */
     protected function lockSession(string $sessionID): bool
     {
@@ -325,8 +308,6 @@ class DatabaseHandler extends BaseHandler
 
     /**
      * Releases the lock, if any.
-     *
-     * @return bool
      */
     protected function releaseLock(): bool
     {

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -64,9 +64,6 @@ class FileHandler extends BaseHandler
 
     /**
      * Constructor
-     *
-     * @param AppConfig $config
-     * @param string    $ipAddress
      */
     public function __construct(AppConfig $config, string $ipAddress)
     {
@@ -99,8 +96,6 @@ class FileHandler extends BaseHandler
      * @param string $name     Session cookie name
      *
      * @throws Exception
-     *
-     * @return bool
      */
     public function open($savePath, $name): bool
     {
@@ -188,8 +183,6 @@ class FileHandler extends BaseHandler
      *
      * @param string $sessionID   Session ID
      * @param string $sessionData Serialized session data
-     *
-     * @return bool
      */
     public function write($sessionID, $sessionData): bool
     {
@@ -237,8 +230,6 @@ class FileHandler extends BaseHandler
      * Close
      *
      * Releases locks and closes file descriptor.
-     *
-     * @return bool
      */
     public function close(): bool
     {
@@ -261,8 +252,6 @@ class FileHandler extends BaseHandler
      * Destroys the current session.
      *
      * @param string $sessionId Session ID
-     *
-     * @return bool
      */
     public function destroy($sessionId): bool
     {
@@ -287,8 +276,6 @@ class FileHandler extends BaseHandler
      * Deletes expired sessions
      *
      * @param int $maxlifetime Maximum lifetime of sessions
-     *
-     * @return bool
      */
     public function gc($maxlifetime): bool
     {

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -51,9 +51,6 @@ class MemcachedHandler extends BaseHandler
     /**
      * Constructor
      *
-     * @param AppConfig $config
-     * @param string    $ipAddress
-     *
      * @throws SessionException
      */
     public function __construct(AppConfig $config, string $ipAddress)
@@ -82,8 +79,6 @@ class MemcachedHandler extends BaseHandler
      *
      * @param string $savePath Server path(s)
      * @param string $name     Session cookie name, unused
-     *
-     * @return bool
      */
     public function open($savePath, $name): bool
     {
@@ -161,8 +156,6 @@ class MemcachedHandler extends BaseHandler
      *
      * @param string $sessionID   Session ID
      * @param string $sessionData Serialized session data
-     *
-     * @return bool
      */
     public function write($sessionID, $sessionData): bool
     {
@@ -203,8 +196,6 @@ class MemcachedHandler extends BaseHandler
      * Close
      *
      * Releases locks and closes connection.
-     *
-     * @return bool
      */
     public function close(): bool
     {
@@ -231,8 +222,6 @@ class MemcachedHandler extends BaseHandler
      * Destroys the current session.
      *
      * @param string $sessionId Session ID
-     *
-     * @return bool
      */
     public function destroy($sessionId): bool
     {
@@ -251,8 +240,6 @@ class MemcachedHandler extends BaseHandler
      * Deletes expired sessions
      *
      * @param int $maxlifetime Maximum lifetime of sessions
-     *
-     * @return bool
      */
     public function gc($maxlifetime): bool
     {
@@ -266,8 +253,6 @@ class MemcachedHandler extends BaseHandler
      * Acquires an (emulated) lock.
      *
      * @param string $sessionID Session ID
-     *
-     * @return bool
      */
     protected function lockSession(string $sessionID): bool
     {
@@ -311,8 +296,6 @@ class MemcachedHandler extends BaseHandler
      * Release lock
      *
      * Releases a previously acquired lock
-     *
-     * @return bool
      */
     protected function releaseLock(): bool
     {

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -60,9 +60,6 @@ class RedisHandler extends BaseHandler
     /**
      * Constructor
      *
-     * @param AppConfig $config
-     * @param string    $ipAddress
-     *
      * @throws Exception
      */
     public function __construct(AppConfig $config, string $ipAddress)
@@ -107,8 +104,6 @@ class RedisHandler extends BaseHandler
      *
      * @param string $savePath Server path
      * @param string $name     Session cookie name, unused
-     *
-     * @return bool
      */
     public function open($savePath, $name): bool
     {
@@ -168,8 +163,6 @@ class RedisHandler extends BaseHandler
      *
      * @param string $sessionID   Session ID
      * @param string $sessionData Serialized session data
-     *
-     * @return bool
      */
     public function write($sessionID, $sessionData): bool
     {
@@ -211,8 +204,6 @@ class RedisHandler extends BaseHandler
      * Close
      *
      * Releases locks and closes connection.
-     *
-     * @return bool
      */
     public function close(): bool
     {
@@ -247,8 +238,6 @@ class RedisHandler extends BaseHandler
      * Destroys the current session.
      *
      * @param string $sessionID
-     *
-     * @return bool
      */
     public function destroy($sessionID): bool
     {
@@ -269,8 +258,6 @@ class RedisHandler extends BaseHandler
      * Deletes expired sessions
      *
      * @param int $maxlifetime Maximum lifetime of sessions
-     *
-     * @return bool
      */
     public function gc($maxlifetime): bool
     {
@@ -284,8 +271,6 @@ class RedisHandler extends BaseHandler
      * Acquires an (emulated) lock.
      *
      * @param string $sessionID Session ID
-     *
-     * @return bool
      */
     protected function lockSession(string $sessionID): bool
     {
@@ -336,8 +321,6 @@ class RedisHandler extends BaseHandler
      * Release lock
      *
      * Releases a previously acquired lock
-     *
-     * @return bool
      */
     protected function releaseLock(): bool
     {

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -163,9 +163,6 @@ class Session implements SessionInterface
      * Constructor.
      *
      * Extract configuration settings and save them here.
-     *
-     * @param SessionHandlerInterface $driver
-     * @param App                     $config
      */
     public function __construct(SessionHandlerInterface $driver, App $config)
     {
@@ -506,8 +503,6 @@ class Session implements SessionInterface
      * Returns whether an index exists in the session array.
      *
      * @param string $key Identifier of the session property we are interested in.
-     *
-     * @return bool
      */
     public function has(string $key): bool
     {
@@ -592,8 +587,6 @@ class Session implements SessionInterface
      * Mostly used by internal PHP functions, users should stick to has()
      *
      * @param string $key Identifier of the session property to remove.
-     *
-     * @return bool
      */
     public function __isset(string $key): bool
     {
@@ -867,8 +860,6 @@ class Session implements SessionInterface
 
     /**
      * Retrieve the keys of all session data that have been marked as temporary data.
-     *
-     * @return array
      */
     public function getTempKeys(): array
     {

--- a/system/Session/SessionInterface.php
+++ b/system/Session/SessionInterface.php
@@ -61,8 +61,6 @@ interface SessionInterface
      * Returns whether an index exists in the session array.
      *
      * @param string $key Identifier of the session property we are interested in.
-     *
-     * @return bool
      */
     public function has(string $key): bool;
 
@@ -181,8 +179,6 @@ interface SessionInterface
 
     /**
      * Retrieve the keys of all session data that have been marked as temporary data.
-     *
-     * @return array
      */
     public function getTempKeys(): array;
 }

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -270,8 +270,6 @@ abstract class CIUnitTestCase extends TestCase
      * methods for setUp or tearDown.
      *
      * @param string $stage 'setUp' or 'tearDown'
-     *
-     * @return void
      */
     private function callTraitMethods(string $stage): void
     {
@@ -345,7 +343,6 @@ abstract class CIUnitTestCase extends TestCase
      * Custom function to hook into CodeIgniter's Logging mechanism
      * to check if certain messages were logged during code execution.
      *
-     * @param string      $level
      * @param string|null $expectedMessage
      *
      * @throws Exception
@@ -369,11 +366,7 @@ abstract class CIUnitTestCase extends TestCase
      * Hooks into CodeIgniter's Events system to check if a specific
      * event was triggered or not.
      *
-     * @param string $eventName
-     *
      * @throws Exception
-     *
-     * @return bool
      */
     public function assertEventTriggered(string $eventName): bool
     {
@@ -398,8 +391,7 @@ abstract class CIUnitTestCase extends TestCase
      * Hooks into xdebug's headers capture, looking for a specific header
      * emitted
      *
-     * @param string $header     The leading portion of the header we are looking for
-     * @param bool   $ignoreCase
+     * @param string $header The leading portion of the header we are looking for
      *
      * @throws Exception
      */
@@ -427,8 +419,7 @@ abstract class CIUnitTestCase extends TestCase
      * Hooks into xdebug's headers capture, looking for a specific header
      * emitted
      *
-     * @param string $header     The leading portion of the header we don't want to find
-     * @param bool   $ignoreCase
+     * @param string $header The leading portion of the header we don't want to find
      *
      * @throws Exception
      */
@@ -459,10 +450,7 @@ abstract class CIUnitTestCase extends TestCase
      * where the result is close but not exactly equal to the
      * expected time, for reasons beyond our control.
      *
-     * @param int    $expected
-     * @param mixed  $actual
-     * @param string $message
-     * @param int    $tolerance
+     * @param mixed $actual
      *
      * @throws Exception
      */
@@ -479,10 +467,8 @@ abstract class CIUnitTestCase extends TestCase
      * where the result is close but not exactly equal to the
      * expected time, for reasons beyond our control.
      *
-     * @param mixed  $expected
-     * @param mixed  $actual
-     * @param string $message
-     * @param int    $tolerance
+     * @param mixed $expected
+     * @param mixed $actual
      *
      * @throws Exception
      *
@@ -531,8 +517,7 @@ abstract class CIUnitTestCase extends TestCase
     /**
      * Return first matching emitted header.
      *
-     * @param string $header     Identifier of the header of interest
-     * @param bool   $ignoreCase
+     * @param string $header Identifier of the header of interest
      *
      * @return string|null The value of the header found, null if not found
      */

--- a/system/Test/Constraints/SeeInDatabase.php
+++ b/system/Test/Constraints/SeeInDatabase.php
@@ -38,9 +38,6 @@ class SeeInDatabase extends Constraint
 
     /**
      * SeeInDatabase constructor.
-     *
-     * @param ConnectionInterface $db
-     * @param array               $data
      */
     public function __construct(ConnectionInterface $db, array $data)
     {
@@ -52,8 +49,6 @@ class SeeInDatabase extends Constraint
      * Check if data is found in the table
      *
      * @param mixed $table
-     *
-     * @return bool
      */
     public function matches($table): bool
     {
@@ -64,8 +59,6 @@ class SeeInDatabase extends Constraint
      * Get the description of the failure
      *
      * @param mixed $table
-     *
-     * @return string
      */
     public function failureDescription($table): string
     {
@@ -79,10 +72,6 @@ class SeeInDatabase extends Constraint
 
     /**
      * Gets additional records similar to $data.
-     *
-     * @param string $table
-     *
-     * @return string
      */
     protected function getAdditionalInfo(string $table): string
     {
@@ -121,8 +110,6 @@ class SeeInDatabase extends Constraint
      * Gets a string representation of the constraint
      *
      * @param int $options
-     *
-     * @return string
      */
     public function toString($options = 0): string
     {

--- a/system/Test/ControllerResponse.php
+++ b/system/Test/ControllerResponse.php
@@ -54,8 +54,6 @@ class ControllerResponse extends TestResponse
     /**
      * Sets the response.
      *
-     * @param ResponseInterface $response
-     *
      * @return $this
      *
      * @deprecated Will revert to parent::setResponse() in a future release (no $body updates)
@@ -71,8 +69,6 @@ class ControllerResponse extends TestResponse
 
     /**
      * Sets the body and updates the DOM.
-     *
-     * @param string $body
      *
      * @return $this
      *

--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -126,8 +126,6 @@ trait ControllerTestTrait
     /**
      * Loads the specified controller, and generates any needed dependencies.
      *
-     * @param string $name
-     *
      * @return mixed
      */
     public function controller(string $name)
@@ -145,8 +143,7 @@ trait ControllerTestTrait
     /**
      * Runs the specified method on the controller and returns the results.
      *
-     * @param string $method
-     * @param array  $params
+     * @param array $params
      *
      * @throws InvalidArgumentException
      *
@@ -274,8 +271,6 @@ trait ControllerTestTrait
 
     /**
      * Set the controller's URI, with method chaining.
-     *
-     * @param string $uri
      *
      * @return mixed
      */

--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -126,8 +126,6 @@ trait ControllerTester
     /**
      * Loads the specified controller, and generates any needed dependencies.
      *
-     * @param string $name
-     *
      * @return mixed
      */
     public function controller(string $name)
@@ -145,8 +143,7 @@ trait ControllerTester
     /**
      * Runs the specified method on the controller and returns the results.
      *
-     * @param string $method
-     * @param array  $params
+     * @param array $params
      *
      * @throws InvalidArgumentException
      *
@@ -270,8 +267,6 @@ trait ControllerTester
 
     /**
      * Set the controller's URI, with method chaining.
-     *
-     * @param string $uri
      *
      * @return mixed
      */

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -48,8 +48,6 @@ class DOMParser
 
     /**
      * Returns the body of the current document.
-     *
-     * @return string
      */
     public function getBody(): string
     {
@@ -58,8 +56,6 @@ class DOMParser
 
     /**
      * Sets a string as the body that we want to work with.
-     *
-     * @param string $content
      *
      * @return $this
      */
@@ -90,8 +86,6 @@ class DOMParser
      * Loads the contents of a file as a string
      * so that we can work with it.
      *
-     * @param string $path
-     *
      * @return DOMParser
      */
     public function withFile(string $path)
@@ -110,8 +104,6 @@ class DOMParser
      *
      * @param string $search
      * @param string $element
-     *
-     * @return bool
      */
     public function see(?string $search = null, ?string $element = null): bool
     {
@@ -130,10 +122,7 @@ class DOMParser
     /**
      * Checks to see if the text is NOT found within the result.
      *
-     * @param string      $search
-     * @param string|null $element
-     *
-     * @return bool
+     * @param string $search
      */
     public function dontSee(?string $search = null, ?string $element = null): bool
     {
@@ -143,10 +132,6 @@ class DOMParser
     /**
      * Checks to see if an element with the matching CSS specifier
      * is found within the current DOM.
-     *
-     * @param string $element
-     *
-     * @return bool
      */
     public function seeElement(string $element): bool
     {
@@ -155,10 +140,6 @@ class DOMParser
 
     /**
      * Checks to see if the element is available within the result.
-     *
-     * @param string $element
-     *
-     * @return bool
      */
     public function dontSeeElement(string $element): bool
     {
@@ -168,11 +149,6 @@ class DOMParser
     /**
      * Determines if a link with the specified text is found
      * within the results.
-     *
-     * @param string      $text
-     * @param string|null $details
-     *
-     * @return bool
      */
     public function seeLink(string $text, ?string $details = null): bool
     {
@@ -181,11 +157,6 @@ class DOMParser
 
     /**
      * Checks for an input named $field with a value of $value.
-     *
-     * @param string $field
-     * @param string $value
-     *
-     * @return bool
      */
     public function seeInField(string $field, string $value): bool
     {
@@ -196,10 +167,6 @@ class DOMParser
 
     /**
      * Checks for checkboxes that are currently checked.
-     *
-     * @param string $element
-     *
-     * @return bool
      */
     public function seeCheckboxIsChecked(string $element): bool
     {
@@ -213,10 +180,6 @@ class DOMParser
 
     /**
      * Search the DOM using an XPath expression.
-     *
-     * @param string|null $search
-     * @param string      $element
-     * @param array       $paths
      *
      * @return DOMNodeList
      */
@@ -270,8 +233,6 @@ class DOMParser
 
     /**
      * Look for the a selector  in the passed text.
-     *
-     * @param string $selector
      *
      * @return array
      */

--- a/system/Test/DatabaseTestTrait.php
+++ b/system/Test/DatabaseTestTrait.php
@@ -200,8 +200,6 @@ trait DatabaseTestTrait
     /**
      * Seeds that database with a specific seeder.
      *
-     * @param string $name
-     *
      * @return void
      */
     public function seed(string $name)
@@ -241,8 +239,6 @@ trait DatabaseTestTrait
     /**
      * Loads the Builder class appropriate for the current database.
      *
-     * @param string $tableName
-     *
      * @return BaseBuilder
      */
     public function loadBuilder(string $tableName)
@@ -255,10 +251,6 @@ trait DatabaseTestTrait
     /**
      * Fetches a single column from a database row with criteria
      * matching $where.
-     *
-     * @param string $table
-     * @param string $column
-     * @param array  $where
      *
      * @throws DatabaseException
      *
@@ -284,9 +276,6 @@ trait DatabaseTestTrait
      * Asserts that records that match the conditions in $where DO
      * exist in the database.
      *
-     * @param string $table
-     * @param array  $where
-     *
      * @throws DatabaseException
      *
      * @return void
@@ -300,9 +289,6 @@ trait DatabaseTestTrait
     /**
      * Asserts that records that match the conditions in $where do
      * not exist in the database.
-     *
-     * @param string $table
-     * @param array  $where
      *
      * @return void
      */
@@ -319,9 +305,6 @@ trait DatabaseTestTrait
      * Inserts a row into to the database. This row will be removed
      * after the test has run.
      *
-     * @param string $table
-     * @param array  $data
-     *
      * @return bool
      */
     public function hasInDatabase(string $table, array $data)
@@ -337,10 +320,6 @@ trait DatabaseTestTrait
     /**
      * Asserts that the number of rows in the database that match $where
      * is equal to $expected.
-     *
-     * @param int    $expected
-     * @param string $table
-     * @param array  $where
      *
      * @throws DatabaseException
      *

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -145,8 +145,6 @@ class Fabricator
      * Get the count for a specific table
      *
      * @param string $table Name of the target table
-     *
-     * @return int
      */
     public static function getCount(string $table): int
     {
@@ -204,8 +202,6 @@ class Fabricator
 
     /**
      * Returns the locale
-     *
-     * @return string
      */
     public function getLocale(): string
     {
@@ -214,8 +210,6 @@ class Fabricator
 
     /**
      * Returns the Faker generator
-     *
-     * @return Generator
      */
     public function getFaker(): Generator
     {
@@ -224,8 +218,6 @@ class Fabricator
 
     /**
      * Return and reset tempOverrides
-     *
-     * @return array
      */
     public function getOverrides(): array
     {
@@ -257,8 +249,6 @@ class Fabricator
 
     /**
      * Returns the current formatters
-     *
-     * @return array|null
      */
     public function getFormatters(): ?array
     {

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -148,10 +148,6 @@ class FeatureTestCase extends CIUnitTestCase
      * Calls a single URI, executes it, and returns a FeatureResponse
      * instance that can be used to run many assertions against.
      *
-     * @param string     $method
-     * @param string     $path
-     * @param array|null $params
-     *
      * @throws Exception
      * @throws RedirectException
      *
@@ -226,9 +222,6 @@ class FeatureTestCase extends CIUnitTestCase
     /**
      * Performs a GET request.
      *
-     * @param string     $path
-     * @param array|null $params
-     *
      * @throws Exception
      * @throws RedirectException
      *
@@ -241,9 +234,6 @@ class FeatureTestCase extends CIUnitTestCase
 
     /**
      * Performs a POST request.
-     *
-     * @param string     $path
-     * @param array|null $params
      *
      * @throws Exception
      * @throws RedirectException
@@ -258,9 +248,6 @@ class FeatureTestCase extends CIUnitTestCase
     /**
      * Performs a PUT request
      *
-     * @param string     $path
-     * @param array|null $params
-     *
      * @throws Exception
      * @throws RedirectException
      *
@@ -273,9 +260,6 @@ class FeatureTestCase extends CIUnitTestCase
 
     /**
      * Performss a PATCH request
-     *
-     * @param string     $path
-     * @param array|null $params
      *
      * @throws Exception
      * @throws RedirectException
@@ -290,9 +274,6 @@ class FeatureTestCase extends CIUnitTestCase
     /**
      * Performs a DELETE request.
      *
-     * @param string     $path
-     * @param array|null $params
-     *
      * @throws Exception
      * @throws RedirectException
      *
@@ -305,9 +286,6 @@ class FeatureTestCase extends CIUnitTestCase
 
     /**
      * Performs an OPTIONS request.
-     *
-     * @param string     $path
-     * @param array|null $params
      *
      * @throws Exception
      * @throws RedirectException
@@ -322,11 +300,6 @@ class FeatureTestCase extends CIUnitTestCase
     /**
      * Setup a Request object to use so that CodeIgniter
      * won't try to auto-populate some of the items.
-     *
-     * @param string      $method
-     * @param string|null $path
-     *
-     * @return IncomingRequest
      */
     protected function setupRequest(string $method, ?string $path = null): IncomingRequest
     {
@@ -349,8 +322,6 @@ class FeatureTestCase extends CIUnitTestCase
     /**
      * Setup the custom request's headers
      *
-     * @param IncomingRequest $request
-     *
      * @return IncomingRequest
      */
     protected function setupHeaders(IncomingRequest $request)
@@ -369,10 +340,6 @@ class FeatureTestCase extends CIUnitTestCase
      * relevant to the request, like $_POST data.
      *
      * Always populate the GET vars based on the URI.
-     *
-     * @param string     $method
-     * @param Request    $request
-     * @param array|null $params
      *
      * @throws ReflectionException
      *
@@ -403,11 +370,8 @@ class FeatureTestCase extends CIUnitTestCase
      * This allows the body to be formatted in a way that the controller is going to
      * expect as in the case of testing a JSON or XML API.
      *
-     * @param Request    $request
-     * @param array|null $params  The parameters to be formatted and put in the body. If this is empty, it will get the
-     *                            what has been loaded into the request global of the request class.
-     *
-     * @return Request
+     * @param array|null $params The parameters to be formatted and put in the body. If this is empty, it will get the
+     *                           what has been loaded into the request global of the request class.
      */
     protected function setRequestBody(Request $request, ?array $params = null): Request
     {

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -138,10 +138,6 @@ trait FeatureTestTrait
      * Calls a single URI, executes it, and returns a TestResponse
      * instance that can be used to run many assertions against.
      *
-     * @param string     $method
-     * @param string     $path
-     * @param array|null $params
-     *
      * @throws RedirectException
      * @throws Exception
      *
@@ -216,9 +212,6 @@ trait FeatureTestTrait
     /**
      * Performs a GET request.
      *
-     * @param string     $path
-     * @param array|null $params
-     *
      * @throws RedirectException
      * @throws Exception
      *
@@ -231,9 +224,6 @@ trait FeatureTestTrait
 
     /**
      * Performs a POST request.
-     *
-     * @param string     $path
-     * @param array|null $params
      *
      * @throws RedirectException
      * @throws Exception
@@ -248,9 +238,6 @@ trait FeatureTestTrait
     /**
      * Performs a PUT request
      *
-     * @param string     $path
-     * @param array|null $params
-     *
      * @throws RedirectException
      * @throws Exception
      *
@@ -263,9 +250,6 @@ trait FeatureTestTrait
 
     /**
      * Performss a PATCH request
-     *
-     * @param string     $path
-     * @param array|null $params
      *
      * @throws RedirectException
      * @throws Exception
@@ -280,9 +264,6 @@ trait FeatureTestTrait
     /**
      * Performs a DELETE request.
      *
-     * @param string     $path
-     * @param array|null $params
-     *
      * @throws RedirectException
      * @throws Exception
      *
@@ -295,9 +276,6 @@ trait FeatureTestTrait
 
     /**
      * Performs an OPTIONS request.
-     *
-     * @param string     $path
-     * @param array|null $params
      *
      * @throws RedirectException
      * @throws Exception
@@ -312,11 +290,6 @@ trait FeatureTestTrait
     /**
      * Setup a Request object to use so that CodeIgniter
      * won't try to auto-populate some of the items.
-     *
-     * @param string      $method
-     * @param string|null $path
-     *
-     * @return IncomingRequest
      */
     protected function setupRequest(string $method, ?string $path = null): IncomingRequest
     {
@@ -342,8 +315,6 @@ trait FeatureTestTrait
     /**
      * Setup the custom request's headers
      *
-     * @param IncomingRequest $request
-     *
      * @return IncomingRequest
      */
     protected function setupHeaders(IncomingRequest $request)
@@ -362,10 +333,6 @@ trait FeatureTestTrait
      * relevant to the request, like $_POST data.
      *
      * Always populate the GET vars based on the URI.
-     *
-     * @param string     $method
-     * @param Request    $request
-     * @param array|null $params
      *
      * @throws ReflectionException
      *
@@ -396,11 +363,8 @@ trait FeatureTestTrait
      * This allows the body to be formatted in a way that the controller is going to
      * expect as in the case of testing a JSON or XML API.
      *
-     * @param Request    $request
-     * @param array|null $params  The parameters to be formatted and put in the body. If this is empty, it will get the
-     *                            what has been loaded into the request global of the request class.
-     *
-     * @return Request
+     * @param array|null $params The parameters to be formatted and put in the body. If this is empty, it will get the
+     *                           what has been loaded into the request global of the request class.
      */
     protected function setRequestBody(Request $request, ?array $params = null): Request
     {

--- a/system/Test/FilterTestTrait.php
+++ b/system/Test/FilterTestTrait.php
@@ -84,8 +84,6 @@ trait FilterTestTrait
 
     /**
      * Initializes dependencies once.
-     *
-     * @return void
      */
     protected function setUpFilterTestTrait(): void
     {
@@ -125,8 +123,6 @@ trait FilterTestTrait
      *
      * @param FilterInterface|string $filter   The filter instance, class, or alias
      * @param string                 $position "before" or "after"
-     *
-     * @return Closure
      */
     protected function getFilterCaller($filter, string $position): Closure
     {
@@ -206,8 +202,6 @@ trait FilterTestTrait
      * @param string $route    The route to test
      * @param string $position "before" or "after"
      * @param string $alias    Alias for the anticipated filter
-     *
-     * @return void
      */
     protected function assertFilter(string $route, string $position, string $alias): void
     {

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -237,8 +237,6 @@ class MockCache extends BaseHandler implements CacheInterface
 
     /**
      * Determines if the driver is supported on this system.
-     *
-     * @return bool
      */
     public function isSupported(): bool
     {

--- a/system/Test/Mock/MockCommon.php
+++ b/system/Test/Mock/MockCommon.php
@@ -17,8 +17,6 @@ if (! function_exists('is_cli')) {
      * You can set the return value for testing.
      *
      * @param bool $newReturn return value to set
-     *
-     * @return bool
      */
     function is_cli(?bool $newReturn = null): bool
     {

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -39,10 +39,7 @@ class MockConnection extends BaseConnection
      * Should automatically handle different connections for read/write
      * queries if needed.
      *
-     * @param string $sql
-     * @param mixed  ...$binds
-     * @param bool   $setEscapeFlags
-     * @param string $queryClass
+     * @param mixed ...$binds
      *
      * @return BaseResult|bool|Query
      *
@@ -89,8 +86,6 @@ class MockConnection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @param bool $persistent
-     *
      * @return mixed
      */
     public function connect(bool $persistent = false)
@@ -109,8 +104,6 @@ class MockConnection extends BaseConnection
     /**
      * Keep or establish the connection if no queries have been sent for
      * a length of time exceeding the server's idle timeout.
-     *
-     * @return bool
      */
     public function reconnect(): bool
     {
@@ -119,8 +112,6 @@ class MockConnection extends BaseConnection
 
     /**
      * Select a specific database table to use.
-     *
-     * @param string $databaseName
      *
      * @return mixed
      */
@@ -133,8 +124,6 @@ class MockConnection extends BaseConnection
 
     /**
      * Returns a string containing the version of the database being used.
-     *
-     * @return string
      */
     public function getVersion(): string
     {
@@ -143,8 +132,6 @@ class MockConnection extends BaseConnection
 
     /**
      * Executes the query against the database.
-     *
-     * @param string $sql
      *
      * @return mixed
      */
@@ -155,8 +142,6 @@ class MockConnection extends BaseConnection
 
     /**
      * Returns the total number of rows affected by this query.
-     *
-     * @return int
      */
     public function affectedRows(): int
     {
@@ -169,21 +154,17 @@ class MockConnection extends BaseConnection
      * Must return an array with keys 'code' and 'message':
      *
      *  return ['code' => null, 'message' => null);
-     *
-     * @return array
      */
     public function error(): array
     {
         return [
-            'code'    => null,
-            'message' => null,
+            'code'    => 0,
+            'message' => '',
         ];
     }
 
     /**
      * Insert ID
-     *
-     * @return int
      */
     public function insertID(): int
     {
@@ -192,10 +173,6 @@ class MockConnection extends BaseConnection
 
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
-     *
-     * @param bool $constrainByPrefix
-     *
-     * @return string
      */
     protected function _listTables(bool $constrainByPrefix = false): string
     {
@@ -204,41 +181,22 @@ class MockConnection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
-     *
-     * @param string $table
-     *
-     * @return string
      */
     protected function _listColumns(string $table = ''): string
     {
         return '';
     }
 
-    /**
-     * @param string $table
-     *
-     * @return array
-     */
     protected function _fieldData(string $table): array
     {
         return [];
     }
 
-    /**
-     * @param string $table
-     *
-     * @return array
-     */
     protected function _indexData(string $table): array
     {
         return [];
     }
 
-    /**
-     * @param string $table
-     *
-     * @return array
-     */
     protected function _foreignKeyData(string $table): array
     {
         return [];
@@ -253,8 +211,6 @@ class MockConnection extends BaseConnection
 
     /**
      * Begin Transaction
-     *
-     * @return bool
      */
     protected function _transBegin(): bool
     {
@@ -263,8 +219,6 @@ class MockConnection extends BaseConnection
 
     /**
      * Commit Transaction
-     *
-     * @return bool
      */
     protected function _transCommit(): bool
     {
@@ -273,8 +227,6 @@ class MockConnection extends BaseConnection
 
     /**
      * Rollback Transaction
-     *
-     * @return bool
      */
     protected function _transRollback(): bool
     {

--- a/system/Test/Mock/MockLanguage.php
+++ b/system/Test/Mock/MockLanguage.php
@@ -28,10 +28,6 @@ class MockLanguage extends Language
      * 'requireFile()' method to allow easy overrides
      * during testing.
      *
-     * @param array       $data
-     * @param string      $file
-     * @param string|null $locale
-     *
      * @return $this
      */
     public function setData(string $file, array $data, ?string $locale = null)
@@ -44,10 +40,6 @@ class MockLanguage extends Language
     /**
      * Provides an override that allows us to set custom
      * data to be returned easily during testing.
-     *
-     * @param string $path
-     *
-     * @return array
      */
     protected function requireFile(string $path): array
     {

--- a/system/Test/Mock/MockResult.php
+++ b/system/Test/Mock/MockResult.php
@@ -17,8 +17,6 @@ class MockResult extends BaseResult
 {
     /**
      * Gets the number of fields in the result set.
-     *
-     * @return int
      */
     public function getFieldCount(): int
     {
@@ -27,8 +25,6 @@ class MockResult extends BaseResult
 
     /**
      * Generates an array of column names in the result set.
-     *
-     * @return array
      */
     public function getFieldNames(): array
     {
@@ -37,8 +33,6 @@ class MockResult extends BaseResult
 
     /**
      * Generates an array of objects representing field meta-data.
-     *
-     * @return array
      */
     public function getFieldData(): array
     {
@@ -94,8 +88,6 @@ class MockResult extends BaseResult
 
     /**
      * Gets the number of fields in the result set.
-     *
-     * @return int
      */
     public function getNumRows(): int
     {

--- a/system/Test/TestLogger.php
+++ b/system/Test/TestLogger.php
@@ -23,9 +23,6 @@ class TestLogger extends Logger
      *
      * @param string $level
      * @param string $message
-     * @param array  $context
-     *
-     * @return bool
      */
     public function log($level, $message, array $context = []): bool
     {
@@ -58,7 +55,6 @@ class TestLogger extends Logger
     /**
      * Used by CIUnitTestCase class to provide ->assertLogged() methods.
      *
-     * @param string $level
      * @param string $message
      *
      * @return bool

--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -54,8 +54,6 @@ class TestResponse extends TestCase
 
     /**
      * Stores or the Response and parses the body in the DOM.
-     *
-     * @param ResponseInterface $response
      */
     public function __construct(ResponseInterface $response)
     {
@@ -69,8 +67,6 @@ class TestResponse extends TestCase
     /**
      * Sets the request.
      *
-     * @param RequestInterface $request
-     *
      * @return $this
      */
     public function setRequest(RequestInterface $request)
@@ -82,8 +78,6 @@ class TestResponse extends TestCase
 
     /**
      * Sets the Response and updates the DOM.
-     *
-     * @param ResponseInterface $response
      *
      * @return $this
      */
@@ -127,8 +121,6 @@ class TestResponse extends TestCase
     /**
      * Boils down the possible responses into a boolean valid/not-valid
      * response type.
-     *
-     * @return bool
      */
     public function isOK(): bool
     {
@@ -145,8 +137,6 @@ class TestResponse extends TestCase
 
     /**
      * Asserts that the status is a specific value.
-     *
-     * @param int $code
      *
      * @throws Exception
      */
@@ -181,8 +171,6 @@ class TestResponse extends TestCase
 
     /**
      * Returns whether or not the Response was a redirect or RedirectResponse
-     *
-     * @return bool
      */
     public function isRedirect(): bool
     {
@@ -204,8 +192,6 @@ class TestResponse extends TestCase
     /**
      * Assert that a given response was a redirect
      * and it was redirect to a specific URI.
-     *
-     * @param string $uri
      *
      * @throws Exception
      */
@@ -235,8 +221,6 @@ class TestResponse extends TestCase
 
     /**
      * Returns the URL set for redirection.
-     *
-     * @return string|null
      */
     public function getRedirectUrl(): ?string
     {
@@ -262,8 +246,7 @@ class TestResponse extends TestCase
     /**
      * Asserts that an SESSION key has been set and, optionally, test it's value.
      *
-     * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @throws Exception
      */
@@ -285,8 +268,6 @@ class TestResponse extends TestCase
     /**
      * Asserts the session is missing $key.
      *
-     * @param string $key
-     *
      * @throws Exception
      */
     public function assertSessionMissing(string $key)
@@ -301,7 +282,6 @@ class TestResponse extends TestCase
     /**
      * Asserts that the Response contains a specific header.
      *
-     * @param string      $key
      * @param string|null $value
      *
      * @throws Exception
@@ -318,8 +298,6 @@ class TestResponse extends TestCase
     /**
      * Asserts the Response headers does not contain the specified header.
      *
-     * @param string $key
-     *
      * @throws Exception
      */
     public function assertHeaderMissing(string $key)
@@ -334,9 +312,7 @@ class TestResponse extends TestCase
     /**
      * Asserts that the response has the specified cookie.
      *
-     * @param string      $key
      * @param string|null $value
-     * @param string      $prefix
      *
      * @throws Exception
      */
@@ -347,8 +323,6 @@ class TestResponse extends TestCase
 
     /**
      * Assert the Response does not have the specified cookie set.
-     *
-     * @param string $key
      */
     public function assertCookieMissing(string $key)
     {
@@ -357,9 +331,6 @@ class TestResponse extends TestCase
 
     /**
      * Asserts that a cookie exists and has an expired time.
-     *
-     * @param string $key
-     * @param string $prefix
      *
      * @throws Exception
      */
@@ -391,9 +362,6 @@ class TestResponse extends TestCase
 
     /**
      * Test that the response contains a matching JSON fragment.
-     *
-     * @param array $fragment
-     * @param bool  $strict
      *
      * @throws Exception
      */
@@ -454,9 +422,6 @@ class TestResponse extends TestCase
     /**
      * Assert that the desired text can be found in the result body.
      *
-     * @param string|null $search
-     * @param string|null $element
-     *
      * @throws Exception
      */
     public function assertSee(?string $search = null, ?string $element = null)
@@ -466,9 +431,6 @@ class TestResponse extends TestCase
 
     /**
      * Asserts that we do not see the specified text.
-     *
-     * @param string|null $search
-     * @param string|null $element
      *
      * @throws Exception
      */
@@ -480,8 +442,6 @@ class TestResponse extends TestCase
     /**
      * Assert that we see an element selected via a CSS selector.
      *
-     * @param string $search
-     *
      * @throws Exception
      */
     public function assertSeeElement(string $search)
@@ -491,8 +451,6 @@ class TestResponse extends TestCase
 
     /**
      * Assert that we do not see an element selected via a CSS selector.
-     *
-     * @param string $search
      *
      * @throws Exception
      */
@@ -504,9 +462,6 @@ class TestResponse extends TestCase
     /**
      * Assert that we see a link with the matching text and/or class.
      *
-     * @param string      $text
-     * @param string|null $details
-     *
      * @throws Exception
      */
     public function assertSeeLink(string $text, ?string $details = null)
@@ -516,9 +471,6 @@ class TestResponse extends TestCase
 
     /**
      * Assert that we see an input with name/value.
-     *
-     * @param string      $field
-     * @param string|null $value
      *
      * @throws Exception
      */

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -58,8 +58,6 @@ class Throttler implements ThrottlerInterface
 
     /**
      * Constructor.
-     *
-     * @param CacheInterface $cache
      */
     public function __construct(CacheInterface $cache)
     {
@@ -69,8 +67,6 @@ class Throttler implements ThrottlerInterface
     /**
      * Returns the number of seconds until the next available token will
      * be released for usage.
-     *
-     * @return int
      */
     public function getTokenTime(): int
     {
@@ -92,8 +88,6 @@ class Throttler implements ThrottlerInterface
      * @param int    $capacity The number of requests the "bucket" can hold
      * @param int    $seconds  The time it takes the "bucket" to completely refill
      * @param int    $cost     The number of tokens this action uses.
-     *
-     * @return bool
      *
      * @internal param int $maxRequests
      */
@@ -161,8 +155,6 @@ class Throttler implements ThrottlerInterface
     /**
      * Used during testing to set the current timestamp to use.
      *
-     * @param int $time
-     *
      * @return $this
      */
     public function setTestTime(int $time)
@@ -174,8 +166,6 @@ class Throttler implements ThrottlerInterface
 
     /**
      * Return the test time, defaulting to current.
-     *
-     * @return int
      */
     public function time(): int
     {

--- a/system/Throttle/ThrottlerInterface.php
+++ b/system/Throttle/ThrottlerInterface.php
@@ -39,8 +39,6 @@ interface ThrottlerInterface
     /**
      * Returns the number of seconds until the next available token will
      * be released for usage.
-     *
-     * @return int
      */
     public function getTokenTime(): int;
 }

--- a/system/Typography/Typography.php
+++ b/system/Typography/Typography.php
@@ -69,10 +69,7 @@ class Typography
      *     - Converts double dashes into em-dashes.
      *  - Converts two spaces into entities
      *
-     * @param string $str
-     * @param bool   $reduceLinebreaks whether to reduce more then two consecutive newlines to two
-     *
-     * @return string
+     * @param bool $reduceLinebreaks whether to reduce more then two consecutive newlines to two
      */
     public function autoTypography(string $str, bool $reduceLinebreaks = false): string
     {
@@ -228,10 +225,6 @@ class Typography
      * This function mainly converts double and single quotes
      * to curly entities, but it also converts em-dashes,
      * double spaces, and ampersands
-     *
-     * @param string $str
-     *
-     * @return string
      */
     public function formatCharacters(string $str): string
     {
@@ -283,10 +276,6 @@ class Typography
      * Format Newlines
      *
      * Converts newline characters into either <p> tags or <br />
-     *
-     * @param string $str
-     *
-     * @return string
      */
     protected function formatNewLines(string $str): string
     {
@@ -320,10 +309,6 @@ class Typography
      * We don't want quotes converted within tags so we'll temporarily convert them to {@DQ} and {@SQ}
      * and we don't want double dashes converted to emdash entities, so they are marked with {@DD}
      * likewise double spaces are converted to {@NBS} to prevent entity conversion
-     *
-     * @param array $match
-     *
-     * @return string
      */
     protected function protectCharacters(array $match): string
     {
@@ -332,10 +317,6 @@ class Typography
 
     /**
      * Convert newlines to HTML line breaks except within PRE tags
-     *
-     * @param string $str
-     *
-     * @return string
      */
     public function nl2brExceptPre(string $str): string
     {

--- a/system/Validation/CreditCardRules.php
+++ b/system/Validation/CreditCardRules.php
@@ -169,11 +169,6 @@ class CreditCardRules
      *  $rules = [
      *      'cc_num' => 'valid_cc_number[visa]'
      *  ];
-     *
-     * @param string|null $ccNumber
-     * @param string      $type
-     *
-     * @return bool
      */
     public function valid_cc_number(?string $ccNumber, string $type): bool
     {
@@ -243,8 +238,6 @@ class CreditCardRules
      * Checks the given number to see if the number passing a Luhn check.
      *
      * @param string $number
-     *
-     * @return bool
      */
     protected function isValidLuhn(?string $number = null): bool
     {

--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -43,11 +43,6 @@ class FileRules
 
     /**
      * Verifies that $name is the name of a valid uploaded file.
-     *
-     * @param string|null $blank
-     * @param string      $name
-     *
-     * @return bool
      */
     public function uploaded(?string $blank, string $name): bool
     {
@@ -79,11 +74,6 @@ class FileRules
 
     /**
      * Verifies if the file's size in Kilobytes is no larger than the parameter.
-     *
-     * @param string|null $blank
-     * @param string      $params
-     *
-     * @return bool
      */
     public function max_size(?string $blank, string $params): bool
     {
@@ -120,11 +110,6 @@ class FileRules
     /**
      * Uses the mime config file to determine if a file is considered an "image",
      * which for our purposes basically means that it's a raster image or svg.
-     *
-     * @param string|null $blank
-     * @param string      $params
-     *
-     * @return bool
      */
     public function is_image(?string $blank, string $params): bool
     {
@@ -160,11 +145,6 @@ class FileRules
 
     /**
      * Checks to see if an uploaded file's mime type matches one in the parameter.
-     *
-     * @param string|null $blank
-     * @param string      $params
-     *
-     * @return bool
      */
     public function mime_in(?string $blank, string $params): bool
     {
@@ -196,11 +176,6 @@ class FileRules
 
     /**
      * Checks to see if an uploaded file's extension matches one in the parameter.
-     *
-     * @param string|null $blank
-     * @param string      $params
-     *
-     * @return bool
      */
     public function ext_in(?string $blank, string $params): bool
     {
@@ -233,11 +208,6 @@ class FileRules
     /**
      * Checks an uploaded file to verify that the dimensions are within
      * a specified allowable dimension.
-     *
-     * @param string|null $blank
-     * @param string      $params
-     *
-     * @return bool
      */
     public function max_dims(?string $blank, string $params): bool
     {

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -20,10 +20,6 @@ class FormatRules
 {
     /**
      * Alpha
-     *
-     * @param string|null $str
-     *
-     * @return bool
      */
     public function alpha(?string $str = null): bool
     {
@@ -49,10 +45,6 @@ class FormatRules
 
     /**
      * Alphanumeric with underscores and dashes
-     *
-     * @param string|null $str
-     *
-     * @return bool
      */
     public function alpha_dash(?string $str = null): bool
     {
@@ -79,10 +71,6 @@ class FormatRules
 
     /**
      * Alphanumeric
-     *
-     * @param string|null $str
-     *
-     * @return bool
      */
     public function alpha_numeric(?string $str = null): bool
     {
@@ -91,10 +79,6 @@ class FormatRules
 
     /**
      * Alphanumeric w/ spaces
-     *
-     * @param string|null $str
-     *
-     * @return bool
      */
     public function alpha_numeric_space(?string $str = null): bool
     {
@@ -109,8 +93,6 @@ class FormatRules
      * it doesn't convert numbers into strings.
      *
      * @param string|null $str
-     *
-     * @return bool
      */
     public function string($str = null): bool
     {
@@ -119,10 +101,6 @@ class FormatRules
 
     /**
      * Decimal number
-     *
-     * @param string|null $str
-     *
-     * @return bool
      */
     public function decimal(?string $str = null): bool
     {
@@ -132,10 +110,6 @@ class FormatRules
 
     /**
      * String of hexidecimal characters
-     *
-     * @param string|null $str
-     *
-     * @return bool
      */
     public function hex(?string $str = null): bool
     {
@@ -144,10 +118,6 @@ class FormatRules
 
     /**
      * Integer
-     *
-     * @param string|null $str
-     *
-     * @return bool
      */
     public function integer(?string $str = null): bool
     {
@@ -156,10 +126,6 @@ class FormatRules
 
     /**
      * Is a Natural number  (0,1,2,3, etc.)
-     *
-     * @param string|null $str
-     *
-     * @return bool
      */
     public function is_natural(?string $str = null): bool
     {
@@ -168,10 +134,6 @@ class FormatRules
 
     /**
      * Is a Natural number, but not a zero  (1,2,3, etc.)
-     *
-     * @param string|null $str
-     *
-     * @return bool
      */
     public function is_natural_no_zero(?string $str = null): bool
     {
@@ -180,10 +142,6 @@ class FormatRules
 
     /**
      * Numeric
-     *
-     * @param string|null $str
-     *
-     * @return bool
      */
     public function numeric(?string $str = null): bool
     {
@@ -193,11 +151,6 @@ class FormatRules
 
     /**
      * Compares value against a regular expression pattern.
-     *
-     * @param string|null $str
-     * @param string      $pattern
-     *
-     * @return bool
      */
     public function regex_match(?string $str, string $pattern): bool
     {
@@ -215,8 +168,6 @@ class FormatRules
      * @see http://php.net/manual/en/datetimezone.listidentifiers.php
      *
      * @param string $str
-     *
-     * @return bool
      */
     public function timezone(?string $str = null): bool
     {
@@ -230,8 +181,6 @@ class FormatRules
      * as defined by RFC 2045 http://www.faqs.org/rfcs/rfc2045
      *
      * @param string $str
-     *
-     * @return bool
      */
     public function valid_base64(?string $str = null): bool
     {
@@ -242,8 +191,6 @@ class FormatRules
      * Valid JSON
      *
      * @param string $str
-     *
-     * @return bool
      */
     public function valid_json(?string $str = null): bool
     {
@@ -256,8 +203,6 @@ class FormatRules
      * Checks for a correctly formatted email address
      *
      * @param string $str
-     *
-     * @return bool
      */
     public function valid_email(?string $str = null): bool
     {
@@ -276,8 +221,6 @@ class FormatRules
      *     valid_emails[one@example.com,two@example.com]
      *
      * @param string $str
-     *
-     * @return bool
      */
     public function valid_emails(?string $str = null): bool
     {
@@ -300,8 +243,6 @@ class FormatRules
      *
      * @param string $ip    IP Address
      * @param string $which IP protocol: 'ipv4' or 'ipv6'
-     *
-     * @return bool
      */
     public function valid_ip(?string $ip = null, ?string $which = null): bool
     {
@@ -330,8 +271,6 @@ class FormatRules
      * Checks a URL to ensure it's formed correctly.
      *
      * @param string $str
-     *
-     * @return bool
      */
     public function valid_url(?string $str = null): bool
     {
@@ -357,8 +296,6 @@ class FormatRules
      *
      * @param string $str
      * @param string $format
-     *
-     * @return bool
      */
     public function valid_date(?string $str = null, ?string $format = null): bool
     {

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -23,10 +23,7 @@ class Rules
      * The value does not match another field in $data.
      *
      * @param string $str
-     * @param string $field
-     * @param array  $data  Other field/value pairs
-     *
-     * @return bool
+     * @param array  $data Other field/value pairs
      */
     public function differs(?string $str, string $field, array $data): bool
     {
@@ -41,9 +38,6 @@ class Rules
      * Equals the static value provided.
      *
      * @param string $str
-     * @param string $val
-     *
-     * @return bool
      */
     public function equals(?string $str, string $val): bool
     {
@@ -55,9 +49,6 @@ class Rules
      * $val = "5" (one) | "5,8,12" (multiple values)
      *
      * @param string $str
-     * @param string $val
-     *
-     * @return bool
      */
     public function exact_length(?string $str, string $val): bool
     {
@@ -76,9 +67,6 @@ class Rules
      * Greater than
      *
      * @param string $str
-     * @param string $min
-     *
-     * @return bool
      */
     public function greater_than(?string $str, string $min): bool
     {
@@ -89,9 +77,6 @@ class Rules
      * Equal to or Greater than
      *
      * @param string $str
-     * @param string $min
-     *
-     * @return bool
      */
     public function greater_than_equal_to(?string $str, string $min): bool
     {
@@ -108,10 +93,6 @@ class Rules
      *    is_not_unique[menu.id,active,1]
      *
      * @param string $str
-     * @param string $field
-     * @param array  $data
-     *
-     * @return bool
      */
     public function is_not_unique(?string $str, string $field, array $data): bool
     {
@@ -139,9 +120,6 @@ class Rules
      * Value should be within an array of values
      *
      * @param string $value
-     * @param string $list
-     *
-     * @return bool
      */
     public function in_list(?string $value, string $list): bool
     {
@@ -160,10 +138,6 @@ class Rules
      *    is_unique[users.email,id,5]
      *
      * @param string $str
-     * @param string $field
-     * @param array  $data
-     *
-     * @return bool
      */
     public function is_unique(?string $str, string $field, array $data): bool
     {
@@ -191,9 +165,6 @@ class Rules
      * Less than
      *
      * @param string $str
-     * @param string $max
-     *
-     * @return bool
      */
     public function less_than(?string $str, string $max): bool
     {
@@ -204,9 +175,6 @@ class Rules
      * Equal to or Less than
      *
      * @param string $str
-     * @param string $max
-     *
-     * @return bool
      */
     public function less_than_equal_to(?string $str, string $max): bool
     {
@@ -217,10 +185,7 @@ class Rules
      * Matches the value of another field in $data.
      *
      * @param string $str
-     * @param string $field
-     * @param array  $data  Other field/value pairs
-     *
-     * @return bool
+     * @param array  $data Other field/value pairs
      */
     public function matches(?string $str, string $field, array $data): bool
     {
@@ -235,9 +200,6 @@ class Rules
      * Returns true if $str is $val or fewer characters in length.
      *
      * @param string $str
-     * @param string $val
-     *
-     * @return bool
      */
     public function max_length(?string $str, string $val): bool
     {
@@ -248,9 +210,6 @@ class Rules
      * Returns true if $str is at least $val length.
      *
      * @param string $str
-     * @param string $val
-     *
-     * @return bool
      */
     public function min_length(?string $str, string $val): bool
     {
@@ -261,9 +220,6 @@ class Rules
      * Does not equal the static value provided.
      *
      * @param string $str
-     * @param string $val
-     *
-     * @return bool
      */
     public function not_equals(?string $str, string $val): bool
     {
@@ -274,9 +230,6 @@ class Rules
      * Value should not be within an array of values.
      *
      * @param string $value
-     * @param string $list
-     *
-     * @return bool
      */
     public function not_in_list(?string $value, string $list): bool
     {
@@ -310,8 +263,6 @@ class Rules
      * @param string|null $str
      * @param string|null $fields List of fields that we should check if present
      * @param array       $data   Complete list of fields from the form
-     *
-     * @return bool
      */
     public function required_with($str = null, ?string $fields = null, array $data = []): bool
     {
@@ -353,10 +304,6 @@ class Rules
      *     required_without[id,email]
      *
      * @param string|null $str
-     * @param string|null $fields
-     * @param array       $data
-     *
-     * @return bool
      */
     public function required_without($str = null, ?string $fields = null, array $data = []): bool
     {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -86,8 +86,7 @@ class Validation implements ValidationInterface
     /**
      * Validation constructor.
      *
-     * @param ValidationConfig  $config
-     * @param RendererInterface $view
+     * @param ValidationConfig $config
      */
     public function __construct($config, RendererInterface $view)
     {
@@ -105,8 +104,6 @@ class Validation implements ValidationInterface
      * @param array|null  $data    The array of data to validate.
      * @param string|null $group   The predefined group of rules to apply.
      * @param string|null $dbGroup The database group to use.
-     *
-     * @return bool
      */
     public function run(?array $data = null, ?string $group = null, ?string $dbGroup = null): bool
     {
@@ -163,10 +160,7 @@ class Validation implements ValidationInterface
      * determining whether validation was successful or not.
      *
      * @param mixed    $value
-     * @param string   $rule
      * @param string[] $errors
-     *
-     * @return bool
      */
     public function check($value, string $rule, array $errors = []): bool
     {
@@ -181,13 +175,9 @@ class Validation implements ValidationInterface
      * the error to $this->errors and moves on to the next,
      * so that we can collect all of the first errors.
      *
-     * @param string       $field
-     * @param string|null  $label
      * @param array|string $value
      * @param array|null   $rules
      * @param array        $data
-     *
-     * @return bool
      */
     protected function processRules(string $field, ?string $label, $value, $rules = null, ?array $data = null): bool
     {
@@ -317,8 +307,6 @@ class Validation implements ValidationInterface
      * array values.
      *
      * @param IncomingRequest|RequestInterface $request
-     *
-     * @return ValidationInterface
      */
     public function withRequest(RequestInterface $request): ValidationInterface
     {
@@ -350,11 +338,6 @@ class Validation implements ValidationInterface
      *        'rule' => 'message',
      *        'rule' => 'message'
      *    ]
-     *
-     * @param string      $field
-     * @param string|null $label
-     * @param string      $rules
-     * @param array       $errors
      *
      * @return $this
      */
@@ -388,10 +371,7 @@ class Validation implements ValidationInterface
      *        ],
      *    ]
      *
-     * @param array $rules
      * @param array $errors // An array of custom error messages
-     *
-     * @return ValidationInterface
      */
     public function setRules(array $rules, array $errors = []): ValidationInterface
     {
@@ -417,8 +397,6 @@ class Validation implements ValidationInterface
 
     /**
      * Returns all of the rules currently defined.
-     *
-     * @return array
      */
     public function getRules(): array
     {
@@ -427,10 +405,6 @@ class Validation implements ValidationInterface
 
     /**
      * Checks to see if the rule for key $field has been set or not.
-     *
-     * @param string $field
-     *
-     * @return bool
      */
     public function hasRule(string $field): bool
     {
@@ -479,10 +453,6 @@ class Validation implements ValidationInterface
 
     /**
      * Returns the rendered HTML of the errors as defined in $template.
-     *
-     * @param string $template
-     *
-     * @return string
      */
     public function listErrors(string $template = 'list'): string
     {
@@ -497,11 +467,6 @@ class Validation implements ValidationInterface
 
     /**
      * Displays a single error in formatted HTML as defined in the $template view.
-     *
-     * @param string $field
-     * @param string $template
-     *
-     * @return string
      */
     public function showError(string $field, string $template = 'single'): string
     {
@@ -540,8 +505,6 @@ class Validation implements ValidationInterface
      * be any name, but must all still be an array of the
      * same format used with setRules(). Additionally, check
      * for {group}_errors for an array of custom error messages.
-     *
-     * @param string|null $group
      *
      * @return array|ValidationException|null
      */
@@ -586,11 +549,6 @@ class Validation implements ValidationInterface
      * The value of {id} would be replaced with the actual id in the form data:
      *
      *  'required|is_unique[users,email,id,13]'
-     *
-     * @param array $rules
-     * @param array $data
-     *
-     * @return array
      */
     protected function fillPlaceholders(array $rules, array $data): array
     {
@@ -625,10 +583,6 @@ class Validation implements ValidationInterface
 
     /**
      * Checks to see if an error exists for the given field.
-     *
-     * @param string $field
-     *
-     * @return bool
      */
     public function hasError(string $field): bool
     {
@@ -681,11 +635,6 @@ class Validation implements ValidationInterface
 
     /**
      * Sets the error for a specific field. Used by custom validation methods.
-     *
-     * @param string $field
-     * @param string $error
-     *
-     * @return ValidationInterface
      */
     public function setError(string $field, string $error): ValidationInterface
     {
@@ -697,13 +646,8 @@ class Validation implements ValidationInterface
     /**
      * Attempts to find the appropriate error message
      *
-     * @param string      $rule
-     * @param string      $field
-     * @param string|null $label
-     * @param string      $param
-     * @param string      $value The value that caused the validation to fail.
-     *
-     * @return string
+     * @param string $param
+     * @param string $value The value that caused the validation to fail.
      */
     protected function getErrorMessage(string $rule, string $field, ?string $label = null, ?string $param = null, ?string $value = null): string
     {
@@ -725,10 +669,6 @@ class Validation implements ValidationInterface
 
     /**
      * Split rules string by pipe operator.
-     *
-     * @param string $rules
-     *
-     * @return array
      */
     protected function splitRules(string $rules): array
     {
@@ -750,8 +690,6 @@ class Validation implements ValidationInterface
     /**
      * Resets the class to a blank slate. Should be called whenever
      * you need to process more than one array.
-     *
-     * @return ValidationInterface
      */
     public function reset(): ValidationInterface
     {

--- a/system/Validation/ValidationInterface.php
+++ b/system/Validation/ValidationInterface.php
@@ -24,8 +24,6 @@ interface ValidationInterface
      *
      * @param array  $data  The array of data to validate.
      * @param string $group The pre-defined group of rules to apply.
-     *
-     * @return bool
      */
     public function run(?array $data = null, ?string $group = null): bool;
 
@@ -44,38 +42,21 @@ interface ValidationInterface
     /**
      * Takes a Request object and grabs the input data to use from its
      * array values.
-     *
-     * @param RequestInterface $request
-     *
-     * @return ValidationInterface
      */
     public function withRequest(RequestInterface $request): ValidationInterface;
 
     /**
      * Stores the rules that should be used to validate the items.
-     *
-     * @param array $rules
-     * @param array $messages
-     *
-     * @return ValidationInterface
      */
     public function setRules(array $rules, array $messages = []): ValidationInterface;
 
     /**
      * Checks to see if the rule for key $field has been set or not.
-     *
-     * @param string $field
-     *
-     * @return bool
      */
     public function hasRule(string $field): bool;
 
     /**
      * Returns the error for a specified $field (or empty string if not set).
-     *
-     * @param string $field
-     *
-     * @return string
      */
     public function getError(string $field): string;
 
@@ -94,19 +75,12 @@ interface ValidationInterface
 
     /**
      * Sets the error for a specific field. Used by custom validation methods.
-     *
-     * @param string $alias
-     * @param string $error
-     *
-     * @return ValidationInterface
      */
     public function setError(string $alias, string $error): ValidationInterface;
 
     /**
      * Resets the class to a blank slate. Should be called whenever
      * you need to process more than one array.
-     *
-     * @return ValidationInterface
      */
     public function reset(): ValidationInterface;
 }

--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -53,8 +53,6 @@ class Cell
 
     /**
      * Cell constructor.
-     *
-     * @param CacheInterface $cache
      */
     public function __construct(CacheInterface $cache)
     {
@@ -64,14 +62,9 @@ class Cell
     /**
      * Render a cell, returning its body as a string.
      *
-     * @param string      $library
-     * @param null        $params
-     * @param int         $ttl
-     * @param string|null $cacheName
+     * @param null $params
      *
      * @throws ReflectionException
-     *
-     * @return string
      */
     public function render(string $library, $params = null, int $ttl = 0, ?string $cacheName = null): string
     {
@@ -191,10 +184,6 @@ class Cell
     /**
      * Given the library string, attempts to determine the class and method
      * to call.
-     *
-     * @param string $library
-     *
-     * @return array
      */
     protected function determineClass(string $library): array
     {

--- a/system/View/Filters.php
+++ b/system/View/Filters.php
@@ -21,10 +21,6 @@ class Filters
 {
     /**
      * Returns $value as all lowercase with the first letter capitalized.
-     *
-     * @param string $value
-     *
-     * @return string
      */
     public static function capitalize(string $value): string
     {
@@ -34,10 +30,7 @@ class Filters
     /**
      * Formats a date into the given $format.
      *
-     * @param mixed  $value
-     * @param string $format
-     *
-     * @return string
+     * @param mixed $value
      */
     public static function date($value, string $format): string
     {
@@ -56,7 +49,6 @@ class Filters
      *      my_date|date_modify(+1 day)
      *
      * @param string $value
-     * @param string $adjustment
      *
      * @return false|int
      */
@@ -70,10 +62,7 @@ class Filters
     /**
      * Returns the given default value if $value is empty or undefined.
      *
-     * @param mixed  $value
-     * @param string $default
-     *
-     * @return string
+     * @param mixed $value
      */
     public static function default($value, string $default): string
     {
@@ -86,9 +75,6 @@ class Filters
      * Escapes the given value with our `esc()` helper function.
      *
      * @param string $value
-     * @param string $context
-     *
-     * @return string
      */
     public static function esc($value, string $context = 'html'): string
     {
@@ -97,12 +83,6 @@ class Filters
 
     /**
      * Returns an excerpt of the given string.
-     *
-     * @param string $value
-     * @param string $phrase
-     * @param int    $radius
-     *
-     * @return string
      */
     public static function excerpt(string $value, string $phrase, int $radius = 100): string
     {
@@ -113,11 +93,6 @@ class Filters
 
     /**
      * Highlights a given phrase within the text using '<mark></mark>' tags.
-     *
-     * @param string $value
-     * @param string $phrase
-     *
-     * @return string
      */
     public static function highlight(string $value, string $phrase): string
     {
@@ -130,8 +105,6 @@ class Filters
      * Highlights code samples with HTML/CSS.
      *
      * @param string $value
-     *
-     * @return string
      */
     public static function highlight_code($value): string
     {
@@ -145,9 +118,6 @@ class Filters
      * Will break at word break so may be more or less than $limit.
      *
      * @param string $value
-     * @param int    $limit
-     *
-     * @return string
      */
     public static function limit_chars($value, int $limit = 500): string
     {
@@ -160,9 +130,6 @@ class Filters
      * Limits the number of words to $limit, and trails of with an ellipsis.
      *
      * @param string $value
-     * @param int    $limit
-     *
-     * @return string
      */
     public static function limit_words($value, int $limit = 100): string
     {
@@ -174,12 +141,7 @@ class Filters
     /**
      * Returns the $value displayed in a localized manner.
      *
-     * @param float|int   $value
-     * @param int         $precision
-     * @param string      $type
-     * @param string|null $locale
-     *
-     * @return string
+     * @param float|int $value
      */
     public static function local_number($value, string $type = 'decimal', int $precision = 4, ?string $locale = null): string
     {
@@ -201,12 +163,8 @@ class Filters
     /**
      * Returns the $value displayed as a currency string.
      *
-     * @param float|int   $value
-     * @param string      $currency
-     * @param string|null $locale
-     * @param int         $fraction
-     *
-     * @return string
+     * @param float|int $value
+     * @param int       $fraction
      */
     public static function local_currency($value, string $currency, ?string $locale = null, $fraction = null): string
     {
@@ -224,10 +182,6 @@ class Filters
     /**
      * Returns a string with all instances of newline character (\n)
      * converted to an HTML <br/> tag.
-     *
-     * @param string $value
-     *
-     * @return string
      */
     public static function nl2br(string $value): string
     {
@@ -239,10 +193,6 @@ class Filters
     /**
      * Takes a body of text and uses the auto_typography() method to
      * turn it into prettier, easier-to-read, prose.
-     *
-     * @param string $value
-     *
-     * @return string
      */
     public static function prose(string $value): string
     {
@@ -258,9 +208,7 @@ class Filters
      *  - ceil      always rounds up
      *  - floor     always rounds down
      *
-     * @param string $value
-     * @param mixed  $precision
-     * @param string $type
+     * @param mixed $precision
      *
      * @return float|string
      */
@@ -288,10 +236,6 @@ class Filters
 
     /**
      * Returns a "title case" version of the string.
-     *
-     * @param string $value
-     *
-     * @return string
      */
     public static function title(string $value): string
     {

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -60,7 +60,6 @@ class Parser extends View
     /**
      * Constructor
      *
-     * @param ViewConfig      $config
      * @param string          $viewPath
      * @param mixed           $loader
      * @param bool            $debug
@@ -80,11 +79,8 @@ class Parser extends View
      * Parses pseudo-variables contained in the specified template view,
      * replacing them with any data that has already been set.
      *
-     * @param string $view
-     * @param array  $options
-     * @param bool   $saveData
-     *
-     * @return string
+     * @param array $options
+     * @param bool  $saveData
      */
     public function render(string $view, ?array $options = null, ?bool $saveData = null): string
     {
@@ -143,11 +139,8 @@ class Parser extends View
      * Parses pseudo-variables contained in the specified string,
      * replacing them with any data that has already been set.
      *
-     * @param string $template
-     * @param array  $options
-     * @param bool   $saveData
-     *
-     * @return string
+     * @param array $options
+     * @param bool  $saveData
      */
     public function renderString(string $template, ?array $options = null, ?bool $saveData = null): string
     {
@@ -179,11 +172,8 @@ class Parser extends View
      * so that the variable is correctly handled within the
      * parsing itself, and contexts (including raw) are respected.
      *
-     * @param array  $data
      * @param string $context The context to escape it for: html, css, js, url, raw
      *                        If 'raw', no escaping will happen
-     *
-     * @return RendererInterface
      */
     public function setData(array $data = [], ?string $context = null): RendererInterface
     {
@@ -213,11 +203,7 @@ class Parser extends View
      * Parses pseudo-variables contained in the specified template,
      * replacing them with the data in the second param
      *
-     * @param string $template
-     * @param array  $data
-     * @param array  $options  Future options
-     *
-     * @return string
+     * @param array $options Future options
      */
     protected function parse(string $template, array $data = [], ?array $options = null): string
     {
@@ -261,11 +247,6 @@ class Parser extends View
 
     /**
      * Parse a single key/value, extracting it
-     *
-     * @param string $key
-     * @param string $val
-     *
-     * @return array
      */
     protected function parseSingle(string $key, string $val): array
     {
@@ -278,12 +259,6 @@ class Parser extends View
      * Parse a tag pair
      *
      * Parses tag pairs: {some_tag} string... {/some_tag}
-     *
-     * @param string $variable
-     * @param array  $data
-     * @param string $template
-     *
-     * @return array
      */
     protected function parsePair(string $variable, array $data, string $template): array
     {
@@ -371,10 +346,6 @@ class Parser extends View
      * Removes any comments from the file. Comments are wrapped in {# #} symbols:
      *
      *      {# This is a comment #}
-     *
-     * @param string $template
-     *
-     * @return string
      */
     protected function parseComments(string $template): string
     {
@@ -384,10 +355,6 @@ class Parser extends View
     /**
      * Extracts noparse blocks, inserting a hash in its place so that
      * those blocks of the page are not touched by parsing.
-     *
-     * @param string $template
-     *
-     * @return string
      */
     protected function extractNoparse(string $template): string
     {
@@ -411,10 +378,6 @@ class Parser extends View
 
     /**
      * Re-inserts the noparsed contents back into the template.
-     *
-     * @param string $template
-     *
-     * @return string
      */
     public function insertNoparse(string $template): string
     {
@@ -434,10 +397,6 @@ class Parser extends View
      *  - if
      *  - elseif
      *  - else
-     *
-     * @param string $template
-     *
-     * @return string
      */
     protected function parseConditionals(string $template): string
     {
@@ -488,8 +447,6 @@ class Parser extends View
      *
      * @param string $leftDelimiter
      * @param string $rightDelimiter
-     *
-     * @return RendererInterface
      */
     public function setDelimiters($leftDelimiter = '{', $rightDelimiter = '}'): RendererInterface
     {
@@ -506,9 +463,6 @@ class Parser extends View
      * @param mixed  $pattern
      * @param string $content
      * @param string $template
-     * @param bool   $escape
-     *
-     * @return string
      */
     protected function replaceSingle($pattern, $content, $template, bool $escape = false): string
     {
@@ -535,12 +489,6 @@ class Parser extends View
 
     /**
      * Callback used during parse() to apply any filters to the value.
-     *
-     * @param array  $matches
-     * @param string $replace
-     * @param bool   $escape
-     *
-     * @return string
      */
     protected function prepareReplacement(array $matches, string $replace, bool $escape = true): string
     {
@@ -559,8 +507,6 @@ class Parser extends View
 
     /**
      * Checks the placeholder the view provided to see if we need to provide any autoescaping.
-     *
-     * @param string $key
      *
      * @return false|string
      */
@@ -596,11 +542,6 @@ class Parser extends View
     /**
      * Given a set of filters, will apply each of the filters in turn
      * to $replace, and return the modified string.
-     *
-     * @param string $replace
-     * @param array  $filters
-     *
-     * @return string
      */
     protected function applyFilters(string $replace, array $filters): string
     {
@@ -643,8 +584,6 @@ class Parser extends View
     /**
      * Scans the template for any parser plugins, and attempts to execute them.
      * Plugins are delimited by {+ ... +}
-     *
-     * @param string $template
      *
      * @return string
      */
@@ -699,10 +638,6 @@ class Parser extends View
     /**
      * Makes a new plugin available during the parsing of the template.
      *
-     * @param string   $alias
-     * @param callable $callback
-     * @param bool     $isPair
-     *
      * @return $this
      */
     public function addPlugin(string $alias, callable $callback, bool $isPair = false)
@@ -714,8 +649,6 @@ class Parser extends View
 
     /**
      * Removes a plugin from the available plugins.
-     *
-     * @param string $alias
      *
      * @return $this
      */

--- a/system/View/Plugins.php
+++ b/system/View/Plugins.php
@@ -41,10 +41,6 @@ class Plugins
 
     /**
      * Wrap helper function to use as view plugin.
-     *
-     * @param array $params
-     *
-     * @return string
      */
     public static function mailto(array $params = []): string
     {
@@ -57,10 +53,6 @@ class Plugins
 
     /**
      * Wrap helper function to use as view plugin.
-     *
-     * @param array $params
-     *
-     * @return string
      */
     public static function safeMailto(array $params = []): string
     {
@@ -73,10 +65,6 @@ class Plugins
 
     /**
      * Wrap helper function to use as view plugin.
-     *
-     * @param array $params
-     *
-     * @return string
      */
     public static function lang(array $params = []): string
     {
@@ -87,10 +75,6 @@ class Plugins
 
     /**
      * Wrap helper function to use as view plugin.
-     *
-     * @param array $params
-     *
-     * @return string
      */
     public static function ValidationErrors(array $params = []): string
     {
@@ -105,8 +89,6 @@ class Plugins
     /**
      * Wrap helper function to use as view plugin.
      *
-     * @param array $params
-     *
      * @return false|string
      */
     public static function route(array $params = [])
@@ -116,10 +98,6 @@ class Plugins
 
     /**
      * Wrap helper function to use as view plugin.
-     *
-     * @param array $params
-     *
-     * @return string
      */
     public static function siteURL(array $params = []): string
     {

--- a/system/View/RendererInterface.php
+++ b/system/View/RendererInterface.php
@@ -22,13 +22,10 @@ interface RendererInterface
      * Builds the output based upon a file name and any
      * data that has already been set.
      *
-     * @param string $view
-     * @param array  $options  Reserved for 3rd-party uses since
-     *                         it might be needed to pass additional info
-     *                         to other template engines.
-     * @param bool   $saveData Whether to save data for subsequent calls
-     *
-     * @return string
+     * @param array $options  Reserved for 3rd-party uses since
+     *                        it might be needed to pass additional info
+     *                        to other template engines.
+     * @param bool  $saveData Whether to save data for subsequent calls
      */
     public function render(string $view, ?array $options = null, bool $saveData = false): string;
 
@@ -41,15 +38,12 @@ interface RendererInterface
      *                         it might be needed to pass additional info
      *                         to other template engines.
      * @param bool   $saveData Whether to save data for subsequent calls
-     *
-     * @return string
      */
     public function renderString(string $view, ?array $options = null, bool $saveData = false): string;
 
     /**
      * Sets several pieces of view data at once.
      *
-     * @param array  $data
      * @param string $context The context to escape it for: html, css, js, url
      *                        If 'raw', no escaping will happen
      *
@@ -60,7 +54,6 @@ interface RendererInterface
     /**
      * Sets a single piece of view data.
      *
-     * @param string $name
      * @param mixed  $value
      * @param string $context The context to escape it for: html, css, js, url
      *                        If 'raw' no escaping will happen

--- a/system/View/Table.php
+++ b/system/View/Table.php
@@ -222,8 +222,6 @@ class Table
      *
      * Ensures a standard associative array format for all cell data
      *
-     * @param array $args
-     *
      * @return array
      */
     protected function _prepArgs(array $args)

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -137,11 +137,7 @@ class View implements RendererInterface
     /**
      * Constructor
      *
-     * @param ViewConfig       $config
-     * @param string|null      $viewPath
-     * @param FileLocator|null $loader
-     * @param bool|null        $debug
-     * @param LoggerInterface  $logger
+     * @param LoggerInterface $logger
      */
     public function __construct(ViewConfig $config, ?string $viewPath = null, ?FileLocator $loader = null, ?bool $debug = null, ?LoggerInterface $logger = null)
     {
@@ -168,8 +164,6 @@ class View implements RendererInterface
      * @param bool|null  $saveData If true, saves data for subsequent calls,
      *                             if false, cleans the data after displaying,
      *                             if null, uses the config setting.
-     *
-     * @return string
      */
     public function render(string $view, ?array $options = null, ?bool $saveData = null): string
     {
@@ -283,8 +277,6 @@ class View implements RendererInterface
      * @param bool|null  $saveData If true, saves data for subsequent calls,
      *                             if false, cleans the data after displaying,
      *                             if null, uses the config setting.
-     *
-     * @return string
      */
     public function renderString(string $view, ?array $options = null, ?bool $saveData = null): string
     {
@@ -312,11 +304,6 @@ class View implements RendererInterface
 
     /**
      * Extract first bit of a long string and add ellipsis
-     *
-     * @param string $string
-     * @param int    $length
-     *
-     * @return string
      */
     public function excerpt(string $string, int $length = 20): string
     {
@@ -326,11 +313,8 @@ class View implements RendererInterface
     /**
      * Sets several pieces of view data at once.
      *
-     * @param array  $data
      * @param string $context The context to escape it for: html, css, js, url
      *                        If null, no escaping will happen
-     *
-     * @return RendererInterface
      */
     public function setData(array $data = [], ?string $context = null): RendererInterface
     {
@@ -347,12 +331,9 @@ class View implements RendererInterface
     /**
      * Sets a single piece of view data.
      *
-     * @param string $name
      * @param mixed  $value
      * @param string $context The context to escape it for: html, css, js, url
      *                        If null, no escaping will happen
-     *
-     * @return RendererInterface
      */
     public function setVar(string $name, $value = null, ?string $context = null): RendererInterface
     {
@@ -368,8 +349,6 @@ class View implements RendererInterface
 
     /**
      * Removes all of the view data from the system.
-     *
-     * @return RendererInterface
      */
     public function resetData(): RendererInterface
     {
@@ -380,8 +359,6 @@ class View implements RendererInterface
 
     /**
      * Returns the current data that will be displayed in the view.
-     *
-     * @return array
      */
     public function getData(): array
     {
@@ -390,8 +367,6 @@ class View implements RendererInterface
 
     /**
      * Specifies that the current view should extend an existing layout.
-     *
-     * @param string $layout
      *
      * @return void
      */
@@ -443,8 +418,6 @@ class View implements RendererInterface
 
     /**
      * Renders a section's contents.
-     *
-     * @param string $sectionName
      */
     public function renderSection(string $sectionName)
     {
@@ -463,11 +436,7 @@ class View implements RendererInterface
     /**
      * Used within layout views to include additional views.
      *
-     * @param string     $view
-     * @param array|null $options
-     * @param bool       $saveData
-     *
-     * @return string
+     * @param bool $saveData
      */
     public function include(string $view, ?array $options = null, $saveData = true): string
     {
@@ -477,8 +446,6 @@ class View implements RendererInterface
     /**
      * Returns the performance data that might have been collected
      * during the execution. Used primarily in the Debug Toolbar.
-     *
-     * @return array
      */
     public function getPerformanceData(): array
     {
@@ -487,10 +454,6 @@ class View implements RendererInterface
 
     /**
      * Logs performance data for rendering a view.
-     *
-     * @param float  $start
-     * @param float  $end
-     * @param string $view
      *
      * @return void
      */

--- a/tests/_support/Autoloader/FatalLocator.php
+++ b/tests/_support/Autoloader/FatalLocator.php
@@ -51,12 +51,6 @@ class FatalLocator extends FileLocator
      *      'app/Modules/foo/Config/Routes.php',
      *      'app/Modules/bar/Config/Routes.php',
      *  ]
-     *
-     * @param string $path
-     * @param string $ext
-     * @param bool   $prioritizeApp
-     *
-     * @return array
      */
     public function search(string $path, string $ext = 'php', bool $prioritizeApp = true): array
     {

--- a/tests/_support/Commands/Unsuffixable.php
+++ b/tests/_support/Commands/Unsuffixable.php
@@ -64,8 +64,6 @@ class Unsuffixable extends BaseCommand
 
     /**
      * Actually execute a command.
-     *
-     * @param array $params
      */
     public function run(array $params)
     {

--- a/tests/_support/Config/Services.php
+++ b/tests/_support/Config/Services.php
@@ -27,7 +27,6 @@ class Services extends BaseServices
      * The URI class provides a way to model and manipulate URIs.
      *
      * @param string $uri
-     * @param bool   $getShared
      *
      * @return URI
      */

--- a/tests/_support/Log/Handlers/TestHandler.php
+++ b/tests/_support/Log/Handlers/TestHandler.php
@@ -46,8 +46,6 @@ class TestHandler extends \CodeIgniter\Log\Handlers\FileHandler
      *
      * @param $level
      * @param $message
-     *
-     * @return bool
      */
     public function handle($level, $message): bool
     {

--- a/tests/_support/Services.php
+++ b/tests/_support/Services.php
@@ -39,7 +39,6 @@ class Services
     /**
      * Inject mock object for testing.
      *
-     * @param string $name
      * @param $mock
      */
     public static function injectMock(string $name, $mock)
@@ -50,9 +49,6 @@ class Services
 
     /**
      * Returns a service
-     *
-     * @param string $name
-     * @param array  $arguments
      */
     public static function __callStatic(string $name, array $arguments)
     {

--- a/tests/system/Cache/Handlers/BaseHandlerTest.php
+++ b/tests/system/Cache/Handlers/BaseHandlerTest.php
@@ -22,6 +22,8 @@ final class BaseHandlerTest extends CIUnitTestCase
 {
     /**
      * @dataProvider invalidTypeProvider
+     *
+     * @param mixed $input
      */
     public function testValidateKeyInvalidType($input)
     {

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -270,6 +270,9 @@ final class FileHandlerTest extends CIUnitTestCase
 
     /**
      * @dataProvider modeProvider
+     *
+     * @param mixed $int
+     * @param mixed $string
      */
     public function testSaveMode($int, $string)
     {

--- a/tests/system/Commands/GenerateKeyTest.php
+++ b/tests/system/Commands/GenerateKeyTest.php
@@ -58,8 +58,6 @@ final class GenerateKeyTest extends CIUnitTestCase
 
     /**
      * Gets buffer contents then releases it.
-     *
-     * @return string
      */
     protected function getBuffer(): string
     {

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -439,6 +439,9 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
     /**
      * @dataProvider dirtyPathsProvider
+     *
+     * @param mixed $input
+     * @param mixed $expected
      */
     public function testCleanPathActuallyCleaningThePaths($input, $expected)
     {

--- a/tests/system/CommonSingleServiceTest.php
+++ b/tests/system/CommonSingleServiceTest.php
@@ -23,10 +23,6 @@ final class CommonSingleServiceTest extends CIUnitTestCase
 {
     /**
      * @dataProvider serviceNamesProvider
-     *
-     * @param string $service
-     *
-     * @return void
      */
     public function testSingleServiceWithNoParamsSupplied(string $service): void
     {
@@ -39,10 +35,6 @@ final class CommonSingleServiceTest extends CIUnitTestCase
 
     /**
      * @dataProvider serviceNamesProvider
-     *
-     * @param string $service
-     *
-     * @return void
      */
     public function testSingleServiceWithAtLeastOneParamSupplied(string $service): void
     {

--- a/tests/system/Config/MimesTest.php
+++ b/tests/system/Config/MimesTest.php
@@ -50,6 +50,7 @@ final class MimesTest extends CIUnitTestCase
      *
      * @param $expected
      * @param $ext
+     * @param mixed $mime
      */
     public function testGuessExtensionFromType($expected, $mime)
     {
@@ -84,6 +85,9 @@ final class MimesTest extends CIUnitTestCase
 
     /**
      * @dataProvider mimesList
+     *
+     * @param mixed $expected
+     * @param mixed $ext
      */
     public function testGuessTypeFromExtension($expected, $ext)
     {

--- a/tests/system/Cookie/CookieTest.php
+++ b/tests/system/Cookie/CookieTest.php
@@ -141,8 +141,6 @@ final class CookieTest extends CIUnitTestCase
      * @dataProvider invalidExpiresProvider
      *
      * @param mixed $expires
-     *
-     * @return void
      */
     public function testInvalidExpires($expires): void
     {
@@ -165,11 +163,6 @@ final class CookieTest extends CIUnitTestCase
 
     /**
      * @dataProvider setCookieHeaderProvider
-     *
-     * @param string $header
-     * @param array  $changed
-     *
-     * @return void
      */
     public function testSetCookieHeaderCreation(string $header, array $changed): void
     {

--- a/tests/system/Database/BaseQueryTest.php
+++ b/tests/system/Database/BaseQueryTest.php
@@ -182,6 +182,9 @@ final class BaseQueryTest extends CIUnitTestCase
 
     /**
      * @dataProvider queryTypes
+     *
+     * @param mixed $expected
+     * @param mixed $sql
      */
     public function testIsWriteType($expected, $sql)
     {

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -225,6 +225,8 @@ final class WhereTest extends CIUnitTestCase
 
     /**
      * @dataProvider provideInvalidKeys
+     *
+     * @param mixed $key
      */
     public function testWhereInvalidKeyThrowInvalidArgumentException($key)
     {
@@ -245,6 +247,8 @@ final class WhereTest extends CIUnitTestCase
 
     /**
      * @dataProvider provideInvalidValues
+     *
+     * @param mixed $values
      */
     public function testWhereInEmptyValuesThrowInvalidArgumentException($values)
     {

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -27,6 +27,9 @@ final class ExceptionsTest extends CIUnitTestCase
 
     /**
      * @dataProvider dirtyPathsProvider
+     *
+     * @param mixed $file
+     * @param mixed $expected
      */
     public function testCleanPaths($file, $expected)
     {

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -39,6 +39,8 @@ final class EmailTest extends CIUnitTestCase
 
     /**
      * @dataProvider autoClearProvider
+     *
+     * @param mixed $autoClear
      */
     public function testEmailSendWithClearance($autoClear)
     {

--- a/tests/system/Format/XMLFormatterTest.php
+++ b/tests/system/Format/XMLFormatterTest.php
@@ -100,9 +100,6 @@ final class XMLFormatterTest extends CIUnitTestCase
     }
 
     /**
-     * @param string $expected
-     * @param array  $input
-     *
      * @dataProvider invalidTagsProvider
      */
     public function testValidatingInvalidTags(string $expected, array $input)

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -514,6 +514,10 @@ final class CLIRequestTest extends CIUnitTestCase
 
     /**
      * @dataProvider ipAddressChecks
+     *
+     * @param mixed      $expected
+     * @param mixed      $address
+     * @param mixed|null $type
      */
     public function testValidIPAddress($expected, $address, $type = null)
     {

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -576,6 +576,9 @@ final class IncomingRequestTest extends CIUnitTestCase
 
     /**
      * @dataProvider providePathChecks
+     *
+     * @param mixed $path
+     * @param mixed $detectPath
      */
     public function testExtensionPHP($path, $detectPath)
     {

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -213,6 +213,8 @@ final class MessageTest extends CIUnitTestCase
 
     /**
      * @dataProvider provideArrayHeaderValue
+     *
+     * @param mixed $arrayHeaderValue
      */
     public function testSetHeaderWithExistingArrayValuesAppendStringValue($arrayHeaderValue)
     {
@@ -224,6 +226,8 @@ final class MessageTest extends CIUnitTestCase
 
     /**
      * @dataProvider provideArrayHeaderValue
+     *
+     * @param mixed $arrayHeaderValue
      */
     public function testSetHeaderWithExistingArrayValuesAppendArrayValue($arrayHeaderValue)
     {

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -581,6 +581,10 @@ final class RequestTest extends CIUnitTestCase
 
     /**
      * @dataProvider ipAddressChecks
+     *
+     * @param mixed      $expected
+     * @param mixed      $address
+     * @param mixed|null $type
      */
     public function testValidIPAddress($expected, $address, $type = null)
     {

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -338,6 +338,9 @@ final class URITest extends CIUnitTestCase
 
     /**
      * @dataProvider invalidPaths
+     *
+     * @param mixed $path
+     * @param mixed $expected
      */
     public function testPathGetsFiltered($path, $expected)
     {
@@ -449,6 +452,9 @@ final class URITest extends CIUnitTestCase
 
     /**
      * @dataProvider authorityInfo
+     *
+     * @param mixed $url
+     * @param mixed $expected
      */
     public function testAuthorityReturnsExceptedValues($url, $expected)
     {
@@ -472,6 +478,9 @@ final class URITest extends CIUnitTestCase
 
     /**
      * @dataProvider defaultPorts
+     *
+     * @param mixed $scheme
+     * @param mixed $port
      */
     public function testAuthorityRemovesDefaultPorts($scheme, $port)
     {
@@ -593,6 +602,9 @@ final class URITest extends CIUnitTestCase
 
     /**
      * @dataProvider defaultDots
+     *
+     * @param mixed $path
+     * @param mixed $expected
      */
     public function testRemoveDotSegments($path, $expected)
     {
@@ -631,6 +643,9 @@ final class URITest extends CIUnitTestCase
 
     /**
      * @dataProvider defaultResolutions
+     *
+     * @param mixed $rel
+     * @param mixed $expected
      */
     public function testResolveRelativeURI($rel, $expected)
     {
@@ -646,6 +661,9 @@ final class URITest extends CIUnitTestCase
     /**
      * @dataProvider defaultResolutions
      * @group        single
+     *
+     * @param mixed $rel
+     * @param mixed $expected
      */
     public function testResolveRelativeURIHTTPS($rel, $expected)
     {

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -176,6 +176,9 @@ final class ArrayHelperTest extends CIUnitTestCase
 
     /**
      * @dataProvider deepSearchProvider
+     *
+     * @param mixed $key
+     * @param mixed $expected
      */
     public function testArrayDeepSearch($key, $expected)
     {
@@ -212,6 +215,10 @@ final class ArrayHelperTest extends CIUnitTestCase
 
     /**
      * @dataProvider sortByMultipleKeysProvider
+     *
+     * @param mixed $data
+     * @param mixed $sortColumns
+     * @param mixed $expected
      */
     public function testArraySortByMultipleKeysWithArray($data, $sortColumns, $expected)
     {
@@ -223,6 +230,10 @@ final class ArrayHelperTest extends CIUnitTestCase
 
     /**
      * @dataProvider sortByMultipleKeysProvider
+     *
+     * @param mixed $data
+     * @param mixed $sortColumns
+     * @param mixed $expected
      */
     public function testArraySortByMultipleKeysWithObjects($data, $sortColumns, $expected)
     {
@@ -239,6 +250,10 @@ final class ArrayHelperTest extends CIUnitTestCase
 
     /**
      * @dataProvider sortByMultipleKeysProvider
+     *
+     * @param mixed $data
+     * @param mixed $sortColumns
+     * @param mixed $expected
      */
     public function testArraySortByMultipleKeysFailsEmptyParameter($data, $sortColumns, $expected)
     {
@@ -261,6 +276,8 @@ final class ArrayHelperTest extends CIUnitTestCase
 
     /**
      * @dataProvider sortByMultipleKeysProvider
+     *
+     * @param mixed $data
      */
     public function testArraySortByMultipleKeysFailsInconsistentArraySizes($data)
     {
@@ -365,8 +382,6 @@ final class ArrayHelperTest extends CIUnitTestCase
      *
      * @param iterable $input
      * @param iterable $expected
-     *
-     * @return void
      */
     public function testArrayFlattening($input, $expected): void
     {

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -161,6 +161,11 @@ final class MiscUrlTest extends CIUnitTestCase
 
     /**
      * @dataProvider anchorNormalPatterns
+     *
+     * @param mixed $expected
+     * @param mixed $uri
+     * @param mixed $title
+     * @param mixed $attributes
      */
     public function testAnchor($expected = '', $uri = '', $title = '', $attributes = '')
     {
@@ -222,6 +227,11 @@ final class MiscUrlTest extends CIUnitTestCase
 
     /**
      * @dataProvider anchorNoindexPatterns
+     *
+     * @param mixed $expected
+     * @param mixed $uri
+     * @param mixed $title
+     * @param mixed $attributes
      */
     public function testAnchorNoindex($expected = '', $uri = '', $title = '', $attributes = '')
     {
@@ -274,6 +284,11 @@ final class MiscUrlTest extends CIUnitTestCase
 
     /**
      * @dataProvider anchorSubpagePatterns
+     *
+     * @param mixed $expected
+     * @param mixed $uri
+     * @param mixed $title
+     * @param mixed $attributes
      */
     public function testAnchorTargetted($expected = '', $uri = '', $title = '', $attributes = '')
     {
@@ -315,6 +330,11 @@ final class MiscUrlTest extends CIUnitTestCase
 
     /**
      * @dataProvider anchorExamplePatterns
+     *
+     * @param mixed $expected
+     * @param mixed $uri
+     * @param mixed $title
+     * @param mixed $attributes
      */
     public function testAnchorExamples($expected = '', $uri = '', $title = '', $attributes = '')
     {
@@ -369,6 +389,11 @@ final class MiscUrlTest extends CIUnitTestCase
 
     /**
      * @dataProvider anchorPopupPatterns
+     *
+     * @param mixed $expected
+     * @param mixed $uri
+     * @param mixed $title
+     * @param mixed $attributes
      */
     public function testAnchorPopup($expected = '', $uri = '', $title = '', $attributes = false)
     {
@@ -404,6 +429,11 @@ final class MiscUrlTest extends CIUnitTestCase
 
     /**
      * @dataProvider mailtoPatterns
+     *
+     * @param mixed $expected
+     * @param mixed $email
+     * @param mixed $title
+     * @param mixed $attributes
      */
     public function testMailto($expected = '', $email = '', $title = '', $attributes = '')
     {
@@ -440,6 +470,11 @@ final class MiscUrlTest extends CIUnitTestCase
 
     /**
      * @dataProvider safeMailtoPatterns
+     *
+     * @param mixed $expected
+     * @param mixed $email
+     * @param mixed $title
+     * @param mixed $attributes
      */
     public function testSafeMailto($expected = '', $email = '', $title = '', $attributes = '')
     {
@@ -493,6 +528,9 @@ final class MiscUrlTest extends CIUnitTestCase
 
     /**
      * @dataProvider autolinkUrls
+     *
+     * @param mixed $in
+     * @param mixed $out
      */
     public function testAutoLinkUrl($in, $out)
     {
@@ -539,6 +577,9 @@ final class MiscUrlTest extends CIUnitTestCase
 
     /**
      * @dataProvider autolinkEmails
+     *
+     * @param mixed $in
+     * @param mixed $out
      */
     public function testAutoLinkEmail($in, $out)
     {
@@ -585,6 +626,9 @@ final class MiscUrlTest extends CIUnitTestCase
 
     /**
      * @dataProvider autolinkBoth
+     *
+     * @param mixed $in
+     * @param mixed $out
      */
     public function testAutolinkBoth($in, $out)
     {
@@ -631,6 +675,9 @@ final class MiscUrlTest extends CIUnitTestCase
 
     /**
      * @dataProvider autolinkPopup
+     *
+     * @param mixed $in
+     * @param mixed $out
      */
     public function testAutoLinkPopup($in, $out)
     {

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -244,6 +244,8 @@ final class LanguageTest extends CIUnitTestCase
      * but we can at least try loading them ... more accurate code coverage?
      *
      * @dataProvider MessageBundles
+     *
+     * @param mixed $bundle
      */
     public function testBundleUniqueKeys($bundle)
     {

--- a/tests/system/Log/Handlers/ErrorlogHandlerTest.php
+++ b/tests/system/Log/Handlers/ErrorlogHandlerTest.php
@@ -35,8 +35,6 @@ final class ErrorlogHandlerTest extends CIUnitTestCase
     }
 
     /**
-     * @param array $config
-     *
      * @return MockObject&ErrorlogHandler
      */
     private function getMockedHandler(array $config = [])

--- a/tests/system/Models/DeleteModelTest.php
+++ b/tests/system/Models/DeleteModelTest.php
@@ -134,6 +134,8 @@ final class DeleteModelTest extends LiveModelTestCase
      * Exception should not be thrown because condition was explicity set
      *
      * @dataProvider emptyPkValues
+     *
+     * @param mixed $emptyValue
      */
     public function testDontThrowExceptionWhenSoftDeleteConditionIsSetWithEmptyValue($emptyValue): void
     {
@@ -146,6 +148,8 @@ final class DeleteModelTest extends LiveModelTestCase
 
     /**
      * @dataProvider emptyPkValues
+     *
+     * @param mixed $emptyValue
      */
     public function testThrowExceptionWhenSoftDeleteParamIsEmptyValue($emptyValue): void
     {
@@ -158,6 +162,8 @@ final class DeleteModelTest extends LiveModelTestCase
 
     /**
      * @dataProvider emptyPkValues
+     *
+     * @param mixed $emptyValue
      */
     public function testDontDeleteRowsWhenSoftDeleteParamIsEmpty($emptyValue): void
     {

--- a/tests/system/Models/FindModelTest.php
+++ b/tests/system/Models/FindModelTest.php
@@ -156,6 +156,9 @@ final class FindModelTest extends LiveModelTestCase
 
     /**
      * @dataProvider provideGroupBy
+     *
+     * @param mixed $groupBy
+     * @param mixed $total
      */
     public function testFirstAggregate($groupBy, $total): void
     {
@@ -179,6 +182,9 @@ final class FindModelTest extends LiveModelTestCase
 
     /**
      * @dataProvider provideAggregateAndGroupBy
+     *
+     * @param mixed $aggregate
+     * @param mixed $groupBy
      */
     public function testFirstRespectsSoftDeletes($aggregate, $groupBy): void
     {
@@ -212,6 +218,9 @@ final class FindModelTest extends LiveModelTestCase
 
     /**
      * @dataProvider provideAggregateAndGroupBy
+     *
+     * @param mixed $aggregate
+     * @param mixed $groupBy
      */
     public function testFirstRecoverTempUseSoftDeletes($aggregate, $groupBy): void
     {

--- a/tests/system/Models/GeneralModelTest.php
+++ b/tests/system/Models/GeneralModelTest.php
@@ -46,11 +46,6 @@ final class GeneralModelTest extends CIUnitTestCase
 
     /**
      * Create an instance of Model for use in testing.
-     *
-     * @param string              $modelName
-     * @param BaseConnection|null $db
-     *
-     * @return Model
      */
     private function createModel(string $modelName, ?BaseConnection $db = null): Model
     {
@@ -160,8 +155,6 @@ final class GeneralModelTest extends CIUnitTestCase
 
             /**
              * Marks the model as initialized.
-             *
-             * @return void
              */
             protected function initialize(): void
             {

--- a/tests/system/Models/LiveModelTestCase.php
+++ b/tests/system/Models/LiveModelTestCase.php
@@ -49,11 +49,6 @@ abstract class LiveModelTestCase extends CIUnitTestCase
 
     /**
      * Create an instance of Model for use in testing.
-     *
-     * @param string              $modelName
-     * @param BaseConnection|null $db
-     *
-     * @return Model
      */
     protected function createModel(string $modelName, ?BaseConnection $db = null): Model
     {

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1577,6 +1577,8 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     /**
      * @dataProvider provideRouteDefaultNamespace
+     *
+     * @param mixed $namespace
      */
     public function testAutoRoutesControllerNameReturnsFQCN($namespace)
     {
@@ -1592,6 +1594,8 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     /**
      * @dataProvider provideRouteDefaultNamespace
+     *
+     * @param mixed $namespace
      */
     public function testRoutesControllerNameReturnsFQCN($namespace)
     {

--- a/tests/system/Test/DOMParserTest.php
+++ b/tests/system/Test/DOMParserTest.php
@@ -89,6 +89,8 @@ final class DOMParserTest extends CIUnitTestCase
 
     /**
      * @dataProvider provideText
+     *
+     * @param mixed $text
      */
     public function testSeeText($text)
     {
@@ -135,6 +137,8 @@ final class DOMParserTest extends CIUnitTestCase
 
     /**
      * @dataProvider provideText
+     *
+     * @param mixed $text
      */
     public function testSeeElement($text)
     {

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -293,6 +293,10 @@ final class FeatureTestTraitTest extends CIUnitTestCase
 
     /**
      * @dataProvider provideRoutesData
+     *
+     * @param mixed $from
+     * @param mixed $to
+     * @param mixed $httpGet
      */
     public function testOpenCliRoutesFromHttpGot404($from, $to, $httpGet)
     {

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -1220,9 +1220,6 @@ final class CreditCardRulesTest extends CIUnitTestCase
      * Used to generate fake credit card numbers that will still pass the Luhn
      * check used to validate the card so we can be sure the cards are recognized correctly.
      *
-     * @param int $prefix
-     * @param int $length
-     *
      * @return string
      */
     protected function generateCardNum(int $prefix, int $length)

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -895,6 +895,7 @@ final class FormatRulesTest extends CIUnitTestCase
      *
      * @param $str
      * @param $expected
+     * @param mixed $first
      */
     public function testNatural($first, $expected)
     {
@@ -940,6 +941,7 @@ final class FormatRulesTest extends CIUnitTestCase
      *
      * @param $str
      * @param $expected
+     * @param mixed $first
      */
     public function testNaturalNoZero($first, $expected)
     {
@@ -985,6 +987,7 @@ final class FormatRulesTest extends CIUnitTestCase
      *
      * @param $str
      * @param $expected
+     * @param mixed $first
      */
     public function testBase64($first, $expected)
     {
@@ -1022,6 +1025,7 @@ final class FormatRulesTest extends CIUnitTestCase
      *
      * @param $str
      * @param $expected
+     * @param mixed $first
      */
     public function testJson($first, $expected)
     {

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -1053,6 +1053,8 @@ final class RulesTest extends CIUnitTestCase
      *
      * @param $str
      * @param $expected
+     * @param mixed $first
+     * @param mixed $second
      */
     public function testGreaterThan($first, $second, $expected)
     {
@@ -1108,6 +1110,8 @@ final class RulesTest extends CIUnitTestCase
      *
      * @param $str
      * @param $expected
+     * @param mixed $first
+     * @param mixed $second
      */
     public function testGreaterThanEqual($first, $second, $expected)
     {
@@ -1168,6 +1172,8 @@ final class RulesTest extends CIUnitTestCase
      *
      * @param $str
      * @param $expected
+     * @param mixed $first
+     * @param mixed $second
      */
     public function testLessThan($first, $second, $expected)
     {
@@ -1228,6 +1234,8 @@ final class RulesTest extends CIUnitTestCase
      *
      * @param $str
      * @param $expected
+     * @param mixed $first
+     * @param mixed $second
      */
     public function testLessEqualThan($first, $second, $expected)
     {
@@ -1386,6 +1394,7 @@ final class RulesTest extends CIUnitTestCase
      *
      * @param $check
      * @param $expected
+     * @param mixed $field
      */
     public function testRequiredWith($field, $check, $expected = false)
     {
@@ -1469,6 +1478,7 @@ final class RulesTest extends CIUnitTestCase
      *
      * @param $check
      * @param $expected
+     * @param mixed $field
      */
     public function testRequiredWithout($field, $check, $expected = false)
     {

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -294,6 +294,10 @@ final class ValidationTest extends CIUnitTestCase
 
     /**
      * @dataProvider rulesSetupProvider
+     *
+     * @param mixed $rules
+     * @param mixed $expected
+     * @param mixed $errors
      */
     public function testRulesSetup($rules, $expected, $errors = [])
     {
@@ -626,6 +630,10 @@ final class ValidationTest extends CIUnitTestCase
 
     /**
      * @dataProvider arrayFieldDataProvider
+     *
+     * @param mixed $body
+     * @param mixed $rules
+     * @param mixed $results
      */
     public function testRulesForArrayField($body, $rules, $results)
     {
@@ -865,12 +873,6 @@ final class ValidationTest extends CIUnitTestCase
      * @dataProvider dotNotationForIfExistProvider
      *
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4521
-     *
-     * @param bool  $expected
-     * @param array $rules
-     * @param array $data
-     *
-     * @return void
      */
     public function testDotNotationOnIfExistRule(bool $expected, array $rules, array $data): void
     {
@@ -937,12 +939,6 @@ final class ValidationTest extends CIUnitTestCase
      * @dataProvider validationArrayDataCaseProvider
      *
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4510
-     *
-     * @param bool  $expected
-     * @param array $rules
-     * @param array $data
-     *
-     * @return void
      */
     public function testValidationOfArrayData(bool $expected, array $rules, array $data): void
     {

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -402,6 +402,9 @@ final class ParserTest extends CIUnitTestCase
 
     /**
      * @dataProvider escValueTypes
+     *
+     * @param mixed      $value
+     * @param mixed|null $expected
      */
     public function testEscHandling($value, $expected = null)
     {

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -226,13 +226,17 @@ final class CodeIgniter4 extends AbstractRuleset
             'no_spaces_around_offset'                     => ['positions' => ['inside', 'outside']],
             'no_spaces_inside_parenthesis'                => true,
             'no_superfluous_elseif'                       => true,
-            'no_superfluous_phpdoc_tags'                  => false,
-            'no_trailing_comma_in_list_call'              => true,
-            'no_trailing_comma_in_singleline_array'       => true,
-            'no_trailing_whitespace'                      => true,
-            'no_trailing_whitespace_in_comment'           => true,
-            'no_trailing_whitespace_in_string'            => true,
-            'no_unneeded_control_parentheses'             => [
+            'no_superfluous_phpdoc_tags'                  => [
+                'allow_mixed'         => true,
+                'allow_unused_params' => true,
+                'remove_inheritdoc'   => false,
+            ],
+            'no_trailing_comma_in_list_call'        => true,
+            'no_trailing_comma_in_singleline_array' => true,
+            'no_trailing_whitespace'                => true,
+            'no_trailing_whitespace_in_comment'     => true,
+            'no_trailing_whitespace_in_string'      => true,
+            'no_unneeded_control_parentheses'       => [
                 'statements' => [
                     'break',
                     'clone',
@@ -305,6 +309,7 @@ final class CodeIgniter4 extends AbstractRuleset
                 'methods'   => [],
             ],
             'php_unit_test_class_requires_covers' => false,
+            'phpdoc_add_missing_param_annotation' => ['only_untyped' => true],
             'phpdoc_align'                        => [
                 'align' => 'vertical',
                 'tags'  => [


### PR DESCRIPTION
**Description**
Alternative to #4940 : Adds param tags if only untyped. However, if deemed superfluous, it will be removed along with other superfluous tags.

**Checklist:**
- [x] Securely signed commits
