### PR TITLE
Include CI-Upgrader in docs

### DIFF
--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -155,3 +155,7 @@ Upgrading Libraries
 
 .. note::
     More upgrade guides coming soon
+    
+.. note::
+    To get a much faster and easier way to upgrade your CI3 project to CI4, you can check out the `CI-Upgrader <https://github.com/FlorianNelles/CI-Upgrader>`_.
+    This tool is able to run the CI4 installation, copy the most important files and directories from your old CI3 project to the new one and also to transfer most of the Code into CI4 syntax.


### PR DESCRIPTION
The CI-Upgrader is a tool, which will help you to upgrade your CodeIgniter 3 project to CodeIgniter 4.
It is able to run the CI4 installation, copy the most important files and directories from your old CI3 project to the new one and also to transfer most of the Code into CI4 syntax.
So I think it would be useful to include a reference to this tool on the 'Upgrading from 3.x to 4.x' -page of the documentation.
