### PR TITLE
Display file:line and trace information to database queries in debug toolbar

### DIFF
--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -144,7 +144,7 @@ class Database extends BaseCollector
                 $traceLine['file'] = str_ireplace(VENDORPATH, 'VENDORPATH/', $traceLine['file']);
                 $traceLine['file'] = str_ireplace(ROOTPATH, 'ROOTPATH/', $traceLine['file']);
 
-                if (strpos($traceLine['file'], 'APPPATH') === false) {
+                if (strpos($traceLine['file'], 'SYSTEMPATH') !== false) {
                     continue;
                 }
                 $line = empty($line) ? $traceLine : $line;

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -137,12 +137,17 @@ class Database extends BaseCollector
             // Find the first line that doesn't include `system` in the backtrace
             $line = [];
 
-            foreach ($query['trace'] as $traceLine) {
-                if (strpos($traceLine['file'], 'system/') !== false) {
+            foreach ($query['trace'] as &$traceLine) {
+                // Clean up the file paths
+                $traceLine['file'] = str_ireplace(APPPATH, 'APPPATH/', $traceLine['file']);
+                $traceLine['file'] = str_ireplace(SYSTEMPATH, 'SYSTEMPATH/', $traceLine['file']);
+                $traceLine['file'] = str_ireplace(VENDORPATH, 'VENDORPATH/', $traceLine['file']);
+                $traceLine['file'] = str_ireplace(ROOTPATH, 'ROOTPATH/', $traceLine['file']);
+
+                if (strpos($traceLine['file'], 'APPPATH') === false) {
                     continue;
                 }
-                $line = $traceLine;
-                break;
+                $line = empty($line) ? $traceLine : $line;
             }
 
             return [
@@ -153,7 +158,7 @@ class Database extends BaseCollector
                 'trace'      => $query['trace'],
                 'trace-file' => str_replace(ROOTPATH, '/', $line['file'] ?? ''),
                 'trace-line' => $line['line'] ?? '',
-                'qid'        => md5((string) $query['query'] . microtime()),
+                'qid'        => md5($query['query'] . microtime()),
             ];
         }, static::$queries);
 

--- a/system/Debug/Toolbar/Views/_database.tpl
+++ b/system/Debug/Toolbar/Views/_database.tpl
@@ -7,9 +7,18 @@
     </thead>
     <tbody>
     {queries}
-        <tr class="{class}" title="{hover}">
+        <tr class="{class}" title="{hover}" data-toggle="{qid}-trace">
             <td class="narrow">{duration}</td>
             <td>{! sql !}</td>
+            <td style="text-align: right">{trace-file}:<strong>{trace-line}</strong></td>
+        </tr>
+        <tr class="muted" id="{qid}-trace" style="display:none">
+            <td></td>
+            <td colspan="2">
+            {trace}
+                {file}:<strong>{line}</strong><br/>
+            {/trace}
+            </td>
         </tr>
     {/queries}
     </tbody>

--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -344,6 +344,8 @@
 
 .debug-view.show-view {
   border-color: #DD8615; }
+#debug-bar tr[data-toggle] {
+  cursor: pointer; }
 
 .debug-view-path {
   background-color: #FDC894;
@@ -407,7 +409,7 @@
     #debug-bar .muted {
       color: #DFDFDF; }
       #debug-bar .muted td {
-        color: #434343; }
+        color: #797979; }
       #debug-bar .muted:hover td {
         color: #DFDFDF; }
     #debug-bar #toolbar-position,

--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -498,7 +498,7 @@
   #toolbarContainer.dark #debug-bar .muted {
     color: #DFDFDF; }
     #toolbarContainer.dark #debug-bar .muted td {
-      color: #434343; }
+      color: #797979; }
     #toolbarContainer.dark #debug-bar .muted:hover td {
       color: #DFDFDF; }
   #toolbarContainer.dark #debug-bar #toolbar-position,
@@ -589,9 +589,9 @@
     -moz-box-shadow: 0 1px 4px #DFDFDF;
     -webkit-box-shadow: 0 1px 4px #DFDFDF; }
   #toolbarContainer.light #debug-bar .muted {
-    color: #434343; }
+    color: #797979; }
     #toolbarContainer.light #debug-bar .muted td {
-      color: #DFDFDF; }
+      color: #797979; }
     #toolbarContainer.light #debug-bar .muted:hover td {
       color: #434343; }
   #toolbarContainer.light #debug-bar #toolbar-position,

--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -58,6 +58,13 @@ var ciDebugBar = {
 		{
 			buttons[i].addEventListener('click', ciDebugBar.showTab, true);
 		}
+
+		// Hook up generic toggle via data attributes `data-toggle="foo"`
+		var links = document.querySelectorAll('[data-toggle]');
+		for (var i = 0; i < links.length; i++)
+		{
+			links[i].addEventListener('click', ciDebugBar.toggleRows, true);
+		}
 	},
 
 	showTab: function () {
@@ -125,6 +132,21 @@ var ciDebugBar = {
 	},
 
 	/**
+	 * Toggle display of another object based on
+	 * the data-toggle value of this object
+	 *
+	 * @param event
+	 */
+	toggleRows : function(event) {
+		if(event.target)
+		{
+			let row = event.target.closest('tr');
+			let target = document.getElementById(row.getAttribute('data-toggle'));
+			target.style.display = target.style.display === 'none' ? 'table-row' : 'none';
+		}
+	},
+
+	/**
 	 * Toggle display of a data table
 	 *
 	 * @param obj
@@ -137,7 +159,7 @@ var ciDebugBar = {
 
 		if (obj)
 		{
-			obj.style.display = obj.style.display == 'none' ? 'block' : 'none';
+			obj.style.display = obj.style.display === 'none' ? 'block' : 'none';
 		}
 	},
 
@@ -155,7 +177,7 @@ var ciDebugBar = {
 
 		if (par && obj)
 		{
-			obj.style.display = obj.style.display == 'none' ? '' : 'none';
+			obj.style.display = obj.style.display === 'none' ? '' : 'none';
 			par.classList.toggle('timeline-parent-open');
 		}
 	},

--- a/user_guide_src/source/changelogs/v4.1.6.rst
+++ b/user_guide_src/source/changelogs/v4.1.6.rst
@@ -14,6 +14,7 @@ BREAKING
 
 Enhancements
 ============
+- Database pane on debug toolbar now displays location where Query was called from. Also displays full backtrace.
 
 Changes
 =======


### PR DESCRIPTION
Added backtrace information and the file:line of each query into the Database pane of the debug toolbar. The backtrace is hidden by default but opens by clicking on the row. 

![Screen Shot 2021-11-15 at 12 51 16 AM](https://user-images.githubusercontent.com/51931/141925272-7d1e12c9-bfbe-4ceb-8dc6-73550f99319a.png)
 