### PR TITLE
refactor: Cookie based CSRF protection

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -259,13 +259,13 @@ if (! function_exists('csrf_header')) {
 
 if (! function_exists('csrf_hash')) {
     /**
-     * Returns the current hash value for the CSRF protection.
+     * Returns the current token value for the CSRF protection.
      * Can be used in Views when building hidden inputs manually,
      * or used in javascript vars for API usage.
      */
     function csrf_hash(): string
     {
-        return Services::security()->getHash();
+        return Services::security()->getToken();
     }
 }
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -201,6 +201,7 @@ class Security implements SecurityInterface
         $this->request       = Services::request();
         $this->tokenInCookie = $this->request->getCookie($this->cookieName);
 
+        $this->restoreHash();
         if ($this->hash === null) {
             $this->generateHash();
         }
@@ -315,16 +316,6 @@ class Security implements SecurityInterface
         }
 
         if ($this->regenerate) {
-            $this->hash = null;
-            if ($this->isCSRFCookie()) {
-                $this->tokenInCookie = null;
-            } else {
-                // Session based CSRF protection
-                $this->session->remove($this->tokenName);
-            }
-        }
-
-        if ($this->hash === null) {
             $this->generateHash();
         }
 
@@ -539,20 +530,10 @@ class Security implements SecurityInterface
     }
 
     /**
-     * Generates the CSRF Hash.
+     * Generates (Regenerate) the CSRF Hash.
      */
     protected function generateHash(): string
     {
-        // If the cookie exists we will use its value.
-        // We don't necessarily want to regenerate it with
-        // each page load since a page could contain embedded
-        // sub-pages causing this feature to fail
-        $this->restoreHash();
-
-        if ($this->hash !== null) {
-            return $this->hash;
-        }
-
         $this->hash = bin2hex(random_bytes(static::CSRF_HASH_BYTES));
 
         if ($this->isCSRFCookie()) {

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -544,7 +544,7 @@ class Security implements SecurityInterface
         $this->hash = bin2hex(random_bytes(static::CSRF_HASH_BYTES));
 
         if ($this->isCSRFCookie()) {
-            $this->saveHashInCookie();
+            $this->saveTokenInCookie();
         } else {
             // Session based CSRF protection
             $this->saveHashInSession();
@@ -559,7 +559,7 @@ class Security implements SecurityInterface
             && preg_match('#^[0-9a-f]{32,64}$#iS', $this->tokenInCookie) === 1;
     }
 
-    private function saveHashInCookie(): void
+    private function saveTokenInCookie(): void
     {
         $this->cookie = new Cookie(
             $this->rawCookieName,

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -553,8 +553,19 @@ class Security implements SecurityInterface
 
     private function isTokenInCookie(): bool
     {
-        return isset($this->tokenInCookie) && is_string($this->tokenInCookie)
-            && preg_match('#^[0-9a-f]{32,64}$#iS', $this->tokenInCookie) === 1;
+        if ($this->tokenInCookie === null) {
+            return false;
+        }
+
+        if ($this->tokenRandomize) {
+            $length = static::CSRF_HASH_BYTES * 4;
+        } else {
+            $length = static::CSRF_HASH_BYTES * 2;
+        }
+
+        $pattern = '#^[0-9a-f]{' . $length . '}$#iS';
+
+        return preg_match($pattern, $this->tokenInCookie) === 1;
     }
 
     private function saveTokenInCookie(): void

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -354,8 +354,18 @@ class Security implements SecurityInterface
 
     /**
      * Returns the CSRF token.
+     *
+     * @deprecated Use getToken()
      */
     public function getHash(): ?string
+    {
+        return $this->getToken();
+    }
+
+    /**
+     * Returns the CSRF token.
+     */
+    public function getToken(): ?string
     {
         return $this->tokenRandomize ? $this->randomize($this->hash) : $this->hash;
     }

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -156,7 +156,7 @@ class Security implements SecurityInterface
     protected ?Session $session = null;
 
     /**
-     * CSRF Token in Cookie
+     * CSRF Token in Request Cookie
      */
     protected ?string $tokenInCookie = null;
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -201,7 +201,9 @@ class Security implements SecurityInterface
         $this->request       = Services::request();
         $this->tokenInCookie = $this->request->getCookie($this->cookieName);
 
-        $this->generateHash();
+        if ($this->hash === null) {
+            $this->generateHash();
+        }
     }
 
     private function isCSRFCookie(): bool
@@ -322,7 +324,9 @@ class Security implements SecurityInterface
             }
         }
 
-        $this->generateHash();
+        if ($this->hash === null) {
+            $this->generateHash();
+        }
 
         log_message('info', 'CSRF token verified.');
 
@@ -508,28 +512,26 @@ class Security implements SecurityInterface
      */
     protected function generateHash(): string
     {
-        if ($this->hash === null) {
-            // If the cookie exists we will use its value.
-            // We don't necessarily want to regenerate it with
-            // each page load since a page could contain embedded
-            // sub-pages causing this feature to fail
-            if ($this->isCSRFCookie()) {
-                if ($this->isHashInCookie()) {
-                    return $this->hash = $this->tokenInCookie;
-                }
-            } elseif ($this->session->has($this->tokenName)) {
-                // Session based CSRF protection
-                return $this->hash = $this->session->get($this->tokenName);
+        // If the cookie exists we will use its value.
+        // We don't necessarily want to regenerate it with
+        // each page load since a page could contain embedded
+        // sub-pages causing this feature to fail
+        if ($this->isCSRFCookie()) {
+            if ($this->isHashInCookie()) {
+                return $this->hash = $this->tokenInCookie;
             }
+        } elseif ($this->session->has($this->tokenName)) {
+            // Session based CSRF protection
+            return $this->hash = $this->session->get($this->tokenName);
+        }
 
-            $this->hash = bin2hex(random_bytes(static::CSRF_HASH_BYTES));
+        $this->hash = bin2hex(random_bytes(static::CSRF_HASH_BYTES));
 
-            if ($this->isCSRFCookie()) {
-                $this->saveHashInCookie();
-            } else {
-                // Session based CSRF protection
-                $this->saveHashInSession();
-            }
+        if ($this->isCSRFCookie()) {
+            $this->saveHashInCookie();
+        } else {
+            // Session based CSRF protection
+            $this->saveHashInSession();
         }
 
         return $this->hash;

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -143,22 +143,22 @@ class Security implements SecurityInterface
      */
     protected $samesite = Cookie::SAMESITE_LAX;
 
-    private IncomingRequest $request;
+    protected IncomingRequest $request;
 
     /**
      * CSRF Cookie Name without Prefix
      */
-    private ?string $rawCookieName = null;
+    protected ?string $rawCookieName = null;
 
     /**
      * Session instance.
      */
-    private ?Session $session = null;
+    protected ?Session $session = null;
 
     /**
      * CSRF Token in Cookie
      */
-    private ?string $tokenInCookie = null;
+    protected ?string $tokenInCookie = null;
 
     /**
      * Constructor.

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -527,7 +527,7 @@ class Security implements SecurityInterface
         // each page load since a page could contain embedded
         // sub-pages causing this feature to fail
         if ($this->isCSRFCookie()) {
-            if ($this->isHashInCookie()) {
+            if ($this->isTokenInCookie()) {
                 return $this->hash = $this->tokenInCookie;
             }
         } elseif ($this->session->has($this->tokenName)) {
@@ -547,7 +547,7 @@ class Security implements SecurityInterface
         return $this->hash;
     }
 
-    private function isHashInCookie(): bool
+    private function isTokenInCookie(): bool
     {
         return isset($this->tokenInCookie) && is_string($this->tokenInCookie)
             && preg_match('#^[0-9a-f]{32}$#iS', $this->tokenInCookie) === 1;

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -291,14 +291,14 @@ class Security implements SecurityInterface
         $postedToken = $this->getPostedToken($request);
 
         try {
-            $token = ($postedToken !== null && $this->tokenRandomize)
+            $hash = ($postedToken !== null && $this->tokenRandomize)
                 ? $this->derandomize($postedToken) : $postedToken;
         } catch (InvalidArgumentException $e) {
-            $token = null;
+            $hash = null;
         }
 
         // Do the tokens match?
-        if (! isset($token, $this->hash) || ! hash_equals($this->hash, $token)) {
+        if (! isset($hash, $this->hash) || ! hash_equals($this->hash, $hash)) {
             throw SecurityException::forDisallowedAction();
         }
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -57,6 +57,7 @@ class Security implements SecurityInterface
      * CSRF Hash
      *
      * Random hash for Cross Site Request Forgery protection.
+     * The Hash value is different from the Token value when Token Randomization is true.
      *
      * @var string|null
      */
@@ -88,7 +89,7 @@ class Security implements SecurityInterface
     protected $cookie;
 
     /**
-     * CSRF Cookie Name
+     * CSRF Cookie Name (with Prefix)
      *
      * Cookie name for Cross Site Request Forgery protection.
      *
@@ -246,7 +247,7 @@ class Security implements SecurityInterface
     }
 
     /**
-     * Returns the CSRF Hash.
+     * Returns the CSRF token.
      *
      * @deprecated Use `CodeIgniter\Security\Security::getHash()` instead of using this method.
      *
@@ -348,7 +349,7 @@ class Security implements SecurityInterface
     }
 
     /**
-     * Returns the CSRF Hash.
+     * Returns the CSRF token.
      */
     public function getHash(): ?string
     {
@@ -357,6 +358,8 @@ class Security implements SecurityInterface
 
     /**
      * Randomize hash to avoid BREACH attacks.
+     *
+     * @return string CSRF token
      */
     protected function randomize(string $hash): string
     {
@@ -374,6 +377,8 @@ class Security implements SecurityInterface
      * Derandomize the token.
      *
      * @throws InvalidArgumentException "hex2bin(): Hexadecimal input string must have an even length"
+     *
+     * @return string CSRF hash
      */
     protected function derandomize(string $token): string
     {

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -303,6 +303,19 @@ class Security implements SecurityInterface
             throw SecurityException::forDisallowedAction();
         }
 
+        $this->removeTokenInRequest($request);
+
+        if ($this->regenerate) {
+            $this->generateHash();
+        }
+
+        log_message('info', 'CSRF token verified.');
+
+        return $this;
+    }
+
+    private function removeTokenInRequest(RequestInterface $request)
+    {
         $json = json_decode($request->getBody() ?? '');
 
         if (isset($_POST[$this->tokenName])) {
@@ -314,14 +327,6 @@ class Security implements SecurityInterface
             unset($json->{$this->tokenName});
             $request->setBody(json_encode($json));
         }
-
-        if ($this->regenerate) {
-            $this->generateHash();
-        }
-
-        log_message('info', 'CSRF token verified.');
-
-        return $this;
     }
 
     private function getPostedToken(RequestInterface $request): ?string

--- a/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
@@ -27,11 +27,6 @@ use Config\Security as SecurityConfig;
 final class SecurityCSRFCookieRandomizeTokenTest extends CIUnitTestCase
 {
     /**
-     * @var string CSRF protection hash
-     */
-    private string $hash = '8b9218a55906f9dcc1dc263dce7f005a';
-
-    /**
      * @var string CSRF randomized token
      */
     private string $randomizedToken = '8bc70b67c91494e815c7d2219c1ae0ab005513c290126d34d41bf41c5265e0f1';

--- a/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Security;
+
+use CodeIgniter\Config\Factories;
+use CodeIgniter\Cookie\Cookie;
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\UserAgent;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockAppConfig;
+use CodeIgniter\Test\Mock\MockSecurity;
+use Config\Security as SecurityConfig;
+
+/**
+ * @internal
+ */
+final class SecurityCSRFCookieRandomizeTokenTest extends CIUnitTestCase
+{
+    /**
+     * @var string CSRF protection hash
+     */
+    private string $hash = '8b9218a55906f9dcc1dc263dce7f005a';
+
+    /**
+     * @var string CSRF randomized token
+     */
+    private string $randomizedToken = '8bc70b67c91494e815c7d2219c1ae0ab005513c290126d34d41bf41c5265e0f1';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_COOKIE = [];
+
+        $config                 = new SecurityConfig();
+        $config->csrfProtection = Security::CSRF_PROTECTION_COOKIE;
+        $config->tokenRandomize = true;
+        Factories::injectMock('config', 'Security', $config);
+
+        // Set Cookie value
+        $security                            = new MockSecurity(new MockAppConfig());
+        $_COOKIE[$security->getCookieName()] = $this->randomizedToken;
+
+        $this->resetServices();
+    }
+
+    public function testTokenIsReadFromCookie()
+    {
+        $security = new MockSecurity(new MockAppConfig());
+
+        $this->assertSame(
+            $this->randomizedToken,
+            $security->getToken()
+        );
+    }
+
+    public function testCSRFVerifySetNewCookie()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['foo']              = 'bar';
+        $_POST['csrf_test_name']   = $this->randomizedToken;
+
+        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+
+        $security = new Security(new MockAppConfig());
+
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+        $this->assertLogged('info', 'CSRF token verified.');
+        $this->assertCount(1, $_POST);
+
+        /** @var Cookie $cookie */
+        $cookie   = $this->getPrivateProperty($security, 'cookie');
+        $newToken = $cookie->getValue();
+
+        $this->assertNotSame($this->randomizedToken, $newToken);
+        $this->assertSame(64, strlen($newToken));
+    }
+}

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -36,7 +36,7 @@ final class SecurityTest extends CIUnitTestCase
 
         $_COOKIE = [];
 
-        Factories::reset();
+        $this->resetServices();
     }
 
     public function testBasicConfigIsSaved()


### PR DESCRIPTION
**Description**
- remove `$_COOKIE`
- always store a non-randomized hash in `$this->hash`
  - when using Cookie based CSRF protection, the current implementation stores randomized token in `$this->hash`
- `generateHash()` always creates new hash
- restore `$this->hash` from Cookie/Session in the constructor

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

