### PR TITLE
test: fix forgetting to restore DBDebug value

### DIFF
--- a/system/Test/DatabaseTestTrait.php
+++ b/system/Test/DatabaseTestTrait.php
@@ -323,4 +323,22 @@ trait DatabaseTestTrait
 
         $this->assertEquals($expected, $count, 'Wrong number of matching rows in database.');
     }
+
+    /**
+     * Sets $DBDebug to false.
+     *
+     * WARNING: this value will persist! take care to roll it back.
+     */
+    protected function disableDBDebug(): void
+    {
+        $this->setPrivateProperty($this->db, 'DBDebug', false);
+    }
+
+    /**
+     * Sets $DBDebug to true.
+     */
+    protected function enableDBDebug(): void
+    {
+        $this->setPrivateProperty($this->db, 'DBDebug', true);
+    }
 }

--- a/tests/system/Database/Live/BadQueryTest.php
+++ b/tests/system/Database/Live/BadQueryTest.php
@@ -27,22 +27,10 @@ final class BadQueryTest extends CIUnitTestCase
 
     protected $refresh = true;
     protected $seed    = CITestSeeder::class;
-    private static $origDebug;
-
-    /**
-     * This test must run first to store the inital debug value before we tinker with it below
-     */
-    public function testFirst()
-    {
-        $this::$origDebug = $this->getPrivateProperty($this->db, 'DBDebug');
-
-        $this->assertIsBool($this::$origDebug);
-    }
 
     public function testBadQueryDebugTrue()
     {
-        // WARNING this value will persist! take care to roll it back.
-        $this->setPrivateProperty($this->db, 'DBDebug', true);
+        $this->enableDBDebug();
         // expect an exception, class and message varies by DBMS
         $this->expectException(Exception::class);
         $this->db->query('SELECT * FROM table_does_not_exist');
@@ -53,12 +41,11 @@ final class BadQueryTest extends CIUnitTestCase
     public function testBadQueryDebugFalse()
     {
         // WARNING this value will persist! take care to roll it back.
-        $this->setPrivateProperty($this->db, 'DBDebug', false);
+        $this->disableDBDebug();
         // this throws an exception when DBDebug is true, but it'll return FALSE when DBDebug is false
         $query = $this->db->query('SELECT * FROM table_does_not_exist');
         $this->assertFalse($query);
 
-        // restore the DBDebug value in effect when this unit test began
-        $this->setPrivateProperty($this->db, 'DBDebug', self::$origDebug);
+        $this->enableDBDebug();
     }
 }

--- a/tests/system/Database/Live/BadQueryTest.php
+++ b/tests/system/Database/Live/BadQueryTest.php
@@ -31,8 +31,10 @@ final class BadQueryTest extends CIUnitTestCase
     public function testBadQueryDebugTrue()
     {
         $this->enableDBDebug();
+
         // expect an exception, class and message varies by DBMS
         $this->expectException(Exception::class);
+
         $this->db->query('SELECT * FROM table_does_not_exist');
 
         // this code is never executed
@@ -42,8 +44,10 @@ final class BadQueryTest extends CIUnitTestCase
     {
         // WARNING this value will persist! take care to roll it back.
         $this->disableDBDebug();
+
         // this throws an exception when DBDebug is true, but it'll return FALSE when DBDebug is false
         $query = $this->db->query('SELECT * FROM table_does_not_exist');
+
         $this->assertFalse($query);
 
         $this->enableDBDebug();

--- a/tests/system/Database/Live/DbDebugTest.php
+++ b/tests/system/Database/Live/DbDebugTest.php
@@ -28,7 +28,9 @@ final class DbDebugTest extends CIUnitTestCase
     public function testDBDebugTrue()
     {
         $this->enableDBDebug();
+
         $this->expectException('Exception');
+
         $this->db->simpleQuery('SELECT * FROM db_error');
     }
 
@@ -36,13 +38,16 @@ final class DbDebugTest extends CIUnitTestCase
     {
         // WARNING this value will persist! take care to roll it back.
         $this->disableDBDebug();
+
         $result = $this->db->simpleQuery('SELECT * FROM db_error');
+
         $this->assertFalse($result);
     }
 
     protected function tearDown(): void
     {
         $this->enableDBDebug();
+
         parent::tearDown();
     }
 }

--- a/tests/system/Database/Live/DbDebugTest.php
+++ b/tests/system/Database/Live/DbDebugTest.php
@@ -27,21 +27,22 @@ final class DbDebugTest extends CIUnitTestCase
 
     public function testDBDebugTrue()
     {
-        $this->setPrivateProperty($this->db, 'DBDebug', true);
+        $this->enableDBDebug();
         $this->expectException('Exception');
         $this->db->simpleQuery('SELECT * FROM db_error');
     }
 
     public function testDBDebugFalse()
     {
-        $this->setPrivateProperty($this->db, 'DBDebug', false);
+        // WARNING this value will persist! take care to roll it back.
+        $this->disableDBDebug();
         $result = $this->db->simpleQuery('SELECT * FROM db_error');
         $this->assertFalse($result);
     }
 
     protected function tearDown(): void
     {
-        $this->setPrivateProperty($this->db, 'DBDebug', true);
+        $this->enableDBDebug();
         parent::tearDown();
     }
 }

