### PR TITLE
feat: add `$includeDir` option to `get_filenames()`

### DIFF
--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -194,9 +194,14 @@ if (! function_exists('get_filenames')) {
      * @param string    $sourceDir   Path to source
      * @param bool|null $includePath Whether to include the path as part of the filename; false for no path, null for a relative path, true for full path
      * @param bool      $hidden      Whether to include hidden files (files beginning with a period)
+     * @param bool      $includeDir  Whether to include directories
      */
-    function get_filenames(string $sourceDir, ?bool $includePath = false, bool $hidden = false): array
-    {
+    function get_filenames(
+        string $sourceDir,
+        ?bool $includePath = false,
+        bool $hidden = false,
+        bool $includeDir = true
+    ): array {
         $files = [];
 
         $sourceDir = realpath($sourceDir) ?: $sourceDir;
@@ -212,12 +217,14 @@ if (! function_exists('get_filenames')) {
                     continue;
                 }
 
-                if ($includePath === false) {
-                    $files[] = $basename;
-                } elseif ($includePath === null) {
-                    $files[] = str_replace($sourceDir, '', $name);
-                } else {
-                    $files[] = $name;
+                if ($includeDir || ! $object->isDir()) {
+                    if ($includePath === false) {
+                        $files[] = $basename;
+                    } elseif ($includePath === null) {
+                        $files[] = str_replace($sourceDir, '', $name);
+                    } else {
+                        $files[] = $name;
+                    }
                 }
             }
         } catch (Throwable $e) {

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -305,6 +305,22 @@ final class FilesystemHelperTest extends CIUnitTestCase
         $this->assertSame($expected, get_filenames($vfs->url(), false));
     }
 
+    public function testGetFilenamesWithoutDirectories()
+    {
+        $vfs = vfsStream::setup('root', null, $this->structure);
+
+        $filenames = get_filenames($vfs->url(), true, false, false);
+
+        $expected = [
+            'vfs://root/boo/far',
+            'vfs://root/boo/faz',
+            'vfs://root/foo/bar',
+            'vfs://root/foo/baz',
+            'vfs://root/simpleFile',
+        ];
+        $this->assertSame($expected, $filenames);
+    }
+
     public function testGetFilenamesWithHidden()
     {
         $this->assertTrue(function_exists('get_filenames'));

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -37,6 +37,7 @@ Enhancements
 - Exception information logged through ``log_message()`` has now improved. It now includes the file and line where the exception originated. It also does not truncate the message anymore.
     - The log format has also changed. If users are depending on the log format in their apps, the new log format is "<1-based count> <cleaned filepath>(<line>): <class><function><args>"
 - Added support for webp files to **app/Config/Mimes.php**.
+- Added 4th parameter ``$includeDir`` to ``get_filenames()``. See :php:func:`get_filenames`.
 
 Changes
 *******

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -150,11 +150,12 @@ The following functions are available:
 
     .. note:: The files must be writable or owned by the system in order to be deleted.
 
-.. php:function:: get_filenames($source_dir[, $include_path = false])
+.. php:function:: get_filenames($sourceDir[, $includePath = false[, $hidden = false[, $includeDir = true]]])
 
-    :param    string    $source_dir: Directory path
-    :param    bool|null    $include_path: Whether to include the path as part of the filename; false for no path, null for the path relative to $source_dir, true for the full path
+    :param    string    $sourceDir: Directory path
+    :param    bool|null    $includePath: Whether to include the path as part of the filename; false for no path, null for the path relative to ``$sourceDir``, true for the full path
     :param    bool    $hidden: Whether to include hidden files (files beginning with a period)
+    :param    bool    $includeDir: Whether to include directories
     :returns:    An array of file names
     :rtype:    array
 

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -155,7 +155,7 @@ The following functions are available:
     :param    string    $sourceDir: Directory path
     :param    bool|null    $includePath: Whether to include the path as part of the filename; false for no path, null for the path relative to ``$sourceDir``, true for the full path
     :param    bool    $hidden: Whether to include hidden files (files beginning with a period)
-    :param    bool    $includeDir: Whether to include directories
+    :param    bool    $includeDir: Whether to include directories in the array output
     :returns:    An array of file names
     :rtype:    array
 


### PR DESCRIPTION
**Description**
- add option to exclude directories

See https://github.com/codeigniter4/CodeIgniter4/pull/5849#discussion_r841375909 and
https://github.com/codeigniter4/CodeIgniter4/blob/8f1ed45f1bb3d2df34665e80767d171bd4cef167/tests/system/Helpers/FilesystemHelperTest.php#L290-L291

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
