### PR TITLE
docs: fix indentation for testing 

### DIFF
--- a/user_guide_src/source/testing/controllers.rst
+++ b/user_guide_src/source/testing/controllers.rst
@@ -209,13 +209,13 @@ on an unfiltered route you could add it to the Config::
     {
         use FilterTestTrait;
 
-		protected function testFilterFailsOnAdminRoute()
-		{
-			$this->filtersConfig->globals['before'] = ['admin-only-filter'];
+        protected function testFilterFailsOnAdminRoute()
+        {
+            $this->filtersConfig->globals['before'] = ['admin-only-filter'];
 
-			$this->assertHasFilters('unfiltered/route', 'before');
-		}
-	...
+            $this->assertHasFilters('unfiltered/route', 'before');
+        }
+    ...
 
 Checking Routes
 ---------------
@@ -227,14 +227,14 @@ a large performance advantage over Controller and HTTP Testing.
 
 .. php:function:: getFiltersForRoute($route, $position)
 
-    :param	string	$route: The URI to check
-    :param	string	$position: The filter method to check, "before" or "after"
-	:returns:	Aliases for each filter that would have run
-	:rtype:	string[]
+    :param    string    $route: The URI to check
+    :param    string    $position: The filter method to check, "before" or "after"
+    :returns:    Aliases for each filter that would have run
+    :rtype:    string[]
 
     Usage example::
 
-		$result = $this->getFiltersForRoute('/', 'after'); // ['toolbar']
+        $result = $this->getFiltersForRoute('/', 'after'); // ['toolbar']
 
 Calling Filter Methods
 ----------------------
@@ -245,22 +245,22 @@ method using these properties to test your Filter code safely and check the resu
 
 .. php:function:: getFilterCaller($filter, $position)
 
-    :param	FilterInterface|string	$filter: The filter instance, class, or alias
-    :param	string	$position: The filter method to run, "before" or "after"
-	:returns:	A callable method to run the simulated Filter event
-	:rtype:	Closure
+    :param    FilterInterface|string    $filter: The filter instance, class, or alias
+    :param    string    $position: The filter method to run, "before" or "after"
+    :returns:    A callable method to run the simulated Filter event
+    :rtype:    Closure
 
     Usage example::
 
-		protected function testUnauthorizedAccessRedirects()
-		{
-			$caller = $this->getFilterCaller('permission', 'before');
-			$result = $caller('MayEditWidgets');
+        protected function testUnauthorizedAccessRedirects()
+        {
+            $caller = $this->getFilterCaller('permission', 'before');
+            $result = $caller('MayEditWidgets');
 
-			$this->assertInstanceOf('CodeIgniter\HTTP\RedirectResponse', $result);
-		}
-	
-	Notice how the ``Closure`` can take input parameters which are passed to your filter method.
+            $this->assertInstanceOf('CodeIgniter\HTTP\RedirectResponse', $result);
+        }
+
+    Notice how the ``Closure`` can take input parameters which are passed to your filter method.
 
 Assertions
 ----------

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -29,20 +29,20 @@ are called if you implement your own methods.
 
     class TestFoo extends FeatureTestCase
     {
-    	use DatabaseTestTrait, FeatureTestTrait;
+        use DatabaseTestTrait, FeatureTestTrait;
 
         protected function setUp(): void
         {
             parent::setUp();
 
-			$this->myClassMethod();
+            $this->myClassMethod();
         }
 
         protected function tearDown(): void
         {
             parent::tearDown();
 
-			$this->anotherClassMethod();
+            $this->anotherClassMethod();
         }
     }
 

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -159,19 +159,19 @@ to run named for the trait itself. For example, if you needed to add authenticat
 of your test cases you could create an authentication trait with a set up method to fake a
 logged in user::
 
-	trait AuthTrait
-	{
-		protected setUpAuthTrait()
-		{
-			$user = $this->createFakeUser();
-			$this->logInUser($user);
-		}
-	...
+    trait AuthTrait
+    {
+        protected setUpAuthTrait()
+        {
+            $user = $this->createFakeUser();
+            $this->logInUser($user);
+        }
+    ...
 
-	class AuthenticationFeatureTest
-	{
-		use AuthTrait;
-	...
+    class AuthenticationFeatureTest
+    {
+        use AuthTrait;
+    ...
 
 
 Additional Assertions

--- a/user_guide_src/source/testing/response.rst
+++ b/user_guide_src/source/testing/response.rst
@@ -7,8 +7,8 @@ from your test cases. Usually a ``TestResponse`` will be provided for you as a r
 `Controller Tests <controllers.html>`_ or `HTTP Feature Tests <feature.html>`_, but you can always
 create your own directly using any ``ResponseInterface``::
 
-	$result = new \CodeIgniter\Test\TestResponse($response);
-	$result->assertOK();
+    $result = new \CodeIgniter\Test\TestResponse($response);
+    $result->assertOK();
 
 Testing the Response
 ====================
@@ -299,8 +299,8 @@ This method will return the body of the response as a JSON string::
 
 You can use this method to determine if ``$response`` actually holds JSON content::
 
-	// Verify the response is JSON
-	$this->assertTrue($result->getJSON() !== false)
+    // Verify the response is JSON
+    $this->assertTrue($result->getJSON() !== false)
 
 .. note:: Be aware that the JSON string will be pretty-printed in the result.
 


### PR DESCRIPTION
**Description**
- replace tab with space

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
