### PR TITLE
Fix debugbar styles printing

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.tpl.php
+++ b/system/Debug/Toolbar/Views/toolbar.tpl.php
@@ -265,10 +265,7 @@
 	</div>
 </div>
 <style type="text/css">
-	<?php foreach ($styles as $name => $style) : ?>
-	.<?= $name ?> {
-		<?= $style ?>
-	}
-
-	<?php endforeach ?>
+<?php foreach ($styles as $name => $style): ?>
+<?= sprintf(".%s { %s }\n", $name, $style) ?>
+<?php endforeach ?>
 </style>

--- a/system/Debug/Toolbar/Views/toolbarloader.js.php
+++ b/system/Debug/Toolbar/Views/toolbarloader.js.php
@@ -44,7 +44,7 @@ function loadDoc(time) {
 				let PosBeg = responseText.indexOf( '>', responseText.lastIndexOf( '<style' ) ) + 1;
 				let PosEnd = responseText.indexOf( '</style>', PosBeg );
 				document.getElementById( 'debugbar_dynamic_style' ).innerHTML += responseText.substr( PosBeg, PosEnd - PosBeg );
-				responseText = responseText.substr( 0, PosBeg + 8 );
+				responseText = responseText.substr( 0, PosBeg - 8 );
 			}
 
 			toolbar.innerHTML = responseText;

--- a/system/Debug/Toolbar/Views/toolbarloader.js.php
+++ b/system/Debug/Toolbar/Views/toolbarloader.js.php
@@ -1,93 +1,92 @@
-<?php if (ENVIRONMENT !== 'testing') : ?>
+<?php if (ENVIRONMENT === 'testing') {
+    return;
+} ?>
+<script>
 document.addEventListener('DOMContentLoaded', loadDoc, false);
 
 function loadDoc(time) {
-	if (isNaN(time)) {
-		time = document.getElementById("debugbar_loader").getAttribute("data-time");
-		localStorage.setItem('debugbar-time', time);
-	}
+    if (isNaN(time)) {
+        time = document.getElementById("debugbar_loader").getAttribute("data-time");
+        localStorage.setItem('debugbar-time', time);
+    }
 
-	localStorage.setItem('debugbar-time-new', time);
+    localStorage.setItem('debugbar-time-new', time);
 
-	var url = "<?= rtrim(site_url(), '/') ?>";
+    let url = "<?= rtrim(site_url(), '/') ?>";
+    let xhttp = new XMLHttpRequest();
 
-	var xhttp = new XMLHttpRequest();
-	xhttp.onreadystatechange = function() {
-		if (this.readyState === 4 && this.status === 200) {
-			var toolbar = document.getElementById("toolbarContainer");
-			if (!toolbar) {
-				toolbar = document.createElement('div');
-				toolbar.setAttribute('id', 'toolbarContainer');
-				document.body.appendChild(toolbar);
-			}
+    xhttp.onreadystatechange = function() {
+        if (this.readyState === 4 && this.status === 200) {
+            let toolbar = document.getElementById("toolbarContainer");
 
-			// copy for easier manipulation
-			let responseText = this.responseText;
+            if (! toolbar) {
+                toolbar = document.createElement('div');
+                toolbar.setAttribute('id', 'toolbarContainer');
+                document.body.appendChild(toolbar);
+            }
 
-			// get csp blocked parts
-			// the style block is the first and starts at 0
-			{
-				let PosBeg = responseText.indexOf( '>', responseText.indexOf( '<style' ) ) + 1;
-				let PosEnd = responseText.indexOf( '</style>', PosBeg );
-				document.getElementById( 'debugbar_dynamic_style' ).innerHTML = responseText.substr( PosBeg, PosEnd - PosBeg );
-				responseText = responseText.substr( PosEnd + 8 );
-			}
-			// the script block starts right after style blocks ended
-			{
-				let PosBeg = responseText.indexOf( '>', responseText.indexOf( '<script' ) ) + 1;
-				let PosEnd = responseText.indexOf( '</script>' );
-				document.getElementById( 'debugbar_dynamic_script' ).innerHTML = responseText.substr( PosBeg, PosEnd - PosBeg );
-				responseText = responseText.substr( PosEnd + 9 );
-			}
-			// check for last style block
-			{
-				let PosBeg = responseText.indexOf( '>', responseText.lastIndexOf( '<style' ) ) + 1;
-				let PosEnd = responseText.indexOf( '</style>', PosBeg );
-				document.getElementById( 'debugbar_dynamic_style' ).innerHTML += responseText.substr( PosBeg, PosEnd - PosBeg );
-				responseText = responseText.substr( 0, PosBeg - 8 );
-			}
+            let responseText = this.responseText;
+            let dynamicStyle = document.getElementById('debugbar_dynamic_style');
+            let dynamicScript = document.getElementById('debugbar_dynamic_script');
 
-			toolbar.innerHTML = responseText;
-			if (typeof ciDebugBar === 'object') {
-				ciDebugBar.init();
-			}
-		} else if (this.readyState === 4 && this.status === 404) {
-			console.log('CodeIgniter DebugBar: File "WRITEPATH/debugbar/debugbar_' + time + '" not found.');
-		}
-	};
+            // get the first style block, copy contents to dynamic_style, then remove here
+            let start = responseText.indexOf('>', responseText.indexOf('<style')) + 1;
+            let end = responseText.indexOf('</style>', start);
+            dynamicStyle.innerHTML = responseText.substr(start, end - start);
+            responseText = responseText.substr(end + 8);
 
-	xhttp.open("GET", url + "?debugbar_time=" + time, true);
-	xhttp.send();
+            // get the first script after the first style, copy contents to dynamic_script, then remove here
+            start = responseText.indexOf('>', responseText.indexOf('<script')) + 1;
+            end = responseText.indexOf('\<\/script>', start);
+            dynamicScript.innerHTML = responseText.substr(start, end - start);
+            responseText = responseText.substr(end + 9);
+
+            // check for last style block, append contents to dynamic_style, then remove here
+            start = responseText.indexOf('>', responseText.indexOf('<style')) + 1;
+            end = responseText.indexOf('</style>', start);
+            dynamicStyle.innerHTML += responseText.substr(start, end - start);
+            responseText = responseText.substr(0, start - 8);
+
+            toolbar.innerHTML = responseText;
+
+            if (typeof ciDebugBar === 'object') {
+                ciDebugBar.init();
+            }
+        } else if (this.readyState === 4 && this.status === 404) {
+            console.log('CodeIgniter DebugBar: File "WRITEPATH/debugbar/debugbar_' + time + '" not found.');
+        }
+    };
+
+    xhttp.open("GET", url + "?debugbar_time=" + time, true);
+    xhttp.send();
 }
 
