### PR TITLE
fix: TypeError when `$tokenRandomize = true` and no token posted

### DIFF
--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -278,9 +278,7 @@ class Security implements SecurityInterface
         }
 
         $rawToken = $this->getPostedToken($request);
-        if ($rawToken !== null) {
-            $token = $this->tokenRandomize ? $this->derandomize($rawToken) : $rawToken;
-        }
+        $token    = ($rawToken !== null && $this->tokenRandomize) ? $this->derandomize($rawToken) : $rawToken;
 
         // Do the tokens match?
         if (! isset($token, $this->hash) || ! hash_equals($this->hash, $token)) {

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -277,8 +277,10 @@ class Security implements SecurityInterface
             return $this;
         }
 
-        $token = $this->tokenRandomize ? $this->derandomize($this->getPostedToken($request))
-            : $this->getPostedToken($request);
+        $rawToken = $this->getPostedToken($request);
+        if ($rawToken !== null) {
+            $token = $this->tokenRandomize ? $this->derandomize($rawToken) : $rawToken;
+        }
 
         // Do the tokens match?
         if (! isset($token, $this->hash) || ! hash_equals($this->hash, $token)) {

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -277,8 +277,9 @@ class Security implements SecurityInterface
             return $this;
         }
 
-        $rawToken = $this->getPostedToken($request);
-        $token    = ($rawToken !== null && $this->tokenRandomize) ? $this->derandomize($rawToken) : $rawToken;
+        $postedToken = $this->getPostedToken($request);
+        $token       = ($postedToken !== null && $this->tokenRandomize)
+            ? $this->derandomize($postedToken) : $postedToken;
 
         // Do the tokens match?
         if (! isset($token, $this->hash) || ! hash_equals($this->hash, $token)) {

--- a/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
@@ -108,6 +108,21 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
         );
     }
 
+    public function testCSRFVerifyPostNoToken()
+    {
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('The action you requested is not allowed.');
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        unset($_POST['csrf_test_name']);
+
+        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+
+        $security = new Security(new MockAppConfig());
+
+        $security->verify($request);
+    }
+
     public function testCSRFVerifyPostThrowsExceptionOnNoMatch()
     {
         $this->expectException(SecurityException::class);


### PR DESCRIPTION
**Description**
Fixes #5741

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
