### PR TITLE
Auto-review required dependency matching in composer.json

### DIFF
--- a/.github/workflows/test-autoreview.yml
+++ b/.github/workflows/test-autoreview.yml
@@ -1,0 +1,49 @@
+name: Automatic Code Review
+
+on:
+  pull_request:
+    paths:
+      - composer.json
+      - spark
+      - '**.php'
+      - .github/workflows/test-autoreview.yml
+  push:
+    paths:
+      - composer.json
+      - spark
+      - '**.php'
+      - .github/workflows/test-autoreview.yml
+
+jobs:
+  auto-review-tests:
+    name: Automatic Code Review
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer update --ansi
+        env:
+          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
+
+      - name: Run AutoReview Tests
+        run: vendor/bin/phpunit --color=always --group=auto-review --no-coverage

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -126,7 +126,7 @@ jobs:
         run: echo "TACHYCARDIA_MONITOR_GA=enabled" >> $GITHUB_ENV
 
       - name: Test with PHPUnit
-        run: script -e -c "vendor/bin/phpunit --color=always"
+        run: script -e -c "vendor/bin/phpunit --color=always --exclude-group=auto-review"
         env:
           DB: ${{ matrix.db-platforms }}
           TERM: xterm-256color

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
     "autoload-dev": {
         "psr-4": {
             "CodeIgniter\\": "tests/system/",
+            "CodeIgniter\\AutoReview\\": "tests/AutoReview/",
             "Utils\\": "utils/"
         }
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,6 +36,9 @@
     </coverage>
 
     <testsuites>
+        <testsuite name="AutoReview">
+            <directory>./tests/AutoReview</directory>
+        </testsuite>
         <testsuite name="System">
             <directory>./tests/system</directory>
             <exclude>./tests/system/Database</exclude>

--- a/tests/AutoReview/ComposerJsonTest.php
+++ b/tests/AutoReview/ComposerJsonTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\AutoReview;
+
+use JsonException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ * @group auto-review
+ */
+final class ComposerJsonTest extends TestCase
+{
+    public function testFrameworkRequireIsTheSameWithDevRequire(): void
+    {
+        $devComposer       = $this->getComposerJson(dirname(__DIR__, 2) . '/composer.json');
+        $frameworkComposer = $this->getComposerJson(dirname(__DIR__, 2) . '/admin/framework/composer.json');
+
+        $this->assertSame(
+            $devComposer['require'],
+            $frameworkComposer['require'],
+            'The framework\'s "require" section is not updated with the main composer.json.'
+        );
+    }
+
+    private function getComposerJson(string $path): array
+    {
+        try {
+            return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            $this->fail(sprintf(
+                'The composer.json at "%s" is not readable or does not exist. Error was "%s".',
+                clean_path($path),
+                $e->getMessage()
+            ));
+        }
+    }
+}


### PR DESCRIPTION
**Description**
This introduces "auto-review tests". Automate the boring task of self-reviewing your own code through GHA.

In this first iteration, this tests the composer.json in root against in `admin/framework` to check if the "require" sections are the same.

This needs #5531 to go green.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
