### PR TITLE
feat: `spark routes` shows filters

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -286,7 +286,7 @@ class CodeIgniter
      * @throws Exception
      * @throws RedirectException
      *
-     * @return bool|mixed|RequestInterface|ResponseInterface
+     * @return bool|mixed|RequestInterface|ResponseInterface|void
      */
     public function run(?RouteCollectionInterface $routes = null, bool $returnResponse = false)
     {

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -703,7 +703,7 @@ class CodeIgniter
      *
      * @throws RedirectException
      *
-     * @return string|string[]|null
+     * @return string|string[]|null Route filters, that is, the filters specified in the routes file
      */
     protected function tryToRouteIt(?RouteCollectionInterface $routes = null)
     {

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -44,7 +44,7 @@ class Routes extends BaseCommand
      *
      * @var string
      */
-    protected $description = 'Displays all of user-defined routes. Does NOT display auto-detected routes.';
+    protected $description = 'Displays all routes.';
 
     /**
      * the Command's usage

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -132,8 +132,8 @@ class Routes extends BaseCommand
             'Method',
             'Route',
             'Handler',
-            'Filters:before',
-            'Filters:after',
+            'Before Filters',
+            'After Filters',
         ];
 
         CLI::table($tbody, $thead);

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -96,7 +96,6 @@ class Routes extends BaseCommand
             $routes = $collection->getRoutes($method);
 
             foreach ($routes as $route => $handler) {
-                // filter for strings, as callbacks aren't displayable
                 if (is_string($handler) || $handler instanceof Closure) {
                     $sampleUri = $uriGenerator->get($route);
                     $filters   = $filterCollector->get($method, $sampleUri);

--- a/system/Commands/Utilities/Routes/FilterCollector.php
+++ b/system/Commands/Utilities/Routes/FilterCollector.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities\Routes;
+
+use CodeIgniter\Config\Services;
+use CodeIgniter\Filters\Filters;
+use CodeIgniter\HTTP\Request;
+use CodeIgniter\Router\Router;
+
+/**
+ * Collects filters for a route.
+ */
+final class FilterCollector
+{
+    /**
+     * @param string $method HTTP method
+     * @param string $uri    URI path to find filters for
+     *
+     * @return array{before: array<class-string>, after: array<class-string>} Filter classnames
+     */
+    public function get(string $method, string $uri): array
+    {
+        if ($method === 'cli') {
+            return [
+                'before' => [],
+                'after'  => [],
+            ];
+        }
+
+        $request = Services::request(null, false);
+        $request->setMethod($method);
+
+        $router  = $this->createRouter($request);
+        $filters = $this->createFilters($request);
+
+        $finder = new FilterFinder($router, $filters);
+
+        return $finder->find($uri);
+    }
+
+    private function createRouter(Request $request): Router
+    {
+        return new Router(Services::routes(), $request);
+    }
+
+    private function createFilters(Request $request): Filters
+    {
+        $config = config('Filters');
+
+        return new Filters($config, $request, Services::response());
+    }
+}

--- a/system/Commands/Utilities/Routes/FilterCollector.php
+++ b/system/Commands/Utilities/Routes/FilterCollector.php
@@ -25,7 +25,7 @@ final class FilterCollector
      * @param string $method HTTP method
      * @param string $uri    URI path to find filters for
      *
-     * @return array{before: array<class-string>, after: array<class-string>} Filter classnames
+     * @return array{before: list<string>, after: list<string>} array of filter alias or classname
      */
     public function get(string $method, string $uri): array
     {

--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -46,7 +46,7 @@ final class FilterFinder
     /**
      * @param string $uri URI path to find filters for
      *
-     * @return array{before: array<class-string>, after: array<class-string>} Filter classnames
+     * @return array{before: list<string>, after: list<string>} array of filter alias or classname
      */
     public function find(string $uri): array
     {
@@ -59,6 +59,6 @@ final class FilterFinder
 
         $this->filters->initialize($uri);
 
-        return $this->filters->getFiltersClass();
+        return $this->filters->getFilters();
     }
 }

--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities\Routes;
+
+use CodeIgniter\Filters\Filters;
+use CodeIgniter\Router\Router;
+use Config\Services;
+
+/**
+ * Finds filters.
+ */
+final class FilterFinder
+{
+    private Router $router;
+    private Filters $filters;
+
+    public function __construct(?Router $router = null, ?Filters $filters = null)
+    {
+        $this->router  = $router ?? Services::router();
+        $this->filters = $filters ?? Services::filters();
+    }
+
+    private function getRouteFilters(string $uri): array
+    {
+        $this->router->handle($uri);
+
+        $multipleFiltersEnabled = config('Feature')->multipleFilters ?? false;
+        if (! $multipleFiltersEnabled) {
+            $filter = $this->router->getFilter();
+
+            return $filter === null ? [] : [$filter];
+        }
+
+        return $this->router->getFilters();
+    }
+
+    /**
+     * @param string $uri URI path to find filters for
+     *
+     * @return array{before: array<class-string>, after: array<class-string>} Filter classnames
+     */
+    public function find(string $uri): array
+    {
+        $this->filters->reset();
+
+        // Add route filters
+        $routeFilters = $this->getRouteFilters($uri);
+        $this->filters->enableFilters($routeFilters, 'before');
+        $this->filters->enableFilters($routeFilters, 'after');
+
+        $this->filters->initialize($uri);
+
+        return $this->filters->getFiltersClass();
+    }
+}

--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Commands\Utilities\Routes;
 
 use CodeIgniter\Filters\Filters;
+use CodeIgniter\Router\Exceptions\RedirectException;
 use CodeIgniter\Router\Router;
 use Config\Services;
 
@@ -53,12 +54,19 @@ final class FilterFinder
         $this->filters->reset();
 
         // Add route filters
-        $routeFilters = $this->getRouteFilters($uri);
-        $this->filters->enableFilters($routeFilters, 'before');
-        $this->filters->enableFilters($routeFilters, 'after');
+        try {
+            $routeFilters = $this->getRouteFilters($uri);
+            $this->filters->enableFilters($routeFilters, 'before');
+            $this->filters->enableFilters($routeFilters, 'after');
 
-        $this->filters->initialize($uri);
+            $this->filters->initialize($uri);
 
-        return $this->filters->getFilters();
+            return $this->filters->getFilters();
+        } catch (RedirectException $e) {
+            return [
+                'before' => [],
+                'after'  => [],
+            ];
+        }
     }
 }

--- a/system/Commands/Utilities/Routes/SampleURIGenerator.php
+++ b/system/Commands/Utilities/Routes/SampleURIGenerator.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities\Routes;
+
+use CodeIgniter\Config\Services;
+use CodeIgniter\Router\RouteCollection;
+
+/**
+ * Generate a sample URI path from route key regex.
+ */
+final class SampleURIGenerator
+{
+    private RouteCollection $routes;
+
+    /**
+     * Sample URI path for placeholder.
+     *
+     * @var array<string, string>
+     */
+    private array $samples = [
+        'any'      => '123/abc',
+        'segment'  => 'abc_123',
+        'alphanum' => 'abc123',
+        'num'      => '123',
+        'alpha'    => 'abc',
+        'hash'     => 'abc_123',
+    ];
+
+    public function __construct(?RouteCollection $routes = null)
+    {
+        $this->routes = $routes ?? Services::routes();
+    }
+
+    /**
+     * @param string $routeKey route key regex
+     *
+     * @return string sample URI path
+     */
+    public function get(string $routeKey): string
+    {
+        $sampleUri = $routeKey;
+
+        foreach ($this->routes->getPlaceholders() as $placeholder => $regex) {
+            $sample = $this->samples[$placeholder] ?? '::unknown::';
+
+            $sampleUri = str_replace('(' . $regex . ')', $sample, $sampleUri);
+        }
+
+        // auto route
+        return str_replace('[/...]', '/1/2/3/4/5', $sampleUri);
+    }
+}

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -355,7 +355,7 @@ class Filters
     }
 
     /**
-     * Ensures that specific filters is on and enabled for the current request.
+     * Ensures that specific filters are on and enabled for the current request.
      *
      * Filters can have "arguments". This is done by placing a colon immediately
      * after the filter name, followed by a comma-separated list of arguments that

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -90,7 +90,7 @@ class RouteCollection implements RouteCollectionInterface
      * Defined placeholders that can be used
      * within the
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $placeholders = [
         'any'      => '.*',
@@ -236,6 +236,18 @@ class RouteCollection implements RouteCollectionInterface
         $this->placeholders = array_merge($this->placeholders, $placeholder);
 
         return $this;
+    }
+
+    /**
+     * For `spark routes`
+     *
+     * @return array<string, string>
+     *
+     * @internal
+     */
+    public function getPlaceholders(): array
+    {
+        return $this->placeholders;
     }
 
     /**

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -429,7 +429,7 @@ class RouteCollection implements RouteCollectionInterface
         $collection = [];
 
         if (isset($this->routes[$verb])) {
-            // Keep current verb's routes at the beginning so they're matched
+            // Keep current verb's routes at the beginning, so they're matched
             // before any of the generic, "add" routes.
             if (isset($this->routes['*'])) {
                 $extraRules = array_diff_key($this->routes['*'], $this->routes[$verb]);

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -182,7 +182,7 @@ class Router implements RouterInterface
     /**
      * Returns the filter info for the matched route, if any.
      *
-     * @return string
+     * @return string|null
      *
      * @deprecated Use getFilters()
      */

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Router;
 
+use Closure;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\Router\Exceptions\RedirectException;
@@ -39,7 +40,7 @@ class Router implements RouterInterface
     /**
      * The name of the controller class.
      *
-     * @var string
+     * @var Closure|string
      */
     protected $controller;
 
@@ -203,7 +204,7 @@ class Router implements RouterInterface
     /**
      * Returns the name of the matched controller.
      *
-     * @return mixed
+     * @return Closure|string
      */
     public function controllerName()
     {

--- a/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
@@ -11,7 +11,6 @@
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
-use CodeIgniter\Filters\DebugToolbar;
 use CodeIgniter\Test\CIUnitTestCase;
 
 /**
@@ -29,7 +28,7 @@ final class FilterCollectorTest extends CIUnitTestCase
             'before' => [
             ],
             'after' => [
-                DebugToolbar::class,
+                'toolbar',
             ],
         ];
         $this->assertSame($expected, $filters);

--- a/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities\Routes;
+
+use CodeIgniter\Filters\DebugToolbar;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class FilterCollectorTest extends CIUnitTestCase
+{
+    public function testGet()
+    {
+        $collector = new FilterCollector();
+
+        $filters = $collector->get('get', '/');
+
+        $expected = [
+            'before' => [
+            ],
+            'after' => [
+                DebugToolbar::class,
+            ],
+        ];
+        $this->assertSame($expected, $filters);
+    }
+}

--- a/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities\Routes;
+
+use CodeIgniter\Config\Services;
+use CodeIgniter\Filters\CSRF;
+use CodeIgniter\Filters\DebugToolbar;
+use CodeIgniter\Filters\Filters;
+use CodeIgniter\Filters\Honeypot;
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Response;
+use CodeIgniter\Router\RouteCollection;
+use CodeIgniter\Router\Router;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\ConfigFromArrayTrait;
+use Config\Filters as FiltersConfig;
+use Config\Modules;
+
+/**
+ * @internal
+ */
+final class FilterFinderTest extends CIUnitTestCase
+{
+    use ConfigFromArrayTrait;
+
+    private IncomingRequest $request;
+    private Response $response;
+    private Modules $moduleConfig;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request  = Services::request();
+        $this->response = Services::response();
+
+        $this->moduleConfig          = new Modules();
+        $this->moduleConfig->enabled = false;
+    }
+
+    private function createRouteCollection(array $routes = []): RouteCollection
+    {
+        $collection = new RouteCollection(Services::locator(), $this->moduleConfig);
+
+        $routes = ($routes !== []) ? $routes : [
+            'users'                   => 'Users::index',
+            'user-setting/show-list'  => 'User_setting::show_list',
+            'user-setting/(:segment)' => 'User_setting::detail/$1',
+        ];
+
+        return $collection->map($routes);
+    }
+
+    private function createRouter(RouteCollection $collection): Router
+    {
+        return new Router($collection, $this->request);
+    }
+
+    private function createFilters(array $config = []): Filters
+    {
+        $config = ($config !== []) ? $config : [
+            'aliases' => [
+                'csrf'     => CSRF::class,
+                'toolbar'  => DebugToolbar::class,
+                'honeypot' => Honeypot::class,
+            ],
+            'globals' => [
+                'before' => [
+                    'csrf',
+                ],
+                'after' => [
+                    'toolbar',
+                ],
+            ],
+            'methods' => [
+                'get' => [],
+            ],
+            'filters' => [
+                'honeypot' => ['before' => ['form/*', 'survey/*']],
+            ],
+        ];
+        $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
+
+        return new Filters($filtersConfig, $this->request, $this->response, $this->moduleConfig);
+    }
+
+    public function testFindGlobalsFilters()
+    {
+        $collection = $this->createRouteCollection();
+        $router     = $this->createRouter($collection);
+        $filters    = $this->createFilters();
+
+        $finder = new FilterFinder($router, $filters);
+
+        $filters = $finder->find('users');
+
+        $expected = [
+            'before' => [CSRF::class],
+            'after'  => [DebugToolbar::class],
+        ];
+        $this->assertSame($expected, $filters);
+    }
+
+    public function testFindGlobalsAndRouteFilters()
+    {
+        $collection = $this->createRouteCollection();
+        $collection->get('admin', ' AdminController::index', ['filter' => 'honeypot']);
+        $router  = $this->createRouter($collection);
+        $filters = $this->createFilters();
+
+        $finder = new FilterFinder($router, $filters);
+
+        $filters = $finder->find('admin');
+
+        $expected = [
+            'before' => [Honeypot::class, CSRF::class],
+            'after'  => [Honeypot::class, DebugToolbar::class],
+        ];
+        $this->assertSame($expected, $filters);
+    }
+}

