### PR TITLE
fix: `is_image` causes PHP 8.1 deprecated error

### DIFF
--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -133,7 +133,7 @@ class FileRules
 
             // We know that our mimes list always has the first mime
             // start with `image` even when then are multiple accepted types.
-            $type = Mimes::guessTypeFromExtension($file->getExtension());
+            $type = Mimes::guessTypeFromExtension($file->getExtension()) ?? '';
 
             if (mb_strpos($type, 'image') !== 0) {
                 return false;

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -41,7 +41,9 @@ final class FileRulesTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
+        $this->resetServices();
         parent::setUp();
+
         $this->validation = new Validation((object) $this->config, Services::renderer());
         $this->validation->reset();
 
@@ -229,6 +231,7 @@ final class FileRulesTest extends CIUnitTestCase
             'type'     => 'application/address',
             'error'    => UPLOAD_ERR_OK,
         ];
+
         $this->validation->setRules(['avatar' => 'is_image[stuff]']);
         $this->assertFalse($this->validation->run([]));
     }

--- a/tests/system/Validation/StrictRules/FileRulesTest.php
+++ b/tests/system/Validation/StrictRules/FileRulesTest.php
@@ -42,7 +42,9 @@ final class FileRulesTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
+        $this->resetServices();
         parent::setUp();
+
         $this->validation = new Validation((object) $this->config, Services::renderer());
         $this->validation->reset();
 
@@ -230,6 +232,7 @@ final class FileRulesTest extends CIUnitTestCase
             'type'     => 'application/address',
             'error'    => UPLOAD_ERR_OK,
         ];
+
         $this->validation->setRules(['avatar' => 'is_image[stuff]']);
         $this->assertFalse($this->validation->run([]));
     }


### PR DESCRIPTION
**Description**
Fixes #6155
Fixes #6156

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

