### PR TITLE
fix: bug that allows dynamic controllers to be used

### DIFF
--- a/system/Language/en/Router.php
+++ b/system/Language/en/Router.php
@@ -11,6 +11,7 @@
 
 // Router language settings
 return [
-    'invalidParameter'    => 'A parameter does not match the expected type.',
-    'missingDefaultRoute' => 'Unable to determine what should be displayed. A default route has not been specified in the routing file.',
+    'invalidParameter'         => 'A parameter does not match the expected type.',
+    'missingDefaultRoute'      => 'Unable to determine what should be displayed. A default route has not been specified in the routing file.',
+    'invalidDynamicController' => 'A dynamic controller is not allowed for security reasons. Route handler: {0}',
 ];

--- a/system/Router/Exceptions/RouterException.php
+++ b/system/Router/Exceptions/RouterException.php
@@ -58,4 +58,14 @@ class RouterException extends FrameworkException
     {
         return new static(lang('HTTP.invalidRoute', [$route]));
     }
+
+    /**
+     * Throw when dynamic controller.
+     *
+     * @return RouterException
+     */
+    public static function forDynamicController(string $handler)
+    {
+        return new static(lang('Router.invalidDynamicController', [$handler]));
+    }
 }

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -420,6 +420,12 @@ class Router implements RouterInterface
                 if (strpos($handler, '$') !== false && strpos($routeKey, '(') !== false) {
                     // Using back-references
 
+                    // Checks dynamic controller
+                    [$controller, ] = explode('::', $handler);
+                    if (strpos($controller, '$') !== false) {
+                        throw RouterException::forDynamicController($handler);
+                    }
+
                     if (strpos($routeKey, '/') !== false) {
                         $replacekey = str_replace('/(.*)', '', $routeKey);
                         $handler    = preg_replace('#^' . $routeKey . '$#u', $handler, $uri);

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -416,10 +416,7 @@ class Router implements RouterInterface
 
                     return true;
                 }
-                // Are we using the default method for back-references?
 
-                // Support resource route when function with subdirectory
-                // ex: $routes->resource('Admin/Admins');
                 if (strpos($handler, '$') !== false && strpos($routeKey, '(') !== false && strpos($routeKey, '/') !== false) {
                     $replacekey = str_replace('/(.*)', '', $routeKey);
                     $handler    = preg_replace('#^' . $routeKey . '$#u', $handler, $uri);

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -417,12 +417,16 @@ class Router implements RouterInterface
                     return true;
                 }
 
-                if (strpos($handler, '$') !== false && strpos($routeKey, '(') !== false && strpos($routeKey, '/') !== false) {
-                    $replacekey = str_replace('/(.*)', '', $routeKey);
-                    $handler    = preg_replace('#^' . $routeKey . '$#u', $handler, $uri);
-                    $handler    = str_replace($replacekey, str_replace('/', '\\', $replacekey), $handler);
-                } elseif (strpos($handler, '$') !== false && strpos($routeKey, '(') !== false) {
-                    $handler = preg_replace('#^' . $routeKey . '$#u', $handler, $uri);
+                if (strpos($handler, '$') !== false && strpos($routeKey, '(') !== false) {
+                    // Using back-references
+
+                    if (strpos($routeKey, '/') !== false) {
+                        $replacekey = str_replace('/(.*)', '', $routeKey);
+                        $handler    = preg_replace('#^' . $routeKey . '$#u', $handler, $uri);
+                        $handler    = str_replace($replacekey, str_replace('/', '\\', $replacekey), $handler);
+                    } else {
+                        $handler = preg_replace('#^' . $routeKey . '$#u', $handler, $uri);
+                    }
                 } elseif (strpos($handler, '/') !== false) {
                     [$controller, $method] = explode('::', $handler);
 

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -362,31 +362,31 @@ class Router implements RouterInterface
             : trim($uri, '/ ');
 
         // Loop through the route array looking for wildcards
-        foreach ($routes as $key => $val) {
+        foreach ($routes as $routeKey => $handler) {
             // Reset localeSegment
             $localeSegment = null;
 
-            $key = $key === '/'
-                ? $key
-                : ltrim($key, '/ ');
+            $routeKey = $routeKey === '/'
+                ? $routeKey
+                : ltrim($routeKey, '/ ');
 
-            $matchedKey = $key;
+            $matchedKey = $routeKey;
 
             // Are we dealing with a locale?
-            if (strpos($key, '{locale}') !== false) {
-                $localeSegment = array_search('{locale}', preg_split('/[\/]*((^[a-zA-Z0-9])|\(([^()]*)\))*[\/]+/m', $key), true);
+            if (strpos($routeKey, '{locale}') !== false) {
+                $localeSegment = array_search('{locale}', preg_split('/[\/]*((^[a-zA-Z0-9])|\(([^()]*)\))*[\/]+/m', $routeKey), true);
 
                 // Replace it with a regex so it
                 // will actually match.
-                $key = str_replace('/', '\/', $key);
-                $key = str_replace('{locale}', '[^\/]+', $key);
+                $routeKey = str_replace('/', '\/', $routeKey);
+                $routeKey = str_replace('{locale}', '[^\/]+', $routeKey);
             }
 
             // Does the RegEx match?
-            if (preg_match('#^' . $key . '$#u', $uri, $matches)) {
+            if (preg_match('#^' . $routeKey . '$#u', $uri, $matches)) {
                 // Is this route supposed to redirect to another?
-                if ($this->collection->isRedirect($key)) {
-                    throw new RedirectException(is_array($val) ? key($val) : $val, $this->collection->getRedirectCode($key));
+                if ($this->collection->isRedirect($routeKey)) {
+                    throw new RedirectException(is_array($handler) ? key($handler) : $handler, $this->collection->getRedirectCode($routeKey));
                 }
                 // Store our locale so CodeIgniter object can
                 // assign it to the Request.
@@ -399,8 +399,8 @@ class Router implements RouterInterface
                 // Are we using Closures? If so, then we need
                 // to collect the params into an array
                 // so it can be passed to the controller method later.
-                if (! is_string($val) && is_callable($val)) {
-                    $this->controller = $val;
+                if (! is_string($handler) && is_callable($handler)) {
+                    $this->controller = $handler;
 
                     // Remove the original string from the matches array
                     array_shift($matches);
@@ -409,7 +409,7 @@ class Router implements RouterInterface
 
                     $this->matchedRoute = [
                         $matchedKey,
-                        $val,
+                        $handler,
                     ];
 
                     $this->matchedRouteOptions = $this->collection->getRoutesOptions($matchedKey);
@@ -420,26 +420,26 @@ class Router implements RouterInterface
 
                 // Support resource route when function with subdirectory
                 // ex: $routes->resource('Admin/Admins');
-                if (strpos($val, '$') !== false && strpos($key, '(') !== false && strpos($key, '/') !== false) {
-                    $replacekey = str_replace('/(.*)', '', $key);
-                    $val        = preg_replace('#^' . $key . '$#u', $val, $uri);
-                    $val        = str_replace($replacekey, str_replace('/', '\\', $replacekey), $val);
-                } elseif (strpos($val, '$') !== false && strpos($key, '(') !== false) {
-                    $val = preg_replace('#^' . $key . '$#u', $val, $uri);
-                } elseif (strpos($val, '/') !== false) {
-                    [$controller, $method] = explode('::', $val);
+                if (strpos($handler, '$') !== false && strpos($routeKey, '(') !== false && strpos($routeKey, '/') !== false) {
+                    $replacekey = str_replace('/(.*)', '', $routeKey);
+                    $handler    = preg_replace('#^' . $routeKey . '$#u', $handler, $uri);
+                    $handler    = str_replace($replacekey, str_replace('/', '\\', $replacekey), $handler);
+                } elseif (strpos($handler, '$') !== false && strpos($routeKey, '(') !== false) {
+                    $handler = preg_replace('#^' . $routeKey . '$#u', $handler, $uri);
+                } elseif (strpos($handler, '/') !== false) {
+                    [$controller, $method] = explode('::', $handler);
 
                     // Only replace slashes in the controller, not in the method.
                     $controller = str_replace('/', '\\', $controller);
 
-                    $val = $controller . '::' . $method;
+                    $handler = $controller . '::' . $method;
                 }
 
-                $this->setRequest(explode('/', $val));
+                $this->setRequest(explode('/', $handler));
 
                 $this->matchedRoute = [
                     $matchedKey,
-                    $val,
+                    $handler,
                 ];
 
                 $this->matchedRouteOptions = $this->collection->getRoutesOptions($matchedKey);

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Router;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\Router\Exceptions\RouterException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
 use Tests\Support\Filters\Customfilter;
@@ -62,6 +63,7 @@ final class RouterTest extends CIUnitTestCase
             'admin/admins'                                    => 'App\Admin\Admins::list_all',
             '/some/slash'                                     => 'App\Slash::index',
             'objects/(:segment)/sort/(:segment)/([A-Z]{3,7})' => 'AdminList::objectsSortCreate/$1/$2/$3',
+            '(:segment)/(:segment)/(:segment)'                => '$2::$3/$1',
         ];
 
         $this->collection->map($routes);
@@ -408,6 +410,16 @@ final class RouterTest extends CIUnitTestCase
 
         $this->assertSame('\App\Slash', $router->controllerName());
         $this->assertSame('index', $router->methodName());
+    }
+
+    public function testRouteWithDynamicController()
+    {
+        $this->expectException(RouterException::class);
+        $this->expectExceptionMessage('A dynamic controller is not allowed for security reasons. Route handler: \$2::$3/$1');
+
+        $router = new Router($this->collection, $this->request);
+
+        $router->handle('en/zoo/bar');
     }
 
     // options need to be declared separately, to not confuse PHPCBF

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -69,10 +69,6 @@ final class RouterTest extends CIUnitTestCase
         $this->request->setMethod('get');
     }
 
-    protected function tearDown(): void
-    {
-    }
-
     public function testEmptyURIMatchesDefaults()
     {
         $router = new Router($this->collection, $this->request);

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -59,7 +59,7 @@ final class RouterTest extends CIUnitTestCase
             'books/(:num)/(:alpha)/(:num)'                    => 'Blog::show/$3/$1',
             'closure/(:num)/(:alpha)'                         => static fn ($num, $str) => $num . '-' . $str,
             '{locale}/pages'                                  => 'App\Pages::list_all',
-            'Admin/Admins'                                    => 'App\Admin\Admins::list_all',
+            'admin/admins'                                    => 'App\Admin\Admins::list_all',
             '/some/slash'                                     => 'App\Slash::index',
             'objects/(:segment)/sort/(:segment)/([A-Z]{3,7})' => 'AdminList::objectsSortCreate/$1/$2/$3',
         ];
@@ -398,7 +398,7 @@ final class RouterTest extends CIUnitTestCase
     {
         $router = new Router($this->collection, $this->request);
 
-        $router->handle('Admin/Admins');
+        $router->handle('admin/admins');
 
         $this->assertSame('\App\Admin\Admins', $router->controllerName());
         $this->assertSame('list_all', $router->methodName());


### PR DESCRIPTION
**Description**
Dynamic controllers are not allowed for security reasons. See https://github.com/codeigniter4/CodeIgniter4/issues/2787#issuecomment-608198225
But there is a bug that allows dynamic controllers.

- add check for dynamic controllers
- refactor

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
