### PR TITLE
fix:  custom validation error is cleared when calling setRule() twice

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -399,7 +399,7 @@ class Validation implements ValidationInterface
             $ruleSet[$field]['errors'] = $errors;
         }
 
-        $this->setRules($ruleSet + $this->getRules());
+        $this->setRules($ruleSet + $this->getRules(), $this->customErrors);
 
         return $this;
     }

--- a/tests/system/Validation/StrictRules/ValidationTest.php
+++ b/tests/system/Validation/StrictRules/ValidationTest.php
@@ -221,6 +221,33 @@ final class ValidationTest extends CIUnitTestCase
         $this->assertSame('No. Not a number.', $this->validation->getError('bar'));
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/6239
+     */
+    public function testSetRuleWithCustomErrors(): void
+    {
+        $data = [
+            'foo' => 'notanumber',
+            'bar' => 'notanumber',
+        ];
+        $this->validation->setRule(
+            'foo',
+            'Foo',
+            ['foo'        => 'is_numeric'],
+            ['is_numeric' => 'Nope. Not a number.']
+        );
+        $this->validation->setRule(
+            'bar',
+            'Bar',
+            ['bar'        => 'is_numeric'],
+            ['is_numeric' => 'Nope. Not a number.']
+        );
+        $this->validation->run($data);
+
+        $this->assertSame('Nope. Not a number.', $this->validation->getError('foo'));
+        $this->assertSame('Nope. Not a number.', $this->validation->getError('bar'));
+    }
+
     public function testCheck(): void
     {
         $this->assertFalse($this->validation->check('notanumber', 'is_numeric'));

--- a/tests/system/Validation/StrictRules/ValidationTest.php
+++ b/tests/system/Validation/StrictRules/ValidationTest.php
@@ -202,17 +202,23 @@ final class ValidationTest extends CIUnitTestCase
 
     public function testRunWithCustomErrors(): void
     {
-        $data = ['foo' => 'notanumber'];
-
+        $data = [
+            'foo' => 'notanumber',
+            'bar' => 'notanumber',
+        ];
         $messages = [
             'foo' => [
                 'is_numeric' => 'Nope. Not a number.',
             ],
+            'bar' => [
+                'is_numeric' => 'No. Not a number.',
+            ],
         ];
-
-        $this->validation->setRules(['foo' => 'is_numeric'], $messages);
+        $this->validation->setRules(['foo' => 'is_numeric', 'bar' => 'is_numeric'], $messages);
         $this->validation->run($data);
+
         $this->assertSame('Nope. Not a number.', $this->validation->getError('foo'));
+        $this->assertSame('No. Not a number.', $this->validation->getError('bar'));
     }
 
     public function testCheck(): void

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -324,6 +324,33 @@ final class ValidationTest extends CIUnitTestCase
         $this->assertSame('No. Not a number.', $this->validation->getError('bar'));
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/6239
+     */
+    public function testSetRuleWithCustomErrors(): void
+    {
+        $data = [
+            'foo' => 'notanumber',
+            'bar' => 'notanumber',
+        ];
+        $this->validation->setRule(
+            'foo',
+            'Foo',
+            ['foo'        => 'is_numeric'],
+            ['is_numeric' => 'Nope. Not a number.']
+        );
+        $this->validation->setRule(
+            'bar',
+            'Bar',
+            ['bar'        => 'is_numeric'],
+            ['is_numeric' => 'Nope. Not a number.']
+        );
+        $this->validation->run($data);
+
+        $this->assertSame('Nope. Not a number.', $this->validation->getError('foo'));
+        $this->assertSame('Nope. Not a number.', $this->validation->getError('bar'));
+    }
+
     public function testCheck(): void
     {
         $this->assertFalse($this->validation->check('notanumber', 'is_numeric'));

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -305,17 +305,23 @@ final class ValidationTest extends CIUnitTestCase
 
     public function testRunWithCustomErrors(): void
     {
-        $data = ['foo' => 'notanumber'];
-
+        $data = [
+            'foo' => 'notanumber',
+            'bar' => 'notanumber',
+        ];
         $messages = [
             'foo' => [
                 'is_numeric' => 'Nope. Not a number.',
             ],
+            'bar' => [
+                'is_numeric' => 'No. Not a number.',
+            ],
         ];
-
-        $this->validation->setRules(['foo' => 'is_numeric'], $messages);
+        $this->validation->setRules(['foo' => 'is_numeric', 'bar' => 'is_numeric'], $messages);
         $this->validation->run($data);
+
         $this->assertSame('Nope. Not a number.', $this->validation->getError('foo'));
+        $this->assertSame('No. Not a number.', $this->validation->getError('bar'));
     }
 
     public function testCheck(): void


### PR DESCRIPTION
**Description**
Fixes #6239

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
