### PR TITLE
fix: Incorrect type `BaseBuilder::$tableName`

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -158,6 +158,9 @@ class BaseBuilder
      * Tracked separately because $QBFrom gets escaped
      * and prefixed.
      *
+     * When $tableName to the constructor has multiple tables,
+     * the value is empty string.
+     *
      * @var string
      */
     protected $tableName;
@@ -276,7 +279,13 @@ class BaseBuilder
          */
         $this->db = $db;
 
-        $this->tableName = $tableName;
+        // If it contains `,`, it has multiple tables
+        if (is_string($tableName) && strpos($tableName, ',') === false) {
+            $this->tableName = $tableName;  // @TODO remove alias if exists
+        } else {
+            $this->tableName = '';
+        }
+
         $this->from($tableName);
 
         if (! empty($options)) {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -264,7 +264,9 @@ class BaseBuilder
     /**
      * Constructor
      *
-     * @param array|string $tableName
+     * @param array|string $tableName tablename or tablenames with or without aliases
+     *
+     * Examples of $tableName: `mytable`, `jobs j`, `jobs j, users u`, `['jobs j','users u']`
      *
      * @throws DatabaseException
      */

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -835,7 +835,7 @@ abstract class BaseConnection implements ConnectionInterface
     abstract protected function _transRollback(): bool;
 
     /**
-     * Returns an instance of the query builder for this connection.
+     * Returns a non-shared new instance of the query builder for this connection.
      *
      * @param array|string $tableName
      *

--- a/user_guide_src/source/changelogs/v4.1.6.rst
+++ b/user_guide_src/source/changelogs/v4.1.6.rst
@@ -11,6 +11,7 @@ Release Date: Not released
 
 BREAKING
 ========
+- Multiple table names will no longer be stored in ``BaseBuilder::$tableName`` - an empty string will be used instead.
 
 Enhancements
 ============


### PR DESCRIPTION
**Description**
Fixes #4457
- make sure `$this->tableName` is string

`$this->tableName` is used only in `BaseBuilder::getTable()`.
`BaseBuilder::getTable()` is used only in `Model::builder()`:
https://github.com/codeigniter4/CodeIgniter4/blob/b8fe16d2ff708971693a5e3325b74447ffb93fdd/system/Model.php#L524

`$table` or `$this->table` in the `Model` is a single table name without an alias.
So the above code is just to make sure that `$table` and the Builder's table name are the same or not.
If these are the same table, it returns existing `$this->builder`.

In other words, if the Builder's table name is not a single table, these are always not the same.

Therefore `BaseBuilder::getTable()` does not have to return array or multiple table string like `'tableA, tableB'`.
Returning empty string is enough.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

