### PR TITLE
feat: add routes useSupportedLocalesOnly property

### DIFF
--- a/system/Exceptions/PageNotFoundException.php
+++ b/system/Exceptions/PageNotFoundException.php
@@ -45,6 +45,11 @@ class PageNotFoundException extends OutOfBoundsException implements ExceptionInt
         return new static(self::lang('HTTP.methodNotFound', [$method]));
     }
 
+    public static function forLocaleNotSupported(string $locale)
+    {
+        return new static(self::lang('HTTP.localeNotSupported', [$locale]));
+    }
+
     /**
      * Get translated system message
      *

--- a/system/Language/en/HTTP.php
+++ b/system/Language/en/HTTP.php
@@ -52,6 +52,7 @@ return [
     'emptyController'    => 'No Controller specified.',
     'controllerNotFound' => 'Controller or its method is not found: {0}::{1}',
     'methodNotFound'     => 'Controller method is not found: {0}',
+    'localeNotSupported' => 'Locale is not supported: {0}',
 
     // CSRF
     // @deprecated use `Security.disallowedAction`

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -224,6 +224,11 @@ class RouteCollection implements RouteCollectionInterface
     private ?string $httpHost = null;
 
     /**
+     * Flag to limit or not the routes with {locale} placeholder to App::$supportedLocales
+     */
+    protected bool $useSupportedLocalesOnly = false;
+
+    /**
      * Constructor
      */
     public function __construct(FileLocator $locator, Modules $moduleConfig)
@@ -1465,5 +1470,23 @@ class RouteCollection implements RouteCollectionInterface
         }
 
         return array_unique($controllers);
+    }
+
+    /**
+     * Set The flag that limit or not the routes with {locale} placeholder to App::$supportedLocales
+     */
+    public function useSupportedLocalesOnly(bool $useOnly): self
+    {
+        $this->useSupportedLocalesOnly = $useOnly;
+
+        return $this;
+    }
+
+    /**
+     * Get the flag that limit or not the routes with {locale} placeholder to App::$supportedLocales
+     */
+    public function shouldUseSupportedLocalesOnly(): bool
+    {
+        return $this->useSupportedLocalesOnly;
     }
 }

--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -184,4 +184,9 @@ interface RouteCollectionInterface
      * Grabs the HTTP status code from a redirecting Route.
      */
     public function getRedirectCode(string $from): int;
+
+    /**
+     * Get the flag that limit or not the routes with {locale} placeholder to App::$supportedLocales
+     */
+    public function shouldUseSupportedLocalesOnly(): bool;
 }

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -441,7 +441,10 @@ class Router implements RouterInterface
 
                     if ($this->collection->shouldUseSupportedLocalesOnly()
                         && ! in_array($matched['locale'], config('App')->supportedLocales, true)) {
-                        return false;
+
+                        // Throw exception to prevent the autorouter, if enabled,
+                        // from trying to find a route
+                        throw PageNotFoundException::forLocaleNotSupported($matched['locale']);
                     }
 
                     $this->detectedLocale = $matched['locale'];

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -439,6 +439,11 @@ class Router implements RouterInterface
                         $matched
                     );
 
+                    if ($this->collection->shouldUseSupportedLocalesOnly()
+                        && ! in_array($matched['locale'], config('App')->supportedLocales, true)) {
+                        return false;
+                    }
+
                     $this->detectedLocale = $matched['locale'];
                     unset($matched);
                 }

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Router;
 
 use CodeIgniter\Config\Services;
+use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
 use Tests\Support\Controllers\Hello;
@@ -1677,5 +1678,19 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $expects = [];
         $this->assertSame($expects, $routes);
+    }
+
+    public function testUseSupportedLocalesOnly()
+    {
+        config('App')->supportedLocales = ['en'];
+
+        $routes = $this->getCollector();
+        $routes->useSupportedLocalesOnly(true);
+        $routes->get('{locale}/products', 'Products::list');
+
+        $router = new Router($routes, Services::request());
+
+        $this->expectException(PageNotFoundException::class);
+        $router->handle('fr/products');
     }
 }

--- a/user_guide_src/source/outgoing/localization.rst
+++ b/user_guide_src/source/outgoing/localization.rst
@@ -81,7 +81,7 @@ segment will be your locale:
 In this example, if the user tried to visit ``http://example.com/fr/books``, then the locale would be
 set to ``fr``, assuming it was configured as a valid locale.
 
-If the value doesn't match a valid locale as defined in the App configuration file, the default
+If the value doesn't match a valid locale as defined in ``$supportedLocales`` in **app/Config/App.php**, the default
 locale will be used in it's place, unless you set to use only the supported locales defined in the App configuration
 file:
 

--- a/user_guide_src/source/outgoing/localization.rst
+++ b/user_guide_src/source/outgoing/localization.rst
@@ -81,8 +81,12 @@ segment will be your locale:
 In this example, if the user tried to visit ``http://example.com/fr/books``, then the locale would be
 set to ``fr``, assuming it was configured as a valid locale.
 
-.. note:: If the value doesn't match a valid locale as defined in the App configuration file, the default
-    locale will be used in it's place.
+If the value doesn't match a valid locale as defined in the App configuration file, the default
+locale will be used in it's place, unless you set to use only the supported locales defined in the App configuration
+file:
+
+.. literalinclude:: localization/018.php
+
 
 Retrieving the Current Locale
 =============================

--- a/user_guide_src/source/outgoing/localization/018.php
+++ b/user_guide_src/source/outgoing/localization/018.php
@@ -1,0 +1,3 @@
+<?php
+
+$routes->useSupportedLocalesOnly(true);


### PR DESCRIPTION
Adds a control flag so that the ``Router`` only validates the locales ​​that are defined in ``App::$supportedLocales``, returning an ``CodeIgniter\Exceptions\PageNotFoundException::forLocaleNotSupported()`` if the locale introduced is not supported.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
