### PR TITLE
fix: forceGlobalSecureRequests break URI schemes other than HTTP

### DIFF
--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -581,11 +581,30 @@ class URI
         $path   = $this->getPath();
         $scheme = $this->getScheme();
 
+        // If the hosts matches then assume this should be relative to baseURL
+        [$scheme, $path] = $this->changeSchemeAndPath($scheme, $path);
+
+        return static::createURIString(
+            $scheme,
+            $this->getAuthority(),
+            $path, // Absolute URIs should use a "/" for an empty path
+            $this->getQuery(),
+            $this->getFragment()
+        );
+    }
+
+    /**
+     * Change the path (and scheme) assuming URIs with the same host as baseURL
+     * should be relative to the project's configuration.
+     *
+     * @deprecated This method will be deleted.
+     */
+    private function changeSchemeAndPath(string $scheme, string $path): array
+    {
         // Check if this is an internal URI
         $config  = config('App');
         $baseUri = new self($config->baseURL);
 
-        // If the hosts matches then assume this should be relative to baseURL
         if (
             substr($this->getScheme(), 0, 4) === 'http'
             && $this->getHost() === $baseUri->getHost()
@@ -604,13 +623,7 @@ class URI
             }
         }
 
-        return static::createURIString(
-            $scheme,
-            $this->getAuthority(),
-            $path, // Absolute URIs should use a "/" for an empty path
-            $this->getQuery(),
-            $this->getFragment()
-        );
+        return [$scheme, $path];
     }
 
     /**

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -586,7 +586,10 @@ class URI
         $baseUri = new self($config->baseURL);
 
         // If the hosts matches then assume this should be relative to baseURL
-        if ($this->getHost() === $baseUri->getHost()) {
+        if (
+            substr($this->getScheme(), 0, 4) === 'http'
+            && $this->getHost() === $baseUri->getHost()
+        ) {
             // Check for additional segments
             $basePath = trim($baseUri->getPath(), '/') . '/';
             $trimPath = ltrim($path, '/');

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -985,4 +985,20 @@ final class URITest extends CIUnitTestCase
 
         $this->assertSame($expected, $uri);
     }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5728
+     */
+    public function testForceGlobalSecureRequestsAndNonHTTPProtocol()
+    {
+        $config                            = new App();
+        $config->forceGlobalSecureRequests = true;
+        $config->baseURL                   = 'https://localhost/';
+        Factories::injectMock('config', 'App', $config);
+
+        $expected = 'ftp://localhost/path/to/test.txt';
+        $uri      = new URI($expected);
+
+        $this->assertSame($expected, (string) $uri);
+    }
 }


### PR DESCRIPTION
**Description**
Fixes #5728

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
