### PR TITLE
Fix debug toolbar db connection count

### DIFF
--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -62,19 +62,11 @@ class Database extends BaseCollector
     protected static $queries = [];
 
     /**
-     * Array of connections used in a collected set
-     * of queries.
-     *
-     * @var array
-     */
-    protected static $activeConnections = [];
-
-    /**
      * Constructor
      */
     public function __construct()
     {
-        $this->connections = \Config\Database::getConnections();
+        $this->getConnections();
     }
 
     /**
@@ -91,12 +83,6 @@ class Database extends BaseCollector
         $max = $config->maxQueries ?: 100;
 
         if (count(static::$queries) < $max) {
-            $connection = $query->db->getDatabase();
-
-            if (! in_array($connection, self::$activeConnections, true)) {
-                self::$activeConnections[] = $connection;
-            }
-
             static::$queries[] = $query;
         }
     }
@@ -162,8 +148,10 @@ class Database extends BaseCollector
      */
     public function getTitleDetails(): string
     {
+        $this->getConnections();
+
         $queryCount      = count(static::$queries);
-        $connectionCount = count(static::$activeConnections);
+        $connectionCount = count($this->connections);
 
         return sprintf(
             '(%d Quer%s across %d Connection%s)',
@@ -190,5 +178,13 @@ class Database extends BaseCollector
     public function icon(): string
     {
         return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADMSURBVEhLY6A3YExLSwsA4nIycQDIDIhRWEBqamo/UNF/SjDQjF6ocZgAKPkRiFeEhoYyQ4WIBiA9QAuWAPEHqBAmgLqgHcolGQD1V4DMgHIxwbCxYD+QBqcKINseKo6eWrBioPrtQBq/BcgY5ht0cUIYbBg2AJKkRxCNWkDQgtFUNJwtABr+F6igE8olGQD114HMgHIxAVDyAhA/AlpSA8RYUwoeXAPVex5qHCbIyMgwBCkAuQJIY00huDBUz/mUlBQDqHGjgBjAwAAACexpph6oHSQAAAAASUVORK5CYII=';
+    }
+
+    /**
+     * Gets the connections from the database config
+     */
+    private function getConnections()
+    {
+        $this->connections = \Config\Database::getConnections();
     }
 }

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -62,6 +62,14 @@ class Database extends BaseCollector
     protected static $queries = [];
 
     /**
+     * Array of connections used in a collected set
+     * of queries.
+     *
+     * @var array
+     */
+    protected static $activeConnections = [];
+
+    /**
      * Constructor
      */
     public function __construct()

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -162,11 +162,13 @@ class Database extends BaseCollector
      */
     public function getTitleDetails(): string
     {
+        $queryCount      = count(static::$queries);
         $connectionCount = count(static::$activeConnections);
 
         return sprintf(
-            '(%d Queries across %d Connection%s)',
-            count(static::$queries),
+            '(%d Quer%s across %d Connection%s)',
+            $queryCount,
+            $queryCount > 1 ? 'ies' : 'y',
             $connectionCount,
             $connectionCount > 1 ? 's' : ''
         );

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -162,9 +162,14 @@ class Database extends BaseCollector
      */
     public function getTitleDetails(): string
     {
-        return '(' . count(static::$queries) . ' Queries across ' .
-                ($countConnection = count(self::$activeConnections)) . ' Connection' .
-                ($countConnection > 1 ? 's' : '') . ')';
+        $connectionCount = count(static::$activeConnections);
+
+        return sprintf(
+            '(%d Queries across %d Connection%s)',
+            count(static::$queries),
+            $connectionCount,
+            $connectionCount > 1 ? 's' : ''
+        );
     }
 
     /**

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -162,7 +162,8 @@ class Database extends BaseCollector
      */
     public function getTitleDetails(): string
     {
-        return '(' . count(static::$queries) . ' Queries across ' . ($countConnection = count($this->connections)) . ' Connection' .
+        return '(' . count(static::$queries) . ' Queries across ' .
+                ($countConnection = count(self::$activeConnections)) . ' Connection' .
                 ($countConnection > 1 ? 's' : '') . ')';
     }
 

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -91,6 +91,12 @@ class Database extends BaseCollector
         $max = $config->maxQueries ?: 100;
 
         if (count(static::$queries) < $max) {
+            $connection = $query->db->getDatabase();
+
+            if (! in_array($connection, self::$activeConnections, true)) {
+                self::$activeConnections[] = $connection;
+            }
+
             static::$queries[] = $query;
         }
     }


### PR DESCRIPTION
Fixes #5160 

**Description**
The debug toolbar's database tab showed X queries 0 connections - the count of used connections was not reported.
The change counts the unique (name) connections while iterating through the queries, and saves them in a new static variable. Then this variable is used to display the count.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide