### PR TITLE
fix: Entity::hasChanged() is unreliable for casts

### DIFF
--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -287,7 +287,7 @@ class Entity implements JsonSerializable
     {
         // If no parameter was given then check all attributes
         if ($key === null) {
-            foreach ($this->attributes as $key => $value) {
+            foreach (array_keys($this->attributes) as $key) {
                 if ($this->isChanged($key)) {
                     return true;
                 }
@@ -574,13 +574,11 @@ class Entity implements JsonSerializable
      */
     private function _getCastData(string $key, array $data)
     {
-        $result = null;
-
         if (array_key_exists($key, $data)) {
-            $result = $this->castAs($data[$key], $key);
+            return $this->castAs($data[$key], $key);
         }
 
-        return $result;
+        return null;
     }
 
     /**

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -570,7 +570,7 @@ class Entity implements JsonSerializable
     /**
      * Get cast value from the data array.
      *
-     * @return mixed|null
+     * @return array|bool|float|int|object|string|null
      */
     private function _getCastData(string $key, array $data)
     {

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -1032,6 +1032,51 @@ final class EntityTest extends CIUnitTestCase
         $this->assertTrue($entity->hasChanged('createdAt'));
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5905
+     */
+    public function testHasChangedCastsItem()
+    {
+        $data = [
+            'id'   => '1',
+            'name' => 'John',
+            'age'  => '35',
+        ];
+        $entity = new class ($data) extends \CodeIgniter\Entity {
+            protected $casts = [
+                'id'   => 'integer',
+                'name' => 'string',
+                'age'  => 'integer',
+            ];
+        };
+        $entity->syncOriginal();
+
+        $entity->age = 35;
+
+        $this->assertFalse($entity->hasChanged('age'));
+    }
+
+    public function testHasChangedCastsWholeEntity()
+    {
+        $data = [
+            'id'   => '1',
+            'name' => 'John',
+            'age'  => '35',
+        ];
+        $entity = new class ($data) extends \CodeIgniter\Entity {
+            protected $casts = [
+                'id'   => 'integer',
+                'name' => 'string',
+                'age'  => 'integer',
+            ];
+        };
+        $entity->syncOriginal();
+
+        $entity->age = 35;
+
+        $this->assertFalse($entity->hasChanged());
+    }
+
     public function testHasChangedWholeEntity(): void
     {
         $entity = $this->getEntity();


### PR DESCRIPTION
~~Need to rebase after merging #6285~~

**Description**
Fixes #5905

- fix `hasChanged()` is unreliable for casts
- ~~fix `hasChanged()` returns wrong result to mapped property~~ --> #6285

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

