### PR TITLE
[Rector] Update Rector to 0.12.23, clean up parallel timeout setting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phpstan/phpstan": "^1.5.6",
         "phpunit/phpunit": "^9.1",
         "predis/predis": "^1.1",
-        "rector/rector": "0.12.22"
+        "rector/rector": "0.12.23"
     },
     "suggest": {
         "ext-fileinfo": "Improves mime type detection for files"

--- a/rector.php
+++ b/rector.php
@@ -27,7 +27,6 @@ use Rector\CodingStyle\Rector\ClassMethod\FuncGetArgsToVariadicParamRector;
 use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Config\RectorConfig;
-use Rector\Core\Configuration\Option;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector;
 use Rector\DeadCode\Rector\If_\UnwrapFutureCompatibleIfPhpVersionRector;
@@ -164,7 +163,4 @@ return static function (RectorConfig $rectorConfig): void {
         'SQLite3',
     ]);
     $rectorConfig->rule(PrivatizeFinalClassPropertyRector::class);
-
-    $parameters = $rectorConfig->parameters();
-    $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, 240);
 };


### PR DESCRIPTION
Rector 0.12.23 resolve slowdown performance at version 0.12.22, ref issue and PR to fix it:

- https://github.com/rectorphp/rector/issues/7144
- https://github.com/rectorphp/rector-src/pull/2209

so parallel timeout increase settings is no longer needed.

**Checklist:**
- [x] Securely signed commits
