### PR TITLE
feat: new improved auto router

### DIFF
--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -30,5 +30,5 @@ class Feature extends BaseConfig
      *
      * @var bool
      */
-    public $autoRoutesImproved = false;
+    public bool $autoRoutesImproved = false;
 }

--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -10,7 +10,7 @@ use CodeIgniter\Config\BaseConfig;
 class Feature extends BaseConfig
 {
     /**
-     * Enable multiple filters for a route or not
+     * Enable multiple filters for a route or not.
      *
      * If you enable this:
      *   - CodeIgniter\CodeIgniter::handleRequest() uses:
@@ -24,4 +24,11 @@ class Feature extends BaseConfig
      * @var bool
      */
     public $multipleFilters = false;
+
+    /**
+     * Use improved new auto routing, instead of the traditional auto routing.
+     *
+     * @var bool
+     */
+    public $autoRoutesImproved = false;
 }

--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -26,7 +26,7 @@ class Feature extends BaseConfig
     public $multipleFilters = false;
 
     /**
-     * Use improved new auto routing, instead of the traditional auto routing.
+     * Use improved new auto routing instead of the default legacy version.
      */
     public bool $autoRoutesImproved = false;
 }

--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -27,8 +27,6 @@ class Feature extends BaseConfig
 
     /**
      * Use improved new auto routing, instead of the traditional auto routing.
-     *
-     * @var bool
      */
     public bool $autoRoutesImproved = false;
 }

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -706,8 +706,8 @@ parameters:
 			path: system/Router/Router.php
 
 		-
-			message: "#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRegisteredControllers\\(\\)\\.$#"
-			count: 1
+			message: "#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRegisteredControllers\\(.*\\)\\.$#"
+			count: 2
 			path: system/Router/Router.php
 
 		-
@@ -719,11 +719,6 @@ parameters:
 			message: "#^Method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRoutes\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 1
 			path: system/Router/Router.php
-
-		-
-			message: "#^Method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRoutes\\(\\) invoked with 1 parameter, 0 required\\.$#"
-			count: 1
-			path: system/Router/AutoRouterImproved.php
 
 		-
 			message: "#^Property Config\\\\App\\:\\:\\$CSRF[a-zA-Z]+ \\([a-zA-Z]+\\) on left side of \\?\\? is not nullable\\.$#"

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -677,7 +677,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getDefaultNamespace\\(\\)\\.$#"
-			count: 2
+			count: 3
 			path: system/Router/Router.php
 
 		-
@@ -719,6 +719,11 @@ parameters:
 			message: "#^Method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRoutes\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 1
 			path: system/Router/Router.php
+
+		-
+			message: "#^Method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRoutes\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: system/Router/AutoRouterImproved.php
 
 		-
 			message: "#^Property Config\\\\App\\:\\:\\$CSRF[a-zA-Z]+ \\([a-zA-Z]+\\) on left side of \\?\\? is not nullable\\.$#"

--- a/system/Router/AutoRouter.php
+++ b/system/Router/AutoRouter.php
@@ -16,7 +16,7 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 /**
  * Router for Auto-Routing
  */
