### PR TITLE
docs: fix RST format in caching.rst

### DIFF
--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -159,7 +159,7 @@ Class Reference
         $cache->deleteMatching('*_suffix'); // deletes all items of which keys end with "_suffix"
 
     For more information on glob-style syntax, please see
-        `https://en.wikipedia.org/wiki/Glob_(programming) <https://en.wikipedia.org/wiki/Glob_(programming)#Syntax>`_.
+    `https://en.wikipedia.org/wiki/Glob_(programming) <https://en.wikipedia.org/wiki/Glob_(programming)#Syntax>`_.
 
 .. php:method:: increment($key[, $offset = 1]): mixed
 

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -159,7 +159,7 @@ Class Reference
         $cache->deleteMatching('*_suffix'); // deletes all items of which keys end with "_suffix"
 
     For more information on glob-style syntax, please see
-    `https://en.wikipedia.org/wiki/Glob_(programming) <https://en.wikipedia.org/wiki/Glob_(programming)#Syntax>`_.
+    `Glob (programming) <https://en.wikipedia.org/wiki/Glob_(programming)#Syntax>`_.
 
 .. php:method:: increment($key[, $offset = 1]): mixed
 


### PR DESCRIPTION
**Description**
- fix RST format 

Before:
![Screenshot 2021-11-07 12 03 39](https://user-images.githubusercontent.com/87955/140630922-a315e6a0-c4c1-4430-b01c-972befde7df0.png)

After:
![Screenshot 2021-11-07 12 04 13](https://user-images.githubusercontent.com/87955/140630924-5c8dfffa-33e2-49d4-a2a9-69e04430593b.png)

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
