### PR TITLE
docs: fix parser.rst

### DIFF
--- a/user_guide_src/source/installation/upgrade_view_parser/001.php
+++ b/user_guide_src/source/installation/upgrade_view_parser/001.php
@@ -7,5 +7,4 @@ $data = [
     'blog_heading' => 'My Blog Heading',
 ];
 
-echo $parser->setData($data)
-    ->render('blog_template');
+echo $parser->setData($data)->render('blog_template');

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -550,8 +550,7 @@ An example with the iteration controlled in the view::
             ['title' => 'Second Link', 'link' => '/second'],
         ]
     ];
-    echo $parser->setData($data)
-                ->renderString($template);
+    echo $parser->setData($data)->renderString($template);
 
 Result::
 

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -595,8 +595,6 @@ Class Reference
             - ``cache_name`` - the ID used to save/retrieve a cached view result; defaults to the viewpath
             - ``cascadeData`` - true if the data pairs in effect when a nested or loop substitution occurs should be propagated
             - ``saveData`` - true if the view data parameter should be retained for subsequent calls
-            - ``leftDelimiter`` - the left delimiter to use in pseudo-variable syntax
-            - ``rightDelimiter`` - the right delimiter to use in pseudo-variable syntax
 
         Any conditional substitutions are performed first, then remaining
         substitutions are performed for each data pair.

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -57,11 +57,11 @@ Then you can use any of the three standard rendering methods that it provides:
 ``setData()``. You will also be able to specify delimiters directly,
 through the ``setDelimiters()`` method.
 
-Using the ``Parser``, your view templates are processed only by the Parser
-itself, and not like a conventional view PHP script. PHP code in such a script
-is ignored by the parser, and only substitutions are performed.
+.. important:: Using the ``Parser``, your view templates are processed only by the Parser
+    itself, and not like a conventional view PHP script. PHP code in such a script
+    is ignored by the parser, and only substitutions are performed.
 
-This is purposeful: view files with no PHP.
+    This is purposeful: view files with no PHP.
 
 What It Does
 ============

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -250,7 +250,7 @@ This example gives different results, depending on cascading:
 Preventing Parsing
 ==================
 
-You can specify portions of the page to not be parsed with the ``{noparse}{/noparse}`` tag pair. Anything in this
+You can specify portions of the page to not be parsed with the ``{noparse}`` ``{/noparse}`` tag pair. Anything in this
 section will stay exactly as it is, with no variable substitution, looping, etc, happening to the markup between the brackets.
 
 ::

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -458,7 +458,7 @@ While plugins will often consist of tag pairs, like shown above, they can also b
 Opening tags can also contain parameters that can customize how the plugin works. The parameters are represented as
 key/value pairs::
 
-    {+ foo bar=2 baz="x y" }
+    {+ foo bar=2 baz="x y" +}
 
 Parameters can also be single values::
 

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -491,7 +491,7 @@ Registering a Plugin
 --------------------
 
 At its simplest, all you need to do to register a new plugin and make it ready for use is to add it to the
-**app/Config/View.php**, under the **$plugins** array. The key is the name of the plugin that is
+**app/Config/View.php**, under the ``$plugins`` array. The key is the name of the plugin that is
 used within the template file. The value is any valid PHP callable, including static class methods:
 
 .. literalinclude:: view_parser/014.php

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -53,9 +53,9 @@ can instantiate it directly:
 .. literalinclude:: view_parser/002.php
 
 Then you can use any of the three standard rendering methods that it provides:
-``render(viewpath, options, save)``, ``setVar(name, value, context)`` and
-``setData(data, context)``. You will also be able to specify delimiters directly,
-through the ``setDelimiters(left, right)`` method.
+``render()``, ``setVar()`` and
+``setData()``. You will also be able to specify delimiters directly,
+through the ``setDelimiters()`` method.
 
 Using the ``Parser``, your view templates are processed only by the Parser
 itself, and not like a conventional view PHP script. PHP code in such a script

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -652,3 +652,14 @@ Class Reference
         Override the substitution field delimiters:
 
         .. literalinclude:: view_parser/026.php
+
+    .. php:method:: setConditionalDelimiters($leftDelimiter = '{', $rightDelimiter = '}')
+
+        :param  string  $leftDelimiter: Left delimiter for conditionals
+        :param  string  $rightDelimiter: right delimiter for conditionals
+        :returns: The Renderer, for method chaining
+        :rtype: CodeIgniter\\View\\RendererInterface.
+
+        Override the conditional delimiters:
+
+        .. literalinclude:: view_parser/027.php

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -336,7 +336,7 @@ Filters
 
 Any single variable substitution can have one or more filters applied to it to modify the way it is presented. These
 are not intended to drastically change the output, but provide ways to reuse the same variable data but with different
