### PR TITLE
fix: `set_radio()` not working as expected

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -571,7 +571,6 @@ if (! function_exists('set_select')) {
      * Set Select
      *
      * Let's you set the selected value of a <select> menu via data in the POST array.
-     * If Form Validation is active it retrieves the info from the validation class
      */
     function set_select(string $field, string $value = '', bool $default = false): string
     {
@@ -608,7 +607,6 @@ if (! function_exists('set_checkbox')) {
      * Set Checkbox
      *
      * Let's you set the selected value of a checkbox via the value in the POST array.
-     * If Form Validation is active it retrieves the info from the validation class
      */
     function set_checkbox(string $field, string $value = '', bool $default = false): string
     {
@@ -646,7 +644,6 @@ if (! function_exists('set_radio')) {
      * Set Radio
      *
      * Let's you set the selected value of a radio field via info in the POST array.
-     * If Form Validation is active it retrieves the info from the validation class
      */
     function set_radio(string $field, string $value = '', bool $default = false): string
     {

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -650,14 +650,21 @@ if (! function_exists('set_radio')) {
         $request = Services::request();
 
         // Try any old input data we may have first
-        $input = $request->getOldInput($field);
-        if ($input === null) {
-            $input = $request->getPost($field) ?? $default;
+        $oldInput = $request->getOldInput($field);
+
+        $postInput = $request->getPost($field);
+
+        if ($oldInput !== null) {
+            $input = $oldInput;
+        } elseif ($postInput !== null) {
+            $input = $postInput;
+        } else {
+            $input = $default;
         }
 
         if (is_array($input)) {
             // Note: in_array('', array(0)) returns TRUE, do not use it
-            foreach ($input as &$v) {
+            foreach ($input as $v) {
                 if ($value === $v) {
                     return ' checked="checked"';
                 }
@@ -667,16 +674,11 @@ if (! function_exists('set_radio')) {
         }
 
         // Unchecked checkbox and radio inputs are not even submitted by browsers ...
-        $result = '';
-        if ((string) $input === '0' || ! empty($input = $request->getPost($field)) || ! empty($input = old($field))) {
-            $result = ($input === $value) ? ' checked="checked"' : '';
+        if ($oldInput !== null || $postInput !== null) {
+            return ((string) $input === $value) ? ' checked="checked"' : '';
         }
 
-        if (empty($result)) {
-            $result = ($default === true) ? ' checked="checked"' : '';
-        }
-
-        return $result;
+        return ($default === true) ? ' checked="checked"' : '';
     }
 }
 

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -919,6 +919,9 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testSetRadioDefault()
     {
+        $_SESSION = [];
+        $_POST    = [];
+
         $this->assertSame(' checked="checked"', set_radio('code', 'alpha', true));
         $this->assertSame('', set_radio('code', 'beta', false));
     }

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -838,7 +838,7 @@ final class FormHelperTest extends CIUnitTestCase
      * @runInSeparateProcess
      * @preserveGlobalState  disabled
      */
-    public function testSetRadio()
+    public function testSetRadioFromSessionOldInput()
     {
         $_SESSION = [
             '_ci_old_input' => [
@@ -883,7 +883,7 @@ final class FormHelperTest extends CIUnitTestCase
         $this->assertSame(' checked="checked"', set_radio('bar', '0', true));
     }
 
-    public function testSetRadioFromPostArray()
+    public function testSetRadioFromSessionOldInputPostArray()
     {
         $_SESSION = [
             '_ci_old_input' => [
@@ -900,7 +900,7 @@ final class FormHelperTest extends CIUnitTestCase
         $this->assertSame('', set_radio('bar', 'baz'));
     }
 
-    public function testSetRadioFromPostArrayWithValueZero()
+    public function testSetRadioFromSessionOldInputPostArrayWithValueZero()
     {
         $_SESSION = [
             '_ci_old_input' => [

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -843,12 +843,12 @@ final class FormHelperTest extends CIUnitTestCase
         $_SESSION = [
             '_ci_old_input' => [
                 'post' => [
-                    'foo' => 'bar',
+                    'foo' => '<bar>',
                 ],
             ],
         ];
 
-        $this->assertSame(' checked="checked"', set_radio('foo', 'bar'));
+        $this->assertSame(' checked="checked"', set_radio('foo', '<bar>'));
         $this->assertSame('', set_radio('foo', 'baz'));
 
         unset($_SESSION['_ci_old_input']);
@@ -864,7 +864,7 @@ final class FormHelperTest extends CIUnitTestCase
 
         $this->assertSame(' checked="checked"', set_radio('bar', 'baz'));
         $this->assertSame('', set_radio('bar', 'boop'));
-        $this->assertSame(' checked="checked"', set_radio('bar', 'boop', true));
+        $this->assertSame('', set_radio('bar', 'boop', true));
     }
 
     /**
@@ -873,7 +873,7 @@ final class FormHelperTest extends CIUnitTestCase
      */
     public function testSetRadioFromPostWithValueZero()
     {
-        $_POST['bar'] = 0;
+        $_POST['bar'] = '0';
 
         $this->assertSame(' checked="checked"', set_radio('bar', '0'));
         $this->assertSame('', set_radio('bar', 'boop'));

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -850,6 +850,7 @@ final class FormHelperTest extends CIUnitTestCase
 
         $this->assertSame(' checked="checked"', set_radio('foo', 'bar'));
         $this->assertSame('', set_radio('foo', 'baz'));
+
         unset($_SESSION['_ci_old_input']);
     }
 
@@ -860,6 +861,7 @@ final class FormHelperTest extends CIUnitTestCase
     public function testSetRadioFromPost()
     {
         $_POST['bar'] = 'baz';
+
         $this->assertSame(' checked="checked"', set_radio('bar', 'baz'));
         $this->assertSame('', set_radio('bar', 'boop'));
         $this->assertSame(' checked="checked"', set_radio('bar', 'boop', true));
@@ -872,10 +874,12 @@ final class FormHelperTest extends CIUnitTestCase
     public function testSetRadioFromPostWithValueZero()
     {
         $_POST['bar'] = 0;
+
         $this->assertSame(' checked="checked"', set_radio('bar', '0'));
         $this->assertSame('', set_radio('bar', 'boop'));
 
         $_POST = [];
+
         $this->assertSame(' checked="checked"', set_radio('bar', '0', true));
     }
 
@@ -891,6 +895,7 @@ final class FormHelperTest extends CIUnitTestCase
                 ],
             ],
         ];
+
         $this->assertSame(' checked="checked"', set_radio('bar', 'boop'));
         $this->assertSame('', set_radio('bar', 'baz'));
     }
@@ -907,6 +912,7 @@ final class FormHelperTest extends CIUnitTestCase
                 ],
             ],
         ];
+
         $this->assertSame(' checked="checked"', set_radio('bar', '0'));
         $this->assertSame('', set_radio('bar', 'baz'));
     }

--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -510,8 +510,3 @@ The following functions are available:
         <input type="radio" name="myradio" value="1" <?= set_radio('myradio', '1', true) ?> />
         <input type="radio" name="myradio" value="2" <?= set_radio('myradio', '2') ?> />
 
-    .. note:: If you are using the Validation class, you must always specify
-        a rule for your field, even if empty, in order for the ``set_*()``
-        functions to work. This is because if a Validation object is
-        defined, the control for ``set_*()`` is handed over to a method of the
-        class instead of the generic helper function.


### PR DESCRIPTION
**Description**
Fixes #6030

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
