### PR TITLE
fix: `$routes->group('/', ...)` creates the route `foo///bar`

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -623,7 +623,7 @@ class RouteCollection implements RouteCollectionInterface
         $oldOptions = $this->currentOptions;
 
         // To register a route, we'll set a flag so that our router
-        // so it will see the group name.
+        // will see the group name.
         // If the group name is empty, we go on using the previously built group name.
         $this->group = $name ? trim($oldGroup . '/' . $name, '/') : $oldGroup;
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -625,7 +625,7 @@ class RouteCollection implements RouteCollectionInterface
         // To register a route, we'll set a flag so that our router
         // so it will see the group name.
         // If the group name is empty, we go on using the previously built group name.
-        $this->group = $name ? ltrim($oldGroup . '/' . $name, '/') : $oldGroup;
+        $this->group = $name ? trim($oldGroup . '/' . $name, '/') : $oldGroup;
 
         $callback = array_pop($params);
 

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -375,6 +375,34 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($expected, $routes->getRoutes());
     }
 
+    public function testNestedGroupingWorksWithRootPrefix()
+    {
+        $routes = $this->getCollector();
+
+        $routes->add('verify/begin', '\VerifyController::begin');
+
+        $routes->group('admin', static function ($routes) {
+            $routes->group(
+                '/',
+                static function ($routes) {
+                    $routes->add('users/list', '\Users::list');
+
+                    $routes->group('delegate', static function ($routes) {
+                        $routes->add('foo', '\Users::foo');
+                    });
+                }
+            );
+        });
+
+        $expected = [
+            'verify/begin'       => '\VerifyController::begin',
+            'admin/users/list'   => '\Users::list',
+            'admin/delegate/foo' => '\Users::foo',
+        ];
+
+        $this->assertSame($expected, $routes->getRoutes());
+    }
+
     public function testHostnameOption()
     {
         $_SERVER['HTTP_HOST'] = 'example.com';

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -375,15 +375,19 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($expected, $routes->getRoutes());
     }
 
-    public function testNestedGroupingWorksWithRootPrefix()
-    {
+    /**
+     * @dataProvider groupProvider
+     */
+    public function testNestedGroupingWorksWithRootPrefix(
+        string $group,
+        string $subgroup,
+        array $expected
+    ) {
         $routes = $this->getCollector();
 
-        $routes->add('verify/begin', '\VerifyController::begin');
-
-        $routes->group('admin', static function ($routes) {
+        $routes->group($group, static function ($routes) use ($subgroup) {
             $routes->group(
-                '/',
+                $subgroup,
                 static function ($routes) {
                     $routes->add('users/list', '\Users::list');
 
@@ -394,13 +398,29 @@ final class RouteCollectionTest extends CIUnitTestCase
             );
         });
 
-        $expected = [
-            'verify/begin'       => '\VerifyController::begin',
-            'admin/users/list'   => '\Users::list',
-            'admin/delegate/foo' => '\Users::foo',
-        ];
-
         $this->assertSame($expected, $routes->getRoutes());
+    }
+
+    public function groupProvider()
+    {
+        yield from [
+            ['admin', '/', [
+                'admin/users/list'   => '\Users::list',
+                'admin/delegate/foo' => '\Users::foo',
+            ]],
+            ['/', '', [
+                'users/list'   => '\Users::list',
+                'delegate/foo' => '\Users::foo',
+            ]],
+            ['', '', [
+                'users/list'   => '\Users::list',
+                'delegate/foo' => '\Users::foo',
+            ]],
+            ['', '/', [
+                'users/list'   => '\Users::list',
+                'delegate/foo' => '\Users::foo',
+            ]],
+        ];
     }
 
     public function testHostnameOption()


### PR DESCRIPTION
**Description**
```php
$routes->group('admin', static function ($routes) {
    $routes->group('/', static function ($routes) {
        $routes->get('list', 'Admin\Users::list');
    });
});
```
creates
```
+--------+--------------+------------------------------------------+----------------+---------------+
| Method | Route        | Handler                                  | Before Filters | After Filters |
+--------+--------------+------------------------------------------+----------------+---------------+
| GET    | admin///list | \App\Controllers\Admin\Users::list       |                | toolbar       |
+--------+--------------+------------------------------------------+----------------+---------------+
```
This PR fixes the route:
```
+--------+------------+------------------------------------------+----------------+---------------+
| Method | Route      | Handler                                  | Before Filters | After Filters |
+--------+------------+------------------------------------------+----------------+---------------+
| GET    | admin/list | \App\Controllers\Admin\Users::list       |                | toolbar       |
+--------+------------+------------------------------------------+----------------+---------------+
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
