### PR TITLE
Add processIndexes() and dropPrimaryKey() to Forge

### DIFF
--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -153,4 +153,39 @@ interface ConnectionInterface
      * @param string $sql
      */
     public function isWriteType($sql): bool;
+
+    /**
+     * Determines if table exists in database.
+     */
+    public function tableExists(string $tableName, bool $cached = true): bool;
+
+    /**
+     * Protect Identifiers
+     *
+     * This function is used extensively by the Query Builder class, and by
+     * a couple functions in this class.
+     * It takes a column or table name (optionally with an alias) and inserts
+     * the table prefix onto it. Some logic is necessary in order to deal with
+     * column names that include the path. Consider a query like this:
+     *
+     * SELECT hostname.database.table.column AS c FROM hostname.database.table
+     *
+     * Or a query with aliasing:
+     *
+     * SELECT m.member_id, m.member_name FROM members AS m
+     *
+     * Since the column name can include up to four segments (host, DB, table, column)
+     * or also have an alias prefix, we need to do a bit of work to figure this out and
+     * insert the table prefix (if it exists) in the proper position, and escape only
+     * the correct identifiers.
+     *
+     * @param array|string $item
+     * @param bool         $prefixSingle       Prefix a table name with no segments?
+     * @param bool         $protectIdentifiers Protect table or column names?
+     * @param bool         $fieldExists        Supplied $item contains a column name?
+     *
+     * @return array|string
+     * @phpstan-return ($item is array ? array : string)
+     */
+    public function protectIdentifiers($item, bool $prefixSingle = false, ?bool $protectIdentifiers = null, bool $fieldExists = true);
 }

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -406,12 +406,16 @@ class Forge
         $fieldName  = (array) $fieldName;
         $tableField = (array) $tableField;
 
+        // same structure as Connection::_foreignKeyData()
         $this->foreignKeys[] = [
+            'name'           => null,
+            'table'          => null,
             'field'          => $fieldName,
-            'referenceTable' => $tableName,
+            'referenceTable' => $this->db->DBPrefix . $tableName,
             'referenceField' => $tableField,
             'onDelete'       => strtoupper($onDelete),
             'onUpdate'       => strtoupper($onUpdate),
+            'match'          => null,
         ];
 
         return $this;
@@ -1135,7 +1139,7 @@ class Forge
             $nameIndex            = $table . '_' . implode('_', $fkey['field']) . '_foreign';
             $nameIndexFilled      = $this->db->escapeIdentifiers($nameIndex);
             $foreignKeyFilled     = implode(', ', $this->db->escapeIdentifiers($fkey['field']));
-            $referenceTableFilled = $this->db->escapeIdentifiers($this->db->DBPrefix . $fkey['referenceTable']);
+            $referenceTableFilled = $this->db->escapeIdentifiers($fkey['referenceTable']);
             $referenceFieldFilled = implode(', ', $this->db->escapeIdentifiers($fkey['referenceField']));
 
             $sqls[$i] = '';

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -408,14 +408,11 @@ class Forge
 
         // same structure as Connection::_foreignKeyData()
         $this->foreignKeys[] = [
-            'name'           => null,
-            'table'          => null,
             'field'          => $fieldName,
             'referenceTable' => $this->db->DBPrefix . $tableName,
             'referenceField' => $tableField,
             'onDelete'       => strtoupper($onDelete),
             'onUpdate'       => strtoupper($onUpdate),
-            'match'          => null,
         ];
 
         return $this;

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -487,7 +487,10 @@ class Connection extends BaseConnection
                         tc.TABLE_NAME,
                         kcu.COLUMN_NAME,
                         rc.REFERENCED_TABLE_NAME,
-                        kcu.REFERENCED_COLUMN_NAME
+                        kcu.REFERENCED_COLUMN_NAME,
+                        rc.DELETE_RULE,
+                        rc.UPDATE_RULE,
+                        rc.MATCH_OPTION
                     FROM information_schema.TABLE_CONSTRAINTS AS tc
                     INNER JOIN information_schema.REFERENTIAL_CONSTRAINTS AS rc
                         ON tc.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
@@ -508,14 +511,14 @@ class Connection extends BaseConnection
         $retVal = [];
 
         foreach ($query as $row) {
-            $obj                      = new stdClass();
-            $obj->constraint_name     = $row->CONSTRAINT_NAME;
-            $obj->table_name          = $row->TABLE_NAME;
-            $obj->column_name         = $row->COLUMN_NAME;
-            $obj->foreign_table_name  = $row->REFERENCED_TABLE_NAME;
-            $obj->foreign_column_name = $row->REFERENCED_COLUMN_NAME;
-
-            $retVal[] = $obj;
+            $retVal[$row->CONSTRAINT_NAME]['name']             = $row->CONSTRAINT_NAME;
+            $retVal[$row->CONSTRAINT_NAME]['table']            = $row->TABLE_NAME;
+            $retVal[$row->CONSTRAINT_NAME]['field'][]          = $row->COLUMN_NAME;
+            $retVal[$row->CONSTRAINT_NAME]['referenceTable']   = $row->REFERENCED_TABLE_NAME;
+            $retVal[$row->CONSTRAINT_NAME]['referenceField'][] = $row->REFERENCED_COLUMN_NAME;
+            $retVal[$row->CONSTRAINT_NAME]['onDelete']         = $row->DELETE_RULE;
+            $retVal[$row->CONSTRAINT_NAME]['onUpdate']         = $row->UPDATE_RULE;
+            $retVal[$row->CONSTRAINT_NAME]['match']            = $row->MATCH_OPTION;
         }
 
         return $retVal;

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -477,7 +477,7 @@ class Connection extends BaseConnection
      *
      * @throws DatabaseException
      *
