### PR TITLE
fix:  page cache saves Response data before running after filters

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -21,7 +21,6 @@ use CodeIgniter\HTTP\DownloadResponse;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Request;
-use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Router\Exceptions\RedirectException;
@@ -298,10 +297,9 @@ class CodeIgniter
      * tries to route the response, loads the controller and generally
      * makes all of the pieces work together.
      *
-     * @throws Exception
      * @throws RedirectException
      *
-     * @return bool|mixed|RequestInterface|ResponseInterface|void
+     * @return ResponseInterface|void
      */
     public function run(?RouteCollectionInterface $routes = null, bool $returnResponse = false)
     {
@@ -409,7 +407,7 @@ class CodeIgniter
      * @throws PageNotFoundException
      * @throws RedirectException
      *
-     * @return mixed|RequestInterface|ResponseInterface
+     * @return ResponseInterface
      */
     protected function handleRequest(?RouteCollectionInterface $routes, Cache $cacheConfig, bool $returnResponse = false)
     {
@@ -641,7 +639,7 @@ class CodeIgniter
      *
      * @throws Exception
      *
-     * @return bool|ResponseInterface
+     * @return false|ResponseInterface
      */
     public function displayCache(Cache $config)
     {
@@ -1069,6 +1067,8 @@ class CodeIgniter
     /**
      * Sends the output of this request back to the client.
      * This is what they've been waiting for!
+     *
+     * @return void
      */
     protected function sendResponse()
     {

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -54,7 +54,7 @@ class CodeIgniter
     /**
      * App startup time.
      *
-     * @var mixed
+     * @var float|null
      */
     protected $startTime;
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -319,7 +319,9 @@ class CodeIgniter
         if ($this->request instanceof IncomingRequest && strtolower($this->request->getMethod()) === 'cli') {
             $this->response->setStatusCode(405)->setBody('Method Not Allowed');
 
-            return $this->sendResponse();
+            $this->sendResponse();
+
+            return;
         }
 
         Events::trigger('pre_system');

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -307,6 +307,8 @@ class CodeIgniter
             throw new LogicException('Context must be set before run() is called. If you are upgrading from 4.1.x, you need to merge `public/index.php` and `spark` file from `vendor/codeigniter4/framework`.');
         }
 
+        static::$cacheTTL = 0;
+
         $this->startBenchmark();
 
         $this->getRequestObject();

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -247,6 +247,8 @@ class DownloadResponse extends Response
     /**
      * {@inheritDoc}
      *
+     * @return $this
+     *
      * @todo Do downloads need CSP or Cookies? Compare with ResponseTrait::send()
      */
     public function send()

--- a/user_guide_src/source/changelogs/v4.2.2.rst
+++ b/user_guide_src/source/changelogs/v4.2.2.rst
@@ -15,6 +15,7 @@ BREAKING
 - Now ``Services::request()`` returns ``IncomingRequest`` or ``CLIRequest``.
 - The method signature of ``CodeIgniter\Debug\Exceptions::__construct()`` has been changed. The ``IncomingRequest`` typehint on the ``$request`` parameter was removed. Extending classes should likewise remove the parameter so as not to break LSP.
 - The method signature of ``BaseBuilder.php::insert()`` and ``BaseBuilder.php::update()`` have been changed. The ``?array`` typehint on the ``$set`` parameter was removed.
+- A bug that caused pages to be cached before after filters were executed when using page caching has been fixed. Adding response headers or changing the response body in after filters now caches them correctly.
 
 Enhancements
 ************
@@ -33,6 +34,7 @@ Deprecations
 ************
 
 - The parameters of ``Services::request()`` are deprecated.
+- The first parameter ``$cacheConfig`` of ``CodeIgniter::gatherOutput()`` is deprecated.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -50,6 +50,8 @@ If a ``Response`` instance is returned, the Response will be sent back to the cl
 This can be useful for implementing rate limiting for APIs. See :doc:`Throttler </libraries/throttler>` for an
 example.
 
+.. _after-filters:
+
 After Filters
 =============
 
@@ -168,6 +170,8 @@ This filter prohibits user input data (``$_GET``, ``$_POST``, ``$_COOKIE``, ``ph
 
 - invalid UTF-8 characters
 - control characters except line break and tab code
+
+.. _secureheaders:
 
 SecureHeaders
 =============

--- a/user_guide_src/source/installation/upgrade_422.rst
+++ b/user_guide_src/source/installation/upgrade_422.rst
@@ -19,6 +19,17 @@ Mandatory File Changes
 Breaking Changes
 ****************
 
+Web Page Caching Bug Fix
+========================
+
+- :doc:`../general/caching` now caches the Response data after :ref:`after-filters` are executed.
+- For example, if you enables :ref:`secureheaders`, the Response headers are now sent when the page comes from the cache.
+
+.. important:: If you have written **code based on the bug** that changes to the Response in the after filters are not cached, **sensitive information could be cached and compromised**. If this is the case, change your code to disable caching of the page.
+
+Others
+======
+
 - The method ``Forge::createTable()`` no longer executes a ``CREATE TABLE IF NOT EXISTS``. If table is not found in ``$db->tableExists($table)`` then ``CREATE TABLE`` is executed.
 - The second parameter ``$ifNotExists`` of ``Forge::_createTable()`` is deprecated. It is no longer used and will be removed in a future release.
 

--- a/user_guide_src/source/installation/upgrade_422.rst
+++ b/user_guide_src/source/installation/upgrade_422.rst
@@ -23,7 +23,7 @@ Web Page Caching Bug Fix
 ========================
 
 - :doc:`../general/caching` now caches the Response data after :ref:`after-filters` are executed.
-- For example, if you enables :ref:`secureheaders`, the Response headers are now sent when the page comes from the cache.
+- For example, if you enable :ref:`secureheaders`, the Response headers are now sent when the page comes from the cache.
 
 .. important:: If you have written **code based on the bug** that changes to the Response in the after filters are not cached, **sensitive information could be cached and compromised**. If this is the case, change your code to disable caching of the page.
 

--- a/user_guide_src/source/installation/upgrade_422.rst
+++ b/user_guide_src/source/installation/upgrade_422.rst
@@ -25,7 +25,7 @@ Web Page Caching Bug Fix
 - :doc:`../general/caching` now caches the Response data after :ref:`after-filters` are executed.
 - For example, if you enable :ref:`secureheaders`, the Response headers are now sent when the page comes from the cache.
 
-.. important:: If you have written **code based on the bug** that changes to the Response in the after filters are not cached, **sensitive information could be cached and compromised**. If this is the case, change your code to disable caching of the page.
+.. important:: If you have written **code based on this bug** that assumes changes to the Response in "after" filters are not cached then **sensitive information could be cached and compromised**. If this is the case, change your code to disable caching of the page.
 
 Others
 ======

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -12,6 +12,7 @@ upgrading from.
 .. toctree::
     :titlesonly:
 
+    upgrade_422
     upgrade_421
     upgrade_420
     upgrade_418


### PR DESCRIPTION
**Description**
Fixes #6281

The page cache saves Response data before running after filters.
So response headers added by after filters and response body changes by after filters will be lost.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
