### PR TITLE
Fix lang() function is overriding locale

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -729,8 +729,21 @@ if (! function_exists('lang')) {
      */
     function lang(string $line, array $args = [], ?string $locale = null)
     {
-        return Services::language($locale)
-            ->getLine($line, $args);
+        if($locale)
+        {
+            //Save previous locale
+            $oldLocale = Services::language()->getLocale();
+        }
+
+        $line = Services::language($locale)
+                        ->getLine($line, $args);
+
+        if($locale && $oldLocale != Services::language()->getLocale())
+        {
+            //Reset to previous locale
+            Services::language($oldLocale);
+        }
+        return $line;
     }
 }
 


### PR DESCRIPTION
After using the `lang()` function with the `$locale` parameter filled in, it overrides the `Language` locale, which shouldn't happen, because when using the `lang()` function with the `$locale` parameter it should be just for that call.

With this change, this override is corrected and the locale that was previously selected is restored.


**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
