### PR TITLE
test: remove `helper('url')`

### DIFF
--- a/tests/system/HTTP/UserAgentTest.php
+++ b/tests/system/HTTP/UserAgentTest.php
@@ -34,8 +34,6 @@ final class UserAgentTest extends CIUnitTestCase
         $_SERVER['HTTP_USER_AGENT'] = $this->_user_agent;
 
         $this->agent = new UserAgent();
-
-        helper('url');
     }
 
     public function testMobile()

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -35,8 +35,6 @@ final class HTMLHelperTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        // URL is needed by the HTML Helper.
-        helper('url');
         helper('html');
 
         $this->tracks = [

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -30,13 +30,6 @@ final class CurrentUrlTest extends CIUnitTestCase
 {
     private App $config;
 
-    public static function setUpBeforeClass(): void
-    {
-        parent::setUpBeforeClass();
-
-        helper('url');
-    }
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -27,13 +27,6 @@ final class MiscUrlTest extends CIUnitTestCase
 {
     private App $config;
 
-    public static function setUpBeforeClass(): void
-    {
-        parent::setUpBeforeClass();
-
-        helper('url');
-    }
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -30,13 +30,6 @@ final class SiteUrlTest extends CIUnitTestCase
 {
     private App $config;
 
-    public static function setUpBeforeClass(): void
-    {
-        parent::setUpBeforeClass();
-
-        helper('url');
-    }
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -35,7 +35,6 @@ final class PagerTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        helper('url');
 
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/';

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -42,7 +42,6 @@ final class ParserPluginTest extends CIUnitTestCase
 
     public function testCurrentURL()
     {
-        helper('url');
         $template = '{+ current_url +}';
 
         $this->assertSame(current_url(), $this->parser->renderString($template));
@@ -50,7 +49,6 @@ final class ParserPluginTest extends CIUnitTestCase
 
     public function testPreviousURL()
     {
-        helper('url');
         $template = '{+ previous_url +}';
 
         // Ensure a previous URL exists to work with.
@@ -61,7 +59,6 @@ final class ParserPluginTest extends CIUnitTestCase
 
     public function testMailto()
     {
-        helper('url');
         $template = '{+ mailto email=foo@example.com title=Silly +}';
 
         $this->assertSame(mailto('foo@example.com', 'Silly'), $this->parser->renderString($template));
@@ -72,7 +69,6 @@ final class ParserPluginTest extends CIUnitTestCase
      */
     public function testMailtoWithDashAndParenthesis()
     {
-        helper('url');
         $template = '{+ mailto email=foo-bar@example.com title="Scilly (the Great)" +}';
 
         $this->assertSame(mailto('foo-bar@example.com', 'Scilly (the Great)'), $this->parser->renderString($template));
@@ -80,7 +76,6 @@ final class ParserPluginTest extends CIUnitTestCase
 
     public function testSafeMailto()
     {
-        helper('url');
         $template = '{+ safe_mailto email=foo@example.com title=Silly +}';
 
         $this->assertSame(safe_mailto('foo@example.com', 'Silly'), $this->parser->renderString($template));


### PR DESCRIPTION
**Description**
URL Helper is automatically loaded.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
