### PR TITLE
Additional fix for deprecated `null` usage

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -565,7 +565,7 @@ class IncomingRequest extends Request
      */
     public function getRawInput()
     {
-        parse_str($this->body, $output);
+        parse_str($this->body ?? '', $output);
 
         return $output;
     }

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -45,11 +45,16 @@ class FormatRules
 
     /**
      * Alphanumeric with underscores and dashes
+     *
+     * @see https://regex101.com/r/XfVY3d/1
      */
     public function alpha_dash(?string $str = null): bool
     {
-        // @see https://regex101.com/r/XfVY3d/1
-        return (bool) preg_match('/\A[a-z0-9_-]+\z/i', $str);
+        if ($str === null) {
+            return false;
+        }
+
+        return preg_match('/\A[a-z0-9_-]+\z/i', $str) === 1;
     }
 
     /**
@@ -59,14 +64,19 @@ class FormatRules
      * _ underscore, + plus, = equals, | vertical bar, : colon, . period
      * ~ ! # $ % & * - _ + = | : .
      *
-     * @param string $str
+     * @param string|null $str
      *
      * @return bool
+     *
+     * @see https://regex101.com/r/6N8dDY/1
      */
     public function alpha_numeric_punct($str)
     {
-        // @see https://regex101.com/r/6N8dDY/1
-        return (bool) preg_match('/\A[A-Z0-9 ~!#$%\&\*\-_+=|:.]+\z/i', $str);
+        if ($str === null) {
+            return false;
+        }
+
+        return preg_match('/\A[A-Z0-9 ~!#$%\&\*\-_+=|:.]+\z/i', $str) === 1;
     }
 
     /**
@@ -307,7 +317,7 @@ class FormatRules
             return false;
         }
 
-        $scheme       = strtolower(parse_url($str, PHP_URL_SCHEME));
+        $scheme       = strtolower(parse_url($str, PHP_URL_SCHEME) ?? ''); // absent scheme gives null
         $validSchemes = explode(
             ',',
             strtolower($validSchemes ?? 'http,https')

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -213,11 +213,19 @@ class Rules
      */
     public function required($str = null): bool
     {
+        if ($str === null) {
+            return false;
+        }
+
         if (is_object($str)) {
             return true;
         }
 
-        return is_array($str) ? ! empty($str) : (trim($str) !== '');
+        if (is_array($str)) {
+            return $str !== [];
+        }
+
+        return trim((string) $str) !== '';
     }
 
     /**


### PR DESCRIPTION
**Description**
#4883 

After merge of latest changes, there seems to be new deprecations detected. So fixing again.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
