### PR TITLE
[4.3] Fix tests. Changed StreamFilterTrait and CITestStreamFilter.

### DIFF
--- a/system/Test/Filters/CITestStreamFilter.php
+++ b/system/Test/Filters/CITestStreamFilter.php
@@ -29,6 +29,16 @@ class CITestStreamFilter extends php_user_filter
     protected static bool $registered = false;
 
     /**
+     * @var resource|null
+     */
+    private static $err;
+
+    /**
+     * @var resource|null
+     */
+    private static $out;
+
+    /**
      * This method is called whenever data is read from or written to the
      * attached stream (such as with fread() or fwrite()).
      *
@@ -55,5 +65,38 @@ class CITestStreamFilter extends php_user_filter
         }
 
         static::$buffer = '';
+    }
+
+    public static function addErrorFilter(): void
+    {
+        self::removeFilter(self::$err);
+        self::$err = stream_filter_append(STDERR, 'CITestStreamFilter');
+    }
+
+    public static function addOutputFilter(): void
+    {
+        self::removeFilter(self::$out);
+        self::$out = stream_filter_append(STDOUT, 'CITestStreamFilter');
+    }
+
+    public static function removeErrorFilter(): void
+    {
+        self::removeFilter(self::$err);
+    }
+
+    public static function removeOutputFilter(): void
+    {
+        self::removeFilter(self::$out);
+    }
+
+    /**
+     * @param resource $stream
+     */
+    protected static function removeFilter(&$stream): void
+    {
+        if (is_resource($stream)) {
+            stream_filter_remove($stream);
+            $stream = null;
+        }
     }
 }

--- a/system/Test/StreamFilterTrait.php
+++ b/system/Test/StreamFilterTrait.php
@@ -15,86 +15,17 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 trait StreamFilterTrait
 {
-    /**
-     * @var resource|null
-     */
-    private $outputStreamFilterResource;
-
-    /**
-     * @var resource|null
-     */
-    private $errorStreamFilterResource;
-
     protected function setUpStreamFilterTrait(): void
     {
-        $this->registerStreamFilterClass()
-            ->appendOutputStreamFilter()
-            ->appendErrorStreamFilter();
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+        CITestStreamFilter::addErrorFilter();
     }
 
     protected function tearDownStreamFilterTrait(): void
     {
-        $this->removeOutputStreamFilter()->removeErrorStreamFilter();
-    }
-
-    /**
-     * @return $this
-     */
-    protected function appendOutputStreamFilter()
-    {
-        $this->removeOutputStreamFilter();
-
-        $this->outputStreamFilterResource = stream_filter_append(STDOUT, 'CITestStreamFilter');
-
-        return $this;
-    }
-
-    /**
-     * @return $this
-     */
-    protected function appendErrorStreamFilter()
-    {
-        $this->removeErrorStreamFilter();
-
-        $this->errorStreamFilterResource = stream_filter_append(STDERR, 'CITestStreamFilter');
-
-        return $this;
-    }
-
-    /**
-     * @return $this
-     */
-    protected function removeOutputStreamFilter()
-    {
-        if (is_resource($this->outputStreamFilterResource)) {
-            stream_filter_remove($this->outputStreamFilterResource);
-            $this->outputStreamFilterResource = null;
-        }
-
-        return $this;
-    }
-
-    /**
-     * @return $this
-     */
-    protected function removeErrorStreamFilter()
-    {
-        if (is_resource($this->errorStreamFilterResource)) {
-            stream_filter_remove($this->errorStreamFilterResource);
-            $this->errorStreamFilterResource = null;
-        }
-
-        return $this;
-    }
-
-    /**
-     * @return $this
-     */
-    protected function registerStreamFilterClass()
-    {
-        CITestStreamFilter::registration();
-
-        return $this;
+        CITestStreamFilter::removeOutputFilter();
+        CITestStreamFilter::removeErrorFilter();
     }
 
     protected function getStreamFilterBuffer(): string

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -569,9 +569,9 @@ final class CodeIgniterTest extends CIUnitTestCase
     public function testPageCacheSendSecureHeaders()
     {
         // Suppress command() output
-        CITestStreamFilter::$buffer = '';
-        $outputStreamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $errorStreamFilter          = stream_filter_append(STDERR, 'CITestStreamFilter');
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addErrorFilter();
+        CITestStreamFilter::addOutputFilter();
 
         // Clear Page cache
         command('cache:clear');
@@ -618,8 +618,8 @@ final class CodeIgniterTest extends CIUnitTestCase
         // Clear Page cache
         command('cache:clear');
 
-        // Remove stream fliters
-        stream_filter_remove($outputStreamFilter);
-        stream_filter_remove($errorStreamFilter);
+        // Remove stream filters
+        CITestStreamFilter::removeErrorFilter();
+        CITestStreamFilter::removeOutputFilter();
     }
 }

--- a/tests/system/Commands/Utilities/NamespacesTest.php
+++ b/tests/system/Commands/Utilities/NamespacesTest.php
@@ -12,37 +12,30 @@
 namespace CodeIgniter\Commands\Utilities;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
  */
 final class NamespacesTest extends CIUnitTestCase
 {
-    private $streamFilter;
+    use StreamFilterTrait;
 
     protected function setUp(): void
     {
         $this->resetServices();
 
         parent::setUp();
-
-        CITestStreamFilter::$buffer = '';
-
-        $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
     }
 
     protected function tearDown(): void
     {
-        stream_filter_remove($this->streamFilter);
-
         $this->resetServices();
     }
 
     protected function getBuffer()
     {
-        return CITestStreamFilter::$buffer;
+        return $this->getStreamFilterBuffer();
     }
 
     public function testNamespacesCommandCodeIgniterOnly()

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -43,7 +43,8 @@ Others
 - The ``spark`` file has been changed due to a change in the processing of Spark commands.
 - ``InvalidArgumentException`` that is a kind of ``LogicException`` in ``BaseBuilder::_whereIn()`` is not suppressed by the configuration. Previously if ``CI_DEBUG`` was false, the exception was suppressed.
 - ``RouteCollection::resetRoutes()`` resets Auto-Discovery of Routes. Previously once discovered, RouteCollection never discover Routes files again even if ``RouteCollection::resetRoutes()`` is called.
-- ``CITestStreamFilter::$buffer = ''`` no longer causes the filter to be registered to listen for streams. Now there is a ``CITestStreamFilter::registration()`` method for this.
+- ``CITestStreamFilter::$buffer = ''`` no longer causes the filter to be registered to listen for streams. Now there
+  is a ``CITestStreamFilter::registration()`` method for this. See :ref:`upgrade-430-stream-filter` for details.
 
 Enhancements
 ************

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -43,6 +43,7 @@ Others
 - The ``spark`` file has been changed due to a change in the processing of Spark commands.
 - ``InvalidArgumentException`` that is a kind of ``LogicException`` in ``BaseBuilder::_whereIn()`` is not suppressed by the configuration. Previously if ``CI_DEBUG`` was false, the exception was suppressed.
 - ``RouteCollection::resetRoutes()`` resets Auto-Discovery of Routes. Previously once discovered, RouteCollection never discover Routes files again even if ``RouteCollection::resetRoutes()`` is called.
+- ``CITestStreamFilter::$buffer = ''`` no longer causes the filter to be registered to listen for streams. Now there is a ``CITestStreamFilter::registration()`` method for this.
 
 Enhancements
 ************
@@ -54,6 +55,7 @@ CLI
 Others
 ======
 - Added the ``StreamFilterTrait`` to make it easier to work with capturing data from STDOUT and STDERR streams. See :ref:`testing-cli-output`.
+- The CITestStreamFilter filter class now implements methods for adding a filter to streams. See :ref:`testing-cli-output`.
 - Added the ``PhpStreamWrapper`` to make it easier to work with setting data to ``php://stdin``. See :ref:`testing-cli-input`.
 - Added before and after events to ``BaseModel::insertBatch()`` and ``BaseModel::updateBatch()`` methods. See :ref:`model-events-callbacks`.
 - Added ``Model::allowEmptyInserts()`` method to insert empty data. See :ref:`Using CodeIgniter's Model <model-allow-empty-inserts>`

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -74,6 +74,43 @@ If you have code that depends on the bug, you need to change the code.
 Use new Form helpers, :php:func:`validation_errors()`, :php:func:`validation_list_errors()` and :php:func:`validation_show_error()` to display Validation Errors,
 instead of the Validation object.
 
+.. _upgrade-430-stream-filter:
+
+Capturing STDERR and STDOUT streams in tests
+============================================
+
+The way error and output streams are captured has changed. Now instead of::
+
+    use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+    protected function setUp(): void
+    {
+        CITestStreamFilter::$buffer = '';
+        $this->stream_filter        = stream_filter_append(STDOUT, 'CITestStreamFilter');
+    }
+
+    protected function tearDown(): void
+    {
+        stream_filter_remove($this->stream_filter);
+    }
+
+need to use::
+
+    use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+    protected function setUp(): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+    }
+
+    protected function tearDown(): void
+    {
+        CITestStreamFilter::removeOutputFilter();
+    }
+
+Or use the trait ``CodeIgniter\Test\StreamFilterTrait``. See :ref:`testing-cli-output`.
+
 Others
 ======
 

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -277,6 +277,21 @@ See :ref:`Testing Traits <testing-overview-traits>`.
 If you override the ``setUp()`` or ``tearDown()`` methods in your test, then you must call the ``parent::setUp()`` and
 ``parent::tearDown()`` methods respectively to configure the ``StreamFilterTrait``.
 
