### PR TITLE
fix: SQLite3\Connection\getIndexData() error

### DIFF
--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -151,6 +151,10 @@ class Connection extends BaseConnection
      */
     protected function _escapeString(string $str): string
     {
+        if (! $this->connID) {
+            $this->initialize();
+        }
+
         return $this->connID->escapeString($str);
     }
 


### PR DESCRIPTION
**Description**
Fixes #6151

- add missing DB initialization

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

