### PR TITLE
docs: fix typo in cli_controllers.rst

### DIFF
--- a/user_guide_src/source/cli/cli_controllers.rst
+++ b/user_guide_src/source/cli/cli_controllers.rst
@@ -23,7 +23,7 @@ in it:
 
 .. literalinclude:: cli_controllers/001.php
 
-.. note:: If you use :ref:`auto-routing-improved`, change the method name to ``cli_message()``.
+.. note:: If you use :ref:`auto-routing-improved`, change the method name to ``cliMessage()``.
 
 Then save the file to your **app/Controllers/** directory.
 


### PR DESCRIPTION
**Description**
- fix typo

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

