### PR TITLE
fix: unable to add more than one file to FileCollection constructor

### DIFF
--- a/system/Files/FileCollection.php
+++ b/system/Files/FileCollection.php
@@ -178,7 +178,9 @@ class FileCollection implements Countable, IteratorAggregate
                 // Test for a directory
                 self::resolveDirectory($path);
             } catch (FileException $e) {
-                return $this->addFile($path);
+                $this->addFile($path);
+
+                continue;
             }
 
             $this->addDirectory($path, $recursive);

--- a/tests/system/Files/FileCollectionTest.php
+++ b/tests/system/Files/FileCollectionTest.php
@@ -178,7 +178,24 @@ final class FileCollectionTest extends CIUnitTestCase
         $this->assertSame($expected, $files->get());
     }
 
-    public function testAddArray()
+    public function testAddArrayFiles()
+    {
+        $files = new FileCollection();
+
+        $expected = [
+            $this->directory . 'apple.php',
+            SUPPORTPATH . 'Files/baker/banana.php',
+        ];
+
+        $files->add([
+            $this->directory . 'apple.php',
+            SUPPORTPATH . 'Files/baker/banana.php',
+        ]);
+
+        $this->assertSame($expected, $files->get());
+    }
+
+    public function testAddArrayDirectoryAndFile()
     {
         $files = new FileCollection();
 
@@ -190,7 +207,7 @@ final class FileCollectionTest extends CIUnitTestCase
         ];
 
         $files->add([
-            SUPPORTPATH . 'Files/able',
+            SUPPORTPATH . 'Files/able', // directory
             SUPPORTPATH . 'Files/baker/banana.php',
         ]);
 


### PR DESCRIPTION
**Description**
Fixes #6290

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

