### PR TITLE
refactor: replace $e->getMessage() with $e in log_message()

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -673,7 +673,7 @@ class CLI
             // Then let the developer know of the error.
             static::$height = null;
             static::$width  = null;
-            log_message('error', $e->getMessage());
+            log_message('error', $e);
         }
     }
 

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -673,7 +673,7 @@ class CLI
             // Then let the developer know of the error.
             static::$height = null;
             static::$width  = null;
-            log_message('error', $e);
+            log_message('error', (string) $e);
         }
     }
 

--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -234,7 +234,7 @@ trait GeneratorTrait
         try {
             return view(config('Generators')->views[$this->name], $data, ['debug' => false]);
         } catch (Throwable $e) {
-            log_message('error', $e);
+            log_message('error', (string) $e);
 
             return view("CodeIgniter\\Commands\\Generators\\Views\\{$this->template}", $data, ['debug' => false]);
         }

--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -234,7 +234,7 @@ trait GeneratorTrait
         try {
             return view(config('Generators')->views[$this->name], $data, ['debug' => false]);
         } catch (Throwable $e) {
-            log_message('error', $e->getMessage());
+            log_message('error', $e);
 
             return view("CodeIgniter\\Commands\\Generators\\Views\\{$this->template}", $data, ['debug' => false]);
         }

--- a/system/Cache/CacheFactory.php
+++ b/system/Cache/CacheFactory.php
@@ -73,7 +73,7 @@ class CacheFactory
         try {
             $adapter->initialize();
         } catch (CriticalError $e) {
-            log_message('critical', $e->getMessage() . ' Resorting to using ' . $backup . ' handler.');
+            log_message('critical', $e . ' Resorting to using ' . $backup . ' handler.');
 
             // get the next best cache handler (or dummy if the $backup also fails)
             $adapter = self::getHandler($config, $backup, 'dummy');

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -102,7 +102,7 @@ class FileHandler extends BaseHandler
 
                 // @codeCoverageIgnoreStart
             } catch (Throwable $e) {
-                log_message('debug', 'Failed to set mode on cache file: ' . $e->getMessage());
+                log_message('debug', 'Failed to set mode on cache file: ' . $e);
                 // @codeCoverageIgnoreEnd
             }
 

--- a/system/Cookie/CookieStore.php
+++ b/system/Cookie/CookieStore.php
@@ -49,7 +49,7 @@ class CookieStore implements Countable, IteratorAggregate
             try {
                 return Cookie::fromHeaderString($header, $raw);
             } catch (CookieException $e) {
-                log_message('error', $e);
+                log_message('error', (string) $e);
 
                 return false;
             }

--- a/system/Cookie/CookieStore.php
+++ b/system/Cookie/CookieStore.php
@@ -49,7 +49,7 @@ class CookieStore implements Countable, IteratorAggregate
             try {
                 return Cookie::fromHeaderString($header, $raw);
             } catch (CookieException $e) {
-                log_message('error', $e->getMessage());
+                log_message('error', $e);
 
                 return false;
             }

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -380,7 +380,7 @@ abstract class BaseConnection implements ConnectionInterface
             $this->connID = $this->connect($this->pConnect);
         } catch (Throwable $e) {
             $connectionErrors[] = sprintf('Main connection [%s]: %s', $this->DBDriver, $e->getMessage());
-            log_message('error', 'Error connecting to the database: ' . $e->getMessage());
+            log_message('error', 'Error connecting to the database: ' . $e);
         }
 
         // No connection resource? Check if there is a failover else throw an error
