### PR TITLE
Update version references to PHP 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Please read the [*Contributing to CodeIgniter*](https://github.com/codeigniter4/
 
 ## Server Requirements
 
-PHP version 7.3 or higher is required, with the following extensions installed:
+PHP version 7.4 or higher is required, with the following extensions installed:
 
 
 - [intl](http://php.net/manual/en/intl.requirements.php)

--- a/Vagrantfile.dist
+++ b/Vagrantfile.dist
@@ -50,7 +50,7 @@ Vagrant.configure("2") do |config|
     PGSQL_ROOT_PASS="password"
     VIRTUALHOST="localhost"
     CODEIGNITER_PATH="/var/www/codeigniter"
-    PHP_VERSION=7.3
+    PHP_VERSION=7.4
     PGSQL_VERSION=10
     #APT_PROXY="192.168.10.1:3142"
 
@@ -166,8 +166,8 @@ Vagrant.configure("2") do |config|
     sed -i "s/APACHE_RUN_USER=www-data/APACHE_RUN_USER=vagrant/" /etc/apache2/envvars
     sed -i "s/APACHE_RUN_GROUP=www-data/APACHE_RUN_GROUP=vagrant/" /etc/apache2/envvars
     grep -q "Listen 81" /etc/apache2/ports.conf || sed -i "s/^Listen 80/Listen 80\\nListen 81\\nListen 82/" /etc/apache2/ports.conf
-    sed -i "s/^display_errors = Off/display_errors = On/" /etc/php/7.3/apache2/php.ini
-    sed -i "s/^display_startup_errors = Off/display_startup_errors = On/" /etc/php/7.3/apache2/php.ini
+    sed -i "s/^display_errors = Off/display_errors = On/" /etc/php/7.4/apache2/php.ini
+    sed -i "s/^display_startup_errors = Off/display_startup_errors = On/" /etc/php/7.4/apache2/php.ini
 
     echo "ServerName ${VIRTUALHOST}
 <Directory ${CODEIGNITER_PATH}>

--- a/admin/framework/README.md
+++ b/admin/framework/README.md
@@ -43,7 +43,7 @@ Please read the [*Contributing to CodeIgniter*](https://github.com/codeigniter4/
 
 ## Server Requirements
 
-PHP version 7.3 or higher is required, with the following extensions installed:
+PHP version 7.4 or higher is required, with the following extensions installed:
 
 - [intl](http://php.net/manual/en/intl.requirements.php)
 - [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library

--- a/admin/module/composer.json
+++ b/admin/module/composer.json
@@ -4,7 +4,7 @@
     "homepage": "https://codeigniter.com",
     "license": "MIT",
     "require": {
-        "php": "^7.3 || ^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "require-dev": {
         "codeigniter4/codeigniter4": "dev-develop",

--- a/admin/starter/.github/workflows/phpunit.yml
+++ b/admin/starter/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4']
+        php-versions: ['7.4', '8.0']
 
     runs-on: ubuntu-latest
 

--- a/admin/starter/README.md
+++ b/admin/starter/README.md
@@ -50,7 +50,7 @@ Problems with it can be raised on our forum, or as issues in the main repository
 
 ## Server Requirements
 
-PHP version 7.3 or higher is required, with the following extensions installed:
+PHP version 7.4 or higher is required, with the following extensions installed:
 
 - [intl](http://php.net/manual/en/intl.requirements.php)
 - [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library

--- a/admin/userguide/composer.json
+++ b/admin/userguide/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://codeigniter.com",
     "license": "MIT",
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "codeigniter4/framework": "^4"
     },
     "support": {

--- a/contributing/pull_request.md
+++ b/contributing/pull_request.md
@@ -119,7 +119,7 @@ See [Contribution CSS](./css.md).
 
 ### Compatibility
 
-CodeIgniter4 requires [PHP 7.3](https://php.net/releases/7_3_0.php).
+CodeIgniter4 requires [PHP 7.4](https://php.net/releases/7_4_0.php).
 
 ### Backwards Compatibility
 

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -35,7 +35,7 @@ General Adjustments
 
 **Namespaces**
 
-- CI4 is built for PHP7.3+, and everything in the framework is namespaced, except for the helpers.
+- CI4 is built for PHP 7.4+, and everything in the framework is namespaced, except for the helpers.
 
 **Application Structure**
 

--- a/user_guide_src/source/intro/requirements.rst
+++ b/user_guide_src/source/intro/requirements.rst
@@ -2,7 +2,7 @@
 Server Requirements
 ###################
 
-`PHP <https://www.php.net/>`_ version 7.3 or newer is required, with the
+`PHP <https://www.php.net/>`_ version 7.4 or newer is required, with the
 `*intl* extension <https://www.php.net/manual/en/intl.requirements.php>`_ and `*mbstring* extension <https://www.php.net/manual/en/mbstring.requirements.php>`_
 installed.
 


### PR DESCRIPTION
**Description**
Follow up #5558
- replace `7.3` with `7.4`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
