### PR TITLE
fix: `number_to_currency()` error on PHP 8.1

### DIFF
--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -112,10 +112,7 @@ if (! function_exists('number_to_amount')) {
 }
 
 if (! function_exists('number_to_currency')) {
-    /**
-     * @param string $locale
-     * @param int    $fraction
-     */
+
     function number_to_currency(float $num, string $currency, ?string $locale = null, int $fraction = 0): string
     {
         return format_number($num, 1, $locale, [

--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -112,7 +112,6 @@ if (! function_exists('number_to_amount')) {
 }
 
 if (! function_exists('number_to_currency')) {
-
     function number_to_currency(float $num, string $currency, ?string $locale = null, int $fraction = 0): string
     {
         return format_number($num, 1, $locale, [

--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -116,7 +116,7 @@ if (! function_exists('number_to_currency')) {
      * @param string $locale
      * @param int    $fraction
      */
-    function number_to_currency(float $num, string $currency, ?string $locale = null, ?int $fraction = null): string
+    function number_to_currency(float $num, string $currency, ?string $locale = null, int $fraction = 0): string
     {
         return format_number($num, 1, $locale, [
             'type'     => NumberFormatter::CURRENCY,

--- a/tests/system/Helpers/NumberHelperTest.php
+++ b/tests/system/Helpers/NumberHelperTest.php
@@ -126,6 +126,7 @@ final class NumberHelperTest extends CIUnitTestCase
      */
     public function testCurrencyCurrentLocale()
     {
+        $this->assertSame('$1,235', number_to_currency(1234.56, 'USD', 'en_US'));
         $this->assertSame('$1,234.56', number_to_currency(1234.56, 'USD', 'en_US', 2));
         $this->assertSame('£1,234.56', number_to_currency(1234.56, 'GBP', 'en_GB', 2));
         $this->assertSame("1.234,56\u{a0}RSD", number_to_currency(1234.56, 'RSD', 'sr_RS', 2));

--- a/user_guide_src/source/helpers/number_helper.rst
+++ b/user_guide_src/source/helpers/number_helper.rst
@@ -27,7 +27,7 @@ Available Functions
 
 The following functions are available:
 
-.. php:function:: number_to_size($num[, $precision = 1[, $locale = null])
+.. php:function:: number_to_size($num[, $precision = 1[, $locale = null]])
 
     :param      mixed     $num: Number of bytes
     :param      int       $precision: Floating point precision
@@ -86,21 +86,23 @@ The following functions are available:
 
         echo number_to_amount('123,456,789,012', 2, 'de_DE'); // Returns 123,46 billion
 
-.. php:function:: number_to_currency($num, $currency[, $locale = null])
+.. php:function:: number_to_currency($num, $currency[, $locale = null[, $fraction = 0]])
 
-    :param mixed $num: Number to format
+    :param float $num: Number to format
     :param string $currency: The currency type, i.e., USD, EUR, etc
-    :param string $locale: The locale to use for formatting
+    :param string|null $locale: The locale to use for formatting
     :param integer $fraction: Number of fraction digits after decimal point
     :returns: The number as the appropriate currency for the locale
     :rtype: string
 
     Converts a number in common currency formats, like USD, EUR, GBP, etc::
 
-        echo number_to_currency(1234.56, 'USD');  // Returns $1,234.56
-        echo number_to_currency(1234.56, 'EUR');  // Returns €1,234.56
-        echo number_to_currency(1234.56, 'GBP');  // Returns £1,234.56
-        echo number_to_currency(1234.56, 'YEN');  // Returns YEN1,234.56
+        echo number_to_currency(1234.56, 'USD', 'en_US', 2);  // Returns $1,234.56
+        echo number_to_currency(1234.56, 'EUR', 'de_DE', 2);  // Returns 1.234,56 €
+        echo number_to_currency(1234.56, 'GBP', 'en_GB', 2);  // Returns £1,234.56
+        echo number_to_currency(1234.56, 'YEN', 'ja_JP', 2);  // Returns YEN 1,234.56
+
+    If you don't specify a locale, the Request locale is used.
 
 .. php:function:: number_to_roman($num)
 


### PR DESCRIPTION
**Description**
Fixes #5452
Follow-up #4883

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

