### PR TITLE
fix: $routes->setDefaultMethod() does not work

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -638,7 +638,7 @@ class Router implements RouterInterface
      */
     protected function setRequest(array $segments = [])
     {
-        // If we don't have any segments - try the default controller;
+        // If we don't have any segments - use the default controller;
         if (empty($segments)) {
             return;
         }

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -459,15 +459,12 @@ class Router implements RouterInterface
     {
         $segments = explode('/', $uri);
 
+        // WARNING: Directories get shifted out of the segments array.
         $segments = $this->scanControllers($segments);
 
-        // If we don't have any segments left - try the default controller;
-        // WARNING: Directories get shifted out of the segments array.
-        if (empty($segments)) {
-            $this->setDefaultController();
-        }
+        // If we don't have any segments left - use the default controller;
         // If not empty, then the first segment should be the controller
-        else {
+        if (! empty($segments)) {
             $this->controller = ucfirst(array_shift($segments));
         }
 
@@ -643,8 +640,6 @@ class Router implements RouterInterface
     {
         // If we don't have any segments - try the default controller;
         if (empty($segments)) {
-            $this->setDefaultController();
-
             return;
         }
 
@@ -665,6 +660,8 @@ class Router implements RouterInterface
 
     /**
      * Sets the default controller based on the info set in the RouteCollection.
+     *
+     * @deprecated This was an unnecessary method, so it is no longer used.
      */
     protected function setDefaultController()
     {

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -427,10 +427,7 @@ class Router implements RouterInterface
                 } elseif (strpos($val, '$') !== false && strpos($key, '(') !== false) {
                     $val = preg_replace('#^' . $key . '$#u', $val, $uri);
                 } elseif (strpos($val, '/') !== false) {
-                    [
-                        $controller,
-                        $method,
-                    ] = explode('::', $val);
+                    [$controller, $method] = explode('::', $val);
 
                     // Only replace slashes in the controller, not in the method.
                     $controller = str_replace('/', '\\', $controller);

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -675,10 +675,7 @@ class Router implements RouterInterface
             throw RouterException::forMissingDefaultRoute();
         }
 
-        // Is the method being specified?
-        if (sscanf($this->controller, '%[^/]/%s', $class, $this->method) !== 2) {
-            $this->method = 'index';
-        }
+        sscanf($this->controller, '%[^/]/%s', $class, $this->method);
 
         if (! is_file(APPPATH . 'Controllers/' . $this->directory . ucfirst($class) . '.php')) {
             return;

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -199,6 +199,18 @@ final class RouterTest extends CIUnitTestCase
         $this->assertSame($expects, '123-alpha');
     }
 
+    public function testAutoRouteFindsDefaultControllerAndMethod()
+    {
+        $this->collection->setDefaultController('Test');
+        $this->collection->setDefaultMethod('test');
+        $router = new Router($this->collection, $this->request);
+
+        $router->autoRoute('/');
+
+        $this->assertSame('Test', $router->controllerName());
+        $this->assertSame('test', $router->methodName());
+    }
+
     public function testAutoRouteFindsControllerWithFileAndMethod()
     {
         $router = new Router($this->collection, $this->request);

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -42,7 +42,7 @@ Deprecations
 - ``CodeIgniter\Database\SQLSRV\Connection::getError()`` is deprecated. Use ``CodeIgniter\Database\SQLSRV\Connection::error()`` instead.
 - ``CodeIgniter\Debug\Exceptions::cleanPath()`` and ``CodeIgniter\Debug\Toolbar\Collectors\BaseCollector::cleanPath()`` are deprecated. Use the ``clean_path()`` function instead.
 - ``CodeIgniter\Log\Logger::cleanFilenames()`` and ``CodeIgniter\Test\TestLogger::cleanup()`` are both deprecated. Use the ``clean_path()`` function instead.
-- ``CodeIgniter\Router\setDefaultController()`` is deprecated.
+- ``CodeIgniter\Router\Router::setDefaultController()`` is deprecated.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -42,6 +42,7 @@ Deprecations
 - ``CodeIgniter\Database\SQLSRV\Connection::getError()`` is deprecated. Use ``CodeIgniter\Database\SQLSRV\Connection::error()`` instead.
 - ``CodeIgniter\Debug\Exceptions::cleanPath()`` and ``CodeIgniter\Debug\Toolbar\Collectors\BaseCollector::cleanPath()`` are deprecated. Use the ``clean_path()`` function instead.
 - ``CodeIgniter\Log\Logger::cleanFilenames()`` and ``CodeIgniter\Test\TestLogger::cleanup()`` are both deprecated. Use the ``clean_path()`` function instead.
+- ``CodeIgniter\Router\setDefaultController()`` is deprecated.
 
 Bugs Fixed
 **********


### PR DESCRIPTION
**Description**
- `$routes->setDefaultMethod()` does not work when you go to `/`

See https://forum.codeigniter.com/thread-81269.html

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

