### PR TITLE
Fix lang() function overriding default locale in Language class

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -763,8 +763,25 @@ if (! function_exists('lang')) {
      */
     function lang(string $line, array $args = [], string $locale = null)
     {
-        return Services::language($locale)
-            ->getLine($line, $args);
+        $language = Services::language();
+
+        //Get active locale
+        $activeLocale = $language->getLocale();
+
+        if ($locale && $locale != $activeLocale)
+        {
+            $language->setLocale($locale);
+        }
+
+        $line = $language->getLine($line, $args);
+
+        if ($locale && $locale != $activeLocale)
+        {
+            //Reset to active locale
+            $language->setLocale($activeLocale);
+        }
+
+        return $line;
     }
 }
 

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -289,6 +289,25 @@ class LanguageTest extends CIUnitTestCase
     //--------------------------------------------------------------------
 
     /**
+     * Test if after using lang() with a locale the Language class keep the locale after return the $line
+     */
+    public function testLangKeepLocale()
+    {
+        $this->lang = Services::language('en', true);
+
+        lang('Language.languageGetLineInvalidArgumentException');
+        $this->assertEquals('en', $this->lang->getLocale());
+
+        lang('Language.languageGetLineInvalidArgumentException', [], 'ru');
+        $this->assertEquals('en', $this->lang->getLocale());
+
+        lang('Language.languageGetLineInvalidArgumentException');
+        $this->assertEquals('en', $this->lang->getLocale());
+    }
+
+    //--------------------------------------------------------------------
+
+    /**
      * Testing base locale vs variants, with fallback to English.
      *
      * Key	en	ab	ac-CD


### PR DESCRIPTION
After using the `lang()` function with the `$locale` parameter filled in, it overrides the default locale in the Language class, which shouldn't happen, because when using the `lang()` function with the `$locale` parameter it should be just for that call.

With this change, this override is corrected and the locale that was previously selected is restored.


**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
