### PR TITLE
Always escape identifiers in the set(), setUpdateBatch(), and insertBatch()

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -366,7 +366,7 @@ abstract class BaseModel
      * This methods works only with dbCalls
      *
      * @param array|null $set       An associative array of insert values
-     * @param bool|null  $escape    Whether to escape values and identifiers
+     * @param bool|null  $escape    Whether to escape values
      * @param int        $batchSize The size of the batch to run
      * @param bool       $testing   True means only number of records is returned, false will execute the query
      *
@@ -763,7 +763,7 @@ abstract class BaseModel
      * Compiles batch insert runs the queries, validating each row prior.
      *
      * @param array|null $set       an associative array of insert values
-     * @param bool|null  $escape    Whether to escape values and identifiers
+     * @param bool|null  $escape    Whether to escape values
      * @param int        $batchSize The size of the batch to run
      * @param bool       $testing   True means only number of records is returned, false will execute the query
      *

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1340,7 +1340,7 @@ class BaseBuilder
      *
      * @param array|object|string $key    Field name, or an array of field/value pairs
      * @param mixed               $value  Field value, if $key is a single field
-     * @param bool|null           $escape Whether to escape values and identifiers
+     * @param bool|null           $escape Whether to escape values
      *
      * @return $this
      */

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1358,9 +1358,9 @@ class BaseBuilder
             if ($escape) {
                 $bind = $this->setBind($k, $v, $escape);
 
-                $this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = ":{$bind}:";
+                $this->QBSet[$this->db->protectIdentifiers($k, false)] = ":{$bind}:";
             } else {
-                $this->QBSet[$this->db->protectIdentifiers($k, false, $escape)] = $v;
+                $this->QBSet[$this->db->protectIdentifiers($k, false)] = $v;
             }
         }
 

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2052,7 +2052,7 @@ class BaseBuilder
 
                 $bind = $this->setBind($k2, $v2, $escape);
 
-                $clean[$this->db->protectIdentifiers($k2, false, $escape)] = ":{$bind}:";
+                $clean[$this->db->protectIdentifiers($k2, false)] = ":{$bind}:";
             }
 
             if ($indexSet === false) {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1604,7 +1604,7 @@ class BaseBuilder
         $affectedRows = 0;
 
         for ($i = 0, $total = count($this->QBSet); $i < $total; $i += $batchSize) {
-            $sql = $this->_insertBatch($this->db->protectIdentifiers($table, true, $escape, false), $this->QBKeys, array_slice($this->QBSet, $i, $batchSize));
+            $sql = $this->_insertBatch($this->db->protectIdentifiers($table, true, null, false), $this->QBKeys, array_slice($this->QBSet, $i, $batchSize));
 
             if ($this->testMode) {
                 $affectedRows++;
@@ -1672,7 +1672,7 @@ class BaseBuilder
         }
 
         foreach ($keys as $k) {
-            $this->QBKeys[] = $this->db->protectIdentifiers($k, false, $escape);
+            $this->QBKeys[] = $this->db->protectIdentifiers($k, false);
         }
 
         return $this;

--- a/system/Model.php
+++ b/system/Model.php
@@ -251,7 +251,7 @@ class Model extends BaseModel
      * This methods works only with dbCalls
      *
      * @param array|null $set       An associative array of insert values
-     * @param bool|null  $escape    Whether to escape values and identifiers
+     * @param bool|null  $escape    Whether to escape values
      * @param int        $batchSize The size of the batch to run
      * @param bool       $testing   True means only number of records is returned, false will execute the query
      *
@@ -559,7 +559,7 @@ class Model extends BaseModel
      *
      * @param mixed     $key    Field name, or an array of field/value pairs
      * @param mixed     $value  Field value, if $key is a single field
-     * @param bool|null $escape Whether to escape values and identifiers
+     * @param bool|null $escape Whether to escape values
      *
      * @return $this
      */

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -124,7 +124,7 @@ final class InsertTest extends CIUnitTestCase
         $raw = 'INSERT INTO "jobs" ("description", "id", "name") VALUES (:description:,:id:,:name:), (:description.1:,:id.1:,:name.1:)';
         $this->assertSame($raw, str_replace("\n", ' ', $query->getOriginalQuery()));
 
-        $expected = "INSERT INTO \"jobs\" (\"description\", \"id\", \"name\") VALUES (1 + 2,2,1 + 1), (2 + 2,3,2 + 1)";
+        $expected = 'INSERT INTO "jobs" ("description", "id", "name") VALUES (1 + 2,2,1 + 1), (2 + 2,3,2 + 1)';
         $this->assertSame($expected, str_replace("\n", ' ', $query->getQuery()));
     }
 

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -98,6 +98,36 @@ final class InsertTest extends CIUnitTestCase
         $this->assertSame($expected, str_replace("\n", ' ', $query->getQuery()));
     }
 
