### PR TITLE
chore: fix indent in views

### DIFF
--- a/app/Views/.editorconfig
+++ b/app/Views/.editorconfig
@@ -1,0 +1,6 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+[*]
+indent_style = tab
+indent_size = 2

--- a/app/Views/errors/cli/.editorconfig
+++ b/app/Views/errors/cli/.editorconfig
@@ -1,13 +1,6 @@
 ; This file is for unifying the coding style for different editors and IDEs.
 ; More information at http://editorconfig.org
 
-; top-most EditorConfig file
-root = true
-
 [*]
-charset = utf-8
 indent_style = space
 indent_size = 4
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true

--- a/system/Debug/Toolbar/Views/.editorconfig
+++ b/system/Debug/Toolbar/Views/.editorconfig
@@ -1,0 +1,6 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+[*]
+indent_style = tab
+indent_size = 2

--- a/system/Debug/Toolbar/Views/_database.tpl
+++ b/system/Debug/Toolbar/Views/_database.tpl
@@ -1,26 +1,26 @@
 <table>
-    <thead>
-        <tr>
-            <th class="debug-bar-width6r">Time</th>
-            <th>Query String</th>
-        </tr>
-    </thead>
-    <tbody>
-    {queries}
-        <tr class="{class}" title="{hover}" data-toggle="{qid}-trace">
-            <td class="narrow">{duration}</td>
-            <td>{! sql !}</td>
-            <td style="text-align: right"><strong>{trace-file}</strong></td>
-        </tr>
-        <tr class="muted" id="{qid}-trace" style="display:none">
-            <td></td>
-            <td colspan="2">
-            {trace}
-                {index}<strong>{file}</strong><br/>
-                {function}<br/><br/>
-            {/trace}
-            </td>
-        </tr>
-    {/queries}
-    </tbody>
+	<thead>
+		<tr>
+			<th class="debug-bar-width6r">Time</th>
+			<th>Query String</th>
+		</tr>
+	</thead>
+	<tbody>
+	{queries}
+		<tr class="{class}" title="{hover}" data-toggle="{qid}-trace">
+			<td class="narrow">{duration}</td>
+			<td>{! sql !}</td>
+			<td style="text-align: right"><strong>{trace-file}</strong></td>
+		</tr>
+		<tr class="muted" id="{qid}-trace" style="display:none">
+			<td></td>
+			<td colspan="2">
+			{trace}
+				{index}<strong>{file}</strong><br/>
+				{function}<br/><br/>
+			{/trace}
+			</td>
+		</tr>
+	{/queries}
+	</tbody>
 </table>

--- a/system/Debug/Toolbar/Views/_events.tpl
+++ b/system/Debug/Toolbar/Views/_events.tpl
@@ -1,18 +1,18 @@
 <table>
-    <thead>
-        <tr>
-            <th class="debug-bar-width6r">Time</th>
-            <th>Event Name</th>
-            <th>Times Called</th>
-        </tr>
-    </thead>
-    <tbody>
-    {events}
-        <tr>
-            <td class="narrow">{ duration } ms</td>
-            <td>{event}</td>
-            <td>{count}</td>
-        </tr>
-    {/events}
-    </tbody>
+	<thead>
+		<tr>
+			<th class="debug-bar-width6r">Time</th>
+			<th>Event Name</th>
+			<th>Times Called</th>
+		</tr>
+	</thead>
+	<tbody>
+	{events}
+		<tr>
+			<td class="narrow">{ duration } ms</td>
+			<td>{event}</td>
+			<td>{count}</td>
+		</tr>
+	{/events}
+	</tbody>
 </table>

--- a/system/Debug/Toolbar/Views/_files.tpl
+++ b/system/Debug/Toolbar/Views/_files.tpl
@@ -1,16 +1,16 @@
 <table>
-    <tbody>
-    {userFiles}
-        <tr>
-            <td>{name}</td>
-            <td>{path}</td>
-        </tr>
-    {/userFiles}
-    {coreFiles}
-        <tr class="muted">
-            <td class="debug-bar-width20e">{name}</td>
-            <td>{path}</td>
-        </tr>
-    {/coreFiles}
-    </tbody>
+	<tbody>
+	{userFiles}
+		<tr>
+			<td>{name}</td>
+			<td>{path}</td>
+		</tr>
+	{/userFiles}
+	{coreFiles}
+		<tr class="muted">
+			<td class="debug-bar-width20e">{name}</td>
+			<td>{path}</td>
+		</tr>
+	{/coreFiles}
+	</tbody>
 </table>

