### PR TITLE
Fix: The subquery adds a prefix for the table alias.

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -577,7 +577,7 @@ class BaseBuilder
     {
         $table = $this->buildSubquery($from, true, $alias);
 
-        $this->trackAliases($table);
+        $this->db->addTableAlias($alias);
         $this->QBFrom[] = $table;
 
         return $this;

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2952,7 +2952,7 @@ class BaseBuilder
             throw new DatabaseException('The subquery cannot be the same object as the main query object.');
         }
 
-        $subquery = strtr($builder->getCompiledSelect(), "\n", ' ');
+        $subquery = strtr($builder->getCompiledSelect(false), "\n", ' ');
 
         if ($wrapped) {
             $subquery = '(' . $subquery . ')';

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -882,7 +882,12 @@ abstract class BaseConnection implements ConnectionInterface
      */
     public function newQuery(): BaseBuilder
     {
-        return $this->table(',')->from([], true);
+        // save table aliases
+        $tempAliases         = $this->aliasedTables;
+        $builder             = $this->table(',')->from([], true);
+        $this->aliasedTables = $tempAliases;
+
+        return $builder;
     }
 
     /**

--- a/tests/system/Database/Builder/PrefixTest.php
+++ b/tests/system/Database/Builder/PrefixTest.php
@@ -49,4 +49,24 @@ final class PrefixTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
+
+    public function testPrefixWithSubquery()
+    {
+        $expected = <<<'NOWDOC'
+            SELECT "u"."id", "u"."name", (SELECT 1 FROM "ci_users" "sub" WHERE "sub"."id" = "u"."id") "one"
+            FROM "ci_users" "u"
+            WHERE "u"."id" = 1
+            NOWDOC;
+
+        $subquery = $this->db->table('users sub')
+            ->select('1', false)
+            ->where('sub.id = u.id');
+
+        $builder = $this->db->table('users u')
+            ->select('u.id, u.name')
+            ->selectSubquery($subquery, 'one')
+            ->where('u.id', 1);
+
+        $this->assertSame($expected, $builder->getCompiledSelect());
+    }
 }

--- a/user_guide_src/source/changelogs/v4.2.5.rst
+++ b/user_guide_src/source/changelogs/v4.2.5.rst
@@ -32,5 +32,6 @@ none.
 
 Bugs Fixed
 **********
+- When using subqueries in the main query, prefixes are added to the table alias.
 
 See the repo's `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_ for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
https://forum.codeigniter.com/showthread.php?tid=82741&pid=399285#pid399285
When creating a query, table aliases are registered. This prevents the prefix being added to the alias.

Due to the fact that aliases are stored in the property of the BaseConnection class, after compiling the subquery using the ``BaseBuilder::geCompiledSelect()`` method, the list of aliases is cleared, which leads to the fact that when compiling the main query, the alias is recognized as a table name and to the alias prefix is added.

This PR prevents resetting alias values.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide