### PR TITLE
[PHPStan] Prepare for PHPStan 1.6.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.3",
         "nexusphp/tachycardia": "^1.0",
-        "phpstan/phpstan": "1.6.x-dev",
+        "phpstan/phpstan": "^1.5.6",
         "phpunit/phpunit": "^9.1",
         "predis/predis": "^1.1",
         "rector/rector": "0.12.20"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.3",
         "nexusphp/tachycardia": "^1.0",
-        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan": "1.6.x-dev",
         "phpunit/phpunit": "^9.1",
         "predis/predis": "^1.1",
         "rector/rector": "0.12.20"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,6 +7,10 @@ services:
 		class: Utils\PHPStan\CheckFrameworkExceptionInstantiationViaNamedConstructorRule
 		tags:
 			- phpstan.rules.rule
+	-
+		class: PhpParser\NodeVisitor\NodeConnectingVisitor
+		tags:
+			- phpstan.parser.richParserNodeVisitor
 
 includes:
 	- phpstan-baseline.neon.dist

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,7 @@
+conditionalTags:
+	PhpParser\NodeVisitor\NodeConnectingVisitor:
+		phpstan.parser.richParserNodeVisitor: true
+
 services:
 	-
 		class: Utils\PHPStan\CheckUseStatementsAfterLicenseRule
@@ -7,10 +11,6 @@ services:
 		class: Utils\PHPStan\CheckFrameworkExceptionInstantiationViaNamedConstructorRule
 		tags:
 			- phpstan.rules.rule
-	-
-		class: PhpParser\NodeVisitor\NodeConnectingVisitor
-		tags:
-			- phpstan.parser.richParserNodeVisitor
 
 includes:
 	- phpstan-baseline.neon.dist


### PR DESCRIPTION
PHPStan 1.6.0 will remove `parent`, `next`, `previous` attribute from node on `bleedingEdge` feature toggles, while it only disable when `bleedingEdge` enabled, it may possibly be removed in the future, so I think it is better to prepare early. 

We used the `previous` attribute check on `CheckUseStatementsAfterLicenseRule` for it:

https://github.com/codeigniter4/CodeIgniter4/blob/622d50aa2976b85f7cb1479faec7558cd9ec2341/utils/PHPStan/CheckUseStatementsAfterLicenseRule.php#L60

This PR is for draft and can be updated to use ^1.6 when PHPStan 1.6 released.

References:

- https://github.com/rectorphp/rector/issues/7088
- https://github.com/rectorphp/rector-src/pull/2014

**Checklist:**
- [x] Securely signed commits


<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
