### PR TITLE
docs: add comment in HTTP/Files/FileCollection.php

### DIFF
--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -220,6 +220,10 @@ class FileCollection
                     $pointer = &$stack[count($stack) - 1];
                     $pointer = &$pointer[$key];
                     $stack[] = &$pointer;
+
+                    // RecursiveIteratorIterator::hasChildren() can be used. RecursiveIteratorIterator
+                    // forwards all unknown method calls to the underlying RecursiveIterator internally.
+                    // See https://github.com/php/doc-en/issues/787#issuecomment-881446121
                     if (! $iterator->hasChildren()) {
                         $pointer[$field] = $val;
                     }

--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -235,7 +235,7 @@ class FileCollection
     }
 
     /**
-     * Navigate through a array looking for a particular index
+     * Navigate through an array looking for a particular index
      *
      * @param array $index The index sequence we are navigating down
      * @param array $value The portion of the array to process


### PR DESCRIPTION
**Description**
- `RecursiveIteratorIterator::hasChildren()` is not documented in PHP manual, and PhpStorm tells not defined.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
