### PR TITLE
Change: PHPDoc return type in ControllerTestTrait methods

### DIFF
--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -126,7 +126,7 @@ trait ControllerTestTrait
     /**
      * Loads the specified controller, and generates any needed dependencies.
      *
-     * @return mixed
+     * @return $this
      */
     public function controller(string $name)
     {
@@ -215,7 +215,7 @@ trait ControllerTestTrait
      *
      * @param mixed $appConfig
      *
-     * @return mixed
+     * @return $this
      */
     public function withConfig($appConfig)
     {
@@ -229,7 +229,7 @@ trait ControllerTestTrait
      *
      * @param mixed $request
      *
-     * @return mixed
+     * @return $this
      */
     public function withRequest($request)
     {
@@ -246,7 +246,7 @@ trait ControllerTestTrait
      *
      * @param mixed $response
      *
-     * @return mixed
+     * @return $this
      */
     public function withResponse($response)
     {
@@ -260,7 +260,7 @@ trait ControllerTestTrait
      *
      * @param mixed $logger
      *
-     * @return mixed
+     * @return $this
      */
     public function withLogger($logger)
     {
@@ -272,7 +272,7 @@ trait ControllerTestTrait
     /**
      * Set the controller's URI, with method chaining.
      *
-     * @return mixed
+     * @return $this
      */
     public function withUri(string $uri)
     {
@@ -286,7 +286,7 @@ trait ControllerTestTrait
      *
      * @param string|null $body
      *
-     * @return mixed
+     * @return $this
      */
     public function withBody($body)
     {


### PR DESCRIPTION
**Description**
Replacing the return type in the ControllerTestTrait methods in the docBlock section from mixed to $this.
This allows the IDE to use hints in the chain call.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide