### PR TITLE
fix: Publisher $restrictions regex to FCPATH

### DIFF
--- a/app/Config/Publisher.php
+++ b/app/Config/Publisher.php
@@ -23,6 +23,6 @@ class Publisher extends BasePublisher
      */
     public $restrictions = [
         ROOTPATH => '*',
-        FCPATH   => '#\.(s?css|js|map|html?|xml|json|webmanifest|tff|eot|woff|gif|jpe?g|tiff?|png|webp|bmp|ico|svg)$#i',
+        FCPATH   => '#\.(s?css|js|map|html?|xml|json|webmanifest|tff|eot|woff2?|gif|jpe?g|tiff?|png|webp|bmp|ico|svg)$#i',
     ];
 }

--- a/app/Config/Publisher.php
+++ b/app/Config/Publisher.php
@@ -23,6 +23,6 @@ class Publisher extends BasePublisher
      */
     public $restrictions = [
         ROOTPATH => '*',
-        FCPATH   => '#\.(?css|js|map|htm?|xml|json|webmanifest|tff|eot|woff?|gif|jpe?g|tiff?|png|webp|bmp|ico|svg)$#i',
+        FCPATH   => '#\.(s?css|js|map|html?|xml|json|webmanifest|tff|eot|woff|gif|jpe?g|tiff?|png|webp|bmp|ico|svg)$#i',
     ];
 }

--- a/tests/system/Publisher/PublisherRestrictionsTest.php
+++ b/tests/system/Publisher/PublisherRestrictionsTest.php
@@ -69,11 +69,11 @@ final class PublisherRestrictionsTest extends CIUnitTestCase
 
     public function fileProvider()
     {
-        yield 'php' => ['index.php'];
-
-        yield 'exe' => ['cat.exe'];
-
-        yield 'flat' => ['banana'];
+        yield from [
+            'php'  => ['index.php'],
+            'exe'  => ['cat.exe'],
+            'flat' => ['banana'],
+        ];
     }
 
     /**

--- a/tests/system/Publisher/PublisherRestrictionsTest.php
+++ b/tests/system/Publisher/PublisherRestrictionsTest.php
@@ -25,7 +25,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 final class PublisherRestrictionsTest extends CIUnitTestCase
 {
     /**
-     * @see Tests\Support\Config\Registrars::Publisher()
+     * @see \Tests\Support\Config\Registrar::Publisher()
      */
     public function testRegistrarsNotAllowed()
     {


### PR DESCRIPTION
**Description**
- fix regex

Related: #5792

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