-// Track all AJAX requests
-if (window.ActiveXObject) {
-	var oldXHR = new ActiveXObject('Microsoft.XMLHTTP');
-} else {
-	var oldXHR = window.XMLHttpRequest;
-}
+window.oldXHR = window.ActiveXObject
+    ? new ActiveXObject('Microsoft.XMLHTTP')
+    : window.XMLHttpRequest;
 
 function newXHR() {
-	var realXHR = new oldXHR();
-	realXHR.addEventListener("readystatechange", function() {
-		// Only success responses and URLs that do not contains "debugbar_time" are tracked
-		if (realXHR.readyState === 4 && realXHR.status.toString()[0] === '2' && realXHR.responseURL.indexOf('debugbar_time') === -1) {
-			if (realXHR.getAllResponseHeaders().indexOf("Debugbar-Time") >= 0) {
-    				var debugbarTime = realXHR.getResponseHeader('Debugbar-Time');
+    const realXHR = new window.oldXHR();
 
-				if (debugbarTime) {
-					var h2 = document.querySelector('#ci-history > h2');
-					if (h2) {
-						h2.innerHTML = 'History <small>You have new debug data.</small> <button onclick="loadDoc(' + debugbarTime + ')">Update</button>';
-						var badge = document.querySelector('a[data-tab="ci-history"] > span > .badge');
-						badge.className += ' active';
-					}
-				}
-			}
-		}
-	}, false);
-	return realXHR;
+    realXHR.addEventListener("readystatechange", function() {
+        // Only success responses and URLs that do not contains "debugbar_time" are tracked
+        if (realXHR.readyState === 4 && realXHR.status.toString()[0] === '2' && realXHR.responseURL.indexOf('debugbar_time') === -1) {
+            if (realXHR.getAllResponseHeaders().indexOf("Debugbar-Time") >= 0) {
+                let debugbarTime = realXHR.getResponseHeader('Debugbar-Time');
+
+                if (debugbarTime) {
+                    let h2 = document.querySelector('#ci-history > h2');
+
+                    if (h2) {
+                        h2.innerHTML = 'History <small>You have new debug data.</small> <button onclick="loadDoc(' + debugbarTime + ')">Update</button>';
+                        document.querySelector('a[data-tab="ci-history"] > span > .badge').className += ' active';
+                    }
+                }
+            }
+        }
+    }, false);
+    return realXHR;
 }
 
 window.XMLHttpRequest = newXHR;
-<?php endif; ?>
+</script>


### PR DESCRIPTION
**Description**
Fixes #5097 

The truncated styles would actually not pose a problem because in `toolbarloader.js.php` the styles and scripts from `toolbarContainer` is dynamically copied to the style and script in the `head`. After dynamically copying, those should be supposedly removed from `toolbarContainer` thru `responseText.substr`. This works well until the last copying of the last style where the removal was "misdirected".

To check that those styles would be redundant if we let it stay is to see that the timeline bars still got styled (in orange bars of varying lengths). Right-clicking on 'Inspect element' you would be that those bars have the class `.debug-bar-timeline-**` styles with the definition at the bottom.

If any of @rramsey or @kenjis can test this ?

**Checklist:**
- [x] Securely signed commits
