### PR TITLE
clarify Models user guide

### DIFF
--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -99,7 +99,8 @@ is used with methods like ``find()`` to know what column to match the specified 
 
 Specifies if the table uses an auto-increment feature for ``$primaryKey``. If set to ``false``
 then you are responsible for providing primary key value for every record in the table. This
-feature may be handy when we want to implement 1:1 relation or use UUIDs for our model.
+feature may be handy when we want to implement 1:1 relation or use UUIDs for our model. The
+default value is ``true``.
 
 .. note:: If you set ``$useAutoIncrement`` to ``false``, then make sure to set your primary
     key in the database to ``unique``. This way you will make sure that all of Model's features


### PR DESCRIPTION
Inform the $useAutoIncrement default value (which is 'true'), so developers would be aware of that option if they don't use auto-incremented INT's on primary keys, especially when triggering an 'afterInsert' event which will eventually cause the $data['id'] value to be 0 instead of the actual primary key (see 'system/Model.php' line 254 : https://github.com/codeigniter4/CodeIgniter4/blob/622d50aa2976b85f7cb1479faec7558cd9ec2341/system/Model.php#L254).

I had an issue with this before and spent a bit long time figuring out what went wrong and it turned out to be a missing information in the user guide.