### PR TITLE
docs: use `get()` not `add()` from the beginning in routing.rst

### DIFF
--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -48,7 +48,7 @@ Setting Your Own Routing Rules
 ******************************
 
 Routing rules are defined in the **app/Config/Routes.php** file. In it you'll see that
-it creates an instance of the RouteCollection class that permits you to specify your own routing criteria.
+it creates an instance of the RouteCollection class (``$routes``) that permits you to specify your own routing criteria.
 Routes can be specified using placeholders or Regular Expressions.
 
 A route simply takes the URI path on the left, and maps it to the controller and method on the right,
@@ -57,10 +57,11 @@ be listed in the same way that you would use a static method, by separating the 
 and its method with a double-colon, like ``Users::list``. If that method requires parameters to be
 passed to it, then they would be listed after the method name, separated by forward-slashes::
 
-    // Calls the $Users->list()
-    Users::list
+    // Calls $Users->list()
+    $routes->get('users', 'Users::list');
+
     // Calls $Users->list(1, 23)
-    Users::list/1/23
+    $routes->get('users/1/23', 'Users::list/1/23');
 
 Placeholders
 ============

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -53,7 +53,7 @@ Routes can be specified using placeholders or Regular Expressions.
 
 A route simply takes the URI path on the left, and maps it to the controller and method on the right,
 along with any parameters that should be passed to the controller. The controller and method should
-be listed in the same way that you would use a static method, by separating the fully-namespaced class
+be listed in the same way that you would use a static method, by separating the class
 and its method with a double-colon, like ``Users::list``. If that method requires parameters to be
 passed to it, then they would be listed after the method name, separated by forward-slashes::
 


### PR DESCRIPTION
**Description**
The `add()` method is not secure, so it is not recommended to use.

The current description is:
1.  Uses `add()` first 
2. After that explains a little that it is not secure

This PR is:
1.  Uses `get()` and other HTTP verb method
2. After that explains `add()` a little

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
