### PR TITLE
Use PHPStan's baseline instead of global ignore of errors

### DIFF
--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0']
+        php-versions: ['8.0', '8.1']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -1,0 +1,1022 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Parameter \\#1 \\$callback of function spl_autoload_register expects \\(callable\\(string\\)\\: void\\)\\|null, array\\{\\$this\\(CodeIgniter\\\\Autoloader\\\\Autoloader\\), 'loadClass'\\} given\\.$#"
+			count: 1
+			path: system/Autoloader/Autoloader.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of function spl_autoload_register expects \\(callable\\(string\\)\\: void\\)\\|null, array\\{\\$this\\(CodeIgniter\\\\Autoloader\\\\Autoloader\\), 'loadClassmap'\\} given\\.$#"
+			count: 1
+			path: system/Autoloader/Autoloader.php
+
+		-
+			message: "#^Property Config\\\\Autoload\\:\\:\\$classmap \\(array\\<string, string\\>\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Autoloader/Autoloader.php
+
+		-
+			message: "#^Property Config\\\\Autoload\\:\\:\\$files \\(array\\<int, string\\>\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Autoloader/Autoloader.php
+
+		-
+			message: "#^Property Config\\\\Autoload\\:\\:\\$psr4 \\(array\\<string, string\\>\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Autoloader/Autoloader.php
+
+		-
+			message: "#^Method CodeIgniter\\\\Validation\\\\ValidationInterface\\:\\:run\\(\\) invoked with 3 parameters, 0\\-2 required\\.$#"
+			count: 1
+			path: system/BaseModel.php
+
+		-
+			message: "#^Property Config\\\\Cache\\:\\:\\$backupHandler \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Cache/CacheFactory.php
+
+		-
+			message: "#^Property Config\\\\Cache\\:\\:\\$handler \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Cache/CacheFactory.php
+
+		-
+			message: "#^Property Config\\\\Cache\\:\\:\\$validHandlers \\(array\\<string, string\\>\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Cache/CacheFactory.php
+
+		-
+			message: "#^Comparison operation \"\\>\" between int\\<1, max\\> and \\(array\\|float\\|int\\) results in an error\\.$#"
+			count: 1
+			path: system/Cache/Handlers/FileHandler.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: system/Cache/Handlers/FileHandler.php
+
+		-
+			message: "#^Property Config\\\\Cache\\:\\:\\$storePath \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Cache/Handlers/FileHandler.php
+
+		-
+			message: "#^Method MemcachePool\\:\\:decrement\\(\\) invoked with 4 parameters, 1\\-2 required\\.$#"
+			count: 1
+			path: system/Cache/Handlers/MemcachedHandler.php
+
+		-
+			message: "#^Method MemcachePool\\:\\:increment\\(\\) invoked with 4 parameters, 1\\-2 required\\.$#"
+			count: 1
+			path: system/Cache/Handlers/MemcachedHandler.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: system/Cache/Handlers/MemcachedHandler.php
+
+		-
+			message: "#^Variable \\$config in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: system/Cache/Handlers/MemcachedHandler.php
+
+		-
+			message: "#^Variable \\$data might not be defined\\.$#"
+			count: 1
+			path: system/Cache/Handlers/MemcachedHandler.php
+
+		-
+			message: "#^Property Config\\\\Cache\\:\\:\\$redis \\(array\\<string, int\\|string\\|null\\>\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Cache/Handlers/PredisHandler.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Cache\\\\Handlers\\\\RedisHandler\\:\\:\\$redis \\(Redis\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Cache/Handlers/RedisHandler.php
+
+		-
+			message: "#^Variable \\$config in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: system/Cache/Handlers/RedisHandler.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\HTTP\\\\Request\\:\\:getPost\\(\\)\\.$#"
+			count: 1
+			path: system/CodeIgniter.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\HTTP\\\\Request\\:\\:getSegments\\(\\)\\.$#"
+			count: 1
+			path: system/CodeIgniter.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\HTTP\\\\Request\\:\\:setLocale\\(\\)\\.$#"
+			count: 1
+			path: system/CodeIgniter.php
+
+		-
+			message: "#^Dead catch \\- CodeIgniter\\\\Exceptions\\\\PageNotFoundException is never thrown in the try block\\.$#"
+			count: 1
+			path: system/CodeIgniter.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$appTimezone \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/CodeIgniter.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$defaultLocale \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/CodeIgniter.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: system/CodeIgniter.php
+
+		-
+			message: "#^Binary operation \"\\+\" between array\\<string, class\\-string\\>\\|false and non\\-empty\\-array\\<string, string\\> results in an error\\.$#"
+			count: 1
+			path: system/Common.php
+
+		-
+			message: "#^Variable \\$params on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: system/Common.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:\\$db \\(CodeIgniter\\\\Database\\\\BaseConnection\\) in empty\\(\\) is not falsy\\.$#"
+			count: 1
+			path: system/Database/BaseBuilder.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\Database\\\\BaseConnection\\:\\:_disableForeignKeyChecks\\(\\)\\.$#"
+			count: 1
+			path: system/Database/BaseConnection.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\Database\\\\BaseConnection\\:\\:_enableForeignKeyChecks\\(\\)\\.$#"
+			count: 1
+			path: system/Database/BaseConnection.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\Database\\\\QueryInterface\\:\\:getOriginalQuery\\(\\)\\.$#"
+			count: 1
+			path: system/Database/BaseConnection.php
+
+		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 1
+			path: system/Database/BaseConnection.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 3
+			path: system/Database/BaseResult.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 2
+			path: system/Database/BaseResult.php
+
+		-
+			message: "#^While loop condition is always true\\.$#"
+			count: 2
+			path: system/Database/BaseResult.php
+
+		-
+			message: "#^Access to an undefined property CodeIgniter\\\\Database\\\\ConnectionInterface\\:\\:\\$DBDriver\\.$#"
+			count: 2
+			path: system/Database/Database.php
+
+		-
+			message: "#^Access to an undefined property CodeIgniter\\\\Database\\\\ConnectionInterface\\:\\:\\$connID\\.$#"
+			count: 2
+			path: system/Database/Database.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Database\\\\Migration\\:\\:\\$DBGroup \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Database/Migration.php
+
+		-
+			message: "#^Property Config\\\\Migrations\\:\\:\\$enabled \\(bool\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Database/MigrationRunner.php
+
+		-
+			message: "#^Property Config\\\\Migrations\\:\\:\\$table \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Database/MigrationRunner.php
+
+		-
+			message: "#^Cannot access property \\$affected_rows on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot access property \\$errno on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot access property \\$error on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot access property \\$insert_id on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot call method autocommit\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 3
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot call method begin_transaction\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot call method close\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot call method commit\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot call method more_results\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot call method next_result\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot call method query\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot call method real_escape_string\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot call method rollback\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot call method select_db\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Cannot call method store_result\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Database\\\\BaseConnection\\:\\:\\$strictOn \\(bool\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Database\\\\MySQLi\\\\Connection\\:\\:\\$mysqli \\(mysqli\\) in empty\\(\\) is not falsy\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Connection.php
+
+		-
+			message: "#^Access to an undefined property CodeIgniter\\\\Database\\\\BaseConnection\\:\\:\\$mysqli\\.$#"
+			count: 3
+			path: system/Database/MySQLi/PreparedQuery.php
+
+		-
+			message: "#^Cannot call method bind_param\\(\\) on object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/PreparedQuery.php
+
+		-
+			message: "#^Cannot call method execute\\(\\) on object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/PreparedQuery.php
+
+		-
+			message: "#^Cannot call method get_result\\(\\) on object\\|resource\\.$#"
+			count: 1
+			path: system/Database/MySQLi/PreparedQuery.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Database/MySQLi/PreparedQuery.php
+
+		-
+			message: "#^Cannot access property \\$field_count on object\\|resource\\|false\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Result.php
+
+		-
+			message: "#^Cannot access property \\$num_rows on object\\|resource\\|false\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Result.php
+
+		-
+			message: "#^Cannot call method data_seek\\(\\) on object\\|resource\\|false\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Result.php
+
+		-
+			message: "#^Cannot call method fetch_assoc\\(\\) on object\\|resource\\|false\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Result.php
+
+		-
+			message: "#^Cannot call method fetch_field\\(\\) on object\\|resource\\|false\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Result.php
+
+		-
+			message: "#^Cannot call method fetch_fields\\(\\) on object\\|resource\\|false\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Result.php
+
+		-
+			message: "#^Cannot call method fetch_object\\(\\) on object\\|resource\\|false\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Result.php
+
+		-
+			message: "#^Cannot call method field_seek\\(\\) on object\\|resource\\|false\\.$#"
+			count: 1
+			path: system/Database/MySQLi/Result.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between array and false will always evaluate to false\\.$#"
+			count: 1
+			path: system/Database/Postgre/Connection.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Database/Postgre/PreparedQuery.php
+
+		-
+			message: "#^Access to an undefined property CodeIgniter\\\\Database\\\\BaseConnection\\:\\:\\$schema\\.$#"
+			count: 2
+			path: system/Database/SQLSRV/Builder.php
+
+		-
+			message: "#^Access to an undefined property CodeIgniter\\\\Database\\\\BaseConnection\\:\\:\\$schema\\.$#"
+			count: 14
+			path: system/Database/SQLSRV/Forge.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Database/SQLSRV/PreparedQuery.php
+
+		-
+			message: "#^Cannot call method changes\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/SQLite3/Connection.php
+
+		-
+			message: "#^Cannot call method close\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/SQLite3/Connection.php
+
+		-
+			message: "#^Cannot call method escapeString\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/SQLite3/Connection.php
+
+		-
+			message: "#^Cannot call method exec\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 4
+			path: system/Database/SQLite3/Connection.php
+
+		-
+			message: "#^Cannot call method lastErrorCode\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/SQLite3/Connection.php
+
+		-
+			message: "#^Cannot call method lastErrorMsg\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/SQLite3/Connection.php
+
+		-
+			message: "#^Cannot call method lastInsertRowID\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/SQLite3/Connection.php
+
+		-
+			message: "#^Cannot call method query\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/SQLite3/Connection.php
+
+		-
+			message: "#^Cannot call method bindValue\\(\\) on object\\|resource\\.$#"
+			count: 1
+			path: system/Database/SQLite3/PreparedQuery.php
+
+		-
+			message: "#^Cannot call method execute\\(\\) on object\\|resource\\.$#"
+			count: 1
+			path: system/Database/SQLite3/PreparedQuery.php
+
+		-
+			message: "#^Cannot call method lastErrorCode\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/SQLite3/PreparedQuery.php
+
+		-
+			message: "#^Cannot call method lastErrorMsg\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/SQLite3/PreparedQuery.php
+
+		-
+			message: "#^Cannot call method prepare\\(\\) on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Database/SQLite3/PreparedQuery.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Database/SQLite3/PreparedQuery.php
+
+		-
+			message: "#^Cannot call method columnName\\(\\) on object\\|resource\\|false\\.$#"
+			count: 2
+			path: system/Database/SQLite3/Result.php
+
+		-
+			message: "#^Cannot call method columnType\\(\\) on object\\|resource\\|false\\.$#"
+			count: 1
+			path: system/Database/SQLite3/Result.php
+
+		-
+			message: "#^Cannot call method fetchArray\\(\\) on object\\|resource\\|false\\.$#"
+			count: 2
+			path: system/Database/SQLite3/Result.php
+
+		-
+			message: "#^Cannot call method numColumns\\(\\) on object\\|resource\\|false\\.$#"
+			count: 1
+			path: system/Database/SQLite3/Result.php
+
+		-
+			message: "#^Cannot call method reset\\(\\) on object\\|resource\\|false\\.$#"
+			count: 2
+			path: system/Database/SQLite3/Result.php
+
+		-
+			message: "#^Property Config\\\\Database\\:\\:\\$filesPath \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Database/Seeder.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Debug/Exceptions.php
+
+		-
+			message: "#^Parameter \\#4 \\$replacement of function array_splice expects array\\|string, true given\\.$#"
+			count: 1
+			path: system/Debug/Exceptions.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Debug\\\\Exceptions\\:\\:\\$formatter \\(CodeIgniter\\\\Format\\\\FormatterInterface\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Debug/Exceptions.php
+
+		-
+			message: "#^Property Config\\\\Exceptions\\:\\:\\$sensitiveDataInTrace \\(array\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Debug/Exceptions.php
+
+		-
+			message: "#^Property Config\\\\Toolbar\\:\\:\\$collectVarData \\(bool\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Debug/Toolbar.php
+
+		-
+			message: "#^Variable \\$request on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: system/Debug/Toolbar.php
+
+		-
+			message: "#^Variable \\$response on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: system/Debug/Toolbar.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\View\\\\RendererInterface\\:\\:getPerformanceData\\(\\)\\.$#"
+			count: 1
+			path: system/Debug/Toolbar/Collectors/Events.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Log\\\\Logger\\:\\:\\$logCache \\(array\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Debug/Toolbar/Collectors/Logs.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\View\\\\RendererInterface\\:\\:getData\\(\\)\\.$#"
+			count: 1
+			path: system/Debug/Toolbar/Collectors/Views.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\View\\\\RendererInterface\\:\\:getPerformanceData\\(\\)\\.$#"
+			count: 2
+			path: system/Debug/Toolbar/Collectors/Views.php
+
+		-
+			message: "#^Static property CodeIgniter\\\\Email\\\\Email\\:\\:\\$func_overload \\(bool\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Email/Email.php
+
+		-
+			message: "#^Property Config\\\\Encryption\\:\\:\\$digest \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 2
+			path: system/Encryption/Encryption.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Files\\\\File\\:\\:\\$size \\(int\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Files/File.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Filters/Filters.php
+
+		-
+			message: "#^Property Config\\\\Filters\\:\\:\\$filters \\(array\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Filters/Filters.php
+
+		-
+			message: "#^Property Config\\\\Filters\\:\\:\\$globals \\(array\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Filters/Filters.php
+
+		-
+			message: "#^Property Config\\\\Filters\\:\\:\\$methods \\(array\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Filters/Filters.php
+
+		-
+			message: "#^Parameter \\#1 \\$seconds of function sleep expects int, float given\\.$#"
+			count: 1
+			path: system/HTTP/CURLRequest.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/HTTP/Files/UploadedFile.php
+
+		-
+			message: "#^Property CodeIgniter\\\\HTTP\\\\Files\\\\UploadedFile\\:\\:\\$error \\(int\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 2
+			path: system/HTTP/Files/UploadedFile.php
+
+		-
+			message: "#^Return type \\(bool\\) of method CodeIgniter\\\\HTTP\\\\Files\\\\UploadedFile\\:\\:move\\(\\) should be compatible with return type \\(CodeIgniter\\\\Files\\\\File\\) of method CodeIgniter\\\\Files\\\\File\\:\\:move\\(\\)$#"
+			count: 1
+			path: system/HTTP/Files/UploadedFile.php
+
+		-
+			message: "#^Property CodeIgniter\\\\HTTP\\\\IncomingRequest\\:\\:\\$locale \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/HTTP/IncomingRequest.php
+
+		-
+			message: "#^Property CodeIgniter\\\\HTTP\\\\Message\\:\\:\\$protocolVersion \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/HTTP/Message.php
+
+		-
+			message: "#^Variable \\$_GET on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: system/HTTP/RedirectResponse.php
+
+		-
+			message: "#^Variable \\$_POST on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: system/HTTP/RedirectResponse.php
+
+		-
+			message: "#^Property CodeIgniter\\\\HTTP\\\\Request\\:\\:\\$proxyIPs \\(array\\|string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/HTTP/Request.php
+
+		-
+			message: "#^Property CodeIgniter\\\\HTTP\\\\Request\\:\\:\\$uri \\(CodeIgniter\\\\HTTP\\\\URI\\) in empty\\(\\) is not falsy\\.$#"
+			count: 1
+			path: system/HTTP/Request.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$cookieSameSite \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 3
+			path: system/HTTP/Response.php
+
+		-
+			message: "#^Cannot unset offset 'path' on array\\{host\\: mixed\\}\\.$#"
+			count: 1
+			path: system/HTTP/URI.php
+
+		-
+			message: "#^Property CodeIgniter\\\\HTTP\\\\URI\\:\\:\\$fragment \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/HTTP/URI.php
+
+		-
+			message: "#^Property CodeIgniter\\\\HTTP\\\\URI\\:\\:\\$host \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/HTTP/URI.php
+
+		-
+			message: "#^Property CodeIgniter\\\\HTTP\\\\URI\\:\\:\\$path \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/HTTP/URI.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 1
+			path: system/Helpers/filesystem_helper.php
+
+		-
+			message: "#^Offset 'checked' on array\\{type\\: 'checkbox', name\\: mixed, value\\: string\\} in isset\\(\\) does not exist\\.$#"
+			count: 1
+			path: system/Helpers/form_helper.php
+
+		-
+			message: "#^Binary operation \"\\+\" between 0 and string results in an error\\.$#"
+			count: 1
+			path: system/Helpers/number_helper.php
+
+		-
+			message: "#^Variable \\$mockService in empty\\(\\) always exists and is always falsy\\.$#"
+			count: 1
+			path: system/Helpers/test_helper.php
+
+		-
+			message: "#^Parameter \\#2 \\$times of function str_repeat expects int, float given\\.$#"
+			count: 1
+			path: system/Helpers/text_helper.php
+
+		-
+			message: "#^Variable \\$pool might not be defined\\.$#"
+			count: 2
+			path: system/Helpers/text_helper.php
+
+		-
+			message: "#^Variable \\$count might not be defined\\.$#"
+			count: 1
+			path: system/Helpers/url_helper.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\:\\:\\$image \\(CodeIgniter\\\\Images\\\\Image\\) in empty\\(\\) is not falsy\\.$#"
+			count: 1
+			path: system/Images/Handlers/BaseHandler.php
+
+		-
+			message: "#^Comparison operation \"\\>\\=\" between \\(array\\|float\\|int\\) and 0 results in an error\\.$#"
+			count: 2
+			path: system/Images/Handlers/ImageMagickHandler.php
+
+		-
+			message: "#^PHPDoc type string\\|null of property CodeIgniter\\\\Images\\\\Handlers\\\\ImageMagickHandler\\:\\:\\$resource is not covariant with PHPDoc type resource\\|null of overridden property CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\:\\:\\$resource\\.$#"
+			count: 1
+			path: system/Images/Handlers/ImageMagickHandler.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\:\\:\\$height \\(int\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 4
+			path: system/Images/Handlers/ImageMagickHandler.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\:\\:\\$width \\(int\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 4
+			path: system/Images/Handlers/ImageMagickHandler.php
+
+		-
+			message: "#^Variable \\$gravity might not be defined\\.$#"
+			count: 1
+			path: system/Images/Handlers/ImageMagickHandler.php
+
+		-
+			message: "#^Variable \\$xAxis might not be defined\\.$#"
+			count: 1
+			path: system/Images/Handlers/ImageMagickHandler.php
+
+		-
+			message: "#^Variable \\$yAxis might not be defined\\.$#"
+			count: 1
+			path: system/Images/Handlers/ImageMagickHandler.php
+
+		-
+			message: "#^Property Config\\\\Logger\\:\\:\\$dateFormat \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Log/Logger.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:asArray\\(\\)\\.$#"
+			count: 1
+			path: system/Model.php
+
+		-
+			message: "#^Property CodeIgniter\\\\RESTful\\\\ResourceController\\:\\:\\$formatter \\(CodeIgniter\\\\Format\\\\FormatterInterface\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/RESTful/ResourceController.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getDefaultNamespace\\(\\)\\.$#"
+			count: 2
+			path: system/Router/Router.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getFilterForRoute\\(\\)\\.$#"
+			count: 1
+			path: system/Router/Router.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getFiltersForRoute\\(\\)\\.$#"
+			count: 1
+			path: system/Router/Router.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRoutesOptions\\(\\)\\.$#"
+			count: 2
+			path: system/Router/Router.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:isFiltered\\(\\)\\.$#"
+			count: 1
+			path: system/Router/Router.php
+
+		-
+			message: "#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:setHTTPVerb\\(\\)\\.$#"
+			count: 1
+			path: system/Router/Router.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Router/Router.php
+
+		-
+			message: "#^Method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRoutes\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 2
+			path: system/Router/Router.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$CSRFCookieName \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Security/Security.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$CSRFExpire \\(int\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Security/Security.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$CSRFHeaderName \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Security/Security.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$CSRFRegenerate \\(bool\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Security/Security.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$CSRFTokenName \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Security/Security.php
+
+		-
+			message: "#^Property Config\\\\Security\\:\\:\\$cookieName \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Security/Security.php
+
+		-
+			message: "#^Property Config\\\\Security\\:\\:\\$csrfProtection \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Security/Security.php
+
+		-
+			message: "#^Property Config\\\\Security\\:\\:\\$expires \\(int\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Security/Security.php
+
+		-
+			message: "#^Property Config\\\\Security\\:\\:\\$headerName \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Security/Security.php
+
+		-
+			message: "#^Property Config\\\\Security\\:\\:\\$regenerate \\(bool\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Security/Security.php
+
+		-
+			message: "#^Property Config\\\\Security\\:\\:\\$tokenName \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Security/Security.php
+
+		-
+			message: "#^Property Config\\\\Security\\:\\:\\$tokenRandomize \\(bool\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Security/Security.php
+
+		-
+			message: "#^Access to an undefined property Config\\\\App\\:\\:\\$sessionDBGroup\\.$#"
+			count: 1
+			path: system/Session/Handlers/DatabaseHandler.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Session\\\\Handlers\\\\BaseHandler\\:\\:\\$sessionID \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Session/Handlers/DatabaseHandler.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Session\\\\Handlers\\\\BaseHandler\\:\\:\\$sessionID \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Session/Handlers/FileHandler.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Session\\\\Handlers\\\\BaseHandler\\:\\:\\$sessionID \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Session/Handlers/MemcachedHandler.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Session\\\\Handlers\\\\BaseHandler\\:\\:\\$sessionID \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Session/Handlers/RedisHandler.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between string and true will always evaluate to false\\.$#"
+			count: 1
+			path: system/Session/Handlers/RedisHandler.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Session\\\\Session\\:\\:\\$sessionExpiration \\(int\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$cookieDomain \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$cookiePath \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$cookieSameSite \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 2
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$cookieSecure \\(bool\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$sessionCookieName \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$sessionExpiration \\(int\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$sessionMatchIP \\(bool\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$sessionRegenerateDestroy \\(bool\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\App\\:\\:\\$sessionTimeToUpdate \\(int\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\Cookie\\:\\:\\$domain \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\Cookie\\:\\:\\$path \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\Cookie\\:\\:\\$raw \\(bool\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\Cookie\\:\\:\\$samesite \\(string\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Property Config\\\\Cookie\\:\\:\\$secure \\(bool\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Session/Session.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: system/Test/CIUnitTestCase.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$createdField\\.$#"
+			count: 1
+			path: system/Test/Fabricator.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$deletedField\\.$#"
+			count: 1
+			path: system/Test/Fabricator.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$updatedField\\.$#"
+			count: 1
+			path: system/Test/Fabricator.php
+
+		-
+			message: "#^Access to protected property CodeIgniter\\\\HTTP\\\\Request\\:\\:\\$uri\\.$#"
+			count: 1
+			path: system/Test/FeatureTestCase.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Test\\\\CIUnitTestCase\\:\\:\\$bodyFormat \\(string\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Test/FeatureTestCase.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Test\\\\CIUnitTestCase\\:\\:\\$clean \\(bool\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Test/FeatureTestCase.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Test\\\\CIUnitTestCase\\:\\:\\$session \\(array\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Test/FeatureTestCase.php
+
+		-
+			message: "#^Cannot access property \\$insert_id on bool\\|object\\|resource\\.$#"
+			count: 1
+			path: system/Test/Mock/MockConnection.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Test\\\\Mock\\\\MockResourcePresenter\\:\\:\\$formatter \\(CodeIgniter\\\\Format\\\\FormatterInterface\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Test/Mock/MockResourcePresenter.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Throttle\\\\Throttler\\:\\:\\$testTime \\(int\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Throttle/Throttler.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Validation\\\\Validation\\:\\:\\$errors \\(array\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/Validation/Validation.php
+
+		-
+			message: "#^Variable \\$error on left side of \\?\\? always exists and is always null\\.$#"
+			count: 1
+			path: system/Validation/Validation.php
+
+		-
+			message: "#^Property CodeIgniter\\\\View\\\\Cell\\:\\:\\$cache \\(CodeIgniter\\\\Cache\\\\CacheInterface\\) in empty\\(\\) is not falsy\\.$#"
+			count: 2
+			path: system/View/Cell.php
+
+		-
+			message: "#^Property Config\\\\View\\:\\:\\$plugins \\(array\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: system/View/Parser.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,9 @@ services:
 		tags:
 			- phpstan.rules.rule
 
+includes:
+	- phpstan-baseline.neon.dist
+
 parameters:
 	tmpDir: build/phpstan
 	level: 5
@@ -28,30 +31,6 @@ parameters:
 		- system/Test/Filters/CITestStreamFilter.php
 		- system/ThirdParty/*
 		- system/Validation/Views/single.php
-	ignoreErrors:
-		- '#Access to an undefined property CodeIgniter\\Database\\BaseConnection::\$mysqli|\$schema#'
-		- '#Access to an undefined property CodeIgniter\\Database\\ConnectionInterface::(\$DBDriver|\$connID|\$likeEscapeStr|\$likeEscapeChar|\$escapeChar|\$protectIdentifiers|\$schema)#'
-		- '#Call to an undefined method CodeIgniter\\Database\\BaseConnection::_(disable|enable)ForeignKeyChecks\(\)#'
-		- '#Call to an undefined method CodeIgniter\\Router\\RouteCollectionInterface::(getDefaultNamespace|isFiltered|getFilterForRoute|getFiltersForRoute|getRoutesOptions)\(\)#'
-		- '#Cannot access property [\$a-z_]+ on ((bool\|)?object\|resource)#'
-		- '#Cannot call method [a-zA-Z_]+\(\) on ((bool\|)?object\|resource)#'
-		- '#Method CodeIgniter\\Router\\RouteCollectionInterface::getRoutes\(\) invoked with 1 parameter, 0 required#'
-		- '#Method CodeIgniter\\Validation\\ValidationInterface::run\(\) invoked with 3 parameters, 0-2 required#'
-		- '#Negated boolean expression is always (true|false)#'
-		- '#Return type \(bool\) of method CodeIgniter\\HTTP\\Files\\UploadedFile::move\(\) should be compatible with return type \(CodeIgniter\\Files\\File\) of method CodeIgniter\\Files\\File::move\(\)#'
-		- '#.*\son left side of \?\? is not nullable#'
-		- '#While loop condition is always true#'
-		- '#Right side of && is always true#'
-		- '#.*in isset\(\) is not nullable#'
-		- '#.*in empty\(\) is not falsy#'
-		- '#.*on left side of \?\? always exists and is not nullable#'
-		- '#Variable \$error on left side of \?\? always exists and is always null#'
-		- '#Variable \$config in empty\(\) always exists and is not falsy#'
-		- '#If condition is always true#'
-		- '#Dead catch - CodeIgniter\\Exceptions\\PageNotFoundException is never thrown in the try block#'
-		- '#.* in isset\(\) does not exist#'
-		- '#Variable \$mockService in empty\(\) always exists and is always falsy#'
-		- '#PHPDoc type string\|null of property CodeIgniter\\Images\\Handlers\\ImageMagickHandler::\$resource is not covariant with PHPDoc type resource\|null of overridden property CodeIgniter\\Images\\Handlers\\BaseHandler::\$resource#'
 	parallel:
 		processTimeout: 300.0
 	scanDirectories:

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -114,10 +114,10 @@ class Autoloader
     public function register()
     {
         // Prepend the PSR4  autoloader for maximum performance.
-        spl_autoload_register([$this, 'loadClass'], true, true); // @phpstan-ignore-line
+        spl_autoload_register([$this, 'loadClass'], true, true);
 
         // Now prepend another loader for the files in our class map.
-        spl_autoload_register([$this, 'loadClassmap'], true, true); // @phpstan-ignore-line
+        spl_autoload_register([$this, 'loadClassmap'], true, true);
 
         // Load our non-class files
         foreach ($this->files as $file) {

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -241,7 +241,6 @@ class FileHandler extends BaseHandler
             return false;
         }
 
-        // @phpstan-ignore-next-line
         if ($data['ttl'] > 0 && time() > $data['time'] + $data['ttl']) {
             // If the file is still there then try to remove it
             if (is_file($this->path . $filename)) {

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -146,7 +146,7 @@ class MemcachedHandler extends BaseHandler
             }
         }
 
-        return is_array($data) ? $data[0] : $data; // @phpstan-ignore-line
+        return is_array($data) ? $data[0] : $data;
     }
 
     /**
@@ -172,7 +172,6 @@ class MemcachedHandler extends BaseHandler
             return $this->memcached->set($key, $value, 0, $ttl);
         }
 
-        // @phpstan-ignore-next-line
         return false;
     }
 
@@ -205,7 +204,6 @@ class MemcachedHandler extends BaseHandler
 
         $key = static::validateKey($key, $this->prefix);
 
-        // @phpstan-ignore-next-line
         return $this->memcached->increment($key, $offset, $offset, 60);
     }
 
@@ -221,7 +219,7 @@ class MemcachedHandler extends BaseHandler
         $key = static::validateKey($key, $this->prefix);
 
         // FIXME: third parameter isn't other handler actions.
-        // @phpstan-ignore-next-line
+
         return $this->memcached->decrement($key, $offset, $offset, 60);
     }
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -537,7 +537,6 @@ class CodeIgniter
             return;
         }
 
-        // @phpstan-ignore-next-line
         if (is_cli() && ENVIRONMENT !== 'testing') {
             // @codeCoverageIgnoreStart
             $this->request = Services::clirequest($this->config);
@@ -721,7 +720,7 @@ class CodeIgniter
         // If a {locale} segment was matched in the final route,
         // then we need to set the correct locale on our Request.
         if ($this->router->hasLocale()) {
-            $this->request->setLocale($this->router->getLocale()); // @phpstan-ignore-line
+            $this->request->setLocale($this->router->getLocale());
         }
 
         $this->benchmark->stop('routing');
@@ -816,7 +815,7 @@ class CodeIgniter
     protected function runController($class)
     {
         // If this is a console request then use the input segments as parameters
-        $params = defined('SPARKED') ? $this->request->getSegments() : $this->router->params(); // @phpstan-ignore-line
+        $params = defined('SPARKED') ? $this->request->getSegments() : $this->router->params();
 
         if (method_exists($class, '_remap')) {
             $output = $class->_remap($this->method, ...$params);
@@ -969,7 +968,7 @@ class CodeIgniter
             return;
         }
 
-        $method = $this->request->getPost('_method'); // @phpstan-ignore-line
+        $method = $this->request->getPost('_method');
 
         if (empty($method)) {
             return;

--- a/system/Common.php
+++ b/system/Common.php
@@ -1153,7 +1153,6 @@ if (! function_exists('class_uses_recursive')) {
 
         $results = [];
 
-        // @phpstan-ignore-next-line
         foreach (array_reverse(class_parents($class)) + [$class => $class] as $class) {
             $results += trait_uses_recursive($class);
         }

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -883,7 +883,6 @@ abstract class BaseConnection implements ConnectionInterface
         $this->pretend(false);
 
         if ($sql instanceof QueryInterface) {
-            // @phpstan-ignore-next-line
             $sql = $sql->getOriginalQuery();
         }
 

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -154,7 +154,6 @@ abstract class BaseResult implements ResultInterface
             $this->customResultObject[$className][] = $row;
         }
 
-        // @phpstan-ignore-next-line
         return $this->customResultObject[$className];
     }
 
@@ -233,7 +232,6 @@ abstract class BaseResult implements ResultInterface
             $this->resultObject[] = $row;
         }
 
-        // @phpstan-ignore-next-line
         return $this->resultObject;
     }
 

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -117,7 +117,6 @@ class Connection extends BaseConnection
             return $this->dataCache['version'];
         }
 
-        // @phpstan-ignore-next-line
         if (! $this->connID || ($pgVersion = pg_version($this->connID)) === false) {
             $this->initialize();
         }

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -27,7 +27,7 @@ class Result extends BaseResult
      */
     public function getFieldCount(): int
     {
-        return $this->resultID->numColumns(); // @phpstan-ignore-line
+        return $this->resultID->numColumns();
     }
 
     /**
@@ -38,7 +38,7 @@ class Result extends BaseResult
         $fieldNames = [];
 
         for ($i = 0, $c = $this->getFieldCount(); $i < $c; $i++) {
-            $fieldNames[] = $this->resultID->columnName($i); // @phpstan-ignore-line
+            $fieldNames[] = $this->resultID->columnName($i);
         }
 
         return $fieldNames;
@@ -58,18 +58,18 @@ class Result extends BaseResult
         ];
 
         $retVal = [];
-        $this->resultID->fetchArray(SQLITE3_NUM); // @phpstan-ignore-line
+        $this->resultID->fetchArray(SQLITE3_NUM);
 
         for ($i = 0, $c = $this->getFieldCount(); $i < $c; $i++) {
             $retVal[$i]             = new stdClass();
-            $retVal[$i]->name       = $this->resultID->columnName($i); // @phpstan-ignore-line
-            $type                   = $this->resultID->columnType($i); // @phpstan-ignore-line
+            $retVal[$i]->name       = $this->resultID->columnName($i);
+            $type                   = $this->resultID->columnType($i);
             $retVal[$i]->type       = $type;
             $retVal[$i]->type_name  = $dataTypes[$type] ?? null;
             $retVal[$i]->max_length = null;
             $retVal[$i]->length     = null;
         }
-        $this->resultID->reset(); // @phpstan-ignore-line
+        $this->resultID->reset();
 
         return $retVal;
     }
@@ -100,7 +100,7 @@ class Result extends BaseResult
             throw new DatabaseException('SQLite3 doesn\'t support seeking to other offset.');
         }
 
-        return $this->resultID->reset(); // @phpstan-ignore-line
+        return $this->resultID->reset();
     }
 
     /**
@@ -112,7 +112,7 @@ class Result extends BaseResult
      */
     protected function fetchAssoc()
     {
-        return $this->resultID->fetchArray(SQLITE3_ASSOC); // @phpstan-ignore-line
+        return $this->resultID->fetchArray(SQLITE3_ASSOC);
     }
 
     /**

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -394,7 +394,7 @@ class Exceptions
         $start = max($lineNumber - (int) round($lines / 2), 0);
 
         // Get just the lines we need to display, while keeping line numbers...
-        $source = array_splice($source, $start, $lines, true); // @phpstan-ignore-line
+        $source = array_splice($source, $start, $lines, true);
 
         // Used to format the line number in the source
         $format = '% ' . strlen((string) ($start + $lines)) . 'd';

--- a/system/Debug/Toolbar/Collectors/Events.php
+++ b/system/Debug/Toolbar/Collectors/Events.php
@@ -74,7 +74,7 @@ class Events extends BaseCollector
     {
         $data = [];
 
-        $rows = $this->viewer->getPerformanceData(); // @phpstan-ignore-line
+        $rows = $this->viewer->getPerformanceData();
 
         foreach ($rows as $info) {
             $data[] = [

--- a/system/Debug/Toolbar/Collectors/Views.php
+++ b/system/Debug/Toolbar/Collectors/Views.php
@@ -89,7 +89,7 @@ class Views extends BaseCollector
     {
         $data = [];
 
-        $rows = $this->viewer->getPerformanceData(); // @phpstan-ignore-line
+        $rows = $this->viewer->getPerformanceData();
 
         foreach ($rows as $info) {
             $data[] = [
@@ -122,7 +122,7 @@ class Views extends BaseCollector
     public function getVarData(): array
     {
         return [
-            // @phpstan-ignore-next-line
+
             'View Data' => $this->viewer->getData(),
         ];
     }
@@ -132,7 +132,7 @@ class Views extends BaseCollector
      */
     public function getBadgeValue(): int
     {
-        return count($this->viewer->getPerformanceData()); // @phpstan-ignore-line
+        return count($this->viewer->getPerformanceData());
     }
 
     /**

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -358,7 +358,7 @@ class CURLRequest extends Request
 
         // Do we need to delay this request?
         if ($this->delay > 0) {
-            sleep($this->delay); // @phpstan-ignore-line
+            sleep($this->delay);
         }
 
         $output = $this->sendRequest($curlOptions);

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -273,7 +273,6 @@ trait RequestTrait
             $value = $this->globals[$method][$index] ?? null;
         }
 
-        // @phpstan-ignore-next-line
         if (is_array($value)
             && (
                 $filter !== FILTER_DEFAULT

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -625,7 +625,7 @@ class URI
 
         if (empty($parts['host']) && $parts['path'] !== '') {
             $parts['host'] = $parts['path'];
-            unset($parts['path']); // @phpstan-ignore-line
+            unset($parts['path']);
         }
 
         $this->applyParts($parts);

--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -77,7 +77,7 @@ if (! function_exists('number_to_amount')) {
     {
         // Strip any formatting & ensure numeric input
         try {
-            $num = 0 + str_replace(',', '', $num); // @phpstan-ignore-line
+            $num = 0 + str_replace(',', '', $num);
         } catch (ErrorException $ee) {
             return false;
         }

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -564,7 +564,6 @@ if (! function_exists('random_string')) {
                         break;
                 }
 
-                // @phpstan-ignore-next-line
                 return substr(str_shuffle(str_repeat($pool, ceil($len / strlen($pool)))), 0, $len);
 
             case 'md5':

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -352,7 +352,7 @@ if (! function_exists('safe_mailto')) {
 
                 $temp[] = $ordinal;
 
-                if (count($temp) === $count) { // @phpstan-ignore-line
+                if (count($temp) === $count) {
                     $number = ($count === 3) ? (($temp[0] % 16) * 4096) + (($temp[1] % 64) * 64) + ($temp[2] % 64) : (($temp[0] % 32) * 64) + ($temp[1] % 64);
                     $x[]    = '|' . $number;
                     $count  = 1;

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -384,10 +384,10 @@ class ImageMagickHandler extends BaseHandler
                     break;
             }
 
-            $xAxis = $xAxis >= 0 ? '+' . $xAxis : $xAxis; // @phpstan-ignore-line
-            $yAxis = $yAxis >= 0 ? '+' . $yAxis : $yAxis; // @phpstan-ignore-line
+            $xAxis = $xAxis >= 0 ? '+' . $xAxis : $xAxis;
+            $yAxis = $yAxis >= 0 ? '+' . $yAxis : $yAxis;
 
-            $cmd .= " -gravity {$gravity} -geometry {$xAxis}{$yAxis}"; // @phpstan-ignore-line
+            $cmd .= " -gravity {$gravity} -geometry {$xAxis}{$yAxis}";
         }
 
         // Color

--- a/system/Model.php
+++ b/system/Model.php
@@ -158,7 +158,7 @@ class Model extends BaseModel
      */
     protected function doFindColumn(string $columnName)
     {
-        return $this->select($columnName)->asArray()->find(); // @phpstan-ignore-line
+        return $this->select($columnName)->asArray()->find();
     }
 
     /**

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -124,7 +124,6 @@ class Router implements RouterInterface
         $this->controller = $this->collection->getDefaultController();
         $this->method     = $this->collection->getDefaultMethod();
 
-        // @phpstan-ignore-next-line
         $this->collection->setHTTPVerb($request->getMethod() ?? strtolower($_SERVER['REQUEST_METHOD']));
     }
 

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -69,7 +69,6 @@ class DatabaseHandler extends BaseHandler
             throw SessionException::forMissingDatabaseTable();
         }
 
-        // @phpstan-ignore-next-line
         $this->DBGroup = $config->sessionDBGroup ?? config(Database::class)->defaultGroup;
 
         $this->db = Database::connect($this->DBGroup);

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -206,7 +206,6 @@ class RedisHandler extends BaseHandler
             try {
                 $pingReply = $this->redis->ping();
 
-                // @phpstan-ignore-next-line
                 if (($pingReply === true) || ($pingReply === '+PONG')) {
                     if (isset($this->lockKey)) {
                         $this->redis->del($this->lockKey);

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -231,7 +231,7 @@ abstract class CIUnitTestCase extends TestCase
     {
         parent::setUp();
 
-        if (! $this->app) { // @phpstan-ignore-line
+        if (! $this->app) {
             $this->app = $this->createApplication();
         }
 

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -510,12 +510,12 @@ class Fabricator
         $fields = [];
 
         if (! empty($this->model->useTimestamps)) {
-            $fields[$this->model->createdField] = $datetime; // @phpstan-ignore-line
-            $fields[$this->model->updatedField] = $datetime; // @phpstan-ignore-line
+            $fields[$this->model->createdField] = $datetime;
+            $fields[$this->model->updatedField] = $datetime;
         }
 
         if (! empty($this->model->useSoftDeletes)) {
-            $fields[$this->model->deletedField] = null; // @phpstan-ignore-line
+            $fields[$this->model->deletedField] = null;
         }
 
         // Iterate over new entities and add the necessary fields

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -349,7 +349,7 @@ class FeatureTestCase extends CIUnitTestCase
         // otherwise set it from the URL.
         $get = ! empty($params) && $method === 'get'
             ? $params
-            : $this->getPrivateProperty($request->uri, 'query'); // @phpstan-ignore-line
+            : $this->getPrivateProperty($request->uri, 'query');
 
         $request->setGlobal('get', $get);
         if ($method !== 'get') {

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -344,7 +344,7 @@ trait FeatureTestTrait
         // otherwise set it from the URL.
         $get = ! empty($params) && $method === 'get'
             ? $params
-            : $this->getPrivateProperty($request->uri, 'query'); // @phpstan-ignore-line
+            : $this->getPrivateProperty($request->uri, 'query');
 
         $request->setGlobal('get', $get);
         if ($method !== 'get') {

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -166,7 +166,7 @@ class MockConnection extends BaseConnection
      */
     public function insertID(): int
     {
-        return $this->connID->insert_id; // @phpstan-ignore-line
+        return $this->connID->insert_id;
     }
 
     /**


### PR DESCRIPTION
**Description**
Take advantage of PHPStan's baseline feature instead of ignoring **all** errors (current and future errors). This way only current errors are ignored, for now and possibly fixed later, and future errors will not be thrown under the rug.

`> vendor/bin/phpstan analyse --generate-baseline`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
