### PR TITLE
add missing valid_url_strict language string

### DIFF
--- a/system/Language/en/Validation.php
+++ b/system/Language/en/Validation.php
@@ -57,6 +57,7 @@ return [
     'valid_emails'          => 'The {field} field must contain all valid email addresses.',
     'valid_ip'              => 'The {field} field must contain a valid IP.',
     'valid_url'             => 'The {field} field must contain a valid URL.',
+    'valid_url_strict'      => 'The {field} field must contain a valid URL.',
     'valid_date'            => 'The {field} field must contain a valid date.',
 
     // Credit Cards


### PR DESCRIPTION
**Description**
There is a missing language string for the valid_url_strict rule.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
