### PR TITLE
Fix: Validation. Error key for field with asterisk

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -631,7 +631,9 @@ class Validation implements ValidationInterface
      */
     public function hasError(string $field): bool
     {
-        return array_key_exists($field, $this->getErrors());
+        $pattern = '/^' . str_replace('\.\*', '\..+', preg_quote($field, '/')) . '$/';
+
+        return (bool) preg_grep($pattern, array_keys($this->getErrors()));
     }
 
     /**

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -139,7 +139,12 @@ class Validation implements ValidationInterface
                 $rules = $this->splitRules($rules);
             }
 
-            $values = dot_array_search($field, $data);
+            $values = strpos($field, '*') !== false
+                ? array_filter(array_flatten_with_dots($data), static fn ($key) => preg_match(
+                    '/^' . str_replace('\.\*', '\..+', preg_quote($field, '/')) . '$/',
+                    $key
+                ), ARRAY_FILTER_USE_KEY)
+                : dot_array_search($field, $data);
 
             if ($values === []) {
                 // We'll process the values right away if an empty array
@@ -148,10 +153,10 @@ class Validation implements ValidationInterface
                 continue;
             }
 
-            if (strpos($field, '*') !== false && is_array($values)) {
+            if (strpos($field, '*') !== false) {
                 // Process multiple fields
-                foreach ($values as $value) {
-                    $this->processRules($field, $setup['label'] ?? $field, $value, $rules, $data);
+                foreach ($values as $dotField => $value) {
+                    $this->processRules($dotField, $setup['label'] ?? $field, $value, $rules, $data);
                 }
             } else {
                 // Process single field

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -646,7 +646,12 @@ class Validation implements ValidationInterface
             $field = array_key_first($this->rules);
         }
 
-        return array_key_exists($field, $this->getErrors()) ? $this->errors[$field] : '';
+        $errors = array_filter($this->getErrors(), static fn ($key) => preg_match(
+            '/^' . str_replace('\.\*', '\..+', preg_quote($field, '/')) . '$/',
+            $key
+        ), ARRAY_FILTER_USE_KEY);
+
+        return $errors === [] ? '' : implode("\n", $errors);
     }
 
     /**

--- a/tests/system/Validation/StrictRules/ValidationTest.php
+++ b/tests/system/Validation/StrictRules/ValidationTest.php
@@ -762,6 +762,16 @@ final class ValidationTest extends CIUnitTestCase
             'name_user.2'             => 'The name_user.* field may only contain alphabetical characters.',
             'contacts.friends.0.name' => 'The contacts.*.name field is required.',
         ], $this->validation->getErrors());
+
+        $this->assertSame(
+            "The name_user.* field may only contain alphabetical characters.\n"
+            . 'The name_user.* field may only contain alphabetical characters.',
+            $this->validation->getError('name_user.*')
+        );
+        $this->assertSame(
+            'The contacts.*.name field is required.',
+            $this->validation->getError('contacts.*.name')
+        );
     }
 
     public function testRulesForSingleRuleWithSingleValue(): void

--- a/tests/system/Validation/StrictRules/ValidationTest.php
+++ b/tests/system/Validation/StrictRules/ValidationTest.php
@@ -530,10 +530,24 @@ final class ValidationTest extends CIUnitTestCase
 
     public function testHasError(): void
     {
-        $data = ['foo' => 'notanumber'];
-        $this->validation->setRules(['foo' => 'is_numeric']);
+        $data = [
+            'foo' => 'notanumber',
+            'bar' => [
+                ['baz' => 'string'],
+                ['baz' => ''],
+            ],
+        ];
+
+        $this->validation->setRules([
+            'foo'       => 'is_numeric',
+            'bar.*.baz' => 'required',
+        ]);
+
         $this->validation->run($data);
         $this->assertTrue($this->validation->hasError('foo'));
+        $this->assertTrue($this->validation->hasError('bar.*.baz'));
+        $this->assertFalse($this->validation->hasError('bar.0.baz'));
+        $this->assertTrue($this->validation->hasError('bar.1.baz'));
     }
 
     public function testSplitRulesTrue(): void

--- a/tests/system/Validation/StrictRules/ValidationTest.php
+++ b/tests/system/Validation/StrictRules/ValidationTest.php
@@ -722,21 +722,31 @@ final class ValidationTest extends CIUnitTestCase
             ],
             'name_user' => [
                 123,
+                'alpha',
                 'xyz098',
+            ],
+            'contacts' => [
+                'friends' => [
+                    ['name' => ''],
+                    ['name' => 'John'],
+                ],
             ],
         ];
 
         $request = new IncomingRequest($config, new URI(), 'php://input', new UserAgent());
 
         $this->validation->setRules([
-            'id_user.*'   => 'numeric',
-            'name_user.*' => 'alpha',
+            'id_user.*'       => 'numeric',
+            'name_user.*'     => 'alpha',
+            'contacts.*.name' => 'required',
         ]);
 
         $this->validation->withRequest($request->withMethod('post'))->run();
         $this->assertSame([
-            'id_user.*'   => 'The id_user.* field must contain only numbers.',
-            'name_user.*' => 'The name_user.* field may only contain alphabetical characters.',
+            'id_user.0'               => 'The id_user.* field must contain only numbers.',
+            'name_user.0'             => 'The name_user.* field may only contain alphabetical characters.',
+            'name_user.2'             => 'The name_user.* field may only contain alphabetical characters.',
+            'contacts.friends.0.name' => 'The contacts.*.name field is required.',
         ], $this->validation->getErrors());
     }
 

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -633,10 +633,24 @@ final class ValidationTest extends CIUnitTestCase
 
     public function testHasError(): void
     {
-        $data = ['foo' => 'notanumber'];
-        $this->validation->setRules(['foo' => 'is_numeric']);
+        $data = [
+            'foo' => 'notanumber',
+            'bar' => [
+                ['baz' => 'string'],
+                ['baz' => ''],
+            ],
+        ];
+
+        $this->validation->setRules([
+            'foo'       => 'is_numeric',
+            'bar.*.baz' => 'required',
+        ]);
+
         $this->validation->run($data);
         $this->assertTrue($this->validation->hasError('foo'));
+        $this->assertTrue($this->validation->hasError('bar.*.baz'));
+        $this->assertFalse($this->validation->hasError('bar.0.baz'));
+        $this->assertTrue($this->validation->hasError('bar.1.baz'));
     }
 
     public function testSplitRulesTrue(): void

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -825,21 +825,31 @@ final class ValidationTest extends CIUnitTestCase
             ],
             'name_user' => [
                 123,
+                'alpha',
                 'xyz098',
+            ],
+            'contacts' => [
+                'friends' => [
+                    ['name' => ''],
+                    ['name' => 'John'],
+                ],
             ],
         ];
 
         $request = new IncomingRequest($config, new URI(), 'php://input', new UserAgent());
 
         $this->validation->setRules([
-            'id_user.*'   => 'numeric',
-            'name_user.*' => 'alpha',
+            'id_user.*'       => 'numeric',
+            'name_user.*'     => 'alpha',
+            'contacts.*.name' => 'required',
         ]);
 
         $this->validation->withRequest($request->withMethod('post'))->run();
         $this->assertSame([
-            'id_user.*'   => 'The id_user.* field must contain only numbers.',
-            'name_user.*' => 'The name_user.* field may only contain alphabetical characters.',
+            'id_user.0'               => 'The id_user.* field must contain only numbers.',
+            'name_user.0'             => 'The name_user.* field may only contain alphabetical characters.',
+            'name_user.2'             => 'The name_user.* field may only contain alphabetical characters.',
+            'contacts.friends.0.name' => 'The contacts.*.name field is required.',
         ], $this->validation->getErrors());
     }
 

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -865,6 +865,16 @@ final class ValidationTest extends CIUnitTestCase
             'name_user.2'             => 'The name_user.* field may only contain alphabetical characters.',
             'contacts.friends.0.name' => 'The contacts.*.name field is required.',
         ], $this->validation->getErrors());
+
+        $this->assertSame(
+            "The name_user.* field may only contain alphabetical characters.\n"
+            . 'The name_user.* field may only contain alphabetical characters.',
+            $this->validation->getError('name_user.*')
+        );
+        $this->assertSame(
+            'The contacts.*.name field is required.',
+            $this->validation->getError('contacts.*.name')
+        );
     }
 
     public function testRulesForSingleRuleWithSingleValue(): void

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -36,6 +36,7 @@ Changes
 - Update minimal PHP requirement to 7.4.
 - The current version of Content Security Policy (CSP) outputs one nonce for script and one for style tags. The previous version outputted one nonce for each tag.
 - The process of sending cookies has been moved to the ``Response`` class. Now the ``Session`` class doesn't send cookies, set them to the Response.
+- Validation. Changed generation of errors when using fields with a wildcard (*). Now the error key contains the full path. See :ref:`validation-getting-all-errors`.
 
 Deprecations
 ************

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -37,6 +37,7 @@ Changes
 - The current version of Content Security Policy (CSP) outputs one nonce for script and one for style tags. The previous version outputted one nonce for each tag.
 - The process of sending cookies has been moved to the ``Response`` class. Now the ``Session`` class doesn't send cookies, set them to the Response.
 - Validation. Changed generation of errors when using fields with a wildcard (*). Now the error key contains the full path. See :ref:`validation-getting-all-errors`.
+- ``Validation::getError()`` when using a wildcard will return all found errors matching the mask as a string.
 
 Deprecations
 ************

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -634,7 +634,7 @@ When using a wildcard, the error will point to a specific field, replacing the a
         ]
     ]
 
-    //rule
+    // rule
     contacts.*.name => 'required'
 
     // error will be
@@ -658,6 +658,16 @@ You can check to see if an error exists with the ``hasError()`` method. The only
     if ($validation->hasError('username')) {
         echo $validation->getError('username');
     }
+
+When specifying a field with a wildcard, all errors matching the mask will be checked.::
+
+    // for errors
+    [
+        'foo.0.bar'   => 'Error',
+        'foo.baz.bar' => 'Error',
+    ]
+
+    $validation->hasError('foo.*.bar'); // return true
 
 Customizing Error Display
 *************************

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -603,6 +603,8 @@ We can simply use the language lines defined in this file, like this::
         ]
     );
 
+.. _validation-getting-all-errors:
+
 Getting All Errors
 ==================
 

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -650,6 +650,8 @@ name::
 
 If no error exists, an empty string will be returned.
 
+.. note:: When using a wildcard, all found errors that match the mask will be combined into one line separated by the EOL character.
+
 Check If Error Exists
 =====================
 

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -618,6 +618,26 @@ If you need to retrieve all error messages for failed fields, you can use the ``
 
 If no errors exist, an empty array will be returned.
 
+When using a wildcard, the error will point to a specific field, replacing the asterisk with the appropriate key/keys.::
+
+    // for data
+    'contacts' => [
+        'friends' => [
+            [
+                'name' => 'Fred Flinstone',
+            ],
+            [
+                'name' => '',
+            ],
+        ]
+    ]
+
+    //rule
+    contacts.*.name => 'required'
+
+    // error will be
+    'contacts.friends.1.name' => 'The contacts.*.name field is required.',
+
 Getting a Single Error
 ======================
 


### PR DESCRIPTION
**Description**
Now, when validating a multidimensional array using a wildcard, only the last error is saved. Therefore, it is impossible to determine which field the error belongs to.

```php
// data
[
    'users' => [
        'friends' => [
            ['name' => 'Jim'],
            ['name' => 'James'],
            ['name' => ''],
        ]
    ]
]

// rules
['users.*.name' => 'required|min_length[4]']

// errors
['users.*.name' => 'The users.*.name field is required.']
```

This PR changes behavior. Errors have a corresponding key.
```php
[
    'users.friends.0.name' => 'The users.*.name field must be at least 4 characters in length.',
    'users.friends.2.name' => 'The users.*.name field is required.',
]
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
