### PR TITLE
fix: failover's DBPrefix not working

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -342,6 +342,13 @@ abstract class BaseConnection implements ConnectionInterface
         if (class_exists($queryClass)) {
             $this->queryClass = $queryClass;
         }
+
+        if ($this->failover !== []) {
+            // If there is a failover database, connect now to do failover.
+            // Otherwise, Query Builder creates SQL statement with the main database config
+            // (DBPrefix) even when the main database is down.
+            $this->initialize();
+        }
     }
 
     /**

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -105,8 +105,11 @@ final class BaseConnectionTest extends CIUnitTestCase
         $options             = $this->options;
         $options['failover'] = [$this->failoverOptions];
 
-        $db = new MockConnection($options);
-        $db->shouldReturn('connect', [false, 345])->initialize();
+        $db                         = new class ($options) extends MockConnection {
+            protected $returnValues = [
+                'connect' => [false, 345],
+            ];
+        };
 
         $this->assertSame(345, $db->getConnection());
         $this->assertSame('failover', $db->username);

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -95,14 +95,22 @@ final class ConnectTest extends CIUnitTestCase
     public function testConnectWithFailover()
     {
         $this->tests['failover'][] = $this->tests;
-
         unset($this->tests['failover'][0]['failover']);
+
+        // Change main's DBPrefix
+        $this->tests['DBPrefix'] = 'main_';
+
+        if ($this->tests['DBDriver'] === 'SQLite3') {
+            // Change main's database path to fail to connect
+            $this->tests['database'] = '/does/not/exists/test.db';
+        }
 
         $this->tests['username'] = 'wrong';
 
         $db1 = Database::connect($this->tests);
 
-        $this->assertSame($this->tests['failover'][0]['DBDriver'], $this->getPrivateProperty($db1, 'DBDriver'));
+        $this->assertSame($this->tests['failover'][0]['DBPrefix'], $this->getPrivateProperty($db1, 'DBPrefix'));
+
         $this->assertGreaterThanOrEqual(0, count($db1->listTables()));
     }
 }


### PR DESCRIPTION
**Description**
Fixes #5812

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
