### PR TITLE
fix: exceptionHandler may return invalid HTTP status code

### DIFF
--- a/system/Database/Exceptions/DatabaseException.php
+++ b/system/Database/Exceptions/DatabaseException.php
@@ -11,9 +11,10 @@
 
 namespace CodeIgniter\Database\Exceptions;
 
+use CodeIgniter\Exceptions\HasExitCodeException;
 use Error;
 
-class DatabaseException extends Error implements ExceptionInterface
+class DatabaseException extends Error implements ExceptionInterface, HasExitCodeException
 {
     /**
      * Exit status code

--- a/system/Database/Exceptions/DatabaseException.php
+++ b/system/Database/Exceptions/DatabaseException.php
@@ -11,10 +11,10 @@
 
 namespace CodeIgniter\Database\Exceptions;
 
-use CodeIgniter\Exceptions\HasExitCodeException;
+use CodeIgniter\Exceptions\ExitExceptionInterface;
 use Error;
 
-class DatabaseException extends Error implements ExceptionInterface, HasExitCodeException
+class DatabaseException extends Error implements ExceptionInterface, ExitExceptionInterface
 {
     /**
      * Exit status code

--- a/system/Database/Exceptions/DatabaseException.php
+++ b/system/Database/Exceptions/DatabaseException.php
@@ -11,15 +11,13 @@
 
 namespace CodeIgniter\Database\Exceptions;
 
-use CodeIgniter\Exceptions\ExitExceptionInterface;
+use CodeIgniter\Exceptions\HasExitCodeInterface;
 use Error;
 
-class DatabaseException extends Error implements ExceptionInterface, ExitExceptionInterface
+class DatabaseException extends Error implements ExceptionInterface, HasExitCodeInterface
 {
-    /**
-     * Exit status code
-     *
-     * @var int
-     */
-    protected $code = EXIT_DATABASE;
+    public function getExitCode(): int
+    {
+        return EXIT_DATABASE;
+    }
 }

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -12,6 +12,8 @@
 namespace CodeIgniter\Debug;
 
 use CodeIgniter\API\ResponseTrait;
