### PR TITLE
fix: add missing Migration lang item

### DIFF
--- a/system/Commands/Database/Migrate.php
+++ b/system/Commands/Database/Migrate.php
@@ -91,7 +91,7 @@ class Migrate extends BaseCommand
                 CLI::write($message);
             }
 
-            CLI::write('Done migrations.', 'green');
+            CLI::write(lang('Migrations.done'), 'green');
 
             // @codeCoverageIgnoreStart
         } catch (Throwable $e) {

--- a/system/Commands/Database/Migrate.php
+++ b/system/Commands/Database/Migrate.php
@@ -91,7 +91,7 @@ class Migrate extends BaseCommand
                 CLI::write($message);
             }
 
-            CLI::write(lang('Migrations.done'), 'green');
+            CLI::write(lang('Migrations.migrated'), 'green');
 
             // @codeCoverageIgnoreStart
         } catch (Throwable $e) {

--- a/system/Language/en/Migrations.php
+++ b/system/Language/en/Migrations.php
@@ -36,7 +36,7 @@ return [
 
     'latest'            => 'Running all new migrations...',
     'generalFault'      => 'Migration failed!',
-    'done'              => 'Done migrations.',
+    'migrated'          => 'Migrations complete.',
     'migInvalidVersion' => 'Invalid version number provided.',
     'toVersionPH'       => 'Migrating to version %s...',
     'toVersion'         => 'Migrating to current version...',

--- a/system/Language/en/Migrations.php
+++ b/system/Language/en/Migrations.php
@@ -36,6 +36,7 @@ return [
 
     'latest'            => 'Running all new migrations...',
     'generalFault'      => 'Migration failed!',
+    'done'              => 'Done migrations.',
     'migInvalidVersion' => 'Invalid version number provided.',
     'toVersionPH'       => 'Migrating to version %s...',
     'toVersion'         => 'Migrating to current version...',

--- a/tests/system/Commands/DatabaseCommandsTest.php
+++ b/tests/system/Commands/DatabaseCommandsTest.php
@@ -52,12 +52,12 @@ final class DatabaseCommandsTest extends CIUnitTestCase
     public function testMigrate()
     {
         command('migrate --all');
-        $this->assertStringContainsString('Done migrations.', $this->getBuffer());
+        $this->assertStringContainsString('Migrations complete.', $this->getBuffer());
         command('migrate:rollback');
 
         $this->clearBuffer();
         command('migrate -n Tests\\\\Support');
-        $this->assertStringContainsString('Done migrations.', $this->getBuffer());
+        $this->assertStringContainsString('Migrations complete.', $this->getBuffer());
     }
 
     public function testMigrateRollback()
@@ -75,7 +75,7 @@ final class DatabaseCommandsTest extends CIUnitTestCase
         $this->clearBuffer();
 
         command('migrate:refresh');
-        $this->assertStringContainsString('Done migrations.', $this->getBuffer());
+        $this->assertStringContainsString('Migrations complete.', $this->getBuffer());
     }
 
     public function testMigrateStatus()


### PR DESCRIPTION
**Description**
- add missing Migration lang item

```
$ php spark migrate

CodeIgniter v4.1.6 Command Line Tool - Server Time: 2022-01-08 20:30:40 UTC-06:00

すべての新しいマイグレーションを実行しています...
Done migrations.
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
