### PR TITLE
Disable `date_time_create_from_format_call`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -58,7 +58,8 @@ $overrides = [
         'allow_single_line_empty_anonymous_classes' => true,
         'allow_single_line_anonymous_functions'     => true,
     ],
-    'function_declaration' => [
+    'date_time_create_from_format_call' => false,
+    'function_declaration'              => [
         'closure_function_spacing'   => 'one',
         'trailing_comma_single_line' => false,
     ],

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -50,7 +50,8 @@ $overrides = [
         'allow_single_line_empty_anonymous_classes' => true,
         'allow_single_line_anonymous_functions'     => true,
     ],
-    'function_declaration' => [
+    'date_time_create_from_format_call' => false,
+    'function_declaration'              => [
         'closure_function_spacing'   => 'one',
         'trailing_comma_single_line' => false,
     ],

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -52,7 +52,8 @@ $overrides = [
         'allow_single_line_empty_anonymous_classes' => true,
         'allow_single_line_anonymous_functions'     => true,
     ],
-    'function_declaration' => [
+    'date_time_create_from_format_call' => false,
+    'function_declaration'              => [
         'closure_function_spacing'   => 'one',
         'trailing_comma_single_line' => false,
     ],


### PR DESCRIPTION
**Description**
This might need discussion.

```console
$ vendor/bin/php-cs-fixer describe date_time_create_from_format_call
Description of date_time_create_from_format_call rule.
The first argument of `DateTime::createFromFormat` method must start with `!`.
Consider this code:
    `DateTime::createFromFormat('Y-m-d', '2022-02-11')`.
    What value will be returned? '2022-01-11 00:00:00.0'? No, actual return value has 'H:i:s' section like '2022-02-11 16:55:37.0'.        
    Change 'Y-m-d' to '!Y-m-d', return value will be '2022-01-11 00:00:00.0'.
    So, adding `!` to format string will make return value more intuitive.

Fixer applying this rule is risky.
Risky when depending on the actual timings being used even when not explicit set in format.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,1 +1,1 @@
   -<?php \DateTime::createFromFormat('Y-m-d', '2022-02-11');
   +<?php \DateTime::createFromFormat('!Y-m-d', '2022-02-11');

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
