### PR TITLE
feat: add SecureHeaders filter

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -7,6 +7,7 @@ use CodeIgniter\Filters\CSRF;
 use CodeIgniter\Filters\DebugToolbar;
 use CodeIgniter\Filters\Honeypot;
 use CodeIgniter\Filters\InvalidChars;
+use CodeIgniter\Filters\SecureHeaders;
 
 class Filters extends BaseConfig
 {
@@ -17,10 +18,11 @@ class Filters extends BaseConfig
      * @var array
      */
     public $aliases = [
-        'csrf'         => CSRF::class,
-        'toolbar'      => DebugToolbar::class,
-        'honeypot'     => Honeypot::class,
-        'invalidchars' => InvalidChars::class,
+        'csrf'          => CSRF::class,
+        'toolbar'       => DebugToolbar::class,
+        'honeypot'      => Honeypot::class,
+        'invalidchars'  => InvalidChars::class,
+        'secureheaders' => SecureHeaders::class,
     ];
 
     /**
@@ -38,6 +40,7 @@ class Filters extends BaseConfig
         'after' => [
             'toolbar',
             // 'honeypot',
+            // 'secureheaders',
         ],
     ];
 

--- a/system/Filters/SecureHeaders.php
+++ b/system/Filters/SecureHeaders.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Filters;
+
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
+
+/**
+ * Add Common Security Headers
+ */
+class SecureHeaders implements FilterInterface
+{
+    /**
+     * @var array<string, string>
+     */
+    protected $headers = [
+        // https://owasp.org/www-project-secure-headers/#x-frame-options
+        'X-Frame-Options' => 'SAMEORIGIN',
+
+        // https://owasp.org/www-project-secure-headers/#x-content-type-options
+        'X-Content-Type-Options' => 'nosniff',
+
+        // https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/jj542450(v=vs.85)#the-noopen-directive
+        'X-Download-Options' => 'noopen',
+
+        // https://owasp.org/www-project-secure-headers/#x-permitted-cross-domain-policies
+        'X-Permitted-Cross-Domain-Policies' => 'none',
+
+        // https://owasp.org/www-project-secure-headers/#referrer-policy
+        'Referrer-Policy' => 'same-origin',
+
+        // https://owasp.org/www-project-secure-headers/#x-xss-protection
+        // If you do not need to support legacy browsers, it is recommended that you use
+        // Content-Security-Policy without allowing unsafe-inline scripts instead.
+        // 'X-XSS-Protection' => '1; mode=block',
+    ];
+
+    /**
+     * We don't have anything to do here.
+     *
+     * @param array|null $arguments
+     *
+     * @return void
+     */
+    public function before(RequestInterface $request, $arguments = null)
+    {
+    }
+
+    /**
+     * Add security headers.
+     *
+     * @param array|null $arguments
+     *
+     * @return void
+     */
+    public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
+    {
+        foreach ($this->headers as $header => $value) {
+            $response->setHeader($header, $value);
+        }
+    }
+}

--- a/tests/system/Filters/SecureHeadersTest.php
+++ b/tests/system/Filters/SecureHeadersTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Filters;
+
+use CodeIgniter\Config\Services;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class SecureHeadersTest extends CIUnitTestCase
+{
+    protected $request;
+    protected $response;
+
+    public function testAfter()
+    {
+        $filter   = new SecureHeaders();
+        $request  = Services::request(null, false);
+        $response = Services::response(null, false);
+
+        $filter->after($request, $response);
+
+        $responseHeaders = $response->headers();
+        $headers         = $this->getPrivateProperty($filter, 'headers');
+
+        foreach ($headers as $header => $value) {
+            $this->assertSame($value, $responseHeaders[$header]->getValue());
+        }
+    }
+}

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -193,6 +193,6 @@ In this example, the array ``['dual', 'noreturn']`` will be passed in ``$argumen
 Provided Filters
 ****************
 
-The filters bundled with CodeIgniter4 are: ``Honeypot``, ``CSRF``, ``DebugToolbar``, and ``InvalidChars``.
+The filters bundled with CodeIgniter4 are: ``Honeypot``, ``CSRF``, ``InvalidChars``, ``SecureHeaders``, and ``DebugToolbar``.
 
 .. note:: The filters are executed in the order defined in the config file. However, if enabled, ``DebugToolbar`` is always executed last because it should be able to capture everything that happens in the other filters.

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -196,3 +196,17 @@ Provided Filters
 The filters bundled with CodeIgniter4 are: ``Honeypot``, ``CSRF``, ``InvalidChars``, ``SecureHeaders``, and ``DebugToolbar``.
 
 .. note:: The filters are executed in the order defined in the config file. However, if enabled, ``DebugToolbar`` is always executed last because it should be able to capture everything that happens in the other filters.
+
+SecureHeaders
+=============
+
+This filter adds HTTP response headers that your application can use to increase the security of your application.
+
+If you want to customize the headers, extend ``CodeIgniter\Filters\SecureHeaders`` and override the ``$headers`` property. And change the ``$aliases`` property in **app/Config/Filters.php**::
+
+    public $aliases = [
+        ...
+        'secureheaders' => \App\Filters\SecureHeaders::class,
+    ];
+
+If you want to know about secure headers, see `OWASP Secure Headers Project <https://owasp.org/www-project-secure-headers/>`_.


### PR DESCRIPTION
**Description**
- add filter that add common security related filters to response object

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
