### PR TITLE
Allow calling getQuery() multiple times, and other improvements

### DIFF
--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -24,9 +24,16 @@ class Query implements QueryInterface
     protected $originalQueryString;
 
     /**
+     * The query string if table prefix has been swapped.
+     *
+     * @var string|null
+     */
+    protected $swappedQueryString;
+
+    /**
      * The final query string after binding, etc.
      *
-     * @var string
+     * @var string|null
      */
     protected $finalQueryString;
 
@@ -99,6 +106,7 @@ class Query implements QueryInterface
     public function setQuery(string $sql, $binds = null, bool $setEscape = true)
     {
         $this->originalQueryString = $sql;
+        unset($this->swappedQueryString);
 
         if ($binds !== null) {
             if (! is_array($binds)) {
@@ -115,6 +123,8 @@ class Query implements QueryInterface
             }
             $this->binds = $binds;
         }
+
+        unset($this->finalQueryString);
 
         return $this;
     }
@@ -134,6 +144,8 @@ class Query implements QueryInterface
 
         $this->binds = $binds;
 
+        unset($this->finalQueryString);
+
         return $this;
     }
 
@@ -144,10 +156,8 @@ class Query implements QueryInterface
     public function getQuery(): string
     {
         if (empty($this->finalQueryString)) {
-            $this->finalQueryString = $this->originalQueryString;
+            $this->compileBinds();
         }
-
-        $this->compileBinds();
 
         return $this->finalQueryString;
     }
@@ -251,9 +261,14 @@ class Query implements QueryInterface
      */
     public function swapPrefix(string $orig, string $swap)
     {
-        $sql = empty($this->finalQueryString) ? $this->originalQueryString : $this->finalQueryString;
+        $sql = $this->swappedQueryString ?? $this->originalQueryString;
 
-        $this->finalQueryString = preg_replace('/(\W)' . $orig . '(\S+?)/', '\\1' . $swap . '\\2', $sql);
+        $from = '/(\W)' . $orig . '(\S+?)/';
+        $to   = '\\1' . $swap . '\\2';
+
+        $this->swappedQueryString = preg_replace($from, $to, $sql);
+
+        unset($this->finalQueryString);
 
         return $this;
     }
@@ -267,16 +282,18 @@ class Query implements QueryInterface
     }
 
     /**
-     * Escapes and inserts any binds into the finalQueryString object.
+     * Escapes and inserts any binds into the finalQueryString property.
      *
      * @see https://regex101.com/r/EUEhay/5
      */
     protected function compileBinds()
     {
-        $sql   = $this->finalQueryString;
+        $sql   = $this->swappedQueryString ?? $this->originalQueryString;
         $binds = $this->binds;
 
         if (empty($binds)) {
+            $this->finalQueryString = $sql;
+
             return;
         }
 
@@ -391,11 +408,7 @@ class Query implements QueryInterface
             'WHERE',
         ];
 
-        if (empty($this->finalQueryString)) {
-            $this->compileBinds(); // @codeCoverageIgnore
-        }
-
-        $sql = esc($this->finalQueryString);
+        $sql = esc($this->getQuery());
 
         /**
          * @see https://stackoverflow.com/a/20767160

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -263,7 +263,7 @@ class Query implements QueryInterface
     {
         $sql = $this->swappedQueryString ?? $this->originalQueryString;
 
-        $from = '/(\W)' . $orig . '(\S+?)/';
+        $from = '/(\W)' . $orig . '(\S)/';
         $to   = '\\1' . $swap . '\\2';
 
         $this->swappedQueryString = preg_replace($from, $to, $sql);

--- a/user_guide_src/source/database/queries.rst
+++ b/user_guide_src/source/database/queries.rst
@@ -356,7 +356,7 @@ INSERT, UPDATE, DELETE, etc)::
 
 **swapPrefix()**
 
-Replaces one table prefix with another value in the final SQL. The first
+Replaces one table prefix with another value in the SQL. The first
 parameter is the original prefix that you want replaced, and the second
 parameter is the value you want it replaced with::
 


### PR DESCRIPTION
Main fix:
- `getQuery()` can now be called multiple times without trouble, `compileBinds()` will be called only on original SQL string. Previously, calling `getQuery()` additional times was executing `compileBinds()` again and again, and on the already compiled SQL string…

Additional improvements and notes:
- [Performances] If `getQuery()` is called multiple times, `compileBinds()` is executed only the first time.
- Calling `setQuery()` or `setBinds()` discard `finalQueryString`, so they can be called multiple times with new data, and the SQL will be generated with this new data.
- `swapPrefix()` will always be executed on the original SQL string (with the bind placeholders), which is a bit safer than on the final SQL string (as the search/replace just operates on the whole SQL string).
- [BC] As previously, it is possible to call `swapPrefix()` multiple times, to execute multiple prefix swaps.
- `swapPrefix()` can be called before or after `setBinds()` (but not before `setQuery()`, as it operates on `originalQueryString`).
- `debugToolbarDisplay()` would fail if called before `finalQueryString` is assigned, as `compileBinds()` was relying on `getQuery()` to assign this property beforehand. (refs #4534)

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
