### PR TITLE
Feature: Request::isMethod() to test the HTTP method.

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -731,11 +731,6 @@ parameters:
 			path: system/Router/Router.php
 
 		-
-			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: system/Router/Router.php
-
-		-
 			message: "#^Method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRoutes\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 2
 			path: system/Router/Router.php

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -297,8 +297,6 @@ class CodeIgniter
 
         $this->forceSecureAccess();
 
-        $this->spoofRequestMethod();
-
         Events::trigger('pre_system');
 
         // Check for a cached page. Execution will stop
@@ -972,6 +970,8 @@ class CodeIgniter
     /**
      * Modifies the Request Object to use a different method if a POST
      * variable called _method is found.
+     *
+     * @deprecated 4.2
      */
     public function spoofRequestMethod()
     {

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -43,8 +43,10 @@ class CLIRequest extends Request
 
     /**
      * Set the expected HTTP verb
+     *
+     * @var string
      */
-    protected string $method = 'cli';
+    protected $method = 'cli';
 
     /**
      * Constructor

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -43,10 +43,8 @@ class CLIRequest extends Request
 
     /**
      * Set the expected HTTP verb
-     *
-     * @var string
      */
-    protected $method = 'cli';
+    protected string $method = 'cli';
 
     /**
      * Constructor

--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -31,10 +31,8 @@ class Request extends Message implements MessageInterface, RequestInterface
 
     /**
      * Request method.
-     *
-     * @var string
      */
-    protected $method;
+    protected string $method;
 
     /**
      * A URI instance.
@@ -56,10 +54,6 @@ class Request extends Message implements MessageInterface, RequestInterface
          * @deprecated $this->proxyIps property will be removed in the future
          */
         $this->proxyIPs = $config->proxyIPs;
-
-        if (empty($this->method)) {
-            $this->method = $this->getServer('REQUEST_METHOD') ?? 'GET';
-        }
 
         if (empty($this->uri)) {
             $this->uri = new URI();
@@ -92,7 +86,17 @@ class Request extends Message implements MessageInterface, RequestInterface
      */
     public function getMethod(bool $upper = false): string
     {
-        return ($upper) ? strtoupper($this->method) : strtolower($this->method);
+        if (empty($this->method)) {
+            $this->method = $this->getServer('REQUEST_METHOD') ?? 'GET';
+
+            if ($this->method === 'POST'
+                && in_array(strtoupper($_POST['_method'] ?? ''), ['PUT', 'PATCH', 'DELETE'], true)
+            ) {
+                $this->method = strtoupper($_POST['_method']);
+            }
+        }
+
+        return $upper ? strtoupper($this->method) : strtolower($this->method);
     }
 
     /**

--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -31,8 +31,10 @@ class Request extends Message implements MessageInterface, RequestInterface
 
     /**
      * Request method.
+     *
+     * @var string
      */
-    protected string $method;
+    protected $method;
 
     /**
      * A URI instance.

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -332,4 +332,9 @@ trait RequestTrait
                 break;
         }
     }
+
+    public function isMethod(string $method): bool
+    {
+        return $this->getMethod(true) === strtoupper($method);
+    }
 }

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -124,7 +124,7 @@ class Router implements RouterInterface
         $this->controller = $this->collection->getDefaultController();
         $this->method     = $this->collection->getDefaultMethod();
 
-        $this->collection->setHTTPVerb($request->getMethod() ?? strtolower($_SERVER['REQUEST_METHOD']));
+        $this->collection->setHTTPVerb($request->getMethod());
     }
 
     /**

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -679,4 +679,22 @@ final class RequestTest extends CIUnitTestCase
         $this->assertSame('get', $this->request->getMethod());
         $this->assertSame('GET', $this->request->getMethod(true));
     }
+
+    public function testIsMethod()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $request = new Request(new App());
+        $this->assertTrue($request->isMethod('post'));
+
+        $_POST['_method'] = 'TEST';
+        $request          = new Request(new App());
+
+        $this->assertFalse($request->isMethod('test'));
+
+        $_POST['_method'] = 'PUT';
+        $request          = new Request(new App());
+
+        $this->assertTrue($request->isMethod('PUT'));
+    }
 }

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -39,6 +39,7 @@ Deprecations
 ************
 
 - ``CodeIgniter\Database\SQLSRV\Connection::getError()`` is deprecated. Use ``CodeIgniter\Database\SQLSRV\Connection::error()`` instead.
+- CodeIgniter::spoofRequestMethod() is deprecated.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -75,7 +75,7 @@ be checked with the ``isAJAX()`` and ``isCLI()`` methods::
     which in some cases is not sent by default in XHR requests via JavaScript (i.e., fetch).
     See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
 
-You can check the HTTP method that this request represents with the ``method()`` method::
+You can get the HTTP method that this request represents with the ``getMethod()`` method::
 
     // Returns 'post'
     $method = $request->getMethod();
@@ -85,6 +85,13 @@ uppercase version by wrapping the call in ``str_to_upper()``::
 
     // Returns 'GET'
     $method = str_to_upper($request->getMethod());
+
+
+You can check the HTTP method that this request represents with the ``isMethod()`` method::
+
+    // Returns true for a POST request.
+    $request->isMethod('post');
+
 
 You can also check if the request was made through and HTTPS connection with the ``isSecure()`` method::
 
@@ -341,6 +348,7 @@ The methods provided by the parent classes that are available are:
 
 * :meth:`CodeIgniter\\HTTP\\Request::getIPAddress`
 * :meth:`CodeIgniter\\HTTP\\Request::isValidIP`
+* :meth:`CodeIgniter\\HTTP\\Request::isMethod`
 * :meth:`CodeIgniter\\HTTP\\Request::getMethod`
 * :meth:`CodeIgniter\\HTTP\\Request::setMethod`
 * :meth:`CodeIgniter\\HTTP\\Request::getServer`

--- a/user_guide_src/source/incoming/request.rst
+++ b/user_guide_src/source/incoming/request.rst
@@ -63,13 +63,20 @@ Class Reference
         :returns: HTTP request method
         :rtype: string
 
-        Returns the ``$_SERVER['REQUEST_METHOD']``, with the option to set it
-        in uppercase or lowercase.
+        Returns the ``$_SERVER['REQUEST_METHOD']`` considering the spoofing method,
+        with the option to set it in uppercase or lowercase.
         ::
 
             echo $request->getMethod(true); // Outputs: POST
             echo $request->getMethod(false); // Outputs: post
             echo $request->getMethod(); // Outputs: post
+
+    .. php:method:: isMethod(string $method)
+
+        :param string $method: The name of the HTTP method. Case-insensitive.
+        :rtype: boolean
+
+        Checks if the passed method is an HTTP request method considering the spoofing method.
 
     .. php:method:: setMethod($method)
 


### PR DESCRIPTION
**Description**
This PR suggests introducing a helper method to check the current HTTP request. This simplifies the code for checking the request method.

```php
$request->isMethod('post'); 
// instead of 
$request->getMethod() === 'post'; 
```
Part of the core has also been reworked. 
The ``Request::getMethod()`` method now pre-sets the value of the ``Request::$method`` property if it has not been previously defined, considering method spoofing. The request method definition has been removed from the Request class constructor, and the ``CodeIgniter::spoofRequestMethod()`` method has been marked deprecated and is no longer called in ``CodeIgniter::run()``. Because it doesn't make sense anymore.

Removed the pointless check for ``Request::getMethod()`` in the constructor of the Router class when setting the request method on a collection of routes.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide