### PR TITLE
chore: update admin/framework/composer.json Kint

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -10,7 +10,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "kint-php/kint": "^3.3",
+        "kint-php/kint": "^4.0",
         "laminas/laminas-escaper": "^2.9",
         "psr/log": "^1.1"
     },


### PR DESCRIPTION
**Description**
- update Kint to `^4.0`
  - fixes the error `Access to undeclared static property Kint\Kint::$depth_limit` in appstarter 4.1.6
 
**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
