### PR TITLE
SQLite3 Connection getIndexData()

### DIFF
--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -303,11 +303,9 @@ class Connection extends BaseConnection
         $retVal = [];
 
         foreach ($tempVal as $val) {
-            $fields = array_values($val['fields']);
-
             $obj                = new stdClass();
             $obj->name          = $val['indexname'];
-            $obj->fields        = $fields;
+            $obj->fields        = array_values($val['fields']);
             $obj->type          = $val['indextype'];
             $retVal[$obj->name] = $obj;
         }

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -274,7 +274,7 @@ class Connection extends BaseConnection
                 WHEN ti.pk <> 0 AND sqlite_master.name LIKE 'sqlite_autoindex_%' THEN 'PRIMARY'
                 WHEN sqlite_master.name LIKE 'sqlite_autoindex_%' THEN 'UNIQUE'
                 WHEN sqlite_master.sql LIKE '% UNIQUE %' THEN 'UNIQUE'
-                ELSE ''
+                ELSE 'INDEX'
                 END as indextype
                 FROM sqlite_master
                 INNER JOIN pragma_index_xinfo(sqlite_master.name) ii ON ii.name IS NOT NULL

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -369,7 +369,7 @@ class Table
             return;
         }
 
-        foreach ($this->keys as $name => $key) {
+        foreach (array_keys($this->keys) as $name) {
             if ($name === 'primary') {
                 continue;
             }

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -110,6 +110,13 @@ class Table
 
         $this->keys = array_merge($this->keys, $this->formatKeys($this->db->getIndexData($table)));
 
+        // if primary key index exists twice then remove psuedo index name 'primary'.
+        $primaryIndexes = array_filter($this->keys, static fn ($index) => $index['type'] === 'primary');
+
+        if (! empty($primaryIndexes) && count($primaryIndexes) > 1 && array_key_exists('primary', $this->keys)) {
+            unset($this->keys['primary']);
+        }
+
         $this->foreignKeys = $this->db->getForeignKeyData($table);
 
         return $this;
@@ -316,7 +323,7 @@ class Table
             ];
 
             if ($field->primary_key) {
-                $this->keys[$field->name] = [
+                $this->keys['primary'] = [
                     'fields' => [$field->name],
                     'type'   => 'primary',
                 ];
@@ -343,9 +350,9 @@ class Table
         $return = [];
 
         foreach ($keys as $name => $key) {
-            $return[$name] = [
+            $return[strtolower($name)] = [
                 'fields' => $key->fields,
-                'type'   => 'index',
+                'type'   => strtolower($key->type),
             ];
         }
 
@@ -363,7 +370,7 @@ class Table
         }
 
         foreach ($this->keys as $name => $key) {
-            if ($key['type'] === 'primary' || $key['type'] === 'unique') {
+            if ($name === 'primary') {
                 continue;
             }
 

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -909,9 +909,11 @@ final class ForgeTest extends CIUnitTestCase
             $this->assertSame($keys['PRIMARY']->name, 'PRIMARY');
             $this->assertSame($keys['PRIMARY']->fields, ['id']);
             $this->assertSame($keys['PRIMARY']->type, 'PRIMARY');
+
             $this->assertSame($keys['code_company']->name, 'code_company');
             $this->assertSame($keys['code_company']->fields, ['code', 'company']);
             $this->assertSame($keys['code_company']->type, 'INDEX');
+
             $this->assertSame($keys['code_active']->name, 'code_active');
             $this->assertSame($keys['code_active']->fields, ['code', 'active']);
             $this->assertSame($keys['code_active']->type, 'UNIQUE');
@@ -919,19 +921,26 @@ final class ForgeTest extends CIUnitTestCase
             $this->assertSame($keys['pk_db_forge_test_1']->name, 'pk_db_forge_test_1');
             $this->assertSame($keys['pk_db_forge_test_1']->fields, ['id']);
             $this->assertSame($keys['pk_db_forge_test_1']->type, 'PRIMARY');
+
             $this->assertSame($keys['db_forge_test_1_code_company']->name, 'db_forge_test_1_code_company');
             $this->assertSame($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
             $this->assertSame($keys['db_forge_test_1_code_company']->type, 'INDEX');
+
             $this->assertSame($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');
             $this->assertSame($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
             $this->assertSame($keys['db_forge_test_1_code_active']->type, 'UNIQUE');
         } elseif ($this->db->DBDriver === 'SQLite3') {
             $this->assertSame($keys['PRIMARY']->name, 'PRIMARY');
             $this->assertSame($keys['PRIMARY']->fields, ['id']);
+            $this->assertSame($keys['PRIMARY']->type, 'PRIMARY');
+
             $this->assertSame($keys['db_forge_test_1_code_company']->name, 'db_forge_test_1_code_company');
             $this->assertSame($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
+            $this->assertSame($keys['db_forge_test_1_code_company']->type, 'INDEX');
+
             $this->assertSame($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');
             $this->assertSame($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
+            $this->assertSame($keys['db_forge_test_1_code_active']->type, 'UNIQUE');
         } elseif ($this->db->DBDriver === 'SQLSRV') {
             $this->assertSame($keys['pk_db_forge_test_1']->name, 'pk_db_forge_test_1');
             $this->assertSame($keys['pk_db_forge_test_1']->fields, ['id']);
@@ -948,9 +957,11 @@ final class ForgeTest extends CIUnitTestCase
             $this->assertSame($keys['pk_db_forge_test_1']->name, 'pk_db_forge_test_1');
             $this->assertSame($keys['pk_db_forge_test_1']->fields, ['id']);
             $this->assertSame($keys['pk_db_forge_test_1']->type, 'PRIMARY');
+
             $this->assertSame($keys['db_forge_test_1_code_company']->name, 'db_forge_test_1_code_company');
             $this->assertSame($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
             $this->assertSame($keys['db_forge_test_1_code_company']->type, 'INDEX');
+
             $this->assertSame($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');
             $this->assertSame($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
             $this->assertSame($keys['db_forge_test_1_code_active']->type, 'UNIQUE');

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -879,14 +879,11 @@ final class ForgeTest extends CIUnitTestCase
 
     public function testCompositeKey()
     {
-        // SQLite3 uses auto increment different
-        $uniqueOrAuto = $this->db->DBDriver === 'SQLite3' ? 'unique' : 'auto_increment';
-
         $this->forge->addField([
             'id' => [
-                'type'        => 'INTEGER',
-                'constraint'  => 3,
-                $uniqueOrAuto => true,
+                'type'           => 'INTEGER',
+                'constraint'     => 3,
+                'auto_increment' => true,
             ],
             'code' => [
                 'type'       => 'VARCHAR',
@@ -929,8 +926,8 @@ final class ForgeTest extends CIUnitTestCase
             $this->assertSame($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
             $this->assertSame($keys['db_forge_test_1_code_active']->type, 'UNIQUE');
         } elseif ($this->db->DBDriver === 'SQLite3') {
-            $this->assertSame($keys['sqlite_autoindex_db_forge_test_1_1']->name, 'sqlite_autoindex_db_forge_test_1_1');
-            $this->assertSame($keys['sqlite_autoindex_db_forge_test_1_1']->fields, ['id']);
+            $this->assertSame($keys['PRIMARY']->name, 'PRIMARY');
+            $this->assertSame($keys['PRIMARY']->fields, ['id']);
             $this->assertSame($keys['db_forge_test_1_code_company']->name, 'db_forge_test_1_code_company');
             $this->assertSame($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
             $this->assertSame($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -107,7 +107,7 @@ final class AlterTableTest extends CIUnitTestCase
 
         $keys = $this->getPrivateProperty($this->table, 'keys');
 
-        $this->assertCount(3, $keys);
+        $this->assertCount(4, $keys);
         $this->assertArrayHasKey('foo_name', $keys);
         $this->assertSame(['fields' => ['name'], 'type' => 'index'], $keys['foo_name']);
         $this->assertArrayHasKey('id', $keys);

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -107,13 +107,13 @@ final class AlterTableTest extends CIUnitTestCase
 
         $keys = $this->getPrivateProperty($this->table, 'keys');
 
-        $this->assertCount(4, $keys);
+        $this->assertCount(3, $keys);
         $this->assertArrayHasKey('foo_name', $keys);
         $this->assertSame(['fields' => ['name'], 'type' => 'index'], $keys['foo_name']);
-        $this->assertArrayHasKey('id', $keys);
-        $this->assertSame(['fields' => ['id'], 'type' => 'primary'], $keys['id']);
-        $this->assertArrayHasKey('id', $keys);
-        $this->assertSame(['fields' => ['id'], 'type' => 'primary'], $keys['id']);
+        $this->assertArrayHasKey('foo_email', $keys);
+        $this->assertSame(['fields' => ['email'], 'type' => 'unique'], $keys['foo_email']);
+        $this->assertArrayHasKey('primary', $keys);
+        $this->assertSame(['fields' => ['id'], 'type' => 'primary'], $keys['primary']);
     }
 
     public function testDropColumnSuccess()

--- a/tests/system/Database/Live/SQLite/GetIndexDataTest.php
+++ b/tests/system/Database/Live/SQLite/GetIndexDataTest.php
@@ -57,16 +57,6 @@ final class GetIndexDataTest extends CIUnitTestCase
 
     public function testGetIndexData()
     {
-        $this->forge->addField([
-            'id'         => ['type' => 'INTEGER', 'constraint' => 3, 'auto_increment' => true],
-            'name'       => ['type' => 'VARCHAR', 'constraint' => 80],
-            'email'      => ['type' => 'VARCHAR', 'constraint' => 100],
-            'country'    => ['type' => 'VARCHAR', 'constraint' => 40],
-            'created_at' => ['type' => 'DATETIME', 'null' => true],
-            'updated_at' => ['type' => 'DATETIME', 'null' => true],
-            'deleted_at' => ['type' => 'DATETIME', 'null' => true],
-        ])->addKey(['id'], true)->createTable('userforeign', true);
-
         // INTEGER PRIMARY KEY AUTO_INCREMENT doesn't get an index by default
         $this->forge->addField([
             'id'         => ['type' => 'INTEGER', 'constraint' => 3, 'auto_increment' => true],
@@ -78,10 +68,9 @@ final class GetIndexDataTest extends CIUnitTestCase
             'updated_at' => ['type' => 'DATETIME', 'null' => true],
             'deleted_at' => ['type' => 'DATETIME', 'null' => true],
         ])
-            ->addKey(['id'], true)->addUniqueKey('email')
+            ->addKey(['id'], true)
+            ->addUniqueKey('email')
             ->addKey('country')
-            ->addForeignKey('userid', 'userforeign', 'id')
-            ->addForeignKey('email', 'userforeign', 'email')
             ->createTable('testuser', true);
 
         $expectedIndexes = [];

--- a/tests/system/Database/Live/SQLite/GetIndexDataTest.php
+++ b/tests/system/Database/Live/SQLite/GetIndexDataTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Live\SQLite;
+
+use CodeIgniter\Database\SQLite3\Connection;
+use CodeIgniter\Database\SQLite3\Forge;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use Config\Database;
+use stdClass;
+
+/**
+ * @group DatabaseLive
+ *
+ * @internal
+ */
+final class GetIndexDataTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    /**
+     * In setUp() db connection is changed. So migration doesn't work
+     *
+     * @var bool
+     */
+    protected $migrate = false;
+
+    /**
+     * @var Connection
+     */
+    protected $db;
+
+    private Forge $forge;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $config = [
+            'DBDriver' => 'SQLite3',
+            'database' => 'database.db',
+            'DBDebug'  => true,
+        ];
+
+        $this->db    = db_connect($config);
+        $this->forge = Database::forge($config);
+    }
+
+    public function testGetIndexData()
+    {
+        $this->forge->addField([
+            'id'         => ['type' => 'INTEGER', 'constraint' => 3, 'auto_increment' => true],
+            'name'       => ['type' => 'VARCHAR', 'constraint' => 80],
+            'email'      => ['type' => 'VARCHAR', 'constraint' => 100],
+            'country'    => ['type' => 'VARCHAR', 'constraint' => 40],
+            'created_at' => ['type' => 'DATETIME', 'null' => true],
+            'updated_at' => ['type' => 'DATETIME', 'null' => true],
+            'deleted_at' => ['type' => 'DATETIME', 'null' => true],
+        ])->addKey(['id'], true)->createTable('userforeign', true);
+
+        // INTEGER PRIMARY KEY AUTO_INCREMENT doesn't get an index by default
+        $this->forge->addField([
+            'id'         => ['type' => 'INTEGER', 'constraint' => 3, 'auto_increment' => true],
+            'userid'     => ['type' => 'INTEGER', 'constraint' => 3],
+            'name'       => ['type' => 'VARCHAR', 'constraint' => 80],
+            'email'      => ['type' => 'VARCHAR', 'constraint' => 100],
+            'country'    => ['type' => 'VARCHAR', 'constraint' => 40],
+            'created_at' => ['type' => 'DATETIME', 'null' => true],
+            'updated_at' => ['type' => 'DATETIME', 'null' => true],
+            'deleted_at' => ['type' => 'DATETIME', 'null' => true],
+        ])
+            ->addKey(['id'], true)->addUniqueKey('email')
+            ->addKey('country')
+            ->addForeignKey('userid', 'userforeign', 'id')
+            ->addForeignKey('email', 'userforeign', 'email')
+            ->createTable('testuser', true);
+
+        $expectedIndexes = [];
+
+        $row                        = new stdclass();
+        $row->name                  = 'PRIMARY';
+        $row->fields                = ['id'];
+        $row->type                  = 'PRIMARY';
+        $expectedIndexes['PRIMARY'] = $row;
+
+        $row                               = new stdclass();
+        $row->name                         = 'testuser_email';
+        $row->fields                       = ['email'];
+        $row->type                         = 'UNIQUE';
+        $expectedIndexes['testuser_email'] = $row;
+
+        $row                                 = new stdclass();
+        $row->name                           = 'testuser_country';
+        $row->fields                         = ['country'];
+        $row->type                           = '';
+        $expectedIndexes['testuser_country'] = $row;
+
+        $indexes = $this->db->getIndexData('testuser');
+
+        $this->assertSame($expectedIndexes['PRIMARY']->fields, $indexes['PRIMARY']->fields);
+        $this->assertSame($expectedIndexes['PRIMARY']->type, $indexes['PRIMARY']->type);
+
+        $this->assertSame($expectedIndexes['testuser_email']->fields, $indexes['testuser_email']->fields);
+        $this->assertSame($expectedIndexes['testuser_email']->type, $indexes['testuser_email']->type);
+
+        $this->assertSame($expectedIndexes['testuser_country']->fields, $indexes['testuser_country']->fields);
+        $this->assertSame($expectedIndexes['testuser_country']->type, $indexes['testuser_country']->type);
+
+        $this->forge->dropTable('testuser', true);
+        $this->forge->dropTable('userforeign', true);
+    }
+}

--- a/tests/system/Database/Live/SQLite/GetIndexDataTest.php
+++ b/tests/system/Database/Live/SQLite/GetIndexDataTest.php
@@ -90,7 +90,7 @@ final class GetIndexDataTest extends CIUnitTestCase
         $row                                 = new stdclass();
         $row->name                           = 'testuser_country';
         $row->fields                         = ['country'];
-        $row->type                           = '';
+        $row->type                           = 'INDEX';
         $expectedIndexes['testuser_country'] = $row;
 
         $indexes = $this->db->getIndexData('testuser');
@@ -105,6 +105,5 @@ final class GetIndexDataTest extends CIUnitTestCase
         $this->assertSame($expectedIndexes['testuser_country']->type, $indexes['testuser_country']->type);
 
         $this->forge->dropTable('testuser', true);
-        $this->forge->dropTable('userforeign', true);
     }
 }

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -37,6 +37,7 @@ Enhancements
 - Added ``Model::allowEmptyInserts()`` method to insert empty data. See :ref:`Using CodeIgniter's Model <model-allow-empty-inserts>`
 - Added ``$routes->useSupportedLocalesOnly(true)`` so that the Router returns 404 Not Found if the locale in the URL is not supported in ``Config\App::$supportedLocales``. See :ref:`Localization <localization-in-routes>`
 - The call handler for Spark commands from the ``CodeIgniter\CodeIgniter`` class has been extracted. This will reduce the cost of console calls.
+- Added a psuedo index named 'PRIMARY' for SQLite `AUTOINCREMENT` column. SQLite treats these in a special way which was excluding them from being retrieved by calling ``BaseConnection::getIndexData()``.
 
 Changes
 *******

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -37,7 +37,7 @@ Enhancements
 - Added ``Model::allowEmptyInserts()`` method to insert empty data. See :ref:`Using CodeIgniter's Model <model-allow-empty-inserts>`
 - Added ``$routes->useSupportedLocalesOnly(true)`` so that the Router returns 404 Not Found if the locale in the URL is not supported in ``Config\App::$supportedLocales``. See :ref:`Localization <localization-in-routes>`
 - The call handler for Spark commands from the ``CodeIgniter\CodeIgniter`` class has been extracted. This will reduce the cost of console calls.
-- Added a psuedo index named 'PRIMARY' for SQLite `AUTOINCREMENT` column. SQLite treats these in a special way which was excluding them from being retrieved by calling ``BaseConnection::getIndexData()``.
+- SQLite ``BaseConnection::getIndexData()`` now can return pseudo index named ``PRIMARY`` for `AUTOINCREMENT` column, and each returned index data has ``type`` property.
 
 Changes
 *******

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -121,9 +121,7 @@ The key types may be unique to the database you are using.
 For instance, MySQL will return one of primary, fulltext, spatial, index or unique
 for each key associated with a table.
 
-SQLite3 includes a psuedo index named 'PRIMARY'. `AUTOINCREMENT` columns are treated
-in special way and wouldn't otherwise be returned. A drop command on this index will
-cause an error.
+SQLite3 returns a pseudo index named ``PRIMARY``. But it is a special index, and you can't use it in your SQL commands.
 
 $db->getForeignKeyData()
 ------------------------

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -121,6 +121,10 @@ The key types may be unique to the database you are using.
 For instance, MySQL will return one of primary, fulltext, spatial, index or unique
 for each key associated with a table.
 
+SQLite3 includes a psuedo index named 'PRIMARY'. `AUTOINCREMENT` columns are treated
+in special way and wouldn't otherwise be returned. A drop command on this index will
+cause an error.
+
 $db->getForeignKeyData()
 ------------------------
 


### PR DESCRIPTION
Supersedes https://github.com/codeigniter4/CodeIgniter4/pull/6207

This is a rewrite of `system/Database/SQLite3/Connection::_indexData()`.

SQLite doesn't show indexes on tables created with `INTEGER PRIMARY KEY AUTO_INCREMENT`. This PR looks for primary keys that don't appear in the normal index lookup and adds it to the return of the method. It also adds the key type: Primary, Unique, or Index.

In the test database creation of the users table the current implementation won't return any index.

```php
        $this->forge->addField([
            'id'         => ['type' => 'INTEGER', 'constraint' => 3, 'auto_increment' => true],
            'name'       => ['type' => 'VARCHAR', 'constraint' => 80],
            'email'      => ['type' => 'VARCHAR', 'constraint' => 100],
            'country'    => ['type' => 'VARCHAR', 'constraint' => 40],
            'created_at' => ['type' => 'DATETIME', 'null' => true],
            'updated_at' => ['type' => 'DATETIME', 'null' => true],
            'deleted_at' => ['type' => 'DATETIME', 'null' => true],
        ])->addKey('id', true)->createTable('user', true); 
```

However if you wrote it like the following it would show up in the indexes:

```php
        $this->forge->addField([
            'id'         => ['type' => 'INTEGER', 'constraint' => 3],
            'name'       => ['type' => 'VARCHAR', 'constraint' => 80],
            'email'      => ['type' => 'VARCHAR', 'constraint' => 100],
            'country'    => ['type' => 'VARCHAR', 'constraint' => 40],
            'created_at' => ['type' => 'DATETIME', 'null' => true],
            'updated_at' => ['type' => 'DATETIME', 'null' => true],
            'deleted_at' => ['type' => 'DATETIME', 'null' => true],
        ])->addKey('id', true)->createTable('user', true); 
```

With this PR both cases will return indexes for primary key.

The need is to get a comprehensive list of database constraints. This will be useful in adding `upsert()` to the database.

Furthermore, this method doesn't use nested queries like the current implementation and requires only one database call.

Its important to note that something like the following would likely cause an error:

```php
        $keys = $db->getIndexData('tablename');
        
        foreach ($keys as $key) {
            // if ($key->name !== 'PRIMARY')
            $forge->dropKey('tablename', $key->name);            
        }
```

SQLite's handling of things the way they do creates a pseudo index but its not an index for the purposes of calling database commands. If you check that the index isn't name PRIMARY then the rest should be ok.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
