### PR TITLE
(User guide) Referenced wrong method

### DIFF
--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -44,10 +44,10 @@ You can check the HTTP method that this request represents with the ``method()``
 .. literalinclude:: incomingrequest/005.php
 
 By default, the method is returned as a lower-case string (i.e., 'get', 'post', etc). You can get an
-uppercase version by wrapping the call in ``str_to_upper()``::
+uppercase version by wrapping the call in ``strtoupper()``::
 
     // Returns 'GET'
-    $method = str_to_upper($request->getMethod());
+    $method = strtoupper($request->getMethod());
 
 You can also check if the request was made through and HTTPS connection with the ``isSecure()`` method:
 


### PR DESCRIPTION
strtoupper is a PHP method for uppercase strings. (https://www.php.net/manual/en/function.strtoupper.php)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
