### PR TITLE
Redirecting Routes. Placeholders.

### DIFF
--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -40,6 +40,7 @@ Enhancements
     - The log format has also changed. If users are depending on the log format in their apps, the new log format is "<1-based count> <cleaned filepath>(<line>): <class><function><args>"
 - Added support for webp files to **app/Config/Mimes.php**.
 - Added 4th parameter ``$includeDir`` to ``get_filenames()``. See :php:func:`get_filenames`.
+- RouteCollection::addRedirect() can now use placeholders.
 
 Changes
 *******

--- a/user_guide_src/source/incoming/routing/022.php
+++ b/user_guide_src/source/incoming/routing/022.php
@@ -6,3 +6,11 @@ $routes->get('users/profile', 'Users::profile', ['as' => 'profile']);
 $routes->addRedirect('users/about', 'profile');
 // Redirect to a URI
 $routes->addRedirect('users/about', 'users/profile');
+
+// Redirect with placeholder
+$routes->get('post/(:num)/comment/(:num)', 'PostsComments::index', ['as' => 'post.comment']);
+
+// Redirect to a URI
+$routes->addRedirect('article/(:num)/(:num)', 'post/$1/comment/$2');
+// Redirect to a named route
+$routes->addRedirect('article/(:num)/(:num)', 'post.comment');


### PR DESCRIPTION
**Description**
PR adds the ability to use placeholders for route redirects.

```php
$routes->get('post/(:num)/comment/(:num)', 'PostsComments::index', ['as' => 'post.comment']);

// Redirect to a URI
$routes->addRedirect('article/(:num)/(:num)', 'post/$1/comment/$2');
// Redirect to a named route
$routes->addRedirect('article/(:num)/(:num)', 'post.comment');
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide