### PR TITLE
fix: redirect() does not send previously set cookies

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -834,7 +834,7 @@ if (! function_exists('redirect')) {
      */
     function redirect(?string $route = null): RedirectResponse
     {
-        $response = Services::redirectresponse(null, true);
+        $response = Services::redirectresponse(null, true)->withCookies();
 
         if (! empty($route)) {
             return $response->route($route);

--- a/tests/system/CommonFunctionsSendTest.php
+++ b/tests/system/CommonFunctionsSendTest.php
@@ -58,4 +58,38 @@ final class CommonFunctionsSendTest extends CIUnitTestCase
         $this->assertHeaderEmitted('Set-Cookie: foo=onething;');
         $this->assertHeaderEmitted('Set-Cookie: login_time');
     }
+
+    /**
+     * See https://github.com/codeigniter4/CodeIgniter4/issues/5422
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState  disabled
+     */
+    public function testRedirectResponseSendsPreviouslySetCookies()
+    {
+        $loginTime = time();
+
+        $routes = service('routes');
+        $routes->add('user/login', 'Auth::verify', ['as' => 'login']);
+
+        $originalResponse = Services::response();
+        $originalResponse->setCookie('foo', 'onething', YEAR)->setCookie('login_time', $loginTime, YEAR);
+
+        $response = redirect()->route('login');
+        $response->pretend(false);
+        $this->assertTrue($response->hasCookie('foo', 'onething'));
+        $this->assertTrue($response->hasCookie('login_time'));
+        $response->setBody('Hello');
+
+        // send it
+        ob_start();
+        $response->send();
+        if (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+
+        // and what actually got sent?
+        $this->assertHeaderEmitted('Set-Cookie: foo=onething;');
+        $this->assertHeaderEmitted('Set-Cookie: login_time');
+    }
 }


### PR DESCRIPTION
**Description**
Fixes #5422

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
