### PR TITLE
Deprecate object implementations of `clean_path()` function

### DIFF
--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -30,7 +30,7 @@
 
 	<!-- Source -->
 	<div class="container">
-		<p><b><?= esc(static::cleanPath($file, $line)) ?></b> at line <b><?= esc($line) ?></b></p>
+		<p><b><?= esc(clean_path($file)) ?></b> at line <b><?= esc($line) ?></b></p>
 
 		<?php if (is_file($file)) : ?>
 			<div class="source">
@@ -64,12 +64,12 @@
 							<?php if (isset($row['file']) && is_file($row['file'])) :?>
 								<?php
                                 if (isset($row['function']) && in_array($row['function'], ['include', 'include_once', 'require', 'require_once'], true)) {
-                                    echo esc($row['function'] . ' ' . static::cleanPath($row['file']));
+                                    echo esc($row['function'] . ' ' . clean_path($row['file']));
                                 } else {
-                                    echo esc(static::cleanPath($row['file']) . ' : ' . $row['line']);
+                                    echo esc(clean_path($row['file']) . ' : ' . $row['line']);
                                 }
                                 ?>
-							<?php else : ?>
+							<?php else: ?>
 								{PHP internal code}
 							<?php endif; ?>
 
@@ -350,7 +350,7 @@
 
 				<ol>
 				<?php foreach ($files as $file) :?>
-					<li><?= esc(static::cleanPath($file)) ?></li>
+					<li><?= esc(clean_path($file)) ?></li>
 				<?php endforeach ?>
 				</ol>
 			</div>

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -318,6 +318,8 @@ class Exceptions
 
     /**
      * This makes nicer looking paths for the error output.
+     *
+     * @deprecated Use dedicated `clean_path()` function.
      */
     public static function cleanPath(string $file): string
     {

--- a/system/Debug/Toolbar/Collectors/BaseCollector.php
+++ b/system/Debug/Toolbar/Collectors/BaseCollector.php
@@ -11,8 +11,6 @@
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
-use CodeIgniter\Debug\Exceptions;
-
 /**
  * Base Toolbar collector
  */
@@ -174,13 +172,13 @@ class BaseCollector
     }
 
     /**
-     * Clean Path
-     *
      * This makes nicer looking paths for the error output.
+     *
+     * @deprecated Use the dedicated `clean_path()` function.
      */
     public function cleanPath(string $file): string
     {
-        return Exceptions::cleanPath($file);
+        return clean_path($file);
     }
 
     /**

--- a/system/Debug/Toolbar/Collectors/Files.php
+++ b/system/Debug/Toolbar/Collectors/Files.php
@@ -58,7 +58,7 @@ class Files extends BaseCollector
         $userFiles = [];
 
         foreach ($rawFiles as $file) {
-            $path = $this->cleanPath($file);
+            $path = clean_path($file);
 
             if (strpos($path, 'SYSTEMPATH') !== false) {
                 $coreFiles[] = [

--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -398,7 +398,7 @@ class Logger implements LoggerInterface
         // Find the first reference to a Logger class method
         foreach ($stackFrames as $frame) {
             if (\in_array($frame['function'], $logFunctions, true)) {
-                $file = isset($frame['file']) ? $this->cleanFileNames($frame['file']) : 'unknown';
+                $file = isset($frame['file']) ? clean_path($frame['file']) : 'unknown';
                 $line = $frame['line'] ?? 'unknown';
 
                 return [
@@ -421,12 +421,11 @@ class Logger implements LoggerInterface
      *  /var/www/site/app/Controllers/Home.php
      *      becomes:
      *  APPPATH/Controllers/Home.php
+     *
+     * @deprecated Use dedicated `clean_path()` function.
      */
     protected function cleanFileNames(string $file): string
     {
-        $file = str_replace(APPPATH, 'APPPATH/', $file);
-        $file = str_replace(SYSTEMPATH, 'SYSTEMPATH/', $file);
-
-        return str_replace(FCPATH, 'FCPATH/', $file);
+        return clean_path($file);
     }
 }

--- a/system/Test/TestLogger.php
+++ b/system/Test/TestLogger.php
@@ -70,9 +70,15 @@ class TestLogger extends Logger
         return false;
     }
 
-    // Expose cleanFileNames()
+    /**
+     * Expose filenames.
+     *
+     * @param string $file
+     *
+     * @deprecated No longer needed as underlying protected method is also deprecated.
+     */
     public function cleanup($file)
     {
-        return $this->cleanFileNames($file);
+        return clean_path($file);
     }
 }

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -61,36 +61,4 @@ final class ExceptionsTest extends CIUnitTestCase
         $this->assertSame([500, 1], $determineCodes(new RuntimeException('That.', 600)));
         $this->assertSame([404, 1], $determineCodes(new RuntimeException('There.', 404)));
     }
