### PR TITLE
Delete `docs` directly, not `api/docs`

### DIFF
--- a/.github/workflows/deploy-apidocs.yml
+++ b/.github/workflows/deploy-apidocs.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: codeigniter4/api
-          token: ${{ secrets.ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           path: api
 
       - name: Setup PHP
@@ -40,10 +40,6 @@ jobs:
         with:
           php-version: '8.0'
           coverage: none
-
-      - name: Install GraphViz for phpDocumentor
-        run: |
-          sudo apt-get install -yq graphviz
 
       - name: Download phpDocumentor v3.1
         run: |
@@ -56,8 +52,8 @@ jobs:
         working-directory: api
         run: |
           git reset --hard master
-          rm -rfv api/docs
-          mkdir --parents --verbose api/docs
+          rm -rfv docs
+          mkdir --parents --verbose docs
 
       - name: Build API in source repo
         working-directory: source


### PR DESCRIPTION
**Description**
Apparently, #4969 only fixed half of the problem (which is the `git reset`). However, the actual contents of `api/docs` are not removed really. Analysing the logs from the verbose `rm` and `mkdir`, it shows that:

> HEAD is now at 13c5ef1 Update README.md
> mkdir: created directory 'api'
> mkdir: created directory 'api/docs'

This means that instead of deleting the contents of `docs` in the root `api`, it instead looks at `api/docs` at the root `api`, a problem of relative paths. This attempts to fix the issue completely.

Successful run (in pull request context):
https://github.com/codeigniter4/CodeIgniter4/actions/runs/1075571421

**Checklist:**
- [x] Securely signed commits
