### PR TITLE
IncomingRequest - Trim trailing slash

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -328,7 +328,9 @@ class Router implements RouterInterface
             return false;
         }
 
-        $uri = trim($uri, '/ ') ?: '/';
+        $uri = $uri === '/'
+            ? $uri
+            : trim($uri, '/ ');
 
         // Loop through the route array looking for wildcards
         foreach ($routes as $key => $val) {

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -328,9 +328,7 @@ class Router implements RouterInterface
             return false;
         }
 
-        $uri = $uri === '/'
-            ? $uri
-            : ltrim($uri, '/ ');
+        $uri = trim($uri, '/ ') ?: '/';
 
         // Loop through the route array looking for wildcards
         foreach ($routes as $key => $val) {

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -103,6 +103,16 @@ final class RouterTest extends CIUnitTestCase
         $this->assertSame('index', $router->methodName());
     }
 
+    public function testURIWithTrailingSlashMapsToController()
+    {
+        $router = new Router($this->collection, $this->request);
+
+        $router->handle('users/');
+
+        $this->assertSame('\Users', $router->controllerName());
+        $this->assertSame('index', $router->methodName());
+    }
+
     public function testURIMapsToControllerAltMethod()
     {
         $router = new Router($this->collection, $this->request);
@@ -161,6 +171,16 @@ final class RouterTest extends CIUnitTestCase
         $router = new Router($this->collection, $this->request);
 
         $router->handle('objects/123/sort/abc/FOO');
+
+        $this->assertSame('objectsSortCreate', $router->methodName());
+        $this->assertSame(['123', 'abc', 'FOO'], $router->params());
+    }
+
+    public function testURIWithTrailingSlashMapsParamsWithMany()
+    {
+        $router = new Router($this->collection, $this->request);
+
+        $router->handle('objects/123/sort/abc/FOO/');
 
         $this->assertSame('objectsSortCreate', $router->methodName());
         $this->assertSame(['123', 'abc', 'FOO'], $router->params());


### PR DESCRIPTION
**Description**
If trailing slash is forced via apache or nginx the router will be unable to find the appropriate route. The router will try to match path from request uri with trailing slash but it is impossible to define such route in the route collection since slash is used as separator. 

This changes the way request uri is handled so that trailing slash is removed at the end which enables the router to handle the url in both cases with or without trailing slash 

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPdocs
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide