### PR TITLE
fix: Email class may not log an error when it fails to send

### DIFF
--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -289,6 +289,13 @@ class Email
     protected $debugMessage = [];
 
     /**
+     * Raw debug messages
+     *
+     * @var string[]
+     */
+    private array $debugMessageRaw = [];
+
+    /**
      * Recipients
      *
      * @var array|string
@@ -434,16 +441,17 @@ class Email
      */
     public function clear($clearAttachments = false)
     {
-        $this->subject      = '';
-        $this->body         = '';
-        $this->finalBody    = '';
-        $this->headerStr    = '';
-        $this->replyToFlag  = false;
-        $this->recipients   = [];
-        $this->CCArray      = [];
-        $this->BCCArray     = [];
-        $this->headers      = [];
-        $this->debugMessage = [];
+        $this->subject         = '';
+        $this->body            = '';
+        $this->finalBody       = '';
+        $this->headerStr       = '';
+        $this->replyToFlag     = false;
+        $this->recipients      = [];
+        $this->CCArray         = [];
+        $this->BCCArray        = [];
+        $this->headers         = [];
+        $this->debugMessage    = [];
+        $this->debugMessageRaw = [];
 
         $this->setHeader('Date', $this->setDate());
 
@@ -1658,7 +1666,12 @@ class Email
         }
 
         if (! $success) {
-            $this->setErrorMessage(lang('Email.sendFailure' . ($protocol === 'mail' ? 'PHPMail' : ucfirst($protocol))));
+            $message = lang('Email.sendFailure' . ($protocol === 'mail' ? 'PHPMail' : ucfirst($protocol)));
+
+            log_message('error', 'Email: ' . $message);
+            log_message('error', $this->printDebuggerRaw());
+
+            $this->setErrorMessage($message);
 
             return false;
         }
@@ -1937,7 +1950,8 @@ class Email
 
         $reply = $this->getSMTPData();
 
-        $this->debugMessage[] = '<pre>' . $cmd . ': ' . $reply . '</pre>';
+        $this->debugMessage[]    = '<pre>' . $cmd . ': ' . $reply . '</pre>';
+        $this->debugMessageRaw[] = $cmd . ': ' . $reply;
 
         if ($resp === null || ((int) static::substr($reply, 0, 3) !== $resp)) {
             $this->setErrorMessage(lang('Email.SMTPError', [$reply]));
@@ -2120,11 +2134,20 @@ class Email
     }
 
     /**
+     * Returns raw debug messages
+     */
+    private function printDebuggerRaw(): string
+    {
+        return implode("\n", $this->debugMessageRaw);
+    }
+
+    /**
      * @param string $msg
      */
     protected function setErrorMessage($msg)
     {
-        $this->debugMessage[] = $msg . '<br />';
+        $this->debugMessage[]    = $msg . '<br />';
+        $this->debugMessageRaw[] = $msg;
     }
 
     /**

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -2090,8 +2090,8 @@ class Email
     }
 
     /**
-     * @param array $include List of raw data chunks to include in the output
-     *                       Valid options are: 'headers', 'subject', 'body'
+     * @param array|string $include List of raw data chunks to include in the output
+     *                              Valid options are: 'headers', 'subject', 'body'
      *
      * @return string
      */


### PR DESCRIPTION
**Description**
Fixes #6350

Before:
no log

After:
```
ERROR - 2022-08-08 23:13:22 --> Email: Unable to send email using PHP SMTP. Your server might not be configured to send mail using this method.
ERROR - 2022-08-08 23:13:22 --> 220 smtp.googlemail.com ESMTP s1-20020a17090a2f0100b001f04479017fsm9022783pjd.29 - gsmtp

hello: 250-smtp.googlemail.com at your service, [133.149.85.47]
250-SIZE 35882577
250-8BITMIME
250-STARTTLS
250-ENHANCEDSTATUSCODES
250-PIPELINING
250-CHUNKING
250 SMTPUTF8

starttls: 220 2.0.0 Ready to start TLS

hello: 250-smtp.googlemail.com at your service, [133.149.85.47]
250-SIZE 35882577
250-8BITMIME
250-AUTH LOGIN PLAIN XOAUTH2 PLAIN-CLIENTTOKEN OAUTHBEARER XOAUTH
250-ENHANCEDSTATUSCODES
250-PIPELINING
250-CHUNKING
250 SMTPUTF8

Failed to authenticate password. Error: 535-5.7.8 Username and Password not accepted. Learn more at
535 5.7.8  https://support.google.com/mail/?p=BadCredentials s1-20020a17090a2f0100b001f04479017fsm9022783pjd.29 - gsmtp
```

**How to Test**
```php
<?php

namespace App\Controllers;

class Home extends BaseController
{
    public function index()
    {
        $email = \Config\Services::email();

        $config['protocol']   = 'smtp';
        $config['SMTPHost']   = 'smtp.googlemail.com';
        $config['SMTPUser']   = 'test@gmail.com';
        $config['SMTPPass']   = 'passwd';
        $config['SMTPPort']   = 587;
        $config['SMTPCrypto'] = 'tls';

        $email->initialize($config);

        $email->setFrom('your@example.com', 'Your Name');
        $email->setTo('someone@example.com');
        $email->setSubject('Email Test');
        $email->setMessage('Testing the email class.');

        $email->send();

        d($email->printDebugger('headers'));
    }
}
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

