### PR TITLE
refactor: use get_filenames() 4th param in FileLocator

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -309,10 +309,7 @@ class FileLocator
                 continue;
             }
 
-            $tempFiles = get_filenames($fullPath, true);
-
-            // Remove directories
-            $tempFiles = array_filter($tempFiles, static fn ($path) => strtolower(substr($path, -4)) === '.php');
+            $tempFiles = get_filenames($fullPath, true, false, false);
 
             if (! empty($tempFiles)) {
                 $files = array_merge($files, $tempFiles);


### PR DESCRIPTION
**Description**
- use get_filenames() 4th param

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

