### PR TITLE
Update to latest laminas-escaper 2.9.0

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -124,7 +124,6 @@ jobs:
         run: |
           composer update --ansi --no-interaction
           composer remove --ansi --dev --unused -W rector/rector phpstan/phpstan friendsofphp/php-cs-fixer nexusphp/cs-config codeigniter/coding-standard
-          php -r 'file_put_contents("vendor/laminas/laminas-zendframework-bridge/src/autoload.php", "");'
         env:
           COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 

--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -11,7 +11,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "kint-php/kint": "^3.3",
-        "laminas/laminas-escaper": "^2.8",
+        "laminas/laminas-escaper": "^2.9",
         "psr/log": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "kint-php/kint": "^3.3",
-        "laminas/laminas-escaper": "^2.8",
+        "laminas/laminas-escaper": "^2.9",
         "psr/log": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
In latest laminas-escaper 2.9.0, `laminas/laminas-zendframework-bridge` no longer required, so no need to tweak test github action.

https://github.com/laminas/laminas-escaper/compare/2.8.0...2.9.0

**Checklist:**
- [x] Securely signed commits
