### PR TITLE
[PHPStan] Pin PHPStan to v1.6.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.3",
         "nexusphp/tachycardia": "^1.0",
-        "phpstan/phpstan": "^1.5.6",
+        "phpstan/phpstan": "1.6.9",
         "phpunit/phpunit": "^9.1",
         "predis/predis": "^1.1",
         "rector/rector": "0.13.0"


### PR DESCRIPTION
Temporary pin PHPStan to 1.6.9 as updating to PHPStan 1.7.0 seems cause infinite loop when used along with Rector somewhere.

**Checklist:**
- [x] Securely signed commits
