### PR TITLE
docs: enable code coverage.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -19,7 +19,7 @@ If running under OS X or Linux, you can create a symbolic link to make running t
 	> ln -s ./vendor/bin/phpunit ./phpunit
 
 You also need to install [XDebug](https://xdebug.org/docs/install) in order
-for code coverage to be calculated successfully.
+for code coverage to be calculated successfully. After installing `XDebug`, you must add `xdebug.mode=coverage` in the **php.ini** file to enable code coverage.
 
 ## Setting Up
 


### PR DESCRIPTION
Explain about the activation `coverage ` that is required to run the **unit test**.