### PR TITLE
Feature: "spark routes" command shows routes with closure.

### DIFF
--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Commands\Utilities;
 
+use Closure;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Commands\Utilities\Routes\AutoRouteCollector;
@@ -92,11 +93,11 @@ class Routes extends BaseCommand
 
             foreach ($routes as $route => $handler) {
                 // filter for strings, as callbacks aren't displayable
-                if (is_string($handler)) {
+                if (is_string($handler) || $handler instanceof Closure) {
                     $tbody[] = [
                         strtoupper($method),
                         $route,
-                        $handler,
+                        is_string($handler) ? $handler : 'Closure',
                     ];
                 }
             }

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -97,7 +97,7 @@ class Routes extends BaseCommand
                     $tbody[] = [
                         strtoupper($method),
                         $route,
-                        is_string($handler) ? $handler : 'Closure',
+                        is_string($handler) ? $handler : '(Closure)',
                     ];
                 }
             }

--- a/tests/_support/Config/Routes.php
+++ b/tests/_support/Config/Routes.php
@@ -13,3 +13,4 @@ namespace Tests\Support\Config;
 
 // This is a simple file to include for testing the RouteCollection class.
 $routes->add('testing', 'TestController::index', ['as' => 'testing-index']);
+$routes->get('closure', static fn () => 'closure test');

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -110,7 +110,7 @@ final class CommandTest extends CIUnitTestCase
     {
         command('routes');
 
-        $this->assertStringContainsString('| Closure', $this->getBuffer());
+        $this->assertStringContainsString('| (Closure)', $this->getBuffer());
         $this->assertStringContainsString('| Route', $this->getBuffer());
         $this->assertStringContainsString('| testing', $this->getBuffer());
         $this->assertStringContainsString('\\TestController::index', $this->getBuffer());

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -110,6 +110,7 @@ final class CommandTest extends CIUnitTestCase
     {
         command('routes');
 
+        $this->assertStringContainsString('| Closure', $this->getBuffer());
         $this->assertStringContainsString('| Route', $this->getBuffer());
         $this->assertStringContainsString('| testing', $this->getBuffer());
         $this->assertStringContainsString('\\TestController::index', $this->getBuffer());


### PR DESCRIPTION
**Description**

The "spark routes" command shows routes with a closure. 

```
+--------+----------------------------+------------------------------------------------+
| Method | Route                      | Handler                                        |
+--------+----------------------------+------------------------------------------------+
| GET    | /                          | \App\Controllers\Home::index                   |
| GET    | closure                    | Closure                                        |
```
**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide