### PR TITLE
PHP Copy-Paste Detector

### DIFF
--- a/.github/workflows/test-phpcpd.yml
+++ b/.github/workflows/test-phpcpd.yml
@@ -1,0 +1,43 @@
+# When a PR is opened or a push is made, check code
+# for duplication with PHP Copy/Paste Detector.
+name: PHPCPD
+
+on:
+  pull_request:
+    branches:
+      - 'develop'
+      - '4.*'
+    paths:
+      - 'app/**'
+      - 'public/**'
+      - 'system/**'
+      - '.github/workflows/test-phpcpd.yml'
+  push:
+    branches:
+      - 'develop'
+      - '4.*'
+    paths:
+      - 'app/**'
+      - 'public/**'
+      - 'system/**'
+      - '.github/workflows/test-phpcpd.yml'
+
+jobs:
+  build:
+    name: Duplicate Code Detection
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          tools: phive
+          extensions: intl, json, mbstring, xml
+
+      - name: Detect code duplication
+        run: |
+            sudo phive --no-progress install --global --trust-gpg-keys 4AA394086372C20A phpcpd 
+            phpcpd --exclude system/Test --exclude system/ThirdParty --exclude system/Database/SQLSRV/Builder.php app/ public/ system/


### PR DESCRIPTION
**Description**
This is a new tool I'm using at work from Sebastian Bergmann (PHPUnit author) that I thought would make a nice addition to the CS Fixer changes were are rolling out soon. The only remaining violation (ignoring **tests/** for now) is in `Database\\SQLSRV\\Builder::coompileSelect()` but refactoring that is beyond the current scope of `develop` so I have ignored the file for now.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [X] Unit testing, with >80% coverage
- n/a User guide updated
- [X] Conforms to style guide
