### PR TITLE
Make the session handlers all compatible with SessionHandlerInterface

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -111,6 +111,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         RecastingRemovalRector::class => [
             __DIR__ . '/tests/system/Entity/EntityTest.php',
         ],
+
+        // session handlers have the gc() method with underscored parameter `$max_lifetime`
+        UnderscoreToCamelCaseVariableNameRector::class => [
+            __DIR__ . '/system/Session/Handlers',
+        ],
     ]);
 
     // auto import fully qualified class names

--- a/system/Session/Handlers/ArrayHandler.php
+++ b/system/Session/Handlers/ArrayHandler.php
@@ -11,7 +11,7 @@
 
 namespace CodeIgniter\Session\Handlers;
 
-use Exception;
+use ReturnTypeWillChange;
 
 /**
  * Session handler using static array for storage.
@@ -22,51 +22,43 @@ class ArrayHandler extends BaseHandler
     protected static $cache = [];
 
     /**
-     * Open
+     * Re-initialize existing session, or creates a new one.
      *
-     * Ensures we have an initialized database connection.
-     *
-     * @param string $savePath Path to session files' directory
-     * @param string $name     Session cookie name
-     *
-     * @throws Exception
+     * @param string $path The path where to store/retrieve the session
+     * @param string $name The session name
      */
-    public function open($savePath, $name): bool
+    public function open($path, $name): bool
     {
         return true;
     }
 
     /**
-     * Read
+     * Reads the session data from the session storage, and returns the results.
      *
-     * Reads session data and acquires a lock
+     * @param string $id The session ID
      *
-     * @param string $sessionID Session ID
-     *
-     * @return string Serialized session data
+     * @return false|string Returns an encoded string of the read data.
+     *                      If nothing was read, it must return false.
      */
-    public function read($sessionID): string
+    #[ReturnTypeWillChange]
+    public function read($id)
     {
         return '';
     }
 
     /**
-     * Write
+     * Writes the session data to the session storage.
      *
-     * Writes (create / update) session data
-     *
-     * @param string $sessionID   Session ID
-     * @param string $sessionData Serialized session data
+     * @param string $id   The session ID
+     * @param string $data The encoded session data
      */
-    public function write($sessionID, $sessionData): bool
+    public function write($id, $data): bool
     {
         return true;
     }
 
     /**
-     * Close
-     *
-     * Releases locks and closes file descriptor.
+     * Closes the current session.
      */
     public function close(): bool
     {
@@ -74,26 +66,26 @@ class ArrayHandler extends BaseHandler
     }
 
     /**
-     * Destroy
+     * Destroys a session
      *
-     * Destroys the current session.
-     *
-     * @param string $sessionID
+     * @param string $id The session ID being destroyed
      */
-    public function destroy($sessionID): bool
+    public function destroy($id): bool
     {
         return true;
     }
 
     /**
-     * Garbage Collector
+     * Cleans up expired sessions.
      *
-     * Deletes expired sessions
+     * @param int $max_lifetime Sessions that have not updated
+     *                          for the last max_lifetime seconds will be removed.
      *
-     * @param int $maxlifetime Maximum lifetime of sessions
+     * @return false|int Returns the number of deleted sessions on success, or false on failure.
      */
-    public function gc($maxlifetime): bool
+    #[ReturnTypeWillChange]
+    public function gc($max_lifetime)
     {
-        return true;
+        return 1;
     }
 }

--- a/system/Session/Handlers/BaseHandler.php
+++ b/system/Session/Handlers/BaseHandler.php
@@ -100,9 +100,6 @@ abstract class BaseHandler implements SessionHandlerInterface
      */
     protected $ipAddress;
 
