### PR TITLE
fix: add missing CLIRequest::getLocale()

### DIFF
--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\HTTP;
 
 use Config\App;
+use Locale;
 use RuntimeException;
 
 /**
@@ -213,5 +214,13 @@ class CLIRequest extends Request
     public function isCLI(): bool
     {
         return true;
+    }
+
+    /**
+     * Gets the current locale.
+     */
+    public function getLocale(): string
+    {
+        return Locale::getDefault();
     }
 }

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -50,7 +50,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
     protected function setUp(): void
     {
         unset($_ENV['foo'], $_SERVER['foo']);
-        Services::reset();
+        $this->resetServices();
 
         parent::setUp();
     }
@@ -593,8 +593,6 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
     public function testCspStyleNonce()
     {
-        $this->resetServices();
-
         $config             = config('App');
         $config->CSPEnabled = true;
 
@@ -603,8 +601,6 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
     public function testCspScriptNonce()
     {
-        $this->resetServices();
-
         $config             = config('App');
         $config->CSPEnabled = true;
 

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -606,4 +606,15 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
         $this->assertStringStartsWith('nonce="', csp_script_nonce());
     }
+
+    public function testLangOnCLI()
+    {
+        Services::createRequest(new App(), true);
+
+        $message = lang('CLI.generator.fileCreate', ['TestController.php']);
+
+        $this->assertSame('File created: TestController.php', $message);
+
+        $this->resetServices();
+    }
 }


### PR DESCRIPTION
**Description**
- add missing `CLIRequest::getLocale()`

```console
$ php spark make:controller Test

CodeIgniter v4.2.1 Command Line Tool - Server Time: 2022-06-28 21:48:32 UTC-05:00


[Error]

Call to undefined method CodeIgniter\HTTP\CLIRequest::getLocale()

at SYSTEMPATH/Config/Services.php:367

Backtrace:
  1    SYSTEMPATH/Config/BaseService.php:253
       CodeIgniter\Config\Services::language(null, false)

  2    SYSTEMPATH/Config/BaseService.php:194
       CodeIgniter\Config\BaseService::__callStatic('language', [...])

  3    SYSTEMPATH/Config/Services.php:363
       CodeIgniter\Config\BaseService::getSharedInstance('language', null)

  4    SYSTEMPATH/Config/BaseService.php:253
       CodeIgniter\Config\Services::language()

  5    SYSTEMPATH/Common.php:745
       CodeIgniter\Config\BaseService::__callStatic('language', [])

  6    SYSTEMPATH/CLI/GeneratorTrait.php:160
       lang('CLI.generator.fileCreate', [...])

  7    SYSTEMPATH/Commands/Generators/ControllerGenerator.php:88
       CodeIgniter\Commands\Generators\ControllerGenerator()->execute([...])

  8    SYSTEMPATH/CLI/Commands.php:63
       CodeIgniter\Commands\Generators\ControllerGenerator()->run([...])

  9    SYSTEMPATH/CLI/CommandRunner.php:65
       CodeIgniter\CLI\Commands()->run('make:controller', [...])

 10    SYSTEMPATH/CLI/CommandRunner.php:51
       CodeIgniter\CLI\CommandRunner()->index([...])

 11    SYSTEMPATH/CodeIgniter.php:887
       CodeIgniter\CLI\CommandRunner()->_remap('index', [...])

 12    SYSTEMPATH/CodeIgniter.php:466
       CodeIgniter\CodeIgniter()->runController(Object(CodeIgniter\CLI\CommandRunner))

 13    SYSTEMPATH/CodeIgniter.php:345
       CodeIgniter\CodeIgniter()->handleRequest(null, Object(Config\Cache), false)

 14    SYSTEMPATH/CLI/Console.php:48
       CodeIgniter\CodeIgniter()->run()

 15    ROOTPATH/spark:86
       CodeIgniter\CLI\Console()->run()
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
