### PR TITLE
test: refactor Entity and Session test

### DIFF
--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -703,13 +703,12 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toArray();
 
-        // @TODO arguments are reversed
-        $this->assertSame($result, [
+        $this->assertSame([
             'foo'       => null,
             'bar'       => ':bar',
             'default'   => 'sumfin',
             'createdAt' => null,
-        ]);
+        ], $result, );
     }
 
     public function testAsArrayRecursive()
@@ -739,11 +738,10 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toArray();
 
-        // @TODO arguments are reversed
-        $this->assertSame($result, [
+        $this->assertSame([
             'bar'  => null,
             'orig' => ':oo',
-        ]);
+        ], $result);
     }
 
     public function testAsArraySwapped()
@@ -752,12 +750,11 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toArray();
 
-        // @TODO arguments are reversed
-        $this->assertSame($result, [
+        $this->assertSame([
             'bar'          => 'foo',
             'foo'          => 'bar',
             'original_bar' => 'bar',
-        ]);
+        ], $result);
     }
 
     public function testToArraySkipAttributesWithUnderscoreInFirstCharacter()
@@ -771,10 +768,9 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toArray();
 
-        // @TODO arguments are reversed
-        $this->assertSame($result, [
+        $this->assertSame([
             'bar' => null,
-        ]);
+        ], $result);
     }
 
     public function testAsArrayOnlyChanged()
@@ -784,10 +780,9 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toArray(true);
 
-        // @TODO arguments are reversed
-        $this->assertSame($result, [
+        $this->assertSame([
             'bar' => 'bar:foo:bar',
-        ]);
+        ], $result);
     }
 
     public function testToRawArray()
@@ -796,13 +791,12 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toRawArray();
 
-        // @TODO arguments are reversed
-        $this->assertSame($result, [
+        $this->assertSame([
             'foo'        => null,
             'bar'        => null,
             'default'    => 'sumfin',
             'created_at' => null,
-        ]);
+        ], $result);
     }
 
     public function testToRawArrayRecursive()
@@ -812,8 +806,7 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toRawArray(false, true);
 
-        // @TODO arguments are reversed
-        $this->assertSame($result, [
+        $this->assertSame([
             'foo'        => null,
             'bar'        => null,
             'default'    => 'sumfin',
@@ -824,7 +817,7 @@ final class EntityTest extends CIUnitTestCase
                 'default'    => 'sumfin',
                 'created_at' => null,
             ],
-        ]);
+        ], $result);
     }
 
     public function testToRawArrayOnlyChanged()
@@ -834,10 +827,9 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toRawArray(true);
 
-        // @TODO arguments are reversed
-        $this->assertSame($result, [
+        $this->assertSame([
             'bar' => 'bar:foo',
-        ]);
+        ], $result);
     }
 
     public function testFilledConstruction()

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -75,13 +75,11 @@ final class EntityTest extends CIUnitTestCase
 
         $attributes = $this->getPrivateProperty($entity, 'attributes');
 
-        $issetReturn = isset($attributes['foo']);
+        $issetFooReturn     = isset($attributes['foo']);
+        $issetDefaultReturn = isset($attributes['default']);
 
-        $this->assertFalse($issetReturn);
-
-        $issetReturn = isset($attributes['default']);
-
-        $this->assertTrue($issetReturn);
+        $this->assertFalse($issetFooReturn);
+        $this->assertTrue($issetDefaultReturn);
     }
 
     public function testFill()
@@ -124,11 +122,9 @@ final class EntityTest extends CIUnitTestCase
 
         // Check mapped field
         $this->assertSame('made it', $entity->foo);
-
         // Should also get from original name
         // since Model's would be looking for the original name
         $this->assertSame('made it', $entity->bar);
-
         // But it shouldn't actually set a class property for the original name...
         $this->expectException(ReflectionException::class);
         $this->getPrivateProperty($entity, 'bar');
@@ -156,7 +152,6 @@ final class EntityTest extends CIUnitTestCase
         $entity->bar = 'here';
 
         $attributes = $this->getPrivateProperty($entity, 'attributes');
