### PR TITLE
[Demo] Loading code examples in docs from external files to ease CS.

### DIFF
--- a/.github/workflows/test-coding-standards.yml
+++ b/.github/workflows/test-coding-standards.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: composer update --ansi --no-interaction
 
-      - name: Run lint on `app/`, `admin/`, `public/`
+      - name: Run lint on `app/`, `admin/`, `public/`, 'user_guide_src/'
         run: vendor/bin/php-cs-fixer fix --verbose --ansi --dry-run --config=.no-header.php-cs-fixer.dist.php --using-cache=no --diff
 
       - name: Run lint on `system/`, `tests`, `utils/`, and root PHP files

--- a/.no-header.php-cs-fixer.dist.php
+++ b/.no-header.php-cs-fixer.dist.php
@@ -24,6 +24,7 @@ $finder = Finder::create()
         __DIR__ . '/admin',
         __DIR__ . '/app',
         __DIR__ . '/public',
+        __DIR__ . '/user_guide_src',
     ])
     ->notName('#Logger\.php$#')
     ->append([

--- a/user_guide_src/source/database/queries.rst
+++ b/user_guide_src/source/database/queries.rst
@@ -45,13 +45,8 @@ such as INSERT, DELETE or UPDATE statements (which is what it really
 should be used for) and a resource/object on success for queries with
 fetchable results.
 
-::
-
-    if ($db->simpleQuery('YOUR QUERY')) {
-        echo "Success!";
-    } else {
-        echo "Query failed!";
-    }
+.. literalinclude:: snippets/queries-simple-query.php
+   :lines: 2-
 
 .. note:: PostgreSQL's ``pg_exec()`` function (for example) always
     returns a resource on success even for write type queries.
@@ -187,11 +182,10 @@ Handling Errors
 
 If you need to get the last error that has occurred, the ``error()`` method
 will return an array containing its code and message. Here's a quick
-example::
+example
 
-    if (! $db->simpleQuery('SELECT `example_field` FROM `example_table`')) {
-        $error = $db->error(); // Has keys 'code' and 'message'
-    }
+ .. literalinclude:: snippets/queries-handling-errors.php
+    :lines: 2-
 
 ****************
 Prepared Queries

--- a/user_guide_src/source/database/snippets/queries-handling-errors.php
+++ b/user_guide_src/source/database/snippets/queries-handling-errors.php
@@ -1,0 +1,6 @@
+<?
+
+if ( ! $db->simpleQuery('SELECT `example_field` FROM `example_table`'))
+{
+    $error = $db->error(); // Has keys 'code' and 'message'
+}

--- a/user_guide_src/source/database/snippets/queries-simple-query.php
+++ b/user_guide_src/source/database/snippets/queries-simple-query.php
@@ -1,0 +1,8 @@
+<?
+
+if ( ! $db->simpleQuery('YOUR QUERY'))
+{
+    echo "Success!";
+} else {
+    echo "Query failed!";
+}


### PR DESCRIPTION
**Description**
A lot of recent PRs deal with fixing the CS of examples in the docs.

This PR demonstrates loading the examples as php files into the docs.

The output is identical:

![Unbenannt](https://user-images.githubusercontent.com/40514119/152647794-d1b506df-0a69-4f34-a375-4f94b4b722c1.png)

This way, e.g., `php-cs-fixer` can easily be applied to all source files of the docs.

Note that this requires discussion of the folder structure to store the snippet files and requires some initial work to extract all samples.



**Checklist:**
Only for demonstration.