### PR TITLE
Convert variable type to int if it was an integer fixes #5688

### DIFF
--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -102,9 +102,17 @@ class BaseConfig
             } elseif ($value === 'true') {
                 $value = true;
             }
-            $property = is_bool($value) ? $value : trim($value, '\'"');
-            if (preg_match("/^[0-9]+$/", $property)) {
-                $property = (int) $property;
+            if (is_bool($value)) {
+                $property = $value;
+            } elseif(is_numeric($value)) {
+                // assume it's a float number if passed is_numeric and has ".", "e" or "E" in it
+                if(preg_match('/\.|[eE]/', $value)) {
+                    $property = (float) $value;
+                } else {
+                    $property = (int) $value;
+                }
+            } else {
+                $property = trim($value, '\'"');
             }
         }
 

--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -103,6 +103,9 @@ class BaseConfig
                 $value = true;
             }
             $property = is_bool($value) ? $value : trim($value, '\'"');
+            if (preg_match("/^[0-9]+$/", $property)) {
+                $property = (int) $property;
+            }
         }
 
         return $property;


### PR DESCRIPTION
Fixes #5688 

**Description**
convert any variable that is a number to int type, so errors like #5688 doesn't happen.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
