### PR TITLE
docs: fix out of dated description in autoloader.rst

### DIFF
--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -10,10 +10,9 @@ hard-coding that location into your files in a series of ``requires()`` is a mas
 headache and very error-prone. That's where autoloaders come in.
 
 CodeIgniter provides a very flexible autoloader that can be used with very little configuration.
-It can locate individual non-namespaced classes, namespaced classes that adhere to
+It can locate individual namespaced classes that adhere to
 `PSR-4 <https://www.php-fig.org/psr/psr-4/>`_ autoloading
-directory structures, and will even attempt to locate classes in common directories (like Controllers,
-Models, etc).
+directory structures.
 
 For performance improvement, the core CodeIgniter components have been added to the classmap.
 


### PR DESCRIPTION
**Description**
- Legacy Support was removed.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
