### PR TITLE
fix: Parser fails with `({variable})` in loop

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -289,7 +289,7 @@ class Parser extends View
          */
         foreach ($matches as $match) {
             // Loop over each piece of $data, replacing
-            // it's contents so that we know what to replace in parse()
+            // its contents so that we know what to replace in parse()
             $str = '';  // holds the new contents for this tag pair.
 
             foreach ($data as $row) {

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -338,8 +338,7 @@ class Parser extends View
                 $str .= $out;
             }
 
-            // Escape | character from filters as it's handled as OR in regex
-            $escapedMatch = preg_replace('/(?<!\\\\)\\|/', '\\|', $match[0]);
+            $escapedMatch = preg_quote($match[0], '#');
 
             $replace['#' . $escapedMatch . '#s'] = $str;
         }
@@ -471,15 +470,7 @@ class Parser extends View
      */
     protected function replaceSingle($pattern, $content, $template, bool $escape = false): string
     {
-        // Any dollar signs in the pattern will be misinterpreted, so slash them
-        $pattern = addcslashes($pattern, '$');
         $content = (string) $content;
-
-        // Flesh out the main pattern from the delimiters and escape the hash
-        // See https://regex101.com/r/IKdUlk/1
-        if (preg_match('/^(#)(.+)(#(m?s)?)$/s', $pattern, $parts)) {
-            $pattern = $parts[1] . addcslashes($parts[2], '#') . $parts[3];
-        }
 
         // Replace the content in the template
         return preg_replace_callback($pattern, function ($matches) use ($content, $escape) {

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -220,6 +220,26 @@ final class ParserTest extends CIUnitTestCase
         $this->assertSame("Super Heroes\nTom Dick Henry ", $this->parser->renderString($template));
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5825
+     */
+    public function testParseLoopVariableWithParentheses()
+    {
+        $data = [
+            'title'  => 'Super Heroes',
+            'powers' => [
+                ['name' => 'Tom'],
+                ['name' => 'Dick'],
+                ['name' => 'Henry'],
+            ],
+        ];
+
+        $template = "{title}\n{powers}({name}) {/powers}";
+
+        $this->parser->setData($data);
+        $this->assertSame("Super Heroes\n(Tom) (Dick) (Henry) ", $this->parser->renderString($template));
+    }
+
     public function testParseLoopObjectProperties()
     {
         $obj1 = new stdClass();


### PR DESCRIPTION
**Description**
Fixes #5825

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
