### PR TITLE
fix: php-cli and Request object

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -321,7 +321,10 @@ trait ResponseTrait
 
         // Determine correct response type through content negotiation if not explicitly declared
         if (empty($this->format) || ! in_array($this->format, ['json', 'xml'], true)) {
-            $mime = $this->request->negotiate('media', $format->getConfig()->supportedResponseFormats, false);
+            if (! is_cli()) {
+                // @phpstan-ignore-next-line
+                $mime = $this->request->negotiate('media', $format->getConfig()->supportedResponseFormats, false);
+            }
         }
 
         $this->response->setContentType($mime);

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -472,10 +472,14 @@ class Services extends BaseService
     /**
      * The Request class models an HTTP request.
      *
-     * @return IncomingRequest
+     * @return Request
      */
     public static function request(?App $config = null, bool $getShared = true)
     {
+        if (is_cli()) {
+            return AppServices::clirequest($config, $getShared);
+        }
+
         if ($getShared) {
             return static::getSharedInstance('request', $config);
         }

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -13,7 +13,7 @@ namespace CodeIgniter\Debug;
 
 use CodeIgniter\API\ResponseTrait;
 use CodeIgniter\Exceptions\PageNotFoundException;
-use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\Response;
 use Config\Exceptions as ExceptionsConfig;
 use Config\Paths;
@@ -50,9 +50,9 @@ class Exceptions
     protected $config;
 
     /**
-     * The incoming request.
+     * The request.
      *
-     * @var IncomingRequest
+     * @var Request
      */
     protected $request;
 
@@ -63,7 +63,7 @@ class Exceptions
      */
     protected $response;
 
-    public function __construct(ExceptionsConfig $config, IncomingRequest $request, Response $response)
+    public function __construct(ExceptionsConfig $config, Request $request, Response $response)
     {
         $this->ob_level = ob_get_level();
         $this->viewPath = rtrim($config->errorViewPath, '\\/ ') . DIRECTORY_SEPARATOR;


### PR DESCRIPTION
**Description**
Fixes #6086

The current implementation has two Request objects (`IncommingRequest` and `CLIRequest`) when running on CLI.
Because some classes call `Services::request()` inside and it always returns `IncommingRequest`.

When `CLIRequest` is used in `CodeIgniter`, developers assume that the `CLIRequest` object is used system-wide.
This PR does so.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

