### PR TITLE
fix: `dot_array_search()` unexpected array structure causes Type Error

### DIFF
--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -53,6 +53,10 @@ if (! function_exists('_array_search_dot')) {
             $answer = [];
 
             foreach ($array as $value) {
+                if (! is_array($value)) {
+                    return null;
+                }
+
                 $answer[] = _array_search_dot($indexes, $value);
             }
 

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -46,6 +46,18 @@ final class ArrayHelperTest extends CIUnitTestCase
         $this->assertSame(23, dot_array_search('foo.bar.baz', $data));
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5369
+     */
+    public function testArrayDotValueIsListArray()
+    {
+        $data = [
+            'arr' => [1, 2, 3],
+        ];
+
+        $this->assertNull(dot_array_search('arr.*.index', $data));
+    }
+
     public function testArrayDotEscape()
     {
         $data = [


### PR DESCRIPTION
**Description**
Fixes #5369

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