-class AutoRouter
+class AutoRouter implements AutoRouterInterface
 {
     /**
      * List of controllers registered for the CLI verb that should not be accessed in the web.
@@ -263,6 +263,8 @@ class AutoRouter
     /**
      * Returns the name of the sub-directory the controller is in,
      * if any. Relative to APPPATH.'Controllers'.
+     *
+     * @deprecated This method is not necessary.
      */
     public function directory(): string
     {

--- a/system/Router/AutoRouter.php
+++ b/system/Router/AutoRouter.php
@@ -16,46 +16,46 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 /**
  * Router for Auto-Routing
  */
-class AutoRouter implements AutoRouterInterface
+final class AutoRouter implements AutoRouterInterface
 {
     /**
      * List of controllers registered for the CLI verb that should not be accessed in the web.
      *
      * @var class-string[]
      */
-    protected array $protectedControllers;
+    private array $protectedControllers;
 
     /**
      * Sub-directory that contains the requested controller class.
      * Primarily used by 'autoRoute'.
      */
-    protected ?string $directory = null;
+    private ?string $directory = null;
 
     /**
      * The name of the controller class.
      */
-    protected string $controller;
+    private string $controller;
 
     /**
      * The name of the method to use.
      */
-    protected string $method;
+    private string $method;
 
     /**
      * Whether dashes in URI's should be converted
      * to underscores when determining method names.
      */
-    protected bool $translateURIDashes;
+    private bool $translateURIDashes;
 
     /**
      * HTTP verb for the request.
      */
-    protected string $httpVerb;
+    private string $httpVerb;
 
     /**
      * Default namespace for controllers.
      */
-    protected string $defaultNamespace;
+    private string $defaultNamespace;
 
     public function __construct(
         array $protectedControllers,
@@ -181,7 +181,7 @@ class AutoRouter implements AutoRouterInterface
      *
      * @return array returns an array of remaining uri segments that don't map onto a directory
      */
-    protected function scanControllers(array $segments): array
+    private function scanControllers(array $segments): array
     {
         $segments = array_filter($segments, static fn ($segment) => $segment !== '');
         // numerically reindex the array, removing gaps

--- a/system/Router/AutoRouter.php
+++ b/system/Router/AutoRouter.php
@@ -20,6 +20,8 @@ class AutoRouter implements AutoRouterInterface
 {
     /**
      * List of controllers registered for the CLI verb that should not be accessed in the web.
+     *
+     * @var class-string[]
      */
     protected array $protectedControllers;
 

--- a/system/Router/AutoRouter.php
+++ b/system/Router/AutoRouter.php
@@ -166,6 +166,8 @@ final class AutoRouter implements AutoRouterInterface
     /**
      * Tells the system whether we should translate URI dashes or not
      * in the URI from a dash to an underscore.
+     *
+     * @deprecated This method should be removed.
      */
     public function setTranslateURIDashes(bool $val = false): self
     {
@@ -236,6 +238,8 @@ final class AutoRouter implements AutoRouterInterface
      * Sets the sub-directory that the controller is in.
      *
      * @param bool $validate if true, checks to make sure $dir consists of only PSR4 compliant segments
+     *
+     * @deprecated This method should be removed.
      */
     public function setDirectory(?string $dir = null, bool $append = false, bool $validate = true)
     {
@@ -266,7 +270,7 @@ final class AutoRouter implements AutoRouterInterface
      * Returns the name of the sub-directory the controller is in,
      * if any. Relative to APPPATH.'Controllers'.
      *
-     * @deprecated This method is not necessary.
+     * @deprecated This method should be removed.
      */
     public function directory(): string
     {

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -187,6 +187,9 @@ class AutoRouterImproved implements AutoRouterInterface
             }
         }
 
+        // Check _remao()
+        $this->checkRemap();
+
         // Check parameters
         try {
             $this->checkParameters($uri);
@@ -213,6 +216,21 @@ class AutoRouterImproved implements AutoRouterInterface
                 . ' Handler:' . $this->controller . '::' . $this->method
                 . ', URI:' . $uri
             );
+        }
+    }
+
+    private function checkRemap()
+    {
+        try {
+            $refClass  = new ReflectionClass($this->controller);
+            $refMethod = $refClass->getMethod('_remap');
+
+            throw new PageNotFoundException(
+                'AutoRouterImproved does not support `_remap()` method.'
+                . ' Controller:' . $this->controller
+            );
+        } catch (ReflectionException $e) {
+            // Do nothing.
         }
     }
 

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -18,65 +18,65 @@ use ReflectionException;
 /**
  * New Secure Router for Auto-Routing
  */
-class AutoRouterImproved implements AutoRouterInterface
+final class AutoRouterImproved implements AutoRouterInterface
 {
     /**
      * List of controllers in Defined Routes that should not be accessed via this Auto-Routing.
      *
      * @var class-string[]
      */
-    protected array $protectedControllers;
+    private array $protectedControllers;
 
     /**
      * Sub-directory that contains the requested controller class.
      */
-    protected ?string $directory = null;
+    private ?string $directory = null;
 
     /**
      * Sub-namespace that contains the requested controller class.
      */
-    protected ?string $subNamespace = null;
+    private ?string $subNamespace = null;
 
     /**
      * The name of the controller class.
      */
-    protected string $controller;
+    private string $controller;
 
     /**
      * The name of the method to use.
      */
-    protected string $method;
+    private string $method;
 
     /**
      * An array of params to the controller method.
      */
-    protected array $params = [];
+    private array $params = [];
 
     /**
      * Whether dashes in URI's should be converted
      * to underscores when determining method names.
      */
-    protected bool $translateURIDashes;
+    private bool $translateURIDashes;
 
     /**
      * HTTP verb for the request.
      */
-    protected string $httpVerb;
+    private string $httpVerb;
 
     /**
      * The namespace for controllers.
      */
-    protected string $namespace;
+    private string $namespace;
 
     /**
      * The name of the default controller class.
      */
-    protected string $defaultController;
+    private string $defaultController;
 
     /**
      * The name of the default method
      */
-    protected string $defaultMethod;
+    private string $defaultMethod;
 
     /**
      * @param class-string[] $protectedControllers

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -188,7 +188,6 @@ class AutoRouterImproved implements AutoRouterInterface
     {
         if ($this->httpVerb !== 'cli') {
             $controller = strtolower($this->controller);
-            $methodName = strtolower($this->method);
 
             foreach ($this->protectedControllers as $controllerInRoutes) {
                 $routeLowerCase = strtolower($controllerInRoutes);
@@ -224,8 +223,8 @@ class AutoRouterImproved implements AutoRouterInterface
     private function checkRemap()
     {
         try {
-            $refClass  = new ReflectionClass($this->controller);
-            $refMethod = $refClass->getMethod('_remap');
+            $refClass = new ReflectionClass($this->controller);
+            $refClass->getMethod('_remap');
 
             throw new PageNotFoundException(
                 'AutoRouterImproved does not support `_remap()` method.'

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -127,7 +127,9 @@ class AutoRouterImproved implements AutoRouterInterface
             strtolower($baseControllerName) === strtolower($this->defaultController)
             && strtolower($controllerSegment) === strtolower($this->defaultController)
         ) {
-            throw PageNotFoundException::forPageNotFound();
+            throw new PageNotFoundException(
+                'Cannot access the default controller "' . $baseControllerName . '" with the controller name URI path.'
+            );
         }
 
         // Use the method name if it exists.
@@ -139,7 +141,9 @@ class AutoRouterImproved implements AutoRouterInterface
 
             // Prevent access to default method path
             if (strtolower($this->method) === strtolower($this->defaultMethod)) {
-                throw PageNotFoundException::forPageNotFound();
+                throw new PageNotFoundException(
+                    'Cannot access the default method "' . $this->method . '" with the method name URI path.'
+                );
             }
         }
 
@@ -164,16 +168,20 @@ class AutoRouterImproved implements AutoRouterInterface
 
             foreach ($this->collection->getRoutes('cli') as $route) {
                 if (is_string($route)) {
-                    $route = strtolower($route);
+                    $routeLowerCase = strtolower($route);
                     if (strpos(
-                            $route,
-                            $controller . '::' . $methodName
-                        ) === 0) {
-                        throw new PageNotFoundException();
+                        $routeLowerCase,
+                        $controller . '::' . $methodName
+                    ) === 0) {
+                        throw new PageNotFoundException(
+                            'Cannot access CLI Route Handler: ' . $route
+                        );
                     }
 
-                    if ($route === $controller) {
-                        throw new PageNotFoundException();
+                    if ($routeLowerCase === $controller) {
+                        throw new PageNotFoundException(
+                            'Cannot access CLI Route Handler: ' . $route
+                        );
                     }
                 }
             }

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -21,7 +21,7 @@ use ReflectionException;
 class AutoRouterImproved implements AutoRouterInterface
 {
     /**
-     * Controller list that can't be accessible.
+     * List of controllers in Defined Routes that should not be accessed via this Auto-Routing.
      *
      * @var class-string[]
      */

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -1,0 +1,268 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router;
+
+use CodeIgniter\Exceptions\PageNotFoundException;
+
+/**
+ * New Secure Router for Auto-Routing
+ */
+class AutoRouterImproved implements AutoRouterInterface
+{
+    /**
+     * A RouteCollection instance.
+     */
+    protected RouteCollectionInterface $collection;
+
+    /**
+     * Sub-directory that contains the requested controller class.
+     */
+    protected ?string $directory = null;
+
+    /**
+     * Sub-namespace that contains the requested controller class.
+     */
+    protected ?string $subNamespace = null;
+
+    /**
+     * The name of the controller class.
+     */
+    protected string $controller;
+
+    /**
+     * The name of the method to use.
+     */
+    protected string $method;
+
+    /**
+     * An array of params to the controller method.
+     */
+    protected array $params = [];
+
+    /**
+     * Whether dashes in URI's should be converted
+     * to underscores when determining method names.
+     */
+    protected bool $translateURIDashes;
+
+    /**
+     * HTTP verb for the request.
+     */
+    protected string $httpVerb;
+
+    /**
+     * The namespace for controllers.
+     */
+    protected string $namespace;
+
+    /**
+     * The name of the default controller class.
+     */
+    protected string $defaultController;
+
+    /**
+     * The name of the default method
+     */
+    protected string $defaultMethod;
+
+    public function __construct(
+        RouteCollectionInterface $routes,
+        string $namespace,
+        bool $translateURIDashes,
+        string $httpVerb
+    ) {
+        $this->collection         = $routes;
+        $this->namespace          = rtrim($namespace, '\\') . '\\';
+        $this->translateURIDashes = $translateURIDashes;
+        $this->httpVerb           = $httpVerb;
+
+        $this->defaultController = $this->collection->getDefaultController();
+        $this->defaultMethod     = $httpVerb . ucfirst($this->collection->getDefaultMethod());
+
+        // Set the default values
+        $this->controller = $this->defaultController;
+        $this->method     = $this->defaultMethod;
+    }
+
+    /**
+     * Finds controller, method and params from the URI.
+     *
+     * @return array [directory_name, controller_name, controller_method, params]
+     */
+    public function getRoute(string $uri): array
+    {
+        $segments = explode('/', $uri);
+
+        // WARNING: Directories get shifted out of the segments array.
+        $nonDirSegments = $this->scanControllers($segments);
+
+        $controllerSegment  = '';
+        $baseControllerName = $this->defaultController;
+
+        // If we don't have any segments left - use the default controller;
+        // If not empty, then the first segment should be the controller
+        if (! empty($nonDirSegments)) {
+            $controllerSegment = array_shift($nonDirSegments);
+
+            $baseControllerName = $this->translateURIDashes(ucfirst($controllerSegment));
+        }
+
+        if (! $this->isValidSegment($baseControllerName)) {
+            throw new PageNotFoundException($baseControllerName . ' is not a valid controller name');
+        }
+
+        // Prevent access to default controller path
+        if (
+            strtolower($baseControllerName) === strtolower($this->defaultController)
+            && strtolower($controllerSegment) === strtolower($this->defaultController)
+        ) {
+            throw PageNotFoundException::forPageNotFound();
+        }
+
+        // Use the method name if it exists.
+        if (! empty($nonDirSegments)) {
+            $methodSegment = $this->translateURIDashes(array_shift($nonDirSegments));
+
+            // Prefix HTTP verb
+            $this->method = $this->httpVerb . ucfirst($methodSegment);
+
+            // Prevent access to default method path
+            if (strtolower($this->method) === strtolower($this->defaultMethod)) {
+                throw PageNotFoundException::forPageNotFound();
+            }
+        }
+
+        if (! empty($nonDirSegments)) {
+            $this->params = $nonDirSegments;
+        }
+
+        // Ensure the controller stores the fully-qualified class name
+        $this->controller = '\\' . ltrim(
+            str_replace(
+                '/',
+                '\\',
+                $this->namespace . $this->subNamespace . $baseControllerName
+            ),
+            '\\'
+        );
+
+        // Ensure routes registered via $routes->cli() are not accessible via web.
+        if ($this->httpVerb !== 'cli') {
+            $controller = strtolower($this->controller);
+            $methodName = strtolower($this->method);
+
+            foreach ($this->collection->getRoutes('cli') as $route) {
+                if (is_string($route)) {
+                    $route = strtolower($route);
+                    if (strpos($route, $controller . '::' . $methodName) === 0) {
+                        throw new PageNotFoundException();
+                    }
+
+                    if ($route === $controller) {
+                        throw new PageNotFoundException();
+                    }
+                }
+            }
+        }
+
+        return [$this->directory, $this->controller, $this->method, $this->params];
+    }
+
+    /**
+     * Scans the controller directory, attempting to locate a controller matching the supplied uri $segments
+     *
+     * @param array $segments URI segments
+     *
+     * @return array returns an array of remaining uri segments that don't map onto a directory
+     */
+    private function scanControllers(array $segments): array
+    {
+        $segments = array_filter($segments, static fn ($segment) => $segment !== '');
+        // numerically reindex the array, removing gaps
+        $segments = array_values($segments);
+
+        // Loop through our segments and return as soon as a controller
+        // is found or when such a directory doesn't exist
+        $c = count($segments);
+
+        while ($c-- > 0) {
+            $segmentConvert = ucfirst(
+                $this->translateURIDashes === true
+                    ? str_replace('-', '_', $segments[0])
+                    : $segments[0]
+            );
+
+            // as soon as we encounter any segment that is not PSR-4 compliant, stop searching
+            if (! $this->isValidSegment($segmentConvert)) {
+                return $segments;
+            }
+
+            $test = $this->namespace . $this->subNamespace . $segmentConvert;
+
+            // as long as each segment is *not* a controller file, add it to $this->subNamespace
+            if (! class_exists($test)) {
+                $this->setSubNamespace($segmentConvert, true, false);
+                array_shift($segments);
+
+                $this->directory .= $this->directory . $segmentConvert . '/';
+
+                continue;
+            }
+
+            return $segments;
+        }
+
+        // This means that all segments were actually directories
+        return $segments;
+    }
+
+    /**
+     * Returns true if the supplied $segment string represents a valid PSR-4 compliant namespace/directory segment
+     *
+     * regex comes from https://www.php.net/manual/en/language.variables.basics.php
+     */
+    private function isValidSegment(string $segment): bool
+    {
+        return (bool) preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $segment);
+    }
+
+    /**
+     * Sets the sub-namespace that the controller is in.
+     *
+     * @param bool $validate if true, checks to make sure $dir consists of only PSR4 compliant segments
+     */
+    private function setSubNamespace(?string $namespace = null, bool $append = false, bool $validate = true)
+    {
+        if ($validate) {
+            $segments = explode('/', trim($namespace, '/'));
+
+            foreach ($segments as $segment) {
+                if (! $this->isValidSegment($segment)) {
+                    return;
+                }
+            }
+        }
+
+        if ($append !== true || empty($this->subNamespace)) {
+            $this->subNamespace = trim($namespace, '/') . '\\';
+        } else {
+            $this->subNamespace .= trim($namespace, '/') . '\\';
+        }
+    }
+
+    private function translateURIDashes(string $classname): string
+    {
+        return $this->translateURIDashes
+            ? str_replace('-', '_', $classname)
+            : $classname;
+    }
+}

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -184,7 +184,7 @@ class AutoRouterImproved implements AutoRouterInterface
         return [$this->directory, $this->controller, $this->method, $this->params];
     }
 
-    private function protectDefinedRoutes()
+    private function protectDefinedRoutes(): void
     {
         if ($this->httpVerb !== 'cli') {
             $controller = strtolower($this->controller);
@@ -201,7 +201,7 @@ class AutoRouterImproved implements AutoRouterInterface
         }
     }
 
-    private function checkParameters(string $uri)
+    private function checkParameters(string $uri): void
     {
         $refClass  = new ReflectionClass($this->controller);
         $refMethod = $refClass->getMethod($this->method);
@@ -220,7 +220,7 @@ class AutoRouterImproved implements AutoRouterInterface
         }
     }
 
-    private function checkRemap()
+    private function checkRemap(): void
     {
         try {
             $refClass = new ReflectionClass($this->controller);
@@ -298,7 +298,7 @@ class AutoRouterImproved implements AutoRouterInterface
      *
      * @param bool $validate if true, checks to make sure $dir consists of only PSR4 compliant segments
      */
-    private function setSubNamespace(?string $namespace = null, bool $append = false, bool $validate = true)
+    private function setSubNamespace(?string $namespace = null, bool $append = false, bool $validate = true): void
     {
         if ($validate) {
             $segments = explode('/', trim($namespace, '/'));

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -171,7 +171,7 @@ final class AutoRouterImproved implements AutoRouterInterface
         // Ensure routes registered via $routes->cli() are not accessible via web.
         $this->protectDefinedRoutes();
 
-        // Check _remao()
+        // Check _remap()
         $this->checkRemap();
 
         // Check parameters

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -169,7 +169,7 @@ class AutoRouterImproved implements AutoRouterInterface
         );
 
         // Ensure routes registered via $routes->cli() are not accessible via web.
-        $this->protectDefinedCliRoutes();
+        $this->protectDefinedRoutes();
 
         // Check _remao()
         $this->checkRemap();
@@ -184,7 +184,7 @@ class AutoRouterImproved implements AutoRouterInterface
         return [$this->directory, $this->controller, $this->method, $this->params];
     }
 
-    private function protectDefinedCliRoutes()
+    private function protectDefinedRoutes()
     {
         if ($this->httpVerb !== 'cli') {
             $controller = strtolower($this->controller);

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -186,17 +186,15 @@ class AutoRouterImproved implements AutoRouterInterface
 
     private function protectDefinedRoutes(): void
     {
-        if ($this->httpVerb !== 'cli') {
-            $controller = strtolower($this->controller);
+        $controller = strtolower($this->controller);
 
-            foreach ($this->protectedControllers as $controllerInRoutes) {
-                $routeLowerCase = strtolower($controllerInRoutes);
+        foreach ($this->protectedControllers as $controllerInRoutes) {
+            $routeLowerCase = strtolower($controllerInRoutes);
 
-                if ($routeLowerCase === $controller) {
-                    throw new PageNotFoundException(
-                        'Cannot access CLI Route Handler: ' . $controllerInRoutes
-                    );
-                }
+            if ($routeLowerCase === $controller) {
+                throw new PageNotFoundException(
+                    'Cannot access the controller in Defined Routes. Controller: ' . $controllerInRoutes
+                );
             }
         }
     }

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -162,6 +162,23 @@ class AutoRouterImproved implements AutoRouterInterface
         );
 
         // Ensure routes registered via $routes->cli() are not accessible via web.
+        $this->protectDefinedCliRoutes();
+
+        // Check _remao()
+        $this->checkRemap();
+
+        // Check parameters
+        try {
+            $this->checkParameters($uri);
+        } catch (ReflectionException $e) {
+            throw PageNotFoundException::forControllerNotFound($this->controller, $this->method);
+        }
+
+        return [$this->directory, $this->controller, $this->method, $this->params];
+    }
+
+    private function protectDefinedCliRoutes()
+    {
         if ($this->httpVerb !== 'cli') {
             $controller = strtolower($this->controller);
             $methodName = strtolower($this->method);
@@ -186,18 +203,6 @@ class AutoRouterImproved implements AutoRouterInterface
                 }
             }
         }
-
-        // Check _remao()
-        $this->checkRemap();
-
-        // Check parameters
-        try {
-            $this->checkParameters($uri);
-        } catch (ReflectionException $e) {
-            throw PageNotFoundException::forControllerNotFound($this->controller, $this->method);
-        }
-
-        return [$this->directory, $this->controller, $this->method, $this->params];
     }
 
     private function checkParameters(string $uri)

--- a/system/Router/AutoRouterInterface.php
+++ b/system/Router/AutoRouterInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router;
+
+/**
+ * Expected behavior of a AutoRouter.
+ */
+interface AutoRouterInterface
+{
+    /**
+     * Returns controller, method and params from the URI.
+     *
+     * @return array [directory_name, controller_name, controller_method, params]
+     */
+    public function getRoute(string $uri): array;
+}

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -134,8 +134,10 @@ class Router implements RouterInterface
             $autoRoutesImproved = config('Feature')->autoRoutesImproved ?? false;
             if ($autoRoutesImproved) {
                 $this->autoRouter = new AutoRouterImproved(
-                    $this->collection,
+                    $this->collection->getRegisteredControllers('*'),
                     $this->collection->getDefaultNamespace(),
+                    $this->collection->getDefaultController(),
+                    $this->collection->getDefaultMethod(),
                     $this->translateURIDashes,
                     $this->collection->getHTTPVerb()
                 );

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -604,8 +604,6 @@ class Router implements RouterInterface
 
         if ($this->autoRouter instanceof AutoRouter) {
             $this->autoRouter->setDirectory($dir, $append, $validate);
-
-            return;
         }
     }
 

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -47,7 +47,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
     public function testAutoRouteFindsDefaultControllerAndMethodGet()
     {
-        $this->collection->setDefaultController('Test');
+        $this->collection->setDefaultController('Index');
 
         $router = $this->createNewAutoRouter();
 
@@ -55,14 +55,14 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('/');
 
         $this->assertNull($directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Test', $controller);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Index', $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame([], $params);
     }
 
     public function testAutoRouteFindsDefaultControllerAndMethodPost()
     {
-        $this->collection->setDefaultController('Test');
+        $this->collection->setDefaultController('Index');
 
         $router = $this->createNewAutoRouter('post');
 
@@ -70,7 +70,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('/');
 
         $this->assertNull($directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Test', $controller);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Index', $controller);
         $this->assertSame('postIndex', $method);
         $this->assertSame([], $params);
     }
@@ -245,6 +245,6 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('test/index');
+        $router->getRoute('mycontroller/index');
     }
 }

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -247,4 +247,16 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router->getRoute('mycontroller/index');
     }
+
+    public function testRejectsControllerWithRemapMethod()
+    {
+        $this->expectException(PageNotFoundException::class);
+        $this->expectExceptionMessage(
+            'AutoRouterImproved does not support `_remap()` method. Controller:\CodeIgniter\Router\Controllers\Remap'
+        );
+
+        $router = $this->createNewAutoRouter();
+
+        $router->getRoute('remap/test');
+    }
 }

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router;
+
+use CodeIgniter\Config\Services;
+use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Modules;
+
+/**
+ * @internal
+ */
+final class AutoRouterImprovedTest extends CIUnitTestCase
+{
+    /**
+     * @var RouteCollection
+     */
+    protected $collection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $moduleConfig          = new Modules();
+        $moduleConfig->enabled = false;
+        $this->collection      = new RouteCollection(Services::locator(), $moduleConfig);
+    }
+
+    private function createNewAutoRouter(): AutoRouterImproved
+    {
+        return new AutoRouterImproved(
+            $this->collection,
+            'CodeIgniter\Router\Controllers',
+            true,
+            'get'
+        );
+    }
+
+    public function testAutoRouteFindsDefaultControllerAndMethodGet()
+    {
+        $this->collection->setDefaultController('Test');
+
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('/');
+
+        $this->assertNull($directory);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Test', $controller);
+        $this->assertSame('getIndex', $method);
+        $this->assertSame([], $params);
+    }
+
+    public function testAutoRouteFindsControllerWithFileAndMethod()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('myController/someMethod');
+
+        $this->assertNull($directory);
+        $this->assertSame('\CodeIgniter\Router\Controllers\MyController', $controller);
+        $this->assertSame('getSomeMethod', $method);
+        $this->assertSame([], $params);
+    }
+
+    public function testAutoRouteFindsControllerWithFile()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('myController');
+
+        $this->assertNull($directory);
+        $this->assertSame('\CodeIgniter\Router\Controllers\MyController', $controller);
+        $this->assertSame('getIndex', $method);
+        $this->assertSame([], $params);
+    }
+
+    public function testAutoRouteFindsControllerWithSubfolder()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('subfolder/myController/someMethod');
+
+        $this->assertSame('Subfolder/', $directory);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Subfolder\MyController', $controller);
+        $this->assertSame('getSomeMethod', $method);
+        $this->assertSame([], $params);
+    }
+
+    public function testAutoRouteFindsDashedSubfolder()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('dash-folder/mycontroller/somemethod');
+
+        $this->assertSame('Dash_folder/', $directory);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Dash_folder\Mycontroller', $controller);
+        $this->assertSame('getSomemethod', $method);
+        $this->assertSame([], $params);
+    }
+
+    public function testAutoRouteFindsDashedController()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('dash-folder/dash-controller/somemethod');
+
+        $this->assertSame('Dash_folder/', $directory);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Dash_folder\Dash_controller', $controller);
+        $this->assertSame('getSomemethod', $method);
+        $this->assertSame([], $params);
+    }
+
+    public function testAutoRouteFindsDashedMethod()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('dash-folder/dash-controller/dash-method');
+
+        $this->assertSame('Dash_folder/', $directory);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Dash_folder\Dash_controller', $controller);
+        $this->assertSame('getDash_method', $method);
+        $this->assertSame([], $params);
+    }
+
+    public function testAutoRouteFindsDefaultDashFolder()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('dash-folder');
+
+        $this->assertSame('Dash_folder/', $directory);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Dash_folder\Home', $controller);
+        $this->assertSame('getIndex', $method);
+        $this->assertSame([], $params);
+    }
+
+    public function testAutoRouteRejectsSingleDot()
+    {
+        $this->expectException(PageNotFoundException::class);
+
+        $router = $this->createNewAutoRouter();
+
+        $router->getRoute('.');
+    }
+
+    public function testAutoRouteRejectsDoubleDot()
+    {
+        $this->expectException(PageNotFoundException::class);
+
+        $router = $this->createNewAutoRouter();
+
+        $router->getRoute('..');
+    }
+
+    public function testAutoRouteRejectsMidDot()
+    {
+        $this->expectException(PageNotFoundException::class);
+
+        $router = $this->createNewAutoRouter();
+
+        $router->getRoute('foo.bar');
+    }
+
+    public function testRejectsDefaultControllerPath()
+    {
+        $this->expectException(PageNotFoundException::class);
+
+        $router = $this->createNewAutoRouter();
+
+        $router->getRoute('home');
+    }
+
+    public function testRejectsDefaultControllerAndDefaultMethodPath()
+    {
+        $this->expectException(PageNotFoundException::class);
+
+        $router = $this->createNewAutoRouter();
+
+        $router->getRoute('home/index');
+    }
+
+    public function testRejectsDefaultMethodPath()
+    {
+        $this->expectException(PageNotFoundException::class);
+
+        $router = $this->createNewAutoRouter();
+
+        $router->getRoute('test/index');
+    }
+}

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -35,13 +35,13 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->collection      = new RouteCollection(Services::locator(), $moduleConfig);
     }
 
