### PR TITLE
Fix options are not passed to Command $params

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -106,11 +106,6 @@ parameters:
 			path: system/CodeIgniter.php
 
 		-
-			message: "#^Call to an undefined method CodeIgniter\\\\HTTP\\\\Request\\:\\:getSegments\\(\\)\\.$#"
-			count: 1
-			path: system/CodeIgniter.php
-
-		-
 			message: "#^Call to an undefined method CodeIgniter\\\\HTTP\\\\Request\\:\\:setLocale\\(\\)\\.$#"
 			count: 1
 			path: system/CodeIgniter.php

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -42,6 +42,13 @@ class CLIRequest extends Request
     protected $options = [];
 
     /**
+     * Command line arguments (segments and options).
+     *
+     * @var array
+     */
+    protected $args = [];
+
+    /**
      * Set the expected HTTP verb
      *
      * @var string
@@ -92,6 +99,14 @@ class CLIRequest extends Request
     public function getOptions(): array
     {
         return $this->options;
+    }
+
+    /**
+     * Returns an array of all CLI arguments (segments and options).
+     */
+    public function getArgs(): array
+    {
+        return $this->args;
     }
 
     /**
@@ -173,6 +188,7 @@ class CLIRequest extends Request
                     $optionValue = false;
                 } else {
                     $this->segments[] = $arg;
+                    $this->args[]     = $arg;
                 }
 
                 continue;
@@ -187,6 +203,7 @@ class CLIRequest extends Request
             }
 
             $this->options[$arg] = $value;
+            $this->args[$arg]    = $value;
         }
     }
 

--- a/tests/system/CLI/CommandRunnerTest.php
+++ b/tests/system/CLI/CommandRunnerTest.php
@@ -118,6 +118,9 @@ final class CommandRunnerTest extends CIUnitTestCase
         $this->assertStringContainsString('Command "bogus" not found', CITestStreamFilter::$buffer);
     }
 
+    /**
+     * @TODO When the first param is empty? Use case?
+     */
     public function testRemapEmptyFirstParams()
     {
         self::$runner->_remap('anyvalue', null, 'list');

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -162,6 +162,34 @@ final class CLIRequestTest extends CIUnitTestCase
         $this->assertSame($expected, $this->request->getOptionString());
     }
 
+    public function testParsingArgs()
+    {
+        $_SERVER['argv'] = [
+            'spark',
+            'command',
+            'param1',
+            'param2',
+            '--opt1',
+            'opt1val',
+            '--opt-2',
+            'opt 2 val',
+            'param3',
+        ];
+
+        // reinstantiate it to force parsing
+        $this->request = new CLIRequest(new App());
+
+        $options = [
+            'command',
+            'param1',
+            'param2',
+            'opt1'  => 'opt1val',
+            'opt-2' => 'opt 2 val',
+            'param3',
+        ];
+        $this->assertSame($options, $this->request->getArgs());
+    }
+
     public function testParsingPath()
     {
         $_SERVER['argv'] = [


### PR DESCRIPTION
**Description**
Fixes #3400

When you run the following command:
```
$ php spark test param1 param2 -opt1 opt1val
```
`$params` of the `Test` command would be:
```
Array
(
    [0] => param1
    [1] => param2
    [opt1] => opt1val
)
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
