### PR TITLE
docs: fix wrong sample code in sessions.rst

### DIFF
--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -91,7 +91,7 @@ longer need it. So, what you need is to close the session for the
 current request after you no longer need it.
 ::
 
-    $session->destroy();
+    session_write_close();
 
 What is Session Data?
 =====================


### PR DESCRIPTION
**Description**
- `$session->destroy()` will destroy the session and log out the user. 

See https://forum.codeigniter.com/thread-80718.html

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

