### PR TITLE
fix: rename Entity::setAttributes() to avoid name collision

### DIFF
--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -142,7 +142,7 @@ class Result extends BaseResult
     protected function fetchObject(string $className = 'stdClass')
     {
         if (is_subclass_of($className, Entity::class)) {
-            return empty($data = $this->fetchAssoc()) ? false : (new $className())->setAttributes($data);
+            return empty($data = $this->fetchAssoc()) ? false : (new $className())->injectRawData($data);
         }
 
         return $this->resultID->fetch_object($className);

--- a/system/Database/OCI8/Result.php
+++ b/system/Database/OCI8/Result.php
@@ -102,7 +102,7 @@ class Result extends BaseResult implements ResultInterface
             return $row;
         }
         if (is_subclass_of($className, Entity::class)) {
-            return (new $className())->setAttributes((array) $row);
+            return (new $className())->injectRawData((array) $row);
         }
 
         $instance = new $className();

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -108,7 +108,7 @@ class Result extends BaseResult
     protected function fetchObject(string $className = 'stdClass')
     {
         if (is_subclass_of($className, Entity::class)) {
-            return empty($data = $this->fetchAssoc()) ? false : (new $className())->setAttributes($data);
+            return empty($data = $this->fetchAssoc()) ? false : (new $className())->injectRawData($data);
         }
 
         return pg_fetch_object($this->resultID, null, $className);

--- a/system/Database/SQLSRV/Result.php
+++ b/system/Database/SQLSRV/Result.php
@@ -150,7 +150,7 @@ class Result extends BaseResult
     protected function fetchObject(string $className = 'stdClass')
     {
         if (is_subclass_of($className, Entity::class)) {
-            return empty($data = $this->fetchAssoc()) ? false : (new $className())->setAttributes($data);
+            return empty($data = $this->fetchAssoc()) ? false : (new $className())->injectRawData($data);
         }
 
         return sqlsrv_fetch_object($this->resultID, $className);

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -136,7 +136,7 @@ class Result extends BaseResult
         $classObj = new $className();
 
         if (is_subclass_of($className, Entity::class)) {
-            return $classObj->setAttributes($row);
+            return $classObj->injectRawData($row);
         }
 
         $classSet = Closure::bind(function ($key, $value) {

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -274,7 +274,7 @@ class Entity implements JsonSerializable
      *
      * @return $this
      */
-    public function setAttributes(array $data)
+    public function injectRawData(array $data)
     {
         $this->attributes = $data;
 

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -32,6 +32,36 @@ final class EntityTest extends CIUnitTestCase
 {
     use ReflectionHelper;
 
+    public function testSetStringToPropertyNamedAttributes()
+    {
+        $entity = $this->getEntity();
+
+        $entity->attributes = 'attributes';
+
+        $this->assertSame('attributes', $entity->attributes);
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues
+     */
+    public function testSetArrayToPropertyNamedAttributes()
+    {
+        $entity = new Entity();
+
+        $entity->a          = 1;
+        $entity->attributes = [1, 2, 3];
+
+        $expected = [
+            'a'          => 1,
+            'attributes' => [
+                0 => 1,
+                1 => 2,
+                2 => 3,
+            ],
+        ];
+        $this->assertSame($expected, $entity->toRawArray());
+    }
+
     public function testSimpleSetAndGet()
     {
         $entity = $this->getEntity();


### PR DESCRIPTION
**Description**
Fixes #5762

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
