### PR TITLE
fix: Validation for invalid type data

### DIFF
--- a/system/Validation/CreditCardRules.php
+++ b/system/Validation/CreditCardRules.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of CodeIgniter 4 framework.
  *
@@ -169,9 +171,15 @@ class CreditCardRules
      *  $rules = [
      *      'cc_num' => 'valid_cc_number[visa]'
      *  ];
+     *
+     * @param mixed $ccNumber
      */
-    public function valid_cc_number(?string $ccNumber, string $type): bool
+    public function valid_cc_number($ccNumber, string $type): bool
     {
+        if (! is_string($ccNumber)) {
+            return false;
+        }
+
         $type = strtolower($type);
         $info = null;
 

--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of CodeIgniter 4 framework.
  *

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -384,6 +384,7 @@ class FormatRules
      * Validate an IP address (human readable format or binary string - inet_pton)
      *
      * @param string|null $which IP protocol: 'ipv4' or 'ipv6'
+     * @param mixed|null  $ip
      */
     public function valid_ip($ip = null, ?string $which = null): bool
     {
@@ -417,6 +418,8 @@ class FormatRules
      *
      * Warning: this rule will pass basic strings like
      * "banana"; use valid_url_strict for a stricter rule.
+     *
+     * @param mixed|null $str
      */
     public function valid_url($str = null): bool
     {
@@ -469,6 +472,8 @@ class FormatRules
 
     /**
      * Checks for a valid date and matches a given date format
+     *
+     * @param mixed|null $str
      */
     public function valid_date($str = null, ?string $format = null): bool
     {

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -460,7 +460,8 @@ class FormatRules
             return false;
         }
 
-        $scheme       = strtolower(parse_url($str, PHP_URL_SCHEME) ?? ''); // absent scheme gives null
+        // parse_url() may return null and false
+        $scheme       = strtolower((string) parse_url($str, PHP_URL_SCHEME));
         $validSchemes = explode(
             ',',
             strtolower($validSchemes ?? 'http,https')

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of CodeIgniter 4 framework.
  *
@@ -20,10 +22,16 @@ class FormatRules
 {
     /**
      * Alpha
+     *
+     * @param mixed|null $str
      */
-    public function alpha(?string $str = null): bool
+    public function alpha($str = null): bool
     {
-        return ctype_alpha($str ?? '');
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return ctype_alpha($str);
     }
 
     /**
@@ -39,6 +47,10 @@ class FormatRules
             return true;
         }
 
+        if (! is_string($value)) {
+            return false;
+        }
+
         // @see https://regex101.com/r/LhqHPO/1
         return (bool) preg_match('/\A[A-Z ]+\z/i', $value);
     }
@@ -46,14 +58,23 @@ class FormatRules
     /**
      * Alphanumeric with underscores and dashes
      *
-     * @see https://regex101.com/r/XfVY3d/1
+     * @param mixed|null $str
      */
-    public function alpha_dash(?string $str = null): bool
+    public function alpha_dash($str = null): bool
     {
         if ($str === null) {
             return false;
         }
 
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        // @see https://regex101.com/r/XfVY3d/1
         return preg_match('/\A[a-z0-9_-]+\z/i', $str) === 1;
     }
 
@@ -67,8 +88,6 @@ class FormatRules
      * @param string|null $str
      *
      * @return bool
-     *
-     * @see https://regex101.com/r/6N8dDY/1
      */
     public function alpha_numeric_punct($str)
     {
@@ -76,31 +95,57 @@ class FormatRules
             return false;
         }
 
+        if (is_int($str) || is_float($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        // @see https://regex101.com/r/6N8dDY/1
         return preg_match('/\A[A-Z0-9 ~!#$%\&\*\-_+=|:.]+\z/i', $str) === 1;
     }
 
     /**
      * Alphanumeric
+     *
+     * @param mixed|null $str
      */
-    public function alpha_numeric(?string $str = null): bool
+    public function alpha_numeric($str = null): bool
     {
-        return ctype_alnum($str ?? '');
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return ctype_alnum($str);
     }
 
     /**
      * Alphanumeric w/ spaces
+     *
+     * @param mixed|null $str
      */
-    public function alpha_numeric_space(?string $str = null): bool
+    public function alpha_numeric_space($str = null): bool
     {
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
         // @see https://regex101.com/r/0AZDME/1
         return (bool) preg_match('/\A[A-Z0-9 ]+\z/i', $str ?? '');
     }
 
     /**
      * Any type of string
-     *
-     * Note: we specifically do NOT type hint $str here so that
-     * it doesn't convert numbers into strings.
      *
      * @param string|null $str
      */
@@ -111,59 +156,125 @@ class FormatRules
 
     /**
      * Decimal number
+     *
+     * @param mixed|null $str
      */
-    public function decimal(?string $str = null): bool
+    public function decimal($str = null): bool
     {
+        if (is_int($str) || is_float($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
         // @see https://regex101.com/r/HULifl/2/
         return (bool) preg_match('/\A[-+]?\d{0,}\.?\d+\z/', $str ?? '');
     }
 
     /**
      * String of hexidecimal characters
+     *
+     * @param mixed|null $str
      */
-    public function hex(?string $str = null): bool
+    public function hex($str = null): bool
     {
-        return ctype_xdigit($str ?? '');
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return ctype_xdigit($str);
     }
 
     /**
      * Integer
+     *
+     * @param mixed|null $str
      */
-    public function integer(?string $str = null): bool
+    public function integer($str = null): bool
     {
-        return (bool) preg_match('/\A[\-+]?\d+\z/', $str ?? '');
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return (bool) preg_match('/\A[\-+]?\d+\z/', $str);
     }
 
     /**
      * Is a Natural number  (0,1,2,3, etc.)
+     *
+     * @param mixed|null $str
      */
-    public function is_natural(?string $str = null): bool
+    public function is_natural($str = null): bool
     {
-        return ctype_digit($str ?? '');
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return ctype_digit($str);
     }
 
     /**
      * Is a Natural number, but not a zero  (1,2,3, etc.)
+     *
+     * @param mixed|null $str
      */
-    public function is_natural_no_zero(?string $str = null): bool
+    public function is_natural_no_zero($str = null): bool
     {
-        return $str !== '0' && ctype_digit($str ?? '');
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return $str !== '0' && ctype_digit($str);
     }
 
     /**
      * Numeric
+     *
+     * @param mixed|null $str
      */
-    public function numeric(?string $str = null): bool
+    public function numeric($str = null): bool
     {
+        if (is_int($str) || is_float($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
         // @see https://regex101.com/r/bb9wtr/2
         return (bool) preg_match('/\A[\-+]?\d*\.?\d+\z/', $str ?? '');
     }
 
     /**
      * Compares value against a regular expression pattern.
+     *
+     * @param mixed $str
      */
-    public function regex_match(?string $str, string $pattern): bool
+    public function regex_match($str, string $pattern): bool
     {
+        if (! is_string($str)) {
+            return false;
+        }
+
         if (strpos($pattern, '/') !== 0) {
             $pattern = "/{$pattern}/";
         }
@@ -179,9 +290,13 @@ class FormatRules
      *
      * @param string $str
      */
-    public function timezone(?string $str = null): bool
+    public function timezone($str = null): bool
     {
-        return in_array($str ?? '', timezone_identifiers_list(), true);
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return in_array($str, timezone_identifiers_list(), true);
     }
 
     /**
@@ -192,9 +307,9 @@ class FormatRules
      *
      * @param string $str
      */
-    public function valid_base64(?string $str = null): bool
+    public function valid_base64($str = null): bool
     {
-        if ($str === null) {
+        if (! is_string($str)) {
             return false;
         }
 
@@ -206,9 +321,13 @@ class FormatRules
      *
      * @param string $str
      */
-    public function valid_json(?string $str = null): bool
+    public function valid_json($str = null): bool
     {
-        json_decode($str ?? '');
+        if (! is_string($str)) {
+            return false;
+        }
+
+        json_decode($str);
 
         return json_last_error() === JSON_ERROR_NONE;
     }
@@ -218,8 +337,12 @@ class FormatRules
      *
      * @param string $str
      */
-    public function valid_email(?string $str = null): bool
+    public function valid_email($str = null): bool
     {
+        if (! is_string($str)) {
+            return false;
+        }
+
         // @see https://regex101.com/r/wlJG1t/1/
         if (function_exists('idn_to_ascii') && defined('INTL_IDNA_VARIANT_UTS46') && preg_match('#\A([^@]+)@(.+)\z#', $str ?? '', $matches)) {
             $str = $matches[1] . '@' . idn_to_ascii($matches[2], 0, INTL_IDNA_VARIANT_UTS46);
@@ -236,9 +359,13 @@ class FormatRules
      *
      * @param string $str
      */
-    public function valid_emails(?string $str = null): bool
+    public function valid_emails($str = null): bool
     {
-        foreach (explode(',', $str ?? '') as $email) {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        foreach (explode(',', $str) as $email) {
             $email = trim($email);
 
             if ($email === '') {
@@ -258,8 +385,12 @@ class FormatRules
      *
      * @param string|null $which IP protocol: 'ipv4' or 'ipv6'
      */
-    public function valid_ip(?string $ip = null, ?string $which = null): bool
+    public function valid_ip($ip = null, ?string $which = null): bool
     {
+        if (! is_string($ip)) {
+            return false;
+        }
+
         if (empty($ip)) {
             return false;
         }
@@ -287,8 +418,12 @@ class FormatRules
      * Warning: this rule will pass basic strings like
      * "banana"; use valid_url_strict for a stricter rule.
      */
-    public function valid_url(?string $str = null): bool
+    public function valid_url($str = null): bool
     {
+        if (! is_string($str)) {
+            return false;
+        }
+
         if (empty($str)) {
             return false;
         }
@@ -310,9 +445,14 @@ class FormatRules
      * Checks a URL to ensure it's formed correctly.
      *
      * @param string|null $validSchemes comma separated list of allowed schemes
+     * @param mixed|null  $str
      */
-    public function valid_url_strict(?string $str = null, ?string $validSchemes = null): bool
+    public function valid_url_strict($str = null, ?string $validSchemes = null): bool
     {
+        if (! is_string($str)) {
+            return false;
+        }
+
         if (empty($str)) {
             return false;
         }
@@ -330,8 +470,12 @@ class FormatRules
     /**
      * Checks for a valid date and matches a given date format
      */
-    public function valid_date(?string $str = null, ?string $format = null): bool
+    public function valid_date($str = null, ?string $format = null): bool
     {
+        if (! is_string($str)) {
+            return false;
+        }
+
         if (empty($format)) {
             return strtotime($str) !== false;
         }

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -119,6 +119,13 @@ class Rules
      */
     public function in_list($value, string $list): bool
     {
+        if (is_int($value)) {
+            $value = (string) $value;
+        }
+        if (is_float($value)) {
+            $value = (string) $value;
+        }
+
         if (! is_string($value)) {
             return false;
         }
@@ -237,6 +244,13 @@ class Rules
     {
         if (null === $value) {
             return true;
+        }
+
+        if (is_int($value)) {
+            $value = (string) $value;
+        }
+        if (is_float($value)) {
+            $value = (string) $value;
         }
 
         if (! is_string($value)) {

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -119,10 +119,7 @@ class Rules
      */
     public function in_list($value, string $list): bool
     {
-        if (is_int($value)) {
-            $value = (string) $value;
-        }
-        if (is_float($value)) {
+        if (is_int($value) || is_float($value)) {
             $value = (string) $value;
         }
 
@@ -246,10 +243,7 @@ class Rules
             return true;
         }
 
-        if (is_int($value)) {
-            $value = (string) $value;
-        }
-        if (is_float($value)) {
+        if (is_int($value) || is_float($value)) {
             $value = (string) $value;
         }
 

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of CodeIgniter 4 framework.
  *
@@ -24,8 +26,12 @@ class Rules
      *
      * @param array $data Other field/value pairs
      */
-    public function differs(?string $str, string $field, array $data): bool
+    public function differs($str, string $field, array $data): bool
     {
+        if (! is_string($str)) {
+            return false;
+        }
+
         if (strpos($field, '.') !== false) {
             return $str !== dot_array_search($field, $data);
         }
@@ -36,7 +42,7 @@ class Rules
     /**
      * Equals the static value provided.
      */
-    public function equals(?string $str, string $val): bool
+    public function equals($str, string $val): bool
     {
         return $str === $val;
     }
@@ -45,8 +51,12 @@ class Rules
      * Returns true if $str is $val characters long.
      * $val = "5" (one) | "5,8,12" (multiple values)
      */
-    public function exact_length(?string $str, string $val): bool
+    public function exact_length($str, string $val): bool
     {
+        if (! is_string($str)) {
+            return false;
+        }
+
         $val = explode(',', $val);
 
         foreach ($val as $tmp) {
@@ -61,7 +71,7 @@ class Rules
     /**
      * Greater than
      */
-    public function greater_than(?string $str, string $min): bool
+    public function greater_than($str, string $min): bool
     {
         return is_numeric($str) && $str > $min;
     }
@@ -69,7 +79,7 @@ class Rules
     /**
      * Equal to or Greater than
      */
-    public function greater_than_equal_to(?string $str, string $min): bool
+    public function greater_than_equal_to($str, string $min): bool
     {
         return is_numeric($str) && $str >= $min;
     }
@@ -83,7 +93,7 @@ class Rules
      *    is_not_unique[table.field,where_field,where_value]
      *    is_not_unique[menu.id,active,1]
      */
-    public function is_not_unique(?string $str, string $field, array $data): bool
+    public function is_not_unique($str, string $field, array $data): bool
     {
         // Grab any data for exclusion of a single row.
         [$field, $whereField, $whereValue] = array_pad(explode(',', $field), 3, null);
@@ -107,8 +117,12 @@ class Rules
     /**
      * Value should be within an array of values
      */
-    public function in_list(?string $value, string $list): bool
+    public function in_list($value, string $list): bool
     {
+        if (! is_string($value)) {
+            return false;
+        }
+
         $list = array_map('trim', explode(',', $list));
 
         return in_array($value, $list, true);
@@ -123,7 +137,7 @@ class Rules
      *    is_unique[table.field,ignore_field,ignore_value]
      *    is_unique[users.email,id,5]
      */
-    public function is_unique(?string $str, string $field, array $data): bool
+    public function is_unique($str, string $field, array $data): bool
     {
         [$field, $ignoreField, $ignoreValue] = array_pad(explode(',', $field), 3, null);
 
@@ -145,7 +159,7 @@ class Rules
     /**
      * Less than
      */
-    public function less_than(?string $str, string $max): bool
+    public function less_than($str, string $max): bool
     {
         return is_numeric($str) && $str < $max;
     }
@@ -153,7 +167,7 @@ class Rules
     /**
      * Equal to or Less than
      */
-    public function less_than_equal_to(?string $str, string $max): bool
+    public function less_than_equal_to($str, string $max): bool
     {
         return is_numeric($str) && $str <= $max;
     }
@@ -163,7 +177,7 @@ class Rules
      *
      * @param array $data Other field/value pairs
      */
-    public function matches(?string $str, string $field, array $data): bool
+    public function matches($str, string $field, array $data): bool
     {
         if (strpos($field, '.') !== false) {
             return $str === dot_array_search($field, $data);
@@ -175,17 +189,33 @@ class Rules
     /**
      * Returns true if $str is $val or fewer characters in length.
      */
-    public function max_length(?string $str, string $val): bool
+    public function max_length($str, string $val): bool
     {
-        return is_numeric($val) && $val >= mb_strlen($str ?? '');
+        if (is_int($str) || is_float($str) || null === $str) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return is_numeric($val) && $val >= mb_strlen($str);
     }
 
     /**
      * Returns true if $str is at least $val length.
      */
-    public function min_length(?string $str, string $val): bool
+    public function min_length($str, string $val): bool
     {
-        return is_numeric($val) && $val <= mb_strlen($str ?? '');
+        if (is_int($str) || is_float($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return is_numeric($val) && $val <= mb_strlen($str);
     }
 
     /**
@@ -193,7 +223,7 @@ class Rules
      *
      * @param string $str
      */
-    public function not_equals(?string $str, string $val): bool
+    public function not_equals($str, string $val): bool
     {
         return $str !== $val;
     }
@@ -203,8 +233,16 @@ class Rules
      *
      * @param string $value
      */
-    public function not_in_list(?string $value, string $list): bool
+    public function not_in_list($value, string $list): bool
     {
+        if (null === $value) {
+            return true;
+        }
+
+        if (! is_string($value)) {
+            return false;
+        }
+
         return ! $this->in_list($value, $list);
     }
 

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -25,6 +25,7 @@ class Rules
      * The value does not match another field in $data.
      *
      * @param array $data Other field/value pairs
+     * @param mixed $str
      */
     public function differs($str, string $field, array $data): bool
     {
@@ -41,6 +42,8 @@ class Rules
 
     /**
      * Equals the static value provided.
+     *
+     * @param mixed $str
      */
     public function equals($str, string $val): bool
     {
@@ -50,6 +53,8 @@ class Rules
     /**
      * Returns true if $str is $val characters long.
      * $val = "5" (one) | "5,8,12" (multiple values)
+     *
+     * @param mixed $str
      */
     public function exact_length($str, string $val): bool
     {
@@ -70,6 +75,8 @@ class Rules
 
     /**
      * Greater than
+     *
+     * @param mixed $str
      */
     public function greater_than($str, string $min): bool
     {
@@ -78,6 +85,8 @@ class Rules
 
     /**
      * Equal to or Greater than
+     *
+     * @param mixed $str
      */
     public function greater_than_equal_to($str, string $min): bool
     {
@@ -92,6 +101,8 @@ class Rules
      * Example:
      *    is_not_unique[table.field,where_field,where_value]
      *    is_not_unique[menu.id,active,1]
+     *
+     * @param mixed $str
      */
     public function is_not_unique($str, string $field, array $data): bool
     {
@@ -116,6 +127,8 @@ class Rules
 
     /**
      * Value should be within an array of values
+     *
+     * @param mixed $value
      */
     public function in_list($value, string $list): bool
     {
@@ -140,6 +153,8 @@ class Rules
      * Example:
      *    is_unique[table.field,ignore_field,ignore_value]
      *    is_unique[users.email,id,5]
+     *
+     * @param mixed $str
      */
     public function is_unique($str, string $field, array $data): bool
     {
@@ -162,6 +177,8 @@ class Rules
 
     /**
      * Less than
+     *
+     * @param mixed $str
      */
     public function less_than($str, string $max): bool
     {
@@ -170,6 +187,8 @@ class Rules
 
     /**
      * Equal to or Less than
+     *
+     * @param mixed $str
      */
     public function less_than_equal_to($str, string $max): bool
     {
@@ -180,6 +199,7 @@ class Rules
      * Matches the value of another field in $data.
      *
      * @param array $data Other field/value pairs
+     * @param mixed $str
      */
     public function matches($str, string $field, array $data): bool
     {
@@ -192,6 +212,8 @@ class Rules
 
     /**
      * Returns true if $str is $val or fewer characters in length.
+     *
+     * @param mixed $str
      */
     public function max_length($str, string $val): bool
     {
@@ -208,6 +230,8 @@ class Rules
 
     /**
      * Returns true if $str is at least $val length.
+     *
+     * @param mixed $str
      */
     public function min_length($str, string $val): bool
     {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of CodeIgniter 4 framework.
  *

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -261,7 +261,7 @@ class Validation implements ValidationInterface
             // Placeholder for custom errors from the rules.
             $error = null;
 
-            // If it's a callable, call and and get out of here.
+            // If it's a callable, call and get out of here.
             if ($isCallable) {
                 $passed = $param === false ? $rule($value) : $rule($value, $param, $data);
             } else {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -141,16 +141,20 @@ class Validation implements ValidationInterface
             }
 
             $values = dot_array_search($field, $data);
-            $values = is_array($values) ? $values : [$values];
 
             if ($values === []) {
                 // We'll process the values right away if an empty array
                 $this->processRules($field, $setup['label'] ?? $field, $values, $rules, $data);
             }
 
-            foreach ($values as $value) {
-                // Otherwise, we'll let the loop do the job
-                $this->processRules($field, $setup['label'] ?? $field, $value, $rules, $data);
+            if (strpos($field, '*') !== false && is_array($values)) {
+                // Process multiple fields
+                foreach ($values as $value) {
+                    $this->processRules($field, $setup['label'] ?? $field, $value, $rules, $data);
+                }
+            } else {
+                // Process single field
+                $this->processRules($field, $setup['label'] ?? $field, $values, $rules, $data);
             }
         }
 
@@ -310,8 +314,6 @@ class Validation implements ValidationInterface
     /**
      * Takes a Request object and grabs the input data to use from its
      * array values.
-     *
-     * @param IncomingRequest|RequestInterface $request
      */
     public function withRequest(RequestInterface $request): ValidationInterface
     {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -651,6 +651,9 @@ class Validation implements ValidationInterface
      */
     protected function getErrorMessage(string $rule, string $field, ?string $label = null, ?string $param = null, ?string $value = null): string
     {
+        $param = $param ?? '';
+
+        // Check if custom message has been defined by user
         if (isset($this->customErrors[$field][$rule])) {
             $message = lang($this->customErrors[$field][$rule]);
         } else {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -221,7 +221,7 @@ class Validation implements ValidationInterface
         }
 
         if (in_array('permit_empty', $rules, true)) {
-            if (! in_array('required', $rules, true) && (is_array($value) ? $value === [] : trim($value ?? '') === '')) {
+            if (! in_array('required', $rules, true) && (is_array($value) ? $value === [] : trim((string) $value) === '')) {
                 $passed = true;
 
                 foreach ($rules as $rule) {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -221,7 +221,9 @@ class Validation implements ValidationInterface
         }
 
         if (in_array('permit_empty', $rules, true)) {
-            if (! in_array('required', $rules, true) && (is_array($value) ? $value === [] : trim((string) $value) === '')) {
+            if (! in_array('required', $rules, true)
+                && (is_array($value) ? $value === [] : trim((string) $value) === '')
+            ) {
                 $passed = true;
 
                 foreach ($rules as $rule) {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -295,7 +295,8 @@ class Validation implements ValidationInterface
                     $value = json_encode($value);
                 }
 
-                $this->errors[$field] = $error ?? $this->getErrorMessage($rule, $field, $label, $param, $value);
+                $param                = ($param === false) ? null : $param;
+                $this->errors[$field] = $error ?? $this->getErrorMessage($rule, $field, $label, $param, (string) $value);
 
                 return false;
             }

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -798,6 +798,72 @@ final class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
+     *
+     * @dataProvider integerInvalidTypeDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testIntegerWithInvalidTypeData($value, bool $expected): void
+    {
+        $this->validation->setRules([
+            'foo' => 'integer',
+        ]);
+
+        $data = [
+            'foo' => $value,
+        ];
+        $this->assertsame($expected, $this->validation->run($data));
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
+     *
+     * @dataProvider integerInvalidTypeDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testNumericWithInvalidTypeData($value, bool $expected): void
+    {
+        $this->validation->setRules([
+            'foo' => 'numeric',
+        ]);
+
+        $data = [
+            'foo' => $value,
+        ];
+        $this->assertsame($expected, $this->validation->run($data));
+    }
+
+    public function integerInvalidTypeDataProvider(): Generator
+    {
+        yield 'array with int' => [
+            [555],
+            false,  // true in v4.1.5 and earlier
+        ];
+
+        yield 'empty array' => [
+            [],
+            false,  // true in v4.1.5 and earlier
+        ];
+
+        yield 'bool true' => [
+            true,
+            false,  // true in v4.1.5 and earlier
+        ];
+
+        yield 'bool false' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
+
+    /**
      * @dataProvider integerProvider
      */
     public function testInteger(?string $str, bool $expected): void

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -862,17 +862,21 @@ final class ValidationTest extends CIUnitTestCase
         yield 'dot-on-middle-fail' => [
             false,
             ['fizz.*.baz' => 'if_exist|numeric'],
-            ['fizz' => [
-                'bar' => ['baz' => 'yes'],
-            ]],
+            [
+                'fizz' => [
+                    'bar' => ['baz' => 'yes'],
+                ],
+            ],
         ];
 
         yield 'dot-on-middle-pass' => [
             true,
             ['fizz.*.baz' => 'if_exist|numeric'],
-            ['fizz' => [
-                'bar' => ['baz' => 30],
-            ]],
+            [
+                'fizz' => [
+                    'bar' => ['baz' => 30],
+                ],
+            ],
         ];
 
         yield 'dot-multiple-fail' => [

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -101,6 +101,58 @@ final class ValidationTest extends CIUnitTestCase
     }
 
     /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5368
+     *
+     * @dataProvider arrayDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testCanValidatetArrayData($value, bool $expected): void
+    {
+        $this->validation->setRules(['arr' => 'is_array']);
+
+        $data['arr'] = $value;
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function arrayDataProvider(): Generator
+    {
+        yield 'list array' => [
+            [1, 2, 3, 4, 5],
+            true,   // false in v4.1.5 and earlier
+        ];
+
+        yield 'associative array' => [
+            [
+                'username' => 'admin001',
+                'role'     => 'administrator',
+                'usepass'  => 0,
+            ],
+            true,   // false in v4.1.5 and earlier
+        ];
+
+        yield 'int' => [
+            0,
+            false,
+        ];
+
+        yield 'string int' => [
+            '0',
+            false,
+        ];
+
+        yield 'bool' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
+
+    /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
      *
      * @dataProvider isIntInvalidTypeDataProvider

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -100,6 +100,49 @@ final class ValidationTest extends CIUnitTestCase
         $this->assertFalse($this->validation->run($data));
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
+     *
+     * @dataProvider isIntInvalidTypeDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testIsIntWithInvalidTypeData($value, bool $expected): void
+    {
+        $this->validation->setRules(['foo' => 'is_int']);
+
+        $data = ['foo' => $value];
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function isIntInvalidTypeDataProvider(): Generator
+    {
+        yield 'array with int' => [
+            [555],
+            false,  // true in v4.1.5 and earlier
+        ];
+
+        yield 'empty array' => [
+            [],
+            false,
+        ];
+
+        yield 'bool true' => [
+            true,
+            false,
+        ];
+
+        yield 'bool false' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
+
     public function testRunReturnsLocalizedErrors(): void
     {
         $data = ['foo' => 'notanumber'];

--- a/user_guide_src/source/installation/upgrade_416.rst
+++ b/user_guide_src/source/installation/upgrade_416.rst
@@ -1,0 +1,56 @@
+#############################
+Upgrading from 4.1.5 to 4.1.6
+#############################
+
+.. contents::
+    :local:
+    :depth: 1
+
+Breaking Changes
+================
+
+Validation change
+-----------------
+
+For bug fixes, Validation and its Rule classes now have ``declare(strict_types=1)`` for strict typing.
+And we removed all implicit type casting and the types for the parameters to validate in Validation.
+
+This change may alter the result of validation. For example, when you validated the bool ``true``,
+it was converted to string ``'1'`` in the previous versions.
+If you validated it with the ``integer`` rule, ``'1'`` passed the validation.
+
+Another breaking change is that if you have custom validation rules, and when you specify the data type to validate,
+if incompatible typed data is passed to the validation rule, it will raise Type Error.
+
+If you have extended the CI4's validation rules, you will need to modify the type of data passed to it.
+
+Breaking Enhancements
+=====================
+
+Project Files
+=============
+
+Numerous files in the project space (root, app, public, writable) received updates. Due to
+these files being outside of the system scope they will not be changed without your intervention.
+There are some third-party CodeIgniter modules available to assist with merging changes to
+the project space: `Explore on Packagist <https://packagist.org/explore/?query=codeigniter4%20updates>`_.
+
+.. note:: Except in very rare cases for bug fixes, no changes made to files for the project space
+    will break your application. All changes noted here are optional until the next major version,
+    and any mandatory changes will be covered in the sections above.
+
+Content Changes
+---------------
+
+The following files received significant changes (including deprecations or visual adjustments)
+and it is recommended that you merge the updated versions with your application:
+
+*
+
+All Changes
+-----------
+
+This is a list of all files in the project space that received changes;
+many will be simple comments or formatting that have no effect on the runtime:
+
+*

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -8,6 +8,7 @@ upgrading from.
 .. toctree::
     :titlesonly:
 
+    Upgrading from 4.1.5 to 4.1.6 <upgrade_416>
     Upgrading from 4.1.4 to 4.1.5 <upgrade_415>
     Upgrading from 4.1.3 to 4.1.4 <upgrade_414>
     Upgrading from 4.1.2 to 4.1.3 <upgrade_413>


### PR DESCRIPTION
**Description**
Fixes #5374
Fixes #5368

Background:
- validation rule should accept non string data, because it may be int, float, bool, null, array or object when JSON data come
- the type of the data to validate can't be define, because a user (or an attacker) can send unexpected types of data
- the current implementation results in implicit type conversions, and e.g, `true` is converted `'1'`, which may change the result of the validation

This PR does:
- add `declare(strict_types=1)` for Validation and Rule classes
- remove parameter types for data to validate in validation rules
- separate validation process of multiple field and single field

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
