### PR TITLE
Improve `BaseBuilder::updateBatch()` SQL

### DIFF
--- a/.github/workflows/test-phpcpd.yml
+++ b/.github/workflows/test-phpcpd.yml
@@ -39,4 +39,4 @@ jobs:
           extensions: dom, mbstring
 
       - name: Detect code duplication
-        run: phpcpd --exclude system/Test --exclude system/ThirdParty --exclude system/Database/SQLSRV/Builder.php --exclude system/Database/SQLSRV/Forge.php -- app/ public/ system/
+        run: phpcpd --exclude system/Test --exclude system/ThirdParty -- app/ public/ system/ --exclude system/Database/SQLSRV/Builder.php --exclude system/Database/SQLSRV/Forge.php --exclude system/Database/MySQLi/Builder.php --exclude system/Database/OCI8/Builder.php

--- a/.github/workflows/test-phpcpd.yml
+++ b/.github/workflows/test-phpcpd.yml
@@ -39,4 +39,4 @@ jobs:
           extensions: dom, mbstring
 
       - name: Detect code duplication
-        run: phpcpd --exclude system/Test --exclude system/ThirdParty -- app/ public/ system/ --exclude system/Database/SQLSRV/Builder.php --exclude system/Database/SQLSRV/Forge.php --exclude system/Database/MySQLi/Builder.php --exclude system/Database/OCI8/Builder.php
+        run: phpcpd --exclude system/Test --exclude system/ThirdParty --exclude system/Database/SQLSRV/Builder.php --exclude system/Database/SQLSRV/Forge.php --exclude system/Database/MySQLi/Builder.php --exclude system/Database/OCI8/Builder.php -- app/ public/ system/

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2255,8 +2255,10 @@ class BaseBuilder
     protected function _updateBatch(string $table, array $values, string $index): string
     {
         // this is a work around until the rest of the platform is refactored
-        $this->QBOptions['constraints'] = [$index];
-        $keys                           = array_keys(current($values));
+        if ($index !== '') {
+            $this->QBOptions['constraints'] = [$index];
+        }
+        $keys = array_keys(current($values));
 
         $sql = $this->QBOptions['sql'] ?? '';
 

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -154,6 +154,23 @@ class BaseBuilder
     protected $QBIgnore = false;
 
     /**
+     * QB Options data
+     * Holds additional options and data used to render SQL
+     * and is reset by resetWrite()
+     *
+     * @phpstan-var array{
+     * updateFields?: array,
+     * constraints?: array,
+     * fromQuery?: string,
+     * sql?: string,
+     * alias?: string
+     * }
+     *
+     * @var array
+     */
+    protected $QBOptions;
+
+    /**
      * A reference to the database connection.
      *
      * @var BaseConnection
@@ -2839,6 +2856,7 @@ class BaseBuilder
             'QBKeys'    => [],
             'QBLimit'   => false,
             'QBIgnore'  => false,
+            'QBOptions' => [],
         ]);
     }
 

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -159,13 +159,12 @@ class BaseBuilder
      * and is reset by resetWrite()
      *
      * @phpstan-var array{
-     * updateFields?: array,
-     * constraints?: array,
-     * fromQuery?: string,
-     * sql?: string,
-     * alias?: string
+     *   updateFields?: array,
+     *   constraints?: array,
+     *   fromQuery?: string,
+     *   sql?: string,
+     *   alias?: string
      * }
-     *
      * @var array
      */
     protected $QBOptions;

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1737,6 +1737,40 @@ class BaseBuilder
     }
 
     /**
+     * Sets update fields for updateBatch
+     *
+     * @param string|string[] $set
+     * @param bool            $addToDefault future use
+     * @param array|null      $ignore       ignores items in set
+     *
+     * @return $this
+     */
+    protected function updateFields($set, bool $addToDefault = false, ?array $ignore = null)
+    {
+        if (! empty($set)) {
+            if (! is_array($set)) {
+                $set = explode(',', $set);
+            }
+
+            foreach ($set as $key => $value) {
+                if (! ($value instanceof RawSql)) {
+                    $value = $this->db->protectIdentifiers($value);
+                }
+
+                if (is_numeric($key)) {
+                    $key = $value;
+                }
+
+                if ($ignore === null || ! in_array($key, $ignore, true)) {
+                    $this->QBOptions['updateFields'][$this->db->protectIdentifiers($key)] = $value;
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Compiles batch insert strings and runs the queries
      *
      * @return false|int|string[] Number of rows inserted or FALSE on failure, SQL array when testMode

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2254,44 +2254,79 @@ class BaseBuilder
      */
     protected function _updateBatch(string $table, array $values, string $index): string
     {
-        $keys = array_keys(current($values));
+        // this is a work around until the rest of the platform is refactored
+        $this->QBOptions['constraints'] = [$index];
+        $keys                           = array_keys(current($values));
 
-        // make array for future use with composite keys - `field`
-        // future: $this->QBOptions['constraints']
-        $constraints = [$index];
+        $sql = $this->QBOptions['sql'] ?? '';
 
-        // future: $this->QBOptions['updateFields']
-        $updateFields = array_filter($keys, static fn ($index) => ! in_array($index, $constraints, true));
+        // if this is the first iteration of batch then we need to build skeleton sql
+        if ($sql === '') {
+            $constraints = $this->QBOptions['constraints'] ?? [];
 
-        $sql = 'UPDATE ' . $this->compileIgnore('update') . $table . "\n";
+            if ($constraints === []) {
+                if ($this->db->DBDebug) {
+                    throw new DatabaseException('You must specify a constraint to match on for batch updates.'); // @codeCoverageIgnore
+                }
 
-        $sql .= 'SET' . "\n";
+                return ''; // @codeCoverageIgnore
+            }
 
-        $sql .= implode(
-            ",\n",
-            array_map(static fn ($key) => $key . ' = u.' . $key, $updateFields)
-        ) . "\n";
+            $updateFields = $this->QBOptions['updateFields'] ??
+                $this->updateFields($keys, false, $constraints)->QBOptions['updateFields'] ??
+                [];
 
-        $sql .= 'FROM (' . "\n";
+            $alias = $this->QBOptions['alias'] ?? '_u';
 
-        $sql .= implode(
-            " UNION ALL\n",
-            array_map(
-                static fn ($value) => 'SELECT ' . implode(', ', array_map(
-                    static fn ($key, $index) => $index . ' ' . $key,
-                    $keys,
-                    $value
-                )),
-                $values
-            )
-        ) . "\n";
+            $sql = 'UPDATE ' . $this->compileIgnore('update') . $table . "\n";
 
-        $sql .= ') u' . "\n";
+            $sql .= 'SET' . "\n";
 
-        return $sql .= 'WHERE ' . implode(
-            ' AND ',
-            array_map(static fn ($key) => $table . '.' . $key . ' = u.' . $key, $constraints)
-        );
+            $sql .= implode(
+                ",\n",
+                array_map(
+                    static fn ($key, $value) => $key . ($value instanceof RawSql ?
+                        ' = ' . $value :
+                        ' = ' . $alias . '.' . $value),
+                    array_keys($updateFields),
+                    $updateFields
+                )
+            ) . "\n";
+
+            $sql .= 'FROM (' . "\n%s";
+
+            $sql .= ') ' . $alias . "\n";
+
+            $sql .= 'WHERE ' . implode(
+                ' AND ',
+                array_map(
+                    static fn ($key) => ($key instanceof RawSql ?
+                    $key :
+                    $table . '.' . $key . ' = ' . $alias . '.' . $key),
+                    $constraints
+                )
+            );
+
+            $this->QBOptions['sql'] = $sql;
+        }
+
+        if (isset($this->QBOptions['fromQuery'])) {
+            $data = $this->QBOptions['fromQuery'];
+        } else {
+            $data = implode(
+                " UNION ALL\n",
+                array_map(
+                    static fn ($value) => 'SELECT ' . implode(', ', array_map(
+                        static fn ($key, $index) => $index . ' ' . $key,
+                        $keys,
+                        $value
+                    )),
+                    $values
+                )
+            ) . "\n";
+        }
+
+        return sprintf($sql, $data);
     }
 
     /**

--- a/system/Database/MySQLi/Builder.php
+++ b/system/Database/MySQLi/Builder.php
@@ -12,6 +12,8 @@
 namespace CodeIgniter\Database\MySQLi;
 
 use CodeIgniter\Database\BaseBuilder;
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\RawSql;
 
 /**
  * Builder for MySQLi
@@ -60,8 +62,10 @@ class Builder extends BaseBuilder
     protected function _updateBatch(string $table, array $values, string $index): string
     {
         // this is a work around until the rest of the platform is refactored
-        $this->QBOptions['constraints'] = [$index];
-        $keys                           = array_keys(current($values));
+        if ($index !== '') {
+            $this->QBOptions['constraints'] = [$index];
+        }
+        $keys = array_keys(current($values));
 
         $sql = $this->QBOptions['sql'] ?? '';
 

--- a/system/Database/MySQLi/Builder.php
+++ b/system/Database/MySQLi/Builder.php
@@ -53,4 +53,49 @@ class Builder extends BaseBuilder
 
         return implode(', ', $this->QBFrom);
     }
+
+    /**
+     * Generates a platform-specific batch update string from the supplied data
+     */
+    protected function _updateBatch(string $table, array $values, string $index): string
+    {
+        $keys = array_keys(current($values));
+
+        // make array for future use with composite keys - `field`
+        // future: $this->QBOptions['constraints']
+        $constraints = [$index];
+
+        // future: $this->QBOptions['updateFields']
+        $updateFields = array_filter($keys, static fn ($index) => ! in_array($index, $constraints, true));
+
+        $sql = 'UPDATE ' . $this->compileIgnore('update') . $table . " AS t\n";
+
+        $sql .= 'INNER JOIN (' . "\n";
+
+        $sql .= implode(
+            " UNION ALL\n",
+            array_map(
+                static fn ($value) => 'SELECT ' . implode(', ', array_map(
+                    static fn ($key, $index) => $index . ' ' . $key,
+                    $keys,
+                    $value
+                )),
+                $values
+            )
+        ) . "\n";
+
+        $sql .= ') u' . "\n";
+
+        $sql .= 'ON ' . implode(
+            ' AND ',
+            array_map(static fn ($key) => 't.' . $key . ' = u.' . $key, $constraints)
+        ) . "\n";
+
+        $sql .= 'SET' . "\n";
+
+        return $sql .= implode(
+            ",\n",
+            array_map(static fn ($key) => 't.' . $key . ' = u.' . $key, $updateFields)
+        );
+    }
 }

--- a/system/Database/MySQLi/Builder.php
+++ b/system/Database/MySQLi/Builder.php
@@ -59,43 +59,78 @@ class Builder extends BaseBuilder
      */
     protected function _updateBatch(string $table, array $values, string $index): string
     {
-        $keys = array_keys(current($values));
+        // this is a work around until the rest of the platform is refactored
+        $this->QBOptions['constraints'] = [$index];
+        $keys                           = array_keys(current($values));
 
-        // make array for future use with composite keys - `field`
-        // future: $this->QBOptions['constraints']
-        $constraints = [$index];
+        $sql = $this->QBOptions['sql'] ?? '';
 
-        // future: $this->QBOptions['updateFields']
-        $updateFields = array_filter($keys, static fn ($index) => ! in_array($index, $constraints, true));
+        // if this is the first iteration of batch then we need to build skeleton sql
+        if ($sql === '') {
+            $constraints = $this->QBOptions['constraints'] ?? [];
 
-        $sql = 'UPDATE ' . $this->compileIgnore('update') . $table . " AS t\n";
+            if ($constraints === []) {
+                if ($this->db->DBDebug) {
+                    throw new DatabaseException('You must specify a constraint to match on for batch updates.'); // @codeCoverageIgnore
+                }
 
-        $sql .= 'INNER JOIN (' . "\n";
+                return ''; // @codeCoverageIgnore
+            }
 
-        $sql .= implode(
-            " UNION ALL\n",
-            array_map(
-                static fn ($value) => 'SELECT ' . implode(', ', array_map(
-                    static fn ($key, $index) => $index . ' ' . $key,
-                    $keys,
-                    $value
-                )),
-                $values
-            )
-        ) . "\n";
+            $updateFields = $this->QBOptions['updateFields'] ??
+                $this->updateFields($keys, false, $constraints)->QBOptions['updateFields'] ??
+                [];
 
-        $sql .= ') u' . "\n";
+            $alias = $this->QBOptions['alias'] ?? '`_u`';
 
-        $sql .= 'ON ' . implode(
-            ' AND ',
-            array_map(static fn ($key) => 't.' . $key . ' = u.' . $key, $constraints)
-        ) . "\n";
+            $sql = 'UPDATE ' . $this->compileIgnore('update') . $table . "\n";
 
-        $sql .= 'SET' . "\n";
+            $sql .= 'INNER JOIN (' . "\n%s";
 
-        return $sql .= implode(
-            ",\n",
-            array_map(static fn ($key) => 't.' . $key . ' = u.' . $key, $updateFields)
-        );
+            $sql .= ') ' . $alias . "\n";
+
+            $sql .= 'ON ' . implode(
+                ' AND ',
+                array_map(
+                    static fn ($key) => ($key instanceof RawSql ?
+                    $key :
+                    $table . '.' . $key . ' = ' . $alias . '.' . $key),
+                    $constraints
+                )
+            ) . "\n";
+
+            $sql .= 'SET' . "\n";
+
+            $sql .= implode(
+                ",\n",
+                array_map(
+                    static fn ($key, $value) => $table . '.' . $key . ($value instanceof RawSql ?
+                        ' = ' . $value :
+                        ' = ' . $alias . '.' . $value),
+                    array_keys($updateFields),
+                    $updateFields
+                )
+            );
+
+            $this->QBOptions['sql'] = $sql;
+        }
+
+        if (isset($this->QBOptions['fromQuery'])) {
+            $data = $this->QBOptions['fromQuery'];
+        } else {
+            $data = implode(
+                " UNION ALL\n",
+                array_map(
+                    static fn ($value) => 'SELECT ' . implode(', ', array_map(
+                        static fn ($key, $index) => $index . ' ' . $key,
+                        $keys,
+                        $value
+                    )),
+                    $values
+                )
+            ) . "\n";
+        }
+
+        return sprintf($sql, $data);
     }
 }

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Database\OCI8;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\RawSql;
 
 /**
  * Builder for OCI8
@@ -234,8 +235,10 @@ class Builder extends BaseBuilder
     protected function _updateBatch(string $table, array $values, string $index): string
     {
         // this is a work around until the rest of the platform is refactored
-        $this->QBOptions['constraints'] = [$index];
-        $keys                           = array_keys(current($values));
+        if ($index !== '') {
+            $this->QBOptions['constraints'] = [$index];
+        }
+        $keys = array_keys(current($values));
 
         $sql = $this->QBOptions['sql'] ?? '';
 

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -242,39 +242,6 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Generates a platform-specific batch update string from the supplied data
-     */
-    protected function _updateBatch(string $table, array $values, string $index): string
-    {
-        $ids   = [];
-        $final = [];
-
-        foreach ($values as $val) {
-            $ids[] = $val[$index];
-
-            foreach (array_keys($val) as $field) {
-                if ($field !== $index) {
-                    $final[$field] ??= [];
-
-                    $final[$field][] = "WHEN {$val[$index]} THEN {$val[$field]}";
-                }
-            }
-        }
-
-        $cases = '';
-
-        foreach ($final as $k => $v) {
-            $cases .= "{$k} = (CASE {$index}\n"
-                    . implode("\n", $v)
-                    . "\nELSE {$k} END), ";
-        }
-
-        $this->where("{$index} IN(" . implode(',', $ids) . ')', null, false);
-
-        return "UPDATE {$table} SET " . substr($cases, 0, -2) . $this->compileWhereHaving('QBWhere');
-    }
-
-    /**
      * Generates a platform-specific delete string from the supplied data
      */
     protected function _delete(string $table): string

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -206,39 +206,6 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Update_Batch statement
-     *
-     * Generates a platform-specific batch update string from the supplied data
-     */
-    protected function _updateBatch(string $table, array $values, string $index): string
-    {
-        $ids   = [];
-        $final = [];
-
-        foreach ($values as $val) {
-            $ids[] = $val[$index];
-
-            foreach (array_keys($val) as $field) {
-                if ($field !== $index) {
-                    $final[$field][] = 'WHEN ' . $index . ' = ' . $val[$index] . ' THEN ' . $val[$field];
-                }
-            }
-        }
-
-        $cases = '';
-
-        foreach ($final as $k => $v) {
-            $cases .= $k . " = CASE \n"
-                . implode("\n", $v) . "\n"
-                . 'ELSE ' . $k . ' END, ';
-        }
-
-        $this->where($index . ' IN(' . implode(',', $ids) . ')', null, false);
-
-        return 'UPDATE ' . $this->compileIgnore('update') . ' ' . $this->getFullName($table) . ' SET ' . substr($cases, 0, -2) . $this->compileWhereHaving('QBWhere');
-    }
-
-    /**
      * Increments a numeric column by the specified value.
      *
      * @return bool

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -70,4 +70,39 @@ class Builder extends BaseBuilder
     {
         return 'DELETE FROM ' . $table;
     }
+
+    /**
+     * Generates a platform-specific batch update string from the supplied data
+     */
+    protected function _updateBatch(string $table, array $values, string $index): string
+    {
+        if (version_compare($this->db->getVersion(), '3.33.0') >= 0) {
+            return parent::_updateBatch($table, $values, $index);
+        }
+
+        $ids   = [];
+        $final = [];
+
+        foreach ($values as $val) {
+            $ids[] = $val[$index];
+
+            foreach (array_keys($val) as $field) {
+                if ($field !== $index) {
+                    $final[$field][] = 'WHEN ' . $index . ' = ' . $val[$index] . ' THEN ' . $val[$field];
+                }
+            }
+        }
+
+        $cases = '';
+
+        foreach ($final as $k => $v) {
+            $cases .= $k . " = CASE \n"
+                . implode("\n", $v) . "\n"
+                . 'ELSE ' . $k . ' END, ';
+        }
+
+        $this->where($index . ' IN(' . implode(',', $ids) . ')', null, false);
+
+        return 'UPDATE ' . $this->compileIgnore('update') . $table . ' SET ' . substr($cases, 0, -2) . $this->compileWhereHaving('QBWhere');
+    }
 }

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -234,13 +234,13 @@ final class UpdateTest extends CIUnitTestCase
         $expected = <<<'EOF'
             UPDATE "jobs"
             SET
-            "name" = u."name",
-            "description" = u."description"
+            "name" = _u."name",
+            "description" = _u."description"
             FROM (
             SELECT 2 "id", 'Comedian' "name", 'There''s something in your teeth' "description" UNION ALL
             SELECT 3 "id", 'Cab Driver' "name", 'I am yellow' "description"
-            ) u
-            WHERE "jobs"."id" = u."id"
+            ) _u
+            WHERE "jobs"."id" = _u."id"
             EOF;
 
         $this->assertSame($expected, $query->getQuery());
@@ -273,13 +273,13 @@ final class UpdateTest extends CIUnitTestCase
         $expected = <<<'EOF'
             UPDATE "jobs"
             SET
-            "name" = u."name",
-            "description" = u."description"
+            "name" = _u."name",
+            "description" = _u."description"
             FROM (
             SELECT 2 "id", SUBSTRING(name, 1) "name", SUBSTRING(description, 3) "description" UNION ALL
             SELECT 3 "id", SUBSTRING(name, 2) "name", SUBSTRING(description, 4) "description"
-            ) u
-            WHERE "jobs"."id" = u."id"
+            ) _u
+            WHERE "jobs"."id" = _u."id"
             EOF;
 
         $this->assertSame($expected, $query->getQuery());

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -231,17 +231,16 @@ final class UpdateTest extends CIUnitTestCase
         $query = $this->db->getLastQuery();
         $this->assertInstanceOf(MockQuery::class, $query);
 
-        $space = ' ';
-
-        $expected = <<<EOF
-            UPDATE "jobs" SET "name" = CASE{$space}
-            WHEN "id" = 2 THEN 'Comedian'
-            WHEN "id" = 3 THEN 'Cab Driver'
-            ELSE "name" END, "description" = CASE{$space}
-            WHEN "id" = 2 THEN 'There''s something in your teeth'
-            WHEN "id" = 3 THEN 'I am yellow'
-            ELSE "description" END
-            WHERE "id" IN(2,3)
+        $expected = <<<'EOF'
+            UPDATE "jobs"
+            SET
+            "name" = u."name",
+            "description" = u."description"
+            FROM (
+            SELECT 2 "id", 'Comedian' "name", 'There''s something in your teeth' "description" UNION ALL
+            SELECT 3 "id", 'Cab Driver' "name", 'I am yellow' "description"
+            ) u
+            WHERE "jobs"."id" = u."id"
             EOF;
 
         $this->assertSame($expected, $query->getQuery());
@@ -271,17 +270,16 @@ final class UpdateTest extends CIUnitTestCase
         $query = $this->db->getLastQuery();
         $this->assertInstanceOf(MockQuery::class, $query);
 
-        $space = ' ';
-
-        $expected = <<<EOF
-            UPDATE "jobs" SET "name" = CASE{$space}
-            WHEN "id" = 2 THEN SUBSTRING(name, 1)
-            WHEN "id" = 3 THEN SUBSTRING(name, 2)
-            ELSE "name" END, "description" = CASE{$space}
-            WHEN "id" = 2 THEN SUBSTRING(description, 3)
-            WHEN "id" = 3 THEN SUBSTRING(description, 4)
-            ELSE "description" END
-            WHERE "id" IN(2,3)
+        $expected = <<<'EOF'
+            UPDATE "jobs"
+            SET
+            "name" = u."name",
+            "description" = u."description"
+            FROM (
+            SELECT 2 "id", SUBSTRING(name, 1) "name", SUBSTRING(description, 3) "description" UNION ALL
+            SELECT 3 "id", SUBSTRING(name, 2) "name", SUBSTRING(description, 4) "description"
+            ) u
+            WHERE "jobs"."id" = u."id"
             EOF;
 
         $this->assertSame($expected, $query->getQuery());

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -109,6 +109,7 @@ Model
 - Added before and after events to ``BaseModel::insertBatch()`` and ``BaseModel::updateBatch()`` methods. See :ref:`model-events-callbacks`.
 - Added ``Model::allowEmptyInserts()`` method to insert empty data. See :ref:`Using CodeIgniter's Model <model-allow-empty-inserts>`
 - Added new :ref:`entities-property-casting` class ``IntBoolCast`` for Entity.
+- Improved the SQL structure for ``Builder::updateBatch()``. See :ref:`update-batch` for the details.
 
 Libraries
 =========

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -102,6 +102,7 @@ Database
 - SQLSRV now automatically drops ``DEFAULT`` constraint when using :ref:`Forge::dropColumn() <db-forge-dropColumn>`.
 - ``BaseConnection::escape()`` now excludes the ``RawSql`` data type. This allows passing SQL strings into data.
 - The new method ``Forge::dropPrimaryKey()`` allows dropping the primary key on a table. See :ref:`dropping-a-primary-key`.
+- Improved the SQL structure for ``Builder::updateBatch()``. See :ref:`update-batch` for the details.
 
 Model
 =====
@@ -109,7 +110,6 @@ Model
 - Added before and after events to ``BaseModel::insertBatch()`` and ``BaseModel::updateBatch()`` methods. See :ref:`model-events-callbacks`.
 - Added ``Model::allowEmptyInserts()`` method to insert empty data. See :ref:`Using CodeIgniter's Model <model-allow-empty-inserts>`
 - Added new :ref:`entities-property-casting` class ``IntBoolCast`` for Entity.
-- Improved the SQL structure for ``Builder::updateBatch()``. See :ref:`update-batch` for the details.
 
 Libraries
 =========

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -939,6 +939,8 @@ Or as an array:
 You may also use the ``$builder->set()`` method described above when
 performing updates.
 
