### PR TITLE
docs: fix coding style

### DIFF
--- a/user_guide_src/source/installation/upgrade_migrations.rst
+++ b/user_guide_src/source/installation/upgrade_migrations.rst
@@ -63,13 +63,13 @@ Path: ``application/migrations``::
         {
             $this->dbforge->add_field(array(
                 'blog_id' => array(
-                    'type' => 'INT',
-                    'constraint' => 5,
-                    'unsigned' => true,
+                    'type'           => 'INT',
+                    'constraint'     => 5,
+                    'unsigned'       => true,
                     'auto_increment' => true,
                 ),
                 'blog_title' => array(
-                    'type' => 'VARCHAR',
+                    'type'       => 'VARCHAR',
                     'constraint' => '100',
                 ),
                 'blog_description' => array(

--- a/user_guide_src/source/installation/upgrade_models.rst
+++ b/user_guide_src/source/installation/upgrade_models.rst
@@ -50,9 +50,9 @@ Path: ``application/models``::
         public function insert($name, $address, $email)
         {
             $this->db->insert('user_contacts', array(
-                "name" => $name,
-                "address" => $address,
-                "email" => $email,
+                'name'    => $name,
+                'address' => $address,
+                'email'   => $email,
             ));
         }
     }

--- a/user_guide_src/source/installation/upgrade_pagination.rst
+++ b/user_guide_src/source/installation/upgrade_pagination.rst
@@ -39,11 +39,11 @@ CodeIgniter Version 3.11
 ::
 
     $this->load->library('pagination');
-    $config['base_url'] = base_url().'users/index/';
-    $config['total_rows'] = $this->db->count_all('users');
-    $config['per_page'] = 10;
+    $config['base_url']    = base_url().'users/index/';
+    $config['total_rows']  = $this->db->count_all('users');
+    $config['per_page']    = 10;
     $config['uri_segment'] = 3;
-    $config['attributes'] = array('class' => 'pagination-link');
+    $config['attributes']  = array('class' => 'pagination-link');
     $this->pagination->initialize($config);
 
     $data['users'] = $this->user_model->get_users(FALSE, $config['per_page'], $offset);

--- a/user_guide_src/source/installation/upgrade_view_parser.rst
+++ b/user_guide_src/source/installation/upgrade_view_parser.rst
@@ -33,7 +33,7 @@ CodeIgniter Version 3.11
     $this->load->library('parser');
 
     $data = array(
-        'blog_title' => 'My Blog Title',
+        'blog_title'   => 'My Blog Title',
         'blog_heading' => 'My Blog Heading'
     );
 

--- a/user_guide_src/source/installation/upgrade_views.rst
+++ b/user_guide_src/source/installation/upgrade_views.rst
@@ -70,7 +70,7 @@ Path: ``app/Views``::
         <ul>
         <?php foreach ($todo_list as $item): ?>
             <li><?= esc($item) ?></li>
-        <?php endforeach; ?>
+        <?php endforeach ?>
         </ul>
 
     </body>

--- a/user_guide_src/source/libraries/pagination.rst
+++ b/user_guide_src/source/libraries/pagination.rst
@@ -250,7 +250,7 @@ usefulness. It is easiest to demonstrate creating a new view by showing you the 
             </li>
         <?php endif ?>
 
-        <?php foreach ($pager->links() as $link) : ?>
+        <?php foreach ($pager->links() as $link): ?>
             <li <?= $link['active'] ? 'class="active"' : '' ?>>
                 <a href="<?= $link['uri'] ?>">
                     <?= $link['title'] ?>
@@ -328,7 +328,7 @@ See following an example with these changes::
                 </li>
             <?php endif ?>
 
-            <?php foreach ($pager->links() as $link) : ?>
+            <?php foreach ($pager->links() as $link): ?>
                 <li <?= $link['active'] ? 'class="active"' : '' ?>>
                     <a href="<?= $link['uri'] ?>">
                         <?= $link['title'] ?>

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -607,7 +607,7 @@ a new view at **/app/Views/_errors_list.php**::
 
     <div class="alert alert-danger" role="alert">
         <ul>
-        <?php foreach ($errors as $error) : ?>
+        <?php foreach ($errors as $error): ?>
             <li><?= esc($error) ?></li>
         <?php endforeach ?>
         </ul>

--- a/user_guide_src/source/outgoing/alternative_php.rst
+++ b/user_guide_src/source/outgoing/alternative_php.rst
@@ -29,7 +29,7 @@ a simplified format as well. Here is an example using ``foreach``::
 
     <ul>
 
-    <?php foreach ($todo as $item) : ?>
+    <?php foreach ($todo as $item): ?>
 
         <li><?= $item ?></li>
 
@@ -46,15 +46,15 @@ Also notice that instead of using a semicolon after each structure
 
 Here is another example, using ``if``/``elseif``/``else``. Notice the colons::
 
-    <?php if ($username === 'sally') : ?>
+    <?php if ($username === 'sally'): ?>
 
         <h3>Hi Sally</h3>
 
-    <?php elseif ($username === 'joe') : ?>
+    <?php elseif ($username === 'joe'): ?>
 
         <h3>Hi Joe</h3>
 
-    <?php else : ?>
+    <?php else: ?>
 
         <h3>Hi unknown user</h3>
 

--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -217,7 +217,7 @@ and add the next piece of code.
             </div>
             <p><a href="/news/<?= esc($news_item['slug'], 'url') ?>">View article</a></p>
 
-        <?php endforeach; ?>
+        <?php endforeach ?>
 
     <?php else: ?>
 


### PR DESCRIPTION
**Description**
- remove unneeded `;`
- remove space before `:`
- align `=` position

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

