### PR TITLE
docs: add Backward Compatibility Notes

### DIFF
--- a/user_guide_src/source/installation/backward_compatibility_notes.rst
+++ b/user_guide_src/source/installation/backward_compatibility_notes.rst
@@ -1,0 +1,16 @@
+############################
+Backward Compatibility Notes
+############################
+
+We try to develop our products to be as backward compatible (BC) as possible.
+
+Only major releases (such as 4.0, 5.0 etc.) are allowed to break backward compatibility.
+Minor releases (such as 4.2, 4.3 etc.) may introduce new features, but must do so without breaking the existing API.
+
+However, the code is not mature and bug fixes may break compatibility in minor releases, or even in patch releases (such as 4.2.5). In that case, all the breaking changes are described in the :doc:`../changelogs/index`.
+
+*****************************
+What are not Breaking Changes
+*****************************
+
+- System messages defined in **system/Language/en/** are strictly for internal framework use and are not covered by backwards compatibility (BC) promise. If developers are relying on language string output they should be checking it against the function call (``lang('...')``), not the content.

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -5,12 +5,16 @@ Upgrading From a Previous Version
 Please read the upgrade notes corresponding to the version you are
 upgrading from.
 
+See also :doc:`./backward_compatibility_notes`.
+
 .. note:: If you don't know what version of CodeIgniter you are currently running,
     you can get it from :ref:`the Debug Toolbar <the-debug-toolbar>`,
     or simply echo the constant ``\CodeIgniter\CodeIgniter::CI_VERSION``.
 
 .. toctree::
     :titlesonly:
+
+    backward_compatibility_notes
 
     upgrade_423
     upgrade_422


### PR DESCRIPTION
**Description**
- add Backward Compatibility Notes. See https://github.com/codeigniter4/CodeIgniter4/pull/6414#issuecomment-1223897237

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
