### PR TITLE
chore: make the URL of the support forum more specific

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: CodeIgniter Forum
-    url: https://forum.codeigniter.com
+    url: https://forum.codeigniter.com/forum-30.html
     about: Please ask your support questions in the forums. Thanks!
 
   - name: CodeIgniter Slack channel


### PR DESCRIPTION
**Description**
- make the URL of the support forum more specific

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
