### PR TITLE
fix: `spark routes` shows "ERROR: 404"

### DIFF
--- a/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollector.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollector.php
@@ -65,7 +65,7 @@ final class AutoRouteCollector
 
         foreach ($finder->find() as $class) {
             // Exclude controllers in Defined Routes.
-            if (in_array($class, $this->protectedControllers, true)) {
+            if (in_array('\\' . $class, $this->protectedControllers, true)) {
                 continue;
             }
 


### PR DESCRIPTION
**Description**
Whe you enable Auto Route Improved,
By adding the method `Home::getTest`, the command `php spark routes` gives the result:
```
ERROR: 404
Cannot access the default controller "Home" with the controller name URI path.
```
Reported in #6097

**How to Test**
```diff
diff --git a/app/Config/Feature.php b/app/Config/Feature.php
index 4c5ec90cd..480697b61 100644
--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -28,5 +28,5 @@ class Feature extends BaseConfig
     /**
      * Use improved new auto routing instead of the default legacy version.
      */
-    public bool $autoRoutesImproved = false;
+    public bool $autoRoutesImproved = true;
 }
```
```diff
diff --git a/app/Config/Routes.php b/app/Config/Routes.php
index ff2ac645c..78a76bc5c 100644
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -25,7 +25,7 @@ $routes->set404Override();
 // where controller filters or CSRF protection are bypassed.
 // If you don't want to define all routes, please use the Auto Routing (Improved).
 // Set `$autoRoutesImproved` to true in `app/Config/Feature.php` and set the following to true.
-//$routes->setAutoRoute(false);
+$routes->setAutoRoute(true);
 
 /*
  * --------------------------------------------------------------------
```
```diff
diff --git a/app/Controllers/Home.php b/app/Controllers/Home.php
index 7f867e95f..3d34582e1 100644
--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -8,4 +8,8 @@ class Home extends BaseController
     {
         return view('welcome_message');
     }
+
+    public function getTest()
+    {
+    }
 }
```
and run `php spark routes`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
