### PR TITLE
fix: when running on CLI, two Request objects were used in the system

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -321,7 +321,9 @@ trait ResponseTrait
 
         // Determine correct response type through content negotiation if not explicitly declared
         if (empty($this->format) || ! in_array($this->format, ['json', 'xml'], true)) {
-            $mime = $this->request->negotiate('media', $format->getConfig()->supportedResponseFormats, false);
+            if ($this->request instanceof IncomingRequest) {
+                $mime = $this->request->negotiate('media', $format->getConfig()->supportedResponseFormats, false);
+            }
         }
 
         $this->response->setContentType($mime);

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -324,7 +324,11 @@ trait ResponseTrait
             (empty($this->format) || ! in_array($this->format, ['json', 'xml'], true))
             && $this->request instanceof IncomingRequest
         ) {
-            $mime = $this->request->negotiate('media', $format->getConfig()->supportedResponseFormats, false);
+            $mime = $this->request->negotiate(
+                'media',
+                $format->getConfig()->supportedResponseFormats,
+                false
+            );
         }
 
         $this->response->setContentType($mime);

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -320,10 +320,11 @@ trait ResponseTrait
         $mime   = "application/{$this->format}";
 
         // Determine correct response type through content negotiation if not explicitly declared
-        if (empty($this->format) || ! in_array($this->format, ['json', 'xml'], true)) {
-            if ($this->request instanceof IncomingRequest) {
-                $mime = $this->request->negotiate('media', $format->getConfig()->supportedResponseFormats, false);
-            }
+        if (
+            (empty($this->format) || ! in_array($this->format, ['json', 'xml'], true))
+            && $this->request instanceof IncomingRequest
+        ) {
+            $mime = $this->request->negotiate('media', $format->getConfig()->supportedResponseFormats, false);
         }
 
         $this->response->setContentType($mime);

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -595,6 +595,9 @@ class CodeIgniter
 
         if ($this->isSparked() || $this->isPhpCli()) {
             $this->request = Services::clirequest($this->config);
+
+            // Inject the request object into Services::request().
+            Services::inject('request', $this->request);
         } else {
             $this->request = Services::request($this->config);
             // guess at protocol if needed

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -583,9 +583,7 @@ class CodeIgniter
     }
 
     /**
-     * Get our Request object, (either IncomingRequest or CLIRequest)
-     * and set the server protocol based on the information provided
-     * by the server.
+     * Get our Request object, (either IncomingRequest or CLIRequest).
      */
     protected function getRequestObject()
     {
@@ -594,15 +592,12 @@ class CodeIgniter
         }
 
         if ($this->isSparked() || $this->isPhpCli()) {
-            $this->request = Services::clirequest($this->config);
-
-            // Inject the request object into Services::request().
-            Services::inject('request', $this->request);
+            Services::createRequest($this->config, true);
         } else {
-            $this->request = Services::request($this->config);
-            // guess at protocol if needed
-            $this->request->setProtocolVersion($_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1');
+            Services::createRequest($this->config);
         }
+
+        $this->request = Services::request();
     }
 
     /**

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -106,7 +106,7 @@ use Config\View as ConfigView;
  * @method static Format format(ConfigFormat $config = null, $getShared = true)
  * @method static Honeypot honeypot(ConfigHoneyPot $config = null, $getShared = true)
  * @method static BaseHandler image($handler = null, Images $config = null, $getShared = true)
- * @method static IncomingRequest incommingrequest(?App $config = null, bool $getShared = true)
+ * @method static IncomingRequest incomingrequest(?App $config = null, bool $getShared = true)
  * @method static Iterator iterator($getShared = true)
  * @method static Language language($locale = null, $getShared = true)
  * @method static Logger logger($getShared = true)

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -96,6 +96,7 @@ use Config\View as ConfigView;
  * @method static CLIRequest clirequest(App $config = null, $getShared = true)
  * @method static CodeIgniter codeigniter(App $config = null, $getShared = true)
  * @method static Commands commands($getShared = true)
+ * @method static void createRequest(App $config, bool $isCli = false)
  * @method static ContentSecurityPolicy csp(CSPConfig $config = null, $getShared = true)
  * @method static CURLRequest curlrequest($options = [], ResponseInterface $response = null, App $config = null, $getShared = true)
  * @method static Email email($config = null, $getShared = true)
@@ -105,6 +106,7 @@ use Config\View as ConfigView;
  * @method static Format format(ConfigFormat $config = null, $getShared = true)
  * @method static Honeypot honeypot(ConfigHoneyPot $config = null, $getShared = true)
  * @method static BaseHandler image($handler = null, Images $config = null, $getShared = true)
+ * @method static IncomingRequest incommingrequest(?App $config = null, bool $getShared = true)
  * @method static Iterator iterator($getShared = true)
  * @method static Language language($locale = null, $getShared = true)
  * @method static Logger logger($getShared = true)
@@ -114,7 +116,7 @@ use Config\View as ConfigView;
  * @method static Parser parser($viewPath = null, ConfigView $config = null, $getShared = true)
  * @method static RedirectResponse redirectresponse(App $config = null, $getShared = true)
  * @method static View renderer($viewPath = null, ConfigView $config = null, $getShared = true)
- * @method static IncomingRequest request(App $config = null, $getShared = true)
+ * @method static IncomingRequest|CLIRequest request(App $config = null, $getShared = true)
  * @method static Response response(App $config = null, $getShared = true)
  * @method static Router router(RouteCollectionInterface $routes = null, Request $request = null, $getShared = true)
  * @method static RouteCollection routes($getShared = true)
@@ -290,18 +292,6 @@ class BaseService
     {
         $name = strtolower($name);
         unset(static::$mocks[$name], static::$instances[$name]);
-    }
-
-    /**
-     * Inject object.
-     *
-     * @param object $obj
-     *
-     * @internal
-     */
-    public static function inject(string $name, $obj)
-    {
-        static::$instances[strtolower($name)] = $obj;
     }
 
     /**

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -293,6 +293,18 @@ class BaseService
     }
 
     /**
+     * Inject object.
+     *
+     * @param object $obj
+     *
+     * @internal
+     */
+    public static function inject(string $name, $obj)
+    {
+        static::$instances[strtolower($name)] = $obj;
+    }
+
+    /**
      * Inject mock object for testing.
      *
      * @param mixed $mock

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -487,7 +487,7 @@ class Services extends BaseService
         }
 
         // @TODO remove the following code for backward compatibility
-        return static::incommingrequest($config, $getShared);
+        return static::incomingrequest($config, $getShared);
     }
 
     /**
@@ -502,7 +502,7 @@ class Services extends BaseService
         if ($isCli) {
             $request = AppServices::clirequest($config);
         } else {
-            $request = AppServices::incommingrequest($config);
+            $request = AppServices::incomingrequest($config);
 
             // guess at protocol if needed
             $request->setProtocolVersion($_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1');
@@ -519,7 +519,7 @@ class Services extends BaseService
      *
      * @internal
      */
-    public static function incommingrequest(?App $config = null, bool $getShared = true)
+    public static function incomingrequest(?App $config = null, bool $getShared = true)
     {
         if ($getShared) {
             return static::getSharedInstance('request', $config);

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -472,7 +472,9 @@ class Services extends BaseService
     /**
      * The Request class models an HTTP request.
      *
-     * @return IncomingRequest
+     * CodeIgniter::getRequestObject() injects CLIRequest if $this->request is CLIRequest.
+     *
+     * @return CLIRequest|IncomingRequest
      */
     public static function request(?App $config = null, bool $getShared = true)
     {

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -117,6 +117,8 @@ class Services extends BaseService
      * a command line request.
      *
      * @return CLIRequest
+     *
+     * @internal
      */
     public static function clirequest(?App $config = null, bool $getShared = true)
     {
@@ -470,13 +472,54 @@ class Services extends BaseService
     }
 
     /**
-     * The Request class models an HTTP request.
+     * Returns the current Request object.
      *
-     * CodeIgniter::getRequestObject() injects CLIRequest if $this->request is CLIRequest.
+     * createRequest() injects IncomingRequest or CLIRequest.
      *
      * @return CLIRequest|IncomingRequest
+     *
+     * @deprecated The parameter $config and $getShared are deprecated.
      */
     public static function request(?App $config = null, bool $getShared = true)
+    {
+        if ($getShared) {
+            return static::getSharedInstance('request', $config);
+        }
+
+        // @TODO remove the following code for backward compatibility
+        return static::incommingrequest($config, $getShared);
+    }
+
+    /**
+     * Create the current Request object, either IncomingRequest or CLIRequest.
+     *
+     * This method is called from CodeIgniter::getRequestObject().
+     *
+     * @internal
+     */
+    public static function createRequest(App $config, bool $isCli = false): void
+    {
+        if ($isCli) {
+            $request = AppServices::clirequest($config);
+        } else {
+            $request = AppServices::incommingrequest($config);
+
+            // guess at protocol if needed
+            $request->setProtocolVersion($_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1');
+        }
+
+        // Inject the request object into Services::request().
+        static::$instances['request'] = $request;
+    }
+
+    /**
+     * The IncomingRequest class models an HTTP request.
+     *
+     * @return IncomingRequest
+     *
+     * @internal
+     */
+    public static function incommingrequest(?App $config = null, bool $getShared = true)
     {
         if ($getShared) {
             return static::getSharedInstance('request', $config);

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Debug;
 
 use CodeIgniter\API\ResponseTrait;
 use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
 use Config\Exceptions as ExceptionsConfig;
@@ -50,9 +51,9 @@ class Exceptions
     protected $config;
 
     /**
-     * The incoming request.
+     * The request.
      *
-     * @var IncomingRequest
+     * @var CLIRequest|IncomingRequest
      */
     protected $request;
 
@@ -63,7 +64,10 @@ class Exceptions
      */
     protected $response;
 
-    public function __construct(ExceptionsConfig $config, IncomingRequest $request, Response $response)
+    /**
+     * @param CLIRequest|IncomingRequest $request
+     */
+    public function __construct(ExceptionsConfig $config, $request, Response $response)
     {
         $this->ob_level = ob_get_level();
         $this->viewPath = rtrim($config->errorViewPath, '\\/ ') . DIRECTORY_SEPARATOR;

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -212,6 +212,6 @@ class CLIRequest extends Request
      */
     public function isCLI(): bool
     {
-        return is_cli();
+        return true;
     }
 }

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -347,7 +347,7 @@ class IncomingRequest extends Request
      */
     public function isCLI(): bool
     {
-        return is_cli();
+        return false;
     }
 
     /**

--- a/tests/system/CommonSingleServiceTest.php
+++ b/tests/system/CommonSingleServiceTest.php
@@ -98,7 +98,6 @@ final class CommonSingleServiceTest extends CIUnitTestCase
             'serviceExists',
             'reset',
             'resetSingle',
-            'inject',
             'injectMock',
             'encrypter', // Encrypter needs a starter key
             'session', // Headers already sent

--- a/tests/system/CommonSingleServiceTest.php
+++ b/tests/system/CommonSingleServiceTest.php
@@ -98,6 +98,7 @@ final class CommonSingleServiceTest extends CIUnitTestCase
             'serviceExists',
             'reset',
             'resetSingle',
+            'inject',
             'injectMock',
             'encrypter', // Encrypter needs a starter key
             'session', // Headers already sent

--- a/tests/system/CommonSingleServiceTest.php
+++ b/tests/system/CommonSingleServiceTest.php
@@ -95,6 +95,7 @@ final class CommonSingleServiceTest extends CIUnitTestCase
         static $services = [];
         static $excl     = [
             '__callStatic',
+            'createRequest',
             'serviceExists',
             'reset',
             'resetSingle',

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -438,8 +438,7 @@ final class IncomingRequestTest extends CIUnitTestCase
 
     public function testIsCLI()
     {
-        // this should be the case in unit testing
-        $this->assertTrue($this->request->isCLI());
+        $this->assertFalse($this->request->isCLI());
     }
 
     public function testIsAJAX()

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -12,6 +12,7 @@ See all the changes.
 .. toctree::
     :titlesonly:
 
+    v4.2.2
     v4.2.1
     v4.2.0
     v4.1.9

--- a/user_guide_src/source/changelogs/v4.2.2.rst
+++ b/user_guide_src/source/changelogs/v4.2.2.rst
@@ -24,7 +24,7 @@ Changes
 *******
 
 - Fixed: ``BaseBuilder::increment()`` and ``BaseBuilder::decrement()`` do not reset the ``BaseBuilder`` state after a query.
-- Now ``CLIRequest::isCLI()`` always return true.
+- Now ``CLIRequest::isCLI()`` always returns true.
 - Now ``IncommingRequest::isCLI()`` always return false.
 
 Deprecations

--- a/user_guide_src/source/changelogs/v4.2.2.rst
+++ b/user_guide_src/source/changelogs/v4.2.2.rst
@@ -12,7 +12,8 @@ Release Date: Unreleased
 BREAKING
 ********
 
-none.
+- Now ``Services::request()`` returns ``IncomingRequest`` or ``CLIRequest``.
+- The method signature of ``CodeIgniter\Debug\Exceptions::__construct()`` has been changed. The ``IncomingRequest`` typehint on the ``$request`` parameter was removed. Extending classes should likewise remove the parameter so as not to break LSP.
 
 Enhancements
 ************
@@ -23,11 +24,13 @@ Changes
 *******
 
 - Fixed: ``BaseBuilder::increment()`` and ``BaseBuilder::decrement()`` do not reset the ``BaseBuilder`` state after a query.
+- Now ``CLIRequest::isCLI()`` always return true.
+- Now ``IncommingRequest::isCLI()`` always return false.
 
 Deprecations
 ************
 
-none.
+- The parameters of ``Services::request()`` are deprecated.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/changelogs/v4.2.2.rst
+++ b/user_guide_src/source/changelogs/v4.2.2.rst
@@ -25,7 +25,7 @@ Changes
 
 - Fixed: ``BaseBuilder::increment()`` and ``BaseBuilder::decrement()`` do not reset the ``BaseBuilder`` state after a query.
 - Now ``CLIRequest::isCLI()`` always returns true.
-- Now ``IncommingRequest::isCLI()`` always return false.
+- Now ``IncommingRequest::isCLI()`` always returns false.
 
 Deprecations
 ************


### PR DESCRIPTION
**Description**
Fixes https://github.com/codeigniter4/CodeIgniter4/issues/6086

The current implementation has two Request objects (`IncommingRequest` and `CLIRequest`) when running on CLI.
Because some classes call `Services::request()` inside and it always returns `IncommingRequest`.

When `CLIRequest` is used in `CodeIgniter`, developers assume that the `CLIRequest` object is used system-wide.
This PR makes that so.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
- [x] Apply reverted #5653 again