### PR TITLE
chore: add .user-guide.php-cs-fixer.dist.php for sample code in docs

### DIFF
--- a/.github/workflows/test-coding-standards.yml
+++ b/.github/workflows/test-coding-standards.yml
@@ -56,3 +56,6 @@ jobs:
 
       - name: Run lint on `system/`, `tests`, `utils/`, and root PHP files
         run: vendor/bin/php-cs-fixer fix --verbose --ansi --dry-run --using-cache=no --diff
+
+      - name: Run lint on `user_guide_src/source/`
+        run: vendor/bin/php-cs-fixer fix --verbose --ansi --dry-run --config=.user-guide.php-cs-fixer.dist.php --using-cache=no --diff

--- a/.user-guide.php-cs-fixer.dist.php
+++ b/.user-guide.php-cs-fixer.dist.php
@@ -26,6 +26,7 @@ $finder = Finder::create()
     ->notPath([
         'ci3sample/',
         'libraries/sessions/017.php',
+        'database/query_builder/074.php',
     ]);
 
 $overrides = [

--- a/.user-guide.php-cs-fixer.dist.php
+++ b/.user-guide.php-cs-fixer.dist.php
@@ -21,25 +21,22 @@ use PhpCsFixer\Finder;
 $finder = Finder::create()
     ->files()
     ->in([
-        __DIR__ . '/system',
-        __DIR__ . '/tests',
-        __DIR__ . '/utils',
+        __DIR__ . '/user_guide_src/source',
     ])
-    ->exclude(['ThirdParty'])
-    ->notName('#Foobar.php$#')
-    ->append([
-        __FILE__,
-        __DIR__ . '/.no-header.php-cs-fixer.dist.php',
-        __DIR__ . '/.user-guide.php-cs-fixer.dist.php',
-        __DIR__ . '/rector.php',
-        __DIR__ . '/spark',
-        __DIR__ . '/user_guide_src/renumerate.php',
+    ->notPath([
+        'ci3sample/',
+        'libraries/sessions/017.php',
     ]);
 
-$overrides = [];
+$overrides = [
+    'echo_tag_syntax'             => false,
+    'php_unit_internal_class'     => false,
+    'no_unused_imports'           => false,
+    'class_attributes_separation' => false,
+];
 
 $options = [
-    'cacheFile'    => 'build/.php-cs-fixer.cache',
+    'cacheFile'    => 'build/.user-guide.php-cs-fixer.cache',
     'finder'       => $finder,
     'customFixers' => FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'),
     'customRules'  => [
@@ -48,8 +45,4 @@ $options = [
     ],
 ];
 
-return Factory::create(new CodeIgniter4(), $overrides, $options)->forLibrary(
-    'CodeIgniter 4 framework',
-    'CodeIgniter Foundation',
-    'admin@codeigniter.com'
-);
+return Factory::create(new CodeIgniter4(), $overrides, $options)->forProjects();

--- a/admin/pre-commit
+++ b/admin/pre-commit
@@ -63,6 +63,18 @@ if [ "$FILES" != "" ]; then
         echo "Files in system, tests, utils, or root are not following the coding standards. Please fix them before commit."
         exit 1
     fi
+
+    # Next, run on user_guide_src/source PHP files
+    if [ -d /proc/cygdrive ]; then
+        ./vendor/bin/php-cs-fixer fix --verbose --dry-run --diff --config=.user-guide.php-cs-fixer.dist.php
+    else
+        php ./vendor/bin/php-cs-fixer fix --verbose --dry-run --diff --config=.user-guide.php-cs-fixer.dist.php
+    fi
+
+    if [ $? != 0 ]; then
+        echo "Files in user_guide_src/source are not following the coding standards. Please fix them before commit."
+        exit 1
+    fi
 fi
 
 if [ "$STAGED_RST_FILES" != "" ]; then

--- a/composer.json
+++ b/composer.json
@@ -62,10 +62,12 @@
         "analyze": "phpstan analyse",
         "test": "phpunit",
         "cs": [
+            "php-cs-fixer fix --verbose --dry-run --diff --config=.user-guide.php-cs-fixer.dist.php",
             "php-cs-fixer fix --verbose --dry-run --diff --config=.no-header.php-cs-fixer.dist.php",
             "php-cs-fixer fix --verbose --dry-run --diff"
         ],
         "cs-fix": [
+            "php-cs-fixer fix --verbose --diff --config=.user-guide.php-cs-fixer.dist.php",
             "php-cs-fixer fix --verbose --diff --config=.no-header.php-cs-fixer.dist.php",
             "php-cs-fixer fix --verbose --diff"
         ]


### PR DESCRIPTION
**Description**
- add `.user-guide.php-cs-fixer.dist.php`
- add user guide cs check in git pre-commit hook
- add user guide cs check in GitHub Action
- update `composer cs-fix`

I propose the following before fixing sample code:
- move CI3 sample code in Upgrading into the folder `ci3sample/`
  - we need exclude the CI3 sample code
  - #5771
- use `/* ... */` style comment for explanation of the code result
  - The comments are not normal comments, so it is better not to use `//`
  - #5770

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
