### PR TITLE
docs: replace `PSR*` with `PSR-*`

### DIFF
--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -11,7 +11,7 @@ headache and very error-prone. That's where autoloaders come in.
 
 CodeIgniter provides a very flexible autoloader that can be used with very little configuration.
 It can locate individual non-namespaced classes, namespaced classes that adhere to
-`PSR4 <https://www.php-fig.org/psr/psr-4/>`_ autoloading
+`PSR-4 <https://www.php-fig.org/psr/psr-4/>`_ autoloading
 directory structures, and will even attempt to locate classes in common directories (like Controllers,
 Models, etc).
 
@@ -30,7 +30,7 @@ Configuration
 =============
 
 Initial configuration is done in **/app/Config/Autoload.php**. This file contains two primary
-arrays: one for the classmap, and one for PSR4-compatible namespaces.
+arrays: one for the classmap, and one for PSR-4 compatible namespaces.
 
 Namespaces
 ==========

--- a/user_guide_src/source/general/logging.rst
+++ b/user_guide_src/source/general/logging.rst
@@ -136,8 +136,8 @@ Using Third-Party Loggers
 =========================
 
 You can use any other logger that you might like as long as it extends from either
-``Psr\Log\LoggerInterface`` and is `PSR3 <https://www.php-fig.org/psr/psr-3/>`_ compatible. This means
-that you can easily drop in use for any PSR3-compatible logger, or create your own.
+``Psr\Log\LoggerInterface`` and is `PSR-3 <https://www.php-fig.org/psr/psr-3/>`_ compatible. This means
+that you can easily drop in use for any PSR-3 compatible logger, or create your own.
 
 You must ensure that the third-party logger can be found by the system, by adding it to either
 the **app/Config/Autoload.php** configuration file, or through another autoloader,

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -15,8 +15,8 @@ language files, etc. Modules may contain as few, or as many, of these as you lik
 Namespaces
 ==========
 
-The core element of the modules functionality comes from the :doc:`PSR4-compatible autoloading </concepts/autoloader>`
-that CodeIgniter uses. While any code can use the PSR4 autoloader and namespaces, the primary way to take full advantage of
+The core element of the modules functionality comes from the :doc:`PSR-4 compatible autoloading </concepts/autoloader>`
+that CodeIgniter uses. While any code can use the PSR-4 autoloader and namespaces, the primary way to take full advantage of
 modules is to namespace your code and add it to **app/Config/Autoload.php**, in the ``psr4`` section.
 
 For example, let's say we want to keep a simple blog module that we can re-use between applications. We might create
@@ -129,7 +129,7 @@ Discovery and Composer
 ======================
 
 Packages that were installed via Composer will also be discovered by default. This only requires that the namespace
-that Composer knows about is a PSR4 namespace. PSR0 namespaces will not be detected.
+that Composer knows about is a PSR-4 namespace. PSR-0 namespaces will not be detected.
 
 If you do not want all of Composer's known directories to be scanned when locating files, you can turn this off
 by editing the ``$discoverInComposer`` variable in ``Config\Modules.php``::

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -77,7 +77,7 @@ General Adjustments
   references magically injected as properties of your controller.
 - Classes are instantiated where needed, and components are managed
   by ``Services``.
-- The class loader automatically handles PSR4 style class locating,
+- The class loader automatically handles PSR-4 style class locating,
   within the ``App`` (application) and ``CodeIgniter`` (i.e., system) top level
   namespaces; with composer autoloading support, and even using educated
   guessing to find your models and libraries if they are in the right


### PR DESCRIPTION
**Description**
- unify notation

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

