### PR TITLE
unsafe-inline

### DIFF
--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -165,6 +165,8 @@ class ContentSecurityPolicy
     protected $validSources = [
         'self',
         'none',
+        'unsafe-hashes',
+        'strict-dynamic',
         'unsafe-inline',
         'unsafe-eval',
     ];
@@ -589,6 +591,9 @@ class ContentSecurityPolicy
         }
 
         // Replace style placeholders with nonces
+        // Skip nonces if unsafe-inline is declared!
+        $ignore_nonce = is_array($this->styleSrc) && (array_key_exists('unsafe-inline', $this->styleSrc));
+        
         $body = preg_replace_callback('/{csp-style-nonce}/', function () {
             $nonce = bin2hex(random_bytes(12));
 
@@ -598,6 +603,9 @@ class ContentSecurityPolicy
         }, $body);
 
         // Replace script placeholders with nonces
+        
+        $ignore_nonce = is_array($this->scriptSrc) && (array_key_exists('unsafe-inline', $this->scriptSrc));
+        
         $body = preg_replace_callback('/{csp-script-nonce}/', function () {
             $nonce = bin2hex(random_bytes(12));
 

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -592,27 +592,31 @@ class ContentSecurityPolicy
 
         // Replace style placeholders with nonces
         // Skip nonces if unsafe-inline is declared!
-        $ignore_nonce = is_array($this->styleSrc) && (array_key_exists('unsafe-inline', $this->styleSrc));
+        $ignore_nonce = is_array($this->styleSrc) && array_key_exists('unsafe-inline', $this->styleSrc);
         
-        $body = preg_replace_callback('/{csp-style-nonce}/', function () {
-            $nonce = bin2hex(random_bytes(12));
+        if(!$ignore_nonce) {
+            $body = preg_replace_callback('/{csp-style-nonce}/', function () {
+                $nonce = bin2hex(random_bytes(12));
 
-            $this->styleSrc[] = 'nonce-' . $nonce;
+                $this->styleSrc[] = 'nonce-' . $nonce;
 
-            return "nonce=\"{$nonce}\"";
-        }, $body);
+                return "nonce=\"{$nonce}\"";
+            }, $body);
+        }
 
         // Replace script placeholders with nonces
         
-        $ignore_nonce = is_array($this->scriptSrc) && (array_key_exists('unsafe-inline', $this->scriptSrc));
+        $ignore_nonce = is_array($this->scriptSrc) && array_key_exists('unsafe-inline', $this->scriptSrc);
         
-        $body = preg_replace_callback('/{csp-script-nonce}/', function () {
-            $nonce = bin2hex(random_bytes(12));
+        if(!$ignore_nonce) {
+            $body = preg_replace_callback('/{csp-script-nonce}/', function () {
+                $nonce = bin2hex(random_bytes(12));
 
-            $this->scriptSrc[] = 'nonce-' . $nonce;
+                $this->scriptSrc[] = 'nonce-' . $nonce;
 
-            return "nonce=\"{$nonce}\"";
-        }, $body);
+                return "nonce=\"{$nonce}\"";
+            }, $body);
+        }
 
         $response->setBody($body);
     }


### PR DESCRIPTION

    An allow-list for specific inline scripts using a cryptographic nonce (number used once). The server must generate a unique nonce value each time it transmits a policy. It is critical to provide an unguessable nonce, as bypassing a resource's policy is otherwise trivial. See unsafe inline script for an example. Specifying nonce makes a modern browser ignore 'unsafe-inline' which could still be set for older browsers without nonce support.

Each pull request should address a single issue and have a meaningful title.

**Description**
Explain what you have changed, and why.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
