### PR TITLE
fix: Call to undefined method CodeIgniter\Pager\PagerRenderer::getDetails()

### DIFF
--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -122,7 +122,8 @@ class Pager implements PagerInterface
 
         $pager = new PagerRenderer($this->getDetails($group));
 
-        return $this->view->setVar('pager', $pager)->render($this->config->templates[$template]);
+        return $this->view->setVar('pager', $pager)
+            ->render($this->config->templates[$template], null, false);
     }
 
     /**


### PR DESCRIPTION
**Description**
Fixes #6230

The `$pager` (PagerRenderer) in the rendering of the pager overrides the variable `$pager` (Pager) in the view.

How to Test: https://github.com/codeigniter4/CodeIgniter4/issues/6230#issuecomment-1174641005

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

