### PR TITLE
[Rector] add PHPUnitSetList::PHPUNIT_SPECIFIC_METHOD

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -42,6 +42,7 @@ use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
+use Rector\PHPUnit\Rector\MethodCall\AssertIssetToSpecificMethodRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
@@ -111,6 +112,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         // use mt_rand instead of random_int on purpose on non-cryptographically random
         RandomFunctionRector::class,
+
+        // $this->assertTrue(isset($bar['foo']))
+        // and $this->assertArrayHasKey('foo', $bar)
+        // or $this->assertObjectHasAttribute('foo', $bar);
+        // are not the same
+        AssertIssetToSpecificMethodRector::class => [
+            __DIR__ . '/tests/system/Entity/EntityTest.php',
+            __DIR__ . '/tests/system/Session/SessionTest.php',
+        ],
     ]);
 
     // auto import fully qualified class names

--- a/rector.php
+++ b/rector.php
@@ -42,6 +42,7 @@ use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
+use Rector\PHPUnit\Rector\MethodCall\AssertFalseStrposToContainsRector;
 use Rector\PHPUnit\Rector\MethodCall\AssertIssetToSpecificMethodRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
@@ -121,6 +122,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             __DIR__ . '/tests/system/Entity/EntityTest.php',
             __DIR__ . '/tests/system/Session/SessionTest.php',
         ],
+
+        // assertContains() to string can't be used in PHPUnit 9.1
+        AssertFalseStrposToContainsRector::class,
     ]);
 
     // auto import fully qualified class names

--- a/rector.php
+++ b/rector.php
@@ -42,6 +42,7 @@ use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -53,6 +54,7 @@ use Utils\Rector\UnderscoreToCamelCaseVariableNameRector;
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(SetList::DEAD_CODE);
     $containerConfigurator->import(LevelSetList::UP_TO_PHP_73);
+    $containerConfigurator->import(PHPUnitSetList::PHPUNIT_SPECIFIC_METHOD);
 
     $parameters = $containerConfigurator->parameters();
 

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -488,7 +488,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $this->formatter = new XMLFormatter();
         $controller      = $this->makeController();
 
-        $this->assertSame('CodeIgniter\Format\XMLFormatter', get_class($this->formatter));
+        $this->assertInstanceOf('CodeIgniter\Format\XMLFormatter', $this->formatter);
 
         $controller->respondCreated(['id' => 3], 'A Custom Reason');
         $expected = <<<'EOH'

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -67,7 +67,7 @@ final class ConsoleTest extends CIUnitTestCase
         $console = new Console($this->app);
         $console->showHeader();
         $result = CITestStreamFilter::$buffer;
-        $this->assertTrue(strpos($result, sprintf('CodeIgniter v%s Command Line Tool', CodeIgniter::CI_VERSION)) > 0);
+        $this->assertGreaterThan(0, strpos($result, sprintf('CodeIgniter v%s Command Line Tool', CodeIgniter::CI_VERSION)));
     }
 
     public function testNoHeader()

--- a/tests/system/CommonSingleServiceTest.php
+++ b/tests/system/CommonSingleServiceTest.php
@@ -34,7 +34,7 @@ final class CommonSingleServiceTest extends CIUnitTestCase
         $service1 = single_service($service);
         $service2 = single_service($service);
 
-        $this->assertSame(get_class($service1), get_class($service2));
+        $this->assertInstanceOf(get_class($service1), $service2);
         $this->assertNotSame($service1, $service2);
     }
 
@@ -62,7 +62,7 @@ final class CommonSingleServiceTest extends CIUnitTestCase
         $service1 = single_service($service, ...$params);
         $service2 = single_service($service, ...$params);
 
-        $this->assertSame(get_class($service1), get_class($service2));
+        $this->assertInstanceOf(get_class($service1), $service2);
         $this->assertNotSame($service1, $service2);
 
         if ($service === 'commands') {
@@ -77,7 +77,7 @@ final class CommonSingleServiceTest extends CIUnitTestCase
 
         // Assert that even passing true as last param this will
         // not create a shared instance.
-        $this->assertSame(get_class($cache1), get_class($cache2));
+        $this->assertInstanceOf(get_class($cache1), $cache2);
         $this->assertNotSame($cache1, $cache2);
     }
 

--- a/tests/system/Config/ConfigTest.php
+++ b/tests/system/Config/ConfigTest.php
@@ -41,7 +41,7 @@ final class ConfigTest extends CIUnitTestCase
         $Config  = Config::get('DocTypes');
         $Config2 = Config::get('Config\\DocTypes');
 
