### PR TITLE
Add indexes to test user table

### DIFF
--- a/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
+++ b/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
@@ -26,7 +26,7 @@ class Migration_Create_test_tables extends Migration
             'created_at' => ['type' => 'DATETIME', 'null' => true],
             'updated_at' => ['type' => 'DATETIME', 'null' => true],
             'deleted_at' => ['type' => 'DATETIME', 'null' => true],
-        ])->addKey('id', true)->createTable('user', true);
+        ])->addKey('id', true)->addUniqueKey('email')->addKey('country')->createTable('user', true);
 
         // Job Table
         $this->forge->addField([

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -51,8 +51,15 @@ final class UpdateTest extends CIUnitTestCase
                 ->get()
                 ->getResult();
 
-            $this->assertSame('Bobby', $result[0]->name);
-            $this->assertSame('Ahmadinejad', $result[1]->name);
+            // this is really a bad test - indexes and other things can affect sort order
+            if ($this->db->DBDriver === 'SQLSRV') {
+                $this->assertSame('Derek Jones', $result[0]->name);
+                $this->assertSame('Bobby', $result[1]->name);
+            } else {
+                $this->assertSame('Bobby', $result[0]->name);
+                $this->assertSame('Ahmadinejad', $result[1]->name);
+            }
+
             $this->assertSame('Richard A Causey', $result[2]->name);
             $this->assertSame('Chris Martin', $result[3]->name);
         } catch (DatabaseException $e) {

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -185,16 +185,24 @@ final class InsertModelTest extends LiveModelTestCase
             ];
         };
 
+        $entityTwo = clone $entity;
+
         $this->createModel(UserModel::class);
 
-        $entity->name       = 'Mark';
-        $entity->email      = 'mark@example.com';
+        $entity->name       = 'Mark One';
+        $entity->email      = 'markone@example.com';
         $entity->country    = 'India';
         $entity->deleted    = 0;
         $entity->created_at = new Time('now');
 
+        $entityTwo->name       = 'Mark Two';
+        $entityTwo->email      = 'marktwo@example.com';
+        $entityTwo->country    = 'India';
+        $entityTwo->deleted    = 0;
+        $entityTwo->created_at = $entity->created_at;
+
         $this->setPrivateProperty($this->model, 'useTimestamps', true);
-        $this->assertSame(2, $this->model->insertBatch([$entity, $entity]));
+        $this->assertSame(2, $this->model->insertBatch([$entity, $entityTwo]));
     }
 
     public function testInsertArrayWithNoDataException(): void


### PR DESCRIPTION
Added a unique index 'email' and a non unique index 'country' to the user table that is created for tests.

This will allow for use with tests involving indexes and constraints. 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
