### PR TITLE
Config Property Types

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -21,10 +21,8 @@ class App extends BaseConfig
      * and path to your installation. However, you should always configure this
      * explicitly and never rely on auto-guessing, especially in production
      * environments.
-     *
-     * @var string
      */
-    public $baseURL = 'http://localhost:8080/';
+    public string $baseURL = 'http://localhost:8080/';
 
     /**
      * --------------------------------------------------------------------------
@@ -34,10 +32,8 @@ class App extends BaseConfig
      * Typically this will be your index.php file, unless you've renamed it to
      * something else. If you are using mod_rewrite to remove the page set this
      * variable so that it is blank.
-     *
-     * @var string
      */
-    public $indexPage = 'index.php';
+    public string $indexPage = 'index.php';
 
     /**
      * --------------------------------------------------------------------------
@@ -53,10 +49,8 @@ class App extends BaseConfig
      * 'PATH_INFO'      Uses $_SERVER['PATH_INFO']
      *
      * WARNING: If you set this to 'PATH_INFO', URIs will always be URL-decoded!
-     *
-     * @var string
      */
-    public $uriProtocol = 'REQUEST_URI';
+    public string $uriProtocol = 'REQUEST_URI';
 
     /**
      * --------------------------------------------------------------------------
@@ -67,10 +61,8 @@ class App extends BaseConfig
      * is viewing the site from. It affects the language strings and other
      * strings (like currency markers, numbers, etc), that your program
      * should run under for this request.
-     *
-     * @var string
      */
-    public $defaultLocale = 'en';
+    public string $defaultLocale = 'en';
 
     /**
      * --------------------------------------------------------------------------
@@ -81,10 +73,8 @@ class App extends BaseConfig
      * language to use based on the value of the Accept-Language header.
      *
      * If false, no automatic detection will be performed.
-     *
-     * @var bool
      */
-    public $negotiateLocale = false;
+    public bool $negotiateLocale = false;
 
     /**
      * --------------------------------------------------------------------------
@@ -97,7 +87,7 @@ class App extends BaseConfig
      *
      * @var string[]
      */
-    public $supportedLocales = ['en'];
+    public array $supportedLocales = ['en'];
 
     /**
      * --------------------------------------------------------------------------
@@ -106,10 +96,8 @@ class App extends BaseConfig
      *
      * The default timezone that will be used in your application to display
      * dates with the date helper, and can be retrieved through app_timezone()
-     *
-     * @var string
      */
-    public $appTimezone = 'America/Chicago';
+    public string $appTimezone = 'America/Chicago';
 
     /**
      * --------------------------------------------------------------------------
@@ -120,10 +108,8 @@ class App extends BaseConfig
      * that require a character set to be provided.
      *
      * @see http://php.net/htmlspecialchars for a list of supported charsets.
-     *
-     * @var string
      */
-    public $charset = 'UTF-8';
+    public string $charset = 'UTF-8';
 
     /**
      * --------------------------------------------------------------------------
@@ -134,10 +120,8 @@ class App extends BaseConfig
      * made via a secure connection (HTTPS). If the incoming request is not
      * secure, the user will be redirected to a secure version of the page
      * and the HTTP Strict Transport Security header will be set.
-     *
-     * @var bool
      */
-    public $forceGlobalSecureRequests = false;
+    public bool $forceGlobalSecureRequests = false;
 
     /**
      * --------------------------------------------------------------------------
@@ -160,10 +144,8 @@ class App extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * The session cookie name, must contain only [0-9a-z_-] characters
-     *
-     * @var string
      */
-    public $sessionCookieName = 'ci_session';
+    public string $sessionCookieName = 'ci_session';
 
     /**
      * --------------------------------------------------------------------------
@@ -172,10 +154,8 @@ class App extends BaseConfig
      *
      * The number of SECONDS you want the session to last.
      * Setting to 0 (zero) means expire when the browser is closed.
-     *
-     * @var int
      */
-    public $sessionExpiration = 7200;
+    public int $sessionExpiration = 7200;
 
     /**
      * --------------------------------------------------------------------------
@@ -191,10 +171,8 @@ class App extends BaseConfig
      * Please read up the manual for the format with other session drivers.
      *
      * IMPORTANT: You are REQUIRED to set a valid save path!
-     *
-     * @var string
      */
-    public $sessionSavePath = WRITEPATH . 'session';
+    public string $sessionSavePath = WRITEPATH . 'session';
 
     /**
      * --------------------------------------------------------------------------
@@ -205,10 +183,8 @@ class App extends BaseConfig
      *
      * WARNING: If you're using the database driver, don't forget to update
      *          your session table's PRIMARY KEY when changing this setting.
-     *
-     * @var bool
      */
-    public $sessionMatchIP = false;
+    public bool $sessionMatchIP = false;
 
     /**
      * --------------------------------------------------------------------------
@@ -216,10 +192,8 @@ class App extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * How many seconds between CI regenerating the session ID.
-     *
-     * @var int
      */
-    public $sessionTimeToUpdate = 300;
+    public int $sessionTimeToUpdate = 300;
 
     /**
      * --------------------------------------------------------------------------
@@ -229,10 +203,8 @@ class App extends BaseConfig
      * Whether to destroy session data associated with the old session ID
      * when auto-regenerating the session ID. When set to FALSE, the data
      * will be later deleted by the garbage collector.
-     *
-     * @var bool
      */
-    public $sessionRegenerateDestroy = false;
+    public bool $sessionRegenerateDestroy = false;
 
     /**
      * --------------------------------------------------------------------------
@@ -241,11 +213,10 @@ class App extends BaseConfig
      *
      * Set a cookie name prefix if you need to avoid collisions.
      *
-     * @var string
      *
      * @deprecated use Config\Cookie::$prefix property instead.
      */
-    public $cookiePrefix = '';
+    public string $cookiePrefix = '';
 
     /**
      * --------------------------------------------------------------------------
@@ -254,11 +225,10 @@ class App extends BaseConfig
      *
      * Set to `.your-domain.com` for site-wide cookies.
      *
-     * @var string
      *
      * @deprecated use Config\Cookie::$domain property instead.
      */
