### PR TITLE
Manual cleanup of docblocks and comments

### DIFF
--- a/admin/pre-commit
+++ b/admin/pre-commit
@@ -69,7 +69,7 @@ if [ "$FILES" != "" ]; then
         php ./vendor/bin/php-cs-fixer fix --verbose --dry-run --using-cache=no --diff
     fi
 
-    if [ $? != 0]; then
+    if [ $? != 0 ]; then
         echo "Files in system, tests, utils, or root are not following the coding standards. Please fix them before commit."
         exit 1
     fi

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -32,16 +32,13 @@ parameters:
 		- '#Access to an undefined property CodeIgniter\\Database\\Forge::\$dropConstraintStr#'
 		- '#Access to an undefined property CodeIgniter\\Database\\BaseConnection::\$mysqli|\$schema#'
 		- '#Access to an undefined property CodeIgniter\\Database\\ConnectionInterface::(\$DBDriver|\$connID|\$likeEscapeStr|\$likeEscapeChar|\$escapeChar|\$protectIdentifiers|\$schema)#'
-		- '#Access to protected property CodeIgniter\\Database\\BaseConnection::(\$DBDebug|\$DBPrefix|\$swapPre|\$charset|\$DBCollat|\$database)#'
 		- '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::_(disable|enable)ForeignKeyChecks\(\)#'
-		- '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::supportsForeignKeys\(\)#'
 		- '#Call to an undefined method CodeIgniter\\Router\\RouteCollectionInterface::(getDefaultNamespace|isFiltered|getFilterForRoute|getRoutesOptions)\(\)#'
 		- '#Cannot access property [\$a-z_]+ on ((bool\|)?object\|resource)#'
 		- '#Cannot call method [a-zA-Z_]+\(\) on ((bool\|)?object\|resource)#'
 		- '#Method CodeIgniter\\Router\\RouteCollectionInterface::getRoutes\(\) invoked with 1 parameter, 0 required#'
 		- '#Method CodeIgniter\\Validation\\ValidationInterface::run\(\) invoked with 3 parameters, 0-2 required#'
 		- '#Negated boolean expression is always (true|false)#'
