### PR TITLE
docs: fix incorrect links to the spark page

### DIFF
--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -329,7 +329,7 @@ available from the command line:
 .. literalinclude:: routing/032.php
 
 .. note:: It is recommended to use Spark Commands for CLI scripts instead of calling controllers via CLI.
-    See the :doc:`../cli/spark_commands` page for detailed information.
+    See the :doc:`../cli/cli_commands` page for detailed information.
 
 .. warning:: If you enable :ref:`auto-routing` and place the command file in **app/Controllers**,
     anyone could access the command with the help of auto-routing via HTTP.
@@ -717,7 +717,7 @@ In this example, if the user were to visit **example.com/products**, and a ``Pro
 Confirming Routes
 *****************
 
-CodeIgniter has the following :doc:`command </cli/cli_commands>` to display all routes.
+CodeIgniter has the following :doc:`command </cli/spark_commands>` to display all routes.
 
 .. _spark-routes:
 


### PR DESCRIPTION
**Description**
- fix links

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
