### PR TITLE
Fix compatibility of Postgres result for PHP 8.1

### DIFF
--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -28,7 +28,7 @@ abstract class BaseResult implements ResultInterface
     /**
      * Result ID
      *
-     * @var bool|object|resource
+     * @var false|object|resource
      */
     public $resultID;
 

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -68,7 +68,7 @@ class Result extends BaseResult
      */
     public function freeResult()
     {
-        if (is_resource($this->resultID)) {
+        if ($this->resultID !== false) {
             pg_free_result($this->resultID);
             $this->resultID = false;
         }


### PR DESCRIPTION
**Description**
As of PHP 8.1, the result resource in Postgres is now a `PgSql\Result` object, so calling `is_resource` will naturally fail now. The 8.1 migration guide suggests using a check against false.
https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.resource2object

Related: #4883 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
