### PR TITLE
fix: `IncomingRequest::getJsonVar()` may cause TypeError

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -537,7 +537,11 @@ class IncomingRequest extends Request
     {
         helper('array');
 
-        $data = dot_array_search($index, $this->getJSON(true));
+        $json = $this->getJSON(true);
+        if (! is_array($json)) {
+            return null;
+        }
+        $data = dot_array_search($index, $json);
 
         if ($data === null) {
             return null;

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -520,7 +520,7 @@ class IncomingRequest extends Request
      */
     public function getJSON(bool $assoc = false, int $depth = 512, int $options = 0)
     {
-        return json_decode($this->body, $assoc, $depth, $options);
+        return json_decode($this->body ?? '', $assoc, $depth, $options);
     }
 
     /**

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -394,6 +394,29 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertSame('buzz', $all['fizz']);
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5391
+     */
+    public function testGetJsonVarReturnsNullFromNullBody()
+    {
+        $config          = new App();
+        $config->baseURL = 'http://example.com/';
+        $json            = null;
+        $request         = new IncomingRequest($config, new URI(), $json, new UserAgent());
+
+        $this->assertNull($request->getJsonVar('myKey'));
+    }
+
+    public function testgetJSONReturnsNullFromNullBody()
+    {
+        $config          = new App();
+        $config->baseURL = 'http://example.com/';
+        $json            = null;
+        $request         = new IncomingRequest($config, new URI(), $json, new UserAgent());
+
+        $this->assertNull($request->getJSON());
+    }
+
     public function testCanGrabGetRawInput()
     {
         $rawstring = 'username=admin001&role=administrator&usepass=0';


### PR DESCRIPTION
**Description**
Fixes #5391

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