-    private function createNewAutoRouter(): AutoRouterImproved
+    private function createNewAutoRouter(string $httpVerb = 'get'): AutoRouterImproved
     {
         return new AutoRouterImproved(
             $this->collection,
             'CodeIgniter\Router\Controllers',
             true,
-            'get'
+            $httpVerb
         );
     }
 
@@ -71,6 +71,31 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame('\CodeIgniter\Router\Controllers\MyController', $controller);
         $this->assertSame('getSomeMethod', $method);
         $this->assertSame([], $params);
+    }
+
+    public function testFindsControllerAndMethodAndParam()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('myController/someMethod/a');
+
+        $this->assertNull($directory);
+        $this->assertSame('\CodeIgniter\Router\Controllers\MyController', $controller);
+        $this->assertSame('getSomeMethod', $method);
+        $this->assertSame(['a'], $params);
+    }
+
+    public function testUriParamCountIsGreaterThanMethodParams()
+    {
+        $this->expectException(PageNotFoundException::class);
+        $this->expectExceptionMessage(
+            'Handler:\CodeIgniter\Router\Controllers\MyController::getSomeMethod, URI:myController/someMethod/a/b'
+        );
+
+        $router = $this->createNewAutoRouter();
+
+        $router->getRoute('myController/someMethod/a/b');
     }
 
     public function testAutoRouteFindsControllerWithFile()

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -80,11 +80,11 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('myController/someMethod');
+            = $router->getRoute('mycontroller/somemethod');
 
         $this->assertNull($directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\MyController', $controller);
-        $this->assertSame('getSomeMethod', $method);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Mycontroller', $controller);
+        $this->assertSame('getSomemethod', $method);
         $this->assertSame([], $params);
     }
 
