### PR TITLE
Fixed an issue where an unnecessary prefix was given when the random number was a column.

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1260,6 +1260,7 @@ class BaseBuilder
         if ($direction === 'RANDOM') {
             $direction = '';
             $orderBy   = ctype_digit($orderBy) ? sprintf($this->randomKeyword[1], $orderBy) : $this->randomKeyword[0];
+            $escape    = false;
         } elseif ($direction !== '') {
             $direction = in_array($direction, ['ASC', 'DESC'], true) ? ' ' . $direction : '';
         }

--- a/tests/system/Database/Builder/OrderTest.php
+++ b/tests/system/Database/Builder/OrderTest.php
@@ -61,4 +61,17 @@ final class OrderTest extends CIUnitTestCase
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
+
+    public function testOrderRandomWithRandomColumn()
+    {
+        $this->db->setPrefix('fail_');
+        $builder = new BaseBuilder('user', $this->db);
+        $this->setPrivateProperty($builder, 'randomKeyword', ['"SYSTEM"."RANDOM"']);
+
+        $builder->orderBy('name', 'random');
+
+        $expectedSQL = 'SELECT * FROM "fail_user" ORDER BY "SYSTEM"."RANDOM"';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
 }


### PR DESCRIPTION
Fixed an issue where an unnecessary prefix was given when the random number was a column.

**Description**

The intention of this fix is because escaping is not necessary for RANDOM.

In ORACLE, random numbers are `DBMS_RANDOM.RANDOM`. That is, it refers to the RANDOM column of the DBMS_RANDOM table.
In MySQL, it is `RAND()`, it is function.

The third argument $escape of orderBy is null if it is omitted.
It depends on the protectIdentifiers property of Connection to toggle whether escaping is performed or not.
Also, the escaping process is to add the prefix to the table name.

In other words, in the case of ORACLE, it will add the prefix to `DBMS_RANDOM.RANDOM` and execute a query for a non-existent table, which will fail.

It is not a good idea for users to specify the value of the third argument escape with the driver in mind.

Therefore, I am making this fix because I thought it would be better to not escape for RANDOM and add the escaped column name to the randomKeyword property of each driver.

https://github.com/codeigniter4/CodeIgniter4/pull/2487#discussion_r720831585

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPdocs
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide