### PR TITLE
refactor: replace $request->uri with $request->getUri()

### DIFF
--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -195,7 +195,7 @@
 					<tbody>
 						<tr>
 							<td style="width: 10em">Path</td>
-							<td><?= esc($request->uri) ?></td>
+							<td><?= esc($request->getUri()) ?></td>
 						</tr>
 						<tr>
 							<td>HTTP Method</td>

--- a/system/Common.php
+++ b/system/Common.php
@@ -480,9 +480,9 @@ if (! function_exists('force_https')) {
         $uri = URI::createURIString(
             'https',
             $baseURL,
-            $request->uri->getPath(), // Absolute URIs should use a "/" for an empty path
-            $request->uri->getQuery(),
-            $request->uri->getFragment()
+            $request->getUri()->getPath(), // Absolute URIs should use a "/" for an empty path
+            $request->getUri()->getQuery(),
+            $request->getUri()->getFragment()
         );
 
         // Set an HSTS header

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -650,6 +650,6 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $request->setPath('apples');
 
-        $this->assertSame('apples', $request->uri->getPath());
+        $this->assertSame('apples', $request->getUri()->getPath());
     }
 }

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -876,14 +876,14 @@ final class URITest extends CIUnitTestCase
 
         // going through request
         $this->assertSame('http://example.com/ci/v4/controller/method', (string) $request->uri);
-        $this->assertSame('/ci/v4/controller/method', $request->uri->getPath());
+        $this->assertSame('/ci/v4/controller/method', $request->getUri()->getPath());
 
         // standalone
         $uri = new URI('http://example.com/ci/v4/controller/method');
         $this->assertSame('http://example.com/ci/v4/controller/method', (string) $uri);
         $this->assertSame('/ci/v4/controller/method', $uri->getPath());
 
-        $this->assertSame($uri->getPath(), $request->uri->getPath());
+        $this->assertSame($uri->getPath(), $request->getUri()->getPath());
     }
 
     public function testBasedWithIndex()
@@ -902,15 +902,15 @@ final class URITest extends CIUnitTestCase
         Services::injectMock('request', $request);
 
         // going through request
-        $this->assertSame('http://example.com/ci/v4/index.php/controller/method', (string) $request->uri);
-        $this->assertSame('/ci/v4/index.php/controller/method', $request->uri->getPath());
+        $this->assertSame('http://example.com/ci/v4/index.php/controller/method', (string) $request->getUri());
+        $this->assertSame('/ci/v4/index.php/controller/method', $request->getUri()->getPath());
 
         // standalone
         $uri = new URI('http://example.com/ci/v4/index.php/controller/method');
         $this->assertSame('http://example.com/ci/v4/index.php/controller/method', (string) $uri);
         $this->assertSame('/ci/v4/index.php/controller/method', $uri->getPath());
 
-        $this->assertSame($uri->getPath(), $request->uri->getPath());
+        $this->assertSame($uri->getPath(), $request->getUri()->getPath());
     }
 
     public function testForceGlobalSecureRequests()
@@ -933,13 +933,13 @@ final class URITest extends CIUnitTestCase
         Services::injectMock('request', $request);
 
         // Detected by request
-        $this->assertSame('https://example.com/ci/v4/controller/method', (string) $request->uri);
+        $this->assertSame('https://example.com/ci/v4/controller/method', (string) $request->getUri());
 
         // Standalone
         $uri = new URI('http://example.com/ci/v4/controller/method');
         $this->assertSame('https://example.com/ci/v4/controller/method', (string) $uri);
 
-        $this->assertSame(trim($uri->getPath(), '/'), trim($request->uri->getPath(), '/'));
+        $this->assertSame(trim($uri->getPath(), '/'), trim($request->getUri()->getPath(), '/'));
     }
 
     public function testZeroAsURIPath()


### PR DESCRIPTION
**Description**
See #5344

There is no `withUri()` method in the Request, can't replace the code like:
```php
$request->uri = new URI('http://example.com/assets/image.jpg');
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
