### PR TITLE
Fix MIME guessing of extension from type

### DIFF
--- a/app/Config/Mimes.php
+++ b/app/Config/Mimes.php
@@ -102,8 +102,6 @@ class Mimes
         ],
         'pptx' => [
             'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-            'application/x-zip',
-            'application/zip',
         ],
         'wbxml' => 'application/wbxml',
         'wmlc'  => 'application/wmlc',
@@ -512,20 +510,19 @@ class Mimes
 
         $proposedExtension = trim(strtolower($proposedExtension ?? ''));
 
-        if ($proposedExtension !== '') {
-            if (array_key_exists($proposedExtension, static::$mimes) && in_array($type, is_string(static::$mimes[$proposedExtension]) ? [static::$mimes[$proposedExtension]] : static::$mimes[$proposedExtension], true)) {
-                // The detected mime type matches with the proposed extension.
-                return $proposedExtension;
-            }
-
-            // An extension was proposed, but the media type does not match the mime type list.
-            return null;
+        if (
+            $proposedExtension !== ''
+            && array_key_exists($proposedExtension, static::$mimes)
+            && in_array($type, (array) static::$mimes[$proposedExtension], true)
+        ) {
+            // The detected mime type matches with the proposed extension.
+            return $proposedExtension;
         }
 
         // Reverse check the mime type list if no extension was proposed.
         // This search is order sensitive!
         foreach (static::$mimes as $ext => $types) {
-            if ((is_string($types) && $types === $type) || (is_array($types) && in_array($type, $types, true))) {
+            if (in_array($type, (array) $types, true)) {
                 return $ext;
             }
         }

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -89,7 +89,12 @@ class File extends SplFileInfo
      */
     public function guessExtension(): ?string
     {
-        return Mimes::guessExtensionFromType($this->getMimeType());
+        // naively get the path extension using pathinfo
+        $pathinfo = pathinfo($this->getRealPath() ?: $this->__toString()) + ['extension' => ''];
+
+        $proposedExtension = $pathinfo['extension'];
+
+        return Mimes::guessExtensionFromType($this->getMimeType(), $proposedExtension);
     }
 
     /**

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Files;
 
 use CodeIgniter\Files\Exceptions\FileNotFoundException;
 use CodeIgniter\Test\CIUnitTestCase;
+use ZipArchive;
 
 /**
  * @internal
@@ -44,10 +45,34 @@ final class FileTest extends CIUnitTestCase
     {
         $file = new File(SYSTEMPATH . 'Common.php');
         $this->assertSame('php', $file->guessExtension());
+
         $file = new File(SYSTEMPATH . 'index.html');
         $this->assertSame('html', $file->guessExtension());
+
         $file = new File(ROOTPATH . 'phpunit.xml.dist');
         $this->assertSame('xml', $file->guessExtension());
+
+        $tmp  = tempnam(SUPPORTPATH, 'foo');
+        $file = new File($tmp, true);
+        $this->assertNull($file->guessExtension());
+        unlink($tmp);
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/6046
+     */
+    public function testGuessExtensionOnZip(): void
+    {
+        $tmp = SUPPORTPATH . 'foobar.zip';
+
+        $zip = new ZipArchive();
+        $zip->open($tmp, ZipArchive::CREATE | ZipArchive::CHECKCONS | ZipArchive::EXCL);
+        $zip->addFile(SYSTEMPATH . 'Common.php');
+        $zip->close();
+
+        $file = new File($tmp, true);
+        $this->assertSame('zip', $file->guessExtension());
+        unlink($tmp);
     }
 
     public function testRandomName()

--- a/tests/system/HTTP/Files/FileCollectionTest.php
+++ b/tests/system/HTTP/Files/FileCollectionTest.php
@@ -194,7 +194,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $this->assertInstanceOf(UploadedFile::class, $file);
         $this->assertSame('txt', $file->getExtension());
         // but not client mime type
-        $this->assertNull(Mimes::guessExtensionFromType($file->getClientMimeType(), $file->getClientExtension()));
+        $this->assertSame('csv', Mimes::guessExtensionFromType($file->getClientMimeType(), $file->getClientExtension()));
 
         // proposed extension does not match finfo_open mime type (text/plain)
         // but can be resolved by reverse searching
@@ -208,14 +208,12 @@ final class FileCollectionTest extends CIUnitTestCase
         $this->assertSame('zip', $file->getExtension());
 
         // proposed extension matches client mime type, but not finfo_open mime type (application/zip)
-        // this is a zip file (userFile4) but hat been renamed to 'rar'
+        // this is a zip file (userFile4) but has been renamed to 'rar'
         $file = $collection->getFile('userfile5');
         $this->assertInstanceOf(UploadedFile::class, $file);
-        // getExtension falls back to clientExtension (insecure)
-        $this->assertSame('rar', $file->getExtension());
+        $this->assertSame('zip', $file->getExtension());
         $this->assertSame('rar', Mimes::guessExtensionFromType($file->getClientMimeType(), $file->getClientExtension()));
-        // guessExtension is secure and does not returns empty
-        $this->assertSame('', $file->guessExtension());
+        $this->assertSame('zip', $file->guessExtension());
     }
 
     /**

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -12,6 +12,7 @@ See all the changes.
 .. toctree::
     :titlesonly:
 
+    v4.2.1
     v4.2.0
     v4.1.9
     v4.1.8

--- a/user_guide_src/source/changelogs/v4.2.1.rst
+++ b/user_guide_src/source/changelogs/v4.2.1.rst
@@ -1,0 +1,18 @@
+Version 4.2.1
+#############
+
+Release Date: Unreleased
+
+**4.2.1 release of CodeIgniter4**
+
+.. contents::
+    :local:
+    :depth: 2
+
+BREAKING
+********
+
+Behavior Changes
+================
+
+- Guessing the file extension from the MIME type has been changed if the proposed extension is not valid. Previously, the guessing will early terminate and return ``null``. Now, if a proposed extension is given and is invalid, the MIME guessing will continue checking using the mapping of extension to MIME types.

--- a/user_guide_src/source/installation/upgrade_421.rst
+++ b/user_guide_src/source/installation/upgrade_421.rst
@@ -16,7 +16,7 @@ Mandatory File Changes
 **********************
 
 app/Config/Mimes.php
-===================
+====================
 
 - The mapping of file extensions to MIME types in **app/Config/Mimes.php** was updated to fix a bug. Also, the logic of ``Mimes::getExtensionFromType()`` was changed.
 

--- a/user_guide_src/source/installation/upgrade_421.rst
+++ b/user_guide_src/source/installation/upgrade_421.rst
@@ -1,0 +1,53 @@
+#############################
+Upgrading from 4.2.0 to 4.2.1
+#############################
+
+Please refer to the upgrade instructions corresponding to your installation method.
+
+- :ref:`Composer Installation App Starter Upgrading <app-starter-upgrading>`
+- :ref:`Composer Installation Adding CodeIgniter4 to an Existing Project Upgrading <adding-codeigniter4-upgrading>`
+- :ref:`Manual Installation Upgrading <installing-manual-upgrading>`
+
+.. contents::
+    :local:
+    :depth: 2
+
+Mandatory File Changes
+**********************
+
+app/Config/Mimes.php
+===================
+
+- The mapping of file extensions to MIME types in **app/Config/Mimes.php** was updated to fix a bug. Also, the logic of ``Mimes::getExtensionFromType()`` was changed.
+
+Breaking Changes
+****************
+
+
+Breaking Enhancements
+*********************
+
+
+Project Files
+*************
+
+Numerous files in the **project space** (root, app, public, writable) received updates. Due to
+these files being outside of the **system** scope they will not be changed without your intervention.
+There are some third-party CodeIgniter modules available to assist with merging changes to
+the project space: `Explore on Packagist <https://packagist.org/explore/?query=codeigniter4%20updates>`_.
+
+.. note:: Except in very rare cases for bug fixes, no changes made to files for the project space
+    will break your application. All changes noted here are optional until the next major version,
+    and any mandatory changes will be covered in the sections above.
+
+Content Changes
+===============
+
+
+All Changes
+===========
+
+This is a list of all files in the **project space** that received changes;
+many will be simple comments or formatting that have no effect on the runtime:
+
+* app/Config/Mimes.php

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -12,6 +12,7 @@ upgrading from.
 .. toctree::
     :titlesonly:
 
+    upgrade_421
     upgrade_420
     upgrade_418
     upgrade_417


### PR DESCRIPTION
**Description**
Fixes #6046 by relying on the path extension as the `$proposedExtension` argument to `Config\Mimes::guessExtensionFromType()`. The extension is derived using `pathinfo()`

However, this fix also changes the behavior of the guessing if a proposed extension is given. Previously, if the proposal is invalid, the guessing ends and returns `null`. Now, this early termination is removed and the guessing is continued using the array mapping of extension to MIME types.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
