### PR TITLE
feat: Add Strict Validation

### DIFF
--- a/.github/workflows/test-phpcpd.yml
+++ b/.github/workflows/test-phpcpd.yml
@@ -38,4 +38,4 @@ jobs:
           extensions: dom, mbstring
 
       - name: Detect code duplication
-        run: phpcpd --exclude system/Test --exclude system/ThirdParty --exclude system/Database/SQLSRV/Builder.php --exclude system/Database/SQLSRV/Forge.php -- app/ public/ system/
+        run: phpcpd --exclude system/Test --exclude system/ThirdParty --exclude system/Database/SQLSRV/Builder.php --exclude system/Database/SQLSRV/Forge.php --exclude system/ValidationStrict -- app/ public/ system/

--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -24,4 +24,15 @@ class Feature extends BaseConfig
      * @var bool
      */
     public $multipleFilters = false;
+
+    /**
+     * Enable strict validation or not
+     *
+     * If you enable this:
+     *   - Don't forget to update `$ruleSets` in `app/Config/Validation.php`.
+     *   - CodeIgniter\ValidationStrict\Validation is used.
+     *
+     * @var bool
+     */
+    public $strictValidation = false;
 }

--- a/app/Config/Validation.php
+++ b/app/Config/Validation.php
@@ -17,6 +17,8 @@ class Validation
      * Stores the classes that contain the
      * rules that are available.
      *
+     * If you use strict validation, please set the classes in ValidationStrict.
+     *
      * @var string[]
      */
     public $ruleSets = [
@@ -24,6 +26,10 @@ class Validation
         FormatRules::class,
         FileRules::class,
         CreditCardRules::class,
+        // \CodeIgniter\ValidationStrict\CreditCardRules::class,
+        // \CodeIgniter\ValidationStrict\FileRules::class,
+        // \CodeIgniter\ValidationStrict\FormatRules::class,
+        // \CodeIgniter\ValidationStrict\Rules::class,
     ];
 
     /**

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -50,6 +50,8 @@ use CodeIgniter\Session\Session;
 use CodeIgniter\Throttle\Throttler;
 use CodeIgniter\Typography\Typography;
 use CodeIgniter\Validation\Validation;
+use CodeIgniter\Validation\ValidationInterface;
+use CodeIgniter\ValidationStrict\Validation as ValidationStrict;
 use CodeIgniter\View\Cell;
 use CodeIgniter\View\Parser;
 use CodeIgniter\View\RendererInterface;
@@ -645,7 +647,7 @@ class Services extends BaseService
     /**
      * The Validation class provides tools for validating input data.
      *
-     * @return Validation
+     * @return ValidationInterface
      */
     public static function validation(?ValidationConfig $config = null, bool $getShared = true)
     {
@@ -654,6 +656,11 @@ class Services extends BaseService
         }
 
         $config = $config ?? config('Validation');
+
+        $strictValidationEnabled = config('Feature')->strictValidation ?? false;
+        if ($strictValidationEnabled) {
+            return new ValidationStrict($config, AppServices::renderer());
+        }
 
         return new Validation($config, AppServices::renderer());
     }

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -15,7 +15,7 @@ use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Validation\Exceptions\ValidationException;
-use CodeIgniter\Validation\Validation;
+use CodeIgniter\Validation\ValidationInterface;
 use Config\Services;
 use Psr\Log\LoggerInterface;
 
@@ -62,7 +62,7 @@ class Controller
     /**
      * Once validation has been run, will hold the Validation instance.
      *
-     * @var Validation
+     * @var ValidationInterface
      */
     protected $validator;
 

