### PR TITLE
Fix: remove incorrect processing of CLI params

### DIFF
--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -170,17 +170,17 @@ class CLIRequest extends Request
                 if ($optionValue) {
                     $optionValue = false;
                 } else {
-                    $this->segments[] = esc(strip_tags($arg));
+                    $this->segments[] = $arg;
                 }
 
                 continue;
             }
 
-            $arg   = esc(strip_tags(ltrim($arg, '-')));
+            $arg   = ltrim($arg, '-');
             $value = null;
 
             if (isset($args[$i + 1]) && mb_strpos($args[$i + 1], '-') !== 0) {
-                $value       = esc(strip_tags($args[$i + 1]));
+                $value       = $args[$i + 1];
                 $optionValue = true;
             }
 

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -61,6 +61,30 @@ final class CLIRequestTest extends CIUnitTestCase
         $this->assertSame($segments, $this->request->getSegments());
     }
 
+    public function testParsingSegmentsWithHTMLMetaChars()
+    {
+        $_SERVER['argv'] = [
+            'index.php',
+            'users',
+            '21',
+            'abc < def',
+            "McDonald's",
+            '<s>aaa</s>',
+        ];
+
+        // reinstantiate it to force parsing
+        $this->request = new CLIRequest(new App());
+
+        $segments = [
+            'users',
+            '21',
+            'abc < def',
+            "McDonald's",
+            '<s>aaa</s>',
+        ];
+        $this->assertSame($segments, $this->request->getSegments());
+    }
+
     public function testParsingOptions()
     {
         $_SERVER['argv'] = [


### PR DESCRIPTION
**Description**
Fixes #5266

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
