### PR TITLE
feat: add method to insert empty data in Model

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -315,9 +315,9 @@ abstract class BaseModel
     protected $afterDelete = [];
 
     /**
-     * Whether to prohibit inserting empty data.
+     * Whether to allow inserting empty data.
      */
-    protected bool $prohibitInsertEmpty = true;
+    protected bool $allowEmptyInserts = false;
 
     public function __construct(?ValidationInterface $validation = null)
     {
@@ -747,7 +747,7 @@ abstract class BaseModel
 
         // doProtectFields() can further remove elements from
         // $data so we need to check for empty dataset again
-        if ($this->prohibitInsertEmpty && empty($data)) {
+        if (! $this->allowEmptyInserts && empty($data)) {
             throw DataException::forEmptyDataset('insert');
         }
 
@@ -769,9 +769,6 @@ abstract class BaseModel
         }
 
         $result = $this->doInsert($eventData['data']);
-
-        // Reset $prohibitInsertEmpty value.
-        $this->prohibitInsertEmpty = true;
 
         $eventData = [
             'id'     => $this->insertID,
@@ -1648,7 +1645,7 @@ abstract class BaseModel
             throw new InvalidArgumentException(sprintf('Invalid type "%s" used upon transforming data to array.', $type));
         }
 
-        if ($this->prohibitInsertEmpty && empty($data)) {
+        if (! $this->allowEmptyInserts && empty($data)) {
             throw DataException::forEmptyDataset($type);
         }
 
@@ -1667,7 +1664,7 @@ abstract class BaseModel
         }
 
         // If it's still empty here, means $data is no change or is empty object
-        if ($this->prohibitInsertEmpty && empty($data)) {
+        if (! $this->allowEmptyInserts && empty($data)) {
             throw DataException::forEmptyDataset($type);
         }
 
@@ -1775,11 +1772,11 @@ abstract class BaseModel
     }
 
     /**
-     * Permits inserting empty date in the next insertion.
+     * Sets $allowEmptyInserts.
      */
-    public function permitInsertEmpty(): self
+    public function allowEmptyInserts(bool $value = true): self
     {
-        $this->prohibitInsertEmpty = false;
+        $this->allowEmptyInserts = $value;
 
         return $this;
     }

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -314,6 +314,11 @@ abstract class BaseModel
      */
     protected $afterDelete = [];
 
+    /**
+     * Whether to prohibit inserting empty data.
+     */
+    protected bool $prohibitInsertEmpty = true;
+
     public function __construct(?ValidationInterface $validation = null)
     {
         $this->tempReturnType     = $this->returnType;
@@ -742,7 +747,7 @@ abstract class BaseModel
 
         // doProtectFields() can further remove elements from
         // $data so we need to check for empty dataset again
-        if (empty($data)) {
+        if ($this->prohibitInsertEmpty && empty($data)) {
             throw DataException::forEmptyDataset('insert');
         }
 
@@ -764,6 +769,9 @@ abstract class BaseModel
         }
 
         $result = $this->doInsert($eventData['data']);
+
+        // Reset $prohibitInsertEmpty value.
+        $this->prohibitInsertEmpty = true;
 
         $eventData = [
             'id'     => $this->insertID,
@@ -1640,7 +1648,7 @@ abstract class BaseModel
             throw new InvalidArgumentException(sprintf('Invalid type "%s" used upon transforming data to array.', $type));
         }
 
-        if (empty($data)) {
+        if ($this->prohibitInsertEmpty && empty($data)) {
             throw DataException::forEmptyDataset($type);
         }
 
@@ -1659,7 +1667,7 @@ abstract class BaseModel
         }
 
         // If it's still empty here, means $data is no change or is empty object
-        if (empty($data)) {
+        if ($this->prohibitInsertEmpty && empty($data)) {
             throw DataException::forEmptyDataset($type);
         }
 
@@ -1764,5 +1772,15 @@ abstract class BaseModel
         }
 
         return $rules;
+    }
+
+    /**
+     * Permits inserting empty date in the next insertion.
+     */
+    public function permitInsertEmpty(): self
+    {
+        $this->prohibitInsertEmpty = false;
+
+        return $this;
     }
 }

