### PR TITLE
fix: using multiple CLI::color() in CLI::write() outputs strings with wrong color

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -473,6 +473,10 @@ class CLI
             return $text;
         }
 
+        if ($text === '') {
+            return $text;
+        }
+
         if (! array_key_exists($foreground, static::$foreground_colors)) {
             throw CLIException::forInvalidColor('foreground', $foreground);
         }
@@ -481,6 +485,51 @@ class CLI
             throw CLIException::forInvalidColor('background', $background);
         }
 
+        // Reset text
+        $newText = '';
+
+        // Detect if color method was already in use with this text
+        if (strpos($text, "\033[0m") !== false) {
+            $pattern = '/\\033\\[0;.+?\\033\\[0m/u';
+
+            preg_match_all($pattern, $text, $matches);
+            $coloredStrings = $matches[0];
+
+            // No colored string found. Invalid strings with no `\033[0;??`.
+            if ($coloredStrings === []) {
+                $newText .= self::getColoredText($text, $foreground, $background, $format);
+
+                return $newText;
+            }
+
+            $nonColoredText = preg_replace(
+                $pattern,
+                '<<__colored_string__>>',
+                $text
+            );
+            $nonColoredChunks = preg_split(
+                '/<<__colored_string__>>/u',
+                $nonColoredText
+            );
+
+            foreach ($nonColoredChunks as $i => $chunk) {
+                if ($chunk !== '') {
+                    $newText .= self::getColoredText($chunk, $foreground, $background, $format);
+                }
+
+                if (isset($coloredStrings[$i])) {
+                    $newText .= $coloredStrings[$i];
+                }
+            }
+        } else {
+            $newText .= self::getColoredText($text, $foreground, $background, $format);
+        }
+
+        return $newText;
+    }
+
+    private static function getColoredText(string $text, string $foreground, ?string $background, ?string $format): string
+    {
         $string = "\033[" . static::$foreground_colors[$foreground] . 'm';
 
         if ($background !== null) {
@@ -491,31 +540,9 @@ class CLI
             $string .= "\033[4m";
         }
 
-        // Detect if color method was already in use with this text
-        if (strpos($text, "\033[0m") !== false) {
-            // Split the text into parts so that we can see
-            // if any part missing the color definition
-            $chunks = mb_split('\\033\\[0m', $text);
-            // Reset text
-            $text = '';
+        $string .= $text . "\033[0m";
 
-            foreach ($chunks as $chunk) {
-                if ($chunk === '') {
-                    continue;
-                }
-
-                // If chunk doesn't have colors defined we need to add them
-                if (strpos($chunk, "\033[") === false) {
-                    $chunk = static::color($chunk, $foreground, $background, $format);
-                    // Add color reset before chunk and clear end of the string
-                    $text .= rtrim("\033[0m" . $chunk, "\033[0m");
-                } else {
-                    $text .= $chunk;
-                }
-            }
-        }
-
-        return $string . $text . "\033[0m";
+        return $string;
     }
 
     /**

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -469,11 +469,7 @@ class CLI
      */
     public static function color(string $text, string $foreground, ?string $background = null, ?string $format = null): string
     {
-        if (! static::$isColored) {
-            return $text;
-        }
-
-        if ($text === '') {
+        if (! static::$isColored || $text === '') {
             return $text;
         }
 

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -533,7 +533,7 @@ class CLI
             $string .= "\033[4m";
         }
 
-        return $string . ($text . "\033[0m");
+        return $string . $text . "\033[0m";
     }
 
     /**

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -497,9 +497,7 @@ class CLI
 
             // No colored string found. Invalid strings with no `\033[0;??`.
             if ($coloredStrings === []) {
-                $newText .= self::getColoredText($text, $foreground, $background, $format);
-
-                return $newText;
+                return $newText . self::getColoredText($text, $foreground, $background, $format);
             }
 
             $nonColoredText = preg_replace(
@@ -540,9 +538,7 @@ class CLI
             $string .= "\033[4m";
         }
 
-        $string .= $text . "\033[0m";
-
-        return $string;
+        return $string . ($text . "\033[0m");
     }
 
     /**

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -485,7 +485,6 @@ class CLI
             throw CLIException::forInvalidColor('background', $background);
         }
 
-        // Reset text
         $newText = '';
 
         // Detect if color method was already in use with this text

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -122,6 +122,7 @@ final class CLITest extends CIUnitTestCase
 
         CLI::init(); // force re-check on env
         $this->assertSame('test', CLI::color('test', 'white', 'green'));
+
         putenv($nocolor ? "NO_COLOR={$nocolor}" : 'NO_COLOR');
     }
 
@@ -132,6 +133,7 @@ final class CLITest extends CIUnitTestCase
 
         CLI::init(); // force re-check on env
         $this->assertSame("\033[1;37m\033[42m\033[4mtest\033[0m", CLI::color('test', 'white', 'green', 'underline'));
+
         putenv($termProgram ? "TERM_PROGRAM={$termProgram}" : 'TERM_PROGRAM');
     }
 
@@ -190,14 +192,30 @@ final class CLITest extends CIUnitTestCase
     public function testWriteForegroundWithColorBefore()
     {
         CLI::write(CLI::color('green', 'green') . ' red', 'red');
-        $expected = "\033[0;31m\033[0;32mgreen\033[0m\033[0;31m red\033[0m" . PHP_EOL;
+
+        $expected = "\033[0;32mgreen\033[0m\033[0;31m red\033[0m" . PHP_EOL;
         $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testWriteForegroundWithColorAfter()
     {
         CLI::write('red ' . CLI::color('green', 'green'), 'red');
-        $expected = "\033[0;31mred \033[0;32mgreen\033[0m" . PHP_EOL;
+
+        $expected = "\033[0;31mred \033[0m\033[0;32mgreen\033[0m" . PHP_EOL;
+        $this->assertSame($expected, CITestStreamFilter::$buffer);
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5892
+     */
+    public function testWriteForegroundWithColorTwice()
+    {
+        CLI::write(
+            CLI::color('green', 'green') . ' red ' . CLI::color('green', 'green'),
+            'red'
+        );
+
+        $expected = "\033[0;32mgreen\033[0m\033[0;31m red \033[0m\033[0;32mgreen\033[0m" . PHP_EOL;
         $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -159,6 +159,14 @@ final class CLITest extends CIUnitTestCase
         );
     }
 
+    public function testColorEmtpyString()
+    {
+        $this->assertSame(
+            '',
+            CLI::color('', 'white', 'green', 'underline')
+        );
+    }
+
     public function testPrint()
     {
         CLI::print('test');

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -39,18 +39,21 @@ final class CLITest extends CIUnitTestCase
     public function testNew()
     {
         $actual = new CLI();
+
         $this->assertInstanceOf(CLI::class, $actual);
     }
 
     public function testBeep()
     {
         $this->expectOutputString("\x07");
+
         CLI::beep();
     }
 
     public function testBeep4()
     {
         $this->expectOutputString("\x07\x07\x07\x07");
+
         CLI::beep(4);
     }
 
@@ -96,6 +99,7 @@ final class CLITest extends CIUnitTestCase
     public function testNewLine()
     {
         $this->expectOutputString('');
+
         CLI::newLine();
     }
 
@@ -119,8 +123,8 @@ final class CLITest extends CIUnitTestCase
     {
         $nocolor = getenv('NO_COLOR');
         putenv('NO_COLOR=1');
-
         CLI::init(); // force re-check on env
+
         $this->assertSame('test', CLI::color('test', 'white', 'green'));
 
         putenv($nocolor ? "NO_COLOR={$nocolor}" : 'NO_COLOR');
@@ -130,8 +134,8 @@ final class CLITest extends CIUnitTestCase
     {
         $termProgram = getenv('TERM_PROGRAM');
         putenv('TERM_PROGRAM=Hyper');
-
         CLI::init(); // force re-check on env
+
         $this->assertSame("\033[1;37m\033[42m\033[4mtest\033[0m", CLI::color('test', 'white', 'green', 'underline'));
 
         putenv($termProgram ? "TERM_PROGRAM={$termProgram}" : 'TERM_PROGRAM');
@@ -148,36 +152,41 @@ final class CLITest extends CIUnitTestCase
         // After the tests on NO_COLOR and TERM_PROGRAM above,
         // the $isColored variable is rigged. So we reset this.
         CLI::init();
-        $this->assertSame("\033[1;37m\033[42m\033[4mtest\033[0m", CLI::color('test', 'white', 'green', 'underline'));
+
+        $this->assertSame(
+            "\033[1;37m\033[42m\033[4mtest\033[0m",
+            CLI::color('test', 'white', 'green', 'underline')
+        );
     }
 
     public function testPrint()
     {
         CLI::print('test');
-        $expected = 'test';
 
+        $expected = 'test';
         $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testPrintForeground()
     {
         CLI::print('test', 'red');
-        $expected = "\033[0;31mtest\033[0m";
 
+        $expected = "\033[0;31mtest\033[0m";
         $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testPrintBackground()
     {
         CLI::print('test', 'red', 'green');
-        $expected = "\033[0;31m\033[42mtest\033[0m";
 
+        $expected = "\033[0;31m\033[42mtest\033[0m";
         $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
 
     public function testWrite()
     {
         CLI::write('test');
+
         $expected = PHP_EOL . 'test' . PHP_EOL;
         $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
@@ -185,6 +194,7 @@ final class CLITest extends CIUnitTestCase
     public function testWriteForeground()
     {
         CLI::write('test', 'red');
+
         $expected = "\033[0;31mtest\033[0m" . PHP_EOL;
         $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
@@ -222,6 +232,7 @@ final class CLITest extends CIUnitTestCase
     public function testWriteBackground()
     {
         CLI::write('test', 'red', 'green');
+
         $expected = "\033[0;31m\033[42mtest\033[0m" . PHP_EOL;
         $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
@@ -229,7 +240,9 @@ final class CLITest extends CIUnitTestCase
     public function testError()
     {
         $this->stream_filter = stream_filter_append(STDERR, 'CITestStreamFilter');
+
         CLI::error('test');
+
         // red expected cuz stderr
         $expected = "\033[1;31mtest\033[0m" . PHP_EOL;
         $this->assertSame($expected, CITestStreamFilter::$buffer);
@@ -238,7 +251,9 @@ final class CLITest extends CIUnitTestCase
     public function testErrorForeground()
     {
         $this->stream_filter = stream_filter_append(STDERR, 'CITestStreamFilter');
+
         CLI::error('test', 'purple');
+
         $expected = "\033[0;35mtest\033[0m" . PHP_EOL;
         $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
@@ -246,7 +261,9 @@ final class CLITest extends CIUnitTestCase
     public function testErrorBackground()
     {
         $this->stream_filter = stream_filter_append(STDERR, 'CITestStreamFilter');
+
         CLI::error('test', 'purple', 'green');
+
         $expected = "\033[0;35m\033[42mtest\033[0m" . PHP_EOL;
         $this->assertSame($expected, CITestStreamFilter::$buffer);
     }
@@ -291,9 +308,18 @@ final class CLITest extends CIUnitTestCase
     public function testWrap()
     {
         $this->assertSame('', CLI::wrap(''));
-        $this->assertSame('1234' . PHP_EOL . ' 5678' . PHP_EOL . ' 90' . PHP_EOL . ' abc' . PHP_EOL . ' de' . PHP_EOL . ' fghij' . PHP_EOL . ' 0987654321', CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 5, 1));
-        $this->assertSame('1234 5678 90' . PHP_EOL . '  abc de fghij' . PHP_EOL . '  0987654321', CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 999, 2));
-        $this->assertSame('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321'));
+        $this->assertSame(
+            '1234' . PHP_EOL . ' 5678' . PHP_EOL . ' 90' . PHP_EOL . ' abc' . PHP_EOL . ' de' . PHP_EOL . ' fghij' . PHP_EOL . ' 0987654321',
+            CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 5, 1)
+        );
+        $this->assertSame(
+            '1234 5678 90' . PHP_EOL . '  abc de fghij' . PHP_EOL . '  0987654321',
+            CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 999, 2)
+        );
+        $this->assertSame(
+            '1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321',
+            CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321')
+        );
     }
 
     public function testParseCommand()
@@ -305,6 +331,7 @@ final class CLITest extends CIUnitTestCase
         ];
         $_SERVER['argc'] = 3;
         CLI::init();
+
         $this->assertNull(CLI::getSegment(3));
         $this->assertSame('b', CLI::getSegment(1));
         $this->assertSame('c', CLI::getSegment(2));
@@ -330,6 +357,7 @@ final class CLITest extends CIUnitTestCase
             'sure',
         ];
         CLI::init();
+
         $this->assertNull(CLI::getSegment(7));
         $this->assertSame('b', CLI::getSegment(1));
         $this->assertSame('c', CLI::getSegment(2));
@@ -353,6 +381,7 @@ final class CLITest extends CIUnitTestCase
             'd',
         ];
         CLI::init();
+
         $this->assertSame(['parm' => 'pvalue'], CLI::getOptions());
         $this->assertSame('pvalue', CLI::getOption('parm'));
         $this->assertSame('-parm pvalue ', CLI::getOptionString());
@@ -377,6 +406,7 @@ final class CLITest extends CIUnitTestCase
             'value 3',
         ];
         CLI::init();
+
         $this->assertSame(['parm' => 'pvalue', 'p2' => null, 'p3' => 'value 3'], CLI::getOptions());
         $this->assertSame('pvalue', CLI::getOption('parm'));
         $this->assertSame('-parm pvalue -p2 -p3 "value 3" ', CLI::getOptionString());
@@ -391,11 +421,13 @@ final class CLITest extends CIUnitTestCase
         $height = new ReflectionProperty(CLI::class, 'height');
         $height->setAccessible(true);
         $height->setValue(null);
+
         $this->assertIsInt(CLI::getHeight());
 
         $width = new ReflectionProperty(CLI::class, 'width');
         $width->setAccessible(true);
         $width->setValue(null);
+
         $this->assertIsInt(CLI::getWidth());
     }
 
@@ -409,6 +441,7 @@ final class CLITest extends CIUnitTestCase
     public function testTable($tbody, $thead, $expected)
     {
         CLI::table($tbody, $thead);
+
         $this->assertSame(CITestStreamFilter::$buffer, $expected);
     }
 

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -18,6 +18,7 @@ BREAKING
     - ``spark``
 - The method signature of ``CodeIgniter\CLI\CommandRunner::_remap()`` has been changed to fix a bug.
 - The ``CodeIgniter\Autoloader\Autoloader::initialize()`` has changed the behavior to fix a bug. It used to use Composer classmap only when ``$modules->discoverInComposer`` is true. Now it always uses the Composer classmap if Composer is available.
+- The color code output by :ref:`CLI::color() <cli-library-color>` has been changed to fix a bug.
 
 Enhancements
 ************

--- a/user_guide_src/source/cli/cli_library.rst
+++ b/user_guide_src/source/cli/cli_library.rst
@@ -52,7 +52,8 @@ Validation rules can also be written in the array syntax:
 
 .. literalinclude:: cli_library/006.php
 
-**promptByKey()**
+promptByKey()
+=============
 
 Predefined answers (options) for prompt sometimes need to be described or are too complex to select via their value.
 ``promptByKey()`` allows the user to select an option by its key instead of its value:
@@ -68,7 +69,8 @@ Finally, you can pass :ref:`validation <validation>` rules to the answer input a
 Providing Feedback
 ******************
 
-**write()**
+write()
+=======
 
 Several methods are provided for you to provide feedback to your users. This can be as simple as a single status update
 or a complex table of information that wraps to the user's terminal window. At the core of this is the ``write()``
@@ -116,7 +118,8 @@ And a smaller number are available as background colors:
 * light_gray
 * magenta
 
-**print()**
+print()
+=======
 
 Print functions identically to the ``write()`` method, except that it does not force a newline either before or after.
 Instead it prints it to the screen wherever the cursor is currently. This allows you to print multiple items all on
@@ -125,7 +128,8 @@ print "Done" on the same line:
 
 .. literalinclude:: cli_library/012.php
 
-**color()**
+color()
+=======
 
 While the ``write()`` command will write a single line to the terminal, ending it with a EOL character, you can
 use the ``color()`` method to make a string fragment that can be used in the same way, except that it will not force
@@ -137,7 +141,8 @@ it inside of a ``write()`` method to create a string of a different color inside
 This example would write a single line to the window, with ``fileA`` in yellow, followed by a tab, and then
 ``/path/to/file`` in white text.
 
-**error()**
+error()
+=======
 
 If you need to output errors, you should use the appropriately named ``error()`` method. This writes light-red text
 to STDERR, instead of STDOUT, like ``write()`` and ``color()`` do. This can be useful if you have scripts watching
