### PR TITLE
Make CookieStore compatible with IteratorAggregate::getIterator

### DIFF
--- a/system/Cookie/CookieStore.php
+++ b/system/Cookie/CookieStore.php
@@ -207,7 +207,7 @@ class CookieStore implements Countable, IteratorAggregate
      *
      * @return Traversable<string, Cookie>
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->cookies);
     }


### PR DESCRIPTION
**Description**
Related to #4883 
> Fatal error: During inheritance of IteratorAggregate: Uncaught Return type of CodeIgniter\Cookie\CookieStore::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

**Checklist:**
- [x] Securely signed commits