-    public $cookieDomain = '';
+    public string $cookieDomain = '';
 
     /**
      * --------------------------------------------------------------------------
@@ -267,11 +237,10 @@ class App extends BaseConfig
      *
      * Typically will be a forward slash.
      *
-     * @var string
      *
      * @deprecated use Config\Cookie::$path property instead.
      */
-    public $cookiePath = '/';
+    public string $cookiePath = '/';
 
     /**
      * --------------------------------------------------------------------------
@@ -280,11 +249,10 @@ class App extends BaseConfig
      *
      * Cookie will only be set if a secure HTTPS connection exists.
      *
-     * @var bool
      *
      * @deprecated use Config\Cookie::$secure property instead.
      */
-    public $cookieSecure = false;
+    public bool $cookieSecure = false;
 
     /**
      * --------------------------------------------------------------------------
@@ -293,11 +261,10 @@ class App extends BaseConfig
      *
      * Cookie will only be accessible via HTTP(S) (no JavaScript).
      *
-     * @var bool
      *
      * @deprecated use Config\Cookie::$httponly property instead.
      */
-    public $cookieHTTPOnly = true;
+    public bool $cookieHTTPOnly = true;
 
     /**
      * --------------------------------------------------------------------------
@@ -319,11 +286,10 @@ class App extends BaseConfig
      * (empty string) means default SameSite attribute set by browsers (`Lax`)
      * will be set on cookies. If set to `None`, `$cookieSecure` must also be set.
      *
-     * @var string|null
      *
      * @deprecated use Config\Cookie::$samesite property instead.
      */
-    public $cookieSameSite = 'Lax';
+    public ?string $cookieSameSite = 'Lax';
 
     /**
      * --------------------------------------------------------------------------
@@ -353,10 +319,8 @@ class App extends BaseConfig
      * The token name.
      *
      * @deprecated Use `Config\Security` $tokenName property instead of using this property.
-     *
-     * @var string
      */
-    public $CSRFTokenName = 'csrf_test_name';
+    public string $CSRFTokenName = 'csrf_test_name';
 
     /**
      * --------------------------------------------------------------------------
@@ -366,10 +330,8 @@ class App extends BaseConfig
      * The header name.
      *
      * @deprecated Use `Config\Security` $headerName property instead of using this property.
-     *
-     * @var string
      */
-    public $CSRFHeaderName = 'X-CSRF-TOKEN';
+    public string $CSRFHeaderName = 'X-CSRF-TOKEN';
 
     /**
      * --------------------------------------------------------------------------
@@ -379,10 +341,8 @@ class App extends BaseConfig
      * The cookie name.
      *
      * @deprecated Use `Config\Security` $cookieName property instead of using this property.
-     *
-     * @var string
      */
-    public $CSRFCookieName = 'csrf_cookie_name';
+    public string $CSRFCookieName = 'csrf_cookie_name';
 
     /**
      * --------------------------------------------------------------------------
@@ -392,10 +352,8 @@ class App extends BaseConfig
      * The number in seconds the token should expire.
      *
      * @deprecated Use `Config\Security` $expire property instead of using this property.
-     *
-     * @var int
      */
-    public $CSRFExpire = 7200;
+    public int $CSRFExpire = 7200;
 
     /**
      * --------------------------------------------------------------------------
@@ -405,10 +363,8 @@ class App extends BaseConfig
      * Regenerate token on every submission?
      *
      * @deprecated Use `Config\Security` $regenerate property instead of using this property.
-     *
-     * @var bool
      */
-    public $CSRFRegenerate = true;
+    public bool $CSRFRegenerate = true;
 
     /**
      * --------------------------------------------------------------------------
@@ -418,10 +374,8 @@ class App extends BaseConfig
      * Redirect to previous page with error on failure?
      *
      * @deprecated Use `Config\Security` $redirect property instead of using this property.
-     *
-     * @var bool
      */
-    public $CSRFRedirect = true;
+    public bool $CSRFRedirect = true;
 
     /**
      * --------------------------------------------------------------------------
@@ -438,10 +392,8 @@ class App extends BaseConfig
      *
      * @see https://portswigger.net/web-security/csrf/samesite-cookies
      * @deprecated `Config\Cookie` $samesite property is used.
-     *
-     * @var string
      */
-    public $CSRFSameSite = 'Lax';
+    public string $CSRFSameSite = 'Lax';
 
     /**
      * --------------------------------------------------------------------------
@@ -458,8 +410,6 @@ class App extends BaseConfig
      *
      * @see http://www.html5rocks.com/en/tutorials/security/content-security-policy/
      * @see http://www.w3.org/TR/CSP/
-     *
-     * @var bool
      */
-    public $CSPEnabled = false;
+    public bool $CSPEnabled = false;
 }

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -213,7 +213,6 @@ class App extends BaseConfig
      *
      * Set a cookie name prefix if you need to avoid collisions.
      *
-     *
      * @deprecated use Config\Cookie::$prefix property instead.
      */
     public string $cookiePrefix = '';
@@ -224,7 +223,6 @@ class App extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * Set to `.your-domain.com` for site-wide cookies.
-     *
      *
      * @deprecated use Config\Cookie::$domain property instead.
      */
@@ -237,7 +235,6 @@ class App extends BaseConfig
      *
      * Typically will be a forward slash.
      *
-     *
      * @deprecated use Config\Cookie::$path property instead.
      */
     public string $cookiePath = '/';
@@ -249,7 +246,6 @@ class App extends BaseConfig
      *
      * Cookie will only be set if a secure HTTPS connection exists.
      *
-     *
      * @deprecated use Config\Cookie::$secure property instead.
      */
     public bool $cookieSecure = false;
@@ -260,7 +256,6 @@ class App extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * Cookie will only be accessible via HTTP(S) (no JavaScript).
-     *
      *
      * @deprecated use Config\Cookie::$httponly property instead.
      */
@@ -285,7 +280,6 @@ class App extends BaseConfig
      * Defaults to `Lax` for compatibility with modern browsers. Setting `''`
      * (empty string) means default SameSite attribute set by browsers (`Lax`)
      * will be set on cookies. If set to `None`, `$cookieSecure` must also be set.
-     *
      *
      * @deprecated use Config\Cookie::$samesite property instead.
      */

--- a/app/Config/CURLRequest.php
+++ b/app/Config/CURLRequest.php
@@ -15,8 +15,6 @@ class CURLRequest extends BaseConfig
      *
      * If true, all the options won't be reset between requests.
      * It may cause an error request with unnecessary headers.
-     *
-     * @var bool
      */
-    public $shareOptions = true;
+    public bool $shareOptions = true;
 }

--- a/app/Config/Cache.php
+++ b/app/Config/Cache.php
@@ -19,10 +19,8 @@ class Cache extends BaseConfig
      *
      * The name of the preferred handler that should be used. If for some reason
      * it is not available, the $backupHandler will be used in its place.
-     *
-     * @var string
      */
-    public $handler = 'file';
+    public string $handler = 'file';
 
     /**
      * --------------------------------------------------------------------------
@@ -32,10 +30,8 @@ class Cache extends BaseConfig
      * The name of the handler that will be used in case the first one is
      * unreachable. Often, 'file' is used here since the filesystem is
      * always available, though that's not always practical for the app.
-     *
-     * @var string
      */
-    public $backupHandler = 'dummy';
+    public string $backupHandler = 'dummy';
 
     /**
      * --------------------------------------------------------------------------
@@ -45,11 +41,10 @@ class Cache extends BaseConfig
      * The path to where cache files should be stored, if using a file-based
      * system.
      *
-     * @var string
      *
      * @deprecated Use the driver-specific variant under $file
      */
-    public $storePath = WRITEPATH . 'cache/';
+    public string $storePath = WRITEPATH . 'cache/';
 
     /**
      * --------------------------------------------------------------------------
@@ -77,10 +72,8 @@ class Cache extends BaseConfig
      *
      * This string is added to all cache item names to help avoid collisions
      * if you run multiple applications with the same cache engine.
-     *
-     * @var string
      */
-    public $prefix = '';
+    public string $prefix = '';
 
     /**
      * --------------------------------------------------------------------------
@@ -92,10 +85,8 @@ class Cache extends BaseConfig
      * WARNING: This is not used by framework handlers where 60 seconds is
      * hard-coded, but may be useful to projects and modules. This will replace
      * the hard-coded value in a future release.
-     *
-     * @var int
      */
-    public $ttl = 60;
+    public int $ttl = 60;
 
     /**
      * --------------------------------------------------------------------------
@@ -106,10 +97,8 @@ class Cache extends BaseConfig
      * Strings that violate this restriction will cause handlers to throw.
      * Default: {}()/\@:
      * Note: The default set is required for PSR-6 compliance.
-     *
-     * @var string
      */
-    public $reservedCharacters = '{}()/\@:';
+    public string $reservedCharacters = '{}()/\@:';
 
     /**
      * --------------------------------------------------------------------------
@@ -120,7 +109,7 @@ class Cache extends BaseConfig
      *
      * @var array<string, int|string|null>
      */
-    public $file = [
+    public array $file = [
         'storePath' => WRITEPATH . 'cache/',
         'mode'      => 0640,
     ];
@@ -136,7 +125,7 @@ class Cache extends BaseConfig
      *
      * @var array<string, boolean|int|string>
      */
-    public $memcached = [
+    public array $memcached = [
         'host'   => '127.0.0.1',
         'port'   => 11211,
         'weight' => 1,
@@ -152,7 +141,7 @@ class Cache extends BaseConfig
      *
      * @var array<string, int|string|null>
      */
-    public $redis = [
+    public array $redis = [
         'host'     => '127.0.0.1',
         'password' => null,
         'port'     => 6379,
@@ -170,7 +159,7 @@ class Cache extends BaseConfig
      *
      * @var array<string, string>
      */
-    public $validHandlers = [
+    public array $validHandlers = [
         'dummy'     => DummyHandler::class,
         'file'      => FileHandler::class,
         'memcached' => MemcachedHandler::class,

--- a/app/Config/Cache.php
+++ b/app/Config/Cache.php
@@ -41,7 +41,6 @@ class Cache extends BaseConfig
      * The path to where cache files should be stored, if using a file-based
      * system.
      *
-     *
      * @deprecated Use the driver-specific variant under $file
      */
     public string $storePath = WRITEPATH . 'cache/';

--- a/app/Config/ContentSecurityPolicy.php
+++ b/app/Config/ContentSecurityPolicy.php
@@ -18,30 +18,23 @@ class ContentSecurityPolicy extends BaseConfig
     //-------------------------------------------------------------------------
     // Broadbrush CSP management
     //-------------------------------------------------------------------------
-
     /**
      * Default CSP report context
-     *
-     * @var bool
      */
-    public $reportOnly = false;
+    public bool $reportOnly = false;
 
     /**
      * Specifies a URL where a browser will send reports
      * when a content security policy is violated.
-     *
-     * @var string|null
      */
-    public $reportURI;
+    public ?string $reportURI = null;
 
     /**
      * Instructs user agents to rewrite URL schemes, changing
      * HTTP to HTTPS. This directive is for websites with
      * large numbers of old URLs that need to be rewritten.
-     *
-     * @var bool
      */
-    public $upgradeInsecureRequests = false;
+    public bool $upgradeInsecureRequests = false;
 
     //-------------------------------------------------------------------------
     // Sources allowed
@@ -167,22 +160,16 @@ class ContentSecurityPolicy extends BaseConfig
 
     /**
      * Nonce tag for style
-     *
-     * @var string
      */
-    public $styleNonceTag = '{csp-style-nonce}';
+    public string $styleNonceTag = '{csp-style-nonce}';
 
     /**
      * Nonce tag for script
-     *
-     * @var string
      */
-    public $scriptNonceTag = '{csp-script-nonce}';
+    public string $scriptNonceTag = '{csp-script-nonce}';
 
     /**
      * Replace nonce tag automatically
-     *
-     * @var bool
      */
-    public $autoNonce = true;
+    public bool $autoNonce = true;
 }

--- a/app/Config/Cookie.php
+++ b/app/Config/Cookie.php
@@ -13,10 +13,8 @@ class Cookie extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * Set a cookie name prefix if you need to avoid collisions.
-     *
-     * @var string
      */
-    public $prefix = '';
+    public string $prefix = '';
 
     /**
      * --------------------------------------------------------------------------
@@ -37,10 +35,8 @@ class Cookie extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * Typically will be a forward slash.
-     *
-     * @var string
      */
-    public $path = '/';
+    public string $path = '/';
 
     /**
      * --------------------------------------------------------------------------
@@ -48,10 +44,8 @@ class Cookie extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * Set to `.your-domain.com` for site-wide cookies.
-     *
-     * @var string
      */
-    public $domain = '';
+    public string $domain = '';
 
     /**
      * --------------------------------------------------------------------------
@@ -59,10 +53,8 @@ class Cookie extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * Cookie will only be set if a secure HTTPS connection exists.
-     *
-     * @var bool
      */
-    public $secure = false;
+    public bool $secure = false;
 
     /**
      * --------------------------------------------------------------------------
@@ -70,10 +62,8 @@ class Cookie extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * Cookie will only be accessible via HTTP(S) (no JavaScript).
-     *
-     * @var bool
      */
-    public $httponly = true;
+    public bool $httponly = true;
 
     /**
      * --------------------------------------------------------------------------
@@ -94,10 +84,8 @@ class Cookie extends BaseConfig
      * Defaults to `Lax` for compatibility with modern browsers. Setting `''`
      * (empty string) means default SameSite attribute set by browsers (`Lax`)
      * will be set on cookies. If set to `None`, `$secure` must also be set.
-     *
-     * @var string
      */
-    public $samesite = 'Lax';
+    public string $samesite = 'Lax';
 
     /**
      * --------------------------------------------------------------------------
@@ -110,10 +98,9 @@ class Cookie extends BaseConfig
      * If this is set to `true`, cookie names should be compliant of RFC 2616's
      * list of allowed characters.
      *
-     * @var bool
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes
      * @see https://tools.ietf.org/html/rfc2616#section-2.2
      */
-    public $raw = false;
+    public bool $raw = false;
 }

--- a/app/Config/Cookie.php
+++ b/app/Config/Cookie.php
@@ -98,7 +98,6 @@ class Cookie extends BaseConfig
      * If this is set to `true`, cookie names should be compliant of RFC 2616's
      * list of allowed characters.
      *
-     *
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes
      * @see https://tools.ietf.org/html/rfc2616#section-2.2
      */

--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -12,25 +12,19 @@ class Database extends Config
     /**
      * The directory that holds the Migrations
      * and Seeds directories.
-     *
-     * @var string
      */
-    public $filesPath = APPPATH . 'Database' . DIRECTORY_SEPARATOR;
+    public string $filesPath = APPPATH . 'Database' . DIRECTORY_SEPARATOR;
 
     /**
      * Lets you choose which connection group to
      * use if no other is specified.
-     *
-     * @var string
      */
-    public $defaultGroup = 'default';
+    public string $defaultGroup = 'default';
 
     /**
      * The default database connection.
-     *
-     * @var array
      */
-    public $default = [
+    public array $default = [
         'DSN'      => '',
         'hostname' => 'localhost',
         'username' => '',
@@ -53,10 +47,8 @@ class Database extends Config
     /**
      * This database connection is used when
      * running PHPUnit database tests.
-     *
-     * @var array
      */
-    public $tests = [
+    public array $tests = [
         'DSN'         => '',
         'hostname'    => '127.0.0.1',
         'username'    => '',

--- a/app/Config/DocTypes.php
+++ b/app/Config/DocTypes.php
@@ -9,7 +9,7 @@ class DocTypes
      *
      * @var array<string, string>
      */
-    public $list = [
+    public array $list = [
         'xhtml11'           => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">',
         'xhtml1-strict'     => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">',
         'xhtml1-trans'      => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">',

--- a/app/Config/Email.php
+++ b/app/Config/Email.php
@@ -7,9 +7,7 @@ use CodeIgniter\Config\BaseConfig;
 class Email extends BaseConfig
 {
     public string $fromEmail;
-
     public string $fromName;
-
     public string $recipients;
 
     /**

--- a/app/Config/Email.php
+++ b/app/Config/Email.php
@@ -6,165 +6,114 @@ use CodeIgniter\Config\BaseConfig;
 
 class Email extends BaseConfig
 {
-    /**
-     * @var string
-     */
-    public $fromEmail;
+    public string $fromEmail;
 
-    /**
-     * @var string
-     */
-    public $fromName;
+    public string $fromName;
 
-    /**
-     * @var string
-     */
-    public $recipients;
+    public string $recipients;
 
     /**
      * The "user agent"
-     *
-     * @var string
      */
-    public $userAgent = 'CodeIgniter';
+    public string $userAgent = 'CodeIgniter';
 
     /**
      * The mail sending protocol: mail, sendmail, smtp
-     *
-     * @var string
      */
-    public $protocol = 'mail';
+    public string $protocol = 'mail';
 
     /**
      * The server path to Sendmail.
-     *
-     * @var string
      */
-    public $mailPath = '/usr/sbin/sendmail';
+    public string $mailPath = '/usr/sbin/sendmail';
 
     /**
      * SMTP Server Address
-     *
-     * @var string
      */
-    public $SMTPHost;
+    public string $SMTPHost;
 
     /**
      * SMTP Username
-     *
-     * @var string
      */
-    public $SMTPUser;
+    public string $SMTPUser;
 
     /**
      * SMTP Password
-     *
-     * @var string
      */
-    public $SMTPPass;
+    public string $SMTPPass;
 
     /**
      * SMTP Port
-     *
-     * @var int
      */
-    public $SMTPPort = 25;
+    public int $SMTPPort = 25;
 
     /**
      * SMTP Timeout (in seconds)
-     *
-     * @var int
      */
-    public $SMTPTimeout = 5;
+    public int $SMTPTimeout = 5;
 
     /**
      * Enable persistent SMTP connections
-     *
-     * @var bool
      */
-    public $SMTPKeepAlive = false;
+    public bool $SMTPKeepAlive = false;
 
     /**
      * SMTP Encryption. Either tls or ssl
-     *
-     * @var string
      */
-    public $SMTPCrypto = 'tls';
+    public string $SMTPCrypto = 'tls';
 
     /**
      * Enable word-wrap
-     *
-     * @var bool
      */
-    public $wordWrap = true;
+    public bool $wordWrap = true;
 
     /**
      * Character count to wrap at
-     *
-     * @var int
      */
-    public $wrapChars = 76;
+    public int $wrapChars = 76;
 
     /**
      * Type of mail, either 'text' or 'html'
-     *
-     * @var string
      */
-    public $mailType = 'text';
+    public string $mailType = 'text';
 
     /**
      * Character set (utf-8, iso-8859-1, etc.)
-     *
-     * @var string
      */
-    public $charset = 'UTF-8';
+    public string $charset = 'UTF-8';
 
     /**
      * Whether to validate the email address
-     *
-     * @var bool
      */
-    public $validate = false;
+    public bool $validate = false;
 
     /**
      * Email Priority. 1 = highest. 5 = lowest. 3 = normal
-     *
-     * @var int
      */
-    public $priority = 3;
+    public int $priority = 3;
 
     /**
      * Newline character. (Use “\r\n” to comply with RFC 822)
-     *
-     * @var string
      */
-    public $CRLF = "\r\n";
+    public string $CRLF = "\r\n";
 
     /**
      * Newline character. (Use “\r\n” to comply with RFC 822)
-     *
-     * @var string
      */
-    public $newline = "\r\n";
+    public string $newline = "\r\n";
 
     /**
      * Enable BCC Batch Mode.
-     *
-     * @var bool
      */
-    public $BCCBatchMode = false;
+    public bool $BCCBatchMode = false;
 
     /**
      * Number of emails in each BCC batch
-     *
-     * @var int
      */
-    public $BCCBatchSize = 200;
+    public int $BCCBatchSize = 200;
 
     /**
      * Enable notify message from server
-     *
-     * @var bool
      */
-    public $DSN = false;
+    public bool $DSN = false;
 }

--- a/app/Config/Encryption.php
+++ b/app/Config/Encryption.php
@@ -20,10 +20,8 @@ class Encryption extends BaseConfig
      * If you use the Encryption class you must set an encryption key (seed).
      * You need to ensure it is long enough for the cipher and mode you plan to use.
      * See the user guide for more info.
-     *
-     * @var string
      */
-    public $key = '';
+    public string $key = '';
 
     /**
      * --------------------------------------------------------------------------
@@ -35,10 +33,8 @@ class Encryption extends BaseConfig
      * Available drivers:
      * - OpenSSL
      * - Sodium
-     *
-     * @var string
      */
-    public $driver = 'OpenSSL';
+    public string $driver = 'OpenSSL';
 
     /**
      * --------------------------------------------------------------------------
@@ -49,10 +45,8 @@ class Encryption extends BaseConfig
      * before it is encrypted. This value should be greater than zero.
      *
      * See the user guide for more information on padding.
-     *
-     * @var int
      */
-    public $blockSize = 16;
+    public int $blockSize = 16;
 
     /**
      * --------------------------------------------------------------------------
@@ -60,8 +54,6 @@ class Encryption extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * HMAC digest to use, e.g. 'SHA512' or 'SHA256'. Default value is 'SHA512'.
-     *
-     * @var string
      */
-    public $digest = 'SHA512';
+    public string $digest = 'SHA512';
 }

--- a/app/Config/Exceptions.php
+++ b/app/Config/Exceptions.php
@@ -17,10 +17,8 @@ class Exceptions extends BaseConfig
      * through Services::Log.
      *
      * Default: true
-     *
-     * @var bool
      */
-    public $log = true;
+    public bool $log = true;
 
     /**
      * --------------------------------------------------------------------------
@@ -28,10 +26,8 @@ class Exceptions extends BaseConfig
      * --------------------------------------------------------------------------
      * Any status codes here will NOT be logged if logging is turned on.
      * By default, only 404 (Page Not Found) exceptions are ignored.
-     *
-     * @var array
      */
-    public $ignoreCodes = [404];
+    public array $ignoreCodes = [404];
 
     /**
      * --------------------------------------------------------------------------
@@ -41,10 +37,8 @@ class Exceptions extends BaseConfig
      * directories that hold the views used to generate errors.
      *
      * Default: APPPATH.'Views/errors'
-     *
-     * @var string
      */
-    public $errorViewPath = APPPATH . 'Views/errors';
+    public string $errorViewPath = APPPATH . 'Views/errors';
 
     /**
      * --------------------------------------------------------------------------
@@ -53,8 +47,6 @@ class Exceptions extends BaseConfig
      * Any data that you would like to hide from the debug trace.
      * In order to specify 2 levels, use "/" to separate.
      * ex. ['server', 'setup/password', 'secret_token']
-     *
-     * @var array
      */
-    public $sensitiveDataInTrace = [];
+    public array $sensitiveDataInTrace = [];
 }

--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -20,10 +20,8 @@ class Feature extends BaseConfig
      *   - CodeIgniter\Router\Router::handle() uses:
      *     - property $filtersInfo, instead of $filterInfo
      *     - CodeIgniter\Router\RouteCollection::getFiltersForRoute(), instead of getFilterForRoute()
-     *
-     * @var bool
      */
-    public $multipleFilters = false;
+    public bool $multipleFilters = false;
 
     /**
      * Use improved new auto routing instead of the default legacy version.

--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -14,10 +14,8 @@ class Filters extends BaseConfig
     /**
      * Configures aliases for Filter classes to
      * make reading things nicer and simpler.
-     *
-     * @var array
      */
-    public $aliases = [
+    public array $aliases = [
         'csrf'          => CSRF::class,
         'toolbar'       => DebugToolbar::class,
         'honeypot'      => Honeypot::class,
@@ -28,10 +26,8 @@ class Filters extends BaseConfig
     /**
      * List of filter aliases that are always
      * applied before and after every request.
-     *
-     * @var array
      */
-    public $globals = [
+    public array $globals = [
         'before' => [
             // 'honeypot',
             // 'csrf',
@@ -54,10 +50,8 @@ class Filters extends BaseConfig
      * If you use this, you should disable auto-routing because auto-routing
      * permits any HTTP method to access a controller. Accessing the controller
      * with a method you don’t expect could bypass the filter.
-     *
-     * @var array
      */
-    public $methods = [];
+    public array $methods = [];
 
     /**
      * List of filter aliases that should run on any
@@ -65,8 +59,6 @@ class Filters extends BaseConfig
      *
      * Example:
      * 'isLoggedIn' => ['before' => ['account/*', 'profiles/*']]
-     *
-     * @var array
      */
-    public $filters = [];
+    public array $filters = [];
 }

--- a/app/Config/Format.php
+++ b/app/Config/Format.php
@@ -24,7 +24,7 @@ class Format extends BaseConfig
      *
      * @var string[]
      */
-    public $supportedResponseFormats = [
+    public array $supportedResponseFormats = [
         'application/json',
         'application/xml', // machine-readable XML
         'text/xml', // human-readable XML
@@ -41,7 +41,7 @@ class Format extends BaseConfig
      *
      * @var array<string, string>
      */
-    public $formatters = [
+    public array $formatters = [
         'application/json' => JSONFormatter::class,
         'application/xml'  => XMLFormatter::class,
         'text/xml'         => XMLFormatter::class,
@@ -57,7 +57,7 @@ class Format extends BaseConfig
      *
      * @var array<string, int>
      */
-    public $formatterOptions = [
+    public array $formatterOptions = [
         'application/json' => JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES,
         'application/xml'  => 0,
         'text/xml'         => 0,

--- a/app/Config/Generators.php
+++ b/app/Config/Generators.php
@@ -25,7 +25,7 @@ class Generators extends BaseConfig
      *
      * @var array<string, string>
      */
-    public $views = [
+    public array $views = [
         'make:command'      => 'CodeIgniter\Commands\Generators\Views\command.tpl.php',
         'make:config'       => 'CodeIgniter\Commands\Generators\Views\config.tpl.php',
         'make:controller'   => 'CodeIgniter\Commands\Generators\Views\controller.tpl.php',

--- a/app/Config/Honeypot.php
+++ b/app/Config/Honeypot.php
@@ -8,36 +8,26 @@ class Honeypot extends BaseConfig
 {
     /**
      * Makes Honeypot visible or not to human
-     *
-     * @var bool
      */
-    public $hidden = true;
+    public bool $hidden = true;
 
     /**
      * Honeypot Label Content
-     *
-     * @var string
      */
-    public $label = 'Fill This Field';
+    public string $label = 'Fill This Field';
 
     /**
      * Honeypot Field Name
-     *
-     * @var string
      */
-    public $name = 'honeypot';
+    public string $name = 'honeypot';
 
     /**
      * Honeypot HTML Template
-     *
-     * @var string
      */
-    public $template = '<label>{label}</label><input type="text" name="{name}" value=""/>';
+    public string $template = '<label>{label}</label><input type="text" name="{name}" value=""/>';
 
     /**
      * Honeypot container
-     *
-     * @var string
      */
-    public $container = '<div style="display:none">{template}</div>';
+    public string $container = '<div style="display:none">{template}</div>';
 }

--- a/app/Config/Images.php
+++ b/app/Config/Images.php
@@ -10,25 +10,21 @@ class Images extends BaseConfig
 {
     /**
      * Default handler used if no other handler is specified.
-     *
-     * @var string
      */
-    public $defaultHandler = 'gd';
+    public string $defaultHandler = 'gd';
 
     /**
      * The path to the image library.
      * Required for ImageMagick, GraphicsMagick, or NetPBM.
-     *
-     * @var string
      */
-    public $libraryPath = '/usr/local/bin/convert';
+    public string $libraryPath = '/usr/local/bin/convert';
 
     /**
      * The available handler classes.
      *
      * @var array<string, string>
      */
-    public $handlers = [
+    public array $handlers = [
         'gd'      => GDHandler::class,
         'imagick' => ImageMagickHandler::class,
     ];

--- a/app/Config/Kint.php
+++ b/app/Config/Kint.php
@@ -24,18 +24,18 @@ class Kint extends BaseConfig
     */
 
     public $plugins;
-    public $maxDepth          = 6;
-    public $displayCalledFrom = true;
-    public $expanded          = false;
+    public int $maxDepth          = 6;
+    public bool $displayCalledFrom = true;
+    public bool $expanded          = false;
 
     /*
     |--------------------------------------------------------------------------
     | RichRenderer Settings
     |--------------------------------------------------------------------------
     */
-    public $richTheme  = 'aante-light.css';
-    public $richFolder = false;
-    public $richSort   = Renderer::SORT_FULL;
+    public string $richTheme  = 'aante-light.css';
+    public bool $richFolder = false;
+    public int $richSort   = Renderer::SORT_FULL;
     public $richObjectPlugins;
     public $richTabPlugins;
 
@@ -44,8 +44,8 @@ class Kint extends BaseConfig
     | CLI Settings
     |--------------------------------------------------------------------------
     */
-    public $cliColors      = true;
-    public $cliForceUTF8   = false;
-    public $cliDetectWidth = true;
-    public $cliMinWidth    = 40;
+    public bool $cliColors      = true;
+    public bool $cliForceUTF8   = false;
+    public bool $cliDetectWidth = true;
+    public int $cliMinWidth    = 40;
 }

--- a/app/Config/Kint.php
+++ b/app/Config/Kint.php
@@ -24,7 +24,7 @@ class Kint extends BaseConfig
     */
 
     public $plugins;
-    public int $maxDepth          = 6;
+    public int $maxDepth           = 6;
     public bool $displayCalledFrom = true;
     public bool $expanded          = false;
 
@@ -33,9 +33,9 @@ class Kint extends BaseConfig
     | RichRenderer Settings
     |--------------------------------------------------------------------------
     */
-    public string $richTheme  = 'aante-light.css';
-    public bool $richFolder = false;
-    public int $richSort   = Renderer::SORT_FULL;
+    public string $richTheme = 'aante-light.css';
+    public bool $richFolder  = false;
+    public int $richSort     = Renderer::SORT_FULL;
     public $richObjectPlugins;
     public $richTabPlugins;
 
@@ -47,5 +47,5 @@ class Kint extends BaseConfig
     public bool $cliColors      = true;
     public bool $cliForceUTF8   = false;
     public bool $cliDetectWidth = true;
-    public int $cliMinWidth    = 40;
+    public int $cliMinWidth     = 40;
 }

--- a/app/Config/Logger.php
+++ b/app/Config/Logger.php
@@ -47,10 +47,8 @@ class Logger extends BaseConfig
      *
      * Each item that is logged has an associated date. You can use PHP date
      * codes to set your own date formatting
-     *
-     * @var string
      */
-    public $dateFormat = 'Y-m-d H:i:s';
+    public string $dateFormat = 'Y-m-d H:i:s';
 
     /**
      * --------------------------------------------------------------------------
@@ -60,7 +58,7 @@ class Logger extends BaseConfig
      * The logging system supports multiple actions to be taken when something
      * is logged. This is done by allowing for multiple Handlers, special classes
      * designed to write the log to their chosen destinations, whether that is
-     * a file on the server, a cloud-based service, or even taking actions such
+     * a file on the getServer, a cloud-based service, or even taking actions such
      * as emailing the dev team.
      *
      * Each handler is defined by the class name used for that handler, and it
@@ -74,10 +72,8 @@ class Logger extends BaseConfig
      *
      * Handlers are executed in the order defined in this array, starting with
      * the handler on top and continuing down.
-     *
-     * @var array
      */
-    public $handlers = [
+    public array $handlers = [
 
         /*
          * --------------------------------------------------------------------

--- a/app/Config/Migrations.php
+++ b/app/Config/Migrations.php
@@ -15,10 +15,8 @@ class Migrations extends BaseConfig
      *
      * You should enable migrations whenever you intend to do a schema migration
      * and disable it back when you're done.
-     *
-     * @var bool
      */
-    public $enabled = true;
+    public bool $enabled = true;
 
     /**
      * --------------------------------------------------------------------------
@@ -30,10 +28,8 @@ class Migrations extends BaseConfig
      * level the system is at. It then compares the migration level in this
      * table to the $config['migration_version'] if they are not the same it
      * will migrate up. This must be set.
-     *
-     * @var string
      */
-    public $table = 'migrations';
+    public string $table = 'migrations';
 
     /**
      * --------------------------------------------------------------------------
@@ -48,8 +44,6 @@ class Migrations extends BaseConfig
      * - YmdHis_
      * - Y-m-d-His_
      * - Y_m_d_His_
-     *
-     * @var string
      */
-    public $timestampFormat = 'Y-m-d-His_';
+    public string $timestampFormat = 'Y-m-d-His_';
 }

--- a/app/Config/Mimes.php
+++ b/app/Config/Mimes.php
@@ -20,10 +20,8 @@ class Mimes
 {
     /**
      * Map of extensions to mime types.
-     *
-     * @var array
      */
-    public static $mimes = [
+    public static array $mimes = [
         'hqx' => [
             'application/mac-binhex40',
             'application/mac-binhex',

--- a/app/Config/Pager.php
+++ b/app/Config/Pager.php
@@ -20,7 +20,7 @@ class Pager extends BaseConfig
      *
      * @var array<string, string>
      */
-    public $templates = [
+    public array $templates = [
         'default_full'   => 'CodeIgniter\Pager\Views\default_full',
         'default_simple' => 'CodeIgniter\Pager\Views\default_simple',
         'default_head'   => 'CodeIgniter\Pager\Views\default_head',
@@ -32,8 +32,6 @@ class Pager extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * The default number of results shown in a single page.
-     *
-     * @var int
      */
-    public $perPage = 20;
+    public int $perPage = 20;
 }

--- a/app/Config/Paths.php
+++ b/app/Config/Paths.php
@@ -22,10 +22,8 @@ class Paths
      *
      * This must contain the name of your "system" folder. Include
      * the path if the folder is not in the same directory as this file.
-     *
-     * @var string
      */
-    public $systemDirectory = __DIR__ . '/../../system';
+    public string $systemDirectory = __DIR__ . '/../../system';
 
     /**
      * ---------------------------------------------------------------
@@ -38,10 +36,8 @@ class Paths
      * you do, use a full server path.
      *
      * @see http://codeigniter.com/user_guide/general/managing_apps.html
-     *
-     * @var string
      */
-    public $appDirectory = __DIR__ . '/..';
+    public string $appDirectory = __DIR__ . '/..';
 
     /**
      * ---------------------------------------------------------------
@@ -53,10 +49,8 @@ class Paths
      * need write permission to a single place that can be tucked away
      * for maximum security, keeping it out of the app and/or
      * system directories.
-     *
-     * @var string
      */
-    public $writableDirectory = __DIR__ . '/../../writable';
+    public string $writableDirectory = __DIR__ . '/../../writable';
 
     /**
      * ---------------------------------------------------------------
@@ -64,10 +58,8 @@ class Paths
      * ---------------------------------------------------------------
      *
      * This variable must contain the name of your "tests" directory.
-     *
-     * @var string
      */
-    public $testsDirectory = __DIR__ . '/../../tests';
+    public string $testsDirectory = __DIR__ . '/../../tests';
 
     /**
      * ---------------------------------------------------------------
@@ -78,8 +70,6 @@ class Paths
      * contains the view files used by your application. By
      * default this is in `app/Views`. This value
      * is used when no value is provided to `Services::renderer()`.
-     *
-     * @var string
      */
-    public $viewDirectory = __DIR__ . '/../Views';
+    public string $viewDirectory = __DIR__ . '/../Views';
 }

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -5,6 +5,12 @@ namespace Config;
 // Create a new instance of our RouteCollection class.
 $routes = Services::routes();
 
+// Load the system's routing file first, so that the app and ENVIRONMENT
+// can override as needed.
+if (is_file(SYSTEMPATH . 'Config/Routes.php')) {
+    require SYSTEMPATH . 'Config/Routes.php';
+}
+
 /*
  * --------------------------------------------------------------------
  * Router Setup

--- a/app/Config/Security.php
+++ b/app/Config/Security.php
@@ -94,8 +94,6 @@ class Security extends BaseConfig
      * Defaults to `Lax` as recommended in this link:
      *
      * @see https://portswigger.net/web-security/csrf/samesite-cookies
-     *
-     *
      * @deprecated `Config\Cookie` $samesite property is used.
      */
     public string $samesite = 'Lax';

--- a/app/Config/Security.php
+++ b/app/Config/Security.php
@@ -15,7 +15,7 @@ class Security extends BaseConfig
      *
      * @var string 'cookie' or 'session'
      */
-    public $csrfProtection = 'cookie';
+    public string $csrfProtection = 'cookie';
 
     /**
      * --------------------------------------------------------------------------
@@ -23,10 +23,8 @@ class Security extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * Randomize the CSRF Token for added security.
-     *
-     * @var bool
      */
-    public $tokenRandomize = false;
+    public bool $tokenRandomize = false;
 
     /**
      * --------------------------------------------------------------------------
@@ -34,10 +32,8 @@ class Security extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * Token name for Cross Site Request Forgery protection.
-     *
-     * @var string
      */
-    public $tokenName = 'csrf_test_name';
+    public string $tokenName = 'csrf_test_name';
 
     /**
      * --------------------------------------------------------------------------
@@ -45,10 +41,8 @@ class Security extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * Header name for Cross Site Request Forgery protection.
-     *
-     * @var string
      */
-    public $headerName = 'X-CSRF-TOKEN';
+    public string $headerName = 'X-CSRF-TOKEN';
 
     /**
      * --------------------------------------------------------------------------
@@ -56,10 +50,8 @@ class Security extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * Cookie name for Cross Site Request Forgery protection.
-     *
-     * @var string
      */
-    public $cookieName = 'csrf_cookie_name';
+    public string $cookieName = 'csrf_cookie_name';
 
     /**
      * --------------------------------------------------------------------------
@@ -69,10 +61,8 @@ class Security extends BaseConfig
      * Expiration time for Cross Site Request Forgery protection cookie.
      *
      * Defaults to two hours (in seconds).
-     *
-     * @var int
      */
-    public $expires = 7200;
+    public int $expires = 7200;
 
     /**
      * --------------------------------------------------------------------------
@@ -80,10 +70,8 @@ class Security extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * Regenerate CSRF Token on every submission.
-     *
-     * @var bool
      */
-    public $regenerate = true;
+    public bool $regenerate = true;
 
     /**
      * --------------------------------------------------------------------------
@@ -91,10 +79,8 @@ class Security extends BaseConfig
      * --------------------------------------------------------------------------
      *
      * Redirect to previous page with error on failure.
-     *
-     * @var bool
      */
-    public $redirect = true;
+    public bool $redirect = true;
 
     /**
      * --------------------------------------------------------------------------
@@ -109,9 +95,8 @@ class Security extends BaseConfig
      *
      * @see https://portswigger.net/web-security/csrf/samesite-cookies
      *
-     * @var string
      *
      * @deprecated `Config\Cookie` $samesite property is used.
      */
-    public $samesite = 'Lax';
+    public string $samesite = 'Lax';
 }

--- a/app/Config/Toolbar.php
+++ b/app/Config/Toolbar.php
@@ -33,7 +33,7 @@ class Toolbar extends BaseConfig
      *
      * @var string[]
      */
-    public $collectors = [
+    public array $collectors = [
         Timers::class,
         Database::class,
         Logs::class,
@@ -51,10 +51,8 @@ class Toolbar extends BaseConfig
      *
      * If set to false var data from the views will not be colleted. Usefull to
      * avoid high memory usage when there are lots of data passed to the view.
-     *
-     * @var bool
      */
-    public $collectVarData = true;
+    public bool $collectVarData = true;
 
     /**
      * --------------------------------------------------------------------------
@@ -64,10 +62,8 @@ class Toolbar extends BaseConfig
      * `$maxHistory` sets a limit on the number of past requests that are stored,
      * helping to conserve file space used to store them. You can set it to
      * 0 (zero) to not have any history stored, or -1 for unlimited history.
-     *
-     * @var int
      */
-    public $maxHistory = 20;
+    public int $maxHistory = 20;
 
     /**
      * --------------------------------------------------------------------------
@@ -76,10 +72,8 @@ class Toolbar extends BaseConfig
      *
      * The full path to the the views that are used by the toolbar.
      * This MUST have a trailing slash.
-     *
-     * @var string
      */
-    public $viewsPath = SYSTEMPATH . 'Debug/Toolbar/Views/';
+    public string $viewsPath = SYSTEMPATH . 'Debug/Toolbar/Views/';
 
     /**
      * --------------------------------------------------------------------------
@@ -92,8 +86,6 @@ class Toolbar extends BaseConfig
      * with hundreds of queries.
      *
      * `$maxQueries` defines the maximum amount of queries that will be stored.
-     *
-     * @var int
      */
-    public $maxQueries = 100;
+    public int $maxQueries = 100;
 }

--- a/app/Config/UserAgents.php
+++ b/app/Config/UserAgents.php
@@ -23,7 +23,7 @@ class UserAgents extends BaseConfig
      *
      * @var array<string, string>
      */
-    public $platforms = [
+    public array $platforms = [
         'windows nt 10.0' => 'Windows 10',
         'windows nt 6.3'  => 'Windows 8.1',
         'windows nt 6.2'  => 'Windows 8',
@@ -78,7 +78,7 @@ class UserAgents extends BaseConfig
      *
      * @var array<string, string>
      */
-    public $browsers = [
+    public array $browsers = [
         'OPR'    => 'Opera',
         'Flock'  => 'Flock',
         'Edge'   => 'Spartan',
@@ -119,7 +119,7 @@ class UserAgents extends BaseConfig
      *
      * @var array<string, string>
      */
-    public $mobiles = [
+    public array $mobiles = [
         // legacy array, old values commented out
         'mobileexplorer' => 'Mobile Explorer',
         // 'openwave'             => 'Open Wave',
@@ -228,7 +228,7 @@ class UserAgents extends BaseConfig
      *
      * @var array<string, string>
      */
-    public $robots = [
+    public array $robots = [
         'googlebot'            => 'Googlebot',
         'msnbot'               => 'MSNBot',
         'baiduspider'          => 'Baiduspider',

--- a/app/Config/Validation.php
+++ b/app/Config/Validation.php
@@ -20,7 +20,7 @@ class Validation extends BaseConfig
      *
      * @var string[]
      */
-    public $ruleSets = [
+    public array $ruleSets = [
         Rules::class,
         FormatRules::class,
         FileRules::class,
@@ -33,7 +33,7 @@ class Validation extends BaseConfig
      *
      * @var array<string, string>
      */
-    public $templates = [
+    public array $templates = [
         'list'   => 'CodeIgniter\Validation\Views\list',
         'single' => 'CodeIgniter\Validation\Views\single',
     ];


### PR DESCRIPTION
**Description**
Applies non-breaking property types to Config files in `App`. Applied by Rector.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
