### PR TITLE
 Fix broken caching system when array of allowed parameters used

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -730,9 +730,12 @@ class CodeIgniter
         }
 
         $uri = $this->request->getUri();
-
         if ($config->cacheQueryString) {
-            $name = URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery());
+            if (is_array($config->cacheQueryString)) {
+                $name = URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(['only' => $config->cacheQueryString]));
+            } else {
+                $name = URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery());
+            }
         } else {
             $name = URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath());
         }


### PR DESCRIPTION
New clean PR of #6410 after rebase

Discussion available here:
https://github.com/codeigniter4/CodeIgniter4/pull/6410

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

