### PR TITLE
Fix lost error message by test when after testInsertResultFail.

### DIFF
--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -26,6 +26,12 @@ use Tests\Support\Models\WithoutAutoIncrementModel;
  */
 final class InsertModelTest extends LiveModelTestCase
 {
+    public function tearDown(): void
+    {
+       parent::tearDown();
+       $this->setPrivateProperty($this->db, 'DBDebug', true);
+    }
+
     public function testSetWorksWithInsert(): void
     {
         $this->dontSeeInDatabase('user', [

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -26,10 +26,10 @@ use Tests\Support\Models\WithoutAutoIncrementModel;
  */
 final class InsertModelTest extends LiveModelTestCase
 {
-    public function tearDown(): void
+    protected function tearDown(): void
     {
-       parent::tearDown();
-       $this->setPrivateProperty($this->db, 'DBDebug', true);
+        parent::tearDown();
+        $this->setPrivateProperty($this->db, 'DBDebug', true);
     }
 
     public function testSetWorksWithInsert(): void


### PR DESCRIPTION
testInsertResultFail is set DBdebug in false.
so that means a lost error message when after a testInsertResultFail run.

**Description**

The test developer can not understand the failure reason.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
