### PR TITLE
fix: tweak empty line output of `spark db:table`

### DIFF
--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -129,6 +129,7 @@ class ShowTableInfo extends BaseCommand
                 $tables,
                 'required'
             );
+            CLI::newLine();
 
             $tableName = $tables[$tableNameNo];
         }
@@ -154,7 +155,6 @@ class ShowTableInfo extends BaseCommand
 
     private function showDataOfTable(string $tableName, int $limitRows, int $limitFieldValue)
     {
-        CLI::newLine();
         CLI::write("Data of Table \"{$tableName}\":", 'black', 'yellow');
         CLI::newLine();
 
@@ -245,7 +245,6 @@ class ShowTableInfo extends BaseCommand
 
     private function showFieldMetaData(string $tableName): void
     {
-        CLI::newLine();
         CLI::write("List of Metadata Information in Table \"{$tableName}\":", 'black', 'yellow');
         CLI::newLine();
 


### PR DESCRIPTION
**Description**
before:
```console
$ php spark db:table ci_sessions

CodeIgniter v4.2.1 Command Line Tool - Server Time: 2022-07-01 03:53:00 UTC-05:00


Data of Table "ci_sessions":

+--------------------+------------+--------------------+--------------------+
| id                 | ip_address | timestamp          | data               |
+--------------------+------------+--------------------+--------------------+
| 1f5o06b43phsnnf... | 127.0.0.1  | 2021-06-25 21:5... | __ci_last_regen... |
+--------------------+------------+--------------------+--------------------+
```
after:
```console
$ php spark db:table ci_sessions

CodeIgniter v4.2.1 Command Line Tool - Server Time: 2022-07-01 03:52:34 UTC-05:00

Data of Table "ci_sessions":

+--------------------+------------+--------------------+--------------------+
| id                 | ip_address | timestamp          | data               |
+--------------------+------------+--------------------+--------------------+
| 1f5o06b43phsnnf... | 127.0.0.1  | 2021-06-25 21:5... | __ci_last_regen... |
+--------------------+------------+--------------------+--------------------+
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

