### PR TITLE
fix: errors when MariaDB/MySQL has `ANSI_QUOTES` enabled

### DIFF
--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -100,19 +100,19 @@ class Connection extends BaseConnection
             if ($this->strictOn) {
                 $this->mysqli->options(
                     MYSQLI_INIT_COMMAND,
-                    'SET SESSION sql_mode = CONCAT(@@sql_mode, ",", "STRICT_ALL_TABLES")'
+                    "SET SESSION sql_mode = CONCAT(@@sql_mode, ',', 'STRICT_ALL_TABLES')"
                 );
             } else {
                 $this->mysqli->options(
                     MYSQLI_INIT_COMMAND,
-                    'SET SESSION sql_mode = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+                    "SET SESSION sql_mode = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
                                         @@sql_mode,
-                                        "STRICT_ALL_TABLES,", ""),
-                                    ",STRICT_ALL_TABLES", ""),
-                                "STRICT_ALL_TABLES", ""),
-                            "STRICT_TRANS_TABLES,", ""),
-                        ",STRICT_TRANS_TABLES", ""),
-                    "STRICT_TRANS_TABLES", "")'
+                                        'STRICT_ALL_TABLES,', ''),
+                                    ',STRICT_ALL_TABLES', ''),
+                                'STRICT_ALL_TABLES', ''),
+                            'STRICT_TRANS_TABLES,', ''),
+                        ',STRICT_TRANS_TABLES', ''),
+                    'STRICT_TRANS_TABLES', '')"
                 );
             }
         }


### PR DESCRIPTION
**Description**
Fixes #5423

> A string is a sequence of bytes or characters, enclosed within either single quote (') or double quote (") characters. 
> ...
> If the ANSI_QUOTES SQL mode is enabled, string literals can be quoted only within single quotation marks because a string quoted within double quotation marks is interpreted as an identifier. 
https://dev.mysql.com/doc/refman/8.0/en/string-literals.html

> ANSI_QUOTES
> Treat " as an identifier quote character (like the `` ` `` quote character) and not as a string quote character. You can still use ` to quote identifiers with this mode enabled. With ANSI_QUOTES enabled, you cannot use double quotation marks to quote literal strings because they are interpreted as identifiers. 
https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_ansi_quotes

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
