### PR TITLE
Remove semicolons from SQL statements.

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -135,7 +135,7 @@ class Forge
      *
      * @var false|string
      */
-    protected $renameTableStr = 'ALTER TABLE %s RENAME TO %s;';
+    protected $renameTableStr = 'ALTER TABLE %s RENAME TO %s';
 
     /**
      * UNSIGNED support
@@ -1042,14 +1042,14 @@ class Forge
             if (in_array($i, $this->uniqueKeys, true)) {
                 $sqls[] = 'ALTER TABLE ' . $this->db->escapeIdentifiers($table)
                     . ' ADD CONSTRAINT ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
-                    . ' UNIQUE (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
+                    . ' UNIQUE (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ')';
 
                 continue;
             }
 
             $sqls[] = 'CREATE INDEX ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
                 . ' ON ' . $this->db->escapeIdentifiers($table)
-                . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
+                . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ')';
         }
 
         return $sqls;


### PR DESCRIPTION
**Description**

Removed unnecessary semicolons.
The reason is the following.

* In [oci_parse](https://www.php.net/manual/en/function.oci-parse.php#refsect1-function.oci-parse-parameters), if there is a semicolon, it is treated as PL/SQL.
* There is no semicolon at the end of the SQL except for the one fixed here.



**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
