### PR TITLE
docs: fix syntax error in files.rst

### DIFF
--- a/user_guide_src/source/libraries/files.rst
+++ b/user_guide_src/source/libraries/files.rst
@@ -140,7 +140,7 @@ Inputting Files
 ***************
 
 add(string[]|string $paths, bool $recursive = true)
----------------------------------------------------
+===================================================
 
 Adds all files indicated by the path or array of paths. If the path resolves to a directory then ``$recursive``
 will include sub-directories.


### PR DESCRIPTION
**Description**
- fix section title level

```
/github/workspace/user_guide_src/source/libraries/files.rst:142: CRITICAL: Title level inconsistent:
add(string[]|string $paths, bool $recursive = true)
---------------------------------------------------
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
