### PR TITLE
docs: don't use `IncomingRequest::$uri`

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -64,6 +64,8 @@ class IncomingRequest extends Request
      * AFTER the script name. So, if hosted in a sub-folder this will
      * appear different than actual URL. If you need that use getPath().
      *
+     * @TODO should be protected. Use getUri() instead.
+     *
      * @var URI
      */
     public $uri;

--- a/user_guide_src/source/concepts/http.rst
+++ b/user_guide_src/source/concepts/http.rst
@@ -75,7 +75,7 @@ is an object-oriented representation of the HTTP request. It provides everything
     $request = service('request');
 
     // the URI being requested (i.e., /about)
-    $request->uri->getPath();
+    $request->getUri()->getPath();
 
     // Retrieve $_GET and $_POST variables
     $request->getGet('foo');

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -249,13 +249,13 @@ The Request URL
 ---------------
 
 You can retrieve a :doc:`URI </libraries/uri>` object that represents the current URI for this request through the
-``$request->uri`` property. You can cast this object as a string to get a full URL for the current request::
+``$request->getUri()`` method. You can cast this object as a string to get a full URL for the current request::
 
-    $uri = (string)$request->uri;
+    $uri = (string) $request->getUri();
 
 The object gives you full abilities to grab any part of the request on it's own::
 
-    $uri = $request->uri;
+    $uri = $request->getUri();
 
     echo $uri->getScheme();         // http
     echo $uri->getAuthority();      // snoopy:password@example.com:88


### PR DESCRIPTION
**Description**
- don't use `IncomingRequest::$uri` in the user guide. See #5344

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
