### PR TITLE
fix: Entity's isset() and unset()

### DIFF
--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -284,8 +284,8 @@ class Entity implements JsonSerializable
     }
 
     /**
-     * Checks the datamap to see if this column name is being mapped,
-     * and returns the mapped name, if any, or the original name.
+     * Checks the datamap to see if this property name is being mapped,
+     * and returns the db column name, if any, or the original property name.
      *
      * @return mixed|string
      */
@@ -510,6 +510,10 @@ class Entity implements JsonSerializable
      */
     public function __isset(string $key): bool
     {
+        if ($this->isMappedDbColumn($key)) {
+            return false;
+        }
+
         $key = $this->mapProperty($key);
 
         $method = 'get' . str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $key)));
@@ -526,6 +530,37 @@ class Entity implements JsonSerializable
      */
     public function __unset(string $key): void
     {
+        if ($this->isMappedDbColumn($key)) {
+            return;
+        }
+
+        $key = $this->mapProperty($key);
+
         unset($this->attributes[$key]);
+    }
+
+    /**
+     * Whether this key is mapped db column name?
+     */
+    protected function isMappedDbColumn(string $key): bool
+    {
+        $maybeColumnName = $this->mapProperty($key);
+
+        // Property name which has mapped column name
+        if (($key !== $maybeColumnName)) {
+            return false;
+        }
+
+        return $this->hasMappedProperty($key);
+    }
+
+    /**
+     * Whether this key has mapped property?
+     */
+    protected function hasMappedProperty(string $key): bool
+    {
+        $property = array_search($key, $this->datamap, true);
+
+        return $property !== false;
     }
 }

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -547,7 +547,7 @@ class Entity implements JsonSerializable
         $maybeColumnName = $this->mapProperty($key);
 
         // Property name which has mapped column name
-        if (($key !== $maybeColumnName)) {
+        if ($key !== $maybeColumnName) {
             return false;
         }
 

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -146,7 +146,7 @@ final class EntityTest extends CIUnitTestCase
         $this->assertSame('oo:second:oo', $entity->simple);
     }
 
-    public function testIssetWorksWithMapping()
+    public function testDataMappingIsset()
     {
         $entity = $this->getMappedEntity();
 
@@ -764,7 +764,7 @@ final class EntityTest extends CIUnitTestCase
         ], $result);
     }
 
-    public function testSwapped()
+    public function testDataMappingIssetSwapped()
     {
         $entity = $this->getSimpleSwappedEntity();
 
@@ -785,6 +785,23 @@ final class EntityTest extends CIUnitTestCase
             'foo' => '222',
             'bar' => '111',
         ], $result);
+    }
+
+    public function testDataMappingIssetUnsetSwapped()
+    {
+        $entity = $this->getSimpleSwappedEntity();
+
+        $entity->foo = '111';
+        $entity->bar = '222';
+        unset($entity->foo);
+
+        $isset = isset($entity->foo);
+        $this->assertFalse($isset);
+        $this->assertNull($entity->foo);
+
+        $isset = isset($entity->bar);
+        $this->assertTrue($isset);
+        $this->assertSame('222', $entity->bar);
     }
 
     public function testToArraySkipAttributesWithUnderscoreInFirstCharacter()
@@ -929,18 +946,18 @@ final class EntityTest extends CIUnitTestCase
         $this->assertFalse($entity->hasChanged('xxx'));
     }
 
-    public function testIssetKeyMap()
+    public function testDataMappingIssetSetGetMethod()
     {
-        $entity             = $this->getEntity();
+        $entity = $this->getEntity();
+
         $entity->created_at = '12345678';
-        $entity->bar        = 'foo';
 
         $issetReturn = isset($entity->createdAt);
-
         $this->assertTrue($issetReturn);
 
-        $issetReturn = isset($entity->FakeBar);
+        $entity->bar = 'foo';
 
+        $issetReturn = isset($entity->FakeBar);
         $this->assertTrue($issetReturn);
     }
 

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -120,12 +120,14 @@ final class EntityTest extends CIUnitTestCase
 
         $entity->bar = 'made it';
 
-        // Check mapped field
+        // Check db column name
         $this->assertSame('made it', $entity->foo);
-        // Should also get from original name
-        // since Model's would be looking for the original name
+
+        // Should also get from property name
+        // since Model's would be looking for the property name
         $this->assertSame('made it', $entity->bar);
-        // But it shouldn't actually set a class property for the original name...
+
+        // But it shouldn't actually set a class property for the column name...
         $this->expectException(ReflectionException::class);
         $this->getPrivateProperty($entity, 'bar');
     }
