### PR TITLE
fix: [Pager] can't get correct current page from segment

### DIFF
--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -163,6 +163,10 @@ class Pager implements PagerInterface
     {
         $this->segment[$group] = $number;
 
+        // Recalculate current page
+        $this->ensureGroup($group);
+        $this->calculateCurrentPage($group);
+
         return $this;
     }
 
@@ -383,6 +387,7 @@ class Pager implements PagerInterface
         }
 
         $this->groups[$group] = [
+            'currentUri'   => clone current_url(true),
             'uri'          => clone current_url(true),
             'hasMore'      => false,
             'total'        => null,
@@ -405,7 +410,7 @@ class Pager implements PagerInterface
     {
         if (array_key_exists($group, $this->segment)) {
             try {
-                $this->groups[$group]['currentPage'] = (int) $this->groups[$group]['uri']->setSilent(false)->getSegment($this->segment[$group]);
+                $this->groups[$group]['currentPage'] = (int) $this->groups[$group]['currentUri']->setSilent(false)->getSegment($this->segment[$group]);
             } catch (HTTPException $e) {
                 $this->groups[$group]['currentPage'] = 1;
             }

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -283,7 +283,15 @@ class Pager implements PagerInterface
             $uri->setQueryArray($query);
         }
 
-        return $returnObject === true ? $uri : URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
+        return ($returnObject === true)
+            ? $uri
+            : URI::createURIString(
+                $uri->getScheme(),
+                $uri->getAuthority(),
+                $uri->getPath(),
+                $uri->getQuery(),
+                $uri->getFragment()
+            );
     }
 
     /**
@@ -410,7 +418,8 @@ class Pager implements PagerInterface
     {
         if (array_key_exists($group, $this->segment)) {
             try {
-                $this->groups[$group]['currentPage'] = (int) $this->groups[$group]['currentUri']->setSilent(false)->getSegment($this->segment[$group]);
+                $this->groups[$group]['currentPage'] = (int) $this->groups[$group]['currentUri']
+                    ->setSilent(false)->getSegment($this->segment[$group]);
             } catch (HTTPException $e) {
                 $this->groups[$group]['currentPage'] = 1;
             }

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -11,7 +11,10 @@
 
 namespace CodeIgniter\Pager;
 
+use CodeIgniter\Config\Factories;
+use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Pager\Exceptions\PagerException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
@@ -46,8 +49,16 @@ final class PagerTest extends CIUnitTestCase
 
         $config          = new App();
         $config->baseURL = 'http://example.com/';
-        $request         = Services::request($config);
-        $request->uri    = new URI($config->baseURL . ltrim($path, '/'));
+        Factories::injectMock('config', 'App', $config);
+
+        $request = new IncomingRequest(
+            $config,
+            new URI($config->baseURL . ltrim($path, '/')),
+            'php://input',
+            new UserAgent()
+        );
+        $request = $request->withMethod('GET');
+        Services::injectMock('request', $request);
 
         Services::injectMock('request', $request);
 
@@ -148,11 +159,11 @@ final class PagerTest extends CIUnitTestCase
 
         $this->pager->store('default', 3, 25, 100);
 
-        $this->assertSame('http://example.com/index.php?page=2&foo=bar', $this->pager->getPreviousPageURI());
-        $this->assertSame('http://example.com/index.php?page=4&foo=bar', $this->pager->getNextPageURI());
-        $this->assertSame('http://example.com/index.php?page=5&foo=bar', $this->pager->getPageURI(5));
+        $this->assertSame('http://example.com/index.php/?page=2&foo=bar', $this->pager->getPreviousPageURI());
+        $this->assertSame('http://example.com/index.php/?page=4&foo=bar', $this->pager->getNextPageURI());
+        $this->assertSame('http://example.com/index.php/?page=5&foo=bar', $this->pager->getPageURI(5));
         $this->assertSame(
-            'http://example.com/index.php?foo=bar&page=5',
+            'http://example.com/index.php/?foo=bar&page=5',
             $this->pager->only(['foo'])->getPageURI(5)
         );
     }

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -45,10 +45,12 @@ final class PagerTest extends CIUnitTestCase
     private function createPager(string $path): void
     {
         $_SERVER['REQUEST_URI'] = $path;
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
         $_GET                   = [];
 
-        $config          = new App();
-        $config->baseURL = 'http://example.com/';
+        $config            = new App();
+        $config->baseURL   = 'http://example.com/';
+        $config->indexPage = '';
         Factories::injectMock('config', 'App', $config);
 
         $request = new IncomingRequest(
@@ -159,11 +161,11 @@ final class PagerTest extends CIUnitTestCase
 
         $this->pager->store('default', 3, 25, 100);
 
-        $this->assertSame('http://example.com/index.php/?page=2&foo=bar', $this->pager->getPreviousPageURI());
-        $this->assertSame('http://example.com/index.php/?page=4&foo=bar', $this->pager->getNextPageURI());
-        $this->assertSame('http://example.com/index.php/?page=5&foo=bar', $this->pager->getPageURI(5));
+        $this->assertSame('http://example.com/?page=2&foo=bar', $this->pager->getPreviousPageURI());
+        $this->assertSame('http://example.com/?page=4&foo=bar', $this->pager->getNextPageURI());
+        $this->assertSame('http://example.com/?page=5&foo=bar', $this->pager->getPageURI(5));
         $this->assertSame(
-            'http://example.com/index.php/?foo=bar&page=5',
+            'http://example.com/?foo=bar&page=5',
             $this->pager->only(['foo'])->getPageURI(5)
         );
     }

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -36,13 +36,18 @@ final class PagerTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $_SERVER['REQUEST_URI'] = '/';
+        $this->createPager('/');
+    }
+
+    private function createPager(string $path): void
+    {
+        $_SERVER['REQUEST_URI'] = $path;
         $_GET                   = [];
 
         $config          = new App();
         $config->baseURL = 'http://example.com/';
         $request         = Services::request($config);
-        $request->uri    = new URI($config->baseURL);
+        $request->uri    = new URI($config->baseURL . ltrim($path, '/'));
 
         Services::injectMock('request', $request);
 

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -42,9 +42,9 @@ final class PagerTest extends CIUnitTestCase
         $this->createPager('/');
     }
 
-    private function createPager(string $path): void
+    private function createPager(string $requestUri): void
     {
-        $_SERVER['REQUEST_URI'] = $path;
+        $_SERVER['REQUEST_URI'] = $requestUri;
         $_SERVER['SCRIPT_NAME'] = '/index.php';
         $_GET                   = [];
 
@@ -55,7 +55,7 @@ final class PagerTest extends CIUnitTestCase
 
         $request = new IncomingRequest(
             $config,
-            new URI($config->baseURL . ltrim($path, '/')),
+            new URI($config->baseURL . ltrim($requestUri, '/')),
             'php://input',
             new UserAgent()
         );

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -36,18 +36,16 @@ final class PagerTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/';
         $_GET                   = [];
 
         $config          = new App();
         $config->baseURL = 'http://example.com/';
         $request         = Services::request($config);
-        $request->uri    = new URI('http://example.com');
+        $request->uri    = new URI($config->baseURL);
 
         Services::injectMock('request', $request);
 
-        $_GET         = [];
         $this->config = new Pager();
         $this->pager  = new \CodeIgniter\Pager\Pager($this->config, Services::renderer());
     }

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -229,6 +229,16 @@ final class PagerTest extends CIUnitTestCase
         $this->assertSame(2, $this->pager->getCurrentPage('foo'));
     }
 
+    public function testGetCurrentPageFromSegment()
+    {
+        $this->createPager('/page/2');
+
+        $this->pager->setPath('foo');
+        $this->pager->setSegment(2);
+
+        $this->assertSame(2, $this->pager->getCurrentPage());
+    }
+
     public function testGetTotalPagesDefaultsToOne()
     {
         $this->assertSame(1, $this->pager->getPageCount());


### PR DESCRIPTION
**Description**
From https://forum.codeigniter.com/thread-81531.html
- `setSegment()` recalculates the current page
- `calculateCurrentPage()` can be called more than once

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
