### PR TITLE
refactor: replace deprecated `getFilterForRoute()`

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1064,6 +1064,10 @@ class RouteCollection implements RouteCollectionInterface
     {
         $options = $this->loadRoutesOptions($verb);
 
+        if (! array_key_exists($search, $options)) {
+            return [];
+        }
+
         if (is_string($options[$search]['filter'])) {
             return [$options[$search]['filter']];
         }

--- a/system/Test/FilterTestTrait.php
+++ b/system/Test/FilterTestTrait.php
@@ -176,8 +176,8 @@ trait FilterTestTrait
 
         $this->filters->reset();
 
-        if ($routeFilter = $this->collection->getFilterForRoute($route)) {
-            $this->filters->enableFilter($routeFilter, $position);
+        if ($routeFilters = $this->collection->getFiltersForRoute($route)) {
+            $this->filters->enableFilters($routeFilters, $position);
         }
 
         $aliases = $this->filters->initialize($route)->getFilters();

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1254,8 +1254,8 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $this->assertTrue($routes->isFiltered('admin/users'));
         $this->assertFalse($routes->isFiltered('admin/franky'));
-        $this->assertSame('role', $routes->getFilterForRoute('admin/users'));
-        $this->assertSame('', $routes->getFilterForRoute('admin/bosses'));
+        $this->assertSame(['role'], $routes->getFiltersForRoute('admin/users'));
+        $this->assertSame([], $routes->getFiltersForRoute('admin/bosses'));
     }
 
     public function testRouteGroupWithFilterWithParams()
@@ -1273,7 +1273,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $this->assertTrue($routes->isFiltered('admin/users'));
         $this->assertFalse($routes->isFiltered('admin/franky'));
-        $this->assertSame('role:admin,manager', $routes->getFilterForRoute('admin/users'));
+        $this->assertSame(['role:admin,manager'], $routes->getFiltersForRoute('admin/users'));
     }
 
     public function test404OverrideNot()


### PR DESCRIPTION
**Description**
- replace deprecated `getFilterForRoute()`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
