### PR TITLE
refactor: extract RedirectResponse::withErrors() method

### DIFF
--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -85,18 +85,35 @@ class RedirectResponse extends Response
     public function withInput()
     {
         $session = Services::session();
-
         $session->setFlashdata('_ci_old_input', [
             'get'  => $_GET ?? [],
             'post' => $_POST ?? [],
         ]);
 
-        // If the validation has any errors, transmit those back
-        // so they can be displayed when the validation is handled
-        // within a method different than displaying the form.
+        // @TODO Remove this in the future.
+        //      See https://github.com/codeigniter4/CodeIgniter4/issues/5839#issuecomment-1086624600
+        $this->withErrors();
+
+        return $this;
+    }
+
+    /**
+     * Set validation errors in the session.
+     *
+     * If the validation has any errors, transmit those back
+     * so they can be displayed when the validation is handled
+     * within a method different than displaying the form.
+     *
+     * @TODO Make this method public when removing $this->withErrors() in withInput().
+     *
+     * @return $this
+     */
+    private function withErrors(): self
+    {
         $validation = Services::validation();
 
         if ($validation->getErrors()) {
+            $session = Services::session();
             $session->setFlashdata('_ci_validation_errors', serialize($validation->getErrors()));
         }
 


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/issues/5839#issuecomment-1086624600
Saving validation errors in the Session has nothing to do with saving input data in the Session.
They are different things and saving validation errors should be another method.

But the change is a breaking change. 
This PR just extract a private method to prepare to the future breaking change.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
