### PR TITLE
Entity: cast scalar types when setting

### DIFF
--- a/system/Entity/Cast/BooleanCast.php
+++ b/system/Entity/Cast/BooleanCast.php
@@ -23,4 +23,12 @@ class BooleanCast extends BaseCast
     {
         return (bool) $value;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function set($value, array $params = []): bool
+    {
+        return (bool) $value;
+    }
 }

--- a/system/Entity/Cast/FloatCast.php
+++ b/system/Entity/Cast/FloatCast.php
@@ -23,4 +23,12 @@ class FloatCast extends BaseCast
     {
         return (float) $value;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function set($value, array $params = []): float
+    {
+        return (float) $value;
+    }
 }

--- a/system/Entity/Cast/IntegerCast.php
+++ b/system/Entity/Cast/IntegerCast.php
@@ -23,4 +23,12 @@ class IntegerCast extends BaseCast
     {
         return (int) $value;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function set($value, array $params = []): int
+    {
+        return (int) $value;
+    }
 }

--- a/system/Entity/Cast/StringCast.php
+++ b/system/Entity/Cast/StringCast.php
@@ -23,4 +23,12 @@ class StringCast extends BaseCast
     {
         return (string) $value;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function set($value, array $params = []): string
+    {
+        return (string) $value;
+    }
 }


### PR DESCRIPTION
**Description**
```
This way Entity stores its attributes using types as specified in the
$casts. This results in:

1. Cleaner logic: data is always stored as expected. Not only read.
2. Fixing reliability of hasChanged()

Without this change what seemed like setting already set (identical to
read) value could actually change type and result in hasChanged()
unexpectedly returning true.

Ref: https://github.com/codeigniter4/CodeIgniter4/issues/5905
Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
```