### PR TITLE
fix: Validation cannot handle array item

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -143,6 +143,8 @@ class Validation implements ValidationInterface
             if ($values === []) {
                 // We'll process the values right away if an empty array
                 $this->processRules($field, $setup['label'] ?? $field, $values, $rules, $data);
+
+                continue;
             }
 
             if (strpos($field, '*') !== false && is_array($values)) {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -295,7 +295,8 @@ class Validation implements ValidationInterface
                     $value = json_encode($value);
                 }
 
-                $this->errors[$field] = $error ?? $this->getErrorMessage($rule, $field, $label, $param, $value);
+                $param                = ($param === false) ? '' : $param;
+                $this->errors[$field] = $error ?? $this->getErrorMessage($rule, $field, $label, $param, (string) $value);
 
                 return false;
             }
@@ -646,6 +647,9 @@ class Validation implements ValidationInterface
      */
     protected function getErrorMessage(string $rule, string $field, ?string $label = null, ?string $param = null, ?string $value = null): string
     {
+        $param = $param ?? '';
+
+        // Check if custom message has been defined by user
         if (isset($this->customErrors[$field][$rule])) {
             $message = lang($this->customErrors[$field][$rule]);
         } else {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -215,7 +215,7 @@ class Validation implements ValidationInterface
         }
 
         if (in_array('permit_empty', $rules, true)) {
-            if (! in_array('required', $rules, true) && (is_array($value) ? $value === [] : trim($value ?? '') === '')) {
+            if (! in_array('required', $rules, true) && (is_array($value) ? $value === [] : trim((string) $value) === '')) {
                 $passed = true;
 
                 foreach ($rules as $rule) {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -308,7 +308,8 @@ class Validation implements ValidationInterface
                     $value = json_encode($value);
                 }
 
-                $param                = ($param === false) ? '' : $param;
+                $param = ($param === false) ? '' : $param;
+
                 $this->errors[$field] = $error ?? $this->getErrorMessage(
                     $rule,
                     $field,

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -285,7 +285,8 @@ class Validation implements ValidationInterface
                     }
 
                     $found  = true;
-                    $passed = $param === false ? $set->{$rule}($value, $error)
+                    $passed = $param === false
+                        ? $set->{$rule}($value, $error)
                         : $set->{$rule}($value, $param, $data, $error);
 
                     break;

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -261,7 +261,7 @@ class Validation implements ValidationInterface
             // Placeholder for custom errors from the rules.
             $error = null;
 
-            // If it's a callable, call and and get out of here.
+            // If it's a callable, call and get out of here.
             if ($isCallable) {
                 $passed = $param === false ? $rule($value) : $rule($value, $param, $data);
             } else {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -198,11 +198,15 @@ class Validation implements ValidationInterface
                 // that can be used later
                 $ifExistField = str_replace('\.\*', '\.(?:[^\.]+)', preg_quote($field, '/'));
 
-                $dataIsExisting = array_reduce(array_keys($flattenedData), static function ($carry, $item) use ($ifExistField) {
-                    $pattern = sprintf('/%s/u', $ifExistField);
+                $dataIsExisting = array_reduce(
+                    array_keys($flattenedData),
+                    static function ($carry, $item) use ($ifExistField) {
+                        $pattern = sprintf('/%s/u', $ifExistField);
 
-                    return $carry || preg_match($pattern, $item) === 1;
-                }, false);
+                        return $carry || preg_match($pattern, $item) === 1;
+                    },
+                    false
+                );
             } else {
                 $dataIsExisting = array_key_exists($ifExistField, $flattenedData);
             }
@@ -219,7 +223,10 @@ class Validation implements ValidationInterface
         }
 
         if (in_array('permit_empty', $rules, true)) {
-            if (! in_array('required', $rules, true) && (is_array($value) ? $value === [] : trim((string) $value) === '')) {
+            if (
+                ! in_array('required', $rules, true)
+                && (is_array($value) ? $value === [] : trim((string) $value) === '')
+            ) {
                 $passed = true;
 
                 foreach ($rules as $rule) {
@@ -278,7 +285,8 @@ class Validation implements ValidationInterface
                     }
 
                     $found  = true;
-                    $passed = $param === false ? $set->{$rule}($value, $error) : $set->{$rule}($value, $param, $data, $error);
+                    $passed = $param === false ? $set->{$rule}($value, $error)
+                        : $set->{$rule}($value, $param, $data, $error);
 
                     break;
                 }
@@ -300,7 +308,13 @@ class Validation implements ValidationInterface
                 }
 
                 $param                = ($param === false) ? '' : $param;
-                $this->errors[$field] = $error ?? $this->getErrorMessage($rule, $field, $label, $param, (string) $value);
+                $this->errors[$field] = $error ?? $this->getErrorMessage(
+                    $rule,
+                    $field,
+                    $label,
+                    $param,
+                    (string) $value
+                );
 
                 return false;
             }
@@ -664,7 +678,11 @@ class Validation implements ValidationInterface
         }
 
         $message = str_replace('{field}', empty($label) ? $field : lang($label), $message);
-        $message = str_replace('{param}', empty($this->rules[$param]['label']) ? $param : lang($this->rules[$param]['label']), $message);
+        $message = str_replace(
+            '{param}',
+            empty($this->rules[$param]['label']) ? $param : lang($this->rules[$param]['label']),
+            $message
+        );
 
         return str_replace('{value}', $value ?? '', $message);
     }

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -139,16 +139,20 @@ class Validation implements ValidationInterface
             }
 
             $values = dot_array_search($field, $data);
