### PR TITLE
feat: add locale param to `route_to()`

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -911,7 +911,8 @@ if (! function_exists('route_to')) {
      * have a route defined in the routes Config file.
      *
      * @param string     $method    Named route or Controller::method
-     * @param int|string ...$params One or more parameters to be passed to the route
+     * @param int|string ...$params One or more parameters to be passed to the route.
+     *                              The last parameter allows you to set the locale.
      *
      * @return false|string
      */

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -14,9 +14,11 @@ namespace CodeIgniter\Router;
 use Closure;
 use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\Router\Exceptions\RouterException;
+use Config\App;
 use Config\Modules;
 use Config\Services;
 use InvalidArgumentException;
+use Locale;
 
 /**
  * @todo Implement nested resource routing (See CakePHP)
@@ -1016,7 +1018,8 @@ class RouteCollection implements RouteCollectionInterface
      *      reverseRoute('Controller::method', $param1, $param2);
      *
      * @param string     $search    Named route or Controller::method
-     * @param int|string ...$params One or more parameters to be passed to the route
+     * @param int|string ...$params One or more parameters to be passed to the route.
+     *                              The last parameter allows you to set the locale.
      *
      * @return false|string
      */
@@ -1025,9 +1028,7 @@ class RouteCollection implements RouteCollectionInterface
         // Named routes get higher priority.
         foreach ($this->routes as $collection) {
             if (array_key_exists($search, $collection)) {
-                $route = $this->fillRouteParams(key($collection[$search]['route']), $params);
-
-                return $this->localizeRoute($route);
+                return $this->buildReverseRoute(key($collection[$search]['route']), $params);
             }
         }
 
@@ -1069,9 +1070,7 @@ class RouteCollection implements RouteCollectionInterface
                     continue;
                 }
 
-                $route = $this->fillRouteParams($from, $params);
-
-                return $this->localizeRoute($route);
+                return $this->buildReverseRoute($from, $params);
             }
         }
 
