### PR TITLE
docs: add note about special characters in paths

### DIFF
--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -39,6 +39,8 @@ The command above will create a "project-root" folder.
 If you omit the "project-root" argument, the command will create an
 "appstarter" folder, which can be renamed as appropriate.
 
+.. note:: CodeIgniter autoloader does not allow special characters that are illegal in filenames on certain operating systems. Only allow characters deemed safe for POSIX portable filenames, plus the forward slash for directory separators. So if you install CodeIgniter under the folder that contains the special characters like ``(``, ``)``, etc., CodeIgniter won't work.
+
 If you don't need or want phpunit installed, and all of its composer
 dependencies, then add the ``--no-dev`` option to the end of the above
 command line. That will result in only the framework, and the three

--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -39,7 +39,9 @@ The command above will create a "project-root" folder.
 If you omit the "project-root" argument, the command will create an
 "appstarter" folder, which can be renamed as appropriate.
 
-.. note:: CodeIgniter autoloader does not allow special characters that are illegal in filenames on certain operating systems. Only allow characters deemed safe for POSIX portable filenames, plus the forward slash for directory separators. So if you install CodeIgniter under the folder that contains the special characters like ``(``, ``)``, etc., CodeIgniter won't work.
+.. note:: CodeIgniter autoloader does not allow special characters that are illegal in filenames on certain operating systems.
+    The symbols that can be used are ``/``, ``_``, ``.``, ``:``, ``\`` and space.
+    So if you install CodeIgniter under the folder that contains the special characters like ``(``, ``)``, etc., CodeIgniter won't work.
 
 If you don't need or want phpunit installed, and all of its composer
 dependencies, then add the ``--no-dev`` option to the end of the above

--- a/user_guide_src/source/installation/installing_manual.rst
+++ b/user_guide_src/source/installation/installing_manual.rst
@@ -22,6 +22,8 @@ Installation
 Download the `latest version <https://github.com/CodeIgniter4/framework/releases/latest>`_,
 and extract it to become your project root.
 
+.. note:: CodeIgniter autoloader does not allow special characters that are illegal in filenames on certain operating systems. Only allow characters deemed safe for POSIX portable filenames, plus the forward slash for directory separators. So if you install CodeIgniter under the folder that contains the special characters like ``(``, ``)``, etc., CodeIgniter won't work.
+
 Setting Up
 ----------
 

--- a/user_guide_src/source/installation/installing_manual.rst
+++ b/user_guide_src/source/installation/installing_manual.rst
@@ -22,7 +22,9 @@ Installation
 Download the `latest version <https://github.com/CodeIgniter4/framework/releases/latest>`_,
 and extract it to become your project root.
 
-.. note:: CodeIgniter autoloader does not allow special characters that are illegal in filenames on certain operating systems. Only allow characters deemed safe for POSIX portable filenames, plus the forward slash for directory separators. So if you install CodeIgniter under the folder that contains the special characters like ``(``, ``)``, etc., CodeIgniter won't work.
+.. note:: CodeIgniter autoloader does not allow special characters that are illegal in filenames on certain operating systems.
+    The symbols that can be used are ``/``, ``_``, ``.``, ``:``, ``\`` and space.
+    So if you install CodeIgniter under the folder that contains the special characters like ``(``, ``)``, etc., CodeIgniter won't work.
 
 Setting Up
 ----------


### PR DESCRIPTION
**Description**
Fixes  #6190

- add note about special characters in paths

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

