### PR TITLE
fix: Throttler does not show correct token time

### DIFF
--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -95,12 +95,20 @@ class Throttler implements ThrottlerInterface
     {
         $tokenName = $this->prefix . $key;
 
+        // Number of tokens to add back per second
+        $rate = $capacity / $seconds;
+        // Number of seconds to get one token
+        $refresh = 1 / $rate;
+
         // Check to see if the bucket has even been created yet.
         if (($tokens = $this->cache->get($tokenName)) === null) {
             // If it hasn't been created, then we'll set it to the maximum
             // capacity - 1, and save it to the cache.
-            $this->cache->save($tokenName, $capacity - $cost, $seconds);
+            $tokens = $capacity - $cost;
+            $this->cache->save($tokenName, $tokens, $seconds);
             $this->cache->save($tokenName . 'Time', $this->time(), $seconds);
+
+            $this->tokenTime = max(1, (int) $refresh);
 
             return true;
         }
@@ -109,15 +117,6 @@ class Throttler implements ThrottlerInterface
         // based on how long it's been since the last update.
         $throttleTime = $this->cache->get($tokenName . 'Time');
         $elapsed      = $this->time() - $throttleTime;
-
-        // Number of tokens to add back per second
-        $rate = $capacity / $seconds;
-
-        // How many seconds till a new token is available.
-        // We must have a minimum wait of 1 second for a new token.
-        // Primarily stored to allow devs to report back to users.
-        $newTokenAvailable = (1 / $rate) - $elapsed;
-        $this->tokenTime   = max(1, $newTokenAvailable);
 
         // Add tokens based up on number per second that
         // should be refilled, then checked against capacity
@@ -128,11 +127,20 @@ class Throttler implements ThrottlerInterface
         // If $tokens >= 1, then we are safe to perform the action, but
         // we need to decrement the number of available tokens.
         if ($tokens >= 1) {
-            $this->cache->save($tokenName, $tokens - $cost, $seconds);
+            $tokens = $tokens - $cost;
+            $this->cache->save($tokenName, $tokens, $seconds);
             $this->cache->save($tokenName . 'Time', $this->time(), $seconds);
+
+            $this->tokenTime = max(1, (int) ($refresh - $elapsed));
 
             return true;
         }
+
+        // How many seconds till a new token is available.
+        // We must have a minimum wait of 1 second for a new token.
+        // Primarily stored to allow devs to report back to users.
+        $newTokenAvailable = (int) ($refresh - $elapsed - $refresh * $tokens);
+        $this->tokenTime   = max(1, $newTokenAvailable);
 
         return false;
     }

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -107,7 +107,7 @@ class Throttler implements ThrottlerInterface
             $this->cache->save($tokenName, $tokens, $seconds);
             $this->cache->save($tokenName . 'Time', $this->time(), $seconds);
 
-            $this->tokenTime = max(1, (int) $refresh);
+            $this->tokenTime = 0;
 
             return true;
         }
@@ -130,7 +130,7 @@ class Throttler implements ThrottlerInterface
             $this->cache->save($tokenName, $tokens, $seconds);
             $this->cache->save($tokenName . 'Time', $this->time(), $seconds);
 
-            $this->tokenTime = max(1, (int) ($refresh - $elapsed));
+            $this->tokenTime = 0;
 
             return true;
         }

--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -79,10 +79,9 @@ class Throttler implements ThrottlerInterface
      *
      * Example:
      *
-     *  if (! $throttler->check($request->ipAddress(), 60, MINUTE))
-     * {
+     *  if (! $throttler->check($request->ipAddress(), 60, MINUTE)) {
      *      die('You submitted over 60 requests within a minute.');
-     * }
+     *  }
      *
      * @param string $key      The name to use as the "bucket" name.
      * @param int    $capacity The number of requests the "bucket" can hold

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -56,7 +56,7 @@ final class ThrottleTest extends CIUnitTestCase
         $throttler->setTestTime($time);
 
         $capacity = 2;
-        $seconds = 200;
+        $seconds  = 200;
 
         // refresh = 200 / 2 = 100 seconds
         // refresh rate = 2 / 200 = 0.01 token per second

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -45,6 +45,42 @@ final class ThrottleTest extends CIUnitTestCase
         $this->assertGreaterThanOrEqual(1, $throttler->getTokenTime());
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5458
+     */
+    public function testTokenTimeCalculation()
+    {
+        $time = 1639441295;
+
+        $throttler = new Throttler($this->cache);
+        $throttler->setTestTime($time);
+
+        $capacity = 2;
+        $seconds = 200;
+
+        // refresh = 200 / 2 = 100 seconds
+        // refresh rate = 2 / 200 = 0.01 token per second
+
+        // token should be 2
+        $this->assertTrue($throttler->check('test', $capacity, $seconds));
+        // token should be 2 - 1 = 1
+        $this->assertSame(100, $throttler->getTokenTime(), 'Wrong token time');
+
+        // do nothing for 3 seconds
+        $throttler = $throttler->setTestTime($time + 3);
+
+        // token should be 1 + 3 * 0.01 = 1.03
+        $this->assertTrue($throttler->check('test', $capacity, $seconds));
+        // token should be 1.03 - 1 = 0.03
+        $this->assertSame(97, $throttler->getTokenTime(), 'Wrong token time');
+
+        $this->assertFalse($throttler->check('test', $capacity, $seconds));
+        // token should still be 0.03 because check failed
+
+        // expect remaining time: (1 - 0.03) * 100 = 97
+        $this->assertSame(97, $throttler->getTokenTime(), 'Wrong token time');
+    }
+
     public function testIPSavesBucket()
     {
         $throttler = new Throttler($this->cache);

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -36,11 +36,11 @@ final class ThrottleTest extends CIUnitTestCase
         // set $rate
         $rate = 1;    // allow 1 request per minute
 
-        // first check just creates a bucket, so tokenTime should be 0
+        // When the first check you have a token, so tokenTime should be 0
         $throttler->check('127.0.0.1', $rate, MINUTE);
         $this->assertSame(0, $throttler->getTokenTime());
 
-        // additional check affects tokenTime, so tokenTime should be 1 or greater
+        // When additional check you don't have one token, so tokenTime should be 1 or greater
         $throttler->check('127.0.0.1', $rate, MINUTE);
         $this->assertGreaterThanOrEqual(1, $throttler->getTokenTime());
     }
@@ -64,7 +64,7 @@ final class ThrottleTest extends CIUnitTestCase
         // token should be 2
         $this->assertTrue($throttler->check('test', $capacity, $seconds));
         // token should be 2 - 1 = 1
-        $this->assertSame(100, $throttler->getTokenTime(), 'Wrong token time');
+        $this->assertSame(0, $throttler->getTokenTime(), 'Wrong token time');
 
         // do nothing for 3 seconds
         $throttler = $throttler->setTestTime($time + 3);
@@ -72,7 +72,7 @@ final class ThrottleTest extends CIUnitTestCase
         // token should be 1 + 3 * 0.01 = 1.03
         $this->assertTrue($throttler->check('test', $capacity, $seconds));
         // token should be 1.03 - 1 = 0.03
-        $this->assertSame(97, $throttler->getTokenTime(), 'Wrong token time');
+        $this->assertSame(0, $throttler->getTokenTime(), 'Wrong token time');
 
         $this->assertFalse($throttler->check('test', $capacity, $seconds));
         // token should still be 0.03 because check failed


### PR DESCRIPTION
Need to rebase after merging #5463.

**Description**
Fixes #5458

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
