### PR TITLE
fix: replace deprecated FILTER_SANITIZE_STRING

### DIFF
--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -65,7 +65,7 @@ if (! function_exists('get_cookie')) {
     {
         $prefix  = isset($_COOKIE[$index]) ? '' : config(App::class)->cookiePrefix;
         $request = Services::request();
-        $filter  = $xssClean ? FILTER_SANITIZE_STRING : FILTER_DEFAULT;
+        $filter  = $xssClean ? FILTER_SANITIZE_FULL_SPECIAL_CHARS : FILTER_DEFAULT;
 
         return $request->getCookie($prefix . $index, $filter);
     }

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -12,6 +12,7 @@ See all the changes.
 .. toctree::
     :titlesonly:
 
+    v4.1.7
     v4.1.6
     v4.1.5
     v4.1.4

--- a/user_guide_src/source/changelogs/v4.1.7.rst
+++ b/user_guide_src/source/changelogs/v4.1.7.rst
@@ -1,0 +1,35 @@
+Version 4.1.7
+#############
+
+Release Date: Not Released
+
+**4.1.7 release of CodeIgniter4**
+
+.. contents::
+    :local:
+    :depth: 2
+
+BREAKING
+********
+
+- Because ``FILTER_SANITIZE_STRING`` is deprecated since PHP 8.1, ``get_cookie()`` that uses it when ``$xssClean`` is true changed the output. Now it uses ``FILTER_SANITIZE_FULL_SPECIAL_CHARS``. Note that using XSS filtering is a bad practice. It does not prevent XSS attacks perfectly. Using ``esc()`` with the correct ``$context`` in the views is recommended.
+
+Enhancements
+************
+
+none.
+
+Changes
+*******
+
+none.
+
+Deprecations
+************
+
+none.
+
+Bugs Fixed
+**********
+
+See the repo's `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_ for a complete list of bugs fixed.

--- a/user_guide_src/source/helpers/cookie_helper.rst
+++ b/user_guide_src/source/helpers/cookie_helper.rst
@@ -53,6 +53,8 @@ The following functions are available:
     the ``$cookiePrefix`` that you might've set in your
     **app/Config/App.php** file.
 
+.. warning:: Using XSS filtering is a bad practice. It does not prevent XSS attacks perfectly. Using ``esc()`` with the correct ``$context`` in the views is recommended.
+
 .. php:function:: delete_cookie($name[, $domain = ''[, $path = '/'[, $prefix = '']]])
 
     :param string $name: Cookie name

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -399,7 +399,7 @@ The methods provided by the parent classes that are available are:
         The second optional parameter lets you run the data through the PHP's
         filters. Pass in the desired filter type as the second parameter::
 
-            $request->getVar('some_data', FILTER_SANITIZE_STRING);
+            $request->getVar('some_data', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 
         To return an array of all POST items call without any parameters.
 
@@ -407,7 +407,7 @@ The methods provided by the parent classes that are available are:
         first parameter to null while setting the second parameter to the filter
         you want to use::
 
-            $request->getVar(null, FILTER_SANITIZE_STRING);
+            $request->getVar(null, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
             // returns all POST items with string sanitation
 
         To return an array of multiple POST parameters, pass all the required keys as an array::
@@ -417,7 +417,7 @@ The methods provided by the parent classes that are available are:
         Same rule applied here, to retrieve the parameters with filtering, set the second parameter to
         the filter type to apply::
 
-            $request->getVar(['field1', 'field2'], FILTER_SANITIZE_STRING);
+            $request->getVar(['field1', 'field2'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 
     .. php:method:: getGet([$index = null[, $filter = null[, $flags = null]]])
 
@@ -489,7 +489,7 @@ The methods provided by the parent classes that are available are:
         This method is identical to ``getPost()`` and ``getGet()``, only it fetches cookie data::
 
             $request->getCookie('some_cookie');
-            $request->getCookie('some_cookie', FILTER_SANITIZE_STRING); // with filter
+            $request->getCookie('some_cookie', FILTER_SANITIZE_FULL_SPECIAL_CHARS); // with filter
 
         To return an array of multiple cookie values, pass all the required keys as an array::
 

--- a/user_guide_src/source/installation/upgrade_417.rst
+++ b/user_guide_src/source/installation/upgrade_417.rst
@@ -1,0 +1,51 @@
+#############################
+Upgrading from 4.1.6 to 4.1.7
+#############################
+
+Please refer to the upgrade instructions corresponding to your installation method.
+
+- :ref:`Composer Installation App Starter Upgrading <app-starter-upgrading>`
+- :ref:`Composer Installation Adding CodeIgniter4 to an Existing Project Upgrading <adding-codeigniter4-upgrading>`
+- :ref:`Manual Installation Upgrading <installing-manual-upgrading>`
+
+.. contents::
+    :local:
+    :depth: 2
+
+Breaking Changes
+****************
+
+- ``get_cookie()`` when ``$xssClean`` is true changed the output. Now it uses ``FILTER_SANITIZE_FULL_SPECIAL_CHARS``, not ``FILTER_SANITIZE_STRING``. Make sure the change is acceptable or not. Note that using XSS filtering is a bad practice. It does not prevent XSS attacks perfectly. Using ``esc()`` with the correct ``$context`` in the views is recommended.
+
+Breaking Enhancements
+*********************
+
+none.
+
+Project Files
+*************
+
+Numerous files in the **project space** (root, app, public, writable) received updates. Due to
+these files being outside of the **system** scope they will not be changed without your intervention.
+There are some third-party CodeIgniter modules available to assist with merging changes to
+the project space: `Explore on Packagist <https://packagist.org/explore/?query=codeigniter4%20updates>`_.
+
+.. note:: Except in very rare cases for bug fixes, no changes made to files for the project space
+    will break your application. All changes noted here are optional until the next major version,
+    and any mandatory changes will be covered in the sections above.
+
+Content Changes
+===============
+
+The following files received significant changes (including deprecations or visual adjustments)
+and it is recommended that you merge the updated versions with your application:
+
+*
+
+All Changes
+===========
+
+This is a list of all files in the **project space** that received changes;
+many will be simple comments or formatting that have no effect on the runtime:
+
+*

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -8,6 +8,7 @@ upgrading from.
 .. toctree::
     :titlesonly:
 
+    Upgrading from 4.1.6 to 4.1.7 <upgrade_417>
     Upgrading from 4.1.5 to 4.1.6 <upgrade_416>
     Upgrading from 4.1.4 to 4.1.5 <upgrade_415>
     Upgrading from 4.1.3 to 4.1.4 <upgrade_414>


### PR DESCRIPTION
This PR goes into `hotfix-4.1.7 `.

**Description**
Supersedes #5540
Follow-up #5005

- replace `FILTER_SANITIZE_STRING` with `FILTER_SANITIZE_FULL_SPECIAL_CHARS` in `get_cookie()`
- add warning on `get_cookie()` xxsClean

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
