### PR TITLE
Throws Exception when getCompiled*() is called in the Model

### DIFF
--- a/system/Exceptions/ModelException.php
+++ b/system/Exceptions/ModelException.php
@@ -25,4 +25,9 @@ class ModelException extends FrameworkException
     {
         return new static(lang('Database.noDateFormat', [$modelName]));
     }
+
+    public static function forMethodNotAvailable(string $modelName, string $methodName)
+    {
+        return new static(lang('Database.methodNotAvailable', [$modelName, $methodName]));
+    }
 }

--- a/system/Language/en/Database.php
+++ b/system/Language/en/Database.php
@@ -27,5 +27,5 @@ return [
     'fieldNotExists'                   => 'Field `{0}` not found.',
     'forEmptyInputGiven'               => 'Empty statement is given for the field `{0}`',
     'forFindColumnHaveMultipleColumns' => 'Only single column allowed in Column name.',
-    'methodNotAvailable'               => 'You cannot use `{1}` in `{0}`. The CodeIgniter\Model is not the Query Builder.',
+    'methodNotAvailable'               => 'You cannot use `{1}` in `{0}`. This is a method of the `Query Builder` class.',
 ];

--- a/system/Language/en/Database.php
+++ b/system/Language/en/Database.php
@@ -27,4 +27,5 @@ return [
     'fieldNotExists'                   => 'Field `{0}` not found.',
     'forEmptyInputGiven'               => 'Empty statement is given for the field `{0}`',
     'forFindColumnHaveMultipleColumns' => 'Only single column allowed in Column name.',
+    'methodNotAvailable'               => 'You cannot use `{1}` in `{0}`. The CodeIgniter\Model is not the Query Builder.',
 ];

--- a/system/Model.php
+++ b/system/Model.php
@@ -90,7 +90,7 @@ class Model extends BaseModel
     protected $escape = [];
 
     /**
-     * Builder method names that are not used in the Model.
+     * Builder method names that should not be used in the Model.
      *
      * @var string[] method name
      */
@@ -750,6 +750,9 @@ class Model extends BaseModel
         return $result;
     }
 
+    /**
+     * Checks the Builder method name that should not be used in the Model.
+     */
     private function checkBuilderMethod(string $name): void
     {
         if (in_array($name, $this->builderMethodsNotAvailable, true)) {

--- a/system/Model.php
+++ b/system/Model.php
@@ -89,6 +89,17 @@ class Model extends BaseModel
      */
     protected $escape = [];
 
+    /**
+     * Builder method names that are not used in the Model.
+     *
+     * @var string[] method name
+     */
+    private array $builderMethodsNotAvailable = [
+        'getCompiledInsert',
+        'getCompiledSelect',
+        'getCompiledUpdate',
+    ];
+
     public function __construct(?ConnectionInterface &$db = null, ?ValidationInterface $validation = null)
     {
         /**
@@ -725,6 +736,8 @@ class Model extends BaseModel
         if (method_exists($this->db, $name)) {
             $result = $this->db->{$name}(...$params);
         } elseif (method_exists($builder, $name)) {
+            $this->checkBuilderMethod($name);
+
             $result = $builder->{$name}(...$params);
         } else {
             throw new BadMethodCallException('Call to undefined method ' . static::class . '::' . $name);
@@ -735,6 +748,13 @@ class Model extends BaseModel
         }
 
         return $result;
+    }
+
+    private function checkBuilderMethod(string $name): void
+    {
+        if (in_array($name, $this->builderMethodsNotAvailable, true)) {
+            throw ModelException::forMethodNotAvailable(static::class, $name . '()');
+        }
     }
 
     /**

--- a/tests/_support/Models/GetCompiledModelTest.php
+++ b/tests/_support/Models/GetCompiledModelTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Models;
+
+use CodeIgniter\Exceptions\ModelException;
+use CodeIgniter\Model;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockConnection;
+use Tests\Support\Models\UserObjModel;
+
+/**
+ * @internal
+ */
+final class GetCompiledModelTest extends CIUnitTestCase
+{
+    /**
+     * @var Model
+     */
+    private $model;
+
+    /**
+     * Create an instance of Model for use in testing.
+     */
+    private function createModel(string $modelName): Model
+    {
+        $db          = new MockConnection([]);
+        $this->model = new $modelName($db);
+
+        return $this->model;
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5549
+     */
+    public function testGetCompiledInsert(): void
+    {
+        $this->expectException(ModelException::class);
+        $this->expectExceptionMessage('You cannot use `getCompiledInsert()` in `Tests\Support\Models\UserObjModel`.');
+
+        $this->createModel(UserObjModel::class);
+
+        $sql = $this->model
+            ->set('name', 'Mark')
+            ->set('email', 'mark@example.com')
+            ->getCompiledInsert();
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5549
+     */
+    public function testGetCompiledUpdate(): void
+    {
+        $this->expectException(ModelException::class);
+        $this->expectExceptionMessage('You cannot use `getCompiledUpdate()` in `Tests\Support\Models\UserObjModel`.');
+
+        $this->createModel(UserObjModel::class);
+
+        $sql = $this->model
+            ->set('name', 'Mark')
+            ->set('email', 'mark@example.com')
+            ->getCompiledUpdate();
+    }
+}


### PR DESCRIPTION
**Description**
Alternative to #5561
Related to #5549
- throws Exception when `getCompiled*()` is called in the Model

Reasons:
- `CodeIgniter\Model` and Query Builder should not be expected to return the same data. They are separate classes with different purposes.
- If you need to get the compiled Insert or Update you should do so directly on the Query Builder instance.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