-            $values = is_array($values) ? $values : [$values];
 
             if ($values === []) {
                 // We'll process the values right away if an empty array
                 $this->processRules($field, $setup['label'] ?? $field, $values, $rules, $data);
             }
 
-            foreach ($values as $value) {
-                // Otherwise, we'll let the loop do the job
-                $this->processRules($field, $setup['label'] ?? $field, $value, $rules, $data);
+            if (strpos($field, '*') !== false && is_array($values)) {
+                // Process multiple fields
+                foreach ($values as $value) {
+                    $this->processRules($field, $setup['label'] ?? $field, $value, $rules, $data);
+                }
+            } else {
+                // Process single field
+                $this->processRules($field, $setup['label'] ?? $field, $values, $rules, $data);
             }
         }
 

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -798,6 +798,73 @@ final class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
+     *
+     * @dataProvider integerInvalidTypeDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testIntegerWithInvalidTypeData($value, bool $expected): void
+    {
+        $this->validation->setRules([
+            'foo' => 'integer',
+        ]);
+
+        $data = [
+            'foo' => $value,
+        ];
+        $this->assertsame($expected, $this->validation->run($data));
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
+     *
+     * @dataProvider integerInvalidTypeDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testNumericWithInvalidTypeData($value, bool $expected): void
+    {
+        $this->validation->setRules([
+            'foo' => 'numeric',
+        ]);
+
+        $data = [
+            'foo' => $value,
+        ];
+        $this->assertsame($expected, $this->validation->run($data));
+    }
+
+    public function integerInvalidTypeDataProvider(): Generator
+    {
+        yield 'array with int' => [
+            [555],
+            true,  // incorrect
+        ];
+
+        // TypeError : CodeIgniter\Validation\FormatRules::integer(): Argument #1 ($str) must be of type ?string, array given
+        // yield 'empty array' => [
+        // [],
+        // false,
+        // ];
+
+        yield 'bool true' => [
+            true,
+            true,  // incorrect
+        ];
+
+        yield 'bool false' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
+
+    /**
      * @dataProvider integerProvider
      */
     public function testInteger(?string $str, bool $expected): void

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -837,10 +837,11 @@ final class FormatRulesTest extends CIUnitTestCase
 
     public function integerInvalidTypeDataProvider(): Generator
     {
-        yield 'array with int' => [
-            [555],
-            true,  // incorrect
-        ];
+        // TypeError : CodeIgniter\Validation\FormatRules::integer(): Argument #1 ($str) must be of type ?string, array given
+        // yield 'array with int' => [
+        // [555],
+        // false,
+        // ];
 
         // TypeError : CodeIgniter\Validation\FormatRules::integer(): Argument #1 ($str) must be of type ?string, array given
         // yield 'empty array' => [

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -100,6 +100,101 @@ final class ValidationTest extends CIUnitTestCase
         $this->assertFalse($this->validation->run($data));
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5368
+     *
+     * @dataProvider arrayDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testCanValidatetArrayData($value, bool $expected): void
+    {
+        $this->validation->setRules(['arr' => 'is_array']);
+
+        $data['arr'] = $value;
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function arrayDataProvider(): Generator
+    {
+        yield 'list array' => [
+            [1, 2, 3, 4, 5],
+            false,   // incorrect
+        ];
+
+        yield 'associative array' => [
+            [
+                'username' => 'admin001',
+                'role'     => 'administrator',
+                'usepass'  => 0,
+            ],
+            false,   // incorrect
+        ];
+
+        yield 'int' => [
+            0,
+            false,
+        ];
+
+        yield 'string int' => [
+            '0',
+            false,
+        ];
+
+        yield 'bool' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
+     *
+     * @dataProvider isIntInvalidTypeDataProvider
+     *
+     * @param mixed $value
+     */
+    public function testIsIntWithInvalidTypeData($value, bool $expected): void
+    {
+        $this->validation->setRules(['foo' => 'is_int']);
+
+        $data = ['foo' => $value];
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public function isIntInvalidTypeDataProvider(): Generator
+    {
+        yield 'array with int' => [
+            [555],
+            true,  // incorrect
+        ];
+
+        yield 'empty array' => [
+            [],
+            false,
+        ];
+
+        yield 'bool true' => [
+            true,
+            false,
+        ];
+
+        yield 'bool false' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
+
     public function testRunReturnsLocalizedErrors(): void
     {
         $data = ['foo' => 'notanumber'];

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -119,7 +119,7 @@ final class ValidationTest extends CIUnitTestCase
     {
         yield 'list array' => [
             [1, 2, 3, 4, 5],
-            false,   // incorrect
+            true,
         ];
 
         yield 'associative array' => [
@@ -128,7 +128,7 @@ final class ValidationTest extends CIUnitTestCase
                 'role'     => 'administrator',
                 'usepass'  => 0,
             ],
-            false,   // incorrect
+            true,
         ];
 
         yield 'int' => [
@@ -171,7 +171,7 @@ final class ValidationTest extends CIUnitTestCase
     {
         yield 'array with int' => [
             [555],
-            true,  // incorrect
+            false,
         ];
 
         yield 'empty array' => [

--- a/user_guide_src/source/changelogs/v4.1.6.rst
+++ b/user_guide_src/source/changelogs/v4.1.6.rst
@@ -7,11 +7,25 @@ Release Date: Not released
 
 .. contents::
     :local:
-    :depth: 1
+    :depth: 2
 
 BREAKING
 ========
 - Multiple table names will no longer be stored in ``BaseBuilder::$tableName`` - an empty string will be used instead.
+
+.. _changelog-v416-validation-changes:
+
+Validation changes
+------------------
+- The previous version of the Validation can't handle an array item.
+  Because of the bug fix, the validation results may be different,
+  or raise an TypeError.
+  But the previous version's results are probably incorrect.
+- The Validation separated the validation process of multiple field
+  like ``contacts.*.name`` and single field.
+  When a single field has an array data, the previous version validates each element of the array.
+  The validation rule gets an element of the array as the parameter.
+  On the other hand, the current version passes the array to the validation rule as a whole.
 
 Enhancements
 ============

--- a/user_guide_src/source/changelogs/v4.1.6.rst
+++ b/user_guide_src/source/changelogs/v4.1.6.rst
@@ -19,7 +19,7 @@ Validation changes
 ------------------
 - The previous version of the Validation can't handle an array item.
   Because of the bug fix, the validation results may be different,
-  or raise an TypeError.
+  or raise a ``TypeError``.
   But the previous version's results are probably incorrect.
 - The Validation separated the validation process of multiple field
   like ``contacts.*.name`` and single field.

--- a/user_guide_src/source/installation/upgrade_416.rst
+++ b/user_guide_src/source/installation/upgrade_416.rst
@@ -12,16 +12,7 @@ Breaking Changes
 Validation result changes
 =========================
 
-The previous version of the Validation can't handle an array item.
-Because of the bug fix, the validation results may be different,
-or raise an TypeError.
-But the previous version's results are probably incorrect.
-
-And the Validation separated the validation process of multiple field
-like ``contacts.*.name`` and single field.
-When a single field has an array data, the previous version validates each element of the array.
-The validation rule gets an element of the array as the parameter.
-On the other hand, the current version passes the array to the validation rule as a whole.
+Due to a bug fix, the Validation now might change the validation results when you validate an array item (see :ref:`Changelog <changelog-v416-validation-changes>`). So check the validation results for all the code that validates the array. Validating multiple fields like ``contacts.*.name`` is not affected.
 
 Breaking Enhancements
 *********************

--- a/user_guide_src/source/installation/upgrade_416.rst
+++ b/user_guide_src/source/installation/upgrade_416.rst
@@ -1,0 +1,55 @@
+#############################
+Upgrading from 4.1.5 to 4.1.6
+#############################
+
+.. contents::
+    :local:
+    :depth: 2
+
+Breaking Changes
+****************
+
+Validation result changes
+=========================
+
+The previous version of the Validation can't handle an array item.
+Because of the bug fix, the validation results may be different,
+or raise an TypeError.
+But the previous version's results are probably incorrect.
+
+And the Validation separated the validation process of multiple field
+like ``contacts.*.name`` and single field.
+When a single field has an array data, the previous version validates each element of the array.
+The validation rule gets an element of the array as the parameter.
+On the other hand, the current version passes the array to the validation rule as a whole.
+
+Breaking Enhancements
+*********************
+
+Project Files
+*************
+
+Numerous files in the project space (root, app, public, writable) received updates. Due to
+these files being outside of the system scope they will not be changed without your intervention.
+There are some third-party CodeIgniter modules available to assist with merging changes to
+the project space: `Explore on Packagist <https://packagist.org/explore/?query=codeigniter4%20updates>`_.
+
+.. note:: Except in very rare cases for bug fixes, no changes made to files for the project space
+    will break your application. All changes noted here are optional until the next major version,
+    and any mandatory changes will be covered in the sections above.
+
+Content Changes
+===============
+
+The following files received significant changes (including deprecations or visual adjustments)
+and it is recommended that you merge the updated versions with your application:
+
+*
+
+All Changes
+===========
+
+This is a list of all files in the project space that received changes;
+many will be simple comments or formatting that have no effect on the runtime:
+
+*

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -8,6 +8,7 @@ upgrading from.
 .. toctree::
     :titlesonly:
 
+    Upgrading from 4.1.5 to 4.1.6 <upgrade_416>
     Upgrading from 4.1.4 to 4.1.5 <upgrade_415>
     Upgrading from 4.1.3 to 4.1.4 <upgrade_414>
     Upgrading from 4.1.2 to 4.1.3 <upgrade_413>


### PR DESCRIPTION
**Description**
Supersedes #5402
Fixes #5368
- separate validation process of multiple field and single field

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
