### PR TITLE
fix: session cookie name bug

### DIFF
--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -119,6 +119,8 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
      * Set the default attributes to a Cookie instance by injecting
      * the values from the `CookieConfig` config or an array.
      *
+     * This method is called from Response::__construct().
+     *
      * @param array<string, mixed>|CookieConfig $config
      *
      * @return array<string, mixed> The old defaults array. Useful for resetting.
@@ -209,7 +211,7 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
         }
 
         // to preserve backward compatibility with array-based cookies in previous CI versions
-        $prefix = $options['prefix'] ?: self::$defaults['prefix'];
+        $prefix = ($options['prefix'] === '') ? self::$defaults['prefix'] : $options['prefix'];
         $path   = $options['path'] ?: self::$defaults['path'];
         $domain = $options['domain'] ?: self::$defaults['domain'];
 

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -187,7 +187,7 @@ class Session implements SessionInterface
         /** @var CookieConfig $cookie */
         $cookie = config('Cookie');
 
-        $this->cookie = new Cookie($this->sessionCookieName, '', [
+        $this->cookie = (new Cookie($this->sessionCookieName, '', [
             'expires'  => $this->sessionExpiration === 0 ? 0 : time() + $this->sessionExpiration,
             'path'     => $cookie->path ?? $config->cookiePath,
             'domain'   => $cookie->domain ?? $config->cookieDomain,
@@ -195,7 +195,7 @@ class Session implements SessionInterface
             'httponly' => true, // for security
             'samesite' => $cookie->samesite ?? $config->cookieSameSite ?? Cookie::SAMESITE_LAX,
             'raw'      => $cookie->raw ?? false,
-        ]);
+        ]))->withPrefix(''); // Cookie prefix should be ignored.
 
         helper('array');
     }

--- a/tests/system/Cookie/CookieTest.php
+++ b/tests/system/Cookie/CookieTest.php
@@ -16,6 +16,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use Config\Cookie as CookieConfig;
 use DateTimeImmutable;
 use DateTimeZone;
+use Generator;
 use LogicException;
 
 /**
@@ -74,6 +75,38 @@ final class CookieTest extends CIUnitTestCase
         $this->assertSame($config->raw, $cookie->isRaw());
 
         Cookie::setDefaults($old);
+    }
+
+    /**
+     * @dataProvider prefixProvider
+     */
+    public function testConfigPrefix(string $configPrefix, string $optionPrefix, string $expected): void
+    {
+        $config         = new CookieConfig();
+        $config->prefix = $configPrefix;
+        Cookie::setDefaults($config);
+
+        $cookie = new Cookie(
+            'test',
+            'value',
+            [
+                'prefix' => $optionPrefix,
+            ]
+        );
+
+        $this->assertSame($expected, $cookie->getPrefixedName());
+    }
+
+    public function prefixProvider(): Generator
+    {
+        yield from [
+            ['prefix_', '', 'prefix_test'],
+            ['prefix_', '0', '0test'],
+            ['prefix_', 'new_', 'new_test'],
+            ['', '', 'test'],
+            ['', '0', '0test'],
+            ['', 'new_', 'new_test'],
+        ];
     }
 
     public function testValidationOfRawCookieName(): void


### PR DESCRIPTION
**Description**
- fix Session Cookie name may have Cookie Config prefix
  - it must be ignored. 
  - "Additionally, the Config\Cookie::$prefix setting is completely ignored." https://codeigniter.com/user_guide/libraries/sessions.html#session-preferences
- fix Cookie class option prefix bug
  - if option prefix is `'0'`, it is not set. Ref, https://github.com/codeigniter4/CodeIgniter4/pull/6083#issuecomment-1148176438

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

