### PR TITLE
fix: prepared query is executed when using QueryBuilder

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -136,11 +136,6 @@ parameters:
 			path: system/Database/BaseConnection.php
 
 		-
-			message: "#^Negated boolean expression is always true\\.$#"
-			count: 2
-			path: system/Database/BaseConnection.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 3
 			path: system/Database/BaseResult.php

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -603,6 +603,15 @@ abstract class BaseConnection implements ConnectionInterface
         // the getLastQuery() method.
         $this->lastQuery = $query;
 
+        // If $pretend is true, then we just want to return
+        // the actual query object here. There won't be
+        // any results to return.
+        if ($this->pretend) {
+            $query->setDuration($startTime);
+
+            return $query;
+        }
+
         // Run the query for real
         try {
             $exception      = null;
@@ -611,7 +620,7 @@ abstract class BaseConnection implements ConnectionInterface
             $this->resultID = false;
         }
 
-        if (! $this->pretend && $this->resultID === false) {
+        if ($this->resultID === false) {
             $query->setDuration($startTime, $startTime);
 
             // This will trigger a rollback if transactions are being used
@@ -634,10 +643,8 @@ abstract class BaseConnection implements ConnectionInterface
                     }
                 }
 
-                if (! $this->pretend) {
-                    // Let others do something with this query.
-                    Events::trigger('DBQuery', $query);
-                }
+                // Let others do something with this query.
+                Events::trigger('DBQuery', $query);
 
                 if ($exception !== null) {
                     throw $exception;
@@ -646,27 +653,16 @@ abstract class BaseConnection implements ConnectionInterface
                 return false;
             }
 
-            if (! $this->pretend) {
-                // Let others do something with this query.
-                Events::trigger('DBQuery', $query);
-            }
+            // Let others do something with this query.
+            Events::trigger('DBQuery', $query);
 
             return false;
         }
 
         $query->setDuration($startTime);
 
-        if (! $this->pretend) {
-            // Let others do something with this query
-            Events::trigger('DBQuery', $query);
-        }
-
-        // If $pretend is true, then we just want to return
-        // the actual query object here. There won't be
-        // any results to return.
-        if ($this->pretend) {
-            return $query;
-        }
+        // Let others do something with this query
+        Events::trigger('DBQuery', $query);
 
         // resultID is not false, so it must be successful
         if ($this->isWriteType($sql)) {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -271,7 +271,7 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * If true, no queries will actually be
-     * ran against the database.
+     * run against the database.
      *
      * @var bool
      */

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -107,6 +107,7 @@ final class PreparedQueryTest extends CIUnitTestCase
         $this->query->execute('foo', 'foo@example.com', 'US');
         $this->query->execute('bar', 'bar@example.com', 'GB');
 
+        $this->dontSeeInDatabase($this->db->DBPrefix . 'user', ['name' => 'a', 'email' => 'b@example.com']);
         $this->seeInDatabase($this->db->DBPrefix . 'user', ['name' => 'foo', 'email' => 'foo@example.com']);
         $this->seeInDatabase($this->db->DBPrefix . 'user', ['name' => 'bar', 'email' => 'bar@example.com']);
     }

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -32,6 +32,7 @@ final class PreparedQueryTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->query = null;
     }
 
@@ -47,8 +48,9 @@ final class PreparedQueryTest extends CIUnitTestCase
     public function testPrepareReturnsPreparedQuery()
     {
         $this->query = $this->db->prepare(static fn ($db) => $db->table('user')->insert([
-            'name'  => 'a',
-            'email' => 'b@example.com',
+            'name'    => 'a',
+            'email'   => 'b@example.com',
+            'country' => 'JP',
         ]));
 
         $this->assertInstanceOf(BasePreparedQuery::class, $this->query);
@@ -56,17 +58,17 @@ final class PreparedQueryTest extends CIUnitTestCase
         $ec  = $this->db->escapeChar;
         $pre = $this->db->DBPrefix;
 
-        $placeholders = '?, ?';
+        $placeholders = '?, ?, ?';
 
         if ($this->db->DBDriver === 'Postgre') {
-            $placeholders = '$1, $2';
+            $placeholders = '$1, $2, $3';
         }
 
         if ($this->db->DBDriver === 'SQLSRV') {
             $database = $this->db->getDatabase();
-            $expected = "INSERT INTO {$ec}{$database}{$ec}.{$ec}{$this->db->schema}{$ec}.{$ec}{$pre}user{$ec} ({$ec}name{$ec},{$ec}email{$ec}) VALUES ({$placeholders})";
+            $expected = "INSERT INTO {$ec}{$database}{$ec}.{$ec}{$this->db->schema}{$ec}.{$ec}{$pre}user{$ec} ({$ec}name{$ec},{$ec}email{$ec},{$ec}country{$ec}) VALUES ({$placeholders})";
         } else {
-            $expected = "INSERT INTO {$ec}{$pre}user{$ec} ({$ec}name{$ec}, {$ec}email{$ec}) VALUES ({$placeholders})";
+            $expected = "INSERT INTO {$ec}{$pre}user{$ec} ({$ec}name{$ec}, {$ec}email{$ec}, {$ec}country{$ec}) VALUES ({$placeholders})";
         }
 
         $this->assertSame($expected, $this->query->getQueryString());


### PR DESCRIPTION
**Description**
- prepared query is executed when using QueryBuilder

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

