### PR TITLE
fix: [BaseConfig] string value is set from environment variable even if it should be int/float

### DIFF
--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -88,7 +88,7 @@ class BaseConfig
      *
      * @param mixed $property
      *
-     * @return mixed
+     * @return void
      */
     protected function initEnvValue(&$property, string $name, string $prefix, string $shortPrefix)
     {
@@ -102,16 +102,28 @@ class BaseConfig
             } elseif ($value === 'true') {
                 $value = true;
             }
-            $property = is_bool($value) ? $value : trim($value, '\'"');
-        }
+            if (is_bool($value)) {
+                $property = $value;
 
-        return $property;
+                return;
+            }
+
+            $value = trim($value, '\'"');
+
+            if (is_int($property)) {
+                $value = (int) $value;
+            } elseif (is_float($property)) {
+                $value = (float) $value;
+            }
+
+            $property = $value;
+        }
     }
 
     /**
      * Retrieve an environment-specific configuration setting
      *
-     * @return mixed
+     * @return string|null
      */
     protected function getEnvValue(string $property, string $prefix, string $shortPrefix)
     {

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -55,6 +55,25 @@ final class BaseConfigTest extends CIUnitTestCase
         $this->assertSame(18, $config->golf);
     }
 
+    public function testUseDefaultValueTypeIntAndFloatValues()
+    {
+        $dotenv = new DotEnv($this->fixturesFolder, '.env');
+        $dotenv->load();
+        $config = new SimpleConfig();
+
+        $this->assertSame(0.0, $config->float);
+        $this->assertSame(999, $config->int);
+    }
+
+    public function testUseDefaultValueTypeStringValue()
+    {
+        $dotenv = new DotEnv($this->fixturesFolder, '.env');
+        $dotenv->load();
+        $config = new SimpleConfig();
+
+        $this->assertSame('123456', $config->password);
+    }
+
     /**
      * @runInSeparateProcess
      * @preserveGlobalState  disabled

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -117,6 +117,9 @@ final class BaseConfigTest extends CIUnitTestCase
         $this->assertSame('bar', $config->onedeep_value);
         // array property name with underscore and key with underscore
         $this->assertSame('foo', $config->one_deep['under_deep']);
+
+        // The default property value is null but has type
+        $this->assertSame(20, $config->size);
     }
 
     public function testPrefixedValues()

--- a/tests/system/Config/fixtures/.env
+++ b/tests/system/Config/fixtures/.env
@@ -33,9 +33,12 @@ SimpleConfig.crew.pilot = Wash
 SimpleConfig.crew.comms = true
 SimpleConfig.crew.doctor = false
 
-SimpleConfig.float = '0.0'
-SimpleConfig.int = '999'
+# The default value's type in the Config class is float, so it will be converted to float
+SimpleConfig.float = 0.0
+# The default value's type in the Config class is int, so it will be converted to int
+SimpleConfig.int = 999
 
 SimpleConfig.password = 123456
 
+# The property type in the Config class is ?int, so it will be converted to int by PHP
 SimpleConfig.size=20

--- a/tests/system/Config/fixtures/.env
+++ b/tests/system/Config/fixtures/.env
@@ -32,3 +32,8 @@ SimpleConfig.crew.captain = Malcolm
 SimpleConfig.crew.pilot = Wash
 SimpleConfig.crew.comms = true
 SimpleConfig.crew.doctor = false
+
+SimpleConfig.float = '0.0'
+SimpleConfig.int = '999'
+
+SimpleConfig.password = 123456

--- a/tests/system/Config/fixtures/.env
+++ b/tests/system/Config/fixtures/.env
@@ -37,3 +37,5 @@ SimpleConfig.float = '0.0'
 SimpleConfig.int = '999'
 
 SimpleConfig.password = 123456
+
+SimpleConfig.size=20

--- a/tests/system/Config/fixtures/SimpleConfig.php
+++ b/tests/system/Config/fixtures/SimpleConfig.php
@@ -48,7 +48,8 @@ class SimpleConfig extends \CodeIgniter\Config\BaseConfig
     public $one_deep = [
         'under_deep' => null,
     ];
-    public $float    = 12.34;
-    public $int      = 1234;
-    public $password = 'secret';
+    public $float     = 12.34;
+    public $int       = 1234;
+    public $password  = 'secret';
+    public ?int $size = null;
 }

--- a/tests/system/Config/fixtures/SimpleConfig.php
+++ b/tests/system/Config/fixtures/SimpleConfig.php
@@ -48,4 +48,7 @@ class SimpleConfig extends \CodeIgniter\Config\BaseConfig
     public $one_deep = [
         'under_deep' => null,
     ];
+    public $float    = 12.34;
+    public $int      = 1234;
+    public $password = 'secret';
 }


### PR DESCRIPTION
**Description**
Fixes #5688
Supersede #5704,  #5691 and #5690

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

