### PR TITLE
refactor: `system/bootstrap.php` only loads files and registers autoloader

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -3,6 +3,9 @@
 // Path to the front controller (this file)
 define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);
 
+// Ensure the current directory is pointing to the front controller's directory
+chdir(FCPATH);
+
 /*
  *---------------------------------------------------------------
  * BOOTSTRAP THE APPLICATION
@@ -11,9 +14,6 @@ define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);
  * our autoloader, along with Composer's, loads our constants
  * and fires up an environment-specific bootstrapping.
  */
-
-// Ensure the current directory is pointing to the front controller's directory
-chdir(FCPATH);
 
 // Load our paths config file
 // This is the line that might need to be changed, depending on your folder structure.
@@ -38,6 +38,7 @@ require_once SYSTEMPATH . 'Config/DotEnv.php';
  * the application run, and does all of the dirty work to get
  * the pieces all working together.
  */
+
 $app = Config\Services::codeigniter();
 $app->initialize();
 $context = is_cli() ? 'php-cli' : 'web';
@@ -50,4 +51,5 @@ $app->setContext($context);
  * Now that everything is setup, it's time to actually fire
  * up the engines and make this app do its thang.
  */
+
 $app->run();

--- a/public/index.php
+++ b/public/index.php
@@ -1,7 +1,5 @@
 <?php
 
-use Config\Services;
-
 // Path to the front controller (this file)
 define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);
 
@@ -15,13 +13,13 @@ define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);
  */
 
 // Ensure the current directory is pointing to the front controller's directory
-chdir(__DIR__);
+chdir(FCPATH);
 
-// Load our paths config file
 // This is the line that might need to be changed, depending on your folder structure.
 $pathsConfig = FCPATH . '../app/Config/Paths.php';
-// ^^^ Change this if you move your application folder
+// ^^^ Change this line if you move your application folder
 
+// Load our paths config file
 require $pathsConfig;
 
 $paths = new Config\Paths();
@@ -40,7 +38,7 @@ require $bootstrap;
  * the application run, and does all of the dirty work to get
  * the pieces all working together.
  */
-$app = Services::codeigniter();
+$app = Config\Services::codeigniter();
 $app->initialize();
 $context = is_cli() ? 'php-cli' : 'web';
 $app->setContext($context);

--- a/public/index.php
+++ b/public/index.php
@@ -29,6 +29,12 @@ $bootstrap = rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'boo
 
 require $bootstrap;
 
+// Load environment settings from .env files into $_SERVER and $_ENV
+require_once SYSTEMPATH . 'Config/DotEnv.php';
+
+$env = new CodeIgniter\Config\DotEnv(ROOTPATH);
+$env->load();
+
 /*
  * ---------------------------------------------------------------
  * GRAB OUR CODEIGNITER INSTANCE

--- a/public/index.php
+++ b/public/index.php
@@ -15,25 +15,19 @@ define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);
 // Ensure the current directory is pointing to the front controller's directory
 chdir(FCPATH);
 
-// This is the line that might need to be changed, depending on your folder structure.
-$pathsConfig = FCPATH . '../app/Config/Paths.php';
-// ^^^ Change this line if you move your application folder
-
 // Load our paths config file
-require $pathsConfig;
+// This is the line that might need to be changed, depending on your folder structure.
+require FCPATH . '../app/Config/Paths.php';
+// ^^^ Change this line if you move your application folder
 
 $paths = new Config\Paths();
 
 // Location of the framework bootstrap file.
-$bootstrap = rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
-
-require $bootstrap;
+require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 // Load environment settings from .env files into $_SERVER and $_ENV
 require_once SYSTEMPATH . 'Config/DotEnv.php';
-
-$env = new CodeIgniter\Config\DotEnv(ROOTPATH);
-$env->load();
+(new CodeIgniter\Config\DotEnv(ROOTPATH))->load();
 
 /*
  * ---------------------------------------------------------------

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,7 @@
 <?php
 
+use Config\Services;
+
 // Path to the front controller (this file)
 define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);
 
@@ -19,14 +21,27 @@ chdir(__DIR__);
 // This is the line that might need to be changed, depending on your folder structure.
 $pathsConfig = FCPATH . '../app/Config/Paths.php';
 // ^^^ Change this if you move your application folder
+
 require realpath($pathsConfig) ?: $pathsConfig;
 
 $paths = new Config\Paths();
 
 // Location of the framework bootstrap file.
 $bootstrap = rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
-/** @var CodeIgniter\CodeIgniter $app */
-$app     = require realpath($bootstrap) ?: $bootstrap;
+
+require realpath($bootstrap) ?: $bootstrap;
+
+/*
+ * ---------------------------------------------------------------
+ * GRAB OUR CODEIGNITER INSTANCE
+ * ---------------------------------------------------------------
+ *
+ * The CodeIgniter class contains the core functionality to make
+ * the application run, and does all of the dirty work to get
+ * the pieces all working together.
+ */
+$app = Services::codeigniter();
+$app->initialize();
 $context = is_cli() ? 'php-cli' : 'web';
 $app->setContext($context);
 

