### PR TITLE
fix: spark can't use options on PHP 7.4

### DIFF
--- a/system/CLI/CommandRunner.php
+++ b/system/CLI/CommandRunner.php
@@ -40,13 +40,13 @@ class CommandRunner extends Controller
      * so we have the chance to look for a Command first.
      *
      * @param string $method
-     * @param array  ...$params
+     * @param array  $params
      *
      * @throws ReflectionException
      *
      * @return mixed
      */
-    public function _remap($method, ...$params)
+    public function _remap($method, $params)
     {
         // The first param is usually empty, so scrap it.
         if (empty($params[0])) {

--- a/system/CLI/CommandRunner.php
+++ b/system/CLI/CommandRunner.php
@@ -48,11 +48,6 @@ class CommandRunner extends Controller
      */
     public function _remap($method, $params)
     {
-        // The first param is usually empty, so scrap it.
-        if (empty($params[0])) {
-            array_shift($params);
-        }
-
         return $this->index($params);
     }
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -884,14 +884,16 @@ class CodeIgniter
             /** @var CLIRequest $request */
             $request = $this->request;
             $params  = $request->getArgs();
+
+            $output = $class->_remap($this->method, $params);
         } else {
             // This is a Web request or PHP CLI request
             $params = $this->router->params();
-        }
 
-        $output = method_exists($class, '_remap')
-            ? $class->_remap($this->method, ...$params)
-            : $class->{$this->method}(...$params);
+            $output = method_exists($class, '_remap')
+                ? $class->_remap($this->method, ...$params)
+                : $class->{$this->method}(...$params);
+        }
 
         $this->benchmark->stop('controller');
 

--- a/tests/system/CLI/CommandRunnerTest.php
+++ b/tests/system/CLI/CommandRunnerTest.php
@@ -123,7 +123,7 @@ final class CommandRunnerTest extends CIUnitTestCase
      */
     public function testRemapEmptyFirstParams()
     {
-        self::$runner->_remap('anyvalue', null, 'list');
+        self::$runner->_remap('anyvalue', [null, 'list']);
         $result = CITestStreamFilter::$buffer;
 
         // make sure the result looks like a command list

--- a/tests/system/CLI/CommandRunnerTest.php
+++ b/tests/system/CLI/CommandRunnerTest.php
@@ -117,16 +117,4 @@ final class CommandRunnerTest extends CIUnitTestCase
         // make sure the result looks like a command list
         $this->assertStringContainsString('Command "bogus" not found', CITestStreamFilter::$buffer);
     }
-
-    /**
-     * @TODO When the first param is empty? Use case?
-     */
-    public function testRemapEmptyFirstParams()
-    {
-        self::$runner->_remap('anyvalue', [null, 'list']);
-        $result = CITestStreamFilter::$buffer;
-
-        // make sure the result looks like a command list
-        $this->assertStringContainsString('Lists the available commands.', $result);
-    }
 }

--- a/tests/system/SparkTest.php
+++ b/tests/system/SparkTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter;
+
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class SparkTest extends CIUnitTestCase
+{
+    public function testCanUseOption()
+    {
+        ob_start();
+        passthru('php spark list --simple');
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('cache:clear', $output);
+    }
+}

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -16,6 +16,7 @@ BREAKING
 - The ``CodeIgniter\CodeIgniter`` class has a new property ``$context`` and it must have the correct context at runtime. So the following files have been changed:
     - ``public/index.php``
     - ``spark``
+- The method signature of ``CodeIgniter\CLI\CommandRunner::_remap()`` has been changed to fix a bug.
 
 Enhancements
 ************


### PR DESCRIPTION
**Description**
Fixes #5835
Follow-up #5206

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
