### PR TITLE
docs: fix parameters display for API response > `setResponseFormat($format)` method

### DIFF
--- a/user_guide_src/source/outgoing/api_responses.rst
+++ b/user_guide_src/source/outgoing/api_responses.rst
@@ -60,7 +60,7 @@ Class Reference
 ***************
 .. php:method:: setResponseFormat($format)
 
-    :param string $format The type of response to return, either ``json`` or ``xml``
+    :param string $format: The type of response to return, either ``json`` or ``xml``
 
     This defines the format to be used when formatting arrays in responses. If you provide a ``null`` value for
     ``$format``, it will be automatically determined through content negotiation.


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/2387514/162448574-340dc2ec-f596-494f-8225-fcfeb32ef5bf.png)

after:
![image](https://user-images.githubusercontent.com/2387514/162448624-2026b6ed-1713-4a0e-8639-0c35486da002.png)


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
