### PR TITLE
docs: fix View/Parser saveData description

### DIFF
--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -106,7 +106,7 @@ Several options can be passed to the ``render()`` or ``renderString()`` methods.
 -   ``cache_name`` - the ID used to save/retrieve a cached view result; defaults to the viewpath;
     ignored for renderString()
 -   ``saveData`` - true if the view data parameters should be retained for subsequent calls;
-    default is **false**
+    default is **true**
 -   ``cascadeData`` - true if pseudo-variable settings should be passed on to nested
     substitutions; default is **true**
 
@@ -578,7 +578,7 @@ Class Reference
 
 .. php:class:: CodeIgniter\\View\\Parser
 
-    .. php:method:: render($view[, $options[, $saveData = false]])
+    .. php:method:: render($view[, $options[, $saveData]])
 
         :param  string  $view: File name of the view source
         :param  array   $options: Array of options, as key/value pairs
@@ -600,7 +600,7 @@ Class Reference
         Any conditional substitutions are performed first, then remaining
         substitutions are performed for each data pair.
 
-    .. php:method:: renderString($template[, $options[, $saveData = false]])
+    .. php:method:: renderString($template[, $options[, $saveData]])
 
         :param  string  $template: View source provided as a string
         :param  array   $options: Array of options, as key/value pairs

--- a/user_guide_src/source/outgoing/views.rst
+++ b/user_guide_src/source/outgoing/views.rst
@@ -123,15 +123,20 @@ Now open your view file and change the text to variables that correspond to the 
 
 Then load the page at the URL you've been using and you should see the variables replaced.
 
-The data passed in is only available during one call to `view`. If you call the function multiple times
-in a single request, you will have to pass the desired data to each view. This keeps any data from "bleeding" into
-other views, potentially causing issues. If you would prefer the data to persist, you can pass the `saveData` option
-into the `$option` array in the third parameter.
+The saveData Option
+-------------------
+
+The data passed in is retained for subsequent calls to ``view()``. If you call the function multiple times
+in a single request, you will not have to pass the desired data to each ``view()``.
+
+But this might not keep any data from "bleeding" into
+other views, potentially causing issues. If you would prefer to clean the data after one call, you can pass the ``saveData`` option
+into the ``$option`` array in the third parameter.
 
 .. literalinclude:: views/010.php
 
-Additionally, if you would like the default functionality of the view function to be that it does save the data
-between calls, you can set ``$saveData`` to **true** in **app/Config/Views.php**.
+Additionally, if you would like the default functionality of the view function to be that it does clear the data
+between calls, you can set ``$saveData`` to **false** in **app/Config/Views.php**.
 
 Creating Loops
 ==============

--- a/user_guide_src/source/outgoing/views.rst
+++ b/user_guide_src/source/outgoing/views.rst
@@ -101,7 +101,7 @@ along ``cache_name`` and the cache ID you wish to use:
 Adding Dynamic Data to the View
 ===============================
 
-Data is passed from the controller to the view by way of an array in the second parameter of the view function.
+Data is passed from the controller to the view by way of an array in the second parameter of the ``view()`` function.
 Here's an example:
 
 .. literalinclude:: views/008.php
@@ -135,7 +135,7 @@ into the ``$option`` array in the third parameter.
 
 .. literalinclude:: views/010.php
 
-Additionally, if you would like the default functionality of the view function to be that it does clear the data
+Additionally, if you would like the default functionality of the ``view()`` function to be that it does clear the data
 between calls, you can set ``$saveData`` to **false** in **app/Config/Views.php**.
 
 Creating Loops

--- a/user_guide_src/source/outgoing/views/010.php
+++ b/user_guide_src/source/outgoing/views/010.php
@@ -6,4 +6,4 @@ $data = [
     'message' => 'My Message',
 ];
 
-return view('blog_view', $data, ['saveData' => true]);
+return view('blog_view', $data, ['saveData' => false]);


### PR DESCRIPTION
**Description**
- `saveData` is `true` by default, but the explanation is the opposite.

See
https://github.com/codeigniter4/CodeIgniter4/blob/a9b086a06ead631e5cdc3bb2966960a8b6bb177e/app/Config/View.php#L20
https://github.com/codeigniter4/CodeIgniter4/blob/a9b086a06ead631e5cdc3bb2966960a8b6bb177e/system/View/Parser.php#L97
https://github.com/codeigniter4/CodeIgniter4/blob/a9b086a06ead631e5cdc3bb2966960a8b6bb177e/system/View/View.php#L166
https://github.com/codeigniter4/CodeIgniter4/blob/a9b086a06ead631e5cdc3bb2966960a8b6bb177e/system/Common.php#L1105

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