@@ -146,7 +151,8 @@ exactly as you would the ``write()`` method:
 
 .. literalinclude:: cli_library/014.php
 
-**wrap()**
+wrap()
+======
 
 This command will take a string, start printing it on the current line, and wrap it to a set length on new lines.
 This might be useful when displaying a list of options with descriptions that you want to wrap in the current
@@ -179,13 +185,15 @@ Would create something like this:
                industry's standard dummy
                text ever since the
 
-**newLine()**
+newLine()
+=========
 
 The ``newLine()`` method displays a blank line to the user. It does not take any parameters:
 
 .. literalinclude:: cli_library/018.php
 
-**clearScreen()**
+clearScreen()
+=============
 
 You can clear the current terminal window with the ``clearScreen()`` method. In most versions of Windows, this will
 simply insert 40 blank lines since Windows doesn't support this feature. Windows 10 bash integration should change
@@ -193,7 +201,8 @@ this:
 
 .. literalinclude:: cli_library/019.php
 
-**showProgress()**
+showProgress()
+==============
 
 If you have a long-running task that you would like to keep the user updated with the progress, you can use the
 ``showProgress()`` method which displays something like the following:
@@ -210,7 +219,8 @@ pass ``false`` as the first parameter and the progress bar will be removed.
 
 .. literalinclude:: cli_library/020.php
 
-**table()**
+table()
+=======
 
 .. literalinclude:: cli_library/021.php
 
@@ -223,7 +233,8 @@ pass ``false`` as the first parameter and the progress bar will be removed.
     | 8  | Another great item title | 2017-11-16 13:46:54 | 0      |
     +----+--------------------------+---------------------+--------+
 
-**wait()**
+wait()
+======
 
 Waits a certain number of seconds, optionally showing a wait message and
 waiting for a key press.

--- a/user_guide_src/source/cli/cli_library.rst
+++ b/user_guide_src/source/cli/cli_library.rst
@@ -15,7 +15,7 @@ CodeIgniter's CLI library makes creating interactive command-line scripts simple
     :depth: 2
 
 Initializing the Class
-======================
+**********************
 
 You do not need to create an instance of the CLI library, since all of it's methods are static. Instead, you simply
 need to ensure your controller can locate it via a ``use`` statement above your class:
@@ -25,7 +25,7 @@ need to ensure your controller can locate it via a ``use`` statement above your 
 The class is automatically initialized when the file is loaded the first time.
 
 Getting Input from the User
-===========================
+***************************
 
 Sometimes you need to ask the user for more information. They might not have provided optional command-line
 arguments, or the script may have encountered an existing file and needs confirmation before overwriting. This is
@@ -66,7 +66,7 @@ Named keys are also possible:
 Finally, you can pass :ref:`validation <validation>` rules to the answer input as the third parameter, the acceptable answers are automatically restricted to the passed options.
 
 Providing Feedback
-==================
+******************
 
 **write()**
 

--- a/user_guide_src/source/cli/cli_library.rst
+++ b/user_guide_src/source/cli/cli_library.rst
@@ -128,6 +128,8 @@ print "Done" on the same line:
 
 .. literalinclude:: cli_library/012.php
 
+.. _cli-library-color:
+
 color()
 =======
 


### PR DESCRIPTION
**Description**
Fixes #5892

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