--- a/tests/system/Database/Live/DbUtilsTest.php
+++ b/tests/system/Database/Live/DbUtilsTest.php
@@ -28,17 +28,6 @@ final class DbUtilsTest extends CIUnitTestCase
 
     protected $refresh = true;
     protected $seed    = CITestSeeder::class;
-    private static $origDebug;
-
-    /**
-     * This test must run first to store the inital debug value before we tinker with it below
-     */
-    public function testFirst()
-    {
-        $this::$origDebug = $this->getPrivateProperty($this->db, 'DBDebug');
-
-        $this->assertIsBool($this::$origDebug);
-    }
 
     public function testUtilsBackup()
     {
@@ -125,8 +114,7 @@ final class DbUtilsTest extends CIUnitTestCase
         $util = (new Database())->loadUtils($this->db);
         $this->setPrivateProperty($util, 'optimizeTable', false);
 
-        // set debug to true -- WARNING this change will persist!
-        $this->setPrivateProperty($this->db, 'DBDebug', true);
+        $this->enableDBDebug();
 
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Unsupported feature of the database platform you are using.');
@@ -140,14 +128,13 @@ final class DbUtilsTest extends CIUnitTestCase
         $util = (new Database())->loadUtils($this->db);
         $this->setPrivateProperty($util, 'optimizeTable', false);
 
-        // set debug to false -- WARNING this change will persist!
-        $this->setPrivateProperty($this->db, 'DBDebug', false);
+        // WARNING this value will persist! take care to roll it back.
+        $this->disableDBDebug();
 
         $result = $util->optimizeDatabase();
         $this->assertFalse($result);
 
-        // restore original value grabbed from testFirst -- WARNING this change will persist!
-        $this->setPrivateProperty($this->db, 'DBDebug', self::$origDebug);
+        $this->enableDBDebug();
     }
 
     public function testUtilsOptimizeTable()

--- a/tests/system/Database/Live/DbUtilsTest.php
+++ b/tests/system/Database/Live/DbUtilsTest.php
@@ -118,6 +118,7 @@ final class DbUtilsTest extends CIUnitTestCase
 
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Unsupported feature of the database platform you are using.');
+
         $util->optimizeDatabase();
 
         // this point in code execution will never be reached

--- a/tests/system/Models/DeleteModelTest.php
+++ b/tests/system/Models/DeleteModelTest.php
@@ -42,6 +42,8 @@ final class DeleteModelTest extends LiveModelTestCase
         $result = $this->model->where('name123', 'Developer')->delete();
         $this->assertFalse($result);
         $this->seeInDatabase('job', ['name' => 'Developer']);
+
+        $this->enableDBDebug();
     }
 
     public function testDeleteStringPrimaryKey(): void
@@ -77,6 +79,8 @@ final class DeleteModelTest extends LiveModelTestCase
         $result = $this->model->where('name123', 'Derek Jones')->delete();
         $this->assertFalse($result);
         $this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
+
+        $this->enableDBDebug();
     }
 
     public function testDeleteWithSoftDeletesPurge(): void

