### PR TITLE
fix: Model::save() may call unneeded countAllResults()

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -584,12 +584,12 @@ class Model extends BaseModel
      */
     protected function shouldUpdate($data): bool
     {
-        // When useAutoIncrement feature is disabled check
+        // When useAutoIncrement feature is disabled, check
         // in the database if given record already exists
         return parent::shouldUpdate($data)
-            && $this->useAutoIncrement
+            && ($this->useAutoIncrement
                 ? true
-                : $this->where($this->primaryKey, $this->getIdValue($data))->countAllResults() === 1;
+                : $this->where($this->primaryKey, $this->getIdValue($data))->countAllResults() === 1);
     }
 
     /**

--- a/system/Model.php
+++ b/system/Model.php
@@ -584,12 +584,15 @@ class Model extends BaseModel
      */
     protected function shouldUpdate($data): bool
     {
+        if (parent::shouldUpdate($data) === false) {
+            return false;
+        }
+
         // When useAutoIncrement feature is disabled, check
         // in the database if given record already exists
-        return parent::shouldUpdate($data)
-            && ($this->useAutoIncrement
+        return $this->useAutoIncrement
                 ? true
-                : $this->where($this->primaryKey, $this->getIdValue($data))->countAllResults() === 1);
+                : $this->where($this->primaryKey, $this->getIdValue($data))->countAllResults() === 1;
     }
 
     /**

--- a/system/Model.php
+++ b/system/Model.php
@@ -588,11 +588,13 @@ class Model extends BaseModel
             return false;
         }
 
+        if ($this->useAutoIncrement === true) {
+            return true;
+        }
+
         // When useAutoIncrement feature is disabled, check
         // in the database if given record already exists
-        return $this->useAutoIncrement
-                ? true
-                : $this->where($this->primaryKey, $this->getIdValue($data))->countAllResults() === 1;
+        return $this->where($this->primaryKey, $this->getIdValue($data))->countAllResults() === 1;
     }
 
     /**


### PR DESCRIPTION
**Description**
When `useAutoIncrement` is disabled, `countAllResults()` is called, even if `$data` does not have id value.
You'll see the query like the following:
```sql
SELECT COUNT(*) AS `numrows` FROM `news` WHERE `id` IS NULL
```

```php
<?php

function f1() {
  return false && false ? true : 'a';
}
function f2() {
  return false && (false ? true : 'a');
}

var_dump(f1()); // "a"
var_dump(f2()); // false
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