--- a/system/Debug/Toolbar/Views/_history.tpl
+++ b/system/Debug/Toolbar/Views/_history.tpl
@@ -1,28 +1,28 @@
 <table>
-    <thead>
-    <tr>
-        <th>Action</th>
-        <th>Datetime</th>
-        <th>Status</th>
-        <th>Method</th>
-        <th>URL</th>
-        <th>Content-Type</th>
-        <th>Is AJAX?</th>
-    </tr>
-    </thead>
-    <tbody>
-    {files}
-        <tr data-active="{active}">
-            <td class="debug-bar-width70p">
-                <button class="ci-history-load" data-time="{time}">Load</button>
-            </td>
-            <td class="debug-bar-width190p">{datetime}</td>
-            <td>{status}</td>
-            <td>{method}</td>
-            <td>{url}</td>
-            <td>{contentType}</td>
-            <td>{isAJAX}</td>
-        </tr>
-    {/files}
-    </tbody>
+	<thead>
+	<tr>
+		<th>Action</th>
+		<th>Datetime</th>
+		<th>Status</th>
+		<th>Method</th>
+		<th>URL</th>
+		<th>Content-Type</th>
+		<th>Is AJAX?</th>
+	</tr>
+	</thead>
+	<tbody>
+	{files}
+		<tr data-active="{active}">
+			<td class="debug-bar-width70p">
+				<button class="ci-history-load" data-time="{time}">Load</button>
+			</td>
+			<td class="debug-bar-width190p">{datetime}</td>
+			<td>{status}</td>
+			<td>{method}</td>
+			<td>{url}</td>
+			<td>{contentType}</td>
+			<td>{isAJAX}</td>
+		</tr>
+	{/files}
+	</tbody>
 </table>

--- a/system/Debug/Toolbar/Views/_logs.tpl
+++ b/system/Debug/Toolbar/Views/_logs.tpl
@@ -2,19 +2,19 @@
 <p>Nothing was logged. If you were expecting logged items, ensure that LoggerConfig file has the correct threshold set.</p>
 { else }
 <table>
-    <thead>
-        <tr>
-            <th>Severity</th>
-            <th>Message</th>
-        </tr>
-    </thead>
-    <tbody>
-    {logs}
-        <tr>
-            <td>{level}</td>
-            <td>{msg}</td>
-        </tr>
-    {/logs}
-    </tbody>
+	<thead>
+		<tr>
+			<th>Severity</th>
+			<th>Message</th>
+		</tr>
+	</thead>
+	<tbody>
+	{logs}
+		<tr>
+			<td>{level}</td>
+			<td>{msg}</td>
+		</tr>
+	{/logs}
+	</tbody>
 </table>
 { endif }

--- a/system/Debug/Toolbar/Views/_routes.tpl
+++ b/system/Debug/Toolbar/Views/_routes.tpl
@@ -1,52 +1,52 @@
 <h3>Matched Route</h3>
 
 <table>
-    <tbody>
-    {matchedRoute}
-        <tr>
-            <td>Directory:</td>
-            <td>{directory}</td>
-        </tr>
-        <tr>
-            <td>Controller:</td>
-            <td>{controller}</td>
-        </tr>
-        <tr>
-            <td>Method:</td>
-            <td>{method}</td>
-        </tr>
-        <tr>
-            <td>Params:</td>
-            <td>{paramCount} / {truePCount}</td>
-        </tr>
-        {params}
-            <tr class="route-params-item">
-                <td>{name}</td>
-                <td>{value}</td>
-            </tr>
-        {/params}
-    {/matchedRoute}
-    </tbody>
+	<tbody>
+	{matchedRoute}
+		<tr>
+			<td>Directory:</td>
+			<td>{directory}</td>
+		</tr>
+		<tr>
+			<td>Controller:</td>
+			<td>{controller}</td>
+		</tr>
+		<tr>
+			<td>Method:</td>
+			<td>{method}</td>
+		</tr>
+		<tr>
+			<td>Params:</td>
+			<td>{paramCount} / {truePCount}</td>
+		</tr>
+		{params}
+			<tr class="route-params-item">
+				<td>{name}</td>
+				<td>{value}</td>
+			</tr>
+		{/params}
+	{/matchedRoute}
+	</tbody>
 </table>
 
 
 <h3>Defined Routes</h3>
 
 <table>
