### PR TITLE
fix: use getenv() instead of $_SERVER in detectEnvironment()

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -528,7 +528,7 @@ class CodeIgniter
     {
         // Make sure ENVIRONMENT isn't already set by other means.
         if (! defined('ENVIRONMENT')) {
-            define('ENVIRONMENT', getenv('CI_ENVIRONMENT') ?? 'production');
+            define('ENVIRONMENT', env('CI_ENVIRONMENT', 'production'));
         }
     }
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -528,7 +528,7 @@ class CodeIgniter
     {
         // Make sure ENVIRONMENT isn't already set by other means.
         if (! defined('ENVIRONMENT')) {
-            define('ENVIRONMENT', $_SERVER['CI_ENVIRONMENT'] ?? 'production');
+            define('ENVIRONMENT', getenv('CI_ENVIRONMENT') ?? 'production');
         }
     }
 


### PR DESCRIPTION
**Description**
Update CodeIgniter.php to use getenv() instead of $_SERVER in detectEnvironment. The outcome of environment variables loading in either  $_SERVER or $_ENV depends on the operating system and web server. For instance, in a Docker environment the `.env` file loads variables in $_ENV, resulting in detectEnvironment() not seeing CI_ENVIRONMENT when defined. Using getenv() instead of directly reading from $_SERVER solves this issue.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

