### PR TITLE
refactor: Session does not use cookies()

### DIFF
--- a/depfile.yaml
+++ b/depfile.yaml
@@ -198,6 +198,7 @@ ruleset:
     - HTTP
   Session:
     - Cookie
+    - HTTP
     - Database
   Throttle:
     - Cache

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -12,8 +12,10 @@
 namespace CodeIgniter\Session;
 
 use CodeIgniter\Cookie\Cookie;
+use CodeIgniter\HTTP\Response;
 use Config\App;
 use Config\Cookie as CookieConfig;
+use Config\Services;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use SessionHandlerInterface;
@@ -904,6 +906,8 @@ class Session implements SessionInterface
         $expiration   = $this->sessionExpiration === 0 ? 0 : time() + $this->sessionExpiration;
         $this->cookie = $this->cookie->withValue(session_id())->withExpires($expiration);
 
-        cookies([$this->cookie], false)->dispatch();
+        /** @var Response $response */
+        $response = Services::response();
+        $response->setCookie($this->cookie);
     }
 }

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -34,6 +34,7 @@ Changes
 
 - Update minimal PHP requirement to 7.4.
 - The current version of Content Security Policy (CSP) outputs one nonce for script and one for style tags. The previous version outputted one nonce for each tag.
+- The process of sending cookies has been moved to the ``Response`` class. Now the ``Session`` class doesn't send cookies, set them to the Response.
 
 Deprecations
 ************


### PR DESCRIPTION
**Description**
- The Response should send all cookies.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
