### PR TITLE
Fix cookie prefixing

### DIFF
--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -60,6 +60,7 @@ if (! function_exists('get_cookie'))
 	 *
 	 * @param string  $index
 	 * @param boolean $xssClean
+	 * @param string  $prefix
 	 *
 	 * @return mixed
 	 *

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -65,9 +65,9 @@ if (! function_exists('get_cookie'))
 	 *
 	 * @see \CodeIgniter\HTTP\IncomingRequest::getCookie()
 	 */
-	function get_cookie($index, bool $xssClean = false)
+	function get_cookie($index, bool $xssClean = false, string $prefix = null)
 	{
-		$prefix  = isset($_COOKIE[$index]) ? '' : config(App::class)->cookiePrefix;
+		$prefix  = $prefix !== null ? $prefix : config(App::class)->cookiePrefix;
 		$request = Services::request();
 		$filter  = $xssClean ? FILTER_SANITIZE_STRING : FILTER_DEFAULT;
 

--- a/system/Session/Handlers/BaseHandler.php
+++ b/system/Session/Handlers/BaseHandler.php
@@ -131,7 +131,7 @@ abstract class BaseHandler implements SessionHandlerInterface
 	protected function destroyCookie(): bool
 	{
 		return setcookie(
-				$this->cookieName, '', 1, $this->cookiePath, $this->cookieDomain, $this->cookieSecure, true
+				config('App')->cookiePrefix . $this->cookieName, '', 1, $this->cookiePath, $this->cookieDomain, $this->cookieSecure, true
 		);
 	}
 

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -238,12 +238,14 @@ class Session implements SessionInterface
 		$this->configure();
 		$this->setSaveHandler();
 
+		$cookieName = $this->cookie->getPrefixedName();
+
 		// Sanitize the cookie, because apparently PHP doesn't do that for userspace handlers
-		if (isset($_COOKIE[$this->sessionCookieName])
-			&& (! is_string($_COOKIE[$this->sessionCookieName]) || ! preg_match('#\A' . $this->sidRegexp . '\z#', $_COOKIE[$this->sessionCookieName]))
+		if (isset($_COOKIE[$cookieName])
+			&& (! is_string($_COOKIE[$cookieName]) || ! preg_match('#\A' . $this->sidRegexp . '\z#', $_COOKIE[$cookieName]))
 		)
 		{
-			unset($_COOKIE[$this->sessionCookieName]);
+			unset($_COOKIE[$cookieName]);
 		}
 
 		$this->startSession();
@@ -264,7 +266,7 @@ class Session implements SessionInterface
 		}
 		// Another work-around ... PHP doesn't seem to send the session cookie
 		// unless it is being currently created or regenerated
-		elseif (isset($_COOKIE[$this->sessionCookieName]) && $_COOKIE[$this->sessionCookieName] === session_id())
+		elseif (isset($_COOKIE[$cookieName]) && $_COOKIE[$cookieName] === session_id())
 		{
 			$this->setCookie();
 		}
@@ -285,7 +287,7 @@ class Session implements SessionInterface
 	public function stop()
 	{
 		setcookie(
-			$this->sessionCookieName,
+			$this->cookie->getPrefixedName(),
 			session_id(),
 			1,
 			$this->cookie->getPath(),
@@ -304,13 +306,15 @@ class Session implements SessionInterface
 	 */
 	protected function configure()
 	{
-		if (empty($this->sessionCookieName))
+		$cookieName = $this->cookie->getPrefixedName();
+
+		if (empty($cookieName))
 		{
-			$this->sessionCookieName = ini_get('session.name');
+			$cookieName = ini_get('session.name');
 		}
 		else
 		{
-			ini_set('session.name', $this->sessionCookieName);
+			ini_set('session.name', $cookieName);
 		}
 
 		$sameSite = $this->cookie->getSameSite() ?: ucfirst(Cookie::SAMESITE_LAX);

--- a/user_guide_src/source/helpers/cookie_helper.rst
+++ b/user_guide_src/source/helpers/cookie_helper.rst
@@ -38,10 +38,11 @@ The following functions are available:
     a description of its use, as this function is an alias for
     ``Response::setCookie()``.
 
-.. php:function:: get_cookie($index[, $xssClean = false])
+.. php:function:: get_cookie($index[, $xssClean = false[, $prefix = null]])
 
     :param	string	$index: Cookie name
     :param	bool	$xss_clean: Whether to apply XSS filtering to the returned value
+    :param  string  $prefix: A custom prefix to overwrite what is set in the App Config
     :returns:	The cookie value or NULL if not found
     :rtype:	mixed
 


### PR DESCRIPTION
Fixes #6009

This allows the cookie_helper to enforce the default prefix if one exists, and also allows the user to set their own prefix including none at all to overwrite the prefix if necessary. This way there is no longer a collision issue if there are cookies that are prefixed and un-prefixed.

There is also an issue with the session setup where it would inconsistently set the name of the session cookie with and without the cookie prefix leading to multiple session cookies and also effectively creating the same prefixed vs un-prefixed issue.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

