### PR TITLE
fix: Entity can't handle column named attributes

### DIFF
--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -439,12 +439,21 @@ class Entity implements JsonSerializable
 
         $value = $this->castAs($value, $key, 'set');
 
-        // if a set* method exists for this key, use that method to
+        // if a setter method exists for this key, use that method to
         // insert this value. should be outside $isNullable check,
         // so maybe wants to do sth with null value automatically
         $method = 'set' . str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $key)));
 
-        if (method_exists($this, $method)) {
+        // If a "`_set` + $key" method exists, it is a setter.
+        if (method_exists($this, '_' . $method)) {
+            $this->{$method}($value);
+
+            return $this;
+        }
+
+        // If a "`set` + $key" method exists, it is also a setter.
+        // But setAttributes() is not a setter for this.
+        if ($key !== 'attributes' && method_exists($this, $method)) {
             $this->{$method}($value);
 
             return $this;

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -32,6 +32,36 @@ final class EntityTest extends CIUnitTestCase
 {
     use ReflectionHelper;
 
+    public function testSetStringToPropertyNamedAttributes()
+    {
+        $entity = $this->getEntity();
+
+        $entity->attributes = 'attributes';
+
+        $this->assertSame('attributes', $entity->attributes);
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues
+     */
+    public function testSetArrayToPropertyNamedAttributes()
+    {
+        $entity = new Entity();
+
+        $entity->a          = 1;
+        $entity->attributes = [1, 2, 3];
+
+        $expected = [
+            'a'          => 1,
+            'attributes' => [
+                0 => 1,
+                1 => 2,
+                2 => 3,
+            ],
+        ];
+        $this->assertSame($expected, $entity->toRawArray());
+    }
+
     public function testSimpleSetAndGet()
     {
         $entity = $this->getEntity();


### PR DESCRIPTION
**Description**
Fixes #5762
Supersede #5763
- fix Entity can't handle column named attributes
- add new setter method "`_set` + key" for a attribute

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
