### PR TITLE
fix: make Time::__toString() database-compatible on any locale

### DIFF
--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -1122,12 +1122,11 @@ class Time extends DateTime
 
     /**
      * Outputs a short format version of the datetime.
-     *
-     * @throws Exception
+     * The output is NOT localized intentionally.
      */
     public function __toString(): string
     {
-        return IntlDateFormatter::formatObject($this->toDateTime(), $this->toStringFormat, $this->locale);
+        return $this->format('Y-m-d H:i:s');
     }
 
     /**

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -17,6 +17,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use DateTime;
 use DateTimeZone;
+use Generator;
 use IntlDateFormatter;
 use Locale;
 
@@ -1137,5 +1138,26 @@ final class TimeTest extends CIUnitTestCase
         $this->assertSame('2017-03-10T12:00:00+09:00', $now);
 
         Locale::setDefault($currentLocale);
+    }
+
+    /**
+     * @dataProvider provideLocales
+     */
+    public function testToStringDoesNotDependOnLocale(string $locale)
+    {
+        Locale::setDefault($locale);
+
+        $time = new Time('2017/03/10 12:00');
+
+        $this->assertSame('2017-03-10 12:00:00', (string) $time);
+    }
+
+    public function provideLocales(): Generator
+    {
+        yield from [
+            ['en'],
+            ['de'],
+            ['fa'],
+        ];
     }
 }

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1154,6 +1154,7 @@ final class TimeTest extends CIUnitTestCase
         yield from [
             ['en'],
             ['de'],
+            ['ar'],
             ['fa'],
         ];
     }

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -56,7 +56,7 @@ final class TimeTest extends CIUnitTestCase
         );
 
         $time = new Time('', 'America/Chicago');
-        $this->assertSame($formatter->format($time), (string) $time);
+        $this->assertSame($formatter->format($time), $time->toDateTimeString());
     }
 
     public function testTimeWithTimezone()
@@ -72,7 +72,7 @@ final class TimeTest extends CIUnitTestCase
 
         $time = new Time('now', 'Europe/London');
 
-        $this->assertSame($formatter->format($time), (string) $time);
+        $this->assertSame($formatter->format($time), $time->toDateTimeString());
     }
 
     public function testTimeWithTimezoneAndLocale()
@@ -88,7 +88,7 @@ final class TimeTest extends CIUnitTestCase
 
         $time = new Time('now', 'Europe/London', 'fr_FR');
 
-        $this->assertSame($formatter->format($time), (string) $time);
+        $this->assertSame($formatter->format($time), $time->toDateTimeString());
     }
 
     public function testTimeWithDateTimeZone()
@@ -104,7 +104,7 @@ final class TimeTest extends CIUnitTestCase
 
         $time = new Time('now', new DateTimeZone('Europe/London'), 'fr_FR');
 
-        $this->assertSame($formatter->format($time), (string) $time);
+        $this->assertSame($formatter->format($time), $time->toDateTimeString());
     }
 
     public function testToDateTime()
@@ -138,7 +138,6 @@ final class TimeTest extends CIUnitTestCase
     {
         $time = Time::parse('2017-01-12 00:00', 'America/Chicago');
 
-        $this->assertSame('2017-01-12 00:00:00', (string) $time);
         $this->assertSame('2017-01-12 00:00:00', $time->toDateTimeString());
     }
 

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1128,7 +1128,6 @@ final class TimeTest extends CIUnitTestCase
 
     public function testSetTestNowWithFaLocale()
     {
-        $currentLocale = Locale::getDefault();
         Locale::setDefault('fa');
 
         Time::setTestNow('2017/03/10 12:00', 'Asia/Tokyo');
@@ -1136,8 +1135,6 @@ final class TimeTest extends CIUnitTestCase
         $now = Time::now()->format('c');
 
         $this->assertSame('2017-03-10T12:00:00+09:00', $now);
-
-        Locale::setDefault($currentLocale);
     }
 
     /**

--- a/user_guide_src/source/changelogs/v4.2.7.rst
+++ b/user_guide_src/source/changelogs/v4.2.7.rst
@@ -12,7 +12,7 @@ Release Date: Unreleased
 BREAKING
 ********
 
--  ``Time::__toStrong()`` is now locale-independent. It returns database-compatible strings like '2022-09-07 12:00:00' in any locale.
+-  ``Time::__toString()`` is now locale-independent. It returns database-compatible strings like '2022-09-07 12:00:00' in any locale.
 
 Enhancements
 ************

--- a/user_guide_src/source/changelogs/v4.2.7.rst
+++ b/user_guide_src/source/changelogs/v4.2.7.rst
@@ -12,7 +12,7 @@ Release Date: Unreleased
 BREAKING
 ********
 
-none.
+-  ``Time::__toStrong()`` is now locale-independent. It returns database-compatible strings like '2022-09-07 12:00:00' in any locale.
 
 Enhancements
 ************

--- a/user_guide_src/source/installation/upgrade_427.rst
+++ b/user_guide_src/source/installation/upgrade_427.rst
@@ -15,7 +15,7 @@ Please refer to the upgrade instructions corresponding to your installation meth
 Breaking Changes
 ****************
 
--  ``Time::__toStrong()`` is now locale-independent. It returns database-compatible strings like '2022-09-07 12:00:00' in any locale. Most locales are not affected by this change. But in a few locales like `ar`, `fa`, ``Time::__toStrong()`` (or ``(string) $time`` or implicit casting to a string) no longer returns a localized datetime string. if you want to get a localized datetime string, use :ref:`Time::toDateTimeString() <time-todatetimestring>` instead.
+-  ``Time::__toString()`` is now locale-independent. It returns database-compatible strings like '2022-09-07 12:00:00' in any locale. Most locales are not affected by this change. But in a few locales like `ar`, `fa`, ``Time::__toString()`` (or ``(string) $time`` or implicit casting to a string) no longer returns a localized datetime string. if you want to get a localized datetime string, use :ref:`Time::toDateTimeString() <time-todatetimestring>` instead.
 
 Project Files
 *************

--- a/user_guide_src/source/installation/upgrade_427.rst
+++ b/user_guide_src/source/installation/upgrade_427.rst
@@ -1,0 +1,33 @@
+#############################
+Upgrading from 4.2.6 to 4.2.7
+#############################
+
+Please refer to the upgrade instructions corresponding to your installation method.
+
+- :ref:`Composer Installation App Starter Upgrading <app-starter-upgrading>`
+- :ref:`Composer Installation Adding CodeIgniter4 to an Existing Project Upgrading <adding-codeigniter4-upgrading>`
+- :ref:`Manual Installation Upgrading <installing-manual-upgrading>`
+
+.. contents::
+    :local:
+    :depth: 2
+
+Breaking Changes
+****************
+
+-  ``Time::__toStrong()`` is now locale-independent. It returns database-compatible strings like '2022-09-07 12:00:00' in any locale. Most locales are not affected by this change. But in a few locales like `ar`, `fa`, ``Time::__toStrong()`` (or ``(string) $time`` or implicit casting to a string) no longer returns a localized datetime string. if you want to get a localized datetime string, use :ref:`Time::toDateTimeString() <time-todatetimestring>` instead.
+
+Project Files
+*************
+
+A few files in the **project space** (root, app, public, writable) received cosmetic updates.
+You need not touch these files at all. There are some third-party CodeIgniter modules available
+to assist with merging changes to the project space: `Explore on Packagist <https://packagist.org/explore/?query=codeigniter4%20updates>`_.
+
+All Changes
+===========
+
+This is a list of all files in the **project space** that received changes;
+many will be simple comments or formatting that have no effect on the runtime:
+
+*

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -16,6 +16,7 @@ See also :doc:`./backward_compatibility_notes`.
 
     backward_compatibility_notes
 
+    upgrade_427
     upgrade_426
     upgrade_425
     upgrade_423

--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -149,6 +149,8 @@ A full listing of values can be found `here <https://unicode-org.github.io/icu-d
 
 .. literalinclude:: time/015.php
 
+.. _time-todatetimestring:
+
 toDateTimeString()
 ==================
 


### PR DESCRIPTION
**Description**
Closes #6439
Supersedes #6456

In this PR, `Time::__toString()` no longer depends on locale.
It always returns database-compatible string like `'2016-03-09 12:00:00'`.

In the current implementation, the `__toString()` output will be changed by the locale.
(But it seems it is not documented in the User Guide.)
It causes database query error in a few locale.

Time is localized class, but `__toString()` does not need to return localized value.
If a dev needs localized string, they can call [toDateTimeString()](https://codeigniter4.github.io/CodeIgniter4/libraries/time.html#todatetimestring).

Implicitly changing behavior depending on locale is a bad practice because it confuses developers.
`__toString()` is a standard PHP method, not a localized helper method. 
The  return value should be database-compatible.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
