### PR TITLE
Adjust orange color in debug toolbar

### DIFF
--- a/admin/css/debug-toolbar/_theme-dark.scss
+++ b/admin/css/debug-toolbar/_theme-dark.scss
@@ -55,7 +55,7 @@
     // Tables
     table {
         strong {
-            color: $m-orange;
+            color: $g-orange;
         }
 
         tbody tr {

--- a/admin/css/debug-toolbar/_theme-light.scss
+++ b/admin/css/debug-toolbar/_theme-light.scss
@@ -55,7 +55,7 @@
     // Tables
     table {
         strong {
-            color: $m-orange;
+            color: $g-orange;
         }
 
         tbody tr {

--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -379,7 +379,7 @@
     #debug-bar button {
       background-color: #252525; }
     #debug-bar table strong {
-      color: #FDC894; }
+      color: #DD8615; }
     #debug-bar table tbody tr:hover {
       background-color: #434343; }
     #debug-bar table tbody tr.current {


### PR DESCRIPTION
Change shade of orange, from matt orange (#FDC894) to glossy orange (#DD8615), as the current color doesn't have enough contrast with background. Before and after:
![light_before](https://user-images.githubusercontent.com/544424/134795851-729a4508-9736-407d-9b91-2857c6d58b24.png)
![light_after](https://user-images.githubusercontent.com/544424/134795854-4a80b59a-0236-4332-acd3-00d02c23cf29.png)

I made the same change to dark theme, as I think it's also prettier, and because currently both light and dark themes use the same shades of *-orange at the same places, so better keep this consistency. Before and after:
![dark_before](https://user-images.githubusercontent.com/544424/134795860-7251e1ce-6da3-4693-aeec-b2aab3bec8db.png)
![dark_after](https://user-images.githubusercontent.com/544424/134795863-e98c9aca-a3b8-452d-be58-7e47de84685f.png)

I made this PR because on Pale Moon browser these texts are less bold, and see how the current color is barely readable:
![pale_moon](https://user-images.githubusercontent.com/544424/134795864-6d67ef34-d7d2-4018-a8df-9b4f487a5716.png)
