### PR TITLE
feat: `spark filter:check` command

### DIFF
--- a/system/Commands/Utilities/FilterCheck.php
+++ b/system/Commands/Utilities/FilterCheck.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\Commands\Utilities\Routes\FilterCollector;
+use Config\Services;
+
+/**
+ * Check filters for a route.
+ */
+class FilterCheck extends BaseCommand
+{
+    /**
+     * The group the command is lumped under
+     * when listing commands.
+     *
+     * @var string
+     */
+    protected $group = 'CodeIgniter';
+
+    /**
+     * The Command's name
+     *
+     * @var string
+     */
+    protected $name = 'filter:check';
+
+    /**
+     * the Command's short description
+     *
+     * @var string
+     */
+    protected $description = 'Check filters for a route.';
+
+    /**
+     * the Command's usage
+     *
+     * @var string
+     */
+    protected $usage = 'filter:check <HTTP method> <route>';
+
+    /**
+     * the Command's Arguments
+     *
+     * @var array<string, string>
+     */
+    protected $arguments = [
+        'method' => 'The HTTP method. get, post, put, etc.',
+        'route'  => 'The route (URI path) to check filtes.',
+    ];
+
+    /**
+     * the Command's Options
+     *
+     * @var array
+     */
+    protected $options = [];
+
+    /**
+     * @return int exit code
+     */
+    public function run(array $params)
+    {
+        if (count($params) !== 2) {
+            CLI::error('You must specify a HTTP verb and a route.', 'light_gray', 'red');
+            CLI::write('  Usage: ' . $this->usage);
+            CLI::write('Example: filter:check get /');
+            CLI::write('         filter:check put products/1');
+
+            return EXIT_ERROR;
+        }
+
+        $method = strtolower($params[0]);
+        $route  = $params[1];
+
+        // Load Routes
+        $routes = Services::routes();
+        require APPPATH . 'Config/Routes.php';
+        $routes->getRoutes('*'); // Triggers discovery
+
+        $filterCollector = new FilterCollector();
+
+        $filters = $filterCollector->get($method, $route);
+
+        // PageNotFoundException
+        if ($filters['before'] === ['<unknown>']) {
+            CLI::error(
+                "Can't find a route: " .
+                CLI::color(
+                    '"' . strtoupper($method) . ' ' . $route . '"',
+                    'black'
+                ),
+            );
+
+            return EXIT_ERROR;
+        }
+
+        $tbody[] = [
+            strtoupper($method),
+            $route,
+            implode(' ', $filters['before']),
+            implode(' ', $filters['after']),
+        ];
+
+        $thead = [
+            'Method',
+            'Route',
+            'Before Filters',
+            'After Filters',
+        ];
+
+        CLI::table($tbody, $thead);
+
+        return EXIT_SUCCESS;
+    }
+}

