### PR TITLE
docs: rename v4.2.0 to v4.1.5

### DIFF
--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -12,7 +12,7 @@ See all the changes.
 .. toctree::
     :titlesonly:
 
-    v4.2.0
+    v4.1.5
     v4.1.4
     v4.1.3
     v4.1.2

--- a/user_guide_src/source/changelogs/v4.1.5.rst
+++ b/user_guide_src/source/changelogs/v4.1.5.rst
@@ -1,9 +1,9 @@
-Version 4.2.0
+Version 4.1.5
 =============
 
 Release Date: Not released
 
-**4.2.0 release of CodeIgniter4**
+**4.1.5 release of CodeIgniter4**
 
 Enhancements:
 

--- a/user_guide_src/source/installation/upgrade_415.rst
+++ b/user_guide_src/source/installation/upgrade_415.rst
@@ -1,5 +1,5 @@
 #############################
-Upgrading from 4.1.4 to 4.2.0
+Upgrading from 4.1.4 to 4.1.5
 #############################
 
 **Changes for set() method in BaseBuilder and Model class**

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -8,7 +8,7 @@ upgrading from.
 .. toctree::
     :titlesonly:
 
-    Upgrading from 4.1.4 to 4.2.0 <upgrade_420>
+    Upgrading from 4.1.4 to 4.1.5 <upgrade_415>
     Upgrading from 4.1.3 to 4.1.4 <upgrade_414>
     Upgrading from 4.1.2 to 4.1.3 <upgrade_413>
     Upgrading from 4.1.1 to 4.1.2 <upgrade_412>


### PR DESCRIPTION
**Description**
The next version will be 4.1.5.
See https://github.com/codeigniter4/CodeIgniter4/pull/5021#issuecomment-917624179

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPdocs
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

