### PR TITLE
fix: multiple pagers with models do not work

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1073,7 +1073,8 @@ abstract class BaseModel
      */
     public function paginate(?int $perPage = null, string $group = 'default', ?int $page = null, int $segment = 0)
     {
-        $pager = Services::pager(null, null, false);
+        // Since multiple models may use the Pager, the Pager must be shared.
+        $pager = Services::pager();
 
         if ($segment) {
             $pager->setSegment($segment, $group);

--- a/tests/system/Models/PaginateModelTest.php
+++ b/tests/system/Models/PaginateModelTest.php
@@ -79,4 +79,26 @@ final class PaginateModelTest extends LiveModelTestCase
         $this->model->paginate(1, 'default', 500);
         $this->assertSame($this->model->pager->getPageCount(), $this->model->pager->getCurrentPage());
     }
+
+    public function testMultiplePager(): void
+    {
+        $validModel = $this->createModel(ValidModel::class);
+        $userModel  = $this->createModel(UserModel::class);
+
+        $validModel->paginate(1, 'valid');
+        $userModel->paginate(1, 'user');
+        $pager = $this->model->pager;
+
+        $this->assertSame(4, $validModel->countAllResults());
+        $this->assertSame(4, $userModel->countAllResults());
+
+        $this->assertStringContainsString('?page_valid=1"', $pager->links('valid'));
+        $this->assertStringContainsString('?page_valid=2"', $pager->links('valid'));
+        $this->assertStringContainsString('?page_valid=3"', $pager->links('valid'));
+        $this->assertStringContainsString('?page_valid=4"', $pager->links('valid'));
+        $this->assertStringContainsString('?page_user=1"', $pager->links('user'));
+        $this->assertStringContainsString('?page_user=2"', $pager->links('user'));
+        $this->assertStringContainsString('?page_user=3"', $pager->links('user'));
+        $this->assertStringContainsString('?page_user=4"', $pager->links('user'));
+    }
 }

--- a/tests/system/Models/PaginateModelTest.php
+++ b/tests/system/Models/PaginateModelTest.php
@@ -82,12 +82,16 @@ final class PaginateModelTest extends LiveModelTestCase
 
     public function testMultiplePager(): void
     {
+        $_GET = [];
+
         $validModel = $this->createModel(ValidModel::class);
         $userModel  = $this->createModel(UserModel::class);
 
         $validModel->paginate(1, 'valid');
         $userModel->paginate(1, 'user');
         $pager = $this->model->pager;
+
+        $this->assertSame($userModel->pager, $validModel->pager);
 
         $this->assertSame(4, $validModel->countAllResults());
         $this->assertSame(4, $userModel->countAllResults());


### PR DESCRIPTION
**Description**
Fixes  #6204

I am not sure if there is something wrong with sharing Pager.
But without sharing the Pager, multiple pagers never work.

See https://codeigniter4.github.io/CodeIgniter4/libraries/pagination.html#paginating-multiple-results

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
