### PR TITLE
[docs] add DB nested transaction

### DIFF
--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -110,5 +110,4 @@ track of the transaction "depth" and only take action at the outermost layer
 
 .. literalinclude:: transactions/007.php
 
-.. note:: Use this technique ONLY IF you actually know what you are doing.
-
+.. note:: Use this technique carefully in order to keep the commands balanced.

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -97,3 +97,18 @@ If you would like to run transactions manually you can do so as follows:
 
 .. note:: Make sure to use ``$this->db->transBegin()`` when running manual
     transactions, **NOT** ``$this->db->transStart()``.
+
+Nested Transactions
+===================
+
+In CodeIgniter, transactions can be nested in a way such that only the
+outmost or top-level transaction commands are executed. You can include as
+many pairs of ``transStart``/``transComplete`` or ``transBegin``/``transCommit``/``transRollback``
+as you want inside a transaction block and so on. CodeIgniter will keep
+track of the transaction "depth" and only take action at the outermost layer
+(zero depth).
+
+.. literalinclude:: transactions/007.php
+
+.. note:: Use this technique ONLY IF you actually know what you are doing.
+

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -103,7 +103,7 @@ Nested Transactions
 
 In CodeIgniter, transactions can be nested in a way such that only the
 outmost or top-level transaction commands are executed. You can include as
-many pairs of ``transStart``/``transComplete`` or ``transBegin``/``transCommit``/``transRollback``
+many pairs of ``transStart()``/``transComplete()`` or ``transBegin()``/``transCommit()``/``transRollback()``
 as you want inside a transaction block and so on. CodeIgniter will keep
 track of the transaction "depth" and only take action at the outermost layer
 (zero depth).

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -110,4 +110,7 @@ track of the transaction "depth" and only take action at the outermost layer
 
 .. literalinclude:: transactions/007.php
 
-.. note:: Use this technique carefully in order to keep the commands balanced.
+.. note:: In case the structure is far more complex, it's your responsibility
+    to ensure that the inner transactions can reach the outermost layer again
+    in order to be fully executed by the database, thus prevents unintended
+    commits/rollbacks.

--- a/user_guide_src/source/database/transactions/007.php
+++ b/user_guide_src/source/database/transactions/007.php
@@ -1,0 +1,9 @@
+<?php
+
+$this->db->transStart(); // actually starts a transaction
+$this->db->query('SOME QUERY 1 ...');
+$this->db->transStart(); // doesn't necessarily start another transaction
+$this->db->query('SOME QUERY 2 ...');
+$this->db->transComplete(); // doesn't necessarily end the transaction, but required to finish the inner transaction
+$this->db->query('SOME QUERY 3 ...');
+$this->db->transComplete(); // actually ends the transaction


### PR DESCRIPTION
There's an explanation that a nested transaction is possible in CodeIgniter 4 by keeping track of the transaction depth (see https://github.com/codeigniter4/CodeIgniter4/blob/febc03a555b222a7a5617f04d7ba2058700cfdb1/system/Database/BaseConnection.php#L766).

I want it to be clearly documented so developers can save their time instead of figuring out by examining the system/ folder.

This implies that every start (transStart/transBegin) command should behave the same as others (pushing the transaction depth) and complete (transComplete/transCommit/transRollback) command should also behave the same as the others (popping the transaction depth) as a requirement. I've examined the code and they actually behave like that so I think it's safe to document this feature.