### PR TITLE
test: replace `$request->uri` with `$request->getUri()`

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -941,11 +941,6 @@ parameters:
 			path: system/Test/Fabricator.php
 
 		-
-			message: "#^Access to protected property CodeIgniter\\\\HTTP\\\\Request\\:\\:\\$uri\\.$#"
-			count: 1
-			path: system/Test/FeatureTestCase.php
-
-		-
 			message: "#^Property CodeIgniter\\\\Test\\\\CIUnitTestCase\\:\\:\\$bodyFormat \\(string\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: system/Test/FeatureTestCase.php

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -349,7 +349,7 @@ class FeatureTestCase extends CIUnitTestCase
         // otherwise set it from the URL.
         $get = ! empty($params) && $method === 'get'
             ? $params
-            : $this->getPrivateProperty($request->uri, 'query');
+            : $this->getPrivateProperty($request->getUri(), 'query');
 
         $request->setGlobal('get', $get);
         if ($method !== 'get') {

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -344,7 +344,7 @@ trait FeatureTestTrait
         // otherwise set it from the URL.
         $get = ! empty($params) && $method === 'get'
             ? $params
-            : $this->getPrivateProperty($request->uri, 'query');
+            : $this->getPrivateProperty($request->getUri(), 'query');
 
         $request->setGlobal('get', $get);
         if ($method !== 'get') {

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -875,7 +875,7 @@ final class URITest extends CIUnitTestCase
         Services::injectMock('request', $request);
 
         // going through request
-        $this->assertSame('http://example.com/ci/v4/controller/method', (string) $request->uri);
+        $this->assertSame('http://example.com/ci/v4/controller/method', (string) $request->getUri());
         $this->assertSame('/ci/v4/controller/method', $request->getUri()->getPath());
 
         // standalone


### PR DESCRIPTION
**Description**
Follow-up #5346
- refactor: $request->uri → $request->getUri()

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
