### PR TITLE
Added `type` param for `get_file_info()`

### DIFF
--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -289,7 +289,7 @@ if (! function_exists('get_file_info')) {
      *
      * Given a file and path, returns the name, path, size, date modified
      * Second parameter allows you to explicitly declare what information you want returned
-     * Options are: name, server_path, size, date, readable, writable, executable, fileperms
+     * Options are: name, server_path, size, date, type, readable, writable, executable, fileperms
      * Returns false if the file cannot be found.
      *
      * @param string $file           Path to file
@@ -297,7 +297,7 @@ if (! function_exists('get_file_info')) {
      *
      * @return array|null
      */
-    function get_file_info(string $file, $returnedValues = ['name', 'server_path', 'size', 'date'])
+    function get_file_info(string $file, $returnedValues = ['name', 'server_path', 'size', 'date', 'type'])
     {
         if (! is_file($file)) {
             return null;
@@ -325,6 +325,10 @@ if (! function_exists('get_file_info')) {
 
                 case 'date':
                     $fileInfo['date'] = filemtime($file);
+                    break;
+
+                case 'type':
+                    $fileInfo['type'] = pathinfo($file, PATHINFO_EXTENSION);
                     break;
 
                 case 'readable':

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -400,6 +400,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
                 'server_path'   => $file,
                 'size'          => $info['size'],
                 'date'          => $info['date'],
+                'type'          => $info['type'],
                 'relative_path' => realpath(__DIR__ . '/../../_support/Files/baker'),
             ],
         ];
@@ -437,6 +438,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
             'server_path' => $file,
             'size'        => $info['size'],
             'date'        => $info['date'],
+            'type'        => $info['type'],
         ];
 
         $this->assertSame($expected, get_file_info(SUPPORTPATH . 'Files/baker/banana.php'));
@@ -451,6 +453,21 @@ final class FilesystemHelperTest extends CIUnitTestCase
         ];
 
         $this->assertSame($expected, get_file_info(SUPPORTPATH . 'Files/baker/banana.php', 'readable,writable,executable'));
+    }
+
+    public function testGetFileType()
+    {
+        $expected = [
+            'type'   => 'gif',
+        ];
+
+        $this->assertSame($expected, get_file_info(SUPPORTPATH . 'Images/ci-logo.gif', 'type'));
+
+        $expected = [
+            'type'   => 'php',
+        ];
+
+        $this->assertSame($expected, get_file_info(SUPPORTPATH . 'Files/able/apple.php', 'type'));
     }
 
     public function testGetFileInfoPerms()

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -91,6 +91,7 @@ Others
     - The log format has also changed. If users are depending on the log format in their apps, the new log format is "<1-based count> <cleaned filepath>(<line>): <class><function><args>"
 - Added support for webp files to **app/Config/Mimes.php**.
 - Added 4th parameter ``$includeDir`` to ``get_filenames()``. See :php:func:`get_filenames`.
+- Added parameter ``type`` to ``get_file_info()``. See :php:func:`get_file_info`.
 - HTML helper ``script_tag()`` now uses ``null`` values to write boolean attributes in minimized form: ``<script src="..." defer />``. See the sample code for :php:func:`script_tag`.
 - RouteCollection::addRedirect() can now use placeholders.
 - Debugbar enhancements

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -184,18 +184,18 @@ The following functions are available:
 
     .. literalinclude:: filesystem_helper/011.php
 
-.. php:function:: get_file_info($file[, $returnedValues = ['name', 'server_path', 'size', 'date']])
+.. php:function:: get_file_info($file[, $returnedValues = ['name', 'server_path', 'size', 'date', 'type']])
 
     :param    string        $file: File path
     :param    array|string  $returnedValues: What type of info to return to be passed as array or comma separated string
     :returns:    An array containing info on the specified file or false on failure
     :rtype:    array
 
-    Given a file and path, returns (optionally) the *name*, *path*, *size* and *date modified*
+    Given a file and path, returns (optionally) the *name*, *path*, *size*, *type* and *date modified*
     information attributes for a file. Second parameter allows you to explicitly declare what
     information you want returned.
 
-    Valid ``$returnedValues`` options are: ``name``, ``size``, ``date``, ``readable``, ``writeable``,
+    Valid ``$returnedValues`` options are: ``name``, ``size``, ``date``, ``type``, ``readable``, ``writeable``,
     ``executable`` and ``fileperms``.
 
 .. php:function:: symbolic_permissions($perms)


### PR DESCRIPTION
PR allows the `get_file_info()` function in file `filesystem_helper.php` to return the file type.


**Description**
Need rebase and cs-fix.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide


