### PR TITLE
Fix query binding with two colons in query

### DIFF
--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -275,12 +275,13 @@ class Query implements QueryInterface
     {
         $sql = $this->finalQueryString;
 
-        $hasNamedBinds = strpos($sql, '?') === false
+        $hasBinds      = strpos($sql, $this->bindMarker) !== false;
+        $hasNamedBinds = ! $hasBinds
             && preg_match('/:((?!=).+):/', $sql) === 1;
 
         if (empty($this->binds)
             || empty($this->bindMarker)
-            || (! $hasNamedBinds && strpos($sql, $this->bindMarker) === false)
+            || (! $hasNamedBinds && ! $hasBinds)
         ) {
             return;
         }

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -277,7 +277,7 @@ class Query implements QueryInterface
 
         $hasBinds      = strpos($sql, $this->bindMarker) !== false;
         $hasNamedBinds = ! $hasBinds
-            && preg_match('/:((?!=).+):/', $sql) === 1;
+            && preg_match('/:(?!=).+:/', $sql) === 1;
 
         if (empty($this->binds)
             || empty($this->bindMarker)

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -269,7 +269,7 @@ class Query implements QueryInterface
     /**
      * Escapes and inserts any binds into the finalQueryString object.
      *
-     * @see https://regex101.com/r/EUEhay/4
+     * @see https://regex101.com/r/EUEhay/5
      */
     protected function compileBinds()
     {

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -275,7 +275,8 @@ class Query implements QueryInterface
     {
         $sql = $this->finalQueryString;
 
-        $hasNamedBinds = preg_match('/:((?!=).+):/', $sql) === 1;
+        $hasNamedBinds = strpos($sql, '?') === false
+            && preg_match('/:((?!=).+):/', $sql) === 1;
 
         if (empty($this->binds)
             || empty($this->bindMarker)

--- a/tests/system/Database/BaseQueryTest.php
+++ b/tests/system/Database/BaseQueryTest.php
@@ -238,6 +238,23 @@ final class BaseQueryTest extends CIUnitTestCase
         $this->assertSame($expected, $query->getQuery());
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5114
+     */
+    public function testBindingWithTwoColons()
+    {
+        $query = new Query($this->db);
+
+        $query->setQuery(
+            "SELECT mytable.id, DATE_FORMAT(mytable.created_at,'%d/%m/%Y %H:%i:%s') AS created_at_uk FROM mytable WHERE mytable.id = ?",
+            [1]
+        );
+
+        $expected = "SELECT mytable.id, DATE_FORMAT(mytable.created_at,'%d/%m/%Y %H:%i:%s') AS created_at_uk FROM mytable WHERE mytable.id = 1";
+
+        $this->assertSame($expected, $query->getQuery());
+    }
+
     public function testNamedBinds()
     {
         $query = new Query($this->db);


### PR DESCRIPTION
**Description**
Fixes #5114

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

