### PR TITLE
chore: fix deploy-framework script to copy `tests` directory

### DIFF
--- a/.github/scripts/deploy-framework
+++ b/.github/scripts/deploy-framework
@@ -28,6 +28,8 @@ done
 
 # Copy repo-specific files
 cp -Rf ${SOURCE}/admin/framework/. ./
+# Copy tests files
+cp -Rf ${SOURCE}/admin/starter/tests/. ./tests/
 
 # Commit the changes
 git add .


### PR DESCRIPTION
**Description**
Fixes #5349

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
