### PR TITLE
feat: `_` can be used as separators in environment variable names

### DIFF
--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -115,24 +115,39 @@ class BaseConfig
      */
     protected function getEnvValue(string $property, string $prefix, string $shortPrefix)
     {
-        $shortPrefix = ltrim($shortPrefix, '\\');
+        $shortPrefix        = ltrim($shortPrefix, '\\');
+        $underscoreProperty = str_replace('.', '_', $property);
 
         switch (true) {
             case array_key_exists("{$shortPrefix}.{$property}", $_ENV):
                 return $_ENV["{$shortPrefix}.{$property}"];
 
+            case array_key_exists("{$shortPrefix}_{$underscoreProperty}", $_ENV):
+                return $_ENV["{$shortPrefix}_{$underscoreProperty}"];
+
             case array_key_exists("{$shortPrefix}.{$property}", $_SERVER):
                 return $_SERVER["{$shortPrefix}.{$property}"];
+
+            case array_key_exists("{$shortPrefix}_{$underscoreProperty}", $_SERVER):
+                return $_SERVER["{$shortPrefix}_{$underscoreProperty}"];
 
             case array_key_exists("{$prefix}.{$property}", $_ENV):
                 return $_ENV["{$prefix}.{$property}"];
 
+            case array_key_exists("{$prefix}_{$underscoreProperty}", $_ENV):
+                return $_ENV["{$prefix}_{$underscoreProperty}"];
+
             case array_key_exists("{$prefix}.{$property}", $_SERVER):
                 return $_SERVER["{$prefix}.{$property}"];
 
+            case array_key_exists("{$prefix}_{$underscoreProperty}", $_SERVER):
+                return $_SERVER["{$prefix}_{$underscoreProperty}"];
+
             default:
                 $value = getenv("{$shortPrefix}.{$property}");
+                $value = $value === false ? getenv("{$shortPrefix}_{$underscoreProperty}") : $value;
                 $value = $value === false ? getenv("{$prefix}.{$property}") : $value;
+                $value = $value === false ? getenv("{$prefix}_{$underscoreProperty}") : $value;
 
                 return $value === false ? null : $value;
         }

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -94,6 +94,10 @@ final class BaseConfigTest extends CIUnitTestCase
         $this->assertSame('banana', $config->dessert);
         // null property should not be affected
         $this->assertNull($config->QEMPTYSTR);
+        // property name with underscore
+        $this->assertSame('bar', $config->onedeep_value);
+        // array property name with underscore and key with underscore
+        $this->assertSame('foo', $config->one_deep['under_deep']);
     }
 
     public function testPrefixedValues()

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -158,7 +158,7 @@ final class DotEnvTest extends CIUnitTestCase
         $dotenv = new DotEnv($this->fixturesFolder, '.env');
         $dotenv->load();
 
-        $this->assertSame('complex', $_SERVER['SimpleConfig.simple.name']);
+        $this->assertSame('complex', $_SERVER['SimpleConfig_simple_name']);
     }
 
     public function testLoadsGetServerVar()

--- a/tests/system/Config/fixtures/.env
+++ b/tests/system/Config/fixtures/.env
@@ -6,15 +6,18 @@ NULL=
 
 SimpleConfig.onedeep=baz
 SimpleConfig.default.name=ci4
-SimpleConfig.simple.name=complex
+# Use underscore as separator
+SimpleConfig_simple_name=complex
 
-# for environment override testing
+## for environment override testing
 SimpleConfig.alpha=pow
 SimpleConfig.charliewrong=null
-SimpleConfig.notthere=missing
+# Use underscore as separator
+SimpleConfig_notthere=missing
 simpleconfig.delta=hubbahubba
 simpleconfig.foxtrot="true"
-simpleconfig.dessert="banana"
+# Use underscore as separator
+simpleconfig_dessert="banana"
 
 bravo=kazaam
 

--- a/tests/system/Config/fixtures/.env
+++ b/tests/system/Config/fixtures/.env
@@ -18,6 +18,10 @@ simpleconfig.delta=hubbahubba
 simpleconfig.foxtrot="true"
 # Use underscore as separator
 simpleconfig_dessert="banana"
+# Properity name with undersocre
+SimpleConfig.onedeep_value=bar
+# Array properity name with undersocre and key name with undersocre
+SimpleConfig.one_deep.under_deep=foo
 
 bravo=kazaam
 

--- a/tests/system/Config/fixtures/SimpleConfig.php
+++ b/tests/system/Config/fixtures/SimpleConfig.php
@@ -44,4 +44,8 @@ class SimpleConfig extends \CodeIgniter\Config\BaseConfig
 
     public $shortie;
     public $longie;
+    public $onedeep_value;
+    public $one_deep = [
+        'under_deep' => null,
+    ];
 }

--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -183,6 +183,13 @@ the value from **.env** replaces the configuration file value.
 
 .. note:: When using the *short prefix* the property names must still exactly match the class defined name.
 
+Some environments do not permit variable name with dots. In such case, you could also use ``_`` as a seperator.
+::
+
+    app_CSRFProtection = true
+    app_CSRFCookieName = csrf_cookie
+    app_CSPEnabled = true
+
 Environment Variables as Replacements for Data
 ==============================================
 


### PR DESCRIPTION
**Description**
You can use both as environment variable name:
- `database.default.hostname` (now) - looking for it first
- `database_default_hostname` (new) - if not found, looking for it

See #4026

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
