### PR TITLE
Doc: Incorrect example of creating an IncomingRequest instance.

### DIFF
--- a/user_guide_src/source/testing/controllers/006.php
+++ b/user_guide_src/source/testing/controllers/006.php
@@ -1,6 +1,12 @@
 <?php
 
-$request = new \CodeIgniter\HTTP\IncomingRequest(new \Config\App(), new URI('http://example.com'));
+$request = new \CodeIgniter\HTTP\IncomingRequest(
+    new \Config\App(),
+    new \CodeIgniter\HTTP\URI('http://example.com'),
+    null,
+    new \CodeIgniter\HTTP\UserAgent()
+);
+
 $request->setLocale($locale);
 
 $results = $this->withRequest($request)


### PR DESCRIPTION
**Description**
There is a mistake in the example code in the documentation for testing controllers using an instance of the IncomingRequest class. The $userAgent argument was not specified.

Although the $userAgent parameter in the constructor of the IncomingRequest class can be null, this will cause an exception to be thrown.
https://github.com/codeigniter4/CodeIgniter4/blob/01804793734610951b4eb4a3e8b1cbfc7826cfc6/system/HTTP/IncomingRequest.php#L150-L154

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide