### PR TITLE
Feature: Adding StreamFilterTrait

### DIFF
--- a/system/Test/Filters/CITestStreamFilter.php
+++ b/system/Test/Filters/CITestStreamFilter.php
@@ -26,6 +26,8 @@ class CITestStreamFilter extends php_user_filter
      */
     public static $buffer = '';
 
+    protected static bool $registered = false;
+
     /**
      * This method is called whenever data is read from or written to the
      * attached stream (such as with fread() or fwrite()).
@@ -45,6 +47,13 @@ class CITestStreamFilter extends php_user_filter
 
         return PSFS_PASS_ON;
     }
-}
 
-stream_filter_register('CITestStreamFilter', CITestStreamFilter::class); // @codeCoverageIgnore
+    public static function init(): void
+    {
+        if (! static::$registered) {
+            static::$registered = stream_filter_register('CITestStreamFilter', self::class); // @codeCoverageIgnore
+        }
+
+        static::$buffer = '';
+    }
+}

--- a/system/Test/Filters/CITestStreamFilter.php
+++ b/system/Test/Filters/CITestStreamFilter.php
@@ -48,7 +48,7 @@ class CITestStreamFilter extends php_user_filter
         return PSFS_PASS_ON;
     }
 
-    public static function init(): void
+    public static function registration(): void
     {
         if (! static::$registered) {
             static::$registered = stream_filter_register('CITestStreamFilter', self::class); // @codeCoverageIgnore

--- a/system/Test/StreamFilterTrait.php
+++ b/system/Test/StreamFilterTrait.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Test;
+
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+trait StreamFilterTrait
+{
+    /**
+     * @var resource|null
+     */
+    protected $streamFilterOutResource;
+
+    /**
+     * @var resource|null
+     */
+    protected $streamFilterErrResource;
+
+    /**
+     * @return $this
+     */
+    protected function appendStreamOutputFilter()
+    {
+        $this->removeStreamOutputFilter();
+
+        $this->streamFilterOutResource = stream_filter_append(STDOUT, 'CITestStreamFilter');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    protected function appendStreamErrorFilter()
+    {
+        $this->removeStreamErrorFilter();
+
+        $this->streamFilterErrResource = stream_filter_append(STDERR, 'CITestStreamFilter');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    protected function removeStreamOutputFilter()
+    {
+        if (is_resource($this->streamFilterOutResource)) {
+            stream_filter_remove($this->streamFilterOutResource);
+            $this->streamFilterOutResource = null;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    protected function removeStreamErrorFilter()
+    {
+        if (is_resource($this->streamFilterErrResource)) {
+            stream_filter_remove($this->streamFilterErrResource);
+            $this->streamFilterErrResource = null;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    protected function registerStreamFilterClass()
+    {
+        CITestStreamFilter::init();
+
+        return $this;
+    }
+
+    protected function getStreamFilterBuffer(): string
+    {
+        return CITestStreamFilter::$buffer;
+    }
+
+    protected function resetStreamFilterBuffer(): void
+    {
+        CITestStreamFilter::$buffer = '';
+    }
+}

--- a/system/Test/StreamFilterTrait.php
+++ b/system/Test/StreamFilterTrait.php
@@ -18,21 +18,21 @@ trait StreamFilterTrait
     /**
      * @var resource|null
      */
-    private $streamFilterOutResource;
+    private $outputStreamFilterResource;
 
     /**
      * @var resource|null
      */
-    private $streamFilterErrResource;
+    private $errorStreamFilterResource;
 
     /**
      * @return $this
      */
-    protected function appendStreamOutputFilter()
+    protected function appendOutputStreamFilter()
     {
-        $this->removeStreamOutputFilter();
+        $this->removeOutputStreamFilter();
 
-        $this->streamFilterOutResource = stream_filter_append(STDOUT, 'CITestStreamFilter');
+        $this->outputStreamFilterResource = stream_filter_append(STDOUT, 'CITestStreamFilter');
 
         return $this;
     }
@@ -40,11 +40,11 @@ trait StreamFilterTrait
     /**
      * @return $this
      */
-    protected function appendStreamErrorFilter()
+    protected function appendErrorStreamFilter()
     {
-        $this->removeStreamErrorFilter();
+        $this->removeErrorStreamFilter();
 
-        $this->streamFilterErrResource = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->errorStreamFilterResource = stream_filter_append(STDERR, 'CITestStreamFilter');
 
         return $this;
     }
@@ -52,11 +52,11 @@ trait StreamFilterTrait
     /**
      * @return $this
      */
-    protected function removeStreamOutputFilter()
+    protected function removeOutputStreamFilter()
     {
-        if (is_resource($this->streamFilterOutResource)) {
-            stream_filter_remove($this->streamFilterOutResource);
-            $this->streamFilterOutResource = null;
+        if (is_resource($this->outputStreamFilterResource)) {
+            stream_filter_remove($this->outputStreamFilterResource);
+            $this->outputStreamFilterResource = null;
         }
 
         return $this;
@@ -65,11 +65,11 @@ trait StreamFilterTrait
     /**
      * @return $this
      */
-    protected function removeStreamErrorFilter()
+    protected function removeErrorStreamFilter()
     {
-        if (is_resource($this->streamFilterErrResource)) {
-            stream_filter_remove($this->streamFilterErrResource);
-            $this->streamFilterErrResource = null;
+        if (is_resource($this->errorStreamFilterResource)) {
+            stream_filter_remove($this->errorStreamFilterResource);
+            $this->errorStreamFilterResource = null;
         }
 
         return $this;

--- a/system/Test/StreamFilterTrait.php
+++ b/system/Test/StreamFilterTrait.php
@@ -18,12 +18,12 @@ trait StreamFilterTrait
     /**
      * @var resource|null
      */
-    protected $streamFilterOutResource;
+    private $streamFilterOutResource;
 
     /**
      * @var resource|null
      */
-    protected $streamFilterErrResource;
+    private $streamFilterErrResource;
 
     /**
      * @return $this

--- a/system/Test/StreamFilterTrait.php
+++ b/system/Test/StreamFilterTrait.php
@@ -25,6 +25,18 @@ trait StreamFilterTrait
      */
     private $errorStreamFilterResource;
 
+    protected function setUpStreamFilterTrait(): void
+    {
+        $this->registerStreamFilterClass()
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
+    }
+
+    protected function tearDownStreamFilterTrait(): void
+    {
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
+    }
+
     /**
      * @return $this
      */
@@ -80,7 +92,7 @@ trait StreamFilterTrait
      */
     protected function registerStreamFilterClass()
     {
-        CITestStreamFilter::init();
+        CITestStreamFilter::registration();
 
         return $this;
     }

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -23,20 +23,6 @@ final class CLITest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-    }
-
     public function testNew()
     {
         $actual = new CLI();

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -28,13 +28,13 @@ final class CLITest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     public function testNew()

--- a/tests/system/CLI/CommandRunnerTest.php
+++ b/tests/system/CLI/CommandRunnerTest.php
@@ -34,20 +34,6 @@ final class CommandRunnerTest extends CIUnitTestCase
         self::$runner->initController(service('request'), service('response'), self::$logger);
     }
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-    }
-
     public function testGoodCommand()
     {
         self::$runner->index(['list']);

--- a/tests/system/CLI/CommandRunnerTest.php
+++ b/tests/system/CLI/CommandRunnerTest.php
@@ -39,13 +39,13 @@ final class CommandRunnerTest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     public function testGoodCommand()

--- a/tests/system/CLI/CommandRunnerTest.php
+++ b/tests/system/CLI/CommandRunnerTest.php
@@ -13,7 +13,7 @@ namespace CodeIgniter\CLI;
 
 use CodeIgniter\Log\Logger;
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 use Config\Services;
 
 /**
@@ -21,10 +21,7 @@ use Config\Services;
  */
 final class CommandRunnerTest extends CIUnitTestCase
 {
-    /**
-     * @var resource
-     */
-    private $streamFilter;
+    use StreamFilterTrait;
 
     private static Logger $logger;
     private static CommandRunner $runner;
@@ -41,56 +38,51 @@ final class CommandRunnerTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
     }
 
     public function testGoodCommand()
     {
         self::$runner->index(['list']);
-        $result = CITestStreamFilter::$buffer;
 
         // make sure the result looks like a command list
-        $this->assertStringContainsString('Lists the available commands.', $result);
-        $this->assertStringContainsString('Displays basic usage information.', $result);
+        $this->assertStringContainsString('Lists the available commands.', $this->getStreamFilterBuffer());
+        $this->assertStringContainsString('Displays basic usage information.', $this->getStreamFilterBuffer());
     }
 
     public function testDefaultCommand()
     {
         self::$runner->index([]);
-        $result = CITestStreamFilter::$buffer;
 
         // make sure the result looks like basic help
-        $this->assertStringContainsString('Lists the available commands.', $result);
-        $this->assertStringContainsString('Displays basic usage information.', $result);
+        $this->assertStringContainsString('Lists the available commands.', $this->getStreamFilterBuffer());
+        $this->assertStringContainsString('Displays basic usage information.', $this->getStreamFilterBuffer());
     }
 
     public function testHelpCommand()
     {
         self::$runner->index(['help']);
-        $result = CITestStreamFilter::$buffer;
 
         // make sure the result looks like basic help
-        $this->assertStringContainsString('Displays basic usage information.', $result);
-        $this->assertStringContainsString('help command_name', $result);
+        $this->assertStringContainsString('Displays basic usage information.', $this->getStreamFilterBuffer());
+        $this->assertStringContainsString('help command_name', $this->getStreamFilterBuffer());
     }
 
     public function testHelpCommandDetails()
     {
         self::$runner->index(['help', 'session:migration']);
-        $result = CITestStreamFilter::$buffer;
 
         // make sure the result looks like more detailed help
-        $this->assertStringContainsString('Description:', $result);
-        $this->assertStringContainsString('Usage:', $result);
-        $this->assertStringContainsString('Options:', $result);
+        $this->assertStringContainsString('Description:', $this->getStreamFilterBuffer());
+        $this->assertStringContainsString('Usage:', $this->getStreamFilterBuffer());
+        $this->assertStringContainsString('Options:', $this->getStreamFilterBuffer());
     }
 
     public function testCommandProperties()
@@ -107,7 +99,7 @@ final class CommandRunnerTest extends CIUnitTestCase
         self::$runner->index([null, 'list']);
 
         // make sure the result looks like a command list
-        $this->assertStringContainsString('Lists the available commands.', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('Lists the available commands.', $this->getStreamFilterBuffer());
     }
 
     public function testBadCommand()
@@ -115,6 +107,6 @@ final class CommandRunnerTest extends CIUnitTestCase
         self::$runner->index(['bogus']);
 
         // make sure the result looks like a command list
-        $this->assertStringContainsString('Command "bogus" not found', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('Command "bogus" not found', $this->getStreamFilterBuffer());
     }
 }

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -30,8 +30,6 @@ final class ConsoleTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->registerStreamFilterClass()->appendOutputStreamFilter();
-
         $this->env = new DotEnv(ROOTPATH);
         $this->env->load();
 
@@ -49,11 +47,6 @@ final class ConsoleTest extends CIUnitTestCase
 
         $this->app = new MockCodeIgniter(new MockCLIConfig());
         $this->app->setContext('spark');
-    }
-
-    protected function tearDown(): void
-    {
-        $this->removeOutputStreamFilter();
     }
 
     public function testNew()

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -30,7 +30,7 @@ final class ConsoleTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->registerStreamFilterClass()->appendStreamOutputFilter();
+        $this->registerStreamFilterClass()->appendOutputStreamFilter();
 
         $this->env = new DotEnv(ROOTPATH);
         $this->env->load();
@@ -53,7 +53,7 @@ final class ConsoleTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter();
+        $this->removeOutputStreamFilter();
     }
 
     public function testNew()

--- a/tests/system/Commands/ClearCacheTest.php
+++ b/tests/system/Commands/ClearCacheTest.php
@@ -13,7 +13,7 @@ namespace CodeIgniter\Commands;
 
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 use Config\Services;
 
 /**
@@ -21,15 +21,15 @@ use Config\Services;
  */
 final class ClearCacheTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        CITestStreamFilter::$buffer = '';
-        $this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
 
         // Make sure we are testing with the correct handler (override injections)
         Services::injectMock('cache', CacheFactory::getHandler(config('Cache')));
@@ -37,14 +37,14 @@ final class ClearCacheTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
     }
 
     public function testClearCacheInvalidHandler()
     {
         command('cache:clear junk');
 
-        $this->assertStringContainsString('junk is not a valid cache handler.', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('junk is not a valid cache handler.', $this->getStreamFilterBuffer());
     }
 
     public function testClearCacheWorks()
@@ -55,6 +55,6 @@ final class ClearCacheTest extends CIUnitTestCase
         command('cache:clear');
 
         $this->assertNull(cache('foo'));
-        $this->assertStringContainsString('Cache cleared.', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('Cache cleared.', $this->getStreamFilterBuffer());
     }
 }

--- a/tests/system/Commands/ClearCacheTest.php
+++ b/tests/system/Commands/ClearCacheTest.php
@@ -27,17 +27,8 @@ final class ClearCacheTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-
         // Make sure we are testing with the correct handler (override injections)
         Services::injectMock('cache', CacheFactory::getHandler(config('Cache')));
-    }
-
-    protected function tearDown(): void
-    {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     public function testClearCacheInvalidHandler()

--- a/tests/system/Commands/ClearCacheTest.php
+++ b/tests/system/Commands/ClearCacheTest.php
@@ -28,8 +28,8 @@ final class ClearCacheTest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
 
         // Make sure we are testing with the correct handler (override injections)
         Services::injectMock('cache', CacheFactory::getHandler(config('Cache')));
@@ -37,7 +37,7 @@ final class ClearCacheTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     public function testClearCacheInvalidHandler()

--- a/tests/system/Commands/ClearDebugbarTest.php
+++ b/tests/system/Commands/ClearDebugbarTest.php
@@ -27,16 +27,7 @@ final class ClearDebugbarTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-
         $this->time = time();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     protected function createDummyDebugbarJson()

--- a/tests/system/Commands/ClearDebugbarTest.php
+++ b/tests/system/Commands/ClearDebugbarTest.php
@@ -28,15 +28,15 @@ final class ClearDebugbarTest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
 
         $this->time = time();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     protected function createDummyDebugbarJson()

--- a/tests/system/Commands/ClearLogsTest.php
+++ b/tests/system/Commands/ClearLogsTest.php
@@ -12,23 +12,24 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class ClearLogsTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
+
     private $date;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        CITestStreamFilter::$buffer = '';
-        $this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
 
         // test runs on other tests may log errors since default threshold
         // is now 4, so set this to a safe distance
@@ -37,7 +38,7 @@ final class ClearLogsTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
     }
 
     protected function createDummyLogFiles()
@@ -65,7 +66,7 @@ final class ClearLogsTest extends CIUnitTestCase
         $this->assertFileExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
 
         command('logs:clear -force');
-        $result = CITestStreamFilter::$buffer;
+        $result = $this->getStreamFilterBuffer();
 
         $this->assertFileDoesNotExist(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . "log-{$this->date}.log");
         $this->assertFileExists(WRITEPATH . 'logs' . DIRECTORY_SEPARATOR . 'index.html');

--- a/tests/system/Commands/ClearLogsTest.php
+++ b/tests/system/Commands/ClearLogsTest.php
@@ -28,8 +28,8 @@ final class ClearLogsTest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
 
         // test runs on other tests may log errors since default threshold
         // is now 4, so set this to a safe distance
@@ -38,7 +38,7 @@ final class ClearLogsTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     protected function createDummyLogFiles()

--- a/tests/system/Commands/ClearLogsTest.php
+++ b/tests/system/Commands/ClearLogsTest.php
@@ -27,18 +27,9 @@ final class ClearLogsTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-
         // test runs on other tests may log errors since default threshold
         // is now 4, so set this to a safe distance
         $this->date = date('Y-m-d', strtotime('+1 year'));
-    }
-
-    protected function tearDown(): void
-    {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     protected function createDummyLogFiles()

--- a/tests/system/Commands/CommandGeneratorTest.php
+++ b/tests/system/Commands/CommandGeneratorTest.php
@@ -21,17 +21,8 @@ final class CommandGeneratorTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
     protected function tearDown(): void
     {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
         $dir    = dirname($file);

--- a/tests/system/Commands/CommandGeneratorTest.php
+++ b/tests/system/Commands/CommandGeneratorTest.php
@@ -24,13 +24,13 @@ final class CommandGeneratorTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -12,7 +12,7 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 use Config\Services;
 use Tests\Support\Commands\ParamsReveal;
 
@@ -21,7 +21,8 @@ use Tests\Support\Commands\ParamsReveal;
  */
 final class CommandTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
+
     private $logger;
     private $commands;
 
@@ -31,10 +32,9 @@ final class CommandTest extends CIUnitTestCase
 
         parent::setUp();
 
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
 
         $this->logger   = Services::logger();
         $this->commands = Services::commands();
@@ -42,12 +42,12 @@ final class CommandTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
     }
 
     protected function getBuffer()
     {
-        return CITestStreamFilter::$buffer;
+        return $this->getStreamFilterBuffer();
     }
 
     public function testListCommands()

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -33,8 +33,8 @@ final class CommandTest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
 
         $this->logger   = Services::logger();
         $this->commands = Services::commands();
@@ -42,7 +42,7 @@ final class CommandTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     protected function getBuffer()

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -32,17 +32,8 @@ final class CommandTest extends CIUnitTestCase
 
         parent::setUp();
 
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-
         $this->logger   = Services::logger();
         $this->commands = Services::commands();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     protected function getBuffer()

--- a/tests/system/Commands/ConfigGeneratorTest.php
+++ b/tests/system/Commands/ConfigGeneratorTest.php
@@ -21,17 +21,8 @@ final class ConfigGeneratorTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
     protected function tearDown(): void
     {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
         if (is_file($file)) {

--- a/tests/system/Commands/ConfigGeneratorTest.php
+++ b/tests/system/Commands/ConfigGeneratorTest.php
@@ -24,13 +24,13 @@ final class ConfigGeneratorTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));

--- a/tests/system/Commands/ConfigGeneratorTest.php
+++ b/tests/system/Commands/ConfigGeneratorTest.php
@@ -12,28 +12,27 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class ConfigGeneratorTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
 
-        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
         if (is_file($file)) {
             unlink($file);

--- a/tests/system/Commands/ConfigurableSortImportsTest.php
+++ b/tests/system/Commands/ConfigurableSortImportsTest.php
@@ -21,20 +21,6 @@ final class ConfigurableSortImportsTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-    }
-
     public function testPublishLanguageWithoutOptions()
     {
         command('publish:language');

--- a/tests/system/Commands/ConfigurableSortImportsTest.php
+++ b/tests/system/Commands/ConfigurableSortImportsTest.php
@@ -12,28 +12,27 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class ConfigurableSortImportsTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
     }
 
     public function testPublishLanguageWithoutOptions()
@@ -41,7 +40,7 @@ final class ConfigurableSortImportsTest extends CIUnitTestCase
         command('publish:language');
 
         $file = APPPATH . 'Language/en/Foobar.php';
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists($file);
         $this->assertNotSame(sha1_file(SUPPORTPATH . 'Commands/Foobar.php'), sha1_file($file));
         if (is_file($file)) {
@@ -54,7 +53,7 @@ final class ConfigurableSortImportsTest extends CIUnitTestCase
         command('publish:language --lang es');
 
         $file = APPPATH . 'Language/es/Foobar.php';
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists($file);
         $this->assertNotSame(sha1_file(SUPPORTPATH . 'Commands/Foobar.php'), sha1_file($file));
         if (is_file($file)) {
@@ -71,7 +70,7 @@ final class ConfigurableSortImportsTest extends CIUnitTestCase
         command('publish:language --lang ar --sort off');
 
         $file = APPPATH . 'Language/ar/Foobar.php';
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists($file);
         $this->assertSame(sha1_file(SUPPORTPATH . 'Commands/Foobar.php'), sha1_file($file));
         if (is_file($file)) {

--- a/tests/system/Commands/ConfigurableSortImportsTest.php
+++ b/tests/system/Commands/ConfigurableSortImportsTest.php
@@ -26,13 +26,13 @@ final class ConfigurableSortImportsTest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     public function testPublishLanguageWithoutOptions()

--- a/tests/system/Commands/ControllerGeneratorTest.php
+++ b/tests/system/Commands/ControllerGeneratorTest.php
@@ -12,28 +12,27 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class ControllerGeneratorTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
 
-        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
         if (is_file($file)) {
             unlink($file);
@@ -52,7 +51,7 @@ final class ControllerGeneratorTest extends CIUnitTestCase
     public function testGenerateController()
     {
         command('make:controller user');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Controllers/User.php';
         $this->assertFileExists($file);
         $this->assertStringContainsString('extends BaseController', $this->getFileContents($file));
@@ -61,7 +60,7 @@ final class ControllerGeneratorTest extends CIUnitTestCase
     public function testGenerateControllerWithOptionBare()
     {
         command('make:controller blog -bare');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Controllers/Blog.php';
         $this->assertFileExists($file);
         $this->assertStringContainsString('extends Controller', $this->getFileContents($file));
@@ -70,7 +69,7 @@ final class ControllerGeneratorTest extends CIUnitTestCase
     public function testGenerateControllerWithOptionRestful()
     {
         command('make:controller order -restful');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Controllers/Order.php';
         $this->assertFileExists($file);
         $this->assertStringContainsString('extends ResourceController', $this->getFileContents($file));
@@ -79,7 +78,7 @@ final class ControllerGeneratorTest extends CIUnitTestCase
     public function testGenerateControllerWithOptionRestfulPresenter()
     {
         command('make:controller pay -restful presenter');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Controllers/Pay.php';
         $this->assertFileExists($file);
         $this->assertStringContainsString('extends ResourcePresenter', $this->getFileContents($file));
@@ -88,7 +87,7 @@ final class ControllerGeneratorTest extends CIUnitTestCase
     public function testGenerateControllerWithOptionSuffix()
     {
         command('make:controller dashboard -suffix');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Controllers/DashboardController.php');
     }
 }

--- a/tests/system/Commands/ControllerGeneratorTest.php
+++ b/tests/system/Commands/ControllerGeneratorTest.php
@@ -24,13 +24,13 @@ final class ControllerGeneratorTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));

--- a/tests/system/Commands/ControllerGeneratorTest.php
+++ b/tests/system/Commands/ControllerGeneratorTest.php
@@ -21,17 +21,8 @@ final class ControllerGeneratorTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
     protected function tearDown(): void
     {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
         if (is_file($file)) {

--- a/tests/system/Commands/CreateDatabaseTest.php
+++ b/tests/system/Commands/CreateDatabaseTest.php
@@ -31,8 +31,8 @@ final class CreateDatabaseTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
 
         $this->connection = Database::connect();
 
@@ -54,7 +54,7 @@ final class CreateDatabaseTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         parent::tearDown();
     }

--- a/tests/system/Commands/CreateDatabaseTest.php
+++ b/tests/system/Commands/CreateDatabaseTest.php
@@ -30,10 +30,6 @@ final class CreateDatabaseTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-
         $this->connection = Database::connect();
 
         parent::setUp();
@@ -50,13 +46,6 @@ final class CreateDatabaseTest extends CIUnitTestCase
                 Database::forge()->dropDatabase('foobar');
             }
         }
-    }
-
-    protected function tearDown(): void
-    {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-
-        parent::tearDown();
     }
 
     protected function getBuffer()

--- a/tests/system/Commands/CreateDatabaseTest.php
+++ b/tests/system/Commands/CreateDatabaseTest.php
@@ -16,7 +16,7 @@ use CodeIgniter\Database\Database as DatabaseFactory;
 use CodeIgniter\Database\OCI8\Connection as OCI8Connection;
 use CodeIgniter\Database\SQLite3\Connection as SQLite3Connection;
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 use Config\Database;
 
 /**
@@ -24,16 +24,17 @@ use Config\Database;
  */
 final class CreateDatabaseTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
+
     private BaseConnection $connection;
 
     protected function setUp(): void
     {
-        CITestStreamFilter::$buffer = '';
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
 
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
-        $this->connection   = Database::connect();
+        $this->connection = Database::connect();
 
         parent::setUp();
 
@@ -53,14 +54,14 @@ final class CreateDatabaseTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
 
         parent::tearDown();
     }
 
     protected function getBuffer()
     {
-        return CITestStreamFilter::$buffer;
+        return $this->getStreamFilterBuffer();
     }
 
     public function testCreateDatabase()
@@ -80,7 +81,7 @@ final class CreateDatabaseTest extends CIUnitTestCase
         }
 
         command('db:create foobar');
-        CITestStreamFilter::$buffer = '';
+        $this->resetStreamFilterBuffer();
 
         command('db:create foobar --ext db');
         $this->assertStringContainsString('already exists.', $this->getBuffer());
@@ -93,7 +94,7 @@ final class CreateDatabaseTest extends CIUnitTestCase
         }
 
         command('db:create foobar');
-        CITestStreamFilter::$buffer = '';
+        $this->resetStreamFilterBuffer();
 
         command('db:create foobar');
         $this->assertStringContainsString('Unable to create the specified database.', $this->getBuffer());

--- a/tests/system/Commands/Database/MigrateStatusTest.php
+++ b/tests/system/Commands/Database/MigrateStatusTest.php
@@ -12,14 +12,15 @@
 namespace CodeIgniter\Commands\Database;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class MigrateStatusTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
+
     private string $migrationFileFrom = SUPPORTPATH . 'MigrationTestMigrations/Database/Migrations/2018-01-24-102301_Some_migration.php';
     private string $migrationFileTo   = APPPATH . 'Database/Migrations/2018-01-24-102301_Some_migration.php';
 
@@ -45,10 +46,9 @@ final class MigrateStatusTest extends CIUnitTestCase
         );
         file_put_contents($this->migrationFileTo, $contents);
 
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
@@ -62,17 +62,17 @@ final class MigrateStatusTest extends CIUnitTestCase
             @unlink($this->migrationFileTo);
         }
 
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
     }
 
     public function testMigrateAllWithWithTwoNamespaces(): void
     {
         command('migrate --all');
-        CITestStreamFilter::$buffer = '';
+        $this->resetStreamFilterBuffer();
 
         command('migrate:status');
 
-        $result   = str_replace(["\033[0;33m", "\033[0m"], '', CITestStreamFilter::$buffer);
+        $result   = str_replace(["\033[0;33m", "\033[0m"], '', $this->getStreamFilterBuffer());
         $result   = preg_replace('/\d{4}-\d\d-\d\d \d\d:\d\d:\d\d/', 'YYYY-MM-DD HH:MM:SS', $result);
         $expected = <<<'EOL'
             +---------------+-------------------+--------------------+-------+---------------------+-------+
@@ -91,11 +91,11 @@ final class MigrateStatusTest extends CIUnitTestCase
     {
         command('migrate -n App');
         command('migrate -n Tests\\\\Support');
-        CITestStreamFilter::$buffer = '';
+        $this->resetStreamFilterBuffer();
 
         command('migrate:status');
 
-        $result   = str_replace(["\033[0;33m", "\033[0m"], '', CITestStreamFilter::$buffer);
+        $result   = str_replace(["\033[0;33m", "\033[0m"], '', $this->getStreamFilterBuffer());
         $result   = preg_replace('/\d{4}-\d\d-\d\d \d\d:\d\d:\d\d/', 'YYYY-MM-DD HH:MM:SS', $result);
         $expected = <<<'EOL'
             +---------------+-------------------+--------------------+-------+---------------------+-------+

--- a/tests/system/Commands/Database/MigrateStatusTest.php
+++ b/tests/system/Commands/Database/MigrateStatusTest.php
@@ -45,10 +45,6 @@ final class MigrateStatusTest extends CIUnitTestCase
             $contents
         );
         file_put_contents($this->migrationFileTo, $contents);
-
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
@@ -61,8 +57,6 @@ final class MigrateStatusTest extends CIUnitTestCase
         if (is_file($this->migrationFileTo)) {
             @unlink($this->migrationFileTo);
         }
-
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     public function testMigrateAllWithWithTwoNamespaces(): void

--- a/tests/system/Commands/Database/MigrateStatusTest.php
+++ b/tests/system/Commands/Database/MigrateStatusTest.php
@@ -47,8 +47,8 @@ final class MigrateStatusTest extends CIUnitTestCase
         file_put_contents($this->migrationFileTo, $contents);
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
@@ -62,7 +62,7 @@ final class MigrateStatusTest extends CIUnitTestCase
             @unlink($this->migrationFileTo);
         }
 
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     public function testMigrateAllWithWithTwoNamespaces(): void

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -27,22 +27,6 @@ final class ShowTableInfoTest extends CIUnitTestCase
 
     protected $migrateOnce = true;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-    }
