### PR TITLE
fix: Timer::getElapsedTime() returns incorrect value

### DIFF
--- a/system/Debug/Timer.php
+++ b/system/Debug/Timer.php
@@ -78,7 +78,7 @@ class Timer
      * @param string $name     The name of the timer.
      * @param int    $decimals Number of decimal places.
      *
-     * @return float|null Returns null if timer exists by that name.
+     * @return float|null Returns null if timer does not exist by that name.
      *                    Returns a float representing the number of
      *                    seconds elapsed while that timer was running.
      */

--- a/system/Debug/Timer.php
+++ b/system/Debug/Timer.php
@@ -96,7 +96,7 @@ class Timer
             $timer['end'] = microtime(true);
         }
 
-        return (float) number_format($timer['end'] - $timer['start'], $decimals);
+        return (float) number_format($timer['end'] - $timer['start'], $decimals, '.', '');
     }
 
     /**

--- a/tests/system/Debug/TimerTest.php
+++ b/tests/system/Debug/TimerTest.php
@@ -92,8 +92,8 @@ final class TimerTest extends CIUnitTestCase
     public function testLongExecutionTime()
     {
         $timer = new Timer();
-        $timer->start('longjohn', strtotime('-11 minutes'));
-        $this->assertCloseEnough(11 * 60, $timer->getElapsedTime('longjohn'));
+        $timer->start('longjohn', strtotime('-110 minutes'));
+        $this->assertCloseEnough(110 * 60, $timer->getElapsedTime('longjohn'));
     }
 
     public function testLongExecutionTimeThroughCommonFunc()


### PR DESCRIPTION
**Description**
Fixes #5797

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
