### PR TITLE
feat: add filter to check invalid chars in user input

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -6,6 +6,7 @@ use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Filters\CSRF;
 use CodeIgniter\Filters\DebugToolbar;
 use CodeIgniter\Filters\Honeypot;
+use CodeIgniter\Filters\InvalidChars;
 
 class Filters extends BaseConfig
 {
@@ -16,9 +17,10 @@ class Filters extends BaseConfig
      * @var array
      */
     public $aliases = [
-        'csrf'     => CSRF::class,
-        'toolbar'  => DebugToolbar::class,
-        'honeypot' => Honeypot::class,
+        'csrf'         => CSRF::class,
+        'toolbar'      => DebugToolbar::class,
+        'honeypot'     => Honeypot::class,
+        'invalidchars' => InvalidChars::class,
     ];
 
     /**
@@ -31,6 +33,7 @@ class Filters extends BaseConfig
         'before' => [
             // 'honeypot',
             // 'csrf',
+            // 'invalidchars',
         ],
         'after' => [
             'toolbar',

--- a/system/Filters/InvalidChars.php
+++ b/system/Filters/InvalidChars.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Filters;
+
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
+use RuntimeException;
+
+/**
+ * InvalidChars filter.
+ *
+ * Check if user input data ($_GET, $_POST, $_COOKIE, php://input) do not contain
+ * invalid characters:
+ *   - invalid UTF-8 characters
+ *   - control characters except line break and tab code
+ */
+class InvalidChars implements FilterInterface
+{
+    /**
+     * Data source
+     *
+     * @var string
+     */
+    protected $source;
+
+    /**
+     * Check invalid characters.
+     *
+     * @param array|null $arguments
+     *
+     * @return void
+     */
+    public function before(RequestInterface $request, $arguments = null)
+    {
+        if ($request->isCLI()) {
+            return;
+        }
+
+        $data = [
+            'get'      => $request->getGet(),
+            'post'     => $request->getPost(),
+            'cookie'   => $request->getCookie(),
+            'rawInput' => $request->getRawInput(),
+        ];
+
+        foreach ($data as $source => $values) {
+            $this->source = $source;
+            $this->checkEncoding($values);
+            $this->checkControl($values);
+        }
+    }
+
+    /**
+     * We don't have anything to do here.
+     *
+     * @param array|null $arguments
+     *
+     * @return void
+     */
+    public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
+    {
+    }
+
+    /**
+     * Check the character encoding is valid UTF-8.
+     *
+     * @param array|string $value
+     *
+     * @return array|string
+     */
+    protected function checkEncoding($value)
+    {
+        if (is_array($value)) {
+            array_map([$this, 'checkEncoding'], $value);
+
+            return $value;
+        }
+
+        if (mb_check_encoding($value, 'UTF-8')) {
+            return $value;
+        }
+
+        throw new RuntimeException(
+            'Invalid UTF-8 characters in ' . $this->source . ': ' . $value
+        );
+    }
+
+    /**
+     * Check for the presence of control characters except line breaks and tabs.
+     *
+     * @param array|string $value
+     *
+     * @return array|string
+     */
+    protected function checkControl($value)
+    {
+        if (is_array($value)) {
+            array_map([$this, 'checkControl'], $value);
+
+            return $value;
+        }
+
+        if (preg_match('/\A[\r\n\t[:^cntrl:]]*\z/u', $value) === 1) {
+            return $value;
+        }
+
+        throw new RuntimeException(
+            'Invalid Control characters in ' . $this->source . ': ' . $value
+        );
+    }
+}

--- a/system/Filters/InvalidChars.php
+++ b/system/Filters/InvalidChars.php
@@ -13,7 +13,7 @@ namespace CodeIgniter\Filters;
 
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
-use RuntimeException;
+use CodeIgniter\Security\Exceptions\SecurityException;
 
 /**
  * InvalidChars filter.
@@ -89,9 +89,7 @@ class InvalidChars implements FilterInterface
             return $value;
         }
 
-        throw new RuntimeException(
-            'Invalid UTF-8 characters in ' . $this->source . ': ' . $value
-        );
+        throw SecurityException::forInvalidUTF8Chars($this->source, $value);
     }
 
     /**
@@ -113,8 +111,6 @@ class InvalidChars implements FilterInterface
             return $value;
         }
 
-        throw new RuntimeException(
-            'Invalid Control characters in ' . $this->source . ': ' . $value
-        );
+        throw SecurityException::forInvalidControlChars($this->source, $value);
     }
 }

--- a/system/Filters/InvalidChars.php
+++ b/system/Filters/InvalidChars.php
@@ -33,6 +33,13 @@ class InvalidChars implements FilterInterface
     protected $source;
 
     /**
+     * Regular expressions for valid control codes
+     *
+     * @var string
+     */
+    protected $controlCodeRegex = '/\A[\r\n\t[:^cntrl:]]*\z/u';
+
+    /**
      * Check invalid characters.
      *
      * @param array|null $arguments
@@ -107,7 +114,7 @@ class InvalidChars implements FilterInterface
             return $value;
         }
 
-        if (preg_match('/\A[\r\n\t[:^cntrl:]]*\z/u', $value) === 1) {
+        if (preg_match($this->controlCodeRegex, $value) === 1) {
             return $value;
         }
 

--- a/system/Security/Exceptions/SecurityException.php
+++ b/system/Security/Exceptions/SecurityException.php
@@ -20,6 +20,22 @@ class SecurityException extends FrameworkException
         return new static(lang('Security.disallowedAction'), 403);
     }
 
+    public static function forInvalidUTF8Chars(string $source, string $string)
+    {
+        return new static(
+            'Invalid UTF-8 characters in ' . $source . ': ' . $string,
+            400
+        );
+    }
+
+    public static function forInvalidControlChars(string $source, string $string)
+    {
+        return new static(
+            'Invalid Control characters in ' . $source . ': ' . $string,
+            400
+        );
+    }
+
     /**
      * @deprecated Use `CookieException::forInvalidSameSite()` instead.
      *

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -121,10 +121,8 @@ final class InvalidCharsTest extends CIUnitTestCase
      * @doesNotPerformAssertions
      *
      * @dataProvider stringWithLineBreakAndTabProvider
-     *
-     * @param string $input
      */
-    public function testCheckControlStringWithLineBreakAndTabReturnsTheString($input)
+    public function testCheckControlStringWithLineBreakAndTabReturnsTheString(string $input)
     {
         $_GET['val'] = $input;
 

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -155,7 +155,7 @@ final class InvalidCharsTest extends CIUnitTestCase
 
     public function stringWithControlCharsProvider()
     {
-        return [
+        yield from [
             ["String contains null char.\0"],
             ["String contains null char and line break.\0\n"],
         ];

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -46,6 +46,15 @@ final class InvalidCharsTest extends CIUnitTestCase
         $this->invalidChars = new InvalidChars();
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $_GET    = [];
+        $_POST   = [];
+        $_COOKIE = [];
+    }
+
     private function createRequest(): IncomingRequest
     {
         $config    = new MockAppConfig();

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -15,9 +15,9 @@ use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
+use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockAppConfig;
-use RuntimeException;
 
 /**
  * @internal
@@ -92,7 +92,7 @@ final class InvalidCharsTest extends CIUnitTestCase
 
     public function testBeforeInvalidUTF8StringCausesException()
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(SecurityException::class);
         $this->expectExceptionMessage('Invalid UTF-8 characters in post:');
 
         $sjisString   = mb_convert_encoding('SJISの文字列です。', 'SJIS');
@@ -106,7 +106,7 @@ final class InvalidCharsTest extends CIUnitTestCase
 
     public function testBeforeInvalidControllCharCausesException()
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(SecurityException::class);
         $this->expectExceptionMessage('Invalid Control characters in cookie:');
 
         $stringWithNullChar = "String contains null char and line break.\0\n";
@@ -147,7 +147,7 @@ final class InvalidCharsTest extends CIUnitTestCase
      */
     public function testCheckControlStringWithControlCharsCausesException($input)
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(SecurityException::class);
         $this->expectExceptionMessage('Invalid Control characters in get:');
 
         $_GET['val'] = $input;

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -131,7 +131,7 @@ final class InvalidCharsTest extends CIUnitTestCase
 
     public function stringWithLineBreakAndTabProvider()
     {
-        return [
+        yield from [
             ["String contains \n line break."],
             ["String contains \r line break."],
             ["String contains \r\n line break."],

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Filters;
+
+use CodeIgniter\HTTP\CLIRequest;
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\UserAgent;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockAppConfig;
+use RuntimeException;
+
+/**
+ * @internal
+ */
+final class InvalidCharsTest extends CIUnitTestCase
+{
+    /**
+     * @var InvalidChars
+     */
+    private $invalidChars;
+
+    /**
+     * @var IncomingRequest
+     */
+    private $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_GET    = [];
+        $_POST   = [];
+        $_COOKIE = [];
+
+        $this->request      = $this->createRequest();
+        $this->invalidChars = new InvalidChars();
+    }
+
+    private function createRequest(): IncomingRequest
+    {
+        $config    = new MockAppConfig();
+        $uri       = new URI();
+        $userAgent = new UserAgent();
+        $request   = $this->getMockBuilder(IncomingRequest::class)
+            ->setConstructorArgs([$config, $uri, null, $userAgent])
+            ->onlyMethods(['isCLI'])
+            ->getMock();
+        $request->method('isCLI')->willReturn(false);
+
+        return $request;
+    }
+
+    public function testBeforeDoNothingWhenCLIRequest()
+    {
+        $cliRequest = new CLIRequest(new MockAppConfig());
+
+        $ret = $this->invalidChars->before($cliRequest);
+
+        $this->assertNull($ret);
+    }
+
+    public function testBeforeValidString()
+    {
+        $_POST['val'] = [
+            'valid string',
+        ];
+        $_COOKIE['val'] = 'valid string';
+
+        $ret = $this->invalidChars->before($this->request);
+
+        $this->assertNull($ret);
+    }
+
+    public function testBeforeInvalidUTF8StringCausesException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid UTF-8 characters in post:');
+
+        $sjisString   = mb_convert_encoding('SJISの文字列です。', 'SJIS');
+        $_POST['val'] = [
+            'valid string',
+            $sjisString,
+        ];
+
+        $this->invalidChars->before($this->request);
+    }
+
+    public function testBeforeInvalidControllCharCausesException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid Control characters in cookie:');
+
+        $stringWithNullChar = "String contains null char and line break.\0\n";
+        $_COOKIE['val']     = $stringWithNullChar;
+
+        $this->invalidChars->before($this->request);
+    }
+
+    /**
+     * @dataProvider stringWithLineBreakAndTabProvider
+     *
+     * @param string $input
+     */
+    public function testCheckControlStringWithLineBreakAndTabReturnsTheString($input)
+    {
+        $_GET['val'] = $input;
+
+        $ret = $this->invalidChars->before($this->request);
+
+        $this->assertNull($ret);
+    }
+
+    public function stringWithLineBreakAndTabProvider()
+    {
+        return [
+            ["String contains \n line break."],
+            ["String contains \r line break."],
+            ["String contains \r\n line break."],
+            ["String contains \t tab."],
+            ["String contains \t and \r line \n break."],
+        ];
+    }
+
+    /**
+     * @dataProvider stringWithControlCharsProvider
+     *
+     * @param string $input
+     */
+    public function testCheckControlStringWithControlCharsCausesException($input)
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid Control characters in get:');
+
+        $_GET['val'] = $input;
+
+        $ret = $this->invalidChars->before($this->request);
+
+        $this->assertNull($ret);
+    }
+
+    public function stringWithControlCharsProvider()
+    {
+        return [
+            ["String contains null char.\0"],
+            ["String contains null char and line break.\0\n"],
+        ];
+    }
+}

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -69,15 +69,19 @@ final class InvalidCharsTest extends CIUnitTestCase
         return $request;
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testBeforeDoNothingWhenCLIRequest()
     {
         $cliRequest = new CLIRequest(new MockAppConfig());
 
-        $ret = $this->invalidChars->before($cliRequest);
-
-        $this->assertNull($ret);
+        $this->invalidChars->before($cliRequest);
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testBeforeValidString()
     {
         $_POST['val'] = [
@@ -85,9 +89,7 @@ final class InvalidCharsTest extends CIUnitTestCase
         ];
         $_COOKIE['val'] = 'valid string';
 
-        $ret = $this->invalidChars->before($this->request);
-
-        $this->assertNull($ret);
+        $this->invalidChars->before($this->request);
     }
 
     public function testBeforeInvalidUTF8StringCausesException()
@@ -104,7 +106,7 @@ final class InvalidCharsTest extends CIUnitTestCase
         $this->invalidChars->before($this->request);
     }
 
-    public function testBeforeInvalidControllCharCausesException()
+    public function testBeforeInvalidControlCharCausesException()
     {
         $this->expectException(SecurityException::class);
         $this->expectExceptionMessage('Invalid Control characters in cookie:');
@@ -116,6 +118,8 @@ final class InvalidCharsTest extends CIUnitTestCase
     }
 
     /**
+     * @doesNotPerformAssertions
+     *
      * @dataProvider stringWithLineBreakAndTabProvider
      *
      * @param string $input
@@ -124,9 +128,7 @@ final class InvalidCharsTest extends CIUnitTestCase
     {
         $_GET['val'] = $input;
 
-        $ret = $this->invalidChars->before($this->request);
-
-        $this->assertNull($ret);
+        $this->invalidChars->before($this->request);
     }
 
     public function stringWithLineBreakAndTabProvider()
@@ -152,9 +154,7 @@ final class InvalidCharsTest extends CIUnitTestCase
 
         $_GET['val'] = $input;
 
-        $ret = $this->invalidChars->before($this->request);
-
-        $this->assertNull($ret);
+        $this->invalidChars->before($this->request);
     }
 
     public function stringWithControlCharsProvider()

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -144,10 +144,8 @@ final class InvalidCharsTest extends CIUnitTestCase
 
     /**
      * @dataProvider stringWithControlCharsProvider
-     *
-     * @param string $input
      */
-    public function testCheckControlStringWithControlCharsCausesException($input)
+    public function testCheckControlStringWithControlCharsCausesException(string $input)
     {
         $this->expectException(SecurityException::class);
         $this->expectExceptionMessage('Invalid Control characters in get:');

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -193,6 +193,6 @@ In this example, the array ``['dual', 'noreturn']`` will be passed in ``$argumen
 Provided Filters
 ****************
 
-These filters are bundled with CodeIgniter4: ``Honeypot``, ``CSRF``, ``DebugToolbar`` and ``InvalidChars``.
+The filters bundled with CodeIgniter4 are: ``Honeypot``, ``CSRF``, ``DebugToolbar``, and ``InvalidChars``.
 
 .. note:: The filters are executed in the declared order  that is defined in the config file, but there is one exception to this and it concerns the ``DebugToolbar``, which is always executed last. This is because ``DebugToolbar`` should be able to register everything that happens in other filters.

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -195,4 +195,4 @@ Provided Filters
 
 The filters bundled with CodeIgniter4 are: ``Honeypot``, ``CSRF``, ``DebugToolbar``, and ``InvalidChars``.
 
-.. note:: The filters are executed in the declared order  that is defined in the config file, but there is one exception to this and it concerns the ``DebugToolbar``, which is always executed last. This is because ``DebugToolbar`` should be able to register everything that happens in other filters.
+.. note:: The filters are executed in the order defined in the config file. However, if enabled, ``DebugToolbar`` is always executed last because it should be able to capture everything that happens in the other filters.

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -193,6 +193,6 @@ In this example, the array ``['dual', 'noreturn']`` will be passed in ``$argumen
 Provided Filters
 ****************
 
-Three filters are bundled with CodeIgniter4: ``Honeypot``, ``CSRF``, and ``DebugToolbar``.
+These filters are bundled with CodeIgniter4: ``Honeypot``, ``CSRF``, ``DebugToolbar`` and ``InvalidChars``.
 
 .. note:: The filters are executed in the declared order  that is defined in the config file, but there is one exception to this and it concerns the ``DebugToolbar``, which is always executed last. This is because ``DebugToolbar`` should be able to register everything that happens in other filters.


### PR DESCRIPTION
**Description**
- add a filter to prevent attacks with malformed character encodings and control characters (null byte)

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
