### PR TITLE
fix: Reverse Routing does not take into account the default namespace

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -522,6 +522,9 @@ if (! function_exists('url_to')) {
      * Get the full, absolute URL to a controller method
      * (with additional arguments)
      *
+     * NOTE: This requires the controller/method to
+     * have a route defined in the routes Config file.
+     *
      * @param mixed ...$args
      *
      * @throws RouterException

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -997,6 +997,15 @@ class RouteCollection implements RouteCollectionInterface
             }
         }
 
+        // Add the default namespace if needed.
+        $namespace = trim($this->defaultNamespace, '\\') . '\\';
+        if (
+            substr($search, 0, 1) !== '\\'
+            || substr($search, 0, strlen($namespace)) !== $namespace
+        ) {
+            $search = $namespace . $search;
+        }
+
         // If it's not a named route, then loop over
         // all routes to find a match.
         foreach ($this->routes as $collection) {

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -849,6 +849,30 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame('/en/contact', $routes->reverseRoute('myController::goto'));
     }
 
+    public function testReverseRoutingDefaultNamespaceAppController()
+    {
+        $routes = $this->getCollector();
+        $routes->setDefaultNamespace('App\Controllers');
+
+        $routes->get('users/(:num)/gallery(:any)', 'Galleries::showUserGallery/$1/$2');
+
+        $match = $routes->reverseRoute('Galleries::showUserGallery', 15, 12);
+
+        $this->assertSame('/users/15/gallery12', $match);
+    }
+
+    public function testReverseRoutingDefaultNamespaceAppControllerSubNamespace()
+    {
+        $routes = $this->getCollector();
+        $routes->setDefaultNamespace('App\Controllers');
+
+        $routes->get('admin/(:num)/gallery(:any)', 'Admin\Galleries::showUserGallery/$1/$2');
+
+        $match = $routes->reverseRoute('Admin\Galleries::showUserGallery', 15, 12);
+
+        $this->assertSame('/admin/15/gallery12', $match);
+    }
+
     public function testNamedRoutes()
     {
         $routes = $this->getCollector();

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -331,6 +331,8 @@ Miscellaneous Functions
     :param   string  $method: The named route alias, or name of the controller/method to match.
     :param   mixed   $params: One or more parameters to be passed to be matched in the route.
 
+    .. note:: This function requires the controller/method to have a route defined in **app/Config/routes.php**.
+
     Generates a URI relative to the domain name (not **baseUrl**) for you based on either a named route alias,
     or a controller::method combination. Will take parameters into effect, if provided.
 

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -351,6 +351,8 @@ The following functions are available:
     :returns: Absolute URL
     :rtype: string
 
+    .. note:: This function requires the controller/method to have a route defined in **app/Config/routes.php**.
+
     Builds an absolute URL to a controller method in your app. Example:
 
     .. literalinclude:: url_helper/021.php

--- a/user_guide_src/source/incoming/routing/029.php
+++ b/user_guide_src/source/incoming/routing/029.php
@@ -1,10 +1,10 @@
 <?php
 
 // The route is defined as:
-$routes->get('users/(:num)/gallery(:any)', 'App\Controllers\Galleries::showUserGallery/$1/$2');
+$routes->get('users/(:num)/gallery(:any)', 'Galleries::showUserGallery/$1/$2');
 
 ?>
 
 <!-- Generate the relative URL to link to user ID 15, gallery 12: -->
-<a href="<?= route_to('App\Controllers\Galleries::showUserGallery', 15, 12) ?>">View Gallery</a>
+<a href="<?= route_to('Galleries::showUserGallery', 15, 12) ?>">View Gallery</a>
 <!-- Result: '/users/15/gallery/12' -->


### PR DESCRIPTION
**Description**
Fixes https://github.com/codeigniter4/CodeIgniter4/issues/5042#issuecomment-1112957814
Fixes #5934

The following code does not work now.
```php
$routes->get('users/(:num)/gallery(:any)', 'Galleries::showUserGallery/$1/$2');
$match = $routes->reverseRoute('Galleries::showUserGallery', 15, 12);
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
