### PR TITLE
refactor: SPARKED

### DIFF
--- a/spark
+++ b/spark
@@ -12,6 +12,7 @@
  * this class mainly acts as a passthru to the framework itself.
  */
 
+// @TODO want to make deprecated. Use CLIRequest::isSparked() instead.
 define('SPARKED', true);
 
 /*
@@ -42,7 +43,14 @@ $paths = new Config\Paths();
 chdir(FCPATH);
 
 $bootstrap = rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
-$app       = require realpath($bootstrap) ?: $bootstrap;
+
+/** @var CodeIgniter\CodeIgniter $app */
+$app = require realpath($bootstrap) ?: $bootstrap;
+
+// Set sparked CLIRequest in CodeIgniter
+$clirequest = Config\Services::clirequest();
+$clirequest->sparked();
+$app->setRequest($clirequest);
 
 // Grab our Console
 $console = new CodeIgniter\CLI\Console($app);

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -317,7 +317,7 @@ class CodeIgniter
         }
 
         // spark command has nothing to do with HTTP redirect and 404
-        if (defined('SPARKED')) {
+        if ($this->isSparked()) {
             return $this->handleRequest($routes, $cacheConfig, $returnResponse);
         }
 
@@ -338,6 +338,11 @@ class CodeIgniter
         } catch (PageNotFoundException $e) {
             $this->display404errors($e);
         }
+    }
+
+    private function isSparked(): bool
+    {
+        return $this->request instanceof CLIRequest && $this->request->isSparked();
     }
 
     /**
@@ -385,7 +390,7 @@ class CodeIgniter
         }
 
         // Never run filters when running through Spark cli
-        if (! defined('SPARKED')) {
+        if (! $this->isSparked()) {
             // Run "before" filters
             $this->benchmark->start('before_filters');
             $possibleResponse = $filters->run($uri, 'before');
@@ -426,7 +431,7 @@ class CodeIgniter
         $this->gatherOutput($cacheConfig, $returned);
 
         // Never run filters when running through Spark cli
-        if (! defined('SPARKED')) {
+        if (! $this->isSparked()) {
             $filters->setResponse($this->response);
 
             // Run "after" filters
@@ -822,7 +827,7 @@ class CodeIgniter
     protected function runController($class)
     {
         // If this is a console request then use the input segments as parameters
-        $params = defined('SPARKED') ? $this->request->getSegments() : $this->router->params();
+        $params = $this->isSparked() ? $this->request->getSegments() : $this->router->params();
 
         if (method_exists($class, '_remap')) {
             $output = $class->_remap($this->method, ...$params);

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -49,6 +49,13 @@ class CLIRequest extends Request
     protected $method = 'cli';
 
     /**
+     * Invoked via spark command?
+     *
+     * @var bool
+     */
+    protected $sparked = false;
+
+    /**
      * Constructor
      */
     public function __construct(App $config)
@@ -196,5 +203,21 @@ class CLIRequest extends Request
     public function isCLI(): bool
     {
         return true;
+    }
+
+    /**
+     * Set sparked true.
+     */
+    public function sparked(): void
+    {
+        $this->sparked = true;
+    }
+
+    /**
+     * Invoked via spark command?
+     */
+    public function isSparked(): bool
+    {
+        return $this->sparked;
     }
 }

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -195,6 +195,6 @@ class CLIRequest extends Request
      */
     public function isCLI(): bool
     {
-        return is_cli();
+        return true;
     }
 }

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -347,7 +347,7 @@ class IncomingRequest extends Request
      */
     public function isCLI(): bool
     {
-        return is_cli();
+        return false;
     }
 
     /**

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -641,4 +641,13 @@ final class CLIRequestTest extends CIUnitTestCase
     {
         $this->assertTrue($this->request->isCLI());
     }
+
+    public function testIsSparked()
+    {
+        $this->assertFalse($this->request->isSparked());
+
+        $this->request->sparked();
+
+        $this->assertTrue($this->request->isCLI());
+    }
 }

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -439,8 +439,7 @@ final class IncomingRequestTest extends CIUnitTestCase
 
     public function testIsCLI()
     {
-        // this should be the case in unit testing
-        $this->assertTrue($this->request->isCLI());
+        $this->assertFalse($this->request->isCLI());
     }
 
     public function testIsAJAX()


### PR DESCRIPTION
**Description**
The current `CLIRequest` does not know whether it is *Spark request* or *PHP CLI request*.

- add `CLIRequest::isSparked()`
- `spark` command uses sparked `CLIRequest`
- and we will not need the constant `SPARKED` that makes testing difficult

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
