### PR TITLE
fix: Commands::discoverCommands() loads incorrect classname

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -289,6 +289,8 @@ class FileLocator
     /**
      * Scans the defined namespaces, returning a list of all files
      * that are contained within the subpath specified by $path.
+     *
+     * @return string[] List of file paths
      */
     public function listFiles(string $path): array
     {
@@ -323,6 +325,8 @@ class FileLocator
     /**
      * Scans the provided namespace, returning a list of all files
      * that are contained within the sub path specified by $path.
+     *
+     * @return string[] List of file paths
      */
     public function listNamespaceFiles(string $prefix, string $path): array
     {

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -309,6 +309,9 @@ class FileLocator
 
             $tempFiles = get_filenames($fullPath, true);
 
+            // Remove directories
+            $tempFiles = array_filter($tempFiles, static fn ($path) => strtolower(substr($path, -4)) === '.php');
+
             if (! empty($tempFiles)) {
                 $files = array_merge($files, $tempFiles);
             }

--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -76,10 +76,6 @@ class Commands
     /**
      * Discovers all commands in the framework and within user code,
      * and collects instances of them to work with.
-     *
-     * @TODO this approach (find qualified classname from path) causes error,
-     *      when using Composer autoloader.
-     *      See https://github.com/codeigniter4/CodeIgniter4/issues/5818
      */
     public function discoverCommands()
     {
@@ -100,9 +96,9 @@ class Commands
         // Loop over each file checking to see if a command with that
         // alias exists in the class.
         foreach ($files as $file) {
-            $className = $locator->findQualifiedNameFromPath($file);
+            $className = $locator->getClassname($file);
 
-            if (empty($className) || ! class_exists($className)) {
+            if ($className === '' || ! class_exists($className)) {
                 continue;
             }
 

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -211,6 +211,18 @@ final class FileLocatorTest extends CIUnitTestCase
         $this->assertTrue(in_array($expectedWin, $files, true) || in_array($expectedLin, $files, true));
     }
 
+    public function testListFilesDoesNotContainDirectories()
+    {
+        $files = $this->locator->listFiles('Config/');
+
+        $directory = str_replace(
+            '/',
+            DIRECTORY_SEPARATOR,
+            APPPATH . 'Config/Boot'
+        );
+        $this->assertNotContains($directory, $files);
+    }
+
     public function testListFilesWithFileAsInput()
     {
         $files = $this->locator->listFiles('Config/App.php');


### PR DESCRIPTION
**Description**
Fixes #5818
Supersedes #5834

- fix: FileLocator::listFiles() returns directories
- fix: discoverCommands() loads incorrect classname

Cannot write a unit test for `Cannot declare class ..., because the name is already in use`. 
To check manually using this repo:
1. Add `"App\\": "app/"` in the `autoload.psr4` section in the root composer.json
2. Run `composer dump -o` to regenerate the class map.
3. Add `'MyNameSpace' => APPPATH . 'ThirdParty/MyFolder'` in `Config\Autoload::$psr4` array.
4. Run `php spark make:command TeseCommand --namespace MyNameSpace`
5. Run `php spark`. This will now error.
6. Check out this PR branch (`fix-discoverCommands`).
7. Run `php spark`. No errors should appear.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

