### PR TITLE
fix: lang() causes Error on CLI

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -75,6 +75,7 @@ use Config\Services as AppServices;
 use Config\Toolbar as ToolbarConfig;
 use Config\Validation as ValidationConfig;
 use Config\View as ViewConfig;
+use Locale;
 
 /**
  * Services Configuration file.
@@ -363,8 +364,14 @@ class Services extends BaseService
             return static::getSharedInstance('language', $locale)->setLocale($locale);
         }
 
+        if (AppServices::request() instanceof IncomingRequest) {
+            $requestLocale = AppServices::request()->getLocale();
+        } else {
+            $requestLocale = Locale::getDefault();
+        }
+
         // Use '?:' for empty string check
-        $locale = $locale ?: AppServices::request()->getLocale();
+        $locale = $locale ?: $requestLocale;
 
         return new Language($locale);
     }

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -50,7 +50,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
     protected function setUp(): void
     {
         unset($_ENV['foo'], $_SERVER['foo']);
-        Services::reset();
+        $this->resetServices();
 
         parent::setUp();
     }
@@ -593,8 +593,6 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
     public function testCspStyleNonce()
     {
-        $this->resetServices();
-
         $config             = config('App');
         $config->CSPEnabled = true;
 
@@ -603,8 +601,6 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
     public function testCspScriptNonce()
     {
-        $this->resetServices();
-
         $config             = config('App');
         $config->CSPEnabled = true;
 

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -606,4 +606,15 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
         $this->assertStringStartsWith('nonce="', csp_script_nonce());
     }
+
+    public function testLangOnCLI()
+    {
+        Services::createRequest(new App(), true);
+
+        $message = lang('CLI.generator.fileCreate', ['TestController.php']);
+
+        $this->assertSame('File created: TestController.php', $message);
+
+        $this->resetServices();
+    }
 }


### PR DESCRIPTION
**Description**
Supersedes #6200

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
