### PR TITLE
(Paging) Ensure page validity

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1082,9 +1082,8 @@ abstract class BaseModel
         $page = $page >= 1 ? $page : $pager->getCurrentPage($group);
         // Store it in the Pager library, so it can be paginated in the views.
         $this->pager = $pager->store($group, $page, $perPage, $this->countAllResults(false), $segment);
-        $page        = $pager->getCurrentPage($group);
         $perPage     = $this->pager->getPerPage($group);
-        $offset      = ($page - 1) * $perPage;
+        $offset      = ($pager->getCurrentPage($group) - 1) * $perPage;
 
         return $this->findAll($perPage, $offset);
     }

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1082,6 +1082,7 @@ abstract class BaseModel
         $page = $page >= 1 ? $page : $pager->getCurrentPage($group);
         // Store it in the Pager library, so it can be paginated in the views.
         $this->pager = $pager->store($group, $page, $perPage, $this->countAllResults(false), $segment);
+        $page        = $pager->getCurrentPage( $group );
         $perPage     = $this->pager->getPerPage($group);
         $offset      = ($page - 1) * $perPage;
 

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1082,7 +1082,7 @@ abstract class BaseModel
         $page = $page >= 1 ? $page : $pager->getCurrentPage($group);
         // Store it in the Pager library, so it can be paginated in the views.
         $this->pager = $pager->store($group, $page, $perPage, $this->countAllResults(false), $segment);
-        $page        = $pager->getCurrentPage( $group );
+        $page        = $pager->getCurrentPage($group);
         $perPage     = $this->pager->getPerPage($group);
         $offset      = ($page - 1) * $perPage;
 

--- a/tests/system/Models/PaginateModelTest.php
+++ b/tests/system/Models/PaginateModelTest.php
@@ -74,12 +74,9 @@ final class PaginateModelTest extends LiveModelTestCase
 	public function testPaginatePageOutOfRange(): void
     {
     	$this->createModel(ValidModel::class);
-    	$pager = $this->model->pager;
-    	// check underflow
     	$this->model->paginate(1,'default', -500);
-    	$this->assertSame(1, $pager->getCurrentPage());
-    	// check overflow
+    	$this->assertSame(1, $this->model->pager->getCurrentPage());
     	$this->model->paginate(1, 'default', 500);
-    	$this->assertSame($pager->getPageCount(),$pager->getCurrentPage());
+    	$this->assertSame($this->model->pager->getPageCount(),$this->model->pager->getCurrentPage());
     }
 }

--- a/tests/system/Models/PaginateModelTest.php
+++ b/tests/system/Models/PaginateModelTest.php
@@ -70,4 +70,16 @@ final class PaginateModelTest extends LiveModelTestCase
         $this->assertCount(3, $data);
         $this->assertSame(3, $this->model->pager->getDetails()['total']);
     }
+	
+	public function testPaginatePageOutOfRange(): void
+    {
+    	$this->createModel(ValidModel::class);
+    	$pager = $this->model->pager;
+    	// check underflow
+    	$this->model->paginate(1,'default', -500);
+    	$this->assertSame(1, $pager->getCurrentPage());
+    	// check overflow
+    	$this->model->paginate(1, 'default', 500);
+    	$this->assertSame($pager->getPageCount(),$pager->getCurrentPage());
+    }
 }

--- a/tests/system/Models/PaginateModelTest.php
+++ b/tests/system/Models/PaginateModelTest.php
@@ -70,13 +70,13 @@ final class PaginateModelTest extends LiveModelTestCase
         $this->assertCount(3, $data);
         $this->assertSame(3, $this->model->pager->getDetails()['total']);
     }
-	
-	public function testPaginatePageOutOfRange(): void
+
+    public function testPaginatePageOutOfRange(): void
     {
-    	$this->createModel(ValidModel::class);
-    	$this->model->paginate(1,'default', -500);
-    	$this->assertSame(1, $this->model->pager->getCurrentPage());
-    	$this->model->paginate(1, 'default', 500);
-    	$this->assertSame($this->model->pager->getPageCount(),$this->model->pager->getCurrentPage());
+        $this->createModel(ValidModel::class);
+        $this->model->paginate(1, 'default', -500);
+        $this->assertSame(1, $this->model->pager->getCurrentPage());
+        $this->model->paginate(1, 'default', 500);
+        $this->assertSame($this->model->pager->getPageCount(), $this->model->pager->getCurrentPage());
     }
 }


### PR DESCRIPTION
An invalid page lead to an exception when using the model paginate function.
page::store validates the page but it doesnt update the page used in the model.

So we need to read the page value again after calling pager::store in paginate