### PR TITLE
chore: rename php-cs-fixer config files

### DIFF
--- a/.github/workflows/test-coding-standards.yml
+++ b/.github/workflows/test-coding-standards.yml
@@ -52,10 +52,10 @@ jobs:
         run: composer update --ansi --no-interaction
 
       - name: Run lint on `app/`, `admin/`, `public/`
-        run: vendor/bin/php-cs-fixer fix --verbose --ansi --dry-run --config=.no-header.php-cs-fixer.dist.php --using-cache=no --diff
+        run: vendor/bin/php-cs-fixer fix --verbose --ansi --dry-run --config=.php-cs-fixer.no-header.php --using-cache=no --diff
 
       - name: Run lint on `system/`, `tests`, `utils/`, and root PHP files
         run: vendor/bin/php-cs-fixer fix --verbose --ansi --dry-run --using-cache=no --diff
 
       - name: Run lint on `user_guide_src/source/`
-        run: vendor/bin/php-cs-fixer fix --verbose --ansi --dry-run --config=.user-guide.php-cs-fixer.dist.php --using-cache=no --diff
+        run: vendor/bin/php-cs-fixer fix --verbose --ansi --dry-run --config=.php-cs-fixer.user-guide.php --using-cache=no --diff

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -29,8 +29,8 @@ $finder = Finder::create()
     ->notName('#Foobar.php$#')
     ->append([
         __FILE__,
-        __DIR__ . '/.no-header.php-cs-fixer.dist.php',
-        __DIR__ . '/.user-guide.php-cs-fixer.dist.php',
+        __DIR__ . '/.php-cs-fixer.no-header.php',
+        __DIR__ . '/.php-cs-fixer.user-guide.php',
         __DIR__ . '/rector.php',
         __DIR__ . '/spark',
         __DIR__ . '/user_guide_src/renumerate.php',

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -33,7 +33,7 @@ $finder = Finder::create()
 $overrides = [];
 
 $options = [
-    'cacheFile'    => 'build/.no-header.php-cs-fixer.cache',
+    'cacheFile'    => 'build/.php-cs-fixer.no-header.cache',
     'finder'       => $finder,
     'customFixers' => FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'),
     'customRules'  => [

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -37,7 +37,7 @@ $overrides = [
 ];
 
 $options = [
-    'cacheFile'    => 'build/.user-guide.php-cs-fixer.cache',
+    'cacheFile'    => 'build/.php-cs-fixer.user-guide.cache',
     'finder'       => $finder,
     'customFixers' => FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'),
     'customRules'  => [

--- a/admin/pre-commit
+++ b/admin/pre-commit
@@ -42,9 +42,9 @@ if [ "$FILES" != "" ]; then
     # Run on whole codebase to skip on unnecessary filtering
     # Run first on app, admin, public
     if [ -d /proc/cygdrive ]; then
-        ./vendor/bin/php-cs-fixer fix --verbose --dry-run --diff --config=.no-header.php-cs-fixer.dist.php
+        ./vendor/bin/php-cs-fixer fix --verbose --dry-run --diff --config=.php-cs-fixer.no-header.php
     else
-        php ./vendor/bin/php-cs-fixer fix --verbose --dry-run --diff --config=.no-header.php-cs-fixer.dist.php
+        php ./vendor/bin/php-cs-fixer fix --verbose --dry-run --diff --config=.php-cs-fixer.no-header.php
     fi
 
     if [ $? != 0 ]; then
@@ -66,9 +66,9 @@ if [ "$FILES" != "" ]; then
 
     # Next, run on user_guide_src/source PHP files
     if [ -d /proc/cygdrive ]; then
-        ./vendor/bin/php-cs-fixer fix --verbose --dry-run --diff --config=.user-guide.php-cs-fixer.dist.php
+        ./vendor/bin/php-cs-fixer fix --verbose --dry-run --diff --config=.php-cs-fixer.user-guide.php
     else
-        php ./vendor/bin/php-cs-fixer fix --verbose --dry-run --diff --config=.user-guide.php-cs-fixer.dist.php
+        php ./vendor/bin/php-cs-fixer fix --verbose --dry-run --diff --config=.php-cs-fixer.user-guide.php
     fi
 
     if [ $? != 0 ]; then


### PR DESCRIPTION
**Description**
The php-cs-fixer configuration files are all in one place and easy to find.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
