### PR TITLE
fix: Time::getAge() calculation

### DIFF
--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -460,12 +460,8 @@ class Time extends DateTime
      */
     public function getAge()
     {
-        $now = self::now();
-
-        $age = (int) (((int) $now->format('Ymd') - (int) $this->format('Ymd')) / 10000);
-
         // future dates have no age
-        return max(0, $age);
+        return max(0, $this->difference(self::now())->getYears());
     }
 
     /**

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -452,7 +452,7 @@ class Time extends DateTime
     }
 
     /**
-     * Returns the age in years from the "current" date and 'now'
+     * Returns the age in years from the date and 'now'
      *
      * @throws Exception
      *
@@ -460,11 +460,12 @@ class Time extends DateTime
      */
     public function getAge()
     {
-        $now  = self::now()->getTimestamp();
-        $time = $this->getTimestamp();
+        $now = self::now();
+
+        $age = (int) (((int) $now->format('Ymd') - (int) $this->format('Ymd')) / 10000);
 
         // future dates have no age
-        return max(0, date('Y', $now) - date('Y', $time));
+        return max(0, $age);
     }
 
     /**

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -383,6 +383,7 @@ final class TimeTest extends CIUnitTestCase
     {
         $time = Time::parse('5 years ago');
 
+        $this->assertSame(5, $time->getAge());
         $this->assertSame(5, $time->age);
     }
 
@@ -390,7 +391,7 @@ final class TimeTest extends CIUnitTestCase
     {
         $time = new Time();
 
-        $this->assertSame(0, $time->age);
+        $this->assertSame(0, $time->getAge());
     }
 
     public function testAgeFuture()
@@ -398,7 +399,7 @@ final class TimeTest extends CIUnitTestCase
         Time::setTestNow('June 20, 2022', 'America/Chicago');
         $time = Time::parse('August 12, 2116 4:15:23pm');
 
-        $this->assertSame(0, $time->age);
+        $this->assertSame(0, $time->getAge());
     }
 
     public function testGetQuarter()

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -395,6 +395,7 @@ final class TimeTest extends CIUnitTestCase
 
     public function testAgeFuture()
     {
+        Time::setTestNow('June 20, 2022', 'America/Chicago');
         $time = Time::parse('August 12, 2116 4:15:23pm');
 
         $this->assertSame(0, $time->age);

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -382,18 +382,21 @@ final class TimeTest extends CIUnitTestCase
     public function testGetAge()
     {
         $time = Time::parse('5 years ago');
+
         $this->assertSame(5, $time->age);
     }
 
     public function testAgeNow()
     {
         $time = new Time();
+
         $this->assertSame(0, $time->age);
     }
 
     public function testAgeFuture()
     {
         $time = Time::parse('August 12, 2116 4:15:23pm');
+
         $this->assertSame(0, $time->age);
     }
 

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -402,6 +402,30 @@ final class TimeTest extends CIUnitTestCase
         $this->assertSame(0, $time->getAge());
     }
 
+    public function testGetAgeSameDayOfBirthday()
+    {
+        Time::setTestNow('December 31, 2022', 'America/Chicago');
+        $time = Time::parse('December 31, 2020');
+
+        $this->assertSame(2, $time->getAge());
+    }
+
+    public function testGetAgeNextDayOfBirthday()
+    {
+        Time::setTestNow('January 1, 2022', 'America/Chicago');
+        $time = Time::parse('December 31, 2020');
+
+        $this->assertSame(1, $time->getAge());
+    }
+
+    public function testGetAgeBeforeDayOfBirthday()
+    {
+        Time::setTestNow('December 30, 2021', 'America/Chicago');
+        $time = Time::parse('December 31, 2020');
+
+        $this->assertSame(0, $time->getAge());
+    }
+
     public function testGetQuarter()
     {
         $time = Time::parse('April 15, 2015');


### PR DESCRIPTION
**Description**
- fix `Time::getAge()` calculation
- fix test case

> Returns the age, in years, of between the Time’s instance and the current time. **Perfect for checking the age of someone based on their birthday**:
https://codeigniter4.github.io/CodeIgniter4/libraries/time.html#getage

There are a few ways to calculate human age.
However, the current implementation does not seem to be common.

E.g.:
- birthdate: December 31, 2020
- now: January 1, 2022
- age: 2

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

