### PR TITLE
refactor: cast string to int in OpenSSLHandler

### DIFF
--- a/system/Encryption/Handlers/OpenSSLHandler.php
+++ b/system/Encryption/Handlers/OpenSSLHandler.php
@@ -89,7 +89,7 @@ class OpenSSLHandler extends BaseHandler
         // derive a secret key
         $secret = \hash_hkdf($this->digest, $this->key);
 
-        $hmacLength = self::substr($this->digest, 3) / 8;
+        $hmacLength = (int) self::substr($this->digest, 3) / 8;
         $hmacKey    = self::substr($data, 0, $hmacLength);
         $data       = self::substr($data, $hmacLength);
         $hmacCalc   = \hash_hmac($this->digest, $data, $secret, true);


### PR DESCRIPTION
**Description**
- to suppress PHPStan 1.4.7 error

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

