### PR TITLE
docs: deprecate Seeder::faker()

### DIFF
--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -68,6 +68,8 @@ class Seeder
      * Faker Generator instance.
      *
      * @var Generator|null
+     *
+     * @deprecated
      */
     private static $faker;
 
@@ -98,6 +100,8 @@ class Seeder
 
     /**
      * Gets the Faker Generator instance.
+     *
+     * @deprecated
      */
     public static function faker(): ?Generator
     {

--- a/tests/system/Database/DatabaseSeederTest.php
+++ b/tests/system/Database/DatabaseSeederTest.php
@@ -38,6 +38,9 @@ final class DatabaseSeederTest extends CIUnitTestCase
         new Seeder($config);
     }
 
+    /**
+     * @TODO remove this when Seeder::faker() is removed
+     */
     public function testFakerGet()
     {
         $this->assertInstanceOf(Generator::class, Seeder::faker());

--- a/user_guide_src/source/changelogs/v4.1.6.rst
+++ b/user_guide_src/source/changelogs/v4.1.6.rst
@@ -42,6 +42,8 @@ Changes
 Deprecations
 ************
 
+- ``Seeder::faker()`` and ``Seeder::$faker`` are deprecated.
+
 Sending Cookies
 ===============
 

--- a/user_guide_src/source/dbmgmt/seeds.rst
+++ b/user_guide_src/source/dbmgmt/seeds.rst
@@ -67,41 +67,6 @@ anywhere the autoloader can find them. This is great for more modular code bases
         $this->call('My\Database\Seeds\CountrySeeder');
     }
 
-Using Faker
-===========
-
-If you want to automate the generation of seed data, you can use
-the `Faker library <https://github.com/fakerphp/faker>`_.
-
-To install Faker into your project::
-
-    > composer require --dev fakerphp/faker
-
-After installation, an instance of ``Faker\Generator`` is available in the main ``Seeder``
-class and is accessible by all child seeders. You must use the static method ``faker()``
-to access the instance.
-
-::
-
-    <?php
-
-    namespace App\Database\Seeds;
-
-    use CodeIgniter\Database\Seeder;
-
-    class UserSeeder extends Seeder
-    {
-        public function run()
-        {
-            $model = model('UserModel');
-
-            $model->insert([
-                'email'      => static::faker()->email,
-                'ip_address' => static::faker()->ipv4,
-            ]);
-        }
-    }
-
 Using Seeders
 =============
 


### PR DESCRIPTION
**Description**
See #5456

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
