### PR TITLE
fix: SecurityException's HTTP status code

### DIFF
--- a/system/Security/Exceptions/SecurityException.php
+++ b/system/Security/Exceptions/SecurityException.php
@@ -12,8 +12,9 @@
 namespace CodeIgniter\Security\Exceptions;
 
 use CodeIgniter\Exceptions\FrameworkException;
+use CodeIgniter\Exceptions\HTTPExceptionInterface;
 
-class SecurityException extends FrameworkException
+class SecurityException extends FrameworkException implements HTTPExceptionInterface
 {
     public static function forDisallowedAction()
     {

--- a/tests/system/Filters/CSRFTest.php
+++ b/tests/system/Filters/CSRFTest.php
@@ -31,22 +31,40 @@ final class CSRFTest extends CIUnitTestCase
         $this->config = new \Config\Filters();
     }
 
-    public function testNormal()
+    public function testDoNotCheckCliRequest()
     {
         $this->config->globals = [
             'before' => ['csrf'],
             'after'  => [],
         ];
 
-        $this->request  = Services::request(null, false);
+        $this->request  = Services::clirequest(null, false);
         $this->response = Services::response();
 
         $filters = new Filters($this->config, $this->request, $this->response);
         $uri     = 'admin/foo/bar';
 
-        // we expect CSRF requests to be ignored in CLI
-        $expected = $this->request;
-        $request  = $filters->run($uri, 'before');
-        $this->assertSame($expected, $request);
+        $request = $filters->run($uri, 'before');
+
+        $this->assertSame($this->request, $request);
+    }
+
+    public function testPassGetRequest()
+    {
+        $this->config->globals = [
+            'before' => ['csrf'],
+            'after'  => [],
+        ];
+
+        $this->request  = Services::incomingrequest(null, false);
+        $this->response = Services::response();
+
+        $filters = new Filters($this->config, $this->request, $this->response);
+        $uri     = 'admin/foo/bar';
+
+        $request = $filters->run($uri, 'before');
+
+        // GET request is not protected, so no SecurityException will be thrown.
+        $this->assertSame($this->request, $request);
     }
 }


### PR DESCRIPTION
**Description**
Follow-up  #6228

- fix SecurityException's HTTP status code

**How to Test**
```diff
diff --git a/app/Config/Filters.php b/app/Config/Filters.php
index 7b70c4fb3..06e0b9941 100644
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -30,7 +30,7 @@ class Filters extends BaseConfig
     public array $globals = [
         'before' => [
             // 'honeypot',
-            // 'csrf',
+            'csrf',
             // 'invalidchars',
         ],
         'after' => [
diff --git a/app/Config/Routes.php b/app/Config/Routes.php
index 71b7a86de..b41442a41 100644
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -30,6 +30,7 @@ $routes->set404Override();
 // We get a performance increase by specifying the default
 // route since we don't have to scan directories.
 $routes->get('/', 'Home::index');
+$routes->post('/', 'Home::index');
 
 /*
  * --------------------------------------------------------------------
diff --git a/app/Config/Security.php b/app/Config/Security.php
index 1474404be..c4cdf9b0e 100644
--- a/app/Config/Security.php
+++ b/app/Config/Security.php
@@ -80,7 +80,7 @@ class Security extends BaseConfig
      *
      * Redirect to previous page with error on failure.
      */
-    public bool $redirect = true;
+    public bool $redirect = false;
 
     /**
      * --------------------------------------------------------------------------
diff --git a/app/Controllers/Home.php b/app/Controllers/Home.php
index 7f867e95f..dd8f1ea72 100644
--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -6,6 +6,6 @@ class Home extends BaseController
 {
     public function index()
     {
-        return view('welcome_message');
+        return '<form method="post" action="/"><input type="submit" value="Submit"></form>';
     }
 }
```

Before:
![screenshot 2022-08-22 8 52 12](https://user-images.githubusercontent.com/87955/185817034-6b22dad5-1780-4ee9-93a3-b899224a7edb.png)

After:
![screenshot 2022-08-22 8 52 46](https://user-images.githubusercontent.com/87955/185817047-3042f44e-9ed8-4149-9325-bcf6c87f29b6.png)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

