### PR TITLE
Previous Responses

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -922,8 +922,8 @@ class CodeIgniter
     public function storePreviousURL($uri)
     {
         // Ignore CLI requests
-        if (is_cli()) {
-            return;
+        if (is_cli() && ENVIRONMENT !== 'testing') {
+            return; // @codeCoverageIgnore
         }
         // Ignore AJAX requests
         if (method_exists($this->request, 'isAJAX') && $this->request->isAJAX()) {

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -19,6 +19,7 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\DownloadResponse;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
@@ -926,6 +927,11 @@ class CodeIgniter
         }
         // Ignore AJAX requests
         if (method_exists($this->request, 'isAJAX') && $this->request->isAJAX()) {
+            return;
+        }
+
+        // Ignore unroutable responses
+        if ($this->response instanceof DownloadResponse || $this->response instanceof RedirectResponse) {
             return;
         }
 

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -345,7 +345,24 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->assertSame(303, $response->getStatusCode());
     }
 
-    public function testRunRedirectionWithHTTPCode301()
+    public function testStoresPreviousURL()
+    {
+        $_SERVER['argv'] = ['index.php', '/'];
+        $_SERVER['argc'] = 2;
+
+        // Inject mock router.
+        $router = Services::router(null, Services::request(), false);
+        Services::injectMock('router', $router);
+
+        ob_start();
+        $this->codeigniter->useSafeOutput(true)->run();
+        ob_get_clean();
+
+        $this->assertArrayHasKey('_ci_previous_url', $_SESSION);
+        $this->assertSame('http://example.com/index.php', $_SESSION['_ci_previous_url']);
+    }
+
+    public function testNotStoresPreviousURL()
     {
         $_SERVER['argv'] = ['index.php', 'example'];
         $_SERVER['argc'] = 2;
@@ -364,8 +381,8 @@ final class CodeIgniterTest extends CIUnitTestCase
         ob_start();
         $this->codeigniter->useSafeOutput(true)->run();
         ob_get_clean();
-        $response = $this->getPrivateProperty($this->codeigniter, 'response');
-        $this->assertSame(301, $response->getStatusCode());
+
+        $this->assertArrayNotHasKey('_ci_previous_url', $_SESSION);
     }
 
     /**


### PR DESCRIPTION
**Description**
`storePreviousURL()` allows `redirect()->back()` to return to the "previous page"; however, there are a few instances where this can create an un-routable situation when a `DownloadResponse` is returned, or (very rarely) a loop when a `RedirectResponse` is encountered. This PR adds exemptions for those cases.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
