### PR TITLE
fix: do not call header() if headers have already been sent

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -109,7 +109,9 @@ class Exceptions
 
         if (! is_cli()) {
             $this->response->setStatusCode($statusCode);
-            header(sprintf('HTTP/%s %s %s', $this->request->getProtocolVersion(), $this->response->getStatusCode(), $this->response->getReasonPhrase()), true, $statusCode);
+            if (! headers_sent()) {
+                header(sprintf('HTTP/%s %s %s', $this->request->getProtocolVersion(), $this->response->getStatusCode(), $this->response->getReasonPhrase()), true, $statusCode);
+            }
 
             if (strpos($this->request->getHeaderLine('accept'), 'text/html') === false) {
                 $this->respond(ENVIRONMENT === 'development' ? $this->collectVars($exception, $statusCode) : '', $statusCode)->send();


### PR DESCRIPTION
**Description**
Fixes #5679

Before:
![Screenshot 2022-02-12 13 02 08](https://user-images.githubusercontent.com/87955/153695877-50371f1e-f349-4e17-bffb-d195813f16dc.png)

After:
![Screenshot 2022-02-12 13 02 12](https://user-images.githubusercontent.com/87955/153695884-ad35a823-93b2-4719-865a-b79ad763ee00.png)

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

