### PR TITLE
PHPUnitTest: Extend the default PHPUnit result printer with a modern, pretty printer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "nexusphp/tachycardia": "^1.0",
         "phpstan/phpstan": "^1.5.6",
         "phpunit/phpunit": "^9.1",
+        "codedungeon/phpunit-result-printer": "^0.32.0",
         "predis/predis": "^1.1",
         "rector/rector": "0.12.22"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,8 @@
          colors="true"
          failOnRisky="true"
          failOnWarning="true"
-         verbose="true">
+         verbose="true"
+         printerClass="Codedungeon\PHPUnitPrettyResultPrinter\Printer">
 
     <coverage processUncoveredFiles="true" ignoreDeprecatedCodeUnits="true">
         <include>


### PR DESCRIPTION
Hello friends.
PR is about beautifying the **output** of the **unit test in the terminal**.
I am currently learning unit test. What I saw at the beginning of running command `vendor/bin/phpunit` caused phrases like `...FF.FE.....F..` To see in the terminal.
I'm a beginner, I did not know what **pass**, **fail**, **error**, **skipped**, **incomplete**, **risky** means. I now know.
In my opinion, if this package was used. In executing Command `vendor/bin/phpunit`, I was not scared at first glance.
Please consider executing command `vendor/bin/phpunit` by a novice user unfamiliar with command **PHPUnit** as well as a user whose native language is not english. Check the subject.
Using this package made me less afraid of **phpunit**.

**Description**
In addition, the package does not require much user-specific configuration, which can be confusing, although it can be customized if desired.
![sample](https://user-images.githubusercontent.com/9530214/166319559-d9d6c856-c68c-46f7-9fea-6d660bbb343a.png)


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
