### PR TITLE
fix: KINT visual error when activating CSP

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -71,6 +71,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::SKIP, [
         __DIR__ . '/app/Views',
         __DIR__ . '/system/Debug/Toolbar/Views/toolbar.tpl.php',
+        __DIR__ . '/system/Debug/Kint/RichRenderer.php',
         __DIR__ . '/system/ThirdParty',
         __DIR__ . '/tests/system/Config/fixtures',
         __DIR__ . '/tests/_support',

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter;
 
 use Closure;
+use CodeIgniter\Debug\Kint\RichRenderer;
 use CodeIgniter\Debug\Timer;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\FrameworkException;
@@ -33,7 +34,6 @@ use Config\Services;
 use Exception;
 use Kint;
 use Kint\Renderer\CliRenderer;
-use Kint\Renderer\RichRenderer;
 
 /**
  * This class is the core of the framework, and will analyse the
@@ -256,6 +256,8 @@ class CodeIgniter
         if (! empty($config->plugins) && is_array($config->plugins)) {
             Kint::$plugins = $config->plugins;
         }
+
+        Kint::$renderers[Kint::MODE_RICH] = RichRenderer::class;
 
         RichRenderer::$theme  = $config->richTheme;
         RichRenderer::$folder = $config->richFolder;

--- a/system/Debug/Kint/RichRenderer.php
+++ b/system/Debug/Kint/RichRenderer.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Debug\Kint;
+
+use Kint\Renderer\RichRenderer as KintRichRenderer;
+
+/**
+ * Overrides RichRenderer::preRender() for CSP
+ */
+class RichRenderer extends KintRichRenderer
+{
+    public function preRender()
+    {
+        $output = '';
+
+        if ($this->pre_render) {
+            foreach (self::$pre_render_sources as $type => $values) {
+                $contents = '';
+
+                foreach ($values as $v) {
+                    $contents .= $v($this);
+                }
+
+                if (! \strlen($contents)) {
+                    continue;
+                }
+
+                switch ($type) {
+                    case 'script':
+                        $output .= '<script {csp-script-nonce} class="kint-rich-script">' . $contents . '</script>';
+                        break;
+
+                    case 'style':
+                        $output .= '<style {csp-style-nonce} class="kint-rich-style">' . $contents . '</style>';
+                        break;
+
+                    default:
+                        $output .= $contents;
+                }
+            }
+
+            // Don't pre-render on every dump
+            if (! $this->force_pre_render) {
+                self::$needs_pre_render = false;
+            }
+        }
+
+        $output .= '<div class="kint-rich';
+
+        if ($this->use_folder) {
+            $output .= ' kint-file';
+
+            if (self::$needs_folder_render || $this->force_pre_render) {
+                $output = $this->renderFolder() . $output;
+
+                if (! $this->force_pre_render) {
+                    self::$needs_folder_render = false;
+                }
+            }
+        }
+
+        $output .= '">';
+
+        return $output;
+    }
+}

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -29,6 +29,7 @@ use Config\App;
 use Config\Logger;
 use Config\Modules;
 use InvalidArgumentException;
+use Kint;
 use stdClass;
 use Tests\Support\Models\JobModel;
 
@@ -481,5 +482,38 @@ final class CommonFunctionsTest extends CIUnitTestCase
     {
         $this->assertIsBool(is_cli());
         $this->assertTrue(is_cli());
+    }
+
+    public function testDWithCSP()
+    {
+        /** @var App $config */
+        $config       = config(App::class);
+        $CSPEnabled   = $config->CSPEnabled;
+        $cliDetection = Kint::$cli_detection;
+
+        $config->CSPEnabled  = true;
+        Kint::$cli_detection = false;
+
+        $this->expectOutputRegex('/<script {csp-script-nonce} class="kint-rich-script">/u');
+        d('string');
+
+        // Restore settings
+        $config->CSPEnabled  = $CSPEnabled;
+        Kint::$cli_detection = $cliDetection;
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState  disabled
+     */
+    public function testTraceWithCSP()
+    {
+        /** @var App $config */
+        $config              = config(App::class);
+        $config->CSPEnabled  = true;
+        Kint::$cli_detection = false;
+
+        $this->expectOutputRegex('/<style {csp-style-nonce} class="kint-rich-style">/u');
+        trace();
     }
 }


### PR DESCRIPTION
**Description**
Supersede #5482
Fixes #5475
- overrides `RichRenderer::preRender()`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