--- a/system/Model.php
+++ b/system/Model.php
@@ -279,6 +279,22 @@ class Model extends BaseModel
             $table = $this->db->protectIdentifiers($this->table, true, null, false);
             if ($this->db->getPlatform() === 'MySQLi') {
                 $sql = 'INSERT INTO ' . $table . ' VALUES ()';
+            } elseif ($this->db->getPlatform() === 'OCI8') {
+                $allFields = $this->db->protectIdentifiers(
+                    array_map(
+                        static fn ($row) => $row->name,
+                        $this->db->getFieldData($this->table)
+                    ),
+                    false,
+                    true
+                );
+
+                $sql = sprintf(
+                    'INSERT INTO %s (%s) VALUES (%s)',
+                    $table,
+                    implode(',', $allFields),
+                    substr(str_repeat(',DEFAULT', count($allFields)), 1)
+                );
             } else {
                 $sql = 'INSERT INTO ' . $table . ' DEFAULT VALUES';
             }

--- a/system/Model.php
+++ b/system/Model.php
@@ -275,7 +275,7 @@ class Model extends BaseModel
             $builder->set($key, $val, $escape[$key] ?? null);
         }
 
-        if (! $this->prohibitInsertEmpty && empty($data)) {
+        if ($this->allowEmptyInserts && empty($data)) {
             $table = $this->db->protectIdentifiers($this->table, true, null, false);
             if ($this->db->getPlatform() === 'MySQLi') {
                 $sql = 'INSERT INTO ' . $table . ' VALUES ()';

--- a/system/Model.php
+++ b/system/Model.php
@@ -275,7 +275,18 @@ class Model extends BaseModel
             $builder->set($key, $val, $escape[$key] ?? null);
         }
 
-        $result = $builder->insert();
+        if (! $this->prohibitInsertEmpty && empty($data)) {
+            $table = $this->db->protectIdentifiers($this->table, true, null, false);
+            if ($this->db->getPlatform() === 'MySQLi') {
+                $sql = 'INSERT INTO ' . $table . ' VALUES ()';
+            } else {
+                $sql = 'INSERT INTO ' . $table . ' DEFAULT VALUES';
+            }
+
+            $result = $this->db->query($sql);
+        } else {
+            $result = $builder->insert();
+        }
 
         // If insertion succeeded then save the insert ID
         if ($result) {

--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -133,7 +133,7 @@ class FileRules
 
             // We know that our mimes list always has the first mime
             // start with `image` even when then are multiple accepted types.
-            $type = Mimes::guessTypeFromExtension($file->getExtension());
+            $type = Mimes::guessTypeFromExtension($file->getExtension()) ?? '';
 
             if (mb_strpos($type, 'image') !== 0) {
                 return false;

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -220,7 +220,7 @@ final class InsertModelTest extends LiveModelTestCase
             ];
         };
 
-        $model->permitInsertEmpty()->insert([]);
+        $model->allowEmptyInserts()->insert([]);
 
         $this->seeInDatabase('insert_no_data', ['id' => $model->getInsertID()]);
 
@@ -229,6 +229,7 @@ final class InsertModelTest extends LiveModelTestCase
         $this->expectException(DataException::class);
         $this->expectExceptionMessage('There is no data to insert.');
 
+        $model->allowEmptyInserts(false);
         $model->insert([]);
     }
 

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -41,7 +41,9 @@ final class FileRulesTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
+        $this->resetServices();
         parent::setUp();
+
         $this->validation = new Validation((object) $this->config, Services::renderer());
         $this->validation->reset();
 
@@ -229,6 +231,7 @@ final class FileRulesTest extends CIUnitTestCase
             'type'     => 'application/address',
             'error'    => UPLOAD_ERR_OK,
         ];
+
         $this->validation->setRules(['avatar' => 'is_image[stuff]']);
         $this->assertFalse($this->validation->run([]));
     }

