### PR TITLE
Fix onlyDeleted and purgeDeleted not working for non-nullable timestamp

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -382,7 +382,7 @@ class Model extends BaseModel
     protected function doPurgeDeleted()
     {
         return $this->builder()
-            ->where($this->table . '.' . $this->deletedField . ' IS NOT NULL')
+            ->where($this->table . '.' . $this->deletedField . ' > 0')
             ->delete();
     }
 
@@ -393,7 +393,7 @@ class Model extends BaseModel
      */
     protected function doOnlyDeleted()
     {
-        $this->builder()->where($this->table . '.' . $this->deletedField . ' IS NOT NULL');
+        $this->builder()->where($this->table . '.' . $this->deletedField . ' > 0');
     }
 
     /**


### PR DESCRIPTION
**Description**
In MySQL, the default value for a non-nullable datetime is '0000-00-00 00:00:00', which would be included in 'IS NOT NULL'.
The default value for all timestamp formats can also be treated as 0, so using '> 0' as the where condition will give the expected behavior.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide