### PR TITLE
fix: CSP reportOnly behavior

### DIFF
--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -776,7 +776,7 @@ class ContentSecurityPolicy
     protected function addToHeader(string $name, $values = null)
     {
         if (is_string($values)) {
-            $values = [$values => 0];
+            $values = [$values => $this->reportOnly];
         }
 
         $sources       = [];
@@ -785,13 +785,15 @@ class ContentSecurityPolicy
         foreach ($values as $value => $reportOnly) {
             if (is_numeric($value) && is_string($reportOnly) && ! empty($reportOnly)) {
                 $value      = $reportOnly;
-                $reportOnly = 0;
+                $reportOnly = $this->reportOnly;
+            }
+
+            if (strpos($value, 'nonce-') === 0) {
+                $value = "'{$value}'";
             }
 
             if ($reportOnly === true) {
                 $reportSources[] = in_array($value, $this->validSources, true) ? "'{$value}'" : $value;
-            } elseif (strpos($value, 'nonce-') === 0) {
-                $sources[] = "'{$value}'";
             } else {
                 $sources[] = in_array($value, $this->validSources, true) ? "'{$value}'" : $value;
             }

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -132,7 +132,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $result = $this->work();
 
         $result = $this->getHeaderEmitted('Content-Security-Policy-Report-Only');
-        $this->assertStringContainsString('connect-src iffy.com maybe.com;', $result);
+        $this->assertStringContainsString("connect-src 'self' iffy.com maybe.com;", $result);
     }
 
     /**
@@ -165,9 +165,10 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $result = $this->work();
 
         $result = $this->getHeaderEmitted('Content-Security-Policy-Report-Only');
-        $this->assertStringContainsString('form-action surveysrus.com;', $result);
+        $this->assertStringContainsString("form-action 'self' surveysrus.com;", $result);
+
         $result = $this->getHeaderEmitted('Content-Security-Policy');
-        $this->assertStringContainsString("form-action 'self';", $result);
+        $this->assertStringNotContainsString("form-action 'self';", $result);
     }
 
     /**


### PR DESCRIPTION
**Description**

If we set `$reportOnly = true`, `Content-Security-Policy` header has some items.

**How to Reproduce**

```diff
diff --git a/app/Config/App.php b/app/Config/App.php
index 1a5e562dd..03e8eb649 100644
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -461,5 +461,5 @@ class App extends BaseConfig
      *
      * @var bool
      */
-    public $CSPEnabled = false;
+    public $CSPEnabled = true;
 }
diff --git a/app/Config/ContentSecurityPolicy.php b/app/Config/ContentSecurityPolicy.php
index aa18ba9f1..d4a0d0817 100644
--- a/app/Config/ContentSecurityPolicy.php
+++ b/app/Config/ContentSecurityPolicy.php
@@ -24,7 +24,7 @@ class ContentSecurityPolicy extends BaseConfig
      *
      * @var bool
      */
-    public $reportOnly = false;
+    public $reportOnly = true;
 
     /**
      * Specifies a URL where a browser will send reports
```

before:
```
Content-Security-Policy: base-uri 'self'; child-src 'self'; connect-src 'self'; default-src 'self'; form-action 'self'; img-src 'self'; object-src 'self'; script-src 'self' 'nonce-3d1190def4cad593bb96b732'; style-src 'self' 'nonce-ddf1da493df6ee57425ef796';
Content-Security-Policy-Report-Only: img-src data:;
```
after:
```
Content-Security-Policy: 
Content-Security-Policy-Report-Only: base-uri 'self'; child-src 'self'; connect-src 'self'; default-src 'self'; form-action 'self'; img-src 'self' data:; object-src 'self'; script-src 'self' 'nonce-d13b60c8c68026e03a3377b7'; style-src 'self' 'nonce-f2471224b8c789bebddbb394'; report-uri /csp-report;
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
