### PR TITLE
docs: fix link to wrong page in changelogs/v4.0.4.rst

### DIFF
--- a/user_guide_src/source/changelogs/v4.0.4.rst
+++ b/user_guide_src/source/changelogs/v4.0.4.rst
@@ -16,7 +16,7 @@ Enhancements:
 - New Testing Feature: :doc:`Fabricator </testing/fabricator>` makes creating mock classes simple and repeatable in your tests.
 - Model class can now have the callbacks overridden at runtime. Useful for testing.
 - A number of improvements to :doc:`Feature Tests </testing/feature>` in general.
-- New :doc:`command() helper function </cli/cli_commands>` to programatically run your CLI commands. Useful for testing and cron jobs.
+- New :doc:`command() helper function </cli/spark_commands>` to programatically run your CLI commands. Useful for testing and cron jobs.
 - New command, ``make:seeder`` to generate a :doc:`Database Seed class </dbmgmt/seeds>` skeleton file.
 - Colors now available on the CLI within Windows, as well as other Windows-related CLI improvements.
 - New helper :doc:`mb_url_title </helpers/url_helper>` that functions like ``url_title`` but automatically escapes and extended URL characters.


### PR DESCRIPTION
**Description**
- fix link to wrong page

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
