### PR TITLE
feat: add methods to modify files in Publisher

### DIFF
--- a/system/Publisher/ContentReplacer.php
+++ b/system/Publisher/ContentReplacer.php
@@ -32,7 +32,7 @@ class ContentReplacer
      *
      * @return bool|string true: already updated, false: regexp error.
      */
-    public function add(string $content, string $text, string $pattern, string $replace)
+    private function add(string $content, string $text, string $pattern, string $replace)
     {
         $return = preg_match('/' . preg_quote($text, '/') . '/u', $content);
 

--- a/system/Publisher/ContentReplacer.php
+++ b/system/Publisher/ContentReplacer.php
@@ -12,7 +12,6 @@
 namespace CodeIgniter\Publisher;
 
 use RuntimeException;
-use stdClass;
 
 class ContentReplacer
 {
@@ -33,12 +32,10 @@ class ContentReplacer
      * @param string $pattern Regexp search pattern.
      * @param string $replace Regexp replacement including text to add.
      *
-     * @return stdClass {updated: bool, content: string}
+     * @return string|null Updated content, or null if not updated.
      */
-    private function add(string $content, string $text, string $pattern, string $replace): stdClass
+    private function add(string $content, string $text, string $pattern, string $replace): ?string
     {
-        $result = new stdClass();
-
         $return = preg_match('/' . preg_quote($text, '/') . '/u', $content);
 
         if ($return === false) {
@@ -48,10 +45,7 @@ class ContentReplacer
 
         if ($return === 1) {
             // It has already been updated.
-            $result->updated = false;
-            $result->content = $content;
-
-            return $result;
+            return null;
         }
 
         $return = preg_replace($pattern, $replace, $content);
@@ -61,10 +55,7 @@ class ContentReplacer
             throw new RuntimeException('Regex error. PCRE error code: ' . preg_last_error());
         }
 
-        $result->updated = true;
-        $result->content = $return;
-
-        return $result;
+        return $return;
     }
 
     /**
@@ -74,9 +65,9 @@ class ContentReplacer
      * @param string $line    Line to add.
      * @param string $after   String to search.
      *
-     * @return stdClass {updated: bool, content: string}
+     * @return string|null Updated content, or null if not updated.
      */
-    public function addAfter(string $content, string $line, string $after): stdClass
+    public function addAfter(string $content, string $line, string $after): ?string
     {
         $pattern = '/(.*)(\n[^\n]*?' . preg_quote($after, '/') . '[^\n]*?\n)/su';
         $replace = '$1$2' . $line . "\n";
@@ -91,9 +82,9 @@ class ContentReplacer
      * @param string $line    Line to add.
      * @param string $before  String to search.
      *
-     * @return stdClass {updated: bool, content: string}
+     * @return string|null Updated content, or null if not updated.
      */
-    public function addBefore(string $content, string $line, string $before): stdClass
+    public function addBefore(string $content, string $line, string $before): ?string
     {
         $pattern = '/(\n)([^\n]*?' . preg_quote($before, '/') . ')(.*)/su';
         $replace = '$1' . $line . "\n" . '$2$3';

--- a/system/Publisher/ContentReplacer.php
+++ b/system/Publisher/ContentReplacer.php
@@ -13,6 +13,9 @@ namespace CodeIgniter\Publisher;
 
 use RuntimeException;
 
+/**
+ * Replace Text Content
+ */
 class ContentReplacer
 {
     /**

--- a/system/Publisher/ContentReplacer.php
+++ b/system/Publisher/ContentReplacer.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Publisher;
+
+class ContentReplacer
+{
+    /**
+     * Replace content
+     *
+     * @param array $replaces [search => replace]
+     */
+    public function replace(string $content, array $replaces): string
+    {
+        return strtr($content, $replaces);
+    }
+
+    /**
+     * Add text
+     *
+     * @param string $text    Text to add.
+     * @param string $pattern Regexp search pattern.
+     * @param string $replace Regexp replacement including text to add.
+     *
+     * @return bool|string true: already updated, false: regexp error.
+     */
+    public function add(string $content, string $text, string $pattern, string $replace)
+    {
+        $return = preg_match('/' . preg_quote($text, '/') . '/u', $content);
+
+        if ($return === 1) {
+            // It has already been updated.
+
+            return true;
+        }
+
+        if ($return === false) {
+            // Regexp error.
+
+            return false;
+        }
+
+        return preg_replace($pattern, $replace, $content);
+    }
+
+    /**
+     * Add line after the line with the string
+     *
+     * @param string $content Whole content.
+     * @param string $line    Line to add.
+     * @param string $after   String to search.
+     *
+     * @return bool|string true: already updated, false: regexp error.
+     */
+    public function addAfter(string $content, string $line, string $after)
+    {
+        $pattern = '/(.*)(\n[^\n]*?' . preg_quote($after, '/') . '[^\n]*?\n)/su';
+        $replace = '$1$2' . $line . "\n";
+
+        return $this->add($content, $line, $pattern, $replace);
+    }
+
+    /**
+     * Add line before the line with the string
+     *
+     * @param string $content Whole content.
+     * @param string $line    Line to add.
+     * @param string $before  String to search.
+     *
+     * @return bool|string true: already updated, false: regexp error.
+     */
+    public function addBefore(string $content, string $line, string $before)
+    {
+        $pattern = '/(\n)([^\n]*?' . preg_quote($before, '/') . ')(.*)/su';
+        $replace = '$1' . $line . "\n" . '$2$3';
+
+        return $this->add($content, $line, $pattern, $replace);
+    }
+}

--- a/system/Publisher/ContentReplacer.php
+++ b/system/Publisher/ContentReplacer.php
@@ -43,7 +43,7 @@ class ContentReplacer
 
         if ($return === false) {
             // Regexp error.
-            throw new RuntimeException(preg_last_error_msg());
+            throw new RuntimeException('Regex error. PCRE error code: ' . preg_last_error());
         }
 
         if ($return === 1) {
@@ -58,7 +58,7 @@ class ContentReplacer
 
         if ($return === null) {
             // Regexp error.
-            throw new RuntimeException(preg_last_error_msg());
+            throw new RuntimeException('Regex error. PCRE error code: ' . preg_last_error());
         }
 
         $result->updated = true;

--- a/system/Publisher/Publisher.php
+++ b/system/Publisher/Publisher.php
@@ -431,15 +431,15 @@ class Publisher extends FileCollection
 
         $content = file_get_contents($file);
 
-        $newContent = $this->replacer->addAfter($content, $line, $after);
+        $result = $this->replacer->addAfter($content, $line, $after);
 
-        if (is_bool($newContent)) {
-            return $newContent;
+        if ($result->updated) {
+            $return = file_put_contents($file, $result->content);
+
+            return $return !== false;
         }
 
-        $return = file_put_contents($file, $newContent);
-
-        return $return !== false;
+        return false;
     }
 
     /**
@@ -453,15 +453,15 @@ class Publisher extends FileCollection
 
         $content = file_get_contents($file);
 
-        $newContent = $this->replacer->addBefore($content, $line, $before);
+        $result = $this->replacer->addBefore($content, $line, $before);
 
-        if (is_bool($newContent)) {
-            return $newContent;
+        if ($result->updated) {
+            $return = file_put_contents($file, $result->content);
+
+            return $return !== false;
         }
 
-        $return = file_put_contents($file, $newContent);
-
-        return $return !== false;
+        return false;
     }
 
     /**

--- a/system/Publisher/Publisher.php
+++ b/system/Publisher/Publisher.php
@@ -71,6 +71,8 @@ class Publisher extends FileCollection
      */
     private array $restrictions;
 
+    private ContentReplacer $replacer;
+
     /**
      * Base path to use for the source.
      *
@@ -156,6 +158,8 @@ class Publisher extends FileCollection
 
         $this->source      = self::resolveDirectory($source ?? $this->source);
         $this->destination = self::resolveDirectory($destination ?? $this->destination);
+
+        $this->replacer = new ContentReplacer();
 
         // Restrictions are intentionally not injected to prevent overriding
         $this->restrictions = config('Publisher')->restrictions;
@@ -397,6 +401,83 @@ class Publisher extends FileCollection
     }
 
     /**
+     * Replace content
+     *
+     * @param array $replaces [search => replace]
+     *
+     * @return bool
+     */
+    public function replace(string $file, array $replaces)
+    {
+        $this->verifyAllowed($file, $file);
+
+        $content = file_get_contents($file);
+
+        $newContent = $this->replacer->replace($content, $replaces);
+
+        $return = file_put_contents($file, $newContent);
+
+        return $return !== false;
+    }
+
+    /**
+     * Add line after the line with the string
+     *
+     * @param string $after String to search.
+     */
+    public function addLineAfter(string $file, string $line, string $after): bool
+    {
+        $this->verifyAllowed($file, $file);
+
+        $content = file_get_contents($file);
+
+        $newContent = $this->replacer->addAfter($content, $line, $after);
+
+        if (is_bool($newContent)) {
+            return $newContent;
+        }
+
+        $return = file_put_contents($file, $newContent);
+
+        return $return !== false;
+    }
+
+    /**
+     * Add line before the line with the string
+     *
+     * @param string $before String to search.
+     */
+    public function addLineBefore(string $file, string $line, string $before): bool
+    {
+        $this->verifyAllowed($file, $file);
+
+        $content = file_get_contents($file);
+
+        $newContent = $this->replacer->addBefore($content, $line, $before);
+
+        if (is_bool($newContent)) {
+            return $newContent;
+        }
+
+        $return = file_put_contents($file, $newContent);
+
+        return $return !== false;
+    }
+
+    /**
+     * Verify this is an allowed file for its destination.
+     */
+    private function verifyAllowed(string $from, string $to)
+    {
+        // Verify this is an allowed file for its destination
+        foreach ($this->restrictions as $directory => $pattern) {
+            if (strpos($to, $directory) === 0 && self::matchFiles([$to], $pattern) === []) {
+                throw PublisherException::forFileNotAllowed($from, $directory, $pattern);
+            }
+        }
+    }
+
+    /**
      * Copies a file with directory creation and identical file awareness.
      * Intentionally allows errors.
      *
@@ -405,11 +486,7 @@ class Publisher extends FileCollection
     private function safeCopyFile(string $from, string $to, bool $replace): void
     {
         // Verify this is an allowed file for its destination
-        foreach ($this->restrictions as $directory => $pattern) {
-            if (strpos($to, $directory) === 0 && self::matchFiles([$to], $pattern) === []) {
-                throw PublisherException::forFileNotAllowed($from, $directory, $pattern);
-            }
-        }
+        $this->verifyAllowed($from, $to);
 
         // Check for an existing file
         if (file_exists($to)) {

--- a/system/Publisher/Publisher.php
+++ b/system/Publisher/Publisher.php
@@ -404,10 +404,8 @@ class Publisher extends FileCollection
      * Replace content
      *
      * @param array $replaces [search => replace]
-     *
-     * @return bool
      */
-    public function replace(string $file, array $replaces)
+    public function replace(string $file, array $replaces): bool
     {
         $this->verifyAllowed($file, $file);
 

--- a/system/Publisher/Publisher.php
+++ b/system/Publisher/Publisher.php
@@ -433,8 +433,8 @@ class Publisher extends FileCollection
 
         $result = $this->replacer->addAfter($content, $line, $after);
 
-        if ($result->updated) {
-            $return = file_put_contents($file, $result->content);
+        if ($result !== null) {
+            $return = file_put_contents($file, $result);
 
             return $return !== false;
         }
@@ -455,8 +455,8 @@ class Publisher extends FileCollection
 
         $result = $this->replacer->addBefore($content, $line, $before);
 
-        if ($result->updated) {
-            $return = file_put_contents($file, $result->content);
+        if ($result !== null) {
+            $return = file_put_contents($file, $result);
 
             return $return !== false;
         }

--- a/tests/system/Publisher/ContentReplacerTest.php
+++ b/tests/system/Publisher/ContentReplacerTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Publisher;
+
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class ContentReplacerTest extends CIUnitTestCase
+{
+    public function testReplace(): void
+    {
+        $replacer = new ContentReplacer();
+        $content  = <<<'FILE'
+            <?php
+
+            namespace CodeIgniter\Shield\Config;
+
+            use CodeIgniter\Config\BaseConfig;
+            use CodeIgniter\Shield\Models\UserModel;
+
+            class Auth extends BaseConfig
+            {
+            FILE;
+
+        $replaces = [
+            'namespace CodeIgniter\Shield\Config'    => 'namespace Config',
+            "use CodeIgniter\\Config\\BaseConfig;\n" => '',
+            'extends BaseConfig'                     => 'extends \\CodeIgniter\\Shield\\Config\\Auth',
+        ];
+        $output = $replacer->replace($content, $replaces);
+
+        $expected = <<<'FILE'
+            <?php
+
+            namespace Config;
+
+            use CodeIgniter\Shield\Models\UserModel;
+
+            class Auth extends \CodeIgniter\Shield\Config\Auth
+            {
+            FILE;
+        $this->assertSame($expected, $output);
+    }
+
+    public function testAddAddingAfter(): void
+    {
+        $replacer = new ContentReplacer();
+        $content  = <<<'FILE'
+            <?php
+
+            namespace Config;
+
+            $routes = Services::routes();
+
+            if (is_file(SYSTEMPATH . 'Config/Routes.php')) {
+                require SYSTEMPATH . 'Config/Routes.php';
+            }
+
+            $routes->get('/', 'Home::index');
+
+            /**
+             * You will have access to the $routes object within that file without
+             * needing to reload it.
+             */
+
+            FILE;
+
+        $text    = 'service(\'auth\')->routes($routes);';
+        $pattern = '/(.*)(\n' . preg_quote('$routes->', '/') . '[^\n]+?\n)/su';
+        $replace = '$1$2' . "\n" . $text . "\n";
+        $output  = $replacer->add($content, $text, $pattern, $replace);
+
+        $expected = <<<'FILE'
+            <?php
+
+            namespace Config;
+
+            $routes = Services::routes();
+
+            if (is_file(SYSTEMPATH . 'Config/Routes.php')) {
+                require SYSTEMPATH . 'Config/Routes.php';
+            }
+
+            $routes->get('/', 'Home::index');
+
+            service('auth')->routes($routes);
+
+            /**
+             * You will have access to the $routes object within that file without
+             * needing to reload it.
+             */
+
+            FILE;
+        $this->assertSame($expected, $output);
+    }
+
+    public function testAddAddingBefore(): void
+    {
+        $replacer = new ContentReplacer();
+        $content  = <<<'FILE'
+            <?php
+
+            namespace App\Controllers;
+
+            abstract class BaseController extends Controller
+            {
+                public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
+                {
+                    // Do Not Edit This Line
+                    parent::initController($request, $response, $logger);
+                }
+            }
+            FILE;
+
+        $text    = '$this->helpers = array_merge($this->helpers, [\'auth\', \'setting\']);';
+        $pattern = '/(' . preg_quote('// Do Not Edit This Line', '/') . ')/u';
+        $replace = $text . "\n\n        " . '$1';
+        $output  = $replacer->add($content, $text, $pattern, $replace);
+
+        $expected = <<<'FILE'
+            <?php
+
+            namespace App\Controllers;
+
+            abstract class BaseController extends Controller
+            {
+                public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
+                {
+                    $this->helpers = array_merge($this->helpers, ['auth', 'setting']);
+
+                    // Do Not Edit This Line
+                    parent::initController($request, $response, $logger);
+                }
+            }
+            FILE;
+        $this->assertSame($expected, $output);
+    }
+
+    public function testAddAfter(): void
+    {
+        $replacer = new ContentReplacer();
+        $content  = <<<'FILE'
+            $routes->get('/', 'Home::index');
+            $routes->get('/login', 'Login::index');
+
+            FILE;
+
+        $line   = "\n" . 'service(\'auth\')->routes($routes);';
+        $after  = '$routes->';
+        $output = $replacer->addAfter($content, $line, $after);
+
+        $expected = <<<'FILE'
+            $routes->get('/', 'Home::index');
+            $routes->get('/login', 'Login::index');
+
+            service('auth')->routes($routes);
+
+            FILE;
+        $this->assertSame($expected, $output);
+    }
+
+    public function testAddBefore(): void
+    {
+        $replacer = new ContentReplacer();
+        $content  = <<<'FILE'
+            <?php
+
+            // Do Not Edit This Line
+            parent::initController($request, $response, $logger);
+            // Do Not Edit This Line
+
+            FILE;
+
+        $line   = '$this->helpers = array_merge($this->helpers, [\'auth\', \'setting\']);';
+        $before = '// Do Not Edit This Line';
+        $output = $replacer->addBefore($content, $line, $before);
+
+        $expected = <<<'FILE'
+            <?php
+
+            $this->helpers = array_merge($this->helpers, ['auth', 'setting']);
+            // Do Not Edit This Line
+            parent::initController($request, $response, $logger);
+            // Do Not Edit This Line
+
+            FILE;
+        $this->assertSame($expected, $output);
+    }
+}

--- a/tests/system/Publisher/ContentReplacerTest.php
+++ b/tests/system/Publisher/ContentReplacerTest.php
@@ -73,8 +73,7 @@ final class ContentReplacerTest extends CIUnitTestCase
             service('auth')->routes($routes);
 
             FILE;
-        $this->assertSame($expected, $result->content);
-        $this->assertTrue($result->updated);
+        $this->assertSame($expected, $result);
     }
 
     public function testAddAfterAlreadyUpdated(): void
@@ -91,16 +90,7 @@ final class ContentReplacerTest extends CIUnitTestCase
         $line   = "\n" . 'service(\'auth\')->routes($routes);';
         $after  = '$routes->';
         $result = $replacer->addAfter($content, $line, $after);
-
-        $expected = <<<'FILE'
-            $routes->get('/', 'Home::index');
-            $routes->get('/login', 'Login::index');
-
-            service('auth')->routes($routes);
-
-            FILE;
-        $this->assertSame($expected, $result->content);
-        $this->assertFalse($result->updated);
+        $this->assertNull($result);
     }
 
     public function testAddBefore(): void
@@ -128,8 +118,7 @@ final class ContentReplacerTest extends CIUnitTestCase
             // Do Not Edit This Line
 
             FILE;
-        $this->assertSame($expected, $result->content);
-        $this->assertTrue($result->updated);
+        $this->assertSame($expected, $result);
     }
 
     public function testAddBeforeAlreadyUpdated(): void
@@ -148,17 +137,6 @@ final class ContentReplacerTest extends CIUnitTestCase
         $line   = '$this->helpers = array_merge($this->helpers, [\'auth\', \'setting\']);';
         $before = '// Do Not Edit This Line';
         $result = $replacer->addBefore($content, $line, $before);
-
-        $expected = <<<'FILE'
-            <?php
-
-            $this->helpers = array_merge($this->helpers, ['auth', 'setting']);
-            // Do Not Edit This Line
-            parent::initController($request, $response, $logger);
-            // Do Not Edit This Line
-
-            FILE;
-        $this->assertSame($expected, $result->content);
-        $this->assertFalse($result->updated);
+        $this->assertNull($result);
     }
 }

--- a/tests/system/Publisher/PublisherContentReplaceTest.php
+++ b/tests/system/Publisher/PublisherContentReplaceTest.php
@@ -42,14 +42,14 @@ final class PublisherContentReplaceTest extends CIUnitTestCase
     {
         $result = $this->publisher->addLineAfter(
             $this->file,
-            '    public $myOwnConfig = 1000;',
-            'public $CSPEnabled = false;'
+            '    public int $myOwnConfig = 1000;',
+            'public bool $CSPEnabled = false;'
         );
 
         $this->assertTrue($result);
         $this->assertStringContainsString(
-            '    public $CSPEnabled = false;
-    public $myOwnConfig = 1000;',
+            '    public bool $CSPEnabled = false;
+    public int $myOwnConfig = 1000;',
             file_get_contents($this->file)
         );
     }
@@ -58,14 +58,14 @@ final class PublisherContentReplaceTest extends CIUnitTestCase
     {
         $result = $this->publisher->addLineBefore(
             $this->file,
-            '    public $myOwnConfig = 1000;',
-            'public $CSPEnabled = false;'
+            '    public int $myOwnConfig = 1000;',
+            'public bool $CSPEnabled = false;'
         );
 
         $this->assertTrue($result);
         $this->assertStringContainsString(
-            '    public $myOwnConfig = 1000;
-    public $CSPEnabled = false;',
+            '    public int $myOwnConfig = 1000;
+    public bool $CSPEnabled = false;',
             file_get_contents($this->file)
         );
     }

--- a/tests/system/Publisher/PublisherContentReplaceTest.php
+++ b/tests/system/Publisher/PublisherContentReplaceTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Publisher;
+
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class PublisherContentReplaceTest extends CIUnitTestCase
+{
+    private string $file;
+    private Publisher $publisher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->file = __DIR__ . '/App.php';
+        copy(APPPATH . 'Config/App.php', $this->file);
+
+        $this->publisher = new Publisher(__DIR__, __DIR__);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unlink($this->file);
+    }
+
+    public function testAddLineAfter()
+    {
+        $result = $this->publisher->addLineAfter(
+            $this->file,
+            '    public $myOwnConfig = 1000;',
+            'public $CSPEnabled = false;'
+        );
+
+        $this->assertTrue($result);
+        $this->assertStringContainsString(
+            '    public $CSPEnabled = false;
+    public $myOwnConfig = 1000;',
+            file_get_contents($this->file)
+        );
+    }
+
+    public function testAddLineBefore()
+    {
+        $result = $this->publisher->addLineBefore(
+            $this->file,
+            '    public $myOwnConfig = 1000;',
+            'public $CSPEnabled = false;'
+        );
+
+        $this->assertTrue($result);
+        $this->assertStringContainsString(
+            '    public $myOwnConfig = 1000;
+    public $CSPEnabled = false;',
+            file_get_contents($this->file)
+        );
+    }
+
+    public function testReplace()
+    {
+        $result = $this->publisher->replace(
+            $this->file,
+            [
+                'use CodeIgniter\Config\BaseConfig;' . "\n" => '',
+                'class App extends BaseConfig'              => 'class App extends \Some\Package\SomeConfig',
+            ]
+        );
+
+        $this->assertTrue($result);
+        $this->assertStringNotContainsString(
+            'use CodeIgniter\Config\BaseConfig;',
+            file_get_contents($this->file)
+        );
+        $this->assertStringContainsString(
+            'class App extends \Some\Package\SomeConfig',
+            file_get_contents($this->file)
+        );
+        $this->assertStringNotContainsString(
+            'class App extends BaseConfig',
+            file_get_contents($this->file)
+        );
+    }
+}

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -36,6 +36,7 @@ Enhancements
 - Added before and after events to ``BaseModel::insertBatch()`` and ``BaseModel::updateBatch()`` methods. See :ref:`model-events-callbacks`.
 - Added ``Model::allowEmptyInserts()`` method to insert empty data. See :ref:`Using CodeIgniter's Model <model-allow-empty-inserts>`
 - Added ``$routes->useSupportedLocalesOnly(true)`` so that the Router returns 404 Not Found if the locale in the URL is not supported in ``Config\App::$supportedLocales``. See :ref:`Localization <localization-in-routes>`
+- Added methods ``replace()``, ``addLineAfter()`` and ``addLineBefore()`` to modify files in Publisher. See :ref:`Publisher <publisher-modifying-files>` for details.
 - The call handler for Spark commands from the ``CodeIgniter\CodeIgniter`` class has been extracted. This will reduce the cost of console calls.
 
 Changes

--- a/user_guide_src/source/libraries/publisher.rst
+++ b/user_guide_src/source/libraries/publisher.rst
@@ -264,3 +264,27 @@ affect other files in the destination. Returns success or failure, use ``getPubl
 Example:
 
 .. literalinclude:: publisher/012.php
+
+Modifying Files
+===============
+
+replace(string $file, array $replaces): bool
+--------------------------------------------
+
+Replaces the ``$file`` contents. The second parameter ``$replaces`` array specifies the search strings as keys and the replacements as values.
+
+.. literalinclude:: publisher/013.php
+
+addLineAfter(string $file, string $line, string $after): bool
+-------------------------------------------------------------
+
+Adds ``$line`` after a line with specific string ``$after``.
+
+.. literalinclude:: publisher/014.php
+
+addLineBefore(string $file, string $line, string $after): bool
+--------------------------------------------------------------
+
+Adds ``$line`` before a line with specific string ``$after``.
+
+.. literalinclude:: publisher/015.php

--- a/user_guide_src/source/libraries/publisher.rst
+++ b/user_guide_src/source/libraries/publisher.rst
@@ -265,6 +265,8 @@ Example:
 
 .. literalinclude:: publisher/012.php
 
+.. _publisher-modifying-files:
+
 Modifying Files
 ===============
 

--- a/user_guide_src/source/libraries/publisher/010.php
+++ b/user_guide_src/source/libraries/publisher/010.php
@@ -15,9 +15,9 @@ class AuthPublish extends BaseCommand
     public function run(array $params)
     {
         // Use the Autoloader to figure out the module path
-        $source = service('autoloader')->getNamespace('Math\\Auth');
+        $source = service('autoloader')->getNamespace('Math\\Auth')[0];
 
-        $publisher = new Publisher($source, APPATH);
+        $publisher = new Publisher($source, APPPATH);
 
         try {
             // Add only the desired components

--- a/user_guide_src/source/libraries/publisher/013.php
+++ b/user_guide_src/source/libraries/publisher/013.php
@@ -1,0 +1,16 @@
+<?php
+
+use CodeIgniter\Publisher\Publisher;
+
+$source    = service('autoloader')->getNamespace('CodeIgniter\\Shield')[0];
+$publisher = new Publisher($source, APPPATH);
+
+$file = APPPATH . 'Config/Auth.php';
+
+$publisher->replace(
+    $file,
+    [
+        'use CodeIgniter\Config\BaseConfig;' . "\n" => '',
+        'class App extends BaseConfig'              => 'class App extends \Some\Package\SomeConfig',
+    ]
+);

--- a/user_guide_src/source/libraries/publisher/014.php
+++ b/user_guide_src/source/libraries/publisher/014.php
@@ -1,0 +1,14 @@
+<?php
+
+use CodeIgniter\Publisher\Publisher;
+
+$source    = service('autoloader')->getNamespace('CodeIgniter\\Shield')[0];
+$publisher = new Publisher($source, APPPATH);
+
+$file = APPPATH . 'Config/App.php';
+
+$publisher->addLineAfter(
+    $file,
+    '    public int $myOwnConfig = 1000;', // Adds this line
+    'public bool $CSPEnabled = false;'     // After this line
+);

--- a/user_guide_src/source/libraries/publisher/015.php
+++ b/user_guide_src/source/libraries/publisher/015.php
@@ -1,0 +1,14 @@
+<?php
+
+use CodeIgniter\Publisher\Publisher;
+
+$source    = service('autoloader')->getNamespace('CodeIgniter\\Shield')[0];
+$publisher = new Publisher($source, APPPATH);
+
+$file = APPPATH . 'Config/App.php';
+
+$publisher->addLineBefore(
+    $file,
+    '    public int $myOwnConfig = 1000;', // Add this line
+    'public bool $CSPEnabled = false;'     // Before this line
+);


### PR DESCRIPTION
**Description**
To modify config files during setup.

- add `Publisher::replace()`
- add `Publisher::addLineAfter()`
- add `Publisher::addLineBefore()`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
