### PR TITLE
[PHPStan] Using PHPStan ^0.12.91

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.1",
         "nexusphp/tachycardia": "^1.0",
-        "phpstan/phpstan": "0.12.91",
+        "phpstan/phpstan": "^0.12.91",
         "phpunit/phpunit": "^9.1",
         "predis/predis": "^1.1",
         "rector/rector": "0.11.37",


### PR DESCRIPTION
Rector is now using pinned PHPStan:

https://github.com/rectorphp/rector/blob/fd9f6abc9e539c011613f88f1da0e8d557ef2ab5/composer.json#L10

So require-dev PHPStan with `^` should be safe already.

**Checklist:**
- [x] Securely signed commits
