### PR TITLE
Update Exceptions.php - determineCodes crash

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -300,18 +300,23 @@ class Exceptions
      */
     protected function determineCodes(Throwable $exception): array
     {
-        $statusCode = abs($exception->getCode());
+        $statusCode = $exception->getCode();
+        if(is_numeric($statusCode)){
+            $statusCode = abs($statusCode);
+            if ($statusCode < 100 || $statusCode > 599) {
+                $exitStatus = $statusCode + EXIT__AUTO_MIN;
 
-        if ($statusCode < 100 || $statusCode > 599) {
-            $exitStatus = $statusCode + EXIT__AUTO_MIN;
+                if ($exitStatus > EXIT__AUTO_MAX) {
+                    $exitStatus = EXIT_ERROR;
+                }
 
-            if ($exitStatus > EXIT__AUTO_MAX) {
+                $statusCode = 500;
+            } else {
                 $exitStatus = EXIT_ERROR;
             }
-
-            $statusCode = 500;
-        } else {
+        }else{
             $exitStatus = EXIT_ERROR;
+            $statusCode = 500;
         }
 
         return [$statusCode, $exitStatus];


### PR DESCRIPTION
**Description**
In `System/Debug/Exceptions.php::determineCodes`
I've been having error with my PDO (custom port of C3) Cause the errors codes are not numeric, and the function 'determineCodes' uses the abs function directly on the result of `$exception->getCode()`
I've just added a check for numeric value before using abs, and non numeric codes right now are treated as 500

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
