### PR TITLE
[PHPStan] Allow null type for request property in CodeIgniter class

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -116,11 +116,6 @@ parameters:
 			path: system/CodeIgniter.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: system/CodeIgniter.php
-
-		-
 			message: "#^Binary operation \"\\+\" between array\\<string, class\\-string\\>\\|false and non\\-empty\\-array\\<string, string\\> results in an error\\.$#"
 			count: 1
 			path: system/Common.php

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -80,7 +80,7 @@ class CodeIgniter
     /**
      * Current request.
      *
-     * @var CLIRequest|IncomingRequest|Request
+     * @var CLIRequest|IncomingRequest|Request|null
      */
     protected $request;
 


### PR DESCRIPTION
to allow remove ignored unreachable phpstan notice as the property is not filled on __construct.

**Checklist:**
- [x] Securely signed commits


<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
