### PR TITLE
docs: fix views.rst

### DIFF
--- a/user_guide_src/source/outgoing/views.rst
+++ b/user_guide_src/source/outgoing/views.rst
@@ -163,10 +163,10 @@ Now open your view file and change the text to variables that correspond to the 
 
     <html>
         <head>
-            <title><?= $title ?></title>
+            <title><?= esc($title) ?></title>
         </head>
         <body>
-            <h1><?= $heading ?></h1>
+            <h1><?= esc($heading) ?></h1>
         </body>
     </html>
 
@@ -220,17 +220,17 @@ Now open your view file and create a loop::
 
     <html>
     <head>
-        <title><?= $title ?></title>
+        <title><?= esc($title) ?></title>
     </head>
     <body>
-        <h1><?= $heading ?></h1>
+        <h1><?= esc($heading) ?></h1>
 
         <h3>My Todo List</h3>
 
         <ul>
         <?php foreach ($todo_list as $item):?>
 
-            <li><?= $item ?></li>
+            <li><?= esc($item) ?></li>
 
         <?php endforeach;?>
         </ul>

--- a/user_guide_src/source/outgoing/views.rst
+++ b/user_guide_src/source/outgoing/views.rst
@@ -228,11 +228,11 @@ Now open your view file and create a loop::
         <h3>My Todo List</h3>
 
         <ul>
-        <?php foreach ($todo_list as $item):?>
+        <?php foreach ($todo_list as $item): ?>
 
             <li><?= esc($item) ?></li>
 
-        <?php endforeach;?>
+        <?php endforeach ?>
         </ul>
 
     </body>


### PR DESCRIPTION
**Description**
- fix sample code
  - It is not good practice to output variables without escaping.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