@@ -93,11 +93,11 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('myController/someMethod/a');
+            = $router->getRoute('mycontroller/somemethod/a');
 
         $this->assertNull($directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\MyController', $controller);
-        $this->assertSame('getSomeMethod', $method);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Mycontroller', $controller);
+        $this->assertSame('getSomemethod', $method);
         $this->assertSame(['a'], $params);
     }
 
@@ -105,12 +105,12 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
     {
         $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage(
-            'Handler:\CodeIgniter\Router\Controllers\MyController::getSomeMethod, URI:myController/someMethod/a/b'
+            'Handler:\CodeIgniter\Router\Controllers\Mycontroller::getSomemethod, URI:mycontroller/somemethod/a/b'
         );
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('myController/someMethod/a/b');
+        $router->getRoute('mycontroller/somemethod/a/b');
     }
 
     public function testAutoRouteFindsControllerWithFile()
@@ -118,10 +118,10 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('myController');
+            = $router->getRoute('mycontroller');
 
         $this->assertNull($directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\MyController', $controller);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Mycontroller', $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame([], $params);
     }
@@ -131,11 +131,11 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('subfolder/myController/someMethod');
+            = $router->getRoute('subfolder/mycontroller/somemethod');
 
         $this->assertSame('Subfolder/', $directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Subfolder\MyController', $controller);
-        $this->assertSame('getSomeMethod', $method);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Subfolder\Mycontroller', $controller);
+        $this->assertSame('getSomemethod', $method);
         $this->assertSame([], $params);
     }
 
@@ -147,7 +147,10 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('dash-folder/mycontroller/somemethod');
 
         $this->assertSame('Dash_folder/', $directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Dash_folder\Mycontroller', $controller);
+        $this->assertSame(
+            '\CodeIgniter\Router\Controllers\Dash_folder\Mycontroller',
+            $controller
+        );
         $this->assertSame('getSomemethod', $method);
         $this->assertSame([], $params);
     }

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -38,8 +38,10 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
     private function createNewAutoRouter(string $httpVerb = 'get'): AutoRouterImproved
     {
         return new AutoRouterImproved(
-            $this->collection,
+            [],
             'CodeIgniter\Router\Controllers',
+            'Home',
+            'index',
             true,
             $httpVerb
         );

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -13,6 +13,10 @@ namespace CodeIgniter\Router;
 
 use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\Router\Controllers\Dash_folder\Dash_controller;
+use CodeIgniter\Router\Controllers\Dash_folder\Home;
+use CodeIgniter\Router\Controllers\Index;
+use CodeIgniter\Router\Controllers\Mycontroller;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
 
@@ -21,10 +25,7 @@ use Config\Modules;
  */
 final class AutoRouterImprovedTest extends CIUnitTestCase
 {
-    /**
-     * @var RouteCollection
-     */
-    protected $collection;
+    protected RouteCollection $collection;
 
     protected function setUp(): void
     {
@@ -57,7 +58,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('/');
 
         $this->assertNull($directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Index', $controller);
+        $this->assertSame(Index::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame([], $params);
     }
@@ -72,7 +73,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('/');
 
         $this->assertNull($directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Index', $controller);
+        $this->assertSame(Index::class, $controller);
         $this->assertSame('postIndex', $method);
         $this->assertSame([], $params);
     }
@@ -85,7 +86,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('mycontroller/somemethod');
 
         $this->assertNull($directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Mycontroller', $controller);
+        $this->assertSame(Mycontroller::class, $controller);
         $this->assertSame('getSomemethod', $method);
         $this->assertSame([], $params);
     }
@@ -98,7 +99,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('mycontroller/somemethod/a');
 
         $this->assertNull($directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Mycontroller', $controller);
+        $this->assertSame(Mycontroller::class, $controller);
         $this->assertSame('getSomemethod', $method);
         $this->assertSame(['a'], $params);
     }
@@ -123,7 +124,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('mycontroller');
 
         $this->assertNull($directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Mycontroller', $controller);
+        $this->assertSame(Mycontroller::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame([], $params);
     }
@@ -136,7 +137,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('subfolder/mycontroller/somemethod');
 
         $this->assertSame('Subfolder/', $directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Subfolder\Mycontroller', $controller);
+        $this->assertSame(\CodeIgniter\Router\Controllers\Subfolder\Mycontroller::class, $controller);
         $this->assertSame('getSomemethod', $method);
         $this->assertSame([], $params);
     }
@@ -150,7 +151,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $this->assertSame('Dash_folder/', $directory);
         $this->assertSame(
-            '\CodeIgniter\Router\Controllers\Dash_folder\Mycontroller',
+            \CodeIgniter\Router\Controllers\Dash_folder\Mycontroller::class,
             $controller
         );
         $this->assertSame('getSomemethod', $method);
@@ -165,7 +166,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('dash-folder/dash-controller/somemethod');
 
         $this->assertSame('Dash_folder/', $directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Dash_folder\Dash_controller', $controller);
+        $this->assertSame(Dash_controller::class, $controller);
         $this->assertSame('getSomemethod', $method);
         $this->assertSame([], $params);
     }
@@ -178,7 +179,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('dash-folder/dash-controller/dash-method');
 
         $this->assertSame('Dash_folder/', $directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Dash_folder\Dash_controller', $controller);
+        $this->assertSame(Dash_controller::class, $controller);
         $this->assertSame('getDash_method', $method);
         $this->assertSame([], $params);
     }
@@ -191,7 +192,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('dash-folder');
 
         $this->assertSame('Dash_folder/', $directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Dash_folder\Home', $controller);
+        $this->assertSame(Home::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame([], $params);
     }

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -60,6 +60,21 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame([], $params);
     }
 
+    public function testAutoRouteFindsDefaultControllerAndMethodPost()
+    {
+        $this->collection->setDefaultController('Test');
+
+        $router = $this->createNewAutoRouter('post');
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('/');
+
+        $this->assertNull($directory);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Test', $controller);
+        $this->assertSame('postIndex', $method);
+        $this->assertSame([], $params);
+    }
+
     public function testAutoRouteFindsControllerWithFileAndMethod()
     {
         $router = $this->createNewAutoRouter();

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -58,7 +58,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('/');
 
         $this->assertNull($directory);
-        $this->assertSame(Index::class, $controller);
+        $this->assertSame('\\' . Index::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame([], $params);
     }
@@ -73,7 +73,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('/');
 
         $this->assertNull($directory);
-        $this->assertSame(Index::class, $controller);
+        $this->assertSame('\\' . Index::class, $controller);
         $this->assertSame('postIndex', $method);
         $this->assertSame([], $params);
     }
@@ -86,7 +86,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('mycontroller/somemethod');
 
         $this->assertNull($directory);
-        $this->assertSame(Mycontroller::class, $controller);
+        $this->assertSame('\\' . Mycontroller::class, $controller);
         $this->assertSame('getSomemethod', $method);
         $this->assertSame([], $params);
     }
@@ -99,7 +99,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('mycontroller/somemethod/a');
 
         $this->assertNull($directory);
-        $this->assertSame(Mycontroller::class, $controller);
+        $this->assertSame('\\' . Mycontroller::class, $controller);
         $this->assertSame('getSomemethod', $method);
         $this->assertSame(['a'], $params);
     }
@@ -124,7 +124,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('mycontroller');
 
         $this->assertNull($directory);
-        $this->assertSame(Mycontroller::class, $controller);
+        $this->assertSame('\\' . Mycontroller::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame([], $params);
     }
@@ -137,7 +137,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('subfolder/mycontroller/somemethod');
 
         $this->assertSame('Subfolder/', $directory);
-        $this->assertSame(\CodeIgniter\Router\Controllers\Subfolder\Mycontroller::class, $controller);
+        $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Mycontroller::class, $controller);
         $this->assertSame('getSomemethod', $method);
         $this->assertSame([], $params);
     }
@@ -151,7 +151,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $this->assertSame('Dash_folder/', $directory);
         $this->assertSame(
-            \CodeIgniter\Router\Controllers\Dash_folder\Mycontroller::class,
+            '\\' . \CodeIgniter\Router\Controllers\Dash_folder\Mycontroller::class,
             $controller
         );
         $this->assertSame('getSomemethod', $method);
@@ -166,7 +166,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('dash-folder/dash-controller/somemethod');
 
         $this->assertSame('Dash_folder/', $directory);
-        $this->assertSame(Dash_controller::class, $controller);
+        $this->assertSame('\\' . Dash_controller::class, $controller);
         $this->assertSame('getSomemethod', $method);
         $this->assertSame([], $params);
     }
