### PR TITLE
Fix MemcachedHandlerTest::testGetMetaData()

### DIFF
--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -191,7 +191,14 @@ final class MemcachedHandlerTest extends CIUnitTestCase
         $this->assertFalse($this->memcachedHandler->getMetaData(self::$dummy));
 
         $actual = $this->memcachedHandler->getMetaData(self::$key1);
-        $this->assertLessThanOrEqual(60, $actual['expire'] - $time);
+
+        // This test is time-dependent, and depending on the timing,
+        // seconds in `$time` (e.g. 12:00:00.9999) and seconds of
+        // `$this->memcachedHandler->save()` (e.g. 12:00:01.0000)
+        // may be off by one second. In that case, the following calculation
+        // will result in maximum of (60 + 1).
+        $this->assertLessThanOrEqual(60 + 1, $actual['expire'] - $time);
+
         $this->assertLessThanOrEqual(1, $actual['mtime'] - $time);
         $this->assertSame('value', $actual['data']);
     }


### PR DESCRIPTION
**Description**
- fix `MemcachedHandlerTest::testGetMetaData()` rarely fails

```
There was 1 failure:

1) CodeIgniter\Cache\Handlers\MemcachedHandlerTest::testGetMetaData
Failed asserting that 61 is equal to 60 or is less than 60.

/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/Cache/Handlers/MemcachedHandlerTest.php:194
```
https://github.com/kenjis/CodeIgniter4/runs/3726773162?check_suite_focus=true

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPdocs
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