-
         $this->assertArrayHasKey('foo', $attributes);
         $this->assertArrayNotHasKey('bar', $attributes);
     }
@@ -164,17 +159,18 @@ final class EntityTest extends CIUnitTestCase
     public function testUnsetWorksWithMapping()
     {
         $entity = $this->getMappedEntity();
-
         // maps to 'foo'
         $entity->bar = 'here';
 
         // doesn't work on original name
         unset($entity->bar);
+
         $this->assertSame('here', $entity->bar);
         $this->assertSame('here', $entity->foo);
 
         // does work on mapped field
         unset($entity->foo);
+
         $this->assertNull($entity->foo);
         $this->assertNull($entity->bar);
     }
@@ -193,8 +189,7 @@ final class EntityTest extends CIUnitTestCase
 
     public function testDateMutationFromTimestamp()
     {
-        $stamp = time();
-
+        $stamp      = time();
         $entity     = $this->getEntity();
         $attributes = ['created_at' => $stamp];
         $this->setPrivateProperty($entity, 'attributes', $attributes);
@@ -238,7 +233,6 @@ final class EntityTest extends CIUnitTestCase
         $entity->created_at = '2017-07-15 13:23:34';
 
         $time = $this->getPrivateProperty($entity, 'attributes')['created_at'];
-
         $this->assertInstanceOf(Time::class, $time);
         $this->assertSame('2017-07-15 13:23:34', $time->format('Y-m-d H:i:s'));
     }
@@ -251,7 +245,6 @@ final class EntityTest extends CIUnitTestCase
         $entity->created_at = $stamp;
 
         $time = $this->getPrivateProperty($entity, 'attributes')['created_at'];
-
         $this->assertInstanceOf(Time::class, $time);
         $this->assertCloseEnoughString(date('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
     }
@@ -264,7 +257,6 @@ final class EntityTest extends CIUnitTestCase
         $entity->created_at = $dt;
 
         $time = $this->getPrivateProperty($entity, 'attributes')['created_at'];
-
         $this->assertInstanceOf(Time::class, $time);
         $this->assertCloseEnoughString($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
     }
@@ -277,7 +269,6 @@ final class EntityTest extends CIUnitTestCase
         $entity->created_at = $dt;
 
         $time = $this->getPrivateProperty($entity, 'attributes')['created_at'];
-
         $this->assertInstanceOf(Time::class, $time);
         $this->assertCloseEnoughString($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
     }
@@ -287,10 +278,12 @@ final class EntityTest extends CIUnitTestCase
         $entity = $this->getCastEntity();
 
         $entity->first = 3.1;
+
         $this->assertIsInt($entity->first);
         $this->assertSame(3, $entity->first);
 
         $entity->first = 3.6;
+
         $this->assertSame(3, $entity->first);
     }
 
@@ -299,10 +292,12 @@ final class EntityTest extends CIUnitTestCase
         $entity = $this->getCastEntity();
 
         $entity->second = 3;
+
         $this->assertIsFloat($entity->second);
         $this->assertSame(3.0, $entity->second);
 
         $entity->second = '3.6';
+
         $this->assertIsFloat($entity->second);
         $this->assertSame(3.6, $entity->second);
     }
@@ -312,10 +307,12 @@ final class EntityTest extends CIUnitTestCase
         $entity = $this->getCastEntity();
 
         $entity->third = 3;
+
         $this->assertIsFloat($entity->third);
         $this->assertSame(3.0, $entity->third);
 
         $entity->third = '3.6';
+
         $this->assertIsFloat($entity->third);
         $this->assertSame(3.6, $entity->third);
     }
@@ -325,6 +322,7 @@ final class EntityTest extends CIUnitTestCase
         $entity = $this->getCastEntity();
 
         $entity->fourth = 3.1415;
+
         $this->assertIsString($entity->fourth);
         $this->assertSame('3.1415', $entity->fourth);
     }
@@ -334,23 +332,24 @@ final class EntityTest extends CIUnitTestCase
         $entity = $this->getCastEntity();
 
         $entity->fifth = 1;
+
         $this->assertIsBool($entity->fifth);
         $this->assertTrue($entity->fifth);
 
         $entity->fifth = 0;
