### PR TITLE
fix: IP address validation with type error prevent

### DIFF
--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -274,7 +274,7 @@ class FormatRules
                 break;
 
             default:
-                $which = 0;
+                $which = FILTER_DEFAULT;
         }
 
         return filter_var($ip, FILTER_VALIDATE_IP, $which) !== false


### PR DESCRIPTION
Ip validation update for default option using FILTER_DEFAULT

**Description**
In php8, $which = 0; results error like:
Fatal error: Uncaught TypeError: filter_var(): Argument #3 ($options) must be of type array

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
