### PR TITLE
Cache Config

### DIFF
--- a/app/Config/Cache.php
+++ b/app/Config/Cache.php
@@ -2,6 +2,7 @@
 
 namespace Config;
 
+use CodeIgniter\Cache\Handlers\BaseHandler;
 use CodeIgniter\Cache\Handlers\DummyHandler;
 use CodeIgniter\Cache\Handlers\FileHandler;
 use CodeIgniter\Cache\Handlers\MemcachedHandler;
@@ -96,6 +97,20 @@ class Cache extends BaseConfig
      * @var int
      */
     public $ttl = 60;
+
+    /**
+     * --------------------------------------------------------------------------
+     * Reserved Characters
+     * --------------------------------------------------------------------------
+     *
+     * A string of reserved characters that will not be allowed in keys or tags.
+     * Strings that violate this restriction will cause handlers to throw.
+     * Default: {}()/\@:
+     * Note: The default set is required for PSR-6 compliance.
+     *
+     * @var string
+     */
+    public $reservedCharacters = '{}()/\@:';
 
     /**
      * --------------------------------------------------------------------------

--- a/app/Config/Cache.php
+++ b/app/Config/Cache.php
@@ -2,7 +2,6 @@
 
 namespace Config;
 
-use CodeIgniter\Cache\Handlers\BaseHandler;
 use CodeIgniter\Cache\Handlers\DummyHandler;
 use CodeIgniter\Cache\Handlers\FileHandler;
 use CodeIgniter\Cache\Handlers\MemcachedHandler;

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -22,8 +22,10 @@ use InvalidArgumentException;
 abstract class BaseHandler implements CacheInterface
 {
     /**
-     * Reserved characters that cannot be used in a key or tag.
+     * Reserved characters that cannot be used in a key or tag. May be overridden by the config.
      * From https://github.com/symfony/cache-contracts/blob/c0446463729b89dd4fa62e9aeecc80287323615d/ItemInterface.php#L43
+     *
+     * @deprecated in favor of the Cache config
      */
     public const RESERVED_CHARACTERS = '{}()/\@:';
 
@@ -58,8 +60,10 @@ abstract class BaseHandler implements CacheInterface
         if ($key === '') {
             throw new InvalidArgumentException('Cache key cannot be empty.');
         }
-        if (strpbrk($key, self::RESERVED_CHARACTERS) !== false) {
-            throw new InvalidArgumentException('Cache key contains reserved characters ' . self::RESERVED_CHARACTERS);
+
+        $reserved = config('Cache')->reservedCharacters ?? self::RESERVED_CHARACTERS;
+        if ($reserved && strpbrk($key, $reserved) !== false) {
+            throw new InvalidArgumentException('Cache key contains reserved characters ' . $reserved);
         }
 
         // If the key with prefix exceeds the length then return the hashed version

--- a/tests/system/Cache/Handlers/BaseHandlerTest.php
+++ b/tests/system/Cache/Handlers/BaseHandlerTest.php
@@ -30,6 +30,16 @@ class BaseHandlerTest extends CIUnitTestCase
         ];
     }
 
+    public function testValidateKeyUsesConfig()
+    {
+    	config('Cache')->reservedCharacters = 'b';
+
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Cache key contains reserved characters b');
+
+        BaseHandler::validateKey('banana');
+    }
+
     public function testValidateKeySuccess()
     {
         $string = 'banana';

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -12,6 +12,7 @@ See all the changes.
 .. toctree::
     :titlesonly:
 
+    v4.2.0
     v4.1.4
     v4.1.3
     v4.1.2

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -1,0 +1,18 @@
+Version 4.2.0
+=============
+
+Release Date: Not released
+
+**4.2.0 release of CodeIgniter4**
+
+Enhancements:
+
+- Added Cache config for reserved characters
+
+Changes:
+
+Deprecations:
+
+- Deprecated ``CodeIgniter\\Cache\\Handlers\\BaseHandler::RESERVED_CHARACTERS`` in favor of the new config property
+
+Bugs Fixed:


### PR DESCRIPTION
**Description**
Adds a new config value for reserved characters so developers may set their own restrictions.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
