### PR TITLE
docs: improve tutorial

### DIFF
--- a/user_guide_src/source/tutorial/create_news_items/002.php
+++ b/user_guide_src/source/tutorial/create_news_items/002.php
@@ -18,11 +18,11 @@ class News extends BaseController
                 'body'  => $this->request->getPost('body'),
             ]);
 
-            echo view('news/success');
-        } else {
-            echo view('templates/header', ['title' => 'Create a news item']);
-            echo view('news/create');
-            echo view('templates/footer');
+            return view('news/success');
         }
+
+        return view('templates/header', ['title' => 'Create a news item'])
+            . view('news/create')
+            . view('templates/footer');
     }
 }

--- a/user_guide_src/source/tutorial/news_section/004.php
+++ b/user_guide_src/source/tutorial/news_section/004.php
@@ -15,8 +15,8 @@ class News extends BaseController
             'title' => 'News archive',
         ];
 
-        echo view('templates/header', $data);
-        echo view('news/overview', $data);
-        echo view('templates/footer', $data);
+        return view('templates/header', $data)
+            . view('news/overview', $data)
+            . view('templates/footer', $data);
     }
 }

--- a/user_guide_src/source/tutorial/news_section/006.php
+++ b/user_guide_src/source/tutorial/news_section/006.php
@@ -18,8 +18,8 @@ class News extends BaseController
 
         $data['title'] = $data['news']['title'];
 
-        echo view('templates/header', $data);
-        echo view('news/view', $data);
-        echo view('templates/footer', $data);
+        return view('templates/header', $data)
+            . view('news/view', $data)
+            . view('templates/footer', $data);
     }
 }

--- a/user_guide_src/source/tutorial/static_pages.rst
+++ b/user_guide_src/source/tutorial/static_pages.rst
@@ -30,7 +30,7 @@ displays the CodeIgniter welcome page.
 
 The ``Pages`` class is extending the ``BaseController`` class that extends the
 ``CodeIgniter\Controller`` class. This means that the new Pages class can access the
-methods and variables defined in the ``CodeIgniter\Controller`` class
+methods and properties defined in the ``CodeIgniter\Controller`` class
 (**system/Controller.php**).
 
 The **controller is what will become the center of every request** to

--- a/user_guide_src/source/tutorial/static_pages/002.php
+++ b/user_guide_src/source/tutorial/static_pages/002.php
@@ -13,8 +13,8 @@ class Pages extends BaseController
 
         $data['title'] = ucfirst($page); // Capitalize the first letter
 
-        echo view('templates/header', $data);
-        echo view('pages/' . $page, $data);
-        echo view('templates/footer', $data);
+        return view('templates/header', $data)
+            . view('pages/' . $page, $data)
+            . view('templates/footer', $data);
     }
 }


### PR DESCRIPTION
**Description**
- use `return` in a controller method, instead of `echo`
  - `echo` has side effects, so `return` is better.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
