### PR TITLE
Exclude field of type identity from insert/update statement

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2493,12 +2493,18 @@ class BaseBuilder
         if (! is_object($object)) {
             return $object;
         }
-
+       
+        try {
+			$identities=$object->get_identities();
+		} catch (\Throwable $th) {
+			$identities=array();
+		}
+        
         $array = [];
 
         foreach (get_object_vars($object) as $key => $val) {
             // There are some built in keys we need to ignore for this conversion
-            if (! is_object($val) && ! is_array($val) && $key !== '_parent_name') {
+            if ( ! is_object($val) && ! is_array($val) && $key !== '_parent_name'  && !in_array($key,$identities))
                 $array[$key] = $val;
             }
         }


### PR DESCRIPTION
SqlServer doesn't support insert/update for identity fields. I've defined a public function "get_identities()" in my model class and this function return an array containing te name of the identity fields so i can exclude from MDL statement,  

Each pull request should address a single issue and have a meaningful title.

**Description**
When it's necessary you can define an array of not updatebale fields like identities: Microsoft SQL Server return error when you try to run statement like "update my_table set id=5, some_text='hello' where id=5" or "insert into my_table (id, some_text) values (null, 'hello')" id filed "id" is an identity.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
