### PR TITLE
fix: FileLocator cannot find files in sub-namespaces of the same vendor

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -55,6 +55,7 @@ class FileLocator
 
         // Standardize slashes to handle nested directories.
         $file = strtr($file, '/', '\\');
+        $file = ltrim($file, '\\');
 
         $segments = explode('\\', $file);
 
@@ -64,23 +65,20 @@ class FileLocator
         }
 
         $paths    = [];
-        $prefix   = '';
         $filename = '';
 
         // Namespaces always comes with arrays of paths
         $namespaces = $this->autoloader->getNamespace();
 
-        while (! empty($segments)) {
-            $prefix .= empty($prefix) ? array_shift($segments) : '\\' . array_shift($segments);
+        foreach (array_keys($namespaces) as $namespace) {
+            if (substr($file, 0, strlen($namespace)) === $namespace) {
+                // There may be sub-namespaces of the same vendor,
+                // so overwrite them with namespaces found later.
+                $paths = $namespaces[$namespace];
 
-            if (empty($namespaces[$prefix])) {
-                continue;
+                $fileWithoutNamespace = substr($file, strlen($namespace));
+                $filename             = ltrim(str_replace('\\', '/', $fileWithoutNamespace), '/');
             }
-
-            $paths = $namespaces[$prefix];
-
-            $filename = implode('/', $segments);
-            break;
         }
 
         // if no namespaces matched then quit

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -39,8 +39,11 @@ final class FileLocatorTest extends CIUnitTestCase
                 TESTPATH,
                 SYSTEMPATH,
             ],
-            'Errors' => APPPATH . 'Views/errors',
-            'System' => SUPPORTPATH . 'Autoloader/system',
+            'Errors'              => APPPATH . 'Views/errors',
+            'System'              => SUPPORTPATH . 'Autoloader/system',
+            'CodeIgniter\\Devkit' => [
+                TESTPATH . '_support/',
+            ],
         ]);
 
         $this->locator = new FileLocator($autoloader);
@@ -123,6 +126,15 @@ final class FileLocatorTest extends CIUnitTestCase
         $expected = APPPATH . 'Views/errors/html/error_404.php';
 
         $this->assertSame($expected, $this->locator->locateFile($file, 'html'));
+    }
+
+    public function testLocateFileCanFindNamespacedViewWhenVendorHasTwoNamespaces()
+    {
+        $file = '\CodeIgniter\Devkit\View\Views/simple';
+
+        $expected = ROOTPATH . 'tests/_support/View/Views/simple.php';
+
+        $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
 
     public function testLocateFileNotFoundExistingNamespace()


### PR DESCRIPTION
**Description**
`FileLocator` cannot find files in sub-namespaces of the same vendor.
For example, when you have `CodeIgniter` and `CodeIgniter\Devkit`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
