### PR TITLE
fix: `migrate --all` causes `Class "SQLite3" not found` error

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -402,6 +402,10 @@ class MigrationRunner
         $migrations = [];
 
         foreach ($namespaces as $namespace) {
+            if (ENVIRONMENT !== 'testing' && $namespace === 'Tests\Support') {
+                continue;
+            }
+
             foreach ($this->findNamespaceMigrations($namespace) as $migration) {
                 $migrations[$migration->uid] = $migration;
             }


### PR DESCRIPTION
**Description**
Fixes https://github.com/codeigniter4/shield/issues/240

See https://github.com/codeigniter4/shield/issues/240#issuecomment-1153594113
- skip `Tests\Support` namespace in not `testing` environments

**How to Test**

**`Tests\Support` namespace is not defined in `codeigniter4/CodeIgniter4`.**

Install appstarter. 

```
$ composer create-project codeigniter4/appstarter ci4app
```

Configure default database.

Change tests database driver.

```diff
--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -62,7 +62,7 @@ class Database extends Config
         'username'    => '',
         'password'    => '',
         'database'    => ':memory:',
-        'DBDriver'    => 'SQLite3',
+        'DBDriver'    => 'xSQLite3',
         'DBPrefix'    => 'db_',  // Needed to ensure we're working correctly with prefixes live. DO NOT REMOVE FOR CI DEVS
         'pConnect'    => false,
         'DBDebug'     => (ENVIRONMENT !== 'production'),
```

```
$ php spark migrate --all

CodeIgniter v4.2.0 Command Line Tool - Server Time: 2022-06-13 16:59:14 UTC-05:00

Running all new migrations...

[Error]

Class "CodeIgniter\Database\xSQLite3\Connection" not found

at SYSTEMPATH/Database/Database.php:136
```

Apply this PR patch.

```
$ php spark migrate --all

CodeIgniter v4.2.0 Command Line Tool - Server Time: 2022-06-13 16:59:49 UTC-05:00

Running all new migrations...
Migrations complete.
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
