### PR TITLE
fix: DownloadResponse memory leak

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -894,6 +894,11 @@ class CodeIgniter
         }
 
         if ($returned instanceof DownloadResponse) {
+            // Turn off output buffering completely, even if php.ini output_buffering is not off
+            while (ob_get_level() > 0) {
+                ob_end_clean();
+            }
+
             $this->response = $returned;
 
             return;

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -306,6 +306,7 @@ class DownloadResponse extends Response
         // Flush 1MB chunks of data
         while (! $splFileObject->eof() && ($data = $splFileObject->fread(1_048_576)) !== false) {
             echo $data;
+            unset($data);
         }
 
         return $this;


### PR DESCRIPTION
**Description**
Fixes #5620

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

