### PR TITLE
Do not call non-statically the static `getPrivateMethodInvoker()` method

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -38,6 +38,7 @@ use Rector\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector;
 use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
+use Rector\Php70\Rector\MethodCall\ThisCallOnStaticMethodToStaticCallRector;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
@@ -145,4 +146,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(MakeInheritedMethodVisibilitySameAsParentRector::class);
     $services->set(SimplifyEmptyArrayCheckRector::class);
     $services->set(NormalizeNamespaceByPSR4ComposerAutoloadRector::class);
+    $services->set(ThisCallOnStaticMethodToStaticCallRector::class);
 };

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -594,7 +594,7 @@ final class ResponseTraitTest extends CIUnitTestCase
 
     private function invoke(object $controller, string $method, array $args = [])
     {
-        $method = $this->getPrivateMethodInvoker($controller, $method);
+        $method = self::getPrivateMethodInvoker($controller, $method);
 
         return $method(...$args);
     }

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -258,8 +258,8 @@ final class CodeIgniterTest extends CIUnitTestCase
 
         $codeigniter = new MockCodeIgniter($config);
 
-        $this->getPrivateMethodInvoker($codeigniter, 'getRequestObject')();
-        $this->getPrivateMethodInvoker($codeigniter, 'getResponseObject')();
+        self::getPrivateMethodInvoker($codeigniter, 'getRequestObject')();
+        self::getPrivateMethodInvoker($codeigniter, 'getResponseObject')();
 
         $response = $this->getPrivateProperty($codeigniter, 'response');
         $this->assertNull($response->header('Location'));

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -216,7 +216,7 @@ final class BaseConfigTest extends CIUnitTestCase
         $config              = new RegistrarConfig();
         $config::$registrars = ['\Tests\Support\Config\TestRegistrar'];
         $this->setPrivateProperty($config, 'didDiscovery', true);
-        $method = $this->getPrivateMethodInvoker($config, 'registerProperties');
+        $method = self::getPrivateMethodInvoker($config, 'registerProperties');
         $method();
 
         // no change to unmodified property
@@ -237,7 +237,7 @@ final class BaseConfigTest extends CIUnitTestCase
         $this->setPrivateProperty($config, 'didDiscovery', true);
 
         $this->expectException(RuntimeException::class);
-        $method = $this->getPrivateMethodInvoker($config, 'registerProperties');
+        $method = self::getPrivateMethodInvoker($config, 'registerProperties');
         $method();
 
         $this->assertSame('bar', $config->foo);
@@ -252,7 +252,7 @@ final class BaseConfigTest extends CIUnitTestCase
         $config::$registrars = [];
         $expected            = $config::$registrars;
 
-        $method = $this->getPrivateMethodInvoker($config, 'registerProperties');
+        $method = self::getPrivateMethodInvoker($config, 'registerProperties');
         $method();
 
         $this->assertSame($expected, $config::$registrars);
@@ -267,7 +267,7 @@ final class BaseConfigTest extends CIUnitTestCase
         $config::$registrars = [];
         $this->setPrivateProperty($config, 'didDiscovery', false);
 
-        $method = $this->getPrivateMethodInvoker($config, 'registerProperties');
+        $method = self::getPrivateMethodInvoker($config, 'registerProperties');
         $method();
 
         $this->assertTrue($this->getPrivateProperty($config, 'didDiscovery'));

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -100,7 +100,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->controller = new Controller();
         $this->controller->initController($this->request, $this->response, $this->logger);
 
-        $method = $this->getPrivateMethodInvoker($this->controller, 'cachePage');
+        $method = self::getPrivateMethodInvoker($this->controller, 'cachePage');
         $this->assertNull($method(10));
     }
 
@@ -111,7 +111,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->controller->initController($this->request, $this->response, $this->logger);
 
         // and that we can attempt validation, with no rules
-        $method = $this->getPrivateMethodInvoker($this->controller, 'validate');
+        $method = self::getPrivateMethodInvoker($this->controller, 'validate');
         $this->assertFalse($method([]));
     }
 
