### PR TITLE
fix: SQLite3\Table::copyData() does not escape column names

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Database;
 use Closure;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Events\Events;
+use stdClass;
 use Throwable;
 
 /**
@@ -974,6 +975,7 @@ abstract class BaseConnection implements ConnectionInterface
      * @param bool         $fieldExists        Supplied $item contains a column name?
      *
      * @return array|string
+     * @phpstan-return ($item is array ? array : string)
      */
     public function protectIdentifiers($item, bool $prefixSingle = false, ?bool $protectIdentifiers = null, bool $fieldExists = true)
     {
@@ -1444,7 +1446,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns an object with field data
      *
-     * @return array
+     * @return stdClass[]
      */
     public function getFieldData(string $table)
     {

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -279,7 +279,9 @@ class Table
         $exFields  = implode(', ', $exFields);
         $newFields = implode(', ', $newFields);
 
-        $this->db->query("INSERT INTO {$this->prefixedTableName}({$newFields}) SELECT {$exFields} FROM {$this->db->DBPrefix}temp_{$this->tableName}");
+        $this->db->query(
+            "INSERT INTO {$this->prefixedTableName}({$newFields}) SELECT {$exFields} FROM {$this->db->DBPrefix}temp_{$this->tableName}"
+        );
     }
 
     /**

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -28,6 +28,7 @@ class Table
      * All of the fields this table represents.
      *
      * @var array
+     * @phpstan-var array<string, array<string, bool|int|string|null>>
      */
     protected $fields = [];
 
@@ -276,8 +277,14 @@ class Table
             $exFields[]  = $name;
         }
 
-        $exFields  = implode(', ', $exFields);
-        $newFields = implode(', ', $newFields);
+        $exFields = implode(
+            ', ',
+            array_map(fn ($item) => $this->db->protectIdentifiers($item), $exFields)
+        );
+        $newFields = implode(
+            ', ',
+            array_map(fn ($item) => $this->db->protectIdentifiers($item), $newFields)
+        );
 
         $this->db->query(
             "INSERT INTO {$this->prefixedTableName}({$newFields}) SELECT {$exFields} FROM {$this->db->DBPrefix}temp_{$this->tableName}"
@@ -291,6 +298,7 @@ class Table
      * @param array|bool $fields
      *
      * @return mixed
+     * @phpstan-return ($fields is array ? array : mixed)
      */
     protected function formatFields($fields)
     {

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -51,6 +51,7 @@ final class AlterTableTest extends CIUnitTestCase
         $config = [
             'DBDriver' => 'SQLite3',
             'database' => 'database.db',
+            'DBDebug'  => true,
         ];
 
         $this->db    = db_connect($config);

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -89,7 +89,7 @@ final class AlterTableTest extends CIUnitTestCase
 
         $fields = $this->getPrivateProperty($this->table, 'fields');
 
-        $this->assertCount(4, $fields);
+        $this->assertCount(5, $fields);
         $this->assertArrayHasKey('id', $fields);
         $this->assertNull($fields['id']['default']);
         $this->assertTrue($fields['id']['null']);
@@ -264,6 +264,11 @@ final class AlterTableTest extends CIUnitTestCase
                 'type'       => 'integer',
                 'constraint' => 11,
                 'unsigned'   => true,
+            ],
+            'group' => [
+                'type'       => 'varchar',
+                'constraint' => 255,
+                'null'       => true,
             ],
         ]);
         $this->forge->addPrimaryKey('id');

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -220,7 +220,7 @@ final class AlterTableTest extends CIUnitTestCase
             ->dropColumn('name')
             ->run();
 
-        $this->dontSeeInDatabase('foo', ['name' => 'George Clinton']);
+        $this->assertFalse($this->db->fieldExists('name', 'foo'));
         $this->seeInDatabase('foo', ['email' => 'funkalicious@example.com']);
     }
 


### PR DESCRIPTION
**Description**
Fixes #5946

- fix `SQLite3\Table::copyData()`
- fix SQLite3 test assertion that raises a hidden error

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
