### PR TITLE
chore: add .github/release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes
+      labels:
+        - 'breaking change'
+    - title: Fixed Bugs
+      labels:
+        - bug
+    - title: New Features
+      labels:
+        - 'new feature'
+    - title: Enhancements
+      labels:
+        - enhancement
+    - title: Refactoring
+      labels:
+        - refactor
+    - title: Others (Only for checking. Remove this category)
+      labels:
+        - "*"

--- a/admin/RELEASE.md
+++ b/admin/RELEASE.md
@@ -12,7 +12,7 @@ To auto-generate changelog, each PR to be listed in changelog must have one of t
 - **new feature** ... PRs for new features
 - **refactor** ... PRs to refactor
 
-And a PRs that has the breaking changes must have the following label:
+And PRs that have the breaking changes must have the following label:
 - **breaking change** ... PRs that may break existing functionalities
 
 ## Preparation

--- a/admin/RELEASE.md
+++ b/admin/RELEASE.md
@@ -4,6 +4,17 @@
 > Updated for `4.1.2` on May 17, 2021.
 > -MGatner
 
+## Labeling PRs
+
+To auto-generate changelog, each PR to be listed in changelog must have one of the following [labels](https://github.com/codeigniter4/CodeIgniter4/labels):
+- **bug** ... PRs that fix bugs
+- **enhancement** ... PRs to improve existing functionalities
+- **new feature** ... PRs for new features
+- **refactor** ... PRs to refactor
+
+And a PRs that has the breaking changes must have the following label:
+- **breaking change** ... PRs that may break existing functionalities
+
 ## Preparation
 
 * Work off direct clones of the repos so the release branches persist for a time

--- a/contributing/pull_request.md
+++ b/contributing/pull_request.md
@@ -225,6 +225,7 @@ The best way to contribute is to fork the CodeIgniter4 repository, and "clone" t
 12. Make sure the tests pass to have a higher chance of merging.
 13. [Push](https://docs.github.com/en/github/using-git/pushing-commits-to-a-remote-repository) your contribution branch to your fork.
 14. Send a [pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).
+15. Label your pull request with the appropriate label if you can.
 
 See [Contribution workflow](./workflow.md) for Git workflow details.
 

--- a/contributing/workflow.md
+++ b/contributing/workflow.md
@@ -185,7 +185,6 @@ Make sure that the PR title is helpful for the maintainers and other
 developers. Add any comments appropriate, for instance asking for
 review.
 
-
 **Note:**
 > If you do not provide a title or description for your PR, the odds of it being summarily rejected
 rise astronomically.
@@ -202,6 +201,19 @@ tests. You don't need to raise a new PR.
 If your PR does not follow our contribution guidelines, or is
 incomplete, the codebase maintainers will comment on it, pointing out
 what needs fixing.
+
+### Labeling PRs
+
+If you have the privilege of labeling PRs, you can help the maintainers.
+
+Label your PRs with the one of the following [labels](https://github.com/codeigniter4/CodeIgniter4/labels):
+- **bug** ... PRs that fix bugs
+- **enhancement** ... PRs to improve existing functionalities
+- **new feature** ... PRs for new features
+- **refactor** ... PRs to refactor
+
+And if your PRs have the breaking changes, label the following label:
+- **breaking change** ... PRs that may break existing functionalities
 
 ## Cleanup
 


### PR DESCRIPTION
**Description**
I propose that labeling PRs and use GitHub auto-generated release note for generating `CHANGELOG.md`.

See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
