### PR TITLE
fix: change BaseService::reset() $initAutoloader to true by default

### DIFF
--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -273,7 +273,7 @@ class BaseService
     /**
      * Reset shared instances and mocks for testing.
      */
-    public static function reset(bool $initAutoloader = false)
+    public static function reset(bool $initAutoloader = true)
     {
         static::$mocks     = [];
         static::$instances = [];

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -299,7 +299,7 @@ abstract class CIUnitTestCase extends TestCase
     /**
      * Resets shared instanced for all Services
      */
-    protected function resetServices(bool $initAutoloader = false)
+    protected function resetServices(bool $initAutoloader = true)
     {
         Services::reset($initAutoloader);
     }


### PR DESCRIPTION
**Description**
`BaseService::reset(false)` makes the autoloader's namespaces empty.
Such use cases are rare and will prevent `lang()` from working. See https://github.com/codeigniter4/shield/issues/88#issuecomment-1134594714

- change `BaseService::reset()` default parameter value to `true`
- change `CIUnitTestCase::resetServices()` default parameter value to `true`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

