### PR TITLE
fix: OCI8 uses deprecated Entity

### DIFF
--- a/system/Database/OCI8/Result.php
+++ b/system/Database/OCI8/Result.php
@@ -13,7 +13,7 @@ namespace CodeIgniter\Database\OCI8;
 
 use CodeIgniter\Database\BaseResult;
 use CodeIgniter\Database\ResultInterface;
-use CodeIgniter\Entity;
+use CodeIgniter\Entity\Entity;
 
 /**
  * Result for OCI8


### PR DESCRIPTION
**Description**
Explain what you have changed, and why.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

