### PR TITLE
Replace usage of `FILTER_SANITIZE_STRING`

### DIFF
--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -15,8 +15,6 @@ use Config\App;
 use RuntimeException;
 
 /**
- * Class CLIRequest
- *
  * Represents a request from the command-line. Provides additional
  * tools to interact with that request since CLI requests are not
  * static like HTTP requests might be.
@@ -172,17 +170,17 @@ class CLIRequest extends Request
                 if ($optionValue) {
                     $optionValue = false;
                 } else {
-                    $this->segments[] = filter_var($arg, FILTER_SANITIZE_STRING);
+                    $this->segments[] = esc(strip_tags($arg));
                 }
 
                 continue;
             }
 
-            $arg   = filter_var(ltrim($arg, '-'), FILTER_SANITIZE_STRING);
+            $arg   = esc(strip_tags(ltrim($arg, '-')));
             $value = null;
 
             if (isset($args[$i + 1]) && mb_strpos($args[$i + 1], '-') !== 0) {
-                $value       = filter_var($args[$i + 1], FILTER_SANITIZE_STRING);
+                $value       = esc(strip_tags($args[$i + 1]));
                 $optionValue = true;
             }
 

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -16,10 +16,7 @@ use Config\App;
 use InvalidArgumentException;
 
 /**
- * Class OutgoingRequest
- *
- * A lightweight HTTP client for sending synchronous HTTP requests
- * via cURL.
+ * A lightweight HTTP client for sending synchronous HTTP requests via cURL.
  */
 class CURLRequest extends Request
 {
@@ -84,10 +81,7 @@ class CURLRequest extends Request
     public function __construct(App $config, URI $uri, ?ResponseInterface $response = null, array $options = [])
     {
         if (! function_exists('curl_version')) {
-            // we won't see this during travis-CI
-            // @codeCoverageIgnoreStart
-            throw HTTPException::forMissingCurl();
-            // @codeCoverageIgnoreEnd
+            throw HTTPException::forMissingCurl(); // @codeCoverageIgnore
         }
 
         parent::__construct($config);
@@ -110,7 +104,7 @@ class CURLRequest extends Request
 
         $url = $this->prepareURL($url);
 
-        $method = filter_var($method, FILTER_SANITIZE_STRING);
+        $method = esc(strip_tags($method));
 
         $this->send($method, $url);
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -19,8 +19,6 @@ use Config\Services;
 use InvalidArgumentException;
 
 /**
- * Class RouteCollection
- *
  * @todo Implement nested resource routing (See CakePHP)
  */
 class RouteCollection implements RouteCollectionInterface
@@ -663,10 +661,11 @@ class RouteCollection implements RouteCollectionInterface
         // resources are sent to, we need to have a new name
         // to store the values in.
         $newName = implode('\\', array_map('ucfirst', explode('/', $name)));
+
         // If a new controller is specified, then we replace the
         // $name value with the name of the new controller.
         if (isset($options['controller'])) {
-            $newName = ucfirst(filter_var($options['controller'], FILTER_SANITIZE_STRING));
+            $newName = ucfirst(esc(strip_tags($options['controller'])));
         }
 
         // In order to allow customization of allowed id values
@@ -756,10 +755,11 @@ class RouteCollection implements RouteCollectionInterface
         // resources are sent to, we need to have a new name
         // to store the values in.
         $newName = implode('\\', array_map('ucfirst', explode('/', $name)));
+
         // If a new controller is specified, then we replace the
         // $name value with the name of the new controller.
         if (isset($options['controller'])) {
-            $newName = ucfirst(filter_var($options['controller'], FILTER_SANITIZE_STRING));
+            $newName = ucfirst(esc(strip_tags($options['controller'])));
         }
 
         // In order to allow customization of allowed id values


### PR DESCRIPTION
**Description**
Related to #4883 and follow-up to #5005

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
