### PR TITLE
fix: CURLRequest request body is not reset on the next request

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -151,6 +151,9 @@ class CURLRequest extends Request
         $this->headers   = [];
         $this->headerMap = [];
 
+        // Reset body
+        $this->body = null;
+
         // Reset configs
         $this->config = $this->defaultConfig;
 

--- a/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
@@ -807,6 +807,21 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $this->assertSame('name=George', $request->curl_options[CURLOPT_POSTFIELDS]);
     }
 
+    public function testBodyIsResstOnSecondRequest()
+    {
+        $request = $this->getRequest([
+            'base_uri' => 'http://www.foo.com/api/v1/',
+            'delay'    => 100,
+        ]);
+        $request->setBody('name=George');
+        $request->setOutput('Hi there');
+
+        $request->post('answer');
+        $request->post('answer');
+
+        $this->assertArrayNotHasKey(CURLOPT_POSTFIELDS, $request->curl_options);
+    }
+
     public function testResponseHeaders()
     {
         $request = $this->getRequest([
@@ -922,7 +937,10 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $this->assertSame('post', $this->request->getMethod());
 
         $expected = json_encode($params);
-        $this->assertSame($expected, $this->request->getBody());
+        $this->assertSame(
+            $expected,
+            $this->request->curl_options[CURLOPT_POSTFIELDS]
+        );
     }
 
     public function testSetJSON()
@@ -936,7 +954,12 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         ];
         $this->request->setJSON($params)->post('/post');
 
-        $this->assertSame(json_encode($params), $this->request->getBody());
+        $expected = json_encode($params);
+        $this->assertSame(
+            $expected,
+            $this->request->curl_options[CURLOPT_POSTFIELDS]
+        );
+
         $this->assertSame(
             'Content-Type: application/json',
             $this->request->curl_options[CURLOPT_HTTPHEADER][0]

--- a/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
@@ -807,7 +807,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $this->assertSame('name=George', $request->curl_options[CURLOPT_POSTFIELDS]);
     }
 
-    public function testBodyIsResstOnSecondRequest()
+    public function testBodyIsResetOnSecondRequest()
     {
         $request = $this->getRequest([
             'base_uri' => 'http://www.foo.com/api/v1/',

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -28,11 +28,13 @@ Sharing Options
 
 Due to historical reasons, by default, the CURLRequest shares all the options between requests.
 If you send more than one request with an instance of the class,
-this behavior may cause an error request with unnecessary headers.
+this behavior may cause an error request with unnecessary headers and body.
 
 You can change the behavior by editing the following config parameter value in **app/Config/CURLRequest.php** to ``false``:
 
 .. literalinclude:: curlrequest/001.php
+
+.. note:: Before v4.2.0, the request body is not reset even if ``$shareOptions`` is false due to a bug.
 
 *******************
 Loading the Library


### PR DESCRIPTION
**Description**
Fixes #5632

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

