### PR TITLE
docs: add/fix @return types in CLI

### DIFF
--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -97,6 +97,8 @@ abstract class BaseCommand
      * Actually execute a command.
      *
      * @param array<int|string, string|null> $params
+     *
+     * @return int|void
      */
     abstract public function run(array $params);
 

--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -48,6 +48,8 @@ class Commands
 
     /**
      * Runs a command given
+     *
+     * @return int|void
      */
     public function run(string $command, array $params)
     {

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -25,7 +25,7 @@ class Console
      *
      * @throws Exception
      *
-     * @return mixed
+     * @return int|void
      */
     public function run()
     {


### PR DESCRIPTION
**Description**
Ref #6310

- add/fix `@return`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