-     * @return stdClass[]
+     * @return array[]
      */
     protected function _foreignKeyData(string $table): array
     {

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -477,7 +477,7 @@ class Connection extends BaseConnection
      *
      * @throws DatabaseException
      *
-     * @return array[]
+     * @return stdClass[]
      */
     protected function _foreignKeyData(string $table): array
     {
@@ -508,17 +508,33 @@ class Connection extends BaseConnection
         }
         $query = $query->getResultObject();
 
-        $retVal = [];
+        $ind = [];
 
         foreach ($query as $row) {
-            $retVal[$row->CONSTRAINT_NAME]['name']             = $row->CONSTRAINT_NAME;
-            $retVal[$row->CONSTRAINT_NAME]['table']            = $row->TABLE_NAME;
-            $retVal[$row->CONSTRAINT_NAME]['field'][]          = $row->COLUMN_NAME;
-            $retVal[$row->CONSTRAINT_NAME]['referenceTable']   = $row->REFERENCED_TABLE_NAME;
-            $retVal[$row->CONSTRAINT_NAME]['referenceField'][] = $row->REFERENCED_COLUMN_NAME;
-            $retVal[$row->CONSTRAINT_NAME]['onDelete']         = $row->DELETE_RULE;
-            $retVal[$row->CONSTRAINT_NAME]['onUpdate']         = $row->UPDATE_RULE;
-            $retVal[$row->CONSTRAINT_NAME]['match']            = $row->MATCH_OPTION;
+            $ind[$row->CONSTRAINT_NAME]['constraint_name']       = $row->CONSTRAINT_NAME;
+            $ind[$row->CONSTRAINT_NAME]['table_name']            = $row->TABLE_NAME;
+            $ind[$row->CONSTRAINT_NAME]['column_name'][]         = $row->COLUMN_NAME;
+            $ind[$row->CONSTRAINT_NAME]['foreign_table_name']    = $row->REFERENCED_TABLE_NAME;
+            $ind[$row->CONSTRAINT_NAME]['foreign_column_name'][] = $row->REFERENCED_COLUMN_NAME;
+            $ind[$row->CONSTRAINT_NAME]['on_delete']             = $row->DELETE_RULE;
+            $ind[$row->CONSTRAINT_NAME]['on_update']             = $row->UPDATE_RULE;
+            $ind[$row->CONSTRAINT_NAME]['match']                 = $row->MATCH_OPTION;
+        }
+
+        $retVal = [];
+
+        foreach ($ind as $row) {
+            $obj                      = new stdClass();
+            $obj->constraint_name     = $row['constraint_name'];
+            $obj->table_name          = $row['table_name'];
+            $obj->column_name         = $row['column_name'];
+            $obj->foreign_table_name  = $row['foreign_table_name'];
+            $obj->foreign_column_name = $row['foreign_column_name'];
+            $obj->on_delete           = $row['on_delete'];
+            $obj->on_update           = $row['on_update'];
+            $obj->match               = $row['match'];
+
+            $retVal[$row['constraint_name']] = $obj;
         }
 
         return $retVal;

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -379,7 +379,7 @@ class Connection extends BaseConnection implements ConnectionInterface
      *
      * @throws DatabaseException
      *
-     * @return stdClass[]
+     * @return array[]
      */
     protected function _foreignKeyData(string $table): array
     {

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -379,7 +379,7 @@ class Connection extends BaseConnection implements ConnectionInterface
      *
      * @throws DatabaseException
      *
-     * @return array[]
+     * @return stdClass[]
      */
     protected function _foreignKeyData(string $table): array
     {
@@ -410,17 +410,33 @@ class Connection extends BaseConnection implements ConnectionInterface
         }
         $query = $query->getResultObject();
 
-        $retVal = [];
+        $ind = [];
 
         foreach ($query as $row) {
-            $retVal[$row->CONSTRAINT_NAME]['name']             = $row->CONSTRAINT_NAME;
-            $retVal[$row->CONSTRAINT_NAME]['table']            = $row->TABLE_NAME;
-            $retVal[$row->CONSTRAINT_NAME]['field'][]          = $row->COLUMN_NAME;
-            $retVal[$row->CONSTRAINT_NAME]['referenceTable']   = $row->FOREIGN_TABLE_NAME;
-            $retVal[$row->CONSTRAINT_NAME]['referenceField'][] = $row->FOREIGN_COLUMN_NAME;
-            $retVal[$row->CONSTRAINT_NAME]['onDelete']         = $row->DELETE_RULE;
-            $retVal[$row->CONSTRAINT_NAME]['onUpdate']         = null;
-            $retVal[$row->CONSTRAINT_NAME]['match']            = null;
+            $ind[$row->CONSTRAINT_NAME]['constraint_name']       = $row->CONSTRAINT_NAME;
+            $ind[$row->CONSTRAINT_NAME]['table_name']            = $row->TABLE_NAME;
+            $ind[$row->CONSTRAINT_NAME]['column_name'][]         = $row->COLUMN_NAME;
+            $ind[$row->CONSTRAINT_NAME]['foreign_table_name']    = $row->FOREIGN_TABLE_NAME;
+            $ind[$row->CONSTRAINT_NAME]['foreign_column_name'][] = $row->FOREIGN_COLUMN_NAME;
+            $ind[$row->CONSTRAINT_NAME]['on_delete']             = $row->DELETE_RULE;
+            $ind[$row->CONSTRAINT_NAME]['on_update']             = null;
+            $ind[$row->CONSTRAINT_NAME]['match']                 = null;
+        }
+
+        $retVal = [];
+
+        foreach ($ind as $row) {
+            $obj                      = new stdClass();
+            $obj->constraint_name     = $row['constraint_name'];
+            $obj->table_name          = $row['table_name'];
+            $obj->column_name         = $row['column_name'];
+            $obj->foreign_table_name  = $row['foreign_table_name'];
+            $obj->foreign_column_name = $row['foreign_column_name'];
+            $obj->on_delete           = $row['on_delete'];
+            $obj->on_update           = $row['on_update'];
+            $obj->match               = $row['match'];
+
+            $retVal[$row['constraint_name']] = $obj;
         }
 
         return $retVal;

--- a/system/Database/OCI8/Forge.php
+++ b/system/Database/OCI8/Forge.php
@@ -312,7 +312,7 @@ class Forge extends BaseForge
             $nameIndex            = $table . '_' . implode('_', $fkey['field']) . '_foreign';
             $nameIndexFilled      = $this->db->escapeIdentifiers($nameIndex);
             $foreignKeyFilled     = implode(', ', $this->db->escapeIdentifiers($fkey['field']));
-            $referenceTableFilled = $this->db->escapeIdentifiers($this->db->DBPrefix . $fkey['referenceTable']);
+            $referenceTableFilled = $this->db->escapeIdentifiers($fkey['referenceTable']);
             $referenceFieldFilled = implode(', ', $this->db->escapeIdentifiers($fkey['referenceField']));
 
             $sqls[$i] = '';

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -321,7 +321,7 @@ class Connection extends BaseConnection
      *
      * @throws DatabaseException
      *
-     * @return array[]
+     * @return stdClass[]
      */
     protected function _foreignKeyData(string $table): array
     {
@@ -346,18 +346,34 @@ class Connection extends BaseConnection
             throw new DatabaseException(lang('Database.failGetForeignKeyData'));
         }
 
-        $query  = $query->getResultObject();
-        $retVal = [];
+        $query = $query->getResultObject();
+        $ind   = [];
 
         foreach ($query as $row) {
-            $retVal[$row->constraint_name]['name']             = $row->constraint_name;
-            $retVal[$row->constraint_name]['table']            = $row->table_name;
-            $retVal[$row->constraint_name]['field'][]          = $row->column_name;
-            $retVal[$row->constraint_name]['referenceTable']   = $row->foreign_table_name;
-            $retVal[$row->constraint_name]['referenceField'][] = $row->foreign_column_name;
-            $retVal[$row->constraint_name]['onDelete']         = $row->delete_rule;
-            $retVal[$row->constraint_name]['onUpdate']         = $row->update_rule;
-            $retVal[$row->constraint_name]['match']            = $row->match_option;
+            $ind[$row->constraint_name]['constraint_name']       = $row->constraint_name;
+            $ind[$row->constraint_name]['table_name']            = $row->table_name;
+            $ind[$row->constraint_name]['column_name'][]         = $row->column_name;
+            $ind[$row->constraint_name]['foreign_table_name']    = $row->foreign_table_name;
+            $ind[$row->constraint_name]['foreign_column_name'][] = $row->foreign_column_name;
+            $ind[$row->constraint_name]['on_delete']             = $row->delete_rule;
+            $ind[$row->constraint_name]['on_update']             = $row->update_rule;
+            $ind[$row->constraint_name]['match']                 = $row->match_option;
+        }
+
+        $retVal = [];
+
+        foreach ($ind as $row) {
+            $obj                      = new stdClass();
+            $obj->constraint_name     = $row['constraint_name'];
+            $obj->table_name          = $row['table_name'];
+            $obj->column_name         = $row['column_name'];
+            $obj->foreign_table_name  = $row['foreign_table_name'];
+            $obj->foreign_column_name = $row['foreign_column_name'];
+            $obj->on_delete           = $row['on_delete'];
+            $obj->on_update           = $row['on_update'];
+            $obj->match               = $row['match'];
+
+            $retVal[$row['constraint_name']] = $obj;
         }
 
         return $retVal;

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -321,7 +321,7 @@ class Connection extends BaseConnection
      *
      * @throws DatabaseException
      *
-     * @return stdClass[]
+     * @return array[]
      */
     protected function _foreignKeyData(string $table): array
     {

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -325,17 +325,22 @@ class Connection extends BaseConnection
      */
     protected function _foreignKeyData(string $table): array
     {
-        $sql = 'SELECT
-            tc.constraint_name, tc.table_name, kcu.column_name,
-            ccu.table_name AS foreign_table_name,
-            ccu.column_name AS foreign_column_name
-        FROM information_schema.table_constraints AS tc
-        JOIN information_schema.key_column_usage AS kcu
-            ON tc.constraint_name = kcu.constraint_name
-        JOIN information_schema.constraint_column_usage AS ccu
-            ON ccu.constraint_name = tc.constraint_name
-        WHERE constraint_type = ' . $this->escape('FOREIGN KEY') . ' AND
-            tc.table_name = ' . $this->escape($table);
+        $sql = 'select c.constraint_name
+            , x.table_name
+            , x.column_name
+            , y.table_name as foreign_table_name
+            , y.column_name as foreign_column_name
+            , c.delete_rule
+            , c.update_rule
+            , c.match_option
+        from information_schema.referential_constraints c
+        join information_schema.key_column_usage x
+            on x.constraint_name = c.constraint_name
+        join information_schema.key_column_usage y
+            on y.ordinal_position = x.position_in_unique_constraint
+            and y.constraint_name = c.unique_constraint_name
+        where x.table_name = ' . $this->escape($table) .
+        'order by c.constraint_name, x.ordinal_position';
 
         if (($query = $this->query($sql)) === false) {
             throw new DatabaseException(lang('Database.failGetForeignKeyData'));
@@ -345,15 +350,14 @@ class Connection extends BaseConnection
         $retVal = [];
 
         foreach ($query as $row) {
-            $obj = new stdClass();
-
-            $obj->constraint_name     = $row->constraint_name;
-            $obj->table_name          = $row->table_name;
-            $obj->column_name         = $row->column_name;
-            $obj->foreign_table_name  = $row->foreign_table_name;
-            $obj->foreign_column_name = $row->foreign_column_name;
-
-            $retVal[] = $obj;
+            $retVal[$row->constraint_name]['name']             = $row->constraint_name;
+            $retVal[$row->constraint_name]['table']            = $row->table_name;
+            $retVal[$row->constraint_name]['field'][]          = $row->column_name;
+            $retVal[$row->constraint_name]['referenceTable']   = $row->foreign_table_name;
+            $retVal[$row->constraint_name]['referenceField'][] = $row->foreign_column_name;
+            $retVal[$row->constraint_name]['onDelete']         = $row->delete_rule;
+            $retVal[$row->constraint_name]['onUpdate']         = $row->update_rule;
+            $retVal[$row->constraint_name]['match']            = $row->match_option;
         }
 
         return $retVal;

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -130,7 +130,7 @@ class Forge extends BaseForge
     protected function _processColumn(array $field): string
     {
         return $this->db->escapeIdentifiers($field['name'])
-            . ' ' . $field['type'] . $field['length']
+            . ' ' . $field['type'] . ($field['type'] === 'text' ? '' : $field['length'])
             . $field['default']
             . $field['null']
             . $field['auto_increment']

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -269,7 +269,7 @@ class Connection extends BaseConnection
      *
      * @throws DatabaseException
      *
-     * @return stdClass[]
+     * @return array[]
      */
     protected function _foreignKeyData(string $table): array
     {

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -269,7 +269,7 @@ class Connection extends BaseConnection
      *
      * @throws DatabaseException
      *
-     * @return array[]
+     * @return stdClass[]
      */
     protected function _foreignKeyData(string $table): array
     {
@@ -298,18 +298,34 @@ class Connection extends BaseConnection
             throw new DatabaseException(lang('Database.failGetForeignKeyData'));
         }
 
-        $query  = $query->getResultObject();
-        $retVal = [];
+        $query = $query->getResultObject();
+        $ind   = [];
 
         foreach ($query as $row) {
-            $retVal[$row->constraint_name]['name']             = $row->constraint_name;
-            $retVal[$row->constraint_name]['table']            = $row->table_name;
-            $retVal[$row->constraint_name]['field'][]          = $row->column_name;
-            $retVal[$row->constraint_name]['referenceTable']   = $row->foreign_table_name;
-            $retVal[$row->constraint_name]['referenceField'][] = $row->foreign_column_name;
-            $retVal[$row->constraint_name]['onDelete']         = $row->DELETE_RULE;
-            $retVal[$row->constraint_name]['onUpdate']         = $row->UPDATE_RULE;
-            $retVal[$row->constraint_name]['match']            = $row->MATCH_OPTION;
+            $ind[$row->constraint_name]['constraint_name']       = $row->constraint_name;
+            $ind[$row->constraint_name]['table_name']            = $row->table_name;
+            $ind[$row->constraint_name]['column_name'][]         = $row->column_name;
+            $ind[$row->constraint_name]['foreign_table_name']    = $row->foreign_table_name;
+            $ind[$row->constraint_name]['foreign_column_name'][] = $row->foreign_column_name;
+            $ind[$row->constraint_name]['on_delete']             = $row->DELETE_RULE;
+            $ind[$row->constraint_name]['on_update']             = $row->UPDATE_RULE;
+            $ind[$row->constraint_name]['match']                 = $row->MATCH_OPTION;
+        }
+
+        $retVal = [];
+
+        foreach ($ind as $row) {
+            $obj                      = new stdClass();
+            $obj->constraint_name     = $row['constraint_name'];
+            $obj->table_name          = $row['table_name'];
+            $obj->column_name         = $row['column_name'];
+            $obj->foreign_table_name  = $row['foreign_table_name'];
+            $obj->foreign_column_name = $row['foreign_column_name'];
+            $obj->on_delete           = $row['on_delete'];
+            $obj->on_update           = $row['on_update'];
+            $obj->match               = $row['match'];
+
+            $retVal[$row['constraint_name']] = $obj;
         }
 
         return $retVal;

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -327,7 +327,7 @@ class Forge extends BaseForge
             $nameIndex            = $table . '_' . implode('_', $fkey['field']) . '_foreign';
             $nameIndexFilled      = $this->db->escapeIdentifiers($nameIndex);
             $foreignKeyFilled     = implode(', ', $this->db->escapeIdentifiers($fkey['field']));
-            $referenceTableFilled = $this->db->escapeIdentifiers($this->db->DBPrefix . $fkey['referenceTable']);
+            $referenceTableFilled = $this->db->escapeIdentifiers($fkey['referenceTable']);
             $referenceFieldFilled = implode(', ', $this->db->escapeIdentifiers($fkey['referenceField']));
 
             $sqls[$i] = '';

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -324,7 +324,7 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with Foreign key data
      *
-     * @return stdClass[]
+     * @return array[]
      */
     protected function _foreignKeyData(string $table): array
     {

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -350,19 +350,23 @@ class Connection extends BaseConnection
                 $indexes[$row->id]['foreign_table_name'] = $row->table;
                 $indexes[$row->id]['fields'][]           = $row->from;
                 $indexes[$row->id]['fields_to'][]        = $row->to;
+                $indexes[$row->id]['on_update']          = $row->on_update;
+                $indexes[$row->id]['on_delete']          = $row->on_delete;
+                $indexes[$row->id]['match']              = $row->match;
             }
 
+            // format same as
             foreach ($indexes as $row) {
-                foreach ($row['fields'] as $key => $field) {
-                    $obj                      = new stdClass();
-                    $obj->constraint_name     = $table . '_' . implode('_', $row['constraint']) . '_foreign';
-                    $obj->table_name          = $table;
-                    $obj->column_name         = $field;
-                    $obj->foreign_table_name  = $row['foreign_table_name'];
-                    $obj->foreign_column_name = $row['fields_to'][$key];
+                $name = $table . '_' . implode('_', $row['constraint']) . '_foreign';
 
-                    $retVal[] = $obj;
-                }
+                $retVal[$name]['name']           = $name;
+                $retVal[$name]['table']          = $table;
+                $retVal[$name]['field']          = $row['fields'];
+                $retVal[$name]['referenceTable'] = $row['foreign_table_name'];
+                $retVal[$name]['referenceField'] = $row['fields_to'];
+                $retVal[$name]['onDelete']       = $row['on_delete'];
+                $retVal[$name]['onUpdate']       = $row['on_update'];
+                $retVal[$name]['match']          = $row['match'];
             }
         }
 

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -324,7 +324,7 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with Foreign key data
      *
-     * @return array[]
+     * @return stdClass[]
      */
     protected function _foreignKeyData(string $table): array
     {
@@ -332,42 +332,53 @@ class Connection extends BaseConnection
             return [];
         }
 
-        $tables = $this->listTables();
+        $retVal = [];
 
-        if (empty($tables)) {
-            return [];
+        $query = $this->query("PRAGMA foreign_key_list({$table})")->getResult();
+
+        $indexes = [];
+
+        foreach ($query as $row) {
+            $indexes[$row->id]['constraint_name'][]     = $row->from;
+            $indexes[$row->id]['foreign_table_name']    = $row->table;
+            $indexes[$row->id]['column_name'][]         = $row->from;
+            $indexes[$row->id]['foreign_column_name'][] = $row->to;
+            $indexes[$row->id]['on_delete']             = $row->on_delete;
+            $indexes[$row->id]['on_update']             = $row->on_update;
+            $indexes[$row->id]['match']                 = $row->match;
+        }
+
+        $ind = [];
+
+        // now we can properly build name
+        foreach ($indexes as $row) {
+            $name = $table . '_' . implode('_', $row['constraint_name']) . '_foreign';
+
+            $ind[$name]['constraint_name']     = $name;
+            $ind[$name]['table_name']          = $table;
+            $ind[$name]['column_name']         = $row['column_name'];
+            $ind[$name]['foreign_table_name']  = $row['foreign_table_name'];
+            $ind[$name]['foreign_column_name'] = $row['foreign_column_name'];
+            $ind[$name]['on_delete']           = $row['on_delete'];
+            $ind[$name]['on_update']           = $row['on_update'];
+            $ind[$name]['match']               = $row['match'];
         }
 
         $retVal = [];
 
-        foreach ($tables as $table) {
-            $query = $this->query("PRAGMA foreign_key_list({$table})")->getResult();
+        // convert to object
+        foreach ($ind as $row) {
+            $obj                      = new stdClass();
+            $obj->constraint_name     = $row['constraint_name'];
+            $obj->table_name          = $row['table_name'];
+            $obj->column_name         = $row['column_name'];
+            $obj->foreign_table_name  = $row['foreign_table_name'];
+            $obj->foreign_column_name = $row['foreign_column_name'];
+            $obj->on_delete           = $row['on_delete'];
+            $obj->on_update           = $row['on_update'];
+            $obj->match               = $row['match'];
 
-            $indexes = [];
-
-            foreach ($query as $row) {
-                $indexes[$row->id]['constraint'][]       = $row->from;
-                $indexes[$row->id]['foreign_table_name'] = $row->table;
-                $indexes[$row->id]['fields'][]           = $row->from;
-                $indexes[$row->id]['fields_to'][]        = $row->to;
-                $indexes[$row->id]['on_update']          = $row->on_update;
-                $indexes[$row->id]['on_delete']          = $row->on_delete;
-                $indexes[$row->id]['match']              = $row->match;
-            }
-
-            // format same as
-            foreach ($indexes as $row) {
-                $name = $table . '_' . implode('_', $row['constraint']) . '_foreign';
-
-                $retVal[$name]['name']           = $name;
-                $retVal[$name]['table']          = $table;
-                $retVal[$name]['field']          = $row['fields'];
-                $retVal[$name]['referenceTable'] = $row['foreign_table_name'];
-                $retVal[$name]['referenceField'] = $row['fields_to'];
-                $retVal[$name]['onDelete']       = $row['on_delete'];
-                $retVal[$name]['onUpdate']       = $row['on_update'];
-                $retVal[$name]['match']          = $row['match'];
-            }
+            $retVal[$row['constraint_name']] = $obj;
         }
 
         return $retVal;

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -311,7 +311,7 @@ class Table
                 }
             }
         }
-
+/*
         foreach ($this->foreignKeys as $foreignKey) {
             $this->forge->addForeignKey(
                 implode(',', $foreignKey['field']),
@@ -319,7 +319,7 @@ class Table
                 implode(',', $foreignKey['referenceField'])
             );
         }
-
+*/
         return $this->forge->createTable($this->tableName);
     }
 

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Database\SQLite3;
 
 use CodeIgniter\Database\Exceptions\DataException;
+use stdClass;
 
 /**
  * Class Table
@@ -220,7 +221,21 @@ class Table
      */
     public function addForeignKey(array $foreignKeys)
     {
-        $this->foreignKeys = array_merge($this->foreignKeys, $foreignKeys);
+        $fk = [];
+
+        // convert to object
+        foreach ($foreignKeys as $row) {
+            $obj                      = new stdClass();
+            $obj->column_name         = $row['field'];
+            $obj->foreign_table_name  = $row['referenceTable'];
+            $obj->foreign_column_name = $row['referenceField'];
+            $obj->on_delete           = $row['onDelete'];
+            $obj->on_update           = $row['onUpdate'];
+
+            $fk[] = $obj;
+        }
+
+        $this->foreignKeys = array_merge($this->foreignKeys, $fk);
 
         return $this;
     }
@@ -314,9 +329,9 @@ class Table
 
         foreach ($this->foreignKeys as $foreignKey) {
             $this->forge->addForeignKey(
-                $foreignKey['field'],
-                trim($foreignKey['referenceTable'], $this->db->DBPrefix),
-                $foreignKey['referenceField']
+                $foreignKey->column_name,
+                trim($foreignKey->foreign_table_name, $this->db->DBPrefix),
+                $foreignKey->foreign_column_name
             );
         }
 

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -311,15 +311,15 @@ class Table
                 }
             }
         }
-/*
+
         foreach ($this->foreignKeys as $foreignKey) {
             $this->forge->addForeignKey(
-                implode(',', $foreignKey['field']),
+                $foreignKey['field'],
                 trim($foreignKey['referenceTable'], $this->db->DBPrefix),
-                implode(',', $foreignKey['referenceField'])
+                $foreignKey['referenceField']
             );
         }
-*/
+
         return $this->forge->createTable($this->tableName);
     }
 

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -200,23 +200,14 @@ class Table
      *
      * @return Table
      */
