### PR TITLE
fix: table alias is prefixed when LIKE clause

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1012,7 +1012,8 @@ abstract class BaseConnection implements ConnectionInterface
             //
             // NOTE: The ! empty() condition prevents this method
             // from breaking when QB isn't enabled.
-            if (! empty($this->aliasedTables) && in_array($parts[0], $this->aliasedTables, true)) {
+            $firstSegment = trim($parts[0], $this->escapeChar);
+            if (! empty($this->aliasedTables) && in_array($firstSegment, $this->aliasedTables, true)) {
                 if ($protectIdentifiers === true) {
                     foreach ($parts as $key => $val) {
                         if (! in_array($val, $this->reservedIdentifiers, true)) {

--- a/tests/system/Database/Builder/AliasTest.php
+++ b/tests/system/Database/Builder/AliasTest.php
@@ -84,4 +84,20 @@ final class AliasTest extends CIUnitTestCase
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5360
+     */
+    public function testAliasSimpleLikeWithDBPrefix()
+    {
+        $this->setPrivateProperty($this->db, 'DBPrefix', 'db_');
+        $builder = $this->db->table('jobs j');
+
+        $builder->like('j.name', 'veloper');
+
+        $expectedSQL = <<<'SQL'
+            SELECT * FROM "db_jobs" "j" WHERE "j"."name" LIKE '%veloper%' ESCAPE '!'
+            SQL;
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
 }


### PR DESCRIPTION
**Description**
Fixes #5360

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
