### PR TITLE
refactor: remove unused `_parent_name` in BaseBuilder::objectToArray()

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2705,8 +2705,7 @@ class BaseBuilder
         $array = [];
 
         foreach (get_object_vars($object) as $key => $val) {
-            // There are some built in keys we need to ignore for this conversion
-            if (! is_object($val) && ! is_array($val) && $key !== '_parent_name') {
+            if (! is_object($val) && ! is_array($val)) {
                 $array[$key] = $val;
             }
         }
@@ -2732,13 +2731,10 @@ class BaseBuilder
         $fields = array_keys($out);
 
         foreach ($fields as $val) {
-            // There are some built in keys we need to ignore for this conversion
-            if ($val !== '_parent_name') {
-                $i = 0;
+            $i = 0;
 
-                foreach ($out[$val] as $data) {
-                    $array[$i++][$val] = $data;
-                }
+            foreach ($out[$val] as $data) {
+                $array[$i++][$val] = $data;
             }
         }
 


### PR DESCRIPTION
**Description**
Closes  #6412

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

