### PR TITLE
change dies() to php's function name die()

### DIFF
--- a/user_guide_src/source/testing/debugging.rst
+++ b/user_guide_src/source/testing/debugging.rst
@@ -37,7 +37,7 @@ allows the script to continue executing:
 dd()
 ----
 
-This method is identical to ``d()``, except that it also ``dies()`` and no further code is executed this request.
+This method is identical to ``d()``, except that it also ``die()`` and no further code is executed this request.
 
 trace()
 -------


### PR DESCRIPTION
dies() may be linguistically more correct, but I would write die() here