### PR TITLE
Remove override

### DIFF
--- a/.no-header.php-cs-fixer.dist.php
+++ b/.no-header.php-cs-fixer.dist.php
@@ -23,9 +23,7 @@ $finder = Finder::create()
         __DIR__ . '/public',
     ]);
 
-$overrides = [
-    'no_blank_lines_after_phpdoc' => false,
-];
+$overrides = [];
 
 $options = [
     'cacheFile' => 'build/.no-header.php-cs-fixer.cache',


### PR DESCRIPTION
**Description**
On update to v3.0.1 of php-cs-fixer the override to `false` of `no_blank_lines_after_phpdoc` is no longer needed as the bug is already fixed.

**Checklist:**
- [x] Securely signed commits
