### PR TITLE
docs: rework about auto-routing

### DIFF
--- a/user_guide_src/source/general/urls.rst
+++ b/user_guide_src/source/general/urls.rst
@@ -11,20 +11,9 @@ By default, URLs in CodeIgniter are designed to be search-engine and human-frien
 
     example.com/news/article/my_article
 
-URI Segments
-============
+Your URLs can be defined using the :doc:`URI Routing </incoming/routing>` feature with flexibility.
 
-The segments in the URL, in following with the Model-View-Controller approach, usually represent::
-
-    example.com/class/method/ID
-
-1. The first segment represents the controller **class** that should be invoked.
-2. The second segment represents the class **method** that should be called.
-3. The third, and any additional segments, represent the ID and any variables that will be passed to the controller.
-
-The :doc:`URI Library <../libraries/uri>` and the :doc:`URL Helper <../helpers/url_helper>` contain functions that make it easy
-to work with your URI data. In addition, your URLs can be remapped using the :doc:`URI Routing </incoming/routing>`
-feature for more flexibility.
+The :doc:`URI Library <../libraries/uri>` and the :doc:`URL Helper <../helpers/url_helper>` contain functions that make it easy to work with your URI data.
 
 Removing the index.php file
 ===========================

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -13,6 +13,128 @@ What is a Controller?
 
 A Controller is simply a class file that is named in a way that it can be associated with a URI.
 
+Remapping Method Calls
+**********************
+
+As noted above, the second segment of the URI typically determines which
+method in the controller gets called. CodeIgniter permits you to override
+this behavior through the use of the ``_remap()`` method:
+
+.. literalinclude:: controllers/010.php
+
+.. important:: If your controller contains a method named ``_remap()``,
+    it will **always** get called regardless of what your URI contains. It
+    overrides the normal behavior in which the URI determines which method
+    is called, allowing you to define your own method routing rules.
+
+The overridden method call (typically the second segment of the URI) will
+be passed as a parameter to the ``_remap()`` method:
+
+.. literalinclude:: controllers/011.php
+
+Any extra segments after the method name are passed into ``_remap()``. These parameters can be passed to the method
+to emulate CodeIgniter's default behavior.
+
+Example:
+
+.. literalinclude:: controllers/012.php
+
+Private methods
+***************
+
+In some cases, you may want certain methods hidden from public access.
+To achieve this, simply declare the method as ``private`` or ``protected``.
+That will prevent it from being served by a URL request. For example,
+if you were to define a method like this for the ``Helloworld`` controller:
+
+.. literalinclude:: controllers/013.php
+
+then trying to access it using the following URL will not work::
+
+    example.com/index.php/helloworld/utility/
+
+Included Properties
+*******************
+
+Every controller you create should extend ``CodeIgniter\Controller`` class.
+This class provides several features that are available to all of your controllers.
+
+**Request Object**
+
+The application's main :doc:`Request Instance </incoming/request>` is always available
+as a class property, ``$this->request``.
+
+**Response Object**
+
+The application's main :doc:`Response Instance </outgoing/response>` is always available
+as a class property, ``$this->response``.
+
+**Logger Object**
+
+An instance of the :doc:`Logger <../general/logging>` class is available as a class property,
+``$this->logger``.
+
+**forceHTTPS**
+
+A convenience method for forcing a method to be accessed via HTTPS is available within all
+controllers:
+
+.. literalinclude:: controllers/014.php
+
+By default, and in modern browsers that support the HTTP Strict Transport Security header, this
+call should force the browser to convert non-HTTPS calls to HTTPS calls for one year. You can
+modify this by passing the duration (in seconds) as the first parameter:
+
+.. literalinclude:: controllers/015.php
+
+.. note:: A number of :doc:`time-based constants </general/common_functions>` are always available for you to use, including ``YEAR``, ``MONTH``, and more.
+
+Helpers
+=======
+
+You can define an array of helper files as a class property. Whenever the controller is loaded
+these helper files will be automatically loaded into memory so that you can use their methods anywhere
+inside the controller:
+
+.. literalinclude:: controllers/016.php
+
+.. _controllers-validating-data:
+
+Validating data
+***************
+
+$this->validate()
+=================
+
+To simplify data checking, the controller also provides the convenience method ``validate()``.
+The method accepts an array of rules in the first parameter,
+and in the optional second parameter, an array of custom error messages to display
+if the items are not valid. Internally, this uses the controller's
+``$this->request`` instance to get the data to be validated.
+The :doc:`Validation Library docs </libraries/validation>` have details on
+rule and message array formats, as well as available rules:
+
+.. literalinclude:: controllers/017.php
+
+If you find it simpler to keep the rules in the configuration file, you can replace
+the ``$rules`` array with the name of the group as defined in ``Config\Validation.php``:
+
+.. literalinclude:: controllers/018.php
+
+.. note:: Validation can also be handled automatically in the model, but sometimes it's easier to do it in the controller. Where is up to you.
+
+$this->validateData()
+=====================
+
+Sometimes you may want to check the controller method parameters or other custom data.
+In that case, you can use the ``$this->validateData()`` method.
+The method accepts an array of data to validate in the first parameter:
+
+.. literalinclude:: controllers/019.php
+
+Auto Routing
+************
+
 Consider this URI::
 
     example.com/index.php/helloworld/
@@ -172,125 +294,6 @@ in there that matches the name of your default controller as specified in
 your **app/Config/Routes.php** file.
 
 CodeIgniter also permits you to remap your URIs using its :doc:`URI Routing <routing>` feature.
-
-Remapping Method Calls
-**********************
-
-As noted above, the second segment of the URI typically determines which
-method in the controller gets called. CodeIgniter permits you to override
-this behavior through the use of the ``_remap()`` method:
-
-.. literalinclude:: controllers/010.php
-
-.. important:: If your controller contains a method named ``_remap()``,
-    it will **always** get called regardless of what your URI contains. It
-    overrides the normal behavior in which the URI determines which method
-    is called, allowing you to define your own method routing rules.
-
-The overridden method call (typically the second segment of the URI) will
-be passed as a parameter to the ``_remap()`` method:
-
-.. literalinclude:: controllers/011.php
-
-Any extra segments after the method name are passed into ``_remap()``. These parameters can be passed to the method
-to emulate CodeIgniter's default behavior.
-
-Example:
-
-.. literalinclude:: controllers/012.php
-
-Private methods
-***************
-
-In some cases, you may want certain methods hidden from public access.
-To achieve this, simply declare the method as ``private`` or ``protected``.
-That will prevent it from being served by a URL request. For example,
-if you were to define a method like this for the ``Helloworld`` controller:
-
-.. literalinclude:: controllers/013.php
-
-then trying to access it using the following URL will not work::
-
-    example.com/index.php/helloworld/utility/
-
-Included Properties
-*******************
-
-Every controller you create should extend ``CodeIgniter\Controller`` class.
-This class provides several features that are available to all of your controllers.
-
-**Request Object**
-
-The application's main :doc:`Request Instance </incoming/request>` is always available
-as a class property, ``$this->request``.
-
-**Response Object**
-
-The application's main :doc:`Response Instance </outgoing/response>` is always available
-as a class property, ``$this->response``.
-
-**Logger Object**
-
-An instance of the :doc:`Logger <../general/logging>` class is available as a class property,
-``$this->logger``.
-
-**forceHTTPS**
-
-A convenience method for forcing a method to be accessed via HTTPS is available within all
-controllers:
-
-.. literalinclude:: controllers/014.php
-
-By default, and in modern browsers that support the HTTP Strict Transport Security header, this
-call should force the browser to convert non-HTTPS calls to HTTPS calls for one year. You can
-modify this by passing the duration (in seconds) as the first parameter:
-
-.. literalinclude:: controllers/015.php
-
-.. note:: A number of :doc:`time-based constants </general/common_functions>` are always available for you to use, including ``YEAR``, ``MONTH``, and more.
-
-Helpers
-=======
-
-You can define an array of helper files as a class property. Whenever the controller is loaded
-these helper files will be automatically loaded into memory so that you can use their methods anywhere
-inside the controller:
-
-.. literalinclude:: controllers/016.php
-
-.. _controllers-validating-data:
-
-Validating data
-***************
-
-$this->validate()
-=================
-
-To simplify data checking, the controller also provides the convenience method ``validate()``.
-The method accepts an array of rules in the first parameter,
-and in the optional second parameter, an array of custom error messages to display
-if the items are not valid. Internally, this uses the controller's
-``$this->request`` instance to get the data to be validated.
-The :doc:`Validation Library docs </libraries/validation>` have details on
-rule and message array formats, as well as available rules:
-
-.. literalinclude:: controllers/017.php
-
-If you find it simpler to keep the rules in the configuration file, you can replace
-the ``$rules`` array with the name of the group as defined in ``Config\Validation.php``:
-
-.. literalinclude:: controllers/018.php
-
-.. note:: Validation can also be handled automatically in the model, but sometimes it's easier to do it in the controller. Where is up to you.
-
-$this->validateData()
-=====================
-
-Sometimes you may want to check the controller method parameters or other custom data.
-In that case, you can use the ``$this->validateData()`` method.
-The method accepts an array of data to validate in the first parameter:
-
-.. literalinclude:: controllers/019.php
 
 That's it!
 **********

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -34,6 +34,17 @@ as a class property, ``$this->response``.
 An instance of the :doc:`Logger <../general/logging>` class is available as a class property,
 ``$this->logger``.
 
+Helpers
+=======
+
+You can define an array of helper files as a class property. Whenever the controller is loaded
+these helper files will be automatically loaded into memory so that you can use their methods anywhere
+inside the controller:
+
+.. literalinclude:: controllers/016.php
+
+.. _controllers-validating-data:
+
 forceHTTPS
 **********
 
@@ -49,17 +60,6 @@ modify this by passing the duration (in seconds) as the first parameter:
 .. literalinclude:: controllers/015.php
 
 .. note:: A number of :doc:`time-based constants </general/common_functions>` are always available for you to use, including ``YEAR``, ``MONTH``, and more.
-
-Helpers
-=======
-
-You can define an array of helper files as a class property. Whenever the controller is loaded
-these helper files will be automatically loaded into memory so that you can use their methods anywhere
-inside the controller:
-
-.. literalinclude:: controllers/016.php
-
-.. _controllers-validating-data:
 
 Validating data
 ***************

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -9,7 +9,7 @@ Controllers are the heart of your application, as they determine how HTTP reques
     :depth: 2
 
 What is a Controller?
-=====================
+*********************
 
 A Controller is simply a class file that is named in a way that it can be associated with a URI.
 
@@ -141,46 +141,6 @@ see the "Hello World" message.
 For more information, please refer to the :ref:`routes-configuration-options` section of the
 :doc:`URI Routing <routing>` documentation.
 
-Remapping Method Calls
-======================
-
-As noted above, the second segment of the URI typically determines which
-method in the controller gets called. CodeIgniter permits you to override
-this behavior through the use of the ``_remap()`` method:
-
-.. literalinclude:: controllers/010.php
-
-.. important:: If your controller contains a method named ``_remap()``,
-    it will **always** get called regardless of what your URI contains. It
-    overrides the normal behavior in which the URI determines which method
-    is called, allowing you to define your own method routing rules.
-
-The overridden method call (typically the second segment of the URI) will
-be passed as a parameter to the ``_remap()`` method:
-
-.. literalinclude:: controllers/011.php
-
-Any extra segments after the method name are passed into ``_remap()``. These parameters can be passed to the method
-to emulate CodeIgniter's default behavior.
-
-Example:
-
-.. literalinclude:: controllers/012.php
-
-Private methods
-===============
-
-In some cases, you may want certain methods hidden from public access.
-To achieve this, simply declare the method as ``private`` or ``protected``.
-That will prevent it from being served by a URL request. For example,
-if you were to define a method like this for the ``Helloworld`` controller:
-
-.. literalinclude:: controllers/013.php
-
-then trying to access it using the following URL will not work::
-
-    example.com/index.php/helloworld/utility/
-
 Organizing Your Controllers into Sub-directories
 ================================================
 
@@ -213,8 +173,48 @@ your **app/Config/Routes.php** file.
 
 CodeIgniter also permits you to remap your URIs using its :doc:`URI Routing <routing>` feature.
 
+Remapping Method Calls
+**********************
+
+As noted above, the second segment of the URI typically determines which
+method in the controller gets called. CodeIgniter permits you to override
+this behavior through the use of the ``_remap()`` method:
+
+.. literalinclude:: controllers/010.php
+
+.. important:: If your controller contains a method named ``_remap()``,
+    it will **always** get called regardless of what your URI contains. It
+    overrides the normal behavior in which the URI determines which method
+    is called, allowing you to define your own method routing rules.
+
+The overridden method call (typically the second segment of the URI) will
+be passed as a parameter to the ``_remap()`` method:
+
+.. literalinclude:: controllers/011.php
+
+Any extra segments after the method name are passed into ``_remap()``. These parameters can be passed to the method
+to emulate CodeIgniter's default behavior.
+
+Example:
+
+.. literalinclude:: controllers/012.php
+
+Private methods
+***************
+
+In some cases, you may want certain methods hidden from public access.
+To achieve this, simply declare the method as ``private`` or ``protected``.
+That will prevent it from being served by a URL request. For example,
+if you were to define a method like this for the ``Helloworld`` controller:
+
+.. literalinclude:: controllers/013.php
+
+then trying to access it using the following URL will not work::
+
+    example.com/index.php/helloworld/utility/
+
 Included Properties
-===================
+*******************
 
 Every controller you create should extend ``CodeIgniter\Controller`` class.
 This class provides several features that are available to all of your controllers.
@@ -250,7 +250,7 @@ modify this by passing the duration (in seconds) as the first parameter:
 .. note:: A number of :doc:`time-based constants </general/common_functions>` are always available for you to use, including ``YEAR``, ``MONTH``, and more.
 
 Helpers
--------
+=======
 
 You can define an array of helper files as a class property. Whenever the controller is loaded
 these helper files will be automatically loaded into memory so that you can use their methods anywhere
@@ -261,10 +261,10 @@ inside the controller:
 .. _controllers-validating-data:
 
 Validating data
-===============
+***************
 
 $this->validate()
------------------
+=================
 
 To simplify data checking, the controller also provides the convenience method ``validate()``.
 The method accepts an array of rules in the first parameter,
@@ -284,7 +284,7 @@ the ``$rules`` array with the name of the group as defined in ``Config\Validatio
 .. note:: Validation can also be handled automatically in the model, but sometimes it's easier to do it in the controller. Where is up to you.
 
 $this->validateData()
----------------------
+=====================
 
 Sometimes you may want to check the controller method parameters or other custom data.
 In that case, you can use the ``$this->validateData()`` method.
@@ -293,6 +293,6 @@ The method accepts an array of data to validate in the first parameter:
 .. literalinclude:: controllers/019.php
 
 That's it!
-==========
+**********
 
 That, in a nutshell, is all there is to know about controllers.

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -11,7 +11,7 @@ Controllers are the heart of your application, as they determine how HTTP reques
 What is a Controller?
 *********************
 
-A Controller is simply a class file that is named in a way that it can be associated with a URI.
+A Controller is simply a class file that handles a HTTP request. :doc:`URI Routing <routing>` associates a URI with a controller.
 
 Remapping Method Calls
 **********************

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -13,46 +13,6 @@ What is a Controller?
 
 A Controller is simply a class file that handles a HTTP request. :doc:`URI Routing <routing>` associates a URI with a controller.
 
-Remapping Method Calls
-**********************
-
-As noted above, the second segment of the URI typically determines which
-method in the controller gets called. CodeIgniter permits you to override
-this behavior through the use of the ``_remap()`` method:
-
-.. literalinclude:: controllers/010.php
-
-.. important:: If your controller contains a method named ``_remap()``,
-    it will **always** get called regardless of what your URI contains. It
-    overrides the normal behavior in which the URI determines which method
-    is called, allowing you to define your own method routing rules.
-
-The overridden method call (typically the second segment of the URI) will
-be passed as a parameter to the ``_remap()`` method:
-
-.. literalinclude:: controllers/011.php
-
-Any extra segments after the method name are passed into ``_remap()``. These parameters can be passed to the method
-to emulate CodeIgniter's default behavior.
-
-Example:
-
-.. literalinclude:: controllers/012.php
-
-Private methods
-***************
-
-In some cases, you may want certain methods hidden from public access.
-To achieve this, simply declare the method as ``private`` or ``protected``.
-That will prevent it from being served by a URL request. For example,
-if you were to define a method like this for the ``Helloworld`` controller:
-
-.. literalinclude:: controllers/013.php
-
-then trying to access it using the following URL will not work::
-
-    example.com/index.php/helloworld/utility/
-
 Included Properties
 *******************
 
@@ -131,6 +91,20 @@ In that case, you can use the ``$this->validateData()`` method.
 The method accepts an array of data to validate in the first parameter:
 
 .. literalinclude:: controllers/019.php
+
+Private methods
+***************
+
+In some cases, you may want certain methods hidden from public access.
+To achieve this, simply declare the method as ``private`` or ``protected``.
+That will prevent it from being served by a URL request. For example,
+if you were to define a method like this for the ``Helloworld`` controller:
+
+.. literalinclude:: controllers/013.php
+
+then trying to access it using the following URL will not work::
+
+    example.com/index.php/helloworld/utility/
 
 Auto Routing
 ************
@@ -303,6 +277,32 @@ in there that matches the name of your default controller as specified in
 your **app/Config/Routes.php** file.
 
 CodeIgniter also permits you to remap your URIs using its :doc:`URI Routing <routing>` feature.
+
+Remapping Method Calls
+**********************
+
+As noted above, the second segment of the URI typically determines which
+method in the controller gets called. CodeIgniter permits you to override
+this behavior through the use of the ``_remap()`` method:
+
+.. literalinclude:: controllers/010.php
+
+.. important:: If your controller contains a method named ``_remap()``,
+    it will **always** get called regardless of what your URI contains. It
+    overrides the normal behavior in which the URI determines which method
+    is called, allowing you to define your own method routing rules.
+
+The overridden method call (typically the second segment of the URI) will
+be passed as a parameter to the ``_remap()`` method:
+
+.. literalinclude:: controllers/011.php
+
+Any extra segments after the method name are passed into ``_remap()``. These parameters can be passed to the method
+to emulate CodeIgniter's default behavior.
+
+Example:
+
+.. literalinclude:: controllers/012.php
 
 That's it!
 **********

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -21,7 +21,7 @@ This class provides several features that are available to all of your controlle
 
 **Request Object**
 
-The application's main :doc:`Request Instance </incoming/request>` is always available
+The application's main :doc:`Request Instance </incoming/incomingrequest>` is always available
 as a class property, ``$this->request``.
 
 **Response Object**

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -34,7 +34,8 @@ as a class property, ``$this->response``.
 An instance of the :doc:`Logger <../general/logging>` class is available as a class property,
 ``$this->logger``.
 
-**forceHTTPS**
+forceHTTPS
+**********
 
 A convenience method for forcing a method to be accessed via HTTPS is available within all
 controllers:

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -107,6 +107,8 @@ then trying to access it using the following URL will not work::
 
     example.com/index.php/helloworld/utility/
 
+.. _controller-auto-routing:
+
 Auto Routing
 ************
 

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -135,6 +135,15 @@ The method accepts an array of data to validate in the first parameter:
 Auto Routing
 ************
 
+This section describes the functionality of the auto-routing.
+It automatically routes an HTTP request, and executes the corresponding controller method
+without route definitions. The auto-routing is enabled by default.
+
+.. note:: To prevent misconfiguration and miscoding, we recommend that you disable
+    the auto-routing feature. See :ref:`use-defined-routes-only`.
+
+.. important:: The auto-routing routes a HTTP request with **any** HTTP method to a controller method.
+
 Consider this URI::
 
     example.com/index.php/helloworld/

--- a/user_guide_src/source/incoming/index.rst
+++ b/user_guide_src/source/incoming/index.rst
@@ -7,8 +7,8 @@ Controllers handle incoming requests.
 .. toctree::
     :titlesonly:
 
-    controllers
     routing
+    controllers
     filters
     message
     request

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -541,6 +541,17 @@ It is recommended that all routes are defined in the **app/Config/Routes.php** f
 However, CodeIgniter can also automatically route HTTP requests based on conventions
 and execute the corresponding controller methods.
 
+URI Segments
+============
+
+The segments in the URL, in following with the Model-View-Controller approach, usually represent::
+
+    example.com/class/method/ID
+
+1. The first segment represents the controller **class** that should be invoked.
+2. The second segment represents the class **method** that should be called.
+3. The third, and any additional segments, represent the ID and any variables that will be passed to the controller.
+
 Consider this URI::
 
     example.com/index.php/helloworld/index/1

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -23,7 +23,7 @@ If you expect a GET request, you use the ``get()`` method:
 
 .. literalinclude:: routing/001.php
 
