### PR TITLE
 Language: Make production error message translatable (replaces #6197)

### DIFF
--- a/app/Views/errors/html/production.php
+++ b/app/Views/errors/html/production.php
@@ -12,13 +12,13 @@
 </head>
 <body>
 
-<div class="container text-center">
+    <div class="container text-center">
 
-    <h1 class="headline"><?= lang('Errors.whoops') ?></h1>
+        <h1 class="headline"><?= lang('Errors.whoops') ?></h1>
 
-    <p class="lead"><?= lang('Errors.weHitASnag') ?></p>
+        <p class="lead"><?= lang('Errors.weHitASnag') ?></p>
 
-</div>
+    </div>
 
 </body>
 

--- a/app/Views/errors/html/production.php
+++ b/app/Views/errors/html/production.php
@@ -6,7 +6,7 @@
 
     <title><?= lang('Errors.whoops') ?></title>
 
-    <style type="text/css">
+    <style>
         <?= preg_replace('#[\r\n\t ]+#', ' ', file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'debug.css')) ?>
     </style>
 </head>

--- a/app/Views/errors/html/production.php
+++ b/app/Views/errors/html/production.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex">
 
-    <title>Whoops!</title>
+    <title><?= lang('Errors.whoops') ?></title>
 
     <style type="text/css">
         <?= preg_replace('#[\r\n\t ]+#', ' ', file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'debug.css')) ?>
@@ -12,13 +12,13 @@
 </head>
 <body>
 
-    <div class="container text-center">
+<div class="container text-center">
 
-        <h1 class="headline">Whoops!</h1>
+    <h1 class="headline"><?= lang('Errors.whoops') ?></h1>
 
-        <p class="lead">We seem to have hit a snag. Please try again later...</p>
+    <p class="lead"><?= lang('Errors.weHitASnag') ?></p>
 
-    </div>
+</div>
 
 </body>
 

--- a/system/Language/en/Errors.php
+++ b/system/Language/en/Errors.php
@@ -1,25 +1,16 @@
-<!doctype html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <meta name="robots" content="noindex">
+<?php
 
-    <title><?= lang('Errors.whoops') ?></title>
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
 
-    <style type="text/css">
-        <?= preg_replace('#[\r\n\t ]+#', ' ', file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'debug.css')) ?>
-    </style>
-</head>
-<body>
-
-<div class="container text-center">
-
-    <h1 class="headline"><?= lang('Errors.whoops') ?></h1>
-
-    <p class="lead"><?= lang('Errors.weHitASnag') ?></p>
-
-</div>
-
-</body>
-
-</html>
+// Errors language settings
+return [
+    'whoops'     => 'Whoops!',
+    'weHitASnag' => 'We seem to have hit a snag. Please try again later...',
+];

--- a/system/Language/en/Errors.php
+++ b/system/Language/en/Errors.php
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="robots" content="noindex">
+
+    <title><?= lang('Errors.whoops') ?></title>
+
+    <style type="text/css">
+        <?= preg_replace('#[\r\n\t ]+#', ' ', file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'debug.css')) ?>
+    </style>
+</head>
+<body>
+
+<div class="container text-center">
+
+    <h1 class="headline"><?= lang('Errors.whoops') ?></h1>
+
+    <p class="lead"><?= lang('Errors.weHitASnag') ?></p>
+
+</div>
+
+</body>
+
+</html>


### PR DESCRIPTION
replaces #6197

With this pull request the error message in the file app/Views/errors/html/production.php can be translated.

Translation for error_404.php and error_exception.php will follow with a other PR