### PR TITLE
Fixed an issue where the dropForeginKey method would execute an empty query when the dropConstraintStr property was empty.

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -29,7 +29,6 @@ parameters:
 		- system/ThirdParty/*
 		- system/Validation/Views/single.php
 	ignoreErrors:
-		- '#Access to an undefined property CodeIgniter\\Database\\Forge::\$dropConstraintStr#'
 		- '#Access to an undefined property CodeIgniter\\Database\\BaseConnection::\$mysqli|\$schema#'
 		- '#Access to an undefined property CodeIgniter\\Database\\ConnectionInterface::(\$DBDriver|\$connID|\$likeEscapeStr|\$likeEscapeChar|\$escapeChar|\$protectIdentifiers|\$schema)#'
 		- '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::_(disable|enable)ForeignKeyChecks\(\)#'

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -161,6 +161,13 @@ class Forge
     protected $default = ' DEFAULT ';
 
     /**
+     * DROP CONSTRAINT statement
+     *
+     * @var string
+     */
+    protected $dropConstraintStr;
+
+    /**
      * Constructor.
      */
     public function __construct(BaseConnection $db)
@@ -427,7 +434,7 @@ class Forge
             $this->db->escapeIdentifiers($this->db->DBPrefix . $foreignName)
         );
 
-        if ($sql === false) { // @phpstan-ignore-line
+        if ($sql === '') {
             if ($this->db->DBDebug) {
                 throw new DatabaseException('This feature is not available for the database you are using.');
             }

--- a/tests/system/Database/Forge/DropForeignKeyTest.php
+++ b/tests/system/Database/Forge/DropForeignKeyTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Forge;
+
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\Forge;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockConnection;
+
+/**
+ * @internal
+ */
+final class DropForeignKeyTest extends CIUnitTestCase
+{
+    protected $db;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->db = new MockConnection([]);
+    }
+
+    public function testDropForeignKeyWithEmptyDropConstraintStrProperty()
+    {
+        $this->setPrivateProperty($this->db, 'DBDebug', true);
+
+        $forge = new Forge($this->db);
+
+        $this->expectException(DatabaseException::class);
+
+        $forge->dropForeignKey('id', 'fail');
+    }
+}


### PR DESCRIPTION
Fixed an issue where the dropForeginKey method would execute an empty query when the dropConstraintStr property was empty.

**Description**

https://github.com/codeigniter4/CodeIgniter4/blob/56add793a949c5021a56b81f6ff7019ac1719f69/system/Database/Forge.php#L424-L430

`sprintf` returns an empty string even if the first argument is null, but it verifies that it is false now.
Fixed, as it is an IF that will never be reached.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide