### PR TITLE
fix: Entity::mapProperty()

### DIFF
--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -299,8 +299,9 @@ class Entity implements JsonSerializable
             return $key;
         }
 
-        if (! empty($this->datamap[$key])) {
-            return $this->datamap[$key];
+        $property = array_search($key, $this->datamap, true);
+        if ($property !== false) {
+            return $property;
         }
 
         return $key;

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -151,9 +151,8 @@ final class EntityTest extends CIUnitTestCase
         // maps to 'foo'
         $entity->bar = 'here';
 
-        $attributes = $this->getPrivateProperty($entity, 'attributes');
-        $this->assertArrayHasKey('foo', $attributes);
-        $this->assertArrayNotHasKey('bar', $attributes);
+        $this->assertTrue(isset($entity->foo));
+        $this->assertTrue(isset($entity->bar));
     }
 
     public function testUnsetWorksWithMapping()
@@ -165,14 +164,16 @@ final class EntityTest extends CIUnitTestCase
         // doesn't work on original name
         unset($entity->bar);
 
+        $this->assertTrue(isset($entity->bar));
         $this->assertSame('here', $entity->bar);
+        $this->assertTrue(isset($entity->foo));
         $this->assertSame('here', $entity->foo);
 
         // does work on mapped field
         unset($entity->foo);
 
-        $this->assertNull($entity->foo);
-        $this->assertNull($entity->bar);
+        $this->assertFalse(isset($entity->foo));
+        $this->assertFalse(isset($entity->bar));
     }
 
     public function testDateMutationFromString()