-    public function dropForeignKey(string $column)
+    public function dropForeignKey(string $foreignName)
     {
         if (empty($this->foreignKeys)) {
             return $this;
         }
 
-        for ($i = 0; $i < count($this->foreignKeys); $i++) {
-            if ($this->foreignKeys[$i]->table_name !== $this->prefixedTableName) {
-                continue;
-            }
-
-            // The column name should be the first thing in the constraint name
-            if ($this->foreignKeys[$i]->constraint_name !== $column) {
-                continue;
-            }
-
-            unset($this->foreignKeys[$i]);
+        if (isset($this->foreignKeys[$foreignName])) {
+            unset($this->foreignKeys[$foreignName]);
         }
 
         return $this;
@@ -325,7 +316,7 @@ class Table
             if (is_array($foreignKey)) {
                 $this->forge->addForeignKey(
                     implode(',', $foreignKey['field']),
-                    $foreignKey['referenceTable'],
+                    trim($foreignKey['referenceTable'], $this->db->DBPrefix),
                     implode(',', $foreignKey['referenceField'])
                 );
             }

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -313,13 +313,11 @@ class Table
         }
 
         foreach ($this->foreignKeys as $foreignKey) {
-            if (is_array($foreignKey)) {
-                $this->forge->addForeignKey(
-                    implode(',', $foreignKey['field']),
-                    trim($foreignKey['referenceTable'], $this->db->DBPrefix),
-                    implode(',', $foreignKey['referenceField'])
-                );
-            }
+            $this->forge->addForeignKey(
+                implode(',', $foreignKey['field']),
+                trim($foreignKey['referenceTable'], $this->db->DBPrefix),
+                implode(',', $foreignKey['referenceField'])
+            );
         }
 
         return $this->forge->createTable($this->tableName);
@@ -349,9 +347,13 @@ class Table
             array_map(fn ($item) => $this->db->protectIdentifiers($item), $newFields)
         );
 
+        $this->forge->dropTable({$this->db->DBPrefix}temp_{$this->tableName}, true);
+
         $this->db->query(
             "INSERT INTO {$this->prefixedTableName}({$newFields}) SELECT {$exFields} FROM {$this->db->DBPrefix}temp_{$this->tableName}"
         );
+
+        $this->forge->dropTable({$this->db->DBPrefix}temp_{$this->tableName}, true);
     }
 
     /**

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -347,13 +347,9 @@ class Table
             array_map(fn ($item) => $this->db->protectIdentifiers($item), $newFields)
         );
 
-        $this->forge->dropTable({$this->db->DBPrefix}temp_{$this->tableName}, true);
-
         $this->db->query(
             "INSERT INTO {$this->prefixedTableName}({$newFields}) SELECT {$exFields} FROM {$this->db->DBPrefix}temp_{$this->tableName}"
         );
-
-        $this->forge->dropTable({$this->db->DBPrefix}temp_{$this->tableName}, true);
     }
 
     /**

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -486,11 +486,11 @@ final class ForgeTest extends CIUnitTestCase
 
         $foreignKeyData = $this->db->getForeignKeyData($tableName);
 
-        $this->assertSame($foreignKeyData[$this->db->DBPrefix . $tableName . '_users_id_foreign']['name'], $this->db->DBPrefix . 'forge_test_invoices_users_id_foreign');
-        $this->assertSame($foreignKeyData[$this->db->DBPrefix . $tableName . '_users_id_foreign']['field'], ['users_id']);
-        $this->assertSame($foreignKeyData[$this->db->DBPrefix . $tableName . '_users_id_foreign']['referenceField'], ['id']);
-        $this->assertSame($foreignKeyData[$this->db->DBPrefix . $tableName . '_users_id_foreign']['table'], $this->db->DBPrefix . $tableName);
-        $this->assertSame($foreignKeyData[$this->db->DBPrefix . $tableName . '_users_id_foreign']['referenceTable'], $this->db->DBPrefix . 'forge_test_users');
+        $this->assertSame($foreignKeyData[$this->db->DBPrefix . $tableName . '_users_id_foreign']->constraint_name, $this->db->DBPrefix . 'forge_test_invoices_users_id_foreign');
+        $this->assertSame($foreignKeyData[$this->db->DBPrefix . $tableName . '_users_id_foreign']->column_name, ['users_id']);
+        $this->assertSame($foreignKeyData[$this->db->DBPrefix . $tableName . '_users_id_foreign']->foreign_column_name, ['id']);
+        $this->assertSame($foreignKeyData[$this->db->DBPrefix . $tableName . '_users_id_foreign']->table_name, $this->db->DBPrefix . $tableName);
+        $this->assertSame($foreignKeyData[$this->db->DBPrefix . $tableName . '_users_id_foreign']->foreign_table_name, $this->db->DBPrefix . 'forge_test_users');
 
         $this->forge->dropTable($tableName, true);
         $this->forge->dropTable('forge_test_users', true);
@@ -523,11 +523,11 @@ final class ForgeTest extends CIUnitTestCase
 
         $foreignKeyData = $this->db->getForeignKeyData('forge_test_invoices');
 
-        $this->assertSame($this->db->DBPrefix . 'forge_test_invoices_users_id_foreign', $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_foreign']['name']);
-        $this->assertSame(['users_id'], $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_foreign']['field']);
-        $this->assertSame(['id'], $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_foreign']['referenceField']);
-        $this->assertSame($this->db->DBPrefix . 'forge_test_invoices', $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_foreign']['table']);
-        $this->assertSame($this->db->DBPrefix . 'forge_test_users', $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_foreign']['referenceTable']);
+        $this->assertSame($this->db->DBPrefix . 'forge_test_invoices_users_id_foreign', $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_foreign']->constraint_name);
+        $this->assertSame(['users_id'], $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_foreign']->column_name);
+        $this->assertSame(['id'], $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_foreign']->foreign_column_name);
+        $this->assertSame($this->db->DBPrefix . 'forge_test_invoices', $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_foreign']->table_name);
+        $this->assertSame($this->db->DBPrefix . 'forge_test_users', $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_foreign']->foreign_table_name);
 
         $this->forge->dropTable('forge_test_invoices', true);
         $this->forge->dropTable('forge_test_users', true);
@@ -592,11 +592,11 @@ final class ForgeTest extends CIUnitTestCase
         $foreignKeyData = $this->db->getForeignKeyData('forge_test_invoices');
 
         $haystack = ['users_id', 'users_second_id'];
-        $this->assertSame($this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign', $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign']['name']);
-        $this->assertSame($foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign']['field'], $haystack);
+        $this->assertSame($this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign', $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign']->constraint_name);
+        $this->assertSame($foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign']->column_name, $haystack);
 
-        $this->assertSame($this->db->DBPrefix . 'forge_test_invoices', $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign']['table']);
-        $this->assertSame($this->db->DBPrefix . 'forge_test_users', $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign']['referenceTable']);
+        $this->assertSame($this->db->DBPrefix . 'forge_test_invoices', $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign']->table_name);
+        $this->assertSame($this->db->DBPrefix . 'forge_test_users', $foreignKeyData[$this->db->DBPrefix . 'forge_test_invoices_users_id_users_second_id_foreign']->foreign_table_name);
 
         $this->forge->dropTable('forge_test_invoices', true);
         $this->forge->dropTable('forge_test_users', true);

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -224,11 +224,11 @@ final class AlterTableTest extends CIUnitTestCase
         $this->createTable('aliens');
 
         $keys = $this->db->getForeignKeyData('aliens');
-        $this->assertSame('aliens_key_id_foreign', $keys[0]->constraint_name);
+        $this->assertSame('aliens_key_id_foreign', $keys[$this->db->DBPrefix . 'aliens_key_id_foreign']['name']);
 
         $result = $this->table
             ->fromTable('aliens')
-            ->dropForeignKey('key_id')
+            ->dropForeignKey('aliens_key_id_foreign')
             ->run();
 
         $this->assertTrue($result);

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -224,7 +224,7 @@ final class AlterTableTest extends CIUnitTestCase
         $this->createTable('aliens');
 
         $keys = $this->db->getForeignKeyData('aliens');
-        $this->assertSame('key_id to aliens_fk.id', $keys[0]->constraint_name);
+        $this->assertSame('aliens_key_id_foreign', $keys[0]->constraint_name);
 
         $result = $this->table
             ->fromTable('aliens')

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -224,7 +224,7 @@ final class AlterTableTest extends CIUnitTestCase
         $this->createTable('aliens');
 
         $keys = $this->db->getForeignKeyData('aliens');
-        $this->assertSame('aliens_key_id_foreign', $keys[$this->db->DBPrefix . 'aliens_key_id_foreign']['name']);
+        $this->assertSame('aliens_key_id_foreign', $keys[$this->db->DBPrefix . 'aliens_key_id_foreign']->constraint_name);
 
         $result = $this->table
             ->fromTable('aliens')


### PR DESCRIPTION
Ref #4814 #4653

This PR adds functionality to create indexes, primary keys, and foreign keys on a table already created. It does this by calling the new function `processIndexes()` instead of `createTable()`.

```php
$forge->addKey(['category', 'name'])
      ->addPrimaryKey('id')
      ->addForeignKey('userid', 'user', 'id')
      ->processIndexes('actions');
```
Also a new method `dropPrimaryKey()` allows to drop the primary key.

There were some differences between DBMS of the naming of indexes. These have been consolidated so each platform follows the same convention.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
