### PR TITLE
feat: [Parser] add configs to change conditional delimiters

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -38,6 +38,16 @@ class Parser extends View
     public $rightDelimiter = '}';
 
     /**
+     * Left delimiter characters for conditionals
+     */
+    protected string $leftConditionalDelimiter = '{';
+
+    /**
+     * Right delimiter characters for conditionals
+     */
+    protected string $rightConditionalDelimiter = '}';
+
+    /**
      * Stores extracted noparse blocks.
      *
      * @var array
@@ -405,7 +415,14 @@ class Parser extends View
      */
     protected function parseConditionals(string $template): string
     {
-        $pattern = '/\{\s*(if|elseif)\s*((?:\()?(.*?)(?:\))?)\s*\}/ms';
+        $leftDelimiter  = preg_quote($this->leftConditionalDelimiter, '/');
+        $rightDelimiter = preg_quote($this->rightConditionalDelimiter, '/');
+
+        $pattern = '/'
+            . $leftDelimiter
+            . '\s*(if|elseif)\s*((?:\()?(.*?)(?:\))?)\s*'
+            . $rightDelimiter
+            . '/ms';
 
         /*
          * For each match:
@@ -424,8 +441,16 @@ class Parser extends View
             $template  = str_replace($match[0], $statement, $template);
         }
 
-        $template = preg_replace('/\{\s*else\s*\}/ms', '<?php else: ?>', $template);
-        $template = preg_replace('/\{\s*endif\s*\}/ms', '<?php endif; ?>', $template);
+        $template = preg_replace(
+            '/' . $leftDelimiter . '\s*else\s*' . $rightDelimiter . '/ms',
+            '<?php else: ?>',
+            $template
+        );
+        $template = preg_replace(
+            '/' . $leftDelimiter . '\s*endif\s*' . $rightDelimiter . '/ms',
+            '<?php endif; ?>',
+            $template
+        );
 
         // Parse the PHP itself, or insert an error so they can debug
         ob_start();
@@ -457,6 +482,20 @@ class Parser extends View
     {
         $this->leftDelimiter  = $leftDelimiter;
         $this->rightDelimiter = $rightDelimiter;
+
+        return $this;
+    }
+
+    /**
+     * Over-ride the substitution conditional delimiters.
+     *
+     * @param string $leftDelimiter
+     * @param string $rightDelimiter
+     */
+    public function setConditionalDelimiters($leftDelimiter = '{', $rightDelimiter = '}'): RendererInterface
+    {
+        $this->leftConditionalDelimiter  = $leftDelimiter;
+        $this->rightConditionalDelimiter = $rightDelimiter;
 
         return $this;
     }

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -938,4 +938,53 @@ final class ParserTest extends CIUnitTestCase
         $expected = '<h1>Hello World</h1>';
         $this->assertSame($expected, $this->parser->render('Simpler.html'));
     }
+
+    public function testChangedConditionalDelimitersTrue()
+    {
+        $this->parser->setConditionalDelimiters('{%', '%}');
+
+        $data = [
+            'doit'     => true,
+            'dontdoit' => false,
+        ];
+        $this->parser->setData($data);
+
+        $template = '{% if $doit %}Howdy{% endif %}{% if $dontdoit === false %}Welcome{% endif %}';
+        $output   = $this->parser->renderString($template);
+
+        $this->assertSame('HowdyWelcome', $output);
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5831
+     */
+    public function testChangeConditionalDelimitersWorkWithJavaScriptCode()
+    {
+        $this->parser->setConditionalDelimiters('{%', '%}');
+
+        $data = [
+            'message' => 'Warning!',
+        ];
+        $this->parser->setData($data);
+
+        $template = <<<'EOL'
+            <script type="text/javascript">
+             var f = function() {
+                 if (true) {
+                     alert('{message}');
+                 }
+             }
+            </script>
+            EOL;
+        $expected = <<<'EOL'
+            <script type="text/javascript">
+             var f = function() {
+                 if (true) {
+                     alert('Warning!');
+                 }
+             }
+            </script>
+            EOL;
+        $this->assertSame($expected, $this->parser->renderString($template));
+    }
 }

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -290,6 +290,31 @@ of the comparison operators you would normally, like ``==``, ``===``, ``!==``, `
 .. warning:: In the background, conditionals are parsed using an ``eval()``, so you must ensure that you take
     care with the user data that is used within conditionals, or you could open your application up to security risks.
 
+Changing the Conditional Delimiters
+-----------------------------------
+
+If you have JavaScript code like the following in your templates, the Parser raises a syntax error because there are strings that can be interpreted as a conditional::
+
+    <script type="text/javascript">
+        var f = function() {
+            if (hasAlert) {
+                alert('{message}');
+            }
+        }
+    </script>
+
+In that case, you can change the delimiters for conditionals with the ``setConditionalDelimiters()`` method to avoid misinterpretations:
+
+.. literalinclude:: view_parser/027.php
+
+In this case, you will write code in your template::
+
+    {% if $role=='admin' %}
+        <h1>Welcome, Admin</h1>
+    {% else %}
+        <h1>Welcome, User</h1>
+    {% endif %}
+
 Escaping Data
 =============
 

--- a/user_guide_src/source/outgoing/view_parser/027.php
+++ b/user_guide_src/source/outgoing/view_parser/027.php
@@ -1,0 +1,3 @@
+<?php
+
+$parser->setConditionalDelimiters('{%', '%}');


### PR DESCRIPTION
**Description**
Fixes #5831

- add properties `$leftConditionalDelimiter` and `$rightConditionalDelimiter`
- add method `setConditionalDelimiters()`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
