### PR TITLE
Fix CURLRequest keeping the last value provided by headers with the same name

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -236,7 +236,12 @@ class CURLRequest extends Request
 
         if (array_key_exists('headers', $options) && is_array($options['headers'])) {
             foreach ($options['headers'] as $name => $value) {
-                $this->setHeader($name, $value);
+                // fix issue #5041 by taking into account multiple headers with the same name
+                if($this->hasHeader($name)) {
+                    $this->appendHeader($name, $value);
+                } else {
+                    $this->setHeader($name, $value);
+                }
             }
 
             unset($options['headers']);

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -468,7 +468,15 @@ trait ResponseTrait
 
         // Send all of our headers
         foreach (array_keys($this->getHeaders()) as $name) {
-            header($name . ': ' . $this->getHeaderLine($name), false, $this->getStatusCode());
+            // fix issue #5041 by taking into account multiple headers with the same name
+            $headerValue = $this->getHeader($name)->getValue();
+            if(is_array($headerValue)) {
+                foreach($headerValue as $h_value) {
+                    header($name . ': ' . $h_value, false, $this->getStatusCode());
+                }
+            } else {
+                header($name . ': ' . $this->getHeaderLine($name), false, $this->getStatusCode());
+            }
         }
 
         return $this;


### PR DESCRIPTION
Fixes #5041 
CURLRequest can now get and forward all headers including multiple headers with the same name

**Description**
Basic minimal modifications to ensure multiple headers with the same name are correctly received and  forwarded.
