### PR TITLE
fix: KINT d()/trace() visual error when activating CSP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,9 @@
     "extra": {
         "branch-alias": {
             "dev-develop": "4.x-dev"
+        },
+        "kint": {
+            "disable-helpers": true
         }
     },
     "autoload": {

--- a/system/Common.php
+++ b/system/Common.php
@@ -332,6 +332,41 @@ if (! function_exists('dd')) {
     }
 }
 
+if (! function_exists('d')) {
+    /**
+     * Prints a Kint debug report with CSP support
+     *
+     * @param array ...$vars
+     */
+    function d(...$vars)
+    {
+        Kint::$aliases[] = 'd';
+
+        ob_start();
+        Kint::dump(...$vars);
+        $output = ob_get_clean();
+
+        /** @var App $config */
+        $config = config(App::class);
+
+        if ($config->CSPEnabled === true) {
+            $output = str_replace(
+                [
+                    '<script class="kint-rich-script">',
+                    '<style class="kint-rich-style">',
+                ],
+                [
+                    '<script {csp-script-nonce} class="kint-rich-script">',
+                    '<style {csp-style-nonce} class="kint-rich-style">',
+                ],
+                $output
+            );
+        }
+
+        echo $output;
+    }
+}
+
 if (! function_exists('env')) {
     /**
      * Allows user to retrieve values from the environment

--- a/system/Common.php
+++ b/system/Common.php
@@ -1096,7 +1096,29 @@ if (! function_exists('trace')) {
     function trace()
     {
         Kint::$aliases[] = 'trace';
+
+        ob_start();
         Kint::trace();
+        $output = ob_get_clean();
+
+        /** @var App $config */
+        $config = config(App::class);
+
+        if ($config->CSPEnabled === true) {
+            $output = str_replace(
+                [
+                    '<script class="kint-rich-script">',
+                    '<style class="kint-rich-style">',
+                ],
+                [
+                    '<script {csp-script-nonce} class="kint-rich-script">',
+                    '<style {csp-style-nonce} class="kint-rich-style">',
+                ],
+                $output
+            );
+        }
+
+        echo $output;
     }
 }
 

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -502,21 +502,18 @@ final class CommonFunctionsTest extends CIUnitTestCase
         Kint::$cli_detection = $cliDetection;
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState  disabled
+     */
     public function testTraceWithCSP()
     {
         /** @var App $config */
-        $config       = config(App::class);
-        $CSPEnabled   = $config->CSPEnabled;
-        $cliDetection = Kint::$cli_detection;
-
+        $config              = config(App::class);
         $config->CSPEnabled  = true;
         Kint::$cli_detection = false;
 
         $this->expectOutputRegex('/<style {csp-style-nonce} class="kint-rich-style">/u');
         trace();
-
-        // Restore settings
-        $config->CSPEnabled  = $CSPEnabled;
-        Kint::$cli_detection = $cliDetection;
     }
 }

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -29,6 +29,7 @@ use Config\App;
 use Config\Logger;
 use Config\Modules;
 use InvalidArgumentException;
+use Kint;
 use stdClass;
 use Tests\Support\Models\JobModel;
 
@@ -481,5 +482,23 @@ final class CommonFunctionsTest extends CIUnitTestCase
     {
         $this->assertIsBool(is_cli());
         $this->assertTrue(is_cli());
+    }
+
+    public function testDWithCSP()
+    {
+        /** @var App $config */
+        $config       = config(App::class);
+        $CSPEnabled   = $config->CSPEnabled;
+        $cliDetection = Kint::$cli_detection;
+
+        $config->CSPEnabled  = true;
+        Kint::$cli_detection = false;
+
+        $this->expectOutputRegex('/<script {csp-script-nonce} class="kint-rich-script">/u');
+        d('string');
+
+        // Restore settings
+        $config->CSPEnabled  = $CSPEnabled;
+        Kint::$cli_detection = $cliDetection;
     }
 }

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -501,4 +501,22 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $config->CSPEnabled  = $CSPEnabled;
         Kint::$cli_detection = $cliDetection;
     }
+
+    public function testTraceWithCSP()
+    {
+        /** @var App $config */
+        $config       = config(App::class);
+        $CSPEnabled   = $config->CSPEnabled;
+        $cliDetection = Kint::$cli_detection;
+
+        $config->CSPEnabled  = true;
+        Kint::$cli_detection = false;
+
+        $this->expectOutputRegex('/<style {csp-style-nonce} class="kint-rich-style">/u');
+        trace();
+
+        // Restore settings
+        $config->CSPEnabled  = $CSPEnabled;
+        Kint::$cli_detection = $cliDetection;
+    }
 }


### PR DESCRIPTION
**Description**
Fixes #5475
- fix `d()`
- fix `trace()`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
