### PR TITLE
Updated to use ::class in $returnType example

### DIFF
--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -116,7 +116,7 @@ The Model's CRUD methods will take a step of work away from you and automaticall
 the resulting data, instead of the Result object. This setting allows you to define
 the type of data that is returned. Valid values are '**array**' (the default), '**object**', or the **fully
 qualified name of a class** that can be used with the Result object's ``getCustomResultObject()``
-method. Using the ``::class`` suffix of the class will allow most IDEs to 
+method. Using the special ``::class`` constant of the class will allow most IDEs to 
 auto-complete the name and allow functions like refactoring to better understand your code.
 
 $useSoftDeletes

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -116,7 +116,8 @@ The Model's CRUD methods will take a step of work away from you and automaticall
 the resulting data, instead of the Result object. This setting allows you to define
 the type of data that is returned. Valid values are '**array**' (the default), '**object**', or the **fully
 qualified name of a class** that can be used with the Result object's ``getCustomResultObject()``
-method.
+method. Using the ``::class`` suffix of the class will allow most IDEs to 
+auto-complete the name and allow functions like refactoring to better understand your code.
 
 $useSoftDeletes
 ---------------

--- a/user_guide_src/source/models/model/021.php
+++ b/user_guide_src/source/models/model/021.php
@@ -7,7 +7,7 @@ use CodeIgniter\Model;
 class JobModel extends Model
 {
     protected $table         = 'jobs';
-    protected $returnType    = '\App\Entities\Job';
+    protected $returnType    = \App\Entities\Job::class;
     protected $allowedFields = [
         'name', 'description',
     ];


### PR DESCRIPTION
**Description**
Updated Model example with `$returnType` to use `::class` instead of string literal.
https://forum.codeigniter.com/showthread.php?tid=82127&pid=397352#pid397352

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
