### PR TITLE
Error when value is an object - validating api data

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -291,6 +291,8 @@ class Validation implements ValidationInterface
                 // if the $value is an array, convert it to as string representation
                 if (is_array($value)) {
                     $value = '[' . implode(', ', $value) . ']';
+                }elseif (\is_object($value)) {
+                    $value = \json_encode( $value );
                 }
 
                 $this->errors[$field] = $error ?? $this->getErrorMessage($rule, $field, $label, $param, $value);

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -291,8 +291,8 @@ class Validation implements ValidationInterface
                 // if the $value is an array, convert it to as string representation
                 if (is_array($value)) {
                     $value = '[' . implode(', ', $value) . ']';
-                }elseif (\is_object($value)) {
-                    $value = \json_encode( $value );
+                } elseif (\is_object($value)) {
+                    $value = \json_encode($value);
                 }
 
                 $this->errors[$field] = $error ?? $this->getErrorMessage($rule, $field, $label, $param, $value);

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -291,8 +291,8 @@ class Validation implements ValidationInterface
                 // if the $value is an array, convert it to as string representation
                 if (is_array($value)) {
                     $value = '[' . implode(', ', $value) . ']';
-                } elseif (\is_object($value)) {
-                    $value = \json_encode($value);
+                } elseif (is_object($value)) {
+                    $value = json_encode($value);
                 }
 
                 $this->errors[$field] = $error ?? $this->getErrorMessage($rule, $field, $label, $param, $value);

--- a/tests/_support/Validation/TestRules.php
+++ b/tests/_support/Validation/TestRules.php
@@ -19,4 +19,18 @@ class TestRules
 
         return false;
     }
+
+    public function check_object_rule( Object $value, ?string $fields, array $data = [] )
+    {
+        $find = false;
+        foreach( $value as $key => $val )
+        {
+            if( $key == 'first' )
+            {
+                $find = true;
+            }
+        }
+
+        return $find;
+    }
 }

--- a/tests/_support/Validation/TestRules.php
+++ b/tests/_support/Validation/TestRules.php
@@ -20,13 +20,12 @@ class TestRules
         return false;
     }
 
-    public function check_object_rule( Object $value, ?string $fields, array $data = [] )
+    public function check_object_rule(object $value, ?string $fields, array $data = [])
     {
         $find = false;
-        foreach( $value as $key => $val )
-        {
-            if( $key == 'first' )
-            {
+
+        foreach ($value as $key => $val) {
+            if ($key === 'first') {
                 $find = true;
             }
         }

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -634,26 +634,25 @@ final class ValidationTest extends CIUnitTestCase
         $config->baseURL = 'http://example.com/';
 
         $this->validation->setRules([
-            'configuration'   => 'required|check_object_rule'
+            'configuration' => 'required|check_object_rule',
         ]);
 
-        $data = (Object) array( 'configuration' => (Object)array( 'first' => 1, 'second' => 2 ) );
-        $this->validation->run( (array)$data );
+        $data = (object) ['configuration' => (object) ['first' => 1, 'second' => 2]];
+        $this->validation->run((array) $data);
         $this->assertSame([], $this->validation->getErrors());
 
         $this->validation->reset();
 
         $this->validation->setRules([
-            'configuration'   => 'required|check_object_rule'
+            'configuration' => 'required|check_object_rule',
         ]);
 
-        $data = (Object) array( 'configuration' => (Object)array( 'first1' => 1, 'second' => 2 ) );
-        $this->validation->run( (array)$data );
+        $data = (object) ['configuration' => (object) ['first1' => 1, 'second' => 2]];
+        $this->validation->run((array) $data);
 
         $this->assertSame([
-            'configuration'   => 'Validation.check_object_rule',
+            'configuration' => 'Validation.check_object_rule',
         ], $this->validation->getErrors());
-        
     }
 
     /**

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -628,6 +628,34 @@ final class ValidationTest extends CIUnitTestCase
         $this->assertSame($expected, $errors['Username']);
     }
 
+    public function testRulesForObjectField()
+    {
+        $config          = new App();
+        $config->baseURL = 'http://example.com/';
+
+        $this->validation->setRules([
+            'configuration'   => 'required|check_object_rule'
+        ]);
+
+        $data = (Object) array( 'configuration' => (Object)array( 'first' => 1, 'second' => 2 ) );
+        $this->validation->run( (array)$data );
+        $this->assertSame([], $this->validation->getErrors());
+
+        $this->validation->reset();
+
+        $this->validation->setRules([
+            'configuration'   => 'required|check_object_rule'
+        ]);
+
+        $data = (Object) array( 'configuration' => (Object)array( 'first1' => 1, 'second' => 2 ) );
+        $this->validation->run( (array)$data );
+
+        $this->assertSame([
+            'configuration'   => 'Validation.check_object_rule',
+        ], $this->validation->getErrors());
+        
+    }
+
     /**
      * @dataProvider arrayFieldDataProvider
      *

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -630,9 +630,6 @@ final class ValidationTest extends CIUnitTestCase
 
     public function testRulesForObjectField()
     {
-        $config          = new App();
-        $config->baseURL = 'http://example.com/';
-
         $this->validation->setRules([
             'configuration' => 'required|check_object_rule',
         ]);


### PR DESCRIPTION
For example:
```json
{
	"configuration" :
        {
	        "consumerKey1" : "aa",
	        "consumerSecret" : "bb",
	        "oauthToken" : "cc",
	        "oauthTokenSecret" : "dd"
        }
}
```

**Description**
Explain what you have changed, and why.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
