### PR TITLE
Remove experimental flag for PHP 8.1

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -36,9 +36,6 @@ jobs:
           - php-versions: '7.4'
             db-platforms: MySQLi
             mysql-versions: '8.0'
-          # @todo remove once 8.1 is stable enough
-          - php-versions: '8.1'
-            composer-flag: '--ignore-platform-req=php'
 
     services:
       mysql:
@@ -119,8 +116,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer update --ansi --no-interaction ${{ matrix.composer-flag }}
-          composer remove --ansi --dev --unused -W ${{ matrix.composer-flag }} -- rector/rector phpstan/phpstan friendsofphp/php-cs-fixer nexusphp/cs-config codeigniter/coding-standard
+          composer update --ansi --no-interaction
+          composer remove --ansi --dev --unused -W -- rector/rector phpstan/phpstan friendsofphp/php-cs-fixer nexusphp/cs-config codeigniter/coding-standard
         env:
           COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 


### PR DESCRIPTION
**Description**
PHP 8.1 is now stable

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
