### PR TITLE
[Rector] add PHPUnitSetList::PHPUNIT_80

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -42,7 +42,6 @@ use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
-use Rector\PHPUnit\Rector\MethodCall\AssertFalseStrposToContainsRector;
 use Rector\PHPUnit\Rector\MethodCall\AssertIssetToSpecificMethodRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
@@ -57,6 +56,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(SetList::DEAD_CODE);
     $containerConfigurator->import(LevelSetList::UP_TO_PHP_73);
     $containerConfigurator->import(PHPUnitSetList::PHPUNIT_SPECIFIC_METHOD);
+    $containerConfigurator->import(PHPUnitSetList::PHPUNIT_80);
 
     $parameters = $containerConfigurator->parameters();
 
@@ -122,9 +122,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             __DIR__ . '/tests/system/Entity/EntityTest.php',
             __DIR__ . '/tests/system/Session/SessionTest.php',
         ],
-
-        // assertContains() to string can't be used in PHPUnit 9.1
-        AssertFalseStrposToContainsRector::class,
     ]);
 
     // auto import fully qualified class names

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -327,7 +327,7 @@ final class ResponseTest extends CIUnitTestCase
         $response->setJSON($body);
 
         $this->assertSame($expected, $response->getJSON());
-        $this->assertNotFalse(strpos($response->getHeaderLine('content-type'), 'application/json'));
+        $this->assertStringContainsString('application/json', $response->getHeaderLine('content-type'));
     }
 
     public function testJSONGetFromNormalBody()
@@ -364,7 +364,7 @@ final class ResponseTest extends CIUnitTestCase
         $response->setXML($body);
 
         $this->assertSame($expected, $response->getXML());
-        $this->assertNotFalse(strpos($response->getHeaderLine('content-type'), 'application/xml'));
+        $this->assertStringContainsString('application/xml', $response->getHeaderLine('content-type'));
     }
 
     public function testXMLGetFromNormalBody()

--- a/tests/system/View/ViewTest.php
+++ b/tests/system/View/ViewTest.php
@@ -316,8 +316,8 @@ final class ViewTest extends CIUnitTestCase
 
         $content = $view->render('extend_include');
 
-        $this->assertNotFalse(strpos($content, '<p>Open</p>'));
-        $this->assertNotFalse(strpos($content, '<h1>Hello World</h1>'));
+        $this->assertStringContainsString('<p>Open</p>', $content);
+        $this->assertStringContainsString('<h1>Hello World</h1>', $content);
         $this->assertSame(2, substr_count($content, 'Hello World'));
     }
 


### PR DESCRIPTION
**Description**
Follow-up: #5320
- use `assertStringContainsString` instead of `strpos()`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
