### PR TITLE
docs: add about Config in Modules

### DIFF
--- a/user_guide_src/source/concepts/factories.rst
+++ b/user_guide_src/source/concepts/factories.rst
@@ -58,6 +58,8 @@ to access user records always go through that connection::
 Now any time the ``UserModel`` is loaded from ``Factories`` it will in fact be returning a
 class instance that uses the alternate database connection.
 
+.. _factories-options:
+
 Factories Options
 ==================
 

--- a/user_guide_src/source/concepts/factories.rst
+++ b/user_guide_src/source/concepts/factories.rst
@@ -67,15 +67,19 @@ The default behavior might not work for every component. For example, say your c
 name and its path do not align, or you need to limit instances to a certain type of class.
 Each component takes a set of options to direct discovery and instantiation.
 
-========== ============== ==================================================================================================================== ===================================================
-Key        Type           Description                                                                                                          Default
-========== ============== ==================================================================================================================== ===================================================
-component  string or null The name of the component (if different than the static method). This can be used to alias one component to another. ``null`` (defaults to the component name)
-path       string or null The relative path within the namespace/folder to look for classes.                                                   ``null`` (defaults to the component name)
-instanceOf string or null A required class name to match on the returned instance.                                                             ``null`` (no filtering)
-getShared  boolean        Whether to return a shared instance of the class or load a fresh one.                                                ``true``
-preferApp  boolean        Whether a class with the same basename in the App namespace overrides other explicit class requests.                 ``true``
-========== ============== ==================================================================================================================== ===================================================
+========== ============== ============================================================ ===================================================
+Key        Type           Description                                                  Default
+========== ============== ============================================================ ===================================================
+component  string or null The name of the component (if different than the static      ``null`` (defaults to the component name)
+                          method). This can be used to alias one component to another.
+path       string or null The relative path within the namespace/folder to look for    ``null`` (defaults to the component name)
+                          classes.
+instanceOf string or null A required class name to match on the returned instance.     ``null`` (no filtering)
+getShared  boolean        Whether to return a shared instance of the class or load a   ``true``
+                          fresh one.
+preferApp  boolean        Whether a class with the same basename in the App namespace  ``true``
+                          overrides other explicit class requests.
+========== ============== ============================================================ ===================================================
 
 Factories Behavior
 ==================

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -191,6 +191,11 @@ with the ``new`` command::
 
 Config files are automatically discovered whenever using the **config()** function that is always available.
 
+.. note:: **config()** finds the file in **app/Config/** when there is a class with the same shortname,
+    even if you specify a full qualified class name like ``config(\Acme\Blog\Config\Blog::class)``.
+
+.. note:: Modules that need to override or add to known configurations in **app/Config/** should use :ref:`registrars`.
+
 Migrations
 ==========
 

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -192,7 +192,7 @@ with the ``new`` command::
 Config files are automatically discovered whenever using the **config()** function that is always available.
 
 .. note:: **config()** finds the file in **app/Config/** when there is a class with the same shortname,
-    even if you specify a full qualified class name like ``config(\Acme\Blog\Config\Blog::class)``.
+    even if you specify a fully qualified class name like ``config(\Acme\Blog\Config\Blog::class)``.
 
 .. note:: Modules that need to override or add to known configurations in **app/Config/** should use :ref:`registrars`.
 

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -191,10 +191,12 @@ with the ``new`` command::
 
 Config files are automatically discovered whenever using the **config()** function that is always available.
 
+.. note:: We don't recommend you use the same short classname in modules.
+    Modules that need to override or add to known configurations in **app/Config/** should use :ref:`registrars`.
+
 .. note:: **config()** finds the file in **app/Config/** when there is a class with the same shortname,
     even if you specify a fully qualified class name like ``config(\Acme\Blog\Config\Blog::class)``.
-
-.. note:: Modules that need to override or add to known configurations in **app/Config/** should use :ref:`registrars`.
+    This is because ``Factories``'s the default configuration. See :ref:`factories-options` for more information.
 
 Migrations
 ==========

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -196,7 +196,7 @@ Config files are automatically discovered whenever using the **config()** functi
 
 .. note:: **config()** finds the file in **app/Config/** when there is a class with the same shortname,
     even if you specify a fully qualified class name like ``config(\Acme\Blog\Config\Blog::class)``.
-    This is because ``Factories``'s the default configuration. See :ref:`factories-options` for more information.
+    This is because ``config()`` is a wrapper for the ``Factories`` class which uses ``preferApp`` by default. See :ref:`factories-options` for more information.
 
 Migrations
 ==========


### PR DESCRIPTION
**Description**
See  [#5356](https://github.com/codeigniter4/CodeIgniter4/issues/5356#issuecomment-974646662)

- add about `config()` `preferApp` and `Registrars`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
