### PR TITLE
wrong function name `or_where()`

### DIFF
--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -804,7 +804,7 @@ Generates a **DELETE** SQL string and runs the query.
 .. literalinclude:: query_builder/093.php
 
 The first parameter is the where clause.
-You can also use the ``where()`` or ``or_where()`` methods instead of passing
+You can also use the ``where()`` or ``orWhere()`` methods instead of passing
 the data to the first parameter of the method:
 
 .. literalinclude:: query_builder/094.php


### PR DESCRIPTION
Needs to be orWhere(). There is no or_where in CI 4.

Each pull request should address a single issue and have a meaningful title.

**Description**
given function name was wrong and cost me some time. I wanted to change it to the correct one so othere won't lose time.


