### PR TITLE
Bump to php-cs-fixer v3.1

### DIFF
--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -82,7 +82,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         }
 
         // Create the controller class finally.
-        $controller = new class($this->request, $this->response, $this->formatter) {
+        $controller = new class ($this->request, $this->response, $this->formatter) {
             use ResponseTrait;
 
             protected $request;
@@ -524,7 +524,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $request  = new MockIncomingRequest($config, new URI($config->baseURL), null, new UserAgent());
         $response = new MockResponse($config);
 
-        $controller = new class($request, $response) {
+        $controller = new class ($request, $response) {
             use ResponseTrait;
 
             protected $request;

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -85,7 +85,7 @@ final class ControllerTest extends CIUnitTestCase
         $original = $_SERVER;
         $_SERVER  = ['HTTPS' => 'on'];
         // make sure we can instantiate one
-        $this->controller         = new class() extends Controller {
+        $this->controller         = new class () extends Controller {
             protected $forceHTTPS = 1;
         };
         $this->controller->initController($this->request, $this->response, $this->logger);
@@ -169,7 +169,7 @@ final class ControllerTest extends CIUnitTestCase
 
     public function testHelpers()
     {
-        $this->controller      = new class() extends Controller {
+        $this->controller      = new class () extends Controller {
             protected $helpers = [
                 'cookie',
                 'text',

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -227,7 +227,7 @@ final class GetTest extends CIUnitTestCase
 
     public function testGetRowWithCustomReturnType()
     {
-        $testClass = new class() {};
+        $testClass = new class () {};
 
         $user = $this->db->table('user')->get()->getRow(0, get_class($testClass));
 

--- a/tests/system/Database/Migrations/MigrationTest.php
+++ b/tests/system/Database/Migrations/MigrationTest.php
@@ -29,7 +29,7 @@ final class MigrationTest extends CIUnitTestCase
 
     public function testDBGroup()
     {
-        $migration             = new class() extends Migration {
+        $migration             = new class () extends Migration {
             protected $DBGroup = 'tests';
 
             public function up()

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -762,7 +762,7 @@ final class EntityTest extends CIUnitTestCase
 
     public function testToArraySkipAttributesWithUnderscoreInFirstCharacter()
     {
-        $entity                   = new class() extends Entity {
+        $entity                   = new class () extends Entity {
             protected $attributes = [
                 '_foo' => null,
                 'bar'  => null,
@@ -923,7 +923,7 @@ final class EntityTest extends CIUnitTestCase
 
     protected function getEntity()
     {
-        return new class() extends Entity {
+        return new class () extends Entity {
             protected $attributes = [
                 'foo'        => null,
                 'bar'        => null,
@@ -963,7 +963,7 @@ final class EntityTest extends CIUnitTestCase
 
     protected function getMappedEntity()
     {
-        return new class() extends Entity {
+        return new class () extends Entity {
             protected $attributes = [
                 'foo'    => null,
                 'simple' => null,
@@ -994,7 +994,7 @@ final class EntityTest extends CIUnitTestCase
 
     protected function getSwappedEntity()
     {
-        return new class() extends Entity {
+        return new class () extends Entity {
             protected $attributes = [
                 'foo' => 'foo',
                 'bar' => 'bar',
@@ -1015,7 +1015,7 @@ final class EntityTest extends CIUnitTestCase
 
     protected function getCastEntity($data = null): Entity
     {
-        return new class($data) extends Entity {
+        return new class ($data) extends Entity {
             protected $attributes = [
                 'first'      => null,
                 'second'     => null,
@@ -1074,7 +1074,7 @@ final class EntityTest extends CIUnitTestCase
 
     protected function getCastNullableEntity()
     {
-        return new class() extends Entity {
+        return new class () extends Entity {
             protected $attributes = [
                 'string_null'           => null,
                 'string_empty'          => null,
@@ -1104,7 +1104,7 @@ final class EntityTest extends CIUnitTestCase
 
     protected function getCustomCastEntity()
     {
-        return new class() extends Entity {
+        return new class () extends Entity {
             protected $attributes = [
                 'first'  => null,
                 'second' => null,

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -280,7 +280,7 @@ final class EventsTest extends CIUnitTestCase
 
     public function testHandleEventCallableClass()
     {
-        $box = new class() {
+        $box = new class () {
             public $logged;
 
             public function hold(string $value)

--- a/tests/system/Models/GeneralModelTest.php
+++ b/tests/system/Models/GeneralModelTest.php
@@ -104,7 +104,7 @@ final class GeneralModelTest extends CIUnitTestCase
             'updated_at',
         ];
 
-        $model                       = new class() extends Model {
+        $model                       = new class () extends Model {
             protected $allowedFields = [
                 'id',
                 'created_at',
@@ -147,7 +147,7 @@ final class GeneralModelTest extends CIUnitTestCase
 
     public function testInitialize(): void
     {
-        $model = new class() extends Model {
+        $model = new class () extends Model {
             /**
              * @var bool
              */

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -157,7 +157,7 @@ final class InsertModelTest extends LiveModelTestCase
 
     public function testInsertBatchNewEntityWithDateTime(): void
     {
-        $entity = new class() extends Entity {
+        $entity = new class () extends Entity {
             protected $id;
             protected $name;
             protected $email;
@@ -215,7 +215,7 @@ final class InsertModelTest extends LiveModelTestCase
     {
         $this->createModel(UserModel::class);
 
-        $entity = new class() extends Entity {
+        $entity = new class () extends Entity {
             protected $id;
             protected $name;
             protected $email;

--- a/tests/system/Models/SaveModelTest.php
+++ b/tests/system/Models/SaveModelTest.php
@@ -208,7 +208,7 @@ final class SaveModelTest extends LiveModelTestCase
 
     public function testSaveNewEntityWithDateTime(): void
     {
-        $entity = new class() extends Entity {
+        $entity = new class () extends Entity {
             protected $id;
             protected $name;
             protected $email;
@@ -242,7 +242,7 @@ final class SaveModelTest extends LiveModelTestCase
 
     public function testSaveNewEntityWithDate(): void
     {
-        $entity = new class() extends Entity {
+        $entity = new class () extends Entity {
             protected $id;
             protected $name;
             protected $created_at;
@@ -258,7 +258,7 @@ final class SaveModelTest extends LiveModelTestCase
             ];
         };
 
-        $testModel                   = new class() extends Model {
+        $testModel                   = new class () extends Model {
             protected $table         = 'empty';
             protected $allowedFields = [
                 'name',

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -158,7 +158,7 @@ final class UpdateModelTest extends LiveModelTestCase
 
     public function testUpdateBatchWithEntity(): void
     {
-        $entity1 = new class() extends Entity {
+        $entity1 = new class () extends Entity {
             protected $id;
             protected $name;
             protected $email;
@@ -178,7 +178,7 @@ final class UpdateModelTest extends LiveModelTestCase
             ];
         };
 
-        $entity2 = new class() extends Entity {
+        $entity2 = new class () extends Entity {
             protected $id;
             protected $name;
             protected $email;
@@ -307,7 +307,7 @@ final class UpdateModelTest extends LiveModelTestCase
     {
         $this->createModel(UserModel::class);
 
-        $entity = new class() extends Entity {
+        $entity = new class () extends Entity {
             protected $id;
             protected $name;
             protected $email;

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -262,7 +262,7 @@ final class ParserTest extends CIUnitTestCase
 
     public function testParseLoopEntityProperties()
     {
-        $power             = new class() extends Entity {
+        $power             = new class () extends Entity {
             public $foo    = 'bar';
             protected $bar = 'baz';
 
@@ -292,7 +292,7 @@ final class ParserTest extends CIUnitTestCase
 
     public function testParseLoopEntityObjectProperties()
     {
-        $power                    = new class() extends Entity {
+        $power                    = new class () extends Entity {
             protected $attributes = [
                 'foo'     => 'bar',
                 'bar'     => 'baz',

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -73,8 +73,6 @@ final class CodeIgniter4 extends AbstractRuleset
             'cast_spaces'                 => ['space' => 'single'],
             'class_attributes_separation' => [
                 'elements' => [
-                    // 'const' => 'one_if_phpdoc', // @todo Enable in php-cs-fixer v3.1
-                    // 'property' => 'one_if_phpdoc', // @todo Enable in php-cs-fixer v3.1
                     'method' => 'one',
                 ],
             ],
@@ -82,8 +80,8 @@ final class CodeIgniter4 extends AbstractRuleset
                 'multi_line_extends_each_single_line' => true,
                 'single_item_single_line'             => true,
                 'single_line'                         => true,
+                'space_before_parenthesis'            => true,
             ],
-            'class_keyword_remove'       => false,
             'clean_namespace'            => true,
             'combine_consecutive_issets' => true,
             'combine_consecutive_unsets' => true,
@@ -103,6 +101,7 @@ final class CodeIgniter4 extends AbstractRuleset
             'constant_case'                        => ['case' => 'lower'],
             'date_time_immutable'                  => false,
             'declare_equal_normalize'              => ['space' => 'none'],
+            'declare_parentheses'                  => true,
             'declare_strict_types'                 => false,
             'dir_constant'                         => true,
             'doctrine_annotation_array_assignment' => false,
@@ -115,6 +114,7 @@ final class CodeIgniter4 extends AbstractRuleset
                 'shorten_simple_statements_only' => false,
             ],
             'elseif'            => true,
+            'empty_loop_body'   => ['style' => 'braces'],
             'encoding'          => true,
             'ereg_to_preg'      => true,
             'error_suppression' => [
@@ -519,6 +519,7 @@ final class CodeIgniter4 extends AbstractRuleset
                 'elements'      => ['arrays'],
             ],
             'trim_array_spaces'               => true,
+            'types_spaces'                    => ['space' => 'none'],
             'unary_operator_spaces'           => true,
             'use_arrow_functions'             => false, // requires PHP7.4+
             'visibility_required'             => ['elements' => ['const', 'method', 'property']],


### PR DESCRIPTION
**Description**
New fixers applied:
- `declare_parentheses`
- `empty_loop_body`
- removed deprecated `class_keyword_remove`
- `types_spaces`
- new option for `class_definition`

Only fixer with effect is the new option of `class_definition` adding a space before the parenthesis of anonymous class instantiation to line it with PSR12 requirement that anonymous classes should follow and behave like closures.

**Checklist:**
- [x] Securely signed commits