-    /**
-     * Constructor
-     */
     public function __construct(AppConfig $config, string $ipAddress)
     {
         $this->cookiePrefix = $config->cookiePrefix;
@@ -155,12 +152,11 @@ abstract class BaseHandler implements SessionHandlerInterface
     }
 
     /**
-     * Fail
-     *
      * Drivers other than the 'files' one don't (need to) use the
      * session.save_path INI setting, but that leads to confusing
      * error messages emitted by PHP when open() or write() fail,
      * as the message contains session.save_path ...
+     *
      * To work around the problem, the drivers will call this method
      * so that the INI is set just in time for the error message to
      * be properly generated.

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -15,7 +15,7 @@ use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Session\Exceptions\SessionException;
 use Config\App as AppConfig;
 use Config\Database;
-use Exception;
+use ReturnTypeWillChange;
 
 /**
  * Session handler using current Database for storage
@@ -58,27 +58,24 @@ class DatabaseHandler extends BaseHandler
     protected $rowExists = false;
 
     /**
-     * Constructor
+     * @throws SessionException
      */
     public function __construct(AppConfig $config, string $ipAddress)
     {
         parent::__construct($config, $ipAddress);
-
-        // Determine Table
         $this->table = $config->sessionSavePath;
 
         if (empty($this->table)) {
             throw SessionException::forMissingDatabaseTable();
         }
 
-        // Get DB Connection
         // @phpstan-ignore-next-line
         $this->DBGroup = $config->sessionDBGroup ?? config(Database::class)->defaultGroup;
 
         $this->db = Database::connect($this->DBGroup);
 
-        // Determine Database type
         $driver = strtolower(get_class($this->db));
+
         if (strpos($driver, 'mysql') !== false) {
             $this->platform = 'mysql';
         } elseif (strpos($driver, 'postgre') !== false) {
@@ -87,16 +84,12 @@ class DatabaseHandler extends BaseHandler
     }
 
     /**
-     * Open
+     * Re-initialize existing session, or creates a new one.
      *
-     * Ensures we have an initialized database connection.
-     *
-     * @param string $savePath Path to session files' directory
-     * @param string $name     Session cookie name
-     *
-     * @throws Exception
+     * @param string $path The path where to store/retrieve the session
+     * @param string $name The session name
      */
-    public function open($savePath, $name): bool
+    public function open($path, $name): bool
     {
         if (empty($this->db->connID)) {
             $this->db->initialize();
@@ -106,30 +99,29 @@ class DatabaseHandler extends BaseHandler
     }
 
     /**
-     * Read
+     * Reads the session data from the session storage, and returns the results.
      *
-     * Reads session data and acquires a lock
+     * @param string $id The session ID
      *
-     * @param string $sessionID Session ID
-     *
-     * @return string Serialized session data
+     * @return false|string Returns an encoded string of the read data.
+     *                      If nothing was read, it must return false.
      */
-    public function read($sessionID): string
+    #[ReturnTypeWillChange]
+    public function read($id)
     {
-        if ($this->lockSession($sessionID) === false) {
+        if ($this->lockSession($id) === false) {
             $this->fingerprint = md5('');
 
             return '';
         }
 
-        // Needed by write() to detect session_regenerate_id() calls
         if (! isset($this->sessionID)) {
-            $this->sessionID = $sessionID;
+            $this->sessionID = $id;
         }
 
         $builder = $this->db->table($this->table)
             ->select($this->platform === 'postgre' ? "encode(data, 'base64') AS data" : 'data')
-            ->where('id', $sessionID);
+            ->where('id', $id);
 
         if ($this->matchIP) {
             $builder = $builder->where('ip_address', $this->ipAddress);
@@ -160,70 +152,63 @@ class DatabaseHandler extends BaseHandler
     }
 
     /**
-     * Write
+     * Writes the session data to the session storage.
      *
-     * Writes (create / update) session data
-     *
-     * @param string $sessionID   Session ID
-     * @param string $sessionData Serialized session data
+     * @param string $id   The session ID
+     * @param string $data The encoded session data
      */
-    public function write($sessionID, $sessionData): bool
+    public function write($id, $data): bool
     {
         if ($this->lock === false) {
             return $this->fail();
         }
 
-        // Was the ID regenerated?
-        if ($sessionID !== $this->sessionID) {
+        if ($this->sessionID !== $id) {
             $this->rowExists = false;
-            $this->sessionID = $sessionID;
+            $this->sessionID = $id;
         }
 
         if ($this->rowExists === false) {
             $insertData = [
-                'id'         => $sessionID,
+                'id'         => $id,
                 'ip_address' => $this->ipAddress,
                 'timestamp'  => 'now()',
-                'data'       => $this->platform === 'postgre' ? '\x' . bin2hex($sessionData) : $sessionData,
+                'data'       => $this->platform === 'postgre' ? '\x' . bin2hex($data) : $data,
             ];
 
             if (! $this->db->table($this->table)->insert($insertData)) {
                 return $this->fail();
             }
 
-            $this->fingerprint = md5($sessionData);
+            $this->fingerprint = md5($data);
             $this->rowExists   = true;
 
             return true;
         }
 
-        $builder = $this->db->table($this->table)->where('id', $sessionID);
+        $builder = $this->db->table($this->table)->where('id', $id);
 
         if ($this->matchIP) {
             $builder = $builder->where('ip_address', $this->ipAddress);
         }
 
-        $updateData = [
-            'timestamp' => 'now()',
-        ];
+        $updateData = ['timestamp' => 'now()'];
 
-        if ($this->fingerprint !== md5($sessionData)) {
-            $updateData['data'] = ($this->platform === 'postgre') ? '\x' . bin2hex($sessionData) : $sessionData;
+        if ($this->fingerprint !== md5($data)) {
+            $updateData['data'] = ($this->platform === 'postgre') ? '\x' . bin2hex($data) : $data;
         }
 
         if (! $builder->update($updateData)) {
             return $this->fail();
         }
 
-        $this->fingerprint = md5($sessionData);
+        $this->fingerprint = md5($data);
 
         return true;
     }
 
     /**
-     * Close
-     *
-     * Releases locks and closes file descriptor.
+     * Closes the current session.
      */
     public function close(): bool
     {
@@ -231,16 +216,14 @@ class DatabaseHandler extends BaseHandler
     }
 
     /**
-     * Destroy
+     * Destroys a session
      *
-     * Destroys the current session.
-     *
-     * @param string $sessionID
+     * @param string $id The session ID being destroyed
      */
-    public function destroy($sessionID): bool
+    public function destroy($id): bool
     {
         if ($this->lock) {
-            $builder = $this->db->table($this->table)->where('id', $sessionID);
+            $builder = $this->db->table($this->table)->where('id', $id);
 
             if ($this->matchIP) {
                 $builder = $builder->where('ip_address', $this->ipAddress);
@@ -261,18 +244,20 @@ class DatabaseHandler extends BaseHandler
     }
 
     /**
-     * Garbage Collector
+     * Cleans up expired sessions.
      *
-     * Deletes expired sessions
+     * @param int $max_lifetime Sessions that have not updated
+     *                          for the last max_lifetime seconds will be removed.
      *
-     * @param int $maxlifetime Maximum lifetime of sessions
+     * @return false|int Returns the number of deleted sessions on success, or false on failure.
      */
-    public function gc($maxlifetime): bool
+    #[ReturnTypeWillChange]
+    public function gc($max_lifetime)
     {
         $separator = $this->platform === 'postgre' ? '\'' : ' ';
-        $interval  = implode($separator, ['', "{$maxlifetime} second", '']);
+        $interval  = implode($separator, ['', "{$max_lifetime} second", '']);
 
-        return $this->db->table($this->table)->delete("timestamp < now() - INTERVAL {$interval}") ? true : $this->fail();
+        return $this->db->table($this->table)->delete("timestamp < now() - INTERVAL {$interval}") ? 1 : $this->fail();
     }
 
     /**

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -13,9 +13,9 @@ namespace CodeIgniter\Session\Handlers;
 
 use CodeIgniter\Session\Exceptions\SessionException;
 use Config\App as AppConfig;
-use Exception;
 use Redis;
 use RedisException;
+use ReturnTypeWillChange;
 
 /**
  * Session handler using Redis for persistence
@@ -58,9 +58,7 @@ class RedisHandler extends BaseHandler
     protected $sessionExpiration = 7200;
 
     /**
-     * Constructor
-     *
-     * @throws Exception
+     * @throws SessionException
      */
     public function __construct(AppConfig $config, string $ipAddress)
     {
@@ -72,8 +70,8 @@ class RedisHandler extends BaseHandler
 
         if (preg_match('#(?:tcp://)?([^:?]+)(?:\:(\d+))?(\?.+)?#', $this->savePath, $matches)) {
             if (! isset($matches[3])) {
-                $matches[3] = '';
-            } // Just to avoid undefined index notices below
+                $matches[3] = ''; // Just to avoid undefined index notices below
+            }
 
             $this->savePath = [
                 'host'     => $matches[1],
@@ -98,14 +96,12 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Open
+     * Re-initialize existing session, or creates a new one.
      *
-     * Sanitizes save_path and initializes connection.
-     *
-     * @param string $savePath Server path
-     * @param string $name     Session cookie name, unused
+     * @param string $path The path where to store/retrieve the session
+     * @param string $name The session name
      */
-    public function open($savePath, $name): bool
+    public function open($path, $name): bool
     {
         if (empty($this->savePath)) {
             return false;
@@ -129,62 +125,63 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Read
+     * Reads the session data from the session storage, and returns the results.
      *
-     * Reads session data and acquires a lock
+     * @param string $id The session ID
      *
-     * @param string $sessionID Session ID
-     *
-     * @return string Serialized session data
+     * @return false|string Returns an encoded string of the read data.
+     *                      If nothing was read, it must return false.
      */
-    public function read($sessionID): string
+    #[ReturnTypeWillChange]
+    public function read($id)
     {
-        if (isset($this->redis) && $this->lockSession($sessionID)) {
-            // Needed by write() to detect session_regenerate_id() calls
+        if (isset($this->redis) && $this->lockSession($id)) {
             if (! isset($this->sessionID)) {
-                $this->sessionID = $sessionID;
+                $this->sessionID = ${$id};
             }
 
-            $sessionData                               = $this->redis->get($this->keyPrefix . $sessionID);
-            is_string($sessionData) ? $this->keyExists = true : $sessionData = '';
+            $data = $this->redis->get($this->keyPrefix . $id);
 
-            $this->fingerprint = md5($sessionData);
+            if (is_string($data)) {
+                $this->keyExists = true;
+            } else {
+                $data = '';
+            }
 
-            return $sessionData;
+            $this->fingerprint = md5($data);
+
+            return $data;
         }
 
         return '';
     }
 
     /**
-     * Write
+     * Writes the session data to the session storage.
      *
-     * Writes (create / update) session data
-     *
-     * @param string $sessionID   Session ID
-     * @param string $sessionData Serialized session data
+     * @param string $id   The session ID
+     * @param string $data The encoded session data
      */
-    public function write($sessionID, $sessionData): bool
+    public function write($id, $data): bool
     {
         if (! isset($this->redis)) {
             return false;
         }
 
-        // Was the ID regenerated?
-        if ($sessionID !== $this->sessionID) {
-            if (! $this->releaseLock() || ! $this->lockSession($sessionID)) {
+        if ($this->sessionID !== $id) {
+            if (! $this->releaseLock() || ! $this->lockSession($id)) {
                 return false;
             }
 
             $this->keyExists = false;
-            $this->sessionID = $sessionID;
+            $this->sessionID = $id;
         }
 
         if (isset($this->lockKey)) {
             $this->redis->expire($this->lockKey, 300);
 
-            if ($this->fingerprint !== ($fingerprint = md5($sessionData)) || $this->keyExists === false) {
-                if ($this->redis->set($this->keyPrefix . $sessionID, $sessionData, $this->sessionExpiration)) {
+            if ($this->fingerprint !== ($fingerprint = md5($data)) || $this->keyExists === false) {
+                if ($this->redis->set($this->keyPrefix . $id, $data, $this->sessionExpiration)) {
                     $this->fingerprint = $fingerprint;
                     $this->keyExists   = true;
 
@@ -194,22 +191,21 @@ class RedisHandler extends BaseHandler
                 return false;
             }
 
-            return $this->redis->expire($this->keyPrefix . $sessionID, $this->sessionExpiration);
+            return $this->redis->expire($this->keyPrefix . $id, $this->sessionExpiration);
         }
 
         return false;
     }
 
     /**
-     * Close
-     *
-     * Releases locks and closes connection.
+     * Closes the current session.
      */
     public function close(): bool
     {
         if (isset($this->redis)) {
             try {
                 $pingReply = $this->redis->ping();
+
                 // @phpstan-ignore-next-line
                 if (($pingReply === true) || ($pingReply === '+PONG')) {
                     if (isset($this->lockKey)) {
@@ -233,16 +229,14 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Destroy
+     * Destroys a session
      *
-     * Destroys the current session.
-     *
-     * @param string $sessionID
+     * @param string $id The session ID being destroyed
      */
-    public function destroy($sessionID): bool
+    public function destroy($id): bool
     {
         if (isset($this->redis, $this->lockKey)) {
-            if (($result = $this->redis->del($this->keyPrefix . $sessionID)) !== 1) {
+            if (($result = $this->redis->del($this->keyPrefix . $id)) !== 1) {
                 $this->logger->debug('Session: Redis::del() expected to return 1, got ' . var_export($result, true) . ' instead.');
             }
 
@@ -253,22 +247,21 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Garbage Collector
+     * Cleans up expired sessions.
      *
-     * Deletes expired sessions
+     * @param int $max_lifetime Sessions that have not updated
+     *                          for the last max_lifetime seconds will be removed.
      *
-     * @param int $maxlifetime Maximum lifetime of sessions
+     * @return false|int Returns the number of deleted sessions on success, or false on failure.
      */
-    public function gc($maxlifetime): bool
+    #[ReturnTypeWillChange]
+    public function gc($max_lifetime)
     {
-        // Not necessary, Redis takes care of that.
-        return true;
+        return 1;
     }
 
     /**
-     * Get lock
-     *
-     * Acquires an (emulated) lock.
+     * Acquires an emulated lock.
      *
      * @param string $sessionID Session ID
      */
@@ -281,7 +274,6 @@ class RedisHandler extends BaseHandler
             return $this->redis->expire($this->lockKey, 300);
         }
 
-        // 30 attempts to obtain a lock, in case another request already has it
         $lockKey = $this->keyPrefix . $sessionID . ':lock';
         $attempt = 0;
 
@@ -318,8 +310,6 @@ class RedisHandler extends BaseHandler
     }
 
     /**
-     * Release lock
-     *
      * Releases a previously acquired lock
      */
     protected function releaseLock(): bool


### PR DESCRIPTION
**Description**
Related to #4883 

Reference for the updated signatures: https://www.php.net/manual/en/class.sessionhandlerinterface.php
I've refactored and cleaned the code a bit as I see fit.

My only concern is for the `gc` method. Our current implementation is using the pre-7.1 behavior where it returns `true` on success. Starting PHP 7.1, on success it should return the number of garbage collected sessions. My initial solution is to turn `true` to `1` for handlers where the number can't easily be determined while returning the true number on others (like the file handler).

**Checklist:**
- [x] Securely signed commits
