### PR TITLE
test: change Config\Images::$libraryPath only when the file exists

### DIFF
--- a/tests/system/Images/ImageMagickHandlerTest.php
+++ b/tests/system/Images/ImageMagickHandlerTest.php
@@ -47,9 +47,11 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
 
         $this->path = $this->origin . 'ci-logo.png';
 
-        $handlerConfig              = new Images();
-        $handlerConfig->libraryPath = '/usr/bin/convert';
-        $this->handler              = Services::image('imagick', $handlerConfig, false);
+        $handlerConfig = new Images();
+        if (is_file('/usr/bin/convert')) {
+            $handlerConfig->libraryPath = '/usr/bin/convert';
+        }
+        $this->handler = Services::image('imagick', $handlerConfig, false);
     }
 
     public function testGetVersion()


### PR DESCRIPTION
**Description**
When there is no `/usr/bin/convert`, the errors occurs.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
