### PR TITLE
CURLRequest raise exception only when `http_errors` is true

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -695,7 +695,7 @@ class CURLRequest extends Request
         // Send the request and wait for a response.
         $output = curl_exec($ch);
 
-        if ($output === false) {
+        if ($output === false && $curlOptions[CURLOPT_FAILONERROR]) {
             throw HTTPException::forCurlError((string) curl_errno($ch), curl_error($ch));
         }
 


### PR DESCRIPTION
Add the statement to returning the exception only when "http_errors" configuration isn't set to "false".