### PR TITLE
Fix API repo preparation step

### DIFF
--- a/.github/workflows/deploy-apidocs.yml
+++ b/.github/workflows/deploy-apidocs.yml
@@ -55,9 +55,9 @@ jobs:
       - name: Prepare API repo
         working-directory: api
         run: |
-          rm -rf api/docs*
-          mkdir -p api/docs
           git reset --hard master
+          rm -rfv api/docs
+          mkdir --parents --verbose api/docs
 
       - name: Build API in source repo
         working-directory: source


### PR DESCRIPTION
**Description**
The current apidocs workflow is largely based on the `apidoc` script. Up until now, there's a typo in the script preventing the removal of the contents of the `api/docs` folder:
> rm -rf api/docs*

As you can see, instead of deleting the contents this tries to delete files starting with `api/docs` which doesn't exist. This PR fixes that and makes the output more verbose.

**Checklist:**
- [x] Securely signed commits
