### PR TITLE
Remove unneeded cast to array

### DIFF
--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -273,13 +273,12 @@ class Query implements QueryInterface
      */
     protected function compileBinds()
     {
-        $sql = $this->finalQueryString;
+        $sql   = $this->finalQueryString;
+        $binds = $this->binds;
 
-        if (empty($this->binds)) {
+        if (empty($binds)) {
             return;
         }
-
-        $binds = (array) $this->binds;
 
         if (is_int(array_key_first($binds))) {
             $bindCount = count($binds);


### PR DESCRIPTION
As discussed on https://github.com/codeigniter4/CodeIgniter4/pull/5138#issuecomment-976864356 onwards, `$this->binds` is not expected to be something else than an array.

The only possibility for the protected property `$this->binds` to be something else than an array, would be that the user extends the Query class and assigns to `$this->binds` from a new method. Such non-array value is not expected nor supported, and would probably trigger errors at other places of the code.