### PR TITLE
Toolbar - Make it possible to turn off var data collection

### DIFF
--- a/app/Config/Toolbar.php
+++ b/app/Config/Toolbar.php
@@ -46,6 +46,18 @@ class Toolbar extends BaseConfig
 
     /**
      * --------------------------------------------------------------------------
+     * Collect Var Data
+     * --------------------------------------------------------------------------
+     *
+     * If set to false var data from the views will not be colleted. Usefull to
+     * avoid high memory usage when there are lots of data passed to the view.
+     *
+     * @var bool
+     */
+    public $collectVarData = true;
+
+    /**
+     * --------------------------------------------------------------------------
      * Max History
      * --------------------------------------------------------------------------
      *

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -310,7 +310,7 @@ class Toolbar
      */
     protected function collectVarData(): array
     {
-        if (! $this->config->collectVarData) {
+        if (! ($this->config->collectVarData ?? true)) {
             return [];
         }
 

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -310,6 +310,10 @@ class Toolbar
      */
     protected function collectVarData(): array
     {
+        if (! $this->config->collectVarData) {
+            return [];
+        }
+
         $data = [];
 
         foreach ($this->collectors as $collector) {


### PR DESCRIPTION
**Description**
When there are a lot of vars being passed to the view for example array of entities with lots of parameters in each entity, var data can get very big and will consume a lot of memory.  A new parameter in toolbar config is introduced here to that collection of var data can be disabled.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide