### PR TITLE
fix: Call to undefined method CodeIgniter\HTTP\CLIRequest::getLocale()

### DIFF
--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\HTTP;
 
 use Config\App;
+use Locale;
 use RuntimeException;
 
 /**
@@ -279,5 +280,14 @@ class CLIRequest extends Request
     private function returnNullOrEmptyArray($index)
     {
         return ($index === null || is_array($index)) ? [] : null;
+    }
+
+    /**
+     * Gets the current locale, with a fallback to the default
+     * locale if none is set.
+     */
+    public function getLocale(): string
+    {
+        return Locale::getDefault();
     }
 }

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -599,16 +599,16 @@ final class CLIRequestTest extends CIUnitTestCase
 
     public function testGetPost()
     {
-        $this->assertSame([], $this->request->getGet());
+        $this->assertSame([], $this->request->getPost());
     }
 
     public function testGetPostGet()
     {
-        $this->assertSame([], $this->request->getGet());
+        $this->assertSame([], $this->request->getPostGet());
     }
 
     public function testGetGetPost()
     {
-        $this->assertSame([], $this->request->getGet());
+        $this->assertSame([], $this->request->getGetPost());
     }
 }

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -611,4 +611,9 @@ final class CLIRequestTest extends CIUnitTestCase
     {
         $this->assertSame([], $this->request->getGetPost());
     }
+
+    public function testGetLocale()
+    {
+        $this->assertSame('en', $this->request->getLocale());
+    }
 }


### PR DESCRIPTION
**Description**
Fixes https://github.com/codeigniter4/CodeIgniter4/issues/6377
Follow-up #6421

- add `CLIRequest::getLocale()`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
