### PR TITLE
feat: add valid_url_strict rule

### DIFF
--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -311,9 +311,8 @@ class FormatRules
             strtolower($validSchemes ?? 'http,https,mailto,tel,sms')
         );
 
-        return ! in_array($scheme, $validSchemes, true)
-            ? false
-            : filter_var($str, FILTER_VALIDATE_URL) !== false;
+        return in_array($scheme, $validSchemes, true)
+            && filter_var($str, FILTER_VALIDATE_URL) !== false;
     }
 
     /**

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -305,19 +305,15 @@ class FormatRules
             return false;
         }
 
-        if ($validSchemes === null) {
-            $validSchemes = 'http,https,mailto,tel,sms';
-        }
+        $scheme       = strtolower(parse_url($str, PHP_URL_SCHEME));
+        $validSchemes = explode(
+            ',',
+            strtolower($validSchemes ?? 'http,https,mailto,tel,sms')
+        );
 
-        $scheme           = strtolower(parse_url($str, PHP_URL_SCHEME));
-        $validSchemes     = strtolower($validSchemes);
-        $validSchemeArray = explode(',', $validSchemes);
-
-        if (! in_array(($scheme), $validSchemeArray, true)) {
-            return false;
-        }
-
-        return filter_var($str, FILTER_VALIDATE_URL) !== false;
+        return ! in_array($scheme, $validSchemes, true)
+            ? false
+            : filter_var($str, FILTER_VALIDATE_URL) !== false;
     }
 
     /**

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -308,7 +308,7 @@ class FormatRules
         $scheme       = strtolower(parse_url($str, PHP_URL_SCHEME));
         $validSchemes = explode(
             ',',
-            strtolower($validSchemes ?? 'http,https,mailto,tel,sms')
+            strtolower($validSchemes ?? 'http,https')
         );
 
         return in_array($scheme, $validSchemes, true)

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -268,7 +268,10 @@ class FormatRules
     }
 
     /**
-     * Checks a URL to ensure it's formed correctly.
+     * Checks a string to ensure it is (loosely) a URL.
+     *
+     * Warning: this rule will pass basic strings like
+     * "banana"; use valid_url_strict for a stricter rule.
      *
      * @param string $str
      */
@@ -287,6 +290,32 @@ class FormatRules
         }
 
         $str = 'http://' . $str;
+
+        return filter_var($str, FILTER_VALIDATE_URL) !== false;
+    }
+
+    /**
+     * Checks a URL to ensure it's formed correctly.
+     *
+     * @param string|null $validSchemes comma separated list of allowed schemes
+     */
+    public function valid_url_strict(?string $str = null, ?string $validSchemes = null): bool
+    {
+        if (empty($str)) {
+            return false;
+        }
+
+        if ($validSchemes === null) {
+            $validSchemes = 'http,https,mailto,tel,sms';
+        }
+
+        $scheme           = strtolower(parse_url($str, PHP_URL_SCHEME));
+        $validSchemes     = strtolower($validSchemes);
+        $validSchemeArray = explode(',', $validSchemes);
+
+        if (! in_array(($scheme), $validSchemeArray, true)) {
+            return false;
+        }
 
         return filter_var($str, FILTER_VALIDATE_URL) !== false;
     }

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -214,7 +214,7 @@ final class FormatRulesTest extends CIUnitTestCase
             [
                 'mailto:support@codeigniter.com',
                 true,
-                true,
+                false,
             ],
             [
                 '//example.com',

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -88,7 +88,7 @@ final class FormatRulesTest extends CIUnitTestCase
     /**
      * @dataProvider urlProvider
      */
-    public function testValidURL(?string $url, bool $expected)
+    public function testValidURL(?string $url, bool $isLoose, bool $isStrict)
     {
         $data = [
             'foo' => $url,
@@ -98,7 +98,36 @@ final class FormatRulesTest extends CIUnitTestCase
             'foo' => 'valid_url',
         ]);
 
-        $this->assertSame($expected, $this->validation->run($data));
+        $this->assertSame($isLoose, $this->validation->run($data));
+    }
+
+    /**
+     * @dataProvider urlProvider
+     */
+    public function testValidURLStrict(?string $url, bool $isLoose, bool $isStrict)
+    {
+        $data = [
+            'foo' => $url,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'valid_url_strict',
+        ]);
+
+        $this->assertSame($isStrict, $this->validation->run($data));
+    }
+
+    public function testValidURLStrictWithSchema()
+    {
+        $data = [
+            'foo' => 'http://www.codeigniter.com',
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'valid_url_strict[https]',
+        ]);
+
+        $this->assertFalse($this->validation->run($data));
     }
 
     public function urlProvider()
@@ -107,60 +136,90 @@ final class FormatRulesTest extends CIUnitTestCase
             [
                 'www.codeigniter.com',
                 true,
+                false,
             ],
             [
                 'http://codeigniter.com',
                 true,
+                true,
             ],
-            //https://bugs.php.net/bug.php?id=51192
+            // https://bugs.php.net/bug.php?id=51192
             [
                 'http://accept-dashes.tld',
+                true,
                 true,
             ],
             [
                 'http://reject_underscores',
                 false,
+                false,
             ],
-            // https://github.com/codeigniter4/CodeIgniter/issues/4415
+            // https://github.com/bcit-ci/CodeIgniter/issues/4415
             [
                 'http://[::1]/ipv6',
+                true,
                 true,
             ],
             [
                 'htt://www.codeigniter.com',
                 false,
+                false,
             ],
             [
                 '',
+                false,
+                false,
+            ],
+            // https://github.com/codeigniter4/CodeIgniter4/issues/3156
+            [
+                'codeigniter',
+                true,   // What?
                 false,
             ],
             [
                 'code igniter',
                 false,
+                false,
             ],
             [
                 null,
                 false,
+                false,
             ],
             [
                 'http://',
-                true,
-            ], // this is apparently valid!
+                true,   // Why?
+                false,
+            ],
             [
                 'http:///oops.com',
+                false,
                 false,
             ],
             [
                 '123.com',
                 true,
+                false,
             ],
             [
                 'abc.123',
                 true,
+                false,
             ],
             [
                 'http:8080//abc.com',
+                true,   // Insane?
+                false,
+            ],
+            [
+                'mailto:support@codeigniter.com',
                 true,
+                true,
+            ],
+            [
+                '//example.com',
+                false,
+                false,
             ],
         ];
     }

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -864,10 +864,10 @@ valid_url               No         Fails if field does not contain (loosely) a
                                    URL. Includes simple strings that could be
                                    hostnames, like "codeigniter".
 valid_url_strict        Yes        Fails if field does not contain a valid URL.  valid_url_strict[https]
-                                   Roughly equivalent to a "fail anything that
-                                   would not be a clickable link." You can
-                                   optionally specify a list of valid schemas.
-                                   If not specified, ``http,https`` are valid.
+                                   You can optionally specify a list of valid
+                                   schemas. If not specified, ``http,https``
+                                   are valid. This rule uses
+                                   PHP's ``FILTER_VALIDATE_URL``.
 valid_date              No         Fails if field does not contain a valid date. valid_date[d/m/Y]
                                    Accepts an optional parameter to matches
                                    a date format.

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -860,7 +860,15 @@ valid_emails            No         Fails if any value provided in a comma
 valid_ip                No         Fails if the supplied IP is not valid.        valid_ip[ipv6]
                                    Accepts an optional parameter of ‘ipv4’ or
                                    ‘ipv6’ to specify an IP format.
-valid_url               No         Fails if field does not contain a valid URL.
+valid_url               No         Fails if field does not contain (loosely) a
+                                   URL. Includes simple strings that could be
+                                   hostnames, like "codeigniter".
+valid_url_strict        Yes        Fails if field does not contain a valid URL.  valid_url_strict[http,https]
+                                   Roughly equivalent to a "fail anything that
+                                   would not be a clickable link." You can
+                                   optionally specify a list of valid schemas.
+                                   If not specified,
+                                   ``http,https,mailto,tel,sms`` are valid.
 valid_date              No         Fails if field does not contain a valid date. valid_date[d/m/Y]
                                    Accepts an optional parameter to matches
                                    a date format.

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -863,12 +863,11 @@ valid_ip                No         Fails if the supplied IP is not valid.       
 valid_url               No         Fails if field does not contain (loosely) a
                                    URL. Includes simple strings that could be
                                    hostnames, like "codeigniter".
-valid_url_strict        Yes        Fails if field does not contain a valid URL.  valid_url_strict[http,https]
+valid_url_strict        Yes        Fails if field does not contain a valid URL.  valid_url_strict[https]
                                    Roughly equivalent to a "fail anything that
                                    would not be a clickable link." You can
                                    optionally specify a list of valid schemas.
-                                   If not specified,
-                                   ``http,https,mailto,tel,sms`` are valid.
+                                   If not specified, ``http,https`` are valid.
 valid_date              No         Fails if field does not contain a valid date. valid_date[d/m/Y]
                                    Accepts an optional parameter to matches
                                    a date format.


### PR DESCRIPTION
**Description**
Supersedes #4658 
Fixes #3156

The current `valid_url` is too loose.

I referred to https://github.com/codeigniter4/CodeIgniter4/pull/4658#issuecomment-838524347

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
