### PR TITLE
User Guide Deploy Action

### DIFF
--- a/.github/scripts/deploy-userguide
+++ b/.github/scripts/deploy-userguide
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+## Deploy codeigniter4/userguide
+
+# Setup variables
+SOURCE=$1
+TARGET=$2
+RELEASE=$3
+VERSION=`echo "$RELEASE" | cut -c 2-`
+
+echo "Preparing for version $3"
+echo "Merging files from $1 to $2"
+
+# Prepare the source
+cd $SOURCE
+git checkout master
+cd user_guide_src
+make html
+make epub
+
+# Prepare the target
+cd $TARGET
+git checkout master
+rm -rf docs
+
+# Copy files
+cp -Rf ${SOURCE}/user_guide_src/build/html ./docs
+cp -Rf ${SOURCE}/user_guide_src/build/epub/CodeIgniter.epub ./CodeIgniter${VERSION}.epub
+
+# Ensure underscore prefixed files are published
+touch ${TARGET}/docs/.nojekyll
+
+# Commit the changes
+git add .
+git commit -m "Release ${RELEASE}"
+git push

--- a/.github/workflows/deploy-userguide.yml
+++ b/.github/workflows/deploy-userguide.yml
@@ -1,0 +1,59 @@
+# When a new Release is created, deploy relevant
+# files to each of the generated repos.
+name: Deploy User Guide
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  framework:
+    name: Deploy to userguide
+    if: (github.repository == 'codeigniter4/CodeIgniter4')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Identify
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "${GITHUB_ACTOR}"
+
+      - name: Checkout source
+        uses: actions/checkout@v3
+        with:
+          path: source
+
+      - name: Checkout target
+        uses: actions/checkout@v3
+        with:
+          repository: codeigniter4/userguide
+          token: ${{ secrets.ACCESS_TOKEN }}
+          path: userguide
+
+      - name: Install Sphinx
+        run: |
+          sudo apt install python3-sphinx
+          sudo pip3 install sphinxcontrib-phpdomain
+          sudo pip3 install sphinx_rtd_theme
+
+      - name: Chmod
+        run: chmod +x ./source/.github/scripts/deploy-userguide
+
+      - name: Deploy
+        run: ./source/.github/scripts/deploy-userguide ${GITHUB_WORKSPACE}/source ${GITHUB_WORKSPACE}/userguide ${GITHUB_REF##*/}
+
+      - name: Release
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.ACCESS_TOKEN}}
+          script: |
+            const release = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            })
+            github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: 'userguide',
+              tag_name: release.data.tag_name,
+              name: release.data.name,
+              body: release.data.body
+            })


### PR DESCRIPTION
**Description**
This PR adds a GitHub Action to automate building and deploying the User Guide to the User Guide repo whenever there is a new release. I tested by setting up parallel repos under my user org, the results are viewable here:
* Action logs: https://github.com/MGatner/CodeIgniter4/runs/5457928233?check_suite_focus=true
* Resulting release: https://github.com/MGatner/userguide/releases

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
