### PR TITLE
Feature. QueryBuilder. Query union.

### DIFF
--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -597,7 +597,7 @@ class Builder extends BaseBuilder
             $sql = $this->_limit($sql . "\n");
         }
 
-        return $sql;
+        return $this->unionInjection($sql);
     }
 
     /**

--- a/tests/system/Database/Builder/UnionTest.php
+++ b/tests/system/Database/Builder/UnionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Builder;
+
+use CodeIgniter\Database\BaseBuilder;
+use CodeIgniter\Database\SQLSRV\Connection as SQLSRVConnection;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockConnection;
+
+/**
+ * @internal
+ */
+final class UnionTest extends CIUnitTestCase
+{
+    /**
+     * @var MockConnection
+     */
+    protected $db;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->db = new MockConnection([]);
+    }
+
+    public function testUnion(): void
+    {
+        $expected = 'SELECT * FROM (SELECT * FROM "test") "uwrp0" UNION SELECT * FROM (SELECT * FROM "test") "uwrp1"';
+        $builder  = $this->db->table('test');
+
+        $builder->union($this->db->table('test'));
+        $this->assertSame($expected, $this->buildSelect($builder));
+
+        $builder = $this->db->table('test');
+
+        $builder->union(static fn ($builder) => $builder->from('test'));
+        $this->assertSame($expected, $this->buildSelect($builder));
+    }
+
+    public function testUnionAll(): void
+    {
+        $expected = 'SELECT * FROM (SELECT * FROM "test") "uwrp0"'
+            . ' UNION ALL SELECT * FROM (SELECT * FROM "test") "uwrp1"';
+        $builder = $this->db->table('test');
+
+        $builder->unionAll($this->db->table('test'));
+        $this->assertSame($expected, $this->buildSelect($builder));
+    }
+
+    public function testOrderLimit(): void
+    {
+        $expected = 'SELECT * FROM (SELECT * FROM "test" ORDER BY "id" DESC  LIMIT 10) "uwrp0"'
+            . ' UNION SELECT * FROM (SELECT * FROM "test") "uwrp1"';
+        $builder = $this->db->table('test');
+
+        $builder->union($this->db->table('test'))->limit(10)->orderBy('id', 'DESC');
+        $this->assertSame($expected, $this->buildSelect($builder));
+    }
+
+    public function testUnionSQLSRV(): void
+    {
+        $expected = 'SELECT * FROM (SELECT * FROM "test"."dbo"."users") "uwrp0"'
+            . ' UNION SELECT * FROM (SELECT * FROM "test"."dbo"."users") "uwrp1"';
+
+        $db = new SQLSRVConnection(['DBDriver' => 'SQLSRV', 'database' => 'test', 'schema' => 'dbo']);
+
+        $builder = $db->table('users');
+
+        $builder->union($db->table('users'));
+        $this->assertSame($expected, $this->buildSelect($builder));
+
+        $builder = $db->table('users');
+
+        $builder->union(static fn ($builder) => $builder->from('users'));
+        $this->assertSame($expected, $this->buildSelect($builder));
+    }
+
+    protected function buildSelect(BaseBuilder $builder): string
+    {
+        return str_replace("\n", ' ', $builder->getCompiledSelect());
+    }
+}

--- a/tests/system/Database/Live/UnionTest.php
+++ b/tests/system/Database/Live/UnionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Live;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use Tests\Support\Database\Seeds\CITestSeeder;
+
+/**
+ * @group DatabaseLive
+ *
+ * @internal
+ */
+final class UnionTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    protected $refresh = true;
+    protected $seed    = CITestSeeder::class;
+
+    public function testUnion(): void
+    {
+        $union = $this->db->table('user')
+            ->limit(1)
+            ->orderBy('id', 'ASC');
+        $builder = $this->db->table('user');
+
+        $builder->union($union)
+            ->limit(1)
+            ->orderBy('id', 'DESC');
+
+        $result = $this->db->newQuery()
+            ->fromSubquery($builder, 'q')
+            ->orderBy('id', 'DESC')
+            ->get();
+
+        $this->assertSame(2, $result->getNumRows());
+
+        $rows = $result->getResult();
+        $this->assertSame(4, (int) $rows[0]->id);
+        $this->assertSame(1, (int) $rows[1]->id);
+    }
+
+    public function testUnionAll(): void
+    {
+        $union   = $this->db->table('user');
+        $builder = $this->db->table('user');
+
+        $result = $builder->unionAll($union)->get();
+
+        $this->assertSame(8, $result->getNumRows());
+    }
+}

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -73,6 +73,7 @@ Database
     - Added the class ``CodeIgniter\Database\RawSql`` which expresses raw SQL strings.
     - :ref:`select() <query-builder-select-rawsql>`, :ref:`where() <query-builder-where-rawsql>`, :ref:`like() <query-builder-like-rawsql>`, :ref:`join() <query-builder-join-rawsql>` accept the ``CodeIgniter\Database\RawSql`` instance.
 - ``DBForge::addField()`` default value raw SQL string support. See :ref:`forge-addfield-default-value-rawsql`.
+- QueryBuilder. Union queries. See :ref:`query-builder-union`.
 
 Others
 ======

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -691,7 +691,7 @@ Union
 $builder->union()
 -----------------
 
