### PR TITLE
Fix: Added alias escaping in subquery

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2767,9 +2767,10 @@ class BaseBuilder
 
         if ($wrapped) {
             $subquery = '(' . $subquery . ')';
+            $alias    = trim($alias);
 
             if ($alias !== '') {
-                $subquery .= " AS {$alias}";
+                $subquery .= ' AS ' . ($this->db->protectIdentifiers ? $this->db->escapeIdentifiers($alias) : $alias);
             }
         }
 

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -103,19 +103,19 @@ final class FromTest extends CIUnitTestCase
 
     public function testFromSubquery()
     {
-        $expectedSQL = 'SELECT * FROM (SELECT * FROM "users") AS alias';
+        $expectedSQL = 'SELECT * FROM (SELECT * FROM "users") AS "alias"';
         $subquery    = new BaseBuilder('users', $this->db);
         $builder     = $this->db->newQuery()->fromSubquery($subquery, 'alias');
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 
-        $expectedSQL = 'SELECT * FROM (SELECT "id", "name" FROM "users") AS users_1';
+        $expectedSQL = 'SELECT * FROM (SELECT "id", "name" FROM "users") AS "users_1"';
         $subquery    = (new BaseBuilder('users', $this->db))->select('id, name');
         $builder     = $this->db->newQuery()->fromSubquery($subquery, 'users_1');
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 
-        $expectedSQL = 'SELECT * FROM (SELECT * FROM "users") AS alias, "some_table"';
+        $expectedSQL = 'SELECT * FROM (SELECT * FROM "users") AS "alias", "some_table"';
         $subquery    = new BaseBuilder('users', $this->db);
         $builder     = $this->db->newQuery()->fromSubquery($subquery, 'alias')->from('some_table');
 
@@ -145,7 +145,7 @@ final class FromTest extends CIUnitTestCase
 
         $builder->fromSubquery($subquery, 'users_1');
 
-        $expectedSQL = 'SELECT * FROM "test"."dbo"."jobs", (SELECT * FROM "test"."dbo"."users") AS users_1';
+        $expectedSQL = 'SELECT * FROM "test"."dbo"."jobs", (SELECT * FROM "test"."dbo"."users") AS "users_1"';
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -234,7 +234,7 @@ This is where we add a subquery to an existing table.::
     $builder  = $db->table('jobs')->fromSubquery($subquery, 'alias');
     $query = $builder->get();
 
-    // Produces: SELECT * FROM `jobs`, (SELECT * FROM `users`) AS alias
+    // Produces: SELECT * FROM `jobs`, (SELECT * FROM `users`) AS `alias`
 
 Use the ``$db->newQuery()`` method to make a subquery the main table.::
 
@@ -242,7 +242,7 @@ Use the ``$db->newQuery()`` method to make a subquery the main table.::
     $builder  = $db->newQuery()->fromSubquery($subquery, 't');
     $query = $builder->get();
 
-    // Produces: SELECT * FROM (SELECT `id`, `name` FROM users) AS t
+    // Produces: SELECT * FROM (SELECT `id`, `name` FROM users) AS `t`
 
 Join
 ====


### PR DESCRIPTION
**Description**
Follow-up #5510
Added alias escaping in subquery 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide