### PR TITLE
Fix CURLRequest extra headers

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -129,6 +129,9 @@ class CURLRequest extends Request
 
         $this->send($method, $url);
 
+        // Reset unshared configs
+        unset($this->config['multipart'], $this->config['form_params']);
+
         return $this->response;
     }
 

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -176,7 +176,7 @@ final class CURLRequestTest extends CIUnitTestCase
     /**
      * @backupGlobals enabled
      */
-    public function testOptionHeadersUsingPopulate()
+    public function testOptionsHeadersUsingPopulate()
     {
         $_SERVER['HTTP_HOST']            = 'site1.com';
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US';
@@ -199,7 +199,7 @@ final class CURLRequestTest extends CIUnitTestCase
     /**
      * @backupGlobals enabled
      */
-    public function testOptionHeadersNotUsingPopulate()
+    public function testOptionsHeadersNotUsingPopulate()
     {
         $_SERVER['HTTP_HOST']            = 'site1.com';
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US';

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -220,6 +220,46 @@ final class CURLRequestTest extends CIUnitTestCase
         $this->assertSame('', $request->header('Accept-Encoding')->getValue());
     }
 
+    public function testHeaderContentLengthNotSharedBetweenRequests()
+    {
+        $options = [
+            'base_uri' => 'http://www.foo.com/api/v1/',
+        ];
+        $request = $this->getRequest($options);
+
+        $request->post('example', [
+            'form_params' => [
+                'q' => 'keyword',
+            ],
+        ]);
+        $request->get('example');
+
+        $this->assertNull($request->header('Content-Length'));
+    }
+
+    /**
+     * @backupGlobals enabled
+     */
+    public function testHeaderContentLengthNotSharedBetweenClients()
+    {
+        $_SERVER['HTTP_CONTENT_LENGTH'] = '10';
+
+        $options = [
+            'base_uri' => 'http://www.foo.com/api/v1/',
+        ];
+        $request = $this->getRequest($options);
+        $request->post('example', [
+            'form_params' => [
+                'q' => 'keyword',
+            ],
+        ]);
+
+        $request = $this->getRequest($options);
+        $request->get('example');
+
+        $this->assertNull($request->header('Content-Length'));
+    }
+
     public function testOptionsDelay()
     {
         $options = [


### PR DESCRIPTION
**Description**
Fixes #4826
- reset unneeded headers
- reset unneeded configs

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
