### PR TITLE
Fix properly the phpstan error in 0.12.93

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,7 +9,6 @@ services:
 			- phpstan.rules.rule
 
 parameters:
-	reportUnmatchedIgnoredErrors: false
 	tmpDir: build/phpstan
 	level: 5
 	paths:

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -100,9 +100,7 @@ class File extends SplFileInfo
     public function getMimeType(): string
     {
         if (! function_exists('finfo_open')) {
-            // @codeCoverageIgnoreStart
-            return $this->originalMimeType ?? 'application/octet-stream';
-            // @codeCoverageIgnoreEnd
+            return $this->originalMimeType ?? 'application/octet-stream'; // @codeCoverageIgnore
         }
 
         $finfo    = finfo_open(FILEINFO_MIME_TYPE);
@@ -157,21 +155,27 @@ class File extends SplFileInfo
      */
     public function getDestination(string $destination, string $delimiter = '_', int $i = 0): string
     {
+        if ($delimiter === '') {
+            $delimiter = '_';
+        }
+
         while (is_file($destination)) {
             $info      = pathinfo($destination);
             $extension = isset($info['extension']) ? '.' . $info['extension'] : '';
+
             if (strpos($info['filename'], $delimiter) !== false) {
-                $parts = explode($delimiter, $info['filename']); // @phpstan-ignore-line
+                $parts = explode($delimiter, $info['filename']);
+
                 if (is_numeric(end($parts))) {
                     $i = end($parts);
                     array_pop($parts);
                     $parts[]     = ++$i;
-                    $destination = $info['dirname'] . '/' . implode($delimiter, $parts) . $extension;
+                    $destination = $info['dirname'] . DIRECTORY_SEPARATOR . implode($delimiter, $parts) . $extension;
                 } else {
-                    $destination = $info['dirname'] . '/' . $info['filename'] . $delimiter . ++$i . $extension;
+                    $destination = $info['dirname'] . DIRECTORY_SEPARATOR . $info['filename'] . $delimiter . ++$i . $extension;
                 }
             } else {
-                $destination = $info['dirname'] . '/' . $info['filename'] . $delimiter . ++$i . $extension;
+                $destination = $info['dirname'] . DIRECTORY_SEPARATOR . $info['filename'] . $delimiter . ++$i . $extension;
             }
         }
 

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -89,4 +89,20 @@ final class FileTest extends CIUnitTestCase
 
         new File(SYSTEMPATH . 'Commoner.php', true);
     }
+
+    public function testGetDestination(): void
+    {
+        $file = new File(SYSTEMPATH . 'Common.php');
+        copy(SYSTEMPATH . 'Common.php', SYSTEMPATH . 'Common_Copy.php');
+
+        $this->assertSame(SYSTEMPATH . 'Common_Copy_1.php', $file->getDestination(SYSTEMPATH . 'Common_Copy.php', ''));
+        $this->assertSame(SYSTEMPATH . 'Common_1.php', $file->getDestination(SYSTEMPATH . 'Common.php'));
+        $this->assertSame(SYSTEMPATH . 'Common_Copy_5.php', $file->getDestination(SYSTEMPATH . 'Common_Copy_5.php'));
+
+        copy(SYSTEMPATH . 'Common_Copy.php', SYSTEMPATH . 'Common_Copy_5.php');
+        $this->assertSame(SYSTEMPATH . 'Common_Copy_6.php', $file->getDestination(SYSTEMPATH . 'Common_Copy_5.php'));
+
+        unlink(SYSTEMPATH . 'Common_Copy.php');
+        unlink(SYSTEMPATH . 'Common_Copy_5.php');
+    }
 }


### PR DESCRIPTION
**Description**
- Proper fix for phpstan error in #4967 (explode does not accept an empty string delimiter which the code does not take into account)
- Add tests for the `File::getDestination` method where this error arises

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide
