### PR TITLE
deprecate Database\SQLSRV\Connection::getError()

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1526,7 +1526,8 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * Must return an array with keys 'code' and 'message':
      *
-     * @return array{code: int|string|null, message: string|null}
+     * @return array<string, int|string|null>
+     * @phpstan-return array{code: int|string|null, message: string|null}
      */
     abstract public function error(): array;
 

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1526,7 +1526,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * Must return an array with keys 'code' and 'message':
      *
-     *  return ['code' => null, 'message' => null);
+     * @return array{code: int|string|null, message: string|null}
      */
     abstract public function error(): array;
 

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -465,6 +465,8 @@ class Connection extends BaseConnection
      * Returns the last error encountered by this connection.
      *
      * @return mixed
+     *
+     * @deprecated Use `error()` instead.
      */
     public function getError()
     {

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -36,7 +36,7 @@ Changes
 Deprecations
 ************
 
-
+- ``CodeIgniter\Database\SQLSRV\Connection::getError()`` is deprecated. Use ``CodeIgniter\Database\SQLSRV\Connection::error()`` instead.
 
 Bugs Fixed
 **********


### PR DESCRIPTION
**Description**
- The method is a duplicate of `error()`.
- `BaseConnection` does not have `getError()`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

