### PR TITLE
[Rector] Update rector to 0.11.37, clean up config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "phpstan/phpstan": "0.12.91",
         "phpunit/phpunit": "^9.1",
         "predis/predis": "^1.1",
-        "rector/rector": "0.11.36",
+        "rector/rector": "0.11.37",
         "symplify/package-builder": "^9.3"
     },
     "suggest": {

--- a/rector.php
+++ b/rector.php
@@ -58,13 +58,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/system/ThirdParty',
         __DIR__ . '/tests/system/Config/fixtures',
         __DIR__ . '/tests/_support',
-        PassStrictParameterToFunctionParameterRector::class => [__DIR__ . '/tests/system/Database/Live/SelectTest.php'],
         JsonThrowOnErrorRector::class,
         StringifyStrNeedlesRector::class,
-        InlineIfToExplicitIfRector::class => [
-            __DIR__ . '/app/Config',
-            __DIR__ . '/system/Test/bootstrap.php',
-        ],
     ]);
 
     // auto import fully qualified class names


### PR DESCRIPTION
- Update rector to 0.11.37
- Clean up rector skip config as already handled in latest 0.11.37 and for strict parameter skip, already handled in coding standard.

**Checklist:**
- [x] Securely signed commits
