### PR TITLE
feat: Autoloader::sanitizeFilename() throws Exception

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -92,6 +92,7 @@ return static function (RectorConfig $rectorConfig): void {
         // check on constant compare
         UnwrapFutureCompatibleIfPhpVersionRector::class => [
             __DIR__ . '/system/CodeIgniter.php',
+            __DIR__ . '/system/Autoloader/Autoloader.php',
         ],
 
         // session handlers have the gc() method with underscored parameter `$max_lifetime`

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -290,9 +290,9 @@ class Autoloader
     }
 
     /**
-     * Sanitizes a filename, replacing spaces with dashes.
+     * Check file path.
      *
-     * Removes special characters that are illegal in filenames on certain
+     * Checks special characters that are illegal in filenames on certain
      * operating systems and special characters requiring special escaping
      * to manipulate at the command line. Replaces spaces and consecutive
      * dashes with a single dash. Trim period, dash and underscore from beginning
@@ -306,10 +306,16 @@ class Autoloader
         // Plus the forward slash for directory separators since this might be a path.
         // http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_278
         // Modified to allow backslash and colons for on Windows machines.
-        $filename = preg_replace('/[^0-9\p{L}\s\/\-\_\.\:\\\\]/u', '', $filename);
+        $tmp = preg_replace('/[^0-9\p{L}\s\/\-\_\.\:\\\\]/u', '', $filename);
 
         // Clean up our filename edges.
-        return trim($filename, '.-_');
+        $cleanFilename = trim($tmp, '.-_');
+
+        if ($filename !== $cleanFilename) {
+            throw new InvalidArgumentException('The file path contains special character that is not allowed: "' . $filename . '"');
+        }
+
+        return $cleanFilename;
     }
 
     private function loadComposerNamespaces(ClassLoader $composer): void

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -318,7 +318,13 @@ class Autoloader
             );
         }
         if ($result === false) {
-            throw new RuntimeException(preg_last_error_msg() . ' filename: "' . $filename . '"');
+            if (version_compare(PHP_VERSION, '8.0.0', '>=')) {
+                $message = preg_last_error_msg();
+            } else {
+                $message = 'Regex error. error code: ' . preg_last_error();
+            }
+
+            throw new RuntimeException($message . '. filename: "' . $filename . '"');
         }
 
         // Clean up our filename edges.

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -16,6 +16,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use Config\Autoload;
 use Config\Modules;
 use Config\Services;
+use InvalidArgumentException;
 use UnnamespacedClass;
 
 /**
@@ -199,18 +200,18 @@ final class AutoloaderTest extends CIUnitTestCase
 
     public function testSanitizationSimply()
     {
-        $test     = '${../path}!#/to/some/file.php_';
-        $expected = '/path/to/some/file.php';
+        $this->expectException(InvalidArgumentException::class);
 
-        $this->assertSame($expected, $this->loader->sanitizeFilename($test));
+        $test = '${../path}!#/to/some/file.php_';
+
+        $this->loader->sanitizeFilename($test);
     }
 
     public function testSanitizationAllowUnicodeChars()
     {
-        $test     = 'Ä/path/to/some/file.php_';
-        $expected = 'Ä/path/to/some/file.php';
+        $test = 'Ä/path/to/some/file.php';
 
-        $this->assertSame($expected, $this->loader->sanitizeFilename($test));
+        $this->assertSame($test, $this->loader->sanitizeFilename($test));
     }
 
     public function testSanitizationAllowsWindowsFilepaths()

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -226,7 +226,6 @@ final class AutoloaderTest extends CIUnitTestCase
     public function testSanitizationRegexError()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded filename:');
 
         $test = mb_convert_encoding('クラスファイル.php', 'EUC-JP', 'UTF-8');
 

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -17,6 +17,7 @@ use Config\Autoload;
 use Config\Modules;
 use Config\Services;
 use InvalidArgumentException;
+use RuntimeException;
 use UnnamespacedClass;
 
 /**
@@ -218,6 +219,16 @@ final class AutoloaderTest extends CIUnitTestCase
         );
 
         $test = '/path/to/some/file.php_';
+
+        $this->loader->sanitizeFilename($test);
+    }
+
+    public function testSanitizationRegexError()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded filename:');
+
+        $test = mb_convert_encoding('クラスファイル.php', 'EUC-JP', 'UTF-8');
 
         $this->loader->sanitizeFilename($test);
     }

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -198,11 +198,26 @@ final class AutoloaderTest extends CIUnitTestCase
         $this->assertFalse($this->loader->loadClass('Modules'));
     }
 
-    public function testSanitizationSimply()
+    public function testSanitizationContailsSpecialChars()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The file path contains special characters "${}!#" that are not allowed: "${../path}!#/to/some/file.php_"'
+        );
 
         $test = '${../path}!#/to/some/file.php_';
+
+        $this->loader->sanitizeFilename($test);
+    }
+
+    public function testSanitizationFilenameEdges()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The characters ".-_" are not allowed in filename edges: "/path/to/some/file.php_"'
+        );
+
+        $test = '/path/to/some/file.php_';
 
         $this->loader->sanitizeFilename($test);
     }


### PR DESCRIPTION
**Description**
Generally Sanitization is bad practice.

before:
```console
$ php spark
```
> PHP Fatal error:  Uncaught Error: Class "Config\App" not found in /Users/kenji/tmp/software(locale)/project-root/vendor/codeigniter4/framework/system/Config/Factories.php:126

after:
```console
$ php spark 
```
> PHP Fatal error:  Uncaught InvalidArgumentException: The file path contains special character that is not allowed: "/Users/kenji/tmp/software(locale)/project-root/vendor/codeigniter4/framework/system/Autoloader/FileLocator.php" in /Users/kenji/tmp/software(locale)/project-root/vendor/codeigniter4/framework/system/Autoloader/Autoloader.php:315

Related #6192

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
