### PR TITLE
Rename docblocks in Routes utilities classes

### DIFF
--- a/system/Commands/Utilities/Routes/AutoRouteCollector.php
+++ b/system/Commands/Utilities/Routes/AutoRouteCollector.php
@@ -36,6 +36,7 @@ final class AutoRouteCollector
 
     /**
      * @return array<int, array<int, string>>
+     * @phpstan-return list<list<string>>
      */
     public function get(): array
     {

--- a/system/Commands/Utilities/Routes/AutoRouteCollector.php
+++ b/system/Commands/Utilities/Routes/AutoRouteCollector.php
@@ -35,7 +35,7 @@ final class AutoRouteCollector
     }
 
     /**
-     * @return list<list<string>>
+     * @return array<int, array<int, string>>
      */
     public function get(): array
     {

--- a/system/Commands/Utilities/Routes/ControllerFinder.php
+++ b/system/Commands/Utilities/Routes/ControllerFinder.php
@@ -36,7 +36,8 @@ final class ControllerFinder
     }
 
     /**
-     * @return class-string[]
+     * @return string[]
+     * @phpstan-return class-string[]
      */
     public function find(): array
     {
@@ -62,7 +63,7 @@ final class ControllerFinder
                 $classnameOrEmpty = $this->locator->getClassname($file);
 
                 if ($classnameOrEmpty !== '') {
-                    /** @var class-string $classname */
+                    /** @phpstan-var class-string $classname */
                     $classname = $classnameOrEmpty;
 
                     $classes[] = $classname;

--- a/system/Commands/Utilities/Routes/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/ControllerMethodReader.php
@@ -36,6 +36,7 @@ final class ControllerMethodReader
      * @phpstan-param class-string $class
      *
      * @return array<int, array{route: string, handler: string}>
+     * @phpstan-return list<array{route: string, handler: string}>
      */
     public function read(string $class, string $defaultController = 'Home', string $defaultMethod = 'index'): array
     {

--- a/system/Commands/Utilities/Routes/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/ControllerMethodReader.php
@@ -33,9 +33,9 @@ final class ControllerMethodReader
     }
 
     /**
-     * @param class-string $class
+     * @phpstan-param class-string $class
      *
-     * @return list<array{route: string, handler: string}>
+     * @return array<int, array{route: string, handler: string}>
      */
     public function read(string $class, string $defaultController = 'Home', string $defaultMethod = 'index'): array
     {
@@ -125,7 +125,7 @@ final class ControllerMethodReader
     }
 
     /**
-     * @param class-string $classname
+     * @phpstan-param class-string $classname
      *
      * @return string URI path part from the folder(s) and controller
      */


### PR DESCRIPTION
**Description**
Extensions in Visual Studio Code do not have access yet to advanced doc blocks like `class-string`, `list`, `T`, causing type error hints when files are opened. I suggest changing them into the conventional formats.

However, for SA, phpstan uderstands them so I just swapped them to the compatible tags (like `@phpstan-return`).

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