--- a/system/Commands/Utilities/FilterCheck.php
+++ b/system/Commands/Utilities/FilterCheck.php
@@ -72,7 +72,7 @@ class FilterCheck extends BaseCommand
      */
     public function run(array $params)
     {
-        if (count($params) !== 2) {
+        if (! isset($params[0], $params[1])) {
             CLI::error('You must specify a HTTP verb and a route.', 'light_gray', 'red');
             CLI::write('  Usage: ' . $this->usage);
             CLI::write('Example: filter:check get /');

--- a/system/Commands/Utilities/FilterCheck.php
+++ b/system/Commands/Utilities/FilterCheck.php
@@ -73,7 +73,7 @@ class FilterCheck extends BaseCommand
     public function run(array $params)
     {
         if (! isset($params[0], $params[1])) {
-            CLI::error('You must specify a HTTP verb and a route.', 'light_gray', 'red');
+            CLI::error('You must specify a HTTP verb and a route.');
             CLI::write('  Usage: ' . $this->usage);
             CLI::write('Example: filter:check get /');
             CLI::write('         filter:check put products/1');
@@ -99,7 +99,8 @@ class FilterCheck extends BaseCommand
                 "Can't find a route: " .
                 CLI::color(
                     '"' . strtoupper($method) . ' ' . $route . '"',
-                    'black'
+                    'black',
+                    'light_gray'
                 ),
             );
 

--- a/tests/system/Commands/FilterCheckTest.php
+++ b/tests/system/Commands/FilterCheckTest.php
@@ -54,7 +54,11 @@ final class FilterCheckTest extends CIUnitTestCase
 
         $this->assertStringContainsString(
             'Can\'t find a route: "PUT product/123"',
-            str_replace(["\033[0m", "\033[0;31m", "\033[0;30m"], '', $this->getBuffer())
+            str_replace(
+                ["\033[0m", "\033[1;31m", "\033[0;30m", "\033[47m"],
+                '',
+                $this->getBuffer()
+            )
         );
     }
 }

--- a/tests/system/Commands/FilterCheckTest.php
+++ b/tests/system/Commands/FilterCheckTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\StreamFilterTrait;
+
+/**
+ * @internal
+ */
+final class FilterCheckTest extends CIUnitTestCase
+{
+    use StreamFilterTrait;
+
+    protected function setUp(): void
+    {
+        $this->resetServices();
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetServices();
+        parent::tearDown();
+    }
+
+    protected function getBuffer()
+    {
+        return $this->getStreamFilterBuffer();
+    }
+
+    public function testFilterCheckDefinedRoute()
+    {
+        command('filter:check get /');
+
+        $this->assertStringContainsString(
+            '|GET|/||toolbar|',
+            str_replace(' ', '', $this->getBuffer())
+        );
+    }
+
+    public function testFilterCheckInvalidRoute()
+    {
+        command('filter:check put product/123');
+
+        $this->assertStringContainsString(
+            'Can\'t find a route: "PUT product/123"',
+            str_replace(["\033[0m", "\033[0;31m", "\033[0;30m"], '', $this->getBuffer())
+        );
+    }
+}

--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -113,7 +113,7 @@ Commands
         - ``spark db:table my_table --limit-rows 50 --limit-field-value 20 --desc``
     - Or you can see metadata like the column type, max length of a table.
         - ``spark db:table my_table --metadata``
-- The ``spark routes`` command now shows closure routes, auto routes, and filters. See :ref:`URI Routing <spark-routes>`.
+- The ``spark routes`` command now shows closure routes, auto routes, and filters. See :ref:`URI Routing <routing-spark-routes>`.
 
 Others
 ======

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -39,6 +39,7 @@ Enhancements
 - Added methods ``replace()``, ``addLineAfter()`` and ``addLineBefore()`` to modify files in Publisher. See :ref:`Publisher <publisher-modifying-files>` for details.
 - The call handler for Spark commands from the ``CodeIgniter\CodeIgniter`` class has been extracted. This will reduce the cost of console calls.
 - SQLite ``BaseConnection::getIndexData()`` now can return pseudo index named ``PRIMARY`` for `AUTOINCREMENT` column, and each returned index data has ``type`` property.
+- Added ``spark filter:check`` command to check the filters for a route. See :ref:`Controller Filters <spark-filter-check>` for the details.
 
 Changes
 *******

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -150,8 +150,29 @@ In this example, the array ``['dual', 'noreturn']`` will be passed in ``$argumen
 Confirming Filters
 ******************
 
-You can see the routes and filters by the ``spark routes`` command.
-See :ref:`URI Routing <spark-routes>`.
+CodeIgniter has the following :doc:`command </cli/spark_commands>` to check the filters for a route.
+
+.. _spark-filter-check:
+
+filter:check
+============
+
+Check the filters for the route ``/`` with **GET** method::
+
+    > php spark filter:check get /
+
+The output is like the following:
+
+.. code-block:: none
+
+    +--------+-------+----------------+---------------+
+    | Method | Route | Before Filters | After Filters |
+    +--------+-------+----------------+---------------+
+    | GET    | /     |                | toolbar       |
+    +--------+-------+----------------+---------------+
+
+You can also see the routes and filters by the ``spark routes`` command.
+See :ref:`URI Routing <routing-spark-routes>`.
 
 ****************
 Provided Filters

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -713,7 +713,7 @@ Confirming Routes
 
 CodeIgniter has the following :doc:`command </cli/cli_commands>` to display all routes.
 
-.. _spark-routes:
+.. _routing-spark-routes:
 
 routes
 ======
@@ -756,4 +756,4 @@ The *Method* will be like ``GET(auto)``. ``/..`` in the *Route* column indicates
 
 .. note:: When auto-routing is enabled, if you have the route ``home``, it can be also accessd by ``Home``, or maybe by ``hOme``, ``hoMe``, ``HOME``, etc. But the command shows only ``home``.
 
-.. important:: The system is not perfect. If you use Custom Placeholders, *Filters* might not be correct. But the filters defined in **app/Config/Routes.php** are always displayed correctly.
+.. important:: The system is not perfect. If you use Custom Placeholders, *Filters* might not be correct. If you want to check filters for a route, you can use :ref:`spark filter:check <spark-filter-check>` command.


### PR DESCRIPTION
**Description**
- add ``spark filter:check`` command to check filters for a route.

<img width="489" alt="screenshot 2022-07-22 9 56 39" src="https://user-images.githubusercontent.com/87955/180339107-522e2488-32ca-405d-848e-b38f78ebe1de.png">

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

