### PR TITLE
Bug: The SQLSRV driver ignores the port value from the config.

### DIFF
--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -120,6 +120,10 @@ class Connection extends BaseConnection
             unset($connection['UID'], $connection['PWD']);
         }
 
+        if (strpos($this->hostname, ',') === false) {
+            $this->hostname = $this->port !== '' ? "{$this->hostname}, {$this->port}" : $this->hostname;
+        }
+
         sqlsrv_configure('WarningsReturnAsErrors', 0);
         $this->connID = sqlsrv_connect($this->hostname, $connection);
 

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -120,8 +120,8 @@ class Connection extends BaseConnection
             unset($connection['UID'], $connection['PWD']);
         }
 
-        if (strpos($this->hostname, ',') === false) {
-            $this->hostname = $this->port !== '' ? "{$this->hostname}, {$this->port}" : $this->hostname;
+        if (strpos($this->hostname, ',') === false && $this->port !== '') {
+            $this->hostname .= ', ' . $this->port;
         }
 
         sqlsrv_configure('WarningsReturnAsErrors', 0);

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -119,5 +119,6 @@ Deprecations
 
 Bugs Fixed
 **********
+- The SQLSRV driver ignores the port value from the config.
 
 See the repo's `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_ for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
Fixes https://github.com/codeigniter4/CodeIgniter4/issues/6032

The SQLSRV driver ignores the port value from the config.

This PR fixes a bug.
Also, if a port is already specified in the hostname, the port from the configuration will be ignored.

It seems to me that the default tests are enough, because the database connection settings for the tests use the default port, which was ignored when configuring the connection.

**Checklist:**
- [x] Securely signed commits


