### PR TITLE
docs: add command prompt `>` before `composer`

### DIFF
--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -32,7 +32,7 @@ Installation & Set Up
 
 In the folder above your project root::
 
-    composer create-project codeigniter4/appstarter project-root
+    > composer create-project codeigniter4/appstarter project-root
 
 The command above will create a "project-root" folder.
 
@@ -46,7 +46,7 @@ trusted dependencies that we bundle, being composer-installed.
 
 A sample such installation command, using the default project-root "appstarter"::
 
-    composer create-project codeigniter4/appstarter --no-dev
+    > composer create-project codeigniter4/appstarter --no-dev
 
 After installation you should follow the steps in the "Upgrading" section.
 
@@ -55,11 +55,11 @@ Upgrading
 
 Whenever there is a new release, then from the command line in your project root::
 
-    composer update
+    > composer update
 
 If you want to compare the latest framework source structure for non-system directory (app, public, etc), you can update with ``--prefer-source``::
 
-    composer update codeigniter4/framework --prefer-source
+    > composer update codeigniter4/framework --prefer-source
 
 If ``--prefer-source`` doesn't automatically update to pull latest framework source structure, you can remove first::
 
@@ -125,7 +125,7 @@ will be your document root.
 
 In your project root::
 
-    composer require codeigniter4/framework --prefer-source
+    > composer require codeigniter4/framework --prefer-source
 
 As with the earlier two composer install methods, you can omit installing
 phpunit and its dependencies by adding the ``--no-dev`` argument to the ``composer require`` command.
@@ -147,7 +147,7 @@ Upgrading
 
 Whenever there is a new release, then from the command line in your project root::
 
-    composer update --prefer-source
+    > composer update --prefer-source
 
 Read the upgrade instructions, and check designated
 ``app/Config`` folders for affected changes.
@@ -179,6 +179,6 @@ they can be added to your project in a similar fashion.
 
 From the command line inside your project root::
 
-    composer require codeigniter4/translations
+    > composer require codeigniter4/translations
 
 These will be updated along with the framework whenever you do a ``composer update``.

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -315,7 +315,7 @@ Predis Caching
 Predis is a flexible and feature-complete PHP client library for the Redis key-value store.
 To use it, from the command line inside your project root::
 
-    composer require predis/predis
+    > composer require predis/predis
 
 For more information on Redis, please see
 `https://github.com/nrk/predis <https://github.com/nrk/predis>`_.

--- a/user_guide_src/source/tutorial/index.rst
+++ b/user_guide_src/source/tutorial/index.rst
@@ -59,7 +59,7 @@ From your command line type the following:
 
 ::
 
-    composer create-project codeigniter4/appstarter ci-news
+    > composer create-project codeigniter4/appstarter ci-news
 
 This creates a new folder, **ci-news**, which contains your application code, with
 CodeIgniter installed in the vendor folder.


### PR DESCRIPTION
**Description**
- add command prompt `>` before `composer`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
