### PR TITLE
Cleanup php-cs-fixer config files

### DIFF
--- a/.no-header.php-cs-fixer.dist.php
+++ b/.no-header.php-cs-fixer.dist.php
@@ -27,26 +27,7 @@ $finder = Finder::create()
     ])
     ->notName('#Logger\.php$#');
 
-$overrides = [
-    // @TODO Remove once these are live in coding-standard
-    'assign_null_coalescing_to_coalesce_equal' => false, // requires 7.4+
-    'class_attributes_separation'              => [
-        'elements' => [
-            'const'        => 'none',
-            'property'     => 'none',
-            'method'       => 'one',
-            'trait_import' => 'none',
-        ],
-    ],
-    'control_structure_continuation_position' => ['position' => 'same_line'],
-    'empty_loop_condition'                    => ['style' => 'while'],
-    'integer_literal_case'                    => true,
-    'modernize_strpos'                        => false, // requires 8.0+
-    'no_alternative_syntax'                   => ['fix_non_monolithic_code' => false],
-    'no_space_around_double_colon'            => true,
-    'octal_notation'                          => false, // requires 8.1+
-    'string_length_to_empty'                  => true,
-];
+$overrides = [];
 
 $options = [
     'cacheFile'    => 'build/.no-header.php-cs-fixer.cache',

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -34,26 +34,7 @@ $finder = Finder::create()
         __DIR__ . '/spark',
     ]);
 
-$overrides = [
-    // @TODO Remove once these are live in coding-standard
-    'assign_null_coalescing_to_coalesce_equal' => false, // requires 7.4+
-    'class_attributes_separation'              => [
-        'elements' => [
-            'const'        => 'none',
-            'property'     => 'none',
-            'method'       => 'one',
-            'trait_import' => 'none',
-        ],
-    ],
-    'control_structure_continuation_position' => ['position' => 'same_line'],
-    'empty_loop_condition'                    => ['style' => 'while'],
-    'integer_literal_case'                    => true,
-    'modernize_strpos'                        => false, // requires 8.0+
-    'no_alternative_syntax'                   => ['fix_non_monolithic_code' => false],
-    'no_space_around_double_colon'            => true,
-    'octal_notation'                          => false, // requires 8.1+
-    'string_length_to_empty'                  => true,
-];
+$overrides = [];
 
 $options = [
     'cacheFile'    => 'build/.php-cs-fixer.cache',


### PR DESCRIPTION
**Description**
Since `coding-standard` v1.2.0, these overrides are no longer needed

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
