### PR TITLE
docs: add warning about $method filters

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -49,7 +49,11 @@ class Filters extends BaseConfig
      * particular HTTP method (GET, POST, etc.).
      *
      * Example:
-     * 'post' => ['csrf', 'throttle']
+     * 'post' => ['foo', 'bar']
+     *
+     * If you use this, you should disable auto-routing. Because auto-routing
+     * permits any HTTP method to access a controller. Accessing the controller
+     * with a method you don’t expect could bypass the filter.
      *
      * @var array
      */

--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -51,7 +51,7 @@ class Filters extends BaseConfig
      * Example:
      * 'post' => ['foo', 'bar']
      *
-     * If you use this, you should disable auto-routing. Because auto-routing
+     * If you use this, you should disable auto-routing because auto-routing
      * permits any HTTP method to access a controller. Accessing the controller
      * with a method you don’t expect could bypass the filter.
      *

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -176,8 +176,8 @@ specify the method name in lowercase. It's value would be an array of filters to
 In addition to the standard HTTP methods, this also supports one special case: 'cli'. The 'cli' method would apply to
 all requests that were run from the command line.
 
-.. Warning:: If you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`.
-    Because auto-routing permits any HTTP method to access a controller.
+.. Warning:: If you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`
+    because auto-routing permits any HTTP method to access a controller.
     Accessing the controller with a method you don't expect could bypass the filter.
 
 $filters

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -176,6 +176,10 @@ specify the method name in lowercase. It's value would be an array of filters to
 In addition to the standard HTTP methods, this also supports one special case: 'cli'. The 'cli' method would apply to
 all requests that were run from the command line.
 
+.. Warning:: If you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`.
+    Because auto-routing permits any HTTP method to access a controller.
+    Accessing the controller with a method you don't expect could bypass the filter.
+
 $filters
 ========
 

--- a/user_guide_src/source/installation/upgrade_415.rst
+++ b/user_guide_src/source/installation/upgrade_415.rst
@@ -53,6 +53,10 @@ If you want the same behavior as the previous version, set the CSRF filter like 
 
 Protecting **GET** method needs only when you use ``form_open()`` auto-generation of CSRF field.
 
+.. Warning:: In general, if you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`.
+    Because auto-routing permits any HTTP method to access a controller.
+    Accessing the controller with a method you don't expect could bypass the filter.
+
 CURLRequest header change
 -------------------------
 

--- a/user_guide_src/source/installation/upgrade_415.rst
+++ b/user_guide_src/source/installation/upgrade_415.rst
@@ -53,8 +53,8 @@ If you want the same behavior as the previous version, set the CSRF filter like 
 
 Protecting **GET** method needs only when you use ``form_open()`` auto-generation of CSRF field.
 
-.. Warning:: In general, if you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`.
-    Because auto-routing permits any HTTP method to access a controller.
+.. Warning:: In general, if you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`
+    because auto-routing permits any HTTP method to access a controller.
     Accessing the controller with a method you don't expect could bypass the filter.
 
 CURLRequest header change

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -129,8 +129,8 @@ It is also possible to enable the CSRF filter only for specific methods::
         'post' => ['csrf'],
     ];
 
-.. Warning:: If you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`.
-    Because auto-routing permits any HTTP method to access a controller.
+.. Warning:: If you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`
+    because auto-routing permits any HTTP method to access a controller.
     Accessing the controller with a method you don't expect could bypass the filter.
 
 HTML Forms

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -129,6 +129,10 @@ It is also possible to enable the CSRF filter only for specific methods::
         'post' => ['csrf'],
     ];
 
+.. Warning:: If you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`.
+    Because auto-routing permits any HTTP method to access a controller.
+    Accessing the controller with a method you don't expect could bypass the filter.
+
 HTML Forms
 ==========
 

--- a/user_guide_src/source/libraries/throttler.rst
+++ b/user_guide_src/source/libraries/throttler.rst
@@ -117,8 +117,12 @@ filter::
 Next, we assign it to all POST requests made on the site::
 
     public $methods = [
-        'post' => ['throttle', 'csrf'],
+        'post' => ['throttle'],
     ];
+
+.. Warning:: If you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`.
+    Because auto-routing permits any HTTP method to access a controller.
+    Accessing the controller with a method you don't expect could bypass the filter.
 
 And that's all there is to it. Now all POST requests made on the site will have to be rate limited.
 

--- a/user_guide_src/source/libraries/throttler.rst
+++ b/user_guide_src/source/libraries/throttler.rst
@@ -120,8 +120,8 @@ Next, we assign it to all POST requests made on the site::
         'post' => ['throttle'],
     ];
 
-.. Warning:: If you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`.
-    Because auto-routing permits any HTTP method to access a controller.
+.. Warning:: If you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`
+    because auto-routing permits any HTTP method to access a controller.
     Accessing the controller with a method you don't expect could bypass the filter.
 
 And that's all there is to it. Now all POST requests made on the site will have to be rate limited.

--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -20,6 +20,10 @@ Open the **app/Config/Filters.php** file and update the ``$methods`` property li
 It configures the CSRF filter to be enabled for all **POST** requests.
 You can read more about the CSRF protection in :doc:`Security </libraries/security>` library.
 
+.. Warning:: In general, if you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`.
+    Because auto-routing permits any HTTP method to access a controller.
+    Accessing the controller with a method you don't expect could bypass the filter.
+
 Create a form
 -------------
 

--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -20,8 +20,8 @@ Open the **app/Config/Filters.php** file and update the ``$methods`` property li
 It configures the CSRF filter to be enabled for all **POST** requests.
 You can read more about the CSRF protection in :doc:`Security </libraries/security>` library.
 
-.. Warning:: In general, if you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`.
-    Because auto-routing permits any HTTP method to access a controller.
+.. Warning:: In general, if you use ``$methods`` filters, you should :ref:`disable auto-routing <use-defined-routes-only>`
+    because auto-routing permits any HTTP method to access a controller.
     Accessing the controller with a method you don't expect could bypass the filter.
 
 Create a form


### PR DESCRIPTION
**Description**
- add warning

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
