### PR TITLE
Fix PHPStan notice on 1.4.4

### DIFF
--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -12,6 +12,7 @@ on:
       - 'system/**'
       - composer.json
       - phpstan.neon.dist
+      - phpstan-baseline.neon.dist
   push:
     branches:
       - 'develop'
@@ -21,6 +22,7 @@ on:
       - 'system/**'
       - composer.json
       - phpstan.neon.dist
+      - phpstan-baseline.neon.dist
 
 jobs:
   build:

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -641,11 +641,6 @@ parameters:
 			path: system/Helpers/number_helper.php
 
 		-
-			message: "#^Variable \\$mockService in empty\\(\\) always exists and is always falsy\\.$#"
-			count: 1
-			path: system/Helpers/test_helper.php
-
-		-
 			message: "#^Variable \\$pool might not be defined\\.$#"
 			count: 2
 			path: system/Helpers/text_helper.php
@@ -980,3 +975,8 @@ parameters:
 			count: 1
 			path: system/View/Parser.php
 
+		-
+			message: "#^Result of \\|\\| is always false\\.$#"
+			paths:
+				- system/Cache/CacheFactory.php
+				- system/Filters/Filters.php


### PR DESCRIPTION
Fix PHPStan notice after PHPStan updated to 1.4.4:

```bash
Note: Using configuration file /Users/samsonasik/www/CodeIgniter4/phpstan.neon.dist.
 423/423 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------- 
  Line   system/Cache/CacheFactory.php  
 ------ ------------------------------- 
  45     Result of || is always false.  
  49     Result of || is always false.  
 ------ ------------------------------- 

 ------ ------------------------------- 
  Line   system/Filters/Filters.php     
 ------ ------------------------------- 
  396    Result of || is always false.  
  436    Result of || is always false.  
 ------ ------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   system/Helpers/test_helper.php                                                                                                                                                                                   
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
         Ignored error pattern #^Variable \$mockService in empty\(\) always exists and is always falsy\.$# in path /Users/samsonasik/www/CodeIgniter4/system/Helpers/test_helper.php was not matched in reported errors.  
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
```

**Checklist:**
- [x] Securely signed commits
