### PR TITLE
Update rector to 0.12.9 and clean up skip config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phpstan/phpstan": "^1.0",
         "phpunit/phpunit": "^9.1",
         "predis/predis": "^1.1",
-        "rector/rector": "0.12.8"
+        "rector/rector": "0.12.9"
     },
     "suggest": {
         "ext-fileinfo": "Improves mime type detection for files"

--- a/rector.php
+++ b/rector.php
@@ -42,7 +42,6 @@ use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
-use Rector\PHPUnit\Rector\MethodCall\AssertIssetToSpecificMethodRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
@@ -113,15 +112,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         // use mt_rand instead of random_int on purpose on non-cryptographically random
         RandomFunctionRector::class,
-
-        // $this->assertTrue(isset($bar['foo']))
-        // and $this->assertArrayHasKey('foo', $bar)
-        // or $this->assertObjectHasAttribute('foo', $bar);
-        // are not the same
-        AssertIssetToSpecificMethodRector::class => [
-            __DIR__ . '/tests/system/Entity/EntityTest.php',
-            __DIR__ . '/tests/system/Session/SessionTest.php',
-        ],
     ]);
 
     // auto import fully qualified class names


### PR DESCRIPTION
@kenjis by update rector to 0.12.9, we can clean up unneeded skip `AssertIssetToSpecificMethodRector` in config definition as already handled in latest rector 0.12.9.

**Checklist:**
- [x] Securely signed commits
