### PR TITLE
feat: QueryBuilder raw SQL string support

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1083,11 +1083,7 @@ class BaseBuilder
             return $this;
         }
 
-        if (! is_array($field)) {
-            $keyValue = [$field => $match];
-        } else {
-            $keyValue = $field;
-        }
+        $keyValue = ! is_array($field) ? [$field => $match] : $field;
 
         foreach ($keyValue as $k => $v) {
             if ($insensitiveSearch === true) {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -371,6 +371,12 @@ class BaseBuilder
             $escape = $this->db->protectIdentifiers;
         }
 
+        if ($select instanceof RawSql) {
+            $this->QBSelect[] = $select;
+
+            return $this;
+        }
+
         foreach ($select as $val) {
             $val = trim($val);
 
@@ -2339,6 +2345,8 @@ class BaseBuilder
 
             if (empty($this->QBSelect)) {
                 $sql .= '*';
+            } elseif ($this->QBSelect[0] instanceof RawSql) {
+                $sql .= (string) $this->QBSelect[0];
             } else {
                 // Cycle through the "select" portion of the query and prep each column name.
                 // The reason we protect identifiers here rather than in the select() function

--- a/system/Database/RawSql.php
+++ b/system/Database/RawSql.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database;
+
+class RawSql
+{
+    /**
+     * @var string Raw SQL string
+     */
+    private string $string;
+
+    public function __construct(string $sqlString)
+    {
+        $this->string = $sqlString;
+    }
+
+    public function __toString(): string
+    {
+        return $this->string;
+    }
+
+    /**
+     * Create new instance with new SQL string
+     */
+    public function with(string $newSqlString): self
+    {
+        $new         = clone $this;
+        $new->string = $newSqlString;
+
+        return $new;
+    }
+
+    /**
+     * Returns unique id for binding key
+     */
+    public function getBindingKey(): string
+    {
+        return 'RawSql' . spl_object_id($this);
+    }
+}

--- a/tests/system/Database/Builder/LikeTest.php
+++ b/tests/system/Database/Builder/LikeTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
+use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 
@@ -39,6 +40,29 @@ final class LikeTest extends CIUnitTestCase
         $expectedBinds = [
             'name' => [
                 '%veloper%',
+                true,
+            ],
+        ];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/3970
+     */
+    public function testLikeWithRawSql()
+    {
+        $builder = new BaseBuilder('users', $this->db);
+
+        $sql    = "concat(users.name, ' ', IF(users.surname IS NULL or users.surname = '', '', users.surname))";
+        $rawSql = new RawSql($sql);
+        $builder->like($rawSql, 'value', 'both');
+
+        $expectedSQL   = "SELECT * FROM \"users\" WHERE  {$sql}  LIKE '%value%' ESCAPE '!' ";
+        $expectedBinds = [
+            $rawSql->getBindingKey() => [
+                '%value%',
                 true,
             ],
         ];

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Database\RawSql;
 use CodeIgniter\Database\SQLSRV\Builder as SQLSRVBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
@@ -92,6 +93,20 @@ final class SelectTest extends CIUnitTestCase
 
         $expected = 'SELECT (SELECT SUM(payments.amount) FROM payments WHERE payments.invoice_id=4) AS amount_paid FROM "users"';
 
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/4355
+     */
+    public function testSelectWorksWithRawSql()
+    {
+        $builder = new BaseBuilder('users', $this->db);
+
+        $sql = 'REGEXP_SUBSTR(ral_anno,"[0-9]{1,2}([,.][0-9]{1,3})([,.][0-9]{1,3})") AS ral';
+        $builder->select(new RawSql($sql));
+
+        $expected = 'SELECT ' . $sql . ' FROM "users"';
         $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
+use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 use stdClass;
@@ -136,6 +137,20 @@ final class WhereTest extends CIUnitTestCase
         $expectedBinds = [];
 
         $builder->where($where);
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testWhereRawSql()
+    {
+        $builder = $this->db->table('jobs');
+
+        $sql = "id > 2 AND name != 'Accountant'";
+        $builder->where(new RawSql($sql));
+
+        $expectedSQL   = "SELECT * FROM \"jobs\" WHERE id > 2 AND name != 'Accountant'";
+        $expectedBinds = [];
+
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
         $this->assertSame($expectedBinds, $builder->getBinds());
     }

--- a/tests/system/Database/RawSqlTest.php
+++ b/tests/system/Database/RawSqlTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database;
+
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class RawSqlTest extends CIUnitTestCase
+{
+    public function testCanConvertToString()
+    {
+        $expected = 'REGEXP_SUBSTR(ral_anno,"[0-9]{1,2}([,.][0-9]{1,3})([,.][0-9]{1,3})") AS ral';
+        $rawSql   = new RawSql($expected);
+
+        $this->assertSame($expected, (string) $rawSql);
+    }
+
+    public function testCanCreateNewObject()
+    {
+        $firstSql = 'a = 1 AND b = 2';
+        $rawSql   = new RawSql($firstSql);
+
+        $secondSql = 'a = 1 AND b = 2 OR c = 3';
+        $newRawSQL = $rawSql->with($secondSql);
+
+        $this->assertSame($firstSql, (string) $rawSql);
+        $this->assertSame($secondSql, (string) $newRawSQL);
+    }
+
+    public function testGetBindingKey()
+    {
+        $firstSql = 'a = 1 AND b = 2';
+        $rawSql   = new RawSql($firstSql);
+
+        $key = $rawSql->getBindingKey();
+
+        $this->assertMatchesRegularExpression('/\ARawSql[0-9]+\z/', $key);
+    }
+}

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -64,7 +64,9 @@ Others
 - Added 4th parameter ``$includeDir`` to ``get_filenames()``. See :php:func:`get_filenames`.
 - HTML helper ``script_tag()`` now uses ``null`` values to write boolean attributes in minimized form: ``<script src="..." defer />``. See the sample code for :php:func:`script_tag`.
 - RouteCollection::addRedirect() can now use placeholders.
-
+- QueryBuilder raw SQL string support
+    - Added the class ``CodeIgniter\Database\RawSql`` which expresses raw SQL strings.
+    - :ref:`select() <query-builder-select-rawsql>`, :ref:`where() <query-builder-where-rawsql>`, :ref:`like() <query-builder-like-rawsql>` accept the ``CodeIgniter\Database\RawSql`` instance.
 
 Changes
 *******

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -41,7 +41,8 @@ The following methods allow you to build SQL **SELECT** statements.
 Get
 ===
 
-**$builder->get()**
+$builder->get()
+---------------
 
 Runs the selection query and returns the result. Can be used by itself
 to retrieve all records from a table:
@@ -61,7 +62,8 @@ $query, which can be used to show the results:
 Please visit the :doc:`getResult*() method <results>` page for a full
 discussion regarding result generation.
 
-**$builder->getCompiledSelect()**
+$builder->getCompiledSelect()
+-----------------------------
 
 Compiles the selection query just like ``$builder->get()`` but does not *run*
 the query. This method simply returns the SQL query as a string.
@@ -81,7 +83,8 @@ parameter. The reason for this outcome is because the query has not been
 executed using ``$builder->get()`` which resets values or reset directly
 using ``$builder->resetQuery()``.
 
-**$builder->getWhere()**
+$builder->getWhere()
+--------------------
 
 Identical to the ``get()`` method except that it permits you to add a
 "where" clause in the first parameter, instead of using the ``$builder->where()``
@@ -96,7 +99,8 @@ Please read about the ``where()`` method below for more information.
 Select
 ======
 
-**$builder->select()**
+$builder->select()
+------------------
 
 Permits you to write the **SELECT** portion of your query:
 
@@ -113,14 +117,16 @@ escaping of fields may break them.
 
 .. literalinclude:: query_builder/009.php
 
-**$builder->selectMax()**
+$builder->selectMax()
+---------------------
 
 Writes a **SELECT MAX(field)** portion for your query. You can optionally
 include a second parameter to rename the resulting field.
 
 .. literalinclude:: query_builder/010.php
 
-**$builder->selectMin()**
+$builder->selectMin()
+---------------------
 
 Writes a **SELECT MIN(field)** portion for your query. As with
 ``selectMax()``, You can optionally include a second parameter to rename
@@ -128,7 +134,8 @@ the resulting field.
 
 .. literalinclude:: query_builder/011.php
 
-**$builder->selectAvg()**
+$builder->selectAvg()
+---------------------
 
 Writes a **SELECT AVG(field)** portion for your query. As with
 ``selectMax()``, You can optionally include a second parameter to rename
@@ -136,7 +143,8 @@ the resulting field.
 
 .. literalinclude:: query_builder/012.php
 
-**$builder->selectSum()**
+$builder->selectSum()
+---------------------
 
 Writes a **SELECT SUM(field)** portion for your query. As with
 ``selectMax()``, You can optionally include a second parameter to rename
@@ -144,7 +152,8 @@ the resulting field.
 
 .. literalinclude:: query_builder/013.php
 
-**$builder->selectCount()**
+$builder->selectCount()
+-----------------------
 
 Writes a **SELECT COUNT(field)** portion for your query. As with
 ``selectMax()``, You can optionally include a second parameter to rename
@@ -155,7 +164,8 @@ the resulting field.
 
 .. literalinclude:: query_builder/014.php
 
-**$builder->selectSubquery()**
+$builder->selectSubquery()
+--------------------------
 
 Adds a subquery to the SELECT section.
 
@@ -165,7 +175,8 @@ Adds a subquery to the SELECT section.
 From
 ====
 
-**$builder->from()**
+$builder->from()
+----------------
 
 Permits you to write the **FROM** portion of your query:
 
@@ -180,7 +191,8 @@ Permits you to write the **FROM** portion of your query:
 Subqueries
 ==========
 
-**$builder->fromSubquery()**
+$builder->fromSubquery()
+------------------------
 
 Permits you to write part of a **FROM** query as a subquery.
 
@@ -195,7 +207,8 @@ Use the ``$db->newQuery()`` method to make a subquery the main table:
 Join
 ====
 
-**$builder->join()**
+$builder->join()
+----------------
 
 Permits you to write the **JOIN** portion of your query:
 
@@ -214,7 +227,11 @@ outer``, and ``right outer``.
 Looking for Specific Data
 *************************
 
-**$builder->where()**
+Where
+=====
+
+$builder->where()
+-----------------
 
 This method enables you to set **WHERE** clauses using one of five
 methods:
@@ -268,14 +285,16 @@ methods:
 
     .. literalinclude:: query_builder/028.php
 
-**$builder->orWhere()**
+$builder->orWhere()
+-------------------
 
 This method is identical to the one above, except that multiple
 instances are joined by **OR**:
 
 .. literalinclude:: query_builder/029.php
 
-**$builder->whereIn()**
+$builder->whereIn()
+-------------------
 
 Generates a **WHERE** field IN ('item', 'item') SQL query joined with **AND** if
 appropriate:
@@ -286,7 +305,8 @@ You can use subqueries instead of an array of values:
 
 .. literalinclude:: query_builder/031.php
 
-**$builder->orWhereIn()**
+$builder->orWhereIn()
+---------------------
 
 Generates a **WHERE field IN ('item', 'item')** SQL query joined with **OR** if
 appropriate:
@@ -297,7 +317,8 @@ You can use subqueries instead of an array of values:
 
 .. literalinclude:: query_builder/033.php
 
-**$builder->whereNotIn()**
+$builder->whereNotIn()
+----------------------
 
 Generates a **WHERE field NOT IN ('item', 'item')** SQL query joined with
 **AND** if appropriate:
@@ -308,7 +329,8 @@ You can use subqueries instead of an array of values:
 
 .. literalinclude:: query_builder/035.php
 
-**$builder->orWhereNotIn()**
+$builder->orWhereNotIn()
+------------------------
 
 Generates a **WHERE field NOT IN ('item', 'item')** SQL query joined with **OR**
 if appropriate:
@@ -323,7 +345,11 @@ You can use subqueries instead of an array of values:
 Looking for Similar Data
 ************************
 
-**$builder->like()**
+Like
+====
+
+$builder->like()
+----------------
 
 This method enables you to generate **LIKE** clauses, useful for doing
 searches.
@@ -354,28 +380,32 @@ searches.
 
        .. literalinclude:: query_builder/041.php
 
-**$builder->orLike()**
+$builder->orLike()
+------------------
 
 This method is identical to the one above, except that multiple
 instances are joined by **OR**:
 
 .. literalinclude:: query_builder/042.php
 
-**$builder->notLike()**
+$builder->notLike()
+-------------------
 
 This method is identical to ``like()``, except that it generates
 **NOT LIKE** statements:
 
 .. literalinclude:: query_builder/043.php
 
-**$builder->orNotLike()**
+$builder->orNotLike()
+---------------------
 
 This method is identical to ``notLike()``, except that multiple
 instances are joined by **OR**:
 
 .. literalinclude:: query_builder/044.php
 
-**$builder->groupBy()**
+$builder->groupBy()
+-------------------
 
 Permits you to write the **GROUP BY** portion of your query:
 
@@ -385,13 +415,15 @@ You can also pass an array of multiple values as well:
 
 .. literalinclude:: query_builder/046.php
 
-**$builder->distinct()**
+$builder->distinct()
+--------------------
 
 Adds the **DISTINCT** keyword to a query
 
 .. literalinclude:: query_builder/047.php
 
-**$builder->having()**
+$builder->having()
+------------------
 
 Permits you to write the **HAVING** portion of your query. There are 2
 possible syntaxes, 1 argument or 2:
@@ -408,11 +440,13 @@ setting it to ``false``.
 
 .. literalinclude:: query_builder/050.php
 
-**$builder->orHaving()**
+$builder->orHaving()
+--------------------
 
 Identical to ``having()``, only separates multiple clauses with **OR**.
 
-**$builder->havingIn()**
+$builder->havingIn()
+--------------------
 
 Generates a **HAVING field IN ('item', 'item')** SQL query joined with **AND** if
 appropriate:
@@ -423,7 +457,8 @@ You can use subqueries instead of an array of values:
 
 .. literalinclude:: query_builder/052.php
 
-**$builder->orHavingIn()**
+$builder->orHavingIn()
+----------------------
 
 Generates a **HAVING field IN ('item', 'item')** SQL query joined with **OR** if
 appropriate
@@ -434,7 +469,8 @@ You can use subqueries instead of an array of values:
 
 .. literalinclude:: query_builder/054.php
 
-**$builder->havingNotIn()**
+$builder->havingNotIn()
+-----------------------
 
 Generates a **HAVING field NOT IN ('item', 'item')** SQL query joined with
 **AND** if appropriate
@@ -445,7 +481,8 @@ You can use subqueries instead of an array of values:
 
 .. literalinclude:: query_builder/056.php
 
-**$builder->orHavingNotIn()**
+$builder->orHavingNotIn()
+-------------------------
 
 Generates a **HAVING field NOT IN ('item', 'item')** SQL query joined with **OR**
 if appropriate
@@ -456,7 +493,8 @@ You can use subqueries instead of an array of values:
 
 .. literalinclude:: query_builder/058.php
 
-**$builder->havingLike()**
+$builder->havingLike()
+----------------------
 
 This method enables you to generate **LIKE** clauses for **HAVING** part or the query, useful for doing
 searches.
@@ -487,21 +525,24 @@ searches.
 
        .. literalinclude:: query_builder/062.php
 
-**$builder->orHavingLike()**
+$builder->orHavingLike()
+------------------------
 
 This method is identical to the one above, except that multiple
 instances are joined by **OR**:
 
 .. literalinclude:: query_builder/063.php
 
-**$builder->notHavingLike()**
+$builder->notHavingLike()
+-------------------------
 
 This method is identical to ``havingLike()``, except that it generates
 **NOT LIKE** statements:
 
 .. literalinclude:: query_builder/064.php
 
-**$builder->orNotHavingLike()**
+$builder->orNotHavingLike()
+---------------------------
 
 This method is identical to ``notHavingLike()``, except that multiple
 instances are joined by **OR**:
@@ -512,7 +553,11 @@ instances are joined by **OR**:
 Ordering Results
 ****************
 
-**$builder->orderBy()**
+OrderBy
+=======
+
+$builder->orderBy()
+-------------------
 
 Lets you set an **ORDER BY** clause.
 
@@ -540,7 +585,11 @@ be ignored, unless you specify a numeric seed value.
 Limiting or Counting Results
 ****************************
 
-**$builder->limit()**
+Limit
+=====
+
+$builder->limit()
+-----------------
 
 Lets you limit the number of rows you would like returned by the query:
 
@@ -550,7 +599,8 @@ The second parameter lets you set a result offset.
 
 .. literalinclude:: query_builder/071.php
 
-**$builder->countAllResults()**
+$builder->countAllResults()
+---------------------------
 
 Permits you to determine the number of rows in a particular Query
 Builder query. Queries will accept Query Builder restrictors such as
@@ -564,7 +614,8 @@ first parameter.
 
 .. literalinclude:: query_builder/073.php
 
-**$builder->countAll()**
+$builder->countAll()
+--------------------
 
 Permits you to determine the number of rows in a particular table.
 Example:
@@ -579,6 +630,9 @@ first parameter.
 Query grouping
 **************
 
+Group
+=====
+
 Query grouping allows you to create groups of **WHERE** clauses by enclosing them in parentheses. This will allow
 you to create queries with complex **WHERE** clauses. Nested groups are supported. Example:
 
@@ -586,43 +640,53 @@ you to create queries with complex **WHERE** clauses. Nested groups are supporte
 
 .. note:: Groups need to be balanced, make sure every ``groupStart()`` is matched by a ``groupEnd()``.
 
-**$builder->groupStart()**
+$builder->groupStart()
+----------------------
 
 Starts a new group by adding an opening parenthesis to the **WHERE** clause of the query.
 
-**$builder->orGroupStart()**
+$builder->orGroupStart()
+------------------------
 
 Starts a new group by adding an opening parenthesis to the **WHERE** clause of the query, prefixing it with **OR**.
 
-**$builder->notGroupStart()**
+$builder->notGroupStart()
+-------------------------
 
 Starts a new group by adding an opening parenthesis to the **WHERE** clause of the query, prefixing it with **NOT**.
 
-**$builder->orNotGroupStart()**
+$builder->orNotGroupStart()
+---------------------------
 
 Starts a new group by adding an opening parenthesis to the **WHERE** clause of the query, prefixing it with **OR NOT**.
 
-**$builder->groupEnd()**
+$builder->groupEnd()
+--------------------
 
 Ends the current group by adding a closing parenthesis to the **WHERE** clause of the query.
 
-**$builder->havingGroupStart()**
+$builder->havingGroupStart()
+----------------------------
 
 Starts a new group by adding an opening parenthesis to the **HAVING** clause of the query.
 
-**$builder->orHavingGroupStart()**
+$builder->orHavingGroupStart()
+------------------------------
 
 Starts a new group by adding an opening parenthesis to the **HAVING** clause of the query, prefixing it with **OR**.
 
-**$builder->notHavingGroupStart()**
+$builder->notHavingGroupStart()
+-------------------------------
 
 Starts a new group by adding an opening parenthesis to the **HAVING** clause of the query, prefixing it with **NOT**.
 
-**$builder->orNotHavingGroupStart()**
+$builder->orNotHavingGroupStart()
+---------------------------------
 
 Starts a new group by adding an opening parenthesis to the **HAVING** clause of the query, prefixing it with **OR NOT**.
 
-**$builder->havingGroupEnd()**
+$builder->havingGroupEnd()
+--------------------------
 
 Ends the current group by adding a closing parenthesis to the **HAVING** clause of the query.
 
@@ -630,7 +694,11 @@ Ends the current group by adding a closing parenthesis to the **HAVING** clause 
 Inserting Data
 **************
 
-**$builder->insert()**
+Insert
+======
+
+$builder->insert()
+------------------
 
 Generates an insert string based on the data you supply, and runs the
 query. You can either pass an **array** or an **object** to the
@@ -648,7 +716,8 @@ The first parameter is an object.
 
 .. note:: All values are escaped automatically producing safer queries.
 
-**$builder->ignore()**
+$builder->ignore()
+------------------
 
 Generates an insert ignore string based on the data you supply, and runs the
 query. So if an entry with the same primary key already exists, the query won't be inserted.
@@ -656,7 +725,8 @@ You can optionally pass an **boolean** to the method. Here is an example using t
 
 .. literalinclude:: query_builder/078.php
 
-**$builder->getCompiledInsert()**
+$builder->getCompiledInsert()
+-----------------------------
 
 Compiles the insertion query just like ``$builder->insert()`` but does not
 *run* the query. This method simply returns the SQL query as a string.
@@ -676,7 +746,11 @@ using ``$builder->insert()`` which resets values or reset directly using
 
 .. note:: This method doesn't work for batch inserts.
 
-**$builder->insertBatch()**
+insertBatch
+===========
+
+$builder->insertBatch()
+-----------------------
 
 Generates an insert string based on the data you supply, and runs the
 query. You can either pass an **array** or an **object** to the
@@ -692,7 +766,11 @@ The first parameter is an associative array of values.
 Updating Data
 *************
 
-**$builder->replace()**
+Update
+======
+
+$builder->replace()
+-------------------
 
 This method executes a **REPLACE** statement, which is basically the SQL
 standard for (optional) **DELETE** + **INSERT**, using *PRIMARY* and *UNIQUE*
@@ -712,7 +790,8 @@ will be deleted with our new row data replacing it.
 Usage of the ``set()`` method is also allowed and all fields are
 automatically escaped, just like with ``insert()``.
 
-**$builder->set()**
+$builder->set()
+---------------
 
 This method enables you to set values for inserts or updates.
 
@@ -741,7 +820,8 @@ Or an object:
 
 .. literalinclude:: query_builder/087.php
 
-**$builder->update()**
+$builder->update()
+------------------
 
 Generates an update string and runs the query based on the data you
 supply. You can pass an **array** or an **object** to the method. Here
@@ -768,7 +848,11 @@ Or as an array:
 You may also use the ``$builder->set()`` method described above when
 performing updates.
 
-**$builder->updateBatch()**
+UpdateBatch
+===========
+
+$builder->updateBatch()
+-----------------------
 
 Generates an update string based on the data you supply, and runs the query.
 You can either pass an **array** or an **object** to the method.
@@ -784,7 +868,8 @@ The first parameter is an associative array of values, the second parameter is t
     due to the very nature of how it works. Instead, ``updateBatch()``
     returns the number of rows affected.
 
-**$builder->getCompiledUpdate()**
+$builder->getCompiledUpdate()
+-----------------------------
 
 This works exactly the same way as ``$builder->getCompiledInsert()`` except
 that it produces an **UPDATE** SQL string instead of an **INSERT** SQL string.
@@ -797,7 +882,11 @@ For more information view documentation for ``$builder->getCompiledInsert()``.
 Deleting Data
 *************
 
-**$builder->delete()**
+Delete
+======
+
+$builder->delete()
+------------------
 
 Generates a **DELETE** SQL string and runs the query.
 
@@ -812,14 +901,16 @@ the data to the first parameter of the method:
 If you want to delete all data from a table, you can use the ``truncate()``
 method, or ``emptyTable()``.
 
-**$builder->emptyTable()**
+$builder->emptyTable()
+----------------------
 
 Generates a **DELETE** SQL string and runs the
 query:
 
 .. literalinclude:: query_builder/095.php
 
-**$builder->truncate()**
+$builder->truncate()
+--------------------
 
 Generates a **TRUNCATE** SQL string and runs the query.
 
@@ -828,7 +919,8 @@ Generates a **TRUNCATE** SQL string and runs the query.
 .. note:: If the TRUNCATE command isn't available, ``truncate()`` will
     execute as "DELETE FROM table".
 
-**$builder->getCompiledDelete()**
+$builder->getCompiledDelete()
+-----------------------------
 
 This works exactly the same way as ``$builder->getCompiledInsert()`` except
 that it produces a **DELETE** SQL string instead of an **INSERT** SQL string.
@@ -850,7 +942,11 @@ multiple methods. Consider this example:
 Resetting Query Builder
 ***********************
 
-**$builder->resetQuery()**
+ResetQuery
+==========
+
+$builder->resetQuery()
+----------------------
 
 Resetting Query Builder allows you to start fresh with your query without
 executing it first using a method like ``$builder->get()`` or ``$builder->insert()``.

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -242,7 +242,8 @@ methods:
 .. note:: ``$builder->where()`` accepts an optional third parameter. If you set it to
     ``false``, CodeIgniter will not try to protect your field or table names.
 
-#. **Simple key/value method:**
+1. Simple key/value method
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     .. literalinclude:: query_builder/021.php
 
@@ -253,14 +254,16 @@ methods:
 
     .. literalinclude:: query_builder/022.php
 
-#. **Custom key/value method:**
+2. Custom key/value method
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     You can include an operator in the first parameter in order to
     control the comparison:
 
     .. literalinclude:: query_builder/023.php
 
-#. **Associative array method:**
+3. Associative array method
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     .. literalinclude:: query_builder/024.php
 
@@ -268,7 +271,8 @@ methods:
 
     .. literalinclude:: query_builder/025.php
 
-#. **Custom string:**
+4. Custom string
+^^^^^^^^^^^^^^^^
 
     You can write your own clauses manually:
 
@@ -281,7 +285,8 @@ methods:
 
 .. _query-builder-where-subquery:
 
-5. **Subqueries:**
+5. Subqueries
+^^^^^^^^^^^^^
 
     .. literalinclude:: query_builder/028.php
 
@@ -361,7 +366,8 @@ searches.
         otherwise, will force the values to be lowercase, i.e., ``WHERE LOWER(column) LIKE '%search%'``. This
         may require indexes to be made for ``LOWER(column)`` instead of ``column`` to be effective.
 
-#. **Simple key/value method:**
+1. Simple key/value method
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     .. literalinclude:: query_builder/038.php
 
@@ -376,7 +382,8 @@ searches.
 
     .. literalinclude:: query_builder/040.php
 
-#. **Associative array method:**
+2. Associative array method
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
        .. literalinclude:: query_builder/041.php
 
@@ -506,7 +513,8 @@ searches.
     otherwise, will force the values to be lowercase, i.e., ``HAVING LOWER(column) LIKE '%search%'``. This
     may require indexes to be made for ``LOWER(column)`` instead of ``column`` to be effective.
 
-#. **Simple key/value method:**
+1. Simple key/value method
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     .. literalinclude:: query_builder/059.php
 
@@ -521,7 +529,8 @@ searches.
 
     .. literalinclude:: query_builder/061.php
 
-#. **Associative array method:**
+2. Associative array method
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
        .. literalinclude:: query_builder/062.php
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1064,7 +1064,7 @@ Class Reference
 
     .. php:method:: select([$select = '*'[, $escape = null]])
 
-        :param string $select: The SELECT portion of a query
+        :param array|RawSql|string $select: The SELECT portion of a query
         :param bool $escape: Whether to escape values and identifiers
         :returns:   ``BaseBuilder`` instance (method chaining)
         :rtype:     ``BaseBuilder``
@@ -1165,7 +1165,7 @@ Class Reference
 
     .. php:method:: where($key[, $value = null[, $escape = null]])
 
-        :param mixed $key: Name of field to compare, or associative array
+        :param array|RawSql|string $key: Name of field to compare, or associative array
         :param mixed $value: If a single key, compared to this value
         :param bool    $escape: Whether to escape values and identifiers
         :returns:   ``BaseBuilder`` instance (method chaining)
@@ -1260,7 +1260,7 @@ Class Reference
 
     .. php:method:: like($field[, $match = ''[, $side = 'both'[, $escape = null[, $insensitiveSearch = false]]]])
 
-        :param string $field: Field name
+        :param array|RawSql|string $field: Field name
         :param string $match: Text portion to match
         :param string $side: Which side of the expression to put the '%' wildcard on
         :param bool    $escape: Whether to escape values and identifiers

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1116,7 +1116,7 @@ Class Reference
 
         Adds a ``SELECT COUNT(field)`` clause to a query.
 
-.. php:method:: selectSubquery(BaseBuilder $subquery, string $as)
+    .. php:method:: selectSubquery(BaseBuilder $subquery, string $as)
 
         :param string $subquery: Instance of BaseBuilder
         :param string $as: Alias for the resulting value name

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -117,6 +117,17 @@ escaping of fields may break them.
 
 .. literalinclude:: query_builder/009.php
 
+.. _query-builder-select-rawsql:
+
+RawSql
+^^^^^^
+
+Since v4.2.0, ``$builder->select()`` accepts a ``CodeIgniter\Database\RawSql`` instance, which expresses raw SQL strings.
+
+.. literalinclude:: query_builder/099.php
+
+.. warning:: When you use ``RawSql``, you MUST escape the data manually. Failure to do so could result in SQL injections.
+
 $builder->selectMax()
 ---------------------
 
@@ -283,9 +294,20 @@ methods:
 
         .. literalinclude:: query_builder/027.php
 
+.. _query-builder-where-rawsql:
+
+5. RawSql
+^^^^^^^^^
+
+    Since v4.2.0, ``$builder->where()`` accepts a ``CodeIgniter\Database\RawSql`` instance, which expresses raw SQL strings.
+
+    .. literalinclude:: query_builder/100.php
+
+    .. warning:: When you use ``RawSql``, you MUST escape the data manually. Failure to do so could result in SQL injections.
+
 .. _query-builder-where-subquery:
 
-5. Subqueries
+6. Subqueries
 ^^^^^^^^^^^^^
 
     .. literalinclude:: query_builder/028.php
@@ -386,6 +408,17 @@ searches.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
        .. literalinclude:: query_builder/041.php
+
+.. _query-builder-like-rawsql:
+
+3. RawSql
+^^^^^^^^^
+
+    Since v4.2.0, ``$builder->like()`` accepts a ``CodeIgniter\Database\RawSql`` instance, which expresses raw SQL strings.
+
+    .. literalinclude:: query_builder/101.php
+
+    .. warning:: When you use ``RawSql``, you MUST escape the data manually. Failure to do so could result in SQL injections.
 
 $builder->orLike()
 ------------------

--- a/user_guide_src/source/database/query_builder/099.php
+++ b/user_guide_src/source/database/query_builder/099.php
@@ -1,0 +1,7 @@
+<?php
+
+use CodeIgniter\Database\RawSql;
+
+$sql = 'REGEXP_SUBSTR(ral_anno,"[0-9]{1,2}([,.][0-9]{1,3})([,.][0-9]{1,3})") AS ral';
+$builder->select(new RawSql($sql));
+$query = $builder->get();

--- a/user_guide_src/source/database/query_builder/100.php
+++ b/user_guide_src/source/database/query_builder/100.php
@@ -1,0 +1,6 @@
+<?php
+
+use CodeIgniter\Database\RawSql;
+
+$sql = "id > 2 AND name != 'Accountant'";
+$builder->where(new RawSql($sql));

--- a/user_guide_src/source/database/query_builder/101.php
+++ b/user_guide_src/source/database/query_builder/101.php
@@ -1,0 +1,7 @@
+<?php
+
+use CodeIgniter\Database\RawSql;
+
+$sql    = "CONCAT(users.name, ' ', IF(users.surname IS NULL OR users.surname = '', '', users.surname))";
+$rawSql = new RawSql($sql);
+$builder->like($rawSql, 'value', 'both');


### PR DESCRIPTION
Related: #4355, #3970, #5810

**Description**
See https://forum.codeigniter.com/showthread.php?tid=80720

- add `RawSql` class
- `select()` supports `RawSql`
- `where()` supports `RawSql`
- `like()` supports `RawSql`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
