### PR TITLE
fix: slash_item() errors when asked for a configuration item which doesn't exist

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -1013,7 +1013,7 @@ if (! function_exists('slash_item')) {
      */
     function slash_item(string $item): ?string
     {
-        $config     = config(App::class);
+        $config = config(App::class);
 
         if (property_exists($config, $item)) {
             $configItem = $config->{$item};

--- a/system/Common.php
+++ b/system/Common.php
@@ -1014,10 +1014,13 @@ if (! function_exists('slash_item')) {
     function slash_item(string $item): ?string
     {
         $config     = config(App::class);
-        $configItem = $config->{$item};
+
+        if (property_exists($config, $item)) {
+            $configItem = $config->{$item};
+        }
 
         if (! isset($configItem) || empty(trim($configItem))) {
-            return $configItem;
+            return null;
         }
 
         return rtrim($configItem, '/') . '/';

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -391,7 +391,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
     public function testSlashItem()
     {
         $this->assertSame('/', slash_item('cookiePath')); // slash already there
-        $this->assertSame('', slash_item('cookieDomain')); // empty, so untouched
+        $this->assertNull(null, slash_item('cookieDomain')); // empty, so untouched
         $this->assertSame('en/', slash_item('defaultLocale')); // slash appended
     }
 


### PR DESCRIPTION
**Description**
Check object property which doesn't exist

Fixes #5967

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
