### PR TITLE
change: remove `$tableName` from `BaseBuilder`

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -154,15 +154,6 @@ class BaseBuilder
     protected $db;
 
     /**
-     * Name of the primary table for this instance.
-     * Tracked separately because $QBFrom gets escaped
-     * and prefixed.
-     *
-     * @var string
-     */
-    protected $tableName;
-
-    /**
      * ORDER BY random keyword
      *
      * @var array
@@ -261,23 +252,22 @@ class BaseBuilder
     /**
      * Constructor
      *
-     * @param array|string $tableName
+     * @param array|string|null $from tablename or tablenames with or without aliases
+     *
+     * Examples of $tableName: `mytable`, `jobs j`, `jobs j, users u`, `['jobs j','users u']`
      *
      * @throws DatabaseException
      */
-    public function __construct($tableName, ConnectionInterface &$db, ?array $options = null)
+    public function __construct($from, ConnectionInterface &$db, ?array $options = null)
     {
-        if (empty($tableName)) {
-            throw new DatabaseException('A table must be specified when creating a new Query Builder.');
-        }
-
         /**
          * @var BaseConnection $db
          */
         $this->db = $db;
 
-        $this->tableName = $tableName;
-        $this->from($tableName);
+        if ($from !== null) {
+            $this->from($from);
+        }
 
         if (! empty($options)) {
             foreach ($options as $key => $value) {
@@ -311,11 +301,17 @@ class BaseBuilder
     }
 
     /**
-     * Gets the name of the primary table.
+     * Gets QBFrom.
+     *
+     * @internal
      */
-    public function getTable(): string
+    public function getFrom(int $index = 0): ?string
     {
-        return $this->tableName;
+        if ($this->QBFrom === []) {
+            return null;
+        }
+
+        return $this->QBFrom[$index];
     }
 
     /**

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -252,22 +252,14 @@ class BaseBuilder
     /**
      * Constructor
      *
-     * @param array|string|null $from tablename or tablenames with or without aliases
-     *
-     * Examples of $tableName: `mytable`, `jobs j`, `jobs j, users u`, `['jobs j','users u']`
-     *
      * @throws DatabaseException
      */
-    public function __construct($from, ConnectionInterface &$db, ?array $options = null)
+    public function __construct(ConnectionInterface &$db, ?array $options = null)
     {
         /**
          * @var BaseConnection $db
          */
         $this->db = $db;
-
-        if ($from !== null) {
-            $this->from($from);
-        }
 
         if (! empty($options)) {
             foreach ($options as $key => $value) {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -837,15 +837,22 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns a non-shared new instance of the query builder for this connection.
      *
-     * @param array|string|null $tableName
+     * @param array|string|null $tableName tablename or tablenames with or without aliases
+     *
+     * Examples of $tableName: `mytable`, `jobs j`, `jobs j, users u`, `['jobs j','users u']`
      *
      * @return BaseBuilder
      */
     public function table($tableName = null)
     {
         $className = str_replace('Connection', 'Builder', static::class);
+        $builder   = new $className($this);
 
-        return new $className($tableName, $this);
+        if ($tableName !== null) {
+            $builder->from($tableName);
+        }
+
+        return $builder;
     }
 
     /**

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -835,20 +835,14 @@ abstract class BaseConnection implements ConnectionInterface
     abstract protected function _transRollback(): bool;
 
     /**
-     * Returns an instance of the query builder for this connection.
+     * Returns a non-shared new instance of the query builder for this connection.
      *
-     * @param array|string $tableName
-     *
-     * @throws DatabaseException
+     * @param array|string|null $tableName
      *
      * @return BaseBuilder
      */
-    public function table($tableName)
+    public function table($tableName = null)
     {
-        if (empty($tableName)) {
-            throw new DatabaseException('You must set the database table to be used with your query.');
-        }
-
         $className = str_replace('Connection', 'Builder', static::class);
 
         return new $className($tableName, $this);

--- a/system/Model.php
+++ b/system/Model.php
@@ -521,7 +521,7 @@ class Model extends BaseModel
         // Check for an existing Builder
         if ($this->builder instanceof BaseBuilder) {
             // Make sure the requested table matches the builder
-            if ($table && $this->builder->getTable() !== $table) {
+            if ($table && $this->table !== $table) {
                 return $this->db->table($table);
             }
 

--- a/system/Test/DatabaseTestTrait.php
+++ b/system/Test/DatabaseTestTrait.php
@@ -240,8 +240,11 @@ trait DatabaseTestTrait
     public function loadBuilder(string $tableName)
     {
         $builderClass = str_replace('Connection', 'Builder', get_class($this->db));
+        $builder      = new $builderClass($this->db);
 
-        return new $builderClass($tableName, $this->db);
+        $builder->from($tableName);
+
+        return $builder;
     }
 
     /**

--- a/tests/system/Database/Builder/BaseTest.php
+++ b/tests/system/Database/Builder/BaseTest.php
@@ -37,20 +37,23 @@ final class BaseTest extends CIUnitTestCase
         $this->assertInstanceOf(MockConnection::class, $result);
     }
 
-    public function testGetTableReturnsTable()
+    public function testGetFromReturnsFirstFrom()
     {
         $builder = $this->db->table('jobs');
 
-        $result = $builder->getTable();
-        $this->assertSame('jobs', $result);
+        $result = $builder->getFrom();
+        $this->assertSame('"jobs"', $result);
     }
 
-    public function testGetTableIgnoresFrom()
+    public function testGetFromCanReturnsSecondFrom()
     {
         $builder = $this->db->table('jobs');
-
         $builder->from('foo');
-        $result = $builder->getTable();
-        $this->assertSame('jobs', $result);
+
+        $result = $builder->getFrom(0);
+        $this->assertSame('"jobs"', $result);
+
+        $result = $builder->getFrom(1);
+        $this->assertSame('"foo"', $result);
     }
 }

--- a/tests/system/Database/Builder/CountTest.php
+++ b/tests/system/Database/Builder/CountTest.php
@@ -31,7 +31,8 @@ final class CountTest extends CIUnitTestCase
 
     public function testCountAll()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
         $builder->testMode();
 
         $expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM "jobs"';
@@ -41,7 +42,8 @@ final class CountTest extends CIUnitTestCase
 
     public function testCountAllResults()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
         $builder->testMode();
 
         $answer = $builder->where('id >', 3)->countAllResults(false);
@@ -53,7 +55,8 @@ final class CountTest extends CIUnitTestCase
 
     public function testCountAllResultsWithGroupBy()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
         $builder->groupBy('id');
         $builder->testMode();
 
@@ -71,7 +74,8 @@ final class CountTest extends CIUnitTestCase
     {
         $this->db = new MockConnection(['DBPrefix' => 'ci_']);
 
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
         $builder->select('jobs.*')->where('id >', 3)->groupBy('id')->testMode();
 
         $expectedSQL = 'SELECT COUNT(*) AS "numrows" FROM ( SELECT "ci_jobs".* FROM "ci_jobs" WHERE "id" > :id: GROUP BY "id" ) CI_count_all_results';
@@ -86,7 +90,8 @@ final class CountTest extends CIUnitTestCase
 
     public function testCountAllResultsWithGroupByAndHaving()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
         $builder->groupBy('id');
         $builder->having('1=1');
         $builder->testMode();
@@ -100,7 +105,8 @@ final class CountTest extends CIUnitTestCase
 
     public function testCountAllResultsWithHavingOnly()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
         $builder->having('1=1');
         $builder->testMode();
 

--- a/tests/system/Database/Builder/DistinctTest.php
+++ b/tests/system/Database/Builder/DistinctTest.php
@@ -31,7 +31,8 @@ final class DistinctTest extends CIUnitTestCase
 
     public function testDelete()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('country')->distinct();
 

--- a/tests/system/Database/Builder/EmptyTest.php
+++ b/tests/system/Database/Builder/EmptyTest.php
@@ -31,7 +31,8 @@ final class EmptyTest extends CIUnitTestCase
 
     public function testEmptyWithNoTable()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $answer = $builder->testMode()->emptyTable();
 

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -32,7 +32,8 @@ final class FromTest extends CIUnitTestCase
 
     public function testSimpleFrom()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->from('jobs');
 
@@ -43,7 +44,8 @@ final class FromTest extends CIUnitTestCase
 
     public function testFromThatOverwrites()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->from('jobs', true);
 
@@ -54,7 +56,8 @@ final class FromTest extends CIUnitTestCase
 
     public function testFromWithMultipleTables()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->from(['jobs', 'roles']);
 
@@ -65,7 +68,8 @@ final class FromTest extends CIUnitTestCase
 
     public function testFromWithMultipleTablesAsString()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->from(['jobs, roles']);
 
@@ -76,7 +80,8 @@ final class FromTest extends CIUnitTestCase
 
     public function testFromReset()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->from(['jobs', 'roles']);
 
@@ -105,7 +110,8 @@ final class FromTest extends CIUnitTestCase
     {
         $this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
 
-        $builder = new SQLSRVBuilder('user', $this->db);
+        $builder = new SQLSRVBuilder($this->db);
+        $builder->from('user');
 
         $builder->from(['jobs, roles']);
 

--- a/tests/system/Database/Builder/GroupTest.php
+++ b/tests/system/Database/Builder/GroupTest.php
@@ -31,7 +31,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testGroupBy()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')->groupBy('name');
 
@@ -42,7 +43,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testHavingBy()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -55,7 +57,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testOrHavingBy()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -69,7 +72,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testHavingIn()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -82,7 +86,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testHavingInClosure()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')->groupBy('name');
 
@@ -97,7 +102,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testOrHavingIn()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -111,7 +117,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testOrHavingInClosure()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')->groupBy('name');
 
@@ -129,7 +136,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testHavingNotIn()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -142,7 +150,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testHavingNotInClosure()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')->groupBy('name');
 
@@ -157,7 +166,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testOrHavingNotIn()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -171,7 +181,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testOrHavingNotInClosure()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')->groupBy('name');
 
@@ -189,7 +200,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testHavingLike()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -202,7 +214,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testHavingLikeBefore()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -215,7 +228,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testHavingLikeAfter()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -228,7 +242,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testNotHavingLike()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -241,7 +256,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testNotHavingLikeBefore()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -254,7 +270,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testNotHavingLikeAfter()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -267,7 +284,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testOrHavingLike()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -281,7 +299,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testOrHavingLikeBefore()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -295,7 +314,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testOrHavingLikeAfter()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -309,7 +329,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testOrNotHavingLike()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -323,7 +344,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testOrNotHavingLikeBefore()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -337,7 +359,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testOrNotHavingLikeAfter()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -351,7 +374,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testHavingAndGroup()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -368,7 +392,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testHavingOrGroup()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -385,7 +410,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testNotHavingAndGroup()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -402,7 +428,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testNotHavingOrGroup()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->select('name')
             ->groupBy('name')
@@ -419,7 +446,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testAndGroups()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->groupStart()
             ->where('id >', 3)
@@ -434,7 +462,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testOrGroups()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->where('name', 'Darth')
             ->orGroupStart()
@@ -449,7 +478,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testNotGroups()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->where('name', 'Darth')
             ->notGroupStart()
@@ -464,7 +494,8 @@ final class GroupTest extends CIUnitTestCase
 
     public function testOrNotGroups()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->where('name', 'Darth')
             ->orNotGroupStart()

--- a/tests/system/Database/Builder/JoinTest.php
+++ b/tests/system/Database/Builder/JoinTest.php
@@ -33,7 +33,8 @@ final class JoinTest extends CIUnitTestCase
 
     public function testJoinSimple()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->join('job', 'user.id = job.id');
 
@@ -44,7 +45,8 @@ final class JoinTest extends CIUnitTestCase
 
     public function testJoinIsNull()
     {
-        $builder = new BaseBuilder('table1', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('table1');
 
         $builder->join('table2', 'field IS NULL');
 
@@ -55,7 +57,8 @@ final class JoinTest extends CIUnitTestCase
 
     public function testJoinIsNotNull()
     {
-        $builder = new BaseBuilder('table1', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('table1');
 
         $builder->join('table2', 'field IS NOT NULL');
 
@@ -66,7 +69,8 @@ final class JoinTest extends CIUnitTestCase
 
     public function testJoinMultipleConditions()
     {
-        $builder = new BaseBuilder('table1', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('table1');
 
         $builder->join('table2', "table1.field1 = table2.field2 AND table1.field1 = 'foo' AND table2.field2 = 0", 'LEFT');
 
@@ -77,7 +81,8 @@ final class JoinTest extends CIUnitTestCase
 
     public function testFullOuterJoin()
     {
-        $builder = new PostgreBuilder('jobs', $this->db);
+        $builder = new PostgreBuilder($this->db);
+        $builder->from('jobs');
         $builder->testMode();
         $builder->join('users as u', 'users.id = jobs.id', 'full outer');
 
@@ -90,7 +95,8 @@ final class JoinTest extends CIUnitTestCase
     {
         $this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
 
-        $builder = new SQLSRVBuilder('jobs', $this->db);
+        $builder = new SQLSRVBuilder($this->db);
+        $builder->from('jobs');
         $builder->testMode();
         $builder->join('users u', 'u.id = jobs.id', 'LEFT');
 

--- a/tests/system/Database/Builder/LikeTest.php
+++ b/tests/system/Database/Builder/LikeTest.php
@@ -31,7 +31,8 @@ final class LikeTest extends CIUnitTestCase
 
     public function testSimpleLike()
     {
-        $builder = new BaseBuilder('job', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('job');
 
         $builder->like('name', 'veloper');
 
@@ -49,7 +50,8 @@ final class LikeTest extends CIUnitTestCase
 
     public function testLikeNoSide()
     {
-        $builder = new BaseBuilder('job', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('job');
 
         $builder->like('name', 'veloper', 'none');
 
@@ -67,7 +69,8 @@ final class LikeTest extends CIUnitTestCase
 
     public function testLikeBeforeOnly()
     {
-        $builder = new BaseBuilder('job', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('job');
 
         $builder->like('name', 'veloper', 'before');
 
@@ -85,7 +88,8 @@ final class LikeTest extends CIUnitTestCase
 
     public function testLikeAfterOnly()
     {
-        $builder = new BaseBuilder('job', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('job');
 
         $builder->like('name', 'veloper', 'after');
 
@@ -103,7 +107,8 @@ final class LikeTest extends CIUnitTestCase
 
     public function testOrLike()
     {
-        $builder = new BaseBuilder('job', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('job');
 
         $builder->like('name', 'veloper')->orLike('name', 'ian');
 
@@ -125,7 +130,8 @@ final class LikeTest extends CIUnitTestCase
 
     public function testNotLike()
     {
-        $builder = new BaseBuilder('job', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('job');
 
         $builder->notLike('name', 'veloper');
 
@@ -143,7 +149,8 @@ final class LikeTest extends CIUnitTestCase
 
     public function testOrNotLike()
     {
-        $builder = new BaseBuilder('job', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('job');
 
         $builder->like('name', 'veloper')->orNotLike('name', 'ian');
 
@@ -168,7 +175,8 @@ final class LikeTest extends CIUnitTestCase
      */
     public function testCaseInsensitiveLike()
     {
-        $builder = new BaseBuilder('job', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('job');
 
         $builder->like('name', 'VELOPER', 'both', null, true);
 

--- a/tests/system/Database/Builder/LimitTest.php
+++ b/tests/system/Database/Builder/LimitTest.php
@@ -31,7 +31,8 @@ final class LimitTest extends CIUnitTestCase
 
     public function testLimitAlone()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->limit(5);
 
@@ -42,7 +43,8 @@ final class LimitTest extends CIUnitTestCase
 
     public function testLimitAndOffset()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->limit(5, 1);
 
@@ -53,7 +55,8 @@ final class LimitTest extends CIUnitTestCase
 
     public function testLimitAndOffsetMethod()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->limit(5)->offset(1);
 

--- a/tests/system/Database/Builder/OrderTest.php
+++ b/tests/system/Database/Builder/OrderTest.php
@@ -31,7 +31,8 @@ final class OrderTest extends CIUnitTestCase
 
     public function testOrderAscending()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->orderBy('name', 'asc');
 
@@ -42,7 +43,8 @@ final class OrderTest extends CIUnitTestCase
 
     public function testOrderDescending()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->orderBy('name', 'desc');
 
@@ -53,7 +55,8 @@ final class OrderTest extends CIUnitTestCase
 
     public function testOrderRandom()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $builder->orderBy('name', 'random');
 
@@ -65,7 +68,8 @@ final class OrderTest extends CIUnitTestCase
     public function testOrderRandomWithRandomColumn()
     {
         $this->db->setPrefix('fail_');
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
         $this->setPrivateProperty($builder, 'randomKeyword', ['"SYSTEM"."RANDOM"']);
 
         $builder->orderBy('name', 'random');

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -33,7 +33,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSimpleSelect()
     {
-        $builder = new BaseBuilder('users', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('users');
 
         $expected = 'SELECT * FROM "users"';
 
@@ -42,7 +43,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectOnlyOneColumn()
     {
-        $builder = new BaseBuilder('users', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('users');
 
         $builder->select('name');
 
@@ -53,7 +55,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectAcceptsArray()
     {
-        $builder = new BaseBuilder('users', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('users');
 
         $builder->select(['name', 'role']);
 
@@ -64,7 +67,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectAcceptsMultipleColumns()
     {
-        $builder = new BaseBuilder('users', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('users');
 
         $builder->select('name, role');
 
@@ -75,7 +79,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectKeepsAliases()
     {
-        $builder = new BaseBuilder('users', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('users');
 
         $builder->select('name, role as myRole');
 
@@ -86,7 +91,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectWorksWithComplexSelects()
     {
-        $builder = new BaseBuilder('users', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('users');
 
         $builder->select('(SELECT SUM(payments.amount) FROM payments WHERE payments.invoice_id=4) AS amount_paid');
 
@@ -97,7 +103,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectMinWithNoAlias()
     {
-        $builder = new BaseBuilder('invoices', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('invoices');
 
         $builder->selectMin('payments');
 
@@ -108,7 +115,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectMinWithAlias()
     {
-        $builder = new BaseBuilder('invoices', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('invoices');
 
         $builder->selectMin('payments', 'myAlias');
 
@@ -119,7 +127,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectMaxWithNoAlias()
     {
-        $builder = new BaseBuilder('invoices', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('invoices');
 
         $builder->selectMax('payments');
 
@@ -130,7 +139,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectMaxWithAlias()
     {
-        $builder = new BaseBuilder('invoices', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('invoices');
 
         $builder->selectMax('payments', 'myAlias');
 
@@ -141,7 +151,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectAvgWithNoAlias()
     {
-        $builder = new BaseBuilder('invoices', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('invoices');
 
         $builder->selectAvg('payments');
 
@@ -152,7 +163,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectAvgWithAlias()
     {
-        $builder = new BaseBuilder('invoices', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('invoices');
 
         $builder->selectAvg('payments', 'myAlias');
 
@@ -163,7 +175,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectSumWithNoAlias()
     {
-        $builder = new BaseBuilder('invoices', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('invoices');
 
         $builder->selectSum('payments');
 
@@ -174,7 +187,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectSumWithAlias()
     {
-        $builder = new BaseBuilder('invoices', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('invoices');
 
         $builder->selectSum('payments', 'myAlias');
 
@@ -185,7 +199,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectCountWithNoAlias()
     {
-        $builder = new BaseBuilder('invoices', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('invoices');
 
         $builder->selectCount('payments');
 
@@ -196,7 +211,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectCountWithAlias()
     {
-        $builder = new BaseBuilder('invoices', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('invoices');
 
         $builder->selectCount('payments', 'myAlias');
 
@@ -207,7 +223,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectMinThrowsExceptionOnEmptyValue()
     {
-        $builder = new BaseBuilder('invoices', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('invoices');
 
         $this->expectException(DataException::class);
         $this->expectExceptionMessage('Empty statement is given for the field `Select`');
@@ -217,7 +234,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectMaxWithDotNameAndNoAlias()
     {
-        $builder = new BaseBuilder('invoices', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('invoices');
 
         $builder->selectMax('db.payments');
 
@@ -228,7 +246,8 @@ final class SelectTest extends CIUnitTestCase
 
     public function testSelectMinThrowsExceptionOnMultipleColumn()
     {
-        $builder = new BaseBuilder('users', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('users');
 
         $this->expectException(DataException::class);
         $this->expectExceptionMessage('You must provide a valid column name not separated by comma.');
@@ -240,7 +259,8 @@ final class SelectTest extends CIUnitTestCase
     {
         $this->db = new MockConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
 
-        $builder = new SQLSRVBuilder('users', $this->db);
+        $builder = new SQLSRVBuilder($this->db);
+        $builder->from('users');
 
         $expected = 'SELECT * FROM "test"."dbo"."users"';
 

--- a/tests/system/Database/Builder/TruncateTest.php
+++ b/tests/system/Database/Builder/TruncateTest.php
@@ -31,7 +31,8 @@ final class TruncateTest extends CIUnitTestCase
 
     public function testTruncate()
     {
-        $builder = new BaseBuilder('user', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
 
         $expectedSQL = 'TRUNCATE "user"';
 

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -35,7 +35,8 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testUpdate()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $builder->testMode()->where('id', 1)->update(['name' => 'Programmer'], null, null);
 
@@ -57,7 +58,8 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testUpdateInternalWhereAndLimit()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $builder->testMode()->update(['name' => 'Programmer'], ['id' => 1], 5);
 
@@ -79,7 +81,8 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testUpdateWithSet()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $builder->testMode()->set('name', 'Programmer')->where('id', 1)->update(null, null, null);
 
@@ -101,7 +104,8 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testUpdateWithSetAsInt()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $builder->testMode()->set('age', 22)->where('id', 1)->update(null, null, null);
 
@@ -123,7 +127,8 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testUpdateWithSetAsBoolean()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $builder->testMode()->set('manager', true)->where('id', 1)->update(null, null, null);
 
@@ -145,7 +150,8 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testUpdateWithSetAsArray()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $builder->testMode()->set(['name' => 'Programmer', 'age' => 22, 'manager' => true])->where('id', 1)->update(null, null, null);
 
@@ -175,7 +181,8 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testUpdateThrowsExceptionWithNoData()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $this->expectException('CodeIgniter\Database\Exceptions\DatabaseException');
         $this->expectExceptionMessage('You must use the "set" method to update an entry.');
@@ -185,7 +192,8 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testUpdateBatch()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $updateData = [
             [
@@ -224,8 +232,9 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testSetUpdateBatchWithoutEscape()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
-        $escape  = false;
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
+        $escape = false;
 
         $builder->setUpdateBatch([
             [
@@ -264,7 +273,8 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testUpdateBatchThrowsExceptionWithNoData()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $this->expectException('\CodeIgniter\Database\Exceptions\DatabaseException');
         $this->expectExceptionMessage('You must use the "set" method to update an entry.');
@@ -274,7 +284,8 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testUpdateBatchThrowsExceptionWithNoID()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $this->expectException('\CodeIgniter\Database\Exceptions\DatabaseException');
         $this->expectExceptionMessage('You must specify an index to match on for batch updates.');
@@ -284,7 +295,8 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testUpdateBatchThrowsExceptionWithEmptySetArray()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $this->expectException('\CodeIgniter\Database\Exceptions\DatabaseException');
         $this->expectExceptionMessage('updateBatch() called with no data');
@@ -294,7 +306,8 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testUpdateWithWhereSameColumn()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $builder->testMode()->update(['name' => 'foobar'], ['name' => 'Programmer'], null);
 
@@ -317,7 +330,8 @@ final class UpdateTest extends CIUnitTestCase
     public function testUpdateWithWhereSameColumn2()
     {
         // calling order: set() -> where()
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $builder->testMode()
             ->set('name', 'foobar')
@@ -343,7 +357,8 @@ final class UpdateTest extends CIUnitTestCase
     public function testUpdateWithWhereSameColumn3()
     {
         // calling order: where() -> set() in update()
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
 
         $builder->testMode()
             ->where('name', 'Programmer')
@@ -370,7 +385,8 @@ final class UpdateTest extends CIUnitTestCase
      */
     public function testSetWithoutEscape()
     {
-        $builder = new BaseBuilder('mytable', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('mytable');
 
         $builder->testMode()
             ->set('field', 'field+1', false)
@@ -391,7 +407,8 @@ final class UpdateTest extends CIUnitTestCase
 
     public function testSetWithAndWithoutEscape()
     {
-        $builder = new BaseBuilder('mytable', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('mytable');
 
         $builder->testMode()
             ->set('foo', 'bar')

--- a/tests/system/Database/Live/WriteTypeQueryTest.php
+++ b/tests/system/Database/Live/WriteTypeQueryTest.php
@@ -56,7 +56,8 @@ final class WriteTypeQueryTest extends CIUnitTestCase
 
     public function testUpdate()
     {
-        $builder = new BaseBuilder('jobs', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('jobs');
         $builder->testMode()->where('id', 1)->update(['name' => 'Programmer'], null, null);
         $sql = $builder->getCompiledInsert();
 
@@ -115,8 +116,9 @@ final class WriteTypeQueryTest extends CIUnitTestCase
 
     public function testTruncate()
     {
-        $builder = new BaseBuilder('user', $this->db);
-        $sql     = $builder->testMode()->truncate();
+        $builder = new BaseBuilder($this->db);
+        $builder->from('user');
+        $sql = $builder->testMode()->truncate();
 
         $this->assertTrue($this->db->isWriteType($sql));
     }
@@ -194,7 +196,8 @@ final class WriteTypeQueryTest extends CIUnitTestCase
 
     public function testSelect()
     {
-        $builder = new BaseBuilder('users', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('users');
         $builder->select('*');
         $sql = $builder->getCompiledSelect();
 
@@ -203,7 +206,8 @@ final class WriteTypeQueryTest extends CIUnitTestCase
 
     public function testTrick()
     {
-        $builder = new BaseBuilder('users', $this->db);
+        $builder = new BaseBuilder($this->db);
+        $builder->from('users');
         $builder->select('UPDATE');
         $sql = $builder->getCompiledSelect();
 

--- a/tests/system/Models/FindModelTest.php
+++ b/tests/system/Models/FindModelTest.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Models;
 
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Exceptions\ModelException;
+use CodeIgniter\Model;
 use Tests\Support\Models\JobModel;
 use Tests\Support\Models\SecondaryModel;
 use Tests\Support\Models\UserModel;
@@ -274,11 +275,12 @@ final class FindModelTest extends LiveModelTestCase
     public function testThrowsWithNoPrimaryKey(): void
     {
         $this->expectException(ModelException::class);
-        $this->expectExceptionMessage('`Tests\Support\Models\UserModel` model class does not specify a Primary Key.');
+        $this->expectExceptionMessage(' model class does not specify a Primary Key.');
 
-        $this->createModel(UserModel::class);
-        $this->setPrivateProperty($this->model, 'primaryKey', '');
-        $this->model->find(1);
+        new class () extends Model {
+            protected $table      = 'dummy';
+            protected $primaryKey = '';
+        };
     }
 
     /**

--- a/tests/system/Models/GeneralModelTest.php
+++ b/tests/system/Models/GeneralModelTest.php
@@ -120,7 +120,7 @@ final class GeneralModelTest extends CIUnitTestCase
     public function testBuilderUsesModelTable(): void
     {
         $builder = $this->createModel(UserModel::class)->builder();
-        $this->assertSame('user', $builder->getTable());
+        $this->assertStringContainsString('db_user', $builder->getFrom());
     }
 
     public function testBuilderRespectsTableParameter(): void
@@ -129,8 +129,8 @@ final class GeneralModelTest extends CIUnitTestCase
         $builder1 = $this->model->builder('jobs');
         $builder2 = $this->model->builder();
 
-        $this->assertSame('jobs', $builder1->getTable());
-        $this->assertSame('user', $builder2->getTable());
+        $this->assertStringContainsString('db_jobs', $builder1->getFrom());
+        $this->assertStringContainsString('db_user', $builder2->getFrom());
     }
 
     public function testBuilderWithParameterIgnoresShared(): void
@@ -140,9 +140,9 @@ final class GeneralModelTest extends CIUnitTestCase
         $builder2 = $this->model->builder('jobs');
         $builder3 = $this->model->builder();
 
-        $this->assertSame('user', $builder1->getTable());
-        $this->assertSame('jobs', $builder2->getTable());
-        $this->assertSame('user', $builder3->getTable());
+        $this->assertStringContainsString('db_user', $builder1->getFrom());
+        $this->assertStringContainsString('db_jobs', $builder2->getFrom());
+        $this->assertSame($builder1, $builder3);
     }
 
     public function testInitialize(): void

--- a/tests/system/Models/GeneralModelTest.php
+++ b/tests/system/Models/GeneralModelTest.php
@@ -105,6 +105,7 @@ final class GeneralModelTest extends CIUnitTestCase
         ];
 
         $model                       = new class () extends Model {
+            protected $table         = 'dummy';
             protected $allowedFields = [
                 'id',
                 'created_at',
@@ -147,7 +148,9 @@ final class GeneralModelTest extends CIUnitTestCase
 
     public function testInitialize(): void
     {
-        $model = new class () extends Model {
+        $model               = new class () extends Model {
+            protected $table = 'dummy';
+
             /**
              * @var bool
              */


### PR DESCRIPTION
**Description**
This is a proposal for v5.0.
It's kind of a memo to remember my current thoughts.

- remove `BaseBuilder::$tableName` and `$tableName` of constructor
  - QueryBuilder's responsibility is to build queries. `$tableName` is not needed
  - The current `$tableName` is only for `Model` knowing the QB's primary table name
- `Model` must have `$table` and `$primaryKey`
  - `Model` is not QueryBuilder. It is tightly coupled with a table
- refactor `Model`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
