### PR TITLE
fix: add parameter checking for max_size

### DIFF
--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Validation;
 use CodeIgniter\HTTP\RequestInterface;
 use Config\Mimes;
 use Config\Services;
+use InvalidArgumentException;
 
 /**
  * File validation rules
@@ -79,8 +80,11 @@ class FileRules
     {
         // Grab the file name off the top of the $params
         // after we split it.
-        $params = explode(',', $params);
-        $name   = array_shift($params);
+        $paramArray = explode(',', $params);
+        if (count($paramArray) !== 2) {
+            throw new InvalidArgumentException('Invalid max_size parameter: "' . $params . '"');
+        }
+        $name = array_shift($paramArray);
 
         if (! ($files = $this->request->getFileMultiple($name))) {
             $files = [$this->request->getFile($name)];
@@ -99,7 +103,7 @@ class FileRules
                 return false;
             }
 
-            if ($file->getSize() / 1024 > $params[0]) {
+            if ($file->getSize() / 1024 > $paramArray[0]) {
                 return false;
             }
         }

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Validation;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;
+use InvalidArgumentException;
 use Tests\Support\Validation\TestRules;
 
 /**
@@ -196,6 +197,15 @@ final class FileRulesTest extends CIUnitTestCase
     {
         $this->validation->setRules(['avatar' => 'max_size[userfile,50]']);
         $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testMaxSizeInvalidParam(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid max_size parameter: "avatar.100"');
+
+        $this->validation->setRules(['avatar' => 'max_size[avatar.100]']);
+        $this->validation->run([]);
     }
 
     public function testMaxDims(): void

--- a/tests/system/Validation/StrictRules/FileRulesTest.php
+++ b/tests/system/Validation/StrictRules/FileRulesTest.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Validation\StrictRules;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Validation;
 use Config\Services;
+use InvalidArgumentException;
 use Tests\Support\Validation\TestRules;
 
 /**
@@ -197,6 +198,15 @@ final class FileRulesTest extends CIUnitTestCase
     {
         $this->validation->setRules(['avatar' => 'max_size[userfile,50]']);
         $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testMaxSizeInvalidParam(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid max_size parameter: "avatar.100"');
+
+        $this->validation->setRules(['avatar' => 'max_size[avatar.100]']);
+        $this->validation->run([]);
     }
 
     public function testMaxDims(): void


### PR DESCRIPTION
**Description**
Fixes  #6255

- add parameter checking

Before:
> ErrorException: array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead from SYSTEMPATH\HTTP\Files\FileCollection.php

After:
> InvalidArgumentException: Invalid max_size parameter: "userfile.100"

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

