### PR TITLE
fix: format_number() can't be used on CLI

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -35,6 +35,7 @@ use Exception;
 use Kint;
 use Kint\Renderer\CliRenderer;
 use Kint\Renderer\RichRenderer;
+use Locale;
 use LogicException;
 
 /**
@@ -190,7 +191,7 @@ class CodeIgniter
         }
 
         // Set default locale on the server
-        locale_set_default($this->config->defaultLocale ?? 'en');
+        Locale::setDefault($this->config->defaultLocale ?? 'en');
 
         // Set default timezone on the server
         date_default_timezone_set($this->config->appTimezone ?? 'UTC');

--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -127,7 +127,7 @@ if (! function_exists('format_number')) {
      */
     function format_number(float $num, int $precision = 1, ?string $locale = null, array $options = []): string
     {
-        // If locate is not passed, get from the default locale that is set from our config file
+        // If locale is not passed, get from the default locale that is set from our config file
         // or set by HTTP content negotiation.
         $locale ??= Locale::getDefault();
 

--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -9,8 +9,6 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-use Config\Services;
-
 // CodeIgniter Number Helpers
 
 if (! function_exists('number_to_size')) {
@@ -129,8 +127,9 @@ if (! function_exists('format_number')) {
      */
     function format_number(float $num, int $precision = 1, ?string $locale = null, array $options = []): string
     {
-        // Locale is either passed in here, negotiated with client, or grabbed from our config file.
-        $locale ??= Services::request()->getLocale();
+        // If locate is not passed, get from the default locale that is set from our config file
+        // or set by HTTP content negotiation.
+        $locale ??= Locale::getDefault();
 
         // Type can be any of the NumberFormatter options, but provide a default.
         $type = (int) ($options['type'] ?? NumberFormatter::DECIMAL);


### PR DESCRIPTION
**Description**
`format_number()` depends on `IncommingRequest::getLocale()`, and causes Error `Call to undefined method CodeIgniter\HTTP\CLIRequest::getLocale()`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

