### PR TITLE
chore: fix example test code for appstarter and module

### DIFF
--- a/admin/module/tests/database/ExampleDatabaseTest.php
+++ b/admin/module/tests/database/ExampleDatabaseTest.php
@@ -1,18 +1,18 @@
 <?php
 
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use Tests\Support\Database\Seeds\ExampleSeeder;
 use Tests\Support\Models\ExampleModel;
 
 /**
  * @internal
  */
-final class ExampleDatabaseTest extends \Tests\Support\DatabaseTestCase
+final class ExampleDatabaseTest extends CIUnitTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
+    use DatabaseTestTrait;
 
-        // Extra code to run before each test
-    }
+    protected $seed = ExampleSeeder::class;
 
     public function testModelFindAll()
     {

--- a/admin/module/tests/session/ExampleSessionTest.php
+++ b/admin/module/tests/session/ExampleSessionTest.php
@@ -1,21 +1,18 @@
 <?php
 
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Services;
+
 /**
  * @internal
  */
-final class ExampleSessionTest extends \Tests\Support\SessionTestCase
+final class ExampleSessionTest extends CIUnitTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function testSessionSimple()
     {
-        $this->session->set('logged_in', 123);
+        $session = Services::session();
 
-        $value = $this->session->get('logged_in');
-
-        $this->assertSame(123, $value);
+        $session->set('logged_in', 123);
+        $this->assertSame(123, $session->get('logged_in'));
     }
 }

--- a/admin/starter/tests/database/ExampleDatabaseTest.php
+++ b/admin/starter/tests/database/ExampleDatabaseTest.php
@@ -2,6 +2,7 @@
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use Tests\Support\Database\Seeds\ExampleSeeder;
 use Tests\Support\Models\ExampleModel;
 
 /**
@@ -10,6 +11,8 @@ use Tests\Support\Models\ExampleModel;
 final class ExampleDatabaseTest extends CIUnitTestCase
 {
     use DatabaseTestTrait;
+
+    protected $seed = ExampleSeeder::class;
 
     public function testModelFindAll()
     {

--- a/admin/starter/tests/session/ExampleSessionTest.php
+++ b/admin/starter/tests/session/ExampleSessionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\Services;
 
 /**
  * @internal
@@ -9,7 +10,9 @@ final class ExampleSessionTest extends CIUnitTestCase
 {
     public function testSessionSimple()
     {
-        $this->session->set('logged_in', 123);
-        $this->assertSame(123, $this->session->get('logged_in'));
+        $session = Services::session();
+
+        $session->set('logged_in', 123);
+        $this->assertSame(123, $session->get('logged_in'));
     }
 }


### PR DESCRIPTION
**Description**
- fix example test code for starter and module

Right after installing CI4, tests fail:
```
$ composer create-project codeigniter4/appstarter ci4
$ cd ci4
$ composer test
> phpunit
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

FEE..                                                               5 / 5 (100%)

Time: 00:00.584, Memory: 26.00 MB

There were 2 errors:

1) ExampleDatabaseTest::testSoftDeleteLeavesRow
ErrorException: Attempt to read property "id" on null

/Users/kenji/tmp/ci4/tests/database/ExampleDatabaseTest.php:32

2) ExampleSessionTest::testSessionSimple
Error: Call to a member function set() on array

/Users/kenji/tmp/ci4/tests/session/ExampleSessionTest.php:12

--

There was 1 failure:

1) ExampleDatabaseTest::testModelFindAll
Failed asserting that actual size 0 matches expected size 3.

/Users/kenji/tmp/ci4/tests/database/ExampleDatabaseTest.php:22

ERRORS!
Tests: 5, Assertions: 3, Errors: 2, Failures: 1.

Generating code coverage report in Clover XML format ... done [00:00.180]

Generating code coverage report in HTML format ... done [00:00.184]

Generating code coverage report in PHP format ... done [00:00.001]


Code Coverage Report:   
  2021-12-01 05:37:22   
                        
 Summary:               
  Classes: 20.00% (1/5) 
  Methods: 16.67% (1/6) 
  Lines:   20.93% (9/43)

Config\Database
  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  4/  4)
Script phpunit handling the test event returned with error code 2
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
