### PR TITLE
Multiple route filters

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -690,7 +690,7 @@ class CodeIgniter
      *
      * @throws RedirectException
      *
-     * @return string|null
+     * @return string|string[]|null
      */
     protected function tryToRouteIt(?RouteCollectionInterface $routes = null)
     {

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -328,6 +328,7 @@ class Filters
             foreach ($name as $filter) {
                 $this->enableFilter($filter, $when);
             }
+
             return $this;
         }
 

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -318,10 +318,19 @@ class Filters
      * after the filter name, followed by a comma-separated list of arguments that
      * are passed to the filter when executed.
      *
+     * @param string|string[] $name
+     *
      * @return Filters
      */
-    public function enableFilter(string $name, string $when = 'before')
+    public function enableFilter($name, string $when = 'before')
     {
+        if (is_array($name)) {
+            foreach ($name as $filter) {
+                $this->enableFilter($filter, $when);
+            }
+            return $this;
+        }
+
         // Get parameters and clean name
         if (strpos($name, ':') !== false) {
             [$name, $params] = explode(':', $name);
@@ -334,7 +343,9 @@ class Filters
             $this->arguments[$name] = $params;
         }
 
-        if (! array_key_exists($name, $this->config->aliases)) {
+        if (class_exists($name)) {
+            $this->config->aliases[$name] = $name;
+        } elseif (! array_key_exists($name, $this->config->aliases)) {
             throw FilterException::forNoAlias($name);
         }
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -512,7 +512,7 @@ class RouteCollection implements RouteCollectionInterface
      * Example:
      *      $routes->add('news', 'Posts::index');
      *
-     * @param array|string $to
+     * @param array|string|Closure $to
      */
     public function add(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -821,7 +821,7 @@ class RouteCollection implements RouteCollectionInterface
      * Example:
      *  $route->match( ['get', 'post'], 'users/(:num)', 'users/$1);
      *
-     * @param array|string $to
+     * @param array|string|Closure $to
      */
     public function match(array $verbs = [], string $from = '', $to = '', ?array $options = null): RouteCollectionInterface
     {
@@ -841,7 +841,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to GET requests.
      *
-     * @param array|string $to
+     * @param array|string|Closure $to
      */
     public function get(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -853,7 +853,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to POST requests.
      *
-     * @param array|string $to
+     * @param array|string|Closure $to
      */
     public function post(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -865,7 +865,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to PUT requests.
      *
-     * @param array|string $to
+     * @param array|string|Closure $to
      */
     public function put(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -877,7 +877,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to DELETE requests.
      *
-     * @param array|string $to
+     * @param array|string|Closure $to
      */
     public function delete(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -889,7 +889,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to HEAD requests.
      *
-     * @param array|string $to
+     * @param array|string|Closure $to
      */
     public function head(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -901,7 +901,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to PATCH requests.
      *
-     * @param array|string $to
+     * @param array|string|Closure $to
      */
     public function patch(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -913,7 +913,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to OPTIONS requests.
      *
-     * @param array|string $to
+     * @param array|string|Closure $to
      */
     public function options(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -925,7 +925,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to command-line requests.
      *
-     * @param array|string $to
+     * @param array|string|Closure $to
      */
     public function cli(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -1040,12 +1040,14 @@ class RouteCollection implements RouteCollectionInterface
      *    'role:admin,manager'
      *
      * has a filter of "role", with parameters of ['admin', 'manager'].
+     *
+     * @retun string|string[]
      */
-    public function getFilterForRoute(string $search, ?string $verb = null): string
+    public function getFilterForRoute(string $search, ?string $verb = null)
     {
         $options = $this->loadRoutesOptions($verb);
 
-        return $options[$search]['filter'] ?? '';
+        return $options[$search]['filter'] ?? [];
     }
 
     /**
@@ -1083,7 +1085,7 @@ class RouteCollection implements RouteCollectionInterface
      * the request method(s) that this route will work for. They can be separated
      * by a pipe character "|" if there is more than one.
      *
-     * @param array|string $to
+     * @param array|string|Closure $to
      */
     protected function create(string $verb, string $from, $to, ?array $options = null)
     {

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -512,7 +512,7 @@ class RouteCollection implements RouteCollectionInterface
      * Example:
      *      $routes->add('news', 'Posts::index');
      *
-     * @param array|string|Closure $to
+     * @param array|Closure|string $to
      */
     public function add(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -821,7 +821,7 @@ class RouteCollection implements RouteCollectionInterface
      * Example:
      *  $route->match( ['get', 'post'], 'users/(:num)', 'users/$1);
      *
-     * @param array|string|Closure $to
+     * @param array|Closure|string $to
      */
     public function match(array $verbs = [], string $from = '', $to = '', ?array $options = null): RouteCollectionInterface
     {
@@ -841,7 +841,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to GET requests.
      *
-     * @param array|string|Closure $to
+     * @param array|Closure|string $to
      */
     public function get(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -853,7 +853,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to POST requests.
      *
-     * @param array|string|Closure $to
+     * @param array|Closure|string $to
      */
     public function post(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -865,7 +865,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to PUT requests.
      *
-     * @param array|string|Closure $to
+     * @param array|Closure|string $to
      */
     public function put(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -877,7 +877,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to DELETE requests.
      *
-     * @param array|string|Closure $to
+     * @param array|Closure|string $to
      */
     public function delete(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -889,7 +889,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to HEAD requests.
      *
-     * @param array|string|Closure $to
+     * @param array|Closure|string $to
      */
     public function head(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -901,7 +901,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to PATCH requests.
      *
-     * @param array|string|Closure $to
+     * @param array|Closure|string $to
      */
     public function patch(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -913,7 +913,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to OPTIONS requests.
      *
-     * @param array|string|Closure $to
+     * @param array|Closure|string $to
      */
     public function options(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -925,7 +925,7 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Specifies a route that is only available to command-line requests.
      *
-     * @param array|string|Closure $to
+     * @param array|Closure|string $to
      */
     public function cli(string $from, $to, ?array $options = null): RouteCollectionInterface
     {
@@ -1085,7 +1085,7 @@ class RouteCollection implements RouteCollectionInterface
      * the request method(s) that this route will work for. They can be separated
      * by a pipe character "|" if there is more than one.
      *
-     * @param array|string|Closure $to
+     * @param array|Closure|string $to
      */
     protected function create(string $verb, string $from, $to, ?array $options = null)
     {

--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -28,7 +28,7 @@ interface RouteCollectionInterface
     /**
      * Adds a single route to the collection.
      *
-     * @param array|string|Closure $to
+     * @param array|Closure|string $to
      * @param array        $options
      *
      * @return mixed

--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -29,7 +29,7 @@ interface RouteCollectionInterface
      * Adds a single route to the collection.
      *
      * @param array|Closure|string $to
-     * @param array        $options
+     * @param array                $options
      *
      * @return mixed
      */

--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -28,7 +28,7 @@ interface RouteCollectionInterface
     /**
      * Adds a single route to the collection.
      *
-     * @param array|string $to
+     * @param array|string|Closure $to
      * @param array        $options
      *
      * @return mixed

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -98,7 +98,7 @@ class Router implements RouterInterface
      * The filter info from Route Collection
      * if the matched route should be filtered.
      *
-     * @var string|null
+     * @var string|string[]|null
      */
     protected $filterInfo;
 
@@ -165,7 +165,7 @@ class Router implements RouterInterface
     /**
      * Returns the filter info for the matched route, if any.
      *
-     * @return string
+     * @return string|string[]
      */
     public function getFilter()
     {

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -193,7 +193,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter->useSafeOutput(true)->run();
         $output = ob_get_clean();
 
-        $this->assertStringContainsString("http://hellowworld.com", $output);
+        $this->assertStringContainsString('http://hellowworld.com', $output);
     }
 
     public function testResponseConfigEmpty()

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -17,6 +17,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
 use Config\App;
 use Config\Modules;
+use Tests\Support\Filters\Customfilter;
 
 /**
  * @backupGlobals enabled
@@ -170,6 +171,29 @@ final class CodeIgniterTest extends CIUnitTestCase
         $output = ob_get_clean();
 
         $this->assertStringContainsString("You want to see 'about' page.", $output);
+    }
+
+    public function testControllersRunFilterByClassName()
+    {
+        $_SERVER['argv'] = ['index.php', 'pages/about'];
+        $_SERVER['argc'] = 2;
+
+        $_SERVER['REQUEST_URI'] = '/pages/about';
+
+        // Inject mock router.
+        $routes = Services::routes();
+        $routes->add('pages/about', static function () {
+            return Services::request()->url;
+        }, ['filter' => Customfilter::class]);
+
+        $router = Services::router($routes, Services::request());
+        Services::injectMock('router', $router);
+
+        ob_start();
+        $this->codeigniter->useSafeOutput(true)->run();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString("http://hellowworld.com", $output);
     }
 
     public function testResponseConfigEmpty()

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -16,7 +16,6 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
-use Tests\Support\Filters\Customfilter;
 
 /**
  * @internal

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -16,6 +16,7 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
+use Tests\Support\Filters\Customfilter;
 
 /**
  * @internal
@@ -507,6 +508,20 @@ final class RouterTest extends CIUnitTestCase
         $this->assertSame('\App\Controllers\Api\PostController', $router->controllerName());
         $this->assertSame('delete', $router->methodName());
         $this->assertSame('api-auth', $router->getFilter());
+    }
+
+    public function testRouteWorksWithMultipleFilters()
+    {
+        $collection = $this->collection;
+
+        $collection->add('foo', 'TestController::foo', ['filter' => ['filter1', 'filter2:param']]);
+        $router = new Router($collection, $this->request);
+
+        $router->handle('foo');
+
+        $this->assertSame('\TestController', $router->controllerName());
+        $this->assertSame('foo', $router->methodName());
+        $this->assertSame(['filter1', 'filter2:param'], $router->getFilter());
     }
 
     /**

--- a/user_guide_src/source/changelogs/v4.1.5.rst
+++ b/user_guide_src/source/changelogs/v4.1.5.rst
@@ -12,6 +12,8 @@ Enhancements:
 
 Changes:
 
+- Now the value of the route filter can also be an array. Instead of an alias, the name of the filter class can be specified.
+
 Deprecations:
 
 - Deprecated ``CodeIgniter\\Cache\\Handlers\\BaseHandler::RESERVED_CHARACTERS`` in favor of the new config property

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -352,11 +352,19 @@ can modify the generated routes, or further restrict them. The ``$options`` arra
 Applying Filters
 ----------------
 
-You can alter the behavior of specific routes by supplying a filter to run before or after the controller. This is especially handy during authentication or api logging::
+You can alter the behavior of specific routes by supplying a filters to run before or after the controller. This is especially handy during authentication or api logging.
+The filters value can be a string or an array of strings:
+
+* matching the aliases defined in ``app/Config/Filters.php``.
+* filter classes
+
+::
 
     $routes->add('admin',' AdminController::index', ['filter' => 'admin-auth']);
 
-The value for the filter must match one of the aliases defined within ``app/Config/Filters.php``. You may also supply arguments to be passed to the filter's ``before()`` and ``after()`` methods::
+    $routes->add('admin',' AdminController::index', ['filter' => ['admin-auth', \App\Filters\SomeFilter::class]]);
+
+You may also supply arguments to be passed to the filter's ``before()`` and ``after()`` methods. ``For filter aliases only``::
 
     $routes->add('users/delete/(:segment)', 'AdminController::index', ['filter' => 'admin-auth:dual,noreturn']);
 


### PR DESCRIPTION
**Description**
https://forum.codeigniter.com/thread-80117-post-390128.html

Several filters can be specified for a route.
Instead of filter aliases, you can use the name of the filter class.

```php
$route->add('foo', 'Home::index', ['filter' => ['filterAlias', \App\Filters\SomeFilter::class]);
```

Also fixed typehint in dockblock in the RouteCollection methods. Missing ``Closure``.


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
