### PR TITLE
fix: validation errors in Model are not cleared when running validation again

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -26,11 +26,6 @@ parameters:
 			path: system/Autoloader/Autoloader.php
 
 		-
-			message: "#^Method CodeIgniter\\\\Validation\\\\ValidationInterface\\:\\:run\\(\\) invoked with 3 parameters, 0\\-2 required\\.$#"
-			count: 1
-			path: system/BaseModel.php
-
-		-
 			message: "#^Property Config\\\\Cache\\:\\:\\$backupHandler \\(string\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: system/Cache/CacheFactory.php

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1344,7 +1344,9 @@ abstract class BaseModel
             return true;
         }
 
-        return $this->validation->setRules($rules, $this->validationMessages)->run($data, null, $this->DBGroup);
+        $this->validation->reset()->setRules($rules, $this->validationMessages);
+
+        return $this->validation->run($data, null, $this->DBGroup);
     }
 
     /**

--- a/tests/system/Models/ValidationModelTest.php
+++ b/tests/system/Models/ValidationModelTest.php
@@ -55,6 +55,29 @@ final class ValidationModelTest extends LiveModelTestCase
         $this->assertSame('You forgot to name the baby.', $errors['name']);
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5859
+     */
+    public function testValidationTwice(): void
+    {
+        $data = [
+            'name'        => null,
+            'description' => 'some great marketing stuff',
+        ];
+
+        $this->assertFalse($this->model->insert($data));
+
+        $errors = $this->model->errors();
+        $this->assertSame('You forgot to name the baby.', $errors['name']);
+
+        $data = [
+            'name'        => 'some name',
+            'description' => 'some great marketing stuff',
+        ];
+
+        $this->assertIsInt($this->model->insert($data));
+    }
+
     public function testValidationWithSetValidationRule(): void
     {
         $data = [


### PR DESCRIPTION
**Description**
Fixes #5859

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

