### PR TITLE
Fix highlighting in database debug toolbar

### DIFF
--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -372,23 +372,23 @@ class Query implements QueryInterface
             'FROM',
             'WHERE',
             'AND',
-            'LEFT&nbsp;JOIN',
-            'RIGHT&nbsp;JOIN',
+            'LEFT JOIN',
+            'RIGHT JOIN',
             'JOIN',
-            'ORDER&nbsp;BY',
-            'GROUP&nbsp;BY',
+            'ORDER BY',
+            'GROUP BY',
             'LIMIT',
             'INSERT',
             'INTO',
             'VALUES',
             'UPDATE',
-            'OR&nbsp;',
+            'OR ',
             'HAVING',
             'OFFSET',
-            'NOT&nbsp;IN',
+            'NOT IN',
             'IN',
             'LIKE',
-            'NOT&nbsp;LIKE',
+            'NOT LIKE',
             'COUNT',
             'MAX',
             'MIN',
@@ -407,7 +407,9 @@ class Query implements QueryInterface
         $sql = $this->finalQueryString;
 
         foreach ($highlight as $term) {
-            $sql = str_replace($term, '<strong>' . $term . '</strong>', $sql);
+            $from = $term;
+            $to   = '<strong>' . str_replace(' ', '&nbsp;', $term) . '</strong>';
+            $sql  = str_replace($from, $to, $sql);
         }
 
         return $sql;

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -376,6 +376,8 @@ class Query implements QueryInterface
             'RIGHT JOIN',
             'JOIN',
             'ORDER BY',
+            'ASC',
+            'DESC',
             'GROUP BY',
             'LIMIT',
             'INSERT',

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -406,11 +406,9 @@ class Query implements QueryInterface
 
         $search = '/\b(?:' . implode('|', $highlight) . ')\b/';
 
-        $sql = preg_replace_callback($search, static function ($matches) {
+        return preg_replace_callback($search, static function ($matches) {
             return '<strong>' . str_replace(' ', '&nbsp;', $matches[0]) . '</strong>';
         }, $sql);
-
-        return str_replace(['(', ')'], ['<strong>(</strong>', '<strong>)</strong>'], $sql);
     }
 
     /**

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -396,8 +396,6 @@ class Query implements QueryInterface
             'AS',
             'AVG',
             'SUM',
-            '(',
-            ')',
         ];
 
         if (empty($this->finalQueryString)) {
@@ -406,17 +404,13 @@ class Query implements QueryInterface
 
         $sql = $this->finalQueryString;
 
-        $escapedTerms = array_map(static function ($term) {
-            return preg_quote($term, '/');
-        }, $highlight);
-
-        $search = '/\b(?:' . implode('|', $escapedTerms) . ')\b/';
+        $search = '/\b(?:' . implode('|', $highlight) . ')\b/';
 
         $sql = preg_replace_callback($search, static function ($matches) {
             return '<strong>' . str_replace(' ', '&nbsp;', $matches[0]) . '</strong>';
         }, $sql);
 
-        return $sql;
+        return str_replace(['(', ')'], ['<strong>(</strong>', '<strong>)</strong>'], $sql);
     }
 
     /**

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -406,11 +406,15 @@ class Query implements QueryInterface
 
         $sql = $this->finalQueryString;
 
-        foreach ($highlight as $term) {
-            $sql = preg_replace_callback('/\b' . preg_quote($term, '/') . '\b/', static function ($matches) {
-                return '<strong>' . str_replace(' ', '&nbsp;', $matches[0]) . '</strong>';
-            }, $sql);
-        }
+        $escapedTerms = array_map(static function ($term) {
+            return preg_quote($term, '/');
+        }, $highlight);
+
+        $search = '/\b(?:' . implode('|', $escapedTerms) . ')\b/';
+
+        $sql = preg_replace_callback($search, static function ($matches) {
+            return '<strong>' . str_replace(' ', '&nbsp;', $matches[0]) . '</strong>';
+        }, $sql);
 
         return $sql;
     }

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -382,7 +382,7 @@ class Query implements QueryInterface
             'INTO',
             'VALUES',
             'UPDATE',
-            'OR ',
+            'OR',
             'HAVING',
             'OFFSET',
             'NOT IN',
@@ -407,9 +407,9 @@ class Query implements QueryInterface
         $sql = $this->finalQueryString;
 
         foreach ($highlight as $term) {
-            $from = $term;
-            $to   = '<strong>' . str_replace(' ', '&nbsp;', $term) . '</strong>';
-            $sql  = str_replace($from, $to, $sql);
+            $sql = preg_replace_callback('/\b' . preg_quote($term, '/') . '\b/', static function ($matches) {
+                return '<strong>' . str_replace(' ', '&nbsp;', $matches[0]) . '</strong>';
+            }, $sql);
         }
 
         return $sql;


### PR DESCRIPTION
Highlighting wasn't working for multiple-word terms, as they were searched in the SQL string with nbsp entities instead of regular spaces.

This code could be optimized, though it's not crucial as it's a debug function.