--- a/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
@@ -111,6 +111,25 @@ final class FilterFinderTest extends CIUnitTestCase
         $this->assertSame($expected, $filters);
     }
 
+    public function testFindGlobalsFiltersWithRedirectRoute()
+    {
+        $collection = $this->createRouteCollection();
+        $collection->addRedirect('users/about', 'profile');
+
+        $router  = $this->createRouter($collection);
+        $filters = $this->createFilters();
+
+        $finder = new FilterFinder($router, $filters);
+
+        $filters = $finder->find('users/about');
+
+        $expected = [
+            'before' => [],
+            'after'  => [],
+        ];
+        $this->assertSame($expected, $filters);
+    }
+
     public function testFindGlobalsAndRouteFilters()
     {
         $collection = $this->createRouteCollection();

--- a/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
+++ b/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities\Routes;
+
+use CodeIgniter\Config\Services;
+use CodeIgniter\Test\CIUnitTestCase;
+use Generator;
+
+/**
+ * @internal
+ */
+final class SampleURIGeneratorTest extends CIUnitTestCase
+{
+    /**
+     * @dataProvider routeKeyProvider
+     */
+    public function testGet(string $routeKey, string $expected)
+    {
+        $generator = new SampleURIGenerator();
+
+        $uri = $generator->get($routeKey);
+
+        $this->assertSame($expected, $uri);
+    }
+
+    public function routeKeyProvider(): Generator
+    {
+        yield from [
+            'root'                => ['/', '/'],
+            'placeholder num'     => ['shop/product/([0-9]+)', 'shop/product/123'],
+            'placeholder segment' => ['shop/product/([^/]+)', 'shop/product/abc_123'],
+            'placeholder any'     => ['shop/product/(.*)', 'shop/product/123/abc'],
+            'auto route'          => ['home/index[/...]', 'home/index/1/2/3/4/5'],
+        ];
+    }
+
+    public function testGetFromPlaceholderCustomPlaceholder()
+    {
+        $routes = Services::routes();
+        $routes->addPlaceholder(
+            'uuid',
+            '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        );
+
+        $generator = new SampleURIGenerator();
+
+        $routeKey = 'shop/product/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})';
+        $uri      = $generator->get($routeKey);
+
+        $this->assertSame('shop/product/::unknown::', $uri);
+    }
+}

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -28,6 +28,7 @@ Enhancements
 - Added Validation Strict Rules. See :ref:`validation-traditional-and-strict-rules`.
 - Added new OCI8 driver for database.
     - It can access Oracle Database and supports SQL and PL/SQL statements.
+- The ``spark routes`` command now shows closure routes, auto routtes, and filters. See :ref:`URI Routing <spark-routes>`.
 
 Changes
 *******

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -196,6 +196,13 @@ When configuring filters, additional arguments may be passed to a filter when se
 
 In this example, the array ``['dual', 'noreturn']`` will be passed in ``$arguments`` to the filter's ``before()`` and ``after()`` implementation methods.
 
+******************
+Confirming Filters
+******************
+
+You can see the routes and filters by the ``spark routes`` command.
+See :ref:`URI Routing <spark-routes>`.
+
 ****************
 Provided Filters
 ****************

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -630,18 +630,16 @@ The output is like the following:
 
 .. code-block:: none
 
-    +--------+----------------------------+------------------------------------------------+----------------+-----------------------+
-    | Method | Route                      | Handler                                        | Filters:before | Filters:after         |
-    +--------+----------------------------+------------------------------------------------+----------------+-----------------------+
-    | GET    | /                          | \App\Controllers\Home::index                   | csrf           | secureheaders toolbar |
-    | CLI    | migrations/([^/]+)/([^/]+) | \CodeIgniter\Commands\MigrationsCommand::$1/$2 |                |                       |
-    | CLI    | migrations/([^/]+)         | \CodeIgniter\Commands\MigrationsCommand::$1    |                |                       |
-    | CLI    | migrations                 | \CodeIgniter\Commands\MigrationsCommand::index |                |                       |
-    | CLI    | ci(.*)                     | \CodeIgniter\CLI\CommandRunner::index/$1       |                |                       |
-    | auto   | /                          | \App\Controllers\Home::index                   | csrf           | secureheaders toolbar |
-    | auto   | home                       | \App\Controllers\Home::index                   | csrf           | secureheaders toolbar |
-    | auto   | home/index[/...]           | \App\Controllers\Home::index                   | csrf           | secureheaders toolbar |
-    +--------+----------------------------+------------------------------------------------+----------------+-----------------------+
+    +--------+------------------+------------------------------------------+----------------+-----------------------+
+    | Method | Route            | Handler                                  | Before Filters | After Filters         |
+    +--------+------------------+------------------------------------------+----------------+-----------------------+
+    | GET    | /                | \App\Controllers\Home::index             | invalidchars   | secureheaders toolbar |
+    | GET    | feed             | (Closure)                                | invalidchars   | secureheaders toolbar |
+    | CLI    | ci(.*)           | \CodeIgniter\CLI\CommandRunner::index/$1 |                |                       |
+    | auto   | /                | \App\Controllers\Home::index             | invalidchars   | secureheaders toolbar |
+    | auto   | home             | \App\Controllers\Home::index             | invalidchars   | secureheaders toolbar |
+    | auto   | home/index[/...] | \App\Controllers\Home::index             | invalidchars   | secureheaders toolbar |
+    +--------+------------------+------------------------------------------+----------------+-----------------------+
 
 The *Method* column shows the HTTP method that the route is listening for. ``auto`` means that the route is discovered by auto routing, so it is not defined in **app/Config/Routes.php**.
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -24,8 +24,9 @@ For example, let’s say you want your URLs to have this prototype::
 Normally the second segment of the URL path is reserved for the method name, but in the example
 above it instead has a product ID. To overcome this, CodeIgniter allows you to remap the URI handler.
 
+******************************
 Setting your own routing rules
-==============================
+******************************
 
 Routing rules are defined in the **app/Config/Routes.php** file. In it you'll see that
 it creates an instance of the RouteCollection class that permits you to specify your own routing criteria.
@@ -497,14 +498,15 @@ To disable this functionality, you must call the method with the parameter ``fal
 
 .. _routes-configuration-options:
 
+****************************
 Routes Configuration Options
-============================
+****************************
 
 The RoutesCollection class provides several options that affect all routes, and can be modified to meet your
 application's needs. These options are available at the top of **app/Config/Routes.php**.
 
 Default Namespace
------------------
+=================
 
 When matching a controller to a route, the router will add the default namespace value to the front of the controller
 specified by the route. By default, this value is ``App\Controllers``.
@@ -532,7 +534,7 @@ then you can change this value to save typing::
     $routes->add('users', 'Admin\Users::index');
 
 Default Controller
-------------------
+==================
 
 When a user visits the root of your site (i.e., example.com) the controller to use is determined by the value set by
 the ``setDefaultController()`` method, unless a route exists for it explicitly. The default value for this is ``Home``
@@ -546,7 +548,7 @@ in the controllers directory. For example, if the user visits **example.com/admi
 **app/Controllers/Admin/Home.php**, it would be used.
 
 Default Method
---------------
+==============
 
 This works similar to the default controller setting, but is used to determine the default method that is used
 when a controller is found that matches the URI, but no segment exists for the method. The default value is
@@ -558,7 +560,7 @@ In this example, if the user were to visit **example.com/products**, and a ``Pro
     $routes->setDefaultMethod('listAll');
 
 Translate URI Dashes
---------------------
+====================
 
 This option enables you to automatically replace dashes (``-``) with underscores in the controller and method
 URI segments, thus saving you additional route entries if you need to do that. This is required because the
@@ -569,7 +571,7 @@ dash isn’t a valid class or method name character and would cause a fatal erro
 .. _use-defined-routes-only:
 
 Use Defined Routes Only
------------------------
+=======================
 
 When no defined route is found that matches the URI, the system will attempt to match that URI against the
 controllers and methods as described above. You can disable this automatic matching, and restrict routes
@@ -581,7 +583,7 @@ to only those defined by you, by setting the ``setAutoRoute()`` option to false:
     requests. If the URI is accessible by the GET method, the CSRF protection will not work.
 
 404 Override
-------------
+============
 
 When a page is not found that matches the current URI, the system will show a generic 404 view. You can change
 what happens by specifying an action to happen with the ``set404Override()`` method. The value can be either
@@ -598,7 +600,7 @@ a valid class/method pair, just like you would show in any route, or a Closure::
 
 
 Route processing by priority
-----------------------------
+============================
 
 Enables or disables processing of the routes queue by priority. Lowering the priority is defined in the route option.
 Disabled by default. This functionality affects all routes.
@@ -609,3 +611,43 @@ For an example use of lowering the priority see :ref:`routing-priority`::
 
     // to disable
     $routes->setPrioritize(false);
+
+*****************
+Confirming Routes
+*****************
+
+CodeIgniter has the following :doc:`command </cli/cli_commands>` to display all routes.
+
+.. _spark-routes:
+
+**routes**
+
+Displays all routes and filters::
+
+    > php spark routes
+
+The output is like the following:
+
+.. code-block:: none
+
+    +--------+----------------------------+------------------------------------------------+----------------+-----------------------+
+    | Method | Route                      | Handler                                        | Filters:before | Filters:after         |
+    +--------+----------------------------+------------------------------------------------+----------------+-----------------------+
+    | GET    | /                          | \App\Controllers\Home::index                   | csrf           | secureheaders toolbar |
+    | CLI    | migrations/([^/]+)/([^/]+) | \CodeIgniter\Commands\MigrationsCommand::$1/$2 |                |                       |
+    | CLI    | migrations/([^/]+)         | \CodeIgniter\Commands\MigrationsCommand::$1    |                |                       |
+    | CLI    | migrations                 | \CodeIgniter\Commands\MigrationsCommand::index |                |                       |
+    | CLI    | ci(.*)                     | \CodeIgniter\CLI\CommandRunner::index/$1       |                |                       |
+    | auto   | /                          | \App\Controllers\Home::index                   | csrf           | secureheaders toolbar |
+    | auto   | home                       | \App\Controllers\Home::index                   | csrf           | secureheaders toolbar |
+    | auto   | home/index[/...]           | \App\Controllers\Home::index                   | csrf           | secureheaders toolbar |
+    +--------+----------------------------+------------------------------------------------+----------------+-----------------------+
+
+The *Method* column shows the HTTP method that the route is listening for. ``auto`` means that the route is discovered by auto routing, so it is not defined in **app/Config/Routes.php**.
+
+The *Route* column shows the URI path to match. The route of a defined route is expressed as a regular expression.
+But ``[/...]`` in the route of an auto route is indicates any number of segments.
+
+.. note:: When auto routing is enabled, if you have the route ``home``, it can be also accessd by ``Home``, or maybe by ``hOme``, ``hoMe``, ``HOME``, etc. But the command shows only ``home``.
+
+.. important:: The system is not perfect. If you use Custom Placeholders, *Filters* might not be correct. But the filters defined in **app/Config/Routes.php** are always displayed correctly.


### PR DESCRIPTION
**Description**
Related #5590

- add filters to `spark routes` command

```
$ php spark routes

CodeIgniter v4.1.8 Command Line Tool - Server Time: 2022-01-28 19:29:51 UTC-06:00

+--------+------------------+------------------------------------------+----------------+-----------------------+
| Method | Route            | Handler                                  | Before Filters | After Filters         |
+--------+------------------+------------------------------------------+----------------+-----------------------+
| GET    | /                | \App\Controllers\Home::index             | invalidchars   | secureheaders toolbar |
| GET    | feed             | (Closure)                                | invalidchars   | secureheaders toolbar |
| CLI    | ci(.*)           | \CodeIgniter\CLI\CommandRunner::index/$1 |                |                       |
| auto   | /                | \App\Controllers\Home::index             | invalidchars   | secureheaders toolbar |
| auto   | home             | \App\Controllers\Home::index             | invalidchars   | secureheaders toolbar |
| auto   | home/index[/...] | \App\Controllers\Home::index             | invalidchars   | secureheaders toolbar |
+--------+------------------+------------------------------------------+----------------+-----------------------+
```

**Checklist:**
- [x] Needs #5625
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

