### PR TITLE
docs: fix PHPDoc in CodeIgniter

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -256,9 +256,7 @@ class CodeIgniter
             require_once SYSTEMPATH . 'ThirdParty/Kint/init.php';
         }
 
-        /**
-         * Config\Kint
-         */
+        /** @var \Config\Kint $config */
         $config = config(KintConfig::class);
 
         Kint::$depth_limit         = $config->maxDepth;


### PR DESCRIPTION
**Description**
- fix PHPDoc

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

