### PR TITLE
docs: make method names linkable in debugging.rst

### DIFF
--- a/user_guide_src/source/testing/debugging.rst
+++ b/user_guide_src/source/testing/debugging.rst
@@ -26,18 +26,21 @@ This is defined in the boot files (e.g. **app/Config/Boot/development.php**).
 Using Kint
 ==========
 
-**d()**
+d()
+---
 
 The ``d()`` method dumps all of the data it knows about the contents passed as the only parameter to the screen, and
 allows the script to continue executing:
 
 .. literalinclude:: debugging/001.php
 
-**dd()**
+dd()
+----
 
 This method is identical to ``d()``, except that it also ``dies()`` and no further code is executed this request.
 
-**trace()**
+trace()
+-------
 
 This provides a backtrace to the current execution point, with Kint's own unique spin:
 


### PR DESCRIPTION
**Description**
- make method names linkable

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