-
-    /**
-     * @dataProvider dirtyPathsProvider
-     */
-    public function testCleanPaths(string $file, string $expected): void
-    {
-        $this->assertSame($expected, Exceptions::cleanPath($file));
-    }
-
-    public function dirtyPathsProvider()
-    {
-        $ds = DIRECTORY_SEPARATOR;
-
-        yield from [
-            [
-                APPPATH . 'Config' . $ds . 'App.php',
-                'APPPATH' . $ds . 'Config' . $ds . 'App.php',
-            ],
-            [
-                SYSTEMPATH . 'CodeIgniter.php',
-                'SYSTEMPATH' . $ds . 'CodeIgniter.php',
-            ],
-            [
-                VENDORPATH . 'autoload.php',
-                'VENDORPATH' . $ds . 'autoload.php',
-            ],
-            [
-                FCPATH . 'index.php',
-                'FCPATH' . $ds . 'index.php',
-            ],
-        ];
-    }
 }

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -15,7 +15,6 @@ use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\Log\Exceptions\LogException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
-use CodeIgniter\Test\TestLogger;
 use Exception;
 use Tests\Support\Log\Handlers\TestHandler;
 
@@ -32,7 +31,7 @@ final class LoggerTest extends CIUnitTestCase
         $this->expectException(FrameworkException::class);
         $this->expectExceptionMessage(lang('Core.noHandlers', ['LoggerConfig']));
 
-        $logger = new Logger($config);
+        new Logger($config);
     }
 
     public function testLogThrowsExceptionOnInvalidLevel()
@@ -60,12 +59,9 @@ final class LoggerTest extends CIUnitTestCase
     public function testLogActuallyLogs()
     {
         $config = new LoggerConfig();
-        //      $Config->handlers['TestHandler']['handles'] =  [LogLevel::CRITICAL];
-
         $logger = new Logger($config);
 
         $expected = 'DEBUG - ' . date('Y-m-d') . ' --> Test message';
-
         $logger->log('debug', 'Test message');
 
         $logs = TestHandler::getLogs();
@@ -76,7 +72,8 @@ final class LoggerTest extends CIUnitTestCase
 
     public function testLogDoesnotLogUnhandledLevels()
     {
-        $config                                                                = new LoggerConfig();
+        $config = new LoggerConfig();
+
         $config->handlers['Tests\Support\Log\Handlers\TestHandler']['handles'] = ['critical'];
 
         $logger = new Logger($config);
@@ -372,17 +369,6 @@ final class LoggerTest extends CIUnitTestCase
 
         $this->assertCount(1, $logs);
         $this->assertStringContainsString($expected, $logs[0]);
-    }
-
-    public function testFilenameCleaning()
-    {
-        $config = new LoggerConfig();
-        $logger = new TestLogger($config);
-
-        $ohoh     = APPPATH . 'LoggerTest';
-        $expected = 'APPPATH/LoggerTest';
-
-        $this->assertSame($expected, $logger->cleanup($ohoh));
     }
 
     public function testDetermineFileNoStackTrace()

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -41,6 +41,7 @@ Deprecations
 
 - ``CodeIgniter\Database\SQLSRV\Connection::getError()`` is deprecated. Use ``CodeIgniter\Database\SQLSRV\Connection::error()`` instead.
 - ``CodeIgniter\Debug\Exceptions::cleanPath()`` and ``CodeIgniter\Debug\Toolbar\Collectors\BaseCollector::cleanPath()`` are deprecated. Use the ``clean_path()`` function instead.
+- ``CodeIgniter\Log\Logger::cleanFilenames()`` and ``CodeIgniter\Test\TestLogger::cleanup()`` are both deprecated. Use the ``clean_path()`` function instead.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -40,6 +40,7 @@ Deprecations
 ************
 
 - ``CodeIgniter\Database\SQLSRV\Connection::getError()`` is deprecated. Use ``CodeIgniter\Database\SQLSRV\Connection::error()`` instead.
+- ``CodeIgniter\Debug\Exceptions::cleanPath()`` and ``CodeIgniter\Debug\Toolbar\Collectors\BaseCollector::cleanPath()`` are deprecated. Use the ``clean_path()`` function instead.
 
 Bugs Fixed
 **********


### PR DESCRIPTION
**Description**
Use the `clean_path()` function instead.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
