### PR TITLE
chore: PHPStan stubs for model()

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -61,3 +61,7 @@ parameters:
 		- CI_DEBUG
 		- ENVIRONMENT
 		- SODIUM_LIBRARY_VERSION
+	stubFiles:
+		- utils/PHPStan/stubs/Factories.stub
+		- utils/PHPStan/stubs/Model.stub
+		- utils/PHPStan/stubs/ConnectionInterface.stub

--- a/system/Common.php
+++ b/system/Common.php
@@ -776,7 +776,6 @@ if (! function_exists('model')) {
      * @param class-string<T> $name
      *
      * @return T
-     * @phpstan-return Model
      */
     function model(string $name, bool $getShared = true, ?ConnectionInterface &$conn = null)
     {

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -23,7 +23,6 @@ use Config\Services;
  * instantiation checks.
  *
  * @method static BaseConfig config(...$arguments)
- * @method static Model models(...$arguments)
  */
 class Factories
 {

--- a/utils/PHPStan/stubs/ConnectionInterface.stub
+++ b/utils/PHPStan/stubs/ConnectionInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace CodeIgniter\Database;
+
+interface ConnectionInterface
+{
+}

--- a/utils/PHPStan/stubs/Factories.stub
+++ b/utils/PHPStan/stubs/Factories.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace CodeIgniter\Config;
+
+use CodeIgniter\Database\ConnectionInterface;
+use CodeIgniter\Model;
+
+class Factories
+{
+    /**
+     * @template T of Model
+     *
+     * @param class-string<T>      $name
+     * @param array<string, mixed> $options
+     *
+     * @return T
+     */
+    public static function models(string $name, array $options = [], ?ConnectionInterface &$conn = null);
+}

--- a/utils/PHPStan/stubs/Model.stub
+++ b/utils/PHPStan/stubs/Model.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace CodeIgniter;
+
+class Model
+{
+}


### PR DESCRIPTION
**Description**
Ref #5358

This does not work.
```
$ composer analyze
> phpstan analyse
Note: Using configuration file /Users/kenji/work/codeigniter/CodeIgniter4/phpstan.neon.dist.
 405/405 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ---------------------------------------------------------------------------- 
  Line   system/Common.php                                                           
 ------ ---------------------------------------------------------------------------- 
  782    Call to an undefined static method CodeIgniter\Config\Factories::models().  
  782    Function model() should return T of CodeIgniter\Model but returns mixed.    
 ------ ---------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------- 
  Line   system/Database/ModelFactory.php                                            
 ------ ---------------------------------------------------------------------------- 
  32     Call to an undefined static method CodeIgniter\Config\Factories::models().  
 ------ ----------------------------------------------------------------------------
```

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

