### PR TITLE
docs: add section to link to "Extending the Controller" in incoming/controllers.rst

### DIFF
--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -307,6 +307,11 @@ Example:
 
 .. literalinclude:: controllers/012.php
 
+Extending the Controller
+************************
+
+If you want to extend the controller, see :doc:`../extending/basecontroller`.
+
 That's it!
 **********
 


### PR DESCRIPTION
**Description**
- Extending the controller is common practice. It should be stated iin the "Controllers" page.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
