### PR TITLE
fix: UploadedFile::move() may return incorrect value

### DIFF
--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -144,7 +144,7 @@ class UploadedFile extends File implements UploadedFileInterface
             $this->hasMoved = move_uploaded_file($this->path, $destination);
         } catch (Exception $e) {
             $error   = error_get_last();
-            $message = isset($error['message']) ? strip_tags($error['message']) : '';
+            $message = strip_tags($error['message'] ?? '');
 
             throw HTTPException::forMoveFailed(basename($this->path), $targetPath, $message);
         }

--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -293,11 +293,9 @@ final class FileMovingTest extends CIUnitTestCase
 
     public function testFailedMoveBecauseOfFalseReturned()
     {
-        $finalFilename = 'fileA';
-
         $_FILES = [
             'userfile1' => [
-                'name'     => $finalFilename . '.txt',
+                'name'     => 'fileA.txt',
                 'type'     => 'text/plain',
                 'size'     => 124,
                 'tmp_name' => '/tmp/fileA.txt',

--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -55,8 +55,7 @@ final class FileMovingTest extends CIUnitTestCase
     public function testMove()
     {
         $finalFilename = 'fileA';
-
-        $_FILES = [
+        $_FILES        = [
             'userfile1' => [
                 'name'     => $finalFilename . '.txt',
                 'type'     => 'text/plain',
@@ -79,7 +78,6 @@ final class FileMovingTest extends CIUnitTestCase
         $this->assertTrue($collection->hasFile('userfile2'));
 
         $destination = $this->destination;
-
         // Create the destination if not exists
         if (! is_dir($destination)) {
             mkdir($destination, 0777, true);
@@ -97,8 +95,7 @@ final class FileMovingTest extends CIUnitTestCase
     public function testMoveOverwriting()
     {
         $finalFilename = 'file_with_delimiters_underscore';
-
-        $_FILES = [
+        $_FILES        = [
             'userfile1' => [
                 'name'     => $finalFilename . '.txt',
                 'type'     => 'text/plain',
@@ -129,7 +126,6 @@ final class FileMovingTest extends CIUnitTestCase
         $this->assertTrue($collection->hasFile('userfile3'));
 
         $destination = $this->destination;
-
         // Create the destination if not exists
         if (! is_dir($destination)) {
             mkdir($destination, 0777, true);
@@ -149,8 +145,7 @@ final class FileMovingTest extends CIUnitTestCase
     public function testMoved()
     {
         $finalFilename = 'fileA';
-
-        $_FILES = [
+        $_FILES        = [
             'userfile1' => [
                 'name'     => $finalFilename . '.txt',
                 'type'     => 'text/plain',
@@ -165,7 +160,6 @@ final class FileMovingTest extends CIUnitTestCase
         $this->assertTrue($collection->hasFile('userfile1'));
 
         $destination = $this->destination;
-
         // Create the destination if not exists
         if (! is_dir($destination)) {
             mkdir($destination, 0777, true);
@@ -175,15 +169,16 @@ final class FileMovingTest extends CIUnitTestCase
 
         $this->assertInstanceOf(UploadedFile::class, $file);
         $this->assertFalse($file->hasMoved());
+
         $file->move($destination, $file->getName(), false);
+
         $this->assertTrue($file->hasMoved());
     }
 
     public function testStore()
     {
         $finalFilename = 'fileA';
-
-        $_FILES = [
+        $_FILES        = [
             'userfile1' => [
                 'name'     => $finalFilename . '.txt',
                 'type'     => 'text/plain',
@@ -198,7 +193,6 @@ final class FileMovingTest extends CIUnitTestCase
         $this->assertTrue($collection->hasFile('userfile1'));
 
         $destination = $this->destination;
-
         // Create the destination if not exists
         if (! is_dir($destination)) {
             mkdir($destination, 0777, true);
@@ -207,15 +201,16 @@ final class FileMovingTest extends CIUnitTestCase
         $file = $collection->getFile('userfile1');
 
         $this->assertInstanceOf(UploadedFile::class, $file);
+
         $path = $file->store($destination, $file->getName());
+
         $this->assertSame($destination . '/fileA.txt', $path);
     }
 
     public function testAlreadyMoved()
     {
         $finalFilename = 'fileA';
-
-        $_FILES = [
+        $_FILES        = [
             'userfile1' => [
                 'name'     => $finalFilename . '.txt',
                 'type'     => 'text/plain',
@@ -230,7 +225,6 @@ final class FileMovingTest extends CIUnitTestCase
         $this->assertTrue($collection->hasFile('userfile1'));
 
         $destination = $this->destination;
-
         // Create the destination if not exists
         if (! is_dir($destination)) {
             mkdir($destination, 0777, true);
@@ -257,11 +251,11 @@ final class FileMovingTest extends CIUnitTestCase
         ];
 
         $destination = $this->destination;
-
-        $collection = new FileCollection();
-        $file       = $collection->getFile('userfile');
+        $collection  = new FileCollection();
 
         $this->expectException(HTTPException::class);
+
+        $file = $collection->getFile('userfile');
         $file->move($destination, $file->getName(), false);
     }
 
@@ -278,16 +272,16 @@ final class FileMovingTest extends CIUnitTestCase
         ];
 
         $destination = $this->destination;
-
         // Create the destination and make it read only
         if (! is_dir($destination)) {
             mkdir($destination, 0400, true);
         }
 
         $collection = new FileCollection();
-        $file       = $collection->getFile('userfile');
 
         $this->expectException(HTTPException::class);
+
+        $file = $collection->getFile('userfile');
         $file->move($destination, $file->getName(), false);
     }
 
@@ -308,20 +302,17 @@ final class FileMovingTest extends CIUnitTestCase
         $this->assertTrue($collection->hasFile('userfile1'));
 
         $destination = $this->destination;
-
         // Create the destination if not exists
         if (! is_dir($destination)) {
             mkdir($destination, 0777, true);
         }
-
-        $file = $collection->getFile('userfile1');
-
         // Set the mock's return value to false
         move_uploaded_file('', '', false);
 
         $this->expectException(HTTPException::class);
         $this->expectExceptionMessage('move_uploaded_file() returned false');
 
+        $file = $collection->getFile('userfile1');
         $file->move($destination, $file->getName(), false);
     }
 }

--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -322,6 +322,7 @@ final class FileMovingTest extends CIUnitTestCase
         move_uploaded_file('', '', false);
 
         $this->expectException(HTTPException::class);
+        $this->expectExceptionMessage('move_uploaded_file() returned false');
 
         $file->move($destination, $file->getName(), false);
     }


### PR DESCRIPTION
Supersedes and closes #5290

**Description**
- if `move_uploaded_file()` returns `false` without warning, `move()` and `hasMoved()` returns `true`

> https://www.php.net/manual/en/function.move-uploaded-file.php#refsect1-function.move-uploaded-file-returnvalues
> Return Values ¶
>
> Returns true on success.
>
> **If from is not a valid upload file, then no action will occur, and move_uploaded_file() will return false.**
>
> If from is a valid upload file, but cannot be moved for some reason, no action will occur, and move_uploaded_file() will return false. **Additionally, a warning will be issued.**

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
