### PR TITLE
docs: fix typos in comments

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -108,7 +108,7 @@ class FileLocator
     }
 
     /**
-     * Examines a file and returns the fully qualified domain name.
+     * Examines a file and returns the fully qualified class name.
      */
     public function getClassname(string $file): string
     {
@@ -319,7 +319,7 @@ class FileLocator
 
     /**
      * Scans the provided namespace, returning a list of all files
-     * that are contained within the subpath specified by $path.
+     * that are contained within the sub path specified by $path.
      */
     public function listNamespaceFiles(string $prefix, string $path): array
     {

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1489,9 +1489,9 @@ abstract class BaseModel
     }
 
     /**
-     * Takes a class an returns an array of it's public and protected
+     * Takes a class and returns an array of it's public and protected
      * properties as an array suitable for use in creates and updates.
-     * This method use objectToRawArray internally and does conversion
+     * This method uses objectToRawArray() internally and does conversion
      * to string on all Time instances
      *
      * @param object|string $data        Data
@@ -1521,7 +1521,7 @@ abstract class BaseModel
     }
 
     /**
-     * Takes a class an returns an array of it's public and protected
+     * Takes a class and returns an array of its public and protected
      * properties as an array with raw values.
      *
      * @param object|string $data        Data

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -240,7 +240,7 @@ final class TimeTest extends CIUnitTestCase
 
     public function testCreateFromTimestamp()
     {
-        // Se the timezone temporarily to UTC to make sure the test timestamp is correct
+        // Set the timezone temporarily to UTC to make sure the test timestamp is correct
         $tz = date_default_timezone_get();
         date_default_timezone_set('UTC');
 


### PR DESCRIPTION
**Description**
- fix typos in comments

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
