### PR TITLE
Fix `Model::__call` throwing `BadMethodCallException` on empty results

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -719,7 +719,7 @@ class Model extends BaseModel
 
         if (method_exists($this->db, $name)) {
             $result = $this->db->{$name}(...$params);
-        } else if (method_exists($builder, $name)) {
+        } elseif (method_exists($builder, $name)) {
             $result = $builder->{$name}(...$params);
         } else {
             $className = static::class;

--- a/system/Model.php
+++ b/system/Model.php
@@ -722,9 +722,7 @@ class Model extends BaseModel
         } elseif (method_exists($builder, $name)) {
             $result = $builder->{$name}(...$params);
         } else {
-            $className = static::class;
-
-            throw new BadMethodCallException('Call to undefined method ' . $className . '::' . $name);
+            throw new BadMethodCallException('Call to undefined method ' . static::class . '::' . $name);
         }
 
         if ($result instanceof BaseBuilder) {

--- a/system/Model.php
+++ b/system/Model.php
@@ -710,7 +710,7 @@ class Model extends BaseModel
      * Provides direct access to method in the builder (if available)
      * and the database connection.
      *
-     * @return $this|null
+     * @return mixed
      */
     public function __call(string $name, array $params)
     {

--- a/system/Model.php
+++ b/system/Model.php
@@ -728,7 +728,6 @@ class Model extends BaseModel
             $result = $builder->{$name}(...$params);
         }
 
-
         if ($result instanceof BaseBuilder) {
             return $this;
         }

--- a/system/Model.php
+++ b/system/Model.php
@@ -714,18 +714,17 @@ class Model extends BaseModel
      */
     public function __call(string $name, array $params)
     {
-        try {
-            $result = parent::__call($name, $params);
-        } catch (BadMethodCallException $e) {
-            $builder = $this->builder();
+        $builder = $this->builder();
+        $result  = null;
 
-            if (! method_exists($builder, $name)) {
-                $className = static::class;
-
-                throw new BadMethodCallException('Call to undefined method ' . $className . '::' . $name);
-            }
-
+        if (method_exists($this->db, $name)) {
+            $result = $this->db->{$name}(...$params);
+        } else if (method_exists($builder, $name)) {
             $result = $builder->{$name}(...$params);
+        } else {
+            $className = static::class;
+
+            throw new BadMethodCallException('Call to undefined method ' . $className . '::' . $name);
         }
 
         if ($result instanceof BaseBuilder) {

--- a/system/Model.php
+++ b/system/Model.php
@@ -714,21 +714,20 @@ class Model extends BaseModel
      */
     public function __call(string $name, array $params)
     {
-        $result = parent::__call($name, $params);
+        try {
+            $result = parent::__call($name, $params);
+        } catch (BadMethodCallException $e) {
+            $builder = $this->builder();
 
-        if ($result === null && method_exists($builder = $this->builder(), $name)) {
-            $result = $builder->{$name}(...$params);
-        }
-
-        if (empty($result)) {
-            if (! method_exists($this->builder(), $name)) {
+            if (! method_exists($builder, $name)) {
                 $className = static::class;
 
                 throw new BadMethodCallException('Call to undefined method ' . $className . '::' . $name);
             }
 
-            return $result;
+            $result = $builder->{$name}(...$params);
         }
+
 
         if ($result instanceof BaseBuilder) {
             return $this;

--- a/tests/system/Models/AffectedRowsTest.php
+++ b/tests/system/Models/AffectedRowsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Models;
+
+use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Entity\Entity;
+use stdClass;
+use Tests\Support\Models\UserModel;
+
+/**
+ * @internal
+ */
+final class AffectedRowsTest extends LiveModelTestCase
+{
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/4087
+     */
+    public function testAffectedRowsWithEmptyUpdate(): void
+    {
+        $this->createModel(UserModel::class);
+        $notExistsId = -1;
+        $this->model
+            ->set('country', 'US')
+            ->where('id', $notExistsId)
+            ->update();
+
+        $this->assertSame(0, $this->model->affectedRows());
+    }
+}

--- a/tests/system/Models/AffectedRowsTest.php
+++ b/tests/system/Models/AffectedRowsTest.php
@@ -11,9 +11,6 @@
 
 namespace CodeIgniter\Models;
 
-use CodeIgniter\Database\Exceptions\DataException;
-use CodeIgniter\Entity\Entity;
-use stdClass;
 use Tests\Support\Models\UserModel;
 
 /**

--- a/tests/system/Models/AffectedRowsTest.php
+++ b/tests/system/Models/AffectedRowsTest.php
@@ -19,7 +19,7 @@ use Tests\Support\Models\UserModel;
 final class AffectedRowsTest extends LiveModelTestCase
 {
     /**
-     * @see https://github.com/codeigniter4/CodeIgniter4/issues/4087
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5137
      */
     public function testAffectedRowsWithEmptyUpdate(): void
     {


### PR DESCRIPTION
Fixes #5137.

**Description**

An error occurs when a method of the Database\Connection class returns a falsy value.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide