### PR TITLE
fix: `is_cli()` returns `true` when `$_SERVER['HTTP_USER_AGENT']` is missing

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -643,7 +643,13 @@ if (! function_exists('is_cli')) {
      */
     function is_cli(): bool
     {
-        return in_array(PHP_SAPI, ['cli', 'phpdbg'], true);
+        if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
+            return true;
+        }
+
+        // PHP_SAPI could be 'cgi-fcgi', 'fpm-fcgi'.
+        // See https://github.com/codeigniter4/CodeIgniter4/pull/5393
+        return ! isset($_SERVER['REMOTE_ADDR']) && ! isset($_SERVER['REQUEST_METHOD']);
     }
 }
 

--- a/system/Common.php
+++ b/system/Common.php
@@ -643,16 +643,7 @@ if (! function_exists('is_cli')) {
      */
     function is_cli(): bool
     {
-        if (defined('STDIN')) {
-            return true;
-        }
-
-        if (! isset($_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_USER_AGENT']) && isset($_SERVER['argv']) && count($_SERVER['argv']) > 0) {
-            return true;
-        }
-
-        // if source of request is from CLI, the `$_SERVER` array will not populate this key
-        return ! isset($_SERVER['REQUEST_METHOD']);
+        return in_array(PHP_SAPI, ['cli', 'phpdbg'], true);
     }
 }
 


### PR DESCRIPTION
**Description**
Fixes #5336

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
