### PR TITLE
Remove unneeded abstract `handle()` method

### DIFF
--- a/system/Log/Handlers/BaseHandler.php
+++ b/system/Log/Handlers/BaseHandler.php
@@ -48,17 +48,6 @@ abstract class BaseHandler implements HandlerInterface
     }
 
     /**
-     * Handles logging the message.
-     * If the handler returns false, then execution of handlers
-     * will stop. Any handlers that have not run, yet, will not
-     * be run.
-     *
-     * @param string $level
-     * @param string $message
-     */
-    abstract public function handle($level, $message): bool;
-
-    /**
      * Stores the date format to use while logging messages.
      */
     public function setDateFormat(string $format): HandlerInterface


### PR DESCRIPTION
**Description**
The abstract `handle()` in the abstract class is unneeded because the its interface is already defining that method. It's redundant.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
