### PR TITLE
feat: [Forge] set foreign key name manually

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -398,6 +398,8 @@ class Forge
      * @param string|string[] $tableField
      * @param string[]|null   $options
      *
+     * @throws DatabaseException
+     *
      * @return Forge
      */
     public function addForeignKey($fieldName = '', string $tableName = '', $tableField = '', string $onUpdate = '', string $onDelete = '', ?array $options = null)

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -396,12 +396,11 @@ class Forge
      *
      * @param string|string[] $fieldName
      * @param string|string[] $tableField
-     *
-     * @throws DatabaseException
+     * @param string[]|null   $options
      *
      * @return Forge
      */
-    public function addForeignKey($fieldName = '', string $tableName = '', $tableField = '', string $onUpdate = '', string $onDelete = '')
+    public function addForeignKey($fieldName = '', string $tableName = '', $tableField = '', string $onUpdate = '', string $onDelete = '', ?array $options = null)
     {
         $fieldName  = (array) $fieldName;
         $tableField = (array) $tableField;
@@ -425,6 +424,7 @@ class Forge
             'referenceField' => $tableField,
             'onDelete'       => strtoupper($onDelete),
             'onUpdate'       => strtoupper($onUpdate),
+            'options'        => $options,
         ];
 
         return $this;
@@ -1054,7 +1054,7 @@ class Forge
         ];
 
         foreach ($this->foreignKeys as $fkey) {
-            $nameIndex            = $table . '_' . implode('_', $fkey['field']) . '_foreign';
+            $nameIndex            = $fkey['options']['constraint'] ?? $table . '_' . implode('_', $fkey['field']) . '_foreign';
             $nameIndexFilled      = $this->db->escapeIdentifiers($nameIndex);
             $foreignKeyFilled     = implode(', ', $this->db->escapeIdentifiers($fkey['field']));
             $referenceTableFilled = $this->db->escapeIdentifiers($this->db->DBPrefix . $fkey['referenceTable']);


### PR DESCRIPTION
**Description**
Ref #5075

custom name for foreign key constraint can be added.

```php
$this->forge->addForeignKey("column_name", "table_name", "id", "onDelete", "onUpdate", ["constraint"=>"foreignkey_name"])
```
auto create name for foreign key is still there, a check is added to choose between two.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide