### PR TITLE
config: disable auto-routing by default

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -21,7 +21,7 @@ $routes->setDefaultController('Home');
 $routes->setDefaultMethod('index');
 $routes->setTranslateURIDashes(false);
 $routes->set404Override();
-$routes->setAutoRoute(true);
+$routes->setAutoRoute(false);
 
 /*
  * --------------------------------------------------------------------

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -21,7 +21,10 @@ $routes->setDefaultController('Home');
 $routes->setDefaultMethod('index');
 $routes->setTranslateURIDashes(false);
 $routes->set404Override();
-$routes->setAutoRoute(false);
+// The auto-routing is very dangerous. It is easy to create vulnerable apps
+// where controller filters or CSRF protection are bypassed.
+// It is recommended that you do not set it to `true`.
+//$routes->setAutoRoute(false);
 
 /*
  * --------------------------------------------------------------------

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -76,7 +76,7 @@ class RouteCollection implements RouteCollectionInterface
      *
      * @var bool
      */
-    protected $autoRoute = true;
+    protected $autoRoute = false;
 
     /**
      * A callable that will be shown

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -47,6 +47,8 @@ final class CodeIgniterTest extends CIUnitTestCase
         if (count(ob_list_handlers()) > 1) {
             ob_end_clean();
         }
+
+        $this->resetServices();
     }
 
     public function testRunEmptyDefaultRoute()
@@ -469,6 +471,12 @@ final class CodeIgniterTest extends CIUnitTestCase
 
         $_POST['_method'] = 'PUT';
 
+        $routes = \Config\Services::routes();
+        $routes->setDefaultNamespace('App\Controllers');
+        $routes->resetRoutes();
+        $routes->post('/', 'Home::index');
+        $routes->put('/', 'Home::index');
+
         ob_start();
         $this->codeigniter->useSafeOutput(true)->run();
         ob_get_clean();
@@ -486,6 +494,12 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['REQUEST_METHOD']  = 'POST';
 
         $_POST['_method'] = 'GET';
+
+        $routes = \Config\Services::routes();
+        $routes->setDefaultNamespace('App\Controllers');
+        $routes->resetRoutes();
+        $routes->post('/', 'Home::index');
+        $routes->get('/', 'Home::index');
 
         ob_start();
         $this->codeigniter->useSafeOutput(true)->run();

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -67,6 +67,7 @@ final class RoutesTest extends CIUnitTestCase
         $routes->setDefaultNamespace('App\Controllers');
         $routes->resetRoutes();
         $routes->get('/', 'Home::index', ['filter' => 'csrf']);
+        $routes->setAutoRoute(true);
 
         command('routes');
 

--- a/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
@@ -23,6 +23,8 @@ final class FilterCollectorTest extends CIUnitTestCase
     {
         $routes = Services::routes();
         $routes->resetRoutes();
+        $routes->setDefaultNamespace('App\Controllers');
+        $routes->get('/', 'Home::index');
 
         $collector = new FilterCollector();
 

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -728,7 +728,10 @@ final class RouterTest extends CIUnitTestCase
     public function testAutoRouteMethodEmpty()
     {
         $router = new Router($this->collection, $this->request);
+        $this->collection->setAutoRoute(true);
+
         $router->handle('Home/');
+
         $this->assertSame('Home', $router->controllerName());
         $this->assertSame('index', $router->methodName());
     }
@@ -775,6 +778,7 @@ final class RouterTest extends CIUnitTestCase
     public function testRouterPriorDirectory()
     {
         $router = new Router($this->collection, $this->request);
+        $this->collection->setAutoRoute(true);
 
         $router->setDirectory('foo/bar/baz', false, true);
         $router->handle('Some_controller/some_method/param1/param2/param3');

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -43,6 +43,7 @@ Changes
 - The process of sending cookies has been moved to the ``Response`` class. Now the ``Session`` class doesn't send cookies, set them to the Response.
 - Validation. Changed generation of errors when using fields with a wildcard (*). Now the error key contains the full path. See :ref:`validation-getting-all-errors`.
 - ``Validation::getError()`` when using a wildcard will return all found errors matching the mask as a string.
+- To make the default configuration more secure, auto-routing has been changed to disabled by default.
 
 Deprecations
 ************

--- a/user_guide_src/source/cli/cli.rst
+++ b/user_guide_src/source/cli/cli.rst
@@ -88,7 +88,7 @@ works exactly like a normal route definition:
 
 For more information, see the :ref:`Routes <command-line-only-routes>` page.
 
-.. warning:: If you don't disable auto-routing and place the command file in **app/Controllers**,
+.. warning:: If you enable auto-routing and place the command file in **app/Controllers**,
     anyone could access the command with the help of auto-routing via HTTP.
 
 The CLI Library

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -116,7 +116,7 @@ This section describes the functionality of the auto-routing.
 It automatically routes an HTTP request, and executes the corresponding controller method
 without route definitions. The auto-routing is disabled by default.
 
-.. note:: To prevent misconfiguration and miscoding, we recommend that you disable
+.. warning:: To prevent misconfiguration and miscoding, we recommend that you disable
     the auto-routing feature.
 
 .. important:: The auto-routing routes a HTTP request with **any** HTTP method to a controller method.

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -114,10 +114,10 @@ Auto Routing
 
 This section describes the functionality of the auto-routing.
 It automatically routes an HTTP request, and executes the corresponding controller method
-without route definitions. The auto-routing is enabled by default.
+without route definitions. The auto-routing is disabled by default.
 
 .. note:: To prevent misconfiguration and miscoding, we recommend that you disable
-    the auto-routing feature. See :ref:`use-defined-routes-only`.
+    the auto-routing feature.
 
 .. important:: The auto-routing routes a HTTP request with **any** HTTP method to a controller method.
 
@@ -220,7 +220,7 @@ Your method will be passed URI segments 3 and 4 (``'sandals'`` and ``'123'``):
 .. literalinclude:: controllers/014.php
 
 .. important:: If you are using the :doc:`URI Routing <routing>`
-    feature, the segments passed to your method will be the re-routed
+    feature, the segments passed to your method will be the defined
     ones.
 
 Defining a Default Controller

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -279,7 +279,7 @@ called if the URL contains *only* the sub-directory. Simply put a controller
 in there that matches the name of your default controller as specified in
 your **app/Config/Routes.php** file.
 
-CodeIgniter also permits you to remap your URIs using its :doc:`URI Routing <routing>` feature.
+CodeIgniter also permits you to map your URIs using its :doc:`URI Routing <routing>` feature.
 
 Remapping Method Calls
 **********************

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -116,8 +116,9 @@ This section describes the functionality of the auto-routing.
 It automatically routes an HTTP request, and executes the corresponding controller method
 without route definitions. The auto-routing is disabled by default.
 
-.. warning:: To prevent misconfiguration and miscoding, we recommend that you disable
-    the auto-routing feature.
+.. warning:: To prevent misconfiguration and miscoding, we recommend that you do not use
+    the auto-routing feature. It is easy to create vulnerable apps where controller filters
+    or CSRF protection are bypassed.
 
 .. important:: The auto-routing routes a HTTP request with **any** HTTP method to a controller method.
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -81,18 +81,18 @@ and the default method, which is usually ``index()``:
 
 .. literalinclude:: routing/006.php
 
-A URL containing the segments **blog/joe** will be mapped to the ``\App\Controllers\Blogs`` class and the ``users`` method.
+A URL containing the segments **blog/joe** will be mapped to the ``\App\Controllers\Blogs`` class and the ``users()`` method.
 The ID will be set to ``34``:
 
 .. literalinclude:: routing/007.php
 
 A URL with **product** as the first segment, and anything in the second will be mapped to the ``\App\Controllers\Catalog`` class
-and the ``productLookup`` method:
+and the ``productLookup()`` method:
 
 .. literalinclude:: routing/008.php
 
 A URL with **product** as the first segment, and a number in the second will be mapped to the ``\App\Controllers\Catalog`` class
-and the ``productLookupByID`` method passing in the match as a variable to the method:
+and the ``productLookupByID()`` method passing in the match as a variable to the method:
 
 .. literalinclude:: routing/009.php
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -539,10 +539,13 @@ and executes the corresponding controller method. The auto-routing is enabled by
 .. note:: To prevent misconfiguration and miscoding, we recommend that you disable
     the auto-routing feature. See :ref:`use-defined-routes-only`.
 
+Configuration Options
+=====================
+
 .. important:: The auto-routing routes a HTTP request with **any** HTTP method to a controller method.
 
 Default Controller
-==================
+------------------
 
 When a user visits the root of your site (i.e., example.com) the controller to use is determined by the value set by
 the ``setDefaultController()`` method, unless a route exists for it explicitly. The default value for this is ``Home``
@@ -557,7 +560,7 @@ in the controllers directory. For example, if the user visits **example.com/admi
 See :ref:`Auto Routing in Controllers <controller-auto-routing>` for more info.
 
 Default Method
-==============
+--------------
 
 This works similar to the default controller setting, but is used to determine the default method that is used
 when a controller is found that matches the URI, but no segment exists for the method. The default value is

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -312,7 +312,7 @@ available from the command line:
 
 .. literalinclude:: routing/032.php
 
-.. warning:: If you don't disable auto-routing and place the command file in **app/Controllers**,
+.. warning:: If you enable auto-routing and place the command file in **app/Controllers**,
     anyone could access the command with the help of auto-routing via HTTP.
 
 Global Options
@@ -515,6 +515,11 @@ It is recommended that all routes are defined in the **app/Config/Routes.php** f
 However, CodeIgniter can also automatically route HTTP requests based on conventions
 and execute the corresponding controller methods.
 
+.. warning:: To prevent misconfiguration and miscoding, we recommend that you disable
+    the auto-routing feature.
+
+.. important:: The auto-routing routes a HTTP request with **any** HTTP method to a controller method.
+
 Enable Auto Routing
 ===================
 
@@ -543,15 +548,14 @@ In the above example, CodeIgniter would attempt to find a controller named **Hel
 and executes ``index()`` method with passing ``'1'`` as the first argument.
 
 We call this "**Auto Routes**". CodeIgniter automatically routes an HTTP request,
-and executes the corresponding controller method. The auto-routing is enabled by default.
+and executes the corresponding controller method. The auto-routing is disabled by default.
 
-.. note:: To prevent misconfiguration and miscoding, we recommend that you disable
-    the auto-routing feature. See :ref:`use-defined-routes-only`.
+See :ref:`Auto Routing in Controllers <controller-auto-routing>` for more info.
 
 Configuration Options
 =====================
 
-.. important:: The auto-routing routes a HTTP request with **any** HTTP method to a controller method.
+These options are available at the top of **app/Config/Routes.php**.
 
 Default Controller
 ------------------

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -515,6 +515,15 @@ It is recommended that all routes are defined in the **app/Config/Routes.php** f
 However, CodeIgniter can also automatically route HTTP requests based on conventions
 and execute the corresponding controller methods.
 
+Enable Auto Routing
+===================
+
+Since v4.2.0, the auto-routing is disabled by default.
+
+To use it, you need to change the setting ``setAutoRoute()`` option to true in **app/Config/Routes.php**::
+
+    $routes->setAutoRoute(true);
+
 URI Segments
 ============
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -479,8 +479,12 @@ dash isn't a valid class or method name character and would cause a fatal error 
 Use Defined Routes Only
 =======================
 
+Since v4.2.0, the auto-routing is disabled by default.
+
 When no defined route is found that matches the URI, the system will attempt to match that URI against the
-controllers and methods as described in :ref:`auto-routing`. You can disable this automatic matching, and restrict routes
+controllers and methods when :ref:`auto-routing` is enabled.
+
+You can disable this automatic matching, and restrict routes
 to only those defined by you, by setting the ``setAutoRoute()`` option to false:
 
 .. literalinclude:: routing/050.php

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -515,8 +515,9 @@ It is recommended that all routes are defined in the **app/Config/Routes.php** f
 However, CodeIgniter can also automatically route HTTP requests based on conventions
 and execute the corresponding controller methods.
 
-.. warning:: To prevent misconfiguration and miscoding, we recommend that you disable
-    the auto-routing feature.
+.. warning:: To prevent misconfiguration and miscoding, we recommend that you do not use
+    the auto-routing feature. It is easy to create vulnerable apps where controller filters
+    or CSRF protection are bypassed.
 
 .. important:: The auto-routing routes a HTTP request with **any** HTTP method to a controller method.
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -465,31 +465,6 @@ then you can change this value to save typing:
 
 .. literalinclude:: routing/046.php
 
-Default Controller
-==================
-
-When a user visits the root of your site (i.e., example.com) the controller to use is determined by the value set by
-the ``setDefaultController()`` method, unless a route exists for it explicitly. The default value for this is ``Home``
-which matches the controller at **app/Controllers/Home.php**:
-
-.. literalinclude:: routing/047.php
-
-The default controller is also used when no matching route has been found, and the URI would point to a directory
-in the controllers directory. For example, if the user visits **example.com/admin**, if a controller was found at
-**app/Controllers/Admin/Home.php**, it would be used.
-
-Default Method
-==============
-
-This works similar to the default controller setting, but is used to determine the default method that is used
-when a controller is found that matches the URI, but no segment exists for the method. The default value is
-``index``.
-
-In this example, if the user were to visit **example.com/products**, and a ``Products`` controller existed, the
-``Products::listAll()`` method would be executed:
-
-.. literalinclude:: routing/048.php
-
 Translate URI Dashes
 ====================
 
@@ -566,7 +541,32 @@ and executes the corresponding controller method. The auto-routing is enabled by
 
 .. important:: The auto-routing routes a HTTP request with **any** HTTP method to a controller method.
 
+Default Controller
+==================
+
+When a user visits the root of your site (i.e., example.com) the controller to use is determined by the value set by
+the ``setDefaultController()`` method, unless a route exists for it explicitly. The default value for this is ``Home``
+which matches the controller at **app/Controllers/Home.php**:
+
+.. literalinclude:: routing/047.php
+
+The default controller is also used when no matching route has been found, and the URI would point to a directory
+in the controllers directory. For example, if the user visits **example.com/admin**, if a controller was found at
+**app/Controllers/Admin/Home.php**, it would be used.
+
 See :ref:`Auto Routing in Controllers <controller-auto-routing>` for more info.
+
+Default Method
+==============
+
+This works similar to the default controller setting, but is used to determine the default method that is used
+when a controller is found that matches the URI, but no segment exists for the method. The default value is
+``index``.
+
+In this example, if the user were to visit **example.com/products**, and a ``Products`` controller existed, the
+``Products::listAll()`` method would be executed:
+
+.. literalinclude:: routing/048.php
 
 Confirming Routes
 *****************

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -76,22 +76,22 @@ Examples
 
 Here are a few basic routing examples.
 
-A URL containing the word **journals** in the first segment will be remapped to the ``\App\Controllers\Blogs`` class,
+A URL containing the word **journals** in the first segment will be mapped to the ``\App\Controllers\Blogs`` class,
 and the default method, which is usually ``index()``:
 
 .. literalinclude:: routing/006.php
 
-A URL containing the segments **blog/joe** will be remapped to the ``\App\Controllers\Blogs`` class and the ``users`` method.
+A URL containing the segments **blog/joe** will be mapped to the ``\App\Controllers\Blogs`` class and the ``users`` method.
 The ID will be set to ``34``:
 
 .. literalinclude:: routing/007.php
 
-A URL with **product** as the first segment, and anything in the second will be remapped to the ``\App\Controllers\Catalog`` class
+A URL with **product** as the first segment, and anything in the second will be mapped to the ``\App\Controllers\Catalog`` class
 and the ``productLookup`` method:
 
 .. literalinclude:: routing/008.php
 
-A URL with **product** as the first segment, and a number in the second will be remapped to the ``\App\Controllers\Catalog`` class
+A URL with **product** as the first segment, and a number in the second will be mapped to the ``\App\Controllers\Catalog`` class
 and the ``productLookupByID`` method passing in the match as a variable to the method:
 
 .. literalinclude:: routing/009.php

--- a/user_guide_src/source/installation/upgrade_420.rst
+++ b/user_guide_src/source/installation/upgrade_420.rst
@@ -49,7 +49,8 @@ Content Changes
 The following files received significant changes (including deprecations or visual adjustments)
 and it is recommended that you merge the updated versions with your application:
 
-*
+* ``app/Config/Routes.php``
+    * To make the default configuration more secure, auto-routing has been changed to disabled by default.
 
 All Changes
 ===========

--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -119,7 +119,7 @@ Routing
 
 Before you can start adding news items into your CodeIgniter application
 you have to add an extra rule to **app/Config/Routes.php** file. Make sure your
-file contains the following. This makes sure CodeIgniter sees ``create``
+file contains the following. This makes sure CodeIgniter sees ``create()``
 as a method instead of a news item's slug. You can read more about different
 routing types :doc:`here </incoming/routing>`.
 

--- a/user_guide_src/source/tutorial/create_news_items/004.php
+++ b/user_guide_src/source/tutorial/create_news_items/004.php
@@ -1,6 +1,11 @@
 <?php
 
+// ...
+
 $routes->match(['get', 'post'], 'news/create', 'News::create');
 $routes->get('news/(:segment)', 'News::view/$1');
 $routes->get('news', 'News::index');
+$routes->get('pages', 'Pages::index');
 $routes->get('(:any)', 'Pages::view/$1');
+
+// ...

--- a/user_guide_src/source/tutorial/news_section.rst
+++ b/user_guide_src/source/tutorial/news_section.rst
@@ -171,8 +171,7 @@ The only thing left to do is create the corresponding view at
 Routing
 *******
 
-Because of the wildcard routing rule created earlier, you need an extra
-route to view the controller that you just made. Modify your routing file
+Modify your routing file
 (**app/Config/Routes.php**) so it looks as follows.
 This makes sure the requests reach the ``News`` controller instead of
 going directly to the ``Pages`` controller. The first line routes URI's

--- a/user_guide_src/source/tutorial/news_section/008.php
+++ b/user_guide_src/source/tutorial/news_section/008.php
@@ -1,5 +1,10 @@
 <?php
 
+// ...
+
 $routes->get('news/(:segment)', 'News::view/$1');
 $routes->get('news', 'News::index');
+$routes->get('pages', 'Pages::index');
 $routes->get('(:any)', 'Pages::view/$1');
+
+// ...

--- a/user_guide_src/source/tutorial/static_pages.rst
+++ b/user_guide_src/source/tutorial/static_pages.rst
@@ -9,20 +9,6 @@ The first thing you're going to do is set up a **controller** to handle
 static pages. A controller is simply a class that helps delegate work.
 It is the glue of your web application.
 
-For example, when a call is made to::
-
-    http://example.com/news/latest/10
-
-We might imagine that there is a controller named "news". The method
-being called on news would be "latest". The news method's job could be to
-grab 10 news items, and render them on the page. Very often in MVC,
-you'll see URL patterns that match::
-
-    http://example.com/[controller-class]/[controller-method]/[arguments]
-
-As URL schemes become more complex, this may change. But for now, this
-is all we will need to know.
-
 Let's Make our First Controller
 *******************************
 
@@ -126,6 +112,45 @@ view.
     throw errors on case-sensitive platforms. You can read more about it
     :doc:`here </outgoing/views>`.
 
+Routing
+*******
+
+We have made the controller. The next thing is to set routing rules.
+Routing associates a URI with a controller's method.
+
+Let's do that. Open the routing file located at
+**app/Config/Routes.php** and look for the "Route Definitions"
+section of the configuration file.
+
+The only uncommented line there to start with should be:
+
+.. literalinclude:: static_pages/003.php
+
+This directive says that any incoming request without any content
+specified should be handled by the ``index()`` method inside the ``Home`` controller.
+
+Add the following lines, **after** the route directive for '/'.
+
+.. literalinclude:: static_pages/004.php
+   :lines: 2-
+
+CodeIgniter reads its routing rules from top to bottom and routes the
+request to the first matching rule. Each rule is a regular expression
+(left-side) mapped to a controller and method name separated by slashes
+(right-side). When a request comes in, CodeIgniter looks for the first
+match, and calls the appropriate controller and method, possibly with
+arguments.
+
+More information about routing can be found in the URI Routing
+:doc:`documentation </incoming/routing>`.
+
+Here, the second rule in the ``$routes`` object matches GET request
+to the URI path ``/pages`` maps the ``index()`` method of the ``Pages`` class.
+
+The third rule in the ``$routes`` object matches GET request to **any** URI path
+using the wildcard string ``(:any)``, and passes the parameter to the
+``view()`` method of the ``Pages`` class.
+
 Running the App
 ***************
 
@@ -141,6 +166,14 @@ From the command line, at the root of your project::
 will start a web server, accessible on port 8080. If you set the location field
 in your browser to ``localhost:8080``, you should see the CodeIgniter welcome page.
 
+Now visit ``localhost:8080/home``. Did it get routed correctly to the ``view()``
+method in the ``Pages`` controller? Awesome!
+
+You should see something like the following:
+
+.. image:: ../images/tutorial1.png
+    :align: center
+
 You can now try several URLs in the browser location field, to see what the ``Pages``
 controller you made above produces...
 
@@ -150,73 +183,18 @@ controller you made above produces...
     +---------------------------------+-----------------------------------------------------------------+
     | URL                             | Will show                                                       |
     +=================================+=================================================================+
-    | localhost:8080/pages            | the results from the `index` method inside our `Pages`          |
-    |                                 | controller, which is to display the CodeIgniter "welcome" page, |
-    |                                 | because "index" is the default controller method                |
-    +---------------------------------+-----------------------------------------------------------------+
-    | localhost:8080/pages/index      | the CodeIgniter "welcome" page, because we explicitly asked for |
-    |                                 | the "index" method                                              |
+    | localhost:8080/pages            | the results from the ``index()`` method inside our ``Pages``    |
+    |                                 | controller, which is to display the CodeIgniter "welcome" page. |
     +---------------------------------+-----------------------------------------------------------------+
     | localhost:8080/pages/view       | the "home" page that you made above, because it is the default  |
     |                                 | "page" parameter to the ``view()`` method.                      |
     +---------------------------------+-----------------------------------------------------------------+
     | localhost:8080/pages/view/home  | show the "home" page that you made above, because we explicitly |
-    |                                 | asked for it                                                    |
+    |                                 | asked for it.                                                   |
     +---------------------------------+-----------------------------------------------------------------+
     | localhost:8080/pages/view/about | the "about" page that you made above, because we explicitly     |
-    |                                 | asked for it                                                    |
+    |                                 | asked for it.                                                   |
     +---------------------------------+-----------------------------------------------------------------+
     | localhost:8080/pages/view/shop  | a "404 - File Not Found" error page, because there is no        |
-    |                                 | `app/Views/pages/shop.php`                                      |
+    |                                 | **app/Views/pages/shop.php**.                                   |
     +---------------------------------+-----------------------------------------------------------------+
-
-Routing
-*******
-
-The controller is now functioning!
-
-Using custom routing rules, you have the power to map any URI to any
-controller and method, and break free from the normal convention::
-
-    http://example.com/[controller-class]/[controller-method]/[arguments]
-
-Let's do that. Open the routing file located at
-**app/Config/Routes.php** and look for the "Route Definitions"
-section of the configuration file.
-
-The only uncommented line there to start with should be:
-
-.. literalinclude:: static_pages/003.php
-
-This directive says that any incoming request without any content
-specified should be handled by the ``index()`` method inside the ``Home`` controller.
-
-Add the following line, **after** the route directive for '/'.
-
-.. literalinclude:: static_pages/004.php
-
-CodeIgniter reads its routing rules from top to bottom and routes the
-request to the first matching rule. Each rule is a regular expression
-(left-side) mapped to a controller and method name separated by slashes
-(right-side). When a request comes in, CodeIgniter looks for the first
-match, and calls the appropriate controller and method, possibly with
-arguments.
-
-More information about routing can be found in the URI Routing
-:doc:`documentation </incoming/routing>`.
-
-Here, the second rule in the ``$routes`` object matches **any** request
-using the wildcard string ``(:any)``. and passes the parameter to the
-``view()`` method of the ``Pages`` class.
-
-Now visit ``localhost:8080/home``. Did it get routed correctly to the ``view()``
-method in the pages controller? Awesome!
-
-You should see something like the following:
-
-.. image:: ../images/tutorial1.png
-    :align: center
-
-.. note:: When manually specifying routes, it is recommended to disable
-    auto-routing by setting ``$routes->setAutoRoute(false);`` in the **Routes.php** file.
-    This ensures that only routes you define can be accessed.

--- a/user_guide_src/source/tutorial/static_pages/003.php
+++ b/user_guide_src/source/tutorial/static_pages/003.php
@@ -1,3 +1,9 @@
 <?php
 
+// ...
+
+// We get a performance increase by specifying the default
+// route since we don't have to scan directories.
 $routes->get('/', 'Home::index');
+
+// ...

--- a/user_guide_src/source/tutorial/static_pages/004.php
+++ b/user_guide_src/source/tutorial/static_pages/004.php
@@ -1,3 +1,4 @@
 <?php
 
+$routes->get('pages', 'Pages::index');
 $routes->get('(:any)', 'Pages::view/$1');


### PR DESCRIPTION
**Description**
- To make the default config more secure, disable  auto-routing by default.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
  - [x] Needs  #5758
  - [x] Tutorial
  - [x] Routing
  - [x] Controller
- [x] Conforms to style guide
