### PR TITLE
refactor: remove `&` before $db

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -270,7 +270,7 @@ class BaseBuilder
      *
      * @throws DatabaseException
      */
-    public function __construct($tableName, ConnectionInterface &$db, ?array $options = null)
+    public function __construct($tableName, ConnectionInterface $db, ?array $options = null)
     {
         if (empty($tableName)) {
             throw new DatabaseException('A table must be specified when creating a new Query Builder.');

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -57,7 +57,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 
     public function __construct(BaseConnection $db)
     {
-        $this->db = &$db;
+        $this->db = $db;
     }
 
     /**

--- a/system/Database/BaseUtils.php
+++ b/system/Database/BaseUtils.php
@@ -49,9 +49,9 @@ abstract class BaseUtils
     /**
      * Class constructor
      */
-    public function __construct(ConnectionInterface &$db)
+    public function __construct(ConnectionInterface $db)
     {
-        $this->db = &$db;
+        $this->db = $db;
     }
 
     /**

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -179,7 +179,7 @@ class Forge
      */
     public function __construct(BaseConnection $db)
     {
-        $this->db = &$db;
+        $this->db = $db;
     }
 
     /**

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -91,7 +91,7 @@ class Query implements QueryInterface
      */
     public $db;
 
-    public function __construct(ConnectionInterface &$db)
+    public function __construct(ConnectionInterface $db)
     {
         $this->db = $db;
     }

--- a/system/Database/SQLSRV/Utils.php
+++ b/system/Database/SQLSRV/Utils.php
@@ -34,7 +34,7 @@ class Utils extends BaseUtils
      */
     protected $optimizeTable = 'ALTER INDEX all ON %s REORGANIZE';
 
-    public function __construct(ConnectionInterface &$db)
+    public function __construct(ConnectionInterface $db)
     {
         parent::__construct($db);
 

--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -92,7 +92,7 @@ class Seeder
 
         $db ??= Database::connect($this->DBGroup);
 
-        $this->db    = &$db;
+        $this->db    = $db;
         $this->forge = Database::forge($this->DBGroup);
     }
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -100,14 +100,14 @@ class Model extends BaseModel
         'getCompiledUpdate',
     ];
 
-    public function __construct(?ConnectionInterface &$db = null, ?ValidationInterface $validation = null)
+    public function __construct(?ConnectionInterface $db = null, ?ValidationInterface $validation = null)
     {
         /**
          * @var BaseConnection|null $db
          */
         $db ??= Database::connect($this->DBGroup);
 
-        $this->db = &$db;
+        $this->db = $db;
 
         parent::__construct($validation);
     }


### PR DESCRIPTION
**Description**
- `$db` is an object. We don't need to use reference. 
  - see https://www.php.net/manual/en/language.oop5.references.php

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
