### PR TITLE
fix: Ajax request makes the session expire when app.sessionExpiration is set to 0

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -170,10 +170,10 @@ class Session implements SessionInterface
 
         $this->sessionDriverName        = $config->sessionDriver;
         $this->sessionCookieName        = $config->sessionCookieName ?? $this->sessionCookieName;
-        $this->sessionExpiration        = $config->sessionExpiration ?? $this->sessionExpiration;
+        $this->sessionExpiration        = (int) ($config->sessionExpiration ?? $this->sessionExpiration);
         $this->sessionSavePath          = $config->sessionSavePath;
         $this->sessionMatchIP           = $config->sessionMatchIP ?? $this->sessionMatchIP;
-        $this->sessionTimeToUpdate      = $config->sessionTimeToUpdate ?? $this->sessionTimeToUpdate;
+        $this->sessionTimeToUpdate      = (int) ($config->sessionTimeToUpdate ?? $this->sessionTimeToUpdate);
         $this->sessionRegenerateDestroy = $config->sessionRegenerateDestroy ?? $this->sessionRegenerateDestroy;
 
         // DEPRECATED COOKIE MANAGEMENT

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -200,4 +200,29 @@ final class DotEnvTest extends CIUnitTestCase
         $this->assertSame('22222:22#2^{', getenv('SPVAR4'));
         $this->assertSame('test some escaped characters like a quote " or maybe a backslash \\', getenv('SPVAR5'));
     }
+
+    public function testInt()
+    {
+        $dotenv = new DotEnv($this->fixturesFolder, 'loose.env');
+        $dotenv->load();
+
+        $this->assertSame('0', getenv('SimpleConfig.QZERO'));
+        $this->assertSame('0', getenv('SimpleConfig.QZEROSTR'));
+    }
+
+    public function testFalse()
+    {
+        $dotenv = new DotEnv($this->fixturesFolder, 'loose.env');
+        $dotenv->load();
+
+        $this->assertSame('false', getenv('SimpleConfig.QFALSE'));
+    }
+
+    public function testEmptyString()
+    {
+        $dotenv = new DotEnv($this->fixturesFolder, 'loose.env');
+        $dotenv->load();
+
+        $this->assertSame(' ', getenv('SimpleConfig.QEMPTYSTR'));
+    }
 }


### PR DESCRIPTION
**Description**
Fixes #5688
- When setting in `.env`, all values are string.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

