### PR TITLE
docs: improve restful.rst

### DIFF
--- a/user_guide_src/source/incoming/restful.rst
+++ b/user_guide_src/source/incoming/restful.rst
@@ -47,7 +47,7 @@ name::
 .. important:: The routes are matched in the order they are specified, so if you have a resource photos above a get 'photos/poll' the show action's route for the resource line will be matched before the get line. To fix this, move the get line above the resource line so that it is matched first.
 
 The second parameter accepts an array of options that can be used to modify the routes that are generated. While these
-routes are geared toward API-usage, where more methods are allowed, you can pass in the 'websafe' option to have it
+routes are geared toward API-usage, where more methods are allowed, you can pass in the ``websafe`` option to have it
 generate update and delete methods that work with HTML forms::
 
     $routes->resource('photos', ['websafe' => 1]);
@@ -90,15 +90,15 @@ Otherwise you can remove unused routes with the ``except`` option. This option r
 
     $routes->resource('photos', ['except' => 'new,edit']);
 
-Valid methods are: index, show, create, update, new, edit and delete.
+Valid methods are: ``index``, ``show``, ``create``, ``update``, ``new``, ``edit`` and ``delete``.
 
 ResourceController
 ============================================================
 
-The `ResourceController` provides a convenient starting point for your RESTful API,
+The ``ResourceController`` provides a convenient starting point for your RESTful API,
 with methods that correspond to the resource routes above.
 
-Extend it, over-riding the `modelName` and `format` properties, and then
+Extend it, over-riding the ``modelName`` and ``format`` properties, and then
 implement those methods that you want handled.::
 
     <?php
@@ -195,16 +195,16 @@ Otherwise you can remove unused routes with the ``except`` option. This option r
 
     $routes->presenter('photos', ['except' => 'new,edit']);
 
-Valid methods are: index, show, new, create, edit, update, remove and delete.
+Valid methods are: ``index``, ``show``, ``new``, ``create``, ``edit``, ``update``, ``remove`` and ``delete``.
 
 ResourcePresenter
 ============================================================
 
-The `ResourcePresenter` provides a convenient starting point for presenting views
+The ``ResourcePresenter`` provides a convenient starting point for presenting views
 of your resource, and processing data from forms in those views,
 with methods that align to the resource routes above.
 
-Extend it, over-riding the `modelName` property, and then
+Extend it, over-riding the ``modelName`` property, and then
 implement those methods that you want handled.::
 
     <?php

--- a/user_guide_src/source/incoming/restful.rst
+++ b/user_guide_src/source/incoming/restful.rst
@@ -81,12 +81,12 @@ in the ``placeholder`` option with the new string to use::
 Limit the Routes Made
 ---------------------
 
-You can restrict the routes generated with the ``only`` option. This should be an array or comma separated list of method names that should
+You can restrict the routes generated with the ``only`` option. This should be **an array** or **comma separated list** of method names that should
 be created. Only routes that match one of these methods will be created. The rest will be ignored::
 
     $routes->resource('photos', ['only' => ['index', 'show']]);
 
-Otherwise you can remove unused routes with the ``except`` option. This option run after ``only``::
+Otherwise you can remove unused routes with the ``except`` option. This should also be **an array** or **comma separated list** of method names. This option run after ``only``::
 
     $routes->resource('photos', ['except' => 'new,edit']);
 
@@ -186,12 +186,12 @@ in the ``placeholder`` option with the new string to use::
 Limit the Routes Made
 ---------------------
 
-You can restrict the routes generated with the ``only`` option. This should be an array or comma separated list of method names that should
+You can restrict the routes generated with the ``only`` option. This should be **an array** or **comma separated list** of method names that should
 be created. Only routes that match one of these methods will be created. The rest will be ignored::
 
     $routes->presenter('photos', ['only' => ['index', 'show']]);
 
-Otherwise you can remove unused routes with the ``except`` option. This option run after ``only``::
+Otherwise you can remove unused routes with the ``except`` option. This should also be **an array** or **comma separated list** of method names. This option run after ``only``::
 
     $routes->presenter('photos', ['except' => 'new,edit']);
 

--- a/user_guide_src/source/incoming/restful.rst
+++ b/user_guide_src/source/incoming/restful.rst
@@ -70,7 +70,7 @@ the controller that should be used::
 Change the Placeholder Used
 ---------------------------
 
-By default, the ``segment`` placeholder is used when a resource ID is needed. You can change this by passing
+By default, the ``(:segment)`` placeholder is used when a resource ID is needed. You can change this by passing
 in the ``placeholder`` option with the new string to use::
 
     $routes->resource('photos', ['placeholder' => '(:num)']);
@@ -175,7 +175,7 @@ the controller that should be used::
 Change the Placeholder Used
 ---------------------------
 
-By default, the ``segment`` placeholder is used when a resource ID is needed. You can change this by passing
+By default, the ``(:segment)`` placeholder is used when a resource ID is needed. You can change this by passing
 in the ``placeholder`` option with the new string to use::
 
     $routes->presenter('photos', ['placeholder' => '(:num)']);


### PR DESCRIPTION
**Description**
- decorate keywords in source code with ` `` `
- improve explanation for `except` option

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

