### PR TITLE
fix: random_string('crypto') may return string less than $len or ErrorException

### DIFF
--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -573,6 +573,12 @@ if (! function_exists('random_string')) {
                 return sha1(uniqid((string) mt_rand(), true));
 
             case 'crypto':
+                if ($len % 2 !== 0) {
+                    throw new InvalidArgumentException(
+                        'You must set an even number to the second parameter when you use `crypto`.'
+                    );
+                }
+
                 return bin2hex(random_bytes($len / 2));
         }
         // 'basic' type treated as default

--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Helpers;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use InvalidArgumentException;
 
 /**
  * @internal
@@ -111,6 +112,19 @@ final class TextHelperTest extends CIUnitTestCase
 
         $this->assertSame(32, strlen($random = random_string('md5')));
         $this->assertSame(40, strlen($random = random_string('sha1')));
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/6330
+     */
+    public function testRandomStringCryptoOddNumber()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'You must set an even number to the second parameter when you use `crypto`'
+        );
+
+        random_string('crypto', 9);
     }
 
     public function testIncrementString()

--- a/user_guide_src/source/changelogs/v4.2.2.rst
+++ b/user_guide_src/source/changelogs/v4.2.2.rst
@@ -16,6 +16,7 @@ BREAKING
 - The method signature of ``CodeIgniter\Debug\Exceptions::__construct()`` has been changed. The ``IncomingRequest`` typehint on the ``$request`` parameter was removed. Extending classes should likewise remove the parameter so as not to break LSP.
 - The method signature of ``BaseBuilder.php::insert()`` and ``BaseBuilder.php::update()`` have been changed. The ``?array`` typehint on the ``$set`` parameter was removed.
 - A bug that caused pages to be cached before after filters were executed when using page caching has been fixed. Adding response headers or changing the response body in after filters now caches them correctly.
+- Due to a bug fix, now :php:func:`random_string` with the first parameter ``'crypto'`` throws ``InvalidArgumentException`` if the second parameter ``$len`` is an odd number.
 
 Enhancements
 ************

--- a/user_guide_src/source/helpers/text_helper.rst
+++ b/user_guide_src/source/helpers/text_helper.rst
@@ -42,6 +42,9 @@ The following functions are available:
     - **sha1**: An encrypted random number based on ``sha1()`` (fixed length of 40).
     - **crypto**: A random string based on ``random_bytes()``.
 
+    .. note:: When you use **crypto**, you must set an even number to the second parameter.
+        Since v4.2.2, if you set an odd number, ``InvalidArgumentException`` will be thrown.
+
     Usage example:
 
     .. literalinclude:: text_helper/002.php

--- a/user_guide_src/source/installation/upgrade_422.rst
+++ b/user_guide_src/source/installation/upgrade_422.rst
@@ -32,6 +32,7 @@ Others
 
 - The method ``Forge::createTable()`` no longer executes a ``CREATE TABLE IF NOT EXISTS``. If table is not found in ``$db->tableExists($table)`` then ``CREATE TABLE`` is executed.
 - The second parameter ``$ifNotExists`` of ``Forge::_createTable()`` is deprecated. It is no longer used and will be removed in a future release.
+- When you use :php:func:`random_string` with the first parameter ``'crypto'``, now if you set the second parameter ``$len`` to an odd number, ``InvalidArgumentException`` will be thrown. Change the parameter to an even number.
 
 Breaking Enhancements
 *********************


### PR DESCRIPTION
**Description**
Fixes #6330

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
