### PR TITLE
test: add $this->markTestSkipped() when extension not loaded

### DIFF
--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -37,6 +37,10 @@ final class MemcachedHandlerTest extends AbstractHandlerTest
     {
         parent::setUp();
 
+        if (! extension_loaded('memcached')) {
+            $this->markTestSkipped('Memcached extension not loaded.');
+        }
+
         $this->config = new Cache();
 
         $this->handler = new MemcachedHandler($this->config);

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -36,6 +36,10 @@ final class RedisHandlerTest extends AbstractHandlerTest
     {
         parent::setUp();
 
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped('redis extension not loaded.');
+        }
+
         $this->config = new Cache();
 
         $this->handler = new RedisHandler($this->config);

--- a/tests/system/Images/BaseHandlerTest.php
+++ b/tests/system/Images/BaseHandlerTest.php
@@ -34,8 +34,6 @@ final class BaseHandlerTest extends CIUnitTestCase
     {
         if (! extension_loaded('gd')) {
             $this->markTestSkipped('The GD extension is not available.');
-
-            return;
         }
 
         // create virtual file system

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -33,8 +33,6 @@ final class GDHandlerTest extends CIUnitTestCase
     {
         if (! extension_loaded('gd')) {
             $this->markTestSkipped('The GD extension is not available.');
-
-            return;
         }
 
         // create virtual file system

--- a/tests/system/Images/ImageMagickHandlerTest.php
+++ b/tests/system/Images/ImageMagickHandlerTest.php
@@ -34,8 +34,6 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
     {
         if (! extension_loaded('imagick')) {
             $this->markTestSkipped('The ImageMagick extension is not available.');
-
-            return;
         }
 
         $this->root = WRITEPATH . 'cache/';


### PR DESCRIPTION
**Description**
- add `$this->markTestSkipped()` when extension not loaded
  - If extension is not loaded, you see Error surely
- remove unneeded `return` after `$this->markTestSkipped()`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
