### PR TITLE
Prefer `is_file()`

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -7,7 +7,7 @@ $routes = Services::routes();
 
 // Load the system's routing file first, so that the app and ENVIRONMENT
 // can override as needed.
-if (file_exists(SYSTEMPATH . 'Config/Routes.php')) {
+if (is_file(SYSTEMPATH . 'Config/Routes.php')) {
     require SYSTEMPATH . 'Config/Routes.php';
 }
 
@@ -50,6 +50,6 @@ $routes->get('/', 'Home::index');
  * You will have access to the $routes object within that file without
  * needing to reload it.
  */
-if (file_exists(APPPATH . 'Config/' . ENVIRONMENT . '/Routes.php')) {
+if (is_file(APPPATH . 'Config/' . ENVIRONMENT . '/Routes.php')) {
     require APPPATH . 'Config/' . ENVIRONMENT . '/Routes.php';
 }

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -246,7 +246,7 @@ class CodeIgniter
 
                 $file = SYSTEMPATH . 'ThirdParty/Kint/' . implode('/', $class) . '.php';
 
-                if (file_exists($file)) {
+                if (is_file($file)) {
                     require_once $file;
                 }
             });

--- a/system/Commands/Encryption/GenerateKey.php
+++ b/system/Commands/Encryption/GenerateKey.php
@@ -151,8 +151,8 @@ class GenerateKey extends BaseCommand
         $baseEnv = ROOTPATH . 'env';
         $envFile = ROOTPATH . '.env';
 
-        if (! file_exists($envFile)) {
-            if (! file_exists($baseEnv)) {
+        if (! is_file($envFile)) {
+            if (! is_file($baseEnv)) {
                 CLI::write('Both default shipped `env` file and custom `.env` are missing.', 'yellow');
                 CLI::write('Here\'s your new key instead: ' . CLI::color($newKey, 'yellow'));
                 CLI::newLine();

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -53,7 +53,7 @@ defined('COMPOSER_PATH') || define('COMPOSER_PATH', realpath(HOMEPATH . 'vendor/
 defined('VENDORPATH')    || define('VENDORPATH', realpath(HOMEPATH . 'vendor') . DIRECTORY_SEPARATOR);
 
 // Load Common.php from App then System
-if (file_exists(APPPATH . 'Common.php')) {
+if (is_file(APPPATH . 'Common.php')) {
     require_once APPPATH . 'Common.php';
 }
 

--- a/tests/system/Commands/CommandGeneratorTest.php
+++ b/tests/system/Commands/CommandGeneratorTest.php
@@ -47,7 +47,7 @@ final class CommandGeneratorTest extends CIUnitTestCase
 
     protected function getFileContents(string $filepath): string
     {
-        if (! file_exists($filepath)) {
+        if (! is_file($filepath)) {
             return '';
         }
 

--- a/tests/system/Commands/ControllerGeneratorTest.php
+++ b/tests/system/Commands/ControllerGeneratorTest.php
@@ -42,7 +42,7 @@ final class ControllerGeneratorTest extends CIUnitTestCase
 
     protected function getFileContents(string $filepath): string
     {
-        if (! file_exists($filepath)) {
+        if (! is_file($filepath)) {
             return '';
         }
 

--- a/tests/system/Commands/CreateDatabaseTest.php
+++ b/tests/system/Commands/CreateDatabaseTest.php
@@ -39,7 +39,7 @@ final class CreateDatabaseTest extends CIUnitTestCase
 
         if ($this->connection instanceof SQLite3Connection) {
             $file = WRITEPATH . 'foobar.db';
-            if (file_exists($file)) {
+            if (is_file($file)) {
                 unlink($file);
             }
         } else {

--- a/tests/system/Commands/GenerateKeyTest.php
+++ b/tests/system/Commands/GenerateKeyTest.php
@@ -36,7 +36,7 @@ final class GenerateKeyTest extends CIUnitTestCase
         $this->envPath       = ROOTPATH . '.env';
         $this->backupEnvPath = ROOTPATH . '.env.backup';
 
-        if (file_exists($this->envPath)) {
+        if (is_file($this->envPath)) {
             rename($this->envPath, $this->backupEnvPath);
         }
 
@@ -47,11 +47,11 @@ final class GenerateKeyTest extends CIUnitTestCase
     {
         stream_filter_remove($this->streamFilter);
 
-        if (file_exists($this->envPath)) {
+        if (is_file($this->envPath)) {
             unlink($this->envPath);
         }
 
-        if (file_exists($this->backupEnvPath)) {
+        if (is_file($this->backupEnvPath)) {
             rename($this->backupEnvPath, $this->envPath);
         }
 

--- a/tests/system/Commands/MigrationGeneratorTest.php
+++ b/tests/system/Commands/MigrationGeneratorTest.php
@@ -35,7 +35,7 @@ final class MigrationGeneratorTest extends CIUnitTestCase
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
-        if (file_exists($file)) {
+        if (is_file($file)) {
             unlink($file);
         }
     }

--- a/tests/system/Commands/ScaffoldGeneratorTest.php
+++ b/tests/system/Commands/ScaffoldGeneratorTest.php
@@ -42,7 +42,7 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
 
     protected function getFileContents(string $filepath): string
     {
-        if (! file_exists($filepath)) {
+        if (! is_file($filepath)) {
             return '';
         }
 

--- a/tests/system/Commands/SeederGeneratorTest.php
+++ b/tests/system/Commands/SeederGeneratorTest.php
@@ -35,7 +35,7 @@ final class SeederGeneratorTest extends CIUnitTestCase
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
-        if (file_exists($file)) {
+        if (is_file($file)) {
             unlink($file);
         }
     }

--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -326,11 +326,11 @@ final class FileMovingTest extends CIUnitTestCase
 
 function is_uploaded_file($filename)
 {
-    if (! file_exists($filename)) {
+    if (! is_file($filename)) {
         file_put_contents($filename, 'data');
     }
 
-    return file_exists($filename);
+    return is_file($filename);
 }
 
 /*

--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -78,7 +78,7 @@ final class BootstrapFCPATHTest extends CIUnitTestCase
 
     private function deleteFiles(): void
     {
-        if (file_exists($this->file1)) {
+        if (is_file($this->file1)) {
             unlink($this->file1);
         }
     }


### PR DESCRIPTION
**Description**
`file_exists()` will confirm hit on any system object (e.g. directory) as well as being less efficient. This switches to `is_file()` wherever relevant.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