-
     private function getResultWithoutControlCode(): string
     {
         return str_replace(

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -13,7 +13,7 @@ namespace CodeIgniter\Commands\Database;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 use Config\Database;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
@@ -23,25 +23,24 @@ use Tests\Support\Database\Seeds\CITestSeeder;
 final class ShowTableInfoTest extends CIUnitTestCase
 {
     use DatabaseTestTrait;
+    use StreamFilterTrait;
 
-    private $streamFilter;
     protected $migrateOnce = true;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
 
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
     }
 
     private function getResultWithoutControlCode(): string
@@ -49,7 +48,7 @@ final class ShowTableInfoTest extends CIUnitTestCase
         return str_replace(
             ["\033[0;30m", "\033[0;33m", "\033[43m", "\033[0m"],
             '',
-            CITestStreamFilter::$buffer
+            $this->getStreamFilterBuffer()
         );
     }
 

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -32,15 +32,15 @@ final class ShowTableInfoTest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
 
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     private function getResultWithoutControlCode(): string

--- a/tests/system/Commands/DatabaseCommandsTest.php
+++ b/tests/system/Commands/DatabaseCommandsTest.php
@@ -12,21 +12,20 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class DatabaseCommandsTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
 
         parent::setUp();
     }
@@ -34,19 +33,19 @@ final class DatabaseCommandsTest extends CIUnitTestCase
     protected function tearDown(): void
     {
         command('migrate:rollback');
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
 
         parent::tearDown();
     }
 
     protected function getBuffer(): string
     {
-        return CITestStreamFilter::$buffer;
+        return $this->getStreamFilterBuffer();
     }
 
     protected function clearBuffer(): void
     {
-        CITestStreamFilter::$buffer = '';
+        $this->resetStreamFilterBuffer();
     }
 
     public function testMigrate()

