### PR TITLE
Validation: support placeholders for anything

### DIFF
--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -12,6 +12,7 @@ Release Date: Not Released
 BREAKING
 ********
 
+- The method signature of ``Validation::setRule()`` has been changed. The ``string`` typehint on the ``$rules`` parameter was removed. Extending classes should likewise remove the parameter so as not to break LSP.
 
 
 Enhancements

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -261,20 +261,28 @@ methods.
 setRule()
 =========
 
-This method sets a single rule. It takes the name of the field as
-the first parameter, an optional label and a string with a pipe-delimited list of rules
-that should be applied::
+This method sets a single rule. It has the method signature
 
-    $validation->setRule('username', 'Username', 'required');
+    setRule(string $field, ?string $label, array|string $rules[, array $errors = []])
 
-The **field name** must match the key of any data array that is sent in. If
+The ``$rules`` either takes in a pipe-delimited list of rules or an array collection of rules.
+
+    $validation->setRule('username', 'Username', 'required|min_length[3]');
+    $validation->setRule('password', 'Password', ['required', 'min_length[8]', 'alpha_numeric_punct']);
+
+The value you pass to ``$field`` must match the key of any data array that is sent in. If
 the data is taken directly from ``$_POST``, then it must be an exact match for
 the form input name.
+
+.. warning:: Prior to v4.2.0, this method's third parameter, ``$rules``, was typehinted to accept
+    ``string``. In v4.2.0 and after, the typehint was removed to allow arrays, too. To avoid LSP being
+    broken in extending classes overriding this method, the child class's method should also be modified
+    to remove the typehint.
 
 setRules()
 ==========
 
-Like, ``setRule()``, but accepts an array of field names and their rules::
+Like ``setRule()``, but accepts an array of field names and their rules::
 
     $validation->setRules([
         'username' => 'required',


### PR DESCRIPTION
**Description**
Supersedes and closes #3910 
Fixes #3774

I tried cherry-picking @element-code 's commit but ended up with merge conflicts instead, so the original authorship was lost.
The breaking change with this is the signature change of `setRule`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
