### PR TITLE
fix: `spark routes` shows 404 error when using regex

### DIFF
--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -18,6 +18,7 @@ use CodeIgniter\Commands\Utilities\Routes\AutoRouteCollector;
 use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\AutoRouteCollector as AutoRouteCollectorImproved;
 use CodeIgniter\Commands\Utilities\Routes\FilterCollector;
 use CodeIgniter\Commands\Utilities\Routes\SampleURIGenerator;
+use CodeIgniter\Exceptions\PageNotFoundException;
 use Config\Services;
 
 /**
@@ -99,7 +100,15 @@ class Routes extends BaseCommand
             foreach ($routes as $route => $handler) {
                 if (is_string($handler) || $handler instanceof Closure) {
                     $sampleUri = $uriGenerator->get($route);
-                    $filters   = $filterCollector->get($method, $sampleUri);
+
+                    try {
+                        $filters = $filterCollector->get($method, $sampleUri);
+                    } catch (PageNotFoundException $e) {
+                        $filters = [
+                            'before' => ['<unknown>'],
+                            'after'  => ['<unknown>'],
+                        ];
+                    }
 
                     $tbody[] = [
                         strtoupper($method),

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -18,7 +18,6 @@ use CodeIgniter\Commands\Utilities\Routes\AutoRouteCollector;
 use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\AutoRouteCollector as AutoRouteCollectorImproved;
 use CodeIgniter\Commands\Utilities\Routes\FilterCollector;
 use CodeIgniter\Commands\Utilities\Routes\SampleURIGenerator;
-use CodeIgniter\Exceptions\PageNotFoundException;
 use Config\Services;
 
 /**
@@ -100,15 +99,7 @@ class Routes extends BaseCommand
             foreach ($routes as $route => $handler) {
                 if (is_string($handler) || $handler instanceof Closure) {
                     $sampleUri = $uriGenerator->get($route);
-
-                    try {
-                        $filters = $filterCollector->get($method, $sampleUri);
-                    } catch (PageNotFoundException $e) {
-                        $filters = [
-                            'before' => ['<unknown>'],
-                            'after'  => ['<unknown>'],
-                        ];
-                    }
+                    $filters   = $filterCollector->get($method, $sampleUri);
 
                     $tbody[] = [
                         strtoupper($method),

--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
+use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Filters\Filters;
 use CodeIgniter\Router\Exceptions\RedirectException;
 use CodeIgniter\Router\Router;
@@ -66,6 +67,11 @@ final class FilterFinder
             return [
                 'before' => [],
                 'after'  => [],
+            ];
+        } catch (PageNotFoundException $e) {
+            return [
+                'before' => ['<unknown>'],
+                'after'  => ['<unknown>'],
             ];
         }
     }


### PR DESCRIPTION
**Description**
Fixes #6276

**How to Test**
```php
$routes->get('detail/([a-z0-9]{40})', 'User::detail/$1');
```

Before:
```console
ERROR: 404
Can't find a route for 'get: detail/([a-z0-9]{40})'.
```

After:
```console
+--------+-----------------------+------------------------------------------+----------------+---------------+
| Method | Route                 | Handler                                  | Before Filters | After Filters |
+--------+-----------------------+------------------------------------------+----------------+---------------+
| GET    | /                     | \App\Controllers\Home::index             |                | toolbar       |
| GET    | detail/([a-z0-9]{40}) | \App\Controllers\User::detail/$1         | <unknown>      | <unknown>     |
| CLI    | ci(.*)                | \CodeIgniter\CLI\CommandRunner::index/$1 |                |               |
+--------+-----------------------+------------------------------------------+----------------+---------------+
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

