### PR TITLE
Enable `ordered_class_elements` rule

### DIFF
--- a/.no-header.php-cs-fixer.dist.php
+++ b/.no-header.php-cs-fixer.dist.php
@@ -30,7 +30,17 @@ $finder = Finder::create()
         __DIR__ . '/admin/starter/builds',
     ]);
 
-$overrides = [];
+$overrides = [
+    'ordered_class_elements' => [
+        'order' => [
+            'use_trait',
+            'constant',
+            'property',
+            'method',
+        ],
+        'sort_algorithm' => 'none',
+    ],
+];
 
 $options = [
     'cacheFile'    => 'build/.no-header.php-cs-fixer.cache',

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -34,7 +34,17 @@ $finder = Finder::create()
         __DIR__ . '/spark',
     ]);
 
-$overrides = [];
+$overrides = [
+    'ordered_class_elements' => [
+        'order' => [
+            'use_trait',
+            'constant',
+            'property',
+            'method',
+        ],
+        'sort_algorithm' => 'none',
+    ],
+];
 
 $options = [
     'cacheFile'    => 'build/.php-cs-fixer.cache',

--- a/tests/_support/Publishers/TestPublisher.php
+++ b/tests/_support/Publishers/TestPublisher.php
@@ -16,14 +16,6 @@ use CodeIgniter\Publisher\Publisher;
 final class TestPublisher extends Publisher
 {
     /**
-     * Fakes an error on the given file.
-     */
-    public static function setResult(bool $result)
-    {
-        self::$result = $result;
-    }
-
-    /**
      * Return value for publish()
      *
      * @var bool
@@ -43,6 +35,14 @@ final class TestPublisher extends Publisher
      * @var string
      */
     protected $destination = WRITEPATH;
+
+    /**
+     * Fakes an error on the given file.
+     */
+    public static function setResult(bool $result)
+    {
+        self::$result = $result;
+    }
 
     /**
      * Fakes a publish event so no files are actually copied.

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -20,6 +20,7 @@ use Config\Cache;
 final class FileHandlerTest extends AbstractHandlerTest
 {
     private static $directory = 'FileHandler';
+    private $config;
 
     private static function getKeyArray()
     {
@@ -29,8 +30,6 @@ final class FileHandlerTest extends AbstractHandlerTest
             self::$key3,
         ];
     }
-
-    private $config;
 
     protected function setUp(): void
     {

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -22,6 +22,8 @@ use Exception;
  */
 final class MemcachedHandlerTest extends AbstractHandlerTest
 {
+    private $config;
+
     private static function getKeyArray()
     {
         return [
@@ -30,8 +32,6 @@ final class MemcachedHandlerTest extends AbstractHandlerTest
             self::$key3,
         ];
     }
-
-    private $config;
 
     protected function setUp(): void
     {

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -21,6 +21,8 @@ use Config\Cache;
  */
 final class PredisHandlerTest extends AbstractHandlerTest
 {
+    private $config;
+
     private static function getKeyArray()
     {
         return [
@@ -29,8 +31,6 @@ final class PredisHandlerTest extends AbstractHandlerTest
             self::$key3,
         ];
     }
-
-    private $config;
 
     protected function setUp(): void
     {

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -21,6 +21,8 @@ use Config\Cache;
  */
 final class RedisHandlerTest extends AbstractHandlerTest
 {
+    private $config;
+
     private static function getKeyArray()
     {
         return [
@@ -29,8 +31,6 @@ final class RedisHandlerTest extends AbstractHandlerTest
             self::$key3,
         ];
     }
-
-    private $config;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
**Description**
Enables the rule to be consistent in ordering the class's properties and methods.
```console
$ vendor/bin/php-cs-fixer describe ordered_class_elements
Description of ordered_class_elements rule.
Orders the elements of classes/interfaces/traits.

Fixer is configurable using following options:
* order (a subset of ['use_trait', 'public', 'protected', 'private', 'constant', 'constant_public', 'constant_protected', 'constant_private', 'property', 'property_static', 'property_public', 'property_protected', 'property_private', 'property_public_readonly', 'property_protected_readonly', 'property_private_readonly', 'property_public_static', 'property_protected_static', 'property_private_static', 'method', 'method_abstract', 'method_static', 'method_public', 'method_protected', 'method_private', 'method_public_abstract', 'method_protected_abstract', 'method_public_abstract_static', 'method_protected_abstract_static', 'method_public_static', 'method_protected_static', 'method_private_static', 'construct', 'destruct', 'magic', 'phpunit']): list of strings defining order of elements; defaults to ['use_trait', 'constant_public', 'constant_protected', 'constant_private', 'property_public', 'property_protected', 'property_private', 'construct', 'destruct', 'magic', 'phpunit', 'method_public', 'method_protected', 'method_private']
* sort_algorithm ('alpha', 'none'): how multiple occurrences of same type statements should be sorted; defaults to 'none'

Fixing examples:
 * Example #1. Fixing with the default configuration.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,30 +1,30 @@
    <?php
    final class Example
    {
        use BarTrait;
        use BazTrait;
        const C1 = 1;
        const C2 = 2;
   -    protected static $protStatProp;
        public static $pubStatProp1;
        public $pubProp1;
   +    var $pubProp2;
   +    public static $pubStatProp2;
   +    public $pubProp3;
   +    protected static $protStatProp;
        protected $protProp;
   -    var $pubProp2;
        private static $privStatProp;
        private $privProp;
   -    public static $pubStatProp2;
   -    public $pubProp3;
        protected function __construct() {}
   -    private static function privStatFunc() {}
   +    public function __destruct() {}
   +    public function __toString() {}
        public function pubFunc1() {}
   -    public function __toString() {}
   -    protected function protFunc() {}
        function pubFunc2() {}
        public static function pubStatFunc1() {}
        public function pubFunc3() {}
        static function pubStatFunc2() {}
   -    private function privFunc() {}
        public static function pubStatFunc3() {}
   +    protected function protFunc() {}
        protected static function protStatFunc() {}
   -    public function __destruct() {}
   +    private static function privStatFunc() {}
   +    private function privFunc() {}
    }

   ----------- end diff -----------

 * Example #2. Fixing with configuration: ['order' => ['method_private', 'method_public']].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,6 +1,6 @@
    <?php
    class Example
    {
   +    private function B(){}
        public function A(){}
   -    private function B(){}
    }

   ----------- end diff -----------

 * Example #3. Fixing with configuration: ['order' => ['method_public'], 'sort_algorithm' => 'alpha'].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,8 +1,8 @@
    <?php
    class Example
    {
   -    public function D(){}
   +    public function A(){}
        public function B(){}
   -    public function A(){}
        public function C(){}
   +    public function D(){}
    }

   ----------- end diff -----------
```

As a possible future enhancement, we can streamline this to sort also the elements by their visibilities (i.e. public, protected, private).

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
