### PR TITLE
fix: add a workaround for upgraded users who do not update Config\Exceptions

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -70,6 +70,11 @@ class Exceptions
         $this->config   = $config;
         $this->request  = $request;
         $this->response = $response;
+
+        // workaround for upgraded users
+        if (! isset($this->config->sensitiveDataInTrace)) {
+            $this->config->sensitiveDataInTrace = [];
+        }
     }
 
     /**


### PR DESCRIPTION
**Description**
Follow-up: #4550

If upgraded users do not update `Config\Exceptions`, the following error occurs:
Uncaught ErrorException: Undefined property: Config\Exceptions::$sensitiveDataInTrace

See https://forum.codeigniter.com/thread-80522.html

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

