### PR TITLE
[Rector] Update to Rector 0.12.17 and Re-run it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phpstan/phpstan": "^1.0",
         "phpunit/phpunit": "^9.1",
         "predis/predis": "^1.1",
-        "rector/rector": "0.12.16"
+        "rector/rector": "0.12.17"
     },
     "suggest": {
         "ext-fileinfo": "Improves mime type detection for files"

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -915,3 +915,7 @@ parameters:
 			paths:
 				- system/Cache/CacheFactory.php
 				- system/Filters/Filters.php
+
+		-
+			message: "#^Binary operation \"/\" between string and 8 results in an error\\.$#"
+			path: system/Encryption/Handlers/OpenSSLHandler.php

--- a/tests/system/Database/Live/FabricatorLiveTest.php
+++ b/tests/system/Database/Live/FabricatorLiveTest.php
@@ -50,7 +50,7 @@ final class FabricatorLiveTest extends CIUnitTestCase
         // Some countries violate the 40 character limit so override that
         $fabricator->setOverrides(['country' => 'France']);
 
-        $result = $fabricator->create($count);
+        $fabricator->create($count);
 
         $this->seeNumRecords($count, 'user', []);
     }

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -30,11 +30,7 @@ final class ForgeTest extends CIUnitTestCase
 
     protected $refresh = true;
     protected $seed    = 'Tests\Support\Database\Seeds\CITestSeeder';
-
-    /**
-     * @var Forge
-     */
-    protected $forge;
+    protected Forge $forge;
 
     protected function setUp(): void
     {
@@ -812,7 +808,7 @@ final class ForgeTest extends CIUnitTestCase
 
         $this->forge->addKey('id', true);
         $this->forge->addUniqueKey(['username', 'active']);
-        $create = $this->forge->createTable($tableName, true);
+        $this->forge->createTable($tableName, true);
 
         $fieldsNames = $this->db->getFieldNames($tableName);
         $fieldsData  = $this->db->getFieldData($tableName);

--- a/tests/system/Filters/HoneypotTest.php
+++ b/tests/system/Filters/HoneypotTest.php
@@ -53,7 +53,7 @@ final class HoneypotTest extends CIUnitTestCase
         $uri     = 'admin/foo/bar';
 
         $this->expectException(HoneypotException::class);
-        $request = $filters->run($uri, 'before');
+        $filters->run($uri, 'before');
     }
 
     public function testBeforeClean()

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -155,7 +155,7 @@ final class URITest extends CIUnitTestCase
     {
         $this->expectException(HTTPException::class);
         $url = 'http://abc:a123';
-        $uri = new URI($url);
+        new URI($url);
     }
 
     public function testMissingScheme()

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -114,7 +114,7 @@ final class HoneypotTest extends CIUnitTestCase
         $uri     = 'admin/foo/bar';
 
         $this->expectException(HoneypotException::class);
-        $request = $filters->run($uri, 'before');
+        $filters->run($uri, 'before');
     }
 
     public function testHoneypotFilterAfter()

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -235,7 +235,7 @@ final class TimeTest extends CIUnitTestCase
         $this->expectException(I18nException::class);
         $this->expectExceptionMessage(lang('Time.invalidFormat', [$format]));
 
-        $time = Time::createFromFormat($format, 'America/Chicago');
+        Time::createFromFormat($format, 'America/Chicago');
     }
 
     public function testCreateFromTimestamp()


### PR DESCRIPTION
- Update Rector to 0.12.17
- Re-run it to apply more removal on unneded variable in assign
- Apply typed property on final class protected property.
- Ignore phpstan 1.4.7 notice on `Binary operation "/" between string and 8 results in an error.` on system/Encryption/Handlers/OpenSSLHandler.php

**Checklist:**
- [x] Securely signed commits
