### PR TITLE
fix: [Validation] valid_date ErrorException when the field is not sent

### DIFF
--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -333,7 +333,7 @@ class FormatRules
      */
     public function valid_date(?string $str = null, ?string $format = null): bool
     {
-        if (($str === null)) {
+        if ($str === null) {
             return false;
         }
 

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -333,6 +333,10 @@ class FormatRules
      */
     public function valid_date(?string $str = null, ?string $format = null): bool
     {
+        if (($str === null)) {
+            return false;
+        }
+
         if (empty($format)) {
             return strtotime($str) !== false;
         }

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -1207,6 +1207,11 @@ final class FormatRulesTest extends CIUnitTestCase
     {
         yield from [
             [
+                null,
+                'Y-m-d',
+                false,
+            ],
+            [
                 'Sun',
                 'D',
                 true,


### PR DESCRIPTION
**Description**
From https://forum.codeigniter.com/thread-81505-post-394652.html
```
DateTime::createFromFormat(): Passing null to parameter #2 ($datetime) of type string is deprecated
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

