### PR TITLE
[Rector] Add back SimplifyUselessVariableRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -17,6 +17,7 @@ use Rector\CodeQuality\Rector\FuncCall\AddPregQuoteDelimiterRector;
 use Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector;
 use Rector\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector;
 use Rector\CodeQuality\Rector\FuncCall\SimplifyStrposLowerRector;
+use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
 use Rector\CodeQuality\Rector\If_\CombineIfRector;
 use Rector\CodeQuality\Rector\If_\ShortenElseIfRector;
 use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
@@ -126,6 +127,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->importNames();
 
     $rectorConfig->rule(UnderscoreToCamelCaseVariableNameRector::class);
+    $rectorConfig->rule(SimplifyUselessVariableRector::class);
     $rectorConfig->rule(RemoveAlwaysElseRector::class);
     $rectorConfig->rule(PassStrictParameterToFunctionParameterRector::class);
     $rectorConfig->rule(CountArrayToEmptyArrayComparisonRector::class);


### PR DESCRIPTION
Ref https://github.com/codeigniter4/devkit/pull/23, it was removed at https://github.com/codeigniter4/CodeIgniter4/pull/5908 which I think because service removed instead of moved to `FunctionLike` namespace.

Thank you @kenjis for re-check.

**Checklist:**
- [x] Securely signed commits
