### PR TITLE
[docs/models] expose getInsertID() method

### DIFF
--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -295,6 +295,8 @@ the array's values are the values to save for that key:
 
 .. literalinclude:: model/015.php
 
+You can retrieve the last inserted row's primary key using the ``getInsertID()`` method.
+
 update()
 --------
 


### PR DESCRIPTION
Fixes #5377

I noticed there's a `getInsertID()` method in the `BaseModel` class (see https://github.com/codeigniter4/CodeIgniter4/blob/88e71c957730d9277ea14b6b2cae577fa305b36c/system/BaseModel.php#L684) and it hasn't been exposed to the user guide yet (if I'm not mistaken).

This will help so much in the case of automatically generated primary keys (like using auto-increment or automatically generated ID's via callbacks).