### PR TITLE
docs: replace getServer with server in comments

### DIFF
--- a/admin/starter/app/Config/Paths.php
+++ b/admin/starter/app/Config/Paths.php
@@ -34,8 +34,8 @@ class Paths
      *
      * If you want this front controller to use a different "app"
      * folder than the default one you can set its name here. The folder
-     * can also be renamed or relocated anywhere on your getServer. If
-     * you do, use a full getServer path.
+     * can also be renamed or relocated anywhere on your server. If
+     * you do, use a full server path.
      *
      * @see http://codeigniter.com/user_guide/general/managing_apps.html
      *

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -44,7 +44,7 @@ class App extends BaseConfig
      * URI PROTOCOL
      * --------------------------------------------------------------------------
      *
-     * This item determines which getServer global should be used to retrieve the
+     * This item determines which server global should be used to retrieve the
      * URI string.  The default setting of 'REQUEST_URI' works for most servers.
      * If your links do not seem to work, try one of the other delicious flavors:
      *

--- a/app/Config/Logger.php
+++ b/app/Config/Logger.php
@@ -60,7 +60,7 @@ class Logger extends BaseConfig
      * The logging system supports multiple actions to be taken when something
      * is logged. This is done by allowing for multiple Handlers, special classes
      * designed to write the log to their chosen destinations, whether that is
-     * a file on the getServer, a cloud-based service, or even taking actions such
+     * a file on the server, a cloud-based service, or even taking actions such
      * as emailing the dev team.
      *
      * Each handler is defined by the class name used for that handler, and it

--- a/app/Config/Paths.php
+++ b/app/Config/Paths.php
@@ -34,8 +34,8 @@ class Paths
      *
      * If you want this front controller to use a different "app"
      * folder than the default one you can set its name here. The folder
-     * can also be renamed or relocated anywhere on your getServer. If
-     * you do, use a full getServer path.
+     * can also be renamed or relocated anywhere on your server. If
+     * you do, use a full server path.
      *
      * @see http://codeigniter.com/user_guide/general/managing_apps.html
      *

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -22,7 +22,7 @@ use Locale;
 /**
  * Class IncomingRequest
  *
- * Represents an incoming, getServer-side HTTP request.
+ * Represents an incoming, server-side HTTP request.
  *
  * Per the HTTP specification, this interface includes properties for
  * each of the following:

--- a/system/HTTP/MessageInterface.php
+++ b/system/HTTP/MessageInterface.php
@@ -37,7 +37,7 @@ interface MessageInterface
     public function appendBody($data);
 
     /**
-     * Populates the $headers array with any headers the getServer knows about.
+     * Populates the $headers array with any headers the server knows about.
      */
     public function populateHeaders(): void;
 

--- a/system/HTTP/MessageTrait.php
+++ b/system/HTTP/MessageTrait.php
@@ -75,7 +75,7 @@ trait MessageTrait
     //--------------------------------------------------------------------
 
     /**
-     * Populates the $headers array with any headers the getServer knows about.
+     * Populates the $headers array with any headers the server knows about.
      */
     public function populateHeaders(): void
     {

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -18,7 +18,7 @@ use CodeIgniter\HTTP\Exceptions\HTTPException;
  *
  * Provides methods to negotiate with the HTTP headers to determine the best
  * type match between what the application supports and what the requesting
- * getServer wants.
+ * server wants.
  *
  * @see http://tools.ietf.org/html/rfc7231#section-5.3
  */

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -19,7 +19,7 @@ use Config\App;
 use Config\Services;
 
 /**
- * Representation of an outgoing, getServer-side response.
+ * Representation of an outgoing, server-side response.
  *
  * Per the HTTP specification, this interface includes properties for
  * each of the following:
@@ -203,7 +203,7 @@ class Response extends Message implements MessageInterface, ResponseInterface
     /**
      * Gets the response status code.
      *
-     * The status code is a 3-digit integer result code of the getServer's attempt
+     * The status code is a 3-digit integer result code of the server's attempt
      * to understand and satisfy the request.
      *
      * @return int Status code.

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -18,7 +18,7 @@ use DateTime;
 use InvalidArgumentException;
 
 /**
- * Representation of an outgoing, getServer-side response.
+ * Representation of an outgoing, server-side response.
  * Most of these methods are supplied by ResponseTrait.
  *
  * Per the HTTP specification, this interface includes properties for
@@ -107,7 +107,7 @@ interface ResponseInterface
     /**
      * Gets the response status code.
      *
-     * The status code is a 3-digit integer result code of the getServer's attempt
+     * The status code is a 3-digit integer result code of the server's attempt
      * to understand and satisfy the request.
      *
      * @return int Status code.

--- a/system/Test/Mock/MockLogger.php
+++ b/system/Test/Mock/MockLogger.php
@@ -65,7 +65,7 @@ class MockLogger
       | The logging system supports multiple actions to be taken when something
       | is logged. This is done by allowing for multiple Handlers, special classes
       | designed to write the log to their chosen destinations, whether that is
-      | a file on the getServer, a cloud-based service, or even taking actions such
+      | a file on the server, a cloud-based service, or even taking actions such
       | as emailing the dev team.
       |
       | Each handler is defined by the class name used for that handler, and it


### PR DESCRIPTION
**Description**
- fix comments

See https://github.com/codeigniter4/CodeIgniter4/commit/f524c25cb04301b00f06905321d26628909a6e3e

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

