### PR TITLE
fix: app/Config/Routes.php is loaded twice on Windows

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -357,9 +357,14 @@ class RouteCollection implements RouteCollectionInterface
         if ($this->moduleConfig->shouldDiscover('routes')) {
             $files = $this->fileLocator->search('Config/Routes.php');
 
+            $excludes = [
+                APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'Routes.php',
+                SYSTEMPATH . 'Config' . DIRECTORY_SEPARATOR . 'Routes.php',
+            ];
+
             foreach ($files as $file) {
                 // Don't include our main file again...
-                if ($file === APPPATH . 'Config/Routes.php') {
+                if (in_array($file, $excludes, true)) {
                     continue;
                 }
 


### PR DESCRIPTION
**Description**
Fixes #2203
See https://github.com/codeigniter4/CodeIgniter4/issues/2203#issuecomment-1059961885
- fix `app/Config/Routes.php` is loaded twice on Windows
- fix `sysmte/Config/Routes.php` is loaded twice

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

