### PR TITLE
docs: fix Google.com to DuckDuckGo.com

### DIFF
--- a/user_guide_src/source/tutorial/index.rst
+++ b/user_guide_src/source/tutorial/index.rst
@@ -121,7 +121,7 @@ greeted by a screen looking something like this:
 There are a couple of things to note here:
 
 1. Hovering over the red header at the top reveals a ``search`` link that will open up
-   Google.com in a new tab and searching for the exception.
+   DuckDuckGo.com in a new tab and searching for the exception.
 2. Clicking the ``arguments`` link on any line in the Backtrace will expand a list of
    the arguments that were passed into that function call.
 


### PR DESCRIPTION
Fix Google.com to DuckDuckGo.com

**Description**
Fix Google.com to DuckDuckGo.com, how is the code running. https://github.com/codeigniter4/CodeIgniter4/blob/7b7d251f898ddb8afcf3fcf0c7d498d448844c19/app/Views/errors/html/error_exception.php#L25

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