+**CITestStreamFilter** for manual/single use.
+
+If you need to capture streams in only one test, then instead of using the StreamFilterTrait trait, you can manually
+add a filter to streams.
+
+**Overview of methods**
+
+- ``CITestStreamFilter::registration()`` Filter registration.
+- ``CITestStreamFilter::addOutputFilter()`` Adding a filter to the output stream.
+- ``CITestStreamFilter::addErrorFilter()`` Adding a filter to the error stream.
+- ``CITestStreamFilter::removeOutputFilter()`` Removing a filter from the output stream.
+- ``CITestStreamFilter::removeErrorFilter()`` Removing a filter from the error stream.
+
+.. literalinclude:: overview/020.php
+
 .. _testing-cli-input:
 
 Testing CLI Input

--- a/user_guide_src/source/testing/overview/020.php
+++ b/user_guide_src/source/testing/overview/020.php
@@ -1,0 +1,15 @@
+<?php
+
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+public function testSomeOutput(): void
+{
+    CITestStreamFilter::registration();
+    CITestStreamFilter::addOutputFilter();
+
+    CLI::write('first.');
+
+    CITestStreamFilter::removeOutputFilter();
+}
+

--- a/user_guide_src/source/testing/overview/020.php
+++ b/user_guide_src/source/testing/overview/020.php
@@ -1,15 +1,18 @@
 <?php
 
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
 
-public function testSomeOutput(): void
+final class SomeTest extends CIUnitTestCase
 {
-    CITestStreamFilter::registration();
-    CITestStreamFilter::addOutputFilter();
+    public function testSomeOutput(): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
 
-    CLI::write('first.');
+        CLI::write('first.');
 
-    CITestStreamFilter::removeOutputFilter();
+        CITestStreamFilter::removeOutputFilter();
+    }
 }
-


### PR DESCRIPTION
**Description**
Tests failed due to changed stream filter initialization.

- Filter additions to STDOUT and STDERR streams moved from trait to filter class.
  - CITestStreamFilter::addErrorFilter()
  - CITestStreamFilter::addOutputFilter()
  - CITestStreamFilter::removeErrorFilter()
  - CITestStreamFilter::removeOutputFilter()
- Fixed failed tests.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
