### PR TITLE
fix: CLIRequest Erros in CLI

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -19,6 +19,7 @@ use CodeIgniter\Database\ConnectionInterface;
 use CodeIgniter\Debug\Timer;
 use CodeIgniter\Files\Exceptions\FileNotFoundException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
+use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
@@ -485,6 +486,10 @@ if (! function_exists('force_https')) {
         }
         if ($response === null) {
             $response = Services::response(null, true);
+        }
+
+        if (! $request instanceof IncomingRequest) {
+            return;
         }
 
         if ((ENVIRONMENT !== 'testing' && (is_cli() || $request->isSecure())) || (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'test')) {

--- a/system/Filters/CSRF.php
+++ b/system/Filters/CSRF.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Filters;
 
+use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
@@ -44,7 +45,7 @@ class CSRF implements FilterInterface
      */
     public function before(RequestInterface $request, $arguments = null)
     {
-        if ($request->isCLI()) {
+        if (! $request instanceof IncomingRequest) {
             return;
         }
 

--- a/system/Filters/Honeypot.php
+++ b/system/Filters/Honeypot.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Filters;
 
 use CodeIgniter\Honeypot\Exceptions\HoneypotException;
+use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Services;
@@ -31,6 +32,10 @@ class Honeypot implements FilterInterface
      */
     public function before(RequestInterface $request, $arguments = null)
     {
+        if (! $request instanceof IncomingRequest) {
+            return;
+        }
+
         if (Services::honeypot()->hasContent($request)) {
             throw HoneypotException::isBot();
         }

--- a/system/Filters/InvalidChars.php
+++ b/system/Filters/InvalidChars.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Filters;
 
+use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Security\Exceptions\SecurityException;
@@ -48,7 +49,7 @@ class InvalidChars implements FilterInterface
      */
     public function before(RequestInterface $request, $arguments = null)
     {
-        if ($request->isCLI()) {
+        if (! $request instanceof IncomingRequest) {
             return;
         }
 

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -226,7 +226,7 @@ class CLIRequest extends Request
      */
     public function getGet($index = null, $filter = null, $flags = null)
     {
-        return null;
+        return $this->returnNullOrEmptyArray($index);
     }
 
     /**
@@ -240,7 +240,7 @@ class CLIRequest extends Request
      */
     public function getPost($index = null, $filter = null, $flags = null)
     {
-        return null;
+        return $this->returnNullOrEmptyArray($index);
     }
 
     /**
@@ -254,7 +254,7 @@ class CLIRequest extends Request
      */
     public function getPostGet($index = null, $filter = null, $flags = null)
     {
-        return null;
+        return $this->returnNullOrEmptyArray($index);
     }
 
     /**
@@ -268,6 +268,16 @@ class CLIRequest extends Request
      */
     public function getGetPost($index = null, $filter = null, $flags = null)
     {
-        return null;
+        return $this->returnNullOrEmptyArray($index);
+    }
+
+    /**
+     * @param array|string|null $index
+     *
+     * @return array|null
+     */
+    private function returnNullOrEmptyArray($index)
+    {
+        return ($index === null || is_array($index)) ? [] : null;
     }
 }

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -214,4 +214,60 @@ class CLIRequest extends Request
     {
         return true;
     }
+
+    /**
+     * Fetch an item from GET data.
+     *
+     * @param array|string|null $index  Index for item to fetch from $_GET.
+     * @param int|null          $filter A filter name to apply.
+     * @param mixed|null        $flags
+     *
+     * @return null
+     */
+    public function getGet($index = null, $filter = null, $flags = null)
+    {
+        return null;
+    }
+
+    /**
+     * Fetch an item from POST.
+     *
+     * @param array|string|null $index  Index for item to fetch from $_POST.
+     * @param int|null          $filter A filter name to apply
+     * @param mixed             $flags
+     *
+     * @return null
+     */
+    public function getPost($index = null, $filter = null, $flags = null)
+    {
+        return null;
+    }
+
+    /**
+     * Fetch an item from POST data with fallback to GET.
+     *
+     * @param array|string|null $index  Index for item to fetch from $_POST or $_GET
+     * @param int|null          $filter A filter name to apply
+     * @param mixed             $flags
+     *
+     * @return null
+     */
+    public function getPostGet($index = null, $filter = null, $flags = null)
+    {
+        return null;
+    }
+
+    /**
+     * Fetch an item from GET data with fallback to POST.
+     *
+     * @param array|string|null $index  Index for item to be fetched from $_GET or $_POST
+     * @param int|null          $filter A filter name to apply
+     * @param mixed             $flags
+     *
+     * @return null
+     */
+    public function getGetPost($index = null, $filter = null, $flags = null)
+    {
+        return null;
+    }
 }

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -27,7 +27,7 @@ class Negotiate
     /**
      * Request
      *
-     * @var IncomingRequest|RequestInterface
+     * @var IncomingRequest
      */
     protected $request;
 
@@ -37,6 +37,8 @@ class Negotiate
     public function __construct(?RequestInterface $request = null)
     {
         if ($request !== null) {
+            assert($request instanceof IncomingRequest);
+
             $this->request = $request;
         }
     }
@@ -48,6 +50,8 @@ class Negotiate
      */
     public function setRequest(RequestInterface $request)
     {
+        assert($request instanceof IncomingRequest);
+
         $this->request = $request;
 
         return $this;

--- a/system/HTTP/RequestInterface.php
+++ b/system/HTTP/RequestInterface.php
@@ -13,10 +13,6 @@ namespace CodeIgniter\HTTP;
 
 /**
  * Expected behavior of an HTTP request
- *
- * @mixin IncomingRequest
- * @mixin CLIRequest
- * @mixin CURLRequest
  */
 interface RequestInterface
 {

--- a/system/Honeypot/Honeypot.php
+++ b/system/Honeypot/Honeypot.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Honeypot;
 
 use CodeIgniter\Honeypot\Exceptions\HoneypotException;
+use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Honeypot as HoneypotConfig;
@@ -59,6 +60,8 @@ class Honeypot
      */
     public function hasContent(RequestInterface $request)
     {
+        assert($request instanceof IncomingRequest);
+
         return ! empty($request->getPost($this->config->name));
     }
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Security;
 
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Security\Exceptions\SecurityException;
@@ -321,6 +322,8 @@ class Security implements SecurityInterface
      */
     private function removeTokenInRequest(RequestInterface $request): void
     {
+        assert($request instanceof Request);
+
         $json = json_decode($request->getBody() ?? '');
 
         if (isset($_POST[$this->tokenName])) {
@@ -336,6 +339,8 @@ class Security implements SecurityInterface
 
     private function getPostedToken(RequestInterface $request): ?string
     {
+        assert($request instanceof IncomingRequest);
+
         // Does the token exist in POST, HEADER or optionally php:://input - json data.
         if ($request->hasHeader($this->headerName) && ! empty($request->header($this->headerName)->getValue())) {
             $tokenName = $request->header($this->headerName)->getValue();
@@ -580,6 +585,8 @@ class Security implements SecurityInterface
      */
     protected function sendCookie(RequestInterface $request)
     {
+        assert($request instanceof IncomingRequest);
+
         if ($this->cookie->isSecure() && ! $request->isSecure()) {
             return false;
         }

--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -11,6 +11,8 @@
 
 namespace CodeIgniter\Validation;
 
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\RequestInterface;
 use Config\Mimes;
 use Config\Services;
@@ -24,20 +26,20 @@ class FileRules
     /**
      * Request instance. So we can get access to the files.
      *
-     * @var RequestInterface
+     * @var IncomingRequest
      */
     protected $request;
 
     /**
      * Constructor.
-     *
-     * @param RequestInterface $request
      */
     public function __construct(?RequestInterface $request = null)
     {
         if ($request === null) {
             $request = Services::request();
         }
+
+        assert($request instanceof IncomingRequest);
 
         $this->request = $request;
     }

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -589,4 +589,24 @@ final class CLIRequestTest extends CIUnitTestCase
     {
         $this->assertTrue($this->request->isCLI());
     }
+
+    public function testGetGet()
+    {
+        $this->assertNull($this->request->getGet());
+    }
+
+    public function testGetPost()
+    {
+        $this->assertNull($this->request->getPost());
+    }
+
+    public function testGetPostGet()
+    {
+        $this->assertNull($this->request->getPostGet());
+    }
+
+    public function testGetGetPost()
+    {
+        $this->assertNull($this->request->getGetPost());
+    }
 }

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -592,21 +592,23 @@ final class CLIRequestTest extends CIUnitTestCase
 
     public function testGetGet()
     {
-        $this->assertNull($this->request->getGet());
+        $this->assertSame([], $this->request->getGet());
+        $this->assertNull($this->request->getGet('test'));
+        $this->assertSame([], $this->request->getGet(['test', 'abc']));
     }
 
     public function testGetPost()
     {
-        $this->assertNull($this->request->getPost());
+        $this->assertSame([], $this->request->getGet());
     }
 
     public function testGetPostGet()
     {
-        $this->assertNull($this->request->getPostGet());
+        $this->assertSame([], $this->request->getGet());
     }
 
     public function testGetGetPost()
     {
-        $this->assertNull($this->request->getGetPost());
+        $this->assertSame([], $this->request->getGet());
     }
 }

--- a/tests/system/HTTP/NegotiateTest.php
+++ b/tests/system/HTTP/NegotiateTest.php
@@ -20,14 +20,14 @@ use Config\App;
  */
 final class NegotiateTest extends CIUnitTestCase
 {
-    private ?Request $request;
+    private ?IncomingRequest $request;
     private ?Negotiate $negotiate;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->request = new Request(new App());
+        $this->request = new IncomingRequest(new App(), new URI(), null, new UserAgent());
 
         $this->negotiate = new Negotiate($this->request);
     }

--- a/tests/system/HTTP/NegotiateTest.php
+++ b/tests/system/HTTP/NegotiateTest.php
@@ -27,15 +27,8 @@ final class NegotiateTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->request = new IncomingRequest(new App(), new URI(), null, new UserAgent());
-
+        $this->request   = new IncomingRequest(new App(), new URI(), null, new UserAgent());
         $this->negotiate = new Negotiate($this->request);
-    }
-
-    protected function tearDown(): void
-    {
-        $this->request = $this->negotiate = null;
-        unset($this->request, $this->negotiate);
     }
 
     public function testNegotiateMediaFindsHighestMatch()


### PR DESCRIPTION
**Description**

Ref #6089

- remove `@mixin` in `RequestInterface`
- add missing `get*()` methods in `CLIRequest`
  - getGet()
  - getPost()
  - getPostGet()
  - getGetPost()
- fix filters
  - CSRF
  - Honeypot: fixes #6419
  - InvalidChars

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
