### PR TITLE
docs: fix wrong namespace `App\Config`

### DIFF
--- a/user_guide_src/source/general/errors/005.php
+++ b/user_guide_src/source/general/errors/005.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Config;
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 

--- a/user_guide_src/source/general/errors/006.php
+++ b/user_guide_src/source/general/errors/006.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Config;
+namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 

--- a/user_guide_src/source/incoming/routing/043.php
+++ b/user_guide_src/source/incoming/routing/043.php
@@ -3,7 +3,7 @@
 // First you need to enable sorting.
 $routes->setPrioritize();
 
-// App\Config\Routes
+// Config\Routes
 $routes->get('(.*)', 'Posts::index', ['priority' => 1]);
 
 // Modules\Acme\Config\Routes


### PR DESCRIPTION
**Description**
- not `App\Config`, but `Config`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

