### PR TITLE
feat: add Config\View::$enableConditionals to disable Parser conditionals

### DIFF
--- a/app/Config/View.php
+++ b/app/Config/View.php
@@ -44,6 +44,16 @@ class View extends BaseView
     public $plugins = [];
 
     /**
+     * Whether to use Parser conditionals (if, else, and elseif).
+     *
+     * This setting is for compatibility with templates that works on CodeIgniter3.
+     * If you have JavaScript code in templates, Parser may raise error
+     * when there are strings that can be interpreted as conditionals.
+     * In that case, set this false.
+     */
+    public bool $enableConditionals = true;
+
+    /**
      * View Decorators are class methods that will be run in sequence to
      * have a chance to alter the generated output just prior to caching
      * the results.

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -60,6 +60,16 @@ class Parser extends View
     protected $dataContexts = [];
 
     /**
+     * Whether to use Parser conditionals (if, else, and elseif).
+     *
+     * This setting is for compatibility with templates that works on CodeIgniter3.
+     * If you have JavaScript code in templates, Parser may raise error
+     * when there are strings that can be interpreted as conditionals.
+     * In that case, set this false.
+     */
+    protected bool $enableConditionals = true;
+
+    /**
      * Constructor
      *
      * @param string          $viewPath
@@ -71,6 +81,8 @@ class Parser extends View
     {
         // Ensure user plugins override core plugins.
         $this->plugins = $config->plugins ?? [];
+
+        $this->enableConditionals = $config->enableConditionals ?? $this->enableConditionals;
 
         parent::__construct($config, $viewPath, $loader, $debug, $logger);
     }
@@ -223,8 +235,10 @@ class Parser extends View
         $template = $this->parseComments($template);
         $template = $this->extractNoparse($template);
 
-        // Replace any conditional code here so we don't have to parse as much
-        $template = $this->parseConditionals($template);
+        if ($this->enableConditionals) {
+            // Replace any conditional code here so we don't have to parse as much
+            $template = $this->parseConditionals($template);
+        }
 
         // Handle any plugins before normal data, so that
         // it can potentially modify any template between its tags.

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -938,4 +938,38 @@ final class ParserTest extends CIUnitTestCase
         $expected = '<h1>Hello World</h1>';
         $this->assertSame($expected, $this->parser->render('Simpler.html'));
     }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5831
+     */
+    public function testEnableConditionalsFalse()
+    {
+        $this->config->enableConditionals = false;
+        $this->parser                     = new Parser($this->config, $this->viewsDir, $this->loader);
+
+        $data = [
+            'message' => 'Warning!',
+        ];
+        $this->parser->setData($data);
+
+        $template = <<<'EOL'
+            <script type="text/javascript">
+             var f = function() {
+                 if (true) {
+                     alert('{message}');
+                 }
+             }
+            </script>
+            EOL;
+        $expected = <<<'EOL'
+            <script type="text/javascript">
+             var f = function() {
+                 if (true) {
+                     alert('Warning!');
+                 }
+             }
+            </script>
+            EOL;
+        $this->assertSame($expected, $this->parser->renderString($template));
+    }
 }


### PR DESCRIPTION
**Description**
Fixes #5831

CI3 Parser does not have conditionals. See https://codeigniter.com/userguide3/libraries/parser.html
CI4 Parser has conditionals, and it is difficult to distinguish if there is JavaScript code in templates.

- add `Config\View::$enalbeConditionals` to disable Parser conditionals
  - The setting is for compatibility with templates that works on CodeIgniter3.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