@@ -1007,7 +1008,7 @@ final class EntityTest extends CIUnitTestCase
                 'bar' => 'bar',
             ];
             protected $datamap = [
-                'bar'          => 'foo',
+                'bar' => 'foo',
                 // @TODO Is it possible that one column has two properties?
                 'foo'          => 'bar',
                 'original_bar' => 'bar',

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -178,10 +178,10 @@ final class EntityTest extends CIUnitTestCase
     public function testDateMutationFromString()
     {
         $entity     = $this->getEntity();
-        $attributes = ['created_at' => '2017-07-15 13:23:34'];
+        $attributes = ['createdAt' => '2017-07-15 13:23:34'];
         $this->setPrivateProperty($entity, 'attributes', $attributes);
 
-        $time = $entity->created_at;
+        $time = $entity->createdAt;
 
         $this->assertInstanceOf(Time::class, $time);
         $this->assertSame('2017-07-15 13:23:34', $time->format('Y-m-d H:i:s'));
@@ -191,10 +191,10 @@ final class EntityTest extends CIUnitTestCase
     {
         $stamp      = time();
         $entity     = $this->getEntity();
-        $attributes = ['created_at' => $stamp];
+        $attributes = ['createdAt' => $stamp];
         $this->setPrivateProperty($entity, 'attributes', $attributes);
 
-        $time = $entity->created_at;
+        $time = $entity->createdAt;
 
         $this->assertInstanceOf(Time::class, $time);
         $this->assertCloseEnoughString(date('Y-m-d H:i:s', $stamp), $time->format('Y-m-d H:i:s'));
@@ -204,10 +204,10 @@ final class EntityTest extends CIUnitTestCase
     {
         $dt         = new DateTime('now');
         $entity     = $this->getEntity();
-        $attributes = ['created_at' => $dt];
+        $attributes = ['createdAt' => $dt];
         $this->setPrivateProperty($entity, 'attributes', $attributes);
 
-        $time = $entity->created_at;
+        $time = $entity->createdAt;
 
         $this->assertInstanceOf(Time::class, $time);
         $this->assertCloseEnoughString($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
@@ -217,10 +217,10 @@ final class EntityTest extends CIUnitTestCase
     {
         $dt         = Time::now();
         $entity     = $this->getEntity();
-        $attributes = ['created_at' => $dt];
+        $attributes = ['createdAt' => $dt];
         $this->setPrivateProperty($entity, 'attributes', $attributes);
 
-        $time = $entity->created_at;
+        $time = $entity->createdAt;
 
         $this->assertInstanceOf(Time::class, $time);
         $this->assertCloseEnoughString($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
@@ -230,9 +230,9 @@ final class EntityTest extends CIUnitTestCase
     {
         $entity = $this->getEntity();
 
-        $entity->created_at = '2017-07-15 13:23:34';
+        $entity->createdAt = '2017-07-15 13:23:34';
 
-        $time = $this->getPrivateProperty($entity, 'attributes')['created_at'];
+        $time = $this->getPrivateProperty($entity, 'attributes')['createdAt'];
         $this->assertInstanceOf(Time::class, $time);
         $this->assertSame('2017-07-15 13:23:34', $time->format('Y-m-d H:i:s'));
     }
@@ -242,9 +242,9 @@ final class EntityTest extends CIUnitTestCase
         $stamp  = time();
         $entity = $this->getEntity();
 
-        $entity->created_at = $stamp;
+        $entity->createdAt = $stamp;
 
-        $time = $this->getPrivateProperty($entity, 'attributes')['created_at'];
+        $time = $this->getPrivateProperty($entity, 'attributes')['createdAt'];
         $this->assertInstanceOf(Time::class, $time);
         $this->assertCloseEnoughString(date('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
     }
@@ -256,7 +256,7 @@ final class EntityTest extends CIUnitTestCase
 
         $entity->created_at = $dt;
 
-        $time = $this->getPrivateProperty($entity, 'attributes')['created_at'];
+        $time = $this->getPrivateProperty($entity, 'attributes')['createdAt'];
         $this->assertInstanceOf(Time::class, $time);
         $this->assertCloseEnoughString($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
     }
@@ -268,7 +268,7 @@ final class EntityTest extends CIUnitTestCase
 
         $entity->created_at = $dt;
 
-        $time = $this->getPrivateProperty($entity, 'attributes')['created_at'];
+        $time = $this->getPrivateProperty($entity, 'attributes')['createdAt'];
         $this->assertInstanceOf(Time::class, $time);
         $this->assertCloseEnoughString($dt->format('Y-m-d H:i:s'), $time->format('Y-m-d H:i:s'));
     }
@@ -719,16 +719,16 @@ final class EntityTest extends CIUnitTestCase
         $result = $entity->toArray(false, true, true);
 
         $this->assertSame([
-            'foo'     => null,
-            'bar'     => ':bar',
-            'default' => 'sumfin',
-            'entity'  => [
+            'foo'       => null,
+            'bar'       => ':bar',
+            'default'   => 'sumfin',
+            'createdAt' => null,
+            'entity'    => [
                 'foo'       => null,
                 'bar'       => ':bar',
                 'default'   => 'sumfin',
                 'createdAt' => null,
             ],
-            'createdAt' => null,
         ], $result);
     }
 
@@ -739,8 +739,8 @@ final class EntityTest extends CIUnitTestCase
         $result = $entity->toArray();
 
         $this->assertSame([
-            'bar'  => null,
-            'orig' => ':oo',
+            'foo'    => null,
+            'simple' => ':oo',
         ], $result);
     }
 
@@ -792,10 +792,10 @@ final class EntityTest extends CIUnitTestCase
         $result = $entity->toRawArray();
 
         $this->assertSame([
-            'foo'        => null,
-            'bar'        => null,
-            'default'    => 'sumfin',
-            'created_at' => null,
+            'foo'       => null,
+            'bar'       => null,
+            'default'   => 'sumfin',
+            'createdAt' => null,
         ], $result);
     }
 
@@ -807,15 +807,15 @@ final class EntityTest extends CIUnitTestCase
         $result = $entity->toRawArray(false, true);
 
         $this->assertSame([
-            'foo'        => null,
-            'bar'        => null,
-            'default'    => 'sumfin',
-            'created_at' => null,
-            'entity'     => [
-                'foo'        => null,
-                'bar'        => null,
-                'default'    => 'sumfin',
-                'created_at' => null,
+            'foo'       => null,
+            'bar'       => null,
+            'default'   => 'sumfin',
+            'createdAt' => null,
+            'entity'    => [
+                'foo'       => null,
+                'bar'       => null,
+                'default'   => 'sumfin',
+                'createdAt' => null,
             ],
         ], $result);
     }
@@ -926,19 +926,24 @@ final class EntityTest extends CIUnitTestCase
     {
         return new class () extends Entity {
             protected $attributes = [
-                'foo'        => null,
-                'bar'        => null,
-                'default'    => 'sumfin',
-                'created_at' => null,
+                'foo'       => null,
+                'bar'       => null,
+                'default'   => 'sumfin',
+                'createdAt' => null,
             ];
             protected $original = [
-                'foo'        => null,
-                'bar'        => null,
-                'default'    => 'sumfin',
-                'created_at' => null,
+                'foo'       => null,
+                'bar'       => null,
+                'default'   => 'sumfin',
+                'createdAt' => null,
             ];
             protected $datamap = [
                 'createdAt' => 'created_at',
+            ];
+            protected $dates = [
+                'createdAt',
+                'updated_at',
+                'deleted_at',
             ];
 
             public function setBar($value)
@@ -972,10 +977,10 @@ final class EntityTest extends CIUnitTestCase
                 'simple' => null,
             ];
 
-            // 'bar' is db column, 'foo' is internal representation
+            // 'foo' is internal representation, 'bar' is db column
             protected $datamap = [
-                'bar'  => 'foo',
-                'orig' => 'simple',
+                'foo'    => 'bar',
+                'simple' => 'orig',
             ];
 
             protected function setSimple(string $val)
@@ -1003,6 +1008,7 @@ final class EntityTest extends CIUnitTestCase
             ];
             protected $datamap = [
                 'bar'          => 'foo',
+                // @TODO Is it possible that one column has two properties?
                 'foo'          => 'bar',
                 'original_bar' => 'bar',
             ];


### PR DESCRIPTION
**Description**
- It seems test code for Entity `$datamap` is broken. 
  - See https://github.com/codeigniter4/CodeIgniter4/pull/5496/files#diff-c08da29b9c95474f0898a44480d40a2b131ab72905a69d73705b2c6fa31feec7L975-R983
 
My Questions:
- I don't understand the test intent. So can't fix it. How do we fix it?
  - https://github.com/codeigniter4/CodeIgniter4/pull/5496/files#diff-c08da29b9c95474f0898a44480d40a2b131ab72905a69d73705b2c6fa31feec7L1005-R1013
- > unset and isset only work on the mapped property, $name, not on the original name, full_name.
https://codeigniter.com/user_guide/models/entities.html#data-mapping
  - But `isset()` works on the original name (db column) already. Should `unset()` not work?

Related #5495, #3508

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
