### PR TITLE
refactor: replace deprecated Response::getReason() with getReasonPhrase()

### DIFF
--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -314,7 +314,7 @@
 				<table>
 					<tr>
 						<td style="width: 15em">Response Status</td>
-						<td><?= esc($response->getStatusCode() . ' - ' . $response->getReason()) ?></td>
+						<td><?= esc($response->getStatusCode() . ' - ' . $response->getReasonPhrase()) ?></td>
 					</tr>
 				</table>
 

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -467,7 +467,7 @@ trait ResponseTrait
         }
 
         // HTTP Status
-        header(sprintf('HTTP/%s %s %s', $this->getProtocolVersion(), $this->getStatusCode(), $this->getReason()), true, $this->getStatusCode());
+        header(sprintf('HTTP/%s %s %s', $this->getProtocolVersion(), $this->getStatusCode(), $this->getReasonPhrase()), true, $this->getStatusCode());
 
         // Send all of our headers
         foreach (array_keys($this->getHeaders()) as $name) {

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -277,7 +277,7 @@ final class DownloadResponseTest extends CIUnitTestCase
     public function testGetReason()
     {
         $response = new DownloadResponse('unit-test.php', false);
-        $this->assertSame('OK', $response->getReason());
+        $this->assertSame('OK', $response->getReasonPhrase());
     }
 
     public function testPretendOutput()


### PR DESCRIPTION
**Description**
- update deprecated method

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
