### PR TITLE
docs: replace `echo` with `return`

### DIFF
--- a/user_guide_src/source/cli/cli/001.php
+++ b/user_guide_src/source/cli/cli/001.php
@@ -8,6 +8,6 @@ class Tools extends Controller
 {
     public function message($to = 'World')
     {
-        echo "Hello {$to}!" . PHP_EOL;
+        return "Hello {$to}!" . PHP_EOL;
     }
 }

--- a/user_guide_src/source/incoming/controllers/008.php
+++ b/user_guide_src/source/incoming/controllers/008.php
@@ -6,6 +6,6 @@ class Helloworld extends BaseController
 {
     public function index()
     {
-        echo 'Hello World!';
+        return 'Hello World!';
     }
 }

--- a/user_guide_src/source/incoming/controllers/013.php
+++ b/user_guide_src/source/incoming/controllers/013.php
@@ -6,11 +6,11 @@ class Helloworld extends BaseController
 {
     public function index()
     {
-        echo 'Hello World!';
+        return 'Hello World!';
     }
 
     public function comment()
     {
-        echo 'I am not flat!';
+        return 'I am not flat!';
     }
 }

--- a/user_guide_src/source/incoming/controllers/014.php
+++ b/user_guide_src/source/incoming/controllers/014.php
@@ -6,7 +6,7 @@ class Products extends BaseController
 {
     public function shoes($sandals, $id)
     {
-        echo $sandals;
-        echo $id;
+        return $sandals
+            . $id;
     }
 }

--- a/user_guide_src/source/installation/upgrade_controllers/001.php
+++ b/user_guide_src/source/installation/upgrade_controllers/001.php
@@ -6,6 +6,6 @@ class Helloworld extends BaseController
 {
     public function index($name)
     {
-        echo 'Hello ' . esc($name) . '!';
+        return 'Hello ' . esc($name) . '!';
     }
 }

--- a/user_guide_src/source/installation/upgrade_file_upload/001.php
+++ b/user_guide_src/source/installation/upgrade_file_upload/001.php
@@ -6,7 +6,7 @@ class Upload extends BaseController
 {
     public function index()
     {
-        echo view('upload_form', ['error' => ' ']);
+        return view('upload_form', ['error' => ' ']);
     }
 
     public function do_upload()
@@ -20,11 +20,10 @@ class Upload extends BaseController
         $file = $this->request->getFile('userfile');
 
         if (! $path = $file->store()) {
-            echo view('upload_form', ['error' => 'upload failed']);
-        } else {
-            $data = ['upload_file_path' => $path];
-
-            echo view('upload_success', $data);
+            return view('upload_form', ['error' => 'upload failed']);
         }
+        $data = ['upload_file_path' => $path];
+
+        return view('upload_success', $data);
     }
 }

--- a/user_guide_src/source/installation/upgrade_pagination/001.php
+++ b/user_guide_src/source/installation/upgrade_pagination/001.php
@@ -7,4 +7,4 @@ $data = [
     'pager' => $model->pager,
 ];
 
-echo view('users/index', $data);
+return view('users/index', $data);

--- a/user_guide_src/source/installation/upgrade_view_parser.rst
+++ b/user_guide_src/source/installation/upgrade_view_parser.rst
@@ -19,7 +19,7 @@ What has been changed
 Upgrade Guide
 =============
 1. Wherever you use the View Parser Library replace ``$this->load->library('parser');`` with ``$parser = service('parser');``.
-2. You have to change the render part in your controller from ``$this->parser->parse('blog_template', $data);`` to ``echo $parser->setData($data)->render('blog_template');``.
+2. You have to change the render part in your controller from ``$this->parser->parse('blog_template', $data);`` to ``return $parser->setData($data)->render('blog_template');``.
 
 Code Example
 ============

--- a/user_guide_src/source/installation/upgrade_view_parser/001.php
+++ b/user_guide_src/source/installation/upgrade_view_parser/001.php
@@ -7,4 +7,4 @@ $data = [
     'blog_heading' => 'My Blog Heading',
 ];
 
