### PR TITLE
refactor: add test for DownloadResponse

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -982,8 +982,10 @@ class CodeIgniter
 
         if ($returned instanceof DownloadResponse) {
             // Turn off output buffering completely, even if php.ini output_buffering is not off
-            while (ob_get_level() > 0) {
-                ob_end_clean();
+            if (ENVIRONMENT !== 'testing') {
+                while (ob_get_level() > 0) {
+                    ob_end_clean();
+                }
             }
 
             $this->response = $returned;

--- a/tests/_support/Filters/Customfilter.php
+++ b/tests/_support/Filters/Customfilter.php
@@ -18,7 +18,7 @@ class Customfilter implements \CodeIgniter\Filters\FilterInterface
 {
     public function before(RequestInterface $request, $arguments = null)
     {
-        $request->url = 'http://hellowworld.com';
+        $request->appendBody('http://hellowworld.com');
 
         return $request;
     }

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -200,7 +200,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
         // Inject mock router.
         $routes = Services::routes();
-        $routes->add('pages/about', static fn () => Services::request()->url, ['filter' => Customfilter::class]);
+        $routes->add('pages/about', static fn () => Services::request()->getBody(), ['filter' => Customfilter::class]);
 
         $router = Services::router($routes, Services::request());
         Services::injectMock('router', $router);
@@ -210,6 +210,8 @@ final class CodeIgniterTest extends CIUnitTestCase
         $output = ob_get_clean();
 
         $this->assertStringContainsString('http://hellowworld.com', $output);
+
+        $this->resetServices();
     }
 
     public function testResponseConfigEmpty()

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -191,6 +191,33 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->assertStringContainsString("You want to see 'about' page.", $output);
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/6358
+     */
+    public function testControllersCanReturnDownloadResponseObject()
+    {
+        $_SERVER['argv'] = ['index.php', 'pages/about'];
+        $_SERVER['argc'] = 2;
+
+        $_SERVER['REQUEST_URI'] = '/pages/about';
+
+        // Inject mock router.
+        $routes = Services::routes();
+        $routes->add('pages/(:segment)', static function ($segment) {
+            $response = Services::response();
+
+            return $response->download('some.txt', 'some text', true);
+        });
+        $router = Services::router($routes, Services::request());
+        Services::injectMock('router', $router);
+
+        ob_start();
+        $this->codeigniter->useSafeOutput(true)->run();
+        $output = ob_get_clean();
+
+        $this->assertSame('some text', $output);
+    }
+
     public function testControllersRunFilterByClassName()
     {
         $_SERVER['argv'] = ['index.php', 'pages/about'];

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -439,7 +439,9 @@ final class FiltersTest extends CIUnitTestCase
         $uri     = 'admin/foo/bar';
         $request = $filters->run($uri, 'before');
 
-        $this->assertSame('http://hellowworld.com', $request->url);
+        $this->assertSame('http://hellowworld.com', $request->getBody());
+
+        $this->resetServices();
     }
 
     /**

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -599,6 +599,8 @@ final class RouterTest extends CIUnitTestCase
         $this->assertSame('\TestController', $router->controllerName());
         $this->assertSame('foo', $router->methodName());
         $this->assertSame(Customfilter::class, $router->getFilter());
+
+        $this->resetServices();
     }
 
     public function testRouteWorksWithMultipleFilters()

--- a/tests/system/Test/FilterTestTraitTest.php
+++ b/tests/system/Test/FilterTestTraitTest.php
@@ -66,10 +66,9 @@ final class FilterTestTraitTest extends CIUnitTestCase
         $caller = $this->getFilterCaller('test-customfilter', 'before');
         $result = $caller();
 
-        $this->assertObjectNotHasAttribute('url', $this->request);
+        $this->assertSame('http://hellowworld.com', $result->getBody());
 
-        $this->assertObjectHasAttribute('url', $result);
-        $this->assertSame('http://hellowworld.com', $result->url);
+        $this->resetServices();
     }
 
     public function testGetFiltersForRoute()


### PR DESCRIPTION
**Description**
Follow-up #6361

- add hack for testing in CodeIgniter.php
- add test for DownloadResponse
- fix tests with dynamic property

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

