### PR TITLE
Modified Model::doUpdate allowing arrays in $this->primaryKey for composite table keys

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -298,7 +298,16 @@ class Model extends BaseModel
         $builder = $this->builder();
 
         if ($id) {
-            $builder = $builder->whereIn($this->table . '.' . $this->primaryKey, $id);
+            if (is_array($id) && is_array($this->primaryKey)) {
+                for ($index = 0; $index < count($this->primaryKey); $index++) {
+                    $primary_key = $this->primaryKey[$index];
+                    $value = $id[$primary_key];
+                    $full_column = sprintf("%s.%s", $this->table, $primary_key);
+                    $builder = $builder->whereIn($full_column, array($value));
+                }
+            } else {
+                $builder = $builder->whereIn($this->table . '.' . $this->primaryKey, $id);
+            }
         }
 
         // Must use the set() method to ensure to set the correct escape flag


### PR DESCRIPTION
I have tables with composite keys and needed the CI Model to work with it so I modified the Model to allow for values similar to this `$this-primaryKey = array('column1','column2').` 

I'm also pushing a separate update for doInsert.


