### PR TITLE
docs: fix debugging.rst

### DIFF
--- a/user_guide_src/source/testing/debugging.rst
+++ b/user_guide_src/source/testing/debugging.rst
@@ -19,10 +19,9 @@ and much, much more.
 Enabling Kint
 =============
 
-By default, Kint is enabled in **development** and **testing** :doc:`environments </general/environments>` only. This can be altered by modifying
-the ``$useKint`` value in the environment configuration section of the main **index.php** file::
-
-    $useKint = true;
+By default, Kint is enabled in **development** and **testing** :doc:`environments </general/environments>` only.
+It will be enabled whenever the constant ``CI_DEBUG`` is defined and its value is truthy.
+This is defined in the boot files (e.g. **app/Config/Boot/development.php**).
 
 Using Kint
 ==========

--- a/user_guide_src/source/testing/debugging.rst
+++ b/user_guide_src/source/testing/debugging.rst
@@ -59,7 +59,7 @@ Enabling the Toolbar
 ====================
 
 The toolbar is enabled by default in any :doc:`environment </general/environments>` *except* **production**. It will be shown whenever the
-constant CI_DEBUG is defined and its value is truthy. This is defined in the boot files (e.g.
+constant ``CI_DEBUG`` is defined and its value is truthy. This is defined in the boot files (e.g.
 **app/Config/Boot/development.php**) and can be modified there to determine what environment to show.
 
 .. note:: The Debug Toolbar is not displayed when your ``baseURL`` setting (in **app/Config/App.php** or ``app.baseURL`` in **.env**) does not match your actual URL.


### PR DESCRIPTION
**Description**
- tthe way to enable Kint seems out-of-dated

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
