### PR TITLE
docs: add index.php/spark changes in changelog

### DIFF
--- a/user_guide_src/requirements.txt
+++ b/user_guide_src/requirements.txt
@@ -2,3 +2,4 @@ sphinx>=2.4.4,<3
 sphinxcontrib-phpdomain>=0.7.1
 docutils>=0.16
 sphinx-rtd-theme>=0.5.0
+jinja2<3.1

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -13,6 +13,9 @@ BREAKING
 ********
 
 - The method signature of ``Validation::setRule()`` has been changed. The ``string`` typehint on the ``$rules`` parameter was removed. Extending classes should likewise remove the parameter so as not to break LSP.
+- The ``CodeIgniter\CodeIgniter`` class has a new property ``$context`` and it must have the correct context at runtime. So the following files have been changed:
+    - ``public/index.php``
+    - ``spark``
 
 Enhancements
 ************


### PR DESCRIPTION
**Description**
- add index.php/spark changes in changelog
- fix ImportError on GitHub Actions. See https://github.com/codeigniter4/CodeIgniter4/runs/5714296426?check_suite_focus=true
  - > ImportError: cannot import name 'environmentfilter' from 'jinja2' (/usr/local/lib/python3.10/site-packages/jinja2/__init__.py)
make: *** [Makefile:20: html] Error 1

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
