### PR TITLE
fix: Composer PSR-4 overwrites Config\Autoload::$psr4

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -328,7 +328,7 @@ class Autoloader
             $newPaths[rtrim($key, '\\ ')] = $value;
         }
 
-        $this->prefixes = array_merge($this->prefixes, $newPaths);
+        $this->addNamespace($newPaths);
     }
 
     private function loadComposerClassmap(ClassLoader $composer): void

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -233,6 +233,23 @@ final class AutoloaderTest extends CIUnitTestCase
         $this->assertArrayHasKey('Laminas\\Escaper', $namespaces);
     }
 
+    public function testComposerNamespaceDoesNotOverwriteConfigAutoloadPsr4()
+    {
+        $config       = new Autoload();
+        $config->psr4 = [
+            'Psr\Log' => '/Config/Autoload/Psr/Log/',
+        ];
+        $modules                     = new Modules();
+        $modules->discoverInComposer = true;
+
+        $this->loader = new Autoloader();
+        $this->loader->initialize($config, $modules);
+
+        $namespaces = $this->loader->getNamespace();
+        $this->assertSame('/Config/Autoload/Psr/Log/', $namespaces['Psr\Log'][0]);
+        $this->assertStringContainsString(VENDORPATH, $namespaces['Psr\Log'][1]);
+    }
+
     public function testFindsComposerRoutesWithComposerPathNotFound()
     {
         $composerPath = COMPOSER_PATH;


### PR DESCRIPTION
**Description**
The user guide says:
> If the same namespace is defined in both CodeIgniter and Composer, CodeIgniter’s autoloader will be the first one to get a chance to locate the file.
https://codeigniter4.github.io/CodeIgniter4/concepts/autoloader.html#composer-support

But if you move the `app/` folder, the autoloader can't find `Config\App.php` only when Composer is enabled.
See https://forum.codeigniter.com/showthread.php?tid=81690

It is because the Composer's namespace paths overwrite the `Config\Autoload::$psr4` settings.
https://github.com/codeigniter4/CodeIgniter4/blob/faff1f8b151686283af67ea7dac5e45da629298e/system/Autoloader/Autoloader.php#L331
> If the input arrays have the same string keys, then the later value for that key will overwrite the previous one. 
https://www.php.net/manual/en/function.array-merge.php#refsect1-function.array-merge-description

This PR fixes the bug.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

