### PR TITLE
docs: replace $response with $this->response in response.rst

### DIFF
--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -147,9 +147,9 @@ When enabled, the response object will contain an instance of ``CodeIgniter\HTTP
 values set in **app/Config/ContentSecurityPolicy.php** are applied to that instance, and if no changes are
 needed during runtime, then the correctly formatted header is sent and you're all done.
 
-With CSP enabled, two header lines are added to the HTTP response: a Content-Security-Policy header, with
+With CSP enabled, two header lines are added to the HTTP response: a **Content-Security-Policy** header, with
 policies identifying content types or origins that are explicitly allowed for different
-contexts, and a Content-Security-Policy-Report-Only header, which identifies content types
+contexts, and a **Content-Security-Policy-Report-Only** header, which identifies content types
 or origins that will be allowed but which will also be reported to the destination
 of your choice.
 

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -161,7 +161,7 @@ call basis, by providing an optional second parameter to the adding method call.
 Runtime Configuration
 ---------------------
 
-If your application needs to make changes at run-time, you can access the instance at ``$response->CSP``. The
+If your application needs to make changes at run-time, you can access the instance at ``$this->response->CSP`` in your controllers. The
 class holds a number of methods that map pretty clearly to the appropriate header value that you need to set.
 Examples are shown below, with different combinations of parameters, though all accept either a directive
 name or an array of them:

--- a/user_guide_src/source/outgoing/response/004.php
+++ b/user_guide_src/source/outgoing/response/004.php
@@ -1,4 +1,4 @@
 <?php
 
-$response->setHeader('Location', 'http://example.com')
+$this->response->setHeader('Location', 'http://example.com')
     ->setHeader('WWW-Authenticate', 'Negotiate');

--- a/user_guide_src/source/outgoing/response/005.php
+++ b/user_guide_src/source/outgoing/response/005.php
@@ -1,4 +1,4 @@
 <?php
 
-$response->setHeader('Cache-Control', 'no-cache')
+$this->response->setHeader('Cache-Control', 'no-cache')
     ->appendHeader('Cache-Control', 'must-revalidate');

--- a/user_guide_src/source/outgoing/response/006.php
+++ b/user_guide_src/source/outgoing/response/006.php
@@ -1,3 +1,3 @@
 <?php
 
-$response->removeHeader('Location');
+$this->response->removeHeader('Location');

--- a/user_guide_src/source/outgoing/response/007.php
+++ b/user_guide_src/source/outgoing/response/007.php
@@ -3,4 +3,4 @@
 $data = 'Here is some text!';
 $name = 'mytext.txt';
 
-return $response->download($name, $data);
+return $this->response->download($name, $data);

--- a/user_guide_src/source/outgoing/response/008.php
+++ b/user_guide_src/source/outgoing/response/008.php
@@ -1,4 +1,4 @@
 <?php
 
 // Contents of photo.jpg will be automatically read
-return $response->download('/path/to/photo.jpg', null);
+return $this->response->download('/path/to/photo.jpg', null);

--- a/user_guide_src/source/outgoing/response/009.php
+++ b/user_guide_src/source/outgoing/response/009.php
@@ -1,3 +1,3 @@
 <?php
 
-return $response->download('awkwardEncryptedFileName.fakeExt', null)->setFileName('expenses.csv');
+return $this->response->download('awkwardEncryptedFileName.fakeExt', null)->setFileName('expenses.csv');

--- a/user_guide_src/source/outgoing/response/012.php
+++ b/user_guide_src/source/outgoing/response/012.php
@@ -1,30 +1,30 @@
 <?php
 
 // specify the default directive treatment
-$response->CSP->reportOnly(false);
+$this->response->CSP->reportOnly(false);
 
 // specify the origin to use if none provided for a directive
-$response->CSP->setDefaultSrc('cdn.example.com');
+$this->response->CSP->setDefaultSrc('cdn.example.com');
 
 // specify the URL that "report-only" reports get sent to
-$response->CSP->setReportURI('http://example.com/csp/reports');
+$this->response->CSP->setReportURI('http://example.com/csp/reports');
 
 // specify that HTTP requests be upgraded to HTTPS
-$response->CSP->upgradeInsecureRequests(true);
+$this->response->CSP->upgradeInsecureRequests(true);
 
 // add types or origins to CSP directives
 // assuming that the default treatment is to block rather than just report
-$response->CSP->addBaseURI('example.com', true); // report only
-$response->CSP->addChildSrc('https://youtube.com'); // blocked
-$response->CSP->addConnectSrc('https://*.facebook.com', false); // blocked
-$response->CSP->addFontSrc('fonts.example.com');
-$response->CSP->addFormAction('self');
-$response->CSP->addFrameAncestor('none', true); // report this one
-$response->CSP->addImageSrc('cdn.example.com');
-$response->CSP->addMediaSrc('cdn.example.com');
-$response->CSP->addManifestSrc('cdn.example.com');
-$response->CSP->addObjectSrc('cdn.example.com', false); // reject from here
-$response->CSP->addPluginType('application/pdf', false); // reject this media type
-$response->CSP->addScriptSrc('scripts.example.com', true); // allow but report requests from here
-$response->CSP->addStyleSrc('css.example.com');
-$response->CSP->addSandbox(['allow-forms', 'allow-scripts']);
+$this->response->CSP->addBaseURI('example.com', true); // report only
+$this->response->CSP->addChildSrc('https://youtube.com'); // blocked
+$this->response->CSP->addConnectSrc('https://*.facebook.com', false); // blocked
+$this->response->CSP->addFontSrc('fonts.example.com');
+$this->response->CSP->addFormAction('self');
+$this->response->CSP->addFrameAncestor('none', true); // report this one
+$this->response->CSP->addImageSrc('cdn.example.com');
+$this->response->CSP->addMediaSrc('cdn.example.com');
+$this->response->CSP->addManifestSrc('cdn.example.com');
+$this->response->CSP->addObjectSrc('cdn.example.com', false); // reject from here
+$this->response->CSP->addPluginType('application/pdf', false); // reject this media type
+$this->response->CSP->addScriptSrc('scripts.example.com', true); // allow but report requests from here
+$this->response->CSP->addStyleSrc('css.example.com');
+$this->response->CSP->addSandbox(['allow-forms', 'allow-scripts']);

--- a/user_guide_src/source/outgoing/response/013.php
+++ b/user_guide_src/source/outgoing/response/013.php
@@ -1,6 +1,6 @@
 <?php
 
-$response->addChildSrc('https://youtube.com'); // allowed
-$response->reportOnly(true);
-$response->addChildSrc('https://metube.com'); // allowed but reported
-$response->addChildSrc('https://ourtube.com', false); // allowed
+$this->response->CSP->addChildSrc('https://youtube.com'); // allowed
+$this->response->CSP->reportOnly(true);
+$this->response->CSP->addChildSrc('https://metube.com'); // allowed but reported
+$this->response->CSP->addChildSrc('https://ourtube.com', false); // allowed


### PR DESCRIPTION
**Description**
The Response object is used mainly in controllers and the user guide explains that "It can be accessed through $this->response."

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
