### PR TITLE
fix: Time::setTestNow() does not work with fa Locale

### DIFF
--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -82,7 +82,7 @@ class Time extends DateTime
         // If a test instance has been provided, use it instead.
         if ($time === '' && static::$testNow instanceof self) {
             $timezone = $timezone ?: static::$testNow->getTimezone();
-            $time     = (string) static::$testNow->toDateTimeString();
+            $time     = static::$testNow->format('Y-m-d H:i:s');
         }
 
         $timezone       = $timezone ?: date_default_timezone_get();

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1058,4 +1058,18 @@ final class TimeTest extends CIUnitTestCase
         $this->assertTrue($time2->equals($time1));
         $this->assertNotSame($time1, $time2);
     }
+
+    public function testSetTestNowWithFaLocale()
+    {
+        $currentLocale = Locale::getDefault();
+        Locale::setDefault('fa');
+
+        Time::setTestNow('2017/03/10 12:00', 'Asia/Tokyo');
+
+        $now = Time::now()->format('c');
+
+        $this->assertSame('2017-03-10T12:00:00+09:00', $now);
+
+        Locale::setDefault($currentLocale);
+    }
 }


### PR DESCRIPTION
**Description**
```
ErrorException : DateTime::modify(): Failed to parse time string (۲۰۱۷-۰۳-۱۰ ۰۰:۰۰:۰۰) at position 0 (�): Unexpected character
 .../CodeIgniter4/system/I18n/Time.php:96
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

