### PR TITLE
Add $cached param to BaseConnection::tableExists()

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1431,7 +1431,8 @@ abstract class BaseConnection implements ConnectionInterface
             );
 
             // table doesn't exist but still in cache - lets reset cache, it can be rebuilt later
-            if ($key !== false && ! $tableExists) {
+            // OR if table does exist but is not found in cache
+            if (($key !== false && ! $tableExists) || ($key === false && $tableExists)) {
                 $this->resetDataCache();
             }
         }

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1405,6 +1405,8 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Determine if a particular table exists
+     *
+     * @param bool $cached Whether to use data cache
      */
     public function tableExists(string $tableName, bool $cached = true): bool
     {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1604,11 +1604,11 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param string $tableName If $tableName is provided will return only this table if exists.
+     * @param null|string $tableName If $tableName is provided will return only this table if exists.
      *
      * @return false|string
      */
-    abstract protected function _listTables(bool $constrainByPrefix = false, string $tableName = '');
+    abstract protected function _listTables(bool $constrainByPrefix = false, ?string $tableName = null);
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1420,7 +1420,7 @@ abstract class BaseConnection implements ConnectionInterface
             return false;
         }
 
-        $result = $this->query($sql)->getResultArray() !== [];
+        $tableExists = $this->query($sql)->getResultArray() !== [];
 
         // if cache has been built already
         if (! empty($this->dataCache['table_names'])) {
@@ -1430,18 +1430,13 @@ abstract class BaseConnection implements ConnectionInterface
                 true
             );
 
-            // remove from cache
-            if ($key !== false) {
-                unset($this->dataCache['table_names'][$key]);
-            }
-
-            // if exists add back to cache (if cache has been built already)
-            if ($result) {
-                $this->dataCache['table_names'][] = strtolower($tableName);
+            // table doesn't exist but still in cache - lets reset cache, it can be rebuilt later
+            if ($key !== false && ! $tableExists) {
+                $this->resetDataCache();
             }
         }
 
-        return $result;
+        return $tableExists;
     }
 
     /**

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1604,7 +1604,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param null|string $tableName If $tableName is provided will return only this table if exists.
+     * @param string|null $tableName If $tableName is provided will return only this table if exists.
      *
      * @return false|string
      */

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -498,7 +498,7 @@ class Forge
         }
 
         // If table exists lets stop here
