### PR TITLE
fix:  [Validation] Fields with an asterisk throws exception

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -145,12 +145,16 @@ class Validation implements ValidationInterface
                 $rules = $this->splitRules($rules);
             }
 
-            $values = strpos($field, '*') !== false
-                ? array_filter(array_flatten_with_dots($data), static fn ($key) => preg_match(
+            if (strpos($field, '*') !== false) {
+                $values = array_filter(array_flatten_with_dots($data), static fn ($key) => preg_match(
                     '/^' . str_replace('\.\*', '\..+', preg_quote($field, '/')) . '$/',
                     $key
-                ), ARRAY_FILTER_USE_KEY)
-                : dot_array_search($field, $data);
+                ), ARRAY_FILTER_USE_KEY);
+                // if keys not found
+                $values = $values ?: [$field => null];
+            } else {
+                $values = dot_array_search($field, $data);
+            }
 
             if ($values === []) {
                 // We'll process the values right away if an empty array


### PR DESCRIPTION
**Description**
Fixes #5922
Supersede #5925

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
