### PR TITLE
feat: `getFieldData()` returns nullable data on PostgreSQL

### DIFF
--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -234,9 +234,9 @@ class Connection extends BaseConnection
      */
     protected function _fieldData(string $table): array
     {
-        $sql = 'SELECT "column_name", "data_type", "character_maximum_length", "numeric_precision", "column_default"
-			FROM "information_schema"."columns"
-			WHERE LOWER("table_name") = '
+        $sql = 'SELECT "column_name", "data_type", "character_maximum_length", "numeric_precision", "column_default",  "is_nullable"
+            FROM "information_schema"."columns"
+            WHERE LOWER("table_name") = '
                 . $this->escape(strtolower($table))
                 . ' ORDER BY "ordinal_position"';
 
@@ -252,6 +252,7 @@ class Connection extends BaseConnection
 
             $retVal[$i]->name       = $query[$i]->column_name;
             $retVal[$i]->type       = $query[$i]->data_type;
+            $retVal[$i]->nullable   = $query[$i]->is_nullable === 'YES';
             $retVal[$i]->default    = $query[$i]->column_default;
             $retVal[$i]->max_length = $query[$i]->character_maximum_length > 0 ? $query[$i]->character_maximum_length : $query[$i]->numeric_precision;
         }

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -843,6 +843,9 @@ final class ForgeTest extends CIUnitTestCase
             $this->assertSame('integer', $fieldsData[0]->type);
             $this->assertSame('character varying', $fieldsData[1]->type);
 
+            $this->assertFalse($fieldsData[0]->nullable);
+            $this->assertFalse($fieldsData[1]->nullable);
+
             $this->assertSame(32, (int) $fieldsData[0]->max_length);
             $this->assertSame(255, (int) $fieldsData[1]->max_length);
 

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -835,31 +835,40 @@ final class ForgeTest extends CIUnitTestCase
 
             $this->assertNull($fieldsData[0]->default);
             $this->assertNull($fieldsData[1]->default);
+
             $this->assertSame(1, (int) $fieldsData[0]->primary_key);
+
             $this->assertSame(255, (int) $fieldsData[1]->max_length);
         } elseif ($this->db->DBDriver === 'Postgre') {
             $this->assertSame('integer', $fieldsData[0]->type);
             $this->assertSame('character varying', $fieldsData[1]->type);
+
             $this->assertSame(32, (int) $fieldsData[0]->max_length);
-            $this->assertNull($fieldsData[1]->default);
             $this->assertSame(255, (int) $fieldsData[1]->max_length);
+
+            $this->assertNull($fieldsData[1]->default);
         } elseif ($this->db->DBDriver === 'SQLite3') {
             $this->assertSame('integer', strtolower($fieldsData[0]->type));
             $this->assertSame('varchar', strtolower($fieldsData[1]->type));
+
             $this->assertNull($fieldsData[1]->default);
         } elseif ($this->db->DBDriver === 'SQLSRV') {
             $this->assertSame('int', $fieldsData[0]->type);
-            $this->assertSame(10, (int) $fieldsData[0]->max_length);
             $this->assertSame('varchar', $fieldsData[1]->type);
-            $this->assertNull($fieldsData[1]->default);
+
+            $this->assertSame(10, (int) $fieldsData[0]->max_length);
             $this->assertSame(255, (int) $fieldsData[1]->max_length);
+
+            $this->assertNull($fieldsData[1]->default);
         } elseif ($this->db->DBDriver === 'OCI8') {
             // Check types
             $this->assertSame('NUMBER', $fieldsData[0]->type);
             $this->assertSame('VARCHAR2', $fieldsData[1]->type);
+
             $this->assertSame('11', $fieldsData[0]->max_length);
-            $this->assertSame('', $fieldsData[1]->default);
             $this->assertSame('255', $fieldsData[1]->max_length);
+
+            $this->assertSame('', $fieldsData[1]->default);
         } else {
             $this->fail(sprintf('DB driver "%s" is not supported.', $this->db->DBDriver));
         }


### PR DESCRIPTION
**Description**
- support nullable on postgre

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
