### PR TITLE
fix: invalid INSERT/DELETE query when Query Builder uses table alias

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1863,7 +1863,12 @@ class BaseBuilder
         }
 
         $sql = $this->_insert(
-            $this->db->protectIdentifiers($this->removeAlias($this->QBFrom[0]), true, null, false),
+            $this->db->protectIdentifiers(
+                $this->removeAlias($this->QBFrom[0]),
+                true,
+                null,
+                false
+            ),
             array_keys($this->QBSet),
             array_values($this->QBSet)
         );
@@ -1895,7 +1900,12 @@ class BaseBuilder
         }
 
         $sql = $this->_insert(
-            $this->db->protectIdentifiers($this->removeAlias($this->QBFrom[0]), true, $escape, false),
+            $this->db->protectIdentifiers(
+                $this->removeAlias($this->QBFrom[0]),
+                true,
+                $escape,
+                false
+            ),
             array_keys($this->QBSet),
             array_values($this->QBSet)
         );

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1863,7 +1863,7 @@ class BaseBuilder
         }
 
         $sql = $this->_insert(
-            $this->db->protectIdentifiers($this->QBFrom[0], true, null, false),
+            $this->db->protectIdentifiers($this->removeAlias($this->QBFrom[0]), true, null, false),
             array_keys($this->QBSet),
             array_values($this->QBSet)
         );
@@ -1895,7 +1895,7 @@ class BaseBuilder
         }
 
         $sql = $this->_insert(
-            $this->db->protectIdentifiers($this->QBFrom[0], true, $escape, false),
+            $this->db->protectIdentifiers($this->removeAlias($this->QBFrom[0]), true, $escape, false),
             array_keys($this->QBSet),
             array_values($this->QBSet)
         );
@@ -1912,6 +1912,19 @@ class BaseBuilder
         }
 
         return false;
+    }
+
+    protected function removeAlias(string $from): string
+    {
+        if (strpos($from, ' ') !== false) {
+            // if the alias is written with the AS keyword, remove it
+            $from = preg_replace('/\s+AS\s+/i', ' ', $from);
+
+            $parts = explode(' ', $from);
+            $from  = $parts[0];
+        }
+
+        return $from;
     }
 
     /**

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2363,7 +2363,7 @@ class BaseBuilder
             return false; // @codeCoverageIgnore
         }
 
-        $sql = $this->_delete($table);
+        $sql = $this->_delete($this->removeAlias($table));
 
         if (! empty($limit)) {
             $this->QBLimit = $limit;

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1924,6 +1924,12 @@ class BaseBuilder
         return false;
     }
 
+    /**
+     * @internal This is a temporary solution.
+     *
+     * @see https://github.com/codeigniter4/CodeIgniter4/pull/5376
+     * @TODO Fix a root cause, and this method should be removed.
+     */
     protected function removeAlias(string $from): string
     {
         if (strpos($from, ' ') !== false) {

--- a/tests/system/Database/Builder/DeleteTest.php
+++ b/tests/system/Database/Builder/DeleteTest.php
@@ -60,6 +60,20 @@ final class DeleteTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, $sql);
     }
 
+    public function testGetCompiledDeleteWithTableAlias()
+    {
+        $builder = $this->db->table('jobs j');
+
+        $builder->where('id', 1);
+        $sql = $builder->getCompiledDelete();
+
+        $expectedSQL = <<<'EOL'
+            DELETE FROM "jobs"
+            WHERE "id" = 1
+            EOL;
+        $this->assertSame($expectedSQL, $sql);
+    }
+
     public function testGetCompiledDeleteWithLimit()
     {
         $builder = $this->db->table('jobs');

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -85,6 +85,35 @@ final class InsertTest extends CIUnitTestCase
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5365
+     */
+    public function testInsertWithTableAlias()
+    {
+        $builder = $this->db->table('jobs as j');
+
+        $insertData = [
+            'id'   => 1,
+            'name' => 'Grocery Sales',
+        ];
+        $builder->testMode()->insert($insertData, true);
+
+        $expectedSQL   = 'INSERT INTO "jobs" ("id", "name") VALUES (1, \'Grocery Sales\')';
+        $expectedBinds = [
+            'id' => [
+                1,
+                true,
+            ],
+            'name' => [
+                'Grocery Sales',
+                true,
+            ],
+        ];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
     public function testThrowsExceptionOnNoValuesSet()
     {
         $builder = $this->db->table('jobs');


### PR DESCRIPTION
**Description**
Fixes #5365
- remove alias from *FROM string* when INSERT/DELETE

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
