### PR TITLE
feat: get codeigniter context access

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -383,7 +383,7 @@ class CodeIgniter
     /**
      * Invoked via spark command?
      */
-    public function isSparked(): bool
+    private function isSparked(): bool
     {
         return $this->context === 'spark';
     }
@@ -391,7 +391,7 @@ class CodeIgniter
     /**
      * Invoked via php-cli command?
      */
-    public function isPhpCli(): bool
+    private function isPhpCli(): bool
     {
         return $this->context === 'php-cli';
     }
@@ -399,7 +399,7 @@ class CodeIgniter
     /**
      * Web access?
      */
-    public function isWeb(): bool
+    private function isWeb(): bool
     {
         return $this->context === 'web';
     }

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -1105,4 +1105,12 @@ class CodeIgniter
 
         return $this;
     }
+
+    /**
+     * Gets the app context.
+     */
+    public function getContext(): ?string
+    {
+        return $this->context;
+    }
 }

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -383,7 +383,7 @@ class CodeIgniter
     /**
      * Invoked via spark command?
      */
-    private function isSparked(): bool
+    public function isSparked(): bool
     {
         return $this->context === 'spark';
     }
@@ -391,7 +391,7 @@ class CodeIgniter
     /**
      * Invoked via php-cli command?
      */
-    private function isPhpCli(): bool
+    public function isPhpCli(): bool
     {
         return $this->context === 'php-cli';
     }
@@ -399,7 +399,7 @@ class CodeIgniter
     /**
      * Web access?
      */
-    private function isWeb(): bool
+    public function isWeb(): bool
     {
         return $this->context === 'web';
     }


### PR DESCRIPTION
With CI 4.2.0 constant ``SPARKED`` is deprecated and we must use the ``CodeIgniter::$context``, but there is no method to obtain it.

Also the ``CodeIgniter::is parked()``, ``CodeIgniter::Php Cli`` and ``CodeIgniter::isWeb()`` methods must be public since ``CodeIgniter::$context`` already has an accessor.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
