### PR TITLE
fix: Validation returns incorrect errors after Redirect with Input

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -108,6 +108,12 @@ class Validation implements ValidationInterface
      */
     public function run(?array $data = null, ?string $group = null, ?string $dbGroup = null): bool
     {
+        // If there are still validation errors for redirect_with_input request, remove them.
+        // See `getErrors()` method.
+        if (isset($_SESSION, $_SESSION['_ci_validation_errors'])) {
+            unset($_SESSION['_ci_validation_errors']);
+        }
+
         $data ??= $this->data;
 
         // i.e. is_unique


### PR DESCRIPTION
**Description**
Fixes #5839
- remove session _ci_validation_errors before running validation

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