-        if ($ifNotExists === true && $this->db->tableExists($table)) {
+        if ($ifNotExists === true && $this->db->tableExists($table, false)) {
             $this->reset();
 
             return true;

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -368,10 +368,16 @@ class Connection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      * Uses escapeLikeStringDirect().
+     *
+     * @param string $tableName If $tableName is provided will return only this table if exists.
      */
-    protected function _listTables(bool $prefixLimit = false): string
+    protected function _listTables(bool $prefixLimit = false, string $tableName = ''): string
     {
         $sql = 'SHOW TABLES FROM ' . $this->escapeIdentifiers($this->database);
+
+        if (! empty($tableName)) {
+            return $sql . ' LIKE ' . $this->escape($tableName);
+        }
 
         if ($prefixLimit !== false && $this->DBPrefix !== '') {
             return $sql . " LIKE '" . $this->escapeLikeStringDirect($this->DBPrefix) . "%'";

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -369,13 +369,13 @@ class Connection extends BaseConnection
      * Generates the SQL for listing tables in a platform-dependent manner.
      * Uses escapeLikeStringDirect().
      *
-     * @param string $tableName If $tableName is provided will return only this table if exists.
+     * @param null|string $tableName If $tableName is provided will return only this table if exists.
      */
-    protected function _listTables(bool $prefixLimit = false, string $tableName = ''): string
+    protected function _listTables(bool $prefixLimit = false, ?string $tableName = null): string
     {
         $sql = 'SHOW TABLES FROM ' . $this->escapeIdentifiers($this->database);
 
-        if (! empty($tableName)) {
+        if ($tableName !== null) {
             return $sql . ' LIKE ' . $this->escape($tableName);
         }
 

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -369,7 +369,7 @@ class Connection extends BaseConnection
      * Generates the SQL for listing tables in a platform-dependent manner.
      * Uses escapeLikeStringDirect().
      *
-     * @param null|string $tableName If $tableName is provided will return only this table if exists.
+     * @param string|null $tableName If $tableName is provided will return only this table if exists.
      */
     protected function _listTables(bool $prefixLimit = false, ?string $tableName = null): string
     {

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -243,7 +243,7 @@ class Connection extends BaseConnection implements ConnectionInterface
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param null|string $tableName If $tableName is provided will return only this table if exists.
+     * @param string|null $tableName If $tableName is provided will return only this table if exists.
      */
     protected function _listTables(bool $prefixLimit = false, ?string $tableName = null): string
     {

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -243,13 +243,13 @@ class Connection extends BaseConnection implements ConnectionInterface
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param string $tableName If $tableName is provided will return only this table if exists.
+     * @param null|string $tableName If $tableName is provided will return only this table if exists.
      */
-    protected function _listTables(bool $prefixLimit = false, string $tableName = ''): string
+    protected function _listTables(bool $prefixLimit = false, ?string $tableName = null): string
     {
         $sql = 'SELECT "TABLE_NAME" FROM "USER_TABLES"';
 
-        if (! empty($tableName)) {
+        if ($tableName !== null) {
             return $sql . ' WHERE "TABLE_NAME" LIKE ' . $this->escape($tableName);
         }
 

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -242,10 +242,16 @@ class Connection extends BaseConnection implements ConnectionInterface
 
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
+     *
+     * @param string $tableName If $tableName is provided will return only this table if exists.
      */
-    protected function _listTables(bool $prefixLimit = false): string
+    protected function _listTables(bool $prefixLimit = false, string $tableName = ''): string
     {
         $sql = 'SELECT "TABLE_NAME" FROM "USER_TABLES"';
+
+        if (! empty($tableName)) {
+            return $sql . ' WHERE "TABLE_NAME" LIKE ' . $this->escape($tableName);
+        }
 
         if ($prefixLimit !== false && $this->DBPrefix !== '') {
             return $sql . ' WHERE "TABLE_NAME" LIKE \'' . $this->escapeLikeString($this->DBPrefix) . "%' "

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -205,13 +205,13 @@ class Connection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param string $tableName If $tableName is provided will return only this table if exists.
+     * @param null|string $tableName If $tableName is provided will return only this table if exists.
      */
-    protected function _listTables(bool $prefixLimit = false, string $tableName = ''): string
+    protected function _listTables(bool $prefixLimit = false, ?string $tableName = null): string
     {
         $sql = 'SELECT "table_name" FROM "information_schema"."tables" WHERE "table_schema" = \'' . $this->schema . "'";
 
-        if (! empty($tableName)) {
+        if ($tableName !== null) {
             return $sql . ' AND "table_name" LIKE ' . $this->escape($tableName);
         }
 

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -205,7 +205,7 @@ class Connection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param null|string $tableName If $tableName is provided will return only this table if exists.
+     * @param string|null $tableName If $tableName is provided will return only this table if exists.
      */
     protected function _listTables(bool $prefixLimit = false, ?string $tableName = null): string
     {

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -204,10 +204,16 @@ class Connection extends BaseConnection
 
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
+     *
+     * @param string $tableName If $tableName is provided will return only this table if exists.
      */
-    protected function _listTables(bool $prefixLimit = false): string
+    protected function _listTables(bool $prefixLimit = false, string $tableName = ''): string
     {
         $sql = 'SELECT "table_name" FROM "information_schema"."tables" WHERE "table_schema" = \'' . $this->schema . "'";
+
+        if (! empty($tableName)) {
+            return $sql . ' AND "table_name" LIKE ' . $this->escape($tableName);
+        }
 
         if ($prefixLimit !== false && $this->DBPrefix !== '') {
             return $sql . ' AND "table_name" LIKE \''

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -183,13 +183,19 @@ class Connection extends BaseConnection
 
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
+     *
+     * @param string $tableName If $tableName is provided will return only this table if exists.
      */
-    protected function _listTables(bool $prefixLimit = false): string
+    protected function _listTables(bool $prefixLimit = false, string $tableName = ''): string
     {
         $sql = 'SELECT [TABLE_NAME] AS "name"'
             . ' FROM [INFORMATION_SCHEMA].[TABLES] '
             . ' WHERE '
             . " [TABLE_SCHEMA] = '" . $this->schema . "'    ";
+
+        if (! empty($tableName)) {
+            return $sql .= ' AND [TABLE_NAME] LIKE ' . $this->escape($tableName);
+        }
 
         if ($prefixLimit === true && $this->DBPrefix !== '') {
             $sql .= " AND [TABLE_NAME] LIKE '" . $this->escapeLikeString($this->DBPrefix) . "%' "

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -184,7 +184,7 @@ class Connection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param null|string $tableName If $tableName is provided will return only this table if exists.
+     * @param string|null $tableName If $tableName is provided will return only this table if exists.
      */
     protected function _listTables(bool $prefixLimit = false, ?string $tableName = null): string
     {

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -184,16 +184,16 @@ class Connection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param string $tableName If $tableName is provided will return only this table if exists.
+     * @param null|string $tableName If $tableName is provided will return only this table if exists.
      */
-    protected function _listTables(bool $prefixLimit = false, string $tableName = ''): string
+    protected function _listTables(bool $prefixLimit = false, ?string $tableName = null): string
     {
         $sql = 'SELECT [TABLE_NAME] AS "name"'
             . ' FROM [INFORMATION_SCHEMA].[TABLES] '
             . ' WHERE '
             . " [TABLE_SCHEMA] = '" . $this->schema . "'    ";
 
-        if (! empty($tableName)) {
+        if ($tableName !== null) {
             return $sql .= ' AND [TABLE_NAME] LIKE ' . $this->escape($tableName);
         }
 

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -160,9 +160,17 @@ class Connection extends BaseConnection
 
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
+     *
+     * @param string $tableName If $tableName is provided will return only this table if exists.
      */
-    protected function _listTables(bool $prefixLimit = false): string
+    protected function _listTables(bool $prefixLimit = false, string $tableName = ''): string
     {
+        if (! empty($tableName)) {
+            return 'SELECT "NAME" FROM "SQLITE_MASTER" WHERE "TYPE" = \'table\''
+                   . ' AND "NAME" NOT LIKE \'sqlite!_%\' ESCAPE \'!\''
+                   . ' AND "NAME" LIKE ' . $this->escape($tableName);
+        }
+
         return 'SELECT "NAME" FROM "SQLITE_MASTER" WHERE "TYPE" = \'table\''
                . ' AND "NAME" NOT LIKE \'sqlite!_%\' ESCAPE \'!\''
                . (($prefixLimit !== false && $this->DBPrefix !== '')

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -161,7 +161,7 @@ class Connection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param null|string $tableName If $tableName is provided will return only this table if exists.
+     * @param string|null $tableName If $tableName is provided will return only this table if exists.
      */
     protected function _listTables(bool $prefixLimit = false, ?string $tableName = null): string
     {

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -161,11 +161,11 @@ class Connection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param string $tableName If $tableName is provided will return only this table if exists.
+     * @param null|string $tableName If $tableName is provided will return only this table if exists.
      */
-    protected function _listTables(bool $prefixLimit = false, string $tableName = ''): string
+    protected function _listTables(bool $prefixLimit = false, ?string $tableName = null): string
     {
-        if (! empty($tableName)) {
+        if ($tableName !== null) {
             return 'SELECT "NAME" FROM "SQLITE_MASTER" WHERE "TYPE" = \'table\''
                    . ' AND "NAME" NOT LIKE \'sqlite!_%\' ESCAPE \'!\''
                    . ' AND "NAME" LIKE ' . $this->escape($tableName);

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -180,9 +180,9 @@ class MockConnection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param string $tableName If $tableName is provided will return only this table if exists.
+     * @param null|string $tableName If $tableName is provided will return only this table if exists.
      */
-    protected function _listTables(bool $constrainByPrefix = false, string $tableName = ''): string
+    protected function _listTables(bool $constrainByPrefix = false, ?string $tableName = null): string
     {
         return '';
     }

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -179,8 +179,10 @@ class MockConnection extends BaseConnection
 
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
+     *
+     * @param string $tableName If $tableName is provided will return only this table if exists.
      */
-    protected function _listTables(bool $constrainByPrefix = false): string
+    protected function _listTables(bool $constrainByPrefix = false, string $tableName = ''): string
     {
         return '';
     }

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -180,7 +180,7 @@ class MockConnection extends BaseConnection
     /**
      * Generates the SQL for listing tables in a platform-dependent manner.
      *
-     * @param null|string $tableName If $tableName is provided will return only this table if exists.
+     * @param string|null $tableName If $tableName is provided will return only this table if exists.
      */
     protected function _listTables(bool $constrainByPrefix = false, ?string $tableName = null): string
     {

--- a/tests/system/Database/Forge/CreateTableTest.php
+++ b/tests/system/Database/Forge/CreateTableTest.php
@@ -21,26 +21,6 @@ use CodeIgniter\Test\Mock\MockConnection;
  */
 final class CreateTableTest extends CIUnitTestCase
 {
-    public function testCreateTableWithExists()
-    {
-        $dbMock = $this->getMockBuilder(MockConnection::class)
-            ->setConstructorArgs([[]])
-            ->onlyMethods(['listTables'])
-            ->getMock();
-        $dbMock
-            ->method('listTables')
-            ->willReturn(['foo']);
-
-        $forge                          = new class ($dbMock) extends Forge {
-            protected $createTableIfStr = false;
-        };
-
-        $forge->addField('id');
-        $actual = $forge->createTable('foo', true);
-
-        $this->assertTrue($actual);
-    }
-
     public function testCreateTableWithDefaultRawSql()
     {
         $sql = <<<'SQL'

--- a/user_guide_src/source/changelogs/v4.2.5.rst
+++ b/user_guide_src/source/changelogs/v4.2.5.rst
@@ -12,7 +12,8 @@ Release Date: Unreleased
 BREAKING
 ********
 
-none.
+- The method signature of ``BaseConnection::tableExists()`` has been changed. A second optional parameter ``$cached`` was added. This directs whether to use cache data or not. Default is ``true``, use cache data.
+- The abstract method signature of ``BaseBuilder::_listTables()`` has been changed. A second optional parameter ``$tableName`` was added. Providing a table name will generate SQL listing only that table.
 
 Enhancements
 ************


### PR DESCRIPTION
Follow-up #6249
This PR fixes https://github.com/codeigniter4/CodeIgniter4/issues/6351

In `Forge::createTable()`

```php
        // If table exists lets stop here
        if ($ifNotExists === true && $this->db->tableExists($table, false)) {
            $this->reset();

            return true;
        }
```
This PR forces to check if table exists rather than relying on cache.

We add $tableName param to `Connection::_listTables()`. This allows us to lookup only one table rather than return a full list of tables.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
