### PR TITLE
Unset Composer's autoloader from the autoload stack

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -312,6 +312,7 @@ class Autoloader
         $paths    = $composer->getPrefixesPsr4();
         $classes  = $composer->getClassMap();
 
+        $composer->unregister();
         unset($composer);
 
         // Get rid of CodeIgniter so we don't have duplicates

--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -102,7 +102,7 @@ class Commands
         foreach ($files as $file) {
             $className = $locator->findQualifiedNameFromPath($file);
 
-            if (empty($className) || ! class_exists($className)) {
+            if ($className === false) {
                 continue;
             }
 

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -84,11 +84,6 @@ if (! class_exists('CodeIgniter\Services', false)) {
 // Initialize and register the loader with the SPL autoloader stack.
 Services::autoloader()->initialize(new Autoload(), new Modules())->register();
 
-// Now load Composer's if it's available
-if (is_file(COMPOSER_PATH)) {
-    require_once COMPOSER_PATH;
-}
-
 // Load environment settings from .env files into $_SERVER and $_ENV
 require_once SYSTEMPATH . 'Config/DotEnv.php';
 

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -109,18 +109,13 @@ if (! class_exists('CodeIgniter\Services', false)) {
 // Initialize and register the loader with the SPL autoloader stack.
 Services::autoloader()->initialize(new Autoload(), new Modules())->register();
 
-// Now load Composer's if it's available
-if (is_file(COMPOSER_PATH)) {
-    /*
-     * The path to the vendor directory.
-     *
-     * We do not want to enforce this, so set the constant if Composer was used.
-     */
-    if (! defined('VENDORPATH')) {
-        define('VENDORPATH', dirname(COMPOSER_PATH) . DIRECTORY_SEPARATOR);
-    }
-
-    require_once COMPOSER_PATH;
+/*
+ * The path to the vendor directory.
+ *
+ * We do not want to enforce this, so set the constant if Composer was used.
+ */
+if (is_file(COMPOSER_PATH) && ! defined('VENDORPATH')) {
+    define('VENDORPATH', dirname(COMPOSER_PATH) . DIRECTORY_SEPARATOR);
 }
 
 // Load environment settings from .env files into $_SERVER and $_ENV


### PR DESCRIPTION
**Description**
Fixes https://github.com/codeigniter4/CodeIgniter4/issues/5818#issuecomment-1077407039

Since we only need Composer to register its PSR4 namespaces and classmaps into our internal autoloader, it should not be in the `spl_autoload` stack after as this messes with `class_exists` checks. When our autoloader fails to find the file, PHP passes the search to the next autoloader, which is Composer. Our internal autoloader uses `include_once` while Composer uses `include` causing the redeclaration error.

Cannot write a unit test for this. To check manually using this repo:
1. Add `"App\\": "app"` in the `autoload.psr4` section in the root composer.json
2. Run `composer dump -o` to regenerate the class map.
3. Add `'MyNameSpace' => APPPATH . 'ThirdParty/MyFolder'` in `Config\Autoload::$psr4` array.
4. Run `php spark make:command TeseCommand --namespace MyNameSpace`
5. Run `php spark`. This will now error.
6. Apply this fix ef7dec6efa9d5ce06d83ab5f4c5f211c64dbbc75
7. Run `php spark`. No errors should appear.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
