### PR TITLE
docs: small fix for installation

### DIFF
--- a/user_guide_src/source/installation/index.rst
+++ b/user_guide_src/source/installation/index.rst
@@ -18,8 +18,8 @@ Which is right for you?
     installing_composer
     installing_manual
     running
-    upgrading
     ../changelogs/index
+    upgrading
     troubleshooting
     repositories
 

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -8,6 +8,7 @@ upgrading from.
 .. toctree::
     :titlesonly:
 
+    Upgrading from 4.1.7 to 4.1.8 <upgrade_418>
     Upgrading from 4.1.6 to 4.1.7 <upgrade_417>
     Upgrading from 4.1.5 to 4.1.6 <upgrade_416>
     Upgrading from 4.1.4 to 4.1.5 <upgrade_415>


### PR DESCRIPTION
**Description**
- add missing upgrade_418 in TOC
- move "Change Logs" up 

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
