### PR TITLE
docs: replace `/app/` with `app/`

### DIFF
--- a/user_guide_src/source/cli/cli_commands.rst
+++ b/user_guide_src/source/cli/cli_commands.rst
@@ -88,7 +88,7 @@ File Location
 =============
 
 Commands must be stored within a directory named **Commands**. However, that directory can be located anywhere
-that the :doc:`Autoloader </concepts/autoloader>` can locate it. This could be in **/app/Commands**, or
+that the :doc:`Autoloader </concepts/autoloader>` can locate it. This could be in **app/Commands**, or
 a directory that you keep commands in to use in all of your project development, like **Acme/Commands**.
 
 .. note:: When the commands are executed, the full CodeIgniter CLI environment has been loaded, making it
@@ -98,7 +98,7 @@ An Example Command
 ==================
 
 Let's step through an example command whose only function is to report basic information about the application
-itself, for demonstration purposes. Start by creating a new file at **/app/Commands/AppInfo.php**. It
+itself, for demonstration purposes. Start by creating a new file at **app/Commands/AppInfo.php**. It
 should contain the following code:
 
 .. literalinclude:: cli_commands/002.php

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -28,7 +28,7 @@ beginning of the framework's execution.
 Configuration
 =============
 
-Initial configuration is done in **/app/Config/Autoload.php**. This file contains two primary
+Initial configuration is done in **app/Config/Autoload.php**. This file contains two primary
 arrays: one for the classmap, and one for PSR-4 compatible namespaces.
 
 Namespaces
@@ -48,7 +48,7 @@ have a trailing slash.
 
 By default, the application folder is namespace to the ``App`` namespace. While you are not forced to namespace the controllers,
 libraries, or models in the application directory, if you do, they will be found under the ``App`` namespace.
-You may change this namespace by editing the **/app/Config/Constants.php** file and setting the
+You may change this namespace by editing the **app/Config/Constants.php** file and setting the
 new namespace value under the ``APP_NAMESPACE`` setting:
 
 .. literalinclude:: autoloader/002.php

--- a/user_guide_src/source/concepts/mvc.rst
+++ b/user_guide_src/source/concepts/mvc.rst
@@ -37,11 +37,11 @@ Views get the data to display from the controllers, who pass it to the views as 
 with simple ``echo`` calls. You can also display other views within a view, making it pretty simple to display a
 common header or footer on every page.
 
-Views are generally stored in **/app/Views**, but can quickly become unwieldy if not organized in some fashion.
+Views are generally stored in **app/Views**, but can quickly become unwieldy if not organized in some fashion.
 CodeIgniter does not enforce any type of organization, but a good rule of thumb would be to create a new directory in
 the **Views** directory for each controller. Then, name views by the method name. This makes them very easy to find later
 on. For example, a user's profile might be displayed in a controller named ``User``, and a method named ``profile``.
-You might store the view file for this method in **/app/Views/User/Profile.php**.
+You might store the view file for this method in **app/Views/User/Profile.php**.
 
 That type of organization works great as a base habit to get into. At times you might need to organize it differently.
 That's not a problem. As long as CodeIgniter can find the file, it can display it.
@@ -61,7 +61,7 @@ it's saved to meet company standards, or formatting a column in a certain way be
 By keeping these business requirements in the model, you won't repeat code throughout several controllers and accidentally
 miss updating an area.
 
-Models are typically stored in **/app/Models**, though they can use a namespace to be grouped however you need.
+Models are typically stored in **app/Models**, though they can use a namespace to be grouped however you need.
 
 :doc:`Find out more about models </models/model>`
 
@@ -77,7 +77,7 @@ The other responsibility of the controller is to handle everything that pertains
 authentication, web safety, encoding, etc. In short, the controller is where you make sure that people are allowed to
 be there, and they get the data they need in a format they can use.
 
-Controllers are typically stored in **/app/Controllers**, though they can use a namespace to be grouped however
+Controllers are typically stored in **app/Controllers**, though they can use a namespace to be grouped however
 you need.
 
 :doc:`Find out more about controllers </incoming/controllers>`

--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -9,7 +9,7 @@ the required settings are public properties.
 Unlike many other frameworks, CodeIgniter configurable items aren't contained in
 a single file. Instead, each class that needs configurable items will have a
 configuration file with the same name as the class that uses it. You will find
-the application configuration files in the **/app/Config** folder.
+the application configuration files in the **app/Config** folder.
 
 .. contents::
     :local:
@@ -33,7 +33,7 @@ All configuration object properties are public, so you access the settings like 
 .. literalinclude:: configuration/003.php
 
 If no namespace is provided, it will look for the file in all defined namespaces
-as well as **/app/Config/**.
+as well as **app/Config/**.
 
 All of the configuration files that ship with CodeIgniter are namespaced with
 ``Config``. Using this namespace in your application will provide the best
@@ -48,7 +48,7 @@ Creating Configuration Files
 ============================
 
 When you need a new configuration, first you create a new file at your desired location.
-The default file location (recommended for most cases) is **/app/Config**.
+The default file location (recommended for most cases) is **app/Config**.
 The class should use the appropriate namespace, and it should extend
 ``CodeIgniter\Config\BaseConfig`` to ensure that it can receive environment-specific settings.
 

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -146,7 +146,7 @@ For security reasons be sure to declare any new utility methods as ``protected``
 
 .. literalinclude:: controllers/008.php
 
-Then save the file to your **/app/Controllers/** directory.
+Then save the file to your **app/Controllers/** directory.
 
 .. important:: The file must be called **Helloworld.php**, with a capital ``H``.
 

--- a/user_guide_src/source/libraries/throttler.rst
+++ b/user_guide_src/source/libraries/throttler.rst
@@ -64,7 +64,7 @@ Applying the Filter
 
 We don't necessarily need to throttle every page on the site. For many web applications, this makes the most sense
 to apply only to POST requests, though API's might want to limit every request made by a user. In order to apply
-this to incoming requests, you need to edit **/app/Config/Filters.php** and first add an alias to the
+this to incoming requests, you need to edit **app/Config/Filters.php** and first add an alias to the
 filter:
 
 .. literalinclude:: throttler/003.php

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -498,7 +498,7 @@ Creating the Views
 
 The first step is to create custom views. These can be placed anywhere that the ``view()`` method can locate them,
 which means the standard View directory, or any namespaced View folder will work. For example, you could create
-a new view at **/app/Views/_errors_list.php**:
+a new view at **app/Views/_errors_list.php**:
 
 .. literalinclude:: validation/030.php
 


### PR DESCRIPTION
**Description**
- Because there are more places written as `app/`.
- `/` at first implies root directory of the file system.
 
**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
