### PR TITLE
Enable `blank_line_between_import_groups`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -39,7 +39,9 @@ $finder = Finder::create()
     ]);
 
 $overrides = [
-    'phpdoc_separation' => [
+    // <<<<<<<<<<<<<<<<<<<<<<<< @TODO TO BE REMOVED ONCE LIVE IN CODING-STANDARD
+    'blank_line_between_import_groups' => true,
+    'phpdoc_separation'                => [
         'groups' => [
             ['immutable', 'psalm-immutable'],
             ['param', 'phpstan-param', 'psalm-param'],
@@ -52,6 +54,7 @@ $overrides = [
             ['var', 'phpstan-var', 'psalm-var'],
         ],
     ],
+    // >>>>>>>>>>>>>>>>>>>>>>>>>
 ];
 
 $options = [

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -31,7 +31,9 @@ $finder = Finder::create()
     ]);
 
 $overrides = [
-    'phpdoc_separation' => [
+    // <<<<<<<<<<<<<<<<<<<<<<<< @TODO TO BE REMOVED ONCE LIVE IN CODING-STANDARD
+    'blank_line_between_import_groups' => true,
+    'phpdoc_separation'                => [
         'groups' => [
             ['immutable', 'psalm-immutable'],
             ['param', 'phpstan-param', 'psalm-param'],
@@ -44,6 +46,7 @@ $overrides = [
             ['var', 'phpstan-var', 'psalm-var'],
         ],
     ],
+    // >>>>>>>>>>>>>>>>>>>>>>>>>
 ];
 
 $options = [

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -33,7 +33,9 @@ $overrides = [
     'php_unit_internal_class'     => false,
     'no_unused_imports'           => false,
     'class_attributes_separation' => false,
-    'phpdoc_separation'           => [
+    // <<<<<<<<<<<<<<<<<<<<<<<< @TODO TO BE REMOVED ONCE LIVE IN CODING-STANDARD
+    'blank_line_between_import_groups' => true,
+    'phpdoc_separation'                => [
         'groups' => [
             ['immutable', 'psalm-immutable'],
             ['param', 'phpstan-param', 'psalm-param'],
@@ -46,6 +48,7 @@ $overrides = [
             ['var', 'phpstan-var', 'psalm-var'],
         ],
     ],
+    // >>>>>>>>>>>>>>>>>>>>>>>>>
 ];
 
 $options = [


### PR DESCRIPTION
**Description**
```console
$ vendor/bin/php-cs-fixer describe blank_line_between_import_groups
Description of blank_line_between_import_groups rule.
Putting blank lines between `use` statement groups.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,5 +1,7 @@
    <?php

    use function AAC;
   +
    use const AAB;
   +
    use AAA;

   ----------- end diff -----------

 * Example #2.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,8 +1,10 @@
    <?php
    use const AAAA;
    use const BBB;
   +
    use Bar;
    use AAC;
    use Acme;
   +
    use function CCC\AA;
    use function DDD;

   ----------- end diff -----------

 * Example #3.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,8 +1,10 @@
    <?php
    use const BBB;
    use const AAAA;
   +
    use Acme;
    use AAC;
    use Bar;
   +
    use function DDD;
    use function CCC\AA;

   ----------- end diff -----------

 * Example #4.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,8 +1,13 @@
    <?php
    use const AAAA;
    use const BBB;
   +
    use Acme;
   +
    use function DDD;
   +
    use AAC;
   +
    use function CCC\AA;
   +
    use Bar;

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