-echo $parser->setData($data)->render('blog_template');
+return $parser->setData($data)->render('blog_template');

--- a/user_guide_src/source/installation/upgrade_views.rst
+++ b/user_guide_src/source/installation/upgrade_views.rst
@@ -15,7 +15,7 @@ What has been changed
 =====================
 
 - Your views look much like before, but they are invoked differently ... instead of CI3's
-  ``$this->load->view(x);``, you can use ``echo view(x);``.
+  ``$this->load->view(x);``, you can use ``return view(x);``.
 - CI4 supports *View Cells* to build your response in pieces, and *View Layouts* for page layout.
 - The template parser is still there, and substantially enhanced.
 
@@ -24,7 +24,7 @@ Upgrade Guide
 
 1. First, move all views  to the folder **app/Views**
 2. Change the loading syntax of views in every script where you load views:
-    - from ``$this->load->view('directory_name/file_name')`` to ``echo view('directory_name/file_name');``
+    - from ``$this->load->view('directory_name/file_name')`` to ``return view('directory_name/file_name');``
     - from ``$content = $this->load->view('file', $data, TRUE);`` to ``$content = view('file', $data);``
 3. (optional) You can change the echo syntax in views from ``<?php echo $title; ?>`` to ``<?= $title ?>``
 

--- a/user_guide_src/source/libraries/pagination/002.php
+++ b/user_guide_src/source/libraries/pagination/002.php
@@ -15,6 +15,6 @@ class UserController extends Controller
             'pager' => $model->pager,
         ];
 
-        echo view('users/index', $data);
+        return view('users/index', $data);
     }
 }

--- a/user_guide_src/source/libraries/validation/001.php
+++ b/user_guide_src/source/libraries/validation/001.php
@@ -11,11 +11,11 @@ class Form extends Controller
         helper(['form', 'url']);
 
         if (! $this->validate([])) {
-            echo view('Signup', [
+            return view('Signup', [
                 'validation' => $this->validator,
             ]);
-        } else {
-            echo view('Success');
         }
+
+        return view('Success');
     }
 }

--- a/user_guide_src/source/outgoing/view_layouts/001.php
+++ b/user_guide_src/source/outgoing/view_layouts/001.php
@@ -6,6 +6,6 @@ class MyController extends BaseController
 {
     public function index()
     {
-        echo view('some_view');
+        return view('some_view');
     }
 }

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -550,7 +550,8 @@ An example with the iteration controlled in the view::
             ['title' => 'Second Link', 'link' => '/second'],
         ]
     ];
-    echo $parser->setData($data)->renderString($template);
+
+    return $parser->setData($data)->renderString($template);
 
 Result::
 

--- a/user_guide_src/source/outgoing/view_parser/003.php
+++ b/user_guide_src/source/outgoing/view_parser/003.php
@@ -5,4 +5,4 @@ $data = [
     'blog_heading' => 'My Blog Heading',
 ];
 
-echo $parser->setData($data)->render('blog_template');
+return $parser->setData($data)->render('blog_template');

--- a/user_guide_src/source/outgoing/view_parser/004.php
+++ b/user_guide_src/source/outgoing/view_parser/004.php
@@ -1,6 +1,6 @@
 <?php
 
-echo $parser->render('blog_template', [
+return $parser->render('blog_template', [
     'cache'      => HOUR,
     'cache_name' => 'something_unique',
 ]);

--- a/user_guide_src/source/outgoing/view_parser/005.php
+++ b/user_guide_src/source/outgoing/view_parser/005.php
@@ -3,5 +3,5 @@
 $template = '<head><title>{blog_title}</title></head>';
 $data     = ['blog_title' => 'My ramblings'];
 
-echo $parser->setData($data)->renderString($template);
+return $parser->setData($data)->renderString($template);
 // Result: <head><title>My ramblings</title></head>

--- a/user_guide_src/source/outgoing/view_parser/006.php
+++ b/user_guide_src/source/outgoing/view_parser/006.php
@@ -12,4 +12,4 @@ $data = [
     ],
 ];
 
-echo $parser->setData($data)->render('blog_template');
+return $parser->setData($data)->render('blog_template');

--- a/user_guide_src/source/outgoing/view_parser/007.php
+++ b/user_guide_src/source/outgoing/view_parser/007.php
@@ -8,4 +8,4 @@ $data = [
     'blog_entries' => $query->getResultArray(),
 ];
 
-echo $parser->setData($data)->render('blog_template');
+return $parser->setData($data)->render('blog_template');

--- a/user_guide_src/source/outgoing/view_parser/008.php
+++ b/user_guide_src/source/outgoing/view_parser/008.php
@@ -9,4 +9,4 @@ $data = [
     ],
 ];
 
-echo $parser->setData($data)->render('blog_template');
+return $parser->setData($data)->render('blog_template');

--- a/user_guide_src/source/outgoing/view_parser/009.php
+++ b/user_guide_src/source/outgoing/view_parser/009.php
@@ -7,5 +7,5 @@ $data = [
     'location' => ['city' => 'Red City', 'planet' => 'Mars'],
 ];
 
-echo $parser->setData($data)->renderString($template);
+return $parser->setData($data)->renderString($template);
 // Result: George lives in Red City on Mars.

--- a/user_guide_src/source/outgoing/view_parser/010.php
+++ b/user_guide_src/source/outgoing/view_parser/010.php
@@ -7,8 +7,10 @@ $data = [
     'location' => ['city' => 'Red City', 'planet' => 'Mars'],
 ];
 
-echo $parser->setData($data)->renderString($template, ['cascadeData' => false]);
+return $parser->setData($data)->renderString($template, ['cascadeData' => false]);
 // Result: {name} lives in Red City on Mars.
 
-echo $parser->setData($data)->renderString($template, ['cascadeData' => true]);
+// or
+
+return $parser->setData($data)->renderString($template, ['cascadeData' => true]);
 // Result: George lives in Red City on Mars.

--- a/user_guide_src/source/outgoing/view_parser/018.php
+++ b/user_guide_src/source/outgoing/view_parser/018.php
@@ -6,5 +6,6 @@ $data     = [
     'firstname' => 'John',
     'lastname'  => 'Doe',
 ];
-echo $parser->setData($data)->renderString($template);
+
+return $parser->setData($data)->renderString($template);
 // Result: Hello, John Doe

--- a/user_guide_src/source/outgoing/view_parser/019.php
+++ b/user_guide_src/source/outgoing/view_parser/019.php
@@ -6,5 +6,6 @@ $data     = [
     'firstname' => 'John',
     'lastname'  => 'Doe',
 ];
-echo $parser->setData($data)->renderString($template);
+
+return $parser->setData($data)->renderString($template);
 // Result: Hello, John {initials} Doe

--- a/user_guide_src/source/outgoing/view_parser/020.php
+++ b/user_guide_src/source/outgoing/view_parser/020.php
@@ -10,5 +10,6 @@ $data     = [
         ['degree' => 'PhD'],
     ],
 ];
-echo $parser->setData($data)->renderString($template);
+
+return $parser->setData($data)->renderString($template);
 // Result: Hello, John Doe (Mr{degree} {/degrees})

--- a/user_guide_src/source/outgoing/view_parser/021.php
+++ b/user_guide_src/source/outgoing/view_parser/021.php
@@ -15,4 +15,5 @@ $template2 = '<ul>{menuitems}</ul>';
 $data      = [
     'menuitems' => $temp,
 ];
-echo $parser->setData($data)->renderString($template2);
+
+return $parser->setData($data)->renderString($template2);

--- a/user_guide_src/source/outgoing/view_parser/022.php
+++ b/user_guide_src/source/outgoing/view_parser/022.php
@@ -1,3 +1,3 @@
 <?php
 
-echo $parser->render('myview');
+return $parser->render('myview');

--- a/user_guide_src/source/outgoing/view_parser/023.php
+++ b/user_guide_src/source/outgoing/view_parser/023.php
@@ -1,3 +1,3 @@
 <?php
 
-echo $parser->render('myview');
+return $parser->render('myview');