--- a/tests/system/Commands/DatabaseCommandsTest.php
+++ b/tests/system/Commands/DatabaseCommandsTest.php
@@ -21,19 +21,9 @@ final class DatabaseCommandsTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-
-        parent::setUp();
-    }
-
     protected function tearDown(): void
     {
         command('migrate:rollback');
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         parent::tearDown();
     }

--- a/tests/system/Commands/DatabaseCommandsTest.php
+++ b/tests/system/Commands/DatabaseCommandsTest.php
@@ -24,8 +24,8 @@ final class DatabaseCommandsTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
 
         parent::setUp();
     }
@@ -33,7 +33,7 @@ final class DatabaseCommandsTest extends CIUnitTestCase
     protected function tearDown(): void
     {
         command('migrate:rollback');
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         parent::tearDown();
     }

--- a/tests/system/Commands/EntityGeneratorTest.php
+++ b/tests/system/Commands/EntityGeneratorTest.php
@@ -12,28 +12,27 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class EntityGeneratorTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
 
-        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
         $dir    = dirname($file);
         if (is_file($file)) {

--- a/tests/system/Commands/EntityGeneratorTest.php
+++ b/tests/system/Commands/EntityGeneratorTest.php
@@ -24,13 +24,13 @@ final class EntityGeneratorTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));

