### PR TITLE
fix: Session Handlers do not take Config\Cookie

### DIFF
--- a/system/Session/Handlers/BaseHandler.php
+++ b/system/Session/Handlers/BaseHandler.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Session\Handlers;
 
 use Config\App as AppConfig;
+use Config\Cookie as CookieConfig;
 use Psr\Log\LoggerAwareTrait;
 use SessionHandlerInterface;
 
@@ -102,14 +103,27 @@ abstract class BaseHandler implements SessionHandlerInterface
 
     public function __construct(AppConfig $config, string $ipAddress)
     {
-        $this->cookiePrefix = $config->cookiePrefix;
-        $this->cookieDomain = $config->cookieDomain;
-        $this->cookiePath   = $config->cookiePath;
-        $this->cookieSecure = $config->cookieSecure;
-        $this->cookieName   = $config->sessionCookieName;
-        $this->matchIP      = $config->sessionMatchIP;
-        $this->savePath     = $config->sessionSavePath;
-        $this->ipAddress    = $ipAddress;
+        /** @var CookieConfig|null $cookie */
+        $cookie = config('Cookie');
+
+        if ($cookie instanceof CookieConfig) {
+            $this->cookiePrefix = $cookie->prefix;
+            $this->cookieDomain = $cookie->domain;
+            $this->cookiePath   = $cookie->path;
+            $this->cookieSecure = $cookie->secure;
+        } else {
+            // @TODO Remove this fallback when deprecated `App` members are removed.
+            // `Config/Cookie.php` is absence
+            $this->cookiePrefix = $config->cookiePrefix;
+            $this->cookieDomain = $config->cookieDomain;
+            $this->cookiePath   = $config->cookiePath;
+            $this->cookieSecure = $config->cookieSecure;
+        }
+
+        $this->cookieName = $config->sessionCookieName;
+        $this->matchIP    = $config->sessionMatchIP;
+        $this->savePath   = $config->sessionSavePath;
+        $this->ipAddress  = $ipAddress;
     }
 
     /**

--- a/system/Session/Handlers/BaseHandler.php
+++ b/system/Session/Handlers/BaseHandler.php
@@ -40,6 +40,9 @@ abstract class BaseHandler implements SessionHandlerInterface
     /**
      * Cookie prefix
      *
+     * The Config\Cookie::$prefix setting is completely ignored.
+     * See https://codeigniter4.github.io/CodeIgniter4/libraries/sessions.html#session-preferences
+     *
      * @var string
      */
     protected $cookiePrefix = '';
@@ -107,14 +110,14 @@ abstract class BaseHandler implements SessionHandlerInterface
         $cookie = config('Cookie');
 
         if ($cookie instanceof CookieConfig) {
-            $this->cookiePrefix = $cookie->prefix;
+            // Session cookies have no prefix.
             $this->cookieDomain = $cookie->domain;
             $this->cookiePath   = $cookie->path;
             $this->cookieSecure = $cookie->secure;
         } else {
             // @TODO Remove this fallback when deprecated `App` members are removed.
             // `Config/Cookie.php` is absence
-            $this->cookiePrefix = $config->cookiePrefix;
+            // Session cookies have no prefix.
             $this->cookieDomain = $config->cookieDomain;
             $this->cookiePath   = $config->cookiePath;
             $this->cookieSecure = $config->cookieSecure;


### PR DESCRIPTION
**Description**
- fix Session Handlers do not take `Config\Cookie`

Related:  #6080

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
