### PR TITLE
docs: fix variable name in get_cookie()

### DIFF
--- a/user_guide_src/source/helpers/cookie_helper.rst
+++ b/user_guide_src/source/helpers/cookie_helper.rst
@@ -42,7 +42,7 @@ The following functions are available:
 .. php:function:: get_cookie($index[, $xssClean = false])
 
     :param    string    $index: Cookie name
-    :param    bool    $xss_clean: Whether to apply XSS filtering to the returned value
+    :param    bool    $xssClean: Whether to apply XSS filtering to the returned value
     :returns:    The cookie value or null if not found
     :rtype:    mixed
 


### PR DESCRIPTION
**Description**
- fix variable name

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

