### PR TITLE
fix: BaseConnection::getConnectDuration() number_format(): Passing null to parameter

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -258,14 +258,14 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * @var float
      */
-    protected $connectTime;
+    protected $connectTime = 0.0;
 
     /**
      * How long it took to establish connection.
      *
      * @var float
      */
-    protected $connectDuration;
+    protected $connectDuration = 0.0;
 
     /**
      * If true, no queries will actually be

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -123,6 +123,16 @@ final class BaseConnectionTest extends CIUnitTestCase
         $this->assertGreaterThan(0.0, $db->getConnectDuration());
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5535
+     */
+    public function testStoresConnectionTimingsNotConnected()
+    {
+        $db = new MockConnection($this->options);
+
+        $this->assertSame('0.000000', $db->getConnectDuration());
+    }
+
     public function testMagicIssetTrue()
     {
         $db = new MockConnection($this->options);


### PR DESCRIPTION
**Description**
Fixes #5535
I've confirmed this error when only connecting db but not running any queries.

The bug reporter confirmed this fix: https://github.com/codeigniter4/CodeIgniter4/issues/5535#issuecomment-1004537979

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