--- a/system/ValidationStrict/CreditCardRules.php
+++ b/system/ValidationStrict/CreditCardRules.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\ValidationStrict;
+
+/**
+ * Class CreditCardRules
+ *
+ * Provides validation methods for common credit-card inputs.
+ *
+ * @see http://en.wikipedia.org/wiki/Credit_card_number
+ */
+class CreditCardRules
+{
+    /**
+     * The cards that we support, with the defining details:
+     *
+     *  name        - The type of card as found in the form. Must match the user's value
+     *  length      - List of possible lengths for the card number
+     *  prefixes    - List of possible prefixes for the card
+     *  checkdigit  - Boolean on whether we should do a modulus10 check on the numbers.
+     *
+     * @var array
+     */
+    protected $cards = [
+        'American Express' => [
+            'name'       => 'amex',
+            'length'     => '15',
+            'prefixes'   => '34,37',
+            'checkdigit' => true,
+        ],
+        'China UnionPay' => [
+            'name'       => 'unionpay',
+            'length'     => '16,17,18,19',
+            'prefixes'   => '62',
+            'checkdigit' => true,
+        ],
+        'Dankort' => [
+            'name'       => 'dankort',
+            'length'     => '16',
+            'prefixes'   => '5019,4175,4571,4',
+            'checkdigit' => true,
+        ],
+        'DinersClub' => [
+            'name'       => 'dinersclub',
+            'length'     => '14,16',
+            'prefixes'   => '300,301,302,303,304,305,309,36,38,39,54,55',
+            'checkdigit' => true,
+        ],
+        'DinersClub CarteBlanche' => [
+            'name'       => 'carteblanche',
+            'length'     => '14',
+            'prefixes'   => '300,301,302,303,304,305',
+            'checkdigit' => true,
+        ],
+        'Discover Card' => [
+            'name'       => 'discover',
+            'length'     => '16,19',
+            'prefixes'   => '6011,622,644,645,656,647,648,649,65',
+            'checkdigit' => true,
+        ],
+        'InterPayment' => [
+            'name'       => 'interpayment',
+            'length'     => '16,17,18,19',
+            'prefixes'   => '4',
+            'checkdigit' => true,
+        ],
+        'JCB' => [
+            'name'       => 'jcb',
+            'length'     => '16,17,18,19',
+            'prefixes'   => '352,353,354,355,356,357,358',
+            'checkdigit' => true,
+        ],
+        'Maestro' => [
+            'name'       => 'maestro',
+            'length'     => '12,13,14,15,16,18,19',
+            'prefixes'   => '50,56,57,58,59,60,61,62,63,64,65,66,67,68,69',
+            'checkdigit' => true,
+        ],
+        'MasterCard' => [
+            'name'       => 'mastercard',
+            'length'     => '16',
+            'prefixes'   => '51,52,53,54,55,22,23,24,25,26,27',
+            'checkdigit' => true,
+        ],
+        'NSPK MIR' => [
+            'name'       => 'mir',
+            'length'     => '16',
+            'prefixes'   => '2200,2201,2202,2203,2204',
+            'checkdigit' => true,
+        ],
+        'Troy' => [
+            'name'       => 'troy',
+            'length'     => '16',
+            'prefixes'   => '979200,979289',
+            'checkdigit' => true,
+        ],
+        'UATP' => [
+            'name'       => 'uatp',
+            'length'     => '15',
+            'prefixes'   => '1',
+            'checkdigit' => true,
+        ],
+        'Verve' => [
+            'name'       => 'verve',
+            'length'     => '16,19',
+            'prefixes'   => '506,650',
+            'checkdigit' => true,
+        ],
+        'Visa' => [
+            'name'       => 'visa',
+            'length'     => '13,16,19',
+            'prefixes'   => '4',
+            'checkdigit' => true,
+        ],
+        // Canadian Cards
+        'BMO ABM Card' => [
+            'name'       => 'bmoabm',
+            'length'     => '16',
+            'prefixes'   => '500',
+            'checkdigit' => false,
+        ],
+        'CIBC Convenience Card' => [
+            'name'       => 'cibc',
+            'length'     => '16',
+            'prefixes'   => '4506',
+            'checkdigit' => false,
+        ],
+        'HSBC Canada Card' => [
+            'name'       => 'hsbc',
+            'length'     => '16',
+            'prefixes'   => '56',
+            'checkdigit' => false,
+        ],
+        'Royal Bank of Canada Client Card' => [
+            'name'       => 'rbc',
+            'length'     => '16',
+            'prefixes'   => '45',
+            'checkdigit' => false,
+        ],
+        'Scotiabank Scotia Card' => [
+            'name'       => 'scotia',
+            'length'     => '16',
+            'prefixes'   => '4536',
+            'checkdigit' => false,
+        ],
+        'TD Canada Trust Access Card' => [
+            'name'       => 'tdtrust',
+            'length'     => '16',
+            'prefixes'   => '589297',
+            'checkdigit' => false,
+        ],
+    ];
+
+    /**
+     * Verifies that a credit card number is valid and matches the known
+     * formats for a wide number of credit card types. This does not verify
+     * that the card is a valid card, only that the number is formatted correctly.
+     *
+     * Example:
+     *  $rules = [
+     *      'cc_num' => 'valid_cc_number[visa]'
+     *  ];
+     *
+     * @param mixed $ccNumber
+     */
+    public function valid_cc_number($ccNumber, string $type): bool
+    {
+        if (! is_string($ccNumber)) {
+            return false;
+        }
+
+        $type = strtolower($type);
+        $info = null;
+
+        // Get our card info based on provided name.
+        foreach ($this->cards as $card) {
+            if ($card['name'] === $type) {
+                $info = $card;
+                break;
+            }
+        }
+
+        // If empty, it's not a card type we recognize, or invalid type.
+        if (empty($info)) {
+            return false;
+        }
+
+        // Make sure we have a valid length
+        if ((string) $ccNumber === '') {
+            return false;
+        }
+
+        // Remove any spaces and dashes
+        $ccNumber = str_replace([' ', '-'], '', $ccNumber);
+
+        // Non-numeric values cannot be a number...duh
+        if (! is_numeric($ccNumber)) {
+            return false;
+        }
+
+        // Make sure it's a valid length for this card
+        $lengths = explode(',', $info['length']);
+
+        if (! in_array((string) strlen($ccNumber), $lengths, true)) {
+            return false;
+        }
+
+        // Make sure it has a valid prefix
+        $prefixes = explode(',', $info['prefixes']);
+
+        $validPrefix = false;
+
+        foreach ($prefixes as $prefix) {
+            if (strpos($ccNumber, $prefix) === 0) {
+                $validPrefix = true;
+                break;
+            }
+        }
+
+        if ($validPrefix === false) {
+            return false;
+        }
+
+        // Still here? Then check the number against the Luhn algorithm, if required
+        // @see https://en.wikipedia.org/wiki/Luhn_algorithm
+        // @see https://gist.github.com/troelskn/1287893
+        if ($info['checkdigit'] === true) {
+            return $this->isValidLuhn($ccNumber);
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks the given number to see if the number passing a Luhn check.
+     *
+     * @param string $number
+     */
+    protected function isValidLuhn(?string $number = null): bool
+    {
+        $number = (string) $number;
+
+        $sumTable = [
+            [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+            ],
+            [
+                0,
+                2,
+                4,
+                6,
+                8,
+                1,
+                3,
+                5,
+                7,
+                9,
+            ],
+        ];
+
+        $sum  = 0;
+        $flip = 0;
+
+        for ($i = strlen($number) - 1; $i >= 0; $i--) {
+            $sum += $sumTable[$flip++ & 0x1][$number[$i]];
+        }
+
+        return $sum % 10 === 0;
+    }
+}

--- a/system/ValidationStrict/FileRules.php
+++ b/system/ValidationStrict/FileRules.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\ValidationStrict;
+
+use CodeIgniter\HTTP\RequestInterface;
+use Config\Mimes;
+use Config\Services;
+
+/**
+ * File validation rules
+ */
+class FileRules
+{
+    /**
+     * Request instance. So we can get access to the files.
+     *
+     * @var RequestInterface
+     */
+    protected $request;
+
+    /**
+     * Constructor.
+     *
+     * @param RequestInterface $request
+     */
+    public function __construct(?RequestInterface $request = null)
+    {
+        if ($request === null) {
+            $request = Services::request();
+        }
+
+        $this->request = $request;
+    }
+
+    /**
+     * Verifies that $name is the name of a valid uploaded file.
+     */
+    public function uploaded(?string $blank, string $name): bool
+    {
+        if (! ($files = $this->request->getFileMultiple($name))) {
+            $files = [$this->request->getFile($name)];
+        }
+
+        foreach ($files as $file) {
+            if ($file === null) {
+                return false;
+            }
+
+            if (ENVIRONMENT === 'testing') {
+                if ($file->getError() !== 0) {
+                    return false;
+                }
+            } else {
+                // Note: cannot unit test this; no way to over-ride ENVIRONMENT?
+                // @codeCoverageIgnoreStart
+                if (! $file->isValid()) {
+                    return false;
+                }
+                // @codeCoverageIgnoreEnd
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Verifies if the file's size in Kilobytes is no larger than the parameter.
+     */
+    public function max_size(?string $blank, string $params): bool
+    {
+        // Grab the file name off the top of the $params
+        // after we split it.
+        $params = explode(',', $params);
+        $name   = array_shift($params);
+
+        if (! ($files = $this->request->getFileMultiple($name))) {
+            $files = [$this->request->getFile($name)];
+        }
+
+        foreach ($files as $file) {
+            if ($file === null) {
+                return false;
+            }
+
+            if ($file->getError() === UPLOAD_ERR_NO_FILE) {
+                return true;
+            }
+
+            if ($file->getError() === UPLOAD_ERR_INI_SIZE) {
+                return false;
+            }
+
+            if ($file->getSize() / 1024 > $params[0]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Uses the mime config file to determine if a file is considered an "image",
+     * which for our purposes basically means that it's a raster image or svg.
+     */
+    public function is_image(?string $blank, string $params): bool
+    {
+        // Grab the file name off the top of the $params
+        // after we split it.
+        $params = explode(',', $params);
+        $name   = array_shift($params);
+
+        if (! ($files = $this->request->getFileMultiple($name))) {
+            $files = [$this->request->getFile($name)];
+        }
+
+        foreach ($files as $file) {
+            if ($file === null) {
+                return false;
+            }
+
+            if ($file->getError() === UPLOAD_ERR_NO_FILE) {
+                return true;
+            }
+
+            // We know that our mimes list always has the first mime
+            // start with `image` even when then are multiple accepted types.
+            $type = Mimes::guessTypeFromExtension($file->getExtension());
+
+            if (mb_strpos($type, 'image') !== 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks to see if an uploaded file's mime type matches one in the parameter.
+     */
+    public function mime_in(?string $blank, string $params): bool
+    {
+        // Grab the file name off the top of the $params
+        // after we split it.
+        $params = explode(',', $params);
+        $name   = array_shift($params);
+
+        if (! ($files = $this->request->getFileMultiple($name))) {
+            $files = [$this->request->getFile($name)];
+        }
+
+        foreach ($files as $file) {
+            if ($file === null) {
+                return false;
+            }
+
+            if ($file->getError() === UPLOAD_ERR_NO_FILE) {
+                return true;
+            }
+
+            if (! in_array($file->getMimeType(), $params, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks to see if an uploaded file's extension matches one in the parameter.
+     */
+    public function ext_in(?string $blank, string $params): bool
+    {
+        // Grab the file name off the top of the $params
+        // after we split it.
+        $params = explode(',', $params);
+        $name   = array_shift($params);
+
+        if (! ($files = $this->request->getFileMultiple($name))) {
+            $files = [$this->request->getFile($name)];
+        }
+
+        foreach ($files as $file) {
+            if ($file === null) {
+                return false;
+            }
+
+            if ($file->getError() === UPLOAD_ERR_NO_FILE) {
+                return true;
+            }
+
+            if (! in_array($file->guessExtension(), $params, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks an uploaded file to verify that the dimensions are within
+     * a specified allowable dimension.
+     */
+    public function max_dims(?string $blank, string $params): bool
+    {
+        // Grab the file name off the top of the $params
+        // after we split it.
+        $params = explode(',', $params);
+        $name   = array_shift($params);
+
+        if (! ($files = $this->request->getFileMultiple($name))) {
+            $files = [$this->request->getFile($name)];
+        }
+
+        foreach ($files as $file) {
+            if ($file === null) {
+                return false;
+            }
+
+            if ($file->getError() === UPLOAD_ERR_NO_FILE) {
+                return true;
+            }
+
+            // Get Parameter sizes
+            $allowedWidth  = $params[0] ?? 0;
+            $allowedHeight = $params[1] ?? 0;
+
+            // Get uploaded image size
+            $info       = getimagesize($file->getTempName());
+            $fileWidth  = $info[0];
+            $fileHeight = $info[1];
+
+            if ($fileWidth > $allowedWidth || $fileHeight > $allowedHeight) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/system/ValidationStrict/FormatRules.php
+++ b/system/ValidationStrict/FormatRules.php
@@ -1,0 +1,494 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\ValidationStrict;
+
+use DateTime;
+
+/**
+ * Format validation Rules.
+ */
+class FormatRules
+{
+    /**
+     * Alpha
+     *
+     * @param mixed|null $str
+     */
+    public function alpha($str = null): bool
+    {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return ctype_alpha($str);
+    }
+
+    /**
+     * Alpha with spaces.
+     *
+     * @param string|null $value Value.
+     *
+     * @return bool True if alpha with spaces, else false.
+     */
+    public function alpha_space(?string $value = null): bool
+    {
+        if ($value === null) {
+            return true;
+        }
+
+        if (! is_string($value)) {
+            return false;
+        }
+
+        // @see https://regex101.com/r/LhqHPO/1
+        return (bool) preg_match('/\A[A-Z ]+\z/i', $value);
+    }
+
+    /**
+     * Alphanumeric with underscores and dashes
+     *
+     * @param mixed|null $str
+     */
+    public function alpha_dash($str = null): bool
+    {
+        if ($str === null) {
+            return false;
+        }
+
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        // @see https://regex101.com/r/XfVY3d/1
+        return preg_match('/\A[a-z0-9_-]+\z/i', $str) === 1;
+    }
+
+    /**
+     * Alphanumeric, spaces, and a limited set of punctuation characters.
+     * Accepted punctuation characters are: ~ tilde, ! exclamation,
+     * # number, $ dollar, % percent, & ampersand, * asterisk, - dash,
+     * _ underscore, + plus, = equals, | vertical bar, : colon, . period
+     * ~ ! # $ % & * - _ + = | : .
+     *
+     * @param string|null $str
+     *
+     * @return bool
+     */
+    public function alpha_numeric_punct($str)
+    {
+        if ($str === null) {
+            return false;
+        }
+
+        if (is_int($str) || is_float($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        // @see https://regex101.com/r/6N8dDY/1
+        return preg_match('/\A[A-Z0-9 ~!#$%\&\*\-_+=|:.]+\z/i', $str) === 1;
+    }
+
+    /**
+     * Alphanumeric
+     *
+     * @param mixed|null $str
+     */
+    public function alpha_numeric($str = null): bool
+    {
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return ctype_alnum($str);
+    }
+
+    /**
+     * Alphanumeric w/ spaces
+     *
+     * @param mixed|null $str
+     */
+    public function alpha_numeric_space($str = null): bool
+    {
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        // @see https://regex101.com/r/0AZDME/1
+        return (bool) preg_match('/\A[A-Z0-9 ]+\z/i', $str ?? '');
+    }
+
+    /**
+     * Any type of string
+     *
+     * @param string|null $str
+     */
+    public function string($str = null): bool
+    {
+        return is_string($str);
+    }
+
+    /**
+     * Decimal number
+     *
+     * @param mixed|null $str
+     */
+    public function decimal($str = null): bool
+    {
+        if (is_int($str) || is_float($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        // @see https://regex101.com/r/HULifl/2/
+        return (bool) preg_match('/\A[-+]?\d{0,}\.?\d+\z/', $str ?? '');
+    }
+
+    /**
+     * String of hexidecimal characters
+     *
+     * @param mixed|null $str
+     */
+    public function hex($str = null): bool
+    {
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return ctype_xdigit($str);
+    }
+
+    /**
+     * Integer
+     *
+     * @param mixed|null $str
+     */
+    public function integer($str = null): bool
+    {
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return (bool) preg_match('/\A[\-+]?\d+\z/', $str);
+    }
+
+    /**
+     * Is a Natural number  (0,1,2,3, etc.)
+     *
+     * @param mixed|null $str
+     */
+    public function is_natural($str = null): bool
+    {
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return ctype_digit($str);
+    }
+
+    /**
+     * Is a Natural number, but not a zero  (1,2,3, etc.)
+     *
+     * @param mixed|null $str
+     */
+    public function is_natural_no_zero($str = null): bool
+    {
+        if (is_int($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return $str !== '0' && ctype_digit($str);
+    }
+
+    /**
+     * Numeric
+     *
+     * @param mixed|null $str
+     */
+    public function numeric($str = null): bool
+    {
+        if (is_int($str) || is_float($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        // @see https://regex101.com/r/bb9wtr/2
+        return (bool) preg_match('/\A[\-+]?\d*\.?\d+\z/', $str ?? '');
+    }
+
+    /**
+     * Compares value against a regular expression pattern.
+     *
+     * @param mixed $str
+     */
+    public function regex_match($str, string $pattern): bool
+    {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        if (strpos($pattern, '/') !== 0) {
+            $pattern = "/{$pattern}/";
+        }
+
+        return (bool) preg_match($pattern, $str ?? '');
+    }
+
+    /**
+     * Validates that the string is a valid timezone as per the
+     * timezone_identifiers_list function.
+     *
+     * @see http://php.net/manual/en/datetimezone.listidentifiers.php
+     *
+     * @param string $str
+     */
+    public function timezone($str = null): bool
+    {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return in_array($str, timezone_identifiers_list(), true);
+    }
+
+    /**
+     * Valid Base64
+     *
+     * Tests a string for characters outside of the Base64 alphabet
+     * as defined by RFC 2045 http://www.faqs.org/rfcs/rfc2045
+     *
+     * @param string $str
+     */
+    public function valid_base64($str = null): bool
+    {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return base64_encode(base64_decode($str, true)) === $str;
+    }
+
+    /**
+     * Valid JSON
+     *
+     * @param string $str
+     */
+    public function valid_json($str = null): bool
+    {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        json_decode($str);
+
+        return json_last_error() === JSON_ERROR_NONE;
+    }
+
+    /**
+     * Checks for a correctly formatted email address
+     *
+     * @param string $str
+     */
+    public function valid_email($str = null): bool
+    {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        // @see https://regex101.com/r/wlJG1t/1/
+        if (function_exists('idn_to_ascii') && defined('INTL_IDNA_VARIANT_UTS46') && preg_match('#\A([^@]+)@(.+)\z#', $str ?? '', $matches)) {
+            $str = $matches[1] . '@' . idn_to_ascii($matches[2], 0, INTL_IDNA_VARIANT_UTS46);
+        }
+
+        return (bool) filter_var($str, FILTER_VALIDATE_EMAIL);
+    }
+
+    /**
+     * Validate a comma-separated list of email addresses.
+     *
+     * Example:
+     *     valid_emails[one@example.com,two@example.com]
+     *
+     * @param string $str
+     */
+    public function valid_emails($str = null): bool
+    {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        foreach (explode(',', $str) as $email) {
+            $email = trim($email);
+
+            if ($email === '') {
+                return false;
+            }
+
+            if ($this->valid_email($email) === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate an IP address (human readable format or binary string - inet_pton)
+     *
+     * @param string|null $which IP protocol: 'ipv4' or 'ipv6'
+     * @param mixed|null  $ip
+     */
+    public function valid_ip($ip = null, ?string $which = null): bool
+    {
+        if (! is_string($ip)) {
+            return false;
+        }
+
+        if (empty($ip)) {
+            return false;
+        }
+
+        switch (strtolower($which ?? '')) {
+            case 'ipv4':
+                $which = FILTER_FLAG_IPV4;
+                break;
+
+            case 'ipv6':
+                $which = FILTER_FLAG_IPV6;
+                break;
+
+            default:
+                $which = 0;
+        }
+
+        return filter_var($ip, FILTER_VALIDATE_IP, $which) !== false
+            || (! ctype_print($ip) && filter_var(inet_ntop($ip), FILTER_VALIDATE_IP, $which) !== false);
+    }
+
+    /**
+     * Checks a string to ensure it is (loosely) a URL.
+     *
+     * Warning: this rule will pass basic strings like
+     * "banana"; use valid_url_strict for a stricter rule.
+     *
+     * @param mixed|null $str
+     */
+    public function valid_url($str = null): bool
+    {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        if (empty($str)) {
+            return false;
+        }
+
+        if (preg_match('/^(?:([^:]*)\:)?\/\/(.+)$/', $str, $matches)) {
+            if (! in_array($matches[1], ['http', 'https'], true)) {
+                return false;
+            }
+
+            $str = $matches[2];
+        }
+
+        $str = 'http://' . $str;
+
+        return filter_var($str, FILTER_VALIDATE_URL) !== false;
+    }
+
+    /**
+     * Checks a URL to ensure it's formed correctly.
+     *
+     * @param string|null $validSchemes comma separated list of allowed schemes
+     * @param mixed|null  $str
+     */
+    public function valid_url_strict($str = null, ?string $validSchemes = null): bool
+    {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        if (empty($str)) {
+            return false;
+        }
+
+        // parse_url() may return null and false
+        $scheme       = strtolower((string) parse_url($str, PHP_URL_SCHEME));
+        $validSchemes = explode(
+            ',',
+            strtolower($validSchemes ?? 'http,https')
+        );
+
+        return in_array($scheme, $validSchemes, true)
+            && filter_var($str, FILTER_VALIDATE_URL) !== false;
+    }
+
+    /**
+     * Checks for a valid date and matches a given date format
+     *
+     * @param mixed|null $str
+     */
+    public function valid_date($str = null, ?string $format = null): bool
+    {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        if (empty($format)) {
+            return strtotime($str) !== false;
+        }
+
+        $date   = DateTime::createFromFormat($format, $str);
+        $errors = DateTime::getLastErrors();
+
+        return $date !== false && $errors !== false && $errors['warning_count'] === 0 && $errors['error_count'] === 0;
+    }
+}

--- a/system/ValidationStrict/Rules.php
+++ b/system/ValidationStrict/Rules.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\ValidationStrict;
+
+use Config\Database;
+use InvalidArgumentException;
+
+/**
+ * Validation Rules.
+ */
+class Rules
+{
+    /**
+     * The value does not match another field in $data.
+     *
+     * @param array $data Other field/value pairs
+     * @param mixed $str
+     */
+    public function differs($str, string $field, array $data): bool
+    {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        if (strpos($field, '.') !== false) {
+            return $str !== dot_array_search($field, $data);
+        }
+
+        return array_key_exists($field, $data) && $str !== $data[$field];
+    }
+
+    /**
+     * Equals the static value provided.
+     *
+     * @param mixed $str
+     */
+    public function equals($str, string $val): bool
+    {
+        return $str === $val;
+    }
+
+    /**
+     * Returns true if $str is $val characters long.
+     * $val = "5" (one) | "5,8,12" (multiple values)
+     *
+     * @param mixed $str
+     */
+    public function exact_length($str, string $val): bool
+    {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        $val = explode(',', $val);
+
+        foreach ($val as $tmp) {
+            if (is_numeric($tmp) && (int) $tmp === mb_strlen($str ?? '')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Greater than
+     *
+     * @param mixed $str
+     */
+    public function greater_than($str, string $min): bool
+    {
+        return is_numeric($str) && $str > $min;
+    }
+
+    /**
+     * Equal to or Greater than
+     *
+     * @param mixed $str
+     */
+    public function greater_than_equal_to($str, string $min): bool
+    {
+        return is_numeric($str) && $str >= $min;
+    }
+
+    /**
+     * Checks the database to see if the given value exist.
+     * Can ignore records by field/value to filter (currently
+     * accept only one filter).
+     *
+     * Example:
+     *    is_not_unique[table.field,where_field,where_value]
+     *    is_not_unique[menu.id,active,1]
+     *
+     * @param mixed $str
+     */
+    public function is_not_unique($str, string $field, array $data): bool
+    {
+        // Grab any data for exclusion of a single row.
+        [$field, $whereField, $whereValue] = array_pad(explode(',', $field), 3, null);
+
+        // Break the table and field apart
+        sscanf($field, '%[^.].%[^.]', $table, $field);
+
+        $row = Database::connect($data['DBGroup'] ?? null)
+            ->table($table)
+            ->select('1')
+            ->where($field, $str)
+            ->limit(1);
+
+        if (! empty($whereField) && ! empty($whereValue) && ! preg_match('/^\{(\w+)\}$/', $whereValue)) {
+            $row = $row->where($whereField, $whereValue);
+        }
+
+        return $row->get()->getRow() !== null;
+    }
+
+    /**
+     * Value should be within an array of values
+     *
+     * @param mixed $value
+     */
+    public function in_list($value, string $list): bool
+    {
+        if (is_int($value) || is_float($value)) {
+            $value = (string) $value;
+        }
+
+        if (! is_string($value)) {
+            return false;
+        }
+
+        $list = array_map('trim', explode(',', $list));
+
+        return in_array($value, $list, true);
+    }
+
+    /**
+     * Checks the database to see if the given value is unique. Can
+     * ignore a single record by field/value to make it useful during
+     * record updates.
+     *
+     * Example:
+     *    is_unique[table.field,ignore_field,ignore_value]
+     *    is_unique[users.email,id,5]
+     *
+     * @param mixed $str
+     */
+    public function is_unique($str, string $field, array $data): bool
+    {
+        [$field, $ignoreField, $ignoreValue] = array_pad(explode(',', $field), 3, null);
+
+        sscanf($field, '%[^.].%[^.]', $table, $field);
+
+        $row = Database::connect($data['DBGroup'] ?? null)
+            ->table($table)
+            ->select('1')
+            ->where($field, $str)
+            ->limit(1);
+
+        if (! empty($ignoreField) && ! empty($ignoreValue) && ! preg_match('/^\{(\w+)\}$/', $ignoreValue)) {
+            $row = $row->where("{$ignoreField} !=", $ignoreValue);
+        }
+
+        return $row->get()->getRow() === null;
+    }
+
+    /**
+     * Less than
+     *
+     * @param mixed $str
+     */
+    public function less_than($str, string $max): bool
+    {
+        return is_numeric($str) && $str < $max;
+    }
+
+    /**
+     * Equal to or Less than
+     *
+     * @param mixed $str
+     */
+    public function less_than_equal_to($str, string $max): bool
+    {
+        return is_numeric($str) && $str <= $max;
+    }
+
+    /**
+     * Matches the value of another field in $data.
+     *
+     * @param array $data Other field/value pairs
+     * @param mixed $str
+     */
+    public function matches($str, string $field, array $data): bool
+    {
+        if (strpos($field, '.') !== false) {
+            return $str === dot_array_search($field, $data);
+        }
+
+        return array_key_exists($field, $data) && $str === $data[$field];
+    }
+
+    /**
+     * Returns true if $str is $val or fewer characters in length.
+     *
+     * @param mixed $str
+     */
+    public function max_length($str, string $val): bool
+    {
+        if (is_int($str) || is_float($str) || null === $str) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return is_numeric($val) && $val >= mb_strlen($str);
+    }
+
+    /**
+     * Returns true if $str is at least $val length.
+     *
+     * @param mixed $str
+     */
+    public function min_length($str, string $val): bool
+    {
+        if (is_int($str) || is_float($str)) {
+            $str = (string) $str;
+        }
+
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return is_numeric($val) && $val <= mb_strlen($str);
+    }
+
+    /**
+     * Does not equal the static value provided.
+     *
+     * @param string $str
+     */
+    public function not_equals($str, string $val): bool
+    {
+        return $str !== $val;
+    }
+
+    /**
+     * Value should not be within an array of values.
+     *
+     * @param string $value
+     */
+    public function not_in_list($value, string $list): bool
+    {
+        if (null === $value) {
+            return true;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            $value = (string) $value;
+        }
+
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return ! $this->in_list($value, $list);
+    }
+
+    /**
+     * @param mixed $str
+     */
+    public function required($str = null): bool
+    {
+        if ($str === null) {
+            return false;
+        }
+
+        if (is_object($str)) {
+            return true;
+        }
+
+        if (is_array($str)) {
+            return $str !== [];
+        }
+
+        return trim((string) $str) !== '';
+    }
+
+    /**
+     * The field is required when any of the other required fields are present
+     * in the data.
+     *
+     * Example (field is required when the password field is present):
+     *
+     *     required_with[password]
+     *
+     * @param string|null $str
+     * @param string|null $fields List of fields that we should check if present
+     * @param array       $data   Complete list of fields from the form
+     */
+    public function required_with($str = null, ?string $fields = null, array $data = []): bool
+    {
+        if ($fields === null || empty($data)) {
+            throw new InvalidArgumentException('You must supply the parameters: fields, data.');
+        }
+
+        // If the field is present we can safely assume that
+        // the field is here, no matter whether the corresponding
+        // search field is present or not.
+        $fields  = explode(',', $fields);
+        $present = $this->required($str ?? '');
+
+        if ($present) {
+            return true;
+        }
+
+        // Still here? Then we fail this test if
+        // any of the fields are present in $data
+        // as $fields is the lis
+        $requiredFields = [];
+
+        foreach ($fields as $field) {
+            if ((array_key_exists($field, $data) && ! empty($data[$field])) || (strpos($field, '.') !== false && ! empty(dot_array_search($field, $data)))) {
+                $requiredFields[] = $field;
+            }
+        }
+
+        return empty($requiredFields);
+    }
+
+    /**
+     * The field is required when all of the other fields are present
+     * in the data but not required.
+     *
+     * Example (field is required when the id or email field is missing):
+     *
+     *     required_without[id,email]
+     *
+     * @param string|null $str
+     */
+    public function required_without($str = null, ?string $fields = null, array $data = []): bool
+    {
+        if ($fields === null || empty($data)) {
+            throw new InvalidArgumentException('You must supply the parameters: fields, data.');
+        }
+
+        // If the field is present we can safely assume that
+        // the field is here, no matter whether the corresponding
+        // search field is present or not.
+        $fields  = explode(',', $fields);
+        $present = $this->required($str ?? '');
+
+        if ($present) {
+            return true;
+        }
+
+        // Still here? Then we fail this test if
+        // any of the fields are not present in $data
+        foreach ($fields as $field) {
+            if ((strpos($field, '.') === false && (! array_key_exists($field, $data) || empty($data[$field]))) || (strpos($field, '.') !== false && empty(dot_array_search($field, $data)))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/system/ValidationStrict/Validation.php
+++ b/system/ValidationStrict/Validation.php
@@ -1,0 +1,729 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\ValidationStrict;
+
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\Validation\Exceptions\ValidationException;
+use CodeIgniter\Validation\ValidationInterface;
+use CodeIgniter\View\RendererInterface;
+use Config\Validation as ValidationConfig;
+use InvalidArgumentException;
+
+/**
+ * Validator
+ */
+class Validation implements ValidationInterface
+{
+    /**
+     * Files to load with validation functions.
+     *
+     * @var array
+     */
+    protected $ruleSetFiles;
+
+    /**
+     * The loaded instances of our validation files.
+     *
+     * @var array
+     */
+    protected $ruleSetInstances = [];
+
+    /**
+     * Stores the actual rules that should
+     * be ran against $data.
+     *
+     * @var array
+     */
+    protected $rules = [];
+
+    /**
+     * The data that should be validated,
+     * where 'key' is the alias, with value.
+     *
+     * @var array
+     */
+    protected $data = [];
+
+    /**
+     * Any generated errors during validation.
+     * 'key' is the alias, 'value' is the message.
+     *
+     * @var array
+     */
+    protected $errors = [];
+
+    /**
+     * Stores custom error message to use
+     * during validation. Where 'key' is the alias.
+     *
+     * @var array
+     */
+    protected $customErrors = [];
+
+    /**
+     * Our configuration.
+     *
+     * @var ValidationConfig
+     */
+    protected $config;
+
+    /**
+     * The view renderer used to render validation messages.
+     *
+     * @var RendererInterface
+     */
+    protected $view;
+
+    /**
+     * Validation constructor.
+     *
+     * @param ValidationConfig $config
+     */
+    public function __construct($config, RendererInterface $view)
+    {
+        $this->ruleSetFiles = $config->ruleSets;
+
+        $this->config = $config;
+
+        $this->view = $view;
+    }
+
+    /**
+     * Runs the validation process, returning true/false determining whether
+     * validation was successful or not.
+     *
+     * @param array|null  $data    The array of data to validate.
+     * @param string|null $group   The predefined group of rules to apply.
+     * @param string|null $dbGroup The database group to use.
+     */
+    public function run(?array $data = null, ?string $group = null, ?string $dbGroup = null): bool
+    {
+        $data = $data ?? $this->data;
+
+        // i.e. is_unique
+        $data['DBGroup'] = $dbGroup;
+
+        $this->loadRuleSets();
+        $this->loadRuleGroup($group);
+
+        // If no rules exist, we return false to ensure
+        // the developer didn't forget to set the rules.
+        if (empty($this->rules)) {
+            return false;
+        }
+
+        // Replace any placeholders (e.g. {id}) in the rules with
+        // the value found in $data, if any.
+        $this->rules = $this->fillPlaceholders($this->rules, $data);
+
+        // Need this for searching arrays in validation.
+        helper('array');
+
+        // Run through each rule. If we have any field set for
+        // this rule, then we need to run them through!
+        foreach ($this->rules as $field => $setup) {
+            // Blast $rSetup apart, unless it's already an array.
+            $rules = $setup['rules'] ?? $setup;
+
+            if (is_string($rules)) {
+                $rules = $this->splitRules($rules);
+            }
+
+            $values = dot_array_search($field, $data);
+
+            if ($values === []) {
+                // We'll process the values right away if an empty array
+                $this->processRules($field, $setup['label'] ?? $field, $values, $rules, $data);
+            }
+
+            if (strpos($field, '*') !== false && is_array($values)) {
+                // Process multiple fields
+                foreach ($values as $value) {
+                    $this->processRules($field, $setup['label'] ?? $field, $value, $rules, $data);
+                }
+            } else {
+                // Process single field
+                $this->processRules($field, $setup['label'] ?? $field, $values, $rules, $data);
+            }
+        }
+
+        return $this->getErrors() === [];
+    }
+
+    /**
+     * Runs the validation process, returning true or false
+     * determining whether validation was successful or not.
+     *
+     * @param mixed    $value
+     * @param string[] $errors
+     */
+    public function check($value, string $rule, array $errors = []): bool
+    {
+        $this->reset();
+
+        return $this->setRule('check', null, $rule, $errors)->run(['check' => $value]);
+    }
+
+    /**
+     * Runs all of $rules against $field, until one fails, or
+     * all of them have been processed. If one fails, it adds
+     * the error to $this->errors and moves on to the next,
+     * so that we can collect all of the first errors.
+     *
+     * @param array|string $value
+     * @param array|null   $rules
+     * @param array        $data
+     */
+    protected function processRules(string $field, ?string $label, $value, $rules = null, ?array $data = null): bool
+    {
+        if ($data === null) {
+            throw new InvalidArgumentException('You must supply the parameter: data.');
+        }
+
+        if (in_array('if_exist', $rules, true)) {
+            $flattenedData = array_flatten_with_dots($data);
+            $ifExistField  = $field;
+
+            if (strpos($field, '.*') !== false) {
+                // We'll change the dot notation into a PCRE pattern
+                // that can be used later
+                $ifExistField = str_replace('\.\*', '\.(?:[^\.]+)', preg_quote($field, '/'));
+
+                $dataIsExisting = array_reduce(array_keys($flattenedData), static function ($carry, $item) use ($ifExistField) {
+                    $pattern = sprintf('/%s/u', $ifExistField);
+
+                    return $carry || preg_match($pattern, $item) === 1;
+                }, false);
+            } else {
+                $dataIsExisting = array_key_exists($ifExistField, $flattenedData);
+            }
+
+            unset($ifExistField, $flattenedData);
+
+            if (! $dataIsExisting) {
+                // we return early if `if_exist` is not satisfied. we have nothing to do here.
+                return true;
+            }
+
+            // Otherwise remove the if_exist rule and continue the process
+            $rules = array_diff($rules, ['if_exist']);
+        }
+
+        if (in_array('permit_empty', $rules, true)) {
+            if (! in_array('required', $rules, true)
+                && (is_array($value) ? $value === [] : trim((string) $value) === '')
+            ) {
+                $passed = true;
+
+                foreach ($rules as $rule) {
+                    if (preg_match('/(.*?)\[(.*)\]/', $rule, $match)) {
+                        $rule  = $match[1];
+                        $param = $match[2];
+
+                        if (! in_array($rule, ['required_with', 'required_without'], true)) {
+                            continue;
+                        }
+
+                        // Check in our rulesets
+                        foreach ($this->ruleSetInstances as $set) {
+                            if (! method_exists($set, $rule)) {
+                                continue;
+                            }
+
+                            $passed = $passed && $set->{$rule}($value, $param, $data);
+                            break;
+                        }
+                    }
+                }
+
+                if ($passed === true) {
+                    return true;
+                }
+            }
+
+            $rules = array_diff($rules, ['permit_empty']);
+        }
+
+        foreach ($rules as $rule) {
+            $isCallable = is_callable($rule);
+
+            $passed = false;
+            $param  = false;
+
+            if (! $isCallable && preg_match('/(.*?)\[(.*)\]/', $rule, $match)) {
+                $rule  = $match[1];
+                $param = $match[2];
+            }
+
+            // Placeholder for custom errors from the rules.
+            $error = null;
+
+            // If it's a callable, call and get out of here.
+            if ($isCallable) {
+                $passed = $param === false ? $rule($value) : $rule($value, $param, $data);
+            } else {
+                $found = false;
+
+                // Check in our rulesets
+                foreach ($this->ruleSetInstances as $set) {
+                    if (! method_exists($set, $rule)) {
+                        continue;
+                    }
+
+                    $found  = true;
+                    $passed = $param === false ? $set->{$rule}($value, $error) : $set->{$rule}($value, $param, $data, $error);
+
+                    break;
+                }
+
+                // If the rule wasn't found anywhere, we
+                // should throw an exception so the developer can find it.
+                if (! $found) {
+                    throw ValidationException::forRuleNotFound($rule);
+                }
+            }
+
+            // Set the error message if we didn't survive.
+            if ($passed === false) {
+                // if the $value is an array, convert it to as string representation
+                if (is_array($value)) {
+                    $value = '[' . implode(', ', $value) . ']';
+                } elseif (is_object($value)) {
+                    $value = json_encode($value);
+                }
+
+                $param                = ($param === false) ? null : $param;
+                $this->errors[$field] = $error ?? $this->getErrorMessage($rule, $field, $label, $param, (string) $value);
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Takes a Request object and grabs the input data to use from its
+     * array values.
+     */
+    public function withRequest(RequestInterface $request): ValidationInterface
+    {
+        /** @var IncomingRequest $request */
+        if (strpos($request->getHeaderLine('Content-Type'), 'application/json') !== false) {
+            $this->data = $request->getJSON(true);
+
+            return $this;
+        }
+
+        if (in_array($request->getMethod(), ['put', 'patch', 'delete'], true)
+            && strpos($request->getHeaderLine('Content-Type'), 'multipart/form-data') === false
+        ) {
+            $this->data = $request->getRawInput();
+        } else {
+            $this->data = $request->getVar() ?? [];
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets an individual rule and custom error messages for a single field.
+     *
+     * The custom error message should be just the messages that apply to
+     * this field, like so:
+     *
+     *    [
+     *        'rule' => 'message',
+     *        'rule' => 'message'
+     *    ]
+     *
+     * @return $this
+     */
+    public function setRule(string $field, ?string $label, string $rules, array $errors = [])
+    {
+        $this->rules[$field] = [
+            'label' => $label,
+            'rules' => $rules,
+        ];
+
+        $this->customErrors = array_merge($this->customErrors, [
+            $field => $errors,
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * Stores the rules that should be used to validate the items.
+     * Rules should be an array formatted like:
+     *
+     *    [
+     *        'field' => 'rule1|rule2'
+     *    ]
+     *
+     * The $errors array should be formatted like:
+     *    [
+     *        'field' => [
+     *            'rule' => 'message',
+     *            'rule' => 'message
+     *        ],
+     *    ]
+     *
+     * @param array $errors // An array of custom error messages
+     */
+    public function setRules(array $rules, array $errors = []): ValidationInterface
+    {
+        $this->customErrors = $errors;
+
+        foreach ($rules as $field => &$rule) {
+            if (! is_array($rule)) {
+                continue;
+            }
+
+            if (! array_key_exists('errors', $rule)) {
+                continue;
+            }
+
+            $this->customErrors[$field] = $rule['errors'];
+            unset($rule['errors']);
+        }
+
+        $this->rules = $rules;
+
+        return $this;
+    }
+
+    /**
+     * Returns all of the rules currently defined.
+     */
+    public function getRules(): array
+    {
+        return $this->rules;
+    }
+
+    /**
+     * Checks to see if the rule for key $field has been set or not.
+     */
+    public function hasRule(string $field): bool
+    {
+        return array_key_exists($field, $this->rules);
+    }
+
+    /**
+     * Get rule group.
+     *
+     * @param string $group Group.
+     *
+     * @throws InvalidArgumentException If group not found.
+     *
+     * @return string[] Rule group.
+     */
+    public function getRuleGroup(string $group): array
+    {
+        if (! isset($this->config->{$group})) {
+            throw ValidationException::forGroupNotFound($group);
+        }
+
+        if (! is_array($this->config->{$group})) {
+            throw ValidationException::forGroupNotArray($group);
+        }
+
+        return $this->config->{$group};
+    }
+
+    /**
+     * Set rule group.
+     *
+     * @param string $group Group.
+     *
+     * @throws InvalidArgumentException If group not found.
+     */
+    public function setRuleGroup(string $group)
+    {
+        $rules = $this->getRuleGroup($group);
+        $this->setRules($rules);
+
+        $errorName = $group . '_errors';
+        if (isset($this->config->{$errorName})) {
+            $this->customErrors = $this->config->{$errorName};
+        }
+    }
+
+    /**
+     * Returns the rendered HTML of the errors as defined in $template.
+     */
+    public function listErrors(string $template = 'list'): string
+    {
+        if (! array_key_exists($template, $this->config->templates)) {
+            throw ValidationException::forInvalidTemplate($template);
+        }
+
+        return $this->view
+            ->setVar('errors', $this->getErrors())
+            ->render($this->config->templates[$template]);
+    }
+
+    /**
+     * Displays a single error in formatted HTML as defined in the $template view.
+     */
+    public function showError(string $field, string $template = 'single'): string
+    {
+        if (! array_key_exists($field, $this->getErrors())) {
+            return '';
+        }
+
+        if (! array_key_exists($template, $this->config->templates)) {
+            throw ValidationException::forInvalidTemplate($template);
+        }
+
+        return $this->view
+            ->setVar('error', $this->getError($field))
+            ->render($this->config->templates[$template]);
+    }
+
+    /**
+     * Loads all of the rulesets classes that have been defined in the
+     * Config\Validation and stores them locally so we can use them.
+     */
+    protected function loadRuleSets()
+    {
+        if (empty($this->ruleSetFiles)) {
+            throw ValidationException::forNoRuleSets();
+        }
+
+        foreach ($this->ruleSetFiles as $file) {
+            $this->ruleSetInstances[] = new $file();
+        }
+    }
+
+    /**
+     * Loads custom rule groups (if set) into the current rules.
+     *
+     * Rules can be pre-defined in Config\Validation and can
+     * be any name, but must all still be an array of the
+     * same format used with setRules(). Additionally, check
+     * for {group}_errors for an array of custom error messages.
+     *
+     * @return array|ValidationException|null
+     */
+    public function loadRuleGroup(?string $group = null)
+    {
+        if (empty($group)) {
+            return null;
+        }
+
+        if (! isset($this->config->{$group})) {
+            throw ValidationException::forGroupNotFound($group);
+        }
+
+        if (! is_array($this->config->{$group})) {
+            throw ValidationException::forGroupNotArray($group);
+        }
+
+        $this->setRules($this->config->{$group});
+
+        // If {group}_errors exists in the config file,
+        // then override our custom errors with them.
+        $errorName = $group . '_errors';
+
+        if (isset($this->config->{$errorName})) {
+            $this->customErrors = $this->config->{$errorName};
+        }
+
+        return $this->rules;
+    }
+
+    /**
+     * Replace any placeholders within the rules with the values that
+     * match the 'key' of any properties being set. For example, if
+     * we had the following $data array:
+     *
+     * [ 'id' => 13 ]
+     *
+     * and the following rule:
+     *
+     *  'required|is_unique[users,email,id,{id}]'
+     *
+     * The value of {id} would be replaced with the actual id in the form data:
+     *
+     *  'required|is_unique[users,email,id,13]'
+     */
+    protected function fillPlaceholders(array $rules, array $data): array
+    {
+        $replacements = [];
+
+        foreach ($data as $key => $value) {
+            $replacements["{{$key}}"] = $value;
+        }
+
+        if (! empty($replacements)) {
+            foreach ($rules as &$rule) {
+                if (is_array($rule)) {
+                    foreach ($rule as &$row) {
+                        // Should only be an `errors` array
+                        // which doesn't take placeholders.
+                        if (is_array($row)) {
+                            continue;
+                        }
+
+                        $row = strtr($row ?? '', $replacements);
+                    }
+
+                    continue;
+                }
+
+                $rule = strtr($rule ?? '', $replacements);
+            }
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Checks to see if an error exists for the given field.
+     */
+    public function hasError(string $field): bool
+    {
+        return array_key_exists($field, $this->getErrors());
+    }
+
+    /**
+     * Returns the error(s) for a specified $field (or empty string if not
+     * set).
+     */
+    public function getError(?string $field = null): string
+    {
+        if ($field === null && count($this->rules) === 1) {
+            $field = array_key_first($this->rules);
+        }
+
+        return array_key_exists($field, $this->getErrors()) ? $this->errors[$field] : '';
+    }
+
+    /**
+     * Returns the array of errors that were encountered during
+     * a run() call. The array should be in the following format:
+     *
+     *    [
+     *        'field1' => 'error message',
+     *        'field2' => 'error message',
+     *    ]
+     *
+     * @return array<string, string>
+     *
+     * @codeCoverageIgnore
+     */
+    public function getErrors(): array
+    {
+        // If we already have errors, we'll use those.
+        // If we don't, check the session to see if any were
+        // passed along from a redirect_with_input request.
+        if (empty($this->errors) && ! is_cli() && isset($_SESSION, $_SESSION['_ci_validation_errors'])) {
+            $this->errors = unserialize($_SESSION['_ci_validation_errors']);
+        }
+
+        return $this->errors ?? [];
+    }
+
+    /**
+     * Sets the error for a specific field. Used by custom validation methods.
+     */
+    public function setError(string $field, string $error): ValidationInterface
+    {
+        $this->errors[$field] = $error;
+
+        return $this;
+    }
+
+    /**
+     * Attempts to find the appropriate error message
+     *
+     * @param string|null $value The value that caused the validation to fail.
+     */
+    protected function getErrorMessage(string $rule, string $field, ?string $label = null, ?string $param = null, ?string $value = null): string
+    {
+        $param = $param ?? '';
+
+        // Check if custom message has been defined by user
+        if (isset($this->customErrors[$field][$rule])) {
+            $message = lang($this->customErrors[$field][$rule]);
+        } else {
+            // Try to grab a localized version of the message...
+            // lang() will return the rule name back if not found,
+            // so there will always be a string being returned.
+            $message = lang('Validation.' . $rule);
+        }
+
+        $message = str_replace('{field}', empty($label) ? $field : lang($label), $message);
+        $message = str_replace('{param}', empty($this->rules[$param]['label']) ? $param : lang($this->rules[$param]['label']), $message);
+
+        return str_replace('{value}', $value ?? '', $message);
+    }
+
+    /**
+     * Split rules string by pipe operator.
+     */
+    protected function splitRules(string $rules): array
+    {
+        if (strpos($rules, '|') === false) {
+            return [$rules];
+        }
+
+        $string = $rules;
+        $rules  = [];
+        $length = strlen($string);
+        $cursor = 0;
+
+        while ($cursor < $length) {
+            $pos = strpos($string, '|', $cursor);
+
+            if ($pos === false) {
+                // we're in the last rule
+                $pos = $length;
+            }
+
+            $rule = substr($string, $cursor, $pos - $cursor);
+
+            while (
+                (substr_count($rule, '[') - substr_count($rule, '\['))
+                !== (substr_count($rule, ']') - substr_count($rule, '\]'))
+            ) {
+                // the pipe is inside the brackets causing the closing bracket to
+                // not be included. so, we adjust the rule to include that portion.
+                $pos  = strpos($string, '|', $cursor + strlen($rule) + 1) ?: $length;
+                $rule = substr($string, $cursor, $pos - $cursor);
+            }
+
+            $rules[] = $rule;
+            $cursor += strlen($rule) + 1; // +1 to exclude the pipe
+        }
+
+        return array_unique($rules);
+    }
+
+    /**
+     * Resets the class to a blank slate. Should be called whenever
+     * you need to process more than one array.
+     */
+    public function reset(): ValidationInterface
+    {
+        $this->data         = [];
+        $this->rules        = [];
+        $this->errors       = [];
+        $this->customErrors = [];
+
+        return $this;
+    }
+}

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -798,6 +798,73 @@ final class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
+     *
+     * @dataProvider integerInvalidTypeDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testIntegerWithInvalidTypeData($value, bool $expected): void
+    {
+        $this->validation->setRules([
+            'foo' => 'integer',
+        ]);
+
+        $data = [
+            'foo' => $value,
+        ];
+        $this->assertsame($expected, $this->validation->run($data));
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
+     *
+     * @dataProvider integerInvalidTypeDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testNumericWithInvalidTypeData($value, bool $expected): void
+    {
+        $this->validation->setRules([
+            'foo' => 'numeric',
+        ]);
+
+        $data = [
+            'foo' => $value,
+        ];
+        $this->assertsame($expected, $this->validation->run($data));
+    }
+
+    public function integerInvalidTypeDataProvider(): Generator
+    {
+        yield 'array with int' => [
+            [555],
+            true,  // incorrect
+        ];
+
+        // TypeError : CodeIgniter\Validation\FormatRules::integer(): Argument #1 ($str) must be of type ?string, array given
+//        yield 'empty array' => [
+        // [],
+        // false,
+        // ];
+
+        yield 'bool true' => [
+            true,
+            true,  // incorrect
+        ];
+
+        yield 'bool false' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
+
+    /**
      * @dataProvider integerProvider
      */
     public function testInteger(?string $str, bool $expected): void

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -100,6 +100,101 @@ final class ValidationTest extends CIUnitTestCase
         $this->assertFalse($this->validation->run($data));
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5368
+     *
+     * @dataProvider arrayDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testCanValidatetArrayData($value, bool $expected): void
+    {
+        $this->validation->setRules(['arr' => 'is_array']);
+
+        $data['arr'] = $value;
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function arrayDataProvider(): Generator
+    {
+        yield 'list array' => [
+            [1, 2, 3, 4, 5],
+            false,   // incorrect
+        ];
+
+        yield 'associative array' => [
+            [
+                'username' => 'admin001',
+                'role'     => 'administrator',
+                'usepass'  => 0,
+            ],
+            false,   // incorrect
+        ];
+
+        yield 'int' => [
+            0,
+            false,
+        ];
+
+        yield 'string int' => [
+            '0',
+            false,
+        ];
+
+        yield 'bool' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
+     *
+     * @dataProvider isIntInvalidTypeDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testIsIntWithInvalidTypeData($value, bool $expected): void
+    {
+        $this->validation->setRules(['foo' => 'is_int']);
+
+        $data = ['foo' => $value];
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function isIntInvalidTypeDataProvider(): Generator
+    {
+        yield 'array with int' => [
+            [555],
+            true,  // incorrect
+        ];
+
+        yield 'empty array' => [
+            [],
+            false,
+        ];
+
+        yield 'bool true' => [
+            true,
+            false,
+        ];
+
+        yield 'bool false' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
+
     public function testRunReturnsLocalizedErrors(): void
     {
         $data = ['foo' => 'notanumber'];

--- a/tests/system/ValidationStrict/CreditCardRulesTest.php
+++ b/tests/system/ValidationStrict/CreditCardRulesTest.php
@@ -1,0 +1,1247 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\ValidationStrict;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Services;
+use Generator;
+use Tests\Support\Validation\TestRules;
+
+/**
+ * @internal
+ */
+final class CreditCardRulesTest extends CIUnitTestCase
+{
+    /**
+     * @var Validation
+     */
+    private $validation;
+
+    private $config = [
+        'ruleSets' => [
+            Rules::class,
+            FormatRules::class,
+            FileRules::class,
+            CreditCardRules::class,
+            TestRules::class,
+        ],
+        'groupA' => [
+            'foo' => 'required|min_length[5]',
+        ],
+        'groupA_errors' => [
+            'foo' => [
+                'min_length' => 'Shame, shame. Too short.',
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validation = new Validation((object) $this->config, Services::renderer());
+        $this->validation->reset();
+    }
+
+    /**
+     * @dataProvider creditCardProvider
+     */
+    public function testValidCCNumber(string $type, ?string $number, bool $expected): void
+    {
+        $data = ['cc' => $number];
+        $this->validation->setRules(['cc' => "valid_cc_number[{$type}]"]);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    /**
+     * Cards shown are test cards found around the web.
+     *
+     * @see https://www.paypalobjects.com/en_US/vhelp/paypalmanager_help/credit_card_numbers.htm
+     */
+    public function creditCardProvider(): Generator
+    {
+        yield from [
+            'null_test' => [
+                'amex',
+                null,
+                false,
+            ],
+            'random_test' => [
+                'amex',
+                $this->generateCardNumber('37', 16),
+                false,
+            ],
+            'invalid_type' => [
+                'shorty',
+                '1111 1111 1111 1111',
+                false,
+            ],
+            'invalid_length' => [
+                'amex',
+                '',
+                false,
+            ],
+            'not_numeric' => [
+                'amex',
+                'abcd efgh ijkl mnop',
+                false,
+            ],
+            'bad_length' => [
+                'amex',
+                '3782 8224 6310 0051',
+                false,
+            ],
+            'bad_prefix' => [
+                'amex',
+                '3582 8224 6310 0051',
+                false,
+            ],
+            'amex1' => [
+                'amex',
+                '3782 8224 6310 005',
+                true,
+            ],
+            'amex2' => [
+                'amex',
+                '3714 4963 5398 431',
+                true,
+            ],
+            'dinersclub1' => [
+                'dinersclub',
+                '3056 9309 0259 04',
+                true,
+            ],
+            'dinersculb2' => [
+                'dinersclub',
+                '3852 0000 0232 37',
+                true,
+            ],
+            'discover1' => [
+                'discover',
+                '6011 1111 1111 1117',
+                true,
+            ],
+            'discover2' => [
+                'discover',
+                '6011 0009 9013 9424',
+                true,
+            ],
+            'jcb8' => [
+                'jcb',
+                '3530 1113 3330 0000',
+                true,
+            ],
+            'jcb9' => [
+                'jcb',
+                '3566 0020 2036 0505',
+                true,
+            ],
+            'mastercard12' => [
+                'mastercard',
+                '5555 5555 5555 4444',
+                true,
+            ],
+            'mastercard13' => [
+                'mastercard',
+                '5105 1051 0510 5100',
+                true,
+            ],
+            'visa4' => [
+                'visa',
+                '4111 1111 1111 1111',
+                true,
+            ],
+            'visa5' => [
+                'visa',
+                '4012 8888 8888 1881',
+                true,
+            ],
+            'visa6' => [
+                'visa',
+                '4222 2222 2222 2',
+                true,
+            ],
+            'dankort5' => [
+                'dankort',
+                '5019 7170 1010 3742',
+                true,
+            ],
+            'unionpay1' => [
+                'unionpay',
+                $this->generateCardNumber(62, 16),
+                true,
+            ],
+            'unionpay2' => [
+                'unionpay',
+                $this->generateCardNumber(62, 17),
+                true,
+            ],
+            'unionpay3' => [
+                'unionpay',
+                $this->generateCardNumber(62, 18),
+                true,
+            ],
+            'unionpay4' => [
+                'unionpay',
+                $this->generateCardNumber(62, 19),
+                true,
+            ],
+            'unionpay5' => [
+                'unionpay',
+                $this->generateCardNumber(63, 19),
+                false,
+            ],
+            'carteblanche1' => [
+                'carteblanche',
+                $this->generateCardNumber(300, 14),
+                true,
+            ],
+            'carteblanche2' => [
+                'carteblanche',
+                $this->generateCardNumber(301, 14),
+                true,
+            ],
+            'carteblanche3' => [
+                'carteblanche',
+                $this->generateCardNumber(302, 14),
+                true,
+            ],
+            'carteblanche4' => [
+                'carteblanche',
+                $this->generateCardNumber(303, 14),
+                true,
+            ],
+            'carteblanche5' => [
+                'carteblanche',
+                $this->generateCardNumber(304, 14),
+                true,
+            ],
+            'carteblanche6' => [
+                'carteblanche',
+                $this->generateCardNumber(305, 14),
+                true,
+            ],
+            'carteblanche7' => [
+                'carteblanche',
+                $this->generateCardNumber(306, 14),
+                false,
+            ],
+            'dinersclub3' => [
+                'dinersclub',
+                $this->generateCardNumber(300, 14),
+                true,
+            ],
+            'dinersclub4' => [
+                'dinersclub',
+                $this->generateCardNumber(301, 14),
+                true,
+            ],
+            'dinersclub5' => [
+                'dinersclub',
+                $this->generateCardNumber(302, 14),
+                true,
+            ],
+            'dinersclub6' => [
+                'dinersclub',
+                $this->generateCardNumber(303, 14),
+                true,
+            ],
+            'dinersclub7' => [
+                'dinersclub',
+                $this->generateCardNumber(304, 14),
+                true,
+            ],
+            'dinersclub8' => [
+                'dinersclub',
+                $this->generateCardNumber(305, 14),
+                true,
+            ],
+            'dinersclub9' => [
+                'dinersclub',
+                $this->generateCardNumber(309, 14),
+                true,
+            ],
+            'dinersclub10' => [
+                'dinersclub',
+                $this->generateCardNumber(36, 14),
+                true,
+            ],
+            'dinersclub11' => [
+                'dinersclub',
+                $this->generateCardNumber(38, 14),
+                true,
+            ],
+            'dinersclub12' => [
+                'dinersclub',
+                $this->generateCardNumber(39, 14),
+                true,
+            ],
+            'dinersclub13' => [
+                'dinersclub',
+                $this->generateCardNumber(54, 14),
+                true,
+            ],
+            'dinersclub14' => [
+                'dinersclub',
+                $this->generateCardNumber(55, 14),
+                true,
+            ],
+            'dinersclub15' => [
+                'dinersclub',
+                $this->generateCardNumber(300, 16),
+                true,
+            ],
+            'dinersclub16' => [
+                'dinersclub',
+                $this->generateCardNumber(301, 16),
+                true,
+            ],
+            'dinersclub17' => [
+                'dinersclub',
+                $this->generateCardNumber(302, 16),
+                true,
+            ],
+            'dinersclub18' => [
+                'dinersclub',
+                $this->generateCardNumber(303, 16),
+                true,
+            ],
+            'dinersclub19' => [
+                'dinersclub',
+                $this->generateCardNumber(304, 16),
+                true,
+            ],
+            'dinersclub20' => [
+                'dinersclub',
+                $this->generateCardNumber(305, 16),
+                true,
+            ],
+            'dinersclub21' => [
+                'dinersclub',
+                $this->generateCardNumber(309, 16),
+                true,
+            ],
+            'dinersclub22' => [
+                'dinersclub',
+                $this->generateCardNumber(36, 16),
+                true,
+            ],
+            'dinersclub23' => [
+                'dinersclub',
+                $this->generateCardNumber(38, 16),
+                true,
+            ],
+            'dinersclub24' => [
+                'dinersclub',
+                $this->generateCardNumber(39, 16),
+                true,
+            ],
+            'dinersclub25' => [
+                'dinersclub',
+                $this->generateCardNumber(54, 16),
+                true,
+            ],
+            'dinersclub26' => [
+                'dinersclub',
+                $this->generateCardNumber(55, 16),
+                true,
+            ],
+            'discover3' => [
+                'discover',
+                $this->generateCardNumber(6011, 16),
+                true,
+            ],
+            'discover4' => [
+                'discover',
+                $this->generateCardNumber(622, 16),
+                true,
+            ],
+            'discover5' => [
+                'discover',
+                $this->generateCardNumber(644, 16),
+                true,
+            ],
+            'discover6' => [
+                'discover',
+                $this->generateCardNumber(645, 16),
+                true,
+            ],
+            'discover7' => [
+                'discover',
+                $this->generateCardNumber(656, 16),
+                true,
+            ],
+            'discover8' => [
+                'discover',
+                $this->generateCardNumber(647, 16),
+                true,
+            ],
+            'discover9' => [
+                'discover',
+                $this->generateCardNumber(648, 16),
+                true,
+            ],
+            'discover10' => [
+                'discover',
+                $this->generateCardNumber(649, 16),
+                true,
+            ],
+            'discover11' => [
+                'discover',
+                $this->generateCardNumber(65, 16),
+                true,
+            ],
+            'discover12' => [
+                'discover',
+                $this->generateCardNumber(6011, 19),
+                true,
+            ],
+            'discover13' => [
+                'discover',
+                $this->generateCardNumber(622, 19),
+                true,
+            ],
+            'discover14' => [
+                'discover',
+                $this->generateCardNumber(644, 19),
+                true,
+            ],
+            'discover15' => [
+                'discover',
+                $this->generateCardNumber(645, 19),
+                true,
+            ],
+            'discover16' => [
+                'discover',
+                $this->generateCardNumber(656, 19),
+                true,
+            ],
+            'discover17' => [
+                'discover',
+                $this->generateCardNumber(647, 19),
+                true,
+            ],
+            'discover18' => [
+                'discover',
+                $this->generateCardNumber(648, 19),
+                true,
+            ],
+            'discover19' => [
+                'discover',
+                $this->generateCardNumber(649, 19),
+                true,
+            ],
+            'discover20' => [
+                'discover',
+                $this->generateCardNumber(65, 19),
+                true,
+            ],
+            'interpayment1' => [
+                'interpayment',
+                $this->generateCardNumber(4, 16),
+                true,
+            ],
+            'interpayment2' => [
+                'interpayment',
+                $this->generateCardNumber(4, 17),
+                true,
+            ],
+            'interpayment3' => [
+                'interpayment',
+                $this->generateCardNumber(4, 18),
+                true,
+            ],
+            'interpayment4' => [
+                'interpayment',
+                $this->generateCardNumber(4, 19),
+                true,
+            ],
+            'jcb1' => [
+                'jcb',
+                $this->generateCardNumber(352, 16),
+                true,
+            ],
+            'jcb2' => [
+                'jcb',
+                $this->generateCardNumber(353, 16),
+                true,
+            ],
+            'jcb3' => [
+                'jcb',
+                $this->generateCardNumber(354, 16),
+                true,
+            ],
+            'jcb4' => [
+                'jcb',
+                $this->generateCardNumber(355, 16),
+                true,
+            ],
+            'jcb5' => [
+                'jcb',
+                $this->generateCardNumber(356, 16),
+                true,
+            ],
+            'jcb6' => [
+                'jcb',
+                $this->generateCardNumber(357, 16),
+                true,
+            ],
+            'jcb7' => [
+                'jcb',
+                $this->generateCardNumber(358, 16),
+                true,
+            ],
+            'maestro1' => [
+                'maestro',
+                $this->generateCardNumber(50, 12),
+                true,
+            ],
+            'maestro2' => [
+                'maestro',
+                $this->generateCardNumber(56, 12),
+                true,
+            ],
+            'maestro3' => [
+                'maestro',
+                $this->generateCardNumber(57, 12),
+                true,
+            ],
+            'maestro4' => [
+                'maestro',
+                $this->generateCardNumber(58, 12),
+                true,
+            ],
+            'maestro5' => [
+                'maestro',
+                $this->generateCardNumber(59, 12),
+                true,
+            ],
+            'maestro6' => [
+                'maestro',
+                $this->generateCardNumber(60, 12),
+                true,
+            ],
+            'maestro7' => [
+                'maestro',
+                $this->generateCardNumber(61, 12),
+                true,
+            ],
+            'maestro8' => [
+                'maestro',
+                $this->generateCardNumber(62, 12),
+                true,
+            ],
+            'maestro9' => [
+                'maestro',
+                $this->generateCardNumber(63, 12),
+                true,
+            ],
+            'maestro10' => [
+                'maestro',
+                $this->generateCardNumber(64, 12),
+                true,
+            ],
+            'maestro11' => [
+                'maestro',
+                $this->generateCardNumber(65, 12),
+                true,
+            ],
+            'maestro12' => [
+                'maestro',
+                $this->generateCardNumber(66, 12),
+                true,
+            ],
+            'maestro13' => [
+                'maestro',
+                $this->generateCardNumber(67, 12),
+                true,
+            ],
+            'maestro14' => [
+                'maestro',
+                $this->generateCardNumber(68, 12),
+                true,
+            ],
+            'maestro15' => [
+                'maestro',
+                $this->generateCardNumber(69, 12),
+                true,
+            ],
+            'maestro16' => [
+                'maestro',
+                $this->generateCardNumber(50, 13),
+                true,
+            ],
+            'maestro17' => [
+                'maestro',
+                $this->generateCardNumber(56, 13),
+                true,
+            ],
+            'maestro18' => [
+                'maestro',
+                $this->generateCardNumber(57, 13),
+                true,
+            ],
+            'maestro19' => [
+                'maestro',
+                $this->generateCardNumber(58, 13),
+                true,
+            ],
+            'maestro20' => [
+                'maestro',
+                $this->generateCardNumber(59, 13),
+                true,
+            ],
+            'maestro21' => [
+                'maestro',
+                $this->generateCardNumber(60, 13),
+                true,
+            ],
+            'maestro22' => [
+                'maestro',
+                $this->generateCardNumber(61, 13),
+                true,
+            ],
+            'maestro23' => [
+                'maestro',
+                $this->generateCardNumber(62, 13),
+                true,
+            ],
+            'maestro24' => [
+                'maestro',
+                $this->generateCardNumber(63, 13),
+                true,
+            ],
+            'maestro25' => [
+                'maestro',
+                $this->generateCardNumber(64, 13),
+                true,
+            ],
+            'maestro26' => [
+                'maestro',
+                $this->generateCardNumber(65, 13),
+                true,
+            ],
+            'maestro27' => [
+                'maestro',
+                $this->generateCardNumber(66, 13),
+                true,
+            ],
+            'maestro28' => [
+                'maestro',
+                $this->generateCardNumber(67, 13),
+                true,
+            ],
+            'maestro29' => [
+                'maestro',
+                $this->generateCardNumber(68, 13),
+                true,
+            ],
+            'maestro30' => [
+                'maestro',
+                $this->generateCardNumber(69, 13),
+                true,
+            ],
+            'maestro31' => [
+                'maestro',
+                $this->generateCardNumber(50, 14),
+                true,
+            ],
+            'maestro32' => [
+                'maestro',
+                $this->generateCardNumber(56, 14),
+                true,
+            ],
+            'maestro33' => [
+                'maestro',
+                $this->generateCardNumber(57, 14),
+                true,
+            ],
+            'maestro34' => [
+                'maestro',
+                $this->generateCardNumber(58, 14),
+                true,
+            ],
+            'maestro35' => [
+                'maestro',
+                $this->generateCardNumber(59, 14),
+                true,
+            ],
+            'maestro36' => [
+                'maestro',
+                $this->generateCardNumber(60, 14),
+                true,
+            ],
+            'maestro37' => [
+                'maestro',
+                $this->generateCardNumber(61, 14),
+                true,
+            ],
+            'maestro38' => [
+                'maestro',
+                $this->generateCardNumber(62, 14),
+                true,
+            ],
+            'maestro39' => [
+                'maestro',
+                $this->generateCardNumber(63, 14),
+                true,
+            ],
+            'maestro40' => [
+                'maestro',
+                $this->generateCardNumber(64, 14),
+                true,
+            ],
+            'maestro41' => [
+                'maestro',
+                $this->generateCardNumber(65, 14),
+                true,
+            ],
+            'maestro42' => [
+                'maestro',
+                $this->generateCardNumber(66, 14),
+                true,
+            ],
+            'maestro43' => [
+                'maestro',
+                $this->generateCardNumber(67, 14),
+                true,
+            ],
+            'maestro44' => [
+                'maestro',
+                $this->generateCardNumber(68, 14),
+                true,
+            ],
+            'maestro45' => [
+                'maestro',
+                $this->generateCardNumber(69, 14),
+                true,
+            ],
+            'maestro46' => [
+                'maestro',
+                $this->generateCardNumber(50, 15),
+                true,
+            ],
+            'maestro47' => [
+                'maestro',
+                $this->generateCardNumber(56, 15),
+                true,
+            ],
+            'maestro48' => [
+                'maestro',
+                $this->generateCardNumber(57, 15),
+                true,
+            ],
+            'maestro49' => [
+                'maestro',
+                $this->generateCardNumber(58, 15),
+                true,
+            ],
+            'maestro50' => [
+                'maestro',
+                $this->generateCardNumber(59, 15),
+                true,
+            ],
+            'maestro51' => [
+                'maestro',
+                $this->generateCardNumber(60, 15),
+                true,
+            ],
+            'maestro52' => [
+                'maestro',
+                $this->generateCardNumber(61, 15),
+                true,
+            ],
+            'maestro53' => [
+                'maestro',
+                $this->generateCardNumber(62, 15),
+                true,
+            ],
+            'maestro54' => [
+                'maestro',
+                $this->generateCardNumber(63, 15),
+                true,
+            ],
+            'maestro55' => [
+                'maestro',
+                $this->generateCardNumber(64, 15),
+                true,
+            ],
+            'maestro56' => [
+                'maestro',
+                $this->generateCardNumber(65, 15),
+                true,
+            ],
+            'maestro57' => [
+                'maestro',
+                $this->generateCardNumber(66, 15),
+                true,
+            ],
+            'maestro58' => [
+                'maestro',
+                $this->generateCardNumber(67, 15),
+                true,
+            ],
+            'maestro59' => [
+                'maestro',
+                $this->generateCardNumber(68, 15),
+                true,
+            ],
+            'maestro60' => [
+                'maestro',
+                $this->generateCardNumber(69, 15),
+                true,
+            ],
+            'maestro61' => [
+                'maestro',
+                $this->generateCardNumber(50, 16),
+                true,
+            ],
+            'maestro62' => [
+                'maestro',
+                $this->generateCardNumber(56, 16),
+                true,
+            ],
+            'maestro63' => [
+                'maestro',
+                $this->generateCardNumber(57, 16),
+                true,
+            ],
+            'maestro64' => [
+                'maestro',
+                $this->generateCardNumber(58, 16),
+                true,
+            ],
+            'maestro65' => [
+                'maestro',
+                $this->generateCardNumber(59, 16),
+                true,
+            ],
+            'maestro66' => [
+                'maestro',
+                $this->generateCardNumber(60, 16),
+                true,
+            ],
+            'maestro67' => [
+                'maestro',
+                $this->generateCardNumber(61, 16),
+                true,
+            ],
+            'maestro68' => [
+                'maestro',
+                $this->generateCardNumber(62, 16),
+                true,
+            ],
+            'maestro69' => [
+                'maestro',
+                $this->generateCardNumber(63, 16),
+                true,
+            ],
+            'maestro70' => [
+                'maestro',
+                $this->generateCardNumber(64, 16),
+                true,
+            ],
+            'maestro71' => [
+                'maestro',
+                $this->generateCardNumber(65, 16),
+                true,
+            ],
+            'maestro72' => [
+                'maestro',
+                $this->generateCardNumber(66, 16),
+                true,
+            ],
+            'maestro73' => [
+                'maestro',
+                $this->generateCardNumber(67, 16),
+                true,
+            ],
+            'maestro74' => [
+                'maestro',
+                $this->generateCardNumber(68, 16),
+                true,
+            ],
+            'maestro75' => [
+                'maestro',
+                $this->generateCardNumber(69, 16),
+                true,
+            ],
+            'maestro91' => [
+                'maestro',
+                $this->generateCardNumber(50, 18),
+                true,
+            ],
+            'maestro92' => [
+                'maestro',
+                $this->generateCardNumber(56, 18),
+                true,
+            ],
+            'maestro93' => [
+                'maestro',
+                $this->generateCardNumber(57, 18),
+                true,
+            ],
+            'maestro94' => [
+                'maestro',
+                $this->generateCardNumber(58, 18),
+                true,
+            ],
+            'maestro95' => [
+                'maestro',
+                $this->generateCardNumber(59, 18),
+                true,
+            ],
+            'maestro96' => [
+                'maestro',
+                $this->generateCardNumber(60, 18),
+                true,
+            ],
+            'maestro97' => [
+                'maestro',
+                $this->generateCardNumber(61, 18),
+                true,
+            ],
+            'maestro98' => [
+                'maestro',
+                $this->generateCardNumber(62, 18),
+                true,
+            ],
+            'maestro99' => [
+                'maestro',
+                $this->generateCardNumber(63, 18),
+                true,
+            ],
+            'maestro100' => [
+                'maestro',
+                $this->generateCardNumber(64, 18),
+                true,
+            ],
+            'maestro101' => [
+                'maestro',
+                $this->generateCardNumber(65, 18),
+                true,
+            ],
+            'maestro102' => [
+                'maestro',
+                $this->generateCardNumber(66, 18),
+                true,
+            ],
+            'maestro103' => [
+                'maestro',
+                $this->generateCardNumber(67, 18),
+                true,
+            ],
+            'maestro104' => [
+                'maestro',
+                $this->generateCardNumber(68, 18),
+                true,
+            ],
+            'maestro105' => [
+                'maestro',
+                $this->generateCardNumber(69, 18),
+                true,
+            ],
+            'maestro106' => [
+                'maestro',
+                $this->generateCardNumber(50, 19),
+                true,
+            ],
+            'maestro107' => [
+                'maestro',
+                $this->generateCardNumber(56, 19),
+                true,
+            ],
+            'maestro108' => [
+                'maestro',
+                $this->generateCardNumber(57, 19),
+                true,
+            ],
+            'maestro109' => [
+                'maestro',
+                $this->generateCardNumber(58, 19),
+                true,
+            ],
+            'maestro110' => [
+                'maestro',
+                $this->generateCardNumber(59, 19),
+                true,
+            ],
+            'maestro111' => [
+                'maestro',
+                $this->generateCardNumber(60, 19),
+                true,
+            ],
+            'maestro112' => [
+                'maestro',
+                $this->generateCardNumber(61, 19),
+                true,
+            ],
+            'maestro113' => [
+                'maestro',
+                $this->generateCardNumber(62, 19),
+                true,
+            ],
+            'maestro114' => [
+                'maestro',
+                $this->generateCardNumber(63, 19),
+                true,
+            ],
+            'maestro115' => [
+                'maestro',
+                $this->generateCardNumber(64, 19),
+                true,
+            ],
+            'maestro116' => [
+                'maestro',
+                $this->generateCardNumber(65, 19),
+                true,
+            ],
+            'maestro117' => [
+                'maestro',
+                $this->generateCardNumber(66, 19),
+                true,
+            ],
+            'maestro118' => [
+                'maestro',
+                $this->generateCardNumber(67, 19),
+                true,
+            ],
+            'maestro119' => [
+                'maestro',
+                $this->generateCardNumber(68, 19),
+                true,
+            ],
+            'maestro120' => [
+                'maestro',
+                $this->generateCardNumber(69, 19),
+                true,
+            ],
+            'dankort1' => [
+                'dankort',
+                $this->generateCardNumber(5019, 16),
+                true,
+            ],
+            'dankort2' => [
+                'dankort',
+                $this->generateCardNumber(4175, 16),
+                true,
+            ],
+            'dankort3' => [
+                'dankort',
+                $this->generateCardNumber(4571, 16),
+                true,
+            ],
+            'dankort4' => [
+                'dankort',
+                $this->generateCardNumber(4, 16),
+                true,
+            ],
+            'mir1' => [
+                'mir',
+                $this->generateCardNumber(2200, 16),
+                true,
+            ],
+            'mir2' => [
+                'mir',
+                $this->generateCardNumber(2201, 16),
+                true,
+            ],
+            'mir3' => [
+                'mir',
+                $this->generateCardNumber(2202, 16),
+                true,
+            ],
+            'mir4' => [
+                'mir',
+                $this->generateCardNumber(2203, 16),
+                true,
+            ],
+            'mir5' => [
+                'mir',
+                $this->generateCardNumber(2204, 16),
+                true,
+            ],
+            'mastercard1' => [
+                'mastercard',
+                $this->generateCardNumber(51, 16),
+                true,
+            ],
+            'mastercard2' => [
+                'mastercard',
+                $this->generateCardNumber(52, 16),
+                true,
+            ],
+            'mastercard3' => [
+                'mastercard',
+                $this->generateCardNumber(53, 16),
+                true,
+            ],
+            'mastercard4' => [
+                'mastercard',
+                $this->generateCardNumber(54, 16),
+                true,
+            ],
+            'mastercard5' => [
+                'mastercard',
+                $this->generateCardNumber(55, 16),
+                true,
+            ],
+            'mastercard6' => [
+                'mastercard',
+                $this->generateCardNumber(22, 16),
+                true,
+            ],
+            'mastercard7' => [
+                'mastercard',
+                $this->generateCardNumber(23, 16),
+                true,
+            ],
+            'mastercard8' => [
+                'mastercard',
+                $this->generateCardNumber(24, 16),
+                true,
+            ],
+            'mastercard9' => [
+                'mastercard',
+                $this->generateCardNumber(25, 16),
+                true,
+            ],
+            'mastercard10' => [
+                'mastercard',
+                $this->generateCardNumber(26, 16),
+                true,
+            ],
+            'mastercard11' => [
+                'mastercard',
+                $this->generateCardNumber(27, 16),
+                true,
+            ],
+            'visa1' => [
+                'visa',
+                $this->generateCardNumber(4, 13),
+                true,
+            ],
+            'visa2' => [
+                'visa',
+                $this->generateCardNumber(4, 16),
+                true,
+            ],
+            'visa3' => [
+                'visa',
+                $this->generateCardNumber(4, 19),
+                true,
+            ],
+            'uatp' => [
+                'uatp',
+                $this->generateCardNumber(1, 15),
+                true,
+            ],
+            'verve1' => [
+                'verve',
+                $this->generateCardNumber(506, 16),
+                true,
+            ],
+            'verve2' => [
+                'verve',
+                $this->generateCardNumber(650, 16),
+                true,
+            ],
+            'verve3' => [
+                'verve',
+                $this->generateCardNumber(506, 19),
+                true,
+            ],
+            'verve4' => [
+                'verve',
+                $this->generateCardNumber(650, 19),
+                true,
+            ],
+            'cibc1' => [
+                'cibc',
+                $this->generateCardNumber(4506, 16),
+                true,
+            ],
+            'rbc1' => [
+                'rbc',
+                $this->generateCardNumber(45, 16),
+                true,
+            ],
+            'tdtrust' => [
+                'tdtrust',
+                $this->generateCardNumber(589297, 16),
+                true,
+            ],
+            'scotia1' => [
+                'scotia',
+                $this->generateCardNumber(4536, 16),
+                true,
+            ],
+            'bmoabm1' => [
+                'bmoabm',
+                $this->generateCardNumber(500, 16),
+                true,
+            ],
+            'hsbc1' => [
+                'hsbc',
+                $this->generateCardNumber(56, 16),
+                true,
+            ],
+            'hsbc2' => [
+                'hsbc',
+                $this->generateCardNumber(57, 16),
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * Generate a fake credit card number that still passes the Luhn algorithm.
+     */
+    private function generateCardNumber(int $prefix, int $length): string
+    {
+        $prefix = (string) $prefix;
+        $cursor = strlen($prefix);
+
+        $digits = str_split($prefix);
+        $digits = array_pad($digits, $length, '0');
+
+        while ($cursor < $length - 1) {
+            $digits[$cursor++] = (string) random_int(0, 9);
+        }
+
+        $digits[$length - 1] = (string) $this->calculateLuhnChecksum($digits, $length);
+
+        return implode('', $digits);
+    }
+
+    private function calculateLuhnChecksum(array $digits, int $length): int
+    {
+        $parity = $length % 2;
+
+        $sum = 0;
+
+        for ($i = $length - 1; $i >= 0; $i--) {
+            $current = $digits[$i];
+
+            if ($i % 2 === $parity) {
+                $current *= 2;
+
+                if ($current > 9) {
+                    $current -= 9;
+                }
+            }
+
+            $sum += $current;
+        }
+
+        return ($sum * 9) % 10;
+    }
+}

--- a/tests/system/ValidationStrict/DatabaseRelatedRulesTest.php
+++ b/tests/system/ValidationStrict/DatabaseRelatedRulesTest.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\ValidationStrict;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use Config\Database;
+use Config\Services;
+use Tests\Support\Validation\TestRules;
+
+/**
+ * @internal
+ *
+ * @group DatabaseLive
+ */
+final class DatabaseRelatedRulesTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    /**
+     * @var Validation
+     */
+    private $validation;
+
+    private $config = [
+        'ruleSets' => [
+            Rules::class,
+            FormatRules::class,
+            FileRules::class,
+            CreditCardRules::class,
+            TestRules::class,
+        ],
+        'groupA' => [
+            'foo' => 'required|min_length[5]',
+        ],
+        'groupA_errors' => [
+            'foo' => [
+                'min_length' => 'Shame, shame. Too short.',
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validation = new Validation((object) $this->config, Services::renderer());
+        $this->validation->reset();
+    }
+
+    public function testIsUniqueFalse(): void
+    {
+        Database::connect()
+            ->table('user')
+            ->insert([
+                'name'    => 'Derek Travis',
+                'email'   => 'derek@world.com',
+                'country' => 'Elbonia',
+            ]);
+
+        $data = ['email' => 'derek@world.com'];
+        $this->validation->setRules(['email' => 'is_unique[user.email]']);
+        $this->assertFalse($this->validation->run($data));
+    }
+
+    public function testIsUniqueTrue(): void
+    {
+        $data = ['email' => 'derek@world.co.uk'];
+        $this->validation->setRules(['email' => 'is_unique[user.email]']);
+        $this->assertTrue($this->validation->run($data));
+    }
+
+    public function testIsUniqueIgnoresParams(): void
+    {
+        $db = Database::connect();
+        $db
+            ->table('user')
+            ->insert([
+                'name'    => 'Developer A',
+                'email'   => 'deva@example.com',
+                'country' => 'Elbonia',
+            ]);
+        $row = $db->table('user')
+            ->limit(1)
+            ->get()
+            ->getRow();
+
+        $data = ['email' => 'derek@world.co.uk'];
+        $this->validation->setRules(['email' => "is_unique[user.email,id,{$row->id}]"]);
+        $this->assertTrue($this->validation->run($data));
+    }
+
+    public function testIsUniqueIgnoresParamsPlaceholders(): void
+    {
+        $this->hasInDatabase('user', [
+            'name'    => 'Derek',
+            'email'   => 'derek@world.co.uk',
+            'country' => 'GB',
+        ]);
+
+        $row = Database::connect()
+            ->table('user')
+            ->limit(1)
+            ->get()
+            ->getRow();
+
+        $data = [
+            'id'    => $row->id,
+            'email' => 'derek@world.co.uk',
+        ];
+
+        $this->validation->setRules(['email' => 'is_unique[user.email,id,{id}]']);
+        $this->assertTrue($this->validation->run($data));
+    }
+
+    public function testIsUniqueByManualRun(): void
+    {
+        Database::connect()
+            ->table('user')
+            ->insert([
+                'name'    => 'Developer A',
+                'email'   => 'deva@example.com',
+                'country' => 'Elbonia',
+            ]);
+
+        $this->assertFalse((new Rules())->is_unique('deva@example.com', 'user.email,id,{id}', []));
+    }
+
+    public function testIsNotUniqueFalse(): void
+    {
+        Database::connect()
+            ->table('user')
+            ->insert([
+                'name'    => 'Derek Travis',
+                'email'   => 'derek@world.com',
+                'country' => 'Elbonia',
+            ]);
+
+        $data = ['email' => 'derek1@world.com'];
+        $this->validation->setRules(['email' => 'is_not_unique[user.email]']);
+        $this->assertFalse($this->validation->run($data));
+    }
+
+    public function testIsNotUniqueTrue(): void
+    {
+        Database::connect()
+            ->table('user')
+            ->insert([
+                'name'    => 'Derek Travis',
+                'email'   => 'derek@world.com',
+                'country' => 'Elbonia',
+            ]);
+
+        $data = ['email' => 'derek@world.com'];
+        $this->validation->setRules(['email' => 'is_not_unique[user.email]']);
+        $this->assertTrue($this->validation->run($data));
+    }
+
+    public function testIsNotUniqueIgnoresParams(): void
+    {
+        $db = Database::connect();
+        $db->table('user')
+            ->insert([
+                'name'    => 'Developer A',
+                'email'   => 'deva@example.com',
+                'country' => 'Elbonia',
+            ]);
+
+        $row = $db->table('user')
+            ->limit(1)
+            ->get()
+            ->getRow();
+
+        $data = ['email' => 'derek@world.co.uk'];
+        $this->validation->setRules(['email' => "is_not_unique[user.email,id,{$row->id}]"]);
+        $this->assertFalse($this->validation->run($data));
+    }
+
+    public function testIsNotUniqueIgnoresParamsPlaceholders(): void
+    {
+        $this->hasInDatabase('user', [
+            'name'    => 'Derek',
+            'email'   => 'derek@world.co.uk',
+            'country' => 'GB',
+        ]);
+
+        $row = Database::connect()
+            ->table('user')
+            ->limit(1)
+            ->get()
+            ->getRow();
+
+        $data = [
+            'id'    => $row->id,
+            'email' => 'derek@world.co.uk',
+        ];
+        $this->validation->setRules(['email' => 'is_not_unique[user.email,id,{id}]']);
+        $this->assertTrue($this->validation->run($data));
+    }
+
+    public function testIsNotUniqueByManualRun(): void
+    {
+        Database::connect()
+            ->table('user')
+            ->insert([
+                'name'    => 'Developer A',
+                'email'   => 'deva@example.com',
+                'country' => 'Elbonia',
+            ]);
+
+        $this->assertTrue((new Rules())->is_not_unique('deva@example.com', 'user.email,id,{id}', []));
+    }
+}

--- a/tests/system/ValidationStrict/FileRulesTest.php
+++ b/tests/system/ValidationStrict/FileRulesTest.php
@@ -1,0 +1,287 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\ValidationStrict;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Services;
+use Tests\Support\Validation\TestRules;
+
+/**
+ * @internal
+ */
+final class FileRulesTest extends CIUnitTestCase
+{
+    /**
+     * @var Validation
+     */
+    private $validation;
+
+    private $config = [
+        'ruleSets' => [
+            Rules::class,
+            FormatRules::class,
+            FileRules::class,
+            CreditCardRules::class,
+            TestRules::class,
+        ],
+        'groupA' => [
+            'foo' => 'required|min_length[5]',
+        ],
+        'groupA_errors' => [
+            'foo' => [
+                'min_length' => 'Shame, shame. Too short.',
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validation = new Validation((object) $this->config, Services::renderer());
+        $this->validation->reset();
+
+        $_FILES = [
+            'avatar' => [
+                'tmp_name' => TESTPATH . '_support/Validation/uploads/phpUxc0ty',
+                'name'     => 'my-avatar.png',
+                'size'     => 4614,
+                'type'     => 'image/png',
+                'error'    => 0,
+                'width'    => 640,
+                'height'   => 400,
+            ],
+            'bigfile' => [
+                'tmp_name' => TESTPATH . '_support/Validation/uploads/phpUxc0ty',
+                'name'     => 'my-big-file.png',
+                'size'     => 1024000,
+                'type'     => 'image/png',
+                'error'    => UPLOAD_ERR_OK,
+                'width'    => 640,
+                'height'   => 400,
+            ],
+            'photo' => [
+                'tmp_name' => TESTPATH . '_support/Validation/uploads/phpUxc0ty',
+                'name'     => 'my-photo.png',
+                'size'     => 4614,
+                'type'     => 'image/png',
+                'error'    => UPLOAD_ERR_INI_SIZE,
+                'width'    => 640,
+                'height'   => 400,
+            ],
+            'images' => [
+                'tmp_name' => [
+                    TESTPATH . '_support/Validation/uploads/phpUxc0ty',
+                    TESTPATH . '_support/Validation/uploads/phpUxc0ty',
+                ],
+                'name' => [
+                    'my_avatar.png',
+                    'my_bigfile.png',
+                ],
+                'size' => [
+                    4614,
+                    1024000,
+                ],
+                'type' => [
+                    'image/png',
+                    'image/png',
+                ],
+                'error' => [
+                    UPLOAD_ERR_OK,
+                    UPLOAD_ERR_OK,
+                ],
+                'width' => [
+                    640,
+                    640,
+                ],
+                'height' => [
+                    400,
+                    400,
+                ],
+            ],
+            'photos' => [
+                'tmp_name' => [
+                    TESTPATH . '_support/Validation/uploads/phpUxc0ty',
+                    TESTPATH . '_support/Validation/uploads/phpUxc0ty',
+                ],
+                'name' => [
+                    'my_avatar.png',
+                    'my_bigfile.png',
+                ],
+                'size' => [
+                    4614,
+                    1024000,
+                ],
+                'type' => [
+                    'image/png',
+                    'image/png',
+                ],
+                'error' => [
+                    UPLOAD_ERR_INI_SIZE,
+                    UPLOAD_ERR_OK,
+                ],
+                'width' => [
+                    640,
+                    640,
+                ],
+                'height' => [
+                    400,
+                    400,
+                ],
+            ],
+        ];
+    }
+
+    public function testUploadedTrue(): void
+    {
+        $this->validation->setRules(['avatar' => 'uploaded[avatar]']);
+        $this->assertTrue($this->validation->run([]));
+    }
+
+    public function testUploadedFalse(): void
+    {
+        $this->validation->setRules(['avatar' => 'uploaded[userfile]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testUploadedArrayReturnsTrue(): void
+    {
+        $this->validation->setRules(['images' => 'uploaded[images]']);
+        $this->assertTrue($this->validation->run([]));
+    }
+
+    public function testUploadedArrayReturnsFalse(): void
+    {
+        $this->validation->setRules(['photos' => 'uploaded[photos]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testMaxSize(): void
+    {
+        $this->validation->setRules(['avatar' => 'max_size[avatar,100]']);
+        $this->assertTrue($this->validation->run([]));
+    }
+
+    public function testMaxSizeBigFile(): void
+    {
+        $this->validation->setRules(['bigfile' => 'max_size[bigfile,9999]']);
+        $this->assertTrue($this->validation->run([]));
+    }
+
+    public function testMaxSizeFail(): void
+    {
+        $this->validation->setRules(['avatar' => 'max_size[avatar,4]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testMaxSizeFailDueToUploadMaxFilesizeExceededInPhpIni(): void
+    {
+        $this->validation->setRules(['photo' => 'max_size[photo,100]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testMaxSizeBigFileFail(): void
+    {
+        $this->validation->setRules(['bigfile' => 'max_size[bigfile,10]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testMaxSizeBad(): void
+    {
+        $this->validation->setRules(['avatar' => 'max_size[userfile,50]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testMaxDims(): void
+    {
+        $this->validation->setRules(['avatar' => 'max_dims[avatar,640,480]']);
+        $this->assertTrue($this->validation->run([]));
+    }
+
+    public function testMaxDimsFail(): void
+    {
+        $this->validation->setRules(['avatar' => 'max_dims[avatar,600,480]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testMaxDimsBad(): void
+    {
+        $this->validation->setRules(['avatar' => 'max_dims[unknown,640,480]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testIsImage(): void
+    {
+        $this->validation->setRules(['avatar' => 'is_image[avatar]']);
+        $this->assertTrue($this->validation->run([]));
+    }
+
+    public function testIsntImage(): void
+    {
+        $_FILES['stuff'] = [
+            'tmp_name' => TESTPATH . '_support/Validation/uploads/abc77tz',
+            'name'     => 'address.book',
+            'size'     => 12345,
+            'type'     => 'application/address',
+            'error'    => UPLOAD_ERR_OK,
+        ];
+        $this->validation->setRules(['avatar' => 'is_image[stuff]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testAlsoIsntImage(): void
+    {
+        $this->validation->setRules(['avatar' => 'is_image[unknown]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testMimeTypeOk(): void
+    {
+        $this->validation->setRules([
+            'avatar' => 'mime_in[avatar,image/jpg,image/jpeg,image/gif,image/png]',
+        ]);
+        $this->assertTrue($this->validation->run([]));
+    }
+
+    public function testMimeTypeNotOk(): void
+    {
+        $this->validation->setRules([
+            'avatar' => 'mime_in[avatar,application/xls,application/doc,application/ppt]',
+        ]);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testMimeTypeImpossible(): void
+    {
+        $this->validation->setRules([
+            'avatar' => 'mime_in[unknown,application/xls,application/doc,application/ppt]',
+        ]);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testExtensionOk(): void
+    {
+        $this->validation->setRules(['avatar' => 'ext_in[avatar,jpg,jpeg,gif,png]']);
+        $this->assertTrue($this->validation->run([]));
+    }
+
+    public function testExtensionNotOk(): void
+    {
+        $this->validation->setRules(['avatar' => 'ext_in[avatar,xls,doc,ppt]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testExtensionImpossible(): void
+    {
+        $this->validation->setRules(['avatar' => 'ext_in[unknown,xls,doc,ppt]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+}

--- a/tests/system/ValidationStrict/FormatRulesTest.php
+++ b/tests/system/ValidationStrict/FormatRulesTest.php
@@ -1,0 +1,1373 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\ValidationStrict;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Services;
+use Generator;
+use Tests\Support\Validation\TestRules;
+
+/**
+ * @internal
+ */
+final class FormatRulesTest extends CIUnitTestCase
+{
+    public const ALPHABET     = 'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ';
+    public const ALPHANUMERIC = 'abcdefghijklmnopqrstuvwxyzABCDEFGHLIJKLMNOPQRSTUVWXYZ0123456789';
+
+    /**
+     * @var Validation
+     */
+    private $validation;
+
+    private $config = [
+        'ruleSets' => [
+            Rules::class,
+            FormatRules::class,
+            FileRules::class,
+            CreditCardRules::class,
+            TestRules::class,
+        ],
+        'groupA' => [
+            'foo' => 'required|min_length[5]',
+        ],
+        'groupA_errors' => [
+            'foo' => [
+                'min_length' => 'Shame, shame. Too short.',
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validation = new Validation((object) $this->config, Services::renderer());
+        $this->validation->reset();
+    }
+
+    public function testRegexMatch(): void
+    {
+        $data = [
+            'foo'   => 'abcde',
+            'phone' => '0987654321',
+        ];
+
+        $this->validation->setRules([
+            'foo'   => 'regex_match[/[a-z]/]',
+            'phone' => 'regex_match[/^(01[2689]|09)[0-9]{8}$/]',
+        ]);
+
+        $this->assertTrue($this->validation->run($data));
+    }
+
+    public function testRegexMatchFalse(): void
+    {
+        $data = [
+            'foo'   => 'abcde',
+            'phone' => '09876543214',
+        ];
+
+        $this->validation->setRules([
+            'foo'   => 'regex_match[\d]',
+            'phone' => 'regex_match[/^(01[2689]|09)[0-9]{8}$/]',
+        ]);
+
+        $this->assertFalse($this->validation->run($data));
+    }
+
+    /**
+     * @dataProvider urlProvider
+     */
+    public function testValidURL(?string $url, bool $isLoose, bool $isStrict)
+    {
+        $data = [
+            'foo' => $url,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'valid_url',
+        ]);
+
+        $this->assertSame($isLoose, $this->validation->run($data));
+    }
+
+    /**
+     * @dataProvider urlProvider
+     */
+    public function testValidURLStrict(?string $url, bool $isLoose, bool $isStrict)
+    {
+        $data = [
+            'foo' => $url,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'valid_url_strict',
+        ]);
+
+        $this->assertSame($isStrict, $this->validation->run($data));
+    }
+
+    public function testValidURLStrictWithSchema()
+    {
+        $data = [
+            'foo' => 'http://www.codeigniter.com',
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'valid_url_strict[https]',
+        ]);
+
+        $this->assertFalse($this->validation->run($data));
+    }
+
+    public function urlProvider(): Generator
+    {
+        yield from [
+            [
+                'www.codeigniter.com',
+                true,
+                false,
+            ],
+            [
+                'http://codeigniter.com',
+                true,
+                true,
+            ],
+            // https://bugs.php.net/bug.php?id=51192
+            [
+                'http://accept-dashes.tld',
+                true,
+                true,
+            ],
+            [
+                'http://reject_underscores',
+                false,
+                false,
+            ],
+            // https://github.com/bcit-ci/CodeIgniter/issues/4415
+            [
+                'http://[::1]/ipv6',
+                true,
+                true,
+            ],
+            [
+                'htt://www.codeigniter.com',
+                false,
+                false,
+            ],
+            [
+                '',
+                false,
+                false,
+            ],
+            // https://github.com/codeigniter4/CodeIgniter4/issues/3156
+            [
+                'codeigniter',
+                true,   // What?
+                false,
+            ],
+            [
+                'code igniter',
+                false,
+                false,
+            ],
+            [
+                null,
+                false,
+                false,
+            ],
+            [
+                'http://',
+                true,   // Why?
+                false,
+            ],
+            [
+                'http:///oops.com',
+                false,
+                false,
+            ],
+            [
+                '123.com',
+                true,
+                false,
+            ],
+            [
+                'abc.123',
+                true,
+                false,
+            ],
+            [
+                'http:8080//abc.com',
+                true,   // Insane?
+                false,
+            ],
+            [
+                'mailto:support@codeigniter.com',
+                true,
+                false,
+            ],
+            [
+                '//example.com',
+                false,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider emailProviderSingle
+     */
+    public function testValidEmail(?string $email, bool $expected): void
+    {
+        $data = [
+            'foo' => $email,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'valid_email',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    /**
+     * @dataProvider emailsProvider
+     */
+    public function testValidEmails(?string $email, bool $expected): void
+    {
+        $data = [
+            'foo' => $email,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'valid_emails',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function emailProviderSingle(): Generator
+    {
+        yield from [
+            [
+                'email@sample.com',
+                true,
+            ],
+            [
+                'valid_email',
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+        ];
+    }
+
+    public function emailsProvider(): Generator
+    {
+        yield from [
+            [
+                '1@sample.com,2@sample.com',
+                true,
+            ],
+            [
+                '1@sample.com, 2@sample.com',
+                true,
+            ],
+            [
+                'email@sample.com',
+                true,
+            ],
+            [
+                '@sample.com,2@sample.com,validemail@email.ca',
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+            [
+                ',',
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider ipProvider
+     */
+    public function testValidIP(?string $ip, ?string $which, bool $expected): void
+    {
+        $data = [
+            'foo' => $ip,
+        ];
+
+        $this->validation->setRules([
+            'foo' => "valid_ip[{$which}]",
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function ipProvider(): Generator
+    {
+        yield from [
+            [
+                '127.0.0.1',
+                null,
+                true,
+            ],
+            [
+                '127.0.0.1',
+                'ipv4',
+                true,
+            ],
+            [
+                '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+                null,
+                true,
+            ],
+            [
+                '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+                'ipv6',
+                true,
+            ],
+            [
+                '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+                'ipv4',
+                false,
+            ],
+            [
+                '127.0.0.1',
+                'ipv6',
+                false,
+            ],
+            [
+                'H001:0db8:85a3:0000:0000:8a2e:0370:7334',
+                null,
+                false,
+            ],
+            [
+                '127.0.0.259',
+                null,
+                false,
+            ],
+            [
+                null,
+                null,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider stringProvider
+     *
+     * @param int|string $str
+     */
+    public function testString($str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'string',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function stringProvider(): Generator
+    {
+        yield from [
+            [
+                '123',
+                true,
+            ],
+            [
+                123,
+                false,
+            ],
+            [
+                'hello',
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider alphaProvider
+     *
+     * @param $str
+     * @param $expected
+     */
+    public function testAlpha(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'alpha',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function alphaProvider(): Generator
+    {
+        yield from [
+            [
+                self::ALPHABET,
+                true,
+            ],
+            [
+                self::ALPHABET . ' ',
+                false,
+            ],
+            [
+                self::ALPHABET . '1',
+                false,
+            ],
+            [
+                self::ALPHABET . '*',
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider alphaSpaceProvider
+     */
+    public function testAlphaSpace(?string $value, bool $expected): void
+    {
+        $data = [
+            'foo' => $value,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'alpha_space',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function alphaSpaceProvider(): Generator
+    {
+        yield from [
+            [
+                null,
+                true,
+            ],
+            [
+                self::ALPHABET,
+                true,
+            ],
+            [
+                self::ALPHABET . ' ',
+                true,
+            ],
+            [
+                self::ALPHABET . "\n",
+                false,
+            ],
+            [
+                self::ALPHABET . '1',
+                false,
+            ],
+            [
+                self::ALPHABET . '*',
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider alphaNumericProvider
+     */
+    public function testAlphaNumeric(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'alpha_numeric',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function alphaNumericProvider(): Generator
+    {
+        yield from [
+            [
+                self::ALPHANUMERIC,
+                true,
+            ],
+            [
+                self::ALPHANUMERIC . '\ ',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . '_',
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider alphaNumericPunctProvider
+     */
+    public function testAlphaNumericPunct(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'alpha_numeric_punct',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function alphaNumericPunctProvider(): Generator
+    {
+        yield from [
+            [
+                self::ALPHANUMERIC . ' ~!#$%&*-_+=|:.',
+                true,
+            ],
+            [
+                self::ALPHANUMERIC . '`',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . "\n",
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . '@',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . '^',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . '(',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . ')',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . '\\',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . '{',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . '}',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . '[',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . ']',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . '"',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . "'",
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . '<',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . '>',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . '/',
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider alphaNumericProvider
+     */
+    public function testAlphaNumericSpace(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'alpha_numeric_space',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function alphaNumericSpaceProvider(): Generator
+    {
+        yield from [
+            [
+                ' ' . self::ALPHANUMERIC,
+                true,
+            ],
+            [
+                ' ' . self::ALPHANUMERIC . '-',
+                false,
+            ],
+            [
+                ' ' . self::ALPHANUMERIC . "\n",
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider alphaDashProvider
+     */
+    public function testAlphaDash(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'alpha_dash',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function alphaDashProvider(): Generator
+    {
+        yield from [
+            [
+                self::ALPHANUMERIC . '-',
+                true,
+            ],
+            [
+                self::ALPHANUMERIC . '-\ ',
+                false,
+            ],
+            [
+                self::ALPHANUMERIC . "-\n",
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider hexProvider
+     */
+    public function testHex(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'hex',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function hexProvider(): Generator
+    {
+        yield from [
+            [
+                'abcdefABCDEF0123456789',
+                true,
+            ],
+            [
+                self::ALPHANUMERIC,
+                false,
+            ],
+            [
+                'asdfjkl;',
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider numericProvider
+     */
+    public function testNumeric(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'numeric',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function numericProvider(): Generator
+    {
+        yield from [
+            [
+                '0',
+                true,
+            ],
+            [
+                '12314',
+                true,
+            ],
+            [
+                '-42',
+                true,
+            ],
+            [
+                '+42',
+                true,
+            ],
+            [
+                "+42\n",
+                false,
+            ],
+            [
+                '123a',
+                false,
+            ],
+            [
+                '--1',
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
+     *
+     * @dataProvider integerInvalidTypeDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testIntegerWithInvalidTypeData($value, bool $expected): void
+    {
+        $this->validation->setRules([
+            'foo' => 'integer',
+        ]);
+
+        $data = [
+            'foo' => $value,
+        ];
+        $this->assertsame($expected, $this->validation->run($data));
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
+     *
+     * @dataProvider integerInvalidTypeDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testNumericWithInvalidTypeData($value, bool $expected): void
+    {
+        $this->validation->setRules([
+            'foo' => 'numeric',
+        ]);
+
+        $data = [
+            'foo' => $value,
+        ];
+        $this->assertsame($expected, $this->validation->run($data));
+    }
+
+    public function integerInvalidTypeDataProvider(): Generator
+    {
+        yield 'array with int' => [
+            [555],
+            false,  // true in v4.1.5 and earlier
+        ];
+
+        yield 'empty array' => [
+            [],
+            false,  // true in v4.1.5 and earlier
+        ];
+
+        yield 'bool true' => [
+            true,
+            false,  // true in v4.1.5 and earlier
+        ];
+
+        yield 'bool false' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
+
+    /**
+     * @dataProvider integerProvider
+     */
+    public function testInteger(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'integer',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function integerProvider(): Generator
+    {
+        yield from [
+            [
+                '0',
+                true,
+            ],
+            [
+                '42',
+                true,
+            ],
+            [
+                '-1',
+                true,
+            ],
+            [
+                "+42\n",
+                false,
+            ],
+            [
+                '123a',
+                false,
+            ],
+            [
+                '1.9',
+                false,
+            ],
+            [
+                '--1',
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider decimalProvider
+     */
+    public function testDecimal(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'decimal',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function decimalProvider(): Generator
+    {
+        yield from [
+            [
+                '1.0',
+                true,
+            ],
+            [
+                '-0.98',
+                true,
+            ],
+            [
+                '0',
+                true,
+            ],
+            [
+                "0\n",
+                false,
+            ],
+            [
+                '1.0a',
+                false,
+            ],
+            [
+                '-i',
+                false,
+            ],
+            [
+                '--1',
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+            [
+                '.25',
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider naturalProvider
+     */
+    public function testNatural(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'is_natural',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function naturalProvider(): Generator
+    {
+        yield from [
+            [
+                '0',
+                true,
+            ],
+            [
+                '12',
+                true,
+            ],
+            [
+                '42a',
+                false,
+            ],
+            [
+                '-1',
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider naturalZeroProvider
+     */
+    public function testNaturalNoZero(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'is_natural_no_zero',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function naturalZeroProvider(): Generator
+    {
+        yield from [
+            [
+                '0',
+                false,
+            ],
+            [
+                '12',
+                true,
+            ],
+            [
+                '42a',
+                false,
+            ],
+            [
+                '-1',
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider base64Provider
+     */
+    public function testBase64(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'valid_base64',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function base64Provider(): Generator
+    {
+        yield from [
+            [
+                base64_encode('string'),
+                true,
+            ],
+            [
+                'FA08GG',
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider jsonProvider
+     */
+    public function testJson(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'valid_json',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function jsonProvider(): Generator
+    {
+        yield from [
+            [
+                'null',
+                true,
+            ],
+            [
+                '"null"',
+                true,
+            ],
+            [
+                '600100825',
+                true,
+            ],
+            [
+                '{"A":"Yay.", "B":[0,5]}',
+                true,
+            ],
+            [
+                '[0,"2",2.2,"3.3"]',
+                true,
+            ],
+            [
+                null,
+                false,
+            ],
+            [
+                '600-Nope. Should not pass.',
+                false,
+            ],
+            [
+                '{"A":SHOULD_NOT_PASS}',
+                false,
+            ],
+            [
+                '[0,"2",2.2 "3.3"]',
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider timezoneProvider
+     */
+    public function testTimeZone(?string $str, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => 'timezone',
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function timezoneProvider(): Generator
+    {
+        yield from [
+            [
+                'America/Chicago',
+                true,
+            ],
+            [
+                'america/chicago',
+                false,
+            ],
+            [
+                'foo/bar',
+                false,
+            ],
+            [
+                null,
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider validDateProvider
+     */
+    public function testValidDate(?string $str, ?string $format, bool $expected): void
+    {
+        $data = [
+            'foo' => $str,
+        ];
+
+        $this->validation->setRules([
+            'foo' => "valid_date[{$format}]",
+        ]);
+
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function validDateProvider(): Generator
+    {
+        yield from [
+            [
+                'Sun',
+                'D',
+                true,
+            ],
+            [
+                'Sun',
+                'd',
+                false,
+            ],
+            [
+                'Sun',
+                null,
+                true,
+            ],
+            [
+                '1500',
+                'Y',
+                true,
+            ],
+            [
+                '1500',
+                'y',
+                false,
+            ],
+            [
+                '1500',
+                null,
+                true,
+            ],
+            [
+                '09:26:05',
+                'H:i:s',
+                true,
+            ],
+            [
+                '09:26:5',
+                'H:i:s',
+                false,
+            ],
+            [
+                '1992-02-29',
+                'Y-m-d',
+                true,
+            ],
+            [
+                '1991-02-29',
+                'Y-m-d',
+                false,
+            ],
+            [
+                '1718-05-10 15:25:59',
+                'Y-m-d H:i:s',
+                true,
+            ],
+            [
+                '1718-05-10 15:5:59',
+                'Y-m-d H:i:s',
+                false,
+            ],
+            [
+                'Thu, 31 Oct 2013 13:31:00',
+                'D, d M Y H:i:s',
+                true,
+            ],
+            [
+                'Thu, 31 Jun 2013 13:31:00',
+                'D, d M Y H:i:s',
+                false,
+            ],
+            [
+                'Thu, 31 Jun 2013 13:31:00',
+                null,
+                true,
+            ],
+            [
+                '07.05.03',
+                'm.d.y',
+                true,
+            ],
+            [
+                '07.05.1803',
+                'm.d.y',
+                false,
+            ],
+            [
+                '19890109',
+                'Ymd',
+                true,
+            ],
+            [
+                '198919',
+                'Ymd',
+                false,
+            ],
+            [
+                '2, 7, 2001',
+                'j, n, Y',
+                true,
+            ],
+            [
+                '2, 17, 2001',
+                'j, n, Y',
+                false,
+            ],
+            [
+                '09-42-25, 12-11-17',
+                'h-i-s, j-m-y',
+                true,
+            ],
+            [
+                '09-42-25, 12-00-17',
+                'h-i-s, j-m-y',
+                false,
+            ],
+            [
+                '09-42-25, 12-00-17',
+                null,
+                false,
+            ],
+            [
+                'November 12, 2017, 9:42 am',
+                'F j, Y, g:i a',
+                true,
+            ],
+            [
+                'November 12, 2017, 19:42 am',
+                'F j, Y, g:i a',
+                false,
+            ],
+            [
+                'November 12, 2017, 9:42 am',
+                null,
+                true,
+            ],
+            [
+                'Monday 8th of August 2005 03:12:46 PM',
+                'l jS \of F Y h:i:s A',
+                true,
+            ],
+            [
+                'Monday 8th of August 2005 13:12:46 PM',
+                'l jS \of F Y h:i:s A',
+                false,
+            ],
+            [
+                '23:01:59 is now',
+                'H:m:s \i\s \n\o\w',
+                true,
+            ],
+            [
+                '23:01:59 is now',
+                'H:m:s is now',
+                false,
+            ],
+            [
+                '12/11/2017',
+                'd/m/Y',
+                true,
+            ],
+        ];
+    }
+}

--- a/tests/system/ValidationStrict/RulesTest.php
+++ b/tests/system/ValidationStrict/RulesTest.php
@@ -1,0 +1,623 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\ValidationStrict;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Services;
+use Generator;
+use stdClass;
+use Tests\Support\Validation\TestRules;
+
+/**
+ * @internal
+ */
+final class RulesTest extends CIUnitTestCase
+{
+    /**
+     * @var Validation
+     */
+    private $validation;
+
+    private $config = [
+        'ruleSets' => [
+            Rules::class,
+            FormatRules::class,
+            FileRules::class,
+            CreditCardRules::class,
+            TestRules::class,
+        ],
+        'groupA' => [
+            'foo' => 'required|min_length[5]',
+        ],
+        'groupA_errors' => [
+            'foo' => [
+                'min_length' => 'Shame, shame. Too short.',
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validation = new Validation((object) $this->config, Services::renderer());
+        $this->validation->reset();
+    }
+
+    /**
+     * @dataProvider provideRequiredCases
+     */
+    public function testRequired(array $data, bool $expected): void
+    {
+        $this->validation->setRules(['foo' => 'required']);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function provideRequiredCases(): Generator
+    {
+        yield from [
+            [['foo' => null], false],
+            [['foo' => 123], true],
+            [['foo' => null, 'bar' => 123], false],
+            [['foo' => [123]], true],
+            [['foo' => []], false],
+            [['foo' => new stdClass()], true],
+        ];
+    }
+
+    /**
+     * @dataProvider ifExistProvider
+     */
+    public function testIfExist(array $rules, array $data, bool $expected): void
+    {
+        $this->validation->setRules($rules);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function ifExistProvider(): Generator
+    {
+        yield from [
+            [
+                ['foo' => 'required'],
+                ['foo' => ''],
+                false,
+            ],
+            [
+                ['foo' => 'required'],
+                ['foo' => null],
+                false,
+            ],
+            [
+                ['foo' => 'if_exist|required'],
+                ['foo' => ''],
+                false,
+            ],
+            // Input data does not exist then the other rules will be ignored
+            [
+                ['foo' => 'if_exist|required'],
+                [],
+                true,
+            ],
+            // Testing for multi-dimensional data
+            [
+                ['foo.bar' => 'if_exist|required'],
+                ['foo' => ['bar' => '']],
+                false,
+            ],
+            [
+                ['foo.bar' => 'if_exist|required'],
+                ['foo' => []],
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providePermitEmptyCases
+     */
+    public function testPermitEmpty(array $rules, array $data, bool $expected): void
+    {
+        $this->validation->setRules($rules);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function providePermitEmptyCases(): Generator
+    {
+        yield from [
+            [
+                ['foo' => 'permit_empty'],
+                ['foo' => ''],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty'],
+                ['foo' => '0'],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty'],
+                ['foo' => 0],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty'],
+                ['foo' => 0.0],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty'],
+                ['foo' => null],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty'],
+                ['foo' => false],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty|valid_email'],
+                ['foo' => ''],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty|valid_email'],
+                ['foo' => 'user@domain.tld'],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty|valid_email'],
+                ['foo' => 'invalid'],
+                false,
+            ],
+            // Required has more priority
+            [
+                ['foo' => 'permit_empty|required|valid_email'],
+                ['foo' => ''],
+                false,
+            ],
+            [
+                ['foo' => 'permit_empty|required'],
+                ['foo' => ''],
+                false,
+            ],
+            [
+                ['foo' => 'permit_empty|required'],
+                ['foo' => null],
+                false,
+            ],
+            [
+                ['foo' => 'permit_empty|required'],
+                ['foo' => false],
+                false,
+            ],
+            // This tests will return true because the input data is trimmed
+            [
+                ['foo' => 'permit_empty|required'],
+                ['foo' => '0'],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty|required'],
+                ['foo' => 0],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty|required'],
+                ['foo' => 0.0],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty|required_with[bar]'],
+                ['foo' => ''],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty|required_with[bar]'],
+                ['foo' => 0],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty|required_with[bar]'],
+                ['foo' => 0.0, 'bar' => 1],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty|required_with[bar]'],
+                ['foo' => '', 'bar' => 1],
+                false,
+            ],
+            [
+                ['foo' => 'permit_empty|required_without[bar]'],
+                ['foo' => ''],
+                false,
+            ],
+            [
+                ['foo' => 'permit_empty|required_without[bar]'],
+                ['foo' => 0],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty|required_without[bar]'],
+                ['foo' => 0.0, 'bar' => 1],
+                true,
+            ],
+            [
+                ['foo' => 'permit_empty|required_without[bar]'],
+                ['foo' => '', 'bar' => 1],
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMatchesCases
+     */
+    public function testMatches(array $data, bool $expected): void
+    {
+        $this->validation->setRules(['foo' => 'matches[bar]']);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function provideMatchesCases(): Generator
+    {
+        yield from [
+            [['foo' => null, 'bar' => null], true],
+            [['foo' => 'match', 'bar' => 'match'], true],
+            [['foo' => 'match', 'bar' => 'nope'], false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMatchesNestedCases
+     */
+    public function testMatchesNested(array $data, bool $expected): void
+    {
+        $this->validation->setRules(['nested.foo' => 'matches[nested.bar]']);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function provideMatchesNestedCases(): Generator
+    {
+        yield from [
+            [['nested' => ['foo' => 'match', 'bar' => 'match']], true],
+            [['nested' => ['foo' => 'match', 'bar' => 'nope']], false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMatchesCases
+     */
+    public function testDiffers(array $data, bool $expected): void
+    {
+        $this->validation->setRules(['foo' => 'differs[bar]']);
+        $this->assertSame(! $expected, $this->validation->run($data));
+    }
+
+    /**
+     * @dataProvider provideMatchesNestedCases
+     */
+    public function testDiffersNested(array $data, bool $expected): void
+    {
+        $this->validation->setRules(['nested.foo' => 'differs[nested.bar]']);
+        $this->assertSame(! $expected, $this->validation->run($data));
+    }
+
+    /**
+     * @dataProvider provideEqualsCases
+     */
+    public function testEquals(array $data, string $param, bool $expected): void
+    {
+        $this->validation->setRules(['foo' => "equals[{$param}]"]);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function provideEqualsCases(): Generator
+    {
+        yield from [
+            'null'   => [['foo' => null], '', false],
+            'empty'  => [['foo' => ''], '', true],
+            'fail'   => [['foo' => 'bar'], 'notbar', false],
+            'pass'   => [['foo' => 'bar'], 'bar', true],
+            'casing' => [['foo' => 'bar'], 'Bar', false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMinLengthCases
+     */
+    public function testMinLength(?string $data, string $length, bool $expected): void
+    {
+        $this->validation->setRules(['foo' => "min_length[{$length}]"]);
+        $this->assertSame($expected, $this->validation->run(['foo' => $data]));
+    }
+
+    public function provideMinLengthCases(): Generator
+    {
+        yield from [
+            'null'    => [null, '2', false],
+            'less'    => ['bar', '2', true],
+            'equal'   => ['bar', '3', true],
+            'greater' => ['bar', '4', false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMinLengthCases
+     */
+    public function testMaxLength(?string $data, string $length, bool $expected): void
+    {
+        $this->validation->setRules(['foo' => "max_length[{$length}]"]);
+        $this->assertSame(! $expected || $length === '3', $this->validation->run(['foo' => $data]));
+    }
+
+    public function testMaxLengthReturnsFalseWithNonNumericVal(): void
+    {
+        $this->validation->setRules(['foo' => 'max_length[bar]']);
+        $this->assertFalse($this->validation->run(['foo' => 'bar']));
+    }
+
+    /**
+     * @dataProvider provideExactLengthCases
+     */
+    public function testExactLength(?string $data, bool $expected): void
+    {
+        $this->validation->setRules(['foo' => 'exact_length[3]']);
+        $this->assertSame($expected, $this->validation->run(['foo' => $data]));
+    }
+
+    public function provideExactLengthCases(): Generator
+    {
+        yield from [
+            'null'    => [null, false],
+            'exact'   => ['bar', true],
+            'less'    => ['ba', false],
+            'greater' => ['bars', false],
+        ];
+    }
+
+    public function testExactLengthDetectsBadLength(): void
+    {
+        $data = ['foo' => 'bar'];
+        $this->validation->setRules(['foo' => 'exact_length[abc]']);
+        $this->assertFalse($this->validation->run($data));
+    }
+
+    /**
+     * @dataProvider greaterThanProvider
+     */
+    public function testGreaterThan(?string $first, ?string $second, bool $expected): void
+    {
+        $data = ['foo' => $first];
+        $this->validation->setRules(['foo' => "greater_than[{$second}]"]);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function greaterThanProvider(): Generator
+    {
+        yield from [
+            ['-10', '-11', true],
+            ['10', '9', true],
+            ['10', '10', false],
+            ['10', 'a', false],
+            ['10a', '10', false],
+            [null, null, false],
+        ];
+    }
+
+    /**
+     * @dataProvider greaterThanEqualProvider
+     */
+    public function testGreaterThanEqual(?string $first, ?string $second, bool $expected): void
+    {
+        $data = ['foo' => $first];
+        $this->validation->setRules(['foo' => "greater_than_equal_to[{$second}]"]);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function greaterThanEqualProvider(): Generator
+    {
+        yield from [
+            ['0', '0', true],
+            ['1', '0', true],
+            ['-1', '0', false],
+            ['10a', '0', false],
+            [null, null, false],
+            ['1', null, true],
+            [null, '1', false],
+        ];
+    }
+
+    /**
+     * @dataProvider lessThanProvider
+     */
+    public function testLessThan(?string $first, ?string $second, bool $expected): void
+    {
+        $data = ['foo' => $first];
+        $this->validation->setRules(['foo' => "less_than[{$second}]"]);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function lessThanProvider(): Generator
+    {
+        yield from [
+            ['-10', '-11', false],
+            ['9', '10', true],
+            ['10', '9', false],
+            ['10', '10', false],
+            ['10', 'a', true],
+            ['10a', '10', false],
+            [null, null, false],
+        ];
+    }
+
+    /**
+     * @dataProvider lessThanEqualProvider
+     */
+    public function testLessEqualThan(?string $first, ?string $second, bool $expected): void
+    {
+        $data = ['foo' => $first];
+        $this->validation->setRules(['foo' => "less_than_equal_to[{$second}]"]);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function lessThanEqualProvider(): Generator
+    {
+        yield from [
+            ['0', '0', true],
+            ['1', '0', false],
+            ['-1', '0', true],
+            ['10a', '0', false],
+            [null, null, false],
+            ['1', null, false],
+            [null, '1', false],
+        ];
+    }
+
+    /**
+     * @dataProvider inListProvider
+     */
+    public function testInList(?string $first, ?string $second, bool $expected): void
+    {
+        $data = ['foo' => $first];
+        $this->validation->setRules(['foo' => "in_list[{$second}]"]);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    /**
+     * @dataProvider inListProvider
+     */
+    public function testNotInList(?string $first, ?string $second, bool $expected): void
+    {
+        $data = ['foo' => $first];
+        $this->validation->setRules(['foo' => "not_in_list[{$second}]"]);
+        $this->assertSame(! $expected, $this->validation->run($data));
+    }
+
+    public function inListProvider(): Generator
+    {
+        yield from [
+            ['red', 'red,Blue,123', true],
+            ['Blue', 'red, Blue,123', true],
+            ['Blue', 'red,Blue,123', true],
+            ['123', 'red,Blue,123', true],
+            ['Red', 'red,Blue,123', false],
+            [' red', 'red,Blue,123', false],
+            ['1234', 'red,Blue,123', false],
+            [null, 'red,Blue,123', false],
+            ['red', null, false],
+        ];
+    }
+
+    /**
+     * @dataProvider requiredWithProvider
+     */
+    public function testRequiredWith(?string $field, ?string $check, bool $expected): void
+    {
+        $data = [
+            'foo'   => 'bar',
+            'bar'   => 'something',
+            'baz'   => null,
+            'array' => [
+                'nonEmptyField1' => 'value1',
+                'nonEmptyField2' => 'value2',
+                'emptyField1'    => null,
+                'emptyField2'    => null,
+            ],
+        ];
+
+        $this->validation->setRules([$field => "required_with[{$check}]"]);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function requiredWithProvider(): Generator
+    {
+        yield from [
+            ['nope', 'bar', false],
+            ['foo', 'bar', true],
+            ['nope', 'baz', true],
+            [null, null, true],
+            [null, 'foo', false],
+            ['foo', null, true],
+            [
+                'array.emptyField1',
+                'array.emptyField2',
+                true,
+            ],
+            [
+                'array.nonEmptyField1',
+                'array.emptyField2',
+                true,
+            ],
+            [
+                'array.emptyField1',
+                'array.nonEmptyField2',
+                false,
+            ],
+            [
+                'array.nonEmptyField1',
+                'array.nonEmptyField2',
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider requiredWithoutProvider
+     */
+    public function testRequiredWithout(?string $field, ?string $check, bool $expected): void
+    {
+        $data = [
+            'foo'   => 'bar',
+            'bar'   => 'something',
+            'baz'   => null,
+            'array' => [
+                'nonEmptyField1' => 'value1',
+                'nonEmptyField2' => 'value2',
+                'emptyField1'    => null,
+                'emptyField2'    => null,
+            ],
+        ];
+
+        $this->validation->setRules([$field => "required_without[{$check}]"]);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function requiredWithoutProvider(): Generator
+    {
+        yield from [
+            ['nope', 'bars', false],
+            ['foo', 'nope', true],
+            [null, null, false],
+            [null, 'foo', true],
+            ['foo', null, true],
+            [
+                'array.emptyField1',
+                'array.emptyField2',
+                false,
+            ],
+            [
+                'array.nonEmptyField1',
+                'array.emptyField2',
+                true,
+            ],
+            [
+                'array.emptyField1',
+                'array.nonEmptyField2',
+                true,
+            ],
+            [
+                'array.nonEmptyField1',
+                'array.nonEmptyField2',
+                true,
+            ],
+        ];
+    }
+}

--- a/tests/system/ValidationStrict/ValidationTest.php
+++ b/tests/system/ValidationStrict/ValidationTest.php
@@ -1,0 +1,1015 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\ValidationStrict;
+
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\UserAgent;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Validation\Exceptions\ValidationException;
+use Config\App;
+use Config\Services;
+use Generator;
+use Tests\Support\Validation\TestRules;
+
+/**
+ * @internal
+ */
+final class ValidationTest extends CIUnitTestCase
+{
+    /**
+     * @var Validation
+     */
+    private $validation;
+
+    private $config = [
+        'ruleSets' => [
+            Rules::class,
+            FormatRules::class,
+            FileRules::class,
+            CreditCardRules::class,
+            TestRules::class,
+        ],
+        'groupA' => [
+            'foo' => 'required|min_length[5]',
+        ],
+        'login' => [
+            'username' => [
+                'label'  => 'Username',
+                'rules'  => 'required',
+                'errors' => [
+                    'required' => 'custom username required error msg.',
+                ],
+            ],
+            'password' => [
+                'label'  => 'Password',
+                'rules'  => 'required',
+                'errors' => [
+                    'required' => 'custom password required error msg.',
+                ],
+            ],
+        ],
+        'groupA_errors' => [
+            'foo' => [
+                'min_length' => 'Shame, shame. Too short.',
+            ],
+        ],
+        'groupX'    => 'Not an array, so not a real group',
+        'templates' => [
+            'list'   => 'CodeIgniter\Validation\Views\list',
+            'single' => 'CodeIgniter\Validation\Views\single',
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validation = new Validation((object) $this->config, Services::renderer());
+        $this->validation->reset();
+    }
+
+    public function testSetRulesStoresRules(): void
+    {
+        $rules = [
+            'foo' => 'bar|baz',
+            'bar' => 'baz|belch',
+        ];
+        $this->validation->setRules($rules);
+        $this->assertSame($rules, $this->validation->getRules());
+    }
+
+    public function testRunReturnsFalseWithNothingToDo(): void
+    {
+        $this->validation->setRules([]);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testRunDoesTheBasics(): void
+    {
+        $data = ['foo' => 'notanumber'];
+        $this->validation->setRules(['foo' => 'is_numeric']);
+        $this->assertFalse($this->validation->run($data));
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5368
+     *
+     * @dataProvider arrayDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testCanValidatetArrayData($value, bool $expected): void
+    {
+        $this->validation->setRules(['arr' => 'is_array']);
+
+        $data['arr'] = $value;
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function arrayDataProvider(): Generator
+    {
+        yield 'list array' => [
+            [1, 2, 3, 4, 5],
+            true,   // false in v4.1.5 and earlier
+        ];
+
+        yield 'associative array' => [
+            [
+                'username' => 'admin001',
+                'role'     => 'administrator',
+                'usepass'  => 0,
+            ],
+            true,   // false in v4.1.5 and earlier
+        ];
+
+        yield 'int' => [
+            0,
+            false,
+        ];
+
+        yield 'string int' => [
+            '0',
+            false,
+        ];
+
+        yield 'bool' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
+     *
+     * @dataProvider isIntInvalidTypeDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testIsIntWithInvalidTypeData($value, bool $expected): void
+    {
+        $this->validation->setRules(['foo' => 'is_int']);
+
+        $data = ['foo' => $value];
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function isIntInvalidTypeDataProvider(): Generator
+    {
+        yield 'array with int' => [
+            [555],
+            false,  // true in v4.1.5 and earlier
+        ];
+
+        yield 'empty array' => [
+            [],
+            false,
+        ];
+
+        yield 'bool true' => [
+            true,
+            false,
+        ];
+
+        yield 'bool false' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
+
+    public function testRunReturnsLocalizedErrors(): void
+    {
+        $data = ['foo' => 'notanumber'];
+        $this->validation->setRules(['foo' => 'is_numeric']);
+        $this->assertFalse($this->validation->run($data));
+        $this->assertSame('Validation.is_numeric', $this->validation->getError('foo'));
+    }
+
+    public function testRunWithCustomErrors(): void
+    {
+        $data = ['foo' => 'notanumber'];
+
+        $messages = [
+            'foo' => [
+                'is_numeric' => 'Nope. Not a number.',
+            ],
+        ];
+
+        $this->validation->setRules(['foo' => 'is_numeric'], $messages);
+        $this->validation->run($data);
+        $this->assertSame('Nope. Not a number.', $this->validation->getError('foo'));
+    }
+
+    public function testCheck(): void
+    {
+        $this->assertFalse($this->validation->check('notanumber', 'is_numeric'));
+    }
+
+    public function testCheckLocalizedError(): void
+    {
+        $this->assertFalse($this->validation->check('notanumber', 'is_numeric'));
+        $this->assertSame('Validation.is_numeric', $this->validation->getError());
+    }
+
+    public function testCheckCustomError(): void
+    {
+        $this->validation->check('notanumber', 'is_numeric', [
+            'is_numeric' => 'Nope. Not a number.',
+        ]);
+        $this->assertSame('Nope. Not a number.', $this->validation->getError());
+    }
+
+    public function testGetErrors(): void
+    {
+        $data = ['foo' => 'notanumber'];
+        $this->validation->setRules(['foo' => 'is_numeric']);
+        $this->validation->run($data);
+        $this->assertSame(['foo' => 'Validation.is_numeric'], $this->validation->getErrors());
+    }
+
+    public function testGetErrorsWhenNone(): void
+    {
+        $data = ['foo' => 123];
+        $this->validation->setRules(['foo' => 'is_numeric']);
+        $this->validation->run($data);
+        $this->assertSame([], $this->validation->getErrors());
+    }
+
+    public function testSetErrors(): void
+    {
+        $this->validation->setRules(['foo' => 'is_numeric']);
+        $this->validation->setError('foo', 'Nadda');
+        $this->assertSame(['foo' => 'Nadda'], $this->validation->getErrors());
+    }
+
+    public function testRulesReturnErrors(): void
+    {
+        $this->validation->setRules(['foo' => 'customError']);
+        $this->validation->run(['foo' => 'bar']);
+        $this->assertSame(['foo' => 'My lovely error'], $this->validation->getErrors());
+    }
+
+    public function testGroupsReadFromConfig(): void
+    {
+        $data = ['foo' => 'bar'];
+        $this->assertFalse($this->validation->run($data, 'groupA'));
+        $this->assertSame('Shame, shame. Too short.', $this->validation->getError('foo'));
+    }
+
+    public function testGroupsReadFromConfigValid(): void
+    {
+        $data = ['foo' => 'barsteps'];
+        $this->assertTrue($this->validation->run($data, 'groupA'));
+    }
+
+    public function testGetRuleGroup(): void
+    {
+        $this->assertSame([
+            'foo' => 'required|min_length[5]',
+        ], $this->validation->getRuleGroup('groupA'));
+    }
+
+    public function testGetRuleGroupException(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validation->getRuleGroup('groupZ');
+    }
+
+    public function testSetRuleGroup(): void
+    {
+        $this->validation->setRuleGroup('groupA');
+        $this->assertSame([
+            'foo' => 'required|min_length[5]',
+        ], $this->validation->getRules());
+    }
+
+    public function testSetRuleGroupException(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validation->setRuleGroup('groupZ');
+    }
+
+    public function testSetRuleGroupWithCustomErrorMessage(): void
+    {
+        $this->validation->reset();
+        $this->validation->setRuleGroup('login');
+        $this->validation->run(['username' => 'codeigniter']);
+        $this->assertSame([
+            'password' => 'custom password required error msg.',
+        ], $this->validation->getErrors());
+    }
+
+    public function testRunGroupWithCustomErrorMessage(): void
+    {
+        $this->validation->reset();
+        $this->validation->run([
+            'username' => 'codeigniter',
+        ], 'login');
+
+        $this->assertSame([
+            'password' => 'custom password required error msg.',
+        ], $this->validation->getErrors());
+    }
+
+    /**
+     * @dataProvider rulesSetupProvider
+     *
+     * @param string|string[] $rules
+     * @param string          $expected
+     */
+    public function testRulesSetup($rules, $expected, array $errors = [])
+    {
+        $data = ['foo' => ''];
+        $this->validation->setRules(['foo' => $rules], $errors);
+        $this->validation->run($data);
+        $this->assertSame($expected, $this->validation->getError('foo'));
+    }
+
+    public function rulesSetupProvider(): Generator
+    {
+        yield from [
+            [
+                'min_length[10]',
+                'The foo field must be at least 10 characters in length.',
+            ],
+            [
+                'min_length[10]',
+                'The foo field is very short.',
+                ['foo' => ['min_length' => 'The {field} field is very short.']],
+            ],
+            [
+                ['min_length[10]'],
+                'The foo field must be at least 10 characters in length.',
+            ],
+            [
+                ['min_length[10]'],
+                'The foo field is very short.',
+                ['foo' => ['min_length' => 'The {field} field is very short.']],
+            ],
+            [
+                ['rules' => 'min_length[10]'],
+                'The foo field must be at least 10 characters in length.',
+            ],
+            [
+                [
+                    'label' => 'Foo Bar',
+                    'rules' => 'min_length[10]',
+                ],
+                'The Foo Bar field must be at least 10 characters in length.',
+            ],
+            [
+                [
+                    'label' => 'Foo Bar',
+                    'rules' => 'min_length[10]',
+                ],
+                'The Foo Bar field is very short.',
+                ['foo' => ['min_length' => 'The {field} field is very short.']],
+            ],
+            [
+                [
+                    'label'  => 'Foo Bar',
+                    'rules'  => 'min_length[10]',
+                    'errors' => ['min_length' => 'The {field} field is very short.'],
+                ],
+                'The Foo Bar field is very short.',
+            ],
+        ];
+    }
+
+    public function testSetRulesRemovesErrorsArray(): void
+    {
+        $rules = [
+            'foo' => [
+                'label'  => 'Foo Bar',
+                'rules'  => 'min_length[10]',
+                'errors' => [
+                    'min_length' => 'The {field} field is very short.',
+                ],
+            ],
+        ];
+
+        $this->validation->setRules($rules, []);
+        $this->validation->run(['foo' => 'abc']);
+        $this->assertSame('The Foo Bar field is very short.', $this->validation->getError('foo'));
+    }
+
+    public function testInvalidRule(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $rules = [
+            'foo' => 'bar|baz',
+            'bar' => 'baz|belch',
+        ];
+        $this->validation->setRules($rules);
+
+        $data = ['foo' => ''];
+        $this->validation->run($data);
+    }
+
+    public function testRawInput(): void
+    {
+        $rawstring = 'username=admin001&role=administrator&usepass=0';
+
+        $data = [
+            'username' => 'admin001',
+            'role'     => 'administrator',
+            'usepass'  => 0,
+        ];
+
+        $config          = new App();
+        $config->baseURL = 'http://example.com/';
+
+        $request = new IncomingRequest($config, new URI(), $rawstring, new UserAgent());
+        $this->validation->withRequest($request->withMethod('patch'))->run($data);
+        $this->assertSame([], $this->validation->getErrors());
+    }
+
+    public function testJsonInput(): void
+    {
+        $data = [
+            'username' => 'admin001',
+            'role'     => 'administrator',
+            'usepass'  => 0,
+        ];
+        $json = json_encode($data);
+
+        $_SERVER['CONTENT_TYPE'] = 'application/json';
+
+        $config          = new App();
+        $config->baseURL = 'http://example.com/';
+
+        $request = new IncomingRequest($config, new URI(), $json, new UserAgent());
+
+        $rules = [
+            'role' => 'required|min_length[5]',
+        ];
+        $validated = $this->validation
+            ->withRequest($request->withMethod('patch'))
+            ->setRules($rules)
+            ->run();
+
+        $this->assertTrue($validated);
+        $this->assertSame([], $this->validation->getErrors());
+
+        unset($_SERVER['CONTENT_TYPE']);
+    }
+
+    public function testHasRule(): void
+    {
+        $this->validation->setRuleGroup('groupA');
+        $this->assertTrue($this->validation->hasRule('foo'));
+    }
+
+    public function testNotARealGroup(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validation->setRuleGroup('groupX');
+        $this->validation->getRuleGroup('groupX');
+    }
+
+    public function testBadTemplate(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validation->listErrors('obviouslyBadTemplate');
+    }
+
+    public function testShowNonError(): void
+    {
+        $this->validation->setRules(['foo' => 'is_numeric']);
+        $this->validation->setError('foo', 'Nadda');
+        $this->assertSame('', $this->validation->showError('bogus'));
+    }
+
+    public function testShowBadTemplate(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->validation->setRules(['foo' => 'is_numeric']);
+        $this->validation->setError('foo', 'Nadda');
+        $this->assertSame('We should never get here', $this->validation->showError('foo', 'bogus_template'));
+    }
+
+    public function testNoRuleSetsSetup(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->config['ruleSets'] = null;
+        $this->validation         = new Validation((object) $this->config, Services::renderer());
+        $this->validation->reset();
+        $this->validation->run(['foo' => '']);
+    }
+
+    public function testNotCustomRuleGroup(): void
+    {
+        $this->expectException(ValidationException::class);
+        $data = ['foo' => ''];
+        $this->validation->run($data, 'GeorgeRules');
+    }
+
+    public function testNotRealCustomRule(): void
+    {
+        $this->expectException(ValidationException::class);
+        $data = ['foo' => ''];
+        $this->validation->run($data, 'groupX');
+    }
+
+    public function testHasError(): void
+    {
+        $data = ['foo' => 'notanumber'];
+        $this->validation->setRules(['foo' => 'is_numeric']);
+        $this->validation->run($data);
+        $this->assertTrue($this->validation->hasError('foo'));
+    }
+
+    public function testSplitRulesTrue(): void
+    {
+        $this->validation->setRules([
+            'phone' => 'required|regex_match[/^(01[2689]|09)[0-9]{8}$/]|numeric',
+        ]);
+        $this->assertTrue($this->validation->run(['phone' => '0987654321']));
+    }
+
+    public function testSplitRulesFalse(): void
+    {
+        $this->validation->setRules([
+            'phone' => 'required|regex_match[/^(01[2689]|09)[0-9]{8}$/]|numeric',
+        ]);
+        $this->assertFalse($this->validation->run(['phone' => '09876543214']));
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/1201
+     */
+    public function testSplitNotRegex(): void
+    {
+        $method = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
+        $result = $method('uploaded[avatar]|max_size[avatar,1024]');
+        $this->assertSame('uploaded[avatar]', $result[0]);
+    }
+
+    public function testSplitRegex(): void
+    {
+        $method = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
+        $result = $method('required|regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]|max_length[10]');
+        $this->assertSame('regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]', $result[1]);
+    }
+
+    public function testTagReplacement(): void
+    {
+        $data = ['Username' => 'Pizza'];
+        $this->validation->setRules(
+            ['Username' => 'min_length[6]'],
+            ['Username' => [
+                'min_length' => 'Supplied value ({value}) for {field} must have at least {param} characters.',
+            ]]
+        );
+        $this->validation->run($data);
+        $errors = $this->validation->getErrors();
+
+        if (! isset($errors['Username'])) {
+            $this->fail('Unable to find "Username"');
+        }
+
+        $expected = 'Supplied value (Pizza) for Username must have at least 6 characters.';
+        $this->assertSame($expected, $errors['Username']);
+    }
+
+    public function testRulesForObjectField(): void
+    {
+        $this->validation->setRules([
+            'configuration' => 'required|check_object_rule',
+        ]);
+
+        $data = (object) ['configuration' => (object) ['first' => 1, 'second' => 2]];
+        $this->validation->run((array) $data);
+        $this->assertSame([], $this->validation->getErrors());
+
+        $this->validation->reset();
+        $this->validation->setRules([
+            'configuration' => 'required|check_object_rule',
+        ]);
+
+        $data = (object) ['configuration' => (object) ['first1' => 1, 'second' => 2]];
+        $this->validation->run((array) $data);
+
+        $this->assertSame([
+            'configuration' => 'Validation.check_object_rule',
+        ], $this->validation->getErrors());
+    }
+
+    /**
+     * @dataProvider arrayFieldDataProvider
+     */
+    public function testRulesForArrayField(array $body, array $rules, array $results)
+    {
+        $config          = new App();
+        $config->baseURL = 'http://example.com/';
+
+        $request = new IncomingRequest($config, new URI(), http_build_query($body), new UserAgent());
+
+        $this->validation->setRules($rules);
+        $this->validation->withRequest($request->withMethod('post'))->run($body);
+        $this->assertSame($results, $this->validation->getErrors());
+    }
+
+    public function arrayFieldDataProvider(): Generator
+    {
+        yield from [
+            'all_rules_should_pass' => [
+                'body' => [
+                    'foo' => [
+                        'a',
+                        'b',
+                        'c',
+                    ],
+                ],
+                'rules' => [
+                    'foo.0' => 'required|alpha|max_length[2]',
+                    'foo.1' => 'required|alpha|max_length[2]',
+                    'foo.2' => 'required|alpha|max_length[2]',
+                ],
+                'results' => [],
+            ],
+            'first_field_will_return_required_error' => [
+                'body' => [
+                    'foo' => [
+                        '',
+                        'b',
+                        'c',
+                    ],
+                ],
+                'rules' => [
+                    'foo.0' => 'required|alpha|max_length[2]',
+                    'foo.1' => 'required|alpha|max_length[2]',
+                    'foo.2' => 'required|alpha|max_length[2]',
+                ],
+                'results' => [
+                    'foo.0' => 'The foo.0 field is required.',
+                ],
+            ],
+            'first_and second_field_will_return_required_and_min_length_error' => [
+                'body' => [
+                    'foo' => [
+                        '',
+                        'b',
+                        'c',
+                    ],
+                ],
+                'rules' => [
+                    'foo.0' => 'required|alpha|max_length[2]',
+                    'foo.1' => 'required|alpha|min_length[2]|max_length[4]',
+                    'foo.2' => 'required|alpha|max_length[2]',
+                ],
+                'results' => [
+                    'foo.0' => 'The foo.0 field is required.',
+                    'foo.1' => 'The foo.1 field must be at least 2 characters in length.',
+                ],
+            ],
+        ];
+    }
+
+    public function testRulesForSingleRuleWithAsteriskWillReturnNoError(): void
+    {
+        $config          = new App();
+        $config->baseURL = 'http://example.com/';
+
+        $_REQUEST = [
+            'id_user' => [
+                1,
+                3,
+            ],
+            'name_user' => [
+                'abc123',
+                'xyz098',
+            ],
+        ];
+
+        $request = new IncomingRequest($config, new URI(), 'php://input', new UserAgent());
+
+        $this->validation->setRules([
+            'id_user.*'   => 'numeric',
+            'name_user.*' => 'alpha_numeric',
+        ]);
+
+        $this->validation->withRequest($request->withMethod('post'))->run();
+        $this->assertSame([], $this->validation->getErrors());
+    }
+
+    public function testRulesForSingleRuleWithAsteriskWillReturnError(): void
+    {
+        $config          = new App();
+        $config->baseURL = 'http://example.com/';
+
+        $_REQUEST = [
+            'id_user' => [
+                '1dfd',
+                3,
+            ],
+            'name_user' => [
+                123,
+                'xyz098',
+            ],
+        ];
+
+        $request = new IncomingRequest($config, new URI(), 'php://input', new UserAgent());
+
+        $this->validation->setRules([
+            'id_user.*'   => 'numeric',
+            'name_user.*' => 'alpha',
+        ]);
+
+        $this->validation->withRequest($request->withMethod('post'))->run();
+        $this->assertSame([
+            'id_user.*'   => 'The id_user.* field must contain only numbers.',
+            'name_user.*' => 'The name_user.* field may only contain alphabetical characters.',
+        ], $this->validation->getErrors());
+    }
+
+    public function testRulesForSingleRuleWithSingleValue(): void
+    {
+        $config          = new App();
+        $config->baseURL = 'http://example.com/';
+
+        $_REQUEST = [
+            'id_user' => 'gh',
+        ];
+
+        $request = new IncomingRequest($config, new URI(), 'php://input', new UserAgent());
+
+        $this->validation->setRules([
+            'id_user' => 'numeric',
+        ]);
+
+        $this->validation->withRequest($request->withMethod('post'))->run();
+        $this->assertSame([
+            'id_user' => 'The id_user field must contain only numbers.',
+        ], $this->validation->getErrors());
+    }
+
+    public function testTranslatedLabel(): void
+    {
+        $rules = [
+            'foo' => [
+                'label' => 'Foo.bar',
+                'rules' => 'min_length[10]',
+            ],
+        ];
+
+        $this->validation->setRules($rules, []);
+        $this->validation->run(['foo' => 'abc']);
+        $this->assertSame('The Foo Bar Translated field must be at least 10 characters in length.', $this->validation->getError('foo'));
+    }
+
+    public function testTranslatedLabelIsMissing(): void
+    {
+        $rules = [
+            'foo' => [
+                'label' => 'Foo.bar.is.missing',
+                'rules' => 'min_length[10]',
+            ],
+        ];
+
+        $this->validation->setRules($rules, []);
+        $this->validation->run(['foo' => 'abc']);
+        $this->assertSame('The Foo.bar.is.missing field must be at least 10 characters in length.', $this->validation->getError('foo'));
+    }
+
+    public function testTranslatedLabelWithCustomErrorMessage(): void
+    {
+        $rules = [
+            'foo' => [
+                'label'  => 'Foo.bar',
+                'rules'  => 'min_length[10]',
+                'errors' => [
+                    'min_length' => 'Foo.bar.min_length1',
+                ],
+            ],
+        ];
+
+        $this->validation->setRules($rules, []);
+        $this->validation->run(['foo' => 'abc']);
+        $this->assertSame('The Foo Bar Translated field is very short.', $this->validation->getError('foo'));
+    }
+
+    public function testTranslatedLabelTagReplacement(): void
+    {
+        $data = ['Username' => 'Pizza'];
+
+        $this->validation->setRules(
+            ['Username' => [
+                'label' => 'Foo.bar',
+                'rules' => 'min_length[6]',
+            ]],
+            ['Username' => [
+                'min_length' => 'Foo.bar.min_length2',
+            ]]
+        );
+
+        $this->validation->run($data);
+        $errors = $this->validation->getErrors();
+
+        if (! isset($errors['Username'])) {
+            $this->fail('Unable to find "Username"');
+        }
+
+        $expected = 'Supplied value (Pizza) for Foo Bar Translated must have at least 6 characters.';
+        $this->assertSame($expected, $errors['Username']);
+    }
+
+    /**
+     * @dataProvider dotNotationForIfExistProvider
+     *
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/4521
+     */
+    public function testDotNotationOnIfExistRule(bool $expected, array $rules, array $data): void
+    {
+        $actual = $this->validation->setRules($rules)->run($data);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function dotNotationForIfExistProvider(): Generator
+    {
+        yield 'dot-on-end-fail' => [
+            false,
+            ['status.*' => 'if_exist|in_list[status_1,status_2]'],
+            ['status'   => ['bad-status']],
+        ];
+
+        yield 'dot-on-end-pass' => [
+            true,
+            ['status.*' => 'if_exist|in_list[status_1,status_2]'],
+            ['status'   => ['status_1']],
+        ];
+
+        yield 'dot-on-middle-fail' => [
+            false,
+            ['fizz.*.baz' => 'if_exist|numeric'],
+            [
+                'fizz' => [
+                    'bar' => ['baz' => 'yes'],
+                ],
+            ],
+        ];
+
+        yield 'dot-on-middle-pass' => [
+            true,
+            ['fizz.*.baz' => 'if_exist|numeric'],
+            [
+                'fizz' => [
+                    'bar' => ['baz' => 30],
+                ],
+            ],
+        ];
+
+        yield 'dot-multiple-fail' => [
+            false,
+            ['fizz.*.bar.*' => 'if_exist|numeric'],
+            ['fizz' => [
+                'bos' => [
+                    'bar' => [
+                        'bub' => 'noo',
+                    ],
+                ],
+            ]],
+        ];
+
+        yield 'dot-multiple-pass' => [
+            true,
+            ['fizz.*.bar.*' => 'if_exist|numeric'],
+            ['fizz' => [
+                'bos' => [
+                    'bar' => [
+                        'bub' => 5,
+                    ],
+                ],
+            ]],
+        ];
+    }
+
+    /**
+     * @dataProvider validationArrayDataCaseProvider
+     *
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/4510
+     */
+    public function testValidationOfArrayData(bool $expected, array $rules, array $data): void
+    {
+        $actual = $this->validation->setRules($rules)->run($data);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function validationArrayDataCaseProvider(): iterable
+    {
+        yield 'fail-empty-string' => [
+            false,
+            ['bar.*.foo' => 'required'],
+            ['bar' => [
+                ['foo' => 'baz'],
+                ['foo' => ''],
+            ]],
+        ];
+
+        yield 'pass-nonempty-string' => [
+            true,
+            ['bar.*.foo' => 'required'],
+            ['bar' => [
+                ['foo' => 'baz'],
+                ['foo' => 'boz'],
+            ]],
+        ];
+
+        yield 'fail-empty-array' => [
+            false,
+            ['bar.*.foo' => 'required'],
+            ['bar' => [
+                ['foo' => 'baz'],
+                ['foo' => []],
+            ]],
+        ];
+
+        yield 'pass-nonempty-array' => [
+            true,
+            ['bar.*.foo' => 'required'],
+            ['bar' => [
+                ['foo' => 'baz'],
+                ['foo' => ['boz']],
+            ]],
+        ];
+    }
+
+    /**
+     * @dataProvider provideStringRulesCases
+     *
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/4929
+     */
+    public function testSplittingOfComplexStringRules(string $input, array $expected): void
+    {
+        $splitter = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
+        $this->assertSame($expected, $splitter($input));
+    }
+
+    public function provideStringRulesCases(): iterable
+    {
+        yield [
+            'required',
+            ['required'],
+        ];
+
+        yield [
+            'required|numeric',
+            ['required', 'numeric'],
+        ];
+
+        yield [
+            'required|max_length[500]|hex',
+            ['required', 'max_length[500]', 'hex'],
+        ];
+
+        yield [
+            'required|numeric|regex_match[/[a-zA-Z]+/]',
+            ['required', 'numeric', 'regex_match[/[a-zA-Z]+/]'],
+        ];
+
+        yield [
+            'required|max_length[500]|regex_match[/^;"\'{}\[\]^<>=/]',
+            ['required', 'max_length[500]', 'regex_match[/^;"\'{}\[\]^<>=/]'],
+        ];
+
+        yield [
+            'regex_match[/^;"\'{}\[\]^<>=/]|regex_match[/[^a-z0-9.\|_]+/]',
+            ['regex_match[/^;"\'{}\[\]^<>=/]', 'regex_match[/[^a-z0-9.\|_]+/]'],
+        ];
+
+        yield [
+            'required|regex_match[/^(01[2689]|09)[0-9]{8}$/]|numeric',
+            ['required', 'regex_match[/^(01[2689]|09)[0-9]{8}$/]', 'numeric'],
+        ];
+
+        yield [
+            'required|regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]|max_length[10]',
+            ['required', 'regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]', 'max_length[10]'],
+        ];
+
+        yield [
+            'required|regex_match[/^(01|2689|09)[0-9]{8}$/]|numeric',
+            ['required', 'regex_match[/^(01|2689|09)[0-9]{8}$/]', 'numeric'],
+        ];
+    }
+}

--- a/user_guide_src/source/installation/upgrade_416.rst
+++ b/user_guide_src/source/installation/upgrade_416.rst
@@ -1,0 +1,89 @@
+#############################
+Upgrading from 4.1.5 to 4.1.6
+#############################
+
+.. contents::
+    :local:
+    :depth: 2
+
+Breaking Changes
+****************
+
+Breaking Enhancements
+*********************
+
+.. _strict-validation:
+
+Strict Validation
+=================
+
+A new Validation class for strict validation.
+
+.. important:: This feature is disabled by default. Because it breaks backward compatibility.
+
+Traditional Validation
+----------------------
+
+The traditional Validation class implicitly assumes that string values are validated.
+It works for most basic cases like validating POST data.
+
+But, for example, if you use JSON input data, it may be type of bool/null/array.
+When you validate the bool ``true``, it is converted to string ``'1'`` in the traditional Validation.
+And if you validate it with the ``integer`` rule, ``'1'`` passes the validation.
+
+Strict Validation
+-----------------
+
+The new Validation and its Rule classes now have ``declare(strict_types=1)`` for strict typing.
+And we removed all implicit type casting and the types for the parameters to validate.
+
+The next change is that the new Validation separates the validation process of multiple field and single field.
+When a single field is an array data, the traditional Validation validates each element of the array.
+The validation rule gets an element of the array as the parameter.
+On the other hand, the new Validation passes the array to the validation rule as a whole.
+
+Another breaking change is that if you have custom validation rules, and when you specify the data type to validate,
+if incompatible typed data is passed to the validation rule, it will raise Type Error.
+
+Using Strict Validation
+------------------------
+
+If you want to use this, you need to set the property ``$strictValidation`` ``true`` in **app/Config/Feature.php**.
+And you need to change the rule classes in **app/Config/Validation.php**::
+
+        public $ruleSets = [
+            \CodeIgniter\ValidationStrict\CreditCardRules::class,
+            \CodeIgniter\ValidationStrict\FileRules::class,
+            \CodeIgniter\ValidationStrict\FormatRules::class,
+            \CodeIgniter\ValidationStrict\Rules::class,
+        ];
+
+If you enable it, ``Config\Services::validation()`` will return a ``ValidationStrict\Validator`` object.
+
+Project Files
+*************
+
+Numerous files in the project space (root, app, public, writable) received updates. Due to
+these files being outside of the system scope they will not be changed without your intervention.
+There are some third-party CodeIgniter modules available to assist with merging changes to
+the project space: `Explore on Packagist <https://packagist.org/explore/?query=codeigniter4%20updates>`_.
+
+.. note:: Except in very rare cases for bug fixes, no changes made to files for the project space
+    will break your application. All changes noted here are optional until the next major version,
+    and any mandatory changes will be covered in the sections above.
+
+Content Changes
+===============
+
+The following files received significant changes (including deprecations or visual adjustments)
+and it is recommended that you merge the updated versions with your application:
+
+*
+
+All Changes
+===========
+
+This is a list of all files in the project space that received changes;
+many will be simple comments or formatting that have no effect on the runtime:
+
+*

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -8,6 +8,7 @@ upgrading from.
 .. toctree::
     :titlesonly:
 
+    Upgrading from 4.1.5 to 4.1.6 <upgrade_416>
     Upgrading from 4.1.4 to 4.1.5 <upgrade_415>
     Upgrading from 4.1.3 to 4.1.4 <upgrade_414>
     Upgrading from 4.1.2 to 4.1.3 <upgrade_413>

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -201,6 +201,16 @@ Then add validation rules in the controller (**Form.php**)::
 
 If you submit the form you should see the success page or the form with error messages.
 
+Traditional and Strict Validation
+*********************************
+
+CI4 has two Validation classes. The default is the ``CodeIgniter\Validation\Validation`` class,
+and the new is the ``CodeIgniter\ValidationStrict\Validation`` class (**Strict Validation**), which provides strict validation.
+
+When validating data that contains non-string values, such as JSON data, it is recommended to use **Strict Validation**.
+
+.. important:: If you want to use **Strict Validation**, you need to configure. See :ref:`strict-validation` for the details.
+
 Loading the Library
 ************************************************
 


### PR DESCRIPTION
**Description**
Supersedes #5375
Fixes #5374
Fixes #5368

- add `CodeIgniter\ValidationStrict`
  - add `declare(strict_types=1)` for Validation and Rule classes
  - remove parameter types for data to validate in validation rules
  - separate validation process of multiple field and single field

See #5375, if you want to see the change to the current Validation class.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
