### PR TITLE
Fix create table if not exists when indexes already exist

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -337,7 +337,7 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property CodeIgniter\\\\Database\\\\BaseConnection\\:\\:\\$schema\\.$#"
-			count: 14
+			count: 13
 			path: system/Database/SQLSRV/Forge.php
 
 		-

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -540,8 +540,6 @@ class Forge
      */
     protected function _createTable(string $table, bool $ifNotExists, array $attributes)
     {
-        $sql = 'CREATE TABLE';
-
         $columns = $this->_processFields(true);
 
         for ($i = 0, $c = count($columns); $i < $c; $i++) {
@@ -563,7 +561,7 @@ class Forge
 
         return sprintf(
             $this->createTableStr . '%s',
-            $sql,
+            'CREATE TABLE',
             $this->db->escapeIdentifiers($table),
             $columns,
             $this->_createTableAttributes($attributes)

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -107,9 +107,7 @@ class Forge
     protected $createTableStr = "%s %s (%s\n)";
 
     /**
-     * CREATE TABLE IF statement
-     *
-     * @var bool|string
+     * @deprecated This is no longer used.
      */
     protected $createTableIfStr = 'CREATE TABLE IF NOT EXISTS';
 
@@ -495,7 +493,14 @@ class Forge
             throw new RuntimeException('Field information is required.');
         }
 
-        $sql = $this->_createTable($table, $ifNotExists, $attributes);
+        // If table exists lets stop here
+        if ($ifNotExists === true && $this->db->tableExists($table)) {
+            $this->reset();
+
+            return true;
+        }
+
+        $sql = $this->_createTable($table, false, $attributes);
 
         if (is_bool($sql)) {
             $this->reset();
@@ -530,20 +535,12 @@ class Forge
 
     /**
      * @return bool|string
+     *
+     * @deprecated $ifNotExists is no longer used, and will be removed.
      */
     protected function _createTable(string $table, bool $ifNotExists, array $attributes)
     {
-        // For any platforms that don't support Create If Not Exists...
-        if ($ifNotExists === true && $this->createTableIfStr === false) {
-            if ($this->db->tableExists($table)) {
-                return true;
-            }
-
-            $ifNotExists = false;
-        }
-
-        $sql = ($ifNotExists) ? sprintf($this->createTableIfStr, $this->db->escapeIdentifiers($table))
-            : 'CREATE TABLE';
+        $sql = 'CREATE TABLE';
 
         $columns = $this->_processFields(true);
 

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -107,6 +107,10 @@ class Forge
     protected $createTableStr = "%s %s (%s\n)";
 
     /**
+     * CREATE TABLE IF statement
+     *
+     * @var bool|string
+     *
      * @deprecated This is no longer used.
      */
     protected $createTableIfStr = 'CREATE TABLE IF NOT EXISTS';

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -506,19 +506,6 @@ class Forge
 
         $sql = $this->_createTable($table, false, $attributes);
 
-        if (is_bool($sql)) {
-            $this->reset();
-            if ($sql === false) {
-                if ($this->db->DBDebug) {
-                    throw new DatabaseException('This feature is not available for the database you are using.');
-                }
-
-                return false;
-            }
-
-            return true;
-        }
-
         if (($result = $this->db->query($sql)) !== false) {
             if (isset($this->db->dataCache['table_names']) && ! in_array($table, $this->db->dataCache['table_names'], true)) {
                 $this->db->dataCache['table_names'][] = $table;
@@ -538,7 +525,7 @@ class Forge
     }
 
     /**
-     * @return bool|string
+     * @return string
      *
      * @deprecated $ifNotExists is no longer used, and will be removed.
      */

--- a/system/Database/OCI8/Forge.php
+++ b/system/Database/OCI8/Forge.php
@@ -33,14 +33,14 @@ class Forge extends BaseForge
     protected $createDatabaseStr = false;
 
     /**
-     * CREATE TABLE IF statement
-     *
-     * @var false
+     * @deprecated This is no longer used.
      */
     protected $createTableIfStr = false;
 
     /**
-     * @deprecated This is no longer used.
+     * DROP TABLE IF EXISTS statement
+     *
+     * @var false
      */
     protected $dropTableIfStr = false;
 

--- a/system/Database/OCI8/Forge.php
+++ b/system/Database/OCI8/Forge.php
@@ -40,9 +40,7 @@ class Forge extends BaseForge
     protected $createTableIfStr = false;
 
     /**
-     * DROP TABLE IF EXISTS statement
-     *
-     * @var false
+     * @deprecated This is no longer used.
      */
     protected $dropTableIfStr = false;
 

--- a/system/Database/OCI8/Forge.php
+++ b/system/Database/OCI8/Forge.php
@@ -33,6 +33,10 @@ class Forge extends BaseForge
     protected $createDatabaseStr = false;
 
     /**
+     * CREATE TABLE IF statement
+     *
+     * @var false
+     *
      * @deprecated This is no longer used.
      */
     protected $createTableIfStr = false;

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -84,6 +84,10 @@ class Forge extends BaseForge
     ];
 
     /**
+     * CREATE TABLE IF statement
+     *
+     * @var string
+     *
      * @deprecated This is no longer used.
      */
     protected $createTableIfStr;

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -91,23 +91,13 @@ class Forge extends BaseForge
     protected $createTableIfStr;
 
     /**
-     * CREATE TABLE statement
-     *
-     * @var string
+     * @deprecated This is no longer used.
      */
     protected $createTableStr;
 
     public function __construct(BaseConnection $db)
     {
         parent::__construct($db);
-
-        $this->createTableIfStr = 'IF NOT EXISTS'
-            . '(SELECT t.name, s.name as schema_name, t.type_desc '
-            . 'FROM sys.tables t '
-            . 'INNER JOIN sys.schemas s on s.schema_id = t.schema_id '
-            . "WHERE s.name=N'" . $this->db->schema . "' "
-            . "AND t.name=REPLACE(N'%s', '\"', '') "
-            . "AND t.type_desc='USER_TABLE')\nCREATE TABLE ";
 
         $this->createTableStr = '%s ' . $this->db->escapeIdentifiers($this->db->schema) . ".%s (%s\n) ";
         $this->renameTableStr = 'EXEC sp_rename [' . $this->db->escapeIdentifiers($this->db->schema) . '.%s] , %s ;';

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -84,14 +84,14 @@ class Forge extends BaseForge
     ];
 
     /**
-     * CREATE TABLE IF statement
-     *
-     * @var string
+     * @deprecated This is no longer used.
      */
     protected $createTableIfStr;
 
     /**
-     * @deprecated This is no longer used.
+     * CREATE TABLE statement
+     *
+     * @var string
      */
     protected $createTableStr;
 

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -56,8 +56,7 @@ class Forge extends BaseForge
         parent::__construct($db);
 
         if (version_compare($this->db->getVersion(), '3.3', '<')) {
-            $this->createTableIfStr = false;
-            $this->dropTableIfStr   = false;
+            $this->dropTableIfStr = false;
         }
     }
 

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -191,8 +191,7 @@ with
 
 .. literalinclude:: forge/014.php
 
-An optional second parameter set to true will only execute create table statement if
-the table name is not in the array of know tables
+An optional second parameter set to true will create the table only if it doesn't already exist.
 
 .. literalinclude:: forge/015.php
 

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -191,8 +191,8 @@ with
 
 .. literalinclude:: forge/014.php
 
-An optional second parameter set to true adds an ``IF NOT EXISTS`` clause
-into the definition
+An optional second parameter set to true will only execute create table statement if
+the table name is not in the array of know tables
 
 .. literalinclude:: forge/015.php
 

--- a/user_guide_src/source/dbmgmt/forge/015.php
+++ b/user_guide_src/source/dbmgmt/forge/015.php
@@ -1,4 +1,4 @@
 <?php
 
 $forge->createTable('table_name', true);
-// gives CREATE TABLE IF NOT EXISTS table_name
+// creates table only if table does not exist

--- a/user_guide_src/source/installation/upgrade_422.rst
+++ b/user_guide_src/source/installation/upgrade_422.rst
@@ -1,0 +1,50 @@
+#############################
+Upgrading from 4.2.1 to 4.2.2
+#############################
+
+Please refer to the upgrade instructions corresponding to your installation method.
+
+- :ref:`Composer Installation App Starter Upgrading <app-starter-upgrading>`
+- :ref:`Composer Installation Adding CodeIgniter4 to an Existing Project Upgrading <adding-codeigniter4-upgrading>`
+- :ref:`Manual Installation Upgrading <installing-manual-upgrading>`
+
+.. contents::
+    :local:
+    :depth: 2
+
+Mandatory File Changes
+**********************
+
+
+Breaking Changes
+****************
+
+- The method ``Forge::createTable()`` no longer executes a ``CREATE TABLE IF NOT EXISTS``. If table is not found in ``$db->tableExists($table)`` then ``CREATE TABLE`` is executed.
+- The method signature of ``Forge::_createTable()`` is deprecated. The ``bool``  ``$ifNotExists`` is no longer used and will be removed in a future release.
+
+Breaking Enhancements
+*********************
+
+
+Project Files
+*************
+
+Numerous files in the **project space** (root, app, public, writable) received updates. Due to
+these files being outside of the **system** scope they will not be changed without your intervention.
+There are some third-party CodeIgniter modules available to assist with merging changes to
+the project space: `Explore on Packagist <https://packagist.org/explore/?query=codeigniter4%20updates>`_.
+
+.. note:: Except in very rare cases for bug fixes, no changes made to files for the project space
+    will break your application. All changes noted here are optional until the next major version,
+    and any mandatory changes will be covered in the sections above.
+
+Content Changes
+===============
+
+
+All Changes
+===========
+
+This is a list of all files in the **project space** that received changes;
+many will be simple comments or formatting that have no effect on the runtime:
+

--- a/user_guide_src/source/installation/upgrade_422.rst
+++ b/user_guide_src/source/installation/upgrade_422.rst
@@ -20,7 +20,7 @@ Breaking Changes
 ****************
 
 - The method ``Forge::createTable()`` no longer executes a ``CREATE TABLE IF NOT EXISTS``. If table is not found in ``$db->tableExists($table)`` then ``CREATE TABLE`` is executed.
-- The method signature of ``Forge::_createTable()`` is deprecated. The ``bool``  ``$ifNotExists`` is no longer used and will be removed in a future release.
+- The second parameter ``$ifNotExists`` of ``Forge::_createTable()`` is deprecated. It is no longer used and will be removed in a future release.
 
 Breaking Enhancements
 *********************


### PR DESCRIPTION
This fixes https://github.com/codeigniter4/CodeIgniter4/issues/6248

This removes all code for CREATE TABLE table `IF NOT EXISTS`. Because all platforms do not support this statement the current implementation queries  the database first to determine if the table exists. If it does then it doesn't execute the create table statement. The problem occurs when the create indexes statements are executed after the create table statement and the indexes already exists. Rather then try and apply CREATE INDEX index IF NOT EXISTS and carry through the logic, this PR removes completely the IF NOT EXISTS regime and instead relies on the query table lookup. If the table exists then there is need to execute anything. This way the code is simpler and all the problems of index creation is averted. 

All the magic happens in (base) Forge here:

```php
    public function createTable(string $table, bool $ifNotExists = false, array $attributes = [])
    {
        if ($table === '') {
            throw new InvalidArgumentException('A table name is required for that operation.');
        }

        $table = $this->db->DBPrefix . $table;

        if ($this->fields === []) {
            throw new RuntimeException('Field information is required.');
        }

        // If table exists lets stop here
        if ($ifNotExists === true && $this->db->tableExists($table)) {
            $this->reset();

            return true;
        }

        $sql = $this->_createTable($table, $attributes);
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
