### PR TITLE
fix: use lang('HTTP.pageNotFound') on production 404 page

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -947,7 +947,7 @@ class CodeIgniter
         }
 
         throw PageNotFoundException::forPageNotFound(
-            (ENVIRONMENT !== 'production' || ! $this->isWeb()) ? $e->getMessage() : ''
+            (ENVIRONMENT !== 'production' || ! $this->isWeb()) ? $e->getMessage() : null
         );
     }
 


### PR DESCRIPTION
**Description**
before:
```
404 - File Not Found

Sorry! Cannot seem to find the page you were looking for. 
```
after:
```
404 - File Not Found

ページが見つかりません。
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

