### PR TITLE
BaseService - Use lowercase key in resetSingle

### DIFF
--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -288,6 +288,7 @@ class BaseService
      */
     public static function resetSingle(string $name)
     {
+        $name = strtolower($name);
         unset(static::$mocks[$name], static::$instances[$name]);
     }
 

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -343,6 +343,17 @@ final class ServicesTest extends CIUnitTestCase
         $this->assertSame($security, $security2);
     }
 
+    public function testResetSingleCaseInsensitive()
+    {
+        Services::injectMock('response', new MockResponse(new App()));
+        $someService = service('response');
+        $this->assertInstanceOf(MockResponse::class, $someService);
+
+        Services::resetSingle('Response');
+        $someService = service('response');
+        $this->assertNotInstanceOf(MockResponse::class, $someService);
+    }
+
     public function testFilters()
     {
         $result = Services::filters();


### PR DESCRIPTION
Since injectMock converts key to lowercase we need to use lowercase key as well in resetSingle method 

**Description**
Fixes #5595

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
