### PR TITLE
chore: set locale and timezone in test bootstrap

### DIFF
--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -12,6 +12,7 @@
 use CodeIgniter\Config\DotEnv;
 use CodeIgniter\Router\RouteCollection;
 use CodeIgniter\Services;
+use Config\App;
 use Config\Autoload;
 use Config\Modules;
 use Config\Paths;
@@ -106,6 +107,14 @@ $env->load();
 
 // Always load the URL helper, it should be used in most of apps.
 helper('url');
+
+// Set locale and timezone
+$appConfig = new App();
+// Set default locale on the server
+locale_set_default($appConfig->defaultLocale ?? 'en');
+// Set default timezone on the server
+date_default_timezone_set($appConfig->appTimezone ?? 'UTC');
+unset($appConfig);
 
 require_once APPPATH . 'Config/Routes.php';
 


### PR DESCRIPTION
**Description**
In app execution, the default locale and timezone are set from `Config\App` values.
But in test execution, these are not set now.

https://github.com/codeigniter4/CodeIgniter4/blob/0a5508202b1c08928c7bcb863837a8a119951b32/system/CodeIgniter.php#L180-L184

The app and system code may depend on the default locale/timezone.
It is better to set these in testing.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
