### PR TITLE
config: DB Error always throws Exception

### DIFF
--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -39,7 +39,7 @@ class Database extends Config
         'DBDriver' => 'MySQLi',
         'DBPrefix' => '',
         'pConnect' => false,
-        'DBDebug'  => (ENVIRONMENT !== 'production'),
+        'DBDebug'  => true,
         'charset'  => 'utf8',
         'DBCollat' => 'utf8_general_ci',
         'swapPre'  => '',
@@ -65,7 +65,7 @@ class Database extends Config
         'DBDriver'    => 'SQLite3',
         'DBPrefix'    => 'db_',  // Needed to ensure we're working correctly with prefixes live. DO NOT REMOVE FOR CI DEVS
         'pConnect'    => false,
-        'DBDebug'     => (ENVIRONMENT !== 'production'),
+        'DBDebug'     => true,
         'charset'     => 'utf8',
         'DBCollat'    => 'utf8_general_ci',
         'swapPre'     => '',

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -124,7 +124,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Debug flag
      *
-     * Whether to display error messages.
+     * Whether to throw Exception or not when an error occurs.
      *
      * @var bool
      */

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -28,7 +28,7 @@ Enhancements
 Changes
 *******
 
-- Be consistent in the behaviors regardless of environments, ``Config\Database::$default['DBDebug']`` and ``Config\Database::$tests['DBDebug']`` has been changed to ``true`` by default. With these settings, an exception is always thrown when a database error occurs.
+- To be consistent in behavior regardless of environments, ``Config\Database::$default['DBDebug']`` and ``Config\Database::$tests['DBDebug']`` has been changed to ``true`` by default. With these settings, an exception is always thrown when a database error occurs.
 - Changed the processing of Spark commands:
     - The ``CodeIgniter\CodeIgniter`` no longer handles Spark commands.
     - The ``CodeIgniter::isSparked()`` method has been removed.

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -28,6 +28,7 @@ Enhancements
 Changes
 *******
 
+- Be consistent in the behaviors regardless of environments, ``Config\Database::$default['DBDebug']`` and ``Config\Database::$tests['DBDebug']`` has been changed to ``true`` by default. With these settings, an exception is always thrown when a database error occurs.
 - Changed the processing of Spark commands:
     - The ``CodeIgniter\CodeIgniter`` no longer handles Spark commands.
     - The ``CodeIgniter::isSparked()`` method has been removed.

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -118,7 +118,7 @@ Explanation of Values:
                 :doc:`Query Builder <query_builder>` queries. This permits multiple CodeIgniter
                 installations to share one database.
 **pConnect**    true/false (boolean) - Whether to use a persistent connection.
-**DBDebug**     true/false (boolean) - Whether database errors should be displayed.
+**DBDebug**     true/false (boolean) - Whether to throw exceptions or not when database errors occur.
 **charset**     The character set used in communicating with the database.
 **DBCollat**    The character collation used in communicating with the database (``MySQLi`` only)
 **swapPre**     A default table prefix that should be swapped with ``DBPrefix``. This is useful for distributed

--- a/user_guide_src/source/database/connecting/006.php
+++ b/user_guide_src/source/database/connecting/006.php
@@ -9,7 +9,7 @@ $custom = [
     'DBDriver' => 'MySQLi',
     'DBPrefix' => '',
     'pConnect' => false,
-    'DBDebug'  => (ENVIRONMENT !== 'production'),
+    'DBDebug'  => true,
     'charset'  => 'utf8',
     'DBCollat' => 'utf8_general_ci',
     'swapPre'  => '',


### PR DESCRIPTION
**Description**
See  #6132
- change the default config to always throw an exception when DB error occurs

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
