### PR TITLE
Fix tag casing and tag types

### DIFF
--- a/system/Commands/Utilities/Environment.php
+++ b/system/Commands/Utilities/Environment.php
@@ -69,7 +69,7 @@ final class Environment extends BaseCommand
     ];
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      *
      * @param array<string, mixed> $params
      *

--- a/system/Entity/Cast/ArrayCast.php
+++ b/system/Entity/Cast/ArrayCast.php
@@ -17,7 +17,7 @@ namespace CodeIgniter\Entity\Cast;
 class ArrayCast extends BaseCast
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function get($value, array $params = []): array
     {
@@ -29,7 +29,7 @@ class ArrayCast extends BaseCast
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function set($value, array $params = []): string
     {

--- a/system/Entity/Cast/BooleanCast.php
+++ b/system/Entity/Cast/BooleanCast.php
@@ -17,7 +17,7 @@ namespace CodeIgniter\Entity\Cast;
 class BooleanCast extends BaseCast
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function get($value, array $params = []): bool
     {

--- a/system/Entity/Cast/CSVCast.php
+++ b/system/Entity/Cast/CSVCast.php
@@ -17,7 +17,7 @@ namespace CodeIgniter\Entity\Cast;
 class CSVCast extends BaseCast
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function get($value, array $params = []): array
     {
@@ -25,7 +25,7 @@ class CSVCast extends BaseCast
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function set($value, array $params = []): string
     {

--- a/system/Entity/Cast/DatetimeCast.php
+++ b/system/Entity/Cast/DatetimeCast.php
@@ -21,7 +21,7 @@ use Exception;
 class DatetimeCast extends BaseCast
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      *
      * @throws Exception
      */

--- a/system/Entity/Cast/FloatCast.php
+++ b/system/Entity/Cast/FloatCast.php
@@ -17,7 +17,7 @@ namespace CodeIgniter\Entity\Cast;
 class FloatCast extends BaseCast
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function get($value, array $params = []): float
     {

--- a/system/Entity/Cast/IntegerCast.php
+++ b/system/Entity/Cast/IntegerCast.php
@@ -17,7 +17,7 @@ namespace CodeIgniter\Entity\Cast;
 class IntegerCast extends BaseCast
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function get($value, array $params = []): int
     {

--- a/system/Entity/Cast/JsonCast.php
+++ b/system/Entity/Cast/JsonCast.php
@@ -21,7 +21,7 @@ use stdClass;
 class JsonCast extends BaseCast
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function get($value, array $params = [])
     {
@@ -48,7 +48,7 @@ class JsonCast extends BaseCast
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function set($value, array $params = []): string
     {

--- a/system/Entity/Cast/ObjectCast.php
+++ b/system/Entity/Cast/ObjectCast.php
@@ -17,7 +17,7 @@ namespace CodeIgniter\Entity\Cast;
 class ObjectCast extends BaseCast
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function get($value, array $params = []): object
     {

--- a/system/Entity/Cast/StringCast.php
+++ b/system/Entity/Cast/StringCast.php
@@ -17,7 +17,7 @@ namespace CodeIgniter\Entity\Cast;
 class StringCast extends BaseCast
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function get($value, array $params = []): string
     {

--- a/system/Entity/Cast/TimestampCast.php
+++ b/system/Entity/Cast/TimestampCast.php
@@ -19,7 +19,7 @@ use CodeIgniter\Entity\Exceptions\CastException;
 class TimestampCast extends BaseCast
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function get($value, array $params = [])
     {

--- a/system/Entity/Cast/URICast.php
+++ b/system/Entity/Cast/URICast.php
@@ -19,7 +19,7 @@ use CodeIgniter\HTTP\URI;
 class URICast extends BaseCast
 {
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function get($value, array $params = []): URI
     {

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -382,6 +382,8 @@ final class CodeIgniter4 extends AbstractRuleset
             'phpdoc_separation'                             => true,
             'phpdoc_single_line_var_spacing'                => true,
             'phpdoc_summary'                                => false,
+            'phpdoc_tag_casing'                             => ['tags' => ['inheritDoc']],
+            'phpdoc_tag_type'                               => ['tags' => ['inheritDoc' => 'inline']],
             'phpdoc_trim'                                   => true,
             'phpdoc_trim_consecutive_blank_line_separation' => true,
             'phpdoc_types'                                  => ['groups' => ['simple', 'alias', 'meta']],


### PR DESCRIPTION
**Description**
- Fixes casing of PHPDoc tags.
- Forces PHPDoc tags to be either regular annotations or inline.

**Checklist:**
- [x] Securely signed commits
