### PR TITLE
[Rector] Apply Rector dead code set list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "phpstan/phpstan": "^0.12.91",
         "phpunit/phpunit": "^9.1",
         "predis/predis": "^1.1",
-        "rector/rector": "0.11.47",
+        "rector/rector": "0.11.48",
         "symplify/package-builder": "^9.3"
     },
     "suggest": {

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -996,20 +996,18 @@ class Forge
             'SET DEFAULT',
         ];
 
-        if ($this->foreignKeys !== []) {
-            foreach ($this->foreignKeys as $field => $fkey) {
-                $nameIndex = $table . '_' . $field . '_foreign';
+        foreach ($this->foreignKeys as $field => $fkey) {
+            $nameIndex = $table . '_' . $field . '_foreign';
 
-                $sql .= ",\n\tCONSTRAINT " . $this->db->escapeIdentifiers($nameIndex)
-                    . ' FOREIGN KEY(' . $this->db->escapeIdentifiers($field) . ') REFERENCES ' . $this->db->escapeIdentifiers($this->db->DBPrefix . $fkey['table']) . ' (' . $this->db->escapeIdentifiers($fkey['field']) . ')';
+            $sql .= ",\n\tCONSTRAINT " . $this->db->escapeIdentifiers($nameIndex)
+                . ' FOREIGN KEY(' . $this->db->escapeIdentifiers($field) . ') REFERENCES ' . $this->db->escapeIdentifiers($this->db->DBPrefix . $fkey['table']) . ' (' . $this->db->escapeIdentifiers($fkey['field']) . ')';
 
-                if ($fkey['onDelete'] !== false && in_array($fkey['onDelete'], $allowActions, true)) {
-                    $sql .= ' ON DELETE ' . $fkey['onDelete'];
-                }
+            if ($fkey['onDelete'] !== false && in_array($fkey['onDelete'], $allowActions, true)) {
+                $sql .= ' ON DELETE ' . $fkey['onDelete'];
+            }
 
-                if ($fkey['onUpdate'] !== false && in_array($fkey['onUpdate'], $allowActions, true)) {
-                    $sql .= ' ON UPDATE ' . $fkey['onUpdate'];
-                }
+            if ($fkey['onUpdate'] !== false && in_array($fkey['onUpdate'], $allowActions, true)) {
+                $sql .= ' ON UPDATE ' . $fkey['onUpdate'];
             }
         }
 

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -89,7 +89,7 @@ class Result extends BaseResult
             $retVal[$i]->type        = $data->type;
             $retVal[$i]->type_name   = in_array($data->type, [1, 247], true) ? 'char' : ($dataTypes[$data->type] ?? null);
             $retVal[$i]->max_length  = $data->max_length;
-            $retVal[$i]->primary_key = (int) ($data->flags & 2);
+            $retVal[$i]->primary_key = $data->flags & 2;
             $retVal[$i]->length      = $data->length;
             $retVal[$i]->default     = $data->def;
         }

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -354,7 +354,7 @@ class Connection extends BaseConnection
      */
     protected function _transBegin(): bool
     {
-        return (bool) sqlsrv_begin_transaction($this->connID);
+        return sqlsrv_begin_transaction($this->connID);
     }
 
     /**
@@ -362,7 +362,7 @@ class Connection extends BaseConnection
      */
     protected function _transCommit(): bool
     {
-        return (bool) sqlsrv_commit($this->connID);
+        return sqlsrv_commit($this->connID);
     }
 
     /**
@@ -370,7 +370,7 @@ class Connection extends BaseConnection
      */
     protected function _transRollback(): bool
     {
-        return (bool) sqlsrv_rollback($this->connID);
+        return sqlsrv_rollback($this->connID);
     }
 
     /**

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -224,21 +224,19 @@ class Forge extends BaseForge
 
         $allowActions = ['CASCADE', 'SET NULL', 'NO ACTION', 'RESTRICT', 'SET DEFAULT'];
 
-        if ($this->foreignKeys !== []) {
-            foreach ($this->foreignKeys as $field => $fkey) {
-                $nameIndex = $table . '_' . $field . '_foreign';
+        foreach ($this->foreignKeys as $field => $fkey) {
+            $nameIndex = $table . '_' . $field . '_foreign';
 
-                $sql .= ",\n\t CONSTRAINT " . $this->db->escapeIdentifiers($nameIndex)
-                    . ' FOREIGN KEY (' . $this->db->escapeIdentifiers($field) . ') '
-                    . ' REFERENCES ' . $this->db->escapeIdentifiers($this->db->getPrefix() . $fkey['table']) . ' (' . $this->db->escapeIdentifiers($fkey['field']) . ')';
+            $sql .= ",\n\t CONSTRAINT " . $this->db->escapeIdentifiers($nameIndex)
+                . ' FOREIGN KEY (' . $this->db->escapeIdentifiers($field) . ') '
+                . ' REFERENCES ' . $this->db->escapeIdentifiers($this->db->getPrefix() . $fkey['table']) . ' (' . $this->db->escapeIdentifiers($fkey['field']) . ')';
 
-                if ($fkey['onDelete'] !== false && in_array($fkey['onDelete'], $allowActions, true)) {
-                    $sql .= ' ON DELETE ' . $fkey['onDelete'];
-                }
+            if ($fkey['onDelete'] !== false && in_array($fkey['onDelete'], $allowActions, true)) {
+                $sql .= ' ON DELETE ' . $fkey['onDelete'];
+            }
 
-                if ($fkey['onUpdate'] !== false && in_array($fkey['onUpdate'], $allowActions, true)) {
-                    $sql .= ' ON UPDATE ' . $fkey['onUpdate'];
-                }
+            if ($fkey['onUpdate'] !== false && in_array($fkey['onUpdate'], $allowActions, true)) {
+                $sql .= ' ON UPDATE ' . $fkey['onUpdate'];
             }
         }
 

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -66,17 +66,14 @@ class Toolbar
     /**
      * Returns all the data required by Debug Bar
      *
-     * @param float $startTime App start time
+     * @param float           $startTime App start time
+     * @param IncomingRequest $request
+     * @param Response        $response
      *
      * @return string JSON encoded data
      */
     public function run(float $startTime, float $totalTime, RequestInterface $request, ResponseInterface $response): string
     {
-        /**
-         * @var IncomingRequest $request
-         * @var Response        $response
-         */
-
         // Data items used within the view.
         $data['url']             = current_url();
         $data['method']          = $request->getMethod(true);

--- a/system/Debug/Toolbar/Collectors/Files.php
+++ b/system/Debug/Toolbar/Collectors/Files.php
@@ -45,7 +45,7 @@ class Files extends BaseCollector
      */
     public function getTitleDetails(): string
     {
-        return '( ' . (int) count(get_included_files()) . ' )';
+        return '( ' . count(get_included_files()) . ' )';
     }
 
     /**

--- a/system/Events/Events.php
+++ b/system/Events/Events.php
@@ -71,9 +71,7 @@ class Events
             return;
         }
 
-        /**
-         * @var Modules
-         */
+        /** @var Modules $config */
         $config = config('Modules');
         $events = APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'Events.php';
         $files  = [];

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -254,8 +254,6 @@ class Filters
      * Restores instance to its pre-initialized state.
      * Most useful for testing so the service can be
      * re-initialized to a different path.
-     *
-     * @return $this
      */
     public function reset(): self
     {
@@ -427,8 +425,6 @@ class Filters
 
         if (array_key_exists($method, $this->config->methods)) {
             $this->filters['before'] = array_merge($this->filters['before'], $this->config->methods[$method]);
-
-            return;
         }
     }
 

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -997,9 +997,6 @@ class URI
      * Section 5.2
      *
      * @see http://tools.ietf.org/html/rfc3986#section-5.2.3
-     *
-     * @param URI $base
-     * @param URI $reference
      */
     protected function mergePaths(self $base, self $reference): string
     {

--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -304,10 +304,8 @@ if (! function_exists('video')) {
 
         $video .= ">\n";
 
-        if (! empty($tracks)) {
-            foreach ($tracks as $track) {
-                $video .= _space_indent() . $track . "\n";
-            }
+        foreach ($tracks as $track) {
+            $video .= _space_indent() . $track . "\n";
         }
 
         if (! empty($unsupportedMessage)) {
@@ -352,10 +350,8 @@ if (! function_exists('audio')) {
 
         $audio .= '>';
 
-        if (! empty($tracks)) {
-            foreach ($tracks as $track) {
-                $audio .= "\n" . _space_indent() . $track;
-            }
+        foreach ($tracks as $track) {
+            $audio .= "\n" . _space_indent() . $track;
         }
 
         if (! empty($unsupportedMessage)) {
@@ -388,10 +384,8 @@ if (! function_exists('_media')) {
             $media .= _space_indent() . $option . "\n";
         }
 
-        if (! empty($tracks)) {
-            foreach ($tracks as $track) {
-                $media .= _space_indent() . $track . "\n";
-            }
+        foreach ($tracks as $track) {
+            $media .= _space_indent() . $track . "\n";
         }
 
         if (! empty($unsupportedMessage)) {

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -395,10 +395,8 @@ if (! function_exists('word_wrap')) {
         }
 
         // Put our markers back
-        if (! empty($unwrap)) {
-            foreach ($unwrap as $key => $val) {
-                $output = str_replace('{{unwrapped' . $key . '}}', $val, $output);
-            }
+        foreach ($unwrap as $key => $val) {
+            $output = str_replace('{{unwrapped' . $key . '}}', $val, $output);
         }
 
         // remove any trailing newline

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -282,7 +282,7 @@ class Logger implements LoggerInterface
             }
 
             /**
-             * @var HandlerInterface
+             * @var HandlerInterface $handler
              */
             $handler = $this->handlers[$className];
 

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -363,8 +363,6 @@ class Pager implements PagerInterface
 
     /**
      * Sets only allowed queries on pagination links.
-     *
-     * @return Pager
      */
     public function only(array $queries): self
     {

--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -239,7 +239,7 @@ class PagerRenderer
             $uri     = $this->segment === 0 ? $uri->addQuery($this->pageSelector, $i) : $uri->setSegment($this->segment, $i);
             $links[] = [
                 'uri'    => URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment()),
-                'title'  => (int) $i,
+                'title'  => $i,
                 'active' => ($i === $this->current),
             ];
         }
@@ -260,8 +260,8 @@ class PagerRenderer
             return;
         }
 
-        $this->first = $this->current - $count > 0 ? (int) ($this->current - $count) : 1;
-        $this->last  = $this->current + $count <= $this->pageCount ? (int) ($this->current + $count) : (int) $this->pageCount;
+        $this->first = $this->current - $count > 0 ? $this->current - $count : 1;
+        $this->last  = $this->current + $count <= $this->pageCount ? $this->current + $count : (int) $this->pageCount;
     }
 
     /**

--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -92,8 +92,6 @@ interface RouteCollectionInterface
      * defined routes.
      *
      * If FALSE, will stop searching and do NO automatic routing.
-     *
-     * @return RouteCollectionInterface
      */
     public function setAutoRoute(bool $value): self;
 
@@ -105,8 +103,6 @@ interface RouteCollectionInterface
      * This setting is passed to the Router class and handled there.
      *
      * @param callable|null $callable
-     *
-     * @return RouteCollectionInterface
      */
     public function set404Override($callable = null): self;
 

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -268,8 +268,6 @@ class Router implements RouterInterface
      * it a blank.
      *
      * @param string $page
-     *
-     * @return $this
      */
     public function setIndexPage($page): self
     {
@@ -281,10 +279,6 @@ class Router implements RouterInterface
     /**
      * Tells the system whether we should translate URI dashes or not
      * in the URI from a dash to an underscore.
-     *
-     * @param bool|false $val
-     *
-     * @return $this
      */
     public function setTranslateURIDashes(bool $val = false): self
     {

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -125,7 +125,9 @@ class Security implements SecurityInterface
      */
     public function __construct(App $config)
     {
-        /** @var SecurityConfig */
+        /**
+         * @var SecurityConfig $security
+         */
         $security = config('Security');
 
         // Store CSRF-related configurations
@@ -134,7 +136,9 @@ class Security implements SecurityInterface
         $this->regenerate = $security->regenerate ?? $config->CSRFRegenerate ?? $this->regenerate;
         $rawCookieName    = $security->cookieName ?? $config->CSRFCookieName ?? $this->cookieName;
 
-        /** @var CookieConfig */
+        /**
+         * @var CookieConfig $cookie
+         */
         $cookie = config('Cookie');
 
         $cookiePrefix     = $cookie->prefix ?? $config->cookiePrefix;

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -125,9 +125,7 @@ class Security implements SecurityInterface
      */
     public function __construct(App $config)
     {
-        /**
-         * @var SecurityConfig $security
-         */
+        /** @var SecurityConfig $security */
         $security = config('Security');
 
         // Store CSRF-related configurations
@@ -136,9 +134,7 @@ class Security implements SecurityInterface
         $this->regenerate = $security->regenerate ?? $config->CSRFRegenerate ?? $this->regenerate;
         $rawCookieName    = $security->cookieName ?? $config->CSRFCookieName ?? $this->cookieName;
 
-        /**
-         * @var CookieConfig $cookie
-         */
+        /** @var CookieConfig $cookie */
         $cookie = config('Cookie');
 
         $cookiePrefix     = $cookie->prefix ?? $config->cookiePrefix;

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -182,9 +182,7 @@ class Session implements SessionInterface
         $this->cookieSecure   = $config->cookieSecure ?? $this->cookieSecure;
         $this->cookieSameSite = $config->cookieSameSite ?? $this->cookieSameSite;
 
-        /**
-         * @var CookieConfig $cookie
-         */
+        /** @var CookieConfig $cookie */
         $cookie = config('Cookie');
 
         $this->cookie = new Cookie($this->sessionCookieName, '', [

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -182,7 +182,9 @@ class Session implements SessionInterface
         $this->cookieSecure   = $config->cookieSecure ?? $this->cookieSecure;
         $this->cookieSameSite = $config->cookieSameSite ?? $this->cookieSameSite;
 
-        /** @var CookieConfig */
+        /**
+         * @var CookieConfig $cookie
+         */
         $cookie = config('Cookie');
 
         $this->cookie = new Cookie($this->sessionCookieName, '', [

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -233,8 +233,6 @@ class Fabricator
      *
      * @param array $overrides Array of [field => value]
      * @param bool  $persist   Whether these overrides should persist through the next operation
-     *
-     * @return $this
      */
     public function setOverrides(array $overrides = [], $persist = true): self
     {
@@ -259,8 +257,6 @@ class Fabricator
      * Set the formatters to use. Will attempt to autodetect if none are available.
      *
      * @param array|null $formatters Array of [field => formatter], or null to detect
-     *
-     * @return $this
      */
     public function setFormatters(?array $formatters = null): self
     {
@@ -277,8 +273,6 @@ class Fabricator
 
     /**
      * Try to identify the appropriate Faker formatter for each field.
-     *
-     * @return $this
      */
     protected function detectFormatters(): self
     {

--- a/system/Test/Mock/MockBuilder.php
+++ b/system/Test/Mock/MockBuilder.php
@@ -12,12 +12,7 @@
 namespace CodeIgniter\Test\Mock;
 
 use CodeIgniter\Database\BaseBuilder;
-use CodeIgniter\Database\ConnectionInterface;
 
 class MockBuilder extends BaseBuilder
 {
-    public function __construct($tableName, ConnectionInterface &$db, ?array $options = null)
-    {
-        parent::__construct($tableName, $db, $options);
-    }
 }

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -139,8 +139,6 @@ class Throttler implements ThrottlerInterface
 
     /**
      * @param string $key The name of the bucket
-     *
-     * @return $this
      */
     public function remove(string $key): self
     {

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -113,7 +113,7 @@ class Rules
             $row = $row->where($whereField, $whereValue);
         }
 
-        return (bool) ($row->get()->getRow() !== null);
+        return $row->get()->getRow() !== null;
     }
 
     /**
@@ -158,7 +158,7 @@ class Rules
             $row = $row->where("{$ignoreField} !=", $ignoreValue);
         }
 
-        return (bool) ($row->get()->getRow() === null);
+        return $row->get()->getRow() === null;
     }
 
     /**

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -64,8 +64,8 @@ final class ResponseTraitTest extends CIUnitTestCase
         }
 
         if ($this->request === null) {
-            $this->request  = new MockIncomingRequest((object) $config, new URI($uri), null, new UserAgent());
-            $this->response = new MockResponse((object) $config);
+            $this->request  = new MockIncomingRequest($config, new URI($uri), null, new UserAgent());
+            $this->response = new MockResponse($config);
         }
 
         // Insert headers into request.

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -345,7 +345,7 @@ final class BaseTestFileHandler extends FileHandler
     public function getFileInfoTest()
     {
         $tmpHandle = tmpfile();
-        stream_get_meta_data($tmpHandle)['uri'];
+        stream_get_meta_data($tmpHandle);
 
         return $this->getFileInfo(stream_get_meta_data($tmpHandle)['uri'], [
             'name',

--- a/tests/system/Cookie/CookieStoreTest.php
+++ b/tests/system/Cookie/CookieStoreTest.php
@@ -110,7 +110,7 @@ final class CookieStoreTest extends CIUnitTestCase
         $prod = $cookies['prod']->getOptions();
 
         /**
-         * @var MockObject&CookieStore
+         * @var MockObject&CookieStore $store
          */
         $store = $this->getMockBuilder(CookieStore::class)
             ->setConstructorArgs([$cookies])

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -58,8 +58,6 @@ final class UpdateTest extends CIUnitTestCase
             // This DB doesn't support Where and Limit together
             // but we don't want it called a "Risky" test.
             $this->assertTrue(true);
-
-            return;
         }
     }
 
@@ -95,8 +93,6 @@ final class UpdateTest extends CIUnitTestCase
             // This DB doesn't support Where and Limit together
             // but we don't want it called a "Risky" test.
             $this->assertTrue(true);
-
-            return;
         }
     }
 

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -48,7 +48,7 @@ final class EventsTest extends CIUnitTestCase
     public function testInitialize()
     {
         /**
-         * @var Modules
+         * @var Modules $config
          */
         $config          = config('Modules');
         $config->aliases = [];

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -241,7 +241,7 @@ final class PagerTest extends CIUnitTestCase
         $expected = current_url(true);
         $expected = (string) $expected->setQuery('page_foo=3');
 
-        $this->assertSame((string) $expected, $this->pager->getNextPageURI('foo'));
+        $this->assertSame($expected, $this->pager->getNextPageURI('foo'));
     }
 
     public function testGetNextURIReturnsNullOnLastPage()
@@ -270,7 +270,7 @@ final class PagerTest extends CIUnitTestCase
         $expected = current_url(true);
         $expected = (string) $expected->setQuery('page_foo=1');
 
-        $this->assertSame((string) $expected, $this->pager->getPreviousPageURI('foo'));
+        $this->assertSame($expected, $this->pager->getPreviousPageURI('foo'));
     }
 
     public function testGetNextURIReturnsNullOnFirstPage()
@@ -292,7 +292,7 @@ final class PagerTest extends CIUnitTestCase
 
         $this->pager->store('foo', $_GET['page_foo'] - 1, 12, 70);
 
-        $this->assertSame((string) $expected, $this->pager->getNextPageURI('foo'));
+        $this->assertSame($expected, $this->pager->getNextPageURI('foo'));
     }
 
     public function testGetPreviousURIWithQueryStringUsesCurrentURI()
@@ -306,7 +306,7 @@ final class PagerTest extends CIUnitTestCase
 
         $this->pager->store('foo', $_GET['page_foo'] + 1, 12, 70);
 
-        $this->assertSame((string) $expected, $this->pager->getPreviousPageURI('foo'));
+        $this->assertSame($expected, $this->pager->getPreviousPageURI('foo'));
     }
 
     public function testGetOnlyQueries()
@@ -453,7 +453,7 @@ final class PagerTest extends CIUnitTestCase
         $expected = current_url(true);
         $expected = (string) $expected->setQuery('page_foo=1');
 
-        $this->assertSame((string) $expected, $this->pager->getPreviousPageURI('foo'));
+        $this->assertSame($expected, $this->pager->getPreviousPageURI('foo'));
     }
 
     public function testAccessPageMoreThanPageCountGetLastPage()

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -180,9 +180,9 @@ final class SessionTest extends CIUnitTestCase
         $session = $this->getInstance();
         $session->start();
 
-        $session->set('foo', (int) 0);
+        $session->set('foo', 0);
 
-        $this->assertSame((int) 0, $session->get('foo'));
+        $this->assertSame(0, $session->get('foo'));
     }
 
     public function testGetReturnsAllWithNoKeys()


### PR DESCRIPTION
Rector dead code set list `SetList::DEAD_CODE` is collection of rector rules to remove dead code at 

https://github.com/rectorphp/rector-src/blob/c3c1411d107534e9d5c103982c9e5442213cc800/config/set/dead-code.php


This PR apply rector dead code set list with use latest rector 0.11.48, with skip some edge cases on purpose or need wait for next release for the false positive check functionality.

**Checklist:**
- [x] Securely signed commits
