### PR TITLE
script_tag: cosmetic for value-less attributes

### DIFF
--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -208,7 +208,7 @@ if (! function_exists('script_tag')) {
                 }
             } else {
                 // for attributes without values, like async or defer, use NULL.
-                $script .= $k . (is_null($v) ? ' ' : '="' . $v . '" ');
+                $script .= $k . (null === $v ? ' ' : '="' . $v . '" ');
             }
         }
 

--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -189,8 +189,8 @@ if (! function_exists('script_tag')) {
      *
      * Generates link to a JS file
      *
-     * @param mixed $src       Script source or an array
-     * @param bool  $indexPage Should indexPage be added to the JS path
+     * @param array|string $src       Script source or an array of attributes
+     * @param bool         $indexPage Should indexPage be added to the JS path
      */
     function script_tag($src = '', bool $indexPage = false): string
     {

--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -207,11 +207,12 @@ if (! function_exists('script_tag')) {
                     $script .= 'src="' . slash_item('baseURL') . $v . '" ';
                 }
             } else {
-                $script .= $k . '="' . $v . '" ';
+                // for attributes without values, like async or defer, use NULL.
+                $script .= $k . (is_null($v) ? ' ' : '="' . $v . '" ');
             }
         }
 
-        return $script . 'type="text/javascript"' . '></script>';
+        return $script . 'type="text/javascript"></script>';
     }
 }
 

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -269,6 +269,16 @@ final class HTMLHelperTest extends CIUnitTestCase
         $this->assertSame($expected, script_tag($target));
     }
 
+    /**
+     * This test has probably no real-world value but may help detecting
+     * a change in the default behaviour.
+     */
+    public function testScriptTagWithoutAnyArg()
+    {
+        $expected = '<script src="http://example.com/" type="text/javascript"></script>';
+        $this->assertSame($expected, script_tag());
+    }
+
     public function testLinkTag()
     {
         $target   = 'css/mystyles.css';

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -248,6 +248,27 @@ final class HTMLHelperTest extends CIUnitTestCase
         $this->assertSame($expected, script_tag($target, true));
     }
 
+    public function testScriptTagWithSrc()
+    {
+        $target   = ['src' => 'http://site.com/js/mystyles.js'];
+        $expected = '<script src="http://site.com/js/mystyles.js" type="text/javascript"></script>';
+        $this->assertSame($expected, script_tag($target));
+    }
+
+    public function testScriptTagWithSrcWithoutProtocol()
+    {
+        $target   = ['src' => 'js/mystyles.js'];
+        $expected = '<script src="http://example.com/js/mystyles.js" type="text/javascript"></script>';
+        $this->assertSame($expected, script_tag($target));
+    }
+
+    public function testScriptTagWithSrcAndAttributes()
+    {
+        $target   = ['src' => 'js/mystyles.js', 'charset' => 'UTF-8', 'defer' => '', 'async' => null];
+        $expected = '<script src="http://example.com/js/mystyles.js" charset="UTF-8" defer="" async type="text/javascript"></script>';
+        $this->assertSame($expected, script_tag($target));
+    }
+
     public function testLinkTag()
     {
         $target   = 'css/mystyles.css';

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -38,6 +38,7 @@ Enhancements
     - The log format has also changed. If users are depending on the log format in their apps, the new log format is "<1-based count> <cleaned filepath>(<line>): <class><function><args>"
 - Added support for webp files to **app/Config/Mimes.php**.
 - Added 4th parameter ``$includeDir`` to ``get_filenames()``. See :php:func:`get_filenames`.
+- HTML helper ``script_tag()`` now uses ``null`` values to write boolean attributes in minimized form: ``<script src="..." defer />``. See the sample code for :php:func:`script_tag`.
 
 Changes
 *******

--- a/user_guide_src/source/helpers/html_helper.rst
+++ b/user_guide_src/source/helpers/html_helper.rst
@@ -104,8 +104,8 @@ The following functions are available:
 
 .. php:function:: script_tag([$src = ''[, $indexPage = false]])
 
-    :param  mixed  $src: The source name of a JavaScript file
-    :param  bool    $indexPage: Whether to treat ``$src`` as a routed URI string
+    :param  array|string  $src: The source name or URL of a JavaScript file, or an associative array specifying the attributes
+    :param  bool          $indexPage: Whether to treat ``$src`` as a routed URI string
     :returns:   HTML script tag
     :rtype: string
 

--- a/user_guide_src/source/helpers/html_helper/011.php
+++ b/user_guide_src/source/helpers/html_helper/011.php
@@ -1,6 +1,6 @@
 <?php
 
-$script = ['src' => 'js/printer.js'];
+$script = ['src' => 'js/printer.js', 'defer' => null];
 
 echo script_tag($script);
-// <script src="http://site.com/js/printer.js" type="text/javascript"></script>
+// <script src="http://site.com/js/printer.js" defer type="text/javascript"></script>


### PR DESCRIPTION
**Description**

For `<script />` elements, some attributes are usually written without values, for example :
`<script defer async src="..." />`

This is purely cosmetic as boolean attributes should also be accepted with an empty
value or a value identical to the attribute's name :
https://dev.w3.org/html5/pf-summary/infrastructure.html#boolean-attribute

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide