### PR TITLE
fix: QueryBuilder breaks select when escape is false

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -369,10 +369,6 @@ class BaseBuilder
      */
     public function select($select = '*', ?bool $escape = null)
     {
-        if (is_string($select)) {
-            $select = explode(',', $select);
-        }
-
         // If the escape value was not set, we will base it on the global setting
         if (! is_bool($escape)) {
             $escape = $this->db->protectIdentifiers;
@@ -382,6 +378,10 @@ class BaseBuilder
             $this->QBSelect[] = $select;
 
             return $this;
+        }
+
+        if (is_string($select)) {
+            $select = $escape === false ? [$select] : explode(',', $select);
         }
 
         foreach ($select as $val) {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1017,6 +1017,11 @@ abstract class BaseConnection implements ConnectionInterface
             return $item;
         }
 
+        // Do not protect identifiers and do not prefix, no swap prefix, there is nothing to do
+        if ($protectIdentifiers === false && $prefixSingle === false && $this->swapPre === '') {
+            return $item;
+        }
+
         // Convert tabs or multiple spaces into single spaces
         $item = preg_replace('/\s+/', ' ', trim($item));
 

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -166,6 +166,9 @@ final class BaseConnectionTest extends CIUnitTestCase
     }
 
     /**
+     * These tests are intended to confirm the current behavior.
+     * We do not know if all of these are the correct behavior.
+     *
      * @dataProvider identifiersProvider
      */
     public function testProtectIdentifiers(
@@ -207,14 +210,14 @@ final class BaseConnectionTest extends CIUnitTestCase
             'quoted table alias'        => [false, true, false, '"jobs" "j"', '"jobs" "j"'],
             'quoted table alias prefix' => [true,  true, false, '"jobs" "j"', '"test_jobs" "j"'],
 
-            'table.*'             => [false, true, true, 'jobs.*', '"test_jobs".*'], // Why prefixed?
+            'table.*'             => [false, true, true, 'jobs.*', '"test_jobs".*'], // Prefixed because it has segments
             'table.* prefix'      => [true,  true, true, 'jobs.*', '"test_jobs".*'],
-            'table.column'        => [false, true, true, 'users.id', '"test_users"."id"'], // Why prefixed?
+            'table.column'        => [false, true, true, 'users.id', '"test_users"."id"'], // Prefixed because it has segments
             'table.column prefix' => [true,  true, true, 'users.id', '"test_users"."id"'],
             'table.column AS'     => [
                 false, true, true,
                 'users.id AS user_id',
-                '"test_users"."id" AS "user_id"', // Why prefixed?
+                '"test_users"."id" AS "user_id"', // Prefixed because it has segments
             ],
             'table.column AS prefix' => [
                 true,  true, true,

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -124,6 +124,25 @@ final class SelectTest extends CIUnitTestCase
         $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/4355
+     */
+    public function testSelectRegularExpressionWorksWithEscpaeFalse()
+    {
+        $builder = new BaseBuilder('ob_human_resources', $this->db);
+
+        $builder->select(
+            'REGEXP_SUBSTR(ral_anno,"[0-9]{1,2}([,.][0-9]{1,3})([,.][0-9]{1,3})") AS ral',
+            false
+        );
+
+        $expected = <<<'SQL'
+            SELECT REGEXP_SUBSTR(ral_anno,"[0-9]{1,2}([,.][0-9]{1,3})([,.][0-9]{1,3})") AS ral
+            FROM "ob_human_resources"
+            SQL;
+        $this->assertSame($expected, $builder->getCompiledSelect());
+    }
+
     public function testSelectMinWithNoAlias()
     {
         $builder = new BaseBuilder('invoices', $this->db);

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -110,6 +110,20 @@ final class SelectTest extends CIUnitTestCase
         $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/4311
+     */
+    public function testSelectWorksWithEscpaeFalse()
+    {
+        $builder = new BaseBuilder('users', $this->db);
+
+        $builder->select('"numericValue1" + "numericValue2" AS "numericResult"', false);
+
+        $expected = 'SELECT "numericValue1" + "numericValue2" AS "numericResult" FROM "users"';
+
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
     public function testSelectMinWithNoAlias()
     {
         $builder = new BaseBuilder('invoices', $this->db);


### PR DESCRIPTION
**Description**
fixes #4311
fixes #4355

I'm not sure correct behavior of `protectIdentifiers()`. See [tests](https://github.com/codeigniter4/CodeIgniter4/pull/5118/files#diff-65d39fd097198820866d41c227f1afbb8db3498670ad049d13f87ad6df2cc97e).

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

