### PR TITLE
Fix key casting in form_dropdown helper.

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -298,7 +298,7 @@ if (! function_exists('form_dropdown')) {
             }
         }
 
-        // standardize selected as strings, like  the option keys will be.
+        // Standardize selected as strings, like the option keys will be
         foreach ($selected as $key => $item) {
             $selected[$key] = (string) $item;
         }
@@ -308,6 +308,7 @@ if (! function_exists('form_dropdown')) {
         $form     = '<select ' . rtrim(parse_form_attributes($data, $defaults)) . $extra . $multiple . ">\n";
 
         foreach ($options as $key => $val) {
+            // Keys should always be strings for strict comparison
             $key = (string) $key;
 
             if (is_array($val)) {
@@ -318,6 +319,9 @@ if (! function_exists('form_dropdown')) {
                 $form .= '<optgroup label="' . $key . "\">\n";
 
                 foreach ($val as $optgroupKey => $optgroupVal) {
+                    // Keys should always be strings for strict comparison
+                    $optgroupKey = (string) $optgroupKey;
+
                     $sel = in_array($optgroupKey, $selected, true) ? ' selected="selected"' : '';
                     $form .= '<option value="' . htmlspecialchars($optgroupKey) . '"' . $sel . '>' . $optgroupVal . "</option>\n";
                 }

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -435,6 +435,34 @@ final class FormHelperTest extends CIUnitTestCase
         $this->assertSame($expected, form_dropdown('cars', $options));
     }
 
+    public function testFormDropdownKeyCasting()
+    {
+        $options = [
+            'Swedish Cars' => [
+                '1' => 'Volvo',
+                '2' => 'Saab',
+            ],
+            2 => [
+                3   => 'Mercedes',
+                '4' => 'Audi',
+            ],
+        ];
+        $selected = [2];
+        $expected = <<<EOH
+            <select name="cars">
+            <optgroup label="Swedish Cars">
+            <option value="1">Volvo</option>
+            <option value="2" selected="selected">Saab</option>
+            </optgroup>
+            <optgroup label="2">
+            <option value="3">Mercedes</option>
+            <option value="4">Audi</option>
+            </optgroup>
+            </select>\n
+            EOH;
+        $this->assertSame($expected, form_dropdown('cars', $options, $selected));
+    }
+
     public function testFormDropdownInferred()
     {
         $options = [


### PR DESCRIPTION
Closes #4993.

**Description**
This fixes the missing string casting for `$optgroupKey` in the `form_dropdown` helper.
This is an issue since strict `in_array` was introduced in #3565. Also adds a test for the casting (not pretty, but working).

I pointed this at develop as it is supposed to be a bugfix. Please correct if thats wrong 😄 

**Checklist:**
- [x] Securely signed commits
- [x] Unit testing, with >80% coverage
- [x] Conforms to style guide