### PR TITLE
fix: Security::derandomize() may cause hex2bin() error

### DIFF
--- a/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
@@ -141,6 +141,21 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
         $security->verify($request);
     }
 
+    public function testCSRFVerifyPostInvalidToken()
+    {
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('The action you requested is not allowed.');
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['csrf_test_name']   = '!';
+
+        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+
+        $security = new Security(new MockAppConfig());
+
+        $security->verify($request);
+    }
+
     public function testCSRFVerifyPostReturnsSelfOnMatch()
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';


### PR DESCRIPTION
**Description**
From https://forum.codeigniter.com/showthread.php?tid=82544

`Security::derandomize()` may throw `ErrorException` "hex2bin(): Hexadecimal input string must have an even length".

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
