### PR TITLE
docs: remove dynamic property injection sample code

### DIFF
--- a/user_guide_src/source/general/configuration/010.php
+++ b/user_guide_src/source/general/configuration/010.php
@@ -8,7 +8,6 @@ class RegionalSales
     {
         return [
             'target' => 45,
-            'actual' => 72,
         ];
     }
 }

--- a/user_guide_src/source/general/configuration/011.php
+++ b/user_guide_src/source/general/configuration/011.php
@@ -2,4 +2,3 @@
 
 $target   = 45;
 $campaign = 'Winter Wonderland';
-$actual   = 72;


### PR DESCRIPTION
**Description**
See #6162

- it will be deprecated in PHP 8.2

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
