### PR TITLE
Custom exception handler

### DIFF
--- a/system/Exceptions/CustomExceptionHandlerInterface.php
+++ b/system/Exceptions/CustomExceptionHandlerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Exceptions;
+
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
+
+/**
+ * Interface for implementing a global custom exception handler
+ */
+interface CustomExceptionHandlerInterface
+{
+    public function renderResponse(RequestInterface $request): ResponseInterface;
+}

--- a/tests/_support/Controllers/Popcorn.php
+++ b/tests/_support/Controllers/Popcorn.php
@@ -11,8 +11,13 @@
 
 namespace Tests\Support\Controllers;
 
+use Exception;
 use CodeIgniter\API\ResponseTrait;
+use CodeIgniter\Config\Services;
 use CodeIgniter\Controller;
+use CodeIgniter\Exceptions\CustomExceptionHandlerInterface;
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
 use RuntimeException;
 
 /**
@@ -88,5 +93,17 @@ class Popcorn extends Controller
     public function echoJson()
     {
         return $this->response->setJSON($this->request->getJSON());
+    }
+
+    public function customException()
+    {
+        throw new class () extends Exception implements CustomExceptionHandlerInterface {
+            public function renderResponse(RequestInterface $request): ResponseInterface
+            {
+                return Services::response()
+                    ->setStatusCode(400)
+                    ->setBody('an exception thrown');
+            }
+        };
     }
 }

--- a/tests/_support/Controllers/Popcorn.php
+++ b/tests/_support/Controllers/Popcorn.php
@@ -11,13 +11,13 @@
 
 namespace Tests\Support\Controllers;
 
-use Exception;
 use CodeIgniter\API\ResponseTrait;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Controller;
 use CodeIgniter\Exceptions\CustomExceptionHandlerInterface;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
+use Exception;
 use RuntimeException;
 
 /**

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -432,10 +432,10 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/exception';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = Services::routes(false);
         $routes->add('exception', '\Tests\Support\Controllers\Popcorn::customException');
 
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::request(), false);
         Services::injectMock('router', $router);
 
         ob_start();

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -134,13 +134,14 @@ redirect code to use instead of the default (``302``, "temporary redirect")::
 
 
 Custom Exception Handler
-------------------------
+========================
 
 You can use your own exception handler which will be called globally.
 
 Your exception must implement ``\CodeIgniter\Exception\CustomExceptionHandlerInterface``::
 
     namespace App\Exceptions;
+
     use App\Config\Services;
     use CodeIgniter\Exception\CustomExceptionHandlerInterface
     use Exception;

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -131,3 +131,32 @@ forcing a redirect to a specific route or URL::
 redirect code to use instead of the default (``302``, "temporary redirect")::
 
     throw new \CodeIgniter\Router\Exceptions\RedirectException($route, 301);
+
+
+Custom Exception Handler
+------------------------
+
+You can use your own exception handler which will be called globally.
+
+Your exception must implement ``\CodeIgniter\Exception\CustomExceptionHandlerInterface``::
+
+    namespace App\Exceptions;
+    use App\Config\Services;
+    use CodeIgniter\Exception\CustomExceptionHandlerInterface
+    use Exception;
+
+    class MyException extends Exception implements CustomExceptionHandlerInterface
+    {
+        public function renderResponse(RequestInterface $request): ResponseInterface
+        {
+            return Services::response()->setBody($this->getMessage());
+        }
+    }
+
+Now, if an exception is thrown in any part of the application, it will be handled.::
+
+    if (someCondition) {
+        throw new MyException('Something wrong')
+    }
+
+.. note:: Of course, if not caught by the try..catch block defined earlier.


### PR DESCRIPTION
**Description**
I offer functionality for global handling of custom exceptions.
An exception for handling will be defined through the interface

```php
namespace CodeIgniter\Exceptions;

use CodeIgniter\HTTP\RequestInterface;
use CodeIgniter\HTTP\ResponseInterface;

interface CustomExceptionHandlerInterface
{
    public function renderResponse(RequestInterface $request): ResponseInterface;
}
```
An exception can be thrown from anywhere in the application.


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
