### PR TITLE
Add app.supportedLocales feature in .env

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -461,4 +461,15 @@ class App extends BaseConfig
      * @var bool
      */
     public $CSPEnabled = false;
+    
+    public function __construct()
+    {
+        parent::__construct();
+        // app.supportedLocales = 'fr,  en ,de' => $this->supportedLocales = array('fr,'en,'de');
+        $envSupportedLocales = getenv('app.supportedLocales');
+        if ($envSupportedLocales)
+        {
+            $this->supportedLocales = array_map('trim', explode(',', $envSupportedLocales));
+        }
+    }
 }


### PR DESCRIPTION
**Description**
* Add `app.supportedLocales` feature in `.env` because indexed arrays are not supported in the `.env` file
* @paulbalandan finded after the pull requests : https://forum.codeigniter.com/thread-77309.html
```
.env
app.supportedLocales = 'fr, en, de'
```

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide (I hope!)