### PR TITLE
Replace explicit calls to `Services::reset()` in tests

### DIFF
--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -36,7 +36,7 @@ final class CodeIgniterTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        Services::reset();
+        $this->resetServices();
 
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
 

--- a/tests/system/CommonHelperTest.php
+++ b/tests/system/CommonHelperTest.php
@@ -32,7 +32,7 @@ final class CommonHelperTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
-        Services::reset();
+        $this->resetServices();
         parent::setUp();
         $this->cleanUpDummyHelpers();
     }
@@ -41,7 +41,7 @@ final class CommonHelperTest extends CIUnitTestCase
     {
         parent::tearDown();
         $this->cleanUpDummyHelpers();
-        Services::reset();
+        $this->resetServices();
     }
 
     private function createDummyHelpers(): void

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -64,7 +64,7 @@ final class ServicesTest extends CIUnitTestCase
     protected function tearDown(): void
     {
         $_SERVER = $this->original;
-        Services::reset();
+        $this->resetServices();
     }
 
     public function testCanReplaceFrameworkServices()

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -40,7 +40,7 @@ final class FiltersTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        Services::reset();
+        $this->resetServices();
 
         $defaults = [
             'Config'        => APPPATH . 'Config',

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -32,7 +32,7 @@ final class CURLRequestTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        Services::reset();
+        $this->resetServices();
         $this->request = $this->getRequest();
     }
 

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -861,7 +861,7 @@ final class URITest extends CIUnitTestCase
 
     public function testBasedNoIndex()
     {
-        Services::reset();
+        $this->resetServices();
 
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/ci/v4/controller/method';
@@ -888,7 +888,7 @@ final class URITest extends CIUnitTestCase
 
     public function testBasedWithIndex()
     {
-        Services::reset();
+        $this->resetServices();
 
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/ci/v4/index.php/controller/method';
@@ -915,7 +915,7 @@ final class URITest extends CIUnitTestCase
 
     public function testForceGlobalSecureRequests()
     {
-        Services::reset();
+        $this->resetServices();
 
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/ci/v4/controller/method';

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -54,7 +54,7 @@ final class ResourceControllerTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        Services::reset();
+        $this->resetServices();
 
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
 

--- a/tests/system/RESTful/ResourcePresenterTest.php
+++ b/tests/system/RESTful/ResourcePresenterTest.php
@@ -48,7 +48,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        Services::reset();
+        $this->resetServices();
 
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
 


### PR DESCRIPTION
**Description**
...with `CIUnitTestCase`'s `resetServices()` method

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
