### PR TITLE
Determine if binds are simple or named by looking at the $binds array

### DIFF
--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -288,7 +288,7 @@ class Query implements QueryInterface
         }
 
         if (is_numeric(key(array_slice($binds, 0, 1)))) {
-            if (empty($this->bindMarker) || strpos($sql, $this->bindMarker) === false) {
+            if (empty($this->bindMarker)) {
                 return;
             }
 
@@ -296,10 +296,6 @@ class Query implements QueryInterface
 
             $this->finalQueryString = $this->matchSimpleBinds($sql, $binds, $bindCount, $ml);
         } else {
-            if (! preg_match('/:(?!=).+:/', $sql)) {
-                return;
-            }
-
             // Reverse the binds so that duplicate named binds
             // will be processed prior to the original binds.
             $binds = array_reverse($binds);

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -288,10 +288,6 @@ class Query implements QueryInterface
         }
 
         if (is_numeric(key(array_slice($binds, 0, 1)))) {
-            if (empty($this->bindMarker)) {
-                return;
-            }
-
             $ml = strlen($this->bindMarker);
 
             $this->finalQueryString = $this->matchSimpleBinds($sql, $binds, $bindCount, $ml);

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -281,7 +281,7 @@ class Query implements QueryInterface
 
         $binds = (array) $this->binds;
 
-        if (is_int(key(array_slice($binds, 0, 1)))) {
+        if (is_int(array_key_first($binds))) {
             $bindCount = count($binds);
             $ml        = strlen($this->bindMarker);
 

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -281,7 +281,7 @@ class Query implements QueryInterface
 
         $binds = (array) $this->binds;
 
-        if (is_numeric(key(array_slice($binds, 0, 1)))) {
+        if (is_int(key(array_slice($binds, 0, 1)))) {
             $bindCount = count($binds);
             $ml        = strlen($this->bindMarker);
 

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -279,16 +279,11 @@ class Query implements QueryInterface
             return;
         }
 
-        if (! is_array($this->binds)) {
-            $binds     = [$this->binds];
-            $bindCount = 1;
-        } else {
-            $binds     = $this->binds;
-            $bindCount = count($binds);
-        }
+        $binds = (array) $this->binds;
 
         if (is_numeric(key(array_slice($binds, 0, 1)))) {
-            $ml = strlen($this->bindMarker);
+            $bindCount = count($binds);
+            $ml        = strlen($this->bindMarker);
 
             $this->finalQueryString = $this->matchSimpleBinds($sql, $binds, $bindCount, $ml);
         } else {

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -275,14 +275,7 @@ class Query implements QueryInterface
     {
         $sql = $this->finalQueryString;
 
-        $hasBinds      = strpos($sql, $this->bindMarker) !== false;
-        $hasNamedBinds = ! $hasBinds
-            && preg_match('/:(?!=).+:/', $sql) === 1;
-
-        if (empty($this->binds)
-            || empty($this->bindMarker)
-            || (! $hasNamedBinds && ! $hasBinds)
-        ) {
+        if (empty($this->binds)) {
             return;
         }
 
@@ -294,16 +287,25 @@ class Query implements QueryInterface
             $bindCount = count($binds);
         }
 
-        // Reverse the binds so that duplicate named binds
-        // will be processed prior to the original binds.
-        if (! is_numeric(key(array_slice($binds, 0, 1)))) {
+        if (is_numeric(key(array_slice($binds, 0, 1)))) {
+            if (empty($this->bindMarker) || strpos($sql, $this->bindMarker) === false) {
+                return;
+            }
+
+            $ml = strlen($this->bindMarker);
+
+            $this->finalQueryString = $this->matchSimpleBinds($sql, $binds, $bindCount, $ml);
+        } else {
+            if (! preg_match('/:(?!=).+:/', $sql)) {
+                return;
+            }
+
+            // Reverse the binds so that duplicate named binds
+            // will be processed prior to the original binds.
             $binds = array_reverse($binds);
+
+            $this->finalQueryString = $this->matchNamedBinds($sql, $binds);
         }
-
-        $ml  = strlen($this->bindMarker);
-        $sql = $hasNamedBinds ? $this->matchNamedBinds($sql, $binds) : $this->matchSimpleBinds($sql, $binds, $bindCount, $ml);
-
-        $this->finalQueryString = $sql;
     }
 
     /**

--- a/tests/system/Database/BaseQueryTest.php
+++ b/tests/system/Database/BaseQueryTest.php
@@ -269,12 +269,36 @@ final class BaseQueryTest extends CIUnitTestCase
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/3566
      */
-    public function testNamedBindsWithColonElseWhere()
+    public function testNamedBindsWithColonElsewhere()
     {
         $query = new Query($this->db);
         $query->setQuery('SELECT `email`, @total:=(total+1) FROM `users` WHERE `id` = :id:', ['id' => 10]);
 
         $sql = 'SELECT `email`, @total:=(total+1) FROM `users` WHERE `id` = 10';
+        $this->assertSame($sql, $query->getQuery());
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/pull/5138
+     */
+    public function testNamedBindsWithBindMarkerElsewhere()
+    {
+        $query = new Query($this->db);
+        $query->setQuery('SELECT * FROM posts WHERE id = :id: AND title = \'The default bind marker is "?"\'', ['id' => 10]);
+
+        $sql = 'SELECT * FROM posts WHERE id = 10 AND title = \'The default bind marker is "?"\'';
+        $this->assertSame($sql, $query->getQuery());
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/pull/5138
+     */
+    public function testSimpleBindsWithNamedBindPlaceholderElsewhere()
+    {
+        $query = new Query($this->db);
+        $query->setQuery('SELECT * FROM posts WHERE id = ? AND title = \'A named bind placeholder looks like ":foobar:"\'', 10);
+
+        $sql = 'SELECT * FROM posts WHERE id = 10 AND title = \'A named bind placeholder looks like ":foobar:"\'';
         $this->assertSame($sql, $query->getQuery());
     }
 


### PR DESCRIPTION
To determine if binds are simple or named, rather than trying to deduce it from the SQL string, which is the source of many errors (for example see #5114, and all the issues it links to), simply look at the `$binds` array. If it's an indexed array, the binds are simple, if it's an associative array, the binds are named.

Note that if #5127 is merged before, this PR will need a slight rebasing before merging.