### PR TITLE
[Rector] Apply Rector: SimplifyEmptyArrayCheckRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -9,6 +9,7 @@
  * the LICENSE file that was distributed with this source code.
  */
 
+use Rector\CodeQuality\Rector\BooleanAnd\SimplifyEmptyArrayCheckRector;
 use Rector\CodeQuality\Rector\Expression\InlineIfToExplicitIfRector;
 use Rector\CodeQuality\Rector\For_\ForToForeachRector;
 use Rector\CodeQuality\Rector\Foreach_\UnusedForeachValueToArrayKeysRector;
@@ -131,4 +132,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(FuncGetArgsToVariadicParamRector::class);
     $services->set(MakeInheritedMethodVisibilitySameAsParentRector::class);
     $services->set(FixClassCaseSensitivityNameRector::class);
+    $services->set(SimplifyEmptyArrayCheckRector::class);
 };

--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -174,7 +174,7 @@ class Cell
             unset($newParams);
         }
 
-        if (is_array($params) && empty($params)) {
+        if ($params === []) {
             return [];
         }
 


### PR DESCRIPTION
Simplify `is_array` and `empty` functions combination into a simple identical check for an empty array with `SimplifyEmptyArrayCheckRector` rector rule.

**Checklist:**
- [x] Securely signed commits
