### PR TITLE
Checking if the subquery uses the same object as the main query

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2763,6 +2763,10 @@ class BaseBuilder
             $builder($builder = $this->db->newQuery());
         }
 
+        if ($builder === $this) {
+            throw new DatabaseException('The subquery cannot be the same object as the main query object.');
+        }
+
         $subquery = strtr($builder->getCompiledSelect(), "\n", ' ');
 
         if ($wrapped) {

--- a/tests/system/Database/Builder/BaseTest.php
+++ b/tests/system/Database/Builder/BaseTest.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Database\Builder;
 
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 
@@ -52,5 +53,16 @@ final class BaseTest extends CIUnitTestCase
         $builder->from('foo');
         $result = $builder->getTable();
         $this->assertSame('jobs', $result);
+    }
+
+    public function testSubquerySameBaseBuilderObject()
+    {
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('The subquery cannot be the same object as the main query object.');
+
+        $builder = $this->db->table('users');
+
+        $builder->fromSubquery($builder, 'sub');
+        $builder->getCompiledSelect();
     }
 }

--- a/tests/system/Database/Builder/BaseTest.php
+++ b/tests/system/Database/Builder/BaseTest.php
@@ -63,6 +63,5 @@ final class BaseTest extends CIUnitTestCase
         $builder = $this->db->table('users');
 
         $builder->fromSubquery($builder, 'sub');
-        $builder->getCompiledSelect();
     }
 }


### PR DESCRIPTION
**Description**
To prevent possible unpredictable behavior, a check has been added for using the same object for the subrequry as the main query.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide