### PR TITLE
docs: fix upgrade_414 format

### DIFF
--- a/user_guide_src/source/installation/upgrade_414.rst
+++ b/user_guide_src/source/installation/upgrade_414.rst
@@ -8,7 +8,7 @@ This release focuses on code style. All changes (except those noted below) are c
 **Method Scope**
 
 The following methods were changed from "public" to "protected" to match their parent class methods and better align with their uses.
-If you relied on any of these methods being public (highly unlikely) adjust your code accordingly::
+If you relied on any of these methods being public (highly unlikely) adjust your code accordingly:
 
 * ``CodeIgniter\Database\MySQLi\Connection::execute()``
 * ``CodeIgniter\Database\MySQLi\Connection::_fieldData()``


### PR DESCRIPTION
**Description**
Before:
![Screenshot 2021-09-10 9 09 16](https://user-images.githubusercontent.com/87955/132778361-ede8a04b-ac25-4df3-a257-e6c45c5e02a9.png)

After:
![Screenshot 2021-09-10 9 09 20](https://user-images.githubusercontent.com/87955/132778379-b6ea3bd4-02c6-48c4-bbaa-e43e8cc438c8.png)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide

