### PR TITLE
feat: QueryBuilder insert/update support Time object

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -161,6 +161,7 @@ parameters:
     Database:
       - Entity
       - Events
+      - I18n
     Email:
       - Events
     Entity:

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2699,7 +2699,11 @@ class BaseBuilder
         $array = [];
 
         foreach (get_object_vars($object) as $key => $val) {
-            if ((! is_object($val) || $val instanceof RawSql || $val instanceof Time) && ! is_array($val)) {
+            if ($val instanceof RawSql) {
+                $array[$key] = $val;
+            } elseif ($val instanceof Time) {
+                $array[$key] = $val;
+            } elseif (! is_object($val) && ! is_array($val)) {
                 $array[$key] = $val;
             }
         }

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Database;
 use Closure;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\I18n\Time;
 use InvalidArgumentException;
 
 /**
@@ -2698,7 +2699,7 @@ class BaseBuilder
         $array = [];
 
         foreach (get_object_vars($object) as $key => $val) {
-            if ((! is_object($val) || $val instanceof RawSql) && ! is_array($val)) {
+            if ((! is_object($val) || $val instanceof RawSql || $val instanceof Time) && ! is_array($val)) {
                 $array[$key] = $val;
             }
         }

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Database;
 use Closure;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Events\Events;
+use CodeIgniter\I18n\Time;
 use stdClass;
 use Throwable;
 
@@ -1245,6 +1246,10 @@ abstract class BaseConnection implements ConnectionInterface
         if (is_string($str) || (is_object($str) && method_exists($str, '__toString'))) {
             if ($str instanceof RawSql) {
                 return $str->__toString();
+            }
+
+            if ($str instanceof Time) {
+                $str = $str->toDatabase();
             }
 
             return "'" . $this->escapeString($str) . "'";

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Database\Postgre;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\RawSql;
+use CodeIgniter\I18n\Time;
 use ErrorException;
 use stdClass;
 
@@ -184,6 +185,10 @@ class Connection extends BaseConnection
         if (is_string($str) || (is_object($str) && method_exists($str, '__toString'))) {
             if ($str instanceof RawSql) {
                 return $str->__toString();
+            }
+
+            if ($str instanceof Time) {
+                $str = $str->toDatabase();
             }
 
             return pg_escape_literal($this->connID, $str);

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -14,8 +14,10 @@ namespace CodeIgniter\Database\Builder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Query;
 use CodeIgniter\Database\RawSql;
+use CodeIgniter\I18n\Time;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use Locale;
 
 /**
  * @internal
@@ -99,6 +101,26 @@ final class InsertTest extends CIUnitTestCase
         $expectedSQL = 'INSERT INTO "jobs" ("id", "name") VALUES (1, CONCAT("id", \'Grocery Sales\'))';
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
+    }
+
+    public function testInsertObjectWithTimeWithLocaleFa()
+    {
+        $currentLocale = Locale::getDefault();
+        Locale::setDefault('fa');
+
+        $builder = $this->db->table('jobs');
+
+        $time       = Time::parse('2022-08-29 13:00');
+        $insertData = (object) [
+            'id'        => 1,
+            'insert_at' => $time,
+        ];
+        $builder->testMode()->insert($insertData, true);
+
+        $expectedSQL = 'INSERT INTO "jobs" ("id", "insert_at") VALUES (1, \'2022-08-29 13:00:00\')';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledInsert()));
+
+        Locale::setDefault($currentLocale);
     }
 
     /**

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -13,9 +13,11 @@ namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\I18n\Time;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 use CodeIgniter\Test\Mock\MockQuery;
+use Locale;
 
 /**
  * @internal
@@ -166,6 +168,34 @@ final class UpdateTest extends CIUnitTestCase
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
         $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testUpdateWithSetAsTimeWithLocaleFa()
+    {
+        $currentLocale = Locale::getDefault();
+        Locale::setDefault('fa');
+
+        $builder = new BaseBuilder('users', $this->db);
+
+        $time = Time::parse('2022-08-29 13:00');
+        $builder->testMode()->set('last_active', $time)->where('id', 1)->update();
+
+        $expectedSQL = 'UPDATE "users" SET "last_active" = \'2022-08-29 13:00:00\' WHERE "id" = 1';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledUpdate()));
+
+        $expectedBinds = [
+            'last_active' => [
+                $time,
+                true,
+            ],
+            'id' => [
+                1,
+                true,
+            ],
+        ];
+        $this->assertSame($expectedBinds, $builder->getBinds());
+
+        Locale::setDefault($currentLocale);
     }
 
     public function testUpdateWithSetAsArray()


### PR DESCRIPTION
**Description**
Closes #6439

Now you can use Time in all locales.

```php
    $time = Time::parse('2022-08-29 13:00');
    $builder->set('last_active', $time)->where('id', 1)->update();
```

Background:
1. Basically QueryBuilder does not support objects.
2. But it supports stringable objects.
3. `Time` is stringable.
4. But it is localized, so it will be converted to invalid datetime string in a few locales.
5. So only in a few locales, if you pass `Time`, it causes a query error.
6. `Time` is a standard class in CI4.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