+    public function testInsertBatchWithoutEscape()
+    {
+        $builder = $this->db->table('jobs');
+
+        $insertData = [
+            [
+                'id'          => 2,
+                'name'        => '1 + 1',
+                'description' => '1 + 2',
+            ],
+            [
+                'id'          => 3,
+                'name'        => '2 + 1',
+                'description' => '2 + 2',
+            ],
+        ];
+
+        $this->db->shouldReturn('execute', 1)->shouldReturn('affectedRows', 1);
+        $builder->insertBatch($insertData, false);
+
+        $query = $this->db->getLastQuery();
+        $this->assertInstanceOf(Query::class, $query);
+
+        $raw = 'INSERT INTO "jobs" ("description", "id", "name") VALUES (:description:,:id:,:name:), (:description.1:,:id.1:,:name.1:)';
+        $this->assertSame($raw, str_replace("\n", ' ', $query->getOriginalQuery()));
+
+        $expected = "INSERT INTO \"jobs\" (\"description\", \"id\", \"name\") VALUES (1 + 2,2,1 + 1), (2 + 2,3,2 + 1)";
+        $this->assertSame($expected, str_replace("\n", ' ', $query->getQuery()));
+    }
+
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4345
      */

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -350,7 +350,7 @@ final class UpdateTest extends CIUnitTestCase
             ->where('id', 2)
             ->update(null, null, null);
 
-        $expectedSQL   = 'UPDATE "mytable" SET field = field+1 WHERE "id" = 2';
+        $expectedSQL   = 'UPDATE "mytable" SET "field" = field+1 WHERE "id" = 2';
         $expectedBinds = [
             'id' => [
                 2,
@@ -372,7 +372,7 @@ final class UpdateTest extends CIUnitTestCase
             ->where('id', 2)
             ->update(null, null, null);
 
-        $expectedSQL   = 'UPDATE "mytable" SET "foo" = \'bar\', field = field+1 WHERE "id" = 2';
+        $expectedSQL   = 'UPDATE "mytable" SET "foo" = \'bar\', "field" = field+1 WHERE "id" = 2';
         $expectedBinds = [
             'foo' => [
                 'bar',

--- a/user_guide_src/source/changelogs/v4.1.5.rst
+++ b/user_guide_src/source/changelogs/v4.1.5.rst
@@ -12,6 +12,8 @@ Enhancements:
 
 Changes:
 
+- Always escape identifiers in the ``set``, ``setUpdateBatch``, and ``insertBatch`` functions in ``BaseBuilder``.
+
 Deprecations:
 
 - Deprecated ``CodeIgniter\\Cache\\Handlers\\BaseHandler::RESERVED_CHARACTERS`` in favor of the new config property

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1701,7 +1701,7 @@ Class Reference
 
         :param mixed $key: Field name, or an array of field/value pairs
         :param mixed $value: Field value, if $key is a single field
-        :param bool    $escape: Whether to escape values and identifiers
+        :param bool    $escape: Whether to escape values
         :returns:   ``BaseBuilder`` instance (method chaining)
         :rtype:     ``BaseBuilder``
 
@@ -1710,7 +1710,7 @@ Class Reference
     .. php:method:: insert([$set = null[, $escape = null]])
 
         :param array $set: An associative array of field/value pairs
-        :param bool $escape: Whether to escape values and identifiers
+        :param bool $escape: Whether to escape values
         :returns:   ``true`` on success, ``false`` on failure
         :rtype:     bool
 
@@ -1719,7 +1719,7 @@ Class Reference
     .. php:method:: insertBatch([$set = null[, $escape = null[, $batch_size = 100]]])
 
         :param array $set: Data to insert
-        :param bool $escape: Whether to escape values and identifiers
+        :param bool $escape: Whether to escape values
         :param int $batch_size: Count of rows to insert at once
         :returns: Number of rows inserted or ``false`` on failure
         :rtype:    int|false
@@ -1734,7 +1734,7 @@ Class Reference
 
         :param mixed $key: Field name or an array of field/value pairs
         :param string $value: Field value, if $key is a single field
-        :param bool $escape: Whether to escape values and identifiers
+        :param bool $escape: Whether to escape values
         :returns:   ``BaseBuilder`` instance (method chaining)
         :rtype:     ``BaseBuilder``
 
@@ -1768,7 +1768,7 @@ Class Reference
 
         :param mixed $key: Field name or an array of field/value pairs
         :param string $value: Field value, if $key is a single field
-        :param bool    $escape: Whether to escape values and identifiers
+        :param bool    $escape: Whether to escape values
         :returns:   ``BaseBuilder`` instance (method chaining)
         :rtype:     ``BaseBuilder``
 


### PR DESCRIPTION
Fixed a problem where identifiers were not escaped in the set, setUpdateBatch, and insertBatch methods. 

**Description**

I decided that there was no case where the column name in the set clause did not need to be escaped, so I turned off the unescaping process.
The same goes for the table name when inserting.

see: https://github.com/codeigniter4/CodeIgniter4/pull/2487#discussion_r716012806

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
  
