### PR TITLE
Fix compatibility of `PgSql\Result` on closing the result instance

### DIFF
--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -144,7 +144,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
      */
     public function close()
     {
-        if (! is_object($this->statement)) {
+        if (! is_object($this->statement) || ! method_exists($this->statement, 'close')) {
             return;
         }
 

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -15,6 +15,7 @@ use CodeIgniter\Database\BasePreparedQuery;
 use CodeIgniter\Database\Query;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**
  * @group DatabaseLive
@@ -26,7 +27,7 @@ final class PreparedQueryTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     protected $refresh = true;
-    protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
+    private $seed      = CITestSeeder::class;
 
     /**
      * @var BasePreparedQuery|null

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -26,8 +26,7 @@ final class PreparedQueryTest extends CIUnitTestCase
 {
     use DatabaseTestTrait;
 
-    protected $refresh = true;
-    private $seed      = CITestSeeder::class;
+    protected $seed = CITestSeeder::class;
 
     /**
      * @var BasePreparedQuery|null


### PR DESCRIPTION
**Description**
In PHP 8.1, Postgres' result is now a `PgSql\Result` object which is a [fully opaque class](https://www.php.net/manual/en/class.pgsql-result.php). This class has no methods so calling on `BasePreparedQuery::close()` will now fail because it calls the `close` method on the object result. Also, this refactors the `PreparedQueryTest` to call the close method on tearDown.

Related: #4883 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