@@ -179,7 +179,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('dash-folder/dash-controller/dash-method');
 
         $this->assertSame('Dash_folder/', $directory);
-        $this->assertSame(Dash_controller::class, $controller);
+        $this->assertSame('\\' . Dash_controller::class, $controller);
         $this->assertSame('getDash_method', $method);
         $this->assertSame([], $params);
     }
@@ -192,7 +192,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('dash-folder');
 
         $this->assertSame('Dash_folder/', $directory);
-        $this->assertSame(Home::class, $controller);
+        $this->assertSame('\\' . Home::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame([], $params);
     }

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -40,8 +40,8 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         return new AutoRouterImproved(
             [],
             'CodeIgniter\Router\Controllers',
-            'Home',
-            'index',
+            $this->collection->getDefaultController(),
+            $this->collection->getDefaultMethod(),
             true,
             $httpVerb
         );

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -25,7 +25,7 @@ use Config\Modules;
  */
 final class AutoRouterImprovedTest extends CIUnitTestCase
 {
-    protected RouteCollection $collection;
+    private RouteCollection $collection;
 
     protected function setUp(): void
     {

--- a/tests/system/Router/Controllers/Dash_folder/Dash_controller.php
+++ b/tests/system/Router/Controllers/Dash_folder/Dash_controller.php
@@ -15,4 +15,11 @@ use App\Controllers\BaseController;
 
 class Dash_controller extends BaseController
 {
+    public function getSomemethod()
+    {
+    }
+
+    public function getDash_method()
+    {
+    }
 }

--- a/tests/system/Router/Controllers/Dash_folder/Dash_controller.php
+++ b/tests/system/Router/Controllers/Dash_folder/Dash_controller.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router\Controllers\Dash_folder;
+
+use App\Controllers\BaseController;
+
+class Dash_controller extends BaseController
+{
+}

--- a/tests/system/Router/Controllers/Dash_folder/Dash_controller.php
+++ b/tests/system/Router/Controllers/Dash_folder/Dash_controller.php
@@ -11,9 +11,9 @@
 
 namespace CodeIgniter\Router\Controllers\Dash_folder;
 
-use App\Controllers\BaseController;
+use CodeIgniter\Controller;
 
-class Dash_controller extends BaseController
+class Dash_controller extends Controller
 {
     public function getSomemethod()
     {

--- a/tests/system/Router/Controllers/Dash_folder/Home.php
+++ b/tests/system/Router/Controllers/Dash_folder/Home.php
@@ -11,9 +11,9 @@
 
 namespace CodeIgniter\Router\Controllers\Dash_folder;
 
-use App\Controllers\BaseController;
+use CodeIgniter\Controller;
 
-class Home extends BaseController
+class Home extends Controller
 {
     public function getIndex()
     {

--- a/tests/system/Router/Controllers/Dash_folder/Home.php
+++ b/tests/system/Router/Controllers/Dash_folder/Home.php
@@ -9,20 +9,13 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace CodeIgniter\Router\Controllers;
+namespace CodeIgniter\Router\Controllers\Dash_folder;
 
 use App\Controllers\BaseController;
 
-/**
- * @internal
- */
-final class Test extends BaseController
+class Home extends BaseController
 {
     public function getIndex()
-    {
-    }
-
-    public function postIndex()
     {
     }
 }

--- a/tests/system/Router/Controllers/Dash_folder/MyController.php
+++ b/tests/system/Router/Controllers/Dash_folder/MyController.php
@@ -15,4 +15,7 @@ use App\Controllers\BaseController;
 
 class MyController extends BaseController
 {
+    public function getSomemethod()
+    {
+    }
 }

--- a/tests/system/Router/Controllers/Dash_folder/MyController.php
+++ b/tests/system/Router/Controllers/Dash_folder/MyController.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router\Controllers\Dash_folder;
+
+use App\Controllers\BaseController;
+
+class MyController extends BaseController
+{
+}

--- a/tests/system/Router/Controllers/Dash_folder/Mycontroller.php
+++ b/tests/system/Router/Controllers/Dash_folder/Mycontroller.php
@@ -11,9 +11,9 @@
 
 namespace CodeIgniter\Router\Controllers\Dash_folder;
 
-use App\Controllers\BaseController;
+use CodeIgniter\Controller;
 
-class Mycontroller extends BaseController
+class Mycontroller extends Controller
 {
     public function getSomemethod()
     {

--- a/tests/system/Router/Controllers/Dash_folder/Mycontroller.php
+++ b/tests/system/Router/Controllers/Dash_folder/Mycontroller.php
@@ -9,17 +9,13 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace CodeIgniter\Router\Controllers;
+namespace CodeIgniter\Router\Controllers\Dash_folder;
 
 use App\Controllers\BaseController;
 
-class MyController extends BaseController
+class Mycontroller extends BaseController
 {
-    public function getIndex()
-    {
-    }
-
-    public function getSomeMethod($first = '')
+    public function getSomemethod()
     {
     }
 }

--- a/tests/system/Router/Controllers/Home.php
+++ b/tests/system/Router/Controllers/Home.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router\Controllers;
+
+use App\Controllers\BaseController;
+
+class Home extends BaseController
+{
+}

--- a/tests/system/Router/Controllers/Home.php
+++ b/tests/system/Router/Controllers/Home.php
@@ -15,4 +15,11 @@ use App\Controllers\BaseController;
 
 class Home extends BaseController
 {
+    public function getIndex()
+    {
+    }
+
+    public function postIndex()
+    {
+    }
 }

--- a/tests/system/Router/Controllers/Home.php
+++ b/tests/system/Router/Controllers/Home.php
@@ -11,9 +11,9 @@
 
 namespace CodeIgniter\Router\Controllers;
 
-use App\Controllers\BaseController;
+use CodeIgniter\Controller;
 
-class Home extends BaseController
+class Home extends Controller
 {
     public function getIndex()
     {

--- a/tests/system/Router/Controllers/Index.php
+++ b/tests/system/Router/Controllers/Index.php
@@ -13,10 +13,7 @@ namespace CodeIgniter\Router\Controllers;
 
 use App\Controllers\BaseController;
 
-/**
- * @internal
- */
-final class Test extends BaseController
+class Index extends BaseController
 {
     public function getIndex()
     {

--- a/tests/system/Router/Controllers/Index.php
+++ b/tests/system/Router/Controllers/Index.php
@@ -11,9 +11,9 @@
 
 namespace CodeIgniter\Router\Controllers;
 
-use App\Controllers\BaseController;
+use CodeIgniter\Controller;
 
-class Index extends BaseController
+class Index extends Controller
 {
     public function getIndex()
     {

--- a/tests/system/Router/Controllers/MyController.php
+++ b/tests/system/Router/Controllers/MyController.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router\Controllers;
+
+use App\Controllers\BaseController;
+
+class MyController extends BaseController
+{
+}

--- a/tests/system/Router/Controllers/MyController.php
+++ b/tests/system/Router/Controllers/MyController.php
@@ -15,4 +15,11 @@ use App\Controllers\BaseController;
 
 class MyController extends BaseController
 {
+    public function getIndex()
+    {
+    }
+
+    public function getSomeMethod($first = '')
+    {
+    }
 }

--- a/tests/system/Router/Controllers/Mycontroller.php
+++ b/tests/system/Router/Controllers/Mycontroller.php
@@ -11,9 +11,9 @@
 
 namespace CodeIgniter\Router\Controllers;
 
-use App\Controllers\BaseController;
+use CodeIgniter\Controller;
 
-class Mycontroller extends BaseController
+class Mycontroller extends Controller
 {
     public function getIndex()
     {

--- a/tests/system/Router/Controllers/Mycontroller.php
+++ b/tests/system/Router/Controllers/Mycontroller.php
@@ -9,13 +9,17 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace CodeIgniter\Router\Controllers\Dash_folder;
+namespace CodeIgniter\Router\Controllers;
 
 use App\Controllers\BaseController;
 
-class MyController extends BaseController
+class Mycontroller extends BaseController
 {
-    public function getSomemethod()
+    public function getIndex()
+    {
+    }
+
+    public function getSomemethod($first = '')
     {
     }
 }

--- a/tests/system/Router/Controllers/Remap.php
+++ b/tests/system/Router/Controllers/Remap.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router\Controllers;
+
+use App\Controllers\BaseController;
+use CodeIgniter\Exceptions\PageNotFoundException;
+
+class Remap extends BaseController
+{
+    public function _remap(string $method, ...$params): string
+    {
+        $method = 'process_' . $method;
+
+        if (method_exists($this, $method)) {
+            return $this->{$method}(...$params);
+        }
+
+        throw PageNotFoundException::forPageNotFound();
+    }
+
+    public function getTest(): string
+    {
+        return __METHOD__;
+    }
+
+    protected function process_index(): string
+    {
+        return __METHOD__;
+    }
+}

--- a/tests/system/Router/Controllers/Remap.php
+++ b/tests/system/Router/Controllers/Remap.php
@@ -11,10 +11,10 @@
 
 namespace CodeIgniter\Router\Controllers;
 
-use App\Controllers\BaseController;
+use CodeIgniter\Controller;
 use CodeIgniter\Exceptions\PageNotFoundException;
 
-class Remap extends BaseController
+class Remap extends Controller
 {
     public function _remap(string $method, ...$params): string
     {

--- a/tests/system/Router/Controllers/Subfolder/MyController.php
+++ b/tests/system/Router/Controllers/Subfolder/MyController.php
@@ -15,4 +15,7 @@ use App\Controllers\BaseController;
 
 class MyController extends BaseController
 {
+    public function getSomeMethod()
+    {
+    }
 }

--- a/tests/system/Router/Controllers/Subfolder/MyController.php
+++ b/tests/system/Router/Controllers/Subfolder/MyController.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router\Controllers\Subfolder;
+
+use App\Controllers\BaseController;
+
+class MyController extends BaseController
+{
+}

--- a/tests/system/Router/Controllers/Subfolder/Mycontroller.php
+++ b/tests/system/Router/Controllers/Subfolder/Mycontroller.php
@@ -13,9 +13,9 @@ namespace CodeIgniter\Router\Controllers\Subfolder;
 
 use App\Controllers\BaseController;
 
-class MyController extends BaseController
+class Mycontroller extends BaseController
 {
-    public function getSomeMethod()
+    public function getSomemethod()
     {
     }
 }

--- a/tests/system/Router/Controllers/Subfolder/Mycontroller.php
+++ b/tests/system/Router/Controllers/Subfolder/Mycontroller.php
@@ -11,9 +11,9 @@
 
 namespace CodeIgniter\Router\Controllers\Subfolder;
 
-use App\Controllers\BaseController;
+use CodeIgniter\Controller;
 
-class Mycontroller extends BaseController
+class Mycontroller extends Controller
 {
     public function getSomemethod()
     {

--- a/tests/system/Router/Controllers/Test.php
+++ b/tests/system/Router/Controllers/Test.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router\Controllers;
+
+use App\Controllers\BaseController;
+
+/**
+ * @internal
+ */
+final class Test extends BaseController
+{
+}

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -19,10 +19,32 @@ BREAKING
 - The method signature of ``CodeIgniter\CLI\CommandRunner::_remap()`` has been changed to fix a bug.
 - The ``CodeIgniter\Autoloader\Autoloader::initialize()`` has changed the behavior to fix a bug. It used to use Composer classmap only when ``$modules->discoverInComposer`` is true. Now it always uses the Composer classmap if Composer is available.
 - The color code output by :ref:`CLI::color() <cli-library-color>` has been changed to fix a bug.
-- To prevent unexpected access from the web browser, if a controller is added to a cli route (``$routes->cli()``), all methods of that controller are no longer accessible via auto routing.
+- To prevent unexpected access from the web browser, if a controller is added to a cli route (``$routes->cli()``), all methods of that controller are no longer accessible via auto-routing.
 
 Enhancements
 ************
+
+New Improved Auto Routing
+=========================
+
+Added an optional new more secure auto router. These are the changes from the traditional auto-routing:
+
+- A controller method needs HTTP verb prefix like ``getIndex()``, ``postCreate()``.
+    - Developers always know HTTP method, so requests by unexpected HTTP method does not happen.
+- The Default Controller (``Home`` by default) and the Default Method (``index`` by default) must be omitted in the URI.
+    - It restricts one-to-one correspondence between controller methods and URIs.
+    - E.g. by default, you can access ``/``, but ``/home`` and ``/home/index`` will be 404.
+- It checks method parameter count.
+    - If there are more parameters in the URI than the method parameters, it results in 404.
+- It does not support ``_remap()`` method.
+    - It restricts one-to-one correspondence between controller methods and URIs.
+- Can't access controllers in Defined Routes.
+    - It completely separates controllers accessible via **Auto Routes** from those accessible via **Defined Routes**.
+
+See :ref:`auto-routing-improved` for the details.
+
+Others
+======
 
 - Content Security Policy (CSP) enhancements
     - Added the configs ``$scriptNonceTag`` and ``$styleNonceTag`` in  ``Config\ContentSecurityPolicy`` to customize the CSP placeholders (``{csp-script-nonce}`` and ``{csp-style-nonce}``)

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -27,7 +27,7 @@ Enhancements
 New Improved Auto Routing
 =========================
 
-Added an optional new more secure auto router. These are the changes from the traditional auto-routing:
+Added an optional new more secure auto router. These are the changes from the legacy auto-routing:
 
 - A controller method needs HTTP verb prefix like ``getIndex()``, ``postCreate()``.
     - Developers always know the HTTP method, so requests by an unexpected HTTP method does not pass.

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -30,7 +30,7 @@ New Improved Auto Routing
 Added an optional new more secure auto router. These are the changes from the traditional auto-routing:
 
 - A controller method needs HTTP verb prefix like ``getIndex()``, ``postCreate()``.
-    - Developers always know HTTP method, so requests by unexpected HTTP method does not happen.
+    - Developers always know the HTTP method, so requests by an unexpected HTTP method does not pass.
 - The Default Controller (``Home`` by default) and the Default Method (``index`` by default) must be omitted in the URI.
     - It restricts one-to-one correspondence between controller methods and URIs.
     - E.g. by default, you can access ``/``, but ``/home`` and ``/home/index`` will be 404.

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -278,18 +278,18 @@ CodeIgniter also permits you to map your URIs using its :ref:`Defined Route Rout
 
 .. _controller-auto-routing:
 
-Auto Routing (Traditional)
-**************************
+Auto Routing (Legacy)
+*********************
 
-This section describes the functionality of Auto Routing (Traditional) that is a routing system from CodeIgniter 3.
+This section describes the functionality of Auto Routing (Legacy) that is a routing system from CodeIgniter 3.
 It automatically routes an HTTP request, and executes the corresponding controller method
 without route definitions. The auto-routing is disabled by default.
 
 .. warning:: To prevent misconfiguration and miscoding, we recommend that you do not use
-    Auto Routing (Traditional). It is easy to create vulnerable apps where controller filters
+    Auto Routing (Legacy). It is easy to create vulnerable apps where controller filters
     or CSRF protection are bypassed.
 
-.. important:: Auto Routing (Traditional) routes a HTTP request with **any** HTTP method to a controller method.
+.. important:: Auto Routing (Legacy) routes a HTTP request with **any** HTTP method to a controller method.
 
 Consider this URI::
 

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -109,28 +109,26 @@ then trying to access it using the following URL will not work::
 
     example.com/index.php/helloworld/utility/
 
-.. _controller-auto-routing:
+.. _controller-auto-routing-improved:
 
-Auto Routing
-************
+Auto Routing (Improved)
+************************
 
-This section describes the functionality of the auto-routing.
+Since v4.2.0, the new more secure Auto Routing has been introduced.
+
+This section describes the functionality of the new auto-routing.
 It automatically routes an HTTP request, and executes the corresponding controller method
-without route definitions. The auto-routing is disabled by default.
+without route definitions.
 
-.. warning:: To prevent misconfiguration and miscoding, we recommend that you do not use
-    the auto-routing feature. It is easy to create vulnerable apps where controller filters
-    or CSRF protection are bypassed.
-
-.. important:: The auto-routing routes a HTTP request with **any** HTTP method to a controller method.
+Since v4.2.0, the auto-routing is disabled by default. To use it, see :ref:`enabled-auto-routing-improved`.
 
 Consider this URI::
 
     example.com/index.php/helloworld/
 
-In the above example, CodeIgniter would attempt to find a controller named **Helloworld.php** and load it.
+In the above example, CodeIgniter would attempt to find a controller named ``App\Controllers\Helloworld`` and load it, when auto-routing is enabled.
 
-**When a controller's name matches the first segment of a URI, it will be loaded.**
+.. note:: When a controller's short name matches the first segment of a URI, it will be loaded.
 
 Let's try it: Hello World!
 ==========================
@@ -142,13 +140,13 @@ also extend the ``CodeIgniter\Controller`` if you do not need the functionality 
 The BaseController provides a convenient place for loading components and performing functions that are needed by all your
 controllers. You can extend this class in any new controller.
 
-For security reasons be sure to declare any new utility methods as ``protected`` or ``private``:
-
-.. literalinclude:: controllers/008.php
+.. literalinclude:: controllers/020.php
 
 Then save the file to your **app/Controllers/** directory.
 
-.. important:: The file must be called **Helloworld.php**, with a capital ``H``.
+.. important:: The file must be called **Helloworld.php**, with a capital ``H``. Controller class names MUST start with an uppercase letter and ONLY the first character can be uppercase.
+
+.. important:: A controller method that will be executed by Auto Routing (Improved) needs HTTP verb (``get``, ``post``, ``put``, etc.) prefix like ``getIndex()``, ``postCreate()``.
 
 Now visit your site using a URL similar to this::
 
@@ -157,8 +155,6 @@ Now visit your site using a URL similar to this::
 If you did it right you should see::
 
     Hello World!
-
-.. important:: Controller class names MUST start with an uppercase letter and ONLY the first character can be uppercase.
 
 This is valid:
 
@@ -179,36 +175,36 @@ class so that it can inherit all its methods.
     The system will attempt to match the URI against Controllers by matching each segment against
     folders/files in **app/Controllers/**, when a match wasn't found against defined routes.
     That's why your folders/files MUST start with a capital letter and the rest MUST be lowercase.
-    If you want another naming convention you need to manually define it using the
-    :doc:`URI Routing <routing>` feature.
 
     Here is an example based on PSR-4 Autoloader:
 
     .. literalinclude:: controllers/012.php
 
+    If you want another naming convention you need to manually define it using the
+    :ref:`Defined Route Routing <defined-route-routing>`.
+
 Methods
 =======
 
-In the above example, the method name is ``index()``. The ``index()`` method
-is always loaded by default if the **second segment** of the URI is
-empty. Another way to show your "Hello World" message would be this::
-
-    example.com/index.php/helloworld/index/
+In the above example, the method name is ``getIndex()``.
+The method (HTTP verb + ``Index()``) is loaded if the **second segment** of the URI is empty.
 
 **The second segment of the URI determines which method in the
 controller gets called.**
 
 Let's try it. Add a new method to your controller:
 
-.. literalinclude:: controllers/013.php
+.. literalinclude:: controllers/021.php
 
-Now load the following URL to see the comment method::
+Now load the following URL to see the ``getComment()`` method::
 
     example.com/index.php/helloworld/comment/
 
 You should see your new message.
 
-Passing URI Segments to your methods
+.. warning:: For security reasons be sure to declare any new utility methods as ``protected`` or ``private``.
+
+Passing URI Segments to Your Methods
 ====================================
 
 If your URI contains more than two segments they will be passed to your
@@ -220,11 +216,7 @@ For example, let's say you have a URI like this::
 
 Your method will be passed URI segments 3 and 4 (``'sandals'`` and ``'123'``):
 
-.. literalinclude:: controllers/014.php
-
-.. important:: If you are using the :doc:`URI Routing <routing>`
-    feature, the segments passed to your method will be the defined
-    ones.
+.. literalinclude:: controllers/022.php
 
 Defining a Default Controller
 =============================
@@ -282,7 +274,177 @@ called if the URL contains *only* the sub-directory. Simply put a controller
 in there that matches the name of your default controller as specified in
 your **app/Config/Routes.php** file.
 
-CodeIgniter also permits you to map your URIs using its :doc:`URI Routing <routing>` feature.
+CodeIgniter also permits you to map your URIs using its :ref:`Defined Route Routing <defined-route-routing>`..
+
+.. _controller-auto-routing:
+
+Auto Routing (Traditional)
+**************************
+
+This section describes the functionality of Auto Routing (Traditional) that is a routing system from CodeIgniter 3.
+It automatically routes an HTTP request, and executes the corresponding controller method
+without route definitions. The auto-routing is disabled by default.
+
+.. warning:: To prevent misconfiguration and miscoding, we recommend that you do not use
+    Auto Routing (Traditional). It is easy to create vulnerable apps where controller filters
+    or CSRF protection are bypassed.
+
+.. important:: Auto Routing (Traditional) routes a HTTP request with **any** HTTP method to a controller method.
+
+Consider this URI::
+
+    example.com/index.php/helloworld/
+
+In the above example, CodeIgniter would attempt to find a controller named **Helloworld.php** and load it.
+
+.. note:: When a controller's short name matches the first segment of a URI, it will be loaded.
+
+Let's try it: Hello World!
+==========================
+
+Let's create a simple controller so you can see it in action. Using your text editor, create a file called **Helloworld.php**,
+and put the following code in it. You will notice that the ``Helloworld`` Controller is extending the ``BaseController``. you can
+also extend the ``CodeIgniter\Controller`` if you do not need the functionality of the BaseController.
+
+The BaseController provides a convenient place for loading components and performing functions that are needed by all your
+controllers. You can extend this class in any new controller.
+
+For security reasons be sure to declare any new utility methods as ``protected`` or ``private``:
+
+.. literalinclude:: controllers/008.php
+
+Then save the file to your **app/Controllers/** directory.
+
+.. important:: The file must be called **Helloworld.php**, with a capital ``H``. Controller class names MUST start with an uppercase letter and ONLY the first character can be uppercase.
+
+Now visit your site using a URL similar to this::
+
+    example.com/index.php/helloworld
+
+If you did it right you should see::
+
+    Hello World!
+
+This is valid:
+
+.. literalinclude:: controllers/009.php
+
+This is **not** valid:
+
+.. literalinclude:: controllers/010.php
+
+This is **not** valid:
+
+.. literalinclude:: controllers/011.php
+
+Also, always make sure your controller extends the parent controller
+class so that it can inherit all its methods.
+
+.. note::
+    The system will attempt to match the URI against Controllers by matching each segment against
+    folders/files in **app/Controllers/**, when a match wasn't found against defined routes.
+    That's why your folders/files MUST start with a capital letter and the rest MUST be lowercase.
+
+    Here is an example based on PSR-4 Autoloader:
+
+    .. literalinclude:: controllers/012.php
+
+    If you want another naming convention you need to manually define it using the
+    :ref:`Defined Route Routing <defined-route-routing>`.
+
+Methods
+=======
+
+In the above example, the method name is ``index()``. The ``index()`` method
+is always loaded by default if the **second segment** of the URI is
+empty. Another way to show your "Hello World" message would be this::
+
+    example.com/index.php/helloworld/index/
+
+**The second segment of the URI determines which method in the
+controller gets called.**
+
+Let's try it. Add a new method to your controller:
+
+.. literalinclude:: controllers/013.php
+
+Now load the following URL to see the comment method::
+
+    example.com/index.php/helloworld/comment/
+
+You should see your new message.
+
+Passing URI Segments to Your Methods
+====================================
+
+If your URI contains more than two segments they will be passed to your
+method as parameters.
+
+For example, let's say you have a URI like this::
+
+    example.com/index.php/products/shoes/sandals/123
+
+Your method will be passed URI segments 3 and 4 (``'sandals'`` and ``'123'``):
+
+.. literalinclude:: controllers/014.php
+
+Defining a Default Controller
+=============================
+
+CodeIgniter can be told to load a default controller when a URI is not
+present, as will be the case when only your site root URL is requested. Let's try it
+with the ``Helloworld`` controller.
+
+To specify a default controller open your **app/Config/Routes.php**
+file and set this variable:
+
+.. literalinclude:: controllers/015.php
+
+Where ``Helloworld`` is the name of the controller class you want to be used.
+
+A few lines further down **Routes.php** in the "Route Definitions" section, comment out the line:
+
+.. literalinclude:: controllers/016.php
+
+If you now browse to your site without specifying any URI segments you'll
+see the "Hello World" message.
+
+.. note:: The line ``$routes->get('/', 'Home::index');`` is an optimization that you will want to use in a "real-world" app. But for demonstration purposes we don't want to use that feature. ``$routes->get()`` is explained in :doc:`URI Routing <routing>`
+
+For more information, please refer to the :ref:`routes-configuration-options` section of the
+:doc:`URI Routing <routing>` documentation.
+
+Organizing Your Controllers into Sub-directories
+================================================
+
+If you are building a large application you might want to hierarchically
+organize or structure your controllers into sub-directories. CodeIgniter
+permits you to do this.
+
+Simply create sub-directories under the main **app/Controllers/**,
+and place your controller classes within them.
+
+.. important:: Folder names MUST start with an uppercase letter and ONLY the first character can be uppercase.
+
+When using this feature the first segment of your URI must
+specify the folder. For example, let's say you have a controller located here::
+
+    app/Controllers/Products/Shoes.php
+
+To call the above controller your URI will look something like this::
+
+    example.com/index.php/products/shoes/show/123
+
+.. note:: You cannot have directories with the same name in **app/Controllers/** and **public/**.
+    This is because if there is a directory, the web server will search for it and
+    it will not be routed to CodeIgniter.
+
+Each of your sub-directories may contain a default controller which will be
+called if the URL contains *only* the sub-directory. Simply put a controller
+in there that matches the name of your default controller as specified in
+your **app/Config/Routes.php** file.
+
+CodeIgniter also permits you to map your URIs using its :ref:`Defined Route Routing <defined-route-routing>`..
 
 Remapping Method Calls
 **********************

--- a/user_guide_src/source/incoming/controllers/020.php
+++ b/user_guide_src/source/incoming/controllers/020.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Controllers;
+
+class Helloworld extends BaseController
+{
+    public function getIndex()
+    {
+        return 'Hello World!';
+    }
+}

--- a/user_guide_src/source/incoming/controllers/021.php
+++ b/user_guide_src/source/incoming/controllers/021.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Controllers;
+
+class Helloworld extends BaseController
+{
+    public function getIndex()
+    {
+        return 'Hello World!';
+    }
+
+    public function getComment()
+    {
+        return 'I am not flat!';
+    }
+}

--- a/user_guide_src/source/incoming/controllers/022.php
+++ b/user_guide_src/source/incoming/controllers/022.php
@@ -4,7 +4,7 @@ namespace App\Controllers;
 
 class Products extends BaseController
 {
-    public function shoes($sandals, $id)
+    public function getShoes($sandals, $id)
     {
         return $sandals . $id;
     }

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -11,6 +11,14 @@ What is URI Routing?
 
 URI Routing associates a URI with a controller's method.
 
+CodeIgniter has two kinds of routing. One is **Defined Route Routing**, and the other is **Auto Routing**.
+With Defined Route Routing, you can define routes manually. It allows flexible URL.
+Auto Routing automatically routes HTTP requests based on conventions and execute the corresponding controller methods. There is no need to define routes manually.
+
+First, let's look at Defined Route Routing. If you want to use Auto Routing, see :ref:`auto-routing-improved`.
+
+.. _defined-route-routing:
+
 Setting Routing Rules
 *********************
 
@@ -482,7 +490,7 @@ Use Defined Routes Only
 Since v4.2.0, the auto-routing is disabled by default.
 
 When no defined route is found that matches the URI, the system will attempt to match that URI against the
-controllers and methods when :ref:`auto-routing` is enabled.
+controllers and methods when Auto Routing is enabled.
 
 You can disable this automatic matching, and restrict routes
 to only those defined by you, by setting the ``setAutoRoute()`` option to false:
@@ -510,23 +518,115 @@ For an example use of lowering the priority see :ref:`routing-priority`:
 
 .. literalinclude:: routing/052.php
 
-.. _auto-routing:
+.. _auto-routing-improved:
 
-Auto Routing
-************
+Auto Routing (Improved)
+***********************
 
-It is recommended that all routes are defined in the **app/Config/Routes.php** file.
-However, CodeIgniter can also automatically route HTTP requests based on conventions
+Since v4.2.0, the new more secure Auto Routing has been introduced.
+
+When no defined route is found that matches the URI, the system will attempt to match that URI against the controllers and methods when Auto Routing is enabled.
+
+.. important:: For security reasons, if a controller is used in the defined routes, Auto Routing (Improved) does not route to the controller.
+
+Auto Routing can automatically route HTTP requests based on conventions
 and execute the corresponding controller methods.
 
-.. warning:: To prevent misconfiguration and miscoding, we recommend that you do not use
-    the auto-routing feature. It is easy to create vulnerable apps where controller filters
-    or CSRF protection are bypassed.
+.. note:: Auto Routing (Improved) is disabled by default. To use it, see below.
 
-.. important:: The auto-routing routes a HTTP request with **any** HTTP method to a controller method.
+.. _enabled-auto-routing-improved:
 
 Enable Auto Routing
 ===================
+
+To use it, you need to change the setting ``setAutoRoute()`` option to true in **app/Config/Routes.php**::
+
+    $routes->setAutoRoute(true);
+
+And you need to change the property ``$autoRoutesImproved`` to ``true`` in **app/Config/Feature.php**::
+
+    public bool $autoRoutesImproved = true;
+
+URI Segments
+============
+
+The segments in the URL, in following with the Model-View-Controller approach, usually represent::
+
+    example.com/class/method/ID
+
+1. The first segment represents the controller **class** that should be invoked.
+2. The second segment represents the class **method** that should be called.
+3. The third, and any additional segments, represent the ID and any variables that will be passed to the controller.
+
+Consider this URI::
+
+    example.com/index.php/helloworld/hello/1
+
+In the above example, when you send a HTTP request with **GET** method,
+Auto Routing would attempt to find a controller named ``App\Controllers\Helloworld``
+and executes ``getHello()`` method with passing ``'1'`` as the first argument.
+
+.. note:: A controller method that will be executed by Auto Routing (Improved) needs HTTP verb (``get``, ``post``, ``put``, etc.) prefix like ``getIndex()``, ``postCreate()``.
+
+See :ref:`Auto Routing in Controllers <controller-auto-routing-improved>` for more info.
+
+Configuration Options
+=====================
+
+These options are available at the top of **app/Config/Routes.php**.
+
+Default Controller
+------------------
+
+When a user visits the root of your site (i.e., **example.com**) the controller to use is determined by the value set by
+the ``setDefaultController()`` method, unless a route exists for it explicitly. The default value for this is ``Home``
+which matches the controller at **app/Controllers/Home.php**:
+
+.. literalinclude:: routing/047.php
+
+The default controller is also used when no matching route has been found, and the URI would point to a directory
+in the controllers directory. For example, if the user visits **example.com/admin**, if a controller was found at
+**app/Controllers/Admin/Home.php**, it would be used.
+
+.. note:: You cannot access the default controller with the URI of the controller name.
+    When the default controller is ``Home``, you can access **example.com/**, but if you access **example.com/home**, it will be not found.
+
+See :ref:`Auto Routing in Controllers <controller-auto-routing-improved>` for more info.
+
+Default Method
+--------------
+
+This works similar to the default controller setting, but is used to determine the default method that is used
+when a controller is found that matches the URI, but no segment exists for the method. The default value is
+``index``.
+
+In this example, if the user were to visit **example.com/products**, and a ``Products`` controller existed, the
+``Products::listAll()`` method would be executed:
+
+.. literalinclude:: routing/048.php
+
+.. note:: You cannot access the controller with the URI of the default method name.
+    In the example above, you can access **example.com/products**, but if you access **example.com/products/listall**, it will be not found.
+
+.. _auto-routing:
+
+Auto Routing (Traditional)
+**************************
+
+Auto Routing (Traditional) is a routing system from CodeIgniter 3.
+It can automatically route HTTP requests based on conventions and execute the corresponding controller methods.
+
+It is recommended that all routes are defined in the **app/Config/Routes.php** file,
+or to use :ref:`auto-routing-improved`,
+
+.. warning:: To prevent misconfiguration and miscoding, we recommend that you do not use
+    Auto Routing (Traditional) feature. It is easy to create vulnerable apps where controller filters
+    or CSRF protection are bypassed.
+
+.. important:: Auto Routing (Traditional) routes a HTTP request with **any** HTTP method to a controller method.
+
+Enable Auto Routing (Traditional)
+=================================
 
 Since v4.2.0, the auto-routing is disabled by default.
 
@@ -534,8 +634,8 @@ To use it, you need to change the setting ``setAutoRoute()`` option to true in *
 
     $routes->setAutoRoute(true);
 
-URI Segments
-============
+URI Segments (Traditional)
+==========================
 
 The segments in the URL, in following with the Model-View-Controller approach, usually represent::
 
@@ -552,18 +652,15 @@ Consider this URI::
 In the above example, CodeIgniter would attempt to find a controller named **Helloworld.php**
 and executes ``index()`` method with passing ``'1'`` as the first argument.
 
-We call this "**Auto Routes**". CodeIgniter automatically routes an HTTP request,
-and executes the corresponding controller method. The auto-routing is disabled by default.
+See :ref:`Auto Routing (Traditional) in Controllers <controller-auto-routing>` for more info.
 
-See :ref:`Auto Routing in Controllers <controller-auto-routing>` for more info.
-
-Configuration Options
-=====================
+Configuration Options (Traditional)
+===================================
 
 These options are available at the top of **app/Config/Routes.php**.
 
-Default Controller
-------------------
+Default Controller (Traditional)
+--------------------------------
 
 When a user visits the root of your site (i.e., example.com) the controller to use is determined by the value set by
 the ``setDefaultController()`` method, unless a route exists for it explicitly. The default value for this is ``Home``
@@ -577,8 +674,8 @@ in the controllers directory. For example, if the user visits **example.com/admi
 
 See :ref:`Auto Routing in Controllers <controller-auto-routing>` for more info.
 
-Default Method
---------------
+Default Method (Traditional)
+----------------------------
 
 This works similar to the default controller setting, but is used to determine the default method that is used
 when a controller is found that matches the URI, but no segment exists for the method. The default value is
@@ -617,11 +714,11 @@ The output is like the following:
     | auto   | home/index[/...] | \App\Controllers\Home::index             | invalidchars   | secureheaders toolbar |
     +--------+------------------+------------------------------------------+----------------+-----------------------+
 
-The *Method* column shows the HTTP method that the route is listening for. ``auto`` means that the route is discovered by auto routing, so it is not defined in **app/Config/Routes.php**.
+The *Method* column shows the HTTP method that the route is listening for. ``auto`` means that the route is discovered by auto-routing, so it is not defined in **app/Config/Routes.php**.
 
 The *Route* column shows the URI path to match. The route of a defined route is expressed as a regular expression.
 But ``[/...]`` in the route of an auto route is indicates any number of segments.
 
-.. note:: When auto routing is enabled, if you have the route ``home``, it can be also accessd by ``Home``, or maybe by ``hOme``, ``hoMe``, ``HOME``, etc. But the command shows only ``home``.
+.. note:: When auto-routing is enabled, if you have the route ``home``, it can be also accessd by ``Home``, or maybe by ``hOme``, ``hoMe``, ``HOME``, etc. But the command shows only ``home``.
 
 .. important:: The system is not perfect. If you use Custom Placeholders, *Filters* might not be correct. But the filters defined in **app/Config/Routes.php** are always displayed correctly.

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -610,23 +610,23 @@ In this example, if the user were to visit **example.com/products**, and a ``Pro
 
 .. _auto-routing:
 
-Auto Routing (Traditional)
-**************************
+Auto Routing (Legacy)
+*********************
 
-Auto Routing (Traditional) is a routing system from CodeIgniter 3.
+Auto Routing (Legacy) is a routing system from CodeIgniter 3.
 It can automatically route HTTP requests based on conventions and execute the corresponding controller methods.
 
 It is recommended that all routes are defined in the **app/Config/Routes.php** file,
 or to use :ref:`auto-routing-improved`,
 
 .. warning:: To prevent misconfiguration and miscoding, we recommend that you do not use
-    Auto Routing (Traditional) feature. It is easy to create vulnerable apps where controller filters
+    Auto Routing (Legacy) feature. It is easy to create vulnerable apps where controller filters
     or CSRF protection are bypassed.
 
-.. important:: Auto Routing (Traditional) routes a HTTP request with **any** HTTP method to a controller method.
+.. important:: Auto Routing (Legacy) routes a HTTP request with **any** HTTP method to a controller method.
 
-Enable Auto Routing (Traditional)
-=================================
+Enable Auto Routing (Legacy)
+============================
 
 Since v4.2.0, the auto-routing is disabled by default.
 
@@ -634,8 +634,8 @@ To use it, you need to change the setting ``setAutoRoute()`` option to true in *
 
     $routes->setAutoRoute(true);
 
-URI Segments (Traditional)
-==========================
+URI Segments (Legacy)
+=====================
 
 The segments in the URL, in following with the Model-View-Controller approach, usually represent::
 
@@ -652,15 +652,15 @@ Consider this URI::
 In the above example, CodeIgniter would attempt to find a controller named **Helloworld.php**
 and executes ``index()`` method with passing ``'1'`` as the first argument.
 
-See :ref:`Auto Routing (Traditional) in Controllers <controller-auto-routing>` for more info.
+See :ref:`Auto Routing (Legacy) in Controllers <controller-auto-routing>` for more info.
 
-Configuration Options (Traditional)
-===================================
+Configuration Options (Legacy)
+==============================
 
 These options are available at the top of **app/Config/Routes.php**.
 
-Default Controller (Traditional)
---------------------------------
+Default Controller (Legacy)
+---------------------------
 
 When a user visits the root of your site (i.e., example.com) the controller to use is determined by the value set by
 the ``setDefaultController()`` method, unless a route exists for it explicitly. The default value for this is ``Home``
@@ -674,8 +674,8 @@ in the controllers directory. For example, if the user visits **example.com/admi
 
 See :ref:`Auto Routing in Controllers <controller-auto-routing>` for more info.
 
-Default Method (Traditional)
-----------------------------
+Default Method (Legacy)
+-----------------------
 
 This works similar to the default controller setting, but is used to determine the default method that is used
 when a controller is found that matches the URI, but no segment exists for the method. The default value is


### PR DESCRIPTION
~~Needs to rebase after merging #5877~~

**Description**
An optional new more secure auto router.
- add `AutoRouterImproved` class and `AutoRouterInterface`
- add `Config\Feature::$autoRoutesImproved` (`false` by default)
- use `AutoRouterImproved` in `Router` if enabled

`AutoRouterImproved` changes:
- A controller method needs HTTP verb prefix like `getIndex()`, `postCreate()`.
  - Developers always know HTTP method, so requests by unexpected HTTP method does not happen.
- The Default Controller (`home` by default) and the Default Method (`index` by default) must be omitted in the URI.
  - Restrict one-to-one correspondence between controller methods and URIs.
  - By default, you can access `/`, but `/home` and `/home/index` are 404.
- It checks method parameter count.
  - If there are more parameters in the URI than the method parameters, it results in 404.
- It does not support `_remap()` method.
  - Restrict one-to-one correspondence between controller methods and URIs.
- Can't access controllers in Defined Routes.
  - Completely separates controllers accessible via Auto Routes from those accessible via Defined Routes.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
