### PR TITLE
fix: Publisher::discover() loads incorrect classname

### DIFF
--- a/system/Publisher/Publisher.php
+++ b/system/Publisher/Publisher.php
@@ -111,9 +111,9 @@ class Publisher extends FileCollection
 
         // Loop over each file checking to see if it is a Publisher
         foreach (array_unique($files) as $file) {
-            $className = $locator->findQualifiedNameFromPath($file);
+            $className = $locator->getClassname($file);
 
-            if (is_string($className) && class_exists($className) && is_a($className, self::class, true)) {
+            if ($className !== '' && class_exists($className) && is_a($className, self::class, true)) {
                 self::$discovered[$directory][] = new $className();
             }
         }


### PR DESCRIPTION
**Description**
Related  #5849

Cannot write a unit test for `Cannot declare class ..., because the name is already in use`. 

To check manually using this repo:
1. Add `"App\\": "app/"` in the `autoload.psr4` section in the root `composer.json`.
2. Run `composer dump -o` to regenerate the class map.
3. Add `'MyNameSpace' => APPPATH . 'ThirdParty/MyFolder'` in `Config\Autoload::$psr4` array.
4. Create `app/ThirdParty/MyFolder/Publishers/BootstrapPublisher.php`:

```php
<?php
namespace MyNameSpace\Publishers;
use CodeIgniter\Publisher\Publisher;
class BootstrapPublisher extends Publisher
{
}
```

5. Run `php spark publish`. 

```
CodeIgniter v4.1.9 Command Line Tool - Server Time: 2022-04-04 06:39:07 UTC-05:00

PHP Fatal error:  Cannot declare class MyNameSpace\Publishers\BootstrapPublisher, because the name is already in use in /Users/kenji/work/codeigniter/CodeIgniter4/app/ThirdParty/MyFolder/Publishers/BootstrapPublisher.php on line 7
PHP Stack trace:
PHP   1. {main}() /Users/kenji/work/codeigniter/CodeIgniter4/spark:0
PHP   2. CodeIgniter\CLI\Console->run($useSafeOutput = *uninitialized*) /Users/kenji/work/codeigniter/CodeIgniter4/spark:79
PHP   3. CodeIgniter\CodeIgniter->run($routes = *uninitialized*, $returnResponse = *uninitialized*) /Users/kenji/work/codeigniter/CodeIgniter4/system/CLI/Console.php:48
PHP   4. CodeIgniter\CodeIgniter->handleRequest($routes = NULL, $cacheConfig = class Config\Cache { public $handler = 'file'; public $backupHandler = 'dummy'; public $storePath = '/Users/kenji/work/codeigniter/CodeIgniter4/writable/cache/'; public $cacheQueryString = FALSE; public $prefix = ''; public $ttl = 60; public $reservedCharacters = '{}()/\\@:'; public $file = ['storePath' => '/Users/kenji/work/codeigniter/CodeIgniter4/writable/cache/', 'mode' => 416]; public $memcached = ['host' => '127.0.0.1', 'port' => 11211, 'weight' => 1, 'raw' => FALSE]; public $redis = ['host' => '127.0.0.1', 'password' => NULL, 'port' => 6379, 'timeout' => 0, 'database' => 0]; public $validHandlers = ['dummy' => 'CodeIgniter\\Cache\\Handlers\\DummyHandler', 'file' => 'CodeIgniter\\Cache\\Handlers\\FileHandler', 'memcached' => 'CodeIgniter\\Cache\\Handlers\\MemcachedHandler', 'predis' => 'CodeIgniter\\Cache\\Handlers\\PredisHandler', 'redis' => 'CodeIgniter\\Cache\\Handlers\\RedisHandler', 'wincache' => 'CodeIgniter\\Cache\\Handlers\\WincacheHandler'] }, $returnResponse = FALSE) /Users/kenji/work/codeigniter/CodeIgniter4/system/CodeIgniter.php:346
PHP   5. CodeIgniter\CodeIgniter->runController($class = class CodeIgniter\CLI\CommandRunner { protected $commands = class CodeIgniter\CLI\Commands { protected $commands = [...]; protected $logger = class CodeIgniter\Log\Logger { ... } }; protected $helpers = []; protected $request = class CodeIgniter\HTTP\CLIRequest { protected $segments = [...]; protected $options = [...]; protected $args = [...]; protected $method = 'cli'; protected $proxyIPs = ''; protected $uri = class CodeIgniter\HTTP\URI { ... }; protected $protocolVersion = NULL; protected $validProtocolVersions = [...]; protected $body = NULL; protected $headers = [...]; protected $headerMap = [...]; protected $ipAddress = ''; protected $globals = [...] }; protected $response = class CodeIgniter\HTTP\Response { protected $reason = 'OK'; protected $statusCode = 200; protected $pretend = FALSE; protected $protocolVersion = NULL; protected $validProtocolVersions = [...]; protected $body = NULL; protected $headers = [...]; protected $headerMap = [...]; protected $CSPEnabled = FALSE; public $CSP = class CodeIgniter\HTTP\ContentSecurityPolicy { ... }; protected $cookieStore = class CodeIgniter\Cookie\CookieStore { ... }; protected $cookiePrefix = ''; protected $cookieDomain = ''; protected $cookiePath = '/'; protected $cookieSecure = FALSE; protected $cookieHTTPOnly = TRUE; protected $cookieSameSite = 'Lax'; protected $cookies = [...]; protected $bodyFormat = 'html' }; protected $logger = class CodeIgniter\Log\Logger { protected $logLevels = [...]; protected $loggableLevels = [...]; protected $filePermissions = 420; protected $dateFormat = 'Y-m-d H:i:s'; protected $fileExt = NULL; protected $handlers = [...]; protected $handlerConfig = [...]; public $logCache = [...]; protected $cacheLogs = TRUE }; protected $forceHTTPS = 0; protected $validator = NULL }) /Users/kenji/work/codeigniter/CodeIgniter4/system/CodeIgniter.php:467
PHP   6. CodeIgniter\CLI\CommandRunner->_remap($method = 'index', $params = [0 => 'publish']) /Users/kenji/work/codeigniter/CodeIgniter4/system/CodeIgniter.php:888
PHP   7. CodeIgniter\CLI\CommandRunner->index($params = [0 => 'publish']) /Users/kenji/work/codeigniter/CodeIgniter4/system/CLI/CommandRunner.php:51
PHP   8. CodeIgniter\CLI\Commands->run($command = 'publish', $params = []) /Users/kenji/work/codeigniter/CodeIgniter4/system/CLI/CommandRunner.php:65
PHP   9. CodeIgniter\Commands\Utilities\Publish->run($params = []) /Users/kenji/work/codeigniter/CodeIgniter4/system/CLI/Commands.php:63
PHP  10. CodeIgniter\Publisher\Publisher::discover($directory = 'Publishers') /Users/kenji/work/codeigniter/CodeIgniter4/system/Commands/Utilities/Publish.php:77
PHP  11. CodeIgniter\Autoloader\FileLocator->findQualifiedNameFromPath($path = '/Users/kenji/work/codeigniter/CodeIgniter4/app/ThirdParty/MyFolder/Publishers/BootstrapPublisher.php') /Users/kenji/work/codeigniter/CodeIgniter4/system/Publisher/Publisher.php:114
PHP  12. class_exists($class = '\\App\\ThirdParty\\MyFolder\\Publishers\\BootstrapPublisher') /Users/kenji/work/codeigniter/CodeIgniter4/system/Autoloader/FileLocator.php:280
PHP  13. Composer\Autoload\ClassLoader->loadClass($class = 'App\\ThirdParty\\MyFolder\\Publishers\\BootstrapPublisher') /Users/kenji/work/codeigniter/CodeIgniter4/system/Autoloader/FileLocator.php:280
PHP  14. Composer\Autoload\includeFile($file = '/Users/kenji/work/codeigniter/CodeIgniter4/vendor/composer/../../app/ThirdParty/MyFolder/Publishers/BootstrapPublisher.php') /Users/kenji/work/codeigniter/CodeIgniter4/vendor/composer/ClassLoader.php:428
PHP  15. include() /Users/kenji/work/codeigniter/CodeIgniter4/vendor/composer/ClassLoader.php:571

[ErrorException]

Cannot declare class MyNameSpace\Publishers\BootstrapPublisher, because the name is already in use

at APPPATH/ThirdParty/MyFolder/Publishers/BootstrapPublisher.php:7

Backtrace:
  1    [internal function]
       CodeIgniter\Debug\Exceptions()->shutdownHandler()
```

6. Check out this PR branch (`fix-publisher-discover`).
9. Run `php spark publish`.  The Fatal error does not occurred.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
