### PR TITLE
feat: `db:table` command

### DIFF
--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -48,7 +48,16 @@ class ShowTableInfo extends BaseCommand
      *
      * @var string
      */
-    protected $usage = 'db:table [<table_name>] [options]';
+    protected $usage = <<<'EOL'
+        db:table [<table_name>] [options]
+
+          Examples:
+            db:table --show
+            db:table --metadata
+            db:table my_table --metadata
+            db:table my_table
+            db:table my_table --limit-rows 5 --limit-field-value 10 --desc
+        EOL;
 
     /**
      * The Command's arguments

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -82,7 +82,7 @@ class ShowTableInfo extends BaseCommand
     /**
      * @var bool Sort the table rows in DESC order or not.
      */
-    private bool $sortIsDESC = false;
+    private bool $sortDesc = false;
 
     public function run(array $params)
     {
@@ -91,7 +91,7 @@ class ShowTableInfo extends BaseCommand
         $tables = $this->db->listTables();
 
         if (CLI::getOption('desc') === true) {
-            $this->sortIsDESC = true;
+            $this->sortDesc = true;
         }
 
         if ($tables === []) {
@@ -164,7 +164,7 @@ class ShowTableInfo extends BaseCommand
             ];
         }
 
-        if ($this->sortIsDESC) {
+        if ($this->sortDesc) {
             krsort($this->tbody);
         }
 
@@ -201,7 +201,7 @@ class ShowTableInfo extends BaseCommand
             $this->tbody[] = $row;
         }
 
-        if ($this->sortIsDESC) {
+        if ($this->sortDesc) {
             krsort($this->tbody);
         }
 
@@ -229,7 +229,7 @@ class ShowTableInfo extends BaseCommand
             ];
         }
 
-        if ($this->sortIsDESC) {
+        if ($this->sortDesc) {
             krsort($this->tbody);
         }
 

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -72,8 +72,16 @@ class ShowTableInfo extends BaseCommand
         '--limit-fields' => 'Limits the number of fields. Default: 15.',
     ];
 
+    /**
+     * @phpstan-var  list<list<string|int>> Table Data.
+     */
     private array $tbody;
+
     private BaseConnection $db;
+
+    /**
+     * @var bool Sort the table rows in DESC order or not.
+     */
     private bool $sortIsDESC = false;
 
     public function run(array $params)

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -1,0 +1,236 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Database;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+use Config\Database;
+
+/**
+ * Get table data if it exists in the database.
+ */
+class ShowTableInfo extends BaseCommand
+{
+    /**
+     * The group the command is lumped under
+     * when listing commands.
+     *
+     * @var string
+     */
+    protected $group = 'Database';
+
+    /**
+     * The Command's name
+     *
+     * @var string
+     */
+    protected $name = 'db:table';
+
+    /**
+     * the Command's short description
+     *
+     * @var string
+     */
+    protected $description = 'Retrieves information on the selected table.';
+
+    /**
+     * the Command's usage
+     *
+     * @var string
+     */
+    protected $usage = 'db:table <table_name> [options]';
+
+    /**
+     * The Command's arguments
+     *
+     * @var array<string, string>
+     */
+    protected $arguments = [
+        'table_name' => 'The table name for show info',
+    ];
+
+    /**
+     * The Command's options
+     *
+     * @var array<string, string>
+     */
+    protected $options = [
+        '--show'               => 'List the names of all database tables.',
+        '--metadata'           => 'Retrieves list of containing field information.',
+        '--desc'               => 'Sort the table rows in DESC order.',
+        '--limit-rows'         => 'Limit the number of rows. [Default = 10]',
+        '--limit-fields-value' => 'Custom length Limit of field values. [Default = 15]',
+    ];
+
+    private array $tbody;
+    private string $db       = '';
+    private bool $sortIsDESC = false;
+
+    public function run(array $params)
+    {
+        $this->db = Database::connect();
+
+        $tables = $this->db->listTables();
+
+        $this->sortIsDESC = CLI::getOption('desc');
+
+        if ($tables === []) {
+            CLI::error('Database has no tables!', 'light_gray', 'red');
+            CLI::newLine();
+
+            return;
+        }
+
+        if (CLI::getOption('show')) {
+            CLI::write('The following is a list of the names of all database tables:', 'black', 'yellow');
+            CLI::newLine();
+
+            $thead       = ['ID', 'Table name', 'Number of rows', 'Number of fields'];
+            $this->tbody = $this->makeTbodyForShowAllTables($tables);
+
+            CLI::table($this->tbody, $thead);
+            CLI::newLine();
+
+            return;
+        }
+
+        $tableName = array_shift($params);
+
+        if (in_array($tableName, $tables, true)) {
+            if (CLI::getOption('metadata')) {
+                $this->showFieldMetaData($tableName);
+
+                return;
+            }
+
+            CLI::newLine();
+            CLI::write("Data of table \"{$tableName}\":", 'black', 'yellow');
+            CLI::newLine();
+
+            $thead       = $this->db->getFieldNames($tableName);
+            $this->tbody = $this->makeTableRows($tableName);
+            CLI::table($this->tbody, $thead);
+
+            return;
+        }
+
+        $tableName = CLI::promptByKey(['Here is the list of your database tables:', 'Which table do you want to see?'], $tables, 'required');
+
+        if (CLI::getOption('metadata')) {
+            $this->showFieldMetaData($tables[$tableName]);
+
+            return;
+        }
+
+        CLI::newLine();
+        CLI::write("Data of table \"{$tables[$tableName]}\":", 'black', 'yellow');
+        CLI::newLine();
+
+        $thead       = $this->db->getFieldNames($tables[$tableName]);
+        $this->tbody = $this->makeTableRows($tables[$tableName]);
+        CLI::table($this->tbody, $thead);
+    }
+
+    private function makeTbodyForShowAllTables(array $tables): array
+    {
+        foreach ($tables  as $id => $tableName) {
+            $db = $this->db->query("SELECT * FROM {$tableName}");
+
+            $this->tbody[] = [
+                $id + 1,
+                $tableName,
+                $db->getNumRows(),
+                $db->getFieldCount(),
+            ];
+        }
+
+        if ($this->sortIsDESC) {
+            krsort($this->tbody);
+        }
+
+        return $this->tbody;
+    }
+
+    private function makeTableRows(string $tableName): array
+    {
+        $limitRows = (int) CLI::getOption('limit-rows');
+
+        if (in_array($limitRows, [null, true, 0, 1], true)) {
+            $limitRows = 10;
+        }
+
+        $limitFieldsValue = (int) CLI::getOption('limit-fields-value');
+
+        if (in_array($limitFieldsValue, [null, true, 0, 1], true)) {
+            $limitFieldsValue = 15;
+        }
+
+        $this->tbody = [];
+
+        $customQueryForEachField = '';
+
+        $fieldNames = $this->db->getFieldNames($tableName);
+
+        foreach ($fieldNames as $fieldName) {
+            $customQueryForEachField .= ",IF(length(`{$fieldName}`) > {$limitFieldsValue} ,CONCAT(SUBSTRING(`{$fieldName}`, 1, {$limitFieldsValue}),'...'), `{$fieldName}` ) as `{$fieldName}`";
+        }
+
+        $rows = $this->db->query('SELECT * ' . $customQueryForEachField . " FROM {$tableName} LIMIT {$limitRows}")->getResultArray();
+
+        foreach ($rows as $row) {
+            $this->tbody[] = $row;
+        }
+
+        if ($this->sortIsDESC) {
+            krsort($this->tbody);
+        }
+
+        return $this->tbody;
+    }
+
+    private function showFieldMetaData(string $tableName): void
+    {
+        CLI::newLine();
+        CLI::write("List of metadata information in table \"{$tableName}\":", 'black', 'yellow');
+        CLI::newLine();
+
+        $thead = ['field name', 'type', 'max_length', 'nullable', 'default', 'primary_key'];
+
+        $fields = $this->db->getFieldData($tableName);
+
+        foreach ($fields as $row) {
+            $this->tbody[] = [
+                $row->name,
+                $row->type,
+                $row->max_length,
+                $this->setYesOrNo($row->nullable),
+                $row->default,
+                $this->setYesOrNo($row->primary_key),
+            ];
+        }
+
+        if ($this->sortIsDESC) {
+            krsort($this->tbody);
+        }
+
+        CLI::table($this->tbody, $thead);
+    }
+
+    private function setYesOrNo(bool $fieldValue): string
+    {
+        if ($fieldValue) {
+            return CLI::color('Yes', 'green');
+        }
+
+        return CLI::color('No', 'red');
+    }
+}

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -217,9 +217,9 @@ class ShowTableInfo extends BaseCommand
                 $row->name,
                 $row->type,
                 $row->max_length,
