### PR TITLE
Fix ResponseTrait methods visibility

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -87,7 +87,7 @@ trait ResponseTrait
      *
      * @return mixed
      */
-    public function respond($data = null, ?int $status = null, string $message = '')
+    protected function respond($data = null, ?int $status = null, string $message = '')
     {
         if ($data === null && $status === null) {
             $status = 404;
@@ -121,7 +121,7 @@ trait ResponseTrait
      *
      * @return mixed
      */
-    public function fail($messages, int $status = 400, ?string $code = null, string $customMessage = '')
+    protected function fail($messages, int $status = 400, ?string $code = null, string $customMessage = '')
     {
         if (! is_array($messages)) {
             $messages = ['error' => $messages];
@@ -147,7 +147,7 @@ trait ResponseTrait
      *
      * @return mixed
      */
-    public function respondCreated($data = null, string $message = '')
+    protected function respondCreated($data = null, string $message = '')
     {
         return $this->respond($data, $this->codes['created'], $message);
     }
@@ -159,7 +159,7 @@ trait ResponseTrait
      *
      * @return mixed
      */
-    public function respondDeleted($data = null, string $message = '')
+    protected function respondDeleted($data = null, string $message = '')
     {
         return $this->respond($data, $this->codes['deleted'], $message);
     }
@@ -171,7 +171,7 @@ trait ResponseTrait
      *
      * @return mixed
      */
-    public function respondUpdated($data = null, string $message = '')
+    protected function respondUpdated($data = null, string $message = '')
     {
         return $this->respond($data, $this->codes['updated'], $message);
     }
@@ -182,7 +182,7 @@ trait ResponseTrait
      *
      * @return mixed
      */
-    public function respondNoContent(string $message = 'No Content')
+    protected function respondNoContent(string $message = 'No Content')
     {
         return $this->respond(null, $this->codes['no_content'], $message);
     }
@@ -194,7 +194,7 @@ trait ResponseTrait
      *
      * @return mixed
      */
-    public function failUnauthorized(string $description = 'Unauthorized', ?string $code = null, string $message = '')
+    protected function failUnauthorized(string $description = 'Unauthorized', ?string $code = null, string $message = '')
     {
         return $this->fail($description, $this->codes['unauthorized'], $code, $message);
     }
@@ -205,7 +205,7 @@ trait ResponseTrait
      *
      * @return mixed
      */
-    public function failForbidden(string $description = 'Forbidden', ?string $code = null, string $message = '')
+    protected function failForbidden(string $description = 'Forbidden', ?string $code = null, string $message = '')
     {
         return $this->fail($description, $this->codes['forbidden'], $code, $message);
     }
@@ -215,7 +215,7 @@ trait ResponseTrait
      *
      * @return mixed
      */
-    public function failNotFound(string $description = 'Not Found', ?string $code = null, string $message = '')
+    protected function failNotFound(string $description = 'Not Found', ?string $code = null, string $message = '')
     {
         return $this->fail($description, $this->codes['resource_not_found'], $code, $message);
     }
@@ -227,7 +227,7 @@ trait ResponseTrait
      *
      * @deprecated Use failValidationErrors instead
      */
-    public function failValidationError(string $description = 'Bad Request', ?string $code = null, string $message = '')
+    protected function failValidationError(string $description = 'Bad Request', ?string $code = null, string $message = '')
     {
         return $this->fail($description, $this->codes['invalid_data'], $code, $message);
     }
@@ -239,7 +239,7 @@ trait ResponseTrait
      *
      * @return mixed
      */
-    public function failValidationErrors($errors, ?string $code = null, string $message = '')
+    protected function failValidationErrors($errors, ?string $code = null, string $message = '')
     {
         return $this->fail($errors, $this->codes['invalid_data'], $code, $message);
     }
@@ -249,7 +249,7 @@ trait ResponseTrait
      *
      * @return mixed
      */
-    public function failResourceExists(string $description = 'Conflict', ?string $code = null, string $message = '')
+    protected function failResourceExists(string $description = 'Conflict', ?string $code = null, string $message = '')
     {
         return $this->fail($description, $this->codes['resource_exists'], $code, $message);
     }
@@ -261,7 +261,7 @@ trait ResponseTrait
      *
      * @return mixed
      */
-    public function failResourceGone(string $description = 'Gone', ?string $code = null, string $message = '')
+    protected function failResourceGone(string $description = 'Gone', ?string $code = null, string $message = '')
     {
         return $this->fail($description, $this->codes['resource_gone'], $code, $message);
     }
@@ -271,7 +271,7 @@ trait ResponseTrait
      *
      * @return mixed
      */
-    public function failTooManyRequests(string $description = 'Too Many Requests', ?string $code = null, string $message = '')
+    protected function failTooManyRequests(string $description = 'Too Many Requests', ?string $code = null, string $message = '')
     {
         return $this->fail($description, $this->codes['too_many_requests'], $code, $message);
     }
@@ -285,7 +285,7 @@ trait ResponseTrait
      *
      * @return Response The value of the Response's send() method.
      */
-    public function failServerError(string $description = 'Internal Server Error', ?string $code = null, string $message = ''): Response
+    protected function failServerError(string $description = 'Internal Server Error', ?string $code = null, string $message = ''): Response
     {
         return $this->fail($description, $this->codes['server_error'], $code, $message);
     }
@@ -346,7 +346,7 @@ trait ResponseTrait
      *
      * @return $this
      */
-    public function setResponseFormat(?string $format = null)
+    protected function setResponseFormat(?string $format = null)
     {
         $this->format = strtolower($format);
 

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -85,7 +85,7 @@ trait ResponseTrait
      *
      * @param array|string|null $data
      *
-     * @return mixed
+     * @return Response
      */
     protected function respond($data = null, ?int $status = null, string $message = '')
     {
@@ -119,7 +119,7 @@ trait ResponseTrait
      * @param int          $status   HTTP status code
      * @param string|null  $code     Custom, API-specific, error code
      *
-     * @return mixed
+     * @return Response
      */
     protected function fail($messages, int $status = 400, ?string $code = null, string $customMessage = '')
     {
@@ -145,7 +145,7 @@ trait ResponseTrait
      *
      * @param mixed $data
      *
-     * @return mixed
+     * @return Response
      */
     protected function respondCreated($data = null, string $message = '')
     {
@@ -157,7 +157,7 @@ trait ResponseTrait
      *
      * @param mixed $data
      *
-     * @return mixed
+     * @return Response
      */
     protected function respondDeleted($data = null, string $message = '')
     {
@@ -169,7 +169,7 @@ trait ResponseTrait
      *
      * @param mixed $data
      *
-     * @return mixed
+     * @return Response
      */
     protected function respondUpdated($data = null, string $message = '')
     {
@@ -180,7 +180,7 @@ trait ResponseTrait
      * Used after a command has been successfully executed but there is no
      * meaningful reply to send back to the client.
      *
-     * @return mixed
+     * @return Response
      */
     protected function respondNoContent(string $message = 'No Content')
     {
@@ -192,7 +192,7 @@ trait ResponseTrait
      * or had bad authorization credentials. User is encouraged to try again
      * with the proper information.
      *
-     * @return mixed
+     * @return Response
      */
     protected function failUnauthorized(string $description = 'Unauthorized', ?string $code = null, string $message = '')
     {
@@ -203,7 +203,7 @@ trait ResponseTrait
      * Used when access is always denied to this resource and no amount
      * of trying again will help.
      *
-     * @return mixed
+     * @return Response
      */
     protected function failForbidden(string $description = 'Forbidden', ?string $code = null, string $message = '')
     {
@@ -213,7 +213,7 @@ trait ResponseTrait
     /**
      * Used when a specified resource cannot be found.
      *
-     * @return mixed
+     * @return Response
      */
     protected function failNotFound(string $description = 'Not Found', ?string $code = null, string $message = '')
     {
@@ -223,7 +223,7 @@ trait ResponseTrait
     /**
      * Used when the data provided by the client cannot be validated.
      *
-     * @return mixed
+     * @return Response
      *
      * @deprecated Use failValidationErrors instead
      */
@@ -237,7 +237,7 @@ trait ResponseTrait
      *
      * @param string|string[] $errors
      *
-     * @return mixed
+     * @return Response
      */
     protected function failValidationErrors($errors, ?string $code = null, string $message = '')
     {
@@ -247,7 +247,7 @@ trait ResponseTrait
     /**
      * Use when trying to create a new resource and it already exists.
      *
-     * @return mixed
+     * @return Response
      */
     protected function failResourceExists(string $description = 'Conflict', ?string $code = null, string $message = '')
     {
@@ -259,7 +259,7 @@ trait ResponseTrait
      * Not Found, because here we know the data previously existed, but is now gone,
      * where Not Found means we simply cannot find any information about it.
      *
-     * @return mixed
+     * @return Response
      */
     protected function failResourceGone(string $description = 'Gone', ?string $code = null, string $message = '')
     {
@@ -269,7 +269,7 @@ trait ResponseTrait
     /**
      * Used when the user has made too many requests for the resource recently.
      *
-     * @return mixed
+     * @return Response
      */
     protected function failTooManyRequests(string $description = 'Too Many Requests', ?string $code = null, string $message = '')
     {

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -110,7 +110,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     {
         $this->formatter = null;
         $controller      = $this->makeController([], 'http://codeigniter.com', ['Accept' => 'application/json']);
-        $controller->respondCreated(['id' => 3], 'A Custom Reason');
+
+        $this->invoke($controller, 'respondCreated', [['id' => 3], 'A Custom Reason']);
 
         $this->assertSame('A Custom Reason', $this->response->getReason());
         $this->assertSame(201, $this->response->getStatusCode());
@@ -127,7 +128,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     {
         $this->formatter = null;
         $controller      = $this->makeController([], 'http://codeigniter.com', ['Accept' => 'application/json']);
-        $controller->respondCreated('A Custom Reason');
+
+        $this->invoke($controller, 'respondCreated', ['A Custom Reason']);
 
         $this->assertSame('A Custom Reason', $this->response->getBody());
     }
@@ -137,12 +139,14 @@ final class ResponseTraitTest extends CIUnitTestCase
         $this->formatter = null;
         $controller      = $this->makeController();
         $payload         = ['answer' => 42];
-        $expected        = <<<'EOH'
+
+        $this->invoke($controller, 'respond', [$payload]);
+
+        $expected = <<<'EOH'
             {
                 "answer": 42
             }
             EOH;
-        $controller->respond($payload);
         $this->assertSame($expected, $this->response->getBody());
     }
 
@@ -155,6 +159,9 @@ final class ResponseTraitTest extends CIUnitTestCase
             2,
             3,
         ];
+
+        $this->invoke($controller, 'respond', [$payload]);
+
         $expected = <<<'EOH'
             [
                 1,
@@ -162,7 +169,6 @@ final class ResponseTraitTest extends CIUnitTestCase
                 3
             ]
             EOH;
-        $controller->respond($payload);
         $this->assertSame($expected, $this->response->getBody());
     }
 
@@ -173,20 +179,23 @@ final class ResponseTraitTest extends CIUnitTestCase
         $payload         = new stdClass();
         $payload->name   = 'Tom';
         $payload->id     = 1;
-        $expected        = <<<'EOH'
+
+        $this->invoke($controller, 'respond', [(array) $payload]);
+
+        $expected = <<<'EOH'
             {
                 "name": "Tom",
                 "id": 1
             }
             EOH;
-        $controller->respond((array) $payload);
         $this->assertSame($expected, $this->response->getBody());
     }
 
     public function testRespondSets404WithNoData()
     {
         $controller = $this->makeController();
-        $controller->respond(null, null);
+
+        $this->invoke($controller, 'respond', [null, null]);
 
         $this->assertSame(404, $this->response->getStatusCode());
         $this->assertNull($this->response->getBody());
@@ -195,7 +204,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testRespondSetsStatusWithEmptyData()
     {
         $controller = $this->makeController();
-        $controller->respond(null, 201);
+
+        $this->invoke($controller, 'respond', [null, 201]);
 
         $this->assertSame(201, $this->response->getStatusCode());
         $this->assertNull($this->response->getBody());
@@ -204,7 +214,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testRespondSetsCorrectBodyAndStatus()
     {
         $controller = $this->makeController();
-        $controller->respond('something', 201);
+
+        $this->invoke($controller, 'respond', ['something', 201]);
 
         $this->assertSame(201, $this->response->getStatusCode());
         $this->assertSame('something', $this->response->getBody());
@@ -215,7 +226,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testRespondWithCustomReason()
     {
         $controller = $this->makeController();
-        $controller->respond('something', 201, 'A Custom Reason');
+
+        $this->invoke($controller, 'respond', ['something', 201, 'A Custom Reason']);
 
         $this->assertSame(201, $this->response->getStatusCode());
         $this->assertSame('A Custom Reason', $this->response->getReason());
@@ -225,7 +237,7 @@ final class ResponseTraitTest extends CIUnitTestCase
     {
         $controller = $this->makeController();
 
-        $controller->fail('Failure to Launch', 500, 'WHAT!', 'A Custom Reason');
+        $this->invoke($controller, 'fail', ['Failure to Launch', 500, 'WHAT!', 'A Custom Reason']);
 
         // Will use the JSON formatter by default
         $expected = [
@@ -235,7 +247,6 @@ final class ResponseTraitTest extends CIUnitTestCase
                 'error' => 'Failure to Launch',
             ],
         ];
-
         $this->assertSame($this->formatter->format($expected), $this->response->getBody());
         $this->assertSame(500, $this->response->getStatusCode());
         $this->assertSame('A Custom Reason', $this->response->getReason());
@@ -244,7 +255,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testCreated()
     {
         $controller = $this->makeController();
-        $controller->respondCreated(['id' => 3], 'A Custom Reason');
+
+        $this->invoke($controller, 'respondCreated', [['id' => 3], 'A Custom Reason']);
 
         $this->assertSame('A Custom Reason', $this->response->getReason());
         $this->assertSame(201, $this->response->getStatusCode());
@@ -254,7 +266,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testDeleted()
     {
         $controller = $this->makeController();
-        $controller->respondDeleted(['id' => 3], 'A Custom Reason');
+
+        $this->invoke($controller, 'respondDeleted', [['id' => 3], 'A Custom Reason']);
 
         $this->assertSame('A Custom Reason', $this->response->getReason());
         $this->assertSame(200, $this->response->getStatusCode());
@@ -264,7 +277,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testUpdated()
     {
         $controller = $this->makeController();
-        $controller->respondUpdated(['id' => 3], 'A Custom Reason');
+
+        $this->invoke($controller, 'respondUpdated', [['id' => 3], 'A Custom Reason']);
 
         $this->assertSame('A Custom Reason', $this->response->getReason());
         $this->assertSame(200, $this->response->getStatusCode());
@@ -274,7 +288,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testUnauthorized()
     {
         $controller = $this->makeController();
-        $controller->failUnauthorized('Nope', 'FAT CHANCE', 'A Custom Reason');
+
+        $this->invoke($controller, 'failUnauthorized', ['Nope', 'FAT CHANCE', 'A Custom Reason']);
 
         $expected = [
             'status'   => 401,
@@ -283,7 +298,6 @@ final class ResponseTraitTest extends CIUnitTestCase
                 'error' => 'Nope',
             ],
         ];
-
         $this->assertSame('A Custom Reason', $this->response->getReason());
         $this->assertSame(401, $this->response->getStatusCode());
         $this->assertSame($this->formatter->format($expected), $this->response->getBody());
@@ -292,7 +306,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testForbidden()
     {
         $controller = $this->makeController();
-        $controller->failForbidden('Nope', 'FAT CHANCE', 'A Custom Reason');
+
+        $this->invoke($controller, 'failForbidden', ['Nope', 'FAT CHANCE', 'A Custom Reason']);
 
         $expected = [
             'status'   => 403,
@@ -301,7 +316,6 @@ final class ResponseTraitTest extends CIUnitTestCase
                 'error' => 'Nope',
             ],
         ];
-
         $this->assertSame('A Custom Reason', $this->response->getReason());
         $this->assertSame(403, $this->response->getStatusCode());
         $this->assertSame($this->formatter->format($expected), $this->response->getBody());
@@ -310,7 +324,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testNoContent()
     {
         $controller = $this->makeController();
-        $controller->respondNoContent('');
+
+        $this->invoke($controller, 'respondNoContent', ['']);
 
         $this->assertSame('No Content', $this->response->getReason());
         $this->assertSame(204, $this->response->getStatusCode());
@@ -319,7 +334,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testNotFound()
     {
         $controller = $this->makeController();
-        $controller->failNotFound('Nope', 'FAT CHANCE', 'A Custom Reason');
+
+        $this->invoke($controller, 'failNotFound', ['Nope', 'FAT CHANCE', 'A Custom Reason']);
 
         $expected = [
             'status'   => 404,
@@ -328,7 +344,6 @@ final class ResponseTraitTest extends CIUnitTestCase
                 'error' => 'Nope',
             ],
         ];
-
         $this->assertSame('A Custom Reason', $this->response->getReason());
         $this->assertSame(404, $this->response->getStatusCode());
         $this->assertSame($this->formatter->format($expected), $this->response->getBody());
@@ -337,7 +352,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testValidationError()
     {
         $controller = $this->makeController();
-        $controller->failValidationError('Nope', 'FAT CHANCE', 'A Custom Reason');
+
+        $this->invoke($controller, 'failValidationError', ['Nope', 'FAT CHANCE', 'A Custom Reason']);
 
         $expected = [
             'status'   => 400,
@@ -346,7 +362,6 @@ final class ResponseTraitTest extends CIUnitTestCase
                 'error' => 'Nope',
             ],
         ];
-
         $this->assertSame('A Custom Reason', $this->response->getReason());
         $this->assertSame(400, $this->response->getStatusCode());
         $this->assertSame($this->formatter->format($expected), $this->response->getBody());
@@ -355,7 +370,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testValidationErrors()
     {
         $controller = $this->makeController();
-        $controller->failValidationErrors(['foo' => 'Nope', 'bar' => 'No way'], 'FAT CHANCE', 'A Custom Reason');
+
+        $this->invoke($controller, 'failValidationErrors', [['foo' => 'Nope', 'bar' => 'No way'], 'FAT CHANCE', 'A Custom Reason']);
 
         $expected = [
             'status'   => 400,
@@ -365,7 +381,6 @@ final class ResponseTraitTest extends CIUnitTestCase
                 'bar' => 'No way',
             ],
         ];
-
         $this->assertSame('A Custom Reason', $this->response->getReason());
         $this->assertSame(400, $this->response->getStatusCode());
         $this->assertSame($this->formatter->format($expected), $this->response->getBody());
@@ -374,7 +389,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testResourceExists()
     {
         $controller = $this->makeController();
-        $controller->failResourceExists('Nope', 'FAT CHANCE', 'A Custom Reason');
+
+        $this->invoke($controller, 'failResourceExists', ['Nope', 'FAT CHANCE', 'A Custom Reason']);
 
         $expected = [
             'status'   => 409,
@@ -383,7 +399,6 @@ final class ResponseTraitTest extends CIUnitTestCase
                 'error' => 'Nope',
             ],
         ];
-
         $this->assertSame('A Custom Reason', $this->response->getReason());
         $this->assertSame(409, $this->response->getStatusCode());
         $this->assertSame($this->formatter->format($expected), $this->response->getBody());
@@ -392,7 +407,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testResourceGone()
     {
         $controller = $this->makeController();
-        $controller->failResourceGone('Nope', 'FAT CHANCE', 'A Custom Reason');
+
+        $this->invoke($controller, 'failResourceGone', ['Nope', 'FAT CHANCE', 'A Custom Reason']);
 
         $expected = [
             'status'   => 410,
@@ -401,7 +417,6 @@ final class ResponseTraitTest extends CIUnitTestCase
                 'error' => 'Nope',
             ],
         ];
-
         $this->assertSame('A Custom Reason', $this->response->getReason());
         $this->assertSame(410, $this->response->getStatusCode());
         $this->assertSame($this->formatter->format($expected), $this->response->getBody());
@@ -410,7 +425,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testTooManyRequests()
     {
         $controller = $this->makeController();
-        $controller->failTooManyRequests('Nope', 'FAT CHANCE', 'A Custom Reason');
+
+        $this->invoke($controller, 'failTooManyRequests', ['Nope', 'FAT CHANCE', 'A Custom Reason']);
 
         $expected = [
             'status'   => 429,
@@ -419,7 +435,6 @@ final class ResponseTraitTest extends CIUnitTestCase
                 'error' => 'Nope',
             ],
         ];
-
         $this->assertSame('A Custom Reason', $this->response->getReason());
         $this->assertSame(429, $this->response->getStatusCode());
         $this->assertSame($this->formatter->format($expected), $this->response->getBody());
@@ -428,7 +443,8 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testServerError()
     {
         $controller = $this->makeController();
-        $controller->failServerError('Nope.', 'FAT-CHANCE', 'A custom reason.');
+
+        $this->invoke($controller, 'failServerError', ['Nope.', 'FAT-CHANCE', 'A custom reason.']);
 
         $this->assertSame('A custom reason.', $this->response->getReason());
         $this->assertSame(500, $this->response->getStatusCode());
@@ -491,7 +507,8 @@ final class ResponseTraitTest extends CIUnitTestCase
 
         $this->assertInstanceOf('CodeIgniter\Format\XMLFormatter', $this->formatter);
 
-        $controller->respondCreated(['id' => 3], 'A Custom Reason');
+        $this->invoke($controller, 'respondCreated', [['id' => 3], 'A Custom Reason']);
+
         $expected = <<<'EOH'
             <?xml version="1.0"?>
             <response><id>3</id></response>
@@ -540,23 +557,24 @@ final class ResponseTraitTest extends CIUnitTestCase
             }
         };
 
-        $controller->respondCreated(['id' => 3], 'A Custom Reason');
+        $this->invoke($controller, 'respondCreated', [['id' => 3], 'A Custom Reason']);
+
         $this->assertStringStartsWith(config('Format')->supportedResponseFormats[0], $response->getHeaderLine('Content-Type'));
     }
 
     public function testResponseFormat()
     {
-        $data = ['foo' => 'something'];
-
+        $data       = ['foo' => 'something'];
         $controller = $this->makeController();
-        $controller->setResponseFormat('json');
-        $controller->respond($data, 201);
+
+        $this->invoke($controller, 'setResponseFormat', ['json']);
+        $this->invoke($controller, 'respond', [$data, 201]);
 
         $this->assertStringStartsWith('application/json', $this->response->getHeaderLine('Content-Type'));
         $this->assertSame($this->formatter->format($data), $this->response->getJSON());
 
-        $controller->setResponseFormat('xml');
-        $controller->respond($data, 201);
+        $this->invoke($controller, 'setResponseFormat', ['xml']);
+        $this->invoke($controller, 'respond', [$data, 201]);
 
         $this->assertStringStartsWith('application/xml', $this->response->getHeaderLine('Content-Type'));
     }
@@ -566,10 +584,18 @@ final class ResponseTraitTest extends CIUnitTestCase
         $data       = ['foo' => 'bar'];
         $controller = $this->makeController();
         $controller->resetFormatter();
-        $controller->setResponseFormat('xml');
-        $controller->respond($data, 201);
+
+        $this->invoke($controller, 'setResponseFormat', ['xml']);
+        $this->invoke($controller, 'respond', [$data, 201]);
 
         $xmlFormatter = new XMLFormatter();
         $this->assertSame($xmlFormatter->format($data), $this->response->getXML());
+    }
+
+    private function invoke(object $controller, string $method, array $args = [])
+    {
+        $method = $this->getPrivateMethodInvoker($controller, $method);
+
+        return $method(...$args);
     }
 }

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -293,7 +293,7 @@ final class ResourceControllerTest extends CIUnitTestCase
             'foo' => 'bar',
         ];
 
-        $theResponse = $resource->respond($data);
+        $theResponse = $this->invoke($resource, 'respond', [$data]);
         $result      = $theResponse->getBody();
 
         $JSONFormatter = new JSONFormatter();
@@ -321,12 +321,19 @@ final class ResourceControllerTest extends CIUnitTestCase
             'foo' => 'bar',
         ];
 
-        $theResponse = $resource->respond($data);
+        $theResponse = $this->invoke($resource, 'respond', [$data]);
         $result      = $theResponse->getBody();
 
         $XMLFormatter = new XMLFormatter();
         $expected     = $XMLFormatter->format($data);
 
         $this->assertSame($expected, $result);
+    }
+
+    private function invoke(object $controller, string $method, array $args = [])
+    {
+        $method = $this->getPrivateMethodInvoker($controller, $method);
+
+        return $method(...$args);
     }
 }


### PR DESCRIPTION
**Description**
- fix ResponseTrait methods visibility. Public methods can be accessible via HTTP.
- fix `@return` types

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
