### PR TITLE
fix: can't load full classname Config file

### DIFF
--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -126,6 +126,11 @@ class Factories
             return $name;
         }
 
+        // Check full classname Config
+        if ($options['component'] === 'config' && class_exists($name)) {
+            return $name;
+        }
+
         // Determine the relative class names we need
         $basename = self::getBasename($name);
         $appname  = $options['component'] === 'config'

--- a/tests/_support/Config/ForeignCharacters.php
+++ b/tests/_support/Config/ForeignCharacters.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Config;
+
+use CodeIgniter\Config\ForeignCharacters as BaseForeignCharacters;
+
+class ForeignCharacters extends BaseForeignCharacters
+{
+}

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Config;
 use CodeIgniter\Test\CIUnitTestCase;
 use ReflectionClass;
 use stdClass;
+use Tests\Support\Config\ForeignCharacters;
 use Tests\Support\Widgets\OtherWidget;
 use Tests\Support\Widgets\SomeWidget;
 
@@ -154,11 +155,18 @@ final class FactoriesTest extends CIUnitTestCase
         $this->assertInstanceOf(SomeWidget::class, $result);
     }
 
-    public function testCreatesByAbsoluteClassname()
+    public function testCreatesModelByAbsoluteClassname()
     {
         $result = Factories::models('\Tests\Support\Models\UserModel', ['getShared' => false]);
 
         $this->assertInstanceOf('Tests\Support\Models\UserModel', $result);
+    }
+
+    public function testCreatesConfigByAbsoluteClassname()
+    {
+        $result = Factories::config('\Tests\Support\Config\ForeignCharacters', ['getShared' => false]);
+
+        $this->assertInstanceOf(ForeignCharacters::class, $result);
     }
 
     public function testCreatesInvalid()


### PR DESCRIPTION
**Description**
Fixes #5356

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
