### PR TITLE
docs: add how to link to a function in contributing/documentation.rst

### DIFF
--- a/contributing/documentation.rst
+++ b/contributing/documentation.rst
@@ -120,3 +120,10 @@ To a URL
 ========
 
     `CodeIgniter 4 framework <https://github.com/codeigniter4/framework>`_
+
+To a Function
+=============
+
+    :php:func:`dot_array_search`
+
+    :php:func:`Response::setCookie() <setCookie>`


### PR DESCRIPTION
**Description**
- add how to link to a function

I don't know why, but the following does not work.
```
:php:meth:`Response::setCookie() <CodeIgniter\\HTTP\\Response::setCookie>`
```
See https://github.com/markstory/sphinxcontrib-phpdomain#quick-sample

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
