### PR TITLE
fix: AssertionError occurs when using Validation in CLI

### DIFF
--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -40,7 +40,7 @@ class FileRules
             $request = Services::request();
         }
 
-        assert($request instanceof CLIRequest ?? IncomingRequest)
+        assert($request instanceof IncomingRequest || $request instanceof CLIRequest);
 
         $this->request = $request;
     }

--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Validation;
 
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\RequestInterface;
 use Config\Mimes;
@@ -39,7 +40,7 @@ class FileRules
             $request = Services::request();
         }
 
-        assert($request instanceof Request);
+        assert($request instanceof CLIRequest ?? IncomingRequest)
 
         $this->request = $request;
     }

--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -39,7 +39,7 @@ class FileRules
             $request = Services::request();
         }
 
-        assert($request instanceof IncomingRequest);
+        assert($request instanceof Request);
 
         $this->request = $request;
     }

--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -11,8 +11,8 @@
 
 namespace CodeIgniter\Validation;
 
-use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\CLIRequest;
+use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\RequestInterface;
 use Config\Mimes;


### PR DESCRIPTION
**Description**

at SYSTEMPATH\Validation\FileRules.php:42

Backtrace:
  1    [internal function]
       CodeIgniter\Debug\Exceptions()->errorHandler(2, 'assert(): assert($request instanceof IncomingRequest) failed', 'C:\\laragon\\www\\test\\vendor\\codeigniter4\\framework\\system\\Validation\\FileRules.php', 42, [...])

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
