### PR TITLE
fix: BaseConnection may create dynamic property

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -336,7 +336,9 @@ abstract class BaseConnection implements ConnectionInterface
     public function __construct(array $params)
     {
         foreach ($params as $key => $value) {
-            $this->{$key} = $value;
+            if (property_exists($this, $key)) {
+                $this->{$key} = $value;
+            }
         }
 
         $queryClass = str_replace('Connection', 'Query', static::class);

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -42,6 +42,11 @@ class Connection extends BaseConnection
      */
     public $escapeChar = '"';
 
+    protected $connect_timeout;
+    protected $options;
+    protected $sslmode;
+    protected $service;
+
     /**
      * Connect to the database.
      *

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -19,6 +19,14 @@ use CodeIgniter\Database\Query;
 class MockConnection extends BaseConnection
 {
     protected $returnValues = [];
+
+    /**
+     * Database schema for Postgre and SQLSRV
+     *
+     * @var string
+     */
+    protected $schema;
+
     public $database;
     public $lastQuery;
 


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/issues/6162#issuecomment-1168005433

- do not create dynamic property in BaseConnection

The current database `tests` group is for SQLite3 that has `foreignKeys` property.
https://github.com/codeigniter4/CodeIgniter4/blob/24f67ea95aa463771360eb38f627675af2fda3d6/app/Config/Database.php#L77
If a user overrides `DBDriver`, the dynamic property `foreignKeys` will be created.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
