### PR TITLE
docs: small fixes for entities

### DIFF
--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -496,12 +496,12 @@ Additional parameters are indicated in square brackets and listed with a comma.
 
 ::
 
-    //Defining a type with parameters
+    // Defining a type with parameters
     protected $casts = [
         'some_attribute' => 'class[App\SomeClass, param2, param3]',
     ];
 
-    //Bind the type to the handler
+    // Bind the type to the handler
     protected $castHandlers = [
         'class' => 'SomeHandler',
     ];

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -506,6 +506,8 @@ Additional parameters are indicated in square brackets and listed with a comma.
         'class' => 'SomeHandler',
     ];
 
+::
+
     use CodeIgniter\Entity\Cast\BaseCast;
 
     class SomeHandler extends BaseCast

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -70,7 +70,7 @@ Create the model first at **app/Models/UserModel.php** so that we can interact w
         protected $allowedFields = [
             'username', 'email', 'password',
         ];
-        protected $returnType    = 'App\Entities\User';
+        protected $returnType    = \App\Entities\User::class;
         protected $useTimestamps = true;
     }
 
@@ -464,7 +464,7 @@ Now you need to register it::
 
         //Bind the type to the handler
         protected $castHandlers = [
-            'base64' => 'App\Entity\Cast\CastBase64',
+            'base64' => \App\Entity\Cast\CastBase64::class,
         ];
     }
 

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -535,7 +535,7 @@ Checking for Changed Attributes
 You can check if an Entity attribute has changed since it was created. The only parameter is the name of the
 attribute to check::
 
-    $user = new User();
+    $user = new \App\Entities\User();
     $user->hasChanged('name'); // false
 
     $user->name = 'Fred';


### PR DESCRIPTION
**Description**
- use `::class` keyword
- fix coding style

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPdocs
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
