### PR TITLE
fix: route_to() cannot be used in CLI

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -906,7 +906,8 @@ if (! function_exists('route_to')) {
      * have a route defined in the routes Config file.
      *
      * @param string     $method    Named route or Controller::method
-     * @param int|string ...$params One or more parameters to be passed to the route
+     * @param int|string ...$params One or more parameters to be passed to the route.
+     *                              The last parameter allows you to set the locale.
      *
      * @return false|string
      */

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -15,6 +15,7 @@ use Closure;
 use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\Router\Exceptions\RouterException;
+use Config\App;
 use Config\Modules;
 use Config\Services;
 use InvalidArgumentException;
@@ -1202,6 +1203,14 @@ class RouteCollection implements RouteCollectionInterface
     {
         if (strpos($route, '{locale}') === false) {
             return $route;
+        }
+
+        if ($locale !== null) {
+            /** @var App $config */
+            $config = config('App');
+            if (! in_array($locale, $config->supportedLocales, true)) {
+                $locale = null;
+            }
         }
 
         if ($locale === null) {

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1151,10 +1151,10 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Builds reverse route
      *
-     * @param array|null $params One or more parameters to be passed to the route.
-     *                           The last parameter allows you to set the locale.
+     * @param array $params One or more parameters to be passed to the route.
+     *                      The last parameter allows you to set the locale.
      */
-    protected function buildReverseRoute(string $from, ?array $params = null): string
+    protected function buildReverseRoute(string $from, array $params): string
     {
         $locale = null;
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1207,11 +1207,7 @@ class RouteCollection implements RouteCollectionInterface
         if ($locale === null) {
             $request = Services::request();
 
-            if ($request instanceof IncomingRequest) {
-                $locale = $request->getLocale();
-            } else {
-                $locale = Locale::getDefault();
-            }
+            $locale = $request instanceof IncomingRequest ? $request->getLocale() : Locale::getDefault();
         }
 
         return strtr($route, ['{locale}' => $locale]);

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -222,6 +222,27 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $this->assertSame('/path/string/to/13', route_to('myController::goto', 'string', 13));
     }
 
+    public function testRouteToInCliWithoutLocaleInRoute()
+    {
+        Services::createRequest(new App(), true);
+        $routes = service('routes');
+        $routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2');
+
+        $this->assertSame('/path/string/to/13', route_to('myController::goto', 'string', 13));
+    }
+
+    public function testRouteToInCliWithLocaleInRoute()
+    {
+        Services::createRequest(new App(), true);
+        $routes = service('routes');
+        $routes->add('{locale}/path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'path-to']);
+
+        $this->assertSame(
+            '/en/path/string/to/13',
+            route_to('path-to', 'string', 13, 'en')
+        );
+    }
+
     public function testInvisible()
     {
         $this->assertSame('Javascript', remove_invisible_characters("Java\0script"));

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -243,6 +243,18 @@ final class CommonFunctionsTest extends CIUnitTestCase
         );
     }
 
+    public function testRouteToWithUnsupportedLocale()
+    {
+        Services::createRequest(new App(), false);
+        $routes = service('routes');
+        $routes->add('{locale}/path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'path-to']);
+
+        $this->assertSame(
+            '/en/path/string/to/13',
+            route_to('path-to', 'string', 13, 'invalid')
+        );
+    }
+
     public function testInvisible()
     {
         $this->assertSame('Javascript', remove_invisible_characters("Java\0script"));

--- a/user_guide_src/source/changelogs/v4.2.5.rst
+++ b/user_guide_src/source/changelogs/v4.2.5.rst
@@ -19,7 +19,7 @@ BREAKING
 Enhancements
 ************
 
-none.
+- You can set the locale to :php:func:`route_to()` if you pass a locale value as the last parameter.
 
 Changes
 *******

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -335,16 +335,21 @@ Miscellaneous Functions
 .. php:function:: route_to($method[, ...$params])
 
     :param   string  $method: The named route alias, or name of the controller/method to match.
-    :param   int|string   $params: One or more parameters to be passed to be matched in the route.
+    :param   int|string   $params: One or more parameters to be passed to be matched in the route. The last parameter allows you to set the locale.
 
     .. note:: This function requires the controller/method to have a route defined in **app/Config/routes.php**.
 
-    Generates a route for you based on either a named route alias,
-    or a controller::method combination. Will take parameters into effect, if provided.
+    Generates a route for you based on a controller::method combination. Will take parameters into effect, if provided.
 
     .. literalinclude:: common_functions/009.php
 
+    Generates a route for you based on a named route alias.
+
     .. literalinclude:: common_functions/010.php
+
+    When you use ``{locale}`` in your route, you can optionally specify the locale value as the last parameter.
+
+    .. literalinclude:: common_functions/011.php
 
     .. note:: ``route_to()`` returns a route, not a full URI path for your site.
         If your **baseURL** contains sub folders, the return value is not the same

--- a/user_guide_src/source/general/common_functions/011.php
+++ b/user_guide_src/source/general/common_functions/011.php
@@ -1,0 +1,16 @@
+<?php
+
+// The route is defined as:
+$routes->add(
+    '{locale}/users/(:num)/gallery(:any)',
+    'Galleries::showUserGallery/$1/$2',
+    ['as' => 'user_gallery']
+);
+
+?>
+
+<?php
+
+// Generate the route with user ID 15, gallery 12 and locale en:
+route_to('user_gallery', 15, 12, 'en');
+// Result: '/en/users/15/gallery/12'


### PR DESCRIPTION
**Description**
Fixes #6377

- Now you can set locale as the last parameter.

  ```php
  // for route 
  $routes->add('{locale}/path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'path-to']);
  
  // the helper should be called like this.
  route_to('path-to', 'string', 13, 'en'); // /en/path/string/to/13
  ```

- In CLI, the default locale is used when locale is not passed.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

