### PR TITLE
docs: fix structure.rst

### DIFF
--- a/user_guide_src/source/concepts/structure.rst
+++ b/user_guide_src/source/concepts/structure.rst
@@ -44,6 +44,9 @@ All files in this directory live under the ``App`` namespace, though you are fre
 
 system
 ------
+
+.. note:: If you install CodeIgniter with Composer, the ``system`` is located in ``vendor/codeigniter4/framework/system``.
+
 This directory stores the files that make up the framework, itself. While you have a lot of flexibility in how you
 use the application directory, the files in the system directory should never be modified. Instead, you should
 extend the classes, or create new classes, to provide the desired functionality.

--- a/user_guide_src/source/concepts/structure.rst
+++ b/user_guide_src/source/concepts/structure.rst
@@ -8,8 +8,8 @@ can change to meet the needs of your application.
 Default Directories
 ===================
 
-A fresh install has six directories: ``/app``, ``/system``, ``/public``,
-``/writable``, ``/tests`` and possibly ``/docs``.
+A fresh install has five directories: ``/app``, ``/public``,
+``/writable``, ``/tests`` and ``/system`` or ``/vendor``.
 Each of these directories has a very specific part to play.
 
 app
@@ -74,11 +74,6 @@ tests
 This directory is set up to hold your test files. The ``_support`` directory holds various mock classes and other
 utilities that you can use while writing your tests. This directory does not need to be transferred to your
 production servers.
-
-docs
-----
-If this directory is part of your project, it holds a local copy of the CodeIgniter4
-User Guide.
 
 Modifying Directory Locations
 -----------------------------


### PR DESCRIPTION
**Description**
- there is no `docs` directory
  - See https://forum.codeigniter.com/thread-79365-post-387929.html#pid387929

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
