### PR TITLE
fix: Config CSRF $redirect does not work

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -436,7 +436,7 @@ class App extends BaseConfig
      * Defaults to `Lax` as recommended in this link:
      *
      * @see https://portswigger.net/web-security/csrf/samesite-cookies
-     * @deprecated Use `Config\Security` $samesite property instead of using this property.
+     * @deprecated `Config\Cookie` $samesite property is used.
      *
      * @var string
      */

--- a/app/Config/Security.php
+++ b/app/Config/Security.php
@@ -111,7 +111,7 @@ class Security extends BaseConfig
      *
      * @var string
      *
-     * @deprecated
+     * @deprecated `Config\Cookie` $samesite property is used.
      */
     public $samesite = 'Lax';
 }

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -741,63 +741,13 @@ parameters:
 			path: system/Router/Router.php
 
 		-
-			message: "#^Property Config\\\\App\\:\\:\\$CSRFCookieName \\(string\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
+			message: "#^Property Config\\\\App\\:\\:\\$CSRF[a-zA-Z]+ \\([a-zA-Z]+\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 6
 			path: system/Security/Security.php
 
 		-
-			message: "#^Property Config\\\\App\\:\\:\\$CSRFExpire \\(int\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: system/Security/Security.php
-
-		-
-			message: "#^Property Config\\\\App\\:\\:\\$CSRFHeaderName \\(string\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: system/Security/Security.php
-
-		-
-			message: "#^Property Config\\\\App\\:\\:\\$CSRFRegenerate \\(bool\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: system/Security/Security.php
-
-		-
-			message: "#^Property Config\\\\App\\:\\:\\$CSRFTokenName \\(string\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: system/Security/Security.php
-
-		-
-			message: "#^Property Config\\\\Security\\:\\:\\$cookieName \\(string\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: system/Security/Security.php
-
-		-
-			message: "#^Property Config\\\\Security\\:\\:\\$csrfProtection \\(string\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: system/Security/Security.php
-
-		-
-			message: "#^Property Config\\\\Security\\:\\:\\$expires \\(int\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: system/Security/Security.php
-
-		-
-			message: "#^Property Config\\\\Security\\:\\:\\$headerName \\(string\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: system/Security/Security.php
-
-		-
-			message: "#^Property Config\\\\Security\\:\\:\\$regenerate \\(bool\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: system/Security/Security.php
-
-		-
-			message: "#^Property Config\\\\Security\\:\\:\\$tokenName \\(string\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: system/Security/Security.php
-
-		-
-			message: "#^Property Config\\\\Security\\:\\:\\$tokenRandomize \\(bool\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
+			message: "#^Property Config\\\\Security\\:\\:\\$[a-zA-Z]+ \\([a-zA-Z]+\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 8
 			path: system/Security/Security.php
 
 		-

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -136,7 +136,7 @@ class Security implements SecurityInterface
      *
      * @var string
      *
-     * @deprecated
+     * @deprecated `Config\Cookie` $samesite property is used.
      */
     protected $samesite = Cookie::SAMESITE_LAX;
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -169,6 +169,7 @@ class Security implements SecurityInterface
             $this->tokenName      = $security->tokenName ?? $this->tokenName;
             $this->headerName     = $security->headerName ?? $this->headerName;
             $this->regenerate     = $security->regenerate ?? $this->regenerate;
+            $this->redirect       = $security->redirect ?? $this->redirect;
             $this->rawCookieName  = $security->cookieName ?? $this->rawCookieName;
             $this->expires        = $security->expires ?? $this->expires;
             $this->tokenRandomize = $security->tokenRandomize ?? $this->tokenRandomize;
@@ -179,6 +180,7 @@ class Security implements SecurityInterface
             $this->regenerate    = $config->CSRFRegenerate ?? $this->regenerate;
             $this->rawCookieName = $config->CSRFCookieName ?? $this->rawCookieName;
             $this->expires       = $config->CSRFExpire ?? $this->expires;
+            $this->redirect      = $config->CSRFRedirect ?? $this->redirect;
         }
 
         if ($this->isCSRFCookie()) {


### PR DESCRIPTION
**Description**
- fix Config CSRF $redirect does not work
- update PHPDocs

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
