### PR TITLE
fix: validation custom error with asterisk field

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -713,6 +713,8 @@ class Validation implements ValidationInterface
         // Check if custom message has been defined by user
         if (isset($this->customErrors[$field][$rule])) {
             $message = lang($this->customErrors[$field][$rule]);
+        } else if (strpos($label, '*') !== false && isset($this->customErrors[$label][$rule])) {
+            $message = lang($this->customErrors[$label][$rule]);
         } else {
             // Try to grab a localized version of the message...
             // lang() will return the rule name back if not found,

--- a/tests/system/Validation/StrictRules/ValidationTest.php
+++ b/tests/system/Validation/StrictRules/ValidationTest.php
@@ -360,6 +360,28 @@ final class ValidationTest extends CIUnitTestCase
     }
 
     /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/6245
+     */
+    public function testRunWithCustomErrorsAndAsteriskField(): void
+    {
+        $data = [
+            'foo' => [
+                ['bar' => null],
+                ['bar' => null],
+            ]
+        ];
+        $this->validation->setRules(
+            ['foo.*.bar' => 'required'],
+            ['foo.*.bar' => ['required' => 'Required']]
+        );
+        $this->validation->run($data);
+        $this->assertSame([
+            'foo.0.bar' => 'Required',
+            'foo.1.bar' => 'Required'
+        ], $this->validation->getErrors());
+    }
+
+    /**
      * @dataProvider rulesSetupProvider
      *
      * @param string|string[] $rules


### PR DESCRIPTION
**Description**
Fixes #6245 

- increase judgment if user set up custom validation error with asterisk field.
- increase **testRunWithCustomErrorsAndAsteriskField** for testing

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
