### PR TITLE
fix: VENDORPATH definition

### DIFF
--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -84,20 +84,6 @@ if (! class_exists('CodeIgniter\Services', false)) {
 // Initialize and register the loader with the SPL autoloader stack.
 Services::autoloader()->initialize(new Autoload(), new Modules())->register();
 
-// Now load Composer's if it's available
-if (is_file(COMPOSER_PATH)) {
-    /*
-     * The path to the vendor directory.
-     *
-     * We do not want to enforce this, so set the constant if Composer was used.
-     */
-    if (! defined('VENDORPATH')) {
-        define('VENDORPATH', realpath(ROOTPATH . 'vendor') . DIRECTORY_SEPARATOR);
-    }
-
-    require_once COMPOSER_PATH;
-}
-
 // Load environment settings from .env files into $_SERVER and $_ENV
 require_once SYSTEMPATH . 'Config/DotEnv.php';
 

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -84,6 +84,11 @@ if (! class_exists('CodeIgniter\Services', false)) {
 // Initialize and register the loader with the SPL autoloader stack.
 Services::autoloader()->initialize(new Autoload(), new Modules())->register();
 
+// Now load Composer's if it's available
+if (is_file(COMPOSER_PATH)) {
+    require_once COMPOSER_PATH;
+}
+
 // Load environment settings from .env files into $_SERVER and $_ENV
 require_once SYSTEMPATH . 'Config/DotEnv.php';
 

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -117,7 +117,7 @@ if (is_file(COMPOSER_PATH)) {
      * We do not want to enforce this, so set the constant if Composer was used.
      */
     if (! defined('VENDORPATH')) {
-        define('VENDORPATH', realpath(ROOTPATH . 'vendor') . DIRECTORY_SEPARATOR);
+        define('VENDORPATH', dirname(COMPOSER_PATH) . DIRECTORY_SEPARATOR);
     }
 
     require_once COMPOSER_PATH;

--- a/user_guide_src/source/general/managing_apps.rst
+++ b/user_guide_src/source/general/managing_apps.rst
@@ -69,8 +69,13 @@ This would have two apps, **foo** and **bar**, both having standard application 
 and a **public** folder, and sharing a common **codeigniter** framework.
 
 The **index.php** inside each application would refer to its own configuration,
-``../app/Config/Paths.php``, and the ``$systemDirectory`` variable inside each
+``../app/Config/Paths.php``, and the ``$systemDirectory`` variable in **app/Config/Paths.php** inside each
 of those would be set to refer to the shared common **system** folder.
 
 If either of the applications had a command-line component, then you would also
 modify **spark** inside each application's project folder, as directed above.
+
+When you use Composer autoloader, fix the ``COMPOSER_PATH`` constant in **app/Config/Constants.php** inside each
+of those::
+
+    defined('COMPOSER_PATH') || define('COMPOSER_PATH', ROOTPATH . '../vendor/autoload.php');


### PR DESCRIPTION
**Description**
- When using multiple apps, `vendor/` is not `ROOTPATH/vendor/`.

See https://forum.codeigniter.com/thread-80732.html

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

