### PR TITLE
Fix Cookie Prefix

### DIFF
--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -61,9 +61,9 @@ if (! function_exists('get_cookie')) {
      *
      * @see \CodeIgniter\HTTP\IncomingRequest::getCookie()
      */
-    function get_cookie($index, bool $xssClean = false)
+    function get_cookie($index, bool $xssClean = false, string $prefix = null)
     {
-        $prefix  = isset($_COOKIE[$index]) ? '' : config(App::class)->cookiePrefix;
+        $prefix  = $prefix !== null ? $prefix : config(App::class)->cookiePrefix;
         $request = Services::request();
         $filter  = $xssClean ? FILTER_SANITIZE_FULL_SPECIAL_CHARS : FILTER_DEFAULT;
 

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -63,7 +63,7 @@ if (! function_exists('get_cookie')) {
      */
     function get_cookie($index, bool $xssClean = false, ?string $prefix = null)
     {
-        $prefix  = $prefix !== null ? $prefix : config(App::class)->cookiePrefix;
+        $prefix ??= config(App::class)->cookiePrefix;
         $request = Services::request();
         $filter  = $xssClean ? FILTER_SANITIZE_FULL_SPECIAL_CHARS : FILTER_DEFAULT;
 

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -61,7 +61,7 @@ if (! function_exists('get_cookie')) {
      *
      * @see \CodeIgniter\HTTP\IncomingRequest::getCookie()
      */
-    function get_cookie($index, bool $xssClean = false, string $prefix = null)
+    function get_cookie($index, bool $xssClean = false, ?string $prefix = null)
     {
         $prefix  = $prefix !== null ? $prefix : config(App::class)->cookiePrefix;
         $request = Services::request();

--- a/system/Session/Handlers/BaseHandler.php
+++ b/system/Session/Handlers/BaseHandler.php
@@ -119,7 +119,7 @@ abstract class BaseHandler implements SessionHandlerInterface
     protected function destroyCookie(): bool
     {
         return setcookie(
-            $this->cookieName,
+            config('App')->cookiePrefix . $this->cookieName,
             '',
             ['expires' => 1, 'path' => $this->cookiePath, 'domain' => $this->cookieDomain, 'secure' => $this->cookieSecure, 'httponly' => true]
         );

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -227,7 +227,7 @@ class Session implements SessionInterface
             return;
         }
 
-         $cookieName = $this->cookie->getPrefixedName();
+        $cookieName = $this->cookie->getPrefixedName();
 
         $this->configure();
         $this->setSaveHandler();

--- a/user_guide_src/source/helpers/cookie_helper.rst
+++ b/user_guide_src/source/helpers/cookie_helper.rst
@@ -39,10 +39,11 @@ The following functions are available:
     a description of its use, as this function is an alias for
     :php:func:`Response::setCookie() <setCookie>`.
 
-.. php:function:: get_cookie($index[, $xssClean = false])
+.. php:function:: get_cookie($index[, $xssClean = false[, $prefix = null]])
 
     :param    string    $index: Cookie name
     :param    bool    $xssClean: Whether to apply XSS filtering to the returned value
+    :param  string  $prefix: A custom prefix to overwrite what is set in the App Config
     :returns:    The cookie value or null if not found
     :rtype:    mixed
 


### PR DESCRIPTION
Fixes #6009

This allows the cookie_helper to enforce the default prefix if one exists, and also allows the user to set their own prefix including none at all to overwrite the prefix if necessary. This way there is no longer a collision issue if there are cookies that are prefixed and un-prefixed.

There is also an issue with the session setup where it would inconsistently set the name of the session cookie with and without the cookie prefix leading to multiple session cookies and also effectively creating the same prefixed vs un-prefixed issue.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