-presentations. The **esc** filter discussed above is one example. Dates are another common use case, where you might
+presentations. The ``esc`` filter discussed above is one example. Dates are another common use case, where you might
 need to format the same data differently in several sections on the same page.
 
 Filters are commands that come after the pseudo-variable name, and are separated by the pipe symbol, ``|``::

--- a/user_guide_src/source/outgoing/view_parser/003.php
+++ b/user_guide_src/source/outgoing/view_parser/003.php
@@ -5,5 +5,4 @@ $data = [
     'blog_heading' => 'My Blog Heading',
 ];
 
-echo $parser->setData($data)
-    ->render('blog_template');
+echo $parser->setData($data)->render('blog_template');

--- a/user_guide_src/source/outgoing/view_parser/006.php
+++ b/user_guide_src/source/outgoing/view_parser/006.php
@@ -12,5 +12,4 @@ $data = [
     ],
 ];
 
-echo $parser->setData($data)
-    ->render('blog_template');
+echo $parser->setData($data)->render('blog_template');

--- a/user_guide_src/source/outgoing/view_parser/007.php
+++ b/user_guide_src/source/outgoing/view_parser/007.php
@@ -8,5 +8,4 @@ $data = [
     'blog_entries' => $query->getResultArray(),
 ];
 
-echo $parser->setData($data)
-    ->render('blog_template');
+echo $parser->setData($data)->render('blog_template');

--- a/user_guide_src/source/outgoing/view_parser/008.php
+++ b/user_guide_src/source/outgoing/view_parser/008.php
@@ -9,5 +9,4 @@ $data = [
     ],
 ];
 
-echo $parser->setData($data)
-    ->render('blog_template');
+echo $parser->setData($data)->render('blog_template');

--- a/user_guide_src/source/outgoing/view_parser/018.php
+++ b/user_guide_src/source/outgoing/view_parser/018.php
@@ -6,6 +6,5 @@ $data     = [
     'firstname' => 'John',
     'lastname'  => 'Doe',
 ];
-echo $parser->setData($data)
-    ->renderString($template);
+echo $parser->setData($data)->renderString($template);
 // Result: Hello, John Doe

--- a/user_guide_src/source/outgoing/view_parser/019.php
+++ b/user_guide_src/source/outgoing/view_parser/019.php
@@ -6,6 +6,5 @@ $data     = [
     'firstname' => 'John',
     'lastname'  => 'Doe',
 ];
-echo $parser->setData($data)
-    ->renderString($template);
+echo $parser->setData($data)->renderString($template);
 // Result: Hello, John {initials} Doe

--- a/user_guide_src/source/outgoing/view_parser/020.php
+++ b/user_guide_src/source/outgoing/view_parser/020.php
@@ -10,6 +10,5 @@ $data     = [
         ['degree' => 'PhD'],
     ],
 ];
-echo $parser->setData($data)
-    ->renderString($template);
+echo $parser->setData($data)->renderString($template);
 // Result: Hello, John Doe (Mr{degree} {/degrees})

--- a/user_guide_src/source/outgoing/view_parser/021.php
+++ b/user_guide_src/source/outgoing/view_parser/021.php
@@ -15,5 +15,4 @@ $template2 = '<ul>{menuitems}</ul>';
 $data      = [
     'menuitems' => $temp,
 ];
-echo $parser->setData($data)
-    ->renderString($template2);
+echo $parser->setData($data)->renderString($template2);

--- a/user_guide_src/source/outgoing/view_parser/024.php
+++ b/user_guide_src/source/outgoing/view_parser/024.php
@@ -1,3 +1,3 @@
 <?php
 
-$renderer->setData(['name' => 'George', 'position' => 'Boss']);
+$parser->setData(['name' => 'George', 'position' => 'Boss']);

--- a/user_guide_src/source/outgoing/view_parser/025.php
+++ b/user_guide_src/source/outgoing/view_parser/025.php
@@ -1,3 +1,3 @@
 <?php
 
-$renderer->setVar('name', 'Joe', 'html');
+$parser->setVar('name', 'Joe', 'html');

--- a/user_guide_src/source/outgoing/view_parser/026.php
+++ b/user_guide_src/source/outgoing/view_parser/026.php
@@ -1,3 +1,3 @@
 <?php
 
-$renderer->setDelimiters('[', ']');
+$parser->setDelimiters('[', ']');


### PR DESCRIPTION
**Description**
- fix text decoration
- change coding style
- add Class reference
- small fixes of description

The documented options `leftDelimiter` and `rightDelimiter` are not implemented.
And I think they are not needed as options. So remove them.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
