### PR TITLE
Remove static variables for PHP 8.1

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2529,8 +2529,8 @@ class BaseBuilder
             return true;
         }
 
-        if (empty($this->isLiteralStr)) {
-            $this->isLiteralStr = ($this->db->escapeChar !== '"') ? ['"', "'"] : ["'"];
+        if ($this->isLiteralStr === []) {
+            $this->isLiteralStr = $this->db->escapeChar !== '"' ? ['"', "'"] : ["'"];
         }
 
         return in_array($str[0], $this->isLiteralStr, true);
@@ -2612,10 +2612,10 @@ class BaseBuilder
      */
     protected function hasOperator(string $str): bool
     {
-        return (bool) preg_match(
+        return preg_match(
             '/(<|>|!|=|\sIS NULL|\sIS NOT NULL|\sEXISTS|\sBETWEEN|\sLIKE|\sIN\s*\(|\s)/i',
             trim($str)
-        );
+        ) === 1;
     }
 
     /**
@@ -2625,8 +2625,8 @@ class BaseBuilder
      */
     protected function getOperator(string $str, bool $list = false)
     {
-        if (empty($this->pregOperators)) {
-            $_les = ($this->db->likeEscapeStr !== '')
+        if ($this->pregOperators === []) {
+            $_les = $this->db->likeEscapeStr !== ''
                 ? '\s+' . preg_quote(trim(sprintf($this->db->likeEscapeStr, $this->db->likeEscapeChar)), '/')
                 : '';
             $this->pregOperators = [

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -245,6 +245,20 @@ class BaseBuilder
     ];
 
     /**
+     * Strings that determine if a string represents a literal value or a field name
+     *
+     * @var string[]
+     */
+    protected $isLiteralStr = [];
+
+    /**
+     * RegExp used to get operators
+     *
+     * @var string[]
+     */
+    protected $pregOperators = [];
+
+    /**
      * Constructor
      *
      * @param array|string $tableName
@@ -2515,13 +2529,11 @@ class BaseBuilder
             return true;
         }
 
-        static $_str;
-
-        if (empty($_str)) {
-            $_str = ($this->db->escapeChar !== '"') ? ['"', "'"] : ["'"];
+        if (empty($this->isLiteralStr)) {
+            $this->isLiteralStr = ($this->db->escapeChar !== '"') ? ['"', "'"] : ["'"];
         }
 
-        return in_array($str[0], $_str, true);
+        return in_array($str[0], $this->isLiteralStr, true);
     }
 
     /**
@@ -2610,11 +2622,9 @@ class BaseBuilder
      */
     protected function getOperator(string $str, bool $list = false)
     {
-        static $_operators;
-
-        if (empty($_operators)) {
+        if (empty($this->pregOperators)) {
             $_les       = ($this->db->likeEscapeStr !== '') ? '\s+' . preg_quote(trim(sprintf($this->db->likeEscapeStr, $this->db->likeEscapeChar)), '/') : '';
-            $_operators = [
+            $this->pregOperators = [
                 '\s*(?:<|>|!)?=\s*', // =, <=, >=, !=
                 '\s*<>?\s*', // <, <>
                 '\s*>\s*', // >
@@ -2630,7 +2640,7 @@ class BaseBuilder
             ];
         }
 
-        return preg_match_all('/' . implode('|', $_operators) . '/i', $str, $match) ? ($list ? $match[0] : $match[0][0]) : false;
+        return preg_match_all('/' . implode('|', $this->pregOperators) . '/i', $str, $match) ? ($list ? $match[0] : $match[0][0]) : false;
     }
 
     /**

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2612,7 +2612,10 @@ class BaseBuilder
      */
     protected function hasOperator(string $str): bool
     {
-        return (bool) preg_match('/(<|>|!|=|\sIS NULL|\sIS NOT NULL|\sEXISTS|\sBETWEEN|\sLIKE|\sIN\s*\(|\s)/i', trim($str));
+        return (bool) preg_match(
+            '/(<|>|!|=|\sIS NULL|\sIS NOT NULL|\sEXISTS|\sBETWEEN|\sLIKE|\sIN\s*\(|\s)/i',
+            trim($str)
+        );
     }
 
     /**
@@ -2623,7 +2626,9 @@ class BaseBuilder
     protected function getOperator(string $str, bool $list = false)
     {
         if (empty($this->pregOperators)) {
-            $_les       = ($this->db->likeEscapeStr !== '') ? '\s+' . preg_quote(trim(sprintf($this->db->likeEscapeStr, $this->db->likeEscapeChar)), '/') : '';
+            $_les = ($this->db->likeEscapeStr !== '')
+                ? '\s+' . preg_quote(trim(sprintf($this->db->likeEscapeStr, $this->db->likeEscapeChar)), '/')
+                : '';
             $this->pregOperators = [
                 '\s*(?:<|>|!)?=\s*', // =, <=, >=, !=
                 '\s*<>?\s*', // <, <>
@@ -2640,7 +2645,11 @@ class BaseBuilder
             ];
         }
 
-        return preg_match_all('/' . implode('|', $this->pregOperators) . '/i', $str, $match) ? ($list ? $match[0] : $match[0][0]) : false;
+        return preg_match_all(
+            '/' . implode('|', $this->pregOperators) . '/i',
+            $str,
+            $match
+        ) ? ($list ? $match[0] : $match[0][0]) : false;
     }
 
     /**

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -239,6 +239,13 @@ abstract class BaseConnection implements ConnectionInterface
     public $likeEscapeChar = '!';
 
     /**
+     * RegExp used to escape identifiers
+     *
+     * @var array
+     */
+    protected $pregEscapeChar = [];
+
+    /**
      * Holds previously looked up data
      * for performance reasons.
      *
@@ -1119,29 +1126,27 @@ abstract class BaseConnection implements ConnectionInterface
             return $item;
         }
 
-        static $pregEc = [];
-
-        if (empty($pregEc)) {
+        if (empty($this->pregEscapeChar)) {
             if (is_array($this->escapeChar)) {
-                $pregEc = [
+                $this->pregEscapeChar = [
                     preg_quote($this->escapeChar[0], '/'),
                     preg_quote($this->escapeChar[1], '/'),
                     $this->escapeChar[0],
                     $this->escapeChar[1],
                 ];
             } else {
-                $pregEc[0] = $pregEc[1] = preg_quote($this->escapeChar, '/');
-                $pregEc[2] = $pregEc[3] = $this->escapeChar;
+                $this->pregEscapeChar[0] = $this->pregEscapeChar[1] = preg_quote($this->escapeChar, '/');
+                $this->pregEscapeChar[2] = $this->pregEscapeChar[3] = $this->escapeChar;
             }
         }
 
         foreach ($this->reservedIdentifiers as $id) {
             if (strpos($item, '.' . $id) !== false) {
-                return preg_replace('/' . $pregEc[0] . '?([^' . $pregEc[1] . '\.]+)' . $pregEc[1] . '?\./i', $pregEc[2] . '$1' . $pregEc[3] . '.', $item);
+                return preg_replace('/' . $this->pregEscapeChar[0] . '?([^' . $this->pregEscapeChar[1] . '\.]+)' . $this->pregEscapeChar[1] . '?\./i', $this->pregEscapeChar[2] . '$1' . $this->pregEscapeChar[3] . '.', $item);
             }
         }
 
-        return preg_replace('/' . $pregEc[0] . '?([^' . $pregEc[1] . '\.]+)' . $pregEc[1] . '?(\.)?/i', $pregEc[2] . '$1' . $pregEc[3] . '$2', $item);
+        return preg_replace('/' . $this->pregEscapeChar[0] . '?([^' . $this->pregEscapeChar[1] . '\.]+)' . $this->pregEscapeChar[1] . '?(\.)?/i', $this->pregEscapeChar[2] . '$1' . $this->pregEscapeChar[3] . '$2', $item);
     }
 
     /**

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1126,7 +1126,7 @@ abstract class BaseConnection implements ConnectionInterface
             return $item;
         }
 
-        if (empty($this->pregEscapeChar)) {
+        if ($this->pregEscapeChar === []) {
             if (is_array($this->escapeChar)) {
                 $this->pregEscapeChar = [
                     preg_quote($this->escapeChar[0], '/'),

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1142,11 +1142,19 @@ abstract class BaseConnection implements ConnectionInterface
 
         foreach ($this->reservedIdentifiers as $id) {
             if (strpos($item, '.' . $id) !== false) {
-                return preg_replace('/' . $this->pregEscapeChar[0] . '?([^' . $this->pregEscapeChar[1] . '\.]+)' . $this->pregEscapeChar[1] . '?\./i', $this->pregEscapeChar[2] . '$1' . $this->pregEscapeChar[3] . '.', $item);
+                return preg_replace(
+                    '/' . $this->pregEscapeChar[0] . '?([^' . $this->pregEscapeChar[1] . '\.]+)' . $this->pregEscapeChar[1] . '?\./i',
+                    $this->pregEscapeChar[2] . '$1' . $this->pregEscapeChar[3] . '.',
+                    $item
+                );
             }
         }
 
-        return preg_replace('/' . $this->pregEscapeChar[0] . '?([^' . $this->pregEscapeChar[1] . '\.]+)' . $this->pregEscapeChar[1] . '?(\.)?/i', $this->pregEscapeChar[2] . '$1' . $this->pregEscapeChar[3] . '$2', $item);
+        return preg_replace(
+            '/' . $this->pregEscapeChar[0] . '?([^' . $this->pregEscapeChar[1] . '\.]+)' . $this->pregEscapeChar[1] . '?(\.)?/i',
+            $this->pregEscapeChar[2] . '$1' . $this->pregEscapeChar[3] . '$2',
+            $item
+        );
     }
 
     /**


### PR DESCRIPTION
**Description**
- make PHP 8.1 compatible
  - see https://github.com/codeigniter4/CodeIgniter4/pull/4883#issuecomment-955622746

See "Usage of static Variables in Inherited Methods"
https://www.php.net/manual/en/migration81.incompatible.php

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
