### PR TITLE
docs: fix cli library

### DIFF
--- a/user_guide_src/source/cli/cli_library.rst
+++ b/user_guide_src/source/cli/cli_library.rst
@@ -199,6 +199,15 @@ on the right with their descriptions. By default, this will wrap back to the lef
 doesn't allow things to line up in columns. In cases like this, you can pass in a number of spaces to pad
 every line after the first line, so that you will have a crisp column edge on the left::
 
+    $titles = [
+        'task1a',
+        'task1abc',
+    ];
+    $descriptions = [
+        'Lorem Ipsum is simply dummy text of the printing and typesetting industry.',
+        "Lorem Ipsum has been the industry's standard dummy text ever since the",
+    ];
+
     // Determine the maximum length of all titles
     // to determine the width of the left column
     $maxlen = max(array_map('strlen', $titles));
@@ -206,7 +215,11 @@ every line after the first line, so that you will have a crisp column edge on th
     for ($i = 0; $i < count($titles); $i++) {
         CLI::write(
             // Display the title on the left of the row
-            $titles[$i] . '   ' .
+            substr(
+                $titles[$i] . str_repeat(' ', $maxlen + 3),
+                0,
+                $maxlen + 3
+            ) .
             // Wrap the descriptions in a right-hand column
             // with its left side 3 characters wider than
             // the longest item on the left.
@@ -218,11 +231,12 @@ Would create something like this:
 
 .. code-block:: none
 
-    task1a   Lorem Ipsum is simply dummy
-               text of the printing and typesetting
-               industry.
-    task1abc   Lorem Ipsum has been the industry's
-               standard dummy text ever since the
+    task1a     Lorem Ipsum is simply dummy
+               text of the printing and
+               typesetting industry.
+    task1abc   Lorem Ipsum has been the
+               industry's standard dummy
+               text ever since the
 
 **newLine()**
 

--- a/user_guide_src/source/cli/cli_library.rst
+++ b/user_guide_src/source/cli/cli_library.rst
@@ -59,7 +59,7 @@ Finally, you can pass :ref:`validation <validation>` rules to the answer input a
 
 Validation rules can also be written in the array syntax.::
 
-	$email = CLI::prompt('What is your email?', null, ['required', 'valid_email']);
+    $email = CLI::prompt('What is your email?', null, ['required', 'valid_email']);
 
 
 **promptByKey()**


### PR DESCRIPTION
**Description**
- replace tab with space
- fix sample code and its output

before:
![Screenshot 2021-09-16 15 32 46](https://user-images.githubusercontent.com/87955/133561714-ed7e882b-e6ab-4aa0-8e46-f08133f2afe2.png)

after:
![Screenshot 2021-09-16 15 32 54](https://user-images.githubusercontent.com/87955/133561748-1fdc5515-f0a8-4052-b7d2-e5270158e1d4.png)


**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPdocs
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