-        $this->assertTrue($Config === $Config2);
+        $this->assertSame($Config2, $Config);
     }
 
     public function testCreateNonConfig()

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -316,7 +316,7 @@ final class ServicesTest extends CIUnitTestCase
         $response2 = service('response');
         $this->assertInstanceOf(MockResponse::class, $response2);
 
-        $this->assertTrue($response !== $response2);
+        $this->assertNotSame($response2, $response);
     }
 
     /**

--- a/tests/system/Cookie/CookieTest.php
+++ b/tests/system/Cookie/CookieTest.php
@@ -268,13 +268,13 @@ final class CookieTest extends CIUnitTestCase
     {
         $cookie = new Cookie('cookie', 'monster');
 
-        $this->assertTrue(isset($cookie['expire']));
+        $this->assertArrayHasKey('expire', $cookie);
         $this->assertSame($cookie['expire'], $cookie->getExpiresTimestamp());
-        $this->assertTrue(isset($cookie['httponly']));
+        $this->assertArrayHasKey('httponly', $cookie);
         $this->assertSame($cookie['httponly'], $cookie->isHTTPOnly());
-        $this->assertTrue(isset($cookie['samesite']));
+        $this->assertArrayHasKey('samesite', $cookie);
         $this->assertSame($cookie['samesite'], $cookie->getSameSite());
-        $this->assertTrue(isset($cookie['path']));
+        $this->assertArrayHasKey('path', $cookie);
         $this->assertSame($cookie['path'], $cookie->getPath());
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -103,6 +103,6 @@ final class ConnectTest extends CIUnitTestCase
         $db1 = Database::connect($this->tests);
 
         $this->assertSame($this->tests['failover'][0]['DBDriver'], $this->getPrivateProperty($db1, 'DBDriver'));
-        $this->assertTrue(count($db1->listTables()) >= 0);
+        $this->assertGreaterThanOrEqual(0, count($db1->listTables()));
     }
 }

--- a/tests/system/Database/Live/DbUtilsTest.php
+++ b/tests/system/Database/Live/DbUtilsTest.php
@@ -79,7 +79,7 @@ final class DbUtilsTest extends CIUnitTestCase
         if (in_array($this->db->DBDriver, ['MySQLi', 'Postgre', 'SQLSRV'], true)) {
             $databases = $util->listDatabases();
 
-            $this->assertTrue(in_array($this->db->getDatabase(), $databases, true));
+            $this->assertContains($this->db->getDatabase(), $databases);
         } elseif ($this->db->DBDriver === 'SQLite3') {
             $this->expectException(DatabaseException::class);
             $this->expectExceptionMessage('Unsupported feature of the database platform you are using.');

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -78,8 +78,8 @@ final class GetTest extends CIUnitTestCase
     {
         $jobs = $this->db->table('job')->get()->getFieldNames();
 
-        $this->assertTrue(in_array('name', $jobs, true));
-        $this->assertTrue(in_array('description', $jobs, true));
+        $this->assertContains('name', $jobs);
+        $this->assertContains('description', $jobs);
     }
 
     public function testGetFieldData()

--- a/tests/system/Database/Live/PretendTest.php
+++ b/tests/system/Database/Live/PretendTest.php
@@ -36,7 +36,7 @@ final class PretendTest extends CIUnitTestCase
             ->table('user')
             ->get();
 
-        $this->assertFalse($result instanceof Query);
+        $this->assertNotInstanceOf(Query::class, $result);
 
         $result = $this->db->pretend(true)
             ->table('user')

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -133,9 +133,9 @@ final class AlterTableTest extends CIUnitTestCase
 
         $columns = $this->db->getFieldNames('foo');
 
-        $this->assertFalse(in_array('name', $columns, true));
-        $this->assertTrue(in_array('id', $columns, true));
-        $this->assertTrue(in_array('email', $columns, true));
+        $this->assertNotContains('name', $columns);
+        $this->assertContains('id', $columns);
+        $this->assertContains('email', $columns);
     }
 
     public function testDropColumnMaintainsKeys()

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -553,7 +553,7 @@ final class FiltersTest extends CIUnitTestCase
         $uri      = 'admin/foo/bar';
         $response = $filters->run($uri, 'before');
 
-        $this->assertTrue($response instanceof ResponseInterface);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertSame('http://google.com', $response->csp);
     }
 
@@ -737,7 +737,7 @@ final class FiltersTest extends CIUnitTestCase
         $filters = $filters->initialize('admin/foo/bar');
         $filters = $filters->getFilters();
 
-        $this->assertTrue(in_array('some_alias', $filters['before'], true));
+        $this->assertContains('some_alias', $filters['before']);
     }
 
     public function testAddFilterSection()
@@ -753,7 +753,7 @@ final class FiltersTest extends CIUnitTestCase
             ->initialize('admin/foo/bar')
             ->getFilters();
 
-        $this->assertTrue(in_array('another', $list['before'], true));
+        $this->assertContains('another', $list['before']);
     }
 
     public function testInitializeTwice()
@@ -770,7 +770,7 @@ final class FiltersTest extends CIUnitTestCase
             ->initialize()
             ->getFilters();
 
-        $this->assertTrue(in_array('another', $list['before'], true));
+        $this->assertContains('another', $list['before']);
     }
 
     public function testEnableFilter()
@@ -791,7 +791,7 @@ final class FiltersTest extends CIUnitTestCase
         $filters->enableFilter('google', 'before');
         $filters = $filters->getFilters();
 
-        $this->assertTrue(in_array('google', $filters['before'], true));
+        $this->assertContains('google', $filters['before']);
     }
 
     public function testEnableFilterWithArguments()
@@ -813,7 +813,7 @@ final class FiltersTest extends CIUnitTestCase
         $filters->enableFilter('role:admin , super', 'after');
         $found = $filters->getFilters();
 
-        $this->assertTrue(in_array('role', $found['before'], true));
+        $this->assertContains('role', $found['before']);
         $this->assertSame(['admin', 'super'], $filters->getArguments('role'));
         $this->assertSame(['role' => ['admin', 'super']], $filters->getArguments());
 
@@ -845,7 +845,7 @@ final class FiltersTest extends CIUnitTestCase
         $filters->enableFilter('role', 'after');
         $found = $filters->getFilters();
 
-        $this->assertTrue(in_array('role', $found['before'], true));
+        $this->assertContains('role', $found['before']);
 
         $response = $filters->run('admin/foo/bar', 'before');
 

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -544,8 +544,8 @@ final class IncomingRequestTest extends CIUnitTestCase
         // Use `false` here to simulate file_get_contents returning a false value
         $request = new IncomingRequest(new App(), new URI(), false, new UserAgent());
 
-        $this->assertTrue($request->getBody() !== false);
-        $this->assertTrue($request->getBody() === null);
+        $this->assertNotFalse($request->getBody());
+        $this->assertNull($request->getBody());
     }
 
     /**

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -63,7 +63,7 @@ final class ResponseTest extends CIUnitTestCase
         $config->CSPEnabled = true;
         $response           = new Response($config);
 
-        $this->assertTrue($response instanceof Response);
+        $this->assertInstanceOf(Response::class, $response);
     }
 
     public function testSetStatusCodeSetsReason()
@@ -327,7 +327,7 @@ final class ResponseTest extends CIUnitTestCase
         $response->setJSON($body);
 
         $this->assertSame($expected, $response->getJSON());
-        $this->assertTrue(strpos($response->getHeaderLine('content-type'), 'application/json') !== false);
+        $this->assertNotFalse(strpos($response->getHeaderLine('content-type'), 'application/json'));
     }
 
     public function testJSONGetFromNormalBody()
@@ -364,7 +364,7 @@ final class ResponseTest extends CIUnitTestCase
         $response->setXML($body);
 
         $this->assertSame($expected, $response->getXML());
-        $this->assertTrue(strpos($response->getHeaderLine('content-type'), 'application/xml') !== false);
+        $this->assertNotFalse(strpos($response->getHeaderLine('content-type'), 'application/xml'));
     }
 
     public function testXMLGetFromNormalBody()

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1023,7 +1023,7 @@ final class TimeTest extends CIUnitTestCase
     {
         $datetime = new DateTime();
         $time     = Time::createFromInstance($datetime);
-        $this->assertTrue($time instanceof Time);
+        $this->assertInstanceOf(Time::class, $time);
         $this->assertTrue($time->sameAs($datetime));
     }
 

--- a/tests/system/Images/BaseHandlerTest.php
+++ b/tests/system/Images/BaseHandlerTest.php
@@ -58,7 +58,7 @@ final class BaseHandlerTest extends CIUnitTestCase
     public function testNew()
     {
         $handler = Services::image('gd', null, false);
-        $this->assertTrue($handler instanceof BaseHandler);
+        $this->assertInstanceOf(BaseHandler::class, $handler);
     }
 
     public function testWithFile()
@@ -68,7 +68,7 @@ final class BaseHandlerTest extends CIUnitTestCase
         $handler->withFile($path);
 
         $image = $handler->getFile();
-        $this->assertTrue($image instanceof Image);
+        $this->assertInstanceOf(Image::class, $image);
         $this->assertSame(155, $image->origWidth);
         $this->assertSame($path, $image->getPathname());
     }
@@ -104,15 +104,15 @@ final class BaseHandlerTest extends CIUnitTestCase
         $handler = Services::image('gd', null, false);
         $handler->withFile($this->start . 'ci-logo.png');
         $image = $handler->getFile();
-        $this->assertTrue($image instanceof Image);
+        $this->assertInstanceOf(Image::class, $image);
 
         $handler->withFile($this->start . 'ci-logo.jpeg');
         $image = $handler->getFile();
-        $this->assertTrue($image instanceof Image);
+        $this->assertInstanceOf(Image::class, $image);
 
         $handler->withFile($this->start . 'ci-logo.gif');
         $image = $handler->getFile();
-        $this->assertTrue($image instanceof Image);
+        $this->assertInstanceOf(Image::class, $image);
     }
 
     // Something handled by our Image

--- a/tests/system/Images/ImageMagickHandlerTest.php
+++ b/tests/system/Images/ImageMagickHandlerTest.php
@@ -58,8 +58,8 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
         // make sure that the call worked
         $this->assertNotFalse($version);
         // we should have a numeric version, greater than 6
-        $this->assertTrue(version_compare($version, '6.0.0') >= 0);
-        $this->assertTrue(version_compare($version, '99.0.0') < 0);
+        $this->assertGreaterThanOrEqual(0, version_compare($version, '6.0.0'));
+        $this->assertLessThan(0, version_compare($version, '99.0.0'));
     }
 
     public function testImageProperties()

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -165,7 +165,7 @@ final class LanguageTest extends CIUnitTestCase
         $this->lang = new SecondMockLanguage('en');
 
         $this->lang->loadem('More', 'en');
-        $this->assertTrue(in_array('More', $this->lang->loaded(), true));
+        $this->assertContains('More', $this->lang->loaded());
 
         $this->lang->loadem('More', 'en');
         $this->assertCount(1, $this->lang->loaded()); // should only be there once
@@ -176,11 +176,11 @@ final class LanguageTest extends CIUnitTestCase
         $this->lang = new SecondMockLanguage('en');
 
         $result = $this->lang->loadem('More', 'en', true);
-        $this->assertFalse(in_array('More', $this->lang->loaded(), true));
+        $this->assertNotContains('More', $this->lang->loaded());
         $this->assertCount(3, $result);
 
         $result = $this->lang->loadem('More', 'en');
-        $this->assertTrue(in_array('More', $this->lang->loaded(), true));
+        $this->assertContains('More', $this->lang->loaded());
         $this->assertCount(1, $this->lang->loaded());
     }
 

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -203,7 +203,7 @@ final class LoggerTest extends CIUnitTestCase
 
         $logs = TestHandler::getLogs();
 
-        $this->assertTrue(strpos($logs[0], $expected) > 1);
+        $this->assertGreaterThan(1, strpos($logs[0], $expected));
     }
 
     public function testLogInterpolatesExceptions()
@@ -222,7 +222,7 @@ final class LoggerTest extends CIUnitTestCase
         $logs = TestHandler::getLogs();
 
         $this->assertCount(1, $logs);
-        $this->assertTrue(strpos($logs[0], $expected) === 0);
+        $this->assertSame(0, strpos($logs[0], $expected));
     }
 
     public function testEmergencyLogsCorrectly()

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -74,7 +74,7 @@ final class InsertModelTest extends LiveModelTestCase
         $this->assertFalse($this->model->insertBatch($jobData));
 
         $error = $this->model->errors();
-        $this->assertTrue(isset($error['description']));
+        $this->assertArrayHasKey('description', $error);
     }
 
     public function testInsertBatchSetsIntTimestamps(): void

--- a/tests/system/Models/MiscellaneousModelTest.php
+++ b/tests/system/Models/MiscellaneousModelTest.php
@@ -93,7 +93,7 @@ final class MiscellaneousModelTest extends LiveModelTestCase
         $this->assertFalse($this->model->replace($jobData));
 
         $error = $this->model->errors();
-        $this->assertTrue(isset($error['description']));
+        $this->assertArrayHasKey('description', $error);
     }
 
     public function testUndefinedTypeInTransformDataToArray(): void

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -153,7 +153,7 @@ final class UpdateModelTest extends LiveModelTestCase
         $this->assertFalse($this->model->updateBatch($data, 'name'));
 
         $error = $this->model->errors();
-        $this->assertTrue(isset($error['country']));
+        $this->assertArrayHasKey('country', $error);
     }
 
     public function testUpdateBatchWithEntity(): void

--- a/tests/system/Models/ValidationModelTest.php
+++ b/tests/system/Models/ValidationModelTest.php
@@ -284,7 +284,7 @@ final class ValidationModelTest extends LiveModelTestCase
             'description' => 'just because we have to',
         ];
 
-        $this->assertTrue($this->model->insert($data) !== false);
+        $this->assertNotFalse($this->model->insert($data));
     }
 
     /**

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -366,7 +366,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $request = $this->withBodyFormat('json')->setRequestBody($request, ['foo1' => 'bar1']);
 
         $this->assertJsonStringEqualsJsonString(json_encode(['foo1' => 'bar1']), $request->getBody());
-        $this->assertTrue($request->header('Content-Type')->getValue() === 'application/json');
+        $this->assertSame('application/json', $request->header('Content-Type')->getValue());
     }
 
     public function testSetupRequestBodyWithXml()
@@ -380,7 +380,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
 ';
 
         $this->assertSame($expectedXml, $request->getBody());
-        $this->assertTrue($request->header('Content-Type')->getValue() === 'application/xml');
+        $this->assertSame('application/xml', $request->header('Content-Type')->getValue());
     }
 
     public function testSetupRequestBodyWithBody()

--- a/tests/system/Test/TestResponseTest.php
+++ b/tests/system/Test/TestResponseTest.php
@@ -152,7 +152,7 @@ final class TestResponseTest extends CIUnitTestCase
     {
         $this->getTestResponse('<h1>Hello World</h1>');
 
-        $this->assertFalse($this->testResponse->response() instanceof RedirectResponse);
+        $this->assertNotInstanceOf(RedirectResponse::class, $this->testResponse->response());
         $this->assertFalse($this->testResponse->isRedirect());
         $this->testResponse->assertNotRedirect();
     }
@@ -162,7 +162,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->getTestResponse('<h1>Hello World</h1>');
         $this->testResponse->setResponse(new RedirectResponse(new App()));
 
-        $this->assertTrue($this->testResponse->response() instanceof RedirectResponse);
+        $this->assertInstanceOf(RedirectResponse::class, $this->testResponse->response());
         $this->assertTrue($this->testResponse->isRedirect());
         $this->testResponse->assertRedirect();
     }
@@ -172,7 +172,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->getTestResponse('<h1>Hello World</h1>');
         $this->response->redirect('foo/bar');
 
-        $this->assertFalse($this->testResponse->response() instanceof RedirectResponse);
+        $this->assertNotInstanceOf(RedirectResponse::class, $this->testResponse->response());
         $this->assertTrue($this->testResponse->isRedirect());
         $this->testResponse->assertRedirect();
         $this->assertSame('foo/bar', $this->testResponse->getRedirectUrl());
@@ -345,7 +345,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->response->setBody($tmp);
 
         // this should be FALSE - invalid JSON - will see if this is working that way ;-)
-        $this->assertFalse($this->response->getBody() === $this->testResponse->getJSON());
+        $this->assertNotSame($this->testResponse->getJSON(), $this->response->getBody());
     }
 
     public function testGetXML()

--- a/tests/system/View/ViewTest.php
+++ b/tests/system/View/ViewTest.php
@@ -316,8 +316,8 @@ final class ViewTest extends CIUnitTestCase
 
         $content = $view->render('extend_include');
 
-        $this->assertTrue(strpos($content, '<p>Open</p>') !== false);
-        $this->assertTrue(strpos($content, '<h1>Hello World</h1>') !== false);
+        $this->assertNotFalse(strpos($content, '<p>Open</p>'));
+        $this->assertNotFalse(strpos($content, '<h1>Hello World</h1>'));
         $this->assertSame(2, substr_count($content, 'Hello World'));
     }
 


### PR DESCRIPTION
**Description**
- to fix assertion method like [AssertCompareToSpecificMethodRector](https://github.com/rectorphp/rector-phpunit/blob/main/docs/rector_rules_overview.md#assertcomparetospecificmethodrector)

See https://github.com/rectorphp/rector-phpunit#rector-rules-for-phpunit

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
