### PR TITLE
config: DB Error always throws Exception CI_DBUG

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -895,19 +895,11 @@ class BaseBuilder
     protected function _whereIn(?string $key = null, $values = null, bool $not = false, string $type = 'AND ', ?bool $escape = null, string $clause = 'QBWhere')
     {
         if (empty($key) || ! is_string($key)) {
-            if ($this->db->DBDebug) {
-                throw new InvalidArgumentException(sprintf('%s() expects $key to be a non-empty string', debug_backtrace(0, 2)[1]['function']));
-            }
-
-            return $this; // @codeCoverageIgnore
+            throw new InvalidArgumentException(sprintf('%s() expects $key to be a non-empty string', debug_backtrace(0, 2)[1]['function']));
         }
 
         if ($values === null || (! is_array($values) && ! $this->isSubquery($values))) {
-            if ($this->db->DBDebug) {
-                throw new InvalidArgumentException(sprintf('%s() expects $values to be of type array or closure', debug_backtrace(0, 2)[1]['function']));
-            }
-
-            return $this; // @codeCoverageIgnore
+            throw new InvalidArgumentException(sprintf('%s() expects $values to be of type array or closure', debug_backtrace(0, 2)[1]['function']));
         }
 
         if (! is_bool($escape)) {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -895,7 +895,7 @@ class BaseBuilder
     protected function _whereIn(?string $key = null, $values = null, bool $not = false, string $type = 'AND ', ?bool $escape = null, string $clause = 'QBWhere')
     {
         if (empty($key) || ! is_string($key)) {
-            if (CI_DEBUG) {
+            if ($this->db->DBDebug) {
                 throw new InvalidArgumentException(sprintf('%s() expects $key to be a non-empty string', debug_backtrace(0, 2)[1]['function']));
             }
 
@@ -903,7 +903,7 @@ class BaseBuilder
         }
 
         if ($values === null || (! is_array($values) && ! $this->isSubquery($values))) {
-            if (CI_DEBUG) {
+            if ($this->db->DBDebug) {
                 throw new InvalidArgumentException(sprintf('%s() expects $values to be of type array or closure', debug_backtrace(0, 2)[1]['function']));
             }
 
@@ -1738,14 +1738,14 @@ class BaseBuilder
     {
         if ($set === null) {
             if (empty($this->QBSet)) {
-                if (CI_DEBUG) {
+                if ($this->db->DBDebug) {
                     throw new DatabaseException('You must use the "set" method to update an entry.');
                 }
 
                 return false; // @codeCoverageIgnore
             }
         } elseif (empty($set)) {
-            if (CI_DEBUG) {
+            if ($this->db->DBDebug) {
                 throw new DatabaseException('insertBatch() called with no data');
             }
 
@@ -1922,7 +1922,7 @@ class BaseBuilder
     protected function validateInsert(): bool
     {
         if (empty($this->QBSet)) {
-            if (CI_DEBUG) {
+            if ($this->db->DBDebug) {
                 throw new DatabaseException('You must use the "set" method to insert an entry.');
             }
 
@@ -1954,7 +1954,7 @@ class BaseBuilder
         }
 
         if (empty($this->QBSet)) {
-            if (CI_DEBUG) {
+            if ($this->db->DBDebug) {
                 throw new DatabaseException('You must use the "set" method to update an entry.');
             }
 
@@ -2085,7 +2085,7 @@ class BaseBuilder
     protected function validateUpdate(): bool
     {
         if (empty($this->QBSet)) {
-            if (CI_DEBUG) {
+            if ($this->db->DBDebug) {
                 throw new DatabaseException('You must use the "set" method to update an entry.');
             }
 
@@ -2105,7 +2105,7 @@ class BaseBuilder
     public function updateBatch(?array $set = null, ?string $index = null, int $batchSize = 100)
     {
         if ($index === null) {
-            if (CI_DEBUG) {
+            if ($this->db->DBDebug) {
                 throw new DatabaseException('You must specify an index to match on for batch updates.');
             }
 
@@ -2114,14 +2114,14 @@ class BaseBuilder
 
         if ($set === null) {
             if (empty($this->QBSet)) {
-                if (CI_DEBUG) {
+                if ($this->db->DBDebug) {
                     throw new DatabaseException('You must use the "set" method to update an entry.');
                 }
 
                 return false; // @codeCoverageIgnore
             }
         } elseif (empty($set)) {
-            if (CI_DEBUG) {
+            if ($this->db->DBDebug) {
                 throw new DatabaseException('updateBatch() called with no data');
             }
 
@@ -2330,7 +2330,7 @@ class BaseBuilder
         }
 
         if (empty($this->QBWhere)) {
-            if (CI_DEBUG) {
+            if ($this->db->DBDebug) {
                 throw new DatabaseException('Deletes are not allowed unless they contain a "where" or "like" clause.');
             }
 

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -121,13 +121,11 @@ abstract class BaseConnection implements ConnectionInterface
     protected $pConnect = false;
 
     /**
-     * Debug flag
-     *
      * Whether to throw Exception or not when an error occurs.
      *
      * @var bool
      */
-    protected $DBDebug = false;
+    protected $DBDebug = true;
 
     /**
      * Character set

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -146,7 +146,7 @@ class Builder extends BaseBuilder
         }
 
         if (! $this->QBSet) {
-            if (CI_DEBUG) {
+            if ($this->db->DBDebug) {
                 throw new DatabaseException('You must use the "set" method to update an entry.');
             }
 

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -350,7 +350,7 @@ class Builder extends BaseBuilder
         }
 
         if (empty($this->QBSet)) {
-            if (CI_DEBUG) {
+            if ($this->db->DBDebug) {
                 throw new DatabaseException('You must use the "set" method to update an entry.');
             }
 
@@ -532,7 +532,7 @@ class Builder extends BaseBuilder
         }
 
         if (empty($this->QBWhere)) {
-            if (CI_DEBUG) {
+            if ($this->db->DBDebug) {
                 throw new DatabaseException('Deletes are not allowed unless they contain a "where" or "like" clause.');
             }
 

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -27,6 +27,7 @@ Others
 ------
 
 - The ``spark`` file has been changed due to a change in the processing of Spark commands.
+- ``InvalidArgumentException`` that is a kind of ``LogicException`` in ``BaseBuilder::_whereIn()`` is not suppressed by the configuration. Previously if ``CI_DEBUG`` was true, the exception was suppressed.
 
 Enhancements
 ************
@@ -41,6 +42,7 @@ Changes
 *******
 
 - To be consistent in behavior regardless of environments, ``Config\Database::$default['DBDebug']`` and ``Config\Database::$tests['DBDebug']`` has been changed to ``true`` by default. With these settings, an exception is always thrown when a database error occurs.
+- ``DatabaseException`` thrown in ``BaseBuilder`` is thrown if ``$DBDebug`` is true. Previously, it is thrown if ``CI_DEBUG`` is true.
 - The default value of ``BaseConnection::$DBDebug`` has been changed to ``true``.
 - Changed the processing of Spark commands:
     - The ``CodeIgniter\CodeIgniter`` no longer handles Spark commands.

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -27,7 +27,7 @@ Others
 ------
 
 - The ``spark`` file has been changed due to a change in the processing of Spark commands.
-- ``InvalidArgumentException`` that is a kind of ``LogicException`` in ``BaseBuilder::_whereIn()`` is not suppressed by the configuration. Previously if ``CI_DEBUG`` was true, the exception was suppressed.
+- ``InvalidArgumentException`` that is a kind of ``LogicException`` in ``BaseBuilder::_whereIn()`` is not suppressed by the configuration. Previously if ``CI_DEBUG`` was false, the exception was suppressed.
 
 Enhancements
 ************

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -41,6 +41,7 @@ Changes
 *******
 
 - To be consistent in behavior regardless of environments, ``Config\Database::$default['DBDebug']`` and ``Config\Database::$tests['DBDebug']`` has been changed to ``true`` by default. With these settings, an exception is always thrown when a database error occurs.
+- The default value of ``BaseConnection::$DBDebu`` has been changed to ``true``.
 - Changed the processing of Spark commands:
     - The ``CodeIgniter\CodeIgniter`` no longer handles Spark commands.
     - The ``CodeIgniter::isSparked()`` method has been removed.

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -41,9 +41,11 @@ Enhancements
 Changes
 *******
 
-- To be consistent in behavior regardless of environments, ``Config\Database::$default['DBDebug']`` and ``Config\Database::$tests['DBDebug']`` has been changed to ``true`` by default. With these settings, an exception is always thrown when a database error occurs.
-- ``DatabaseException`` thrown in ``BaseBuilder`` is thrown if ``$DBDebug`` is true. Previously, it is thrown if ``CI_DEBUG`` is true.
-- The default value of ``BaseConnection::$DBDebug`` has been changed to ``true``.
+- DBDebug
+    - To be consistent in behavior regardless of environments, ``Config\Database::$default['DBDebug']`` and ``Config\Database::$tests['DBDebug']`` has been changed to ``true`` by default. With these settings, an exception is always thrown when a database error occurs.
+    - Now ``DatabaseException`` thrown in ``BaseBuilder`` is thrown if ``$DBDebug`` is true. Previously, it is thrown if ``CI_DEBUG`` is true.
+    - The default value of ``BaseConnection::$DBDebug`` has been changed to ``true``.
+    - With these changes, ``DBDebug`` now means whether or not to throw an exception when an error occurs. Although unrelated to debugging, the name has not been changed.
 - Changed the processing of Spark commands:
     - The ``CodeIgniter\CodeIgniter`` no longer handles Spark commands.
     - The ``CodeIgniter::isSparked()`` method has been removed.

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -41,7 +41,7 @@ Changes
 *******
 
 - To be consistent in behavior regardless of environments, ``Config\Database::$default['DBDebug']`` and ``Config\Database::$tests['DBDebug']`` has been changed to ``true`` by default. With these settings, an exception is always thrown when a database error occurs.
-- The default value of ``BaseConnection::$DBDebu`` has been changed to ``true``.
+- The default value of ``BaseConnection::$DBDebug`` has been changed to ``true``.
 - Changed the processing of Spark commands:
     - The ``CodeIgniter\CodeIgniter`` no longer handles Spark commands.
     - The ``CodeIgniter::isSparked()`` method has been removed.


### PR DESCRIPTION
**Description**
Follow-up #6140
- use `$DBDebug` instead of `CI_DEBUG`
- change the `BaseConnection::$DBDebug` default value to `true`
- `InvalidArgumentException` in `BaseBuilder::_whereIn()` is never suppressed by config

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
