### PR TITLE
Fix `array_flatten_with_dots` ignores empty array values

### DIFF
--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -203,7 +203,7 @@ if (! function_exists('array_flatten_with_dots')) {
         foreach ($array as $key => $value) {
             $newKey = $id . $key;
 
-            if (is_array($value)) {
+            if (is_array($value) && $value !== []) {
                 $flattened = array_merge($flattened, array_flatten_with_dots($value, $newKey . '.'));
             } else {
                 $flattened[$newKey] = $value;

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -391,11 +391,8 @@ final class ArrayHelperTest extends CIUnitTestCase
 
     /**
      * @dataProvider arrayFlattenProvider
-     *
-     * @param iterable $input
-     * @param iterable $expected
      */
-    public function testArrayFlattening($input, $expected): void
+    public function testArrayFlattening(array $input, array $expected): void
     {
         $this->assertSame($expected, array_flatten_with_dots($input));
     }
@@ -452,24 +449,22 @@ final class ArrayHelperTest extends CIUnitTestCase
             ],
             [
                 'foo'      => 'bar',
+                'baz'      => [],
                 'bar.fizz' => 'buzz',
                 'bar.nope' => 'yeah',
+                'bar.why'  => [],
             ],
         ];
 
-        yield 'with-mixed-empty' => [
+        yield 'with-empty-string-index' => [
             [
                 'foo' => 1,
                 ''    => [
                     'bar' => 2,
                     'baz' => 3,
                 ],
-                0 => [
-                    'fizz' => 4,
-                ],
-                1 => [
-                    'buzz' => 5,
-                ],
+                ['fizz' => 4],
+                ['buzz' => 5],
             ],
             [
                 'foo'    => 1,
@@ -477,6 +472,19 @@ final class ArrayHelperTest extends CIUnitTestCase
                 '.baz'   => 3,
                 '0.fizz' => 4,
                 '1.buzz' => 5,
+            ],
+        ];
+
+        yield 'empty-array-and-lists' => [
+            [
+                'bar' => [
+                    ['foo' => 'baz'],
+                    ['foo' => []],
+                ],
+            ],
+            [
+                'bar.0.foo' => 'baz',
+                'bar.1.foo' => [],
             ],
         ];
     }


### PR DESCRIPTION
**Description**
Fixes #5603 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