--- a/public/index.php
+++ b/public/index.php
@@ -22,14 +22,14 @@ chdir(__DIR__);
 $pathsConfig = FCPATH . '../app/Config/Paths.php';
 // ^^^ Change this if you move your application folder
 
-require realpath($pathsConfig) ?: $pathsConfig;
+require $pathsConfig;
 
 $paths = new Config\Paths();
 
 // Location of the framework bootstrap file.
 $bootstrap = rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
-require realpath($bootstrap) ?: $bootstrap;
+require $bootstrap;
 
 /*
  * ---------------------------------------------------------------

--- a/spark
+++ b/spark
@@ -62,6 +62,12 @@ $bootstrap = rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'boo
 
 require $bootstrap;
 
+// Load environment settings from .env files into $_SERVER and $_ENV
+require_once SYSTEMPATH . 'Config/DotEnv.php';
+
+$env = new CodeIgniter\Config\DotEnv(ROOTPATH);
+$env->load();
+
 $app = Config\Services::codeigniter();
 $app->initialize();
 $app->setContext('spark');

--- a/spark
+++ b/spark
@@ -26,6 +26,10 @@ if (strpos(PHP_SAPI, 'cgi') === 0) {
     exit("The cli tool is not supported when running php-cgi. It needs php-cli to function!\n\n");
 }
 
+// We want errors to be shown when using it from the CLI.
+error_reporting(-1);
+ini_set('display_errors', '1');
+
 /**
  * @var bool
  *
@@ -74,10 +78,6 @@ $app->setContext('spark');
 
 // Grab our Console
 $console = new CodeIgniter\CLI\Console($app);
-
-// We want errors to be shown when using it from the CLI.
-error_reporting(-1);
-ini_set('display_errors', '1');
 
 // Show basic information before we do anything else.
 if (is_int($suppress = array_search('--no-header', $_SERVER['argv'], true))) {

--- a/spark
+++ b/spark
@@ -40,6 +40,9 @@ define('SPARKED', true);
 // Path to the front controller
 define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR);
 
+// Ensure the current directory is pointing to the front controller's directory
+chdir(FCPATH);
+
 /*
  *---------------------------------------------------------------
  * BOOTSTRAP THE APPLICATION
@@ -48,9 +51,6 @@ define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR)
  * our autoloader, along with Composer's, loads our constants
  * and fires up an environment-specific bootstrapping.
  */
-
-// Ensure the current directory is pointing to the front controller's directory
-chdir(FCPATH);
 
 // Load our paths config file
 // This is the line that might need to be changed, depending on your folder structure.
@@ -66,6 +66,7 @@ require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstra
 require_once SYSTEMPATH . 'Config/DotEnv.php';
 (new CodeIgniter\Config\DotEnv(ROOTPATH))->load();
 
+// Grab our CodeIgniter
 $app = Config\Services::codeigniter();
 $app->initialize();
 $app->setContext('spark');

--- a/spark
+++ b/spark
@@ -21,6 +21,11 @@
  * this class mainly acts as a passthru to the framework itself.
  */
 
+// Refuse to run when called from php-cgi
+if (strpos(PHP_SAPI, 'cgi') === 0) {
+    exit("The cli tool is not supported when running php-cgi. It needs php-cli to function!\n\n");
+}
+
 /**
  * @var bool
  *
@@ -42,11 +47,6 @@ define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR)
 
 // Ensure the current directory is pointing to the front controller's directory
 chdir(FCPATH);
-
-// Refuse to run when called from php-cgi
-if (strpos(PHP_SAPI, 'cgi') === 0) {
-    exit("The cli tool is not supported when running php-cgi. It needs php-cli to function!\n\n");
-}
 
 // This is the line that might need to be changed, depending on your folder structure.
 $pathsConfig = FCPATH . '../app/Config/Paths.php';

--- a/spark
+++ b/spark
@@ -51,7 +51,7 @@ define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR)
 $pathsConfig = 'app/Config/Paths.php';
 // ^^^ Change this line if you move your application folder
 
-require realpath($pathsConfig) ?: $pathsConfig;
+require $pathsConfig;
 
 $paths = new Config\Paths();
 
@@ -60,7 +60,7 @@ chdir(FCPATH);
 
 $bootstrap = rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
-require realpath($bootstrap) ?: $bootstrap;
+require $bootstrap;
 
 $app = Services::codeigniter();
 $app->initialize();

--- a/spark
+++ b/spark
@@ -21,6 +21,8 @@
  * this class mainly acts as a passthru to the framework itself.
  */
 
+use Config\Services;
+
 /**
  * @var bool
  *
@@ -48,6 +50,7 @@ define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR)
 // Load our paths config file
 $pathsConfig = 'app/Config/Paths.php';
 // ^^^ Change this line if you move your application folder
+
 require realpath($pathsConfig) ?: $pathsConfig;
 
 $paths = new Config\Paths();
@@ -56,8 +59,11 @@ $paths = new Config\Paths();
 chdir(FCPATH);
 
 $bootstrap = rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
-/** @var CodeIgniter\CodeIgniter $app */
-$app = require realpath($bootstrap) ?: $bootstrap;
+
+require realpath($bootstrap) ?: $bootstrap;
+
+$app = Services::codeigniter();
+$app->initialize();
 $app->setContext('spark');
 
 // Grab our Console

--- a/spark
+++ b/spark
@@ -21,14 +21,15 @@
  * this class mainly acts as a passthru to the framework itself.
  */
 
-use Config\Services;
-
 /**
  * @var bool
  *
  * @deprecated No longer in use. `CodeIgniter` has `$context` property.
  */
 define('SPARKED', true);
+
+// Path to the front controller
+define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR);
 
 /*
  *---------------------------------------------------------------
@@ -39,30 +40,29 @@ define('SPARKED', true);
  * and fires up an environment-specific bootstrapping.
  */
 
+// Ensure the current directory is pointing to the front controller's directory
+chdir(FCPATH);
+
 // Refuse to run when called from php-cgi
 if (strpos(PHP_SAPI, 'cgi') === 0) {
     exit("The cli tool is not supported when running php-cgi. It needs php-cli to function!\n\n");
 }
 
-// Path to the front controller
-define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR);
-
-// Load our paths config file
-$pathsConfig = 'app/Config/Paths.php';
+// This is the line that might need to be changed, depending on your folder structure.
+$pathsConfig = FCPATH . '../app/Config/Paths.php';
 // ^^^ Change this line if you move your application folder
 
+// Load our paths config file
 require $pathsConfig;
 
 $paths = new Config\Paths();
 
-// Ensure the current directory is pointing to the front controller's directory
-chdir(FCPATH);
-
+// Location of the framework bootstrap file.
 $bootstrap = rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 require $bootstrap;
 
-$app = Services::codeigniter();
+$app = Config\Services::codeigniter();
 $app->initialize();
 $app->setContext('spark');
 

--- a/spark
+++ b/spark
@@ -52,25 +52,19 @@ define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR)
 // Ensure the current directory is pointing to the front controller's directory
 chdir(FCPATH);
 
-// This is the line that might need to be changed, depending on your folder structure.
-$pathsConfig = FCPATH . '../app/Config/Paths.php';
-// ^^^ Change this line if you move your application folder
-
 // Load our paths config file
-require $pathsConfig;
+// This is the line that might need to be changed, depending on your folder structure.
+require FCPATH . '../app/Config/Paths.php';
+// ^^^ Change this line if you move your application folder
 
 $paths = new Config\Paths();
 
 // Location of the framework bootstrap file.
-$bootstrap = rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
-
-require $bootstrap;
+require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 // Load environment settings from .env files into $_SERVER and $_ENV
 require_once SYSTEMPATH . 'Config/DotEnv.php';
