### PR TITLE
docs: fix view() $options explanation

### DIFF
--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -179,11 +179,12 @@ Service Accessors
     a convenience method that can be used in Controllers,
     libraries, and routed closures.
 
-    Currently, only one option is available for use within the `$options` array, `saveData` which specifies
-    that data will persistent between multiple calls to `view()` within the same request. By default, the
-    data for that view is forgotten after displaying that single view file.
+    Currently, only two options are available for use within the ``$options`` array:
 
-    The $option array is provided primarily to facilitate third-party integrations with
+    - ``saveData`` specifies that data will persistent between multiple calls to ``view()`` within the same request. If you do not want the data to be persisted, specify false.
+    - ``debug`` can be set to false to disable the addition of debug code for :ref:`Debug Toolbar <the-debug-toolbar>`.
+
+    The ``$option`` array is provided primarily to facilitate third-party integrations with
     libraries like Twig.
 
     Example::

--- a/user_guide_src/source/testing/debugging.rst
+++ b/user_guide_src/source/testing/debugging.rst
@@ -45,6 +45,8 @@ This provides a backtrace to the current execution point, with Kint's own unique
 
 For more information, see `Kint's page <https://kint-php.github.io/kint//>`_.
 
+.. _the-debug-toolbar:
+
 =================
 The Debug Toolbar
 =================


### PR DESCRIPTION
**Description**
- fix incorrect explanation for `saveData`
  - https://github.com/codeigniter4/CodeIgniter4/blob/c6dbfb4953f7b16360bda58ff44c2c39b265d1c3/system/Common.php#L1087
  - https://github.com/codeigniter4/CodeIgniter4/blob/c6dbfb4953f7b16360bda58ff44c2c39b265d1c3/app/Config/View.php#L19 
- add missing `debug`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

