### PR TITLE
[Rector] Apply PHPUnitSetList::REMOVE_MOCKS

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -57,6 +57,7 @@ return static function (RectorConfig $rectorConfig): void {
         LevelSetList::UP_TO_PHP_74,
         PHPUnitSetList::PHPUNIT_SPECIFIC_METHOD,
         PHPUnitSetList::PHPUNIT_80,
+        PHPUnitSetList::REMOVE_MOCKS,
     ]);
 
     $rectorConfig->parallel();

--- a/tests/system/Database/Forge/CreateTableTest.php
+++ b/tests/system/Database/Forge/CreateTableTest.php
@@ -27,7 +27,7 @@ final class CreateTableTest extends CIUnitTestCase
             ->setConstructorArgs([[]])
             ->onlyMethods(['listTables'])
             ->getMock();
-        $dbMock->expects($this->any())
+        $dbMock
             ->method('listTables')
             ->willReturn(['foo']);
 
@@ -53,7 +53,7 @@ final class CreateTableTest extends CIUnitTestCase
             ->setConstructorArgs([[]])
             ->onlyMethods(['query'])
             ->getMock();
-        $dbMock->expects($this->any())
+        $dbMock
             ->method('query')
             ->with($sql)
             ->willReturn(true);

--- a/tests/system/Debug/Toolbar/Collectors/DatabaseTest.php
+++ b/tests/system/Debug/Toolbar/Collectors/DatabaseTest.php
@@ -37,7 +37,7 @@ final class DatabaseTest extends CIUnitTestCase
 
         $this->assertSame('1234.56 ms', $queries[0]['duration']);
         $this->assertSame('<strong>SHOW</strong> TABLES;', $queries[0]['sql']);
-        $this->assertSame(clean_path(__FILE__) . ':35', $queries[0]['trace-file']);
+        $this->assertSame(clean_path(__FILE__) . ':33', $queries[0]['trace-file']);
 
         foreach ($queries[0]['trace'] as $i => $trace) {
             // since we added the index numbering

--- a/tests/system/Debug/Toolbar/Collectors/DatabaseTest.php
+++ b/tests/system/Debug/Toolbar/Collectors/DatabaseTest.php
@@ -23,9 +23,7 @@ final class DatabaseTest extends CIUnitTestCase
     public function testDisplay(): void
     {
         /** @var MockObject&Query $query */
-        $query = $this->getMockBuilder(Query::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $query = $this->createMock(Query::class);
 
         // set mock returns
         $query->method('getQuery')->willReturn('SHOW TABLES;');


### PR DESCRIPTION
Apply PHPUnitSetList::REMOVE_MOCKS to remove unnecessary mock calls.

**Checklist:**
- [x] Securely signed commits
