### PR TITLE
chore: generate coverage report by PHPUnit only on PHP 8.0

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -126,7 +126,15 @@ jobs:
         if: matrix.php-versions == '8.0'
         run: echo "TACHYCARDIA_MONITOR_GA=enabled" >> $GITHUB_ENV
 
-      - name: Test with PHPUnit
+      - name: Test with PHPUnit w/o Coverage
+        if: matrix.php-versions != '8.0'
+        run: script -e -c "vendor/bin/phpunit --color=always --exclude-group=auto-review --no-coverage"
+        env:
+          DB: ${{ matrix.db-platforms }}
+          TERM: xterm-256color
+
+      - name: Test with PHPUnit with Coverage
+        if: matrix.php-versions == '8.0'
         run: script -e -c "vendor/bin/phpunit --color=always --exclude-group=auto-review"
         env:
           DB: ${{ matrix.db-platforms }}

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -126,16 +126,15 @@ jobs:
         if: matrix.php-versions == '8.0'
         run: echo "TACHYCARDIA_MONITOR_GA=enabled" >> $GITHUB_ENV
 
-      - name: Test with PHPUnit w/o Coverage
-        if: matrix.php-versions != '8.0'
-        run: script -e -c "vendor/bin/phpunit --color=always --exclude-group=auto-review --no-coverage"
-        env:
-          DB: ${{ matrix.db-platforms }}
-          TERM: xterm-256color
+      - name: Compute coverage option
+        uses: actions/github-script@v3
+        id: phpunit-coverage-option
+        with:
+          script: 'return "${{ matrix.php-versions }}" == "8.0" ? "" : "--no-coverage"'
+          result-encoding: string
 
-      - name: Test with PHPUnit with Coverage
-        if: matrix.php-versions == '8.0'
-        run: script -e -c "vendor/bin/phpunit --color=always --exclude-group=auto-review"
+      - name: Test with PHPUnit
+        run: script -e -c "vendor/bin/phpunit --color=always --exclude-group=auto-review ${{ steps.phpunit-coverage-option.outputs.result }}"
         env:
           DB: ${{ matrix.db-platforms }}
           TERM: xterm-256color


### PR DESCRIPTION
**Description**
- To reduce test time
  - add `--no-coverage` option to PHPUnit other than on PHP 8.0

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide

