### PR TITLE
docs: add about setCookie() prefix details

### DIFF
--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -543,7 +543,7 @@ trait ResponseTrait
      * @param string              $expire   Cookie expiration time in seconds
      * @param string              $domain   Cookie domain (e.g.: '.yourdomain.com')
      * @param string              $path     Cookie path (default: '/')
-     * @param string              $prefix   Cookie name prefix
+     * @param string              $prefix   Cookie name prefix ('': the default prefix)
      * @param bool                $secure   Whether to only transfer cookies via SSL
      * @param bool                $httponly Whether only make the cookie accessible via HTTP (no javascript)
      * @param string|null         $samesite
@@ -617,6 +617,9 @@ trait ResponseTrait
 
     /**
      * Returns the cookie
+     *
+     * @param string $prefix Cookie prefix.
+     *                       '': the default prefix
      *
      * @return Cookie|Cookie[]|null
      */

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -28,7 +28,7 @@ if (! function_exists('set_cookie')) {
      * @param string       $expire   The number of seconds until expiration
      * @param string       $domain   For site-wide cookie. Usually: .yourdomain.com
      * @param string       $path     The cookie path
-     * @param string       $prefix   The cookie prefix
+     * @param string       $prefix   The cookie prefix ('': the default prefix)
      * @param bool         $secure   True makes the cookie secure
      * @param bool         $httpOnly True makes the cookie accessible via http(s) only (no javascript)
      * @param string|null  $sameSite The cookie SameSite value

--- a/user_guide_src/source/helpers/cookie_helper.rst
+++ b/user_guide_src/source/helpers/cookie_helper.rst
@@ -28,7 +28,7 @@ The following functions are available:
     :param    int    $expire: Number of seconds until expiration
     :param    string    $domain: Cookie domain (usually: .yourdomain.com)
     :param    string    $path: Cookie path
-    :param    string    $prefix: Cookie name prefix
+    :param    string    $prefix: Cookie name prefix. If ``''``, the default from **app/Config/Cookie.php** is used
     :param    bool    $secure: Whether to only send the cookie through HTTPS
     :param    bool    $httpOnly: Whether to hide the cookie from JavaScript
     :param    string    $sameSite: The value for the SameSite cookie parameter. If ``null``, the default from **app/Config/Cookie.php** is used

--- a/user_guide_src/source/libraries/cookies/002.php
+++ b/user_guide_src/source/libraries/cookies/002.php
@@ -3,7 +3,7 @@
 use CodeIgniter\Cookie\Cookie;
 use Config\Cookie as CookieConfig;
 
-// pass in an Config\Cookie instance before constructing a Cookie class
+// pass in a Config\Cookie instance before constructing a Cookie class
 Cookie::setDefaults(new CookieConfig());
 $cookie = new Cookie('login_token');
 

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -367,7 +367,7 @@ The methods provided by the parent class that are available are:
         :param int $expire: Cookie expiration time in seconds
         :param string $domain: Cookie domain
         :param string $path: Cookie path
-        :param string $prefix: Cookie name prefix
+        :param string $prefix: Cookie name prefix. If set to ``''``, the default value from **app/Config/Cookie.php** will be used
         :param bool $secure: Whether to only transfer the cookie through HTTPS
         :param bool $httponly: Whether to only make the cookie accessible for HTTP requests (no JavaScript)
         :param string $samesite: The value for the SameSite cookie parameter. If set to ``''``, no SameSite attribute will be set on the cookie. If set to ``null``, the default value from **app/Config/Cookie.php** will be used


### PR DESCRIPTION
**Description**
- update `set_cookie()`
- update `Response::setCookie()`

Ref https://github.com/codeigniter4/CodeIgniter4/issues/6009#issuecomment-1136003776

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

