### PR TITLE
Extend Validation from BaseConfig so Registrars can add rules.

### DIFF
--- a/app/Config/Validation.php
+++ b/app/Config/Validation.php
@@ -2,12 +2,13 @@
 
 namespace Config;
 
+use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Validation\CreditCardRules;
 use CodeIgniter\Validation\FileRules;
 use CodeIgniter\Validation\FormatRules;
 use CodeIgniter\Validation\Rules;
 
-class Validation
+class Validation extends BaseConfig
 {
     //--------------------------------------------------------------------
     // Setup


### PR DESCRIPTION
The Config\Validation file was not extending BaseConfig. This prevents Registrars from being able to add rules or rulesets. 