### PR TITLE
[Rector] Apply Option::PARALLEL to speed up analyze

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -43,6 +43,7 @@ use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\PSR4\Rector\FileWithoutNamespace\NormalizeNamespaceByPSR4ComposerAutoloadRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -59,6 +60,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $parameters = $containerConfigurator->parameters();
 
+    $parameters->set(Option::PARALLEL, true);
     // paths to refactor; solid alternative to CLI arguments
     $parameters->set(Option::PATHS, [__DIR__ . '/app', __DIR__ . '/system', __DIR__ . '/tests', __DIR__ . '/utils/Rector']);
 
@@ -145,4 +147,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(FuncGetArgsToVariadicParamRector::class);
     $services->set(MakeInheritedMethodVisibilitySameAsParentRector::class);
     $services->set(SimplifyEmptyArrayCheckRector::class);
+    $services->set(NormalizeNamespaceByPSR4ComposerAutoloadRector::class);
 };

--- a/tests/system/Commands/BaseCommandTest.php
+++ b/tests/system/Commands/BaseCommandTest.php
@@ -35,14 +35,14 @@ final class BaseCommandTest extends CIUnitTestCase
     {
         $command = new AppInfo($this->logger, service('commands'));
 
-        $this->assertTrue(isset($command->group));
+        $this->assertObjectHasAttribute('group', $command);
     }
 
     public function testMagicIssetFalse()
     {
         $command = new AppInfo($this->logger, service('commands'));
 
-        $this->assertFalse(isset($command->foobar));
+        $this->assertObjectNotHasAttribute('foobar', $command);
     }
 
     public function testMagicGet()

--- a/tests/system/Files/FileCollectionTest.php
+++ b/tests/system/Files/FileCollectionTest.php
@@ -9,9 +9,9 @@
  * the LICENSE file that was distributed with this source code.
  */
 
+namespace CodeIgniter\Files;
+
 use CodeIgniter\Files\Exceptions\FileException;
-use CodeIgniter\Files\File;
-use CodeIgniter\Files\FileCollection;
 use CodeIgniter\Test\CIUnitTestCase;
 
 /**

--- a/tests/system/Publisher/PublisherInputTest.php
+++ b/tests/system/Publisher/PublisherInputTest.php
@@ -9,7 +9,8 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-use CodeIgniter\Publisher\Publisher;
+namespace CodeIgniter\Publisher;
+
 use CodeIgniter\Test\CIUnitTestCase;
 
 /**

--- a/tests/system/Publisher/PublisherOutputTest.php
+++ b/tests/system/Publisher/PublisherOutputTest.php
@@ -9,7 +9,8 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-use CodeIgniter\Publisher\Publisher;
+namespace CodeIgniter\Publisher;
+
 use CodeIgniter\Test\CIUnitTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;

--- a/tests/system/Publisher/PublisherRestrictionsTest.php
+++ b/tests/system/Publisher/PublisherRestrictionsTest.php
@@ -9,8 +9,9 @@
  * the LICENSE file that was distributed with this source code.
  */
 
+namespace CodeIgniter\Publisher;
+
 use CodeIgniter\Publisher\Exceptions\PublisherException;
-use CodeIgniter\Publisher\Publisher;
 use CodeIgniter\Test\CIUnitTestCase;
 
 /**

--- a/tests/system/Publisher/PublisherSupportTest.php
+++ b/tests/system/Publisher/PublisherSupportTest.php
@@ -9,8 +9,9 @@
  * the LICENSE file that was distributed with this source code.
  */
 
+namespace CodeIgniter\Publisher;
+
 use CodeIgniter\Publisher\Exceptions\PublisherException;
-use CodeIgniter\Publisher\Publisher;
 use CodeIgniter\Test\CIUnitTestCase;
 use Tests\Support\Publishers\TestPublisher;
 


### PR DESCRIPTION
Rector 0.12.10 has new `Option::PARALLEL` to speed up process, It now require `Psr4` to be applied in tests to avoid ` Class was not found` notice, ref https://github.com/rectorphp/rector/issues/6903

**Checklist:**
- [x] Securely signed commits
