### PR TITLE
fix: add config for SQLite3 Foreign Keys

### DIFF
--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -38,6 +38,20 @@ class Connection extends BaseConnection
     public $escapeChar = '`';
 
     /**
+     * @var bool Enable Foreign Key constraint or not
+     */
+    protected $foreignKeys = false;
+
+    public function initialize()
+    {
+        parent::initialize();
+
+        if ($this->foreignKeys) {
+            $this->enableForeignKeyChecks();
+        }
+    }
+
+    /**
      * Connect to the database.
      *
      * @throws DatabaseException

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -105,9 +105,9 @@ default group's configuration settings. The values should be name following this
 Explanation of Values:
 **********************
 
-==============  ===========================================================================================================
+=============== ===========================================================================================================
  Name Config    Description
-==============  ===========================================================================================================
+=============== ===========================================================================================================
 **dsn**         The DSN connect string (an all-in-one configuration sequence).
 **hostname**    The hostname of your database server. Often this is 'localhost'.
 **username**    The username used to connect to the database.
@@ -140,8 +140,12 @@ Explanation of Values:
 **port**        The database port number. To use this value you have to add a line to the database config array.
 
                 .. literalinclude:: configuration/009.php
+**foreignKeys** true/false (boolean) - Whether or not to enable Foreign Key constraint (``SQLite3`` only).
 
-==============  ===========================================================================================================
+                .. important:: SQLite3 Foreign Key constraint is disabled by default.
+                    See `SQLite documentation <https://www.sqlite.org/pragma.html#pragma_foreign_keys>`_.
+                    To enforce Foreign Key constraint, set this config item to true.
+=============== ===========================================================================================================
 
 .. note:: Depending on what database platform you are using (MySQL, PostgreSQL,
     etc.) not all values will be needed. For example, when using SQLite you


### PR DESCRIPTION
~~Need to rebase after merging #6049~~

**Description**
Fixes #6008
- add DB config `foreignKeys` for SQLite3 (disabled by default)

**How to Test**
```php
<?php

namespace App\Controllers;

use Config\Database;

class Home extends BaseController
{
    public function index()
    {
        $group = [
            'database'    => 'sqlite3.db',
            'DBDriver'    => 'SQLite3',
            'DBPrefix'    => 'db_',
            'DBDebug'     => (ENVIRONMENT !== 'production'),
            'foreignKeys' => true, // Add the config
        ];
        $db = \Config\Database::connect($group);

        $this->forge = Database::forge($group);

        $this->createTableAuthUsers();
        $this->createTableAuthIdentities();

        $prefix = $db->getPrefix();

        $sql = "INSERT INTO {$prefix}auth_identities"
            . ' (user_id, type, secret, created_at)'
            . " VALUES (2, 'email_2fa', '479123', '2022-05-18 23:01:46')";
        $db->simpleQuery($sql);

        $query = $db->query("select * from {$prefix}auth_users");
        var_dump($query->getResult());
        $query = $db->query("select * from {$prefix}auth_identities");
        var_dump($query->getResult());
    }

    private function createTableAuthUsers()
    {
        $this->forge->addField([
            'id' => [
                'type'           => 'int',
                'constraint'     => 11,
                'unsigned'       => true,
                'auto_increment' => true,
            ],
            'username' => [
                'type'       => 'varchar',
                'constraint' => 30,
                'null'       => true,
            ],
            'active' => [
                'type'       => 'tinyint',
                'constraint' => 1,
                'null'       => 0,
                'default'    => 0,
            ],
            'last_active' => [
                'type' => 'datetime',
                'null' => true,
            ],
            'created_at' => [
                'type' => 'datetime',
                'null' => true,
            ],
        ]);
        $this->forge->addPrimaryKey('id');
        $this->forge->addUniqueKey('username');
        $this->forge->createTable('auth_users', true);
    }

    private function createTableAuthIdentities()
    {
        $this->forge->addField([
            'id'           => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'auto_increment' => true],
            'user_id'      => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'null' => true],
            'type'         => ['type' => 'varchar', 'constraint' => 255],
            'secret'       => ['type' => 'varchar', 'constraint' => 255],
            'secret2'      => ['type' => 'varchar', 'constraint' => 255, 'null' => true],
            'expires'      => ['type' => 'datetime', 'null' => true],
            'last_used_at' => ['type' => 'datetime', 'null' => true],
            'created_at'   => ['type' => 'datetime', 'null' => true],
        ]);
        $this->forge->addPrimaryKey('id');
        $this->forge->addUniqueKey(['type', 'secret']);
        $this->forge->addKey('user_id');
        $this->forge->addForeignKey('user_id', 'auth_users', 'id', '', 'CASCADE');
        $this->forge->createTable('auth_identities', true);
    }
}
```
Navigate to http://localhost:8080/
```
ErrorException
SQLite3::exec(): FOREIGN KEY constraint failed 
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

