### PR TITLE
chore: move Kint to `require-dev`

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -10,11 +10,11 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "kint-php/kint": "^4.2",
         "laminas/laminas-escaper": "^2.9",
         "psr/log": "^1.1"
     },
     "require-dev": {
+        "kint-php/kint": "^4.2",
         "codeigniter/coding-standard": "^1.1",
         "fakerphp/faker": "^1.9",
         "friendsofphp/php-cs-fixer": "3.6.*",

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "kint-php/kint": "^4.2",
         "laminas/laminas-escaper": "^2.9",
         "psr/log": "^1.1"
     },
     "require-dev": {
+        "kint-php/kint": "^4.2",
         "codeigniter/coding-standard": "^1.1",
         "fakerphp/faker": "^1.9",
         "friendsofphp/php-cs-fixer": "3.6.*",

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -223,11 +223,10 @@ class CodeIgniter
         if (CI_DEBUG) {
             $this->autoloadKint();
             $this->configureKint();
-        } else {
-            if (class_exists(Kint::class)) {
-                // In case that Kint is already loaded via Composer.
-                Kint::$enabled_mode = false; // @codeCoverageIgnore
-            }
+        } elseif (class_exists(Kint::class)) {
+            // In case that Kint is already loaded via Composer.
+            Kint::$enabled_mode = false;
+            // @codeCoverageIgnore
         }
 
         helper('kint');

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -182,11 +182,15 @@ class CodeIgniter
         // Set default timezone on the server
         date_default_timezone_set($this->config->appTimezone ?? 'UTC');
 
-        $this->initializeKint();
-
-        if (! CI_DEBUG) {
-            Kint::$enabled_mode = false; // @codeCoverageIgnore
+        if (CI_DEBUG) {
+            $this->initializeKint();
+        } else {
+            if (class_exists(Kint::class)) {
+                // In case that Kint is already loaded via Composer.
+                Kint::$enabled_mode = false; // @codeCoverageIgnore
+            }
         }
+        helper('kint');
     }
 
     /**

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -182,15 +182,7 @@ class CodeIgniter
         // Set default timezone on the server
         date_default_timezone_set($this->config->appTimezone ?? 'UTC');
 
-        if (CI_DEBUG) {
-            $this->initializeKint();
-        } else {
-            if (class_exists(Kint::class)) {
-                // In case that Kint is already loaded via Composer.
-                Kint::$enabled_mode = false; // @codeCoverageIgnore
-            }
-        }
-        helper('kint');
+        $this->initializeKint();
     }
 
     /**
@@ -228,6 +220,21 @@ class CodeIgniter
      */
     protected function initializeKint()
     {
+        if (CI_DEBUG) {
+            $this->autoloadKint();
+            $this->configureKint();
+        } else {
+            if (class_exists(Kint::class)) {
+                // In case that Kint is already loaded via Composer.
+                Kint::$enabled_mode = false; // @codeCoverageIgnore
+            }
+        }
+
+        helper('kint');
+    }
+
+    private function autoloadKint(): void
+    {
         // If we have KINT_DIR it means it's already loaded via composer
         if (! defined('KINT_DIR')) {
             spl_autoload_register(function ($class) {
@@ -246,7 +253,10 @@ class CodeIgniter
 
             require_once SYSTEMPATH . 'ThirdParty/Kint/init.php';
         }
+    }
 
+    private function configureKint(): void
+    {
         /** @var \Config\Kint $config */
         $config = config(KintConfig::class);
 

--- a/system/Common.php
+++ b/system/Common.php
@@ -347,25 +347,6 @@ if (! function_exists('db_connect')) {
     }
 }
 
-if (! function_exists('dd')) {
-    /**
-     * Prints a Kint debug report and exits.
-     *
-     * @param array ...$vars
-     *
-     * @codeCoverageIgnore Can't be tested ... exits
-     */
-    function dd(...$vars)
-    {
-        // @codeCoverageIgnoreStart
-        Kint::$aliases[] = 'dd';
-        Kint::dump(...$vars);
-
-        exit;
-        // @codeCoverageIgnoreEnd
-    }
-}
-
 if (! function_exists('env')) {
     /**
      * Allows user to retrieve values from the environment
@@ -1105,17 +1086,6 @@ if (! function_exists('timer')) {
         }
 
         return $timer->start($name);
-    }
-}
-
-if (! function_exists('trace')) {
-    /**
-     * Provides a backtrace to the current execution point, from Kint.
-     */
-    function trace()
-    {
-        Kint::$aliases[] = 'trace';
-        Kint::trace();
     }
 }
 

--- a/system/ComposerScripts.php
+++ b/system/ComposerScripts.php
@@ -69,8 +69,14 @@ final class ComposerScripts
     {
         self::recursiveDelete(self::$path);
 
-        foreach (self::$dependencies as $dependency) {
+        foreach (self::$dependencies as $key => $dependency) {
+            // Kint may be removed.
+            if (! is_dir($dependency['from']) && strpos($key, 'kint') === 0) {
+                continue;
+            }
+
             self::recursiveMirror($dependency['from'], $dependency['to']);
+
             if (isset($dependency['license'])) {
                 $license = basename($dependency['license']);
                 copy($dependency['license'], $dependency['to'] . '/' . $license);

--- a/system/Helpers/kint_helper.php
+++ b/system/Helpers/kint_helper.php
@@ -38,13 +38,11 @@ if (! function_exists('dd')) {
     }
 }
 
-if (! function_exists('d')) {
-    if (! class_exists(Kint::class)) {
-        // In case that Kint is not loaded.
-        function d(...$vars)
-        {
-            return 0;
-        }
+if (! function_exists('d') && ! class_exists(Kint::class)) {
+    // In case that Kint is not loaded.
+    function d(...$vars)
+    {
+        return 0;
     }
 }
 

--- a/system/Helpers/kint_helper.php
+++ b/system/Helpers/kint_helper.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+// This helper is autoloaded by CodeIgniter.
+
+if (! function_exists('dd')) {
+    if (class_exists(Kint::class)) {
+        /**
+         * Prints a Kint debug report and exits.
+         *
+         * @param array ...$vars
+         *
+         * @codeCoverageIgnore Can't be tested ... exits
+         */
+        function dd(...$vars)
+        {
+            // @codeCoverageIgnoreStart
+            Kint::$aliases[] = 'dd';
+            Kint::dump(...$vars);
+
+            exit;
+            // @codeCoverageIgnoreEnd
+        }
+    } else {
+        // In case that Kint is not loaded.
+        function dd(...$vars)
+        {
+            return 0;
+        }
+    }
+}
+
+if (! function_exists('d')) {
+    if (! class_exists(Kint::class)) {
+        // In case that Kint is not loaded.
+        function d(...$vars)
+        {
+            return 0;
+        }
+    }
+}
+
+if (! function_exists('trace')) {
+    if (class_exists(Kint::class)) {
+        /**
+         * Provides a backtrace to the current execution point, from Kint.
+         */
+        function trace()
+        {
+            Kint::$aliases[] = 'trace';
+            Kint::trace();
+        }
+    } else {
+        // In case that Kint is not loaded.
+        function trace()
+        {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
**Description**
Kint is not needed on production environment.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