--- a/user_guide_src/source/outgoing/views.rst
+++ b/user_guide_src/source/outgoing/views.rst
@@ -51,9 +51,6 @@ If you visit your site using the URL you did earlier you should see your new vie
 
     example.com/index.php/blog/
 
-.. note:: While all of the examples show echo the view directly, you can also return the output from the view, instead,
-    and it will be appended to any captured output.
-
 Loading Multiple Views
 ======================
 

--- a/user_guide_src/source/outgoing/views/001.php
+++ b/user_guide_src/source/outgoing/views/001.php
@@ -1,3 +1,3 @@
 <?php
 
-echo view('name');
+return view('name');

--- a/user_guide_src/source/outgoing/views/002.php
+++ b/user_guide_src/source/outgoing/views/002.php
@@ -8,6 +8,6 @@ class Blog extends Controller
 {
     public function index()
     {
-        echo view('blog_view');
+        return view('blog_view');
     }
 }

--- a/user_guide_src/source/outgoing/views/003.php
+++ b/user_guide_src/source/outgoing/views/003.php
@@ -12,9 +12,9 @@ class Page extends Controller
             'page_title' => 'Your title',
         ];
 
-        echo view('header');
-        echo view('menu');
-        echo view('content', $data);
-        echo view('footer');
+        return view('header')
+            . view('menu')
+            . view('content', $data)
+            . view('footer');
     }
 }

--- a/user_guide_src/source/outgoing/views/004.php
+++ b/user_guide_src/source/outgoing/views/004.php
@@ -1,3 +1,3 @@
 <?php
 
-echo view('directory_name/file_name');
+return view('directory_name/file_name');

--- a/user_guide_src/source/outgoing/views/005.php
+++ b/user_guide_src/source/outgoing/views/005.php
@@ -1,3 +1,3 @@
 <?php
 
-echo view('Example\Blog\Views\blog_view');
+return view('Example\Blog\Views\blog_view');

--- a/user_guide_src/source/outgoing/views/006.php
+++ b/user_guide_src/source/outgoing/views/006.php
@@ -1,4 +1,4 @@
 <?php
 
 // Cache the view for 60 seconds
-echo view('file_name', $data, ['cache' => 60]);
+return view('file_name', $data, ['cache' => 60]);

--- a/user_guide_src/source/outgoing/views/007.php
+++ b/user_guide_src/source/outgoing/views/007.php
@@ -1,4 +1,4 @@
 <?php
 
 // Cache the view for 60 seconds
-echo view('file_name', $data, ['cache' => 60, 'cache_name' => 'my_cached_view']);
+return view('file_name', $data, ['cache' => 60, 'cache_name' => 'my_cached_view']);

--- a/user_guide_src/source/outgoing/views/008.php
+++ b/user_guide_src/source/outgoing/views/008.php
@@ -6,4 +6,4 @@ $data = [
     'message' => 'My Message',
 ];
 
-echo view('blog_view', $data);
+return view('blog_view', $data);

--- a/user_guide_src/source/outgoing/views/009.php
+++ b/user_guide_src/source/outgoing/views/009.php
@@ -11,6 +11,6 @@ class Blog extends Controller
         $data['title']   = 'My Real Title';
         $data['heading'] = 'My Real Heading';
 
-        echo view('blog_view', $data);
+        return view('blog_view', $data);
     }
 }

--- a/user_guide_src/source/outgoing/views/010.php
+++ b/user_guide_src/source/outgoing/views/010.php
@@ -6,4 +6,4 @@ $data = [
     'message' => 'My Message',
 ];
 
-echo view('blog_view', $data, ['saveData' => true]);
+return view('blog_view', $data, ['saveData' => true]);

--- a/user_guide_src/source/outgoing/views/011.php
+++ b/user_guide_src/source/outgoing/views/011.php
@@ -14,6 +14,6 @@ class Blog extends Controller
             'heading'   => 'My Real Heading',
         ];
 
-        echo view('blog_view', $data);
+        return view('blog_view', $data);
     }
 }


### PR DESCRIPTION
**Description**
Related  #5843

- `echo()` has side effects, so `return` is better.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