-		- '#Parameter \#1 \$db of class CodeIgniter\\Database\\SQLite3\\Table constructor expects CodeIgniter\\Database\\SQLite3\\Connection, CodeIgniter\\Database\\BaseConnection given#'
 		- '#Return type \(bool\) of method CodeIgniter\\HTTP\\Files\\UploadedFile::move\(\) should be compatible with return type \(CodeIgniter\\Files\\File\) of method CodeIgniter\\Files\\File::move\(\)#'
 	parallel:
 		processTimeout: 300.0

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -17,8 +17,6 @@ use CodeIgniter\HTTP\Response;
 use Config\Services;
 
 /**
- * Response trait.
- *
  * Provides common, more readable, methods to provide
  * consistent HTTP responses under a variety of common
  * situations when working as an API.
@@ -32,7 +30,7 @@ trait ResponseTrait
      * Allows child classes to override the
      * status code that is used in their API.
      *
-     * @var array
+     * @var array<string, int>
      */
     protected $codes = [
         'created'                   => 201,
@@ -86,21 +84,15 @@ trait ResponseTrait
      * to match the requested format, with proper content-type and status code.
      *
      * @param array|string|null $data
-     * @param int               $status
      *
      * @return mixed
      */
     public function respond($data = null, ?int $status = null, string $message = '')
     {
-        // If data is null and status code not provided, exit and bail
         if ($data === null && $status === null) {
             $status = 404;
-
-            // Create the output var here in case of $this->response([]);
             $output = null;
-        }
-        // If data is null but status provided, keep the output empty.
-        elseif ($data === null && is_numeric($status)) {
+        } elseif ($data === null && is_numeric($status)) {
             $output = null;
         } else {
             $status = empty($status) ? 200 : $status;
@@ -151,8 +143,7 @@ trait ResponseTrait
     /**
      * Used after successfully creating a new resource.
      *
-     * @param mixed  $data    Data.
-     * @param string $message Message.
+     * @param mixed $data
      *
      * @return mixed
      */
@@ -164,8 +155,7 @@ trait ResponseTrait
     /**
      * Used after a resource has been successfully deleted.
      *
-     * @param mixed  $data    Data.
-     * @param string $message Message.
+     * @param mixed $data
      *
      * @return mixed
      */
@@ -177,8 +167,7 @@ trait ResponseTrait
     /**
      * Used after a resource has been successfully updated.
      *
-     * @param mixed  $data    Data.
-     * @param string $message Message.
+     * @param mixed $data
      *
      * @return mixed
      */
@@ -190,8 +179,6 @@ trait ResponseTrait
     /**
      * Used after a command has been successfully executed but there is no
      * meaningful reply to send back to the client.
-     *
-     * @param string $message Message.
      *
      * @return mixed
      */
@@ -205,8 +192,6 @@ trait ResponseTrait
      * or had bad authorization credentials. User is encouraged to try again
      * with the proper information.
      *
-     * @param string $code
-     *
      * @return mixed
      */
     public function failUnauthorized(string $description = 'Unauthorized', ?string $code = null, string $message = '')
@@ -218,8 +203,6 @@ trait ResponseTrait
      * Used when access is always denied to this resource and no amount
      * of trying again will help.
      *
-     * @param string $code
-     *
      * @return mixed
      */
     public function failForbidden(string $description = 'Forbidden', ?string $code = null, string $message = '')
@@ -230,8 +213,6 @@ trait ResponseTrait
     /**
      * Used when a specified resource cannot be found.
      *
-     * @param string $code
-     *
      * @return mixed
      */
     public function failNotFound(string $description = 'Not Found', ?string $code = null, string $message = '')
@@ -241,8 +222,6 @@ trait ResponseTrait
 
     /**
      * Used when the data provided by the client cannot be validated.
-     *
-     * @param string $code
      *
      * @return mixed
      *
@@ -268,8 +247,6 @@ trait ResponseTrait
     /**
      * Use when trying to create a new resource and it already exists.
      *
-     * @param string $code
-     *
      * @return mixed
      */
     public function failResourceExists(string $description = 'Conflict', ?string $code = null, string $message = '')
@@ -282,8 +259,6 @@ trait ResponseTrait
      * Not Found, because here we know the data previously existed, but is now gone,
      * where Not Found means we simply cannot find any information about it.
      *
-     * @param string $code
-     *
      * @return mixed
      */
     public function failResourceGone(string $description = 'Gone', ?string $code = null, string $message = '')
@@ -293,8 +268,6 @@ trait ResponseTrait
 
     /**
      * Used when the user has made too many requests for the resource recently.
-     *
-     * @param string $code
      *
      * @return mixed
      */
@@ -370,8 +343,6 @@ trait ResponseTrait
 
     /**
      * Sets the format the response should be in.
-     *
-     * @param string $format
      *
      * @return $this
      */

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -17,8 +17,6 @@ use Config\Modules;
 use InvalidArgumentException;
 
 /**
- * CodeIgniter Autoloader
- *
  * An autoloader that uses both PSR4 autoloading, and traditional classmaps.
  *
  * Given a foo-bar package of classes in the file system at the following paths:
@@ -296,8 +294,6 @@ class Autoloader
 
     /**
      * Locates autoload information from Composer, if available.
-     *
-     * @return void
      */
     protected function discoverComposerNamespaces()
     {

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -12,8 +12,6 @@
 namespace CodeIgniter\Autoloader;
 
 /**
- * Class FileLocator
- *
  * Allows loading non-class files in a namespaced manner.
  * Works with Helpers, Views, etc.
  */
@@ -26,9 +24,6 @@ class FileLocator
      */
     protected $autoloader;
 
-    /**
-     * Constructor
-     */
     public function __construct(Autoloader $autoloader)
     {
         $this->autoloader = $autoloader;

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -29,8 +29,6 @@ use ReflectionProperty;
 use stdClass;
 
 /**
- * Class Model
- *
  * The BaseModel class provides a number of convenient features that
  * makes working with a databases less painful. Extending this class
  * provide means of implementing various database systems
@@ -288,11 +286,6 @@ abstract class BaseModel
      */
     protected $afterDelete = [];
 
-    /**
-     * BaseModel constructor.
-     *
-     * @param ValidationInterface|null $validation Validation
-     */
     public function __construct(?ValidationInterface $validation = null)
     {
         $this->tempReturnType     = $this->returnType;
@@ -431,8 +424,6 @@ abstract class BaseModel
      * Works with the find* methods to return only the rows that
      * have been deleted.
      * This methods works only with dbCalls
-     *
-     * @return void
      */
     abstract protected function doOnlyDeleted();
 
@@ -500,8 +491,6 @@ abstract class BaseModel
      * @param Closure $userFunc Callback Function
      *
      * @throws DataException
-     *
-     * @return void
      */
     abstract public function chunk(int $size, Closure $userFunc);
 
@@ -829,8 +818,8 @@ abstract class BaseModel
      * Updates a single record in the database. If an object is provided,
      * it will attempt to convert it into an array.
      *
-     * @param array|int|string|null $id   ID
-     * @param array|object|null     $data Data
+     * @param array|int|string|null $id
+     * @param array|object|null     $data
      *
      * @throws ReflectionException
      */
@@ -987,7 +976,7 @@ abstract class BaseModel
      * Permanently deletes all rows that have been marked as deleted
      * through soft deletes (deleted = 1)
      *
-     * @return bool|mixed
+     * @return mixed
      */
     public function purgeDeleted()
     {

--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -87,9 +87,6 @@ abstract class BaseCommand
      */
     protected $commands;
 
-    /**
-     * BaseCommand constructor.
-     */
     public function __construct(LoggerInterface $logger, Commands $commands)
     {
         $this->logger   = $logger;
@@ -98,7 +95,8 @@ abstract class BaseCommand
 
     /**
      * Actually execute a command.
-     * This has to be over-ridden in any concrete implementation.
+     *
+     * @param array<string, mixed> $params
      */
     abstract public function run(array $params);
 

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -60,7 +60,7 @@ class CLI
     /**
      * Foreground color list
      *
-     * @var array
+     * @var array<string, string>
      */
     protected static $foreground_colors = [
         'black'        => '0;30',
@@ -85,7 +85,7 @@ class CLI
     /**
      * Background color list
      *
-     * @var array
+     * @var array<string, string>
      */
     protected static $background_colors = [
         'black'      => '40',
@@ -164,9 +164,7 @@ class CLI
         } else {
             // If the command is being called from a controller
             // we need to define STDOUT ourselves
-            // @codeCoverageIgnoreStart
-            define('STDOUT', 'php://output');
-            // @codeCoverageIgnoreEnd
+            define('STDOUT', 'php://output'); // @codeCoverageIgnore
         }
     }
 
@@ -312,10 +310,6 @@ class CLI
 
     /**
      * Outputs a string to the cli on it's own line.
-     *
-     * @param string $text       The text to output
-     * @param string $foreground
-     * @param string $background
      */
     public static function write(string $text = '', ?string $foreground = null, ?string $background = null)
     {
@@ -333,8 +327,6 @@ class CLI
 
     /**
      * Outputs an error to the CLI using STDERR instead of STDOUT
-     *
-     * @param string $text The text to output, or array of errors
      */
     public static function error(string $text, string $foreground = 'light_red', ?string $background = null)
     {
@@ -402,10 +394,6 @@ class CLI
 
     /**
      * Enter a number of empty lines
-     *
-     * @param int $num Number of lines to output
-     *
-     * @return void
      */
     public static function newLine(int $num = 1)
     {
@@ -417,8 +405,6 @@ class CLI
 
     /**
      * Clears the screen of output
-     *
-     * @return void
      *
      * @codeCoverageIgnore
      */
@@ -496,8 +482,6 @@ class CLI
     /**
      * Get the number of characters in string having encoded characters
      * and ignores styles set by the color() function
-     *
-     * @param string $string
      */
     public static function strlen(?string $string): int
     {
@@ -533,9 +517,7 @@ class CLI
             return function_exists($function);
         }
 
-        // @codeCoverageIgnoreStart
-        return function_exists($function) && @$function($resource);
-        // @codeCoverageIgnoreEnd
+        return function_exists($function) && @$function($resource); // @codeCoverageIgnore
     }
 
     /**
@@ -599,7 +581,7 @@ class CLI
     /**
      * Populates the CLI's dimensions.
      *
-     * @return void
+     * @codeCoverageIgnore
      */
     public static function generateDimensions()
     {
@@ -607,7 +589,6 @@ class CLI
             if (static::isWindows()) {
                 // Shells such as `Cygwin` and `Git bash` returns incorrect values
                 // when executing `mode CON`, so we use `tput` instead
-                // @codeCoverageIgnoreStart
                 if (getenv('TERM') || (($shell = getenv('SHELL')) && preg_match('/(?:bash|zsh)(?:\.exe)?$/', $shell))) {
                     static::$height = (int) exec('tput lines');
                     static::$width  = (int) exec('tput cols');
@@ -623,26 +604,20 @@ class CLI
                         static::$width  = (int) $matches[2];
                     }
                 }
-                // @codeCoverageIgnoreEnd
             } elseif (($size = exec('stty size')) && preg_match('/(\d+)\s+(\d+)/', $size, $matches)) {
                 static::$height = (int) $matches[1];
                 static::$width  = (int) $matches[2];
             } else {
-                // @codeCoverageIgnoreStart
                 static::$height = (int) exec('tput lines');
                 static::$width  = (int) exec('tput cols');
-                // @codeCoverageIgnoreEnd
             }
-        }
-        // @codeCoverageIgnoreStart
-        catch (Throwable $e) {
+        } catch (Throwable $e) {
             // Reset the dimensions so that the default values will be returned later.
             // Then let the developer know of the error.
             static::$height = null;
             static::$width  = null;
             log_message('error', $e->getMessage());
         }
-        // @codeCoverageIgnoreEnd
     }
 
     /**
@@ -686,8 +661,6 @@ class CLI
      * If an int is passed into $pad_left, then all strings after the first
      * will padded with that many spaces to the left. Useful when printing
      * short descriptions that need to start on an existing line.
-     *
-     * @param string $string
      */
     public static function wrap(?string $string = null, int $max = 0, int $padLeft = 0): string
     {
@@ -789,7 +762,7 @@ class CLI
      *
      * **IMPORTANT:** The index here is one-based instead of zero-based.
      *
-     * @return mixed|null
+     * @return mixed
      */
     public static function getSegment(int $index)
     {
@@ -808,7 +781,7 @@ class CLI
      * Gets a single command-line option. Returns TRUE if the option
      * exists, but doesn't have a value, and is simply acting as a flag.
      *
-     * @return bool|mixed|null
+     * @return mixed
      */
     public static function getOption(string $name)
     {
@@ -870,8 +843,6 @@ class CLI
      *
      * @param array $tbody List of rows
      * @param array $thead List of columns
-     *
-     * @return void
      */
     public static function table(array $tbody, array $thead = [])
     {
@@ -969,8 +940,6 @@ class CLI
      * solution down the road.
      *
      * @param resource $handle
-     *
-     * @return void
      */
     protected static function fwrite($handle, string $string)
     {

--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -76,8 +76,6 @@ class Commands
     /**
      * Discovers all commands in the framework and within user code,
      * and collects instances of them to work with.
-     *
-     * @return void
      */
     public function discoverCommands()
     {

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -12,9 +12,6 @@
 namespace CodeIgniter\CLI;
 
 use CodeIgniter\CodeIgniter;
-use CodeIgniter\HTTP\RequestInterface;
-use CodeIgniter\HTTP\Response;
-use CodeIgniter\HTTP\ResponseInterface;
 use Exception;
 
 /**
@@ -29,9 +26,6 @@ class Console
      */
     protected $app;
 
-    /**
-     * Console constructor.
-     */
     public function __construct(CodeIgniter $app)
     {
         $this->app = $app;
@@ -42,7 +36,7 @@ class Console
      *
      * @throws Exception
      *
-     * @return mixed|RequestInterface|Response|ResponseInterface
+     * @return mixed
      */
     public function run(bool $useSafeOutput = false)
     {

--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -228,8 +228,6 @@ trait GeneratorTrait
     /**
      * Gets the generator view as defined in the `Config\Generators::$views`,
      * with fallback to `$template` when the defined view does not exist.
-     *
-     * @param array $data Data to be passed to the view.
      */
     protected function renderTemplate(array $data = []): string
     {

--- a/system/Cache/CacheFactory.php
+++ b/system/Cache/CacheFactory.php
@@ -16,8 +16,6 @@ use CodeIgniter\Exceptions\CriticalError;
 use Config\Cache;
 
 /**
- * Class Cache
- *
  * A factory for loading the desired
  */
 class CacheFactory

--- a/system/Cache/Handlers/DummyHandler.php
+++ b/system/Cache/Handlers/DummyHandler.php
@@ -19,18 +19,14 @@ use Closure;
 class DummyHandler extends BaseHandler
 {
     /**
-     * Takes care of any handler-specific setup that must be done.
+     * {@inheritDoc}
      */
     public function initialize()
     {
     }
 
     /**
-     * Attempts to fetch an item from the cache store.
-     *
-     * @param string $key Cache item name
-     *
-     * @return null
+     * {@inheritDoc}
      */
     public function get(string $key)
     {
@@ -38,13 +34,7 @@ class DummyHandler extends BaseHandler
     }
 
     /**
-     * Get an item from the cache, or execute the given Closure and store the result.
-     *
-     * @param string  $key      Cache item name
-     * @param int     $ttl      Time to live
-     * @param Closure $callback Callback return value
-     *
-     * @return null
+     * {@inheritDoc}
      */
     public function remember(string $key, int $ttl, Closure $callback)
     {
@@ -52,13 +42,7 @@ class DummyHandler extends BaseHandler
     }
 
     /**
-     * Saves an item to the cache store.
-     *
-     * @param string $key   Cache item name
-     * @param mixed  $value The data to save
-     * @param int    $ttl   Time To Live, in seconds (default 60)
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function save(string $key, $value, int $ttl = 60)
     {
@@ -66,11 +50,7 @@ class DummyHandler extends BaseHandler
     }
 
     /**
-     * Deletes a specific item from the cache store.
-     *
-     * @param string $key Cache item name
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function delete(string $key)
     {
@@ -78,11 +58,7 @@ class DummyHandler extends BaseHandler
     }
 
     /**
-     * Deletes items from the cache store matching a given pattern.
-     *
-     * @param string $pattern Cache items glob-style pattern
-     *
-     * @return int The number of deleted items
+     * {@inheritDoc}
      */
     public function deleteMatching(string $pattern)
     {
@@ -90,12 +66,7 @@ class DummyHandler extends BaseHandler
     }
 
     /**
-     * Performs atomic incrementation of a raw stored value.
-     *
-     * @param string $key    Cache ID
-     * @param int    $offset Step/value to increase by
-     *
-     * @return bool
+     * {@inheritDoc}
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -103,12 +74,7 @@ class DummyHandler extends BaseHandler
     }
 
     /**
-     * Performs atomic decrementation of a raw stored value.
-     *
-     * @param string $key    Cache ID
-     * @param int    $offset Step/value to increase by
-     *
-     * @return bool
+     * {@inheritDoc}
      */
     public function decrement(string $key, int $offset = 1)
     {
@@ -116,9 +82,7 @@ class DummyHandler extends BaseHandler
     }
 
     /**
-     * Will delete all items in the entire cache.
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function clean()
     {
@@ -126,12 +90,7 @@ class DummyHandler extends BaseHandler
     }
 
     /**
-     * Returns information on the entire cache.
-     *
-     * The information returned and the structure of the data
-     * varies depending on the handler.
-     *
-     * @return null
+     * {@inheritDoc}
      */
     public function getCacheInfo()
     {
@@ -139,11 +98,7 @@ class DummyHandler extends BaseHandler
     }
 
     /**
-     * Returns detailed information about the specific item in the cache.
-     *
-     * @param string $key Cache item name.
-     *
-     * @return null
+     * {@inheritDoc}
      */
     public function getMetaData(string $key)
     {
@@ -151,7 +106,7 @@ class DummyHandler extends BaseHandler
     }
 
     /**
-     * Determines if the driver is supported on this system.
+     * {@inheritDoc}
      */
     public function isSupported(): bool
     {

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -43,8 +43,6 @@ class FileHandler extends BaseHandler
     protected $mode;
 
     /**
-     * Constructor.
-     *
      * @throws CacheException
      */
     public function __construct(Cache $config)
@@ -68,18 +66,14 @@ class FileHandler extends BaseHandler
     }
 
     /**
-     * Takes care of any handler-specific setup that must be done.
+     * {@inheritDoc}
      */
     public function initialize()
     {
     }
 
     /**
-     * Attempts to fetch an item from the cache store.
-     *
-     * @param string $key Cache item name
-     *
-     * @return mixed
+     * {@inheritDoc}
      */
     public function get(string $key)
     {
@@ -90,13 +84,7 @@ class FileHandler extends BaseHandler
     }
 
     /**
-     * Saves an item to the cache store.
-     *
-     * @param string $key   Cache item name
-     * @param mixed  $value The data to save
-     * @param int    $ttl   Time To Live, in seconds (default 60)
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function save(string $key, $value, int $ttl = 60)
     {
@@ -111,12 +99,12 @@ class FileHandler extends BaseHandler
         if ($this->writeFile($this->path . $key, serialize($contents))) {
             try {
                 chmod($this->path . $key, $this->mode);
-            }
-            // @codeCoverageIgnoreStart
-            catch (Throwable $e) {
+
+                // @codeCoverageIgnoreStart
+            } catch (Throwable $e) {
                 log_message('debug', 'Failed to set mode on cache file: ' . $e->getMessage());
+                // @codeCoverageIgnoreEnd
             }
-            // @codeCoverageIgnoreEnd
 
             return true;
         }
@@ -125,11 +113,7 @@ class FileHandler extends BaseHandler
     }
 
     /**
-     * Deletes a specific item from the cache store.
-     *
-     * @param string $key Cache item name
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function delete(string $key)
     {
@@ -139,11 +123,7 @@ class FileHandler extends BaseHandler
     }
 
     /**
-     * Deletes items from the cache store matching a given pattern.
-     *
-     * @param string $pattern Cache items glob-style pattern
-     *
-     * @return int The number of deleted items
+     * {@inheritDoc}
      */
     public function deleteMatching(string $pattern)
     {
@@ -159,12 +139,7 @@ class FileHandler extends BaseHandler
     }
 
     /**
-     * Performs atomic incrementation of a raw stored value.
-     *
-     * @param string $key    Cache ID
-     * @param int    $offset Step/value to increase by
-     *
-     * @return bool
+     * {@inheritDoc}
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -186,12 +161,7 @@ class FileHandler extends BaseHandler
     }
 
     /**
-     * Performs atomic decrementation of a raw stored value.
-     *
-     * @param string $key    Cache ID
-     * @param int    $offset Step/value to increase by
-     *
-     * @return bool
+     * {@inheritDoc}
      */
     public function decrement(string $key, int $offset = 1)
     {
@@ -213,9 +183,7 @@ class FileHandler extends BaseHandler
     }
 
     /**
-     * Will delete all items in the entire cache.
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function clean()
     {
@@ -223,12 +191,7 @@ class FileHandler extends BaseHandler
     }
 
     /**
-     * Returns information on the entire cache.
-     *
-     * The information returned and the structure of the data
-     * varies depending on the handler.
-     *
-     * @return array|false
+     * {@inheritDoc}
      */
     public function getCacheInfo()
     {
@@ -236,14 +199,7 @@ class FileHandler extends BaseHandler
     }
 
     /**
-     * Returns detailed information about the specific item in the cache.
-     *
-     * @param string $key Cache item name.
-     *
-     * @return array|false|null
-     *                          Returns null if the item does not exist, otherwise array<string, mixed>
-     *                          with at least the 'expire' key for absolute epoch expiry (or null).
-     *                          Some handlers may return false when an item does not exist, which is deprecated.
+     * {@inheritDoc}
      */
     public function getMetaData(string $key)
     {
@@ -261,7 +217,7 @@ class FileHandler extends BaseHandler
     }
 
     /**
-     * Determines if the driver is supported on this system.
+     * {@inheritDoc}
      */
     public function isSupported(): bool
     {
@@ -272,7 +228,7 @@ class FileHandler extends BaseHandler
      * Does the heavy lifting of actually retrieving the file and
      * verifying it's age.
      *
-     * @return bool|mixed
+     * @return mixed
      */
     protected function getItem(string $filename)
     {
@@ -328,8 +284,6 @@ class FileHandler extends BaseHandler
     }
 
     /**
-     * Delete Files
-     *
      * Deletes all files contained in the supplied directory path.
      * Files must be writable or owned by the system in order to be deleted.
      * If the second parameter is set to TRUE, any directories contained
@@ -365,8 +319,6 @@ class FileHandler extends BaseHandler
     }
 
     /**
-     * Get Directory File Information
-     *
      * Reads the specified directory and builds an array containing the filenames,
      * filesize, dates, and permissions
      *
@@ -409,8 +361,6 @@ class FileHandler extends BaseHandler
     }
 
     /**
-     * Get File Info
-     *
      * Given a file and path, returns the name, path, size, date modified
      * Second parameter allows you to explicitly declare what information you want returned
      * Options are: name, server_path, size, date, readable, writable, executable, fileperms

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -41,9 +41,6 @@ class MemcachedHandler extends BaseHandler
         'raw'    => false,
     ];
 
-    /**
-     * Constructor.
-     */
     public function __construct(Cache $config)
     {
         $this->prefix = $config->prefix;
@@ -54,8 +51,6 @@ class MemcachedHandler extends BaseHandler
     }
 
     /**
-     * Class destructor
-     *
      * Closes the connection to Memcache(d) if present.
      */
     public function __destruct()
@@ -68,12 +63,10 @@ class MemcachedHandler extends BaseHandler
     }
 
     /**
-     * Takes care of any handler-specific setup that must be done.
+     * {@inheritDoc}
      */
     public function initialize()
     {
-        // Try to connect to Memcache or Memcached, if an issue occurs throw a CriticalError exception,
-        // so that the CacheFactory can attempt to initiate the next cache handler.
         try {
             if (class_exists(Memcached::class)) {
                 // Create new instance of Memcached
@@ -130,11 +123,7 @@ class MemcachedHandler extends BaseHandler
     }
 
     /**
-     * Attempts to fetch an item from the cache store.
-     *
-     * @param string $key Cache item name
-     *
-     * @return mixed
+     * {@inheritDoc}
      */
     public function get(string $key)
     {
@@ -161,13 +150,7 @@ class MemcachedHandler extends BaseHandler
     }
 
     /**
-     * Saves an item to the cache store.
-     *
-     * @param string $key   Cache item name
-     * @param mixed  $value The data to save
-     * @param int    $ttl   Time To Live, in seconds (default 60)
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function save(string $key, $value, int $ttl = 60)
     {
@@ -194,11 +177,7 @@ class MemcachedHandler extends BaseHandler
     }
 
     /**
-     * Deletes a specific item from the cache store.
-     *
-     * @param string $key Cache item name
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function delete(string $key)
     {
@@ -208,11 +187,7 @@ class MemcachedHandler extends BaseHandler
     }
 
     /**
-     * Deletes items from the cache store matching a given pattern.
-     *
-     * @param string $pattern Cache items glob-style pattern
-     *
-     * @throws Exception
+     * {@inheritDoc}
      */
     public function deleteMatching(string $pattern)
     {
@@ -220,12 +195,7 @@ class MemcachedHandler extends BaseHandler
     }
 
     /**
-     * Performs atomic incrementation of a raw stored value.
-     *
-     * @param string $key    Cache ID
-     * @param int    $offset Step/value to increase by
-     *
-     * @return false|int
+     * {@inheritDoc}
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -240,12 +210,7 @@ class MemcachedHandler extends BaseHandler
     }
 
     /**
-     * Performs atomic decrementation of a raw stored value.
-     *
-     * @param string $key    Cache ID
-     * @param int    $offset Step/value to increase by
-     *
-     * @return false|int
+     * {@inheritDoc}
      */
     public function decrement(string $key, int $offset = 1)
     {
@@ -261,9 +226,7 @@ class MemcachedHandler extends BaseHandler
     }
 
     /**
-     * Will delete all items in the entire cache.
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function clean()
     {
@@ -271,12 +234,7 @@ class MemcachedHandler extends BaseHandler
     }
 
     /**
-     * Returns information on the entire cache.
-     *
-     * The information returned and the structure of the data
-     * varies depending on the handler.
-     *
-     * @return array|false
+     * {@inheritDoc}
      */
     public function getCacheInfo()
     {
@@ -284,14 +242,7 @@ class MemcachedHandler extends BaseHandler
     }
 
     /**
-     * Returns detailed information about the specific item in the cache.
-     *
-     * @param string $key Cache item name.
-     *
-     * @return array|false|null
-     *                          Returns null if the item does not exist, otherwise array<string, mixed>
-     *                          with at least the 'expire' key for absolute epoch expiry (or null).
-     *                          Some handlers may return false when an item does not exist, which is deprecated.
+     * {@inheritDoc}
      */
     public function getMetaData(string $key)
     {
@@ -313,7 +264,7 @@ class MemcachedHandler extends BaseHandler
     }
 
     /**
-     * Determines if the driver is supported on this system.
+     * {@inheritDoc}
      */
     public function isSupported(): bool
     {

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -42,9 +42,6 @@ class PredisHandler extends BaseHandler
      */
     protected $redis;
 
-    /**
-     * Constructor.
-     */
     public function __construct(Cache $config)
     {
         $this->prefix = $config->prefix;
@@ -55,30 +52,20 @@ class PredisHandler extends BaseHandler
     }
 
     /**
-     * Takes care of any handler-specific setup that must be done.
+     * {@inheritDoc}
      */
     public function initialize()
     {
-        // Try to connect to Redis, if an issue occurs throw a CriticalError exception,
-        // so that the CacheFactory can attempt to initiate the next cache handler.
         try {
-            // Create a new instance of Predis\Client
             $this->redis = new Client($this->config, ['prefix' => $this->prefix]);
-
-            // Check if the connection is valid by trying to get the time.
             $this->redis->time();
         } catch (Exception $e) {
-            // thrown if can't connect to redis server.
             throw new CriticalError('Cache: Predis connection refused (' . $e->getMessage() . ').');
         }
     }
 
     /**
-     * Attempts to fetch an item from the cache store.
-     *
-     * @param string $key Cache item name
-     *
-     * @return mixed
+     * {@inheritDoc}
      */
     public function get(string $key)
     {
@@ -112,13 +99,7 @@ class PredisHandler extends BaseHandler
     }
 
     /**
-     * Saves an item to the cache store.
-     *
-     * @param string $key   Cache item name
-     * @param mixed  $value The data to save
-     * @param int    $ttl   Time To Live, in seconds (default 60)
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function save(string $key, $value, int $ttl = 60)
     {
@@ -152,11 +133,7 @@ class PredisHandler extends BaseHandler
     }
 
     /**
-     * Deletes a specific item from the cache store.
-     *
-     * @param string $key Cache item name
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function delete(string $key)
     {
@@ -166,11 +143,7 @@ class PredisHandler extends BaseHandler
     }
 
     /**
-     * Deletes items from the cache store matching a given pattern.
-     *
-     * @param string $pattern Cache items glob-style pattern
-     *
-     * @return int The number of deleted items
+     * {@inheritDoc}
      */
     public function deleteMatching(string $pattern)
     {
@@ -184,12 +157,7 @@ class PredisHandler extends BaseHandler
     }
 
     /**
-     * Performs atomic incrementation of a raw stored value.
-     *
-     * @param string $key    Cache ID
-     * @param int    $offset Step/value to increase by
-     *
-     * @return int
+     * {@inheritDoc}
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -199,12 +167,7 @@ class PredisHandler extends BaseHandler
     }
 
     /**
-     * Performs atomic decrementation of a raw stored value.
-     *
-     * @param string $key    Cache ID
-     * @param int    $offset Step/value to increase by
-     *
-     * @return int
+     * {@inheritDoc}
      */
     public function decrement(string $key, int $offset = 1)
     {
@@ -214,9 +177,7 @@ class PredisHandler extends BaseHandler
     }
 
     /**
-     * Will delete all items in the entire cache.
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function clean()
     {
@@ -224,12 +185,7 @@ class PredisHandler extends BaseHandler
     }
 
     /**
-     * Returns information on the entire cache.
-     *
-     * The information returned and the structure of the data
-     * varies depending on the handler.
-     *
-     * @return array
+     * {@inheritDoc}
      */
     public function getCacheInfo()
     {
@@ -237,13 +193,7 @@ class PredisHandler extends BaseHandler
     }
 
     /**
-     * Returns detailed information about the specific item in the cache.
-     *
-     * @param string $key Cache item name.
-     *
-     * @return array|false|null
-     *                          Returns null if the item does not exist, otherwise array<string, mixed>
-     *                          with at least the 'expire' key for absolute epoch expiry (or null).
+     * {@inheritDoc}
      */
     public function getMetaData(string $key)
     {
@@ -266,10 +216,10 @@ class PredisHandler extends BaseHandler
     }
 
     /**
-     * Determines if the driver is supported on this system.
+     * {@inheritDoc}
      */
     public function isSupported(): bool
     {
-        return class_exists('\Predis\Client');
+        return class_exists('Predis\Client');
     }
 }

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -41,9 +41,6 @@ class RedisHandler extends BaseHandler
      */
     protected $redis;
 
-    /**
-     * Constructor.
-     */
     public function __construct(Cache $config)
     {
         $this->prefix = $config->prefix;
@@ -54,8 +51,6 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Class destructor
-     *
      * Closes the connection to Redis if present.
      */
     public function __destruct()
@@ -66,7 +61,7 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Takes care of any handler-specific setup that must be done.
+     * {@inheritDoc}
      */
     public function initialize()
     {
@@ -74,8 +69,6 @@ class RedisHandler extends BaseHandler
 
         $this->redis = new Redis();
 
-        // Try to connect to Redis, if an issue occurs throw a CriticalError exception,
-        // so that the CacheFactory can attempt to initiate the next cache handler.
         try {
             // Note:: If Redis is your primary cache choice, and it is "offline", every page load will end up been delayed by the timeout duration.
             // I feel like some sort of temporary flag should be set, to indicate that we think Redis is "offline", allowing us to bypass the timeout for a set period of time.
@@ -99,18 +92,12 @@ class RedisHandler extends BaseHandler
                 throw new CriticalError('Cache: Redis select database failed.');
             }
         } catch (RedisException $e) {
-            // $this->redis->connect() can sometimes throw a RedisException.
-            // We need to convert the exception into a CriticalError exception and throw it.
             throw new CriticalError('Cache: RedisException occurred with message (' . $e->getMessage() . ').');
         }
     }
 
     /**
-     * Attempts to fetch an item from the cache store.
-     *
-     * @param string $key Cache item name
-     *
-     * @return mixed
+     * {@inheritDoc}
      */
     public function get(string $key)
     {
@@ -140,13 +127,7 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Saves an item to the cache store.
-     *
-     * @param string $key   Cache item name
-     * @param mixed  $value The data to save
-     * @param int    $ttl   Time To Live, in seconds (default 60)
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function save(string $key, $value, int $ttl = 60)
     {
@@ -182,11 +163,7 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Deletes a specific item from the cache store.
-     *
-     * @param string $key Cache item name
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function delete(string $key)
     {
@@ -196,11 +173,7 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Deletes items from the cache store matching a given pattern.
-     *
-     * @param string $pattern Cache items glob-style pattern
-     *
-     * @return int The number of deleted items
+     * {@inheritDoc}
      */
     public function deleteMatching(string $pattern)
     {
@@ -223,12 +196,7 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Performs atomic incrementation of a raw stored value.
-     *
-     * @param string $key    Cache ID
-     * @param int    $offset Step/value to increase by
-     *
-     * @return int
+     * {@inheritDoc}
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -238,12 +206,7 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Performs atomic decrementation of a raw stored value.
-     *
-     * @param string $key    Cache ID
-     * @param int    $offset Step/value to increase by
-     *
-     * @return int
+     * {@inheritDoc}
      */
     public function decrement(string $key, int $offset = 1)
     {
@@ -253,9 +216,7 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Will delete all items in the entire cache.
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function clean()
     {
@@ -263,12 +224,7 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Returns information on the entire cache.
-     *
-     * The information returned and the structure of the data
-     * varies depending on the handler.
-     *
-     * @return array
+     * {@inheritDoc}
      */
     public function getCacheInfo()
     {
@@ -276,13 +232,7 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Returns detailed information about the specific item in the cache.
-     *
-     * @param string $key Cache item name.
-     *
-     * @return array|null
-     *                    Returns null if the item does not exist, otherwise array<string, mixed>
-     *                    with at least the 'expire' key for absolute epoch expiry (or null).
+     * {@inheritDoc}
      */
     public function getMetaData(string $key)
     {
@@ -304,7 +254,7 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Determines if the driver is supported on this system.
+     * {@inheritDoc}
      */
     public function isSupported(): bool
     {

--- a/system/Cache/Handlers/WincacheHandler.php
+++ b/system/Cache/Handlers/WincacheHandler.php
@@ -21,27 +21,20 @@ use Exception;
  */
 class WincacheHandler extends BaseHandler
 {
-    /**
-     * Constructor.
-     */
     public function __construct(Cache $config)
     {
         $this->prefix = $config->prefix;
     }
 
     /**
-     * Takes care of any handler-specific setup that must be done.
+     * {@inheritDoc}
      */
     public function initialize()
     {
     }
 
     /**
-     * Attempts to fetch an item from the cache store.
-     *
-     * @param string $key Cache item name
-     *
-     * @return mixed
+     * {@inheritDoc}
      */
     public function get(string $key)
     {
@@ -55,13 +48,7 @@ class WincacheHandler extends BaseHandler
     }
 
     /**
-     * Saves an item to the cache store.
-     *
-     * @param string $key   Cache item name
-     * @param mixed  $value The data to save
-     * @param int    $ttl   Time To Live, in seconds (default 60)
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function save(string $key, $value, int $ttl = 60)
     {
@@ -71,11 +58,7 @@ class WincacheHandler extends BaseHandler
     }
 
     /**
-     * Deletes a specific item from the cache store.
-     *
-     * @param string $key Cache item name
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function delete(string $key)
     {
@@ -85,11 +68,7 @@ class WincacheHandler extends BaseHandler
     }
 
     /**
-     * Deletes items from the cache store matching a given pattern.
-     *
-     * @param string $pattern Cache items glob-style pattern
-     *
-     * @throws Exception
+     * {@inheritDoc}
      */
     public function deleteMatching(string $pattern)
     {
@@ -97,12 +76,7 @@ class WincacheHandler extends BaseHandler
     }
 
     /**
-     * Performs atomic incrementation of a raw stored value.
-     *
-     * @param string $key    Cache ID
-     * @param int    $offset Step/value to increase by
-     *
-     * @return false|int
+     * {@inheritDoc}
      */
     public function increment(string $key, int $offset = 1)
     {
@@ -112,12 +86,7 @@ class WincacheHandler extends BaseHandler
     }
 
     /**
-     * Performs atomic decrementation of a raw stored value.
-     *
-     * @param string $key    Cache ID
-     * @param int    $offset Step/value to increase by
-     *
-     * @return false|int
+     * {@inheritDoc}
      */
     public function decrement(string $key, int $offset = 1)
     {
@@ -127,9 +96,7 @@ class WincacheHandler extends BaseHandler
     }
 
     /**
-     * Will delete all items in the entire cache.
-     *
-     * @return bool Success or failure
+     * {@inheritDoc}
      */
     public function clean()
     {
@@ -137,12 +104,7 @@ class WincacheHandler extends BaseHandler
     }
 
     /**
-     * Returns information on the entire cache.
-     *
-     * The information returned and the structure of the data
-     * varies depending on the handler.
-     *
-     * @return array|false
+     * {@inheritDoc}
      */
     public function getCacheInfo()
     {
@@ -150,14 +112,7 @@ class WincacheHandler extends BaseHandler
     }
 
     /**
-     * Returns detailed information about the specific item in the cache.
-     *
-     * @param string $key Cache item name.
-     *
-     * @return array|false|null
-     *                          Returns null if the item does not exist, otherwise array<string, mixed>
-     *                          with at least the 'expire' key for absolute epoch expiry (or null).
-     *                          Some handlers may return false when an item does not exist, which is deprecated.
+     * {@inheritDoc}
      */
     public function getMetaData(string $key)
     {
@@ -180,7 +135,7 @@ class WincacheHandler extends BaseHandler
     }
 
     /**
-     * Determines if the driver is supported on this system.
+     * {@inheritDoc}
      */
     public function isSupported(): bool
     {

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -194,8 +194,6 @@ class CodeIgniter
      *
      * @throws FrameworkException
      *
-     * @return void
-     *
      * @codeCoverageIgnore
      */
     protected function resolvePlatformExtensions()
@@ -609,8 +607,6 @@ class CodeIgniter
 
     /**
      * Tells the app that the final output should be cached.
-     *
-     * @return void
      */
     public static function cache(int $time)
     {

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -72,8 +72,6 @@ class CreateDatabase extends BaseCommand
 
     /**
      * Creates a new database.
-     *
-     * @return void
      */
     public function run(array $params)
     {

--- a/system/Commands/Database/Migrate.php
+++ b/system/Commands/Database/Migrate.php
@@ -63,8 +63,6 @@ class Migrate extends BaseCommand
 
     /**
      * Ensures that all migrations have been run.
-     *
-     * @return void
      */
     public function run(array $params)
     {
@@ -77,12 +75,9 @@ class Migrate extends BaseCommand
         $group     = $params['g'] ?? CLI::getOption('g');
 
         try {
-            // Check for 'all' namespaces
             if (array_key_exists('all', $params) || CLI::getOption('all')) {
                 $runner->setNamespace(null);
-            }
-            // Check for a specified namespace
-            elseif ($namespace) {
+            } elseif ($namespace) {
                 $runner->setNamespace($namespace);
             }
 
@@ -97,11 +92,11 @@ class Migrate extends BaseCommand
             }
 
             CLI::write('Done migrations.', 'green');
-        }
-        // @codeCoverageIgnoreStart
-        catch (Throwable $e) {
+
+            // @codeCoverageIgnoreStart
+        } catch (Throwable $e) {
             $this->showError($e);
+            // @codeCoverageIgnoreEnd
         }
-        // @codeCoverageIgnoreEnd
     }
 }

--- a/system/Commands/Database/MigrateRefresh.php
+++ b/system/Commands/Database/MigrateRefresh.php
@@ -64,8 +64,6 @@ class MigrateRefresh extends BaseCommand
     /**
      * Does a rollback followed by a latest to refresh the current state
      * of the database.
-     *
-     * @return void
      */
     public function run(array $params)
     {

--- a/system/Commands/Database/MigrateRollback.php
+++ b/system/Commands/Database/MigrateRollback.php
@@ -65,8 +65,6 @@ class MigrateRollback extends BaseCommand
     /**
      * Runs all of the migrations in reverse order, until they have
      * all been unapplied.
-     *
-     * @return void
      */
     public function run(array $params)
     {
@@ -102,11 +100,11 @@ class MigrateRollback extends BaseCommand
             }
 
             CLI::write('Done rolling back migrations.', 'green');
-        }
-        // @codeCoverageIgnoreStart
-        catch (Throwable $e) {
+
+            // @codeCoverageIgnoreStart
+        } catch (Throwable $e) {
             $this->showError($e);
+            // @codeCoverageIgnoreEnd
         }
-        // @codeCoverageIgnoreEnd
     }
 }

--- a/system/Commands/Database/MigrateStatus.php
+++ b/system/Commands/Database/MigrateStatus.php
@@ -76,8 +76,6 @@ class MigrateStatus extends BaseCommand
      * Displays a list of all migrations and whether they've been run or not.
      *
      * @param array<string, mixed> $params
-     *
-     * @return void
      */
     public function run(array $params)
     {

--- a/system/Commands/Database/Seed.php
+++ b/system/Commands/Database/Seed.php
@@ -63,8 +63,6 @@ class Seed extends BaseCommand
 
     /**
      * Passes to Seeder to populate the database.
-     *
-     * @return void
      */
     public function run(array $params)
     {

--- a/system/Commands/Encryption/GenerateKey.php
+++ b/system/Commands/Encryption/GenerateKey.php
@@ -63,8 +63,6 @@ class GenerateKey extends BaseCommand
 
     /**
      * Actually execute the command.
-     *
-     * @return void
      */
     public function run(array $params)
     {
@@ -72,9 +70,7 @@ class GenerateKey extends BaseCommand
         if (in_array($prefix, [null, true], true)) {
             $prefix = 'hex2bin';
         } elseif (! in_array($prefix, ['hex2bin', 'base64'], true)) {
-            // @codeCoverageIgnoreStart
-            $prefix = CLI::prompt('Please provide a valid prefix to use.', ['hex2bin', 'base64'], 'required');
-            // @codeCoverageIgnoreEnd
+            $prefix = CLI::prompt('Please provide a valid prefix to use.', ['hex2bin', 'base64'], 'required'); // @codeCoverageIgnore
         }
 
         $length = $params['length'] ?? CLI::getOption('length');

--- a/system/Commands/Housekeeping/ClearDebugbar.php
+++ b/system/Commands/Housekeeping/ClearDebugbar.php
@@ -50,8 +50,6 @@ class ClearDebugbar extends BaseCommand
 
     /**
      * Actually runs the command.
-     *
-     * @return void
      */
     public function run(array $params)
     {

--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -85,10 +85,6 @@ class Serve extends BaseCommand
 
     /**
      * Run the server
-     *
-     * @param array $params Parameters
-     *
-     * @return void
      */
     public function run(array $params)
     {

--- a/system/Commands/Utilities/Environment.php
+++ b/system/Commands/Utilities/Environment.php
@@ -79,10 +79,6 @@ final class Environment extends BaseCommand
 
     /**
      * {@inheritDoc}
-     *
-     * @param array<string, mixed> $params
-     *
-     * @return void
      */
     public function run(array $params)
     {

--- a/system/ComposerScripts.php
+++ b/system/ComposerScripts.php
@@ -63,8 +63,6 @@ final class ComposerScripts
     /**
      * This static method is called by Composer after every update event,
      * i.e., `composer install`, `composer update`, `composer remove`.
-     *
-     * @return void
      */
     public static function postUpdate()
     {

--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -168,9 +168,7 @@ class BaseConfig
         foreach (static::$registrars as $callable) {
             // ignore non-applicable registrars
             if (! method_exists($callable, $shortName)) {
-                // @codeCoverageIgnoreStart
-                continue;
-                // @codeCoverageIgnoreEnd
+                continue; // @codeCoverageIgnore
             }
 
             $properties = $callable::$shortName();

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -269,8 +269,6 @@ class BaseService
 
     /**
      * Reset shared instances and mocks for testing.
-     *
-     * @param bool $initAutoloader Initializes autoloader instance
      */
     public static function reset(bool $initAutoloader = false)
     {

--- a/system/Config/Config.php
+++ b/system/Config/Config.php
@@ -12,8 +12,6 @@
 namespace CodeIgniter\Config;
 
 /**
- * Class Config
- *
  * @deprecated Use CodeIgniter\Config\Factories::config()
  */
 class Config

--- a/system/Config/View.php
+++ b/system/Config/View.php
@@ -87,8 +87,6 @@ class View extends BaseConfig
     ];
 
     /**
-     * Constructor.
-     *
      * Merge the built-in and developer-configured filters and plugins,
      * with preference to the developer ones.
      */

--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -596,8 +596,6 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
      * @param mixed  $value
      *
      * @throws LogicException
-     *
-     * @return void
      */
     public function offsetSet($offset, $value)
     {
@@ -610,8 +608,6 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
      * @param string $offset
      *
      * @throws LogicException
-     *
-     * @return void
      */
     public function offsetUnset($offset)
     {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -287,8 +287,6 @@ class BaseBuilder
     /**
      * Sets a test mode status.
      *
-     * @param bool $mode Mode to set
-     *
      * @return $this
      */
     public function testMode(bool $mode = true)
@@ -331,12 +329,9 @@ class BaseBuilder
     }
 
     /**
-     * Select
-     *
      * Generates the SELECT portion of the query
      *
      * @param array|string $select
-     * @param bool         $escape
      *
      * @return $this
      */
@@ -376,12 +371,7 @@ class BaseBuilder
     }
 
     /**
-     * Select Max
-     *
      * Generates a SELECT MAX(field) portion of a query
-     *
-     * @param string $select The field
-     * @param string $alias  An alias
      *
      * @return $this
      */
@@ -391,12 +381,7 @@ class BaseBuilder
     }
 
     /**
-     * Select Min
-     *
      * Generates a SELECT MIN(field) portion of a query
-     *
-     * @param string $select The field
-     * @param string $alias  An alias
      *
      * @return $this
      */
@@ -406,12 +391,7 @@ class BaseBuilder
     }
 
     /**
-     * Select Average
-     *
      * Generates a SELECT AVG(field) portion of a query
-     *
-     * @param string $select The field
-     * @param string $alias  An alias
      *
      * @return $this
      */
@@ -421,12 +401,7 @@ class BaseBuilder
     }
 
     /**
-     * Select Sum
-     *
      * Generates a SELECT SUM(field) portion of a query
-     *
-     * @param string $select The field
-     * @param string $alias  An alias
      *
      * @return $this
      */
@@ -436,12 +411,7 @@ class BaseBuilder
     }
 
     /**
-     * Select Count
-     *
      * Generates a SELECT COUNT(field) portion of a query
-     *
-     * @param string $select The field
-     * @param string $alias  An alias
      *
      * @return $this
      */
@@ -457,8 +427,6 @@ class BaseBuilder
      * @used-by selectMin()
      * @used-by selectAvg()
      * @used-by selectSum()
-     *
-     * @param string $select Field name
      *
      * @throws DatabaseException
      * @throws DataException
@@ -508,8 +476,6 @@ class BaseBuilder
     }
 
     /**
-     * DISTINCT
-     *
      * Sets a flag which tells the query string compiler to add DISTINCT
      *
      * @return $this
@@ -522,12 +488,9 @@ class BaseBuilder
     }
 
     /**
-     * From
-     *
      * Generates the FROM portion of the query
      *
-     * @param mixed $from      can be a string or array
-     * @param bool  $overwrite Should we remove the first table existing?
+     * @param array|string $from
      *
      * @return $this
      */
@@ -561,13 +524,7 @@ class BaseBuilder
     }
 
     /**
-     * JOIN
-     *
      * Generates the JOIN portion of the query
-     *
-     * @param string $cond   The join condition
-     * @param string $type   The type of join
-     * @param bool   $escape Whether not to try to escape identifiers
      *
      * @return $this
      */
@@ -636,14 +593,11 @@ class BaseBuilder
     }
 
     /**
-     * WHERE
-     *
      * Generates the WHERE portion of the query.
      * Separates multiple calls with 'AND'.
      *
      * @param mixed $key
      * @param mixed $value
-     * @param bool  $escape
      *
      * @return $this
      */
@@ -670,17 +624,13 @@ class BaseBuilder
     }
 
     /**
-     * WHERE, HAVING
-     *
      * @used-by where()
      * @used-by orWhere()
      * @used-by having()
      * @used-by orHaving()
      *
-     * @param string $qbKey  'QBWhere' or 'QBHaving'
-     * @param mixed  $key
-     * @param mixed  $value
-     * @param bool   $escape
+     * @param mixed $key
+     * @param mixed $value
      *
      * @return $this
      */
@@ -744,14 +694,10 @@ class BaseBuilder
     }
 
     /**
-     * WHERE IN
-     *
      * Generates a WHERE field IN('item', 'item') SQL query,
      * joined with 'AND' if appropriate.
      *
-     * @param string               $key    The field to search
      * @param array|Closure|string $values The values searched on, or anonymous function with subquery
-     * @param bool                 $escape
      *
      * @return $this
      */
@@ -761,14 +707,10 @@ class BaseBuilder
     }
 
     /**
-     * OR WHERE IN
-     *
      * Generates a WHERE field IN('item', 'item') SQL query,
      * joined with 'OR' if appropriate.
      *
-     * @param string               $key    The field to search
      * @param array|Closure|string $values The values searched on, or anonymous function with subquery
-     * @param bool                 $escape
      *
      * @return $this
      */
@@ -778,14 +720,10 @@ class BaseBuilder
     }
 
     /**
-     * WHERE NOT IN
-     *
      * Generates a WHERE field NOT IN('item', 'item') SQL query,
      * joined with 'AND' if appropriate.
      *
-     * @param string               $key    The field to search
      * @param array|Closure|string $values The values searched on, or anonymous function with subquery
-     * @param bool                 $escape
      *
      * @return $this
      */
@@ -795,14 +733,10 @@ class BaseBuilder
     }
 
     /**
-     * OR WHERE NOT IN
-     *
      * Generates a WHERE field NOT IN('item', 'item') SQL query,
      * joined with 'OR' if appropriate.
      *
-     * @param string               $key    The field to search
      * @param array|Closure|string $values The values searched on, or anonymous function with subquery
-     * @param bool                 $escape
      *
      * @return $this
      */
@@ -812,14 +746,10 @@ class BaseBuilder
     }
 
     /**
-     * HAVING IN
-     *
      * Generates a HAVING field IN('item', 'item') SQL query,
      * joined with 'AND' if appropriate.
      *
-     * @param string               $key    The field to search
      * @param array|Closure|string $values The values searched on, or anonymous function with subquery
-     * @param bool                 $escape
      *
      * @return $this
      */
@@ -829,14 +759,10 @@ class BaseBuilder
     }
 
     /**
-     * OR HAVING IN
-     *
      * Generates a HAVING field IN('item', 'item') SQL query,
      * joined with 'OR' if appropriate.
      *
-     * @param string               $key    The field to search
      * @param array|Closure|string $values The values searched on, or anonymous function with subquery
-     * @param bool                 $escape
      *
      * @return $this
      */
@@ -846,14 +772,10 @@ class BaseBuilder
     }
 
     /**
-     * HAVING NOT IN
-     *
      * Generates a HAVING field NOT IN('item', 'item') SQL query,
      * joined with 'AND' if appropriate.
      *
-     * @param string               $key    The field to search
      * @param array|Closure|string $values The values searched on, or anonymous function with subquery
-     * @param bool                 $escape
      *
      * @return $this
      */
@@ -863,14 +785,10 @@ class BaseBuilder
     }
 
     /**
-     * OR HAVING NOT IN
-     *
      * Generates a HAVING field NOT IN('item', 'item') SQL query,
      * joined with 'OR' if appropriate.
      *
-     * @param string               $key    The field to search
      * @param array|Closure|string $values The values searched on, or anonymous function with subquery
-     * @param bool                 $escape
      *
      * @return $this
      */
@@ -880,18 +798,12 @@ class BaseBuilder
     }
 
     /**
-     * Internal WHERE IN
-     *
      * @used-by WhereIn()
      * @used-by orWhereIn()
      * @used-by whereNotIn()
      * @used-by orWhereNotIn()
      *
-     * @param string             $key    The field to search
      * @param array|Closure|null $values The values searched on, or anonymous function with subquery
-     * @param bool               $not    If the statement would be IN or NOT IN
-     * @param bool               $escape
-     * @param string             $clause (Internal use only)
      *
      * @throws InvalidArgumentException
      *
@@ -903,9 +815,8 @@ class BaseBuilder
             if (CI_DEBUG) {
                 throw new InvalidArgumentException(sprintf('%s() expects $key to be a non-empty string', debug_backtrace(0, 2)[1]['function']));
             }
-            // @codeCoverageIgnoreStart
-            return $this;
-            // @codeCoverageIgnoreEnd
+
+            return $this; // @codeCoverageIgnore
         }
 
         if ($values === null || (! is_array($values) && ! ($values instanceof Closure))) {
@@ -949,14 +860,10 @@ class BaseBuilder
     }
 
     /**
-     * LIKE
-     *
      * Generates a %LIKE% portion of the query.
      * Separates multiple calls with 'AND'.
      *
      * @param mixed $field
-     * @param bool  $escape
-     * @param bool  $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -966,14 +873,10 @@ class BaseBuilder
     }
 
     /**
-     * NOT LIKE
-     *
      * Generates a NOT LIKE portion of the query.
      * Separates multiple calls with 'AND'.
      *
      * @param mixed $field
-     * @param bool  $escape
-     * @param bool  $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -983,14 +886,10 @@ class BaseBuilder
     }
 
     /**
-     * OR LIKE
-     *
      * Generates a %LIKE% portion of the query.
      * Separates multiple calls with 'OR'.
      *
      * @param mixed $field
-     * @param bool  $escape
-     * @param bool  $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -1000,14 +899,10 @@ class BaseBuilder
     }
 
     /**
-     * OR NOT LIKE
-     *
      * Generates a NOT LIKE portion of the query.
      * Separates multiple calls with 'OR'.
      *
      * @param mixed $field
-     * @param bool  $escape
-     * @param bool  $insensitiveSearch IF true, will force a case-insensitive search
      *
      * @return $this
      */
@@ -1017,13 +912,10 @@ class BaseBuilder
     }
 
     /**
-     * LIKE with HAVING clause
-     *
      * Generates a %LIKE% portion of the query.
      * Separates multiple calls with 'AND'.
      *
      * @param mixed $field
-     * @param bool  $escape
      *
      * @return $this
      */
@@ -1033,13 +925,10 @@ class BaseBuilder
     }
 
     /**
-     * NOT LIKE with HAVING clause
-     *
      * Generates a NOT LIKE portion of the query.
      * Separates multiple calls with 'AND'.
      *
      * @param mixed $field
-     * @param bool  $escape
      *
      * @return $this
      */
@@ -1049,13 +938,10 @@ class BaseBuilder
     }
 
     /**
-     * OR LIKE with HAVING clause
-     *
      * Generates a %LIKE% portion of the query.
      * Separates multiple calls with 'OR'.
      *
      * @param mixed $field
-     * @param bool  $escape
      *
      * @return $this
      */
@@ -1065,13 +951,10 @@ class BaseBuilder
     }
 
     /**
-     * OR NOT LIKE with HAVING clause
-     *
      * Generates a NOT LIKE portion of the query.
      * Separates multiple calls with 'OR'.
      *
      * @param mixed $field
-     * @param bool  $escape
      *
      * @return $this
      */
@@ -1081,8 +964,6 @@ class BaseBuilder
     }
 
     /**
-     * Internal LIKE
-     *
      * @used-by like()
      * @used-by orLike()
      * @used-by notLike()
@@ -1092,10 +973,7 @@ class BaseBuilder
      * @used-by notHavingLike()
      * @used-by orNotHavingLike()
      *
-     * @param mixed  $field
-     * @param bool   $escape
-     * @param bool   $insensitiveSearch IF true, will force a case-insensitive search
-     * @param string $clause            (Internal use only)
+     * @param mixed $field
      *
      * @return $this
      */
@@ -1106,9 +984,7 @@ class BaseBuilder
         }
 
         $escape = is_bool($escape) ? $escape : $this->db->protectIdentifiers;
-
-        // lowercase $side in case somebody writes e.g. 'BEFORE' instead of 'before' (doh)
-        $side = strtolower($side);
+        $side   = strtolower($side);
 
         foreach ($field as $k => $v) {
             if ($insensitiveSearch === true) {
@@ -1145,8 +1021,6 @@ class BaseBuilder
 
     /**
      * Platform independent LIKE statement builder.
-     *
-     * @return string $like_statement
      */
     protected function _like_statement(?string $prefix, string $column, ?string $not, string $bind, bool $insensitiveSearch = false): string
     {
@@ -1297,8 +1171,6 @@ class BaseBuilder
     }
 
     /**
-     * Group_get_type
-     *
      * @used-by groupStart()
      * @used-by _like()
      * @used-by whereHaving()
@@ -1316,10 +1188,7 @@ class BaseBuilder
     }
 
     /**
-     * GROUP BY
-     *
      * @param array|string $by
-     * @param bool         $escape
      *
      * @return $this
      */
@@ -1350,13 +1219,10 @@ class BaseBuilder
     }
 
     /**
-     * HAVING
-     *
      * Separates multiple calls with 'AND'.
      *
      * @param array|string $key
      * @param mixed        $value
-     * @param bool         $escape
      *
      * @return $this
      */
@@ -1366,13 +1232,10 @@ class BaseBuilder
     }
 
     /**
-     * OR HAVING
-     *
      * Separates multiple calls with 'OR'.
      *
      * @param array|string $key
      * @param mixed        $value
-     * @param bool         $escape
      *
      * @return $this
      */
@@ -1382,24 +1245,21 @@ class BaseBuilder
     }
 
     /**
-     * ORDER BY
-     *
      * @param string $direction ASC, DESC or RANDOM
-     * @param bool   $escape
      *
      * @return $this
      */
     public function orderBy(string $orderBy, string $direction = '', ?bool $escape = null)
     {
+        if (empty($orderBy)) {
+            return $this;
+        }
+
         $direction = strtoupper(trim($direction));
 
         if ($direction === 'RANDOM') {
             $direction = '';
-
-            // Do we have a seed value?
-            $orderBy = ctype_digit($orderBy) ? sprintf($this->randomKeyword[1], $orderBy) : $this->randomKeyword[0];
-        } elseif (empty($orderBy)) {
-            return $this;
+            $orderBy   = ctype_digit($orderBy) ? sprintf($this->randomKeyword[1], $orderBy) : $this->randomKeyword[0];
         } elseif ($direction !== '') {
             $direction = in_array($direction, ['ASC', 'DESC'], true) ? ' ' . $direction : '';
         }
@@ -1419,14 +1279,12 @@ class BaseBuilder
 
             foreach (explode(',', $orderBy) as $field) {
                 $qbOrderBy[] = ($direction === '' && preg_match('/\s+(ASC|DESC)$/i', rtrim($field), $match, PREG_OFFSET_CAPTURE))
-                    ?
-                    [
+                    ? [
                         'field'     => ltrim(substr($field, 0, $match[0][1])),
                         'direction' => ' ' . $match[1][0],
                         'escape'    => true,
                     ]
-                    :
-                    [
+                    : [
                         'field'     => trim($field),
                         'direction' => $direction,
                         'escape'    => true,
@@ -1440,11 +1298,6 @@ class BaseBuilder
     }
 
     /**
-     * LIMIT
-     *
-     * @param int|null $value  LIMIT value
-     * @param int|null $offset OFFSET value
-     *
      * @return $this
      */
     public function limit(?int $value = null, ?int $offset = 0)
@@ -1463,8 +1316,6 @@ class BaseBuilder
     /**
      * Sets the OFFSET value
      *
-     * @param int $offset OFFSET value
-     *
      * @return $this
      */
     public function offset(int $offset)
@@ -1477,11 +1328,7 @@ class BaseBuilder
     }
 
     /**
-     * LIMIT string
-     *
      * Generates a platform-specific LIMIT clause.
-     *
-     * @param string $sql SQL Query
      */
     protected function _limit(string $sql, bool $offsetIgnore = false): string
     {
@@ -1489,13 +1336,11 @@ class BaseBuilder
     }
 
     /**
-     * The "set" function.
-     *
      * Allows key/value pairs to be set for insert(), update() or replace().
      *
      * @param array|object|string $key    Field name, or an array of field/value pairs
-     * @param string              $value  Field value, if $key is a single field
-     * @param bool                $escape Whether to escape values and identifiers
+     * @param string|null         $value  Field value, if $key is a single field
+     * @param bool|null           $escape Whether to escape values and identifiers
      *
      * @return $this
      */
@@ -1511,7 +1356,8 @@ class BaseBuilder
 
         foreach ($key as $k => $v) {
             if ($escape) {
-                $bind                                                           = $this->setBind($k, $v, $escape);
+                $bind = $this->setBind($k, $v, $escape);
+
                 $this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = ":{$bind}:";
             } else {
                 $this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = $v;
@@ -1522,8 +1368,7 @@ class BaseBuilder
     }
 
     /**
-     * Returns the previously set() data, alternatively resetting it
-     * if needed.
+     * Returns the previously set() data, alternatively resetting it if needed.
      */
     public function getSetData(bool $clean = false): array
     {
@@ -1537,11 +1382,7 @@ class BaseBuilder
     }
 
     /**
-     * Get SELECT query string
-     *
      * Compiles a SELECT query string and returns the sql.
-     *
-     * @param bool $reset TRUE: resets QB values; FALSE: leave QB values alone
      */
     public function getCompiledSelect(bool $reset = true): string
     {
@@ -1571,14 +1412,8 @@ class BaseBuilder
     }
 
     /**
-     * Get
-     *
      * Compiles the select statement based on the other functions called
      * and runs the query
-     *
-     * @param int  $limit  The limit clause
-     * @param int  $offset The offset clause
-     * @param bool $reset  Are we want to clear query builder values?
      *
      * @return false|ResultInterface
      */
@@ -1603,27 +1438,24 @@ class BaseBuilder
     }
 
     /**
-     * "Count All" query
-     *
      * Generates a platform-specific query string that counts all records in
      * the particular table
      *
-     * @param bool $reset Are we want to clear query builder values?
-     *
-     * @return int|string when $test = true
+     * @return int|string
      */
     public function countAll(bool $reset = true)
     {
         $table = $this->QBFrom[0];
 
         $sql = $this->countString . $this->db->escapeIdentifiers('numrows') . ' FROM ' .
-                $this->db->protectIdentifiers($table, true, null, false);
+            $this->db->protectIdentifiers($table, true, null, false);
 
         if ($this->testMode) {
             return $sql;
         }
 
         $query = $this->db->query($sql, null, false);
+
         if (empty($query->getResult())) {
             return 0;
         }
@@ -1638,12 +1470,10 @@ class BaseBuilder
     }
 
     /**
-     * "Count All Results" query
-     *
      * Generates a platform-specific query string that counts all records
      * returned by an Query Builder query.
      *
-     * @return int|string when $test = true
+     * @return int|string
      */
     public function countAllResults(bool $reset = true)
     {
@@ -1651,19 +1481,23 @@ class BaseBuilder
         // on Microsoft SQL Server) and ultimately unnecessary
         // for selecting COUNT(*) ...
         $orderBy = [];
+
         if (! empty($this->QBOrderBy)) {
-            $orderBy         = $this->QBOrderBy;
+            $orderBy = $this->QBOrderBy;
+
             $this->QBOrderBy = null;
         }
 
         // We cannot use a LIMIT when getting the single row COUNT(*) result
-        $limit         = $this->QBLimit;
+        $limit = $this->QBLimit;
+
         $this->QBLimit = false;
 
         if ($this->QBDistinct === true || ! empty($this->QBGroupBy)) {
             // We need to backup the original SELECT in case DBPrefix is used
             $select = $this->QBSelect;
             $sql    = $this->countString . $this->db->protectIdentifiers('numrows') . "\nFROM (\n" . $this->compileSelect() . "\n) CI_count_all_results";
+
             // Restore SELECT part
             $this->QBSelect = $select;
             unset($select);
@@ -1679,18 +1513,14 @@ class BaseBuilder
 
         if ($reset === true) {
             $this->resetSelect();
-        }
-        // If we've previously reset the QBOrderBy values, get them back
-        elseif (! isset($this->QBOrderBy)) {
+        } elseif (! isset($this->QBOrderBy)) {
             $this->QBOrderBy = $orderBy;
         }
 
         // Restore the LIMIT setting
         $this->QBLimit = $limit;
 
-        $row = (! $result instanceof ResultInterface)
-            ? null
-            : $result->getRow();
+        $row = ! $result instanceof ResultInterface ? null : $result->getRow();
 
         if (empty($row)) {
             return 0;
@@ -1700,8 +1530,6 @@ class BaseBuilder
     }
 
     /**
-     * Get compiled 'where' condition string
-     *
      * Compiles the set conditions and returns the sql statement
      *
      * @return array
@@ -1712,14 +1540,9 @@ class BaseBuilder
     }
 
     /**
-     * Get_Where
-     *
      * Allows the where clause, limit and offset to be added directly
      *
-     * @param array|string $where  Where condition
-     * @param int          $limit  Limit value
-     * @param int          $offset Offset value
-     * @param bool         $reset  Are we want to clear query builder values?
+     * @param array|string $where
      *
      * @return ResultInterface
      */
@@ -1748,13 +1571,7 @@ class BaseBuilder
     }
 
     /**
-     * Insert_Batch
-     *
      * Compiles batch insert strings and runs the queries
-     *
-     * @param array $set       An associative array of insert values
-     * @param bool  $escape    Whether to escape values and identifiers
-     * @param int   $batchSize Batch size
      *
      * @throws DatabaseException
      *
@@ -1767,9 +1584,8 @@ class BaseBuilder
                 if (CI_DEBUG) {
                     throw new DatabaseException('You must use the "set" method to update an entry.');
                 }
-                // @codeCoverageIgnoreStart
-                return false;
-                // @codeCoverageIgnoreEnd
+
+                return false; // @codeCoverageIgnore
             }
         } else {
             if (empty($set)) {
@@ -1785,7 +1601,6 @@ class BaseBuilder
 
         $table = $this->QBFrom[0];
 
-        // Batch this baby
         $affectedRows = 0;
 
         for ($i = 0, $total = count($this->QBSet); $i < $total; $i += $batchSize) {
@@ -1807,13 +1622,7 @@ class BaseBuilder
     }
 
     /**
-     * Insert batch statement
-     *
      * Generates a platform-specific insert string from the supplied data.
-     *
-     * @param string $table  Table name
-     * @param array  $keys   INSERT keys
-     * @param array  $values INSERT values
      */
     protected function _insertBatch(string $table, array $keys, array $values): string
     {
@@ -1821,10 +1630,9 @@ class BaseBuilder
     }
 
     /**
-     * The "setInsertBatch" function.  Allows key/value pairs to be set for batch inserts
+     * Allows key/value pairs to be set for batch inserts
      *
      * @param mixed $key
-     * @param bool  $escape
      *
      * @return $this|null
      */
@@ -1871,11 +1679,7 @@ class BaseBuilder
     }
 
     /**
-     * Get INSERT query string
-     *
      * Compiles an insert query and returns the sql
-     *
-     * @param bool $reset TRUE: reset QB values; FALSE: leave QB values alone
      *
      * @throws DatabaseException
      *
@@ -1888,12 +1692,7 @@ class BaseBuilder
         }
 
         $sql = $this->_insert(
-            $this->db->protectIdentifiers(
-                $this->QBFrom[0],
-                true,
-                null,
-                false
-            ),
+            $this->db->protectIdentifiers($this->QBFrom[0], true, null, false),
             array_keys($this->QBSet),
             array_values($this->QBSet)
         );
@@ -1906,12 +1705,7 @@ class BaseBuilder
     }
 
     /**
-     * Insert
-     *
      * Compiles an insert string and runs the query
-     *
-     * @param array $set    An associative array of insert values
-     * @param bool  $escape Whether to escape values and identifiers
      *
      * @throws DatabaseException
      *
@@ -1928,12 +1722,7 @@ class BaseBuilder
         }
 
         $sql = $this->_insert(
-            $this->db->protectIdentifiers(
-                $this->QBFrom[0],
-                true,
-                $escape,
-                false
-            ),
+            $this->db->protectIdentifiers($this->QBFrom[0], true, $escape, false),
             array_keys($this->QBSet),
             array_values($this->QBSet)
         );
@@ -1953,8 +1742,6 @@ class BaseBuilder
     }
 
     /**
-     * Validate Insert
-     *
      * This method is used by both insert() and getCompiledInsert() to
      * validate that the there data is actually being set and that table
      * has been chosen to be inserted into.
@@ -1967,22 +1754,15 @@ class BaseBuilder
             if (CI_DEBUG) {
                 throw new DatabaseException('You must use the "set" method to update an entry.');
             }
-            // @codeCoverageIgnoreStart
-            return false;
-            // @codeCoverageIgnoreEnd
+
+            return false; // @codeCoverageIgnore
         }
 
         return true;
     }
 
     /**
-     * Insert statement
-     *
      * Generates a platform-specific insert string from the supplied data
-     *
-     * @param string $table         The table name
-     * @param array  $keys          The insert keys
-     * @param array  $unescapedKeys The insert values
      */
     protected function _insert(string $table, array $keys, array $unescapedKeys): string
     {
@@ -1990,11 +1770,7 @@ class BaseBuilder
     }
 
     /**
-     * Replace
-     *
      * Compiles an replace into string and runs the query
-     *
-     * @param array $set An associative array of insert values
      *
      * @throws DatabaseException
      *
@@ -2010,9 +1786,8 @@ class BaseBuilder
             if (CI_DEBUG) {
                 throw new DatabaseException('You must use the "set" method to update an entry.');
             }
-            // @codeCoverageIgnoreStart
-            return false;
-            // @codeCoverageIgnoreEnd
+
+            return false; // @codeCoverageIgnore
         }
 
         $table = $this->QBFrom[0];
@@ -2025,13 +1800,7 @@ class BaseBuilder
     }
 
     /**
-     * Replace statement
-     *
      * Generates a platform-specific replace string from the supplied data
-     *
-     * @param string $table  The table name
-     * @param array  $keys   The insert keys
-     * @param array  $values The insert values
      */
     protected function _replace(string $table, array $keys, array $values): string
     {
@@ -2039,8 +1808,6 @@ class BaseBuilder
     }
 
     /**
-     * FROM tables
-     *
      * Groups tables in FROM clauses if needed, so there is no confusion
      * about operator precedence.
      *
@@ -2052,11 +1819,7 @@ class BaseBuilder
     }
 
     /**
-     * Get UPDATE query string
-     *
      * Compiles an update query and returns the sql
-     *
-     * @param bool $reset TRUE: reset QB values; FALSE: leave QB values alone
      *
      * @return bool|string
      */
@@ -2076,17 +1839,11 @@ class BaseBuilder
     }
 
     /**
-     * UPDATE
-     *
      * Compiles an update string and runs the query.
      *
-     * @param array $set   An associative array of update values
      * @param mixed $where
-     * @param int   $limit
      *
      * @throws DatabaseException
-     *
-     * @return bool TRUE on success, FALSE on failure
      */
     public function update(?array $set = null, $where = null, ?int $limit = null): bool
     {
@@ -2131,12 +1888,7 @@ class BaseBuilder
     }
 
     /**
-     * Update statement
-     *
      * Generates a platform-specific update string from the supplied data
-     *
-     * @param string $table  the Table name
-     * @param array  $values the Update data
      */
     protected function _update(string $table, array $values): string
     {
@@ -2147,14 +1899,12 @@ class BaseBuilder
         }
 
         return 'UPDATE ' . $this->compileIgnore('update') . $table . ' SET ' . implode(', ', $valStr)
-                . $this->compileWhereHaving('QBWhere')
-                . $this->compileOrderBy()
-                . ($this->QBLimit ? $this->_limit(' ', true) : '');
+            . $this->compileWhereHaving('QBWhere')
+            . $this->compileOrderBy()
+            . ($this->QBLimit ? $this->_limit(' ', true) : '');
     }
 
     /**
-     * Validate Update
-     *
      * This method is used by both update() and getCompiledUpdate() to
      * validate that data is actually being set and that a table has been
      * chosen to be update.
@@ -2167,22 +1917,15 @@ class BaseBuilder
             if (CI_DEBUG) {
                 throw new DatabaseException('You must use the "set" method to update an entry.');
             }
-            // @codeCoverageIgnoreStart
-            return false;
-            // @codeCoverageIgnoreEnd
+
+            return false; // @codeCoverageIgnore
         }
 
         return true;
     }
 
     /**
-     * Update_Batch
-     *
      * Compiles an update string and runs the query
-     *
-     * @param array  $set       An associative array of update values
-     * @param string $index     The where key
-     * @param int    $batchSize The size of the batch to run
      *
      * @throws DatabaseException
      *
@@ -2194,9 +1937,8 @@ class BaseBuilder
             if (CI_DEBUG) {
                 throw new DatabaseException('You must specify an index to match on for batch updates.');
             }
-            // @codeCoverageIgnoreStart
-            return false;
-            // @codeCoverageIgnoreEnd
+
+            return false; // @codeCoverageIgnore
         }
 
         if ($set === null) {
@@ -2204,18 +1946,16 @@ class BaseBuilder
                 if (CI_DEBUG) {
                     throw new DatabaseException('You must use the "set" method to update an entry.');
                 }
-                // @codeCoverageIgnoreStart
-                return false;
-                // @codeCoverageIgnoreEnd
+
+                return false; // @codeCoverageIgnore
             }
         } else {
             if (empty($set)) {
                 if (CI_DEBUG) {
                     throw new DatabaseException('updateBatch() called with no data');
                 }
-                // @codeCoverageIgnoreStart
-                return false;
-                // @codeCoverageIgnoreEnd
+
+                return false; // @codeCoverageIgnore
             }
 
             $this->setUpdateBatch($set, $index);
@@ -2223,7 +1963,6 @@ class BaseBuilder
 
         $table = $this->QBFrom[0];
 
-        // Batch this baby
         $affectedRows = 0;
         $savedSQL     = [];
         $savedQBWhere = $this->QBWhere;
@@ -2251,13 +1990,7 @@ class BaseBuilder
     }
 
     /**
-     * Update_Batch statement
-     *
      * Generates a platform-specific batch update string from the supplied data
-     *
-     * @param string $table  Table name
-     * @param array  $values Update data
-     * @param string $index  WHERE key
      */
     protected function _updateBatch(string $table, array $values, string $index): string
     {
@@ -2278,8 +2011,8 @@ class BaseBuilder
 
         foreach ($final as $k => $v) {
             $cases .= $k . " = CASE \n"
-                    . implode("\n", $v) . "\n"
-                    . 'ELSE ' . $k . ' END, ';
+                . implode("\n", $v) . "\n"
+                . 'ELSE ' . $k . ' END, ';
         }
 
         $this->where($index . ' IN(' . implode(',', $ids) . ')', null, false);
@@ -2288,10 +2021,9 @@ class BaseBuilder
     }
 
     /**
-     * The "setUpdateBatch" function.  Allows key/value pairs to be set for batch updating
+     * Allows key/value pairs to be set for batch updating
      *
      * @param array|object $key
-     * @param bool         $escape
      *
      * @throws DatabaseException
      *
@@ -2334,8 +2066,6 @@ class BaseBuilder
     }
 
     /**
-     * Empty Table
-     *
      * Compiles a delete string and runs "DELETE FROM table"
      *
      * @return bool|string TRUE on success, FALSE on failure, string on testMode
@@ -2356,8 +2086,6 @@ class BaseBuilder
     }
 
     /**
-     * Truncate
-     *
      * Compiles a truncate string and runs the query
      * If the database does not support the truncate() command
      * This function maps to "DELETE FROM table"
@@ -2380,14 +2108,10 @@ class BaseBuilder
     }
 
     /**
-     * Truncate statement
-     *
      * Generates a platform-specific truncate string from the supplied data
      *
      * If the database does not support the truncate() command,
      * then this method maps to 'DELETE FROM table'
-     *
-     * @param string $table The table name
      */
     protected function _truncate(string $table): string
     {
@@ -2395,11 +2119,7 @@ class BaseBuilder
     }
 
     /**
-     * Get DELETE query string
-     *
      * Compiles a delete query string and returns the sql
-     *
-     * @param bool $reset TRUE: reset QB values; FALSE: leave QB values alone
      */
     public function getCompiledDelete(bool $reset = true): string
     {
@@ -2410,12 +2130,9 @@ class BaseBuilder
     }
 
     /**
-     * Delete
-     *
      * Compiles a delete string and runs the query
      *
-     * @param mixed $where The where clause
-     * @param int   $limit The limit clause
+     * @param mixed $where
      *
      * @throws DatabaseException
      *
@@ -2433,9 +2150,8 @@ class BaseBuilder
             if (CI_DEBUG) {
                 throw new DatabaseException('Deletes are not allowed unless they contain a "where" or "like" clause.');
             }
-            // @codeCoverageIgnoreStart
-            return false;
-            // @codeCoverageIgnoreEnd
+
+            return false; // @codeCoverageIgnore
         }
 
         $sql = $this->_delete($table);
@@ -2488,11 +2204,7 @@ class BaseBuilder
     }
 
     /**
-     * Delete statement
-     *
      * Generates a platform-specific delete string from the supplied data
-     *
-     * @param string $table The table name
      */
     protected function _delete(string $table): string
     {
@@ -2500,8 +2212,6 @@ class BaseBuilder
     }
 
     /**
-     * Track Aliases
-     *
      * Used to track SQL statements written with aliased tables.
      *
      * @param array|string $table The table to inspect
@@ -2547,7 +2257,6 @@ class BaseBuilder
      */
     protected function compileSelect($selectOverride = false): string
     {
-        // Write the "select" portion of the query
         if ($selectOverride !== false) {
             $sql = $selectOverride;
         } else {
@@ -2568,21 +2277,19 @@ class BaseBuilder
             }
         }
 
-        // Write the "FROM" portion of the query
         if (! empty($this->QBFrom)) {
             $sql .= "\nFROM " . $this->_fromTables();
         }
 
-        // Write the "JOIN" portion of the query
         if (! empty($this->QBJoin)) {
             $sql .= "\n" . implode("\n", $this->QBJoin);
         }
 
         $sql .= $this->compileWhereHaving('QBWhere')
-                . $this->compileGroupBy()
-                . $this->compileWhereHaving('QBHaving')
-                . $this->compileOrderBy(); // ORDER BY
-        // LIMIT
+            . $this->compileGroupBy()
+            . $this->compileWhereHaving('QBHaving')
+            . $this->compileOrderBy();
+
         if ($this->QBLimit) {
             return $this->_limit($sql . "\n");
         }
@@ -2591,8 +2298,6 @@ class BaseBuilder
     }
 
     /**
-     * Compile Ignore Statement
-     *
      * Checks if the ignore option is supported by
      * the Database Driver for the specific statement.
      *
@@ -2600,9 +2305,7 @@ class BaseBuilder
      */
     protected function compileIgnore(string $statement)
     {
-        if ($this->QBIgnore
-            && isset($this->supportedIgnoreStatements[$statement])
-        ) {
+        if ($this->QBIgnore && isset($this->supportedIgnoreStatements[$statement])) {
             return trim($this->supportedIgnoreStatements[$statement]) . ' ';
         }
 
@@ -2610,8 +2313,6 @@ class BaseBuilder
     }
 
     /**
-     * Compile WHERE, HAVING statements
-     *
      * Escapes identifiers in WHERE and HAVING statements at execution time.
      *
      * Required so that aliases are tracked properly, regardless of whether
@@ -2647,7 +2348,7 @@ class BaseBuilder
 
                 foreach ($conditions as &$condition) {
                     if (($op = $this->getOperator($condition)) === false
-                            || ! preg_match('/^(\(?)(.*)(' . preg_quote($op, '/') . ')\s*(.*(?<!\)))?(\)?)$/i', $condition, $matches)
+                        || ! preg_match('/^(\(?)(.*)(' . preg_quote($op, '/') . ')\s*(.*(?<!\)))?(\)?)$/i', $condition, $matches)
                     ) {
                         continue;
                     }
@@ -2674,29 +2375,25 @@ class BaseBuilder
                     }
 
                     $condition = $matches[1] . $this->db->protectIdentifiers(trim($matches[2]))
-                            . ' ' . trim($matches[3]) . $matches[4] . $matches[5];
+                        . ' ' . trim($matches[3]) . $matches[4] . $matches[5];
                 }
 
                 $qbkey = implode('', $conditions);
             }
 
             return ($qbKey === 'QBHaving' ? "\nHAVING " : "\nWHERE ")
-                    . implode("\n", $this->{$qbKey});
+                . implode("\n", $this->{$qbKey});
         }
 
         return '';
     }
 
     /**
-     * Compile GROUP BY
-     *
      * Escapes identifiers in GROUP BY statements at execution time.
      *
      * Required so that aliases are tracked properly, regardless of whether
      * groupBy() is called prior to from(), join() and prefixTable is added
      * only if needed.
-     *
-     * @return string SQL statement
      */
     protected function compileGroupBy(): string
     {
@@ -2719,15 +2416,11 @@ class BaseBuilder
     }
 
     /**
-     * Compile ORDER BY
-     *
      * Escapes identifiers in ORDER BY statements at execution time.
      *
      * Required so that aliases are tracked properly, regardless of whether
      * orderBy() is called prior to from(), join() and prefixTable is added
      * only if needed.
-     *
-     * @return string SQL statement
      */
     protected function compileOrderBy(): string
     {
@@ -2751,13 +2444,11 @@ class BaseBuilder
     }
 
     /**
-     * Object to Array
-     *
      * Takes an object as input and converts the class variables to array key/vals
      *
-     * @param mixed $object
+     * @param object $object
      *
-     * @return mixed
+     * @return array
      */
     protected function objectToArray($object)
     {
@@ -2778,13 +2469,11 @@ class BaseBuilder
     }
 
     /**
-     * Object to Array
-     *
      * Takes an object as input and converts the class variables to array key/vals
      *
-     * @param mixed $object
+     * @param object $object
      *
-     * @return mixed
+     * @return array
      */
     protected function batchObjectToArray($object)
     {
@@ -2811,8 +2500,6 @@ class BaseBuilder
     }
 
     /**
-     * Is literal
-     *
      * Determines if a string represents a literal value or a field name
      */
     protected function isLiteral(string $str): bool
@@ -2837,8 +2524,6 @@ class BaseBuilder
     }
 
     /**
-     * Reset Query Builder values.
-     *
      * Publicly-visible method to reset the QB values.
      *
      * @return $this
@@ -2855,8 +2540,6 @@ class BaseBuilder
      * Resets the query builder values.  Called by the get() function
      *
      * @param array $qbResetItems An array of fields to reset
-     *
-     * @return void
      */
     protected function resetRun(array $qbResetItems)
     {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -17,7 +17,33 @@ use CodeIgniter\Events\Events;
 use Throwable;
 
 /**
- * Class BaseConnection
+ * @property array      $aliasedTables
+ * @property string     $charset
+ * @property bool       $compress
+ * @property float      $connectDuration
+ * @property float      $connectTime
+ * @property string     $database
+ * @property string     $DBCollat
+ * @property bool       $DBDebug
+ * @property string     $DBDriver
+ * @property string     $DBPrefix
+ * @property string     $DSN
+ * @property mixed      $encrypt
+ * @property array      $failover
+ * @property string     $hostname
+ * @property mixed      $lastQuery
+ * @property string     $password
+ * @property bool       $pConnect
+ * @property int|string $port
+ * @property bool       $pretend
+ * @property string     $queryClass
+ * @property array      $reservedIdentifiers
+ * @property bool       $strictOn
+ * @property string     $subdriver
+ * @property string     $swapPre
+ * @property int        $transDepth
+ * @property bool       $transFailure
+ * @property bool       $transStatus
  */
 abstract class BaseConnection implements ConnectionInterface
 {
@@ -316,7 +342,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * @throws DatabaseException
      *
-     * @return mixed|void
+     * @return mixed
      */
     public function initialize()
     {
@@ -391,8 +417,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Close the database connection.
-     *
-     * @return void
      */
     public function close()
     {
@@ -643,8 +667,6 @@ abstract class BaseConnection implements ConnectionInterface
      * Disable Transactions
      *
      * This permits transactions to be disabled at run-time.
-     *
-     * @return void
      */
     public function transOff()
     {
@@ -704,7 +726,6 @@ abstract class BaseConnection implements ConnectionInterface
                 $this->transStatus = true;
             }
 
-            //            log_message('debug', 'DB Transaction Failure');
             return false;
         }
 
@@ -840,8 +861,6 @@ abstract class BaseConnection implements ConnectionInterface
      *                     ->get();
      *           })
      *
-     * @param array $options Passed to the prepare() method
-     *
      * @return BasePreparedQuery|null
      */
     public function prepare(Closure $func, array $options = [])
@@ -862,9 +881,7 @@ abstract class BaseConnection implements ConnectionInterface
         }
 
         $class = str_ireplace('Connection', 'PreparedQuery', static::class);
-        /**
-         * @var BasePreparedQuery $class
-         */
+        /** @var BasePreparedQuery $class */
         $class = new $class($this);
 
         return $class->prepare($sql, $options);
@@ -931,7 +948,6 @@ abstract class BaseConnection implements ConnectionInterface
      * the correct identifiers.
      *
      * @param array|string $item
-     * @param bool         $protectIdentifiers
      *
      * @return array|string
      */
@@ -1131,8 +1147,6 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Prepends a database prefix if one exists in configuration
      *
-     * @param string $table the table
-     *
      * @throws DatabaseException
      */
     public function prefixTable(string $table = ''): string
@@ -1280,8 +1294,6 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns an array of table names
      *
-     * @param bool $constrainByPrefix = FALSE
-     *
      * @throws DatabaseException
      *
      * @return array|bool
@@ -1304,7 +1316,8 @@ abstract class BaseConnection implements ConnectionInterface
         }
 
         $this->dataCache['table_names'] = [];
-        $query                          = $this->query($sql);
+
+        $query = $this->query($sql);
 
         foreach ($query->getResultArray() as $row) {
             // Do we know from which column to get the table name?
@@ -1341,8 +1354,6 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Fetch Field Names
      *
-     * @param string $table Table name
-     *
      * @throws DatabaseException
      *
      * @return array|false
@@ -1366,7 +1377,8 @@ abstract class BaseConnection implements ConnectionInterface
             return false;
         }
 
-        $query                                  = $this->query($sql);
+        $query = $this->query($sql);
+
         $this->dataCache['field_names'][$table] = [];
 
         foreach ($query->getResultArray() as $row) {
@@ -1399,8 +1411,6 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns an object with field data
      *
-     * @param string $table the table name
-     *
      * @return array
      */
     public function getFieldData(string $table)
@@ -1411,8 +1421,6 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns an object with key data
      *
-     * @param string $table the table name
-     *
      * @return array
      */
     public function getIndexData(string $table)
@@ -1422,8 +1430,6 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Returns an object with foreign key data
-     *
-     * @param string $table the table name
      *
      * @return array
      */

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -55,9 +55,6 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
      */
     protected $db;
 
-    /**
-     * Constructor.
-     */
     public function __construct(BaseConnection $db)
     {
         $this->db = &$db;
@@ -70,8 +67,6 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
      * NOTE: This version is based on SQL code. Child classes should
      * override this method.
      *
-     * @param array $options Passed to the connection's prepare statement.
-     *
      * @return mixed
      */
     public function prepare(string $sql, array $options = [], string $queryClass = 'CodeIgniter\\Database\\Query')
@@ -81,9 +76,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
         // need to replace our named placeholders (:name)
         $sql = preg_replace('/:[^\s,)]+/', '?', $sql);
 
-        /**
-         * @var Query $query
-         */
+        /** @var Query $query */
         $query = new $queryClass($this->db);
 
         $query->setQuery($sql);
@@ -100,8 +93,6 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
     /**
      * The database-dependent portion of the prepare statement.
      *
-     * @param array $options Passed to the connection's prepare statement.
-     *
      * @return mixed
      */
     abstract public function _prepare(string $sql, array $options = []);
@@ -109,8 +100,6 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
     /**
      * Takes a new set of data and runs it against the currently
      * prepared query. Upon success, will return a Results object.
-     *
-     * @param array $data
      *
      * @return ResultInterface
      */
@@ -152,8 +141,6 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 
     /**
      * Explicitly closes the statement.
-     *
-     * @return void
      */
     public function close()
     {

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -109,8 +109,6 @@ abstract class BaseResult implements ResultInterface
     /**
      * Returns the results as an array of custom objects.
      *
-     * @param string $className The name of the class to use.
-     *
      * @return mixed
      */
     public function getCustomResultObject(string $className)
@@ -484,8 +482,6 @@ abstract class BaseResult implements ResultInterface
 
     /**
      * Frees the current result.
-     *
-     * @return void
      */
     abstract public function freeResult();
 

--- a/system/Database/BaseUtils.php
+++ b/system/Database/BaseUtils.php
@@ -195,11 +195,6 @@ abstract class BaseUtils
     /**
      * Generate CSV from a query result object
      *
-     * @param ResultInterface $query     Query result object
-     * @param string          $delim     Delimiter (default: ,)
-     * @param string          $newline   Newline character (default: \n)
-     * @param string          $enclosure Enclosure (default: ")
-     *
      * @return string
      */
     public function getCSVFromResult(ResultInterface $query, string $delim = ',', string $newline = "\n", string $enclosure = '"')
@@ -228,28 +223,21 @@ abstract class BaseUtils
 
     /**
      * Generate XML data from a query result object
-     *
-     * @param ResultInterface $query  Query result object
-     * @param array           $params Any preferences
      */
     public function getXMLFromResult(ResultInterface $query, array $params = []): string
     {
-        // Set our default values
         foreach (['root' => 'root', 'element' => 'element', 'newline' => "\n", 'tab' => "\t"] as $key => $val) {
             if (! isset($params[$key])) {
                 $params[$key] = $val;
             }
         }
 
-        // Create variables for convenience
         $root    = $params['root'];
         $newline = $params['newline'];
         $tab     = $params['tab'];
         $element = $params['element'];
 
-        // Load the xml helper
         helper('xml');
-        // Generate the result
         $xml = '<' . $root . '>' . $newline;
 
         while ($row = $query->getUnbufferedRow()) {
@@ -278,14 +266,10 @@ abstract class BaseUtils
      */
     public function backup($params = [])
     {
-        // If the parameters have not been submitted as an
-        // array then we know that it is simply the table
-        // name, which is a valid short cut.
         if (is_string($params)) {
             $params = ['tables' => $params];
         }
 
-        // Set up our default preferences
         $prefs = [
             'tables'             => [],
             'ignore'             => [],
@@ -297,7 +281,6 @@ abstract class BaseUtils
             'foreign_key_checks' => true,
         ];
 
-        // Did the user submit any preferences? If so set them....
         if (! empty($params)) {
             foreach (array_keys($prefs) as $key) {
                 if (isset($params[$key])) {
@@ -306,19 +289,14 @@ abstract class BaseUtils
             }
         }
 
-        // Are we backing up a complete database or individual tables?
-        // If no table names were submitted we'll fetch the entire table list
         if (empty($prefs['tables'])) {
             $prefs['tables'] = $this->db->listTables();
         }
 
-        // Validate the format
         if (! in_array($prefs['format'], ['gzip', 'txt'], true)) {
             $prefs['format'] = 'txt';
         }
 
-        // Is the encoder supported? If not, we'll either issue an
-        // error or use plain text depending on the debug settings
         if ($prefs['format'] === 'gzip' && ! function_exists('gzencode')) {
             if ($this->db->DBDebug) {
                 throw new DatabaseException('The file compression format you chose is not supported by your server.');
@@ -327,7 +305,7 @@ abstract class BaseUtils
             $prefs['format'] = 'txt';
         }
 
-        if ($prefs['format'] === 'txt') { // Was a text file requested?
+        if ($prefs['format'] === 'txt') {
             return $this->_backup($prefs);
         }
 

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -38,8 +38,7 @@ class Config extends BaseConfig
     /**
      * Creates the default
      *
-     * @param array|string $group     The name of the connection group to use,
-     *                                or an array of configuration settings.
+     * @param array|string $group     The name of the connection group to use, or an array of configuration settings.
      * @param bool         $getShared Whether to return a shared instance of the connection.
      *
      * @return BaseConnection

--- a/system/Database/Database.php
+++ b/system/Database/Database.php
@@ -38,8 +38,6 @@ class Database
      * @throws InvalidArgumentException
      *
      * @return mixed
-     *
-     * @internal param bool $useBuilder
      */
     public function load(array $params = [], string $alias = '')
     {
@@ -47,17 +45,14 @@ class Database
             throw new InvalidArgumentException('You must supply the parameter: alias.');
         }
 
-        // Handle universal DSN connection string
         if (! empty($params['DSN']) && strpos($params['DSN'], '://') !== false) {
             $params = $this->parseDSN($params);
         }
 
-        // No DB specified? Beat them senseless...
         if (empty($params['DBDriver'])) {
             throw new InvalidArgumentException('You have not selected a database type to connect to.');
         }
 
-        // Store the connection
         $this->connections[$alias] = $this->initDriver($params['DBDriver'], 'Connection', $params);
 
         return $this->connections[$alias];
@@ -68,7 +63,6 @@ class Database
      */
     public function loadForge(ConnectionInterface $db): object
     {
-        // Initialize database connection if not exists.
         if (! $db->connID) {
             $db->initialize();
         }
@@ -81,7 +75,6 @@ class Database
      */
     public function loadUtils(ConnectionInterface $db): object
     {
-        // Initialize database connection if not exists.
         if (! $db->connID) {
             $db->initialize();
         }
@@ -112,7 +105,6 @@ class Database
             'database' => isset($dsn['path']) ? rawurldecode(substr($dsn['path'], 1)) : '',
         ];
 
-        // Do we have additional config items set?
         if (! empty($dsn['query'])) {
             parse_str($dsn['query'], $extra);
 
@@ -131,8 +123,6 @@ class Database
     /**
      * Initialize database driver.
      *
-     * @param string       $driver   Database driver name (e.g. 'MySQLi')
-     * @param string       $class    Database class name (e.g. 'Forge')
      * @param array|object $argument
      */
     protected function initDriver(string $driver, string $class, $argument): object

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -220,7 +220,6 @@ class Forge
 
             return true;
         } catch (Throwable $e) {
-            // @phpstan-ignore-next-line
             if ($this->db->DBDebug) {
                 throw new DatabaseException('Unable to create the specified database.', 0, $e);
             }
@@ -387,11 +386,6 @@ class Forge
     }
 
     /**
-     * Foreign Key Drop
-     *
-     * @param string $table       Table name
-     * @param string $foreignName Foreign name
-     *
      * @throws DatabaseException
      *
      * @return BaseResult|bool|false|mixed|Query
@@ -416,12 +410,6 @@ class Forge
     }
 
     /**
-     * Create Table
-     *
-     * @param string $table       Table name
-     * @param bool   $ifNotExists Whether to add IF NOT EXISTS condition
-     * @param array  $attributes  Associative array of table attributes
-     *
      * @throws DatabaseException
      *
      * @return mixed
@@ -470,12 +458,6 @@ class Forge
     }
 
     /**
-     * Create Table
-     *
-     * @param string $table       Table name
-     * @param bool   $ifNotExists Whether to add 'IF NOT EXISTS' condition
-     * @param array  $attributes  Associative array of table attributes
-     *
      * @return mixed
      */
     protected function _createTable(string $table, bool $ifNotExists, array $attributes)
@@ -504,7 +486,6 @@ class Forge
         $columns .= $this->_processPrimaryKeys($table);
         $columns .= $this->_processForeignKeys($table);
 
-        // Are indexes created from within the CREATE TABLE statement? (e.g. in MySQL)
         if ($this->createTableKeys === true) {
             $indexes = $this->_processIndexes($table);
             if (is_string($indexes)) {
@@ -512,7 +493,6 @@ class Forge
             }
         }
 
-        // createTableStr will usually have the following format: "%s %s (%s\n)"
         return sprintf(
             $this->createTableStr . '%s',
             $sql,
@@ -522,11 +502,6 @@ class Forge
         );
     }
 
-    /**
-     * CREATE TABLE attributes
-     *
-     * @param array $attributes Associative array of table attributes
-     */
     protected function _createTableAttributes(array $attributes): string
     {
         $sql = '';
@@ -541,12 +516,6 @@ class Forge
     }
 
     /**
-     * Drop Table
-     *
-     * @param string $tableName Table name
-     * @param bool   $ifExists  Whether to add an IF EXISTS condition
-     * @param bool   $cascade   Whether to add an CASCADE condition
-     *
      * @throws DatabaseException
      *
      * @return mixed
@@ -561,7 +530,6 @@ class Forge
             return false;
         }
 
-        // If the prefix is already starting the table name, remove it...
         if ($this->db->DBPrefix && strpos($tableName, $this->db->DBPrefix) === 0) {
             $tableName = substr($tableName, strlen($this->db->DBPrefix));
         }
@@ -576,7 +544,6 @@ class Forge
 
         $this->db->enableForeignKeyChecks();
 
-        // Update table list cache
         if ($query && ! empty($this->db->dataCache['table_names'])) {
             $key = array_search(
                 strtolower($this->db->DBPrefix . $tableName),
@@ -593,13 +560,7 @@ class Forge
     }
 
     /**
-     * Drop Table
-     *
      * Generates a platform-specific DROP TABLE string
-     *
-     * @param string $table    Table name
-     * @param bool   $ifExists Whether to add an IF EXISTS condition
-     * @param bool   $cascade  Whether to add an CASCADE condition
      *
      * @return bool|string
      */
@@ -621,11 +582,6 @@ class Forge
     }
 
     /**
-     * Rename Table
-     *
-     * @param string $tableName    Old table name
-     * @param string $newTableName New table name
-     *
      * @throws DatabaseException
      *
      * @return mixed
@@ -666,10 +622,7 @@ class Forge
     }
 
     /**
-     * Column Add
-     *
-     * @param string       $table Table name
-     * @param array|string $field Column definition
+     * @param array|string $field
      *
      * @throws DatabaseException
      */
@@ -704,10 +657,7 @@ class Forge
     }
 
     /**
-     * Column Drop
-     *
-     * @param string       $table      Table name
-     * @param array|string $columnName Column name Array or comma separated
+     * @param array|string $columnName
      *
      * @throws DatabaseException
      *
@@ -728,10 +678,7 @@ class Forge
     }
 
     /**
-     * Column Modify
-     *
-     * @param string       $table Table name
-     * @param array|string $field Column definition
+     * @param array|string $field
      *
      * @throws DatabaseException
      */
@@ -772,11 +719,7 @@ class Forge
     }
 
     /**
-     * ALTER TABLE
-     *
-     * @param string $alterType ALTER type
-     * @param string $table     Table name
-     * @param mixed  $fields    Column definition
+     * @param mixed $fields
      *
      * @return false|string|string[]
      */
@@ -899,20 +842,16 @@ class Forge
     protected function _processColumn(array $field): string
     {
         return $this->db->escapeIdentifiers($field['name'])
-               . ' ' . $field['type'] . $field['length']
-               . $field['unsigned']
-               . $field['default']
-               . $field['null']
-               . $field['auto_increment']
-               . $field['unique'];
+            . ' ' . $field['type'] . $field['length']
+            . $field['unsigned']
+            . $field['default']
+            . $field['null']
+            . $field['auto_increment']
+            . $field['unique'];
     }
 
     /**
-     * Field attribute TYPE
-     *
      * Performs a data type mapping between different databases.
-     *
-     * @return void
      */
     protected function _attributeType(array &$attributes)
     {
@@ -920,8 +859,6 @@ class Forge
     }
 
     /**
-     * Field attribute UNSIGNED
-     *
      * Depending on the unsigned property value:
      *
      *    - TRUE will always set $field['unsigned'] to 'UNSIGNED'
@@ -930,8 +867,6 @@ class Forge
      *        if $attributes['TYPE'] is found in the array
      *    - array(TYPE => UTYPE) will change $field['type'],
      *        from TYPE to UTYPE in case of a match
-     *
-     * @return void|null
      */
     protected function _attributeUnsigned(array &$attributes, array &$field)
     {
@@ -963,11 +898,6 @@ class Forge
         $field['unsigned'] = ($this->unsigned === true) ? ' UNSIGNED' : '';
     }
 
-    /**
-     * Field attribute DEFAULT
-     *
-     * @return void|null
-     */
     protected function _attributeDefault(array &$attributes, array &$field)
     {
         if ($this->default === false) {
@@ -987,11 +917,6 @@ class Forge
         }
     }
 
-    /**
-     * Field attribute UNIQUE
-     *
-     * @return void
-     */
     protected function _attributeUnique(array &$attributes, array &$field)
     {
         if (! empty($attributes['UNIQUE']) && $attributes['UNIQUE'] === true) {
@@ -999,11 +924,6 @@ class Forge
         }
     }
 
-    /**
-     * Field attribute AUTO_INCREMENT
-     *
-     * @return void
-     */
     protected function _attributeAutoIncrement(array &$attributes, array &$field)
     {
         if (! empty($attributes['AUTO_INCREMENT']) && $attributes['AUTO_INCREMENT'] === true
@@ -1013,11 +933,6 @@ class Forge
         }
     }
 
-    /**
-     * Process primary keys
-     *
-     * @param string $table Table name
-     */
     protected function _processPrimaryKeys(string $table): string
     {
         $sql = '';
@@ -1036,11 +951,6 @@ class Forge
         return $sql;
     }
 
-    /**
-     * Process indexes
-     *
-     * @return array|string
-     */
     protected function _processIndexes(string $table)
     {
         $sqls = [];
@@ -1053,31 +963,27 @@ class Forge
                     unset($this->keys[$i][$i2]);
                 }
             }
+
             if (count($this->keys[$i]) <= 0) {
                 continue;
             }
 
             if (in_array($i, $this->uniqueKeys, true)) {
                 $sqls[] = 'ALTER TABLE ' . $this->db->escapeIdentifiers($table)
-                          . ' ADD CONSTRAINT ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
-                          . ' UNIQUE (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
+                    . ' ADD CONSTRAINT ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
+                    . ' UNIQUE (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
 
                 continue;
             }
 
             $sqls[] = 'CREATE INDEX ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
-                      . ' ON ' . $this->db->escapeIdentifiers($table)
-                      . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
+                . ' ON ' . $this->db->escapeIdentifiers($table)
+                . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
         }
 
         return $sqls;
     }
 
-    /**
-     * Process foreign keys
-     *
-     * @param string $table Table name
-     */
     protected function _processForeignKeys(string $table): string
     {
         $sql = '';
@@ -1111,11 +1017,7 @@ class Forge
     }
 
     /**
-     * Reset
-     *
      * Resets table creation vars
-     *
-     * @return void
      */
     public function reset()
     {

--- a/system/Database/ModelFactory.php
+++ b/system/Database/ModelFactory.php
@@ -25,11 +25,7 @@ class ModelFactory
     /**
      * Creates new Model instances or returns a shared instance
      *
-     * @param string              $name       Model name, namespace optional
-     * @param bool                $getShared  Use shared instance
-     * @param ConnectionInterface $connection
-     *
-     * @return mixed|null
+     * @return mixed
      */
     public static function get(string $name, bool $getShared = true, ?ConnectionInterface $connection = null)
     {

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -209,8 +209,6 @@ class Connection extends BaseConnection
     /**
      * Keep or establish the connection if no queries have been sent for
      * a length of time exceeding the server's idle timeout.
-     *
-     * @return void
      */
     public function reconnect()
     {
@@ -220,8 +218,6 @@ class Connection extends BaseConnection
 
     /**
      * Close the database connection.
-     *
-     * @return void
      */
     protected function _close()
     {
@@ -294,11 +290,7 @@ class Connection extends BaseConnection
     }
 
     /**
-     * Prep the query
-     *
-     * If needed, each database adapter can prep the query string
-     *
-     * @param string $sql an SQL query
+     * Prep the query. If needed, each database adapter can prep the query string
      */
     protected function prepQuery(string $sql): string
     {
@@ -534,7 +526,7 @@ class Connection extends BaseConnection
      * Must return this format: ['code' => string|int, 'message' => string]
      * intval(code) === 0 means "no error".
      *
-     * @return array<string,int|string>
+     * @return array<string, int|string>
      */
     public function error(): array
     {

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -99,8 +99,6 @@ class Result extends BaseResult
 
     /**
      * Frees the current result.
-     *
-     * @return void
      */
     public function freeResult()
     {
@@ -152,8 +150,6 @@ class Result extends BaseResult
 
     /**
      * Returns the number of rows in the resultID (i.e., mysqli_result object)
-     *
-     * @return int number of rows in a query result
      */
     public function getNumRows(): int
     {

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -61,7 +61,6 @@ class Builder extends BaseBuilder
      * ORDER BY
      *
      * @param string $direction ASC, DESC or RANDOM
-     * @param bool   $escape
      *
      * @return BaseBuilder
      */
@@ -118,8 +117,6 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Replace
-     *
      * Compiles an replace into string and runs the query.
      * Because PostgreSQL doesn't support the replace into command,
      * we simply do a DELETE and an INSERT on the first key/value
@@ -143,9 +140,8 @@ class Builder extends BaseBuilder
             if (CI_DEBUG) {
                 throw new DatabaseException('You must use the "set" method to update an entry.');
             }
-            // @codeCoverageIgnoreStart
-            return false;
-            // @codeCoverageIgnoreEnd
+
+            return false; // @codeCoverageIgnore
         }
 
         $table = $this->QBFrom[0];
@@ -170,13 +166,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Insert statement
-     *
      * Generates a platform-specific insert string from the supplied data
-     *
-     * @param string $table         The table name
-     * @param array  $keys          The insert keys
-     * @param array  $unescapedKeys The insert values
      */
     protected function _insert(string $table, array $keys, array $unescapedKeys): string
     {
@@ -184,13 +174,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Insert batch statement
-     *
      * Generates a platform-specific insert string from the supplied data.
-     *
-     * @param string $table  Table name
-     * @param array  $keys   INSERT keys
-     * @param array  $values INSERT values
      */
     protected function _insertBatch(string $table, array $keys, array $values): string
     {
@@ -198,20 +182,13 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Delete
-     *
      * Compiles a delete string and runs the query
      *
      * @param mixed $where
-     * @param int   $limit
      *
      * @throws DatabaseException
      *
      * @return mixed
-     *
-     * @internal param $bool
-     * @internal param the $mixed limit clause
-     * @internal param the $mixed where clause
      */
     public function delete($where = '', ?int $limit = null, bool $resetData = true)
     {
@@ -223,11 +200,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * LIMIT string
-     *
      * Generates a platform-specific LIMIT clause.
-     *
-     * @param string $sql SQL Query
      */
     protected function _limit(string $sql, bool $offsetIgnore = false): string
     {
@@ -235,14 +208,9 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Update statement
-     *
      * Generates a platform-specific update string from the supplied data
      *
      * @throws DatabaseException
-     *
-     * @internal param the $array update data
-     * @internal param the $string table name
      */
     protected function _update(string $table, array $values): string
     {
@@ -256,13 +224,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Update_Batch statement
-     *
      * Generates a platform-specific batch update string from the supplied data
-     *
-     * @param string $table  Table name
-     * @param array  $values Update data
-     * @param string $index  WHERE key
      */
     protected function _updateBatch(string $table, array $values, string $index): string
     {
@@ -295,11 +257,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Delete statement
-     *
      * Generates a platform-specific delete string from the supplied data
-     *
-     * @param string $table The table name
      */
     protected function _delete(string $table): string
     {
@@ -309,14 +267,10 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Truncate statement
-     *
      * Generates a platform-specific truncate string from the supplied data
      *
      * If the database does not support the truncate() command,
      * then this method maps to 'DELETE FROM table'
-     *
-     * @param string $table The table name
      */
     protected function _truncate(string $table): string
     {
@@ -330,8 +284,6 @@ class Builder extends BaseBuilder
      * searches according to the current locale.
      *
      * @see https://www.postgresql.org/docs/9.2/static/functions-matching.html
-     *
-     * @return string $like_statement
      */
     protected function _like_statement(?string $prefix, string $column, ?string $not, string $bind, bool $insensitiveSearch = false): string
     {
@@ -341,13 +293,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * JOIN
-     *
      * Generates the JOIN portion of the query
-     *
-     * @param string $cond   The join condition
-     * @param string $type   The type of join
-     * @param bool   $escape Whether not to try to escape identifiers
      *
      * @return BaseBuilder
      */

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -84,8 +84,6 @@ class Connection extends BaseConnection
     /**
      * Keep or establish the connection if no queries have been sent for
      * a length of time exceeding the server's idle timeout.
-     *
-     * @return void
      */
     public function reconnect()
     {
@@ -96,8 +94,6 @@ class Connection extends BaseConnection
 
     /**
      * Close the database connection.
-     *
-     * @return void
      */
     protected function _close()
     {
@@ -203,8 +199,8 @@ class Connection extends BaseConnection
 
         if ($prefixLimit !== false && $this->DBPrefix !== '') {
             return $sql . ' AND "table_name" LIKE \''
-                    . $this->escapeLikeString($this->DBPrefix) . "%' "
-                    . sprintf($this->likeEscapeStr, $this->likeEscapeChar);
+                . $this->escapeLikeString($this->DBPrefix) . "%' "
+                . sprintf($this->likeEscapeStr, $this->likeEscapeChar);
         }
 
         return $sql;
@@ -365,7 +361,7 @@ class Connection extends BaseConnection
      * Must return this format: ['code' => string|int, 'message' => string]
      * intval(code) === 0 means "no error".
      *
-     * @return array<string,int|string>
+     * @return array<string, int|string>
      */
     public function error(): array
     {
@@ -376,8 +372,6 @@ class Connection extends BaseConnection
     }
 
     /**
-     * Insert ID
-     *
      * @return int|string
      */
     public function insertID()
@@ -415,8 +409,6 @@ class Connection extends BaseConnection
 
     /**
      * Build a DSN from the provided parameters
-     *
-     * @return void
      */
     protected function buildDSN()
     {
@@ -467,8 +459,6 @@ class Connection extends BaseConnection
 
     /**
      * Set client encoding
-     *
-     * @param string $charset The client encoding to which the data will be converted.
      */
     protected function setClientEncoding(string $charset): bool
     {
@@ -504,7 +494,7 @@ class Connection extends BaseConnection
      *
      * Overrides BaseConnection::isWriteType, adding additional read query types.
      *
-     * @param string $sql An SQL query string
+     * @param mixed $sql
      */
     public function isWriteType($sql): bool
     {

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -69,11 +69,7 @@ class Forge extends BaseForge
     }
 
     /**
-     * ALTER TABLE
-     *
-     * @param string $alterType ALTER type
-     * @param string $table     Table name
-     * @param mixed  $field     Column definition
+     * @param mixed $field
      *
      * @return array|bool|string
      */
@@ -93,28 +89,28 @@ class Forge extends BaseForge
 
             if (version_compare($this->db->getVersion(), '8', '>=') && isset($data['type'])) {
                 $sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
-                        . " TYPE {$data['type']}{$data['length']}";
+                    . " TYPE {$data['type']}{$data['length']}";
             }
 
             if (! empty($data['default'])) {
                 $sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
-                        . " SET DEFAULT {$data['default']}";
+                    . " SET DEFAULT {$data['default']}";
             }
 
             if (isset($data['null'])) {
                 $sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
-                        . ($data['null'] === true ? ' DROP' : ' SET') . ' NOT NULL';
+                    . ($data['null'] === true ? ' DROP' : ' SET') . ' NOT NULL';
             }
 
             if (! empty($data['new_name'])) {
                 $sqls[] = $sql . ' RENAME COLUMN ' . $this->db->escapeIdentifiers($data['name'])
-                        . ' TO ' . $this->db->escapeIdentifiers($data['new_name']);
+                    . ' TO ' . $this->db->escapeIdentifiers($data['new_name']);
             }
 
             if (! empty($data['comment'])) {
                 $sqls[] = 'COMMENT ON COLUMN' . $this->db->escapeIdentifiers($table)
-                        . '.' . $this->db->escapeIdentifiers($data['name'])
-                        . " IS {$data['comment']}";
+                    . '.' . $this->db->escapeIdentifiers($data['name'])
+                    . " IS {$data['comment']}";
             }
         }
 
@@ -127,19 +123,15 @@ class Forge extends BaseForge
     protected function _processColumn(array $field): string
     {
         return $this->db->escapeIdentifiers($field['name'])
-                . ' ' . $field['type'] . $field['length']
-                . $field['default']
-                . $field['null']
-                . $field['auto_increment']
-                . $field['unique'];
+            . ' ' . $field['type'] . $field['length']
+            . $field['default']
+            . $field['null']
+            . $field['auto_increment']
+            . $field['unique'];
     }
 
     /**
-     * Field attribute TYPE
-     *
      * Performs a data type mapping between different databases.
-     *
-     * @return void
      */
     protected function _attributeType(array &$attributes)
     {
@@ -170,8 +162,6 @@ class Forge extends BaseForge
 
     /**
      * Field attribute AUTO_INCREMENT
-     *
-     * @return void
      */
     protected function _attributeAutoIncrement(array &$attributes, array &$field)
     {
@@ -181,12 +171,7 @@ class Forge extends BaseForge
     }
 
     /**
-     * Drop Table
-     *
      * Generates a platform-specific DROP TABLE string
-     *
-     * @param string $table    Table name
-     * @param bool   $ifExists Whether to add an IF EXISTS condition
      */
     protected function _dropTable(string $table, bool $ifExists, bool $cascade): string
     {

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -65,8 +65,6 @@ class Result extends BaseResult
 
     /**
      * Frees the current result.
-     *
-     * @return void
      */
     public function freeResult()
     {
@@ -118,8 +116,6 @@ class Result extends BaseResult
 
     /**
      * Returns the number of rows in the resultID (i.e., PostgreSQL query result resource)
-     *
-     * @return int The number of rows in the query result
      */
     public function getNumRows(): int
     {

--- a/system/Database/PreparedQueryInterface.php
+++ b/system/Database/PreparedQueryInterface.php
@@ -20,8 +20,6 @@ interface PreparedQueryInterface
      * Takes a new set of data and runs it against the currently
      * prepared query. Upon success, will return a Results object.
      *
-     * @param array $data
-     *
      * @return ResultInterface
      */
     public function execute(...$data);
@@ -29,8 +27,6 @@ interface PreparedQueryInterface
     /**
      * Prepares the query against the database, and saves the connection
      * info necessary to execute the query later.
-     *
-     * @param array $options Passed to the connection's prepare statement.
      *
      * @return mixed
      */

--- a/system/Database/QueryInterface.php
+++ b/system/Database/QueryInterface.php
@@ -41,8 +41,6 @@ interface QueryInterface
      * for it's start and end values. If no end value is present, will
      * use the current time to determine total duration.
      *
-     * @param float $end
-     *
      * @return mixed
      */
     public function setDuration(float $start, ?float $end = null);

--- a/system/Database/ResultInterface.php
+++ b/system/Database/ResultInterface.php
@@ -92,7 +92,7 @@ interface ResultInterface
      * Assigns an item into a particular column slot.
      *
      * @param string $key
-     * @param null   $value
+     * @param mixed  $value
      *
      * @return mixed
      */
@@ -150,8 +150,6 @@ interface ResultInterface
 
     /**
      * Frees the current result.
-     *
-     * @return void
      */
     public function freeResult();
 

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -61,8 +61,6 @@ class Builder extends BaseBuilder
     public $keyPermission = false;
 
     /**
-     * FROM tables
-     *
      * Groups tables in FROM clauses if needed, so there is no confusion
      * about operator precedence.
      */
@@ -78,14 +76,10 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Truncate statement
-     *
      * Generates a platform-specific truncate string from the supplied data
      *
      * If the database does not support the truncate() command,
      * then this method maps to 'DELETE FROM table'
-     *
-     * @param string $table The table name
      */
     protected function _truncate(string $table): string
     {
@@ -93,13 +87,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * JOIN
-     *
      * Generates the JOIN portion of the query
-     *
-     * @param string $cond   The join condition
-     * @param string $type   The type of join
-     * @param bool   $escape Whether not to try to escape identifiers
      *
      * @return $this
      */
@@ -169,16 +157,9 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Insert statement
-     *
      * Generates a platform-specific insert string from the supplied data
-     * auto-enable
      *
-     * @todo implement check for this instad static $insertKeyPermission
-     *
-     * @param string $table         The table name
-     * @param array  $keys          The insert keys
-     * @param array  $unescapedKeys The insert values
+     * @todo implement check for this instead static $insertKeyPermission
      */
     protected function _insert(string $table, array $keys, array $unescapedKeys): string
     {
@@ -191,12 +172,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Update statement
-     *
      * Generates a platform-specific update string from the supplied data
-     *
-     * @param string $table  the Table name
-     * @param array  $values the Update data
      */
     protected function _update(string $table, array $values): string
     {
@@ -209,7 +185,7 @@ class Builder extends BaseBuilder
         $fullTableName = $this->getFullName($table);
 
         $statement = 'UPDATE ' . (empty($this->QBLimit) ? '' : 'TOP(' . $this->QBLimit . ') ') . $fullTableName . ' SET '
-                . implode(', ', $valstr) . $this->compileWhereHaving('QBWhere') . $this->compileOrderBy();
+            . implode(', ', $valstr) . $this->compileWhereHaving('QBWhere') . $this->compileOrderBy();
 
         return $this->keyPermission ? $this->addIdentity($fullTableName, $statement) : $statement;
     }
@@ -274,9 +250,6 @@ class Builder extends BaseBuilder
 
     /**
      * Add permision statements for index value inserts
-     *
-     * @param string $fullTable full table name
-     * @param string $insert    statement
      */
     private function addIdentity(string $fullTable, string $insert): string
     {
@@ -302,11 +275,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Replace
-     *
      * Compiles a replace into string and runs the query
-     *
-     * @param array|null $set An associative array of insert values
      *
      * @throws DatabaseException
      *
@@ -344,15 +313,8 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Replace statement
-     *
      * Generates a platform-specific replace string from the supplied data
-     *
      * on match delete and insert
-     *
-     * @param string $table  The table name
-     * @param array  $keys   The insert keys
-     * @param array  $values The insert values
      */
     protected function _replace(string $table, array $keys, array $values): string
     {
@@ -420,8 +382,6 @@ class Builder extends BaseBuilder
      *
      * Handle float return value
      *
-     * @param string $select Field name
-     *
      * @return BaseBuilder
      */
     protected function maxMinAvgSum(string $select = '', string $alias = '', string $type = 'MAX')
@@ -453,8 +413,6 @@ class Builder extends BaseBuilder
 
     /**
      * Delete statement
-     *
-     * @param string $table The table name
      */
     protected function _delete(string $table): string
     {
@@ -462,12 +420,9 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Delete
-     *
      * Compiles a delete string and runs the query
      *
-     * @param mixed $where The where clause
-     * @param int   $limit The limit clause
+     * @param mixed $where
      *
      * @throws DatabaseException
      *
@@ -507,7 +462,7 @@ class Builder extends BaseBuilder
      *
      * Generates a query string based on which functions were used.
      *
-     * @param mixed $selectOverride
+     * @param bool $selectOverride
      */
     protected function compileSelect($selectOverride = false): string
     {
@@ -564,10 +519,8 @@ class Builder extends BaseBuilder
     /**
      * WHERE, HAVING
      *
-     * @param string $qbKey  'QBWhere' or 'QBHaving'
-     * @param mixed  $key
-     * @param mixed  $value
-     * @param bool   $escape
+     * @param mixed $key
+     * @param mixed $value
      *
      * @return $this
      */
@@ -631,14 +584,8 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Get
-     *
      * Compiles the select statement based on the other functions called
      * and runs the query
-     *
-     * @param int  $limit  The limit clause
-     * @param int  $offset The offset clause
-     * @param bool $reset  Are we want to clear query builder values?
      *
      * @return ResultInterface
      */

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -82,12 +82,8 @@ class Connection extends BaseConnection
 
     /**
      * Class constructor
-     *
-     * @param array $params
-     *
-     * @return void
      */
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
 
@@ -150,8 +146,6 @@ class Connection extends BaseConnection
     /**
      * Keep or establish the connection if no queries have been sent for
      * a length of time exceeding the server's idle timeout.
-     *
-     * @return void
      */
     public function reconnect()
     {
@@ -161,8 +155,6 @@ class Connection extends BaseConnection
 
     /**
      * Close the database connection.
-     *
-     * @return void
      */
     protected function _close()
     {
@@ -191,13 +183,13 @@ class Connection extends BaseConnection
     protected function _listTables(bool $prefixLimit = false): string
     {
         $sql = 'SELECT [TABLE_NAME] AS "name"'
-                . ' FROM [INFORMATION_SCHEMA].[TABLES] '
-                . ' WHERE '
-                . " [TABLE_SCHEMA] = '" . $this->schema . "'    ";
+            . ' FROM [INFORMATION_SCHEMA].[TABLES] '
+            . ' WHERE '
+            . " [TABLE_SCHEMA] = '" . $this->schema . "'    ";
 
         if ($prefixLimit === true && $this->DBPrefix !== '') {
             $sql .= " AND [TABLE_NAME] LIKE '" . $this->escapeLikeString($this->DBPrefix) . "%' "
-                    . sprintf($this->likeEscapeStr, $this->likeEscapeChar);
+                . sprintf($this->likeEscapeStr, $this->likeEscapeChar);
         }
 
         return $sql;
@@ -209,9 +201,9 @@ class Connection extends BaseConnection
     protected function _listColumns(string $table = ''): string
     {
         return 'SELECT [COLUMN_NAME] '
-                . ' FROM [INFORMATION_SCHEMA].[COLUMNS]'
-                . ' WHERE  [TABLE_NAME] = ' . $this->escape($this->DBPrefix . $table)
-                . ' AND [TABLE_SCHEMA] = ' . $this->escape($this->schema);
+            . ' FROM [INFORMATION_SCHEMA].[COLUMNS]'
+            . ' WHERE  [TABLE_NAME] = ' . $this->escape($this->DBPrefix . $table)
+            . ' AND [TABLE_SCHEMA] = ' . $this->escape($this->schema);
     }
 
     /**
@@ -264,27 +256,27 @@ class Connection extends BaseConnection
     protected function _foreignKeyData(string $table): array
     {
         $sql = 'SELECT '
-                . 'f.name as constraint_name, '
-                . 'OBJECT_NAME (f.parent_object_id) as table_name, '
-                . 'COL_NAME(fc.parent_object_id,fc.parent_column_id) column_name, '
-                . 'OBJECT_NAME(f.referenced_object_id) foreign_table_name, '
-                . 'COL_NAME(fc.referenced_object_id,fc.referenced_column_id) foreign_column_name '
-                . 'FROM  '
-                . 'sys.foreign_keys AS f '
-                . 'INNER JOIN  '
-                . 'sys.foreign_key_columns AS fc  '
-                . 'ON f.OBJECT_ID = fc.constraint_object_id '
-                . 'INNER JOIN  '
-                . 'sys.tables t  '
-                . 'ON t.OBJECT_ID = fc.referenced_object_id '
-                . 'WHERE  '
-                . 'OBJECT_NAME (f.parent_object_id) = ' . $this->escape($table);
+            . 'f.name as constraint_name, '
+            . 'OBJECT_NAME (f.parent_object_id) as table_name, '
+            . 'COL_NAME(fc.parent_object_id,fc.parent_column_id) column_name, '
+            . 'OBJECT_NAME(f.referenced_object_id) foreign_table_name, '
+            . 'COL_NAME(fc.referenced_object_id,fc.referenced_column_id) foreign_column_name '
+            . 'FROM  '
+            . 'sys.foreign_keys AS f '
+            . 'INNER JOIN  '
+            . 'sys.foreign_key_columns AS fc  '
+            . 'ON f.OBJECT_ID = fc.constraint_object_id '
+            . 'INNER JOIN  '
+            . 'sys.tables t  '
+            . 'ON t.OBJECT_ID = fc.referenced_object_id '
+            . 'WHERE  '
+            . 'OBJECT_NAME (f.parent_object_id) = ' . $this->escape($table);
 
         if (($query = $this->query($sql)) === false) {
             throw new DatabaseException(lang('Database.failGetForeignKeyData'));
         }
-        $query = $query->getResultObject();
 
+        $query  = $query->getResultObject();
         $retVal = [];
 
         foreach ($query as $row) {
@@ -386,7 +378,7 @@ class Connection extends BaseConnection
      * Must return this format: ['code' => string|int, 'message' => string]
      * intval(code) === 0 means "no error".
      *
-     * @return array<string,int|string>
+     * @return array<string, int|string>
      */
     public function error(): array
     {
@@ -532,7 +524,7 @@ class Connection extends BaseConnection
      *
      * Overrides BaseConnection::isWriteType, adding additional read query types.
      *
-     * @param string $sql An SQL query string
+     * @param mixed $sql
      */
     public function isWriteType($sql): bool
     {

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -98,8 +98,6 @@ class Forge extends BaseForge
 
     /**
      * CREATE TABLE attributes
-     *
-     * @param array $attributes Associative array of table attributes
      */
     protected function _createTableAttributes(array $attributes): string
     {
@@ -107,11 +105,7 @@ class Forge extends BaseForge
     }
 
     /**
-     * ALTER TABLE
-     *
-     * @param string $alterType ALTER type
-     * @param string $table     Table name
-     * @param mixed  $field     Column definition
+     * @param mixed $field
      *
      * @return false|string|string[]
      */
@@ -159,29 +153,28 @@ class Forge extends BaseForge
 
             if (isset($data['type'])) {
                 $sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
-                        . " {$data['type']}{$data['length']}";
+                    . " {$data['type']}{$data['length']}";
             }
 
             if (! empty($data['default'])) {
                 $sqls[] = $sql . ' ALTER COLUMN ADD CONSTRAINT ' . $this->db->escapeIdentifiers($data['name']) . '_def'
-                        . " DEFAULT {$data['default']} FOR " . $this->db->escapeIdentifiers($data['name']);
+                    . " DEFAULT {$data['default']} FOR " . $this->db->escapeIdentifiers($data['name']);
             }
 
             if (isset($data['null'])) {
                 $sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
-                        . ($data['null'] === true ? ' DROP' : '') . " {$data['type']}{$data['length']} NOT NULL";
+                    . ($data['null'] === true ? ' DROP' : '') . " {$data['type']}{$data['length']} NOT NULL";
             }
 
             if (! empty($data['comment'])) {
                 $sqls[] = 'EXEC sys.sp_addextendedproperty '
-                        . "@name=N'Caption', @value=N'" . $data['comment'] . "' , "
-                        . "@level0type=N'SCHEMA',@level0name=N'" . $this->db->schema . "', "
-                        . "@level1type=N'TABLE',@level1name=N'" . $this->db->escapeIdentifiers($table) . "', "
-                        . "@level2type=N'COLUMN',@level2name=N'" . $this->db->escapeIdentifiers($data['name']) . "'";
+                    . "@name=N'Caption', @value=N'" . $data['comment'] . "' , "
+                    . "@level0type=N'SCHEMA',@level0name=N'" . $this->db->schema . "', "
+                    . "@level1type=N'TABLE',@level1name=N'" . $this->db->escapeIdentifiers($table) . "', "
+                    . "@level2type=N'COLUMN',@level2name=N'" . $this->db->escapeIdentifiers($data['name']) . "'";
             }
 
             if (! empty($data['new_name'])) {
-                // EXEC sp_rename '[dbo].[db_misc].[value]', 'valueasdasd', 'COLUMN';
                 $sqls[] = "EXEC sp_rename  '[" . $this->db->schema . '].[' . $table . '].[' . $data['name'] . "]' , '" . $data['new_name'] . "', 'COLUMN';";
             }
         }
@@ -211,13 +204,13 @@ class Forge extends BaseForge
     protected function _processColumn(array $field): string
     {
         return $this->db->escapeIdentifiers($field['name'])
-                . (empty($field['new_name']) ? '' : ' ' . $this->db->escapeIdentifiers($field['new_name']))
-                . ' ' . $field['type'] . $field['length']
-                . $field['default']
-                . $field['null']
-                . $field['auto_increment']
-                . '' // (empty($field['comment']) ? '' : ' COMMENT ' . $field['comment'])
-                . $field['unique'];
+            . (empty($field['new_name']) ? '' : ' ' . $this->db->escapeIdentifiers($field['new_name']))
+            . ' ' . $field['type'] . $field['length']
+            . $field['default']
+            . $field['null']
+            . $field['auto_increment']
+            . ''
+            . $field['unique'];
     }
 
     /**
@@ -229,21 +222,15 @@ class Forge extends BaseForge
     {
         $sql = '';
 
-        $allowActions = [
-            'CASCADE',
-            'SET NULL',
-            'NO ACTION',
-            'RESTRICT',
-            'SET DEFAULT',
-        ];
+        $allowActions = ['CASCADE', 'SET NULL', 'NO ACTION', 'RESTRICT', 'SET DEFAULT'];
 
         if ($this->foreignKeys !== []) {
             foreach ($this->foreignKeys as $field => $fkey) {
                 $nameIndex = $table . '_' . $field . '_foreign';
 
                 $sql .= ",\n\t CONSTRAINT " . $this->db->escapeIdentifiers($nameIndex)
-                        . ' FOREIGN KEY (' . $this->db->escapeIdentifiers($field) . ') '
-                        . ' REFERENCES ' . $this->db->escapeIdentifiers($this->db->getPrefix() . $fkey['table']) . ' (' . $this->db->escapeIdentifiers($fkey['field']) . ')';
+                    . ' FOREIGN KEY (' . $this->db->escapeIdentifiers($field) . ') '
+                    . ' REFERENCES ' . $this->db->escapeIdentifiers($this->db->getPrefix() . $fkey['table']) . ' (' . $this->db->escapeIdentifiers($fkey['field']) . ')';
 
                 if ($fkey['onDelete'] !== false && in_array($fkey['onDelete'], $allowActions, true)) {
                     $sql .= ' ON DELETE ' . $fkey['onDelete'];
@@ -273,18 +260,14 @@ class Forge extends BaseForge
 
         if ($this->primaryKeys !== []) {
             $sql = ",\n\tCONSTRAINT " . $this->db->escapeIdentifiers('pk_' . $table)
-                    . ' PRIMARY KEY(' . implode(', ', $this->db->escapeIdentifiers($this->primaryKeys)) . ')';
+                . ' PRIMARY KEY(' . implode(', ', $this->db->escapeIdentifiers($this->primaryKeys)) . ')';
         }
 
         return $sql ?? '';
     }
 
     /**
-     * Field attribute TYPE
-     *
      * Performs a data type mapping between different databases.
-     *
-     * @return void
      */
     protected function _attributeType(array &$attributes)
     {
@@ -301,17 +284,13 @@ class Forge extends BaseForge
 
             case 'INTEGER':
                 $attributes['TYPE'] = 'INT';
-
                 break;
 
             case 'ENUM':
                 $attributes['TYPE']       = 'TEXT';
                 $attributes['CONSTRAINT'] = null;
-
                 break;
-            /* case 'DATETIME':
-              $attributes['TYPE'] = 'TIMESTAMP';
-              break; */
+
             case 'TIMESTAMP':
                 $attributes['TYPE'] = 'DATETIME';
                 break;
@@ -323,8 +302,6 @@ class Forge extends BaseForge
 
     /**
      * Field attribute AUTO_INCREMENT
-     *
-     * @return void
      */
     protected function _attributeAutoIncrement(array &$attributes, array &$field)
     {
@@ -334,14 +311,9 @@ class Forge extends BaseForge
     }
 
     /**
-     * Drop Table
-     *
      * Generates a platform-specific DROP TABLE string
      *
      * @todo Support for cascade
-     *
-     * @param string $table    Table name
-     * @param bool   $ifExists Whether to add an IF EXISTS condition
      */
     protected function _dropTable(string $table, bool $ifExists, bool $cascade): string
     {

--- a/system/Database/SQLSRV/Result.php
+++ b/system/Database/SQLSRV/Result.php
@@ -101,8 +101,6 @@ class Result extends BaseResult
 
     /**
      * Frees the current result.
-     *
-     * @return void
      */
     public function freeResult()
     {
@@ -147,8 +145,6 @@ class Result extends BaseResult
     /**
      * Returns the result set as an object.
      *
-     * Overridden by child classes.
-     *
      * @return bool|Entity|object
      */
     protected function fetchObject(string $className = 'stdClass')
@@ -162,8 +158,6 @@ class Result extends BaseResult
 
     /**
      * Returns the number of rows in the resultID (i.e., SQLSRV query result resource)
-     *
-     * @return int Returns the number of rows retrieved on success
      */
     public function getNumRows(): int
     {

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -54,10 +54,6 @@ class Builder extends BaseBuilder
      * Replace statement
      *
      * Generates a platform-specific replace string from the supplied data
-     *
-     * @param string $table  the table name
-     * @param array  $keys   the insert keys
-     * @param array  $values the insert values
      */
     protected function _replace(string $table, array $keys, array $values): string
     {
@@ -65,8 +61,6 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Truncate statement
-     *
      * Generates a platform-specific truncate string from the supplied data
      *
      * If the database does not support the TRUNCATE statement,

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -66,8 +66,6 @@ class Connection extends BaseConnection
     /**
      * Keep or establish the connection if no queries have been sent for
      * a length of time exceeding the server's idle timeout.
-     *
-     * @return void
      */
     public function reconnect()
     {
@@ -77,8 +75,6 @@ class Connection extends BaseConnection
 
     /**
      * Close the database connection.
-     *
-     * @return void
      */
     protected function _close()
     {
@@ -165,10 +161,6 @@ class Connection extends BaseConnection
     }
 
     /**
-     * Fetch Field Names
-     *
-     * @param string $table Table name
-     *
      * @throws DatabaseException
      *
      * @return array|false
@@ -349,7 +341,7 @@ class Connection extends BaseConnection
      * Must return this format: ['code' => string|int, 'message' => string]
      * intval(code) === 0 means "no error".
      *
-     * @return array<string,int|string>
+     * @return array<string, int|string>
      */
     public function error(): array
     {

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -21,6 +21,11 @@ use CodeIgniter\Database\Forge as BaseForge;
 class Forge extends BaseForge
 {
     /**
+     * @var Connection
+     */
+    protected $db;
+
+    /**
      * UNSIGNED support
      *
      * @var array|bool
@@ -98,11 +103,7 @@ class Forge extends BaseForge
     }
 
     /**
-     * ALTER TABLE
-     *
-     * @param string $alterType ALTER type
-     * @param string $table     Table name
-     * @param mixed  $field     Column definition
+     * @param mixed $field
      *
      * @return array|string|null
      */
@@ -142,11 +143,11 @@ class Forge extends BaseForge
         }
 
         return $this->db->escapeIdentifiers($field['name'])
-               . ' ' . $field['type']
-               . $field['auto_increment']
-               . $field['null']
-               . $field['unique']
-               . $field['default'];
+            . ' ' . $field['type']
+            . $field['auto_increment']
+            . $field['null']
+            . $field['unique']
+            . $field['default'];
     }
 
     /**
@@ -170,15 +171,15 @@ class Forge extends BaseForge
 
             if (in_array($i, $this->uniqueKeys, true)) {
                 $sqls[] = 'CREATE UNIQUE INDEX ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
-                          . ' ON ' . $this->db->escapeIdentifiers($table)
-                          . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
+                    . ' ON ' . $this->db->escapeIdentifiers($table)
+                    . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
 
                 continue;
             }
 
             $sqls[] = 'CREATE INDEX ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
-                      . ' ON ' . $this->db->escapeIdentifiers($table)
-                      . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
+                . ' ON ' . $this->db->escapeIdentifiers($table)
+                . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
         }
 
         return $sqls;
@@ -188,8 +189,6 @@ class Forge extends BaseForge
      * Field attribute TYPE
      *
      * Performs a data type mapping between different databases.
-     *
-     * @return void
      */
     protected function _attributeType(array &$attributes)
     {
@@ -206,8 +205,6 @@ class Forge extends BaseForge
 
     /**
      * Field attribute AUTO_INCREMENT
-     *
-     * @return void
      */
     protected function _attributeAutoIncrement(array &$attributes, array &$field)
     {
@@ -225,9 +222,6 @@ class Forge extends BaseForge
 
     /**
      * Foreign Key Drop
-     *
-     * @param string $table       Table name
-     * @param string $foreignName Foreign name
      *
      * @throws DatabaseException
      */

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -36,7 +36,7 @@ class PreparedQuery extends BasePreparedQuery
      * @param array $options Passed to the connection's prepare statement.
      *                       Unused in the MySQLi driver.
      *
-     * @return mixed
+     * @return $this
      */
     public function _prepare(string $sql, array $options = [])
     {

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -76,8 +76,6 @@ class Result extends BaseResult
 
     /**
      * Frees the current result.
-     *
-     * @return void
      */
     public function freeResult()
     {

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -93,9 +93,8 @@ class Table
     {
         $this->prefixedTableName = $table;
 
-        // Remove the prefix, if any, since it's
-        // already been added by the time we get here...
-        $prefix = $this->db->DBPrefix; // @phpstan-ignore-line
+        $prefix = $this->db->DBPrefix;
+
         if (! empty($prefix) && strpos($table, $prefix) === 0) {
             $table = substr($table, strlen($prefix));
         }
@@ -155,8 +154,6 @@ class Table
      */
     public function dropColumn($columns)
     {
-        //unset($this->fields[$column]);
-
         if (is_string($columns)) {
             $columns = explode(',', $columns);
         }
@@ -261,8 +258,6 @@ class Table
             }
         }
 
-        // Foreign Keys
-
         return $this->forge->createTable($this->tableName);
     }
 
@@ -270,8 +265,6 @@ class Table
      * Copies data from our old table to the new one,
      * taking care map data correctly based on any columns
      * that have been renamed.
-     *
-     * @return void
      */
     protected function copyData()
     {
@@ -286,7 +279,6 @@ class Table
         $exFields  = implode(', ', $exFields);
         $newFields = implode(', ', $newFields);
 
-        // @phpstan-ignore-next-line
         $this->db->query("INSERT INTO {$this->prefixedTableName}({$newFields}) SELECT {$exFields} FROM {$this->db->DBPrefix}temp_{$this->tableName}");
     }
 
@@ -353,8 +345,6 @@ class Table
     /**
      * Attempts to drop all indexes and constraints
      * from the database for this table.
-     *
-     * @return void|null
      */
     protected function dropIndexes()
     {

--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -112,8 +112,6 @@ class Seeder
      * Loads the specified seeder and runs it.
      *
      * @throws InvalidArgumentException
-     *
-     * @return void
      */
     public function call(string $class)
     {
@@ -140,9 +138,7 @@ class Seeder
             // @codeCoverageIgnoreEnd
         }
 
-        /**
-         * @var Seeder
-         */
+        /** @var Seeder $seeder */
         $seeder = new $class($this->config);
         $seeder->setSilent($this->silent)->run();
 

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -27,8 +27,6 @@ use Config\Toolbar as ToolbarConfig;
 use Kint\Kint;
 
 /**
- * Debug Toolbar
- *
  * Displays a toolbar with bits of stats to aid a developer in debugging.
  *
  * Inspiration: http://prophiler.fabfuel.de
@@ -49,9 +47,6 @@ class Toolbar
      */
     protected $collectors = [];
 
-    /**
-     * Constructor
-     */
     public function __construct(ToolbarConfig $config)
     {
         $this->config = $config;
@@ -261,8 +256,6 @@ class Toolbar
      * @param ResponseInterface $response
      *
      * @global \CodeIgniter\CodeIgniter $app
-     *
-     * @return void
      */
     public function prepare(?RequestInterface $request = null, ?ResponseInterface $response = null)
     {
@@ -321,13 +314,13 @@ class Toolbar
             $kintScript         = substr($kintScript, 0, strpos($kintScript, '</style>') + 8);
 
             $script = PHP_EOL
-                    . '<script type="text/javascript" {csp-script-nonce} id="debugbar_loader" '
-                    . 'data-time="' . $time . '" '
-                    . 'src="' . site_url() . '?debugbar"></script>'
-                    . '<script type="text/javascript" {csp-script-nonce} id="debugbar_dynamic_script"></script>'
-                    . '<style type="text/css" {csp-style-nonce} id="debugbar_dynamic_style"></style>'
-                    . $kintScript
-                    . PHP_EOL;
+                . '<script type="text/javascript" {csp-script-nonce} id="debugbar_loader" '
+                . 'data-time="' . $time . '" '
+                . 'src="' . site_url() . '?debugbar"></script>'
+                . '<script type="text/javascript" {csp-script-nonce} id="debugbar_dynamic_script"></script>'
+                . '<style type="text/css" {csp-style-nonce} id="debugbar_dynamic_style"></style>'
+                . $kintScript
+                . PHP_EOL;
 
             if (strpos($response->getBody(), '<head>') !== false) {
                 $response->setBody(preg_replace('/<head>/', '<head>' . $script, $response->getBody(), 1));
@@ -397,9 +390,6 @@ class Toolbar
 
     /**
      * Format output
-     *
-     * @param string $data   JSON encoded Toolbar data
-     * @param string $format html, json, xml
      */
     protected function format(string $data, string $format = 'html'): string
     {

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -337,8 +337,6 @@ class Email
     ];
 
     /**
-     * Base charsets
-     *
      * Character sets valid for 7-bit encoding,
      * excluding language suffix.
      *
@@ -386,10 +384,6 @@ class Email
     protected static $func_overload;
 
     /**
-     * Constructor - Sets Email Preferences
-     *
-     * The constructor can be passed an array of config values
-     *
      * @param array|null $config
      */
     public function __construct($config = null)
@@ -434,8 +428,6 @@ class Email
     }
 
     /**
-     * Initialize the Email Data
-     *
      * @param bool $clearAttachments
      *
      * @return Email
@@ -463,8 +455,6 @@ class Email
     }
 
     /**
-     * Set FROM
-     *
      * @param string      $from
      * @param string      $name
      * @param string|null $returnPath Return-Path
@@ -485,15 +475,12 @@ class Email
             }
         }
 
-        // Store the plain text values
         $this->tmpArchive['fromEmail'] = $from;
         $this->tmpArchive['fromName']  = $name;
 
-        // prepare the display name
         if ($name !== '') {
             // only use Q encoding if there are characters that would require it
             if (! preg_match('/[\200-\377]/', $name)) {
-                // add slashes for non-printing characters, slashes, and double quotes, and surround it in double quotes
                 $name = '"' . addcslashes($name, "\0..\37\177'\"\\") . '"';
             } else {
                 $name = $this->prepQEncoding($name);
@@ -511,8 +498,6 @@ class Email
     }
 
     /**
-     * Set Reply-to
-     *
      * @param string $replyto
      * @param string $name
      *
@@ -533,7 +518,6 @@ class Email
 
             // only use Q encoding if there are characters that would require it
             if (! preg_match('/[\200-\377]/', $name)) {
-                // add slashes for non-printing characters, slashes, and double quotes, and surround it in double quotes
                 $name = '"' . addcslashes($name, "\0..\37\177'\"\\") . '"';
             } else {
                 $name = $this->prepQEncoding($name);
@@ -548,8 +532,6 @@ class Email
     }
 
     /**
-     * Set Recipients
-     *
      * @param array|string $to
      *
      * @return Email
@@ -573,8 +555,6 @@ class Email
     }
 
     /**
-     * Set CC
-     *
      * @param string $cc
      *
      * @return Email
@@ -599,8 +579,6 @@ class Email
     }
 
     /**
-     * Set BCC
-     *
      * @param string $bcc
      * @param string $limit
      *
@@ -630,8 +608,6 @@ class Email
     }
 
     /**
-     * Set Email Subject
-     *
      * @param string $subject
      *
      * @return Email
@@ -647,8 +623,6 @@ class Email
     }
 
     /**
-     * Set Body
-     *
      * @param string $body
      *
      * @return Email
@@ -661,8 +635,6 @@ class Email
     }
 
     /**
-     * Assign file attachments
-     *
      * @param string      $file        Can be local path, URL or buffered content
      * @param string      $disposition 'attachment'
      * @param string|null $newname
@@ -695,10 +667,7 @@ class Email
         }
 
         // declare names on their own, to make phpcbf happy
-        $namesAttached = [
-            $file,
-            $newname,
-        ];
+        $namesAttached = [$file, $newname];
 
         $this->attachments[] = [
             'name'        => $namesAttached,
@@ -714,7 +683,6 @@ class Email
 
     /**
      * Set and return attachment Content-ID
-     *
      * Useful for attached inline pictures
      *
      * @param string $filename
@@ -737,8 +705,6 @@ class Email
     }
 
     /**
-     * Add a Header Item
-     *
      * @param string $header
      * @param string $value
      *
@@ -752,8 +718,6 @@ class Email
     }
 
     /**
-     * Convert a String to an Array
-     *
      * @param string $email
      *
      * @return array
@@ -768,8 +732,6 @@ class Email
     }
 
     /**
-     * Set Multipart Value
-     *
      * @param string $str
      *
      * @return Email
@@ -782,8 +744,6 @@ class Email
     }
 
     /**
-     * Set Mailtype
-     *
      * @param string $type
      *
      * @return Email
@@ -796,8 +756,6 @@ class Email
     }
 
     /**
-     * Set Wordwrap
-     *
      * @param bool $wordWrap
      *
      * @return Email
@@ -810,8 +768,6 @@ class Email
     }
 
     /**
-     * Set Protocol
-     *
      * @param string $protocol
      *
      * @return Email
@@ -824,8 +780,6 @@ class Email
     }
 
     /**
-     * Set Priority
-     *
      * @param int $n
      *
      * @return Email
@@ -838,8 +792,6 @@ class Email
     }
 
     /**
-     * Set Newline Character
-     *
      * @param string $newline
      *
      * @return Email
@@ -852,8 +804,6 @@ class Email
     }
 
     /**
-     * Set CRLF
-     *
      * @param string $CRLF
      *
      * @return Email
@@ -866,8 +816,6 @@ class Email
     }
 
     /**
-     * Get the Message ID
-     *
      * @return string
      */
     protected function getMessageID()
@@ -878,8 +826,6 @@ class Email
     }
 
     /**
-     * Get Mail Protocol
-     *
      * @return string
      */
     protected function getProtocol()
@@ -894,8 +840,6 @@ class Email
     }
 
     /**
-     * Get Mail Encoding
-     *
      * @return string
      */
     protected function getEncoding()
@@ -916,8 +860,6 @@ class Email
     }
 
     /**
-     * Get content type (text/html/attachment)
-     *
      * @return string
      */
     protected function getContentType()
@@ -949,8 +891,6 @@ class Email
     }
 
     /**
-     * Mime message
-     *
      * @return string
      */
     protected function getMimeMessage()
@@ -959,8 +899,6 @@ class Email
     }
 
     /**
-     * Validate Email Address
-     *
      * @param array|string $email
      *
      * @return bool
@@ -985,8 +923,6 @@ class Email
     }
 
     /**
-     * Email Validation
-     *
      * @param string $email
      *
      * @return bool
@@ -1002,8 +938,6 @@ class Email
     }
 
     /**
-     * Clean Extended Email Address: Joe Smith <joe@smith.com>
-     *
      * @param array|string $email
      *
      * @return array|string
@@ -1028,6 +962,7 @@ class Email
      *
      * Provides the raw message for use in plain-text headers of
      * HTML-formatted emails.
+     *
      * If the user hasn't specified his own alternative message
      * it creates one by stripping the HTML
      *
@@ -1046,15 +981,12 @@ class Email
             $body = str_replace(str_repeat("\n", $i), "\n\n", $body);
         }
 
-        // Reduce multiple spaces
         $body = preg_replace('| +|', ' ', $body);
 
         return ($this->wordWrap) ? $this->wordWrap($body, 76) : $body;
     }
 
     /**
-     * Word Wrap
-     *
      * @param string   $str
      * @param int|null $charlim Line-length limit
      *
@@ -1062,21 +994,16 @@ class Email
      */
     public function wordWrap($str, $charlim = null)
     {
-        // Set the character limit, if not already present
         if (empty($charlim)) {
             $charlim = empty($this->wrapChars) ? 76 : $this->wrapChars;
         }
 
-        // Standardize newlines
         if (strpos($str, "\r") !== false) {
             $str = str_replace(["\r\n", "\r"], "\n", $str);
         }
 
-        // Reduce multiple spaces at end of line
         $str = preg_replace('| +\n|', "\n", $str);
 
-        // If the current word is surrounded by {unwrap} tags we'll
-        // strip the entire chunk and replace it with a marker.
         $unwrap = [];
 
         if (preg_match_all('|\{unwrap\}(.+?)\{/unwrap\}|s', $str, $matches)) {
@@ -1095,8 +1022,6 @@ class Email
         $output = '';
 
         foreach (explode("\n", $str) as $line) {
-            // Is the line within the allowed character count?
-            // If so we'll join it to the output and continue
             if (static::strlen($line) <= $charlim) {
                 $output .= $line . $this->newline;
 
@@ -1106,18 +1031,14 @@ class Email
             $temp = '';
 
             do {
-                // If the over-length word is a URL we won't wrap it
                 if (preg_match('!\[url.+\]|://|www\.!', $line)) {
                     break;
                 }
 
-                // Trim the word down
                 $temp .= static::substr($line, 0, $charlim - 1);
                 $line = static::substr($line, $charlim - 1);
             } while (static::strlen($line) > $charlim);
 
-            // If $temp contains data it means we had to split up an over-length
-            // word into smaller chunks so we'll add it back to our current line
             if ($temp !== '') {
                 $output .= $temp . $this->newline;
             }
@@ -1125,7 +1046,6 @@ class Email
             $output .= $line . $this->newline;
         }
 
-        // Put our markers back
         if ($unwrap) {
             foreach ($unwrap as $key => $val) {
                 $output = str_replace('{{unwrapped' . $key . '}}', $val, $output);
@@ -1333,13 +1253,9 @@ class Email
     }
 
     /**
-     * Prepares attachment string
-     *
      * @param string      $body      Message body to append to
      * @param string      $boundary  Multipart boundary
      * @param string|null $multipart When provided, only attachments of this type will be processed
-     *
-     * @return void
      */
     protected function appendAttachments(&$body, $boundary, $multipart = null)
     {
@@ -1366,8 +1282,6 @@ class Email
     }
 
     /**
-     * Prep Quoted Printable
-     *
      * Prepares string for Quoted-Printable Content-Transfer-Encoding
      * Refer to RFC 2045 http://www.ietf.org/rfc/rfc2045.txt
      *
@@ -1531,8 +1445,6 @@ class Email
     }
 
     /**
-     * Prep Q Encoding
-     *
      * Performs "Q Encoding" on a string for use in email headers.
      * It's related but not identical to quoted-printable, so it has its
      * own method.
@@ -1600,8 +1512,6 @@ class Email
     }
 
     /**
-     * Send Email
-     *
      * @param bool $autoClear
      *
      * @return bool
@@ -1822,9 +1732,7 @@ class Email
 
         $from = $this->validateEmailForShell($from) ? '-f ' . $from : '';
 
-        // is popen() enabled?
         if (! function_usable('popen') || false === ($fp = @popen($this->mailPath . ' -oi ' . $from . ' -t', 'w'))) {
-            // server probably has popen disabled, so nothing we can do to get a verbose error.
             return false;
         }
 
@@ -1912,8 +1820,6 @@ class Email
     }
 
     /**
-     * SMTP End
-     *
      * Shortcut to send RSET or QUIT depending on keep-alive
      */
     protected function SMTPEnd()
@@ -1922,8 +1828,6 @@ class Email
     }
 
     /**
-     * SMTP Connect
-     *
      * @return bool|string
      */
     protected function SMTPConnect()
@@ -1977,8 +1881,6 @@ class Email
     }
 
     /**
-     * Send SMTP command
-     *
      * @param string $cmd
      * @param string $data
      *
@@ -2053,8 +1955,6 @@ class Email
     }
 
     /**
-     * SMTP Authenticate
-     *
      * @return bool
      */
     protected function SMTPAuthenticate()
@@ -2108,8 +2008,6 @@ class Email
     }
 
     /**
-     * Send SMTP data
-     *
      * @param string $data
      *
      * @return bool
@@ -2153,8 +2051,6 @@ class Email
     }
 
     /**
-     * Get SMTP data
-     *
      * @return string
      */
     protected function getSMTPData()
@@ -2173,8 +2069,6 @@ class Email
     }
 
     /**
-     * Get Hostname
-     *
      * There are only two legal types of hostname - either a fully
      * qualified domain name (eg: "mail.example.com") or an IP literal
      * (eg: "[1.2.3.4]").
@@ -2198,8 +2092,6 @@ class Email
     }
 
     /**
-     * Get Debug Message
-     *
      * @param array $include List of raw data chunks to include in the output
      *                       Valid options are: 'headers', 'subject', 'body'
      *
@@ -2230,8 +2122,6 @@ class Email
     }
 
     /**
-     * Set Message
-     *
      * @param string $msg
      */
     protected function setErrorMessage($msg)
@@ -2253,9 +2143,6 @@ class Email
         return ! empty($mime) ? $mime : 'application/x-unknown-content-type';
     }
 
-    /**
-     * Destructor
-     */
     public function __destruct()
     {
         if (is_resource($this->SMTPConnect)) {

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -76,13 +76,7 @@ class Encryption
     protected $handlers = [];
 
     /**
-     * Class constructor
-     *
-     * @param EncryptionConfig $config Configuration parameters
-     *
      * @throws EncryptionException
-     *
-     * @return void
      */
     public function __construct(?EncryptionConfig $config = null)
     {
@@ -92,16 +86,13 @@ class Encryption
         $this->driver = $config->driver;
         $this->digest = $config->digest ?? 'SHA512';
 
-        // Map what we have installed
         $this->handlers = [
             'OpenSSL' => extension_loaded('openssl'),
             // the SodiumHandler uses some API (like sodium_pad) that is available only on v1.0.14+
             'Sodium' => extension_loaded('sodium') && version_compare(SODIUM_LIBRARY_VERSION, '1.0.14', '>='),
         ];
 
-        // If requested driver is not active, bail
         if (! in_array($this->driver, $this->drivers, true) || (array_key_exists($this->driver, $this->handlers) && ! $this->handlers[$this->driver])) {
-            // this should never happen in travis-ci
             throw EncryptionException::forNoHandlerAvailable($this->driver);
         }
     }
@@ -109,27 +100,22 @@ class Encryption
     /**
      * Initialize or re-initialize an encrypter
      *
-     * @param EncryptionConfig $config Configuration parameters
-     *
      * @throws EncryptionException
      *
      * @return EncrypterInterface
      */
     public function initialize(?EncryptionConfig $config = null)
     {
-        // override config?
         if ($config) {
             $this->key    = $config->key;
             $this->driver = $config->driver;
             $this->digest = $config->digest ?? 'SHA512';
         }
 
-        // Insist on a driver
         if (empty($this->driver)) {
             throw EncryptionException::forNoDriverRequested();
         }
 
-        // Check for an unknown driver
         if (! in_array($this->driver, $this->drivers, true)) {
             throw EncryptionException::forUnKnownHandler($this->driver);
         }
@@ -138,7 +124,6 @@ class Encryption
             throw EncryptionException::forNeedsStarterKey();
         }
 
-        // Derive a secret key for the encrypter
         $this->hmacKey = bin2hex(\hash_hkdf($this->digest, $this->key));
 
         $handlerName     = 'CodeIgniter\\Encryption\\Handlers\\' . $this->driver . 'Handler';

--- a/system/Encryption/Handlers/SodiumHandler.php
+++ b/system/Encryption/Handlers/SodiumHandler.php
@@ -113,8 +113,6 @@ class SodiumHandler extends BaseHandler
      * @param array|string|null $params
      *
      * @throws EncryptionException If key is empty
-     *
-     * @return void
      */
     protected function parseParams($params)
     {

--- a/system/Events/Events.php
+++ b/system/Events/Events.php
@@ -63,8 +63,6 @@ class Events
 
     /**
      * Ensures that we have a events file ready.
-     *
-     * @return void
      */
     public static function initialize()
     {
@@ -113,8 +111,6 @@ class Events
      * @param string   $eventName
      * @param callable $callback
      * @param int      $priority
-     *
-     * @return void
      */
     public static function on($eventName, $callback, $priority = EVENT_PRIORITY_NORMAL)
     {
@@ -229,8 +225,6 @@ class Events
      * removed, otherwise all listeners for all events are removed.
      *
      * @param string|null $eventName
-     *
-     * @return void
      */
     public static function removeAllListeners($eventName = null)
     {
@@ -243,8 +237,6 @@ class Events
 
     /**
      * Sets the path to the file that routes are read from.
-     *
-     * @return void
      */
     public static function setFiles(array $files)
     {
@@ -265,8 +257,6 @@ class Events
      * Turns simulation on or off. When on, events will not be triggered,
      * simply logged. Useful during testing when you don't actually want
      * the tests to run.
-     *
-     * @return void
      */
     public static function simulate(bool $choice = true)
     {

--- a/system/Filters/DebugToolbar.php
+++ b/system/Filters/DebugToolbar.php
@@ -24,8 +24,6 @@ class DebugToolbar implements FilterInterface
      * We don't need to do anything here.
      *
      * @param array|null $arguments
-     *
-     * @return void
      */
     public function before(RequestInterface $request, $arguments = null)
     {
@@ -36,8 +34,6 @@ class DebugToolbar implements FilterInterface
      * and debug information and display it in a toolbar.
      *
      * @param array|null $arguments
-     *
-     * @return void
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
     {

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -372,8 +372,6 @@ class Filters
      * Add any applicable (not excluded) global filter settings to the mix.
      *
      * @param string $uri
-     *
-     * @return void
      */
     protected function processGlobals(?string $uri = null)
     {
@@ -417,8 +415,6 @@ class Filters
 
     /**
      * Add any method-specific filters to the mix.
-     *
-     * @return void
      */
     protected function processMethods()
     {
@@ -440,8 +436,6 @@ class Filters
      * Add any applicable configured filters to the mix.
      *
      * @param string $uri
-     *
-     * @return void
      */
     protected function processFilters(?string $uri = null)
     {
@@ -474,8 +468,6 @@ class Filters
      * Maps filter aliases to the equivalent filter classes
      *
      * @throws FilterException
-     *
-     * @return void
      */
     protected function processAliasesToClass(string $position)
     {

--- a/system/Filters/Honeypot.php
+++ b/system/Filters/Honeypot.php
@@ -28,8 +28,6 @@ class Honeypot implements FilterInterface
      * @param array|null $arguments
      *
      * @throws HoneypotException
-     *
-     * @return void
      */
     public function before(RequestInterface $request, $arguments = null)
     {
@@ -42,8 +40,6 @@ class Honeypot implements FilterInterface
      * Attach a honeypot to the current response.
      *
      * @param array|null $arguments
-     *
-     * @return void
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
     {

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -210,8 +210,6 @@ class ContentSecurityPolicy
      * Compiles and sets the appropriate headers in the request.
      *
      * Should be called just prior to sending the response to the user agent.
-     *
-     * @return void
      */
     public function finalize(ResponseInterface &$response)
     {
@@ -552,8 +550,6 @@ class ContentSecurityPolicy
      * DRY method to add an string or array to a class property.
      *
      * @param array|string $options
-     *
-     * @return void
      */
     protected function addOption($options, string $target, ?bool $explicitReporting = null)
     {
@@ -575,8 +571,6 @@ class ContentSecurityPolicy
      * Scans the body of the request message and replaces any nonce
      * placeholders with actual nonces, that we'll then add to our
      * headers.
-     *
-     * @return void
      */
     protected function generateNonces(ResponseInterface &$response)
     {
@@ -619,8 +613,6 @@ class ContentSecurityPolicy
      * Based on the current state of the elements, will add the appropriate
      * Content-Security-Policy and Content-Security-Policy-Report-Only headers
      * with their values to the response object.
-     *
-     * @return void
      */
     protected function buildHeaders(ResponseInterface &$response)
     {
@@ -705,8 +697,6 @@ class ContentSecurityPolicy
      * reportOnly header, since it's viable to have both simultaneously.
      *
      * @param array|string|null $values
-     *
-     * @return void
      */
     protected function addToHeader(string $name, $values = null)
     {

--- a/system/HTTP/UserAgent.php
+++ b/system/HTTP/UserAgent.php
@@ -247,8 +247,6 @@ class UserAgent
 
     /**
      * Parse a custom user-agent string
-     *
-     * @return void
      */
     public function parse(string $string)
     {
@@ -271,8 +269,6 @@ class UserAgent
 
     /**
      * Compile the User Agent Data
-     *
-     * @return void
      */
     protected function compileData()
     {

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -80,8 +80,6 @@ if (! function_exists('delete_cookie')) {
      * @param string $path   the cookie path
      * @param string $prefix the cookie prefix
      *
-     * @return void
-     *
      * @see \CodeIgniter\HTTP\Response::deleteCookie()
      */
     function delete_cookie($name, string $domain = '', string $path = '/', string $prefix = '')

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -720,13 +720,10 @@ abstract class BaseHandler implements ImageHandlerInterface
      *
      * This function lets us re-proportion the width/height
      * if users choose to maintain the aspect ratio when resizing.
-     *
-     * @return void
      */
     protected function reproportion()
     {
-        if (($this->width === 0 && $this->height === 0) || $this->image()->origWidth === 0 || $this->image()->origHeight === 0 || (! ctype_digit((string) $this->width) && ! ctype_digit((string) $this->height)) || ! ctype_digit((string) $this->image()->origWidth) || ! ctype_digit((string) $this->image()->origHeight)
-        ) {
+        if (($this->width === 0 && $this->height === 0) || $this->image()->origWidth === 0 || $this->image()->origHeight === 0 || (! ctype_digit((string) $this->width) && ! ctype_digit((string) $this->height)) || ! ctype_digit((string) $this->image()->origWidth) || ! ctype_digit((string) $this->image()->origHeight)) {
             return;
         }
 

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -30,12 +30,9 @@ class GDHandler extends BaseHandler
     {
         parent::__construct($config);
 
-        // We should never see this, so can't test it
-        // @codeCoverageIgnoreStart
         if (! extension_loaded('gd')) {
-            throw ImageException::forMissingExtension('GD');
+            throw ImageException::forMissingExtension('GD'); // @codeCoverageIgnore
         }
-        // @codeCoverageIgnoreEnd
     }
 
     /**
@@ -367,8 +364,6 @@ class GDHandler extends BaseHandler
 
     /**
      * Add text overlay to an image.
-     *
-     * @return void
      */
     protected function _text(string $text, array $options = [])
     {
@@ -446,8 +441,6 @@ class GDHandler extends BaseHandler
      * Handler-specific method for overlaying text on an image.
      *
      * @param bool $isShadow Whether we are drawing the dropshadow or actual text
-     *
-     * @return void
      */
     protected function textOverlay(string $text, array $options = [], bool $isShadow = false)
     {

--- a/system/Model.php
+++ b/system/Model.php
@@ -29,8 +29,6 @@ use ReflectionException;
 use ReflectionProperty;
 
 /**
- * Class Model
- *
  * The Model class extends BaseModel and provides additional
  * convenient features that makes working with a SQL database
  * table less painful.
@@ -40,7 +38,7 @@ use ReflectionProperty;
  *      - allow intermingling calls to the builder
  *      - removes the need to use Result object directly in most cases
  *
- * @mixin    BaseBuilder
+ * @mixin BaseBuilder
  *
  * @property BaseConnection $db
  */
@@ -91,12 +89,6 @@ class Model extends BaseModel
      */
     protected $escape = [];
 
-    /**
-     * Model constructor.
-     *
-     * @param ConnectionInterface|null $db         DB Connection
-     * @param ValidationInterface|null $validation Validation
-     */
     public function __construct(?ConnectionInterface &$db = null, ?ValidationInterface $validation = null)
     {
         /**
@@ -284,8 +276,8 @@ class Model extends BaseModel
      * Updates a single record in $this->table.
      * This methods works only with dbCalls
      *
-     * @param array|int|string|null $id   ID
-     * @param array|null            $data Data
+     * @param array|int|string|null $id
+     * @param array|null            $data
      */
     protected function doUpdate($id = null, $data = null): bool
     {
@@ -385,8 +377,6 @@ class Model extends BaseModel
      * Works with the find* methods to return only the rows that
      * have been deleted.
      * This methods works only with dbCalls
-     *
-     * @return void
      */
     protected function doOnlyDeleted()
     {
@@ -467,12 +457,7 @@ class Model extends BaseModel
      * determine the rows to operate on.
      * This methods works only with dbCalls
      *
-     * @param int     $size     Size
-     * @param Closure $userFunc Callback Function
-     *
      * @throws DataException
-     *
-     * @return void
      */
     public function chunk(int $size, Closure $userFunc)
     {
@@ -506,9 +491,6 @@ class Model extends BaseModel
     /**
      * Override countAllResults to account for soft deleted accounts.
      *
-     * @param bool $reset Reset
-     * @param bool $test  Test
-     *
      * @return mixed
      */
     public function countAllResults(bool $reset = true, bool $test = false)
@@ -529,8 +511,6 @@ class Model extends BaseModel
 
     /**
      * Provides a shared instance of the Query Builder.
-     *
-     * @param string|null $table Table name
      *
      * @throws ModelException
      *
@@ -577,9 +557,9 @@ class Model extends BaseModel
      * data here. This allows it to be used with any of the other
      * builder methods and still get validated data, like replace.
      *
-     * @param mixed       $key    Field name, or an array of field/value pairs
-     * @param string|null $value  Field value, if $key is a single field
-     * @param bool|null   $escape Whether to escape values and identifiers
+     * @param array|string $key    Field name, or an array of field/value pairs
+     * @param string|null  $value  Field value, if $key is a single field
+     * @param bool|null    $escape Whether to escape values and identifiers
      *
      * @return $this
      */
@@ -616,7 +596,7 @@ class Model extends BaseModel
      * Inserts data into the database. If an object is provided,
      * it will attempt to convert it to an array.
      *
-     * @param array|object|null $data     Data
+     * @param array|object|null $data
      * @param bool              $returnID Whether insert ID should be returned or not.
      *
      * @throws ReflectionException
@@ -644,8 +624,8 @@ class Model extends BaseModel
      * Updates a single record in the database. If an object is provided,
      * it will attempt to convert it into an array.
      *
-     * @param array|int|string|null $id   ID
-     * @param array|object|null     $data Data
+     * @param array|int|string|null $id
+     * @param array|object|null     $data
      *
      * @throws ReflectionException
      */
@@ -670,9 +650,8 @@ class Model extends BaseModel
      * Takes a class an returns an array of it's public and protected
      * properties as an array with raw values.
      *
-     * @param object|string $data        Data
-     * @param bool          $onlyChanged Only Changed Property
-     * @param bool          $recursive   If true, inner entities will be casted as array as well
+     * @param object|string $data
+     * @param bool          $recursive If true, inner entities will be casted as array as well
      *
      * @throws ReflectionException
      *
@@ -683,8 +662,10 @@ class Model extends BaseModel
         $properties = parent::objectToRawArray($data, $onlyChanged);
 
         // Always grab the primary key otherwise updates will fail.
-        if (method_exists($data, 'toRawArray') && (! empty($properties) && ! empty($this->primaryKey) && ! in_array($this->primaryKey, $properties, true)
-                && ! empty($data->{$this->primaryKey}))) {
+        if (
+            method_exists($data, 'toRawArray') && (! empty($properties) && ! empty($this->primaryKey) && ! in_array($this->primaryKey, $properties, true)
+            && ! empty($data->{$this->primaryKey}))
+        ) {
             $properties[$this->primaryKey] = $data->{$this->primaryKey};
         }
 
@@ -729,9 +710,6 @@ class Model extends BaseModel
      * Provides direct access to method in the builder (if available)
      * and the database connection.
      *
-     * @param string $name   Name
-     * @param array  $params Params
-     *
      * @return $this|null
      */
     public function __call(string $name, array $params)
@@ -763,10 +741,8 @@ class Model extends BaseModel
      * Takes a class an returns an array of it's public and protected
      * properties as an array suitable for use in creates and updates.
      *
-     * @param object|string $data        Data
-     * @param string|null   $primaryKey  Primary Key
-     * @param string        $dateFormat  Date Format
-     * @param bool          $onlyChanged Only Changed
+     * @param object|string $data
+     * @param string|null   $primaryKey
      *
      * @throws ReflectionException
      *

--- a/system/RESTful/BaseResource.php
+++ b/system/RESTful/BaseResource.php
@@ -34,8 +34,6 @@ abstract class BaseResource extends Controller
     public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
     {
         parent::initController($request, $response, $logger);
-
-        // instantiate our model, if needed
         $this->setModel($this->modelName);
     }
 
@@ -44,23 +42,18 @@ abstract class BaseResource extends Controller
      * Given either the name or the object, determine the other.
      *
      * @param object|string|null $which
-     *
-     * @return void
      */
     public function setModel($which = null)
     {
-        // save what we have been given
         if ($which) {
             $this->model     = is_object($which) ? $which : null;
             $this->modelName = is_object($which) ? null : $which;
         }
 
-        // make a model object if needed
         if (empty($this->model) && ! empty($this->modelName) && class_exists($this->modelName)) {
             $this->model = model($this->modelName);
         }
 
-        // determine model name if needed
         if (! empty($this->model) && empty($this->modelName)) {
             $this->modelName = get_class($this->model);
         }

--- a/system/RESTful/ResourceController.php
+++ b/system/RESTful/ResourceController.php
@@ -100,8 +100,6 @@ class ResourceController extends BaseResource
 
     /**
      * Set/change the expected response representation for returned objects
-     *
-     * @return void
      */
     public function setFormat(string $format = 'json')
     {

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -588,8 +588,6 @@ class RouteCollection implements RouteCollectionInterface
      *
      * @param string         $name      The name to group/prefix the routes with.
      * @param array|callable ...$params
-     *
-     * @return void
      */
     public function group(string $name, ...$params)
     {

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -339,8 +339,6 @@ class Session implements SessionInterface
      *
      * So we were forced to make changes, and OF COURSE something was
      * going to break and now we have this pile of shit. -- Narf
-     *
-     * @return void
      */
     protected function configureSidLength()
     {
@@ -514,8 +512,6 @@ class Session implements SessionInterface
      *
      * @param string $key  Identifier of the session property we are interested in.
      * @param array  $data value to be pushed to existing session key.
-     *
-     * @return void
      */
     public function push(string $key, array $data)
     {

--- a/system/Test/DatabaseTestTrait.php
+++ b/system/Test/DatabaseTestTrait.php
@@ -199,8 +199,6 @@ trait DatabaseTestTrait
 
     /**
      * Seeds that database with a specific seeder.
-     *
-     * @return void
      */
     public function seed(string $name)
     {
@@ -277,8 +275,6 @@ trait DatabaseTestTrait
      * exist in the database.
      *
      * @throws DatabaseException
-     *
-     * @return void
      */
     public function seeInDatabase(string $table, array $where)
     {
@@ -289,8 +285,6 @@ trait DatabaseTestTrait
     /**
      * Asserts that records that match the conditions in $where do
      * not exist in the database.
-     *
-     * @return void
      */
     public function dontSeeInDatabase(string $table, array $where)
     {
@@ -322,8 +316,6 @@ trait DatabaseTestTrait
      * is equal to $expected.
      *
      * @throws DatabaseException
-     *
-     * @return void
      */
     public function seeNumRecords(int $expected, string $table, array $where)
     {

--- a/system/Test/FilterTestTrait.php
+++ b/system/Test/FilterTestTrait.php
@@ -221,8 +221,6 @@ trait FilterTestTrait
      * @param string $route    The route to test
      * @param string $position "before" or "after"
      * @param string $alias    Alias for the anticipated filter
-     *
-     * @return void
      */
     protected function assertNotFilter(string $route, string $position, string $alias)
     {
@@ -241,8 +239,6 @@ trait FilterTestTrait
      *
      * @param string $route    The route to test
      * @param string $position "before" or "after"
-     *
-     * @return void
      */
     protected function assertHasFilters(string $route, string $position)
     {
@@ -260,8 +256,6 @@ trait FilterTestTrait
      *
      * @param string $route    The route to test
      * @param string $position "before" or "after"
-     *
-     * @return void
      */
     protected function assertNotHasFilters(string $route, string $position)
     {

--- a/system/View/Table.php
+++ b/system/View/Table.php
@@ -87,8 +87,6 @@ class Table
      * Set the template from the table config file if it exists
      *
      * @param array $config (default: array())
-     *
-     * @return void
      */
     public function __construct($config = [])
     {
@@ -404,8 +402,6 @@ class Table
      * Set table data from a database result object
      *
      * @param BaseResult $object Database result object
-     *
-     * @return void
      */
     protected function _setFromDBResult($object)
     {
@@ -423,8 +419,6 @@ class Table
      * Set table data from an array
      *
      * @param array $data
-     *
-     * @return void
      */
     protected function _setFromArray($data)
     {
@@ -439,8 +433,6 @@ class Table
 
     /**
      * Compile Template
-     *
-     * @return void
      */
     protected function _compileTemplate()
     {

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -134,11 +134,6 @@ class View implements RendererInterface
      */
     protected $sectionStack = [];
 
-    /**
-     * Constructor
-     *
-     * @param LoggerInterface $logger
-     */
     public function __construct(ViewConfig $config, ?string $viewPath = null, ?FileLocator $loader = null, ?bool $debug = null, ?LoggerInterface $logger = null)
     {
         $this->config   = $config;
@@ -331,14 +326,14 @@ class View implements RendererInterface
     /**
      * Sets a single piece of view data.
      *
-     * @param mixed  $value
-     * @param string $context The context to escape it for: html, css, js, url
-     *                        If null, no escaping will happen
+     * @param mixed       $value
+     * @param string|null $context The context to escape it for: html, css, js, url
+     *                             If null, no escaping will happen
      */
     public function setVar(string $name, $value = null, ?string $context = null): RendererInterface
     {
         if ($context) {
-            $value = \esc($value, $context);
+            $value = esc($value, $context);
         }
 
         $this->tempData        = $this->tempData ?? $this->data;
@@ -367,8 +362,6 @@ class View implements RendererInterface
 
     /**
      * Specifies that the current view should extend an existing layout.
-     *
-     * @return void
      */
     public function extend(string $layout)
     {
@@ -379,8 +372,6 @@ class View implements RendererInterface
      * Starts holds content for a section within the layout.
      *
      * @param string $name Section name
-     *
-     * @return void
      */
     public function section(string $name)
     {
@@ -395,8 +386,6 @@ class View implements RendererInterface
      * Captures the last section
      *
      * @throws RuntimeException
-     *
-     * @return void
      */
     public function endSection()
     {
@@ -454,8 +443,6 @@ class View implements RendererInterface
 
     /**
      * Logs performance data for rendering a view.
-     *
-     * @return void
      */
     protected function logPerformance(float $start, float $end, string $view)
     {


### PR DESCRIPTION
**Description**
- Fix inconsistency in docblock against typehint
- Remove unremoved superfluous doc tags
- Remove unnecessary or redundant doc comments
- Remove unnecessary comments only stating the obvious
- EXTRA: Fix notice in pre-commit hook for missing whitespace

**Checklist:**
- [x] Securely signed commits
- [x] Conforms to style guide
