### PR TITLE
Fix Autoloader::initialize()

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -82,6 +82,10 @@ class Autoloader
      */
     public function initialize(Autoload $config, Modules $modules)
     {
+        $this->prefixes = [];
+        $this->classmap = [];
+        $this->files    = [];
+
         // We have to have one or the other, though we don't enforce the need
         // to have both present in order to work.
         if (empty($config->psr4) && empty($config->classmap)) {

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -70,6 +70,22 @@ final class AutoloaderTest extends CIUnitTestCase
         (new Autoloader())->initialize($config, $modules);
     }
 
+    public function testInitializeTwice()
+    {
+        $loader = new Autoloader();
+        $loader->initialize(new Autoload(), new Modules());
+
+        $ns = $loader->getNamespace();
+        $this->assertCount(1, $ns['App']);
+        $this->assertSame('ROOTPATH/app', clean_path($ns['App'][0]));
+
+        $loader->initialize(new Autoload(), new Modules());
+
+        $ns = $loader->getNamespace();
+        $this->assertCount(1, $ns['App']);
+        $this->assertSame('ROOTPATH/app', clean_path($ns['App'][0]));
+    }
+
     public function testServiceAutoLoaderFromShareInstances()
     {
         $autoloader = Services::autoloader();

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
@@ -56,9 +56,24 @@ final class DatabaseTestCaseMigrationOnce1Test extends CIUnitTestCase
 
     protected function setUp(): void
     {
-        Services::autoloader()->addNamespace('Tests\Support\MigrationTestMigrations', SUPPORTPATH . 'MigrationTestMigrations');
+        $this->setUpMethods[] = 'setUpAddNamespace';
 
         parent::setUp();
+    }
+
+    protected function setUpAddNamespace()
+    {
+        Services::autoloader()->addNamespace(
+            'Tests\Support\MigrationTestMigrations',
+            SUPPORTPATH . 'MigrationTestMigrations'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->regressDatabase();
     }
 
     public function testMigrationDone()

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
@@ -55,9 +55,24 @@ final class DatabaseTestCaseMigrationOnce2Test extends CIUnitTestCase
 
     protected function setUp(): void
     {
-        Services::autoloader()->addNamespace('Tests\Support\MigrationTestMigrations', SUPPORTPATH . 'MigrationTestMigrations');
+        $this->setUpMethods[] = 'setUpAddNamespace';
 
         parent::setUp();
+    }
+
+    protected function setUpAddNamespace()
+    {
+        Services::autoloader()->addNamespace(
+            'Tests\Support\MigrationTestMigrations',
+            SUPPORTPATH . 'MigrationTestMigrations'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->regressDatabase();
     }
 
     public function testMigrationDone()

--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -60,12 +60,24 @@ final class DatabaseTestCaseTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
-        if (! self::$loaded) {
-            Services::autoloader()->addNamespace('Tests\Support\MigrationTestMigrations', SUPPORTPATH . 'MigrationTestMigrations');
-            self::$loaded = true;
-        }
+        $this->setUpMethods[] = 'setUpAddNamespace';
 
         parent::setUp();
+    }
+
+    protected function setUpAddNamespace()
+    {
+        Services::autoloader()->addNamespace(
+            'Tests\Support\MigrationTestMigrations',
+            SUPPORTPATH . 'MigrationTestMigrations'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->regressDatabase();
     }
 
     public function testMultipleSeeders()

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -39,6 +39,8 @@ final class MigrationRunnerTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
+        $this->setUpMethods[] = 'setUpAddNamespace';
+
         parent::setUp();
 
         $this->root   = vfsStream::setup('root');
@@ -46,8 +48,21 @@ final class MigrationRunnerTest extends CIUnitTestCase
         $this->config = new Migrations();
 
         $this->config->enabled = true;
+    }
 
-        Services::autoloader()->addNamespace('Tests\Support\MigrationTestMigrations', TESTPATH . '_support/MigrationTestMigrations');
+    protected function setUpAddNamespace()
+    {
+        Services::autoloader()->addNamespace(
+            'Tests\Support\MigrationTestMigrations',
+            SUPPORTPATH . 'MigrationTestMigrations'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->regressDatabase();
     }
 
     public function testLoadsDefaultDatabaseWhenNoneSpecified()


### PR DESCRIPTION
**Description**
- reset the state when `initialize()` is called

```
$ ./phpunit --exclude-group DatabaseLive,CacheLive 

Memory: 188.00 MB <- before
Memory: 186.00 MB <- after
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
