### PR TITLE
fix: `spark routes` does not show routes at all

### DIFF
--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -75,7 +75,10 @@ class Routes extends BaseCommand
      */
     public function run(array $params)
     {
-        $collection = Services::routes(true);
+        $routes = Services::routes(true);
+        require APPPATH . 'Config/Routes.php';
+
+        $collection = $routes;
         $methods    = [
             'get',
             'head',


### PR DESCRIPTION
**Description**
Follow-up #6110

- add loading of `Conig/Routes.php`

Before:
```
+--------+-------+---------+----------------+---------------+
| Method | Route | Handler | Before Filters | After Filters |
+--------+-------+---------+----------------+---------------+
```

After:
```
+--------+-------+------------------------------+----------------+---------------+
| Method | Route | Handler                      | Before Filters | After Filters |
+--------+-------+------------------------------+----------------+---------------+
| GET    | /     | \App\Controllers\Home::index |                | toolbar       |
+--------+-------+------------------------------+----------------+---------------+
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

