### PR TITLE
config: remove App\ and Config\ in autoload.psr-4 in app starter composer.json

### DIFF
--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -17,10 +17,6 @@
         "ext-fileinfo": "Improves mime type detection for files"
     },
     "autoload": {
-        "psr-4": {
-            "App\\": "app",
-            "Config\\": "app/Config"
-        },
         "exclude-from-classmap": [
             "**/Database/Migrations/**"
         ]

--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -76,6 +76,10 @@ class Commands
     /**
      * Discovers all commands in the framework and within user code,
      * and collects instances of them to work with.
+     *
+     * @TODO this approach (find qualified classname from path) causes error,
+     *      when using Composer autoloader.
+     *      See https://github.com/codeigniter4/CodeIgniter4/issues/5818
      */
     public function discoverCommands()
     {


### PR DESCRIPTION
**Description**
Revert #3423
Fixes #5818

Why
- The `autoload.psr-4` causes problems:
  - Cannot change `app` folder name. Because the composer's path overwrite the config in `Config\Autoload`. See https://forum.codeigniter.com/thread-81153.html
  - Causes error when defining new namespace under `app/`. See https://github.com/codeigniter4/CodeIgniter4/issues/5818
  - These are very difficult to debug.
- Only app starter has the configs. So it is not consistent.

If there is a user who wants to use Composer autoloader optimization (`dump-autoload -o`) for `App` namespace class files, they could add it in `autoload.psr-4` by themself.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide

