### PR TITLE
Fix: Toolbar. ciDebugBar.showTab() context.

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -84,7 +84,7 @@ var ciDebugBar = {
 		var state = tab.style.display;
 
 		// Hide all tabs
-		var tabs = this.toolbar.querySelectorAll('.tab');
+		var tabs = document.querySelectorAll('#debug-bar .tab');
 
 		for (var i = 0; i < tabs.length; i++)
 		{
@@ -92,7 +92,7 @@ var ciDebugBar = {
 		}
 
 		// Mark all labels as inactive
-		var labels = this.toolbar.querySelectorAll('.ci-label');
+		var labels = document.querySelectorAll('#debug-bar .ci-label');
 
 		for (var i = 0; i < labels.length; i++)
 		{


### PR DESCRIPTION
**Description**
Follow-up #5544
Calling the showTab method changes the context if the method is not called directly, but as an "internal call".
Rollback of previous changes.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide