### PR TITLE
fix: `Time::createFromTimestamp()` sets incorrect time when specifying timezone

### DIFF
--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -256,7 +256,10 @@ class Time extends DateTime
      */
     public static function createFromTimestamp(int $timestamp, $timezone = null, ?string $locale = null)
     {
-        return new self(gmdate('Y-m-d H:i:s', $timestamp), $timezone ?? 'UTC', $locale);
+        $timezone ??= 'UTC';
+        $date = new DateTime('now', new DateTimeZone($timezone));
+
+        return new self($date->setTimestamp($timestamp)->format('Y-m-d H:i:s'), $timezone, $locale);
     }
 
     /**

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -256,10 +256,10 @@ class Time extends DateTime
      */
     public static function createFromTimestamp(int $timestamp, $timezone = null, ?string $locale = null)
     {
+        $time = new self(gmdate('Y-m-d H:i:s', $timestamp), 'UTC', $locale);
         $timezone ??= 'UTC';
-        $date = new DateTime('now', new DateTimeZone($timezone));
 
-        return new self($date->setTimestamp($timestamp)->format('Y-m-d H:i:s'), $timezone, $locale);
+        return $time->setTimezone($timezone);
     }
 
     /**

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -253,6 +253,21 @@ final class TimeTest extends CIUnitTestCase
         $this->assertSame(date('2017-03-18 00:00:00'), $time->toDateTimeString());
     }
 
+    public function testCreateFromTimestampWithTimezone()
+    {
+        // Set the timezone temporarily to UTC to make sure the test timestamp is correct
+        $tz = date_default_timezone_get();
+        date_default_timezone_set('UTC');
+
+        $timestamp = strtotime('2017-03-18 midnight'); // in UTC
+
+        date_default_timezone_set($tz);
+
+        $time = Time::createFromTimestamp($timestamp, 'Asia/Jakarta'); // UTC +7
+
+        $this->assertSame(date('2017-03-18 07:00:00'), $time->toDateTimeString());
+    }
+
     public function testTestNow()
     {
         $this->assertFalse(Time::hasTestNow());


### PR DESCRIPTION
**Description**
previously not updating date even though time zone has been set


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