-A route simply takes the URI path (``/``) on the left, and maps it to the controller and method (``Home::index``) on the right,
+A route takes the URI path (``/``) on the left, and maps it to the controller and method (``Home::index``) on the right,
 along with any parameters that should be passed to the controller. The controller and method should
 be listed in the same way that you would use a static method, by separating the class
 and its method with a double-colon, like ``Users::list``. If that method requires parameters to be

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -6,46 +6,13 @@ URI Routing
     :local:
     :depth: 2
 
-******************************
-Auto Routes and Defined Routes
-******************************
+What is URI Routing?
+********************
 
-Auto Routes
-===========
+URI Routing associates a URI with a controller's method.
 
-Typically there is a one-to-one relationship between a URL string and its corresponding
-controller class/method. The segments in a URI normally follow this pattern::
-
-    example.com/class/method/id/
-
-We call this "**Auto Routes**". CodeIgniter automatically routes an HTTP request,
-and executes the corresponding controller method. The auto-routing is enabled by default.
-
-.. note:: To prevent misconfiguration and miscoding, we recommend that you disable
-    the auto-routing feature. See :ref:`use-defined-routes-only`.
-
-.. important:: The auto-routing routes a HTTP request with **any** HTTP method to a controller method.
-
-Defined Routes
-==============
-
-In some instances, however, you may want to remap this relationship so that a different
-class/method can be called instead of the one corresponding to the URL.
-
-For example, let's say you want your URLs to have this prototype::
-
-    example.com/product/1/
-    example.com/product/2/
-    example.com/product/3/
-    example.com/product/4/
-
-Normally the second segment of the URL path is reserved for the method name, but in the example
-above it instead has a product ID. To overcome this, CodeIgniter allows you to remap the URI handler.
-We call this "**Defined Routes**".
-
-******************************
-Setting Your Own Routing Rules
-******************************
+Setting Routing Rules
+*********************
 
 Routing rules are defined in the **app/Config/Routes.php** file. In it you'll see that
 it creates an instance of the RouteCollection class (``$routes``) that permits you to specify your own routing criteria.
@@ -56,7 +23,7 @@ If you expect a GET request, you use the ``get()`` method:
 
 .. literalinclude:: routing/001.php
 
-A route simply takes the URI path on the left, and maps it to the controller and method on the right,
+A route simply takes the URI path (``/``) on the left, and maps it to the controller and method (``Home::index``) on the right,
 along with any parameters that should be passed to the controller. The controller and method should
 be listed in the same way that you would use a static method, by separating the class
 and its method with a double-colon, like ``Users::list``. If that method requires parameters to be
@@ -539,7 +506,7 @@ Use Defined Routes Only
 =======================
 
 When no defined route is found that matches the URI, the system will attempt to match that URI against the
-controllers and methods as described above. You can disable this automatic matching, and restrict routes
+controllers and methods as described in :ref:`auto-routing`. You can disable this automatic matching, and restrict routes
 to only those defined by you, by setting the ``setAutoRoute()`` option to false:
 
 .. literalinclude:: routing/046.php
@@ -565,7 +532,32 @@ For an example use of lowering the priority see :ref:`routing-priority`:
 
 .. literalinclude:: routing/048.php
 
-*****************
+.. _auto-routing:
+
+Auto Routing
+************
+
+It is recommended that all routes are defined in the **app/Config/Routes.php** file.
+However, CodeIgniter can also automatically route HTTP requests based on conventions
+and execute the corresponding controller methods.
+
+Consider this URI::
+
+    example.com/index.php/helloworld/index/1
+
+In the above example, CodeIgniter would attempt to find a controller named **Helloworld.php**
+and executes ``index()`` method with passing ``'1'`` as the first argument.
+
+We call this "**Auto Routes**". CodeIgniter automatically routes an HTTP request,
+and executes the corresponding controller method. The auto-routing is enabled by default.
+
+.. note:: To prevent misconfiguration and miscoding, we recommend that you disable
+    the auto-routing feature. See :ref:`use-defined-routes-only`.
+
+.. important:: The auto-routing routes a HTTP request with **any** HTTP method to a controller method.
+
+See :ref:`Auto Routing in Controllers <controller-auto-routing>` for more info.
+
 Confirming Routes
 *****************
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -443,7 +443,6 @@ To disable this functionality, you must call the method with the parameter ``fal
 
 .. _routes-configuration-options:
 
-****************************
 Routes Configuration Options
 ****************************
 


### PR DESCRIPTION
**Description**
Rework docs to disable auto-routing by default.
- explain defined routes first, auto-routes last

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
