### PR TITLE
docs: improve PR workflow

### DIFF
--- a/contributing/workflow.md
+++ b/contributing/workflow.md
@@ -259,6 +259,12 @@ Synchronize your repository:
 > git push origin develop
 ```
 
+(Optional) Create a new branch as a backup, just in case:
+
+```console
+> git branch fix/problem123.bk fix/problem123
+```
+
 Bring your feature branch up to date:
 
 ```console

--- a/contributing/workflow.md
+++ b/contributing/workflow.md
@@ -276,6 +276,54 @@ And finally push your local branch to your GitHub repository:
 > git push --force-with-lease origin fix/problem123
 ```
 
+## If you sent to the wrong branch
+
+If you have sent a PR to the wrong branch, you need to create a new PR branch.
+
+When you have the PR branch `feat-abc` and you should have sent the PR to `4.3`,
+but you created the PR branch from `develop` and sent a PR.
+
+Update your `4.3` branch:
+
+```console
+> git switch 4.3
+> git fetch upstream
+> git merge upstream/4.3
+> git push origin 4.3
+```
+
+Create a new branch `feat-ab.new` from the correct branch `4.3`:
+
+```console
+> git switch -c feat-abc.new 4.3
+```
+
+Cherry-pick the commits you did:
+
+```console
+> git cherry-pick <commit_id> <commit_id> <commit_id> ...
+```
+
+Rename the PR branch `feat-abc`:
+
+```console
+> git branch -m feat-abc feat-abc.old
+```
+
+Rename the new branch  `feat-abc.new` to `feat-abc`.
+
+```console
+> git branch -m feat-abc.new feat-abc
+```
+
+Force push.
+
+```console
+> git push --force-with-lease origin feat-abc
+```
+
+On the GitHub PR page, change the base branch to the correct branch `4.3`.
+
 ## Cleanup
 
 If your PR is accepted and merged into the shared repository, you can

--- a/contributing/workflow.md
+++ b/contributing/workflow.md
@@ -289,6 +289,12 @@ If you have sent a PR to the wrong branch, you need to create a new PR branch.
 When you have the PR branch `feat-abc` and you should have sent the PR to `4.3`,
 but you created the PR branch from `develop` and sent a PR.
 
+Copy the IDs of any commits you made that you want to keep:
+
+```console
+> git log
+```
+
 Update your `4.3` branch:
 
 ```console

--- a/contributing/workflow.md
+++ b/contributing/workflow.md
@@ -174,7 +174,7 @@ are working in.
 At some point, you will decide that your feature branch is complete, or
 that it could benefit from a review by fellow developers.
 
-**Note:**
+> **Note**
 > Remember to sync your local repo with the shared one before pushing!
 It is a lot easier to resolve conflicts at this stage.
 
@@ -213,7 +213,7 @@ Make sure that the PR title is helpful for the maintainers and other
 developers. Add any comments appropriate, for instance asking for
 review.
 
-**Note:**
+> **Note**
 > If you do not provide a title or description for your PR, the odds of it being summarily rejected
 rise astronomically.
 


### PR DESCRIPTION
**Description**
- add "If you sent to the wrong branch"
- add optional step to back up the PR branch

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
