### PR TITLE
Expand `.env` values conversion ability of `BaseConfig`

### DIFF
--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -96,13 +96,39 @@ class BaseConfig
             foreach (array_keys($property) as $key) {
                 $this->initEnvValue($property[$key], "{$name}.{$key}", $prefix, $shortPrefix);
             }
-        } elseif (($value = $this->getEnvValue($name, $prefix, $shortPrefix)) !== false && $value !== null) {
-            if ($value === 'false') {
-                $value = false;
-            } elseif ($value === 'true') {
-                $value = true;
+        } else {
+            $value = $this->getEnvValue($name, $prefix, $shortPrefix);
+
+            if ($value !== null) {
+                $lowered = strtolower($value);
+
+                switch (true) {
+                    case $lowered === 'false':
+                        $value = false;
+                        break;
+
+                    case $lowered === 'true':
+                        $value = true;
+                        break;
+
+                    case $lowered === 'empty':
+                        $value = '';
+                        break;
+
+                    case $lowered === 'null':
+                        $value = null;
+                        break;
+
+                    default:
+                        $value = trim($value, '\'"');
+                }
+
+                if (is_numeric($value)) {
+                    $value = strpos($value, '.') !== false ? (float) $value : (int) $value;
+                }
+
+                $property = $value;
             }
-            $property = is_bool($value) ? $value : trim($value, '\'"');
         }
 
         return $property;
@@ -111,7 +137,7 @@ class BaseConfig
     /**
      * Retrieve an environment-specific configuration setting
      *
-     * @return mixed
+     * @return string|null
      */
     protected function getEnvValue(string $property, string $prefix, string $shortPrefix)
     {

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -62,15 +62,15 @@ final class BaseConfigTest extends CIUnitTestCase
     public function testServerValues()
     {
         $_SERVER = [
-            'simpleconfig.shortie' => 123,
-            'SimpleConfig.longie'  => 456,
+            'simpleconfig.shortie' => '123',
+            'simpleconfig.longie'  => '456',
         ];
         $dotenv = new DotEnv($this->fixturesFolder, '.env');
         $dotenv->load();
         $config = new SimpleConfig();
 
-        $this->assertSame('123', $config->shortie);
-        $this->assertSame('456', $config->longie);
+        $this->assertSame(123, $config->shortie);
+        $this->assertSame(456, $config->longie);
     }
 
     public function testEnvironmentOverrides()
@@ -123,6 +123,10 @@ final class BaseConfigTest extends CIUnitTestCase
         $this->assertArrayNotHasKey('pilot', $config->crew);
         $this->assertTrue($config->crew['comms']);
         $this->assertFalse($config->crew['doctor']);
+        $this->assertNull($config->crew['ranger']);
+        $this->assertSame('', $config->crew['poacher']);
+        $this->assertSame(12.45, $config->shortie);
+        $this->assertSame(250, $config->longie);
     }
 
     public function testArrayValues()
@@ -205,8 +209,7 @@ final class BaseConfigTest extends CIUnitTestCase
 
         $config = new SimpleConfig();
 
-        $this->assertSame(0, (int) $config->QZERO);
-        $this->assertSame('0', $config->QZEROSTR);
+        $this->assertSame(0, $config->QZERO);
         $this->assertSame(' ', $config->QEMPTYSTR);
         $this->assertFalse($config->QFALSE);
     }

--- a/tests/system/Config/fixtures/.env
+++ b/tests/system/Config/fixtures/.env
@@ -32,3 +32,8 @@ SimpleConfig.crew.captain = Malcolm
 SimpleConfig.crew.pilot = Wash
 SimpleConfig.crew.comms = true
 SimpleConfig.crew.doctor = false
+SimpleConfig.crew.ranger = null
+SimpleConfig.crew.poacher = empty
+
+SimpleConfig.shortie = '12.45'
+SimpleConfig.longie = '250'

--- a/tests/system/Config/fixtures/SimpleConfig.php
+++ b/tests/system/Config/fixtures/SimpleConfig.php
@@ -12,7 +12,6 @@
 class SimpleConfig extends \CodeIgniter\Config\BaseConfig
 {
     public $QZERO;
-    public $QZEROSTR;
     public $QEMPTYSTR;
     public $QFALSE;
     public $first  = 'foo';
@@ -41,6 +40,8 @@ class SimpleConfig extends \CodeIgniter\Config\BaseConfig
         'science' => 'Spock',
         'doctor'  => 'Bones',
         'comms'   => 'Uhuru',
+        'ranger'  => 'Red',
+        'poacher' => 'Nice',
     ];
     public $shortie;
     public $longie;

--- a/tests/system/Config/fixtures/loose.env
+++ b/tests/system/Config/fixtures/loose.env
@@ -1,4 +1,3 @@
 SimpleConfig.QZERO=0
-SimpleConfig.QZEROSTR="0"
 SimpleConfig.QEMPTYSTR=" "
 SimpleConfig.QFALSE=false

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -31,6 +31,7 @@ Enhancements
 - The ``spark routes`` command now shows closure routes, auto routtes, and filters. See :ref:`URI Routing <spark-routes>`.
 - Exception information logged through ``log_message()`` has now improved. It now includes the file and line where the exception originated. It also does not truncate the message anymore.
     - The log format has also changed. If users are depending on the log format in their apps, the new log format is "<1-based count> <cleaned filepath>(<line>): <class><function><args>"
+- BaseConfig's ability to convert ``.env`` values has improved. Numeric strings will be converted to either integers or floats. String "null" will be changed to ``null``. String "empty" will be changed to ``''``.
 
 Changes
 *******


### PR DESCRIPTION
**Description**
Initial (current):
```php
'true' => true
'false' => false
all other strings => trimmed
```

Additional (proposed):
```php
'12' => 12
'1.25' => 1.25
'null' => null
'empty' => ''
```

Supersedes and closes #5691 
Fixes #5688 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
