### PR TITLE
fix: route limit to subdomains does not work

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1297,7 +1297,7 @@ class RouteCollection implements RouteCollectionInterface
      * Compares the subdomain(s) passed in against the current subdomain
      * on this page request.
      *
-     * @param mixed $subdomains
+     * @param string|string[] $subdomains
      */
     private function checkSubdomains($subdomains): bool
     {
@@ -1330,7 +1330,7 @@ class RouteCollection implements RouteCollectionInterface
      * It's especially not perfect since it's possible to register a domain
      * with a period (.) as part of the domain name.
      *
-     * @return mixed
+     * @return false|string the subdomain
      */
     private function determineCurrentSubdomain()
     {
@@ -1351,7 +1351,7 @@ class RouteCollection implements RouteCollectionInterface
         }
 
         // Get rid of any domains, which will be the last
-        unset($host[count($host)]);
+        unset($host[count($host) - 1]);
 
         // Account for .co.uk, .co.nz, etc. domains
         if (end($host) === 'co') {

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1157,6 +1157,20 @@ final class RouteCollectionTest extends CIUnitTestCase
     }
 
     /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5959
+     */
+    public function testWithNoSubdomainAndDot()
+    {
+        $_SERVER['HTTP_HOST'] = 'example.com';
+
+        $routes = $this->getCollector();
+
+        $routes->add('/objects/(:alphanum)', 'App::objectsList/$1', ['subdomain' => '*']);
+
+        $this->assertSame([], $routes->getRoutes());
+    }
+
+    /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/1692
      */
     public function testWithSubdomainOrdered()

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1128,7 +1128,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     {
         $routes = $this->getCollector();
 
-        $_SERVER['HTTP_HOST'] = 'example.uk.co';
+        $_SERVER['HTTP_HOST'] = 'example.co.uk';
 
         $routes->add('/objects/(:alphanum)', 'Admin::objectsList/$1', ['subdomain' => 'sales']);
         $routes->add('/objects/(:alphanum)', 'App::objectsList/$1');

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1462,7 +1462,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes->get('i/(:any)', 'App\Controllers\Site\CDoc::item/$1', ['subdomain' => '*', 'as' => 'doc_item']);
 
-        $this->assertSame('/i/sth', $routes->reverseRoute('doc_item', 'sth'));
+        $this->assertFalse($routes->reverseRoute('doc_item', 'sth'));
     }
 
     public function testRouteToWithoutSubdomainMatch()


### PR DESCRIPTION
**Description**
Fixes  #5959

```php
// Limit to any sub-domain
$routes->add('from', 'to', ['subdomain' => '*']); // not work
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
