### PR TITLE
Fixed the problem that _createTable does not take into account that it returns true.

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -466,6 +466,8 @@ class Forge
 
                 return false;
             }
+
+            return true;
         }
 
         if (($result = $this->db->query($sql)) !== false) {

--- a/tests/system/Database/Forge/CreateTableTest.php
+++ b/tests/system/Database/Forge/CreateTableTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Forge;
+
+use CodeIgniter\Database\Forge;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockConnection;
+
+/**
+ * @internal
+ */
+final class CreateTableTest extends CIUnitTestCase
+{
+    public function testCreateTableWithExists()
+    {
+        $dbMock = $this->getMockBuilder(MockConnection::class)
+            ->setConstructorArgs([[]])
+            ->setMethods(['listTables'])
+            ->getMock();
+        $dbMock->expects($this->any())
+            ->method('listTables')
+            ->willReturn(['foo']);
+
+        $forge                          = new class ($dbMock) extends Forge {
+            protected $createTableIfStr = false;
+        };
+
+        $forge->addField('id');
+        $actual = $forge->createTable('foo', true);
+
+        $this->assertTrue($actual);
+    }
+}


### PR DESCRIPTION
Fixed the problem that `_createTable` does not take into account that it returns true.

**Description**

If `_createTable` returns true, then `createTable` will return true.
This occurs only when the `createTableIfStr` property is false in the Forge class.
I had trouble with this behavior when I was creating the OCI8 driver.

see: https://github.com/codeigniter4/CodeIgniter4/pull/2487#discussion_r716022511

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
