### PR TITLE
fix: Builder insert()/update() does not accept an object

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2014,11 +2014,12 @@ class BaseBuilder
     /**
      * Compiles an update string and runs the query.
      *
-     * @param mixed $where
+     * @param array|object|null        $set
+     * @param array|RawSql|string|null $where
      *
      * @throws DatabaseException
      */
-    public function update(?array $set = null, $where = null, ?int $limit = null): bool
+    public function update($set = null, $where = null, ?int $limit = null): bool
     {
         if ($set !== null) {
             $this->set($set);

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1878,11 +1878,13 @@ class BaseBuilder
     /**
      * Compiles an insert string and runs the query
      *
+     * @param array|object|null $set
+     *
      * @throws DatabaseException
      *
      * @return bool|Query
      */
-    public function insert(?array $set = null, ?bool $escape = null)
+    public function insert($set = null, ?bool $escape = null)
     {
         if ($set !== null) {
             $this->set($set, '', $escape);

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -33,11 +33,37 @@ final class InsertTest extends CIUnitTestCase
         $this->db = new MockConnection([]);
     }
 
-    public function testSimpleInsert()
+    public function testInsertArray()
     {
         $builder = $this->db->table('jobs');
 
         $insertData = [
+            'id'   => 1,
+            'name' => 'Grocery Sales',
+        ];
+        $builder->testMode()->insert($insertData, true);
+
+        $expectedSQL   = 'INSERT INTO "jobs" ("id", "name") VALUES (1, \'Grocery Sales\')';
+        $expectedBinds = [
+            'id' => [
+                1,
+                true,
+            ],
+            'name' => [
+                'Grocery Sales',
+                true,
+            ],
+        ];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testInsertObject()
+    {
+        $builder = $this->db->table('jobs');
+
+        $insertData = (object) [
             'id'   => 1,
             'name' => 'Grocery Sales',
         ];

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -34,11 +34,35 @@ final class UpdateTest extends CIUnitTestCase
         $this->db = new MockConnection([]);
     }
 
-    public function testUpdate()
+    public function testUpdateArray()
     {
         $builder = new BaseBuilder('jobs', $this->db);
 
-        $builder->testMode()->where('id', 1)->update(['name' => 'Programmer'], null, null);
+        $data = ['name' => 'Programmer'];
+        $builder->testMode()->where('id', 1)->update($data, null, null);
+
+        $expectedSQL   = 'UPDATE "jobs" SET "name" = \'Programmer\' WHERE "id" = 1';
+        $expectedBinds = [
+            'id' => [
+                1,
+                true,
+            ],
+            'name' => [
+                'Programmer',
+                true,
+            ],
+        ];
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testUpdateObject()
+    {
+        $builder = new BaseBuilder('jobs', $this->db);
+
+        $data = (object) ['name' => 'Programmer'];
+        $builder->testMode()->where('id', 1)->update($data, null, null);
 
         $expectedSQL   = 'UPDATE "jobs" SET "name" = \'Programmer\' WHERE "id" = 1';
         $expectedBinds = [

--- a/user_guide_src/source/changelogs/v4.2.2.rst
+++ b/user_guide_src/source/changelogs/v4.2.2.rst
@@ -14,6 +14,7 @@ BREAKING
 
 - Now ``Services::request()`` returns ``IncomingRequest`` or ``CLIRequest``.
 - The method signature of ``CodeIgniter\Debug\Exceptions::__construct()`` has been changed. The ``IncomingRequest`` typehint on the ``$request`` parameter was removed. Extending classes should likewise remove the parameter so as not to break LSP.
+- The method signature of ``BaseBuilder.php::insert()`` and ``BaseBuilder.php::update()`` have been changed. The ``?array`` typehint on the ``$set`` parameter was removed.
 
 Enhancements
 ************


### PR DESCRIPTION
**Description**
Fixes #6210

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
