### PR TITLE
CLI: quick jump after running `make` command from IDE terminal

### DIFF
--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -157,7 +157,7 @@ trait GeneratorTrait
             return;
         }
 
-        CLI::write(lang('CLI.generator.fileCreate', [clean_path($path)]), 'green');
+        CLI::write(lang('CLI.generator.fileCreate', [clean_path($path), $path]), 'green');
         CLI::newLine();
     }
 

--- a/system/Language/en/CLI.php
+++ b/system/Language/en/CLI.php
@@ -30,7 +30,7 @@ return [
         ],
         'commandType'      => 'Command type',
         'databaseGroup'    => 'Database group',
-        'fileCreate'       => 'File created: {0}',
+        'fileCreate'       => 'File created: {0}, Path: {1}',
         'fileError'        => 'Error while creating file: {0}',
         'fileExist'        => 'File exists: {0}',
         'fileOverwrite'    => 'File overwritten: {0}',


### PR DESCRIPTION
**Description**
Hello.
We all need to edit the file after creating it.
For example ``php spark make:config`` . Then search and open the file for editing.
I think this helps with the ``alt+click`` for open file in editor.
This feature is **not supported on all terminals**, but is supported on **many popular IDEs**.
It seems useful. 
Do you agree with me?

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