@@ -1081,6 +1080,8 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Replaces the {locale} tag with the current application locale
+     *
+     * @deprecated Unused.
      */
     protected function localizeRoute(string $route): string
     {
@@ -1145,6 +1146,8 @@ class RouteCollection implements RouteCollectionInterface
      * Given a
      *
      * @throws RouterException
+     *
+     * @deprecated Unused. Now uses buildReverseRoute().
      */
     protected function fillRouteParams(string $from, ?array $params = null): string
     {
@@ -1169,6 +1172,78 @@ class RouteCollection implements RouteCollectionInterface
         }
 
         return '/' . ltrim($from, '/');
+    }
+
+    /**
+     * Builds reverse route
+     *
+     * @param array $params One or more parameters to be passed to the route.
+     *                      The last parameter allows you to set the locale.
+     */
+    protected function buildReverseRoute(string $from, array $params): string
+    {
+        $locale = null;
+
+        // Find all of our back-references in the original route
+        preg_match_all('/\(([^)]+)\)/', $from, $matches);
+
+        if (empty($matches[0])) {
+            if (strpos($from, '{locale}') !== false) {
+                $locale = $params[0] ?? null;
+            }
+
+            $from = $this->replaceLocale($from, $locale);
+
+            return '/' . ltrim($from, '/');
+        }
+
+        // Locale is passed?
+        $placeholderCount = count($matches[0]);
+        if (count($params) > $placeholderCount) {
+            $locale = $params[$placeholderCount];
+        }
+
+        // Build our resulting string, inserting the $params in
+        // the appropriate places.
+        foreach ($matches[0] as $index => $pattern) {
+            if (! preg_match('#^' . $pattern . '$#u', $params[$index])) {
+                throw RouterException::forInvalidParameterType();
+            }
+
+            // Ensure that the param we're inserting matches
+            // the expected param type.
+            $pos  = strpos($from, $pattern);
+            $from = substr_replace($from, $params[$index], $pos, strlen($pattern));
+        }
+
+        $from = $this->replaceLocale($from, $locale);
+
+        return '/' . ltrim($from, '/');
+    }
+
+    /**
+     * Replaces the {locale} tag with the locale
+     */
+    private function replaceLocale(string $route, ?string $locale = null): string
+    {
+        if (strpos($route, '{locale}') === false) {
+            return $route;
+        }
+
+        // Check invalid locale
+        if ($locale !== null) {
+            /** @var App $config */
+            $config = config('App');
+            if (! in_array($locale, $config->supportedLocales, true)) {
+                $locale = null;
+            }
+        }
+
+        if ($locale === null) {
+            $locale = Services::request()->getLocale();
+        }
+
+        return strtr($route, ['{locale}' => $locale]);
     }
 
     /**

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -222,6 +222,39 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $this->assertSame('/path/string/to/13', route_to('myController::goto', 'string', 13));
     }
 
+    public function testRouteToInCliWithoutLocaleInRoute()
+    {
+        Services::createRequest(new App(), true);
+        $routes = service('routes');
+        $routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2');
+
+        $this->assertSame('/path/string/to/13', route_to('myController::goto', 'string', 13));
+    }
+
+    public function testRouteToInCliWithLocaleInRoute()
+    {
+        Services::createRequest(new App(), true);
+        $routes = service('routes');
+        $routes->add('{locale}/path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'path-to']);
+
+        $this->assertSame(
+            '/en/path/string/to/13',
+            route_to('path-to', 'string', 13, 'en')
+        );
+    }
+
+    public function testRouteToWithUnsupportedLocale()
+    {
+        Services::createRequest(new App(), false);
+        $routes = service('routes');
+        $routes->add('{locale}/path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'path-to']);
+
+        $this->assertSame(
+            '/en/path/string/to/13',
+            route_to('path-to', 'string', 13, 'invalid')
+        );
+    }
+
     public function testInvisible()
     {
         $this->assertSame('Javascript', remove_invisible_characters("Java\0script"));

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -71,6 +71,7 @@ Others
 - Now you can autoload helpers by **app/Config/Autoload.php**.
 - ``BaseConnection::escape()`` now excludes the ``RawSql`` data type. This allows passing SQL strings into data.
 - Added :ref:`Time::toDatabase() <time-todatabase>` to get a datetime string that can be used with databases regardless of locale.
+- You can set the locale to :php:func:`route_to()` if you pass a locale value as the last parameter.
 
 Changes
 *******
@@ -93,7 +94,8 @@ Changes
 Deprecations
 ************
 
-none.
+- ``RouteCollection::localizeRoute()`` is deprecated.
+- ``RouteCollection::fillRouteParams()`` is deprecated. Use ``RouteCollection::buildReverseRoute()`` instead.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -335,16 +335,21 @@ Miscellaneous Functions
 .. php:function:: route_to($method[, ...$params])
 
     :param   string  $method: The named route alias, or name of the controller/method to match.
-    :param   int|string   $params: One or more parameters to be passed to be matched in the route.
+    :param   int|string   $params: One or more parameters to be passed to be matched in the route. The last parameter allows you to set the locale.
 
     .. note:: This function requires the controller/method to have a route defined in **app/Config/routes.php**.
 
-    Generates a route for you based on either a named route alias,
-    or a controller::method combination. Will take parameters into effect, if provided.
+    Generates a route for you based on a controller::method combination. Will take parameters into effect, if provided.
 
     .. literalinclude:: common_functions/009.php
 
+    Generates a route for you based on a named route alias.
+
     .. literalinclude:: common_functions/010.php
+
+    Since v4.3.0, when you use ``{locale}`` in your route, you can optionally specify the locale value as the last parameter.
+
+    .. literalinclude:: common_functions/011.php
 
     .. note:: ``route_to()`` returns a route, not a full URI path for your site.
         If your **baseURL** contains sub folders, the return value is not the same

--- a/user_guide_src/source/general/common_functions/011.php
+++ b/user_guide_src/source/general/common_functions/011.php
@@ -1,0 +1,16 @@
+<?php
+
+// The route is defined as:
+$routes->add(
+    '{locale}/users/(:num)/gallery(:any)',
+    'Galleries::showUserGallery/$1/$2',
+    ['as' => 'user_gallery']
+);
+
+?>
+
+<?php
+
+// Generate the route with user ID 15, gallery 12 and locale en:
+route_to('user_gallery', 15, 12, 'en');
+// Result: '/en/users/15/gallery/12'


### PR DESCRIPTION
**Description**
Supersedes #6379

- Now you can set locale as the last parameter.

  ```php
  // for route 
  $routes->add('{locale}/path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'path-to']);
  
  // the helper should be called like this.
  route_to('path-to', 'string', 13, 'en'); // /en/path/string/to/13
  ```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
