### PR TITLE
feat: add param $withSessionErrors to Validation::getErrors()

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -651,11 +651,6 @@ parameters:
 			path: system/Throttle/Throttler.php
 
 		-
-			message: "#^Property CodeIgniter\\\\Validation\\\\Validation\\:\\:\\$errors \\(array\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: system/Validation/Validation.php
-
-		-
 			message: "#^Variable \\$error on left side of \\?\\? always exists and is always null\\.$#"
 			count: 1
 			path: system/Validation/Validation.php

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -675,20 +675,33 @@ class Validation implements ValidationInterface
      *        'field2' => 'error message',
      *    ]
      *
+     * @param bool $withSessionErrors Whether to get the validation errors in Session by redirect()->withErrors().
+     *
      * @return array<string, string>
      *
      * @codeCoverageIgnore
      */
-    public function getErrors(): array
+    public function getErrors(bool $withSessionErrors = true): array
     {
         // If we already have errors, we'll use those.
-        // If we don't, check the session to see if any were
-        // passed along from a redirect_with_input request.
-        if (empty($this->errors) && ! is_cli() && isset($_SESSION, $_SESSION['_ci_validation_errors'])) {
-            $this->errors = unserialize($_SESSION['_ci_validation_errors']);
+        if ($this->errors !== []) {
+            return $this->errors;
         }
 
-        return $this->errors ?? [];
+        // If we don't get the errors in the Session.
+        if (! $withSessionErrors) {
+            return $this->errors;
+        }
+
+        // Check the session to see if any were
+        // passed along from a redirect withErrors() request.
+        if (isset($_SESSION, $_SESSION['_ci_validation_errors'])) {
+            if (ENVIRONMENT === 'testing' || ! is_cli()) {
+                $this->errors = unserialize($_SESSION['_ci_validation_errors']);
+            }
+        }
+
+        return $this->errors;
     }
 
     /**

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -695,10 +695,8 @@ class Validation implements ValidationInterface
 
         // Check the session to see if any were
         // passed along from a redirect withErrors() request.
-        if (isset($_SESSION, $_SESSION['_ci_validation_errors'])) {
-            if (ENVIRONMENT === 'testing' || ! is_cli()) {
-                $this->errors = unserialize($_SESSION['_ci_validation_errors']);
-            }
+        if (isset($_SESSION, $_SESSION['_ci_validation_errors']) && (ENVIRONMENT === 'testing' || ! is_cli())) {
+            $this->errors = unserialize($_SESSION['_ci_validation_errors']);
         }
 
         return $this->errors;

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -379,6 +379,24 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame(['foo' => 'Validation.is_numeric'], $this->validation->getErrors());
     }
 
+    public function testGetErrorsWithSession(): void
+    {
+        $_SESSION = ['_ci_validation_errors' => 'a:1:{s:3:"foo";s:3:"bar";}'];
+
+        $this->assertSame(['foo' => 'bar'], $this->validation->getErrors());
+
+        $_SESSION = [];
+    }
+
+    public function testGetErrorsWithoutSessionErrorDataWithSession(): void
+    {
+        $_SESSION = ['_ci_validation_errors' => 'a:1:{s:3:"foo";s:3:"bar";}'];
+
+        $this->assertSame([], $this->validation->getErrors(false));
+
+        $_SESSION = [];
+    }
+
     public function testGetErrorsWhenNone(): void
     {
         $data = ['foo' => 123];

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -43,6 +43,7 @@ Others
 - The ``spark`` file has been changed due to a change in the processing of Spark commands.
 - ``InvalidArgumentException`` that is a kind of ``LogicException`` in ``BaseBuilder::_whereIn()`` is not suppressed by the configuration. Previously if ``CI_DEBUG`` was false, the exception was suppressed.
 - ``RouteCollection::resetRoutes()`` resets Auto-Discovery of Routes. Previously once discovered, RouteCollection never discover Routes files again even if ``RouteCollection::resetRoutes()`` is called.
+- The method signature of ``Validation::getErrors()`` has been changed. A first optional parameter ``$withSessionErrors`` was added. When you pass ``false``, the method does not return errors that are stored in the session.
 
 Enhancements
 ************


### PR DESCRIPTION
**Description**
See #6380

- add a parameter to exclude validation errors in the session

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
