### PR TITLE
feat: improve namespaces command

### DIFF
--- a/tests/system/Commands/Utilities/NamespacesTest.php
+++ b/tests/system/Commands/Utilities/NamespacesTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+/**
+ * @internal
+ */
+final class NamespacesTest extends CIUnitTestCase
+{
+    private $streamFilter;
+
+    protected function setUp(): void
+    {
+        $this->resetServices();
+
+        parent::setUp();
+
+        CITestStreamFilter::$buffer = '';
+
+        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
+        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
+    }
+
+    protected function tearDown(): void
+    {
+        stream_filter_remove($this->streamFilter);
+
+        $this->resetServices();
+    }
+
+    protected function getBuffer()
+    {
+        return CITestStreamFilter::$buffer;
+    }
+
+    public function testNamespacesCommandCodeIgniterOnly()
+    {
+        command('namespaces -c');
+
+        $expected = <<<'EOL'
+            +---------------+-------------------------+--------+
+            | Namespace     | Path                    | Found? |
+            +---------------+-------------------------+--------+
+            | CodeIgniter   | ROOTPATH/system         | Yes    |
+            | App           | ROOTPATH/app            | Yes    |
+            | Config        | APPPATH/Config          | Yes    |
+            | Tests\Support | ROOTPATH/tests/_support | Yes    |
+            +---------------+-------------------------+--------+
+            EOL;
+
+        $this->assertStringContainsString($expected, $this->getBuffer());
+    }
+
+    public function testNamespacesCommandAllNamespaces()
+    {
+        command('namespaces');
+
+        $this->assertStringContainsString(
+            '|CodeIgniter|ROOTPATH/system|Yes|',
+            str_replace(' ', '', $this->getBuffer())
+        );
+        $this->assertStringContainsString(
+            '|App|ROOTPATH/app|Yes|',
+            str_replace(' ', '', $this->getBuffer())
+        );
+        $this->assertStringContainsString(
+            '|Config|APPPATH/Config|Yes|',
+            str_replace(' ', '', $this->getBuffer())
+        );
+    }
+}


### PR DESCRIPTION
**Description**
- improve output of `namespaces` command
- add options
  - `-c`:  show CodeIgniter namespace only
  - `-r`: show raw path strings
  - `-m`: specify max length of the path strings

```console
$ php spark namespaces -c

CodeIgniter v4.2.1 Command Line Tool - Server Time: 2022-06-17 02:43:54 UTC-05:00

+-------------+-----------------+--------+
| Namespace   | Path            | Found? |
+-------------+-----------------+--------+
| CodeIgniter | ROOTPATH/system | Yes    |
| App         | ROOTPATH/app    | Yes    |
| Config      | APPPATH/Config  | Yes    |
+-------------+-----------------+--------+
```

```console
$ php spark namespaces 

CodeIgniter v4.2.1 Command Line Tool - Server Time: 2022-06-17 02:44:09 UTC-05:00

+-----------------+----------------------------------------+--------+
| Namespace       | Path                                   | Found? |
+-----------------+----------------------------------------+--------+
| CodeIgniter     | ROOTPATH/system                        | Yes    |
| App             | ROOTPATH/app                           | Yes    |
| Config          | APPPATH/Config                         | Yes    |
| Psr\Log         | VENDORPATH/psr/log/Psr/Log             | Yes    |
| Laminas\Escaper | VENDORPATH/laminas/laminas-escaper/src | Yes    |
| Kint            | VENDORPATH/kint-php/kint/src           | Yes    |
+-----------------+----------------------------------------+--------+
```

```console
$ php spark namespaces -r -c

CodeIgniter v4.2.1 Command Line Tool - Server Time: 2022-06-17 04:14:49 UTC-05:00

+-------------+-------------------------------------------------------+--------+
| Namespace   | Path                                                  | Found? |
+-------------+-------------------------------------------------------+--------+
| CodeIgniter | /Users/kenji/work/codeigniter/CodeIgniter4/system/    | Yes    |
| App         | /Users/kenji/work/codeigniter/CodeIgniter4/app/       | Yes    |
| Config      | /Users/kenji/work/codeigniter/CodeIgniter4/app/Config | Yes    |
+-------------+-------------------------------------------------------+--------+
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
