### PR TITLE
Fix Sqlite Table::createTable()

### DIFF
--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -240,6 +240,14 @@ class Table
 
         $this->forge->addField($fields);
 
+        $fieldNames = array_keys($fields);
+
+        $this->keys = array_filter(
+            $this->keys,
+            static fn ($index) => count(array_intersect($index['fields'], $fieldNames))
+            === count($index['fields'])
+        );
+
         // Unique/Index keys
         if (is_array($this->keys)) {
             foreach ($this->keys as $key) {

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -244,8 +244,7 @@ class Table
 
         $this->keys = array_filter(
             $this->keys,
-            static fn ($index) => count(array_intersect($index['fields'], $fieldNames))
-            === count($index['fields'])
+            static fn ($index) => count(array_intersect($index['fields'], $fieldNames)) === count($index['fields'])
         );
 
         // Unique/Index keys

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -189,6 +189,10 @@ final class AlterTableTest extends CIUnitTestCase
         // check that composite index was dropped.
         $this->assertFalse(isset($indexes['actions_category_name']));
 
+        // check that that other keys are present
+        $this->assertTrue(isset($indexes['actions_name']));
+        $this->assertTrue(isset($indexes['actions_created_at']));
+
         $this->forge->dropTable('actions');
     }
 

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -187,11 +187,11 @@ final class AlterTableTest extends CIUnitTestCase
         $indexes = $this->db->getIndexData('actions');
 
         // check that composite index was dropped.
-        $this->assertFalse(isset($indexes['actions_category_name']));
+        $this->assertArrayNotHasKey('actions_category_name', $indexes);
 
         // check that that other keys are present
-        $this->assertTrue(isset($indexes['actions_name']));
-        $this->assertTrue(isset($indexes['actions_created_at']));
+        $this->assertArrayHasKey('actions_name', $indexes);
+        $this->assertArrayHasKey('actions_created_at', $indexes);
 
         $this->forge->dropTable('actions');
     }

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -156,6 +156,42 @@ final class AlterTableTest extends CIUnitTestCase
         $this->assertTrue($result);
     }
 
+    public function testDropColumnDropCompositeKey()
+    {
+        $this->forge->dropTable('actions', true);
+
+        $fields = [
+            'category'   => ['type' => 'varchar', 'constraint' => 63],
+            'name'       => ['type' => 'varchar', 'constraint' => 63],
+            'created_at' => ['type' => 'datetime', 'null' => true],
+        ];
+
+        $this->forge->addField('id');
+        $this->forge->addField($fields);
+
+        $this->forge->addKey('name');
+        $this->forge->addKey(['category', 'name']);
+        $this->forge->addKey('created_at');
+
+        $this->forge->createTable('actions');
+
+        $indexes = $this->db->getIndexData('actions');
+
+        // the composite index was created
+        $this->assertSame(['category', 'name'], $indexes['actions_category_name']->fields);
+
+        // drop one of the columns in the composite index
+        $this->forge->dropColumn('actions', 'category');
+
+        // get indexes again
+        $indexes = $this->db->getIndexData('actions');
+
+        // check that composite index was dropped.
+        $this->assertFalse(isset($indexes['actions_category_name']));
+
+        $this->forge->dropTable('actions');
+    }
+
     public function testModifyColumnSuccess()
     {
         $this->createTable('janky');


### PR DESCRIPTION
This PR fixes https://github.com/codeigniter4/CodeIgniter4/issues/6205

The indexes need to be checked for missing fields on composite keys.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