+.. _update-batch:
+
 UpdateBatch
 ===========
 

--- a/user_guide_src/source/database/query_builder/092.php
+++ b/user_guide_src/source/database/query_builder/092.php
@@ -2,27 +2,28 @@
 
 $data = [
     [
-        'title' => 'My title',
-        'name'  => 'My Name 2',
-        'date'  => 'My date 2',
+        'title' => 'Title 1',
+        'name'  => 'Name 1',
+        'date'  => 'Date 1',
     ],
     [
-        'title' => 'Another title',
-        'name'  => 'Another Name 2',
-        'date'  => 'Another date 2',
+        'title' => 'Title 2',
+        'name'  => 'Name 2',
+        'date'  => 'Date 2',
     ],
 ];
 
 $builder->updateBatch($data, 'title');
 /*
  * Produces:
- * UPDATE `mytable` SET `name` = CASE
- * WHEN `title` = 'My title' THEN 'My Name 2'
- * WHEN `title` = 'Another title' THEN 'Another Name 2'
- * ELSE `name` END,
- * `date` = CASE
- * WHEN `title` = 'My title' THEN 'My date 2'
- * WHEN `title` = 'Another title' THEN 'Another date 2'
- * ELSE `date` END
- * WHERE `title` IN ('My title','Another title')
+ * UPDATE `mytable`
+ * INNER JOIN (
+ * SELECT 'Title 1' `title`, 'Name 1' `name`, 'Date 1' `date` UNION ALL
+ * SELECT 'Title 2' `title`, 'Name 2' `name`, 'Date 2' `date`
+ * ) u
+ * ON `mytable`.`title` = u.`title`
+ * SET
+ * `mytable`.`title` = u.`title`,
+ * `mytable`.`name` = u.`name`,
+ * `mytable`.`date` = u.`date`
  */


### PR DESCRIPTION
This PR redesigns the SQL queries generated in `_batchUpdate()`.

This implementation provides more elegant and smaller queries. This method selects the data into a psudo in memory table which provides more flexibility and availability to do more things with.

Because it treats the dataset as a table, a query or a table can be substituted for the dataset. This will be helpful in future ambitions.

Here is a sample of the difference in MySQL:

Old way - 982 Characters - This gets really hard to read when 100 rows long and 15 columns wide:

```SQL
UPDATE `db_update_batch` SET `column1` = CASE 
WHEN `primary_key` = 1 THEN 'test data string T'
WHEN `primary_key` = 2 THEN 'test data string T'
WHEN `primary_key` = 3 THEN 'test data string T'
ELSE `column1` END, `column2` = CASE 
WHEN `primary_key` = 1 THEN 'test data string T'
WHEN `primary_key` = 2 THEN 'test data string T'
WHEN `primary_key` = 3 THEN 'test data string T'
ELSE `column2` END, `column3` = CASE 
WHEN `primary_key` = 1 THEN 'test data string T'
WHEN `primary_key` = 2 THEN 'test data string T'
WHEN `primary_key` = 3 THEN 'test data string T'
ELSE `column3` END, `column4` = CASE 
WHEN `primary_key` = 1 THEN 'test data string T'
WHEN `primary_key` = 2 THEN 'test data string T'
WHEN `primary_key` = 3 THEN 'test data string T'
ELSE `column4` END, `column5` = CASE 
WHEN `primary_key` = 1 THEN 'test data string T'
WHEN `primary_key` = 2 THEN 'test data string T'
WHEN `primary_key` = 3 THEN 'test data string T'
ELSE `column5` END
WHERE `primary_key` IN(1,2,3)
```

New way - 791 Characters - This is easy to read no matter the number of rows:

```SQL
UPDATE `db_update_batch` AS t
INNER JOIN (
SELECT 1 `primary_key`, 'test data string T' `column1`, 'test data string T' `column2`, 'test data string T' `column3`, 'test data string T' `column4`, 'test data string T' `column5` UNION ALL
SELECT 2 `primary_key`, 'test data string T' `column1`, 'test data string T' `column2`, 'test data string T' `column3`, 'test data string T' `column4`, 'test data string T' `column5` UNION ALL
SELECT 3 `primary_key`, 'test data string T' `column1`, 'test data string T' `column2`, 'test data string T' `column3`, 'test data string T' `column4`, 'test data string T' `column5`
) u
ON t.`primary_key` = u.`primary_key`
SET 
t.`column1` = u.`column1`,
t.`column2` = u.`column2`,
t.`column3` = u.`column3`,
t.`column4` = u.`column4`,
t.`column5` = u.`column5`
```

The size difference varies depending on the query. A long or multiple primary key significantly lengthens the old method. This then is compounded by the length of the dataset.

On MySQL I ran some tests on performance:

```
With 100 records with 55 character primary_key and 15 columns - Query strlen():
Old Method: 157,605
New Method: 54,821

50,000 records update - 15 Fields 255 characters - Four passes each:
Old Method: 29,368 ms 84.68 mb
New Method: 28,374 ms 83.25 mb

Query execution of batch of 100 Fields 55 Characters - 2 passes:
Old Method: 0.0195 s
New Method: 0.0095 s
```
There doesn't seem to be a huge gain in performance but no loss either. Smaller queries should perform much better when using a remote database where network speed becomes a factor.

Future ambitions include being able to update from a query or another table. Also, the current implementation limits the use of a single field as a constraint. This makes it useless if you have composite primary keys. I work with tables all the time that have as many as six fields composing the primary key. This PR has already built in the use of multiple constraints. The rest of it will need to be implemented later. I'd like to have it working with the `onConstraint()` method created in the upsert PR.

All the drivers are updated to use this type of query. Oracle is using MERGE instead of UPDATE. It accomplishes the same thing and works in the same way as the other queries.

The `BaseBuilder` method was switched from MySQL to a method used by SQLite, MSSQL, Postgre. MySql and Oracle have methods in `Builder`. SQLite has method in Builder for < version 3.33.0.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