@@ -123,7 +123,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->controller = new Controller();
         $this->controller->initController($this->request, $this->response, $this->logger);
 
-        $method = $this->getPrivateMethodInvoker($this->controller, 'validate');
+        $method = self::getPrivateMethodInvoker($this->controller, 'validate');
         $this->assertFalse($method('signup'));
     }
 
@@ -143,7 +143,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->controller = new Controller();
         $this->controller->initController($this->request, $this->response, $this->logger);
 
-        $method = $this->getPrivateMethodInvoker($this->controller, 'validate');
+        $method = self::getPrivateMethodInvoker($this->controller, 'validate');
         $this->assertFalse($method('signup'));
         $this->assertSame('You must choose a username.', Services::validation()->getError());
     }
@@ -159,7 +159,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->controller = new Controller();
         $this->controller->initController($this->request, $this->response, $this->logger);
 
-        $method = $this->getPrivateMethodInvoker($this->controller, 'validate');
+        $method = self::getPrivateMethodInvoker($this->controller, 'validate');
         $this->assertFalse($method('signup', [
             'username' => [
                 'required' => 'You must choose a username.',

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -162,7 +162,7 @@ final class ConfigTest extends CIUnitTestCase
         $this->assertSame('5', $this->getPrivateProperty($conn, 'connect_timeout'));
         $this->assertSame('1', $this->getPrivateProperty($conn, 'sslmode'));
 
-        $method = $this->getPrivateMethodInvoker($conn, 'buildDSN');
+        $method = self::getPrivateMethodInvoker($conn, 'buildDSN');
         $method();
 
         $expected = "host=localhost port=5432 user=user password='pass' dbname=dbname connect_timeout='5' sslmode='1'";

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -266,7 +266,7 @@ final class ForgeTest extends CIUnitTestCase
             ],
         ]);
 
-        $createTable = $this->getPrivateMethodInvoker($this->forge, '_createTable');
+        $createTable = self::getPrivateMethodInvoker($this->forge, '_createTable');
 
         $sql = $createTable('forge_nullable_table', false, []);
 

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -142,7 +142,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
     {
         $runner = new MigrationRunner($this->config);
 
-        $method = $this->getPrivateMethodInvoker($runner, 'getMigrationNumber');
+        $method = self::getPrivateMethodInvoker($runner, 'getMigrationNumber');
 
         $this->assertSame('20190806235100', $method('20190806235100_Foo'));
     }
@@ -151,7 +151,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
     {
         $runner = new MigrationRunner($this->config);
 
-        $method = $this->getPrivateMethodInvoker($runner, 'getMigrationNumber');
+        $method = self::getPrivateMethodInvoker($runner, 'getMigrationNumber');
 
         $this->assertSame('2019-08-06-235100', $method('2019-08-06-235100_Foo'));
     }
@@ -160,7 +160,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
     {
         $runner = new MigrationRunner($this->config);
 
-        $method = $this->getPrivateMethodInvoker($runner, 'getMigrationNumber');
+        $method = self::getPrivateMethodInvoker($runner, 'getMigrationNumber');
 
         $this->assertSame('2019_08_06_235100', $method('2019_08_06_235100_Foo'));
     }
@@ -169,7 +169,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
     {
         $runner = new MigrationRunner($this->config);
 
-        $method = $this->getPrivateMethodInvoker($runner, 'getMigrationNumber');
+        $method = self::getPrivateMethodInvoker($runner, 'getMigrationNumber');
 
         $this->assertSame('0', $method('Foo'));
     }

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -34,7 +34,7 @@ final class ExceptionsTest extends CIUnitTestCase
 
     public function testDetermineViews(): void
     {
-        $determineView = $this->getPrivateMethodInvoker($this->exception, 'determineView');
+        $determineView = self::getPrivateMethodInvoker($this->exception, 'determineView');
 
         $this->assertSame('error_404.php', $determineView(PageNotFoundException::forControllerNotFound('Foo', 'bar'), ''));
         $this->assertSame('error_exception.php', $determineView(new RuntimeException('Exception'), ''));
@@ -43,7 +43,7 @@ final class ExceptionsTest extends CIUnitTestCase
 
     public function testCollectVars(): void
     {
-        $vars = $this->getPrivateMethodInvoker($this->exception, 'collectVars')(new RuntimeException('This.'), 404);
+        $vars = self::getPrivateMethodInvoker($this->exception, 'collectVars')(new RuntimeException('This.'), 404);
 
         $this->assertIsArray($vars);
         $this->assertCount(7, $vars);
@@ -55,7 +55,7 @@ final class ExceptionsTest extends CIUnitTestCase
 
     public function testDetermineCodes(): void
     {
-        $determineCodes = $this->getPrivateMethodInvoker($this->exception, 'determineCodes');
+        $determineCodes = self::getPrivateMethodInvoker($this->exception, 'determineCodes');
 
         $this->assertSame([500, 9], $determineCodes(new RuntimeException('This.')));
         $this->assertSame([500, 1], $determineCodes(new RuntimeException('That.', 600)));

--- a/tests/system/Files/FileCollectionTest.php
+++ b/tests/system/Files/FileCollectionTest.php
@@ -43,14 +43,14 @@ final class FileCollectionTest extends CIUnitTestCase
 
     public function testResolveDirectoryDirectory()
     {
-        $method = $this->getPrivateMethodInvoker(FileCollection::class, 'resolveDirectory');
+        $method = self::getPrivateMethodInvoker(FileCollection::class, 'resolveDirectory');
 
         $this->assertSame($this->directory, $method($this->directory));
     }
 
     public function testResolveDirectoryFile()
     {
-        $method = $this->getPrivateMethodInvoker(FileCollection::class, 'resolveDirectory');
+        $method = self::getPrivateMethodInvoker(FileCollection::class, 'resolveDirectory');
 
         $this->expectException(FileException::class);
         $this->expectExceptionMessage(lang('Files.expectedDirectory', ['invokeArgs']));
@@ -64,7 +64,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $link = sys_get_temp_dir() . DIRECTORY_SEPARATOR . bin2hex(random_bytes(4));
         symlink($this->directory, $link);
 
-        $method = $this->getPrivateMethodInvoker(FileCollection::class, 'resolveDirectory');
+        $method = self::getPrivateMethodInvoker(FileCollection::class, 'resolveDirectory');
 
         $this->assertSame($this->directory, $method($link));
 
@@ -73,7 +73,7 @@ final class FileCollectionTest extends CIUnitTestCase
 
     public function testResolveFileFile()
     {
-        $method = $this->getPrivateMethodInvoker(FileCollection::class, 'resolveFile');
+        $method = self::getPrivateMethodInvoker(FileCollection::class, 'resolveFile');
 
         $this->assertSame($this->file, $method($this->file));
     }
@@ -84,7 +84,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $link = sys_get_temp_dir() . DIRECTORY_SEPARATOR . bin2hex(random_bytes(4));
         symlink($this->file, $link);
 
-        $method = $this->getPrivateMethodInvoker(FileCollection::class, 'resolveFile');
+        $method = self::getPrivateMethodInvoker(FileCollection::class, 'resolveFile');
 
         $this->assertSame($this->file, $method($link));
 
@@ -93,7 +93,7 @@ final class FileCollectionTest extends CIUnitTestCase
 
     public function testResolveFileDirectory()
     {
-        $method = $this->getPrivateMethodInvoker(FileCollection::class, 'resolveFile');
+        $method = self::getPrivateMethodInvoker(FileCollection::class, 'resolveFile');
 
         $this->expectException(FileException::class);
         $this->expectExceptionMessage(lang('Files.expectedFile', ['invokeArgs']));

--- a/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
@@ -59,7 +59,7 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
 
         $request = $this->getRequest(['base_uri' => 'http://example.com/v1/']);
 
-        $method = $this->getPrivateMethodInvoker($request, 'prepareURL');
+        $method = self::getPrivateMethodInvoker($request, 'prepareURL');
 
         $this->assertSame('http://example.com/v1/bananas', $method('bananas'));
     }

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -59,7 +59,7 @@ final class CURLRequestTest extends CIUnitTestCase
 
         $request = $this->getRequest(['base_uri' => 'http://example.com/v1/']);
 
-        $method = $this->getPrivateMethodInvoker($request, 'prepareURL');
+        $method = self::getPrivateMethodInvoker($request, 'prepareURL');
 
         $this->assertSame('http://example.com/v1/bananas', $method('bananas'));
     }

--- a/tests/system/Models/MiscellaneousModelTest.php
+++ b/tests/system/Models/MiscellaneousModelTest.php
@@ -106,7 +106,7 @@ final class MiscellaneousModelTest extends LiveModelTestCase
         $this->expectExceptionMessage('Invalid type "whatever" used upon transforming data to array.');
 
         $this->createModel(JobModel::class);
-        $method = $this->getPrivateMethodInvoker($this->model, 'transformDataToArray');
+        $method = self::getPrivateMethodInvoker($this->model, 'transformDataToArray');
         $method([], 'whatever');
     }
 
@@ -116,7 +116,7 @@ final class MiscellaneousModelTest extends LiveModelTestCase
         $this->expectExceptionMessage('There is no data to insert.');
 
         $this->createModel(JobModel::class);
-        $method = $this->getPrivateMethodInvoker($this->model, 'transformDataToArray');
+        $method = self::getPrivateMethodInvoker($this->model, 'transformDataToArray');
         $method([], 'insert');
     }
 }

--- a/tests/system/Models/ValidationModelTest.php
+++ b/tests/system/Models/ValidationModelTest.php
@@ -153,7 +153,7 @@ final class ValidationModelTest extends LiveModelTestCase
 
     public function testCleanValidationRemovesAllWhenNoDataProvided(): void
     {
-        $cleaner = $this->getPrivateMethodInvoker($this->model, 'cleanValidationRules');
+        $cleaner = self::getPrivateMethodInvoker($this->model, 'cleanValidationRules');
 
         $rules = [
             'name' => 'required',
@@ -166,7 +166,7 @@ final class ValidationModelTest extends LiveModelTestCase
 
     public function testCleanValidationRemovesOnlyForFieldsNotProvided(): void
     {
-        $cleaner = $this->getPrivateMethodInvoker($this->model, 'cleanValidationRules');
+        $cleaner = self::getPrivateMethodInvoker($this->model, 'cleanValidationRules');
 
         $rules = [
             'name' => 'required',
@@ -184,7 +184,7 @@ final class ValidationModelTest extends LiveModelTestCase
 
     public function testCleanValidationReturnsAllWhenAllExist(): void
     {
-        $cleaner = $this->getPrivateMethodInvoker($this->model, 'cleanValidationRules');
+        $cleaner = self::getPrivateMethodInvoker($this->model, 'cleanValidationRules');
 
         $rules = [
             'name' => 'required',

--- a/tests/system/Publisher/PublisherSupportTest.php
+++ b/tests/system/Publisher/PublisherSupportTest.php
@@ -123,7 +123,7 @@ final class PublisherSupportTest extends CIUnitTestCase
         mkdir($directory, 0700);
         $this->assertDirectoryExists($directory);
 
-        $method = $this->getPrivateMethodInvoker(Publisher::class, 'wipeDirectory');
+        $method = self::getPrivateMethodInvoker(Publisher::class, 'wipeDirectory');
         $method($directory);
 
         $this->assertDirectoryDoesNotExist($directory);
@@ -131,7 +131,7 @@ final class PublisherSupportTest extends CIUnitTestCase
 
     public function testWipeIgnoresFiles()
     {
-        $method = $this->getPrivateMethodInvoker(Publisher::class, 'wipeDirectory');
+        $method = self::getPrivateMethodInvoker(Publisher::class, 'wipeDirectory');
         $method($this->file);
 
         $this->assertFileExists($this->file);

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -332,7 +332,7 @@ final class ResourceControllerTest extends CIUnitTestCase
 
     private function invoke(object $controller, string $method, array $args = [])
     {
-        $method = $this->getPrivateMethodInvoker($controller, $method);
+        $method = self::getPrivateMethodInvoker($controller, $method);
 
         return $method(...$args);
     }

--- a/tests/system/Session/Handlers/DatabaseHandlerTest.php
+++ b/tests/system/Session/Handlers/DatabaseHandlerTest.php
@@ -115,13 +115,13 @@ final class DatabaseHandlerTest extends CIUnitTestCase
         $this->setPrivateProperty($handler, 'sessionID', '1f5o06b43phsnnf8if6bo33b635e4p2o');
         $this->setPrivateProperty($handler, 'rowExists', true);
 
-        $lockSession = $this->getPrivateMethodInvoker($handler, 'lockSession');
+        $lockSession = self::getPrivateMethodInvoker($handler, 'lockSession');
         $lockSession('1f5o06b43phsnnf8if6bo33b635e4p2o');
 
         $data = '__ci_last_regenerate|i:1624650854;_ci_previous_url|s:40:\"http://localhost/index.php/home/index\";';
         $this->assertTrue($handler->write('1f5o06b43phsnnf8if6bo33b635e4p2o', $data));
 
-        $releaseLock = $this->getPrivateMethodInvoker($handler, 'releaseLock');
+        $releaseLock = self::getPrivateMethodInvoker($handler, 'releaseLock');
         $releaseLock();
 
         $row = $this->db->table('ci_sessions')

--- a/tests/system/Test/FabricatorTest.php
+++ b/tests/system/Test/FabricatorTest.php
@@ -151,7 +151,7 @@ final class FabricatorTest extends CIUnitTestCase
         $formatters = ['boo' => 'hiss'];
         $fabricator = new Fabricator(UserModel::class, $formatters);
 
-        $method = $this->getPrivateMethodInvoker($fabricator, 'detectFormatters');
+        $method = self::getPrivateMethodInvoker($fabricator, 'detectFormatters');
 
         $method();
 
@@ -194,7 +194,7 @@ final class FabricatorTest extends CIUnitTestCase
     {
         $fabricator = new Fabricator(UserModel::class);
 
-        $method = $this->getPrivateMethodInvoker($fabricator, 'guessFormatter');
+        $method = self::getPrivateMethodInvoker($fabricator, 'guessFormatter');
 
         $field     = 'catchPhrase';
         $formatter = $method($field);
@@ -206,7 +206,7 @@ final class FabricatorTest extends CIUnitTestCase
     {
         $fabricator = new Fabricator(UserModel::class);
 
-        $method = $this->getPrivateMethodInvoker($fabricator, 'guessFormatter');
+        $method = self::getPrivateMethodInvoker($fabricator, 'guessFormatter');
 
         $field     = 'created_at';
         $formatter = $method($field);
@@ -218,7 +218,7 @@ final class FabricatorTest extends CIUnitTestCase
     {
         $fabricator = new Fabricator(UserModel::class);
 
-        $method = $this->getPrivateMethodInvoker($fabricator, 'guessFormatter');
+        $method = self::getPrivateMethodInvoker($fabricator, 'guessFormatter');
 
         $field     = 'id';
         $formatter = $method($field);
@@ -230,7 +230,7 @@ final class FabricatorTest extends CIUnitTestCase
     {
         $fabricator = new Fabricator(UserModel::class);
 
-        $method = $this->getPrivateMethodInvoker($fabricator, 'guessFormatter');
+        $method = self::getPrivateMethodInvoker($fabricator, 'guessFormatter');
 
         $field     = 'business_email';
         $formatter = $method($field);
@@ -242,7 +242,7 @@ final class FabricatorTest extends CIUnitTestCase
     {
         $fabricator = new Fabricator(UserModel::class);
 
-        $method = $this->getPrivateMethodInvoker($fabricator, 'guessFormatter');
+        $method = self::getPrivateMethodInvoker($fabricator, 'guessFormatter');
 
         $field     = 'zaboomafoo';
         $formatter = $method($field);

--- a/tests/system/Test/ReflectionHelperTest.php
+++ b/tests/system/Test/ReflectionHelperTest.php
@@ -66,7 +66,7 @@ final class ReflectionHelperTest extends CIUnitTestCase
     public function testGetPrivateMethodInvokerWithObject()
     {
         $obj    = new __TestForReflectionHelper();
-        $method = $this->getPrivateMethodInvoker(
+        $method = self::getPrivateMethodInvoker(
             $obj,
             'privateMethod'
         );
@@ -78,7 +78,7 @@ final class ReflectionHelperTest extends CIUnitTestCase
 
     public function testGetPrivateMethodInvokerWithStatic()
     {
-        $method = $this->getPrivateMethodInvoker(
+        $method = self::getPrivateMethodInvoker(
             __TestForReflectionHelper::class,
             'privateStaticMethod'
         );

--- a/tests/system/Validation/StrictRules/ValidationTest.php
+++ b/tests/system/Validation/StrictRules/ValidationTest.php
@@ -571,14 +571,14 @@ final class ValidationTest extends CIUnitTestCase
      */
     public function testSplitNotRegex(): void
     {
-        $method = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
+        $method = self::getPrivateMethodInvoker($this->validation, 'splitRules');
         $result = $method('uploaded[avatar]|max_size[avatar,1024]');
         $this->assertSame('uploaded[avatar]', $result[0]);
     }
 
     public function testSplitRegex(): void
     {
-        $method = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
+        $method = self::getPrivateMethodInvoker($this->validation, 'splitRules');
         $result = $method('required|regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]|max_length[10]');
         $this->assertSame('regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]', $result[1]);
     }
@@ -992,7 +992,7 @@ final class ValidationTest extends CIUnitTestCase
      */
     public function testSplittingOfComplexStringRules(string $input, array $expected): void
     {
-        $splitter = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
+        $splitter = self::getPrivateMethodInvoker($this->validation, 'splitRules');
         $this->assertSame($expected, $splitter($input));
     }
 

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -674,14 +674,14 @@ final class ValidationTest extends CIUnitTestCase
      */
     public function testSplitNotRegex(): void
     {
-        $method = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
+        $method = self::getPrivateMethodInvoker($this->validation, 'splitRules');
         $result = $method('uploaded[avatar]|max_size[avatar,1024]');
         $this->assertSame('uploaded[avatar]', $result[0]);
     }
 
     public function testSplitRegex(): void
     {
-        $method = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
+        $method = self::getPrivateMethodInvoker($this->validation, 'splitRules');
         $result = $method('required|regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]|max_length[10]');
         $this->assertSame('regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]', $result[1]);
     }
@@ -1095,7 +1095,7 @@ final class ValidationTest extends CIUnitTestCase
      */
     public function testSplittingOfComplexStringRules(string $input, array $expected): void
     {
-        $splitter = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
+        $splitter = self::getPrivateMethodInvoker($this->validation, 'splitRules');
         $this->assertSame($expected, $splitter($input));
     }
 
@@ -1161,10 +1161,10 @@ final class ValidationTest extends CIUnitTestCase
             $data = [$placeholder => 'placeholder-value'];
         }
 
-        $validationRules = $this->getPrivateMethodInvoker($this->validation, 'fillPlaceholders')($this->validation->getRules(), $data);
+        $validationRules = self::getPrivateMethodInvoker($this->validation, 'fillPlaceholders')($this->validation->getRules(), $data);
         $fieldRules      = $validationRules['foo']['rules'] ?? $validationRules['foo'];
         if (is_string($fieldRules)) {
-            $fieldRules = $this->getPrivateMethodInvoker($this->validation, 'splitRules')($fieldRules);
+            $fieldRules = self::getPrivateMethodInvoker($this->validation, 'splitRules')($fieldRules);
         }
 
         // loop all rules for this field

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -273,7 +273,7 @@ parameter is an instance of the class to test. The second parameter is the name 
     $obj = new Foo();
 
     // Get the invoker for the 'privateMethod' method.
-    $method = $this->getPrivateMethodInvoker($obj, 'privateMethod');
+    $method = self::getPrivateMethodInvoker($obj, 'privateMethod');
 
     // Test the results
     $this->assertEquals('bar', $method('param1', 'param2'));


### PR DESCRIPTION
**Description**
Although PHP does not complain with it (only complains with the reverse scenario), the usage is still bad code.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
