### PR TITLE
docs: fix incorrect config filename in factories.rst

### DIFF
--- a/user_guide_src/source/concepts/factories.rst
+++ b/user_guide_src/source/concepts/factories.rst
@@ -79,8 +79,8 @@ Factories Behavior
 
 Options can be applied in one of three ways (listed in ascending priority):
 
-* A configuration file ``Factory`` with a component property.
-* The static method ``Factories::setOptions``.
+* A configuration class ``Config\Factory`` with a ``$component`` property.
+* The static method ``Factories::setOptions()``.
 * Passing options directly at call time with a parameter.
 
 Configurations
@@ -89,7 +89,7 @@ Configurations
 To set default component options, create a new Config files at **app/Config/Factory.php**
 that supplies options as an array property that matches the name of the component. For example,
 if you wanted to ensure that all Filters used by your app were valid framework instances,
-your **Factories.php** file might look like this:
+your **Factory.php** file might look like this:
 
 .. literalinclude:: factories/005.php
 

--- a/user_guide_src/source/concepts/factories/005.php
+++ b/user_guide_src/source/concepts/factories/005.php
@@ -5,7 +5,7 @@ namespace Config;
 use CodeIgniter\Config\Factory as BaseFactory;
 use CodeIgniter\Filters\FilterInterface;
 
-class Factories extends BaseFactory
+class Factory extends BaseFactory
 {
     public $filters = [
         'instanceOf' => FilterInterface::class,


### PR DESCRIPTION
Each pull request should address a single issue and have a meaningful title.

**Description**
- fix incorrect config filename

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

