### PR TITLE
fix: event DBQuery is not fired on failed query when DBDebug is true

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -137,7 +137,7 @@ parameters:
 
 		-
 			message: "#^Negated boolean expression is always true\\.$#"
-			count: 1
+			count: 2
 			path: system/Database/BaseConnection.php
 
 		-

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -91,5 +91,5 @@ The following is a list of available event points within the CodeIgniter core co
 * **post_controller_constructor** Called immediately after your controller is instantiated, but prior to any method calls happening.
 * **post_system** Called after the final rendered page is sent to the browser, at the end of system execution after the finalized data is sent to the browser.
 * **email** Called after an email sent successfully from ``CodeIgniter\Email\Email``. Receives an array of the ``Email`` class's properties as a parameter.
-* **DBQuery** Called after a successfully-completed database query. Receives the ``Query`` object.
+* **DBQuery** Called after a database query whether successful or not. Receives the ``Query`` object.
 * **migrate** Called after a successful migration call to ``latest()`` or ``regress()``. Receives the current properties of ``MigrationRunner`` as well as the name of the method.


### PR DESCRIPTION
**Description**
> DBQuery
This event is triggered whenever a new query has been run, whether successful or not.
https://codeigniter4.github.io/CodeIgniter4/database/events.html#the-events

But the event `DBQuery` is not fired on failed query when `DBDebug` is true.

- fix BaseConnection
- fix user guide

**How to Test**
```diff
--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -46,3 +46,8 @@ Events::on('pre_system', static function () {
         Services::toolbar()->respond();
     }
 });
+
+Events::on(
+    'DBQuery',
+    static function (\CodeIgniter\Database\Query $query) { log_message('alert', (string) $query); }
+);
diff --git a/app/Controllers/Home.php b/app/Controllers/Home.php
index 7f867e95f..492606d92 100644
--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -6,6 +6,8 @@ class Home extends BaseController
 {
     public function index()
     {
+        db_connect()->query('select * from bad_table where a = 1');
+
         return view('welcome_message');
     }
 }
```

Navigate to http://localhost:8080/ and see log file.

Before:
```
ERROR - 2022-06-14 22:11:50 --> Table 'ci4.bad_table' doesn't exist
CRITICAL - 2022-06-14 22:11:50 --> Table 'ci4.bad_table' doesn't exist
```

After:
```
ERROR - 2022-06-14 22:13:32 --> Table 'ci4.bad_table' doesn't exist
ALERT - 2022-06-14 22:13:32 --> select * from bad_table where a = 1
CRITICAL - 2022-06-14 22:13:32 --> Table 'ci4.bad_table' doesn't exist
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