-                $this->setYesOrNo($row->nullable),
+                isset($row->nullable) ? $this->setYesOrNo($row->nullable) : 'n/a',
                 $row->default,
-                $this->setYesOrNo($row->primary_key),
+                isset($row->primary_key) ? $this->setYesOrNo($row->primary_key) : 'n/a',
             ];
         }
 

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -56,7 +56,7 @@ class ShowTableInfo extends BaseCommand
      * @var array<string, string>
      */
     protected $arguments = [
-        'table_name' => 'The table name for show info',
+        'table_name' => 'The table name to show info',
     ];
 
     /**
@@ -65,11 +65,11 @@ class ShowTableInfo extends BaseCommand
      * @var array<string, string>
      */
     protected $options = [
-        '--show'               => 'List the names of all database tables.',
-        '--metadata'           => 'Retrieves list of containing field information.',
-        '--desc'               => 'Sort the table rows in DESC order.',
-        '--limit-rows'         => 'Limit the number of rows. [Default = 10]',
-        '--limit-fields' => 'Limit the number of fields. Default: 15.',
+        '--show'         => 'Lists the names of all database tables.',
+        '--metadata'     => 'Retrieves list containing field information.',
+        '--desc'         => 'Sorts the table rows in DESC order.',
+        '--limit-rows'   => 'Limits the number of rows. Default: 10.',
+        '--limit-fields' => 'Limits the number of fields. Default: 15.',
     ];
 
     private array $tbody;
@@ -97,7 +97,7 @@ class ShowTableInfo extends BaseCommand
             CLI::write('The following is a list of the names of all database tables:', 'black', 'yellow');
             CLI::newLine();
 
-            $thead       = ['ID', 'Table name', 'Number of rows', 'Number of fields'];
+            $thead       = ['ID', 'Table Name', 'Num of Rows', 'Num of Fields'];
             $this->tbody = $this->makeTbodyForShowAllTables($tables);
 
             CLI::table($this->tbody, $thead);
@@ -116,7 +116,7 @@ class ShowTableInfo extends BaseCommand
             }
 
             CLI::newLine();
-            CLI::write("Data of table \"{$tableName}\":", 'black', 'yellow');
+            CLI::write("Data of Table \"{$tableName}\":", 'black', 'yellow');
             CLI::newLine();
 
             $thead       = $this->db->getFieldNames($tableName);
@@ -135,7 +135,7 @@ class ShowTableInfo extends BaseCommand
         }
 
         CLI::newLine();
-        CLI::write("Data of table \"{$tables[$tableName]}\":", 'black', 'yellow');
+        CLI::write("Data of Table \"{$tables[$tableName]}\":", 'black', 'yellow');
         CLI::newLine();
 
         $thead       = $this->db->getFieldNames($tables[$tableName]);
@@ -203,10 +203,10 @@ class ShowTableInfo extends BaseCommand
     private function showFieldMetaData(string $tableName): void
     {
         CLI::newLine();
-        CLI::write("List of metadata information in table \"{$tableName}\":", 'black', 'yellow');
+        CLI::write("List of Metadata Information in Table \"{$tableName}\":", 'black', 'yellow');
         CLI::newLine();
 
-        $thead = ['field name', 'type', 'max_length', 'nullable', 'default', 'primary_key'];
+        $thead = ['Field Name', 'Type', 'Max Length', 'Nullable', 'Default', 'Primary Key'];
 
         $fields = $this->db->getFieldData($tableName);
 

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -178,10 +178,8 @@ class ShowTableInfo extends BaseCommand
     {
         $this->tbody = [];
 
-        $table = $this->db->protectIdentifiers($tableName);
-        $rows  = $this->db->query(
-            "SELECT * FROM {$table} LIMIT {$limitRows}"
-        )->getResultArray();
+        $builder = $this->db->table($tableName);
+        $rows    = $builder->limit($limitRows)->get()->getResultArray();
 
         foreach ($rows as $row) {
             $row = array_map(

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -205,10 +205,9 @@ class ShowTableInfo extends BaseCommand
 
         foreach ($rows as $row) {
             $row = array_map(
-                static fn ($item): string => mb_strlen((string) $item) > $limitFieldValue) 
+                static fn ($item): string => mb_strlen((string) $item) > $limitFieldValue
                     ? mb_substr((string) $item, 0, $limitFieldValue) . '...'
-                    : $item
-                ,
+                    : (string) $item,
                 $row
             );
             $this->tbody[] = $row;

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -48,7 +48,7 @@ class ShowTableInfo extends BaseCommand
      *
      * @var string
      */
-    protected $usage = 'db:table <table_name> [options]';
+    protected $usage = 'db:table [<table_name>] [options]';
 
     /**
      * The Command's arguments

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -69,7 +69,7 @@ class ShowTableInfo extends BaseCommand
         '--metadata'           => 'Retrieves list of containing field information.',
         '--desc'               => 'Sort the table rows in DESC order.',
         '--limit-rows'         => 'Limit the number of rows. [Default = 10]',
-        '--limit-fields-value' => 'Custom length Limit of field values. [Default = 15]',
+        '--limit-fields' => 'Limit the number of fields. Default: 15.',
     ];
 
     private array $tbody;
@@ -171,7 +171,7 @@ class ShowTableInfo extends BaseCommand
             $limitRows = 10;
         }
 
-        $limitFieldsValue = (int) CLI::getOption('limit-fields-value');
+        $limitFieldsValue = (int) CLI::getOption('limit-fields');
 
         if (in_array($limitFieldsValue, [null, true, 0, 1], true)) {
             $limitFieldsValue = 15;

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -90,7 +90,7 @@ class ShowTableInfo extends BaseCommand
 
         $tables = $this->db->listTables();
 
-        if (CLI::getOption('desc') === true) {
+        if (array_key_exists('desc', $params)) {
             $this->sortDesc = true;
         }
 
@@ -101,7 +101,7 @@ class ShowTableInfo extends BaseCommand
             return;
         }
 
-        if (CLI::getOption('show')) {
+        if (array_key_exists('show', $params)) {
             CLI::write('The following is a list of the names of all database tables:', 'black', 'yellow');
             CLI::newLine();
 
@@ -114,10 +114,12 @@ class ShowTableInfo extends BaseCommand
             return;
         }
 
-        $tableName = array_shift($params);
+        $tableName   = $params[0] ?? null;
+        $limitRows   = (int) ($params['limit-rows'] ?? 10);
+        $limitFields = (int) ($params['limit-fields'] ?? 15);
 
         if (in_array($tableName, $tables, true)) {
-            if (CLI::getOption('metadata')) {
+            if (array_key_exists('metadata', $params)) {
                 $this->showFieldMetaData($tableName);
 
                 return;
@@ -128,7 +130,7 @@ class ShowTableInfo extends BaseCommand
             CLI::newLine();
 
             $thead       = $this->db->getFieldNames($tableName);
-            $this->tbody = $this->makeTableRows($tableName);
+            $this->tbody = $this->makeTableRows($tableName, $limitRows, $limitFields);
             CLI::table($this->tbody, $thead);
 
             return;
@@ -136,7 +138,7 @@ class ShowTableInfo extends BaseCommand
 
         $tableName = CLI::promptByKey(['Here is the list of your database tables:', 'Which table do you want to see?'], $tables, 'required');
 
-        if (CLI::getOption('metadata')) {
+        if (array_key_exists('metadata', $params)) {
             $this->showFieldMetaData($tables[$tableName]);
 
             return;
@@ -147,7 +149,7 @@ class ShowTableInfo extends BaseCommand
         CLI::newLine();
 
         $thead       = $this->db->getFieldNames($tables[$tableName]);
-        $this->tbody = $this->makeTableRows($tables[$tableName]);
+        $this->tbody = $this->makeTableRows($tables[$tableName], $limitRows, $limitFields);
         CLI::table($this->tbody, $thead);
     }
 
@@ -171,20 +173,8 @@ class ShowTableInfo extends BaseCommand
         return $this->tbody;
     }
 
-    private function makeTableRows(string $tableName): array
+    private function makeTableRows(string $tableName, $limitRows, $limitFields): array
     {
-        $limitRows = (int) CLI::getOption('limit-rows');
-
-        if (in_array($limitRows, [null, true, 0, 1], true)) {
-            $limitRows = 10;
-        }
-
-        $limitFields = (int) CLI::getOption('limit-fields');
-
-        if (in_array($limitFields, [null, true, 0, 1], true)) {
-            $limitFields = 15;
-        }
-
         $this->tbody = [];
 
         $customQueryForEachField = '';

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -65,11 +65,11 @@ class ShowTableInfo extends BaseCommand
      * @var array<string, string>
      */
     protected $options = [
-        '--show'                => 'Lists the names of all database tables.',
-        '--metadata'            => 'Retrieves list containing field information.',
-        '--desc'                => 'Sorts the table rows in DESC order.',
-        '--limit-rows'          => 'Limits the number of rows. Default: 10.',
-        '--limit-column-length' => 'Limits the length of columns. Default: 15.',
+        '--show'              => 'Lists the names of all database tables.',
+        '--metadata'          => 'Retrieves list containing field information.',
+        '--desc'              => 'Sorts the table rows in DESC order.',
+        '--limit-rows'        => 'Limits the number of rows. Default: 10.',
+        '--limit-field-value' => 'Limits the length of field values. Default: 15.',
     ];
 
     /**
@@ -107,9 +107,9 @@ class ShowTableInfo extends BaseCommand
             return;
         }
 
-        $tableName         = $params[0] ?? null;
-        $limitRows         = (int) ($params['limit-rows'] ?? 10);
-        $limitColumnLength = (int) ($params['limit-column-length'] ?? 15);
+        $tableName       = $params[0] ?? null;
+        $limitRows       = (int) ($params['limit-rows'] ?? 10);
+        $limitFieldValue = (int) ($params['limit-field-value'] ?? 15);
 
         if (! in_array($tableName, $tables, true)) {
             $tableNameNo = CLI::promptByKey(
@@ -127,17 +127,17 @@ class ShowTableInfo extends BaseCommand
             return;
         }
 
-        $this->showDataOfTable($tableName, $limitRows, $limitColumnLength);
+        $this->showDataOfTable($tableName, $limitRows, $limitFieldValue);
     }
 
-    private function showDataOfTable(string $tableName, int $limitRows, int $limitColumnLength)
+    private function showDataOfTable(string $tableName, int $limitRows, int $limitFieldValue)
     {
         CLI::newLine();
         CLI::write("Data of Table \"{$tableName}\":", 'black', 'yellow');
         CLI::newLine();
 
         $thead       = $this->db->getFieldNames($tableName);
-        $this->tbody = $this->makeTableRows($tableName, $limitRows, $limitColumnLength);
+        $this->tbody = $this->makeTableRows($tableName, $limitRows, $limitFieldValue);
         CLI::table($this->tbody, $thead);
     }
 
@@ -174,7 +174,7 @@ class ShowTableInfo extends BaseCommand
         return $this->tbody;
     }
 
-    private function makeTableRows(string $tableName, int $limitRows, int $limitColumnLength): array
+    private function makeTableRows(string $tableName, int $limitRows, int $limitFieldValue): array
     {
         $this->tbody = [];
 
@@ -184,7 +184,7 @@ class ShowTableInfo extends BaseCommand
 
         foreach ($fieldNames as $fieldName) {
             $field = $this->db->protectIdentifiers($fieldName);
-            $customQueryForEachField .= ", IF(LENGTH({$field}) > {$limitColumnLength}, CONCAT(SUBSTRING({$field}, 1, {$limitColumnLength}), '...'), {$field}) AS {$field}";
+            $customQueryForEachField .= ", IF(LENGTH({$field}) > {$limitFieldValue}, CONCAT(SUBSTRING({$field}, 1, {$limitFieldValue}), '...'), {$field}) AS {$field}";
         }
 
         $table = $this->db->protectIdentifiers($tableName);

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -178,21 +178,22 @@ class ShowTableInfo extends BaseCommand
     {
         $this->tbody = [];
 
-        $customQueryForEachField = '';
-
-        $fieldNames = $this->db->getFieldNames($tableName);
-
-        foreach ($fieldNames as $fieldName) {
-            $field = $this->db->protectIdentifiers($fieldName);
-            $customQueryForEachField .= ", IF(LENGTH({$field}) > {$limitFieldValue}, CONCAT(SUBSTRING({$field}, 1, {$limitFieldValue}), '...'), {$field}) AS {$field}";
-        }
-
         $table = $this->db->protectIdentifiers($tableName);
         $rows  = $this->db->query(
-            'SELECT * ' . $customQueryForEachField . " FROM {$table} LIMIT {$limitRows}"
+            "SELECT * FROM {$table} LIMIT {$limitRows}"
         )->getResultArray();
 
         foreach ($rows as $row) {
+            $row = array_map(
+                static function ($item) use ($limitFieldValue) {
+                    if (mb_strlen((string) $item) > $limitFieldValue) {
+                        return mb_substr((string) $item, 0, $limitFieldValue) . '...';
+                    }
+
+                    return $item;
+                },
+                $row
+            );
             $this->tbody[] = $row;
         }
 

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -65,11 +65,11 @@ class ShowTableInfo extends BaseCommand
      * @var array<string, string>
      */
     protected $options = [
-        '--show'         => 'Lists the names of all database tables.',
-        '--metadata'     => 'Retrieves list containing field information.',
-        '--desc'         => 'Sorts the table rows in DESC order.',
-        '--limit-rows'   => 'Limits the number of rows. Default: 10.',
-        '--limit-fields' => 'Limits the number of fields. Default: 15.',
+        '--show'                => 'Lists the names of all database tables.',
+        '--metadata'            => 'Retrieves list containing field information.',
+        '--desc'                => 'Sorts the table rows in DESC order.',
+        '--limit-rows'          => 'Limits the number of rows. Default: 10.',
+        '--limit-column-length' => 'Limits the length of columns. Default: 15.',
     ];
 
     /**
@@ -107,9 +107,9 @@ class ShowTableInfo extends BaseCommand
             return;
         }
 
-        $tableName   = $params[0] ?? null;
-        $limitRows   = (int) ($params['limit-rows'] ?? 10);
-        $limitFields = (int) ($params['limit-fields'] ?? 15);
+        $tableName         = $params[0] ?? null;
+        $limitRows         = (int) ($params['limit-rows'] ?? 10);
+        $limitColumnLength = (int) ($params['limit-column-length'] ?? 15);
 
         if (! in_array($tableName, $tables, true)) {
             $tableNameNo = CLI::promptByKey(
@@ -127,17 +127,17 @@ class ShowTableInfo extends BaseCommand
             return;
         }
 
-        $this->showDataOfTable($tableName, $limitRows, $limitFields);
+        $this->showDataOfTable($tableName, $limitRows, $limitColumnLength);
     }
 
-    private function showDataOfTable(string $tableName, int $limitRows, int $limitFields)
+    private function showDataOfTable(string $tableName, int $limitRows, int $limitColumnLength)
     {
         CLI::newLine();
         CLI::write("Data of Table \"{$tableName}\":", 'black', 'yellow');
         CLI::newLine();
 
         $thead       = $this->db->getFieldNames($tableName);
-        $this->tbody = $this->makeTableRows($tableName, $limitRows, $limitFields);
+        $this->tbody = $this->makeTableRows($tableName, $limitRows, $limitColumnLength);
         CLI::table($this->tbody, $thead);
     }
 
@@ -173,7 +173,7 @@ class ShowTableInfo extends BaseCommand
         return $this->tbody;
     }
 
-    private function makeTableRows(string $tableName, $limitRows, $limitFields): array
+    private function makeTableRows(string $tableName, $limitRows, $limitColumnLength): array
     {
         $this->tbody = [];
 
@@ -182,7 +182,7 @@ class ShowTableInfo extends BaseCommand
         $fieldNames = $this->db->getFieldNames($tableName);
 
         foreach ($fieldNames as $fieldName) {
-            $customQueryForEachField .= ",IF(length(`{$fieldName}`) > {$limitFields} ,CONCAT(SUBSTRING(`{$fieldName}`, 1, {$limitFields}),'...'), `{$fieldName}` ) as `{$fieldName}`";
+            $customQueryForEachField .= ",IF(length(`{$fieldName}`) > {$limitColumnLength} ,CONCAT(SUBSTRING(`{$fieldName}`, 1, {$limitColumnLength}),'...'), `{$fieldName}` ) as `{$fieldName}`";
         }
 
         $rows = $this->db->query('SELECT * ' . $customQueryForEachField . " FROM {$tableName} LIMIT {$limitRows}")->getResultArray();

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -81,7 +81,9 @@ class ShowTableInfo extends BaseCommand
 
         $tables = $this->db->listTables();
 
-        $this->sortIsDESC = CLI::getOption('desc');
+        if (CLI::getOption('desc') === true) {
+            $this->sortIsDESC = true;
+        }
 
         if ($tables === []) {
             CLI::error('Database has no tables!', 'light_gray', 'red');

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -111,27 +111,23 @@ class ShowTableInfo extends BaseCommand
         $limitRows   = (int) ($params['limit-rows'] ?? 10);
         $limitFields = (int) ($params['limit-fields'] ?? 15);
 
-        if (in_array($tableName, $tables, true)) {
-            if (array_key_exists('metadata', $params)) {
-                $this->showFieldMetaData($tableName);
+        if (! in_array($tableName, $tables, true)) {
+            $tableNameNo = CLI::promptByKey(
+                ['Here is the list of your database tables:', 'Which table do you want to see?'],
+                $tables,
+                'required'
+            );
 
-                return;
-            }
-
-            $this->showDataOfTable($tableName, $limitRows, $limitFields);
-
-            return;
+            $tableName = $tables[$tableNameNo];
         }
-
-        $tableName = CLI::promptByKey(['Here is the list of your database tables:', 'Which table do you want to see?'], $tables, 'required');
 
         if (array_key_exists('metadata', $params)) {
-            $this->showFieldMetaData($tables[$tableName]);
+            $this->showFieldMetaData($tableName);
 
             return;
         }
 
-        $this->showDataOfTable($tables[$tableName], $limitRows, $limitFields);
+        $this->showDataOfTable($tableName, $limitRows, $limitFields);
     }
 
     private function showDataOfTable(string $tableName, int $limitRows, int $limitFields)

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -171,10 +171,10 @@ class ShowTableInfo extends BaseCommand
             $limitRows = 10;
         }
 
-        $limitFieldsValue = (int) CLI::getOption('limit-fields');
+        $limitFields = (int) CLI::getOption('limit-fields');
 
-        if (in_array($limitFieldsValue, [null, true, 0, 1], true)) {
-            $limitFieldsValue = 15;
+        if (in_array($limitFields, [null, true, 0, 1], true)) {
+            $limitFields = 15;
         }
 
         $this->tbody = [];
@@ -184,7 +184,7 @@ class ShowTableInfo extends BaseCommand
         $fieldNames = $this->db->getFieldNames($tableName);
 
         foreach ($fieldNames as $fieldName) {
-            $customQueryForEachField .= ",IF(length(`{$fieldName}`) > {$limitFieldsValue} ,CONCAT(SUBSTRING(`{$fieldName}`, 1, {$limitFieldsValue}),'...'), `{$fieldName}` ) as `{$fieldName}`";
+            $customQueryForEachField .= ",IF(length(`{$fieldName}`) > {$limitFields} ,CONCAT(SUBSTRING(`{$fieldName}`, 1, {$limitFields}),'...'), `{$fieldName}` ) as `{$fieldName}`";
         }
 
         $rows = $this->db->query('SELECT * ' . $customQueryForEachField . " FROM {$tableName} LIMIT {$limitRows}")->getResultArray();

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -102,14 +102,7 @@ class ShowTableInfo extends BaseCommand
         }
 
         if (array_key_exists('show', $params)) {
-            CLI::write('The following is a list of the names of all database tables:', 'black', 'yellow');
-            CLI::newLine();
-
-            $thead       = ['ID', 'Table Name', 'Num of Rows', 'Num of Fields'];
-            $this->tbody = $this->makeTbodyForShowAllTables($tables);
-
-            CLI::table($this->tbody, $thead);
-            CLI::newLine();
+            $this->showAllTables($tables);
 
             return;
         }
@@ -125,13 +118,7 @@ class ShowTableInfo extends BaseCommand
                 return;
             }
 
-            CLI::newLine();
-            CLI::write("Data of Table \"{$tableName}\":", 'black', 'yellow');
-            CLI::newLine();
-
-            $thead       = $this->db->getFieldNames($tableName);
-            $this->tbody = $this->makeTableRows($tableName, $limitRows, $limitFields);
-            CLI::table($this->tbody, $thead);
+            $this->showDataOfTable($tableName, $limitRows, $limitFields);
 
             return;
         }
@@ -144,13 +131,30 @@ class ShowTableInfo extends BaseCommand
             return;
         }
 
+        $this->showDataOfTable($tables[$tableName], $limitRows, $limitFields);
+    }
+
+    private function showDataOfTable(string $tableName, int $limitRows, int $limitFields)
+    {
         CLI::newLine();
-        CLI::write("Data of Table \"{$tables[$tableName]}\":", 'black', 'yellow');
+        CLI::write("Data of Table \"{$tableName}\":", 'black', 'yellow');
         CLI::newLine();
 
-        $thead       = $this->db->getFieldNames($tables[$tableName]);
-        $this->tbody = $this->makeTableRows($tables[$tableName], $limitRows, $limitFields);
+        $thead       = $this->db->getFieldNames($tableName);
+        $this->tbody = $this->makeTableRows($tableName, $limitRows, $limitFields);
         CLI::table($this->tbody, $thead);
+    }
+
+    private function showAllTables(array $tables)
+    {
+        CLI::write('The following is a list of the names of all database tables:', 'black', 'yellow');
+        CLI::newLine();
+
+        $thead       = ['ID', 'Table Name', 'Num of Rows', 'Num of Fields'];
+        $this->tbody = $this->makeTbodyForShowAllTables($tables);
+
+        CLI::table($this->tbody, $thead);
+        CLI::newLine();
     }
 
     private function makeTbodyForShowAllTables(array $tables): array

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Commands\Database;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Database\BaseConnection;
 use Config\Database;
 
 /**
@@ -72,7 +73,7 @@ class ShowTableInfo extends BaseCommand
     ];
 
     private array $tbody;
-    private string $db       = '';
+    private BaseConnection $db;
     private bool $sortIsDESC = false;
 
     public function run(array $params)

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -205,13 +205,10 @@ class ShowTableInfo extends BaseCommand
 
         foreach ($rows as $row) {
             $row = array_map(
-                static function ($item) use ($limitFieldValue) {
-                    if (mb_strlen((string) $item) > $limitFieldValue) {
-                        return mb_substr((string) $item, 0, $limitFieldValue) . '...';
-                    }
-
-                    return $item;
-                },
+                static fn ($item): string => mb_strlen((string) $item) > $limitFieldValue) 
+                    ? mb_substr((string) $item, 0, $limitFieldValue) . '...'
+                    : $item
+                ,
                 $row
             );
             $this->tbody[] = $row;

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -129,12 +129,12 @@ final class ShowTableInfoTest extends CIUnitTestCase
         $this->assertStringContainsString($expected, $result);
     }
 
-    public function testDbTableLimitColumnLength(): void
+    public function testDbTableLimitFieldValueLength(): void
     {
         $seeder = Database::seeder();
         $seeder->call(CITestSeeder::class);
 
-        command('db:table db_user --limit-column-length 5');
+        command('db:table db_user --limit-field-value 5');
 
         $result = $this->getResultWithoutControlCode();
 

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -96,10 +96,9 @@ final class ShowTableInfoTest extends CIUnitTestCase
         $expected = 'List of Metadata Information in Table "db_migrations":';
         $this->assertStringContainsString($expected, $result);
 
+        $result   = preg_replace('/\s+/', ' ', $result);
         $expected = <<<'EOL'
-            +------------+---------+------------+----------+---------+-------------+
-            | Field Name | Type    | Max Length | Nullable | Default | Primary Key |
-            +------------+---------+------------+----------+---------+-------------+
+            | Field Name | Type | Max Length | Nullable | Default | Primary Key |
             EOL;
         $this->assertStringContainsString($expected, $result);
     }

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -149,4 +149,24 @@ final class ShowTableInfoTest extends CIUnitTestCase
             EOL;
         $this->assertStringContainsString($expected, $result);
     }
+
+    public function testDbTableLimitRows(): void
+    {
+        command('db:table db_user --limit-rows 2');
+
+        $result = $this->getResultWithoutControlCode();
+
+        $expected = 'Data of Table "db_user":';
+        $this->assertStringContainsString($expected, $result);
+
+        $expected = <<<'EOL'
+            +----+-------------+--------------------+---------+------------+------------+------------+
+            | id | name        | email              | country | created_at | updated_at | deleted_at |
+            +----+-------------+--------------------+---------+------------+------------+------------+
+            | 1  | Derek Jones | derek@world.com    | US      |            |            |            |
+            | 2  | Ahmadinejad | ahmadinejad@wor... | Iran    |            |            |            |
+            +----+-------------+--------------------+---------+------------+------------+------------+
+            EOL;
+        $this->assertStringContainsString($expected, $result);
+    }
 }

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -131,9 +131,6 @@ final class ShowTableInfoTest extends CIUnitTestCase
 
     public function testDbTableLimitFieldValueLength(): void
     {
-        $seeder = Database::seeder();
-        $seeder->call(CITestSeeder::class);
-
         command('db:table db_user --limit-field-value 5');
 
         $result = $this->getResultWithoutControlCode();

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -127,4 +127,29 @@ final class ShowTableInfoTest extends CIUnitTestCase
             EOL;
         $this->assertStringContainsString($expected, $result);
     }
+
+    public function testDbTableLimitColumnLength(): void
+    {
+        $seeder = \Config\Database::seeder();
+        $seeder->call(CITestSeeder::class);
+
+        command('db:table db_user --limit-column-length 5');
+
+        $result = $this->getResultWithoutControlCode();
+
+        $expected = 'Data of Table "db_user":';
+        $this->assertStringContainsString($expected, $result);
+
+        $expected = <<<'EOL'
+            +----+----------+----------+---------+------------+------------+------------+
+            | id | name     | email    | country | created_at | updated_at | deleted_at |
+            +----+----------+----------+---------+------------+------------+------------+
+            | 1  | Derek... | derek... | US      |            |            |            |
+            | 2  | Ahmad... | ahmad... | Iran    |            |            |            |
+            | 3  | Richa... | richa... | US      |            |            |            |
+            | 4  | Chris... | chris... | UK      |            |            |            |
+            +----+----------+----------+---------+------------+------------+------------+
+            EOL;
+        $this->assertStringContainsString($expected, $result);
+    }
 }

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Commands\Database;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Config\Database;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**
@@ -105,7 +106,7 @@ final class ShowTableInfoTest extends CIUnitTestCase
 
     public function testDbTableDesc(): void
     {
-        $seeder = \Config\Database::seeder();
+        $seeder = Database::seeder();
         $seeder->call(CITestSeeder::class);
 
         command('db:table db_user --desc');
@@ -130,7 +131,7 @@ final class ShowTableInfoTest extends CIUnitTestCase
 
     public function testDbTableLimitColumnLength(): void
     {
-        $seeder = \Config\Database::seeder();
+        $seeder = Database::seeder();
         $seeder->call(CITestSeeder::class);
 
         command('db:table db_user --limit-column-length 5');

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Database;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use Tests\Support\Database\Seeds\CITestSeeder;
+
+/**
+ * @internal
+ */
+final class ShowTableInfoTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    private $streamFilter;
+    protected $migrateOnce = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        CITestStreamFilter::$buffer = '';
+
+        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
+        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        stream_filter_remove($this->streamFilter);
+    }
+
+    private function getResultWithoutControlCode(): string
+    {
+        return str_replace(
+            ["\033[0;30m", "\033[0;33m", "\033[43m", "\033[0m"],
+            '',
+            CITestStreamFilter::$buffer
+        );
+    }
+
+    public function testDbTable(): void
+    {
+        command('db:table db_migrations');
+
+        $result = $this->getResultWithoutControlCode();
+
+        $expected = 'Data of Table "db_migrations":';
+        $this->assertStringContainsString($expected, $result);
+
+        $expected = <<<'EOL'
+            +----+----------------+--------------------+-------+---------------+------------+-------+
+            | id | version        | class              | group | namespace     | time       | batch |
+            +----+----------------+--------------------+-------+---------------+------------+-------+
+            EOL;
+        $this->assertStringContainsString($expected, $result);
+    }
+
+    public function testDbTableShow(): void
+    {
+        command('db:table --show');
+
+        $result = $this->getResultWithoutControlCode();
+
+        $expected = 'The following is a list of the names of all database tables:';
+        $this->assertStringContainsString($expected, $result);
+
+        $expected = <<<'EOL'
+            +----+---------------------------+-------------+---------------+
+            | ID | Table Name                | Num of Rows | Num of Fields |
+            +----+---------------------------+-------------+---------------+
+            EOL;
+        $this->assertStringContainsString($expected, $result);
+    }
+
+    public function testDbTableMetadata(): void
+    {
+        command('db:table db_migrations --metadata');
+
+        $result = $this->getResultWithoutControlCode();
+
+        $expected = 'List of Metadata Information in Table "db_migrations":';
+        $this->assertStringContainsString($expected, $result);
+
+        $expected = <<<'EOL'
+            +------------+---------+------------+----------+---------+-------------+
+            | Field Name | Type    | Max Length | Nullable | Default | Primary Key |
+            +------------+---------+------------+----------+---------+-------------+
+            EOL;
+        $this->assertStringContainsString($expected, $result);
+    }
+
+    public function testDbTableDesc(): void
+    {
+        $seeder = \Config\Database::seeder();
+        $seeder->call(CITestSeeder::class);
+
+        command('db:table db_user --desc');
+
+        $result = $this->getResultWithoutControlCode();
+
+        $expected = 'Data of Table "db_user":';
+        $this->assertStringContainsString($expected, $result);
+
+        $expected = <<<'EOL'
+            +----+--------------------+--------------------+---------+------------+------------+------------+
+            | id | name               | email              | country | created_at | updated_at | deleted_at |
+            +----+--------------------+--------------------+---------+------------+------------+------------+
+            | 4  | Chris Martin       | chris@world.com    | UK      |            |            |            |
+            | 3  | Richard A Cause... | richard@world.c... | US      |            |            |            |
+            | 2  | Ahmadinejad        | ahmadinejad@wor... | Iran    |            |            |            |
+            | 1  | Derek Jones        | derek@world.com    | US      |            |            |            |
+            +----+--------------------+--------------------+---------+------------+------------+------------+
+            EOL;
+        $this->assertStringContainsString($expected, $result);
+    }
+}

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -169,4 +169,24 @@ final class ShowTableInfoTest extends CIUnitTestCase
             EOL;
         $this->assertStringContainsString($expected, $result);
     }
+
+    public function testDbTableAllOptions(): void
+    {
+        command('db:table db_user --limit-rows 2 --limit-field-value 5 --desc');
+
+        $result = $this->getResultWithoutControlCode();
+
+        $expected = 'Data of Table "db_user":';
+        $this->assertStringContainsString($expected, $result);
+
+        $expected = <<<'EOL'
+            +----+----------+----------+---------+------------+------------+------------+
+            | id | name     | email    | country | created_at | updated_at | deleted_at |
+            +----+----------+----------+---------+------------+------------+------------+
+            | 4  | Chris... | chris... | UK      |            |            |            |
+            | 3  | Richa... | richa... | US      |            |            |            |
+            +----+----------+----------+---------+------------+------------+------------+
+            EOL;
+        $this->assertStringContainsString($expected, $result);
+    }
 }

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -47,12 +47,14 @@ See :ref:`auto-routing-improved` for the details.
 Commands
 ========
 
-- Added ``db:table`` command.
-    - You can now see the names of all the tables in the database you are currently connected, field names or other metadata, like the column type, max length and ... each table, and the information in that table in the terminal.
-        - ``db:table --show``
-        - ``db:table my_table``
-        - ``db:table my_table --metadata``
-        - ``db:table my_table --limit-row 50 --limit-field-value 20 --desc``
+- Added ``spark db:table`` command.
+    - You can now see the names of all the tables in the database you are currently connected in the terminal.
+        - ``spark db:table --show``
+    - Or you can see the field names and the records of a table.
+        - ``spark db:table my_table``
+        - ``spark db:table my_table --limit-row 50 --limit-field-value 20 --desc``
+    - Or you can see metadata like the column type, max length of a table.
+        - ``spark db:table my_table --metadata``
 - The ``spark routes`` command now shows closure routes, auto routes, and filters. See :ref:`URI Routing <spark-routes>`.
 
 Others

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -75,7 +75,7 @@ Others
     - ``db:table --show``
     - ``db:table my_table``
     - ``db:table my_table --metadata``
-    - ``db:table my_table --limit-row 50 --limit-column-length 20 --desc``
+    - ``db:table my_table --limit-row 50 --limit-field-value 20 --desc``
 
 Changes
 *******

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -44,6 +44,17 @@ Added an optional new more secure auto router. These are the changes from the le
 
 See :ref:`auto-routing-improved` for the details.
 
+Commands
+========
+
+- Added ``db:table`` command.
+    - You can now see the names of all the tables in the database you are currently connected, field names or other metadata, like the column type, max length and ... each table, and the information in that table in the terminal.
+        - ``db:table --show``
+        - ``db:table my_table``
+        - ``db:table my_table --metadata``
+        - ``db:table my_table --limit-row 50 --limit-field-value 20 --desc``
+- The ``spark routes`` command now shows closure routes, auto routes, and filters. See :ref:`URI Routing <spark-routes>`.
+
 Others
 ======
 
@@ -58,7 +69,6 @@ Others
 - Added Validation Strict Rules. See :ref:`validation-traditional-and-strict-rules`.
 - Added new OCI8 driver for database.
     - It can access Oracle Database and supports SQL and PL/SQL statements.
-- The ``spark routes`` command now shows closure routes, auto routes, and filters. See :ref:`URI Routing <spark-routes>`.
 - Exception information logged through ``log_message()`` has now improved. It now includes the file and line where the exception originated. It also does not truncate the message anymore.
     - The log format has also changed. If users are depending on the log format in their apps, the new log format is "<1-based count> <cleaned filepath>(<line>): <class><function><args>"
 - Added support for webp files to **app/Config/Mimes.php**.
@@ -70,12 +80,6 @@ Others
     - :ref:`select() <query-builder-select-rawsql>`, :ref:`where() <query-builder-where-rawsql>`, :ref:`like() <query-builder-like-rawsql>` accept the ``CodeIgniter\Database\RawSql`` instance.
 - Debugbar enhancements
     - Debug toolbar is now using ``microtime()`` instead of ``time()``.
-- Added new Command for CLI.
-  - ``db:table`` - You can now see the names of all the tables in the database you are currently connected, field names or other metadata, like the column type, max length and ... each table, and the information in that table in the terminal.
-    - ``db:table --show``
-    - ``db:table my_table``
-    - ``db:table my_table --metadata``
-    - ``db:table my_table --limit-row 50 --limit-field-value 20 --desc``
 
 Changes
 *******

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -52,7 +52,7 @@ Commands
         - ``spark db:table --show``
     - Or you can see the field names and the records of a table.
         - ``spark db:table my_table``
-        - ``spark db:table my_table --limit-row 50 --limit-field-value 20 --desc``
+        - ``spark db:table my_table --limit-rows 50 --limit-field-value 20 --desc``
     - Or you can see metadata like the column type, max length of a table.
         - ``spark db:table my_table --metadata``
 - The ``spark routes`` command now shows closure routes, auto routes, and filters. See :ref:`URI Routing <spark-routes>`.

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -70,6 +70,12 @@ Others
     - :ref:`select() <query-builder-select-rawsql>`, :ref:`where() <query-builder-where-rawsql>`, :ref:`like() <query-builder-like-rawsql>` accept the ``CodeIgniter\Database\RawSql`` instance.
 - Debugbar enhancements
     - Debug toolbar is now using ``microtime()`` instead of ``time()``.
+- Added new Command for CLI.
+  - ``db:table`` - You can now see the names of all the tables in the database you are currently connected, field names or other metadata, like the column type, max length and ... each table, and the information in that table in the terminal.
+    - ``db:table --show``
+    - ``db:table my_table``
+    - ``db:table my_table --metadata``
+    - ``db:table my_table --limit-row 50 --limit-fields-value 20 --desc``
 
 Changes
 *******

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -75,7 +75,7 @@ Others
     - ``db:table --show``
     - ``db:table my_table``
     - ``db:table my_table --metadata``
-    - ``db:table my_table --limit-row 50 --limit-fields-value 20 --desc``
+    - ``db:table my_table --limit-row 50 --limit-column-length 20 --desc``
 
 Changes
 *******

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -47,7 +47,7 @@ See :ref:`auto-routing-improved` for the details.
 Commands
 ========
 
-- Added ``spark db:table`` command.
+- Added ``spark db:table`` command. See :doc:`../dbmgmt/db_commands` for the details.
     - You can now see the names of all the tables in the database you are currently connected in the terminal.
         - ``spark db:table --show``
     - Or you can see the field names and the records of a table.

--- a/user_guide_src/source/database/examples.rst
+++ b/user_guide_src/source/database/examples.rst
@@ -77,20 +77,20 @@ Query Builder Insert
 
 .. literalinclude:: examples/008.php
 
-Get table rows in the Command Line
-===============================
+Get Table Rows in the Command Line
+==================================
 
 You can see specific table info on the command line. Assuming there is a table called ``my_table`` , use the following command to get started::
 
     > php spark db:table my_table
 
-If table `my_table` is not in the database, the CodeIgniter displays a list of available tables to select.
+If table ``my_table`` is not in the database, the CodeIgniter displays a list of available tables to select.
 You can also use only the following command without the table name. In this case, the table name will be asked ::
 
     > php spark db:table
 
-.. note:: You can use the optional ``--desc``, ``--limit-rows``, ``--limit-fields-value`` options at any time when using command ``db:table`` .
+.. note:: You can use the optional ``--desc``, ``--limit-rows``, ``--limit-column-length`` options at any time when using command ``db:table`` .
 
 Command ``db:table --limit-rows 50``, for example, limits the number of rows to 50 rows.
 Command ``db:table --desc``, set the sort direction to "DESC".
-And Command ``db:table --limit-fields-value 10`` limits the values of the fields to "10" characters, to prevent confusion of the table output in the terminal.
+And Command ``db:table --limit-column-length 10`` limits the length of the columns to 10 characters, to prevent confusion of the table output in the terminal.

--- a/user_guide_src/source/database/examples.rst
+++ b/user_guide_src/source/database/examples.rst
@@ -80,7 +80,7 @@ Query Builder Insert
 Get Table Rows in the Command Line
 ==================================
 
-You can see specific table info on the command line. Assuming there is a table called ``my_table`` , use the following command to get started::
+You can see specific table information on the command line. Assuming there is a table called ``my_table``, use the following command to get started::
 
     > php spark db:table my_table
 

--- a/user_guide_src/source/database/examples.rst
+++ b/user_guide_src/source/database/examples.rst
@@ -76,3 +76,21 @@ Query Builder Insert
 ====================
 
 .. literalinclude:: examples/008.php
+
+Get table rows in the Command Line
+===============================
+
+You can see specific table info on the command line. Assuming there is a table called ``my_table`` , use the following command to get started::
+
+    > php spark db:table my_table
+
+If table `my_table` is not in the database, the CodeIgniter displays a list of available tables to select.
+You can also use only the following command without the table name. In this case, the table name will be asked ::
+
+    > php spark db:table
+
+.. note:: You can use the optional ``--desc``, ``--limit-rows``, ``--limit-fields-value`` options at any time when using command ``db:table`` .
+
+Command ``db:table --limit-rows 50``, for example, limits the number of rows to 50 rows.
+Command ``db:table --desc``, set the sort direction to "DESC".
+And Command ``db:table --limit-fields-value 10`` limits the values of the fields to "10" characters, to prevent confusion of the table output in the terminal.

--- a/user_guide_src/source/database/examples.rst
+++ b/user_guide_src/source/database/examples.rst
@@ -89,8 +89,8 @@ You can also use only the following command without the table name. In this case
 
     > php spark db:table
 
-.. note:: You can use the optional ``--desc``, ``--limit-rows``, ``--limit-column-length`` options at any time when using command ``db:table`` .
+.. note:: You can use the optional ``--desc``, ``--limit-rows``, ``--limit-field-value`` options at any time when using command ``db:table`` .
 
 Command ``db:table --limit-rows 50``, for example, limits the number of rows to 50 rows.
 Command ``db:table --desc``, set the sort direction to "DESC".
-And Command ``db:table --limit-column-length 10`` limits the length of the columns to 10 characters, to prevent confusion of the table output in the terminal.
+And Command ``db:table --limit-field-value 10`` limits the length of the field values to 10 characters, to prevent confusion of the table output in the terminal.

--- a/user_guide_src/source/database/examples.rst
+++ b/user_guide_src/source/database/examples.rst
@@ -76,21 +76,3 @@ Query Builder Insert
 ====================
 
 .. literalinclude:: examples/008.php
-
-Get Table Rows in the Command Line
-==================================
-
-You can see specific table information on the command line. Assuming there is a table called ``my_table``, use the following command to get started::
-
-    > php spark db:table my_table
-
-If table ``my_table`` is not in the database, CodeIgniter displays a list of available tables to select.
-You can also use only the following command without the table name. In this case, the table name will be asked ::
-
-    > php spark db:table
-
-.. note:: You can use the optional ``--desc``, ``--limit-rows``, ``--limit-field-value`` options at any time when using command ``db:table`` .
-
-Command ``db:table --limit-rows 50``, for example, limits the number of rows to 50 rows.
-Command ``db:table --desc``, set the sort direction to "DESC".
-And Command ``db:table --limit-field-value 10`` limits the length of the field values to 10 characters, to prevent confusion of the table output in the terminal.

--- a/user_guide_src/source/database/examples.rst
+++ b/user_guide_src/source/database/examples.rst
@@ -84,7 +84,7 @@ You can see specific table information on the command line. Assuming there is a 
 
     > php spark db:table my_table
 
-If table ``my_table`` is not in the database, the CodeIgniter displays a list of available tables to select.
+If table ``my_table`` is not in the database, CodeIgniter displays a list of available tables to select.
 You can also use only the following command without the table name. In this case, the table name will be asked ::
 
     > php spark db:table

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -24,6 +24,12 @@ you are currently connected to. Example:
 
 .. note:: Some drivers have additional system tables that are excluded from this return.
 
+CodeIgniter supports show List the tables in your database straight from your favorite terminal using the dedicated ``db:table --show`` command. By using this command it is assumed that the tables is   existing. Otherwise, CodeIgniter will complain that tables list show has failed.
+
+To start, just type ::
+
+    > php spark db:table --show
+
 Determine If a Table Exists
 ===========================
 
@@ -99,6 +105,15 @@ database:
 -  max_length - maximum length of the column
 -  primary_key - 1 if the column is a primary key
 -  type - the type of the column
+
+CodeIgniter supports show table containing field information in your database straight from your favorite terminal using the dedicated ``db:table my_table --metadata`` command. By using this command it is assumed that the table ``my_table`` is existing. Otherwise, CodeIgniter will show that tables list for select.
+Also, you can use this command as ``db:table --metadata``.
+
+.. note:: You can use the optional ``--desc``, ``--limit-rows``, ``--limit-fields-value`` options at any time when using command ``db:table`` .
+
+Command ``db:table --limit-rows 50``, for example, limits the number of rows to 50 rows.
+Command ``db:table --desc``, set the sort direction to "DESC". 
+And Command ``db:table --limit-fields-value 10`` limits the values of the fields to 10 characters, to prevent confusion of the table output in the terminal.
 
 List the Indexes in a Table
 ===========================

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -25,15 +25,6 @@ you are currently connected to. Example:
 
 .. note:: Some drivers have additional system tables that are excluded from this return.
 
-db:table --show command
------------------------
-
-CodeIgniter supports show list the tables in your database straight from your favorite terminal using the dedicated ``db:table --show`` command. By using this command it is assumed that the tables is   existing. Otherwise, CodeIgniter will complain that tables list show has failed.
-
-To start, just type ::
-
-    > php spark db:table --show
-
 Determine If a Table Exists
 ===========================
 
@@ -113,18 +104,6 @@ database:
 -  max_length - maximum length of the column
 -  primary_key - 1 if the column is a primary key
 -  type - the type of the column
-
-db:table --metadata command
----------------------------
-
-CodeIgniter supports show table containing field information in your database straight from your favorite terminal using the dedicated ``db:table my_table --metadata`` command. By using this command it is assumed that the table ``my_table`` is existing. Otherwise, CodeIgniter will show that tables list for select.
-Also, you can use this command as ``db:table --metadata``.
-
-.. note:: You can use the optional ``--desc``, ``--limit-rows``, ``--limit-field-value`` options at any time when using command ``db:table`` .
-
-Command ``db:table --limit-rows 50``, for example, limits the number of rows to 50 rows.
-Command ``db:table --desc``, set the sort direction to "DESC". 
-And Command ``db:table --limit-field-value 10`` limits the length of the field values to 10 characters, to prevent confusion of the table output in the terminal.
 
 List the Indexes in a Table
 ===========================

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -15,7 +15,8 @@ These functions let you fetch table information.
 List the Tables in Your Database
 ================================
 
-**$db->listTables();**
+$db->listTables()
+-----------------
 
 Returns an array containing the names of all the tables in the database
 you are currently connected to. Example:
@@ -24,7 +25,10 @@ you are currently connected to. Example:
 
 .. note:: Some drivers have additional system tables that are excluded from this return.
 
-CodeIgniter supports show List the tables in your database straight from your favorite terminal using the dedicated ``db:table --show`` command. By using this command it is assumed that the tables is   existing. Otherwise, CodeIgniter will complain that tables list show has failed.
+db:table --show command
+-----------------------
+
+CodeIgniter supports show list the tables in your database straight from your favorite terminal using the dedicated ``db:table --show`` command. By using this command it is assumed that the tables is   existing. Otherwise, CodeIgniter will complain that tables list show has failed.
 
 To start, just type ::
 
@@ -33,7 +37,8 @@ To start, just type ::
 Determine If a Table Exists
 ===========================
 
-**$db->tableExists();**
+$db->tableExists()
+------------------
 
 Sometimes it's helpful to know whether a particular table exists before
 running an operation on it. Returns a boolean true/false. Usage example:
@@ -49,7 +54,8 @@ Field MetaData
 List the Fields in a Table
 ==========================
 
-**$db->getFieldNames()**
+$db->getFieldNames()
+--------------------
 
 Returns an array containing the field names. This query can be called
 two ways:
@@ -66,7 +72,8 @@ calling the function from your query result object:
 Determine If a Field is Present in a Table
 ==========================================
 
-**$db->fieldExists()**
+$db->fieldExists()
+------------------
 
 Sometimes it's helpful to know whether a particular field exists before
 performing an action. Returns a boolean true/false. Usage example:
@@ -80,7 +87,8 @@ performing an action. Returns a boolean true/false. Usage example:
 Retrieve Field Metadata
 =======================
 
-**$db->getFieldData()**
+$db->getFieldData()
+-------------------
 
 Returns an array of objects containing field information.
 
@@ -106,19 +114,23 @@ database:
 -  primary_key - 1 if the column is a primary key
 -  type - the type of the column
 
+db:table --metadata command
+---------------------------
+
 CodeIgniter supports show table containing field information in your database straight from your favorite terminal using the dedicated ``db:table my_table --metadata`` command. By using this command it is assumed that the table ``my_table`` is existing. Otherwise, CodeIgniter will show that tables list for select.
 Also, you can use this command as ``db:table --metadata``.
 
-.. note:: You can use the optional ``--desc``, ``--limit-rows``, ``--limit-fields-value`` options at any time when using command ``db:table`` .
+.. note:: You can use the optional ``--desc``, ``--limit-rows``, ``--limit-column-length`` options at any time when using command ``db:table`` .
 
 Command ``db:table --limit-rows 50``, for example, limits the number of rows to 50 rows.
 Command ``db:table --desc``, set the sort direction to "DESC". 
-And Command ``db:table --limit-fields-value 10`` limits the values of the fields to 10 characters, to prevent confusion of the table output in the terminal.
+And Command ``db:table --limit-column-length 10`` limits the length of the column to 10 characters, to prevent confusion of the table output in the terminal.
 
 List the Indexes in a Table
 ===========================
 
-**$db->getIndexData()**
+$db->getIndexData()
+-------------------
 
 Returns an array of objects containing index information.
 

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -120,11 +120,11 @@ db:table --metadata command
 CodeIgniter supports show table containing field information in your database straight from your favorite terminal using the dedicated ``db:table my_table --metadata`` command. By using this command it is assumed that the table ``my_table`` is existing. Otherwise, CodeIgniter will show that tables list for select.
 Also, you can use this command as ``db:table --metadata``.
 
-.. note:: You can use the optional ``--desc``, ``--limit-rows``, ``--limit-column-length`` options at any time when using command ``db:table`` .
+.. note:: You can use the optional ``--desc``, ``--limit-rows``, ``--limit-field-value`` options at any time when using command ``db:table`` .
 
 Command ``db:table --limit-rows 50``, for example, limits the number of rows to 50 rows.
 Command ``db:table --desc``, set the sort direction to "DESC". 
-And Command ``db:table --limit-column-length 10`` limits the length of the column to 10 characters, to prevent confusion of the table output in the terminal.
+And Command ``db:table --limit-field-value 10`` limits the length of the field values to 10 characters, to prevent confusion of the table output in the terminal.
 
 List the Indexes in a Table
 ===========================

--- a/user_guide_src/source/dbmgmt/db_commands.rst
+++ b/user_guide_src/source/dbmgmt/db_commands.rst
@@ -1,0 +1,61 @@
+#################
+Database Commands
+#################
+
+CodeIgniter provides some simple commands for databse management.
+
+.. contents::
+    :local:
+    :depth: 2
+
+*************************
+Showing Table Information
+*************************
+
+List the Tables in Your Database
+================================
+
+db:table --show
+---------------
+
+To list all the tables in your database straight from your favorite terminal,
+you can use the ``db:table --show`` command::
+
+    > php spark db:table --show
+
+When using this command it is assumed that a table exists.
+Otherwise, CodeIgniter will complain that the database has no tables.
+
+Retrieve Some Records
+=====================
+
+db:table
+--------
+
+When you have a table named ``my_table``, you can see the field names and the records of a table::
+
+    > php spark db:table my_table
+
+You can also pass a few options::
+
+    > php spark db:table my_table --limit-rows 50 --limit-field-value 20 --desc
+
+The option ``--limit-rows 50`` limits the number of rows to 50 rows.
+
+The option  ``--limit-field-value 20`` limits the length of the field values to 20 characters, to prevent confusion of the table output in the terminal.
+
+The option ``--desc`` sets the sort direction to "DESC".
+
+Retrieve Field Metadata
+=======================
+
+db:table --metadata
+-------------------
+
+When you have a table named ``my_table``, you can see metadata like the column type, max length of the table with the ``--metadata`` option::
+
+    > php spark db:table my_table --metadata
+
+When using this command it is assumed that the table exists.
+Otherwise, CodeIgniter will show a table list to select.
+Also, you can use this command as ``db:table --metadata``.

--- a/user_guide_src/source/dbmgmt/db_commands.rst
+++ b/user_guide_src/source/dbmgmt/db_commands.rst
@@ -36,6 +36,14 @@ When you have a table named ``my_table``, you can see the field names and the re
 
     > php spark db:table my_table
 
+If the table ``my_table`` is not in the database, CodeIgniter displays a list of available tables to select.
+
+You can also use the following command without the table name::
+
+    > php spark db:table
+
+In this case, the table name will be asked.
+
 You can also pass a few options::
 
     > php spark db:table my_table --limit-rows 50 --limit-field-value 20 --desc

--- a/user_guide_src/source/dbmgmt/index.rst
+++ b/user_guide_src/source/dbmgmt/index.rst
@@ -10,3 +10,4 @@ CodeIgniter comes with tools to restructure or seed your database.
     Database Manipulation with Database Forge <forge>
     Database Migrations <migration>
     Database Seeding <seeds>
+    db_commands


### PR DESCRIPTION
**Description**
Supersedes and closes #5895

```
Usage:
  db:table [<table_name>] [options]

Description:
  Retrieves information on the selected table.

Arguments:
  table_name  The table name to show info

Options:
  --show               Lists the names of all database tables.
  --metadata           Retrieves list containing field information.
  --desc               Sorts the table rows in DESC order.
  --limit-rows         Limits the number of rows. Default: 10.
  --limit-field-value  Limits the length of field values. Default: 15.
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
