### PR TITLE
fix: prefix primary key with table name

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -589,7 +589,7 @@ class Model extends BaseModel
         return parent::shouldUpdate($data)
             && $this->useAutoIncrement
                 ? true
-                : $this->where($this->primaryKey, $this->getIdValue($data))->countAllResults() === 1;
+                : $this->where($this->table . '.' . $this->primaryKey, $this->getIdValue($data))->countAllResults() === 1;
     }
 
     /**


### PR DESCRIPTION
This fix prevents ambiguity in case of complex queries.

**Description**
When injecting joins in the Model's `beforeFind` event it could happen that two tables have the same `$this->primaryKey` (ex: id) so the final query could result in the following mysql error: `Column 'id' in where clause is ambiguous`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide