### PR TITLE
refactor: add Factories::models() to suppress PHPStan error

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -773,7 +773,6 @@ if (! function_exists('model')) {
      * @param class-string<T> $name
      *
      * @return T
-     * @phpstan-return Model
      */
     function model(string $name, bool $getShared = true, ?ConnectionInterface &$conn = null)
     {

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Config;
 
+use CodeIgniter\Database\ConnectionInterface;
 use CodeIgniter\Model;
 use Config\Services;
 
@@ -23,7 +24,6 @@ use Config\Services;
  * instantiation checks.
  *
  * @method static BaseConfig config(...$arguments)
- * @method static Model models(...$arguments)
  */
 class Factories
 {
@@ -66,6 +66,22 @@ class Factories
      * @var array<string, array>
      */
     protected static $instances = [];
+
+    /**
+     * This method is only to prevent PHPStan error.
+     * If we have a solution, we can remove this method.
+     * See https://github.com/codeigniter4/CodeIgniter4/pull/5358
+     *
+     * @template T of Model
+     *
+     * @param class-string<T> $name
+     *
+     * @return T
+     */
+    public static function models(string $name, array $options = [], ?ConnectionInterface &$conn = null)
+    {
+        return self::__callStatic('models', [$name, $options, $conn]);
+    }
 
     /**
      * Loads instances based on the method component name. Either
@@ -263,7 +279,7 @@ class Factories
     /**
      * Resets the static arrays, optionally just for one component
      *
-     * @param string $component Lowercase, plural component name
+     * @param string|null $component Lowercase, plural component name
      */
     public static function reset(?string $component = null)
     {


### PR DESCRIPTION
**Description**
Follow-up: #5186
- add Factories::models() to suppress PHPStan error

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
