### PR TITLE
feat: can add route handler as callable

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1137,7 +1137,8 @@ class RouteCollection implements RouteCollectionInterface
             $from = trim($from, '/');
         }
 
-        if (is_array($to)) {
+        // When redirecting to named route, $to is an array like `['zombies' => '\Zombies::index']`.
+        if (is_array($to) && count($to) === 2) {
             $to = $this->processArrayCallableSyntax($from, $to);
         }
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1265,10 +1265,8 @@ class RouteCollection implements RouteCollectionInterface
 
         $params = '';
 
-        if ($count > 0) {
-            for ($i = 1; $i <= $count; $i++) {
-                $params .= '/$' . $i;
-            }
+        for ($i = 1; $i <= $count; $i++) {
+            $params .= '/$' . $i;
         }
 
         return $params;

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1231,10 +1231,7 @@ class RouteCollection implements RouteCollectionInterface
         }
     }
 
-    /**
-     * @return string
-     */
-    private function processArrayCallableSyntax(string $from, array $to)
+    private function processArrayCallableSyntax(string $from, array $to): string
     {
         // [classname, method]
         // eg, [Home::class, 'index']

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -15,6 +15,7 @@ use CodeIgniter\Config\Services;
 use CodeIgniter\Router\Exceptions\RouterException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
+use Tests\Support\Controllers\Hello;
 
 /**
  * @backupGlobals enabled
@@ -55,6 +56,45 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes = $routes->getRoutes();
 
+        $this->assertSame($expects, $routes);
+    }
+
+    public function testBasicAddCallable()
+    {
+        $routes = $this->getCollector();
+
+        $routes->add('home', [Hello::class, 'index']);
+
+        $routes  = $routes->getRoutes();
+        $expects = [
+            'home' => '\Tests\Support\Controllers\Hello::index',
+        ];
+        $this->assertSame($expects, $routes);
+    }
+
+    public function testBasicAddCallableWithParamsString()
+    {
+        $routes = $this->getCollector();
+
+        $routes->add('product/(:num)/(:num)', [[Hello::class, 'index'], '$2/$1']);
+
+        $routes  = $routes->getRoutes();
+        $expects = [
+            'product/([0-9]+)/([0-9]+)' => '\Tests\Support\Controllers\Hello::index/$2/$1',
+        ];
+        $this->assertSame($expects, $routes);
+    }
+
+    public function testBasicAddCallableWithParamsWithoutString()
+    {
+        $routes = $this->getCollector();
+
+        $routes->add('product/(:num)/(:num)', [Hello::class, 'index']);
+
+        $routes  = $routes->getRoutes();
+        $expects = [
+            'product/([0-9]+)/([0-9]+)' => '\Tests\Support\Controllers\Hello::index/$1/$2',
+        ];
         $this->assertSame($expects, $routes);
     }
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -157,6 +157,31 @@ routes. With the examples URLs from above:
 
 will only match **product/123** and generate 404 errors for other example.
 
+
+Array Callable Syntax
+=====================
+
+Since v4.2.0, you can use array callable syntax to specify the controller:
+
+.. literalinclude:: routing/004_1.php
+   :lines: 2-
+
+Or using ``use`` keyword:
+
+.. literalinclude:: routing/004_2.php
+   :lines: 2-
+
+If there are placeholders, it will automatically set the parameters in the specified order:
+
+.. literalinclude:: routing/004_3.php
+   :lines: 2-
+
+But the auto-configured parameters may not be correct if you use regular expressions in routes.
+In such a case, you can specify the parameters manually:
+
+.. literalinclude:: routing/004_4.php
+   :lines: 2-
+
 Custom Placeholders
 ===================
 

--- a/user_guide_src/source/incoming/routing/004_1.php
+++ b/user_guide_src/source/incoming/routing/004_1.php
@@ -1,0 +1,3 @@
+<?php
+
+$routes->get('/', [\App\Controllers\Home::class, 'index']);

--- a/user_guide_src/source/incoming/routing/004_2.php
+++ b/user_guide_src/source/incoming/routing/004_2.php
@@ -1,0 +1,5 @@
+<?php
+
+use App\Controllers\Home;
+
+$routes->get('/', [Home::class, 'index']);

--- a/user_guide_src/source/incoming/routing/004_3.php
+++ b/user_guide_src/source/incoming/routing/004_3.php
@@ -1,0 +1,8 @@
+<?php
+
+use App\Controllers\Product;
+
+$routes->get('product/(:num)/(:num)', [Product::class, 'index']);
+
+// The above code is the same as the following:
+$routes->get('product/(:num)/(:num)', 'Product::index/$1/$2');

--- a/user_guide_src/source/incoming/routing/004_4.php
+++ b/user_guide_src/source/incoming/routing/004_4.php
@@ -1,0 +1,8 @@
+<?php
+
+use App\Controllers\Product;
+
+$routes->get('product/(:num)/(:num)', [[Product::class, 'index'], '$2/$1']);
+
+// The above code is the same as the following:
+$routes->get('product/(:num)/(:num)', 'Product::index/$2/$1');


### PR DESCRIPTION
**Description**
- You can jump to the controller method with IDE.

E.g.:
```php
$routes->get('home', [Hello::class, 'index']);
$routes->get('product/(:num)/(:num)', [[Hello::class, 'index'], '$1/$2']);
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
