### PR TITLE
Changing the subquery builder for the Oracle

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2846,7 +2846,7 @@ class BaseBuilder
             $alias    = trim($alias);
 
             if ($alias !== '') {
-                $subquery .= ' AS ' . ($this->db->protectIdentifiers ? $this->db->escapeIdentifiers($alias) : $alias);
+                $subquery .= ' ' . ($this->db->protectIdentifiers ? $this->db->escapeIdentifiers($alias) : $alias);
             }
         }
 

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -103,19 +103,19 @@ final class FromTest extends CIUnitTestCase
 
     public function testFromSubquery()
     {
-        $expectedSQL = 'SELECT * FROM (SELECT * FROM "users") AS "alias"';
+        $expectedSQL = 'SELECT * FROM (SELECT * FROM "users") "alias"';
         $subquery    = new BaseBuilder('users', $this->db);
         $builder     = $this->db->newQuery()->fromSubquery($subquery, 'alias');
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 
-        $expectedSQL = 'SELECT * FROM (SELECT "id", "name" FROM "users") AS "users_1"';
+        $expectedSQL = 'SELECT * FROM (SELECT "id", "name" FROM "users") "users_1"';
         $subquery    = (new BaseBuilder('users', $this->db))->select('id, name');
         $builder     = $this->db->newQuery()->fromSubquery($subquery, 'users_1');
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
 
-        $expectedSQL = 'SELECT * FROM (SELECT * FROM "users") AS "alias", "some_table"';
+        $expectedSQL = 'SELECT * FROM (SELECT * FROM "users") "alias", "some_table"';
         $subquery    = new BaseBuilder('users', $this->db);
         $builder     = $this->db->newQuery()->fromSubquery($subquery, 'alias')->from('some_table');
 
@@ -145,7 +145,7 @@ final class FromTest extends CIUnitTestCase
 
         $builder->fromSubquery($subquery, 'users_1');
 
-        $expectedSQL = 'SELECT * FROM "test"."dbo"."jobs", (SELECT * FROM "test"."dbo"."users") AS "users_1"';
+        $expectedSQL = 'SELECT * FROM "test"."dbo"."jobs", (SELECT * FROM "test"."dbo"."users") "users_1"';
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -270,7 +270,7 @@ final class SelectTest extends CIUnitTestCase
         $subquery->select('name')->where('id', 1);
         $builder->select('name')->selectSubquery($subquery, 'country');
 
-        $expected = 'SELECT "name", (SELECT "name" FROM "countries" WHERE "id" = 1) AS "country" FROM "users"';
+        $expected = 'SELECT "name", (SELECT "name" FROM "countries" WHERE "id" = 1) "country" FROM "users"';
 
         $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }

--- a/user_guide_src/source/database/query_builder/015.php
+++ b/user_guide_src/source/database/query_builder/015.php
@@ -3,4 +3,4 @@
 $subquery = $db->table('countries')->select('name')->where('id', 1);
 $builder  = $db->table('users')->select('name')->selectSubquery($subquery, 'country');
 $query    = $builder->get();
-// Produces: SELECT `name`, (SELECT `name` FROM `countries` WHERE `id` = 1) AS `country` FROM `users`
+// Produces: SELECT `name`, (SELECT `name` FROM `countries` WHERE `id` = 1) `country` FROM `users`

--- a/user_guide_src/source/database/query_builder/017.php
+++ b/user_guide_src/source/database/query_builder/017.php
@@ -3,4 +3,4 @@
 $subquery = $db->table('users');
 $builder  = $db->table('jobs')->fromSubquery($subquery, 'alias');
 $query    = $builder->get();
-// Produces: SELECT * FROM `jobs`, (SELECT * FROM `users`) AS `alias`
+// Produces: SELECT * FROM `jobs`, (SELECT * FROM `users`) `alias`

--- a/user_guide_src/source/database/query_builder/018.php
+++ b/user_guide_src/source/database/query_builder/018.php
@@ -3,4 +3,4 @@
 $subquery = $db->table('users')->select('id, name');
 $builder  = $db->newQuery()->fromSubquery($subquery, 't');
 $query    = $builder->get();
-// Produces: SELECT * FROM (SELECT `id`, `name` FROM users) AS `t`
+// Produces: SELECT * FROM (SELECT `id`, `name` FROM users) `t`


### PR DESCRIPTION
**Description**
Because Oracle does not support using the ``AS`` keyword for table aliases. 
This PR removes the ``AS`` keyword when building subqueries.

**Checklist:**
- [x] Securely signed commits
- [x] User guide updated
