### PR TITLE
docs: deprecate Cookie::withNeverExpiring()

### DIFF
--- a/system/Cookie/CloneableCookieInterface.php
+++ b/system/Cookie/CloneableCookieInterface.php
@@ -60,6 +60,8 @@ interface CloneableCookieInterface extends CookieInterface
      * Creates a new Cookie that will virtually never expire from the browser.
      *
      * @return static
+     *
+     * @deprecated See https://github.com/codeigniter4/CodeIgniter4/pull/6413
      */
     public function withNeverExpiring();
 

--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -460,8 +460,6 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
     }
 
     /**
-     * {@inheritDoc}
-     *
      * @deprecated See https://github.com/codeigniter4/CodeIgniter4/pull/6413
      */
     public function withNeverExpiring()

--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -461,6 +461,8 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated See https://github.com/codeigniter4/CodeIgniter4/pull/6413
      */
     public function withNeverExpiring()
     {

--- a/user_guide_src/source/changelogs/v4.2.6.rst
+++ b/user_guide_src/source/changelogs/v4.2.6.rst
@@ -27,7 +27,7 @@ none.
 Deprecations
 ************
 
-none.
+- :php:meth:`CodeIgniter\\Cookie\\Cookie::withNeverExpiring()` is deprecated.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/libraries/cookies.rst
+++ b/user_guide_src/source/libraries/cookies.rst
@@ -326,6 +326,8 @@ Class Reference
 
     .. php:method:: withNeverExpiring()
 
+        .. important:: This method is deprecated.
+
         :param string $name:
         :rtype: ``Cookie``
         :returns: new ``Cookie`` instance

--- a/user_guide_src/source/libraries/cookies.rst
+++ b/user_guide_src/source/libraries/cookies.rst
@@ -223,7 +223,7 @@ In runtime, you can manually supply a new default using the ``Cookie::setDefault
 Class Reference
 ***************
 
-.. php:namespace:: CodeIgniter\HTTP\Cookie
+.. php:namespace:: CodeIgniter\Cookie
 
 .. php:class:: Cookie
 


### PR DESCRIPTION
**Description**
See [#6413](https://github.com/codeigniter4/CodeIgniter4/pull/6413#issuecomment-1227060599)
Supersedes #6413

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

