### PR TITLE
fix: directory_mirror() throws an error if destination directory exists

### DIFF
--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -91,7 +91,9 @@ if (! function_exists('directory_mirror')) {
             $target = $targetDir . substr($origin, $dirLen);
 
             if ($file->isDir()) {
-                mkdir($target, 0755);
+                if (! is_dir($target)) {
+                    mkdir($target, 0755);
+                }
             } elseif (! is_file($target) || ($overwrite && is_file($target))) {
                 copy($origin, $target);
             }


### PR DESCRIPTION
**Description**
Fixes #5478
- do nothing if destination directory exists
  - I don't see the reason to raise error when destination directory exists
 
**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
