### PR TITLE
Update to phpdocumentor v3.1.1

### DIFF
--- a/.github/workflows/deploy-apidocs.yml
+++ b/.github/workflows/deploy-apidocs.yml
@@ -41,12 +41,9 @@ jobs:
           php-version: '8.0'
           coverage: none
 
-      - name: Download phpDocumentor v3.1
-        run: |
-          cd ./source
-          curl \
-            -L https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.1.0/phpDocumentor.phar \
-            -o admin/phpDocumentor.phar
+      - name: Download latest phpDocumentor
+        working-directory: source
+        run: phive install --no-progress --trust-gpg-keys 67F861C3D889C656 --target ./admin phpDocumentor
 
       - name: Prepare API repo
         working-directory: api


### PR DESCRIPTION
**Description**
To prevent parsing errors from `nikic/php-parser` (fix in v4.12 present in v3.1.1)

**Checklist:**
- [x] Securely signed commits
