### PR TITLE
Fix Session::configure() to add cookie prefix to cookie name

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -289,7 +289,7 @@ class Session implements SessionInterface
         if (empty($this->sessionCookieName)) {
             $this->sessionCookieName = ini_get('session.name');
         } else {
-            ini_set('session.name', $this->sessionCookieName);
+            ini_set('session.name', $this->cookie->getPrefix() . $this->sessionCookieName);
         }
 
         $sameSite = $this->cookie->getSameSite() ?: ucfirst(Cookie::SAMESITE_LAX);

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -188,6 +188,7 @@ class Session implements SessionInterface
         $cookie = config('Cookie');
 
         $this->cookie = new Cookie($this->sessionCookieName, '', [
+            'prefix'   => $cookie->prefix ?? $config->cookiePrefix,
             'expires'  => $this->sessionExpiration === 0 ? 0 : time() + $this->sessionExpiration,
             'path'     => $cookie->path ?? $config->cookiePath,
             'domain'   => $cookie->domain ?? $config->cookieDomain,
@@ -289,7 +290,7 @@ class Session implements SessionInterface
         if (empty($this->sessionCookieName)) {
             $this->sessionCookieName = ini_get('session.name');
         } else {
-            ini_set('session.name', $this->cookie->getPrefix() . $this->sessionCookieName);
+            ini_set('session.name', $this->cookie->getPrefixedName());
         }
 
         $sameSite = $this->cookie->getSameSite() ?: ucfirst(Cookie::SAMESITE_LAX);

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -647,11 +647,11 @@ final class SessionTest extends CIUnitTestCase
 
     public function testCookieCreatedHasNameWithPrefix()
     {
-        $config           = new CookieConfig();
+        $config         = new CookieConfig();
         $config->prefix = 'test_';
         Factories::injectMock('config', CookieConfig::class, $config);
 
-        $session = $this->getInstance(['sessionCookieName'=>'ci_session']);
+        $session = $this->getInstance(['sessionCookieName' => 'ci_session']);
 
         $session->start();
 

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -644,4 +644,22 @@ final class SessionTest extends CIUnitTestCase
         $this->assertCount(1, $cookies);
         $this->assertSame(0, $cookies[0]->getExpiresTimestamp());
     }
+
+    public function testCookieCreatedHasNameWithPrefix()
+    {
+        $config           = new CookieConfig();
+        $config->prefix = 'test_';
+        Factories::injectMock('config', CookieConfig::class, $config);
+
+        $session = $this->getInstance(['sessionCookieName'=>'ci_session']);
+
+        $session->start();
+
+        $cookies = $session->cookies;
+        $this->assertCount(1, $cookies);
+        $this->assertSame('test_', $cookies[0]->getPrefix());
+        $this->assertSame('ci_session', $cookies[0]->getName());
+        $this->assertSame('test_ci_session', $cookies[0]->getPrefixedName());
+        $this->assertSame('test_ci_session', ini_get('session.name'));
+    }
 }


### PR DESCRIPTION
When the `\CodeIgniter\Session\Session` class creates the cookie, it is not adding the prefix that was defined in `\Config\Cookie::$prefix` to the name, so the name of the generated cookie is incomplete without having the prefix that was defined in the config.

To maintain consistency with the `\CodeIgniter\Cookie\Cookie` class, this change must be made so that the creation of the session cookie follows the same conditions as the creation of a normal cookie.


**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
