### PR TITLE
feat: throws exception when controller name in routes contains `/`

### DIFF
--- a/system/Language/en/Router.php
+++ b/system/Language/en/Router.php
@@ -14,4 +14,5 @@ return [
     'invalidParameter'         => 'A parameter does not match the expected type.',
     'missingDefaultRoute'      => 'Unable to determine what should be displayed. A default route has not been specified in the routing file.',
     'invalidDynamicController' => 'A dynamic controller is not allowed for security reasons. Route handler: {0}',
+    'invalidControllerName'    => 'The namespace delimiter is a backslash (\), not a slash (/). Route handler: {0}',
 ];

--- a/system/Router/Exceptions/RouterException.php
+++ b/system/Router/Exceptions/RouterException.php
@@ -68,4 +68,14 @@ class RouterException extends FrameworkException
     {
         return new static(lang('Router.invalidDynamicController', [$handler]));
     }
+
+    /**
+     * Throw when controller name has `/`.
+     *
+     * @return RouterException
+     */
+    public static function forInvalidControllerName(string $handler)
+    {
+        return new static(lang('Router.invalidControllerName', [$handler]));
+    }
 }

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -426,6 +426,11 @@ class Router implements RouterInterface
                         throw RouterException::forDynamicController($handler);
                     }
 
+                    // Checks `/` in controller name
+                    if (strpos($controller, '/') !== false) {
+                        throw RouterException::forInvalidControllerName($handler);
+                    }
+
                     if (strpos($routeKey, '/') !== false) {
                         $replacekey = str_replace('/(.*)', '', $routeKey);
                         $handler    = preg_replace('#^' . $routeKey . '$#u', $handler, $uri);

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -61,6 +61,7 @@ final class RouterTest extends CIUnitTestCase
             'closure/(:num)/(:alpha)'                         => static fn ($num, $str) => $num . '-' . $str,
             '{locale}/pages'                                  => 'App\Pages::list_all',
             'admin/admins'                                    => 'App\Admin\Admins::list_all',
+            'admin/admins/edit/(:any)'                        => 'App/Admin/Admins::edit_show/$1',
             '/some/slash'                                     => 'App\Slash::index',
             'objects/(:segment)/sort/(:segment)/([A-Z]{3,7})' => 'AdminList::objectsSortCreate/$1/$2/$3',
             '(:segment)/(:segment)/(:segment)'                => '$2::$3/$1',
@@ -400,6 +401,17 @@ final class RouterTest extends CIUnitTestCase
 
         $this->assertSame('\App\Admin\Admins', $router->controllerName());
         $this->assertSame('list_all', $router->methodName());
+    }
+
+    public function testRouteWithSlashInControllerName()
+    {
+        $this->expectExceptionMessage(
+            'The namespace delimiter is a backslash (\), not a slash (/). Route handler: \App/Admin/Admins::edit_show/$1'
+        );
+
+        $router = new Router($this->collection, $this->request);
+
+        $router->handle('admin/admins/edit/1');
     }
 
     public function testRouteWithLeadingSlash()


### PR DESCRIPTION
**Description**
- Throws Exception when a routes has invalid controller name like `'Admin/AdminGlavni::cam_edit_show/$1'`

It is better users know it should be `\` than replacing `/` with `\` without notice.
Because `Admin/AdminGlavni` is a wrong classname.

See https://forum.codeigniter.com/showthread.php?tid=81681&pid=395315#pid395315

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
