### PR TITLE
docs: add that `deleted_at` column must be nullable

### DIFF
--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -131,6 +131,8 @@ This requires either a DATETIME or INTEGER field in the database as per the mode
 ``$dateFormat`` setting. The default field name is ``deleted_at`` however this name can be
 configured to any name of your choice by using ``$deletedField`` property.
 
+.. important:: The ``deleted_at`` field must be nullable.
+
 $allowedFields
 --------------
 


### PR DESCRIPTION
**Description**
Fixes #5913

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