@@ -401,7 +401,7 @@ abstract class BaseConnection implements ConnectionInterface
                         $this->connID = $this->connect($this->pConnect);
                     } catch (Throwable $e) {
                         $connectionErrors[] = sprintf('Failover #%d [%s]: %s', ++$index, $this->DBDriver, $e->getMessage());
-                        log_message('error', 'Error connecting to the database: ' . $e->getMessage());
+                        log_message('error', 'Error connecting to the database: ' . $e);
                     }
 
                     // If a connection is made break the foreach loop

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -291,7 +291,7 @@ class Connection extends BaseConnection
         try {
             return $this->connID->query($this->prepQuery($sql), $this->resultMode);
         } catch (mysqli_sql_exception $e) {
-            log_message('error', $e->getMessage());
+            log_message('error', $e);
 
             if ($this->DBDebug) {
                 throw $e;

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -291,7 +291,7 @@ class Connection extends BaseConnection
         try {
             return $this->connID->query($this->prepQuery($sql), $this->resultMode);
         } catch (mysqli_sql_exception $e) {
-            log_message('error', $e);
+            log_message('error', (string) $e);
 
             if ($this->DBDebug) {
                 throw $e;

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -204,7 +204,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 
             return $result;
         } catch (ErrorException $e) {
-            log_message('error', $e->getMessage());
+            log_message('error', $e);
 
             if ($this->DBDebug) {
                 throw $e;

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -204,7 +204,7 @@ class Connection extends BaseConnection implements ConnectionInterface
 
             return $result;
         } catch (ErrorException $e) {
-            log_message('error', $e);
+            log_message('error', (string) $e);
 
             if ($this->DBDebug) {
                 throw $e;

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -134,7 +134,7 @@ class Connection extends BaseConnection
         try {
             return pg_query($this->connID, $sql);
         } catch (ErrorException $e) {
-            log_message('error', $e);
+            log_message('error', (string) $e);
             if ($this->DBDebug) {
                 throw $e;
             }

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -129,7 +129,7 @@ class Connection extends BaseConnection
                 ? $this->connID->exec($sql)
                 : $this->connID->query($sql);
         } catch (ErrorException $e) {
-            log_message('error', $e);
+            log_message('error', (string) $e);
             if ($this->DBDebug) {
                 throw $e;
             }

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -1654,7 +1654,7 @@ class Email
             $success = $this->{$method}();
         } catch (ErrorException $e) {
             $success = false;
-            log_message('error', 'Email: ' . $method . ' throwed ' . $e->getMessage());
+            log_message('error', 'Email: ' . $method . ' throwed ' . $e);
         }
 
         if (! $success) {

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -634,7 +634,7 @@ trait ResponseTrait
 
             return $this->cookieStore->get($name, $prefix);
         } catch (CookieException $e) {
-            log_message('error', $e->getMessage());
+            log_message('error', $e);
 
             return null;
         }

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -634,7 +634,7 @@ trait ResponseTrait
 
             return $this->cookieStore->get($name, $prefix);
         } catch (CookieException $e) {
-            log_message('error', $e);
+            log_message('error', (string) $e);
 
             return null;
         }


### PR DESCRIPTION
**Description**
Depending on exception classes, but generally `(string) $e` has more info than `$e->getMessage()`.

<s>If this is not BC, then I would change the base branch to `develop`. </s>

`$e->getMessage()`:
```
ERROR - 2022-06-23 19:09:15 --> Cookie object with name "unknown" and prefix "" was not found in the collection.
```
`$e`:
```
ERROR - 2022-06-23 19:09:31 --> CodeIgniter\Cookie\Exceptions\CookieException: Cookie object with name "unknown" and prefix "" was not found in the collection. in /Users/kenji/work/codeigniter/CodeIgniter4/system/Cookie/CookieStore.php:114
Stack trace:
#0 /Users/kenji/work/codeigniter/CodeIgniter4/system/Cookie/CookieStore.php(114): CodeIgniter\Cookie\Exceptions\CookieException::forUnknownCookieInstance(Array)
#1 /Users/kenji/work/codeigniter/CodeIgniter4/system/HTTP/ResponseTrait.php(635): CodeIgniter\Cookie\CookieStore->get('unknown', '')
#2 /Users/kenji/work/codeigniter/CodeIgniter4/app/Controllers/Home.php(14): CodeIgniter\HTTP\Response->getCookie('unknown')
#3 /Users/kenji/work/codeigniter/CodeIgniter4/system/CodeIgniter.php(862): App\Controllers\Home->index()
#4 /Users/kenji/work/codeigniter/CodeIgniter4/system/CodeIgniter.php(452): CodeIgniter\CodeIgniter->runController(Object(App\Controllers\Home))
#5 /Users/kenji/work/codeigniter/CodeIgniter4/system/CodeIgniter.php(346): CodeIgniter\CodeIgniter->handleRequest(NULL, Object(Config\Cache), false)
#6 /Users/kenji/work/codeigniter/CodeIgniter4/public/index.php(55): CodeIgniter\CodeIgniter->run()
#7 /Users/kenji/work/codeigniter/CodeIgniter4/system/Commands/Server/rewrite.php(43): require_once('/Users/kenji/wo...')
#8 {main}
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
