### PR TITLE
required rule error fix

### DIFF
--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -324,7 +324,7 @@ class Rules
      */
     public function required($str = null): bool
     {
-        if (is_object($str)) {
+        if (is_object($str) || is_bool($str)) {
             return true;
         }
 

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -144,6 +144,23 @@ class RulesTest extends CIUnitTestCase
 
     //--------------------------------------------------------------------
 
+    public function testRequiredBoolean()
+    {
+        $data = [
+            'foo' => true,
+            'bar' => false
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'required',
+            'bar' => 'required'
+        ]);
+
+        $this->assertTrue($this->validation->run($data));
+    }
+
+    //--------------------------------------------------------------------
+
     /**
      * @dataProvider ifExistProvider
      *
@@ -280,10 +297,11 @@ class RulesTest extends CIUnitTestCase
                 ['foo' => null],
                 false,
             ],
+            // This test will return true because false value is boolean
             [
                 ['foo' => 'permit_empty|required'],
                 ['foo' => false],
-                false,
+                true,
             ],
             // This tests will return true because the input data is trimmed
             [


### PR DESCRIPTION
Fixes #4971

**Description**
I modified the required rule in Validation/Rules. 
I did it because the required rule blocks the false value when the user try to send a false value to the database.
This problem affected one of my applications when I update the  available value in a product field.
So I decided to solve this problem and helps the community.
The modification is short. Nothing too big.
I updated one of the tests because my objective is modify this behavior.
This a new pull request. More clean, more readable. I think more acceptable.
A little modification but I needed modify this.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
  