### PR TITLE
docs: fix heading level in api_responses.rst

### DIFF
--- a/user_guide_src/source/outgoing/api_responses.rst
+++ b/user_guide_src/source/outgoing/api_responses.rst
@@ -56,8 +56,10 @@ So, if your request asks for JSON formatted data in an **Accept** header, the da
 ``respond*`` or ``fail*`` methods will be formatted by the ``CodeIgniter\Format\JSONFormatter`` class. The resulting
 JSON data will be sent back to the client.
 
+***************
 Class Reference
 ***************
+
 .. php:method:: setResponseFormat($format)
 
     :param string $format: The type of response to return, either ``json`` or ``xml``


### PR DESCRIPTION
**Description**
Before:
![screenshot 2022-04-09 9 30 13](https://user-images.githubusercontent.com/87955/162549236-474bef38-3d80-48b0-908a-4e962b21122a.png)

After:
![screenshot 2022-04-09 9 30 17](https://user-images.githubusercontent.com/87955/162549241-101a09ee-2f22-4ff6-aa8e-ce2a7f6270d6.png)

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

