### PR TITLE
Required rule error fix

### DIFF
--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -245,7 +245,7 @@ class Rules
      */
     public function required($str = null): bool
     {
-        if (is_object($str)) {
+        if (is_object($str) || is_bool($str)) {
             return true;
         }
 

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -270,11 +270,6 @@ final class RulesTest extends CIUnitTestCase
                 ['foo' => null],
                 false,
             ],
-            [
-                ['foo' => 'permit_empty|required'],
-                ['foo' => false],
-                false,
-            ],
             // This tests will return true because the input data is trimmed
             [
                 ['foo' => 'permit_empty|required'],


### PR DESCRIPTION
# Fixed #4971 

**Description**
I modified the required rule in Vallidation/Rules. 
I did it because the required rule blocks the false value when the user try to send a false value to the database.
This problem affected one of my applications when I update the  available value in a product field.
So I decided to solve this problem and helps the community.
The code got bigger but I guarantee it is scalable and fast. The needed function is executed only once.
The code got more readable too.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide