### PR TITLE
docs: add composer.json in Mandatory File Changes in upgrade_420.rst

### DIFF
--- a/user_guide_src/source/installation/upgrade_420.rst
+++ b/user_guide_src/source/installation/upgrade_420.rst
@@ -38,6 +38,26 @@ Config/Constants.php
 
 The constants ``EVENT_PRIORITY_LOW``, ``EVENT_PRIORITY_NORMAL`` and ``EVENT_PRIORITY_HIGH`` are deprecated, and the definitions are moved to ``app/Config/Constants.php``. If you use these constants, define them in ``app/Config/Constants.php``. Or use new class constants ``CodeIgniter\Events\Events::PRIORITY_LOW``, ``CodeIgniter\Events\Events::PRIORITY_NORMAL`` and ``CodeIgniter\Events\Events::PRIORITY_HIGH``.
 
+composer.json
+=============
+
+If you use Composer, when you installed CodeIgniter v4.1.9 or before, and
+if there are ``App\\`` and ``Config\\`` namespaces in your ``/composer.json``'s ``autoload.psr-4``
+like the following, you need to remove these lines, and run ``composer dump-autoload``.
+
+.. code-block:: text
+
+    {
+        ...
+        "autoload": {
+            "psr-4": {
+                "App\\": "app",             <-- Remove this line
+                "Config\\": "app/Config"    <-- Remove this line
+            }
+        },
+        ...
+    }
+
 Breaking Changes
 ****************
 


### PR DESCRIPTION
**Description**
- add about composer.json autoload.psr-4

The config makes `spark migrate:status` output duplicated.
The same explanation is already here: https://codeigniter4.github.io/CodeIgniter4/general/managing_apps.html
But it is better to have it in Upgrading Guide.

The following is the result of installing v4.1.5 and updated to v4.2.5:
```console
$ php spark migrate:status

CodeIgniter v4.2.5 Command Line Tool - Server Time: 2022-09-02 18:25:16 UTC-05:00

+-----------+-------------------+----------+-------+-------------+-------+
| Namespace | Version           | Filename | Group | Migrated On | Batch |
+-----------+-------------------+----------+-------+-------------+-------+
| App       | 2022-09-02-231945 | Test     | ---   | ---         | ---   |
| App       | 2022-09-02-231945 | Test     | ---   | ---         | ---   |
+-----------+-------------------+----------+-------+-------------+-------+
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
