### PR TITLE
[Rector] Clean up skip UnwrapFutureCompatibleIfPhpVersionRector

### DIFF
--- a/.github/workflows/test-rector.yml
+++ b/.github/workflows/test-rector.yml
@@ -14,6 +14,7 @@ on:
       - 'utils/**.php'
       - '.github/workflows/test-rector.yml'
       - composer.json
+      - rector.php
 
   push:
     branches:

--- a/.github/workflows/test-rector.yml
+++ b/.github/workflows/test-rector.yml
@@ -27,6 +27,7 @@ on:
       - 'utils/**.php'
       - '.github/workflows/test-rector.yml'
       - composer.json
+      - rector.php
 
 jobs:
   build:

--- a/rector.php
+++ b/rector.php
@@ -29,7 +29,6 @@ use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsPar
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
-use Rector\DeadCode\Rector\If_\UnwrapFutureCompatibleIfPhpVersionRector;
 use Rector\DeadCode\Rector\MethodCall\RemoveEmptyMethodCallRector;
 use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
 use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
@@ -91,11 +90,6 @@ return static function (RectorConfig $rectorConfig): void {
         // call on purpose for nothing happen check
         RemoveEmptyMethodCallRector::class => [
             __DIR__ . '/tests',
-        ],
-
-        // check on constant compare
-        UnwrapFutureCompatibleIfPhpVersionRector::class => [
-            __DIR__ . '/system/CodeIgniter.php',
         ],
 
         // session handlers have the gc() method with underscored parameter `$max_lifetime`


### PR DESCRIPTION
PHP version compare no longer exists in CodeIgniter.php so skip UnwrapFutureCompatibleIfPhpVersionRector no longer needed.

**Checklist:**
- [x] Securely signed commits
