### PR TITLE
fix: 404 override controller does not output Response object body

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -847,6 +847,8 @@ class CodeIgniter
     {
         // Is there a 404 Override available?
         if ($override = $this->router->get404Override()) {
+            $returned = null;
+
             if ($override instanceof Closure) {
                 echo $override($e->getMessage());
             } elseif (is_array($override)) {
@@ -857,13 +859,13 @@ class CodeIgniter
                 $this->method     = $override[1];
 
                 $controller = $this->createController();
-                $this->runController($controller);
+                $returned   = $this->runController($controller);
             }
 
             unset($override);
 
             $cacheConfig = new Cache();
-            $this->gatherOutput($cacheConfig);
+            $this->gatherOutput($cacheConfig, $returned);
             $this->sendResponse();
 
             return;

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -777,6 +777,8 @@ class CodeIgniter
      * Now that everything has been setup, this method attempts to run the
      * controller method and make the script go. If it's not able to, will
      * show the appropriate Page Not Found error.
+     *
+     * @return ResponseInterface|string|void
      */
     protected function startController()
     {
@@ -804,7 +806,7 @@ class CodeIgniter
     /**
      * Instantiates the controller class.
      *
-     * @return mixed
+     * @return Controller
      */
     protected function createController()
     {
@@ -821,7 +823,7 @@ class CodeIgniter
      *
      * @param mixed $class
      *
-     * @return mixed
+     * @return false|ResponseInterface|string|void
      */
     protected function runController($class)
     {
@@ -893,7 +895,7 @@ class CodeIgniter
      * Gathers the script output from the buffer, replaces some execution
      * time tag in the output and displays the debug toolbar, if required.
      *
-     * @param mixed|null $returned
+     * @param ResponseInterface|string|null $returned
      */
     protected function gatherOutput(?Cache $cacheConfig = null, $returned = null)
     {

--- a/tests/_support/Controllers/Popcorn.php
+++ b/tests/_support/Controllers/Popcorn.php
@@ -30,7 +30,7 @@ class Popcorn extends Controller
 
     public function pop()
     {
-        $this->respond('Oops', 567, 'Surprise');
+        return $this->respond('Oops', 567, 'Surprise');
     }
 
     public function popper()
@@ -40,12 +40,12 @@ class Popcorn extends Controller
 
     public function weasel()
     {
-        $this->respond('', 200);
+        return $this->respond('', 200);
     }
 
     public function oops()
     {
-        $this->failUnauthorized();
+        return $this->failUnauthorized();
     }
 
     public function goaway()
@@ -72,12 +72,12 @@ class Popcorn extends Controller
 
     public function json()
     {
-        $this->respond(['answer' => 42]);
+        return $this->respond(['answer' => 42]);
     }
 
     public function xml()
     {
-        $this->respond('<my><pet>cat</pet></my>');
+        return $this->respond('<my><pet>cat</pet></my>');
     }
 
     public function toindex()

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -94,15 +94,15 @@ final class CodeIgniterTest extends CIUnitTestCase
         // Inject mock router.
         $routes = Services::routes();
         $routes->setAutoRoute(false);
-        $routes->set404Override('Home::index');
+        $routes->set404Override('Tests\Support\Controllers\Hello::index');
         $router = Services::router($routes, Services::request());
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->useSafeOutput(true)->run($routes);
         $output = ob_get_clean();
 
-        $this->assertStringContainsString('Welcome to CodeIgniter', $output);
+        $this->assertStringContainsString('Hello', $output);
     }
 
     public function testRun404OverrideControllerReturnsResponse()

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -105,6 +105,25 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->assertStringContainsString('Welcome to CodeIgniter', $output);
     }
 
+    public function testRun404OverrideControllerReturnsResponse()
+    {
+        $_SERVER['argv'] = ['index.php', '/'];
+        $_SERVER['argc'] = 2;
+
+        // Inject mock router.
+        $routes = Services::routes();
+        $routes->setAutoRoute(false);
+        $routes->set404Override('Tests\Support\Controllers\Popcorn::pop');
+        $router = Services::router($routes, Services::request());
+        Services::injectMock('router', $router);
+
+        ob_start();
+        $this->codeigniter->useSafeOutput(true)->run($routes);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('Oops', $output);
+    }
+
     public function testRun404OverrideByClosure()
     {
         $_SERVER['argv'] = ['index.php', '/'];


### PR DESCRIPTION
**Description**
Fixes #5697

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

