### PR TITLE
Fix: Deletion timestamp of the Model is updated when a record that has been soft-deleted is deleted again

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -358,7 +358,7 @@ class Model extends BaseModel
                 return false; // @codeCoverageIgnore
             }
 
-            $builder->where($this->deletedField, null);
+            $builder->where($this->deletedField);
 
             $set[$this->deletedField] = $this->setDate();
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -358,6 +358,8 @@ class Model extends BaseModel
                 return false; // @codeCoverageIgnore
             }
 
+            $builder->where($this->deletedField, null);
+
             $set[$this->deletedField] = $this->setDate();
 
             if ($this->useTimestamps && $this->updatedField) {

--- a/tests/system/Models/DeleteModelTest.php
+++ b/tests/system/Models/DeleteModelTest.php
@@ -60,6 +60,10 @@ final class DeleteModelTest extends LiveModelTestCase
         $result = $this->model->delete(1);
         $this->assertTrue($result);
         $this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NOT NULL' => null]);
+        $this->assertSame(1, $this->db->affectedRows());
+
+        $this->model->delete(1);
+        $this->assertSame(0, $this->db->affectedRows());
     }
 
     public function testDeleteWithSoftDeleteFail(): void

--- a/tests/system/Models/DeleteModelTest.php
+++ b/tests/system/Models/DeleteModelTest.php
@@ -59,8 +59,8 @@ final class DeleteModelTest extends LiveModelTestCase
 
         $result = $this->model->delete(1);
         $this->assertTrue($result);
-        $this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NOT NULL' => null]);
         $this->assertSame(1, $this->db->affectedRows());
+        $this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NOT NULL' => null]);
 
         $this->model->delete(1);
         $this->assertSame(0, $this->db->affectedRows());


### PR DESCRIPTION
**Description**
Related #5576
If the model provides for soft deletion of records and an attempt is made to re-delete, then timestamps are changed in the record marked as deleted.

This PR adds a condition under which the update will only occur if the deletion timestamp has not yet been set.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide