### PR TITLE
Use FrameworkException instead of assert on missing context on CodeIgniter::run()

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -304,10 +304,9 @@ class CodeIgniter
      */
     public function run(?RouteCollectionInterface $routes = null, bool $returnResponse = false)
     {
-        assert(
-            $this->context !== null,
-            'Context must be set before run() is called. If you are upgrading from 4.1.x, you need to merge `public/index.php` and `spark` file from `vendor/codeigniter4/framework`.'
-        );
+        if ($this->context === null) {
+            throw FrameworkException::forMissingContext();
+        }
 
         $this->startBenchmark();
 

--- a/system/Exceptions/FrameworkException.php
+++ b/system/Exceptions/FrameworkException.php
@@ -63,4 +63,16 @@ class FrameworkException extends RuntimeException implements ExceptionInterface
     {
         return new static(lang('Fabricator.createFailed', [$table, $reason]));
     }
+
+    public static function forMissingContext()
+    {
+        $message = <<<'MESSAGE'
+            Context must be set before $app->run() is called. If you are upgrading from 4.1.x, you need to merge the following files:
+                - public/index.php
+                - spark
+            from vendor/codeigniter4/framework
+            MESSAGE;
+
+        return new static($message);
+    }
 }


### PR DESCRIPTION
@paulbalandan @kenjis based on our discussion on on slack, this PR update `assert()` usage to `FrameworkException` for missing context in `CodeIgniter::run()`.

**Before**

![Screen Shot 2022-05-30 at 09 08 39](https://user-images.githubusercontent.com/459648/170904574-35fe1271-8b4f-422d-bf0d-c3e5e4f4a8b2.png)

**After**

![Screen Shot 2022-05-30 at 09 10 30](https://user-images.githubusercontent.com/459648/170904629-bad458db-94ab-4423-bb1b-dadd7465d4ac.png)


**Checklist:**
- [x] Securely signed commits
