### PR TITLE
docs: fix environments.rst

### DIFF
--- a/user_guide_src/source/general/environments.rst
+++ b/user_guide_src/source/general/environments.rst
@@ -99,7 +99,7 @@ Error Reporting
 
 Setting the ENVIRONMENT constant to a value of ``development`` will cause
 all PHP errors to be rendered to the browser when they occur.
-Conversely, setting the constant to 'production' will disable all error
+Conversely, setting the constant to ``production`` will disable all error
 output. Disabling error reporting in production is a
 :doc:`good security practice </concepts/security>`.
 

--- a/user_guide_src/source/general/environments.rst
+++ b/user_guide_src/source/general/environments.rst
@@ -103,11 +103,3 @@ Conversely, setting the constant to 'production' will disable all error
 output. Disabling error reporting in production is a
 :doc:`good security practice </concepts/security>`.
 
-Configuration Files
--------------------
-
-Optionally, you can have CodeIgniter load environment-specific
-configuration files. This may be useful for managing things like
-differing API keys across multiple environments. This is described in
-more detail in the Handling Different Environments section of the
-:doc:`Working with Configuration Files </general/configuration>` documentation.

--- a/user_guide_src/source/general/environments.rst
+++ b/user_guide_src/source/general/environments.rst
@@ -97,7 +97,7 @@ is affected.
 Error Reporting
 ---------------
 
-Setting the ENVIRONMENT constant to a value of 'development' will cause
+Setting the ENVIRONMENT constant to a value of ``development`` will cause
 all PHP errors to be rendered to the browser when they occur.
 Conversely, setting the constant to 'production' will disable all error
 output. Disabling error reporting in production is a


### PR DESCRIPTION
**Description**
- remove environment-specific configuration files 

It seems there is no such a thing in CI4.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
