### PR TITLE
fix: Ignore non-HTML responses in storePreviousURL

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -1031,6 +1031,11 @@ class CodeIgniter
             return;
         }
 
+        // Ignore non-HTML responses
+        if (strpos($this->response->getHeaderLine('Content-Type'), 'text/html') === false) {
+            return;
+        }
+
         // This is mainly needed during testing...
         if (is_string($uri)) {
             $uri = new URI($uri);

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -424,6 +424,30 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->assertArrayNotHasKey('_ci_previous_url', $_SESSION);
     }
 
+    public function testNotStoresPreviousURLByCheckingContentType()
+    {
+        $_SERVER['argv'] = ['index.php', 'image'];
+        $_SERVER['argc'] = 2;
+
+        $_SERVER['REQUEST_URI'] = '/image';
+
+        // Inject mock router.
+        $routes = Services::routes();
+        $routes->add('image', static function () {
+            $response = Services::response();
+
+            return $response->setContentType('image/jpeg', '');
+        });
+        $router = Services::router($routes, Services::request());
+        Services::injectMock('router', $router);
+
+        ob_start();
+        $this->codeigniter->useSafeOutput(true)->run();
+        ob_get_clean();
+
+        $this->assertArrayNotHasKey('_ci_previous_url', $_SESSION);
+    }
+
     /**
      * The method after all test, reset Servces:: config
      * Can't use static::tearDownAfterClass. This will cause a buffer exception

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -32,6 +32,7 @@ Behavior Changes
 - To prevent unexpected access from the web browser, if a controller is added to a cli route (``$routes->cli()``), all methods of that controller are no longer accessible via auto-routing.
 - There is a possible backward compatibility break for those users extending the History Collector and they should probably update ``History::setFiles()`` method.
 - The :php:func:`dot_array_search`'s unexpected behavior has been fixed. Now ``dot_array_search('foo.bar.baz', ['foo' => ['bar' => 23]])`` returns ``null``. The previous versions returned ``23``.
+- The ``CodeIgniter::storePreviousURL()`` has been changed to store only the URLs whose Content-Type was ``text/html``. It also affects the behavior of ``previous_url()`` and ``redirect()->back()``.
 
 Enhancements
 ************

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -32,7 +32,7 @@ Behavior Changes
 - To prevent unexpected access from the web browser, if a controller is added to a cli route (``$routes->cli()``), all methods of that controller are no longer accessible via auto-routing.
 - There is a possible backward compatibility break for those users extending the History Collector and they should probably update ``History::setFiles()`` method.
 - The :php:func:`dot_array_search`'s unexpected behavior has been fixed. Now ``dot_array_search('foo.bar.baz', ['foo' => ['bar' => 23]])`` returns ``null``. The previous versions returned ``23``.
-- The ``CodeIgniter::storePreviousURL()`` has been changed to store only the URLs whose Content-Type was ``text/html``. It also affects the behavior of ``previous_url()`` and ``redirect()->back()``.
+- The ``CodeIgniter::storePreviousURL()`` has been changed to store only the URLs whose Content-Type was ``text/html``. It also affects the behavior of :php:func:`previous_url` and :php:func:`redirect()->back() <redirect>`.
 
 Enhancements
 ************

--- a/user_guide_src/source/installation/upgrade_420.rst
+++ b/user_guide_src/source/installation/upgrade_420.rst
@@ -42,7 +42,6 @@ Breaking Changes
 ****************
 
 - The ``system/bootstrap.php`` file no longer returns a ``CodeIgniter`` instance, and does not load the ``.env`` file (now handled in ``index.php`` and ``spark``). If you have code that expects these behaviors it will no longer work and must be modified. This has been changed to make `Preloading <https://www.php.net/manual/en/opcache.preloading.php>`_ easier to implement.
-- ``previous_url()`` has been changed to return only the URLs whose Content-Type was ``text/html``. Accordingly, the behavior of ``redirect()->back()`` has been changed.
 
 Breaking Enhancements
 *********************

--- a/user_guide_src/source/installation/upgrade_420.rst
+++ b/user_guide_src/source/installation/upgrade_420.rst
@@ -42,6 +42,7 @@ Breaking Changes
 ****************
 
 - The ``system/bootstrap.php`` file no longer returns a ``CodeIgniter`` instance, and does not load the ``.env`` file (now handled in ``index.php`` and ``spark``). If you have code that expects these behaviors it will no longer work and must be modified. This has been changed to make `Preloading <https://www.php.net/manual/en/opcache.preloading.php>`_ easier to implement.
+- ``previous_url()`` has been changed to return only the URLs whose Content-Type was ``text/html``. Accordingly, the behavior of ``redirect()->back()`` has been changed.
 
 Breaking Enhancements
 *********************


### PR DESCRIPTION
**Description**

In this PR, I added an exclusion condition for `storePreviousURL`: "Response Content-Type is not text/html".

**Background**

In our application, some images are composited in the CodeIgnitor controller and returned.

The request URL for such case is saved as `_ci_previous_url` because it does not meet any of the exclusion conditions of the existing `storePreviousURL` implementation, and when redirecting back, etc., there is a case where the request is redirected to the URL of the image.

The URL to store as `previous_url` is usually considered to be an HTML (`text/html`) case, so I have added that as a condition.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
