### PR TITLE
Model - Fix zero value primary key

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -673,7 +673,7 @@ abstract class BaseModel
      */
     protected function shouldUpdate($data): bool
     {
-        return ! empty($this->getIdValue($data));
+        return $this->getIdValue($data) !== null;
     }
 
     /**
@@ -943,7 +943,7 @@ abstract class BaseModel
      */
     public function delete($id = null, bool $purge = false)
     {
-        if ($id && (is_numeric($id) || is_string($id))) {
+        if (isset($id) && (is_numeric($id) || is_string($id))) {
             $id = [$id];
         }
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -225,7 +225,7 @@ class Model extends BaseModel
 
         // Require non empty primaryKey when
         // not using auto-increment feature
-        if (! $this->useAutoIncrement && empty($data[$this->primaryKey])) {
+        if (! $this->useAutoIncrement && ! isset($data[$this->primaryKey])) {
             throw DataException::forEmptyPrimaryKey('insert');
         }
 
@@ -263,7 +263,7 @@ class Model extends BaseModel
             foreach ($set as $row) {
                 // Require non empty primaryKey when
                 // not using auto-increment feature
-                if (! $this->useAutoIncrement && empty($row[$this->primaryKey])) {
+                if (! $this->useAutoIncrement && ! isset($row[$this->primaryKey])) {
                     throw DataException::forEmptyPrimaryKey('insertBatch');
                 }
             }
@@ -332,7 +332,7 @@ class Model extends BaseModel
     {
         $builder = $this->builder();
 
-        if ($id) {
+        if (isset($id)) {
             $builder = $builder->whereIn($this->primaryKey, $id);
         }
 
@@ -444,7 +444,7 @@ class Model extends BaseModel
             return $data->{$this->primaryKey};
         }
 
-        if (is_array($data) && ! empty($data[$this->primaryKey])) {
+        if (is_array($data) && isset($data[$this->primaryKey])) {
             return $data[$this->primaryKey];
         }
 
@@ -661,12 +661,12 @@ class Model extends BaseModel
     {
         $properties = parent::objectToRawArray($data, $onlyChanged);
 
-        // Always grab the primary key otherwise updates will fail.
-        if (
-            method_exists($data, 'toRawArray') && (! empty($properties) && ! empty($this->primaryKey) && ! in_array($this->primaryKey, $properties, true)
-            && ! empty($data->{$this->primaryKey}))
-        ) {
-            $properties[$this->primaryKey] = $data->{$this->primaryKey};
+        if (! empty($properties) && ! in_array($this->primaryKey, $properties, true)) {
+            // Always grab the primary key otherwise updates will fail.
+            $primaryKey = $this->getIdValue($data);
+            if ($primaryKey !== null) {
+                $properties[$this->primaryKey] = $primaryKey;
+            }
         }
 
         return $properties;
@@ -756,7 +756,7 @@ class Model extends BaseModel
             $properties = $data->toRawArray($onlyChanged);
 
             // Always grab the primary key otherwise updates will fail.
-            if (! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties, true) && ! empty($data->{$primaryKey})) {
+            if (! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties, true) && isset($data->{$primaryKey})) {
                 $properties[$primaryKey] = $data->{$primaryKey};
             }
         } else {

--- a/tests/_support/Database/Seeds/CITestSeeder.php
+++ b/tests/_support/Database/Seeds/CITestSeeder.php
@@ -78,6 +78,14 @@ class CITestSeeder extends Seeder
                     'id'    => 'A01',
                     'value' => 'test',
                 ],
+                [
+                    'id'    => '0',
+                    'value' => 'test zero key',
+                ],
+                [
+                    'id'    => '',
+                    'value' => 'test empty key',
+                ],
             ],
             'without_auto_increment' => [
                 [

--- a/tests/system/Models/DeleteModelTest.php
+++ b/tests/system/Models/DeleteModelTest.php
@@ -52,6 +52,24 @@ final class DeleteModelTest extends LiveModelTestCase
         $this->dontSeeInDatabase('stringifypkey', ['value' => 'test']);
     }
 
+    public function testDeleteZeroPrimaryKey(): void
+    {
+        $this->createModel(StringifyPkeyModel::class);
+        $this->seeInDatabase('stringifypkey', ['value' => 'test zero key']);
+
+        $this->model->delete('0');
+        $this->dontSeeInDatabase('stringifypkey', ['value' => 'test zero key']);
+    }
+
+    public function testDeleteEmptyPrimaryKey(): void
+    {
+        $this->createModel(StringifyPkeyModel::class);
+        $this->seeInDatabase('stringifypkey', ['value' => 'test empty key']);
+
+        $this->model->delete('');
+        $this->dontSeeInDatabase('stringifypkey', ['value' => 'test empty key']);
+    }
+
     public function testDeleteWithSoftDeletes(): void
     {
         $this->createModel(UserModel::class);

--- a/tests/system/Models/FindModelTest.php
+++ b/tests/system/Models/FindModelTest.php
@@ -15,6 +15,7 @@ use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Exceptions\ModelException;
 use Tests\Support\Models\JobModel;
 use Tests\Support\Models\SecondaryModel;
+use Tests\Support\Models\StringifyPkeyModel;
 use Tests\Support\Models\UserModel;
 
 /**
@@ -26,6 +27,18 @@ final class FindModelTest extends LiveModelTestCase
     {
         $this->createModel(JobModel::class);
         $this->assertSame('Musician', $this->model->find(4)->name);
+    }
+
+    public function testFindReturnsRowZeroId(): void
+    {
+        $this->createModel(StringifyPkeyModel::class);
+        $this->assertSame('test zero key', $this->model->find('0')->value);
+    }
+
+    public function testFindReturnsRowEmptyId(): void
+    {
+        $this->createModel(StringifyPkeyModel::class);
+        $this->assertSame('test empty key', $this->model->find('')->value);
     }
 
     public function testFindReturnsMultipleRows(): void

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -268,6 +268,81 @@ final class InsertModelTest extends LiveModelTestCase
         $this->seeInDatabase('without_auto_increment', $insert);
     }
 
+    public function testInsertIdZero(): void
+    {
+        $data = [
+            'key'   => 0,
+            'value' => 'value',
+        ];
+
+        $this->createModel(WithoutAutoIncrementModel::class);
+
+        $result = $this->model->protect(false)->insert($data, false);
+        $this->assertTrue($result);
+
+        $this->seeInDatabase('without_auto_increment', ['key' => 0]);
+    }
+
+    public function testInsertIdZeroString(): void
+    {
+        $data = [
+            'key'   => '0',
+            'value' => 'value',
+        ];
+
+        $this->createModel(WithoutAutoIncrementModel::class);
+
+        $result = $this->model->protect(false)->insert($data, false);
+        $this->assertTrue($result);
+
+        $this->seeInDatabase('without_auto_increment', ['key' => 0]);
+    }
+
+    public function testInsertIdFalse(): void
+    {
+        $data = [
+            'key'   => false,
+            'value' => 'value',
+        ];
+
+        $this->createModel(WithoutAutoIncrementModel::class);
+
+        $result = $this->model->protect(false)->insert($data, false);
+        $this->assertTrue($result);
+
+        $this->seeInDatabase('without_auto_increment', ['key' => '']);
+    }
+
+    public function testInsertIdFalseString(): void
+    {
+        $data = [
+            'key'   => 'false',
+            'value' => 'value',
+        ];
+
+        $this->createModel(WithoutAutoIncrementModel::class);
+
+        $result = $this->model->protect(false)->insert($data, false);
+        $this->assertTrue($result);
+
+        $this->seeInDatabase('without_auto_increment', ['key' => 'false']);
+    }
+
+    public function testInsertIdEmptyString(): void
+    {
+        $data = [
+            'key'   => '',
+            'value' => 'value',
+        ];
+
+        $this->createModel(WithoutAutoIncrementModel::class);
+
+        $result = $this->model->protect(false)->insert($data, false);
+        $this->assertTrue($result);
+
+        $this->seeInDatabase('without_auto_increment', ['key' => '']);
+    }
+
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4087
      */

--- a/tests/system/Models/SaveModelTest.php
+++ b/tests/system/Models/SaveModelTest.php
@@ -315,4 +315,73 @@ final class SaveModelTest extends LiveModelTestCase
         $this->assertSame($insert['key'], $this->model->getInsertID());
         $this->seeInDatabase('without_auto_increment', $update);
     }
+
+    public function testUseAutoIncrementSetToFalseSaveEmptyID(): void
+    {
+        $insert = [
+            'key'   => '',
+            'value' => 'some value',
+        ];
+
+        $this->createModel(WithoutAutoIncrementModel::class);
+        $this->model->save($insert);
+
+        $this->assertSame($insert['key'], $this->model->getInsertID());
+        $this->seeInDatabase('without_auto_increment', $insert);
+
+        $update = [
+            'key'   => '',
+            'value' => 'some different value',
+        ];
+
+        $this->model->save($update);
+        $this->assertSame($insert['key'], $this->model->getInsertID());
+        $this->seeInDatabase('without_auto_increment', $update);
+    }
+
+    public function testUseAutoIncrementSetToFalseSaveZeroID(): void
+    {
+        $insert = [
+            'key'   => 0,
+            'value' => 'some value',
+        ];
+
+        $this->createModel(WithoutAutoIncrementModel::class);
+        $this->model->save($insert);
+
+        $this->assertSame($insert['key'], $this->model->getInsertID());
+        $this->seeInDatabase('without_auto_increment', $insert);
+
+        $update = [
+            'key'   => 0,
+            'value' => 'some different value',
+        ];
+
+        $this->model->save($update);
+        $this->assertSame($insert['key'], $this->model->getInsertID());
+        $this->seeInDatabase('without_auto_increment', $update);
+    }
+
+    public function testUseAutoIncrementSetToFalseSaveFalseID(): void
+    {
+        $insert = [
+            'key'   => false,
+            'value' => 'some value',
+        ];
+
+        $this->createModel(WithoutAutoIncrementModel::class);
+        $this->model->save($insert);
+
+        $this->assertSame(0, $this->model->getInsertID());
+        $this->seeInDatabase('without_auto_increment', $insert);
+
+        $update = [
+            'key'   => false,
+            'value' => 'some different value',
+        ];
+
+        $this->model->save($update);
+        $this->assertSame(0, $this->model->getInsertID());
+        $this->seeInDatabase('without_auto_increment', $update);
+    }
 }

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -17,6 +17,7 @@ use stdClass;
 use Tests\Support\Models\EventModel;
 use Tests\Support\Models\JobModel;
 use Tests\Support\Models\SecondaryModel;
+use Tests\Support\Models\StringifyPkeyModel;
 use Tests\Support\Models\UserModel;
 use Tests\Support\Models\ValidModel;
 use Tests\Support\Models\WithoutAutoIncrementModel;
@@ -353,6 +354,30 @@ final class UpdateModelTest extends LiveModelTestCase
 
         $this->createModel(WithoutAutoIncrementModel::class)->update($key, $update);
         $this->seeInDatabase('without_auto_increment', ['key' => $key, 'value' => $update['value']]);
+    }
+
+    public function testUpdateEmptyID(): void
+    {
+        $id = '';
+
+        $update = [
+            'value' => 'some different value',
+        ];
+
+        $this->createModel(StringifyPkeyModel::class)->protect(false)->update($id, $update);
+        $this->seeInDatabase('stringifypkey', ['id' => $id, 'value' => $update['value']]);
+    }
+
+    public function testUpdateZeroID(): void
+    {
+        $id = 0;
+
+        $update = [
+            'value' => 'some different value',
+        ];
+
+        $this->createModel(StringifyPkeyModel::class)->protect(false)->update($id, $update);
+        $this->seeInDatabase('stringifypkey', ['id' => $id, 'value' => $update['value']]);
     }
 
     /**


### PR DESCRIPTION
**Description**
Primary key in SQL can have value of 0 or empty string. This modifies the model to use isset to handle such values instead of doing an empty check so that rows which such keys can be inserted/updated in the DB

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
