### PR TITLE
fix: $builder->ignore()->insertBatch() only ignores on first iteration

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1662,7 +1662,10 @@ class BaseBuilder
             }
 
             if (! $hasQBSet) {
-                $this->resetWrite();
+                $this->resetRun([
+                    'QBSet'  => [],
+                    'QBKeys' => [],
+                ]);
             }
         }
 

--- a/system/Test/Mock/MockBuilder.php
+++ b/system/Test/Mock/MockBuilder.php
@@ -15,4 +15,9 @@ use CodeIgniter\Database\BaseBuilder;
 
 class MockBuilder extends BaseBuilder
 {
+    protected $supportedIgnoreStatements = [
+        'update' => 'IGNORE',
+        'insert' => 'IGNORE',
+        'delete' => 'IGNORE',
+    ];
 }


### PR DESCRIPTION
**Description**
Fixes #5671

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
