### PR TITLE
fix: replace EVENT_PRIORITY_NORMAL with Events::PRIORITY_NORMAL

### DIFF
--- a/system/Events/Events.php
+++ b/system/Events/Events.php
@@ -110,7 +110,7 @@ class Events
      * @param callable $callback
      * @param int      $priority
      */
-    public static function on($eventName, $callback, $priority = EVENT_PRIORITY_NORMAL)
+    public static function on($eventName, $callback, $priority = self::PRIORITY_NORMAL)
     {
         if (! isset(static::$listeners[$eventName])) {
             static::$listeners[$eventName] = [


### PR DESCRIPTION
**Description**
Follow-up  #6000

EVENT_PRIORITY_NORMAL still remained.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
