### PR TITLE
Logger - Can use custom log levels

### DIFF
--- a/system/Test/Mock/MockLogger.php
+++ b/system/Test/Mock/MockLogger.php
@@ -92,6 +92,7 @@ class MockLogger
                 'info',
                 'notice',
                 'warning',
+                'custom',
             ],
 
             // Logging Directory Path

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -345,6 +345,21 @@ final class LoggerTest extends CIUnitTestCase
         $this->assertSame($expected, $logs[0]);
     }
 
+    public function testCustomLogsCorrectly()
+    {
+        $config = new LoggerConfig();
+        $logger = new Logger($config);
+
+        $expected = 'CUSTOM - ' . date('Y-m-d') . ' --> Test message';
+
+        $logger->log('custom', 'Test message');
+
+        $logs = TestHandler::getLogs();
+
+        $this->assertCount(1, $logs);
+        $this->assertSame($expected, $logs[0]);
+    }
+
     public function testLogLevels()
     {
         $config = new LoggerConfig();


### PR DESCRIPTION
**Description**

Logger currently prohibits logging levels which are not included in $logLevels
This one removes that limitation so that custom levels can be implemented using custom handlers.

One possible use case is when you want to log API errors in separate files for each API identified by slug. 

So a custom handler can be made like this:

```php
class FetcherFileHandler extends FileHandler
{
    public function canHandle(string $level): bool
    {
        return substr($level, 0, 8) === 'fetcher-';
    }

    public function handle($level, $message): bool
    {
        $slug   = substr($level, 8);

        $this->path = WRITEPATH . 'logs'. DIRECTORY_SEPARATOR . 'fetcher' . DIRECTORY_SEPARATOR . $slug; 

        if (! file_exists($this->path)) {
            mkdir($this->path, 0755, true);
        }

        return parent::handle($level, $message);
    }
}
```

and then logging can simply be done with
```php
log('fetcher-'.$slug, $message);
```

This will not affect behavior of other handlers in any way as they still have handles specified in config so they won't even be triggered for custom levels.

The only thing that cannot be handled with this is threshold from config but those can be handled in the custom handler implementation.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide