### PR TITLE
Make log_message() compatible with PSR-3

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -767,7 +767,7 @@ if (! function_exists('log_message')) {
 
         // @codeCoverageIgnoreStart
         return Services::logger(true)
-            ->log($level, $message, $context);
+            ->{$level}($message, $context);
         // @codeCoverageIgnoreEnd
     }
 }


### PR DESCRIPTION
**Description**

> Now, any call that is done through the log_message() function will use your library instead.
https://codeigniter4.github.io/CodeIgniter4/general/logging.html#using-third-party-loggers

But the method `log()` does not exist in PSR-3, so `log_message()` does not work with PSR-3 logger.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPdocs
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