-
-$env = new CodeIgniter\Config\DotEnv(ROOTPATH);
-$env->load();
+(new CodeIgniter\Config\DotEnv(ROOTPATH))->load();
 
 $app = Config\Services::codeigniter();
 $app->initialize();

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -66,6 +66,7 @@ if (! defined('TESTPATH')) {
  * GRAB OUR CONSTANTS & COMMON
  * ---------------------------------------------------------------
  */
+
 if (! defined('APP_NAMESPACE')) {
     require_once APPPATH . 'Config/Constants.php';
 }

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -131,18 +131,3 @@ $env->load();
 
 // Always load the URL helper, it should be used in most of apps.
 helper('url');
-
-/*
- * ---------------------------------------------------------------
- * GRAB OUR CODEIGNITER INSTANCE
- * ---------------------------------------------------------------
- *
- * The CodeIgniter class contains the core functionality to make
- * the application run, and does all of the dirty work to get
- * the pieces all working together.
- */
-
-$app = Services::codeigniter();
-$app->initialize();
-
-return $app;

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -9,7 +9,6 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-use CodeIgniter\Config\DotEnv;
 use Config\Autoload;
 use Config\Modules;
 use Config\Paths;
@@ -122,12 +121,6 @@ if (is_file(COMPOSER_PATH)) {
 
     require_once COMPOSER_PATH;
 }
-
-// Load environment settings from .env files into $_SERVER and $_ENV
-require_once SYSTEMPATH . 'Config/DotEnv.php';
-
-$env = new DotEnv(ROOTPATH);
-$env->load();
 
 // Always load the URL helper, it should be used in most of apps.
 helper('url');

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -16,6 +16,7 @@ BREAKING
 - The ``CodeIgniter\CodeIgniter`` class has a new property ``$context`` and it must have the correct context at runtime. So the following files have been changed:
     - ``public/index.php``
     - ``spark``
+- The ``system/bootstrap.php`` no longer returns a ``CodeIgniter`` instance, and does not load ``.env`` file.
 - The method signature of ``CodeIgniter\CLI\CommandRunner::_remap()`` has been changed to fix a bug.
 - The ``CodeIgniter\Autoloader\Autoloader::initialize()`` has changed the behavior to fix a bug. It used to use Composer classmap only when ``$modules->discoverInComposer`` is true. Now it always uses the Composer classmap if Composer is available.
 - The color code output by :ref:`CLI::color() <cli-library-color>` has been changed to fix a bug.

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -16,7 +16,7 @@ BREAKING
 - The ``CodeIgniter\CodeIgniter`` class has a new property ``$context`` and it must have the correct context at runtime. So the following files have been changed:
     - ``public/index.php``
     - ``spark``
-- The ``system/bootstrap.php`` no longer returns a ``CodeIgniter`` instance, and does not load ``.env`` file.
+- The ``system/bootstrap.php`` file has been modified to easily implement `Preloading <https://www.php.net/manual/en/opcache.preloading.php>`_. Returning a ``CodeIgniter`` instance and loading ``.env`` file have been moved to ``index.php`` and ``spark``.
 - The method signature of ``CodeIgniter\CLI\CommandRunner::_remap()`` has been changed to fix a bug.
 - The ``CodeIgniter\Autoloader\Autoloader::initialize()`` has changed the behavior to fix a bug. It used to use Composer classmap only when ``$modules->discoverInComposer`` is true. Now it always uses the Composer classmap if Composer is available.
 - The color code output by :ref:`CLI::color() <cli-library-color>` has been changed to fix a bug.

--- a/user_guide_src/source/installation/upgrade_420.rst
+++ b/user_guide_src/source/installation/upgrade_420.rst
@@ -24,7 +24,7 @@ The following files received significant changes and
 Breaking Changes
 ****************
 
-
+- The ``system/bootstrap.php`` file no longer returns a ``CodeIgniter`` instance, and does not load ``.env`` file. The ``index.php`` and ``spark`` now do them. If you have code that expects these behaviors, it will no longer work and must be modified.
 
 Breaking Enhancements
 *********************

--- a/user_guide_src/source/installation/upgrade_420.rst
+++ b/user_guide_src/source/installation/upgrade_420.rst
@@ -24,7 +24,7 @@ The following files received significant changes and
 Breaking Changes
 ****************
 
-- The ``system/bootstrap.php`` file no longer returns a ``CodeIgniter`` instance, and does not load ``.env`` file. The ``index.php`` and ``spark`` now do them. If you have code that expects these behaviors, it will no longer work and must be modified.
+- The ``system/bootstrap.php`` file no longer returns a ``CodeIgniter`` instance, and does not load the ``.env`` file (now handled in ``index.php`` and ``spark``). If you have code that expects these behaviors it will no longer work and must be modified.
 
 Breaking Enhancements
 *********************

--- a/user_guide_src/source/installation/upgrade_420.rst
+++ b/user_guide_src/source/installation/upgrade_420.rst
@@ -24,7 +24,7 @@ The following files received significant changes and
 Breaking Changes
 ****************
 
-- The ``system/bootstrap.php`` file no longer returns a ``CodeIgniter`` instance, and does not load the ``.env`` file (now handled in ``index.php`` and ``spark``). If you have code that expects these behaviors it will no longer work and must be modified.
+- The ``system/bootstrap.php`` file no longer returns a ``CodeIgniter`` instance, and does not load the ``.env`` file (now handled in ``index.php`` and ``spark``). If you have code that expects these behaviors it will no longer work and must be modified. This has been changed to make `Preloading <https://www.php.net/manual/en/opcache.preloading.php>`_ easier to implement.
 
 Breaking Enhancements
 *********************


### PR DESCRIPTION
**Description**
When we want to use [Preloading](https://www.php.net/manual/en/opcache.preloading.php), we need CI4 Autoloader.
But it is not easy to make the Autoloader work fine.
If you use this `system/bootstrap.php`, you can make it a bit easily.

- move `CodeIgniter` instantiation and `DotEnv` loading from `system/bootstrap.php`
- tweak `index.php` and `spark.php`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
