### PR TITLE
Feature: Subqueries in the FROM section

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2761,6 +2761,7 @@ class BaseBuilder
     /**
      * @param BaseBuilder|Closure $builder
      * @param bool                $wrapped Wrap the subquery in brackets
+     * @param string              $alias   Subquery alias
      */
     protected function buildSubquery($builder, bool $wrapped = false, string $alias = ''): string
     {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -531,6 +531,11 @@ class BaseBuilder
                 $this->from(explode(',', $table));
             } else {
                 $table = trim($table);
+
+                if ($table === '') {
+                    continue;
+                }
+
                 $this->trackAliases($table);
                 $this->QBFrom[] = $this->db->protectIdentifiers($table, true, null, false);
             }

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -855,11 +855,11 @@ abstract class BaseConnection implements ConnectionInterface
     }
 
     /**
-     * Returns a new instance of the BaseBuilder class without a table.
+     * Returns a new instance of the BaseBuilder class with a cleared FROM clause.
      */
     public function newQuery(): BaseBuilder
     {
-        return $this->table('crunch')->from([], true);
+        return $this->table(uniqid())->from([], true);
     }
 
     /**

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -859,7 +859,7 @@ abstract class BaseConnection implements ConnectionInterface
      */
     public function newQuery(): BaseBuilder
     {
-        return $this->table(uniqid())->from([], true);
+        return $this->table(',')->from([], true);
     }
 
     /**

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -837,7 +837,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns a non-shared new instance of the query builder for this connection.
      *
-     * @param array|BaseBuilder|Closure|string $tableName
+     * @param array|string $tableName
      *
      * @throws DatabaseException
      *
@@ -852,6 +852,14 @@ abstract class BaseConnection implements ConnectionInterface
         $className = str_replace('Connection', 'Builder', static::class);
 
         return new $className($tableName, $this);
+    }
+
+    /**
+     * Returns a new instance of the BaseBuilder class without a table.
+     */
+    public function newQuery(): BaseBuilder
+    {
+        return $this->table('crunch')->from([], true);
     }
 
     /**

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -837,7 +837,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns a non-shared new instance of the query builder for this connection.
      *
-     * @param array|string $tableName
+     * @param array|BaseBuilder|Closure|string $tableName
      *
      * @throws DatabaseException
      *

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -68,7 +68,7 @@ class Builder extends BaseBuilder
         $from = [];
 
         foreach ($this->QBFrom as $value) {
-            $from[] = $this->getFullName($value);
+            $from[] = strpos($value, '(SELECT') === 0 ? $value : $this->getFullName($value);
         }
 
         return implode(', ', $from);

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -104,9 +104,9 @@ final class FromTest extends CIUnitTestCase
     public function testFromSubquery()
     {
         // Subquery as table
-        $expectedSQL = 'SELECT * FROM (SELECT * FROM "users")';
+        $expectedSQL = 'SELECT * FROM (SELECT * FROM "users") AS alias';
         $subquery    = new BaseBuilder('users', $this->db);
-        $builder     = $this->db->newQuery()->fromSubquery($subquery);
+        $builder     = $this->db->newQuery()->fromSubquery($subquery, 'alias');
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -110,7 +110,6 @@ final class FromTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 
         $expectedSQL = 'SELECT * FROM (SELECT "id", "name" FROM "users") AS users_1';
-
         $subquery = (new BaseBuilder('users', $this->db))->select('id, name');
         $builder  = $this->db->newQuery()->fromSubquery($subquery, 'users_1');
 

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -12,7 +12,6 @@
 namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
-use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\SQLSRV\Builder as SQLSRVBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
@@ -107,7 +106,7 @@ final class FromTest extends CIUnitTestCase
         // Subquery as table
         $expectedSQL = 'SELECT * FROM (SELECT * FROM "users")';
         $subquery    = new BaseBuilder('users', $this->db);
-        $builder     = new BaseBuilder($subquery, $this->db);
+        $builder     = $this->db->newQuery()->fromSubquery($subquery);
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 
@@ -115,23 +114,9 @@ final class FromTest extends CIUnitTestCase
         $expectedSQL = 'SELECT * FROM (SELECT "id", "name" FROM "users") AS users_1';
 
         $subquery = (new BaseBuilder('users', $this->db))->select('id, name');
-        $builder  = new BaseBuilder([$subquery, 'users_1'], $this->db);
+        $builder  = $this->db->newQuery()->fromSubquery($subquery, 'users_1');
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
-    }
-
-    public function testFromSubqueryExceptions()
-    {
-        $this->expectException(DatabaseException::class);
-        $this->expectExceptionMessage('Table name must be string or instance of the BaseBuilder');
-        $subquery = new BaseBuilder('users', $this->db);
-        $builder  = new BaseBuilder([$subquery], $this->db);
-
-        $this->expectException(DatabaseException::class);
-        $this->expectExceptionMessage('Subquery must have an alias');
-        $subquery = new BaseBuilder('users', $this->db);
-        $builder  = new BaseBuilder('jobs', $this->db);
-        $builder->from($subquery);
     }
 
     public function testFromWithMultipleTablesAsStringWithSQLSRV()
@@ -155,7 +140,7 @@ final class FromTest extends CIUnitTestCase
 
         $builder = new SQLSRVBuilder('jobs', $this->db);
 
-        $builder->from([$subquery, 'users_1']);
+        $builder->fromSubquery($subquery, 'users_1');
 
         $expectedSQL = 'SELECT * FROM "test"."dbo"."jobs", (SELECT * FROM "test"."dbo"."users") AS users_1';
 

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -110,8 +110,8 @@ final class FromTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 
         $expectedSQL = 'SELECT * FROM (SELECT "id", "name" FROM "users") AS users_1';
-        $subquery = (new BaseBuilder('users', $this->db))->select('id, name');
-        $builder  = $this->db->newQuery()->fromSubquery($subquery, 'users_1');
+        $subquery    = (new BaseBuilder('users', $this->db))->select('id, name');
+        $builder     = $this->db->newQuery()->fromSubquery($subquery, 'users_1');
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -103,18 +103,22 @@ final class FromTest extends CIUnitTestCase
 
     public function testFromSubquery()
     {
-        // Subquery as table
         $expectedSQL = 'SELECT * FROM (SELECT * FROM "users") AS alias';
         $subquery    = new BaseBuilder('users', $this->db);
         $builder     = $this->db->newQuery()->fromSubquery($subquery, 'alias');
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 
-        // Subquery with alias
         $expectedSQL = 'SELECT * FROM (SELECT "id", "name" FROM "users") AS users_1';
 
         $subquery = (new BaseBuilder('users', $this->db))->select('id, name');
         $builder  = $this->db->newQuery()->fromSubquery($subquery, 'users_1');
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+        $expectedSQL = 'SELECT * FROM (SELECT * FROM "users") AS alias, "some_table"';
+        $subquery    = new BaseBuilder('users', $this->db);
+        $builder     = $this->db->newQuery()->fromSubquery($subquery, 'alias')->from('some_table');
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -214,7 +214,7 @@ Permits you to write the FROM portion of your query::
 
 In special cases, you can compose a database query using subqueries::
 
-    $subquery = $db->table('users);
+    $subquery = $db->table('users');
     $builder  = $db->table($subquery);
     $query = $builder->get();
 
@@ -222,7 +222,7 @@ In special cases, you can compose a database query using subqueries::
 
 You can specify an alias for a subquery by passing an array the first value of which will be the subquery, and the second an alias.::
 
-    $subquery = $db->table('users)->select('id, name');
+    $subquery = $db->table('users')->select('id, name');
     $builder  = $db->table([$subquery, 't']);
     $query = $builder->get();
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -210,6 +210,26 @@ Permits you to write the FROM portion of your query::
     in the ``$db->table()`` function. Additional calls to ``from()`` will add more tables
     to the FROM portion of your query.
 
+#. **Subqueries:**
+
+In special cases, you can compose a database query using subqueries::
+
+    $subquery = $db->table('users);
+    $builder  = $db->table($subquery);
+    $query = $builder->get();
+
+    // Produces: SELECT * FROM (SELECT * FROM users)
+
+You can specify an alias for a subquery by passing an array the first value of which will be the subquery, and the second an alias.::
+
+    $subquery = $db->table('users)->select('id, name');
+    $builder  = $db->table([$subquery, 't']);
+    $query = $builder->get();
+
+    // Produces: SELECT * FROM (SELECT `id`, `name` FROM users) AS t
+
+.. note:: Only one subquery can be passed to a method.
+
 **$builder->join()**
 
 Permits you to write the JOIN portion of your query::
@@ -1394,7 +1414,7 @@ Class Reference
 
     .. php:method:: from($from[, $overwrite = false])
 
-        :param mixed $from: Table name(s); string or array
+        :param mixed $from: Table name(s); string, array or BaseBuilder
         :param bool    $overwrite: Should we remove the first table existing?
         :returns:   ``BaseBuilder`` instance (method chaining)
         :rtype:     ``BaseBuilder``

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -210,20 +210,22 @@ Permits you to write the FROM portion of your query::
     in the ``$db->table()`` function. Additional calls to ``from()`` will add more tables
     to the FROM portion of your query.
 
-#. **Subqueries:**
+**$builder->fromSubquery()**
 
-In special cases, you can compose a database query using subqueries::
+Permits you to write part of a FROM query as a subquery.
+
+This is where we add a subquery to an existing table.::
 
     $subquery = $db->table('users');
-    $builder  = $db->table($subquery);
+    $builder  = $db->table('jobs')->fromSubquery($subquery, 'alias');
     $query = $builder->get();
 
-    // Produces: SELECT * FROM (SELECT * FROM users)
+    // Produces: SELECT * FROM `jobs`, (SELECT * FROM `users`) AS alias
 
-You can specify an alias for a subquery by passing an array the first value of which will be the subquery, and the second an alias.::
+Use the ``$db->newQuery()`` method to make a subquery the main table.::
 
     $subquery = $db->table('users')->select('id, name');
-    $builder  = $db->table([$subquery, 't']);
+    $builder  = $db->newQuery()->fromSubquery($subquery, 't');
     $query = $builder->get();
 
     // Produces: SELECT * FROM (SELECT `id`, `name` FROM users) AS t
@@ -1414,12 +1416,21 @@ Class Reference
 
     .. php:method:: from($from[, $overwrite = false])
 
-        :param mixed $from: Table name(s); string, array or BaseBuilder
+        :param mixed $from: Table name(s); string or array
         :param bool    $overwrite: Should we remove the first table existing?
         :returns:   ``BaseBuilder`` instance (method chaining)
         :rtype:     ``BaseBuilder``
 
         Specifies the ``FROM`` clause of a query.
+
+    .. php:method:: fromSubquery($from, $alias)
+
+        :param BaseBuilder $from: Instance of the BaseBuilder class
+        :param string      $alias: Subquery alias
+        :returns:   ``BaseBuilder`` instance (method chaining)
+        :rtype:     ``BaseBuilder``
+
+        Specifies the ``FROM`` clause of a query using a subquery.
 
     .. php:method:: join($table, $cond[, $type = ''[, $escape = null]])
 


### PR DESCRIPTION
**Description**
This PR makes it possible to use subqueries created using the QueryBuilder instead of the table in the FROM section.

This is where we add a subquery to an existing table.::
```php
    $subquery = $db->table('users');
    $builder  = $db->table('jobs')->fromSubquery($subquery, 'alias');
    $query = $builder->get();

    // Produces: SELECT * FROM `jobs`, (SELECT * FROM `users`) AS alias
```

Use the ``$db->newQuery()`` method to make a subquery the main table.::
```php
    $subquery = $db->table('users')->select('id, name');
    $builder  = $db->newQuery()->fromSubquery($subquery, 't');
    $query = $builder->get();

    // Produces: SELECT * FROM (SELECT `id`, `name` FROM users) AS t
```

---
**The following is the first interface. It has been modified along the way.**

A subquery can be passed either directly as a variable or as an array ``[BaseBuilder, 'alias']`` to specify an alias.

```php
$subquery = $db->table('users');
$db->table($subquery)->get();
// SELECT * FROM (SELECT * FROM `users`)

$subquery = $db->table('jobs')
$db->table('users)->from([$subquery, 't])->get();
// SELECT * FROM `users`, (SELECT * FROM `jobs`) AS t
```
Only one subquery can be passed at a time.
```php
$db->table([$subquery1, $subquery2])
// An exception will be thrown
```
This solution will add flexibility to the QueryBuilder and prepare the ground for other features.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide