### PR TITLE
refactor: isCLI() in CLIRequest and IncomingRequest

### DIFF
--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -195,6 +195,6 @@ class CLIRequest extends Request
      */
     public function isCLI(): bool
     {
-        return is_cli();
+        return true;
     }
 }

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -347,7 +347,7 @@ class IncomingRequest extends Request
      */
     public function isCLI(): bool
     {
-        return is_cli();
+        return false;
     }
 
     /**

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -439,8 +439,7 @@ final class IncomingRequestTest extends CIUnitTestCase
 
     public function testIsCLI()
     {
-        // this should be the case in unit testing
-        $this->assertTrue($this->request->isCLI());
+        $this->assertFalse($this->request->isCLI());
     }
 
     public function testIsAJAX()


### PR DESCRIPTION
**Description**
From  #5649

- no need to depend on `is_cli()`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
