### PR TITLE
refactor: CURLRequest and the slow tests

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -561,11 +561,6 @@ parameters:
 			path: system/Filters/Filters.php
 
 		-
-			message: "#^Parameter \\#1 \\$seconds of function sleep expects int, float given\\.$#"
-			count: 1
-			path: system/HTTP/CURLRequest.php
-
-		-
 			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: system/HTTP/Files/UploadedFile.php

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -354,7 +354,7 @@ class CURLRequest extends Request
 
         // Do we need to delay this request?
         if ($this->delay > 0) {
-            sleep($this->delay);
+            usleep((int) $this->delay * 1_000_000);
         }
 
         $output = $this->sendRequest($curlOptions);

--- a/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
@@ -267,13 +267,13 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
 
     public function testOptionsDelay()
     {
+        $request = $this->getRequest();
+        $this->assertSame(0.0, $request->getDelay());
+
         $options = [
             'delay'   => 2000,
             'headers' => ['fruit' => 'apple'],
         ];
-        $request = $this->getRequest();
-        $this->assertSame(0.0, $request->getDelay());
-
         $request = $this->getRequest($options);
         $this->assertSame(2.0, $request->getDelay());
     }
@@ -715,20 +715,20 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $request->get('products');
 
         // we still need to check the code coverage to make sure this was done
-        $this->assertSame(1.0, $request->getDelay());
+        $this->assertSame(0.1, $request->getDelay());
     }
 
     public function testSendContinued()
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $request->setOutput("HTTP/1.1 100 Continue\x0d\x0a\x0d\x0aHi there");
@@ -743,7 +743,7 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $output = "HTTP/1.1 100 Continue
@@ -787,7 +787,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $request->setOutput("Accept: text/html\x0d\x0a\x0d\x0aHi there");
@@ -799,7 +799,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $request->setBody('name=George');
@@ -814,7 +814,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $request->setOutput("HTTP/2.0 234 Ohoh\x0d\x0aAccept: text/html\x0d\x0a\x0d\x0aHi there");
@@ -828,7 +828,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $request->setOutput("HTTP/2 235 Ohoh\x0d\x0aAccept: text/html\x0d\x0a\x0d\x0aHi there shortie");

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -250,13 +250,13 @@ final class CURLRequestTest extends CIUnitTestCase
 
     public function testOptionsDelay()
     {
+        $request = $this->getRequest();
+        $this->assertSame(0.0, $request->getDelay());
+
         $options = [
             'delay'   => 2000,
             'headers' => ['fruit' => 'apple'],
         ];
-        $request = $this->getRequest();
-        $this->assertSame(0.0, $request->getDelay());
-
         $request = $this->getRequest($options);
         $this->assertSame(2.0, $request->getDelay());
     }
@@ -698,20 +698,20 @@ final class CURLRequestTest extends CIUnitTestCase
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $request->get('products');
 
         // we still need to check the code coverage to make sure this was done
-        $this->assertSame(1.0, $request->getDelay());
+        $this->assertSame(0.1, $request->getDelay());
     }
 
     public function testSendContinued()
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $request->setOutput("HTTP/1.1 100 Continue\x0d\x0a\x0d\x0aHi there");
@@ -726,7 +726,7 @@ final class CURLRequestTest extends CIUnitTestCase
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $output = "HTTP/1.1 100 Continue
@@ -770,7 +770,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $request->setOutput("Accept: text/html\x0d\x0a\x0d\x0aHi there");
@@ -782,7 +782,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $request->setBody('name=George');
@@ -797,7 +797,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $request->setOutput("HTTP/2.0 234 Ohoh\x0d\x0aAccept: text/html\x0d\x0a\x0d\x0aHi there");
@@ -811,7 +811,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 1000,
+            'delay'    => 100,
         ]);
 
         $request->setOutput("HTTP/2 235 Ohoh\x0d\x0aAccept: text/html\x0d\x0a\x0d\x0aHi there shortie");


### PR DESCRIPTION
**Description**
To improve test speed.
- CURLReqest
  - `sleep()` -> `usleep()`
- Tests
  - `delay` 1000 -> 100

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
