### PR TITLE
refactor: fix `ThrottleTest::testFlooding`

### DIFF
--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -100,7 +100,7 @@ class Throttler implements ThrottlerInterface
             // If it hasn't been created, then we'll set it to the maximum
             // capacity - 1, and save it to the cache.
             $this->cache->save($tokenName, $capacity - $cost, $seconds);
-            $this->cache->save($tokenName . 'Time', time(), $seconds);
+            $this->cache->save($tokenName . 'Time', $this->time(), $seconds);
 
             return true;
         }
@@ -129,7 +129,7 @@ class Throttler implements ThrottlerInterface
         // we need to decrement the number of available tokens.
         if ($tokens >= 1) {
             $this->cache->save($tokenName, $tokens - $cost, $seconds);
-            $this->cache->save($tokenName . 'Time', time(), $seconds);
+            $this->cache->save($tokenName . 'Time', $this->time(), $seconds);
 
             return true;
         }
@@ -164,6 +164,8 @@ class Throttler implements ThrottlerInterface
 
     /**
      * Return the test time, defaulting to current.
+     *
+     * @TODO should be private
      */
     public function time(): int
     {

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -127,7 +127,10 @@ final class ThrottleTest extends CIUnitTestCase
 
     public function testFlooding()
     {
+        $time = 1639441295;
+
         $throttler = new Throttler($this->cache);
+        $throttler->setTestTime($time);
 
         $rate = 60; // allow 1 per second after the bucket is emptied
         $cost = 1;
@@ -141,7 +144,7 @@ final class ThrottleTest extends CIUnitTestCase
         $this->assertFalse($throttler->check('127.0.0.1', $rate, MINUTE, $cost));
         $this->assertSame(0, $this->cache->get('throttler_127.0.0.1'));
 
-        $throttler = $throttler->setTestTime(strtotime('+10 seconds'));
+        $throttler = $throttler->setTestTime($time + 10);
 
         $this->assertTrue($throttler->check('127.0.0.1', $rate, MINUTE, 0));
         $this->assertSame(10.0, round($this->cache->get('throttler_127.0.0.1')));


### PR DESCRIPTION
**Description**
Fixes #5444
- remove time dependency from the test

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
