### PR TITLE
Set cookie max Expires to 400 days

### DIFF
--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -461,12 +461,14 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @see https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#section-4.1.2.1
      */
     public function withNeverExpiring()
     {
         $cookie = clone $this;
 
-        $cookie->expires = time() + 5 * YEAR;
+        $cookie->expires = time() + 400 * DAY;
 
         return $cookie;
     }


### PR DESCRIPTION
**Description**
Based on [Replacement to RFC 6265](https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#section-4.1.2.1), the max Expires SHOULD NOT be greater than 400 days.

> Expires attributes that are greater than the limit MUST be reduced to the limit.

Thus, browsers crop the expires limit to this amount.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
