### PR TITLE
test: add tests for various types of values to where() in QueryBuilder

### DIFF
--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -15,6 +15,9 @@ use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use DateTime;
+use Error;
+use ErrorException;
 use stdClass;
 
 /**
@@ -459,5 +462,120 @@ final class WhereTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" WHERE LOWER(jobs.name) = \'accountant\'';
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhereValueIsString()
+    {
+        $builder = $this->db->table('users');
+
+        $builder->where('id', '1');
+
+        $expectedSQL = <<<'SQL'
+            SELECT * FROM "users" WHERE "id" = '1'
+            SQL;
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhereValueIsFloat()
+    {
+        $builder = $this->db->table('users');
+
+        $builder->where('id', 1.234);
+
+        $expectedSQL = <<<'SQL'
+            SELECT * FROM "users" WHERE "id" = 1.234
+            SQL;
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhereValueIsTrue()
+    {
+        $builder = $this->db->table('users');
+
+        $builder->where('id', true);
+
+        $expectedSQL = 'SELECT * FROM "users" WHERE "id" = 1';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhereValueIsFalse()
+    {
+        $builder = $this->db->table('users');
+
+        $builder->where('id', false);
+
+        $expectedSQL = 'SELECT * FROM "users" WHERE "id" = 0';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhereValueIsArray()
+    {
+        $builder = $this->db->table('users');
+
+        $builder->where('id', ['a', 'b']);
+
+        // SQL syntax error
+        $expectedSQL = <<<'SQL'
+            SELECT * FROM "users" WHERE "id" = ('a','b')
+            SQL;
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhereValueIsArrayOfArray()
+    {
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('Array to string conversion');
+
+        $builder = $this->db->table('users');
+
+        $builder->where('id', [['a', 'b'], ['c', 'd']]);
+
+        $builder->getCompiledSelect();
+    }
+
+    public function testWhereValueIsArrayOfObject()
+    {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Object of class stdClass could not be converted to string');
+
+        $builder = $this->db->table('users');
+
+        $builder->where('id', [(object) ['a' => 'b'], (object) ['c' => 'd']]);
+
+        $builder->getCompiledSelect();
+    }
+
+    public function testWhereValueIsNull()
+    {
+        $builder = $this->db->table('users');
+
+        $builder->where('id', null);
+
+        $expectedSQL = 'SELECT * FROM "users" WHERE "id" IS NULL';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhereValueIsStdClass()
+    {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Object of class stdClass could not be converted to string');
+
+        $builder = $this->db->table('users');
+
+        $builder->where('id', (object) ['a' => 'b']);
+
+        $builder->getCompiledSelect();
+    }
+
+    public function testWhereValueIsDateTime()
+    {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Object of class DateTime could not be converted to string');
+
+        $builder = $this->db->table('users');
+
+        $builder->where('id', new DateTime('2022-02-19 12:00'));
+
+        $builder->getCompiledSelect();
     }
 }

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -488,6 +488,11 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
+    /**
+     * The current behavior assumes MySQL.
+     * Other databases may not work well, so we may want to change the behavior
+     * to match the specifications of the database driver.
+     */
     public function testWhereValueIsTrue()
     {
         $builder = $this->db->table('users');
@@ -498,6 +503,11 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
+    /**
+     * The current behavior assumes MySQL.
+     * Other databases may not work well, so we may want to change the behavior
+     * to match the specifications of the database driver.
+     */
     public function testWhereValueIsFalse()
     {
         $builder = $this->db->table('users');
@@ -508,6 +518,9 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
+    /**
+     * Check if SQL injection is not possible when unexpected values are passed
+     */
     public function testWhereValueIsArray()
     {
         $builder = $this->db->table('users');
@@ -521,6 +534,9 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
+    /**
+     * Check if SQL injection is not possible when unexpected values are passed
+     */
     public function testWhereValueIsArrayOfArray()
     {
         $this->expectException(ErrorException::class);
@@ -533,6 +549,9 @@ final class WhereTest extends CIUnitTestCase
         $builder->getCompiledSelect();
     }
 
+    /**
+     * Check if SQL injection is not possible when unexpected values are passed
+     */
     public function testWhereValueIsArrayOfObject()
     {
         $this->expectException(Error::class);
@@ -555,6 +574,9 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
+    /**
+     * Check if SQL injection is not possible when unexpected values are passed
+     */
     public function testWhereValueIsStdClass()
     {
         $this->expectException(Error::class);
@@ -567,6 +589,9 @@ final class WhereTest extends CIUnitTestCase
         $builder->getCompiledSelect();
     }
 
+    /**
+     * Check if SQL injection is not possible when unexpected values are passed
+     */
     public function testWhereValueIsDateTime()
     {
         $this->expectException(Error::class);


### PR DESCRIPTION
**Description**
- check behavior for various type values
- this is security checking
  - some ORMs have unexpected feature to devs, and easily results in SQL injection
  - it seems there is no problem

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

