### PR TITLE
fix: undefined constant `VENDORPATH` in `Debug\Toolbar\Collectors\Database`

### DIFF
--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -141,7 +141,10 @@ class Database extends BaseCollector
                 // Clean up the file paths
                 $traceLine['file'] = str_ireplace(APPPATH, 'APPPATH/', $traceLine['file']);
                 $traceLine['file'] = str_ireplace(SYSTEMPATH, 'SYSTEMPATH/', $traceLine['file']);
-                $traceLine['file'] = str_ireplace(VENDORPATH, 'VENDORPATH/', $traceLine['file']);
+                if (defined('VENDORPATH')) {
+                    // VENDORPATH is not defined unless `vendor/autoload.php` exists
+                    $traceLine['file'] = str_ireplace(VENDORPATH, 'VENDORPATH/', $traceLine['file']);
+                }
                 $traceLine['file'] = str_ireplace(ROOTPATH, 'ROOTPATH/', $traceLine['file']);
 
                 if (strpos($traceLine['file'], 'SYSTEMPATH') !== false) {


### PR DESCRIPTION
**Description**
Fixes #5401

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