@@ -134,7 +136,7 @@ final class EntityTest extends CIUnitTestCase
     {
         $entity = $this->getMappedEntity();
 
-        // Will map to "simple"
+        // Will map to "simple" column
         $entity->orig = 'first';
 
         $this->assertSame('oo:first:oo', $entity->simple);
@@ -148,31 +150,36 @@ final class EntityTest extends CIUnitTestCase
     {
         $entity = $this->getMappedEntity();
 
-        // maps to 'foo'
+        // maps to 'foo' column
         $entity->bar = 'here';
 
-        $attributes = $this->getPrivateProperty($entity, 'attributes');
-        $this->assertArrayHasKey('foo', $attributes);
-        $this->assertArrayNotHasKey('bar', $attributes);
+        $isset = isset($entity->bar);
+        $this->assertTrue($isset);
+
+        $isset = isset($entity->foo);
+        $this->assertFalse($isset);
     }
 
     public function testUnsetWorksWithMapping()
     {
         $entity = $this->getMappedEntity();
-        // maps to 'foo'
+
+        // maps to 'foo' column
         $entity->bar = 'here';
 
-        // doesn't work on original name
-        unset($entity->bar);
+        // doesn't work on db column name
+        unset($entity->foo);
 
         $this->assertSame('here', $entity->bar);
         $this->assertSame('here', $entity->foo);
 
-        // does work on mapped field
-        unset($entity->foo);
+        // does work on property name
+        unset($entity->bar);
 
-        $this->assertNull($entity->foo);
-        $this->assertNull($entity->bar);
+        $isset = isset($entity->foo);
+        $this->assertFalse($isset);
+        $isset = isset($entity->bar);
+        $this->assertFalse($isset);
     }
 
     public function testDateMutationFromString()
@@ -757,6 +764,29 @@ final class EntityTest extends CIUnitTestCase
         ], $result);
     }
 
+    public function testSwapped()
+    {
+        $entity = $this->getSimpleSwappedEntity();
+
+        $entity->foo = '111';
+        $entity->bar = '222';
+
+        $isset = isset($entity->foo);
+        $this->assertTrue($isset);
+        $this->assertSame('111', $entity->foo);
+
+        $isset = isset($entity->bar);
+        $this->assertTrue($isset);
+        $this->assertSame('222', $entity->bar);
+
+        $result = $entity->toRawArray();
+
+        $this->assertSame([
+            'foo' => '222',
+            'bar' => '111',
+        ], $result);
+    }
+
     public function testToArraySkipAttributesWithUnderscoreInFirstCharacter()
     {
         $entity                   = new class () extends Entity {
@@ -972,7 +1002,7 @@ final class EntityTest extends CIUnitTestCase
                 'simple' => null,
             ];
 
-            // 'bar' is db column, 'foo' is internal representation
+            // 'bar' is class property, 'foo' is db column
             protected $datamap = [
                 'bar'  => 'foo',
                 'orig' => 'simple',
@@ -1005,6 +1035,24 @@ final class EntityTest extends CIUnitTestCase
                 'bar'          => 'foo',
                 'foo'          => 'bar',
                 'original_bar' => 'bar',
+            ];
+        };
+    }
+
+    protected function getSimpleSwappedEntity()
+    {
+        return new class () extends Entity {
+            protected $attributes = [
+                'foo' => 'foo',
+                'bar' => 'bar',
+            ];
+            protected $_original = [
+                'foo' => 'foo',
+                'bar' => 'bar',
+            ];
+            protected $datamap = [
+                'bar' => 'foo',
+                'foo' => 'bar',
             ];
         };
     }

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -267,7 +267,7 @@ simply map the ``full_name`` column in the database to the ``$name`` property, a
     {
         protected $attributes = [
             'id'         => null,
-            'name'       => null, // Represents a username
+            'full_name'  => null, // In the $attributes, the key is the column name
             'email'      => null,
             'password'   => null,
             'created_at' => null,
@@ -286,8 +286,8 @@ name of the column in the database.
 In this example, when the model sets the ``full_name`` field on the User class, it actually assigns that value to the
 class' ``$name`` property, so it can be set and retrieved through ``$user->name``. The value will still be accessible
 through the original ``$user->full_name``, also, as this is needed for the model to get the data back out and save it
-to the database. However, ``unset`` and ``isset`` only work on the mapped property, ``$name``, not on the original name,
-``full_name``.
+to the database. However, ``unset()`` and ``isset()`` only work on the mapped property, ``$user->name``, not on the database column name,
+``$user->full_name``.
 
 Mutators
 ========


### PR DESCRIPTION
**Description**
- fixes #5495
- fixes `isset()`may work on db column name in some cases

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
