### PR TITLE
feat: DBForge::addField() `default` value raw SQL string support

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -980,6 +980,8 @@ class Forge
                 // Override the NULL attribute if that's our default
                 $attributes['NULL'] = true;
                 $field['null']      = empty($this->null) ? '' : ' ' . $this->null;
+            } elseif ($attributes['DEFAULT'] instanceof RawSql) {
+                $field['default'] = $this->default . $attributes['DEFAULT'];
             } else {
                 $field['default'] = $this->default . $this->db->escape($attributes['DEFAULT']);
             }

--- a/tests/system/Database/Forge/CreateTableTest.php
+++ b/tests/system/Database/Forge/CreateTableTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Database\Forge;
 
 use CodeIgniter\Database\Forge;
+use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 
@@ -36,6 +37,43 @@ final class CreateTableTest extends CIUnitTestCase
 
         $forge->addField('id');
         $actual = $forge->createTable('foo', true);
+
+        $this->assertTrue($actual);
+    }
+
+    public function testCreateTableWithDefaultRawSql()
+    {
+        $sql = <<<'SQL'
+            CREATE TABLE "foo" (
+            	"id" INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
+            	"ts" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+            )
+            SQL;
+        $dbMock = $this->getMockBuilder(MockConnection::class)
+            ->setConstructorArgs([[]])
+            ->onlyMethods(['query'])
+            ->getMock();
+        $dbMock->expects($this->any())
+            ->method('query')
+            ->with($sql)
+            ->willReturn(true);
+
+        $forge = new class ($dbMock) extends Forge {};
+
+        $fields = [
+            'id' => [
+                'type'           => 'INT',
+                'constraint'     => 5,
+                'unsigned'       => true,
+                'auto_increment' => true,
+            ],
+            'ts' => [
+                'type'    => 'TIMESTAMP',
+                'default' => new RawSql('CURRENT_TIMESTAMP'),
+            ],
+        ];
+        $forge->addField($fields);
+        $actual = $forge->createTable('foo');
 
         $this->assertTrue($actual);
     }

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -72,6 +72,7 @@ Database
 - QueryBuilder raw SQL string support
     - Added the class ``CodeIgniter\Database\RawSql`` which expresses raw SQL strings.
     - :ref:`select() <query-builder-select-rawsql>`, :ref:`where() <query-builder-where-rawsql>`, :ref:`like() <query-builder-like-rawsql>`, :ref:`join() <query-builder-join-rawsql>` accept the ``CodeIgniter\Database\RawSql`` instance.
+- ``DBForge::addField()`` default value raw SQL string support. See :ref:`forge-addfield-default-value-rawsql`.
 
 Others
 ======

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -12,8 +12,8 @@ Release Date: Not Released
 BREAKING
 ********
 
-- The method signature of ``Validation::setRule()`` has been changed.
 - The method signature of ``CodeIgniter\Database\BaseBuilder::join()`` and ``CodeIgniter\Database\*\Builder::join()`` have been changed.
+- The method signature of ``Validation::setRule()`` has been changed. The ``string`` typehint on the ``$rules`` parameter was removed. Extending classes should likewise remove the parameter so as not to break LSP.
 - The method signature of ``CodeIgniter\CLI\CommandRunner::_remap()`` has been changed to fix a bug.
 - The ``CodeIgniter\CodeIgniter`` class has a new property ``$context`` and it must have the correct context at runtime. So the following files have been changed:
     - ``public/index.php``

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -117,7 +117,7 @@ $forge->addField()
 
 The add fields method will accept the above array.
 
-Passing strings as fields
+Passing Strings as Fields
 -------------------------
 
 If you know exactly how you want a field to be created, you can pass the

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -117,6 +117,18 @@ $forge->addField()
 
 The add fields method will accept the above array.
 
+.. _forge-addfield-default-value-rawsql:
+
+Raw Sql Strings as Default Values
+---------------------------------
+
+Since v4.2.0, ``$forge->addField()`` accepts a ``CodeIgniter\Database\RawSql`` instance, which expresses raw SQL strings.
+
+
+.. literalinclude:: forge/027.php
+
+.. warning:: When you use ``RawSql``, you MUST escape the data manually. Failure to do so could result in SQL injections.
+
 Passing Strings as Fields
 -------------------------
 

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -31,7 +31,8 @@ to connect to as the first parameter.
 Creating and Dropping Databases
 *******************************
 
-**$forge->createDatabase('db_name')**
+$forge->createDatabase('db_name')
+=================================
 
 Permits you to create the database specified in the first parameter.
 Returns true/false based on success or failure:
@@ -43,7 +44,8 @@ or will check if a database exists before create it (depending on DBMS).
 
 .. literalinclude:: forge/004.php
 
-**$forge->dropDatabase('db_name')**
+$forge->dropDatabase('db_name')
+===============================
 
 Permits you to drop the database specified in the first parameter.
 Returns true/false based on success or failure:
@@ -110,7 +112,8 @@ After the fields have been defined, they can be added using
 ``$forge->addField($fields)`` followed by a call to the
 ``createTable()`` method.
 
-**$forge->addField()**
+$forge->addField()
+------------------
 
 The add fields method will accept the above array.
 
@@ -229,7 +232,8 @@ Modifying Tables
 Adding a Column to a Table
 ==========================
 
-**$forge->addColumn()**
+$forge->addColumn()
+-------------------
 
 The ``addColumn()`` method is used to modify an existing table. It
 accepts the same field array as above, and can be used for an unlimited
@@ -247,7 +251,8 @@ Examples:
 Dropping Columns From a Table
 ==============================
 
-**$forge->dropColumn()**
+$forge->dropColumn()
+--------------------
 
 Used to remove a column from a table.
 
@@ -260,7 +265,8 @@ Used to remove multiple columns from a table.
 Modifying a Column in a Table
 =============================
 
-**$forge->modifyColumn()**
+$forge->modifyColumn()
+----------------------
 
 The usage of this method is identical to ``addColumn()``, except it
 alters an existing column rather than adding a new one. In order to

--- a/user_guide_src/source/dbmgmt/forge/027.php
+++ b/user_guide_src/source/dbmgmt/forge/027.php
@@ -1,0 +1,22 @@
+<?php
+
+use CodeIgniter\Database\RawSql;
+
+$fields = [
+    'id' => [
+        'type'           => 'INT',
+        'constraint'     => 5,
+        'unsigned'       => true,
+        'auto_increment' => true,
+    ],
+    'created_at' => [
+        'type'    => 'TIMESTAMP',
+        'default' => new RawSql('CURRENT_TIMESTAMP'),
+    ],
+];
+$forge->addField($fields);
+/*
+gives:
+    "id" INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
+    "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+*/


### PR DESCRIPTION
~~Needs to rebase after merging #5875~~

**Description**
Fixes #4174 
Supersedes #4222

- `DBForge::addField()` default support `RawSql`

```php
        $fields = [
            'id' => [
                'type'           => 'INT',
                'constraint'     => 5,
                'unsigned'       => true,
                'auto_increment' => true,
            ],
            'ts' => [
                'type'    => 'TIMESTAMP',
                'default' => new RawSql('CURRENT_TIMESTAMP'),
            ],
        ];
        $forge->addField($fields);
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

