### PR TITLE
Refactor BaseBuilder.php and fix xxxBatch() methods docs

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2023,7 +2023,7 @@ class BaseBuilder
     /**
      * Allows key/value pairs to be set for batch updating
      *
-     * @param array|object $set An associative array or an object of field/value pairs
+     * @param array $set An array of field/value associative arrays or objects
      *
      * @throws DatabaseException
      *
@@ -2471,7 +2471,7 @@ class BaseBuilder
     /**
      * Takes an object as input and converts the class variables to array key/vals
      *
-     * @param object $object
+     * @param array|object $object
      *
      * @return array
      */

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2023,17 +2023,17 @@ class BaseBuilder
     /**
      * Allows key/value pairs to be set for batch updating
      *
-     * @param array|object $key
+     * @param array|object $set An associative array or an object of field/value pairs
      *
      * @throws DatabaseException
      *
      * @return $this|null
      */
-    public function setUpdateBatch($key, string $index = '', ?bool $escape = null)
+    public function setUpdateBatch($set, string $index = '', ?bool $escape = null)
     {
-        $key = $this->batchObjectToArray($key);
+        $set = $this->batchObjectToArray($set);
 
-        if (! is_array($key)) {
+        if (! is_array($set)) {
             return null;
         }
 
@@ -2041,7 +2041,7 @@ class BaseBuilder
             $escape = $this->db->protectIdentifiers;
         }
 
-        foreach ($key as $v) {
+        foreach ($set as $v) {
             $indexSet = false;
             $clean    = [];
 

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -68,22 +68,45 @@ final class InsertTest extends CIUnitTestCase
         $builder->testMode()->insert(null, true);
     }
 
-    public function testInsertBatch()
+    public function insertDataProvider()
     {
-        $builder = $this->db->table('jobs');
-
-        $insertData = [
+        yield 'array' => [
             [
-                'id'          => 2,
-                'name'        => 'Commedian',
-                'description' => 'There\'s something in your teeth',
-            ],
-            [
-                'id'          => 3,
-                'name'        => 'Cab Driver',
-                'description' => 'I am yellow',
+                [
+                    'id'          => 2,
+                    'name'        => 'Commedian',
+                    'description' => 'There\'s something in your teeth',
+                ],
+                [
+                    'id'          => 3,
+                    'name'        => 'Cab Driver',
+                    'description' => 'I am yellow',
+                ],
             ],
         ];
+
+        yield 'object' => [
+            [
+                (object) [
+                    'id'          => 2,
+                    'name'        => 'Commedian',
+                    'description' => 'There\'s something in your teeth',
+                ],
+                (object) [
+                    'id'          => 3,
+                    'name'        => 'Cab Driver',
+                    'description' => 'I am yellow',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider  insertDataProvider
+     */
+    public function testInsertBatch(array $insertData)
+    {
+        $builder = $this->db->table('jobs');
 
         $this->db->shouldReturn('execute', 1)->shouldReturn('affectedRows', 1);
         $builder->insertBatch($insertData, true);

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -183,22 +183,45 @@ final class UpdateTest extends CIUnitTestCase
         $builder->update(null, null, null);
     }
 
-    public function testUpdateBatch()
+    public function updateDataProvider()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
-
-        $updateData = [
+        yield 'array' => [
             [
-                'id'          => 2,
-                'name'        => 'Comedian',
-                'description' => 'There\'s something in your teeth',
-            ],
-            [
-                'id'          => 3,
-                'name'        => 'Cab Driver',
-                'description' => 'I am yellow',
+                [
+                    'id'          => 2,
+                    'name'        => 'Comedian',
+                    'description' => 'There\'s something in your teeth',
+                ],
+                [
+                    'id'          => 3,
+                    'name'        => 'Cab Driver',
+                    'description' => 'I am yellow',
+                ],
             ],
         ];
+
+        yield 'object' => [
+            [
+                (object) [
+                    'id'          => 2,
+                    'name'        => 'Comedian',
+                    'description' => 'There\'s something in your teeth',
+                ],
+                (object) [
+                    'id'          => 3,
+                    'name'        => 'Cab Driver',
+                    'description' => 'I am yellow',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider updateDataProvider
+     */
+    public function testUpdateBatch(array $updateData)
+    {
+        $builder = new BaseBuilder('jobs', $this->db);
 
         $this->db->shouldReturn('execute', 1)->shouldReturn('affectedRows', 1);
         $builder->updateBatch($updateData, 'id');

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -913,7 +913,7 @@ using ``$builder->insert()`` which resets values or reset directly using
 **$builder->insertBatch()**
 
 Generates an insert string based on the data you supply, and runs the
-query. You can either pass an **array** or an **object** to the
+query. You can either pass an array of **arrays** or **objects** to the
 function. Here is an example using an array::
 
     $data = [
@@ -932,7 +932,7 @@ function. Here is an example using an array::
     $builder->insertBatch($data);
     // Produces: INSERT INTO mytable (title, name, date) VALUES ('My title', 'My name', 'My date'),  ('Another title', 'Another name', 'Another date')
 
-The first parameter is an associative array of values.
+The first parameter is an array of associative arrays of values.
 
 .. note:: All values are escaped automatically producing safer queries.
 
@@ -1086,7 +1086,7 @@ performing updates.
 **$builder->updateBatch()**
 
 Generates an update string based on the data you supply, and runs the query.
-You can either pass an **array** or an **object** to the function.
+You can either pass an array of **arrays** or **objects** to the function.
 Here is an example using an array::
 
     $data = [
@@ -1115,7 +1115,7 @@ Here is an example using an array::
     // ELSE `date` END
     // WHERE `title` IN ('My title','Another title')
 
-The first parameter is an associative array of values, the second parameter is the where key.
+The first parameter is an array of associative arrays of values, the second parameter is the where key.
 
 .. note:: All values are escaped automatically producing safer queries.
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1718,7 +1718,7 @@ Class Reference
 
     .. php:method:: insertBatch([$set = null[, $escape = null[, $batch_size = 100]]])
 
-        :param array $set: Data to insert
+        :param array $set: An array of field/value associative arrays or objects
         :param bool $escape: Whether to escape values and identifiers
         :param int $batch_size: Count of rows to insert at once
         :returns: Number of rows inserted or ``false`` on failure
@@ -1750,11 +1750,11 @@ Class Reference
 
         Compiles and executes an ``UPDATE`` statement.
 
-    .. php:method:: updateBatch([$set = null[, $value = null[, $batch_size = 100]]])
+    .. php:method:: updateBatch([$set = null[, $index = null[, $batch_size = 100]]])
 
-        :param array $set: Field name, or an associative array of field/value pairs
-        :param string $value: Field value, if $set is a single field
-        :param int $batch_size: Count of conditions to group in a single query
+        :param  array    $set: An array of field/value associative arrays or objects
+        :param  string   $index: The where key
+        :param  int      $batch_size: Count of conditions to group in a single query
         :returns:   Number of rows updated or ``false`` on failure
         :rtype:     int|false
 
@@ -1764,11 +1764,11 @@ Class Reference
             multiple queries will be executed, each handling up to
             ``$batch_size`` field/value pairs.
 
-    .. php:method:: setUpdateBatch($key[, $value = ''[, $escape = null]])
+    .. php:method:: setUpdateBatch($set[, $index = ''[, $escape = null]])
 
-        :param mixed $key: Field name or an array of field/value pairs
-        :param string $value: Field value, if $key is a single field
-        :param bool    $escape: Whether to escape values and identifiers
+        :param  array   $set: An array of field/value associative arrays or objects
+        :param  string  $index: The where key
+        :param  bool    $escape: Whether to escape values and identifiers
         :returns:   ``BaseBuilder`` instance (method chaining)
         :rtype:     ``BaseBuilder``
 


### PR DESCRIPTION
**Description**
- refactor variable name in system/Database/BaseBuilder.php
- fix insertBatch() / updateBatch() / setUpdateBatch() user guide
- add tests for insertBatch() / updateBatch() with array of objects param

 ### insertBatch() updateBatch() the first param

The User Guide says "You can either pass an **array** or an **object** to the function."
But the the first param type is `?array` in the code.

In fact, you can pass an array of arrays or objects.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
