### PR TITLE
fix: auto routes incorrectly display route filters with GET method

### DIFF
--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -120,7 +120,9 @@ class Routes extends BaseCommand
             $autoRoutes = $autoRouteCollector->get();
 
             foreach ($autoRoutes as &$routes) {
-                $filters  = $filterCollector->get('get', $uriGenerator->get($routes[1]));
+                // There is no `auto` method, but it is intentional not to get route filters.
+                $filters = $filterCollector->get('auto', $uriGenerator->get($routes[1]));
+
                 $routes[] = implode(' ', array_map('class_basename', $filters['before']));
                 $routes[] = implode(' ', array_map('class_basename', $filters['after']));
             }

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -106,16 +106,6 @@ final class CommandTest extends CIUnitTestCase
         $this->assertStringContainsString('| Yes', $this->getBuffer());
     }
 
-    public function testRoutesCommand()
-    {
-        command('routes');
-
-        $this->assertStringContainsString('| (Closure)', $this->getBuffer());
-        $this->assertStringContainsString('| Route', $this->getBuffer());
-        $this->assertStringContainsString('| testing', $this->getBuffer());
-        $this->assertStringContainsString('\\TestController::index', $this->getBuffer());
-    }
-
     public function testInexistentCommandWithNoAlternatives()
     {
         command('app:oops');

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Config\Services;
+
+/**
+ * @internal
+ */
+final class RoutesTest extends CIUnitTestCase
+{
+    private $streamFilter;
+    protected $logger;
+    protected $commands;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        CITestStreamFilter::$buffer = '';
+
+        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
+        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+
+        $this->logger   = Services::logger();
+        $this->commands = Services::commands();
+    }
+
+    protected function tearDown(): void
+    {
+        stream_filter_remove($this->streamFilter);
+    }
+
+    protected function getBuffer()
+    {
+        return CITestStreamFilter::$buffer;
+    }
+
+    public function testRoutesCommand()
+    {
+        command('routes');
+
+        $this->assertStringContainsString('| (Closure)', $this->getBuffer());
+        $this->assertStringContainsString('| Route', $this->getBuffer());
+        $this->assertStringContainsString('| testing', $this->getBuffer());
+        $this->assertStringContainsString('\\TestController::index', $this->getBuffer());
+    }
+
+    public function testRoutesCommandRouteFilterAndAutoRoute()
+    {
+        $routes = Services::routes();
+        $routes->resetRoutes();
+        $routes->get('/', 'Home::index', ['filter' => 'csrf']);
+
+        command('routes');
+
+        $this->assertStringContainsString(
+            '|auto|/|\App\Controllers\Home::index||toolbar|',
+            str_replace(' ', '', $this->getBuffer())
+        );
+    }
+}

--- a/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Commands\Utilities\Routes;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\Services;
 
 /**
  * @internal
@@ -20,6 +21,9 @@ final class FilterCollectorTest extends CIUnitTestCase
 {
     public function testGet()
     {
+        $routes = Services::routes();
+        $routes->resetRoutes();
+
         $collector = new FilterCollector();
 
         $filters = $collector->get('get', '/');


### PR DESCRIPTION
**Description**
Follow-up  #5628

- auto routes incorrectly display route filters with GET method

```diff
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -31,7 +31,7 @@ $routes->setAutoRoute(true);
 
 // We get a performance increase by specifying the default
 // route since we don't have to scan directories.
-$routes->get('/', 'Home::index');
+$routes->get('/', 'Home::index', ['filter' => 'csrf'] );
 
 /*
  * --------------------------------------------------------------------
```

Before:
```
+--------+------------------+------------------------------------------+----------------+---------------+
| Method | Route            | Handler                                  | Before Filters | After Filters |
+--------+------------------+------------------------------------------+----------------+---------------+
| GET    | /                | \App\Controllers\Home::index             | csrf           | csrf toolbar  |
| CLI    | ci(.*)           | \CodeIgniter\CLI\CommandRunner::index/$1 |                |               |
| auto   | /                | \App\Controllers\Home::index             | csrf           | csrf toolbar  |
| auto   | home             | \App\Controllers\Home::index             |                | toolbar       |
| auto   | home/index[/...] | \App\Controllers\Home::index             |                | toolbar       |
+--------+------------------+------------------------------------------+----------------+---------------+
```
- The auto route `/` does not reach when GET.
- It can be accessible when POST/PUT/..., but it has no filters actually.

After:
```
+--------+------------------+------------------------------------------+----------------+---------------+
| Method | Route            | Handler                                  | Before Filters | After Filters |
+--------+------------------+------------------------------------------+----------------+---------------+
| GET    | /                | \App\Controllers\Home::index             | csrf           | csrf toolbar  |
| CLI    | ci(.*)           | \CodeIgniter\CLI\CommandRunner::index/$1 |                |               |
| auto   | /                | \App\Controllers\Home::index             |                | toolbar       |
| auto   | home             | \App\Controllers\Home::index             |                | toolbar       |
| auto   | home/index[/...] | \App\Controllers\Home::index             |                | toolbar       |
+--------+------------------+------------------------------------------+----------------+---------------+
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