--- a/tests/system/Models/DeleteModelTest.php
+++ b/tests/system/Models/DeleteModelTest.php
@@ -34,7 +34,8 @@ final class DeleteModelTest extends LiveModelTestCase
 
     public function testDeleteFail(): void
     {
-        $this->setPrivateProperty($this->db, 'DBDebug', false);
+        // WARNING this value will persist! take care to roll it back.
+        $this->disableDBDebug();
         $this->createModel(JobModel::class);
         $this->seeInDatabase('job', ['name' => 'Developer']);
 
@@ -68,7 +69,8 @@ final class DeleteModelTest extends LiveModelTestCase
 
     public function testDeleteWithSoftDeleteFail(): void
     {
-        $this->setPrivateProperty($this->db, 'DBDebug', false);
+        // WARNING this value will persist! take care to roll it back.
+        $this->disableDBDebug();
         $this->createModel(UserModel::class);
         $this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
 

--- a/tests/system/Models/DeleteModelTest.php
+++ b/tests/system/Models/DeleteModelTest.php
@@ -36,10 +36,13 @@ final class DeleteModelTest extends LiveModelTestCase
     {
         // WARNING this value will persist! take care to roll it back.
         $this->disableDBDebug();
+
         $this->createModel(JobModel::class);
+
         $this->seeInDatabase('job', ['name' => 'Developer']);
 
         $result = $this->model->where('name123', 'Developer')->delete();
+
         $this->assertFalse($result);
         $this->seeInDatabase('job', ['name' => 'Developer']);
 
@@ -73,10 +76,13 @@ final class DeleteModelTest extends LiveModelTestCase
     {
         // WARNING this value will persist! take care to roll it back.
         $this->disableDBDebug();
+
         $this->createModel(UserModel::class);
+
         $this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
 
         $result = $this->model->where('name123', 'Derek Jones')->delete();
+
         $this->assertFalse($result);
         $this->seeInDatabase('user', ['name' => 'Derek Jones', 'deleted_at IS NULL' => null]);
 

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -147,7 +147,8 @@ final class InsertModelTest extends LiveModelTestCase
 
     public function testInsertResultFail(): void
     {
-        $this->setPrivateProperty($this->db, 'DBDebug', false);
+        // WARNING this value will persist! take care to roll it back.
+        $this->disableDBDebug();
 
         $data = [
             'name123'     => 'Apprentice',

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -26,12 +26,6 @@ use Tests\Support\Models\WithoutAutoIncrementModel;
  */
 final class InsertModelTest extends LiveModelTestCase
 {
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        $this->setPrivateProperty($this->db, 'DBDebug', true);
-    }
-
     public function testSetWorksWithInsert(): void
     {
         $this->dontSeeInDatabase('user', [
@@ -162,6 +156,8 @@ final class InsertModelTest extends LiveModelTestCase
         $lastInsertId = $this->model->getInsertID();
         $this->assertSame(0, $lastInsertId);
         $this->dontSeeInDatabase('job', ['id' => $lastInsertId]);
+
+        $this->enableDBDebug();
     }
 
     public function testInsertBatchNewEntityWithDateTime(): void

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -148,12 +148,14 @@ final class InsertModelTest extends LiveModelTestCase
             'name123'     => 'Apprentice',
             'description' => 'That thing you do.',
         ];
-
         $this->createModel(JobModel::class);
+
         $result = $this->model->protect(false)->insert($data, false);
+
         $this->assertFalse($result);
 
         $lastInsertId = $this->model->getInsertID();
+
         $this->assertSame(0, $lastInsertId);
         $this->dontSeeInDatabase('job', ['id' => $lastInsertId]);
 

--- a/tests/system/Models/SaveModelTest.php
+++ b/tests/system/Models/SaveModelTest.php
@@ -67,6 +67,8 @@ final class SaveModelTest extends LiveModelTestCase
         $result = $this->model->protect(false)->save($data);
         $this->assertFalse($result);
         $this->dontSeeInDatabase('job', ['name' => 'Apprentice']);
+
+        $this->enableDBDebug();
     }
 
     public function testSaveUpdateRecordArray(): void
@@ -98,6 +100,8 @@ final class SaveModelTest extends LiveModelTestCase
         $result = $this->model->protect(false)->save($data);
         $this->assertFalse($result);
         $this->dontSeeInDatabase('job', ['name' => 'Apprentice']);
+
+        $this->enableDBDebug();
     }
 
     public function testSaveUpdateRecordObject(): void

--- a/tests/system/Models/SaveModelTest.php
+++ b/tests/system/Models/SaveModelTest.php
@@ -55,7 +55,8 @@ final class SaveModelTest extends LiveModelTestCase
 
     public function testSaveNewRecordArrayFail(): void
     {
-        $this->setPrivateProperty($this->db, 'DBDebug', false);
+        // WARNING this value will persist! take care to roll it back.
+        $this->disableDBDebug();
         $this->createModel(JobModel::class);
 
         $data = [
@@ -84,7 +85,8 @@ final class SaveModelTest extends LiveModelTestCase
 
     public function testSaveUpdateRecordArrayFail(): void
     {
-        $this->setPrivateProperty($this->db, 'DBDebug', false);
+        // WARNING this value will persist! take care to roll it back.
+        $this->disableDBDebug();
         $this->createModel(JobModel::class);
 
         $data = [

--- a/tests/system/Models/SaveModelTest.php
+++ b/tests/system/Models/SaveModelTest.php
@@ -63,8 +63,8 @@ final class SaveModelTest extends LiveModelTestCase
             'name123'     => 'Apprentice',
             'description' => 'That thing you do.',
         ];
-
         $result = $this->model->protect(false)->save($data);
+
         $this->assertFalse($result);
         $this->dontSeeInDatabase('job', ['name' => 'Apprentice']);
 
@@ -96,8 +96,8 @@ final class SaveModelTest extends LiveModelTestCase
             'name123'     => 'Apprentice',
             'description' => 'That thing you do.',
         ];
-
         $result = $this->model->protect(false)->save($data);
+
         $this->assertFalse($result);
         $this->dontSeeInDatabase('job', ['name' => 'Apprentice']);
 

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -330,6 +330,7 @@ final class UpdateModelTest extends LiveModelTestCase
 
         $entity->id      = 1;
         $entity->name    = 'Jones Martin';
+        $entity->email   = 'jones@example.org';
         $entity->country = 'India';
         $entity->deleted = 0;
 

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -96,7 +96,8 @@ final class UpdateModelTest extends LiveModelTestCase
 
     public function testUpdateResultFail(): void
     {
-        $this->setPrivateProperty($this->db, 'DBDebug', false);
+        // WARNING this value will persist! take care to roll it back.
+        $this->disableDBDebug();
 
         $data = [
             'name'    => 'Foo',

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -98,6 +98,7 @@ final class UpdateModelTest extends LiveModelTestCase
     {
         // WARNING this value will persist! take care to roll it back.
         $this->disableDBDebug();
+        $this->createModel(UserModel::class);
 
         $data = [
             'name'    => 'Foo',
@@ -105,12 +106,12 @@ final class UpdateModelTest extends LiveModelTestCase
             'country' => 'US',
             'deleted' => 0,
         ];
-
-        $this->createModel(UserModel::class);
         $this->model->insert($data);
 
         $this->setPrivateProperty($this->model, 'allowedFields', ['name123']);
+
         $result = $this->model->update(1, ['name123' => 'Foo Bar 1']);
+
         $this->assertFalse($result);
         $this->dontSeeInDatabase('user', ['id' => 1, 'name' => 'Foo Bar 1']);
 

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -113,6 +113,8 @@ final class UpdateModelTest extends LiveModelTestCase
         $result = $this->model->update(1, ['name123' => 'Foo Bar 1']);
         $this->assertFalse($result);
         $this->dontSeeInDatabase('user', ['id' => 1, 'name' => 'Foo Bar 1']);
+
+        $this->enableDBDebug();
     }
 
     public function testUpdateBatchSuccess(): void


### PR DESCRIPTION
**Description**
- add `disableDBDebug()` and `enableDBDebug()` in `DatabaseTestTrait`
- add missing `enableDBDebug()`
- refactor

Related #6113

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