-    <thead>
-        <tr>
-            <th>Method</th>
-            <th>Route</th>
-            <th>Handler</th>
-        </tr>
-    </thead>
-    <tbody>
-    {routes}
-        <tr>
-            <td>{method}</td>
-            <td data-debugbar-route="{method}">{route}</td>
-            <td>{handler}</td>
-        </tr>
-    {/routes}
-    </tbody>
+	<thead>
+		<tr>
+			<th>Method</th>
+			<th>Route</th>
+			<th>Handler</th>
+		</tr>
+	</thead>
+	<tbody>
+	{routes}
+		<tr>
+			<td>{method}</td>
+			<td data-debugbar-route="{method}">{route}</td>
+			<td>{handler}</td>
+		</tr>
+	{/routes}
+	</tbody>
 </table>

--- a/system/Debug/Toolbar/Views/toolbarloader.js
+++ b/system/Debug/Toolbar/Views/toolbarloader.js
@@ -1,87 +1,87 @@
 document.addEventListener('DOMContentLoaded', loadDoc, false);
 
 function loadDoc(time) {
-    if (isNaN(time)) {
-        time = document.getElementById("debugbar_loader").getAttribute("data-time");
-        localStorage.setItem('debugbar-time', time);
-    }
+	if (isNaN(time)) {
+		time = document.getElementById("debugbar_loader").getAttribute("data-time");
+		localStorage.setItem('debugbar-time', time);
+	}
 
-    localStorage.setItem('debugbar-time-new', time);
+	localStorage.setItem('debugbar-time-new', time);
 
-    let url = '{url}';
-    let xhttp = new XMLHttpRequest();
+	let url = '{url}';
+	let xhttp = new XMLHttpRequest();
 
-    xhttp.onreadystatechange = function() {
-        if (this.readyState === 4 && this.status === 200) {
-            let toolbar = document.getElementById("toolbarContainer");
+	xhttp.onreadystatechange = function() {
+		if (this.readyState === 4 && this.status === 200) {
+			let toolbar = document.getElementById("toolbarContainer");
 
-            if (! toolbar) {
-                toolbar = document.createElement('div');
-                toolbar.setAttribute('id', 'toolbarContainer');
-                document.body.appendChild(toolbar);
-            }
+			if (! toolbar) {
+				toolbar = document.createElement('div');
+				toolbar.setAttribute('id', 'toolbarContainer');
+				document.body.appendChild(toolbar);
+			}
 
-            let responseText = this.responseText;
-            let dynamicStyle = document.getElementById('debugbar_dynamic_style');
-            let dynamicScript = document.getElementById('debugbar_dynamic_script');
+			let responseText = this.responseText;
+			let dynamicStyle = document.getElementById('debugbar_dynamic_style');
+			let dynamicScript = document.getElementById('debugbar_dynamic_script');
 
-            // get the first style block, copy contents to dynamic_style, then remove here
-            let start = responseText.indexOf('>', responseText.indexOf('<style')) + 1;
-            let end = responseText.indexOf('</style>', start);
-            dynamicStyle.innerHTML = responseText.substr(start, end - start);
-            responseText = responseText.substr(end + 8);
+			// get the first style block, copy contents to dynamic_style, then remove here
+			let start = responseText.indexOf('>', responseText.indexOf('<style')) + 1;
+			let end = responseText.indexOf('</style>', start);
+			dynamicStyle.innerHTML = responseText.substr(start, end - start);
+			responseText = responseText.substr(end + 8);
 
-            // get the first script after the first style, copy contents to dynamic_script, then remove here
-            start = responseText.indexOf('>', responseText.indexOf('<script')) + 1;
-            end = responseText.indexOf('\<\/script>', start);
-            dynamicScript.innerHTML = responseText.substr(start, end - start);
-            responseText = responseText.substr(end + 9);
+			// get the first script after the first style, copy contents to dynamic_script, then remove here
+			start = responseText.indexOf('>', responseText.indexOf('<script')) + 1;
+			end = responseText.indexOf('\<\/script>', start);
+			dynamicScript.innerHTML = responseText.substr(start, end - start);
+			responseText = responseText.substr(end + 9);
 
-            // check for last style block, append contents to dynamic_style, then remove here
-            start = responseText.indexOf('>', responseText.indexOf('<style')) + 1;
-            end = responseText.indexOf('</style>', start);
-            dynamicStyle.innerHTML += responseText.substr(start, end - start);
-            responseText = responseText.substr(0, start - 8);
+			// check for last style block, append contents to dynamic_style, then remove here
+			start = responseText.indexOf('>', responseText.indexOf('<style')) + 1;
+			end = responseText.indexOf('</style>', start);
+			dynamicStyle.innerHTML += responseText.substr(start, end - start);
+			responseText = responseText.substr(0, start - 8);
 
-            toolbar.innerHTML = responseText;
+			toolbar.innerHTML = responseText;
 
-            if (typeof ciDebugBar === 'object') {
-                ciDebugBar.init();
-            }
-        } else if (this.readyState === 4 && this.status === 404) {
-            console.log('CodeIgniter DebugBar: File "WRITEPATH/debugbar/debugbar_' + time + '" not found.');
-        }
-    };
+			if (typeof ciDebugBar === 'object') {
+				ciDebugBar.init();
+			}
+		} else if (this.readyState === 4 && this.status === 404) {
+			console.log('CodeIgniter DebugBar: File "WRITEPATH/debugbar/debugbar_' + time + '" not found.');
+		}
+	};
 
-    xhttp.open("GET", url + "?debugbar_time=" + time, true);
-    xhttp.send();
+	xhttp.open("GET", url + "?debugbar_time=" + time, true);
+	xhttp.send();
 }
 
 window.oldXHR = window.ActiveXObject
-    ? new ActiveXObject('Microsoft.XMLHTTP')
-    : window.XMLHttpRequest;
+	? new ActiveXObject('Microsoft.XMLHTTP')
+	: window.XMLHttpRequest;
 
 function newXHR() {
-    const realXHR = new window.oldXHR();
+	const realXHR = new window.oldXHR();
 
-    realXHR.addEventListener("readystatechange", function() {
-        // Only success responses and URLs that do not contains "debugbar_time" are tracked
-        if (realXHR.readyState === 4 && realXHR.status.toString()[0] === '2' && realXHR.responseURL.indexOf('debugbar_time') === -1) {
-            if (realXHR.getAllResponseHeaders().indexOf("Debugbar-Time") >= 0) {
-                let debugbarTime = realXHR.getResponseHeader('Debugbar-Time');
+	realXHR.addEventListener("readystatechange", function() {
+		// Only success responses and URLs that do not contains "debugbar_time" are tracked
+		if (realXHR.readyState === 4 && realXHR.status.toString()[0] === '2' && realXHR.responseURL.indexOf('debugbar_time') === -1) {
+			if (realXHR.getAllResponseHeaders().indexOf("Debugbar-Time") >= 0) {
+				let debugbarTime = realXHR.getResponseHeader('Debugbar-Time');
 
-                if (debugbarTime) {
-                    let h2 = document.querySelector('#ci-history > h2');
+				if (debugbarTime) {
+					let h2 = document.querySelector('#ci-history > h2');
 
-                    if (h2) {
-                        h2.innerHTML = 'History <small>You have new debug data.</small> <button onclick="loadDoc(' + debugbarTime + ')">Update</button>';
-                        document.querySelector('a[data-tab="ci-history"] > span > .badge').className += ' active';
-                    }
-                }
-            }
-        }
-    }, false);
-    return realXHR;
+					if (h2) {
+						h2.innerHTML = 'History <small>You have new debug data.</small> <button onclick="loadDoc(' + debugbarTime + ')">Update</button>';
+						document.querySelector('a[data-tab="ci-history"] > span > .badge').className += ' active';
+					}
+				}
+			}
+		}
+	}, false);
+	return realXHR;
 }
 
 window.XMLHttpRequest = newXHR;


### PR DESCRIPTION
**Description**
Although not explicitly stated, it appears that view file indentation is basically done with tabs.
This PR adds `.editorconfig` for Views and fixes indentation in some files.

It seems two space size indentation is common for HTML/CSS, so I set `indent_size = 2`.

The only one exception is `system/Debug/Toolbar/Views/toolbar.css`.
It is generated by scss and it uses space 2 indentation.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
