### PR TITLE
fix: GDHandler::save() removes transparency

### DIFF
--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -225,6 +225,12 @@ class GDHandler extends BaseHandler
 
         $this->ensureResource();
 
+        // for png and webp we can actually preserve transparency
+        if (in_array($this->image()->imageType, $this->supportTransparency, true)) {
+            imagealphablending($this->resource, false);
+            imagesavealpha($this->resource, true);
+        }
+
         switch ($this->image()->imageType) {
             case IMAGETYPE_GIF:
                 if (! function_exists('imagegif')) {


### PR DESCRIPTION
**Description**
Fixes  #4178

**How to Test:**
Prepare `sample.png` with transparency.

```php
<?php
namespace App\Controllers;
class Home extends BaseController
{
    public function index()
    {
        \Config\Services::image('gd')
            ->withFile(WRITEPATH . 'sample.png')
            ->reorient()
            ->save(WRITEPATH . 'new.png', 70);
    }
}
```

Run the controller, and see `new.png`.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