--- a/tests/system/Commands/EntityGeneratorTest.php
+++ b/tests/system/Commands/EntityGeneratorTest.php
@@ -21,17 +21,8 @@ final class EntityGeneratorTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
     protected function tearDown(): void
     {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
         $dir    = dirname($file);

--- a/tests/system/Commands/EnvironmentCommandTest.php
+++ b/tests/system/Commands/EnvironmentCommandTest.php
@@ -27,9 +27,6 @@ final class EnvironmentCommandTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
 
         if (is_file($this->envPath)) {
             rename($this->envPath, $this->backupEnvPath);
@@ -39,7 +36,6 @@ final class EnvironmentCommandTest extends CIUnitTestCase
     protected function tearDown(): void
     {
         parent::tearDown();
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         if (is_file($this->envPath)) {
             unlink($this->envPath);

--- a/tests/system/Commands/EnvironmentCommandTest.php
+++ b/tests/system/Commands/EnvironmentCommandTest.php
@@ -28,8 +28,8 @@ final class EnvironmentCommandTest extends CIUnitTestCase
     {
         parent::setUp();
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
 
         if (is_file($this->envPath)) {
             rename($this->envPath, $this->backupEnvPath);
@@ -39,7 +39,7 @@ final class EnvironmentCommandTest extends CIUnitTestCase
     protected function tearDown(): void
     {
         parent::tearDown();
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         if (is_file($this->envPath)) {
             unlink($this->envPath);

--- a/tests/system/Commands/EnvironmentCommandTest.php
+++ b/tests/system/Commands/EnvironmentCommandTest.php
@@ -12,24 +12,24 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class EnvironmentCommandTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
+
     private string $envPath       = ROOTPATH . '.env';
     private string $backupEnvPath = ROOTPATH . '.env.backup';
 
     protected function setUp(): void
     {
         parent::setUp();
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
 
         if (is_file($this->envPath)) {
             rename($this->envPath, $this->backupEnvPath);
@@ -39,7 +39,7 @@ final class EnvironmentCommandTest extends CIUnitTestCase
     protected function tearDown(): void
     {
         parent::tearDown();
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
 
         if (is_file($this->envPath)) {
             unlink($this->envPath);
@@ -55,20 +55,23 @@ final class EnvironmentCommandTest extends CIUnitTestCase
     public function testUsingCommandWithNoArgumentsGivesCurrentEnvironment(): void
     {
         command('env');
-        $this->assertStringContainsString('testing', CITestStreamFilter::$buffer);
-        $this->assertStringContainsString(ENVIRONMENT, CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('testing', $this->getStreamFilterBuffer());
+        $this->assertStringContainsString(ENVIRONMENT, $this->getStreamFilterBuffer());
     }
 
     public function testProvidingTestingAsEnvGivesErrorMessage(): void
     {
         command('env testing');
-        $this->assertStringContainsString('The "testing" environment is reserved for PHPUnit testing.', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString(
+            'The "testing" environment is reserved for PHPUnit testing.',
+            $this->getStreamFilterBuffer()
+        );
     }
 
     public function testProvidingUnknownEnvGivesErrorMessage(): void
     {
         command('env foobar');
-        $this->assertStringContainsString('Invalid environment type "foobar".', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('Invalid environment type "foobar".', $this->getStreamFilterBuffer());
     }
 
     public function testDefaultShippedEnvIsMissing()
@@ -77,8 +80,11 @@ final class EnvironmentCommandTest extends CIUnitTestCase
         command('env development');
         rename(ROOTPATH . 'lostenv', ROOTPATH . 'env');
 
-        $this->assertStringContainsString('Both default shipped', CITestStreamFilter::$buffer);
-        $this->assertStringContainsString('It is impossible to write the new environment type.', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('Both default shipped', $this->getStreamFilterBuffer());
+        $this->assertStringContainsString(
+            'It is impossible to write the new environment type.',
+            $this->getStreamFilterBuffer()
+        );
     }
 
     public function testSettingNewEnvIsSuccess(): void
@@ -87,7 +93,7 @@ final class EnvironmentCommandTest extends CIUnitTestCase
         $_SERVER['CI_ENVIRONMENT'] = 'production';
         command('env development');
 
-        $this->assertStringContainsString('Environment is successfully changed to', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('Environment is successfully changed to', $this->getStreamFilterBuffer());
         $this->assertStringContainsString('CI_ENVIRONMENT = development', file_get_contents($this->envPath));
     }
 }

--- a/tests/system/Commands/FilterGeneratorTest.php
+++ b/tests/system/Commands/FilterGeneratorTest.php
@@ -12,28 +12,27 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class FilterGeneratorTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamErrorFilter()
+            ->appendStreamOutputFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamErrorFilter()->removeStreamOutputFilter();
 
-        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
         if (is_file($file)) {
             unlink($file);

--- a/tests/system/Commands/FilterGeneratorTest.php
+++ b/tests/system/Commands/FilterGeneratorTest.php
@@ -24,13 +24,13 @@ final class FilterGeneratorTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->registerStreamFilterClass()
-            ->appendStreamErrorFilter()
-            ->appendStreamOutputFilter();
+            ->appendErrorStreamFilter()
+            ->appendOutputStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamErrorFilter()->removeStreamOutputFilter();
+        $this->removeErrorStreamFilter()->removeOutputStreamFilter();
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));

--- a/tests/system/Commands/FilterGeneratorTest.php
+++ b/tests/system/Commands/FilterGeneratorTest.php
@@ -21,17 +21,8 @@ final class FilterGeneratorTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        $this->registerStreamFilterClass()
-            ->appendErrorStreamFilter()
-            ->appendOutputStreamFilter();
-    }
-
     protected function tearDown(): void
     {
-        $this->removeErrorStreamFilter()->removeOutputStreamFilter();
-
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
         if (is_file($file)) {

--- a/tests/system/Commands/GenerateKeyTest.php
+++ b/tests/system/Commands/GenerateKeyTest.php
@@ -31,8 +31,8 @@ final class GenerateKeyTest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
 
         $this->envPath       = ROOTPATH . '.env';
         $this->backupEnvPath = ROOTPATH . '.env.backup';
@@ -46,7 +46,7 @@ final class GenerateKeyTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         if (is_file($this->envPath)) {
             unlink($this->envPath);

--- a/tests/system/Commands/GenerateKeyTest.php
+++ b/tests/system/Commands/GenerateKeyTest.php
@@ -30,10 +30,6 @@ final class GenerateKeyTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-
         $this->envPath       = ROOTPATH . '.env';
         $this->backupEnvPath = ROOTPATH . '.env.backup';
 
@@ -46,8 +42,6 @@ final class GenerateKeyTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-
         if (is_file($this->envPath)) {
             unlink($this->envPath);
         }

--- a/tests/system/Commands/GenerateKeyTest.php
+++ b/tests/system/Commands/GenerateKeyTest.php
@@ -12,7 +12,7 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
@@ -21,7 +21,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
  */
 final class GenerateKeyTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
+
     private string $envPath;
     private string $backupEnvPath;
 
@@ -29,9 +30,9 @@ final class GenerateKeyTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        CITestStreamFilter::$buffer = '';
-        $this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
 
         $this->envPath       = ROOTPATH . '.env';
         $this->backupEnvPath = ROOTPATH . '.env.backup';
@@ -45,7 +46,7 @@ final class GenerateKeyTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
 
         if (is_file($this->envPath)) {
             unlink($this->envPath);
@@ -63,7 +64,7 @@ final class GenerateKeyTest extends CIUnitTestCase
      */
     protected function getBuffer(): string
     {
-        return CITestStreamFilter::$buffer;
+        return $this->getStreamFilterBuffer();
     }
 
     protected function resetEnvironment()

--- a/tests/system/Commands/GeneratorsTest.php
+++ b/tests/system/Commands/GeneratorsTest.php
@@ -24,13 +24,13 @@ final class GeneratorsTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     public function testGenerateFileCreated()

--- a/tests/system/Commands/GeneratorsTest.php
+++ b/tests/system/Commands/GeneratorsTest.php
@@ -21,18 +21,6 @@ final class GeneratorsTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-    }
-
     public function testGenerateFileCreated()
     {
         command('make:seeder categories');

--- a/tests/system/Commands/GeneratorsTest.php
+++ b/tests/system/Commands/GeneratorsTest.php
@@ -12,32 +12,31 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class GeneratorsTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
     }
 
     public function testGenerateFileCreated()
     {
         command('make:seeder categories');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Database/Seeds/Categories.php';
         if (is_file($file)) {
             unlink($file);
@@ -47,10 +46,10 @@ final class GeneratorsTest extends CIUnitTestCase
     public function testGenerateFileExists()
     {
         command('make:filter items');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
-        CITestStreamFilter::$buffer = '';
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
+        $this->resetStreamFilterBuffer();
         command('make:filter items');
-        $this->assertStringContainsString('File exists: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File exists: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Filters/Items.php';
         if (is_file($file)) {
             unlink($file);
@@ -60,10 +59,10 @@ final class GeneratorsTest extends CIUnitTestCase
     public function testGenerateFileOverwritten()
     {
         command('make:controller products');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
-        CITestStreamFilter::$buffer = '';
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
+        $this->resetStreamFilterBuffer();
         command('make:controller products -force');
-        $this->assertStringContainsString('File overwritten: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File overwritten: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Controllers/Products.php';
         if (is_file($file)) {
             unlink($file);
@@ -79,7 +78,7 @@ final class GeneratorsTest extends CIUnitTestCase
         chmod(APPPATH . 'Filters', 0444);
 
         command('make:filter permissions');
-        $this->assertStringContainsString('Error while creating file: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('Error while creating file: ', $this->getStreamFilterBuffer());
 
         chmod(APPPATH . 'Filters', 0755);
     }
@@ -87,7 +86,7 @@ final class GeneratorsTest extends CIUnitTestCase
     public function testGenerateFailsOnUndefinedNamespace()
     {
         command('make:model cars -namespace CodeIgnite');
-        $this->assertStringContainsString('Namespace "CodeIgnite" is not defined.', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('Namespace "CodeIgnite" is not defined.', $this->getStreamFilterBuffer());
     }
 
     public function testGenerateFileInSubfolders()

--- a/tests/system/Commands/HelpCommandTest.php
+++ b/tests/system/Commands/HelpCommandTest.php
@@ -12,32 +12,32 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class HelpCommandTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        CITestStreamFilter::$buffer = '';
-        $this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
     }
 
     protected function getBuffer()
     {
-        return CITestStreamFilter::$buffer;
+        return $this->getStreamFilterBuffer();
     }
 
     public function testHelpCommand()

--- a/tests/system/Commands/HelpCommandTest.php
+++ b/tests/system/Commands/HelpCommandTest.php
@@ -26,13 +26,13 @@ final class HelpCommandTest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     protected function getBuffer()

--- a/tests/system/Commands/HelpCommandTest.php
+++ b/tests/system/Commands/HelpCommandTest.php
@@ -21,20 +21,6 @@ final class HelpCommandTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-    }
-
     protected function getBuffer()
     {
         return $this->getStreamFilterBuffer();

--- a/tests/system/Commands/InfoCacheTest.php
+++ b/tests/system/Commands/InfoCacheTest.php
@@ -13,7 +13,7 @@ namespace CodeIgniter\Commands;
 
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 use Config\Services;
 
 /**
@@ -21,15 +21,15 @@ use Config\Services;
  */
 final class InfoCacheTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        CITestStreamFilter::$buffer = '';
-        $this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
 
         // Make sure we are testing with the correct handler (override injections)
         Services::injectMock('cache', CacheFactory::getHandler(config('Cache')));
@@ -37,7 +37,7 @@ final class InfoCacheTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
 
         // restore default cache handler
         config('Cache')->handler = 'file';
@@ -45,7 +45,7 @@ final class InfoCacheTest extends CIUnitTestCase
 
     protected function getBuffer()
     {
-        return CITestStreamFilter::$buffer;
+        return $this->getStreamFilterBuffer();
     }
 
     public function testInfoCacheErrorsOnInvalidHandler()

--- a/tests/system/Commands/InfoCacheTest.php
+++ b/tests/system/Commands/InfoCacheTest.php
@@ -28,8 +28,8 @@ final class InfoCacheTest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
 
         // Make sure we are testing with the correct handler (override injections)
         Services::injectMock('cache', CacheFactory::getHandler(config('Cache')));
@@ -37,7 +37,7 @@ final class InfoCacheTest extends CIUnitTestCase
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         // restore default cache handler
         config('Cache')->handler = 'file';

--- a/tests/system/Commands/InfoCacheTest.php
+++ b/tests/system/Commands/InfoCacheTest.php
@@ -27,18 +27,12 @@ final class InfoCacheTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-
         // Make sure we are testing with the correct handler (override injections)
         Services::injectMock('cache', CacheFactory::getHandler(config('Cache')));
     }
 
     protected function tearDown(): void
     {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-
         // restore default cache handler
         config('Cache')->handler = 'file';
     }

--- a/tests/system/Commands/MigrationGeneratorTest.php
+++ b/tests/system/Commands/MigrationGeneratorTest.php
@@ -24,13 +24,13 @@ final class MigrationGeneratorTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->registerStreamFilterClass()
-            ->appendStreamErrorFilter()
-            ->appendStreamOutputFilter();
+            ->appendErrorStreamFilter()
+            ->appendOutputStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));

--- a/tests/system/Commands/MigrationGeneratorTest.php
+++ b/tests/system/Commands/MigrationGeneratorTest.php
@@ -21,17 +21,8 @@ final class MigrationGeneratorTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        $this->registerStreamFilterClass()
-            ->appendErrorStreamFilter()
-            ->appendOutputStreamFilter();
-    }
-
     protected function tearDown(): void
     {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
         if (is_file($file)) {

--- a/tests/system/Commands/MigrationGeneratorTest.php
+++ b/tests/system/Commands/MigrationGeneratorTest.php
@@ -12,28 +12,27 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class MigrationGeneratorTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamErrorFilter()
+            ->appendStreamOutputFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
 
-        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
         if (is_file($file)) {
             unlink($file);
@@ -43,24 +42,24 @@ final class MigrationGeneratorTest extends CIUnitTestCase
     public function testGenerateMigration()
     {
         command('make:migration database');
-        $this->assertStringContainsString('_Database.php', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('_Database.php', $this->getStreamFilterBuffer());
     }
 
     public function testGenerateMigrationWithOptionSession()
     {
         command('make:migration -session');
-        $this->assertStringContainsString('_CreateCiSessionsTable.php', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('_CreateCiSessionsTable.php', $this->getStreamFilterBuffer());
     }
 
     public function testGenerateMigrationWithOptionTable()
     {
         command('make:migration -session -table logger');
-        $this->assertStringContainsString('_CreateLoggerTable.php', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('_CreateLoggerTable.php', $this->getStreamFilterBuffer());
     }
 
     public function testGenerateMigrationWithOptionSuffix()
     {
         command('make:migration database -suffix');
-        $this->assertStringContainsString('_DatabaseMigration.php', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('_DatabaseMigration.php', $this->getStreamFilterBuffer());
     }
 }

--- a/tests/system/Commands/MigrationIntegrationTest.php
+++ b/tests/system/Commands/MigrationIntegrationTest.php
@@ -41,10 +41,6 @@ final class MigrationIntegrationTest extends CIUnitTestCase
         $contents = file_get_contents($this->migrationFileTo);
         $contents = str_replace('namespace Tests\Support\Database\Migrations;', 'namespace App\Database\Migrations;', $contents);
         file_put_contents($this->migrationFileTo, $contents);
-
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
@@ -54,8 +50,6 @@ final class MigrationIntegrationTest extends CIUnitTestCase
         if (is_file($this->migrationFileTo)) {
             @unlink($this->migrationFileTo);
         }
-
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     public function testMigrationWithRollbackHasSameNameFormat(): void

--- a/tests/system/Commands/MigrationIntegrationTest.php
+++ b/tests/system/Commands/MigrationIntegrationTest.php
@@ -43,8 +43,8 @@ final class MigrationIntegrationTest extends CIUnitTestCase
         file_put_contents($this->migrationFileTo, $contents);
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
@@ -55,7 +55,7 @@ final class MigrationIntegrationTest extends CIUnitTestCase
             @unlink($this->migrationFileTo);
         }
 
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     public function testMigrationWithRollbackHasSameNameFormat(): void

--- a/tests/system/Commands/ModelGeneratorTest.php
+++ b/tests/system/Commands/ModelGeneratorTest.php
@@ -12,30 +12,29 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class ModelGeneratorTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
 
-        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
 
         if (is_file($file)) {
@@ -55,7 +54,7 @@ final class ModelGeneratorTest extends CIUnitTestCase
     public function testGenerateModel()
     {
         command('make:model user --table users');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Models/User.php';
         $this->assertFileExists($file);
         $this->assertStringContainsString('extends Model', $this->getFileContent($file));
@@ -67,7 +66,7 @@ final class ModelGeneratorTest extends CIUnitTestCase
     public function testGenerateModelWithOptionTable()
     {
         command('make:model cars -table utilisateur');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Models/Cars.php';
         $this->assertFileExists($file);
         $this->assertStringContainsString('protected $table            = \'utilisateur\';', $this->getFileContent($file));
@@ -76,7 +75,7 @@ final class ModelGeneratorTest extends CIUnitTestCase
     public function testGenerateModelWithOptionDBGroup()
     {
         command('make:model user -dbgroup testing');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Models/User.php';
         $this->assertFileExists($file);
         $this->assertStringContainsString('protected $DBGroup          = \'testing\';', $this->getFileContent($file));
@@ -85,7 +84,7 @@ final class ModelGeneratorTest extends CIUnitTestCase
     public function testGenerateModelWithOptionReturnArray()
     {
         command('make:model user --return array');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Models/User.php';
         $this->assertFileExists($file);
         $this->assertStringContainsString('protected $returnType       = \'array\';', $this->getFileContent($file));
@@ -94,7 +93,7 @@ final class ModelGeneratorTest extends CIUnitTestCase
     public function testGenerateModelWithOptionReturnObject()
     {
         command('make:model user --return object');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $file = APPPATH . 'Models/User.php';
         $this->assertFileExists($file);
         $this->assertStringContainsString('protected $returnType       = \'object\';', $this->getFileContent($file));
@@ -103,7 +102,7 @@ final class ModelGeneratorTest extends CIUnitTestCase
     public function testGenerateModelWithOptionReturnEntity()
     {
         command('make:model user --return entity');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
 
         $file = APPPATH . 'Models/User.php';
         $this->assertFileExists($file);

--- a/tests/system/Commands/ModelGeneratorTest.php
+++ b/tests/system/Commands/ModelGeneratorTest.php
@@ -21,18 +21,9 @@ final class ModelGeneratorTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
     protected function tearDown(): void
     {
         parent::tearDown();
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));

--- a/tests/system/Commands/ModelGeneratorTest.php
+++ b/tests/system/Commands/ModelGeneratorTest.php
@@ -25,14 +25,14 @@ final class ModelGeneratorTest extends CIUnitTestCase
     {
         parent::setUp();
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));

--- a/tests/system/Commands/PublishCommandTest.php
+++ b/tests/system/Commands/PublishCommandTest.php
@@ -27,15 +27,15 @@ final class PublishCommandTest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
 
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
         TestPublisher::setResult(true);
     }
 

--- a/tests/system/Commands/PublishCommandTest.php
+++ b/tests/system/Commands/PublishCommandTest.php
@@ -12,7 +12,7 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 use Tests\Support\Publishers\TestPublisher;
 
 /**
@@ -20,22 +20,22 @@ use Tests\Support\Publishers\TestPublisher;
  */
 final class PublishCommandTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
-        CITestStreamFilter::$buffer = '';
 
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
 
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
         TestPublisher::setResult(true);
     }
 
@@ -47,7 +47,7 @@ final class PublishCommandTest extends CIUnitTestCase
             TestPublisher::class,
             0,
             WRITEPATH,
-        ]), CITestStreamFilter::$buffer);
+        ]), $this->getStreamFilterBuffer());
     }
 
     public function testFailure()
@@ -59,6 +59,6 @@ final class PublishCommandTest extends CIUnitTestCase
         $this->assertStringContainsString(lang('Publisher.publishFailure', [
             TestPublisher::class,
             WRITEPATH,
-        ]), CITestStreamFilter::$buffer);
+        ]), $this->getStreamFilterBuffer());
     }
 }

--- a/tests/system/Commands/PublishCommandTest.php
+++ b/tests/system/Commands/PublishCommandTest.php
@@ -22,20 +22,10 @@ final class PublishCommandTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
     protected function tearDown(): void
     {
         parent::tearDown();
 
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
         TestPublisher::setResult(true);
     }
 

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -25,19 +25,13 @@ final class RoutesTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->resetServices();
-
         parent::setUp();
-
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-
         $this->resetServices();
+        parent::tearDown();
     }
 
     protected function getBuffer()

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -29,13 +29,13 @@ final class RoutesTest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         $this->resetServices();
     }

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -12,7 +12,7 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 use Config\Services;
 
 /**
@@ -20,7 +20,7 @@ use Config\Services;
  */
 final class RoutesTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
@@ -28,22 +28,21 @@ final class RoutesTest extends CIUnitTestCase
 
         parent::setUp();
 
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
 
         $this->resetServices();
     }
 
     protected function getBuffer()
     {
-        return CITestStreamFilter::$buffer;
+        return $this->getStreamFilterBuffer();
     }
 
     public function testRoutesCommand()

--- a/tests/system/Commands/ScaffoldGeneratorTest.php
+++ b/tests/system/Commands/ScaffoldGeneratorTest.php
@@ -30,13 +30,13 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
         Services::autoloader()->initialize(new Autoload(), new Modules());
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     protected function getFileContents(string $filepath): string

--- a/tests/system/Commands/ScaffoldGeneratorTest.php
+++ b/tests/system/Commands/ScaffoldGeneratorTest.php
@@ -29,14 +29,7 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
         $this->resetServices();
         Services::autoloader()->initialize(new Autoload(), new Modules());
 
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
+        parent::setUp();
     }
 
     protected function getFileContents(string $filepath): string

--- a/tests/system/Commands/ScaffoldGeneratorTest.php
+++ b/tests/system/Commands/ScaffoldGeneratorTest.php
@@ -12,7 +12,7 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 use Config\Autoload;
 use Config\Modules;
 use Config\Services;
@@ -22,22 +22,21 @@ use Config\Services;
  */
 final class ScaffoldGeneratorTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
         $this->resetServices();
         Services::autoloader()->initialize(new Autoload(), new Modules());
 
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
     }
 
     protected function getFileContents(string $filepath): string
@@ -55,14 +54,14 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
 
         $dir       = '\\' . DIRECTORY_SEPARATOR;
         $migration = "APPPATH{$dir}Database{$dir}Migrations{$dir}(.*)\\.php";
-        preg_match('/' . $migration . '/u', CITestStreamFilter::$buffer, $matches);
+        preg_match('/' . $migration . '/u', $this->getStreamFilterBuffer(), $matches);
         $matches[0] = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $matches[0]);
 
         // Files check
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Controllers/People.php');
         $this->assertFileExists(APPPATH . 'Models/People.php');
-        $this->assertStringContainsString('_People.php', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('_People.php', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Database/Seeds/People.php');
 
         // Options check
@@ -78,13 +77,13 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
 
         $dir       = '\\' . DIRECTORY_SEPARATOR;
         $migration = "APPPATH{$dir}Database{$dir}Migrations{$dir}(.*)\\.php";
-        preg_match('/' . $migration . '/u', CITestStreamFilter::$buffer, $matches);
+        preg_match('/' . $migration . '/u', $this->getStreamFilterBuffer(), $matches);
         $matches[0] = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $matches[0]);
 
         // Files check
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Controllers/User.php');
-        $this->assertStringContainsString('_User.php', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('_User.php', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Database/Seeds/User.php');
         $this->assertFileExists(APPPATH . 'Entities/User.php');
         $this->assertFileExists(APPPATH . 'Models/User.php');
@@ -107,13 +106,13 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
 
         $dir       = '\\' . DIRECTORY_SEPARATOR;
         $migration = "APPPATH{$dir}Database{$dir}Migrations{$dir}(.*)\\.php";
-        preg_match('/' . $migration . '/u', CITestStreamFilter::$buffer, $matches);
+        preg_match('/' . $migration . '/u', $this->getStreamFilterBuffer(), $matches);
         $matches[0] = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $matches[0]);
 
         // Files check
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Controllers/OrderController.php');
-        $this->assertStringContainsString('_OrderMigration.php', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('_OrderMigration.php', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Database/Seeds/OrderSeeder.php');
         $this->assertFileExists(APPPATH . 'Models/OrderModel.php');
 
@@ -127,28 +126,28 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
     public function testCreateComponentWithOptionForce()
     {
         command('make:controller fixer');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertStringContainsString('extends BaseController', $this->getFileContents(APPPATH . 'Controllers/Fixer.php'));
         $this->assertFileExists(APPPATH . 'Controllers/Fixer.php');
-        CITestStreamFilter::$buffer = '';
+        $this->resetStreamFilterBuffer();
 
         command('make:scaffold fixer -bare -force');
 
         $dir       = '\\' . DIRECTORY_SEPARATOR;
         $migration = "APPPATH{$dir}Database{$dir}Migrations{$dir}(.*)\\.php";
-        preg_match('/' . $migration . '/u', CITestStreamFilter::$buffer, $matches);
+        preg_match('/' . $migration . '/u', $this->getStreamFilterBuffer(), $matches);
         $matches[0] = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $matches[0]);
 
         // Files check
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Controllers/Fixer.php');
-        $this->assertStringContainsString('_Fixer.php', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('_Fixer.php', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Database/Seeds/Fixer.php');
         $this->assertFileExists(APPPATH . 'Models/Fixer.php');
 
         // Options check
         $this->assertStringContainsString('extends Controller', $this->getFileContents(APPPATH . 'Controllers/Fixer.php'));
-        $this->assertStringContainsString('File overwritten: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File overwritten: ', $this->getStreamFilterBuffer());
 
         // Clean up
         unlink(APPPATH . 'Controllers/Fixer.php');
@@ -163,13 +162,13 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
 
         $dir       = '\\' . DIRECTORY_SEPARATOR;
         $migration = "APPPATH{$dir}Database{$dir}Migrations{$dir}(.*)\\.php";
-        preg_match('/' . $migration . '/u', CITestStreamFilter::$buffer, $matches);
+        preg_match('/' . $migration . '/u', $this->getStreamFilterBuffer(), $matches);
         $matches[0] = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, $matches[0]);
 
         // Files check
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Controllers/Product.php');
-        $this->assertStringContainsString('_Product.php', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('_Product.php', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Database/Seeds/Product.php');
         $this->assertFileExists(APPPATH . 'Models/Product.php');
 

--- a/tests/system/Commands/SeederGeneratorTest.php
+++ b/tests/system/Commands/SeederGeneratorTest.php
@@ -24,13 +24,13 @@ final class SeederGeneratorTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));

--- a/tests/system/Commands/SeederGeneratorTest.php
+++ b/tests/system/Commands/SeederGeneratorTest.php
@@ -21,16 +21,9 @@ final class SeederGeneratorTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
     protected function tearDown(): void
     {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
+        parent::tearDown();
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));

--- a/tests/system/Commands/SeederGeneratorTest.php
+++ b/tests/system/Commands/SeederGeneratorTest.php
@@ -12,28 +12,27 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class SeederGeneratorTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
 
-        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
         if (is_file($file)) {
             unlink($file);
@@ -43,14 +42,14 @@ final class SeederGeneratorTest extends CIUnitTestCase
     public function testGenerateSeeder()
     {
         command('make:seeder cars');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Database/Seeds/Cars.php');
     }
 
     public function testGenerateSeederWithOptionSuffix()
     {
         command('make:seeder cars -suffix');
-        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists(APPPATH . 'Database/Seeds/CarsSeeder.php');
     }
 }

--- a/tests/system/Commands/ValidationGeneratorTest.php
+++ b/tests/system/Commands/ValidationGeneratorTest.php
@@ -21,16 +21,9 @@ final class ValidationGeneratorTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
     protected function tearDown(): void
     {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
+        parent::tearDown();
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));

--- a/tests/system/Commands/ValidationGeneratorTest.php
+++ b/tests/system/Commands/ValidationGeneratorTest.php
@@ -12,28 +12,27 @@
 namespace CodeIgniter\Commands;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class ValidationGeneratorTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
 
-        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
         $dir    = dirname($file);
         if (is_file($file)) {

--- a/tests/system/Commands/ValidationGeneratorTest.php
+++ b/tests/system/Commands/ValidationGeneratorTest.php
@@ -24,13 +24,13 @@ final class ValidationGeneratorTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
 
         $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
         $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));

--- a/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
+++ b/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
@@ -30,10 +30,6 @@ final class HistoryTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-
         $this->time = (float) sprintf('%.6f', microtime(true));
     }
 
@@ -41,7 +37,7 @@ final class HistoryTest extends CIUnitTestCase
     {
         command('debugbar:clear');
 
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
+        parent::tearDown();
     }
 
     private function createDummyDebugbarJson()

--- a/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
+++ b/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
@@ -12,7 +12,7 @@
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 use DateTime;
 
 /**
@@ -20,18 +20,19 @@ use DateTime;
  */
 final class HistoryTest extends CIUnitTestCase
 {
+    use StreamFilterTrait;
+
     private const STEP = 0.000001;
 
     private float $time;
-    private $streamFilter;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        CITestStreamFilter::$buffer = '';
-        $this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
 
         $this->time = (float) sprintf('%.6f', microtime(true));
     }
@@ -40,7 +41,7 @@ final class HistoryTest extends CIUnitTestCase
     {
         command('debugbar:clear');
 
-        stream_filter_remove($this->streamFilter);
+        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
     }
 
     private function createDummyDebugbarJson()

--- a/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
+++ b/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
@@ -31,8 +31,8 @@ final class HistoryTest extends CIUnitTestCase
         parent::setUp();
 
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
 
         $this->time = (float) sprintf('%.6f', microtime(true));
     }
@@ -41,7 +41,7 @@ final class HistoryTest extends CIUnitTestCase
     {
         command('debugbar:clear');
 
-        $this->removeStreamOutputFilter()->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
     }
 
     private function createDummyDebugbarJson()

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -14,7 +14,7 @@ namespace CodeIgniter\Test;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\Response;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+
 use Config\App;
 
 /**
@@ -22,6 +22,8 @@ use Config\App;
  */
 final class TestCaseTest extends CIUnitTestCase
 {
+    use StreamFilterTrait;
+
     public function testGetPrivatePropertyWithObject()
     {
         $obj    = new __TestForReflectionHelper();
@@ -48,12 +50,11 @@ final class TestCaseTest extends CIUnitTestCase
 
     public function testStreamFilter()
     {
-        CITestStreamFilter::$buffer = '';
-        $this->stream_filter        = stream_filter_append(STDOUT, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()->appendStreamOutputFilter();
         CLI::write('first.');
         $expected = "first.\n";
-        $this->assertSame($expected, CITestStreamFilter::$buffer);
-        stream_filter_remove($this->stream_filter);
+        $this->assertSame($expected, $this->getStreamFilterBuffer());
+        $this->removeStreamOutputFilter();
     }
 
     /**

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -50,11 +50,11 @@ final class TestCaseTest extends CIUnitTestCase
 
     public function testStreamFilter()
     {
-        $this->registerStreamFilterClass()->appendStreamOutputFilter();
+        $this->registerStreamFilterClass()->appendOutputStreamFilter();
         CLI::write('first.');
         $expected = "first.\n";
         $this->assertSame($expected, $this->getStreamFilterBuffer());
-        $this->removeStreamOutputFilter();
+        $this->removeOutputStreamFilter();
     }
 
     /**

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -50,11 +50,9 @@ final class TestCaseTest extends CIUnitTestCase
 
     public function testStreamFilter()
     {
-        $this->registerStreamFilterClass()->appendOutputStreamFilter();
         CLI::write('first.');
         $expected = "first.\n";
         $this->assertSame($expected, $this->getStreamFilterBuffer());
-        $this->removeOutputStreamFilter();
     }
 
     /**

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -12,6 +12,7 @@ See all the changes.
 .. toctree::
     :titlesonly:
 
+    v4.3.0
     v4.2.1
     v4.2.0
     v4.1.9

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -1,0 +1,35 @@
+Version 4.3.0
+#############
+
+Release Date: Unreleased
+
+**4.3.0 release of CodeIgniter4**
+
+.. contents::
+    :local:
+    :depth: 2
+
+BREAKING
+********
+
+none.
+
+Enhancements
+************
+
+- Added the ``StreamFilterTrait`` to make it easier to work with capturing data from STDOUT and STDERR streams. See :ref:`testing-overview-stream-filters`.
+
+Changes
+*******
+
+none.
+
+Deprecations
+************
+
+none.
+
+Bugs Fixed
+**********
+
+none.

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -262,13 +262,13 @@ might be helpful. The ``StreamFilterTrait`` helps you capture the output from th
 
 ``StreamFilterTrait::registerStreamFilterClass()`` Registering a filter to capture streams.
 
-``StreamFilterTrait::appendStreamOutputFilter()`` Adding a filter to the output stream.
+``StreamFilterTrait::appendOutputStreamFilter()`` Adding a filter to the output stream.
 
-``StreamFilterTrait::appendStreamErrorFilter()`` Adding a filter to the error stream.
+``StreamFilterTrait::appendErrorStreamFilter()`` Adding a filter to the error stream.
 
-``StreamFilterTrait::removeStreamOutputFilter()`` Removing the filter from the output stream.
+``StreamFilterTrait::removeOutputStreamFilter()`` Removing the filter from the output stream.
 
-``StreamFilterTrait::removeStreamErrorFilter()`` Removing the filter from the error stream.
+``StreamFilterTrait::removeErrorStreamFilter()`` Removing the filter from the error stream.
 
 ``StreamFilterTrait::getStreamFilterBuffer()`` Get the captured data from the buffer.
 

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -253,10 +253,26 @@ component name:
 Stream Filters
 ==============
 
-**CITestStreamFilter** provides an alternate to these helper methods.
+**StreamFilterTrait** provides an alternate to these helper methods.
 
 You may need to test things that are difficult to test. Sometimes, capturing a stream, like PHP's own STDOUT, or STDERR,
-might be helpful. The ``CITestStreamFilter`` helps you capture the output from the stream of your choice.
+might be helpful. The ``StreamFilterTrait`` helps you capture the output from the stream of your choice.
+
+**Overview of methods**
+
+``StreamFilterTrait::registerStreamFilterClass()`` Registering a filter to capture streams.
+
+``StreamFilterTrait::appendStreamOutputFilter()`` Adding a filter to the output stream.
+
+``StreamFilterTrait::appendStreamErrorFilter()`` Adding a filter to the error stream.
+
+``StreamFilterTrait::removeStreamOutputFilter()`` Removing the filter from the output stream.
+
+``StreamFilterTrait::removeStreamErrorFilter()`` Removing the filter from the error stream.
+
+``StreamFilterTrait::getStreamFilterBuffer()`` Get the captured data from the buffer.
+
+``StreamFilterTrait::resetStreamFilterBuffer()`` Reset captured data.
 
 An example demonstrating this inside one of your test cases:
 

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -103,6 +103,8 @@ parent as well so extended test cases do not interfere with staging:
 
 .. literalinclude:: overview/003.php
 
+.. _testing-overview-traits:
+
 Traits
 ------
 
@@ -250,6 +252,8 @@ component name:
 
 .. note:: All component Factories are reset by default between each test. Modify your test case's ``$setUpMethods`` if you need instances to persist.
 
+.. _testing-overview-stream-filters:
+
 Stream Filters
 ==============
 
@@ -260,20 +264,15 @@ might be helpful. The ``StreamFilterTrait`` helps you capture the output from th
 
 **Overview of methods**
 
-``StreamFilterTrait::registerStreamFilterClass()`` Registering a filter to capture streams.
-
-``StreamFilterTrait::appendOutputStreamFilter()`` Adding a filter to the output stream.
-
-``StreamFilterTrait::appendErrorStreamFilter()`` Adding a filter to the error stream.
-
-``StreamFilterTrait::removeOutputStreamFilter()`` Removing the filter from the output stream.
-
-``StreamFilterTrait::removeErrorStreamFilter()`` Removing the filter from the error stream.
-
-``StreamFilterTrait::getStreamFilterBuffer()`` Get the captured data from the buffer.
-
-``StreamFilterTrait::resetStreamFilterBuffer()`` Reset captured data.
+- ``StreamFilterTrait::getStreamFilterBuffer()`` Get the captured data from the buffer.
+- ``StreamFilterTrait::resetStreamFilterBuffer()`` Reset captured data.
 
 An example demonstrating this inside one of your test cases:
 
 .. literalinclude:: overview/018.php
+
+The ``StreamFilterTrait`` has a configurator that is called automatically.
+See :ref:`Testing Traits <testing-overview-traits>`.
+
+If you override the ``setUp()`` or ``tearDown()`` methods in your test, then you must call the ``parent::setUp()`` and
+``parent::tearDown()`` methods respectively to configure the ``StreamFilterTrait``.

--- a/user_guide_src/source/testing/overview/018.php
+++ b/user_guide_src/source/testing/overview/018.php
@@ -10,11 +10,14 @@ final class SomeTest extends CIUnitTestCase
 
     public function testSomeOutput(): void
     {
-        $this->resetStreamFilterBuffer();
-
         CLI::write('first.');
 
-        $expected = "first.\n";
-        $this->assertSame($expected, $this->getStreamFilterBuffer());
+        $this->assertSame("\nfirst.\n", $this->getStreamFilterBuffer());
+
+        $this->resetStreamFilterBuffer();
+
+        CLI::write('second.');
+
+        $this->assertSame("second.\n", $this->getStreamFilterBuffer());
     }
 }

--- a/user_guide_src/source/testing/overview/018.php
+++ b/user_guide_src/source/testing/overview/018.php
@@ -8,19 +8,6 @@ final class SomeTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    protected function setUp(): void
-    {
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->removeOutputStreamFilter()
-            ->removeErrorStreamFilter();
-    }
-
     public function testSomeOutput(): void
     {
         $this->resetStreamFilterBuffer();

--- a/user_guide_src/source/testing/overview/018.php
+++ b/user_guide_src/source/testing/overview/018.php
@@ -11,14 +11,14 @@ final class SomeTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->registerStreamFilterClass()
-            ->appendStreamOutputFilter()
-            ->appendStreamErrorFilter();
+            ->appendOutputStreamFilter()
+            ->appendErrorStreamFilter();
     }
 
     protected function tearDown(): void
     {
-        $this->removeStreamOutputFilter()
-            ->removeStreamErrorFilter();
+        $this->removeOutputStreamFilter()
+            ->removeErrorStreamFilter();
     }
 
     public function testSomeOutput(): void

--- a/user_guide_src/source/testing/overview/018.php
+++ b/user_guide_src/source/testing/overview/018.php
@@ -2,26 +2,32 @@
 
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 final class SomeTest extends CIUnitTestCase
 {
+    use StreamFilterTrait;
+
     protected function setUp(): void
     {
-        CITestStreamFilter::$buffer = '';
-        $this->stream_filter        = stream_filter_append(STDOUT, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->stream_filter);
+        $this->removeStreamOutputFilter()
+            ->removeStreamErrorFilter();
     }
 
     public function testSomeOutput(): void
     {
+        $this->resetStreamFilterBuffer();
+
         CLI::write('first.');
 
         $expected = "first.\n";
-        $this->assertSame($expected, CITestStreamFilter::$buffer);
+        $this->assertSame($expected, $this->getStreamFilterBuffer());
     }
 }


### PR DESCRIPTION
**Description**
StreamFilterTrait trait, which correctly adds and removes filters for capturing stream output, since the current implementation in the tests is not correct enough in my opinion.

**Overview of methods**

- ``StreamFilterTrait::registerStreamFilterClass()`` Registering a filter to capture streams.
- ``StreamFilterTrait::appendStreamOutputFilter()`` Adding a filter to the output stream.
- ``StreamFilterTrait::appendStreamErrorFilter()`` Adding a filter to the error stream.
- ``StreamFilterTrait::removeStreamOutputFilter()`` Removing the filter from the output stream.
- ``StreamFilterTrait::removeStreamErrorFilter()`` Removing the filter from the error stream.
- ``StreamFilterTrait::getStreamFilterBuffer()`` Get the captured data from the buffer.
- ``StreamFilterTrait::resetStreamFilterBuffer()`` Reset captured data.

```diff
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+        $this->registerStreamFilterClass()
+            ->appendStreamOutputFilter()
+            ->appendStreamErrorFilter();
```
**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide