### PR TITLE
docs: add full support for PHP 8.1 in changelogs/v4.1.6.rst

### DIFF
--- a/user_guide_src/source/changelogs/v4.1.6.rst
+++ b/user_guide_src/source/changelogs/v4.1.6.rst
@@ -37,6 +37,7 @@ Validation changes
 Enhancements
 ************
 
+- Full support for PHP 8.1.
 - Database pane on debug toolbar now displays location where Query was called from. Also displays full backtrace.
 - :ref:`Subqueries <query-builder-where-subquery>` in QueryBuilder can now be an instance of the BaseBuilder class.
 - Kint was updated from ^3.3 to ^4.0.


### PR DESCRIPTION
**Description**
It is not clear that PHP 8.1 is fully supported.
See https://forum.codeigniter.com/thread-81591.html

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
