### PR TITLE
bug: Publisher typo

### DIFF
--- a/app/Config/Publisher.php
+++ b/app/Config/Publisher.php
@@ -23,6 +23,6 @@ class Publisher extends BasePublisher
      */
     public $restrictions = [
         ROOTPATH => '*',
-        FCPATH   => '#\.(s?css|js|map|html?|xml|json|webmanifest|tff|eot|woff2?|gif|jpe?g|tiff?|png|webp|bmp|ico|svg)$#i',
+        FCPATH   => '#\.(s?css|js|map|html?|xml|json|webmanifest|ttf|eot|woff2?|gif|jpe?g|tiff?|png|webp|bmp|ico|svg)$#i',
     ];
 }


### PR DESCRIPTION
**Description**
Fixes the intended font extension `ttf` - no idea what `tff` is.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