+
         $this->assertIsBool($entity->fifth);
         $this->assertFalse($entity->fifth);
     }
 
     public function testCastCSV()
     {
-        $entity = $this->getCastEntity();
-
-        $data = ['foo', 'bar', 'bam'];
-
+        $entity          = $this->getCastEntity();
+        $data            = ['foo', 'bar', 'bam'];
         $entity->twelfth = $data;
 
         $result = $entity->toRawArray();
+
         $this->assertIsString($result['twelfth']);
         $this->assertSame('foo,bar,bam', $result['twelfth']);
 
@@ -362,9 +361,9 @@ final class EntityTest extends CIUnitTestCase
     {
         $entity = $this->getCastEntity();
 
-        $data = ['foo' => 'bar'];
-
+        $data          = ['foo' => 'bar'];
         $entity->sixth = $data;
+
         $this->assertIsObject($entity->sixth);
         $this->assertInstanceOf(stdClass::class, $entity->sixth);
         $this->assertSame($data, (array) $entity->sixth);
@@ -375,6 +374,7 @@ final class EntityTest extends CIUnitTestCase
         $entity = $this->getCastEntity();
 
         $entity->eighth = 'March 12, 2017';
+
         $this->assertInstanceOf('DateTime', $entity->eighth);
         $this->assertSame('2017-03-12', $entity->eighth->format('Y-m-d'));
     }
@@ -383,21 +383,20 @@ final class EntityTest extends CIUnitTestCase
     {
         $entity = $this->getCastEntity();
 
-        $date = 'March 12, 2017';
-
+        $date          = 'March 12, 2017';
         $entity->ninth = $date;
+
         $this->assertIsInt($entity->ninth);
         $this->assertSame(strtotime($date), $entity->ninth);
     }
 
     public function testCastTimestampException()
     {
-        $entity = $this->getCastEntity();
-
-        $entity->ninth = 'some string';
-
         $this->expectException(CastException::class);
         $this->expectErrorMessage('Type casting "timestamp" expects a correct timestamp.');
+
+        $entity        = $this->getCastEntity();
+        $entity->ninth = 'some string';
 
         $entity->ninth;
     }
@@ -410,7 +409,6 @@ final class EntityTest extends CIUnitTestCase
 
         $check = $this->getPrivateProperty($entity, 'attributes')['seventh'];
         $this->assertSame(serialize(['foo' => 'bar']), $check);
-
         $this->assertSame(['foo' => 'bar'], $entity->seventh);
     }
 
@@ -445,27 +443,23 @@ final class EntityTest extends CIUnitTestCase
         $entity = $this->getCastEntity();
 
         $data = ['seventh' => [1, 2, 3]];
-
         $entity->fill($data);
 
         // Check if serialiazed
         $check = $this->getPrivateProperty($entity, 'attributes')['seventh'];
         $this->assertSame(serialize([1, 2, 3]), $check);
-
         // Check if unserialized
         $this->assertSame([1, 2, 3], $entity->seventh);
     }
 
     public function testCastArrayByConstructor()
     {
-        $data = ['seventh' => [1, 2, 3]];
-
+        $data   = ['seventh' => [1, 2, 3]];
         $entity = $this->getCastEntity($data);
 
         // Check if serialiazed
         $check = $this->getPrivateProperty($entity, 'attributes')['seventh'];
         $this->assertSame(serialize([1, 2, 3]), $check);
-
         // Check if unserialized
         $this->assertSame([1, 2, 3], $entity->seventh);
     }
