### PR TITLE
fix: Parse error occurs before PHP version check

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,17 @@
 <?php
 
+// Check PHP version.
+$minPhpVersion = '7.4'; // If you update this, don't forget to update `spark`.
+if (version_compare(PHP_VERSION, $minPhpVersion, '<')) {
+    $message = sprintf(
+        'Your PHP version must be %s or higher to run CodeIgniter. Current version: %s',
+        $minPhpVersion,
+        PHP_VERSION
+    );
+
+    exit($message);
+}
+
 // Path to the front controller (this file)
 define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);
 

--- a/spark
+++ b/spark
@@ -26,6 +26,18 @@ if (strpos(PHP_SAPI, 'cgi') === 0) {
     exit("The cli tool is not supported when running php-cgi. It needs php-cli to function!\n\n");
 }
 
+// Check PHP version.
+$minPhpVersion = '7.4'; // If you update this, don't forget to update `public/index.php`.
+if (version_compare(PHP_VERSION, $minPhpVersion, '<')) {
+    $message = sprintf(
+        'Your PHP version must be %s or higher to run CodeIgniter. Current version: %s',
+        $minPhpVersion,
+        PHP_VERSION
+    );
+
+    exit($message);
+}
+
 // We want errors to be shown when using it from the CLI.
 error_reporting(-1);
 ini_set('display_errors', '1');

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -49,8 +49,6 @@ class CodeIgniter
      */
     public const CI_VERSION = '4.2.1';
 
-    private const MIN_PHP_VERSION = '7.4';
-
     /**
      * App startup time.
      *
@@ -158,16 +156,6 @@ class CodeIgniter
      */
     public function __construct(App $config)
     {
-        if (version_compare(PHP_VERSION, self::MIN_PHP_VERSION, '<')) {
-            // @codeCoverageIgnoreStart
-            $message = extension_loaded('intl')
-                ? lang('Core.invalidPhpVersion', [self::MIN_PHP_VERSION, PHP_VERSION])
-                : sprintf('Your PHP version must be %s or higher to run CodeIgniter. Current version: %s', self::MIN_PHP_VERSION, PHP_VERSION);
-
-            exit($message);
-            // @codeCoverageIgnoreEnd
-        }
-
         $this->startTime = microtime(true);
         $this->config    = $config;
     }
@@ -962,6 +950,7 @@ class CodeIgniter
             ob_end_flush(); // @codeCoverageIgnore
         }
 
+        // Throws new PageNotFoundException and remove exception message on production.
         throw PageNotFoundException::forPageNotFound(
             (ENVIRONMENT !== 'production' || ! $this->isWeb()) ? $e->getMessage() : null
         );


### PR DESCRIPTION
**Description**
Fixes #6306

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

