### PR TITLE
fix: [Autoloader] Composer classmap usage

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -111,7 +111,7 @@ class Autoloader
         return $this;
     }
 
-    protected function loadComposerInfo(Modules $modules): void
+    private function loadComposerInfo(Modules $modules): void
     {
         /**
          * @var ClassLoader $composer
@@ -312,7 +312,7 @@ class Autoloader
         return trim($filename, '.-_');
     }
 
-    protected function loadComposerNamespaces(ClassLoader $composer): void
+    private function loadComposerNamespaces(ClassLoader $composer): void
     {
         $paths = $composer->getPrefixesPsr4();
 
@@ -331,7 +331,7 @@ class Autoloader
         $this->prefixes = array_merge($this->prefixes, $newPaths);
     }
 
-    protected function loadComposerClassmap(ClassLoader $composer): void
+    private function loadComposerClassmap(ClassLoader $composer): void
     {
         $classes = $composer->getClassMap();
 

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -337,4 +337,40 @@ class Autoloader
 
         $this->classmap = array_merge($this->classmap, $classes);
     }
+
+    /**
+     * Locates autoload information from Composer, if available.
+     *
+     * @deprecated No longer used.
+     */
+    protected function discoverComposerNamespaces()
+    {
+        if (! is_file(COMPOSER_PATH)) {
+            return;
+        }
+
+        /**
+         * @var ClassLoader $composer
+         */
+        $composer = include COMPOSER_PATH;
+        $paths    = $composer->getPrefixesPsr4();
+        $classes  = $composer->getClassMap();
+
+        unset($composer);
+
+        // Get rid of CodeIgniter so we don't have duplicates
+        if (isset($paths['CodeIgniter\\'])) {
+            unset($paths['CodeIgniter\\']);
+        }
+
+        $newPaths = [];
+
+        foreach ($paths as $key => $value) {
+            // Composer stores namespaces with trailing slash. We don't.
+            $newPaths[rtrim($key, '\\ ')] = $value;
+        }
+
+        $this->prefixes = array_merge($this->prefixes, $newPaths);
+        $this->classmap = array_merge($this->classmap, $classes);
+    }
 }

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -106,7 +106,8 @@ class Autoloader
 
         // Should we load through Composer's namespaces, also?
         if ($modules->discoverInComposer) {
-            $this->discoverComposerNamespaces();
+            $this->loadComposerClassmap();
+            $this->loadComposerNamespaces();
         }
 
         return $this;
@@ -296,10 +297,7 @@ class Autoloader
         return trim($filename, '.-_');
     }
 
-    /**
-     * Locates autoload information from Composer, if available.
-     */
-    protected function discoverComposerNamespaces()
+    protected function loadComposerNamespaces()
     {
         if (! is_file(COMPOSER_PATH)) {
             return;
@@ -310,7 +308,6 @@ class Autoloader
          */
         $composer = include COMPOSER_PATH;
         $paths    = $composer->getPrefixesPsr4();
-        $classes  = $composer->getClassMap();
 
         unset($composer);
 
@@ -327,6 +324,23 @@ class Autoloader
         }
 
         $this->prefixes = array_merge($this->prefixes, $newPaths);
+    }
+
+    protected function loadComposerClassmap(): void
+    {
+        if (! is_file(COMPOSER_PATH)) {
+            return;
+        }
+
+        /**
+         * @var ClassLoader $composer
+         */
+        $composer = include COMPOSER_PATH;
+
+        $classes = $composer->getClassMap();
+
+        unset($composer);
+
         $this->classmap = array_merge($this->classmap, $classes);
     }
 }

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -105,22 +105,27 @@ class Autoloader
         }
 
         if (is_file(COMPOSER_PATH)) {
-            /**
-             * @var ClassLoader $composer
-             */
-            $composer = include COMPOSER_PATH;
-
-            $this->loadComposerClassmap($composer);
-
-            // Should we load through Composer's namespaces, also?
-            if ($modules->discoverInComposer) {
-                $this->loadComposerNamespaces($composer);
-            }
-
-            unset($composer);
+            $this->loadComposerInfo($modules);
         }
 
         return $this;
+    }
+
+    protected function loadComposerInfo(Modules $modules): void
+    {
+        /**
+         * @var ClassLoader $composer
+         */
+        $composer = include COMPOSER_PATH;
+
+        $this->loadComposerClassmap($composer);
+
+        // Should we load through Composer's namespaces, also?
+        if ($modules->discoverInComposer) {
+            $this->loadComposerNamespaces($composer);
+        }
+
+        unset($composer);
     }
 
     /**

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -110,9 +110,10 @@ class Autoloader
              */
             $composer = include COMPOSER_PATH;
 
+            $this->loadComposerClassmap($composer);
+
             // Should we load through Composer's namespaces, also?
             if ($modules->discoverInComposer) {
-                $this->loadComposerClassmap($composer);
                 $this->loadComposerNamespaces($composer);
             }
 

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -88,7 +88,7 @@ final class AutoloaderTest extends CIUnitTestCase
         // look for Home controller, as that should be in base repo
         $actual   = $autoloader->loadClass('App\Controllers\Home');
         $expected = APPPATH . 'Controllers' . DIRECTORY_SEPARATOR . 'Home.php';
-        $this->assertSame($expected, $actual);
+        $this->assertSame($expected, realpath($actual) ?: $actual);
     }
 
     public function testServiceAutoLoader()
@@ -99,7 +99,7 @@ final class AutoloaderTest extends CIUnitTestCase
         // look for Home controller, as that should be in base repo
         $actual   = $autoloader->loadClass('App\Controllers\Home');
         $expected = APPPATH . 'Controllers' . DIRECTORY_SEPARATOR . 'Home.php';
-        $this->assertSame($expected, $actual);
+        $this->assertSame($expected, realpath($actual) ?: $actual);
     }
 
     public function testExistingFile()

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -17,6 +17,7 @@ BREAKING
     - ``public/index.php``
     - ``spark``
 - The method signature of ``CodeIgniter\CLI\CommandRunner::_remap()`` has been changed to fix a bug.
+- The ``CodeIgniter\Autoloader\Autoloader::initialize()`` has changed the behavior to fix a bug. It used to use Composer classmap only when ``$modules->discoverInComposer`` is true. Now it always uses the Composer classmap if Composer is available.
 
 Enhancements
 ************
@@ -55,6 +56,7 @@ Deprecations
 - ``CodeIgniter\Log\Logger::cleanFilenames()`` and ``CodeIgniter\Test\TestLogger::cleanup()`` are both deprecated. Use the ``clean_path()`` function instead.
 - ``CodeIgniter\Router\Router::setDefaultController()`` is deprecated.
 - The constant ``SPARKED`` in **spark** is deprecated. Use the ``$context`` property in ``CodeIgniter\CodeIgniter`` instead.
+- ``CodeIgniter\Autoloader\Autoloader::discoverComposerNamespaces()`` is deprecated, and no longer used.
 
 Bugs Fixed
 **********


### PR DESCRIPTION
**Description**
The current implementation uses Composer classmap  only when `$modules->discoverInComposer` is true.
`discoverInComposer` is the setting for Auto-Discovery within Composer Packages.
It has nothing to do with classmap usage.

This PR makes it use always if Composer is available.

Related: #5834

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

