### PR TITLE
docs: add command prompt `>` before `php spark`

### DIFF
--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -260,7 +260,7 @@ generator command are recognized by the scaffold command.
 
 Running this in your terminal::
 
-    php spark make:scaffold user
+    > php spark make:scaffold user
 
 will create the following classes:
 

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -67,7 +67,7 @@ will complain that the database creation has failed.
 
 To start, just type the command and the name of the database (e.g., ``foo``)::
 
-    php spark db:create foo
+    > php spark db:create foo
 
 If everything went fine, you should expect the ``Database "foo" successfully created.`` message displayed.
 
@@ -76,7 +76,7 @@ for the file where the database will be created using the ``--ext`` option. Vali
 ``sqlite`` and defaults to ``db``. Remember that these should not be preceded by a period.
 ::
 
-    php spark db:create foo --ext sqlite
+    > php spark db:create foo --ext sqlite
     // will create the db file in WRITEPATH/foo.sqlite
 
 .. note:: When using the special SQLite3 database name ``:memory:``, expect that the command will still

--- a/user_guide_src/source/installation/running.rst
+++ b/user_guide_src/source/installation/running.rst
@@ -43,7 +43,7 @@ CodeIgniter 4 comes with a local development server, leveraging PHP's built-in w
 with CodeIgniter routing. You can use the ``serve`` script to launch it,
 with the following command line in the main directory::
 
-    php spark serve
+    > php spark serve
 
 This will launch the server and you can now view your application in your browser at http://localhost:8080.
 
@@ -58,17 +58,17 @@ The local development server can be customized with three command line options:
 
 - You can use the ``--host`` CLI option to specify a different host to run the application at::
 
-    php spark serve --host example.dev
+    > php spark serve --host example.dev
 
 - By default, the server runs on port 8080 but you might have more than one site running, or already have
   another application using that port. You can use the ``--port`` CLI option to specify a different one::
 
-    php spark serve --port 8081
+    > php spark serve --port 8081
 
 - You can also specify a specific version of PHP to use, with the ``--php`` CLI option, with its value
   set to the path of the PHP executable you want to use::
 
-    php spark serve --php /usr/bin/php7.6.5.4
+    > php spark serve --php /usr/bin/php7.6.5.4
 
 Hosting with Apache
 ===================

--- a/user_guide_src/source/installation/troubleshooting.rst
+++ b/user_guide_src/source/installation/troubleshooting.rst
@@ -9,7 +9,7 @@ How do I know if my install is working?
 
 From the command line, at your project root::
 
-    php spark serve
+    > php spark serve
 
 ``http://localhost:8080`` in your browser should then show the default
 welcome page:

--- a/user_guide_src/source/tutorial/index.rst
+++ b/user_guide_src/source/tutorial/index.rst
@@ -82,7 +82,7 @@ comes with a simple command that takes advantage of PHP's built-in server to get
 you up and running fast on your development machines. Type the following on the
 command line from the root of your project::
 
-    php spark serve
+    > php spark serve
 
 
 The Welcome Page

--- a/user_guide_src/source/tutorial/static_pages.rst
+++ b/user_guide_src/source/tutorial/static_pages.rst
@@ -178,7 +178,7 @@ From the command line, at the root of your project:
 
 ::
 
-    php spark serve
+    > php spark serve
 
 will start a web server, accessible on port 8080. If you set the location field
 in your browser to ``localhost:8080``, you should see the CodeIgniter welcome page.


### PR DESCRIPTION
**Description**
- add command prompt `>` before `php spark`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
