### PR TITLE
Fixed a problem with not run escape for identities in like when `insensitiveSearch` is true.

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1003,7 +1003,7 @@ class BaseBuilder
                 $bind = $this->setBind($k, "%{$v}%", $escape);
             }
 
-            $likeStatement = $this->_like_statement($prefix, $k, $not, $bind, $insensitiveSearch);
+            $likeStatement = $this->_like_statement($prefix, $this->db->protectIdentifiers($k, false, $escape), $not, $bind, $insensitiveSearch);
 
             // some platforms require an escape sequence definition for LIKE wildcards
             if ($escape === true && $this->db->likeEscapeStr !== '') {

--- a/tests/system/Database/Builder/LikeTest.php
+++ b/tests/system/Database/Builder/LikeTest.php
@@ -172,7 +172,7 @@ final class LikeTest extends CIUnitTestCase
 
         $builder->like('name', 'VELOPER', 'both', null, true);
 
-        $expectedSQL   = "SELECT * FROM \"job\" WHERE LOWER(name) LIKE '%veloper%' ESCAPE '!'";
+        $expectedSQL   = "SELECT * FROM \"job\" WHERE LOWER(\"name\") LIKE '%veloper%' ESCAPE '!'";
         $expectedBinds = [
             'name' => [
                 '%veloper%',


### PR DESCRIPTION
Fixed a problem with not run escape for identities in like when `insensitiveSearch` is true.

**Description**

Items that can be escaped are not escaped.
Even if the escape flag is true or null, there is no escaping process in place.
This has been fixed so that escaping will be done.

link: #2487

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide