### PR TITLE
refactor: remove migrations routes

### DIFF
--- a/contributing/internals.md
+++ b/contributing/internals.md
@@ -122,17 +122,9 @@ scans and keep performance high.
 
 ## Command-Line Support
 
-CodeIgniter has never been known for it's strong CLI support. However,
+CodeIgniter has never been known for its strong CLI support. However,
 if your package could benefit from it, create a new file under
-**system/Commands**. The class contained within is simply a controller
-that is intended for CLI usage only. The `index()` method should provide
-a list of available commands provided by that package.
-
-Routes must be added to **system/Config/Routes.php** using the `cli()`
-method to ensure it is not accessible through the browser, but is
-restricted to the CLI only.
-
-See the **MigrationsCommand** file for an example.
+**system/Commands**.
 
 ## Documentation
 

--- a/system/Config/Routes.php
+++ b/system/Config/Routes.php
@@ -19,10 +19,5 @@
  * already loaded up and ready for us to use.
  */
 
-// Migrations
-$routes->cli('migrations/(:segment)/(:segment)', '\CodeIgniter\Commands\MigrationsCommand::$1/$2');
-$routes->cli('migrations/(:segment)', '\CodeIgniter\Commands\MigrationsCommand::$1');
-$routes->cli('migrations', '\CodeIgniter\Commands\MigrationsCommand::index');
-
 // CLI Catchall - uses a _remap to call Commands
 $routes->cli('ci(:any)', '\CodeIgniter\CLI\CommandRunner::index/$1');


### PR DESCRIPTION
**Description**
- `Commands\MigrationsCommand` was removed in 2016 49ec1083e508c8839f845f69b415b1739e9a7ed7

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

