### PR TITLE
Extract method to get prefix for DB access function

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1269,8 +1269,7 @@ abstract class BaseConnection implements ConnectionInterface
      */
     public function callFunction(string $functionName, ...$params): bool
     {
-        $driver = strtolower($this->DBDriver);
-        $driver = ($driver === 'postgre' ? 'pg' : $driver) . '_';
+        $driver = $this->getDriverFunctionPrefix();
 
         if (strpos($driver, $functionName) === false) {
             $functionName = $driver . $functionName;
@@ -1285,6 +1284,14 @@ abstract class BaseConnection implements ConnectionInterface
         }
 
         return $functionName(...$params);
+    }
+
+    /**
+     * Get the prefix of the function to access the DB.
+     */
+    protected function getDriverFunctionPrefix(): string
+    {
+        return strtolower($this->DBDriver) . '_';
     }
 
     //--------------------------------------------------------------------

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -145,6 +145,14 @@ class Connection extends BaseConnection
     }
 
     /**
+     * Get the prefix of the function to access the DB.
+     */
+    protected function getDriverFunctionPrefix(): string
+    {
+        return 'pg_';
+    }
+
+    /**
      * Returns the total number of rows affected by this query.
      */
     public function affectedRows(): int


### PR DESCRIPTION
The process of getting the prefix of the db access function was extracted to the method.

**Description**

It is incorrect that this is in the parent class, BaseConnection.
This is because the parent class will behave as if it knows the implementation of the child class.
With this code, there will be a lack of coverage when trying to add a new driver as shown below.

https://github.com/codeigniter4/CodeIgniter4/pull/2487#discussion_r720942310

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
  