-Is used to combine the result-set of two or more SELECT statements.
+Is used to combine the result-set of two or more SELECT statements. It will return only the unique results.
 
 .. literalinclude:: query_builder/103.php
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -679,6 +679,41 @@ As is in ``countAllResult()`` method, this method resets any field values that y
 to ``select()`` as well. If you need to keep them, you can pass ``false`` as the
 first parameter.
 
+.. _query-builder-union:
+
+*************
+Union queries
+*************
+
+Union
+=====
+
+$builder->union()
+-----------------
+
+Is used to combine the result-set of two or more SELECT statements.
+
+.. literalinclude:: query_builder/103.php
+
+.. note:: For correct work with DBMS (such as MSSQL and Oracle) queries are wrapped in ``SELECT * FROM ( ... ) alias``
+    The main query will always have an alias of ``uwrp0``. Each subsequent query added via ``union()`` will have an
+    alias ``uwrpN+1``.
+
+All union queries will be added after the main query, regardless of the order in which the ``union()`` method was
+called. That is, the ``limit()`` or ``orderBy()`` methods will be relative to the main query, even if called after
+``union()``.
+
+In some cases, it may be necessary, for example, to sort or limit the number of records of the query result.
+The solution is to use the wrapper created via ``$db->newQuery()``.
+In the example below, we get the first 5 users + the last 5 users and sort the result by id:
+
+.. literalinclude:: query_builder/104.php
+
+$builder->unionAll()
+--------------------
+
+The behavior is the same as the ``union()`` method.
+
 **************
 Query grouping
 **************
@@ -1494,6 +1529,22 @@ Class Reference
         :rtype:     ``BaseBuilder``
 
         Adds an ``OFFSET`` clause to a query.
+
+    .. php:method:: union($union)
+
+        :param BaseBulder|Closure $union: Union query
+        :returns:   ``BaseBuilder`` instance (method chaining)
+        :rtype:     ``BaseBuilder``
+
+        Adds a ``UNION`` clause.
+
+    .. php:method:: unionAll($union)
+
+        :param BaseBulder|Closure $union: Union query
+        :returns:   ``BaseBuilder`` instance (method chaining)
+        :rtype:     ``BaseBuilder``
+
+        Adds a ``UNION ALL`` clause.
 
     .. php:method:: set($key[, $value = ''[, $escape = null]])
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -712,7 +712,7 @@ In the example below, we get the first 5 users + the last 5 users and sort the r
 $builder->unionAll()
 --------------------
 
-The behavior is the same as the ``union()`` method.
+The behavior is the same as the ``union()`` method. However, all results will be returned, not just the unique ones.
 
 **************
 Query grouping

--- a/user_guide_src/source/database/query_builder/103.php
+++ b/user_guide_src/source/database/query_builder/103.php
@@ -1,0 +1,11 @@
+<?php
+
+$union   = $this->db->table('users')->select('id', 'name');
+$builder = $this->db->table('users')->select('id', 'name');
+
+$builder->union($union)->limit(10)->get();
+/*
+ * Produces:
+ * SELECT * FROM (SELECT `id`, `name` FROM `users` LIMIT 10) uwrp0
+ * UNION SELECT * FROM (SELECT `id`, `name` FROM `users`) uwrp1
+ */

--- a/user_guide_src/source/database/query_builder/104.php
+++ b/user_guide_src/source/database/query_builder/104.php
@@ -1,0 +1,14 @@
+<?php
+
+$union   = $this->db->table('users')->select('id', 'name')->orderBy('id', 'DESC')->limit(5);
+$builder = $this->db->table('users')->select('id', 'name')->orderBy('id', 'ASC')->limit(5)->union($union);
+
+$this->db->newQuery()->fromSubquery($builder, 'q')->orderBy('id', 'DESC')->get();
+/*
+ * Produces:
+ * SELECT * FROM (
+ *      SELECT * FROM (SELECT `id`, `name` FROM `users` ORDER BY `id` ASC LIMIT 5) uwrp0
+ *      UNION
+ *      SELECT * FROM (SELECT `id`, `name` FROM `users` ORDER BY `id` DESC LIMIT 5) uwrp1
+ * ) q ORDER BY `id` DESC
+ */


### PR DESCRIPTION
**Description**
This is the second attempt to add a query union to QueryBuilder.
Ref #4291

The implementation provides two methods:
-  `BaseBuilder::union(BaseBuilder|Closure $union)`
-  `BaseBuilder::unionAll(BaseBuilder|Closure $union)`

The union() method can be called in any order relative to the main query, but the union query will always be appended to the end. That is, the ``LIMIT`` or ``ORDER BY`` clauses will be relative to the main query.
```php
$builder->union($union)->limit(1)->orderBy('id');
// SELECT * FROM table LIMIT 1 ORDER BY id UNION query
```

Since DBMSs (MSSQL and Oracle) are demanding on queries using ``LIMIT`` and ``ORDER BY``, when generating SQL, all queries are wrapped in a ``SELECT * FROM(....) alias`` query.
The alias uwrp0 is used for the main query. Each subsequent query will have an alias with index +1.
```php
$builder->union($union)->limit(1)->orderBy('id')->unionAll($union2);
// SELECT * (SELECT * FROM table LIMIT 1 ORDER BY id) uwrp0 
// UNION SELECT * FROM (query) uwrp1 
// UNION ALL SELECT * FROM (query2) uwrp2
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide