### PR TITLE
fix: do not use ValidationInterface

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -20,7 +20,6 @@ use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Pager\Pager;
 use CodeIgniter\Validation\Validation;
-use CodeIgniter\Validation\ValidationInterface;
 use Config\Services;
 use InvalidArgumentException;
 use ReflectionClass;
@@ -319,7 +318,7 @@ abstract class BaseModel
      */
     protected bool $allowEmptyInserts = false;
 
-    public function __construct(?ValidationInterface $validation = null)
+    public function __construct(?Validation $validation = null)
     {
         $this->tempReturnType     = $this->returnType;
         $this->tempUseSoftDeletes = $this->useSoftDeletes;

--- a/system/Model.php
+++ b/system/Model.php
@@ -22,7 +22,7 @@ use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Database\Query;
 use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\I18n\Time;
-use CodeIgniter\Validation\ValidationInterface;
+use CodeIgniter\Validation\Validation;
 use Config\Database;
 use ReflectionClass;
 use ReflectionException;
@@ -128,7 +128,7 @@ class Model extends BaseModel
         'getCompiledUpdate',
     ];
 
-    public function __construct(?ConnectionInterface $db = null, ?ValidationInterface $validation = null)
+    public function __construct(?ConnectionInterface $db = null, ?Validation $validation = null)
     {
         /**
          * @var BaseConnection|null $db

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -22,7 +22,7 @@ use TypeError;
 /**
  * Validator
  */
-class Validation implements ValidationInterface
+class Validation
 {
     /**
      * Files to load with validation functions.
@@ -344,8 +344,10 @@ class Validation implements ValidationInterface
     /**
      * Takes a Request object and grabs the input data to use from its
      * array values.
+     *
+     * @return $this
      */
-    public function withRequest(RequestInterface $request): ValidationInterface
+    public function withRequest(RequestInterface $request)
     {
         /** @var IncomingRequest $request */
         if (strpos($request->getHeaderLine('Content-Type'), 'application/json') !== false) {
@@ -421,8 +423,10 @@ class Validation implements ValidationInterface
      *    ]
      *
      * @param array $errors // An array of custom error messages
+     *
+     * @return $this
      */
-    public function setRules(array $rules, array $errors = []): ValidationInterface
+    public function setRules(array $rules, array $errors = [])
     {
         $this->customErrors = $errors;
 
@@ -691,8 +695,10 @@ class Validation implements ValidationInterface
 
     /**
      * Sets the error for a specific field. Used by custom validation methods.
+     *
+     * @return $this
      */
-    public function setError(string $field, string $error): ValidationInterface
+    public function setError(string $field, string $error)
     {
         $this->errors[$field] = $error;
 
@@ -772,8 +778,10 @@ class Validation implements ValidationInterface
     /**
      * Resets the class to a blank slate. Should be called whenever
      * you need to process more than one array.
+     *
+     * @return $this
      */
-    public function reset(): ValidationInterface
+    public function reset()
     {
         $this->data         = [];
         $this->rules        = [];


### PR DESCRIPTION
**Description**
Fixes #6224

`BaseModel` uses the 3rd param of `$this->validation->run($data, null, $this->DBGroup)`.
So it depends on `Validation`, not `ValidationInterface`.

Ref: https://github.com/codeigniter4/CodeIgniter4/pull/5909#issuecomment-1179518692

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

