### PR TITLE
Add close PR action for repo splits

### DIFF
--- a/admin/framework/.github/workflows/close-pull-request.yml
+++ b/admin/framework/.github/workflows/close-pull-request.yml
@@ -1,0 +1,18 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close PR with nice message
+        uses: superbrothers/close-pull-request@v3
+        with:
+          comment: >
+            Thank you for your pull request. However, you have submitted your PR on a read-only
+            split of `codeigniter4/CodeIgniter4`. This repository, unfortunately, does
+            not accept PRs. Please submit your PR at https://github.com/codeigniter4/CodeIgniter4
+            repository.<br/><br/>Thank you.

--- a/admin/starter/.github/workflows/close-pull-request.yml
+++ b/admin/starter/.github/workflows/close-pull-request.yml
@@ -1,0 +1,18 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close PR with nice message
+        uses: superbrothers/close-pull-request@v3
+        with:
+          comment: >
+            Thank you for your pull request. However, you have submitted your PR on a read-only
+            split of `codeigniter4/CodeIgniter4`. This repository, unfortunately, does
+            not accept PRs. Please submit your PR at https://github.com/codeigniter4/CodeIgniter4
+            repository.<br/><br/>Thank you.

--- a/admin/userguide/.github/workflows/close-pull-request.yml
+++ b/admin/userguide/.github/workflows/close-pull-request.yml
@@ -1,0 +1,18 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close PR with nice message
+        uses: superbrothers/close-pull-request@v3
+        with:
+          comment: >
+            Thank you for your pull request. However, you have submitted your PR on a read-only
+            split of `codeigniter4/CodeIgniter4`. This repository, unfortunately, does
+            not accept PRs. Please submit your PR at https://github.com/codeigniter4/CodeIgniter4
+            repository.<br/><br/>Thank you.


### PR DESCRIPTION
**Description**
Adding a close PR action to automatically close PRs in the splits (framework, starter, userguide) and direct them to submit the PR to this repo.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
