### PR TITLE
docs: Typo on assertSessionMissing method

### DIFF
--- a/user_guide_src/source/testing/response/012.php
+++ b/user_guide_src/source/testing/response/012.php
@@ -1,3 +1,3 @@
 <?php
 
-$result->assertSessionMissin('logged_in');
+$result->assertSessionMissing('logged_in');


### PR DESCRIPTION
Tiny Typo on `assertSessionMissing` docs (Currently `assertSessionMissin( .. )` 

[https://www.codeigniter.com/user_guide/testing/response.html#assertsessionmissing-string-key](https://www.codeigniter.com/user_guide/testing/response.html#assertsessionmissing-string-key)