--- a/tests/system/Validation/StrictRules/FileRulesTest.php
+++ b/tests/system/Validation/StrictRules/FileRulesTest.php
@@ -42,7 +42,9 @@ final class FileRulesTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
+        $this->resetServices();
         parent::setUp();
+
         $this->validation = new Validation((object) $this->config, Services::renderer());
         $this->validation->reset();
 
@@ -230,6 +232,7 @@ final class FileRulesTest extends CIUnitTestCase
             'type'     => 'application/address',
             'error'    => UPLOAD_ERR_OK,
         ];
+
         $this->validation->setRules(['avatar' => 'is_image[stuff]']);
         $this->assertFalse($this->validation->run([]));
     }

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -13,6 +13,7 @@ Highlights
 **********
 
 - Update minimal PHP requirement to 7.4.
+- To make the default configuration more secure, auto-routing has been changed to disabled by default.
 - **OCI8 Driver for Oracle Database** (*contributed by* `ytetsuro <https://github.com/ytetsuro>`_). See `Database`_.
 - **Improved Auto Routing** (opt-in) (*contributed by* `kenjis <https://github.com/kenjis>`_). See `New Improved Auto Routing`_.
 - Query Builder **Subqueries** and **UNION** support (*contributed by* `Andrey Pyzhikov <https://github.com/iRedds>`_). See `Database`_.

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -135,11 +135,11 @@ Changes
 *******
 
 - Update minimal PHP requirement to 7.4.
-- The current version of Content Security Policy (CSP) outputs one nonce for script and one for style tags. The previous version outputted one nonce for each tag.
-- The process of sending cookies has been moved to the ``Response`` class. Now the ``Session`` class doesn't send cookies, set them to the Response.
+- To make the default configuration more secure, auto-routing has been changed to disabled by default.
 - Validation. Changed generation of errors when using fields with a wildcard (*). Now the error key contains the full path. See :ref:`validation-getting-all-errors`.
 - ``Validation::getError()`` when using a wildcard will return all found errors matching the mask as a string.
-- To make the default configuration more secure, auto-routing has been changed to disabled by default.
+- The current version of Content Security Policy (CSP) outputs one nonce for script and one for style tags. The previous version outputted one nonce for each tag.
+- The process of sending cookies has been moved to the ``Response`` class. Now the ``Session`` class doesn't send cookies, set them to the Response.
 
 Deprecations
 ************

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -21,6 +21,7 @@ Enhancements
 
 - Added the ``StreamFilterTrait`` to make it easier to work with capturing data from STDOUT and STDERR streams. See :ref:`testing-overview-stream-filters`.
 - Added before and after events to ``BaseModel::insertBatch()`` and ``BaseModel::updateBatch()`` methods. See :ref:`model-events-callbacks`.
+- Added ``Model::allowEmptyInserts()`` method to insert empty data. See :ref:`Using CodeIgniter's Model <model-allow-empty-inserts>`
 - Added ``$routes->useSupportedLocalesOnly(true)`` so that the Router returns 404 Not Found if the locale in the URL is not supported in ``Config\App::$supportedLocales``. See :ref:`Localization <localization-in-routes>`
 - The call handler for Spark commands from the ``CodeIgniter\CodeIgniter`` class has been extracted. This will reduce the cost of console calls.
 

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -310,6 +310,17 @@ the array's values are the values to save for that key:
 
 You can retrieve the last inserted row's primary key using the ``getInsertID()`` method.
 
+.. _model-allow-empty-inserts:
+
+allowEmptyInserts()
+-------------------
+
+Since v4.3.0, you can use ``allowEmptyInserts()`` method to insert empty data. The Model throws an exception when you try to insert empty data by default. But if you call this method, the check will no longer be performed.
+
+.. literalinclude:: model/056.php
+
+You can enable the check again by calling ``allowEmptyInserts(false)``.
+
 update()
 --------
 

--- a/user_guide_src/source/models/model/056.php
+++ b/user_guide_src/source/models/model/056.php
@@ -1,0 +1,3 @@
+<?php
+
+$userModel->allowEmptyInserts()->insert([]);


### PR DESCRIPTION
**Description**
- add `Model::allowEmptyInserts()` to insert empty data

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
