### PR TITLE
docs: fix 404 links to sytle guide

### DIFF
--- a/contributing/guidelines.rst
+++ b/contributing/guidelines.rst
@@ -11,7 +11,7 @@ PHP Style
 =========
 
 All code must conform to our `Style Guide
-<./styleguide.rst>`_, which is
+<./styleguide.md>`_, which is
 essentially the `Allman indent style
 <https://en.wikipedia.org/wiki/Indent_style#Allman_style>`_, with
 elaboration on naming and readable operators.

--- a/contributing/internals.rst
+++ b/contributing/internals.rst
@@ -70,7 +70,7 @@ The package itself will need its own sub-namespace
 that collects all related files into one grouping, like ``CodeIgniter\HTTP``.
 
 Files MUST be named the same as the class they hold, and they must match the
-:doc:`Style Guide <./styleguide.rst>`, meaning CamelCase class and file names.
+:doc:`Style Guide <./styleguide.md>`, meaning CamelCase class and file names.
 They should be in their own directory that matches the sub-namespace under the
 **system** directory.
 


### PR DESCRIPTION
**Description**
-  fix 404 links to sytle guide

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPdocs
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