@@ -485,9 +479,9 @@ final class EntityTest extends CIUnitTestCase
     {
         $entity = $this->getCastEntity();
 
-        $data = 'https://codeigniter.com/banana';
-
+        $data               = 'https://codeigniter.com/banana';
         $entity->thirteenth = $data;
+
         $this->assertInstanceOf(URI::class, $entity->thirteenth);
         $this->assertSame($data, (string) $entity->thirteenth);
         $this->assertSame('/banana', $entity->thirteenth->getPath());
@@ -497,9 +491,9 @@ final class EntityTest extends CIUnitTestCase
     {
         $entity = $this->getCastEntity();
 
-        $data = 'https://codeigniter.com/banana';
-
+        $data               = 'https://codeigniter.com/banana';
         $entity->thirteenth = new URI($data);
+
         $this->assertInstanceOf(URI::class, $entity->thirteenth);
         $this->assertSame($data, (string) $entity->thirteenth);
         $this->assertSame('/banana', $entity->thirteenth->getPath());
@@ -523,8 +517,7 @@ final class EntityTest extends CIUnitTestCase
     {
         $entity = $this->getCastEntity();
 
-        $data = ['Sun', 'Mon', 'Tue'];
-
+        $data             = ['Sun', 'Mon', 'Tue'];
         $entity->eleventh = $data;
 
         // Should be a JSON-encoded string now...
@@ -537,14 +530,13 @@ final class EntityTest extends CIUnitTestCase
     public function testCastAsJsonByFill()
     {
         $entity = $this->getCastEntity();
-        $data   = ['eleventh' => [1, 2, 3]];
 
+        $data = ['eleventh' => [1, 2, 3]];
         $entity->fill($data);
 
         // Check if serialiazed
         $check = $this->getPrivateProperty($entity, 'attributes')['eleventh'];
         $this->assertSame(json_encode([1, 2, 3]), $check);
-
         // Check if unserialized
         $this->assertSame([1, 2, 3], $entity->eleventh);
     }
@@ -557,13 +549,15 @@ final class EntityTest extends CIUnitTestCase
         // Check if serialiazed
         $check = $this->getPrivateProperty($entity, 'attributes')['eleventh'];
         $this->assertSame(json_encode([1, 2, 3]), $check);
-
         // Check if unserialized
         $this->assertSame([1, 2, 3], $entity->eleventh);
     }
 
     public function testCastAsJSONErrorDepth()
     {
+        $this->expectException(CastException::class);
+        $this->expectExceptionMessage('Maximum stack depth exceeded');
+
         $entity = $this->getCastEntity();
 
         // Create array with depth 513 to get depth error
@@ -576,24 +570,18 @@ final class EntityTest extends CIUnitTestCase
         foreach ($keys as $key) {
             $current = &$current[$key];
         }
-
-        $current = $value;
-        $this->expectException(CastException::class);
-        $this->expectExceptionMessage('Maximum stack depth exceeded');
-
+        $current       = $value;
         $entity->tenth = $array;
-        $this->getPrivateProperty($entity, 'tenth');
     }
 
     public function testCastAsJSONErrorUTF8()
     {
-        $entity = $this->getCastEntity();
-
         $this->expectException(CastException::class);
         $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded');
 
+        $entity = $this->getCastEntity();
+
         $entity->tenth = "\xB1\x31";
-        $this->getPrivateProperty($entity, 'tenth');
     }
 
     public function testCastAsJSONSyntaxError()
@@ -615,7 +603,6 @@ final class EntityTest extends CIUnitTestCase
         $this->expectExceptionMessage('Maximum stack depth exceeded');
 
         $string = '{' . str_repeat('"test":{', 513) . '"test":"value"' . str_repeat('}', 513) . '}';
-
         (Closure::bind(static function (string $value) {
             $entity = new Entity();
             $entity->casts['dummy'] = 'json[array]';
@@ -630,7 +617,6 @@ final class EntityTest extends CIUnitTestCase
         $this->expectExceptionMessage('Unexpected control character found');
 
         $string = "{\n\t\"property1\": \"The quick brown fox\njumps over the lazy dog\",\n\t\"property2\":\"value2\"\n}";
-
         (Closure::bind(static function (string $value) {
             $entity = new Entity();
             $entity->casts['dummy'] = 'json[array]';
@@ -645,7 +631,6 @@ final class EntityTest extends CIUnitTestCase
         $this->expectExceptionMessage('Underflow or the modes mismatch');
 
         $string = '[{"name":"jack","product_id":"1234"]';
-
         (Closure::bind(static function (string $value) {
             $entity = new Entity();
             $entity->casts['dummy'] = 'json[array]';
@@ -656,16 +641,17 @@ final class EntityTest extends CIUnitTestCase
 
     public function testCastSetter()
     {
-        $string = '321 String with numbers 123';
-        $entity = $this->getCastEntity();
-
+        $string        = '321 String with numbers 123';
+        $entity        = $this->getCastEntity();
         $entity->first = $string;
 
         $entity->cast(false);
+
         $this->assertIsString($entity->first);
         $this->assertSame($string, $entity->first);
 
         $entity->cast(true);
+
         $this->assertIsInt($entity->first);
         $this->assertSame((int) $string, $entity->first);
     }
@@ -684,18 +670,17 @@ final class EntityTest extends CIUnitTestCase
         $entity->first = 'base 64';
 
         $fieldValue = $this->getPrivateProperty($entity, 'attributes')['first'];
-
         $this->assertSame(base64_encode('base 64'), $fieldValue);
-
         $this->assertSame('base 64', $entity->first);
     }
 
     public function testCustomCastException()
     {
-        $entity = $this->getCustomCastEntity();
-
         $this->expectException(CastException::class);
         $this->expectErrorMessage('The "Tests\Support\Entity\Cast\NotExtendsBaseCast" class must inherit the "CodeIgniter\Entity\Cast\BaseCast" class');
+
+        $entity = $this->getCustomCastEntity();
+
         $entity->second = 'throw Exception';
     }
 
@@ -708,14 +693,17 @@ final class EntityTest extends CIUnitTestCase
         $this->assertSame('value:["param1","param2","param3"]', $entity->third);
 
         $entity->fourth = 'test_nullable_type';
+
         $this->assertSame('test_nullable_type:["nullable"]', $entity->fourth);
     }
 
     public function testAsArray()
     {
         $entity = $this->getEntity();
+
         $result = $entity->toArray();
 
+        // @TODO arguments are reversed
         $this->assertSame($result, [
             'foo'       => null,
             'bar'       => ':bar',
@@ -748,8 +736,10 @@ final class EntityTest extends CIUnitTestCase
     public function testAsArrayMapped()
     {
         $entity = $this->getMappedEntity();
+
         $result = $entity->toArray();
 
+        // @TODO arguments are reversed
         $this->assertSame($result, [
             'bar'  => null,
             'orig' => ':oo',
@@ -759,8 +749,10 @@ final class EntityTest extends CIUnitTestCase
     public function testAsArraySwapped()
     {
         $entity = $this->getSwappedEntity();
+
         $result = $entity->toArray();
 
+        // @TODO arguments are reversed
         $this->assertSame($result, [
             'bar'          => 'foo',
             'foo'          => 'bar',
@@ -779,6 +771,7 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toArray();
 
+        // @TODO arguments are reversed
         $this->assertSame($result, [
             'bar' => null,
         ]);
@@ -786,12 +779,12 @@ final class EntityTest extends CIUnitTestCase
 
     public function testAsArrayOnlyChanged()
     {
-        $entity = $this->getEntity();
-
+        $entity      = $this->getEntity();
         $entity->bar = 'foo';
 
         $result = $entity->toArray(true);
 
+        // @TODO arguments are reversed
         $this->assertSame($result, [
             'bar' => 'bar:foo:bar',
         ]);
@@ -803,6 +796,7 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toRawArray();
 
+        // @TODO arguments are reversed
         $this->assertSame($result, [
             'foo'        => null,
             'bar'        => null,
@@ -818,6 +812,7 @@ final class EntityTest extends CIUnitTestCase
 
         $result = $entity->toRawArray(false, true);
 
+        // @TODO arguments are reversed
         $this->assertSame($result, [
             'foo'        => null,
             'bar'        => null,
@@ -834,12 +829,12 @@ final class EntityTest extends CIUnitTestCase
 
     public function testToRawArrayOnlyChanged()
     {
-        $entity = $this->getEntity();
-
+        $entity      = $this->getEntity();
         $entity->bar = 'foo';
 
         $result = $entity->toRawArray(true);
 
+        // @TODO arguments are reversed
         $this->assertSame($result, [
             'bar' => 'bar:foo',
         ]);
@@ -851,17 +846,17 @@ final class EntityTest extends CIUnitTestCase
             'foo' => 'bar',
             'bar' => 'baz',
         ];
-
         $something = new SomeEntity($data);
+
         $this->assertSame('bar', $something->foo);
         $this->assertSame('baz', $something->bar);
     }
 
     public function testChangedArray()
     {
-        $data = ['bar' => 'baz'];
-
+        $data      = ['bar' => 'baz'];
         $something = new SomeEntity($data);
+
         $this->assertSame($data, $something->toArray(true));
 
         $something->magic = 'rockin';
@@ -908,6 +903,7 @@ final class EntityTest extends CIUnitTestCase
     public function testHasChangedKeyNotExists()
     {
         $entity = $this->getEntity();
+
         $this->assertFalse($entity->hasChanged('xxx'));
     }
 
@@ -930,6 +926,7 @@ final class EntityTest extends CIUnitTestCase
     {
         $entity = $this->getEntity();
         $entity->setBar('foo');
+
         $this->assertSame(json_encode($entity->toArray()), json_encode($entity));
     }
 

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -69,11 +69,19 @@ final class EntityTest extends CIUnitTestCase
     {
         $entity = $this->getEntity();
 
-        $this->assertFalse(isset($entity->foo));
+        $issetReturn = isset($entity->foo);
+
+        $this->assertFalse($issetReturn);
 
         $attributes = $this->getPrivateProperty($entity, 'attributes');
-        $this->assertFalse(isset($attributes['foo']));
-        $this->assertTrue(isset($attributes['default']));
+
+        $issetReturn = isset($attributes['foo']);
+
+        $this->assertFalse($issetReturn);
+
+        $issetReturn = isset($attributes['default']);
+
+        $this->assertTrue($issetReturn);
     }
 
     public function testFill()
@@ -905,13 +913,17 @@ final class EntityTest extends CIUnitTestCase
 
     public function testIssetKeyMap()
     {
-        $entity = $this->getEntity();
-
+        $entity             = $this->getEntity();
         $entity->created_at = '12345678';
-        $this->assertTrue(isset($entity->createdAt));
+        $entity->bar        = 'foo';
 
-        $entity->bar = 'foo';
-        $this->assertTrue(isset($entity->FakeBar));
+        $issetReturn = isset($entity->createdAt);
+
+        $this->assertTrue($issetReturn);
+
+        $issetReturn = isset($entity->FakeBar);
+
+        $this->assertTrue($issetReturn);
     }
 
     public function testJsonSerializableEntity()

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -245,20 +245,22 @@ final class SessionTest extends CIUnitTestCase
     {
         $session = $this->getInstance();
         $session->start();
-
         $_SESSION['foo'] = 'bar';
 
-        $this->assertTrue(isset($session->foo));
+        $issetReturn = isset($session->foo);
+
+        $this->assertTrue($issetReturn);
     }
 
     public function testIssetReturnsFalseOnNotFound()
     {
         $session = $this->getInstance();
         $session->start();
-
         $_SESSION['foo'] = 'bar';
 
-        $this->assertFalse(isset($session->bar));
+        $issetReturn = isset($session->bar);
+
+        $this->assertFalse($issetReturn);
     }
 
     public function testPushNewValueIntoArraySessionValue()
@@ -400,7 +402,8 @@ final class SessionTest extends CIUnitTestCase
         // Should still be here
         $this->assertTrue($session->has('foo'));
         // but no longer marked as flash
-        $this->assertFalse(isset($_SESSION['__ci_vars']['foo']));
+        $issetReturn = isset($_SESSION['__ci_vars']['foo']);
+        $this->assertFalse($issetReturn);
     }
 
     public function testGetFlashKeysOnlyReturnsFlashKeys()


### PR DESCRIPTION
**Description**
- refactor `isset()` tests
- fix `assert*()` argument order
- separete Arrange, Act, and Assert
- to remove skip of `AssertIssetToSpecificMethodRector::class` https://github.com/codeigniter4/CodeIgniter4/pull/5320#discussion_r748949988

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
