### PR TITLE
Fix `slash_item()` erroring when property fetched does not exist on `Config\App`

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -1013,7 +1013,7 @@ if (! function_exists('slash_item')) {
      */
     function slash_item(string $item): ?string
     {
-        $config     = config(App::class);
+        $config = config(App::class);
 
         if (property_exists($config, $item)) {
             $configItem = $config->{$item};

--- a/system/Common.php
+++ b/system/Common.php
@@ -1015,12 +1015,25 @@ if (! function_exists('slash_item')) {
     {
         $config = config(App::class);
 
-        if (property_exists($config, $item)) {
-            $configItem = $config->{$item};
+        if (! property_exists($config, $item)) {
+            return null;
         }
 
-        if (! isset($configItem) || empty(trim($configItem))) {
-            return null;
+        $configItem = $config->{$item};
+
+        if (! is_scalar($configItem)) {
+            throw new RuntimeException(sprintf(
+                'Cannot convert "%s::$%s" of type "%s" to type "string".',
+                App::class,
+                $item,
+                gettype($configItem)
+            ));
+        }
+
+        $configItem = trim((string) $configItem);
+
+        if ($configItem === '') {
+            return $configItem;
         }
 
         return rtrim($configItem, '/') . '/';

--- a/system/Common.php
+++ b/system/Common.php
@@ -1014,10 +1014,13 @@ if (! function_exists('slash_item')) {
     function slash_item(string $item): ?string
     {
         $config     = config(App::class);
-        $configItem = $config->{$item};
+
+        if (property_exists($config, $item)) {
+            $configItem = $config->{$item};
+        }
 
         if (! isset($configItem) || empty(trim($configItem))) {
-            return $configItem;
+            return null;
         }
 
         return rtrim($configItem, '/') . '/';

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -391,7 +391,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
     public function testSlashItem()
     {
         $this->assertSame('/', slash_item('cookiePath')); // slash already there
-        $this->assertSame('', slash_item('cookieDomain')); // empty, so untouched
+        $this->assertNull(null, slash_item('cookieDomain')); // empty, so untouched
         $this->assertSame('en/', slash_item('defaultLocale')); // slash appended
     }
 

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -30,6 +30,7 @@ use Config\App;
 use Config\Logger;
 use Config\Modules;
 use Kint;
+use RuntimeException;
 use stdClass;
 use Tests\Support\Models\JobModel;
 
@@ -390,9 +391,28 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
     public function testSlashItem()
     {
-        $this->assertSame('/', slash_item('cookiePath')); // slash already there
-        $this->assertNull(null, slash_item('cookieDomain')); // empty, so untouched
-        $this->assertSame('en/', slash_item('defaultLocale')); // slash appended
+        $this->assertSame('/', slash_item('cookiePath')); // /
+        $this->assertSame('', slash_item('cookieDomain')); // ''
+        $this->assertSame('en/', slash_item('defaultLocale')); // en
+        $this->assertSame('7200/', slash_item('sessionExpiration')); // int 7200
+        $this->assertSame('', slash_item('negotiateLocale')); // false
+        $this->assertSame('1/', slash_item('cookieHTTPOnly')); // true
+    }
+
+    public function testSlashItemOnInexistentItem()
+    {
+        $this->assertNull(slash_item('foo'));
+        $this->assertNull(slash_item('bar'));
+        $this->assertNull(slash_item('cookieDomains'));
+        $this->assertNull(slash_item('indices'));
+    }
+
+    public function testSlashItemThrowsErrorOnNonStringableItem()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot convert "Config\\App::$supportedLocales" of type "array" to type "string".');
+
+        slash_item('supportedLocales');
     }
 
     protected function injectSessionMock()


### PR DESCRIPTION
**Description**
Supersedes and closes #5973 
Fixes #5967 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