+use CodeIgniter\Exceptions\ExitExceptionInterface;
+use CodeIgniter\Exceptions\HTTPExceptionInterface;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
@@ -312,18 +314,15 @@ class Exceptions
      */
     protected function determineCodes(Throwable $exception): array
     {
-        $statusCode = abs($exception->getCode());
+        $statusCode = 500;
+        $exitStatus = EXIT_ERROR;
 
-        if ($statusCode < 100 || $statusCode > 599) {
-            $exitStatus = $statusCode + EXIT__AUTO_MIN;
+        if ($exception instanceof HTTPExceptionInterface) {
+            $statusCode = $exception->getCode();
+        }
 
-            if ($exitStatus > EXIT__AUTO_MAX) {
-                $exitStatus = EXIT_ERROR;
-            }
-
-            $statusCode = 500;
-        } else {
-            $exitStatus = EXIT_ERROR;
+        if ($exception instanceof ExitExceptionInterface) {
+            $exitStatus = $exception->getCode();
         }
 
         return [$statusCode, $exitStatus];

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -12,7 +12,7 @@
 namespace CodeIgniter\Debug;
 
 use CodeIgniter\API\ResponseTrait;
-use CodeIgniter\Exceptions\ExitExceptionInterface;
+use CodeIgniter\Exceptions\HasExitCodeInterface;
 use CodeIgniter\Exceptions\HTTPExceptionInterface;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\CLIRequest;
@@ -321,8 +321,8 @@ class Exceptions
             $statusCode = $exception->getCode();
         }
 
-        if ($exception instanceof ExitExceptionInterface) {
-            $exitStatus = $exception->getCode();
+        if ($exception instanceof HasExitCodeInterface) {
+            $exitStatus = $exception->getExitCode();
         }
 
         return [$statusCode, $exitStatus];

--- a/system/Entity/Exceptions/CastException.php
+++ b/system/Entity/Exceptions/CastException.php
@@ -11,17 +11,21 @@
 
 namespace CodeIgniter\Entity\Exceptions;
 
+use CodeIgniter\Exceptions\ExitExceptionInterface;
 use CodeIgniter\Exceptions\FrameworkException;
 
 /**
  * CastException is thrown for invalid cast initialization and management.
- *
- * @TODO CodeIgniter\Exceptions\CastException is deprecated and this class is used.
- *      CodeIgniter\Exceptions\CastException has the property $code = EXIT_CONFIG,
- *      but this class does not have the code.
  */
-class CastException extends FrameworkException
+class CastException extends FrameworkException implements ExitExceptionInterface
 {
+    /**
+     * Exit status code
+     *
+     * @var int
+     */
+    protected $code = EXIT_CONFIG;
+
     /**
      * Thrown when the cast class does not extends BaseCast.
      *

--- a/system/Entity/Exceptions/CastException.php
+++ b/system/Entity/Exceptions/CastException.php
@@ -11,20 +11,18 @@
 
 namespace CodeIgniter\Entity\Exceptions;
 
-use CodeIgniter\Exceptions\ExitExceptionInterface;
 use CodeIgniter\Exceptions\FrameworkException;
+use CodeIgniter\Exceptions\HasExitCodeInterface;
 
 /**
  * CastException is thrown for invalid cast initialization and management.
  */
-class CastException extends FrameworkException implements ExitExceptionInterface
+class CastException extends FrameworkException implements HasExitCodeInterface
 {
-    /**
-     * Exit status code
-     *
-     * @var int
-     */
-    protected $code = EXIT_CONFIG;
+    public function getExitCode(): int
+    {
+        return EXIT_CONFIG;
+    }
 
     /**
      * Thrown when the cast class does not extends BaseCast.

--- a/system/Exceptions/CastException.php
+++ b/system/Exceptions/CastException.php
@@ -18,7 +18,7 @@ namespace CodeIgniter\Exceptions;
  *
  * @codeCoverageIgnore
  */
-class CastException extends CriticalError
+class CastException extends CriticalError implements HasExitCodeException
 {
     use DebugTraceableTrait;
 

--- a/system/Exceptions/CastException.php
+++ b/system/Exceptions/CastException.php
@@ -18,7 +18,7 @@ namespace CodeIgniter\Exceptions;
  *
  * @codeCoverageIgnore
  */
-class CastException extends CriticalError implements HasExitCodeException
+class CastException extends CriticalError implements ExitExceptionInterface
 {
     use DebugTraceableTrait;
 

--- a/system/Exceptions/CastException.php
+++ b/system/Exceptions/CastException.php
@@ -18,16 +18,14 @@ namespace CodeIgniter\Exceptions;
  *
  * @codeCoverageIgnore
  */
-class CastException extends CriticalError implements ExitExceptionInterface
+class CastException extends CriticalError implements HasExitCodeInterface
 {
     use DebugTraceableTrait;
 
-    /**
-     * Exit status code
-     *
-     * @var int
-     */
-    protected $code = EXIT_CONFIG;
+    public function getExitCode(): int
+    {
+        return EXIT_CONFIG;
+    }
 
     public static function forInvalidJsonFormatException(int $error)
     {

--- a/system/Exceptions/ConfigException.php
+++ b/system/Exceptions/ConfigException.php
@@ -14,16 +14,14 @@ namespace CodeIgniter\Exceptions;
 /**
  * Exception for automatic logging.
  */
-class ConfigException extends CriticalError implements ExitExceptionInterface
+class ConfigException extends CriticalError implements HasExitCodeInterface
 {
     use DebugTraceableTrait;
 
-    /**
-     * Exit status code
-     *
-     * @var int
-     */
-    protected $code = EXIT_CONFIG;
+    public function getExitCode(): int
+    {
+        return EXIT_CONFIG;
+    }
 
     public static function forDisabledMigrations()
     {

--- a/system/Exceptions/ConfigException.php
+++ b/system/Exceptions/ConfigException.php
@@ -14,7 +14,7 @@ namespace CodeIgniter\Exceptions;
 /**
  * Exception for automatic logging.
  */
-class ConfigException extends CriticalError
+class ConfigException extends CriticalError implements HasExitCodeException
 {
     use DebugTraceableTrait;
 

--- a/system/Exceptions/ConfigException.php
+++ b/system/Exceptions/ConfigException.php
@@ -14,7 +14,7 @@ namespace CodeIgniter\Exceptions;
 /**
  * Exception for automatic logging.
  */
-class ConfigException extends CriticalError implements HasExitCodeException
+class ConfigException extends CriticalError implements ExitExceptionInterface
 {
     use DebugTraceableTrait;
 

--- a/system/Exceptions/ExitExceptionInterface.php
+++ b/system/Exceptions/ExitExceptionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Exceptions;
+
+/**
+ * Interface for Exceptions that has exception code as exit code.
+ */
+interface ExitExceptionInterface
+{
+}

--- a/system/Exceptions/HTTPExceptionInterface.php
+++ b/system/Exceptions/HTTPExceptionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Exceptions;
+
+/**
+ * Interface for Exceptions that has exception code as HTTP status code.
+ */
+interface HTTPExceptionInterface
+{
+}

--- a/system/Exceptions/HasExitCodeInterface.php
+++ b/system/Exceptions/HasExitCodeInterface.php
@@ -14,6 +14,10 @@ namespace CodeIgniter\Exceptions;
 /**
  * Interface for Exceptions that has exception code as exit code.
  */
-interface ExitExceptionInterface
+interface HasExitCodeInterface
 {
+    /**
+     * Returns exit status code.
+     */
+    public function getExitCode(): int;
 }

--- a/system/Exceptions/PageNotFoundException.php
+++ b/system/Exceptions/PageNotFoundException.php
@@ -14,7 +14,7 @@ namespace CodeIgniter\Exceptions;
 use Config\Services;
 use OutOfBoundsException;
 
-class PageNotFoundException extends OutOfBoundsException implements ExceptionInterface, HasHttpStatusCodeException
+class PageNotFoundException extends OutOfBoundsException implements ExceptionInterface, HTTPExceptionInterface
 {
     use DebugTraceableTrait;
 

--- a/system/Exceptions/PageNotFoundException.php
+++ b/system/Exceptions/PageNotFoundException.php
@@ -14,7 +14,7 @@ namespace CodeIgniter\Exceptions;
 use Config\Services;
 use OutOfBoundsException;
 
-class PageNotFoundException extends OutOfBoundsException implements ExceptionInterface
+class PageNotFoundException extends OutOfBoundsException implements ExceptionInterface, HasHttpStatusCodeException
 {
     use DebugTraceableTrait;
 

--- a/system/Router/Exceptions/RedirectException.php
+++ b/system/Router/Exceptions/RedirectException.php
@@ -11,13 +11,13 @@
 
 namespace CodeIgniter\Router\Exceptions;
 
-use CodeIgniter\Exceptions\HasHttpStatusCodeException;
+use CodeIgniter\Exceptions\HTTPExceptionInterface;
 use Exception;
 
 /**
  * RedirectException
  */
-class RedirectException extends Exception implements HasHttpStatusCodeException
+class RedirectException extends Exception implements HTTPExceptionInterface
 {
     /**
      * HTTP status code for redirects

--- a/system/Router/Exceptions/RedirectException.php
+++ b/system/Router/Exceptions/RedirectException.php
@@ -11,12 +11,13 @@
 
 namespace CodeIgniter\Router\Exceptions;
 
+use CodeIgniter\Exceptions\HasHttpStatusCodeException;
 use Exception;
 
 /**
  * RedirectException
  */
-class RedirectException extends Exception
+class RedirectException extends Exception implements HasHttpStatusCodeException
 {
     /**
      * HTTP status code for redirects

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -60,16 +60,13 @@ final class ExceptionsTest extends CIUnitTestCase
     {
         $determineCodes = $this->getPrivateMethodInvoker($this->exception, 'determineCodes');
 
-        $this->assertSame([500, EXIT__AUTO_MIN], $determineCodes(new RuntimeException('This.')));
+        $this->assertSame([500, EXIT_ERROR], $determineCodes(new RuntimeException('This.')));
         $this->assertSame([500, EXIT_ERROR], $determineCodes(new RuntimeException('That.', 600)));
-        $this->assertSame([404, EXIT_ERROR], $determineCodes(new RuntimeException('There.', 404)));
-        $this->assertSame([167, EXIT_ERROR], $determineCodes(new RuntimeException('This.', 167)));
-        // @TODO This exit code should be EXIT_CONFIG.
-        $this->assertSame([500, 12], $determineCodes(new ConfigException('This.')));
-        // @TODO This exit code should be EXIT_CONFIG.
-        $this->assertSame([500, 9], $determineCodes(new CastException('This.')));
-        // @TODO This exit code should be EXIT_DATABASE.
-        $this->assertSame([500, 17], $determineCodes(new DatabaseException('This.')));
+        $this->assertSame([500, EXIT_ERROR], $determineCodes(new RuntimeException('There.', 404)));
+        $this->assertSame([500, EXIT_ERROR], $determineCodes(new RuntimeException('This.', 167)));
+        $this->assertSame([500, EXIT_CONFIG], $determineCodes(new ConfigException('This.')));
+        $this->assertSame([500, EXIT_CONFIG], $determineCodes(new CastException('This.')));
+        $this->assertSame([500, EXIT_DATABASE], $determineCodes(new DatabaseException('This.')));
     }
 
     public function testRenderBacktrace(): void

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -26,7 +26,7 @@ Exceptions when Database Errors Occur
 HTTP Status Code and Exit Code when Exception Occurs
 ----------------------------------------------------
 
-Previously, the CodeIgniter's Exception Handler used the *Exception code* as *HTTP status code* in some cases, and set calculated *Exit code* based on the Exception code. However there is essentially nothing to do with Exception code and HTTP Status Code or Exit code.
+Previously, CodeIgniter's Exception Handler used the *Exception code* as the *HTTP status code* in some cases, and calculated the *Exit code* based on the Exception code. However there should be no logical connection with Exception code and HTTP Status Code or Exit code.
 
 - Now the Exception Handler sets HTTP status code to ``500`` and set Exit code to the constant ``EXIT_ERROR`` (= ``1``) by default.
 - You can change HTTP status code or Exit code to implements ``HTTPExceptionInterface`` or ``HasExitCodeInterface`` in your Exception class. See :ref:`error-specify-http-status-code` and :ref:`error-specify-exit-code`.

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -23,6 +23,20 @@ Exceptions when Database Errors Occur
 - The exceptions thrown by the database connection classes have been changed to ``CodeIgniter\Database\Exceptions\DatabaseException``. Previously, different database drivers threw different exception classes, but these have been unified into ``DatabaseException``.
 - The exceptions thrown by the ``execute()`` method of Prepared Queries have been changed to ``DatabaseException``. Previously, different database drivers might throw different exception classes or did not throw exceptions, but these have been unified into ``DatabaseException``.
 
+HTTP Status Code and Exit Code when Exception Occurs
+----------------------------------------------------
+
+Previously, the CodeIgniter's Exception Handler used the *Exception code* as *HTTP status code* in some cases, and set calculated *Exit code* based on the Exception code. However there is essentially nothing to do with Exception code and HTTP Status Code or Exit code.
+
+- Now the Exception Handler sets HTTP status code to ``500`` and set Exit code to the constant ``EXIT_ERROR`` (= ``1``) by default.
+- You can change HTTP status code or Exit code to implements ``HTTPExceptionInterface`` or ``HasExitCodeInterface`` in your Exception class. See :ref:`error-specify-http-status-code` and :ref:`error-specify-exit-code`.
+
+For example, the Exit code has been changed like the following:
+
+- If an uncaught ``ConfigException`` occurs, the Exit code is ``EXIT_CONFIG`` (= ``3``) instead of ``12``.
+- If an uncaught ``CastException`` occurs, the Exit code is ``EXIT_CONFIG`` (= ``3``) instead of ``9``.
+- If an uncaught ``DatabaseException`` occurs, the Exit code is ``EXIT_DATABASE`` (= ``8``) instead of ``17``.
+
 Others
 ------
 

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -29,7 +29,7 @@ HTTP Status Code and Exit Code when Exception Occurs
 Previously, CodeIgniter's Exception Handler used the *Exception code* as the *HTTP status code* in some cases, and calculated the *Exit code* based on the Exception code. However there should be no logical connection with Exception code and HTTP Status Code or Exit code.
 
 - Now the Exception Handler sets HTTP status code to ``500`` and set Exit code to the constant ``EXIT_ERROR`` (= ``1``) by default.
-- You can change HTTP status code or Exit code to implements ``HTTPExceptionInterface`` or ``HasExitCodeInterface`` in your Exception class. See :ref:`error-specify-http-status-code` and :ref:`error-specify-exit-code`.
+- You can change HTTP status code or Exit code to implement ``HTTPExceptionInterface`` or ``HasExitCodeInterface`` in your Exception class. See :ref:`error-specify-http-status-code` and :ref:`error-specify-exit-code`.
 
 For example, the Exit code has been changed like the following:
 

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -64,10 +64,10 @@ To ignore logging on other status codes, you can set the status code to ignore i
 .. note:: It is possible that logging still will not happen for exceptions if your current Log settings
     are not set up to log **critical** errors, which all exceptions are logged as.
 
-Custom Exceptions
-=================
+Framework Exceptions
+====================
 
-The following custom exceptions are available:
+The following framework exceptions are available:
 
 PageNotFoundException
 ---------------------
@@ -89,7 +89,7 @@ is not the right type, etc:
 
 .. literalinclude:: errors/008.php
 
-This provides an HTTP status code of 500 and an exit code of 3.
+This provides an exit code of 3.
 
 DatabaseException
 -----------------
@@ -99,7 +99,7 @@ or when it is temporarily lost:
 
 .. literalinclude:: errors/009.php
 
-This provides an HTTP status code of 500 and an exit code of 8.
+This provides an exit code of 8.
 
 RedirectException
 -----------------
@@ -113,3 +113,23 @@ forcing a redirect to a specific route or URL:
 redirect code to use instead of the default (``302``, "temporary redirect"):
 
 .. literalinclude:: errors/011.php
+
+.. _error-specify-http-status-code:
+
+Specify HTTP Status Code in Your Exception
+==========================================
+
+Since v4.3.0, you can specify the HTTP status code for your Exception class to implement
+``HTTPExceptionInterface``.
+
+When an exception implemented ``HTTPExceptionInterface`` is caught by CodeIgniter's exception handler, the Exception code will be the HTTP status code.
+
+.. _error-specify-exit-code:
+
+Specify Exit Code in Your Exception
+===================================
+
+Since v4.3.0, you can specify the exit code for your Exception class to implement
+``HasExitCodeInterface``.
+
+When an exception implemented ``HasExitCodeInterface`` is caught by CodeIgniter's exception handler, the code returned from the ``getExitCode()`` method will be the exit code.

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -122,7 +122,7 @@ Specify HTTP Status Code in Your Exception
 Since v4.3.0, you can specify the HTTP status code for your Exception class to implement
 ``HTTPExceptionInterface``.
 
-When an exception implemented ``HTTPExceptionInterface`` is caught by CodeIgniter's exception handler, the Exception code will be the HTTP status code.
+When an exception implementing ``HTTPExceptionInterface`` is caught by CodeIgniter's exception handler, the Exception code will become the HTTP status code.
 
 .. _error-specify-exit-code:
 

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -132,4 +132,4 @@ Specify Exit Code in Your Exception
 Since v4.3.0, you can specify the exit code for your Exception class to implement
 ``HasExitCodeInterface``.
 
-When an exception implemented ``HasExitCodeInterface`` is caught by CodeIgniter's exception handler, the code returned from the ``getExitCode()`` method will be the exit code.
+When an exception implementing ``HasExitCodeInterface`` is caught by CodeIgniter's exception handler, the code returned from the ``getExitCode()`` method will become the exit code.

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -50,7 +50,7 @@ HTTP Status Code and Exit Code of Uncaught Exceptions
 - If you expect *Exception code* as *HTTP status code*, the HTTP status code will be changed.
   In that case, you need to implement ``HTTPExceptionInterface`` in the Exception. See :ref:`error-specify-http-status-code`.
 - If you expect *Exit code* based on *Exception code*, the Exit code will be changed.
-  In that case, you need to implements ``HasExitCodeInterface`` in the Exception. See :ref:`error-specify-exit-code`.
+  In that case, you need to implement ``HasExitCodeInterface`` in the Exception. See :ref:`error-specify-exit-code`.
 
 Others
 ======

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -44,6 +44,17 @@ Add **types** to the properties in these Config classes. You may need to fix the
 Breaking Changes
 ****************
 
+HTTP Status Code and Exit Code of Uncaught Exceptions
+=====================================================
+
+- If you expect *Exception code* as *HTTP status code*, the HTTP status code will be changed.
+  In that case, you need to implements ``HTTPExceptionInterface`` in the Exception. See :ref:`error-specify-http-status-code`.
+- If you expect *Exit code* based on *Exception code*, the Exit code will be changed.
+  In that case, you need to implements ``HasExitCodeInterface`` in the Exception. See :ref:`error-specify-exit-code`.
+
+Others
+======
+
 - The exception classes may be changed when database errors occur. If you catch the exceptions, you must confirm that your code can catch the exceptions. See :ref:`exceptions-when-database-errors-occur` for details.
 
 Breaking Enhancements

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -48,7 +48,7 @@ HTTP Status Code and Exit Code of Uncaught Exceptions
 =====================================================
 
 - If you expect *Exception code* as *HTTP status code*, the HTTP status code will be changed.
-  In that case, you need to implements ``HTTPExceptionInterface`` in the Exception. See :ref:`error-specify-http-status-code`.
+  In that case, you need to implement ``HTTPExceptionInterface`` in the Exception. See :ref:`error-specify-http-status-code`.
 - If you expect *Exit code* based on *Exception code*, the Exit code will be changed.
   In that case, you need to implements ``HasExitCodeInterface`` in the Exception. See :ref:`error-specify-exit-code`.
 


### PR DESCRIPTION
**Description**
The current implementation has undocumented behavior that use **Exception code** as **HTTP status code**,
and determine **Exit code** from Exception code.
But Exception code has nothing to do with HTTP status code or Exit code.

This PR introduces interfaces that explicitly show the Exception code is  HTTP status code or Exit code

- add `HTTPExceptionInterface` and `HasExitCodeInterface`
- fix `Exceptions::determineCodes()`

**Breaking Changes:**
- If you expect Exception code as HTTP status code, the HTTP status code will be changed.
In that case, you need to implements `HTTPExceptionInterface` in the Exception.
- If you expect Exit code based on Exception code, the Exit code will be changed.
In that case, you need to implements `HasExitCodeInterface` in the Exception.

Related: #6286

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
