### PR TITLE
Fix: Validation. Fields with an asterisk.

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -145,12 +145,16 @@ class Validation implements ValidationInterface
                 $rules = $this->splitRules($rules);
             }
 
-            $values = strpos($field, '*') !== false
-                ? array_filter(array_flatten_with_dots($data), static fn ($key) => preg_match(
+            if (strpos($field, '*') !== false) {
+                $values = array_filter(array_flatten_with_dots($data), static fn ($key) => preg_match(
                     '/^' . str_replace('\.\*', '\..+', preg_quote($field, '/')) . '$/',
                     $key
-                ), ARRAY_FILTER_USE_KEY)
-                : dot_array_search($field, $data);
+                ), ARRAY_FILTER_USE_KEY);
+                // if keys not found
+                $values = $values ?: [$field => null];
+            } else {
+                $values = dot_array_search($field, $data);
+            }
 
             if ($values === []) {
                 // We'll process the values right away if an empty array

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1244,4 +1244,41 @@ final class ValidationTest extends CIUnitTestCase
 
         $this->placeholderReplacementResultDetermination();
     }
+
+    public function testNullValueForNotFoundField()
+    {
+        $validator = $this->getMockBuilder(Validation::class)
+            ->setConstructorArgs([(object) $this->config, Services::renderer()])
+            ->onlyMethods(['processRules'])
+            ->getMock();
+
+        $validator->expects($this->exactly(2))
+            ->method('processRules')
+            ->withConsecutive(
+                [
+                    // string $field,
+                    $this->equalTo('users.*.name'),
+                    // ?string $label,
+                    $this->anything(),
+                    // $value,
+                    $this->equalTo(null),
+                    // $rules = null,
+                    $this->anything(),
+                    // ?array $data = null
+                    $this->anything(),
+                ],
+                [
+                    $this->equalTo('country'),
+                    $this->anything(),
+                    $this->equalTo(null),
+                    $this->anything(),
+                    $this->anything(),
+                ],
+            );
+
+        $validator->setRules([
+            'users.*.name' => 'rule',
+            'country'      => 'rule',
+        ])->run(['users' => []]);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/codeigniter4/CodeIgniter4/issues/5922

**Description**
If the field contains a asterisk and is not found in the validation dataset, then `array_filter()` returns an empty array. This case is not handled, which may cause errors.
So I suggest setting ``$values = [$field => null]`` if the field is not found.

It also prevents a TypeError exception from being thrown if an array is passed to the function (rule) instead of a string. But this only applies to fields not found.