### PR TITLE
docs: replace tabs with spaces

### DIFF
--- a/user_guide_src/README.rst
+++ b/user_guide_src/README.rst
@@ -22,15 +22,15 @@ or ``python3``.
 
 .. code-block:: bash
 
-	python --version
-	Python 2.7.17
+    python --version
+    Python 2.7.17
 
-	python3 --version
-	Python 3.6.9
+    python3 --version
+    Python 3.6.9
 
-	# For Windows using the Python Launcher
-	py -3 --version
-	Python 3.8.1
+    # For Windows using the Python Launcher
+    py -3 --version
+    Python 3.8.1
 
 If you're not on 3.5+, go ahead and install the latest 3.x version from
 `Python.org <https://www.python.org/downloads/>`_. Linux users should use their
@@ -48,15 +48,15 @@ Please take note that it should say ``python 3.x`` at the very end.
 
 .. code-block:: bash
 
-	pip --version
-	pip 9.0.1 from /usr/lib/python2.7/dist-packages (python 2.7)
+    pip --version
+    pip 9.0.1 from /usr/lib/python2.7/dist-packages (python 2.7)
 
-	pip3 --version
-	pip 9.0.1 from /usr/lib/python3/dist-packages (python 3.6)
+    pip3 --version
+    pip 9.0.1 from /usr/lib/python3/dist-packages (python 3.6)
 
-	# For Windows using the Python Launcher
-	py -3 -m pip --version
-	pip 20.0.2 from C:\Users\<username>\AppData\Local\Programs\Python\Python38\lib\site-packages\pip (python 3.8)
+    # For Windows using the Python Launcher
+    py -3 -m pip --version
+    pip 20.0.2 from C:\Users\<username>\AppData\Local\Programs\Python\Python38\lib\site-packages\pip (python 3.8)
 
 Linux
 ^^^^^
@@ -79,19 +79,19 @@ window as Python won't find all applications we just installed othervise.
 
 .. code-block:: bash
 
-	pip install -r user_guide_src/requirements.txt
+    pip install -r user_guide_src/requirements.txt
 
-	pip3 install -r user_guide_src/requirements.txt
+    pip3 install -r user_guide_src/requirements.txt
 
-	# For Windows using the Python Launcher
-	py -3 -m pip install -r user_guide_src/requirements.txt
+    # For Windows using the Python Launcher
+    py -3 -m pip install -r user_guide_src/requirements.txt
 
 It's time to wrap things up and generate the documentation.
 
 .. code-block:: bash
 
-	cd user_guide_src
-	make html
+    cd user_guide_src
+    make html
 
 Editing and Creating Documentation
 ==================================
@@ -111,7 +111,7 @@ you to regenerate as necessary if you want to "preview" your work. Generating
 the HTML is very simple. From the root directory of your user guide repo
 fork issue the command you used at the end of the installation instructions::
 
-	make html
+    make html
 
 You will see it do a whiz-bang compilation, at which point the fully rendered
 user guide and images will be in *build/html/*. After the HTML has been built,

--- a/user_guide_src/source/helpers/test_helper.rst
+++ b/user_guide_src/source/helpers/test_helper.rst
@@ -21,10 +21,10 @@ The following functions are available:
 
 .. php:function:: fake($model, array $overrides = null)
 
-    :param	Model|object|string	$model: Instance or name of the model to use with Fabricator
-    :param	array|null $overrides: Overriding data to pass to Fabricator::setOverrides()
-    :returns:	A random fake item created and added to the database by Fabricator
-    :rtype:	object|array
+    :param    Model|object|string    $model: Instance or name of the model to use with Fabricator
+    :param    array|null $overrides: Overriding data to pass to Fabricator::setOverrides()
+    :returns:    A random fake item created and added to the database by Fabricator
+    :rtype:    object|array
 
     Uses ``CodeIgniter\Test\Fabricator`` to create a random item and add it to the database.
 

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -23,7 +23,7 @@ The following functions are available:
     :param  string        $protocol: Protocol, e.g., 'http' or 'https'
     :param  \\Config\\App $altConfig: Alternate configuration to use
     :returns: Site URL
-    :rtype:	string
+    :rtype:    string
 
     Returns your site URL, as specified in your config file. The index.php
     file (or whatever you have set as your site **indexPage** in your config
@@ -83,10 +83,10 @@ The following functions are available:
 
 .. php:function:: current_url([$returnObject = false[, $request = null]])
 
-    :param	boolean	$returnObject: True if you would like a URI instance returned, instead of a string.
-    :param	IncomingRequest|null	$request: An alternate request to use for path detection; useful for testing.
+    :param    boolean    $returnObject: True if you would like a URI instance returned, instead of a string.
+    :param    IncomingRequest|null    $request: An alternate request to use for path detection; useful for testing.
     :returns: The current URL
-    :rtype:	string|\\CodeIgniter\\HTTP\\URI
+    :rtype:    string|\\CodeIgniter\\HTTP\\URI
 
     Returns the full URL (including segments) of the page being currently
     viewed.
@@ -113,9 +113,9 @@ The following functions are available:
 
 .. php:function:: uri_string([$relative = false])
 
-    :param	boolean	$relative: True if you would like the string relative to baseURL
+    :param    boolean    $relative: True if you would like the string relative to baseURL
     :returns: A URI string
-    :rtype:	string
+    :rtype:    string
 
     Returns the path part of the current URL.
     For example, if your URL was this::
@@ -137,7 +137,7 @@ The following functions are available:
 
     :param \\Config\\App $altConfig: Alternate configuration to use
     :returns: 'index_page' value
-    :rtype:	string
+    :rtype:    string
 
     Returns your site **indexPage**, as specified in your config file.
     Example::
@@ -156,7 +156,7 @@ The following functions are available:
     :param  mixed         $attributes: HTML attributes
     :param  \\Config\\App $altConfig: Alternate configuration to use
     :returns: HTML hyperlink (anchor tag)
-    :rtype:	string
+    :rtype:    string
 
     Creates a standard HTML anchor link based on your local site URL.
 

--- a/user_guide_src/source/incoming/request.rst
+++ b/user_guide_src/source/incoming/request.rst
@@ -32,7 +32,7 @@ Class Reference
 
     .. php:method:: isValidIP($ip[, $which = ''])
 
-		.. important:: This method is deprecated.
+        .. important:: This method is deprecated.
 
         :param    string $ip: IP address
         :param    string $which: IP protocol ('ipv4' or 'ipv6')
@@ -57,7 +57,7 @@ Class Reference
 
     .. php:method:: getMethod([$upper = false])
 
-		.. important:: Use of the ``$upper`` parameter is deprecated.
+        .. important:: Use of the ``$upper`` parameter is deprecated.
 
         :param bool $upper: Whether to return the request method name in upper or lower case
         :returns: HTTP request method
@@ -120,7 +120,7 @@ Class Reference
         :param    string $method: Method name
         :param    mixed  $value:  Data to be added
         :returns: HTTP request method
-        :rtype:	Request
+        :rtype:    Request
 
         Allows manually setting the value of PHP global, like $_GET, $_POST, etc.
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -92,7 +92,7 @@ The ID will be set to “34”::
 A URL with “product” as the first segment, and anything in the second will be remapped to the “\Catalog” class
 and the “productLookup” method::
 
-	$routes->add('product/(:any)', 'Catalog::productLookup');
+    $routes->add('product/(:any)', 'Catalog::productLookup');
 
 A URL with “product” as the first segment, and a number in the second will be remapped to the “\Catalog” class
 and the “productLookupByID” method passing in the match as a variable to the method::
@@ -101,7 +101,7 @@ and the “productLookupByID” method passing in the match as a variable to the
 
 Note that a single ``(:any)`` will match multiple segments in the URL if present. For example the route::
 
-	$routes->add('product/(:any)', 'Catalog::productLookup/$1');
+    $routes->add('product/(:any)', 'Catalog::productLookup/$1');
 
 will match product/123, product/123/456, product/123/456/789 and so on. The implementation in the
 Controller should take into account the maximum parameters::
@@ -115,7 +115,7 @@ Controller should take into account the maximum parameters::
 If matching multiple segments is not the intended behavior, ``(:segment)`` should be used when defining the
 routes. With the examples URLs from above::
 
-	$routes->add('product/(:segment)', 'Catalog::productLookup/$1');
+    $routes->add('product/(:segment)', 'Catalog::productLookup/$1');
 
 will only match product/123 and generate 404 errors for other example.
 

--- a/user_guide_src/source/installation/upgrade_412.rst
+++ b/user_guide_src/source/installation/upgrade_412.rst
@@ -15,13 +15,13 @@ and View Parser). Update your projects accordingly.
 Cache handlers had wildly different compatibility for keys. The updated cache drivers now pass
 all keys through validation, roughly matching PSR-6's recommendations:
 
-	A string of at least one character that uniquely identifies a cached item. Implementing libraries
-	MUST support keys consisting of the characters A-Z, a-z, 0-9, _, and . in any order in UTF-8 encoding
-	and a length of up to 64 characters. Implementing libraries MAY support additional characters and
-	encodings or longer lengths, but must support at least that minimum. Libraries are responsible for
-	their own escaping of key strings as appropriate, but MUST be able to return the original unmodified
-	key string. The following characters are reserved for future extensions and MUST NOT be supported by
-	implementing libraries: ``{}()/\@:``
+    A string of at least one character that uniquely identifies a cached item. Implementing libraries
+    MUST support keys consisting of the characters A-Z, a-z, 0-9, _, and . in any order in UTF-8 encoding
+    and a length of up to 64 characters. Implementing libraries MAY support additional characters and
+    encodings or longer lengths, but must support at least that minimum. Libraries are responsible for
+    their own escaping of key strings as appropriate, but MUST be able to return the original unmodified
+    key string. The following characters are reserved for future extensions and MUST NOT be supported by
+    implementing libraries: ``{}()/\@:``
 
 Update your projects to remove any invalid cache keys.
 

--- a/user_guide_src/source/libraries/throttler.rst
+++ b/user_guide_src/source/libraries/throttler.rst
@@ -109,10 +109,10 @@ to apply only to POST requests, though API's might want to limit every request m
 this to incoming requests, you need to edit **/app/Config/Filters.php** and first add an alias to the
 filter::
 
-	public $aliases = [
-		...
-		'throttle' => \App\Filters\Throttle::class,
-	];
+    public $aliases = [
+        ...
+        'throttle' => \App\Filters\Throttle::class,
+    ];
 
 Next, we assign it to all POST requests made on the site::
 


### PR DESCRIPTION
**Description**
- replace tabs with spaces

Finally, tabs are gone from the RST file.
```sh-session
$ find user_guide_src/ -name '*.rst' | xargs grep "\t"
$ 
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
