### PR TITLE
Fix color not updated in several places of the precompiled CSS

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -292,7 +292,7 @@
   #debug-bar button {
     background-color: #FFFFFF; }
   #debug-bar table strong {
-    color: #FDC894; }
+    color: #DD8615; }
   #debug-bar table tbody tr:hover {
     background-color: #DFDFDF; }
   #debug-bar table tbody tr.current {
@@ -466,7 +466,7 @@
   #toolbarContainer.dark #debug-bar button {
     background-color: #252525; }
   #toolbarContainer.dark #debug-bar table strong {
-    color: #FDC894; }
+    color: #DD8615; }
   #toolbarContainer.dark #debug-bar table tbody tr:hover {
     background-color: #434343; }
   #toolbarContainer.dark #debug-bar table tbody tr.current {
@@ -559,7 +559,7 @@
   #toolbarContainer.light #debug-bar button {
     background-color: #FFFFFF; }
   #toolbarContainer.light #debug-bar table strong {
-    color: #FDC894; }
+    color: #DD8615; }
   #toolbarContainer.light #debug-bar table tbody tr:hover {
     background-color: #DFDFDF; }
   #toolbarContainer.light #debug-bar table tbody tr.current {


### PR DESCRIPTION
Follow-up to #5136.

I didn't notice the color was present at several places of the precompiled CSS…
(we have the regular mode, the Windows dark theme, and the light/dark switch button, for a total of 4 occurrences of the color)