### PR TITLE
refactor: CSRF protection

### DIFF
--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -200,6 +200,7 @@ class Security implements SecurityInterface
         $this->request      = Services::request();
         $this->hashInCookie = $this->request->getCookie($this->cookieName);
 
+        $this->restoreHash();
         if ($this->hash === null) {
             $this->generateHash();
         }
@@ -314,16 +315,6 @@ class Security implements SecurityInterface
         }
 
         if ($this->regenerate) {
-            $this->hash = null;
-            if ($this->isCSRFCookie()) {
-                $this->hashInCookie = null;
-            } else {
-                // Session based CSRF protection
-                $this->session->remove($this->tokenName);
-            }
-        }
-
-        if ($this->hash === null) {
             $this->generateHash();
         }
 
@@ -518,20 +509,10 @@ class Security implements SecurityInterface
     }
 
     /**
-     * Generates the CSRF Hash.
+     * Generates (Regenerate) the CSRF Hash.
      */
     protected function generateHash(): string
     {
-        // If the cookie exists we will use its value.
-        // We don't necessarily want to regenerate it with
-        // each page load since a page could contain embedded
-        // sub-pages causing this feature to fail
-        $this->restoreHash();
-
-        if ($this->hash !== null) {
-            return $this->hash;
-        }
-
         $this->hash = bin2hex(random_bytes(static::CSRF_HASH_BYTES));
 
         if ($this->isCSRFCookie()) {

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -54,7 +54,7 @@ class Security implements SecurityInterface
     protected $tokenRandomize = false;
 
     /**
-     * CSRF Hash
+     * CSRF Hash (without randomization)
      *
      * Random hash for Cross Site Request Forgery protection.
      *
@@ -88,7 +88,7 @@ class Security implements SecurityInterface
     protected $cookie;
 
     /**
-     * CSRF Cookie Name
+     * CSRF Cookie Name (with Prefix)
      *
      * Cookie name for Cross Site Request Forgery protection.
      *
@@ -155,7 +155,10 @@ class Security implements SecurityInterface
     private ?Session $session = null;
 
     /**
-     * CSRF Hash in Cookie
+     * CSRF Hash in Request Cookie
+     *
+     * The cookie value is always CSRF hash (without randomization) even if
+     * $tokenRandomize is true.
      */
     private ?string $hashInCookie = null;
 
@@ -249,7 +252,7 @@ class Security implements SecurityInterface
     }
 
     /**
-     * Returns the CSRF Hash.
+     * Returns the CSRF Token.
      *
      * @deprecated Use `CodeIgniter\Security\Security::getHash()` instead of using this method.
      *
@@ -351,7 +354,7 @@ class Security implements SecurityInterface
     }
 
     /**
-     * Returns the CSRF Hash.
+     * Returns the CSRF Token.
      */
     public function getHash(): ?string
     {
@@ -360,6 +363,10 @@ class Security implements SecurityInterface
 
     /**
      * Randomize hash to avoid BREACH attacks.
+     *
+     * @params string $hash CSRF hash
+     *
+     * @return string CSRF token
      */
     protected function randomize(string $hash): string
     {
@@ -376,7 +383,11 @@ class Security implements SecurityInterface
     /**
      * Derandomize the token.
      *
+     * @params string $token CSRF token
+     *
      * @throws InvalidArgumentException "hex2bin(): Hexadecimal input string must have an even length"
+     *
+     * @return string CSRF hash
      */
     protected function derandomize(string $token): string
     {

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -155,6 +155,11 @@ class Security implements SecurityInterface
     private ?Session $session = null;
 
     /**
+     * CSRF Hash in Cookie
+     */
+    private ?string $hashInCookie = null;
+
+    /**
      * Constructor.
      *
      * Stores our configuration and fires off the init() method to setup
@@ -192,7 +197,8 @@ class Security implements SecurityInterface
             $this->configureSession();
         }
 
-        $this->request = Services::request();
+        $this->request      = Services::request();
+        $this->hashInCookie = $this->request->getCookie($this->cookieName);
 
         $this->generateHash();
     }
@@ -308,7 +314,7 @@ class Security implements SecurityInterface
         if ($this->regenerate) {
             $this->hash = null;
             if ($this->isCSRFCookie()) {
-                unset($_COOKIE[$this->cookieName]);
+                $this->hashInCookie = null;
             } else {
                 // Session based CSRF protection
                 $this->session->remove($this->tokenName);
@@ -504,7 +510,7 @@ class Security implements SecurityInterface
             // sub-pages causing this feature to fail
             if ($this->isCSRFCookie()) {
                 if ($this->isHashInCookie()) {
-                    return $this->hash = $_COOKIE[$this->cookieName];
+                    return $this->hash = $this->hashInCookie;
                 }
             } elseif ($this->session->has($this->tokenName)) {
                 // Session based CSRF protection
@@ -526,9 +532,14 @@ class Security implements SecurityInterface
 
     private function isHashInCookie(): bool
     {
-        return isset($_COOKIE[$this->cookieName])
-        && is_string($_COOKIE[$this->cookieName])
-        && preg_match('#^[0-9a-f]{32}$#iS', $_COOKIE[$this->cookieName]) === 1;
+        if ($this->hashInCookie === null) {
+            return false;
+        }
+
+        $length  = static::CSRF_HASH_BYTES * 2;
+        $pattern = '#^[0-9a-f]{' . $length . '}$#iS';
+
+        return preg_match($pattern, $this->hashInCookie) === 1;
     }
 
     private function saveHashInCookie(): void

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -302,6 +302,22 @@ class Security implements SecurityInterface
             throw SecurityException::forDisallowedAction();
         }
 
+        $this->removeTokenInRequest($request);
+
+        if ($this->regenerate) {
+            $this->generateHash();
+        }
+
+        log_message('info', 'CSRF token verified.');
+
+        return $this;
+    }
+
+    /**
+     * Remove token in POST or JSON request data
+     */
+    private function removeTokenInRequest(RequestInterface $request): void
+    {
         $json = json_decode($request->getBody() ?? '');
 
         if (isset($_POST[$this->tokenName])) {
@@ -313,14 +329,6 @@ class Security implements SecurityInterface
             unset($json->{$this->tokenName});
             $request->setBody(json_encode($json));
         }
-
-        if ($this->regenerate) {
-            $this->generateHash();
-        }
-
-        log_message('info', 'CSRF token verified.');
-
-        return $this;
     }
 
     private function getPostedToken(RequestInterface $request): ?string

--- a/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Security;
+
+use CodeIgniter\Config\Factories;
+use CodeIgniter\Cookie\Cookie;
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\UserAgent;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockAppConfig;
+use CodeIgniter\Test\Mock\MockSecurity;
+use Config\Security as SecurityConfig;
+
+/**
+ * @internal
+ */
+final class SecurityCSRFCookieRandomizeTokenTest extends CIUnitTestCase
+{
+    /**
+     * @var string CSRF protection hash
+     */
+    private string $hash = '8b9218a55906f9dcc1dc263dce7f005a';
+
+    /**
+     * @var string CSRF randomized token
+     */
+    private string $randomizedToken = '8bc70b67c91494e815c7d2219c1ae0ab005513c290126d34d41bf41c5265e0f1';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_COOKIE = [];
+
+        $config                 = new SecurityConfig();
+        $config->csrfProtection = Security::CSRF_PROTECTION_COOKIE;
+        $config->tokenRandomize = true;
+        Factories::injectMock('config', 'Security', $config);
+
+        // Set Cookie value
+        $security                            = new MockSecurity(new MockAppConfig());
+        $_COOKIE[$security->getCookieName()] = $this->hash;
+
+        $this->resetServices();
+    }
+
+    public function testTokenIsReadFromCookie()
+    {
+        $security = new MockSecurity(new MockAppConfig());
+
+        $this->assertSame(
+            $this->randomizedToken,
+            $security->getHash()
+        );
+    }
+
+    public function testCSRFVerifySetNewCookie()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['foo']              = 'bar';
+        $_POST['csrf_test_name']   = $this->randomizedToken;
+
+        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+
+        $security = new Security(new MockAppConfig());
+
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+        $this->assertLogged('info', 'CSRF token verified.');
+        $this->assertCount(1, $_POST);
+
+        /** @var Cookie $cookie */
+        $cookie  = $this->getPrivateProperty($security, 'cookie');
+        $newHash = $cookie->getValue();
+
+        $this->assertNotSame($this->hash, $newHash);
+        $this->assertSame(32, strlen($newHash));
+    }
+}

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -36,7 +36,7 @@ final class SecurityTest extends CIUnitTestCase
 
         $_COOKIE = [];
 
-        Factories::reset();
+        $this->resetServices();
     }
 
     public function testBasicConfigIsSaved()


### PR DESCRIPTION
**Description**
- remove `$_COOKIE`
- `generateHash()` always creates new hash

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

