### PR TITLE
refactor: add strtolower() to Request::getMethod()

### DIFF
--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -199,7 +199,7 @@
 						</tr>
 						<tr>
 							<td>HTTP Method</td>
-							<td><?= esc($request->getMethod(true)) ?></td>
+							<td><?= esc(strtoupper($request->getMethod())) ?></td>
 						</tr>
 						<tr>
 							<td>IP Address</td>

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -318,7 +318,7 @@ class CodeIgniter
 
         $this->spoofRequestMethod();
 
-        if ($this->request instanceof IncomingRequest && $this->request->getMethod() === 'cli') {
+        if ($this->request instanceof IncomingRequest && strtolower($this->request->getMethod()) === 'cli') {
             $this->response->setStatusCode(405)->setBody('Method Not Allowed');
 
             return $this->sendResponse();
@@ -1047,7 +1047,7 @@ class CodeIgniter
     public function spoofRequestMethod()
     {
         // Only works with POSTED forms
-        if ($this->request->getMethod() !== 'post') {
+        if (strtolower($this->request->getMethod()) !== 'post') {
             return;
         }
 

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -76,7 +76,7 @@ class Toolbar
     {
         // Data items used within the view.
         $data['url']             = current_url();
-        $data['method']          = $request->getMethod(true);
+        $data['method']          = strtoupper($request->getMethod());
         $data['isAJAX']          = $request->isAJAX();
         $data['startTime']       = $startTime;
         $data['totalTime']       = $totalTime * 1000;

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -126,7 +126,7 @@ class Router implements RouterInterface
         $this->controller = $this->collection->getDefaultController();
         $this->method     = $this->collection->getDefaultMethod();
 
-        $this->collection->setHTTPVerb($request->getMethod() ?? strtolower($_SERVER['REQUEST_METHOD']));
+        $this->collection->setHTTPVerb(strtolower($request->getMethod() ?? $_SERVER['REQUEST_METHOD']));
 
         $this->translateURIDashes = $this->collection->shouldTranslateURIDashes();
 

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -354,7 +354,7 @@ class Validation implements ValidationInterface
             return $this;
         }
 
-        if (in_array($request->getMethod(), ['put', 'patch', 'delete'], true)
+        if (in_array(strtolower($request->getMethod()), ['put', 'patch', 'delete'], true)
             && strpos($request->getHeaderLine('Content-Type'), 'multipart/form-data') === false
         ) {
             $this->data = $request->getRawInput();


### PR DESCRIPTION
**Description**
Supersedes #5766

The `$upper` functionality will be removed.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

